### PR TITLE
Update @wordpress/edit-site

### DIFF
--- a/apps/wpcom-block-editor/package.json
+++ b/apps/wpcom-block-editor/package.json
@@ -31,7 +31,7 @@
 		"@wordpress/data": "^6.9.0",
 		"@wordpress/dom-ready": "^3.9.0",
 		"@wordpress/edit-post": "^6.6.0",
-		"@wordpress/edit-site": "^4.6.0",
+		"@wordpress/edit-site": "^4.17.0",
 		"@wordpress/editor": "^12.8.0",
 		"@wordpress/element": "^4.7.0",
 		"@wordpress/hooks": "^3.9.0",

--- a/client/blocks/time-mismatch-warning/test/index.jsx
+++ b/client/blocks/time-mismatch-warning/test/index.jsx
@@ -24,9 +24,13 @@ jest.mock( 'calypso/state/preferences/selectors', () => ( {
 	getPreference: jest.fn( () => false ),
 } ) );
 
+// Simulate the time Feb 27, 2017 05:25 UTC
+const NOW = 1488173100125;
+
 describe( 'TimeMismatchWarning', () => {
 	beforeAll( () => {
 		jest.spyOn( global, 'Date' ).mockImplementation( () => ( { getTimezoneOffset: () => 240 } ) );
+		Date.now = jest.fn().mockReturnValue( NOW );
 	} );
 
 	afterAll( () => {

--- a/packages/design-preview/package.json
+++ b/packages/design-preview/package.json
@@ -33,7 +33,7 @@
 		"@automattic/design-picker": "workspace:^",
 		"@automattic/i18n-utils": "workspace:^",
 		"@wordpress/components": "^19.15.0",
-		"@wordpress/edit-site": "^4.6.0",
+		"@wordpress/edit-site": "^4.17.0",
 		"@wordpress/react-i18n": "^3.7.0",
 		"classnames": "^2.3.1",
 		"tslib": "^2.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -531,7 +531,7 @@ __metadata:
     "@testing-library/jest-dom": ^5.16.2
     "@testing-library/react": ^12.1.3
     "@wordpress/components": ^19.15.0
-    "@wordpress/edit-site": ^4.6.0
+    "@wordpress/edit-site": ^4.17.0
     "@wordpress/react-i18n": ^3.7.0
     classnames: ^2.3.1
     react: ^17.0.2
@@ -1591,7 +1591,7 @@ __metadata:
     "@wordpress/dependency-extraction-webpack-plugin": ^3.5.0
     "@wordpress/dom-ready": ^3.9.0
     "@wordpress/edit-post": ^6.6.0
-    "@wordpress/edit-site": ^4.6.0
+    "@wordpress/edit-site": ^4.17.0
     "@wordpress/editor": ^12.8.0
     "@wordpress/element": ^4.7.0
     "@wordpress/hooks": ^3.9.0
@@ -3873,7 +3873,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@emotion/utils@npm:^1.1.0, @emotion/utils@npm:^1.2.0":
+"@emotion/utils@npm:^1.0.0, @emotion/utils@npm:^1.1.0, @emotion/utils@npm:^1.2.0":
   version: 1.2.0
   resolution: "@emotion/utils@npm:1.2.0"
   checksum: 7051cec83bb49688549667484058d3a19a30001fa3692c23f7a2e727c05121f952854e1196feb9ece4fa36914705ebf474edba833a2178bdc133c654b5e3ca7d
@@ -3946,12 +3946,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@floating-ui/core@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "@floating-ui/core@npm:1.0.1"
+  checksum: c8b7c09b852e9b3422c5ff57f09cdaa0b40206ed147ab6721aa8ee2c4e88eab2e2a8f7d886d92df4ec08537d85b534aae19aa5eff1fa45dd80be885a435389b0
+  languageName: node
+  linkType: hard
+
 "@floating-ui/dom@npm:^0.4.5":
   version: 0.4.5
   resolution: "@floating-ui/dom@npm:0.4.5"
   dependencies:
     "@floating-ui/core": ^0.6.2
   checksum: dad990e9164c92c251fd5687d9e1461083005b203468183468313a3907992242b6281de2b2e3e874ab84459bf18ea4b4c0459223ab66d89e11928fe060a946f5
+  languageName: node
+  linkType: hard
+
+"@floating-ui/dom@npm:^1.0.0":
+  version: 1.0.3
+  resolution: "@floating-ui/dom@npm:1.0.3"
+  dependencies:
+    "@floating-ui/core": ^1.0.1
+  checksum: b1ccc5677a5945ab26ca334357678593444e40858a1c10e7a6e25b9a1af215e419dcd4fbc428387767278dc6191a6c5169806750e13b19f49dc09916256ff0dc
   languageName: node
   linkType: hard
 
@@ -3965,6 +3981,18 @@ __metadata:
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
   checksum: 83b89c0535b283ce2ae8b637237987bbece02bb15f9765d94004ce5ca0d77e32ef1402f6499c04b357787d010d9ec23d2eaf0b6ab7ab8b2c53a39ab813c8d046
+  languageName: node
+  linkType: hard
+
+"@floating-ui/react-dom@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "@floating-ui/react-dom@npm:1.0.0"
+  dependencies:
+    "@floating-ui/dom": ^1.0.0
+  peerDependencies:
+    react: ">=16.8.0"
+    react-dom: ">=16.8.0"
+  checksum: 381f5747bf1a34e6ed55c80ed05cd3357803a576dd05c7b67af5c7f60365fb95a456190d80fdd9b9be337bdb55625f8612773101de7c367f590c0e47974c2850
   languageName: node
   linkType: hard
 
@@ -4839,69 +4867,70 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-spring/animated@npm:~9.3.0":
-  version: 9.3.0
-  resolution: "@react-spring/animated@npm:9.3.0"
+"@react-spring/animated@npm:~9.5.5":
+  version: 9.5.5
+  resolution: "@react-spring/animated@npm:9.5.5"
   dependencies:
-    "@react-spring/shared": ~9.3.0
-    "@react-spring/types": ~9.3.0
+    "@react-spring/shared": ~9.5.5
+    "@react-spring/types": ~9.5.5
   peerDependencies:
-    react: ^16.8.0  || ^17.0.0
-  checksum: 1207bf3faefc94aa62983c87ca9b137314c80961604864b9562aceded326c53cb215ad7e9a9e209c61a4bdda89d9e53c5e2acb1ba54c0adb35b41aa2b98c091b
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+  checksum: f7c68d5685365e4ddb6112c3e8e31f6104825f487fdebd5ff8c16e047e5ff2b8570b1cf1585a68b1bd679324dfb56ae5421da17341a04b3c79951d3f35f26cbd
   languageName: node
   linkType: hard
 
-"@react-spring/core@npm:~9.3.0":
-  version: 9.3.0
-  resolution: "@react-spring/core@npm:9.3.0"
+"@react-spring/core@npm:~9.5.5":
+  version: 9.5.5
+  resolution: "@react-spring/core@npm:9.5.5"
   dependencies:
-    "@react-spring/animated": ~9.3.0
-    "@react-spring/shared": ~9.3.0
-    "@react-spring/types": ~9.3.0
+    "@react-spring/animated": ~9.5.5
+    "@react-spring/rafz": ~9.5.5
+    "@react-spring/shared": ~9.5.5
+    "@react-spring/types": ~9.5.5
   peerDependencies:
-    react: ^16.8.0  || ^17.0.0
-  checksum: 3e58ec235790db43a3058ca68d1818869f9c24e2445bedc92a61b4b49387598a49564a531c5a776663076dbf36f8e0844a991d7c2e5b548035578e8cd76840fb
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+  checksum: fe40f99e6de261391c2bf0ca56eeac071c0e1b6cf5a145b2acaefc12d076bcadae973bbfa4adf2171240268884befd2d7f4cb3cd5be4dd8106a3dd6179e059b4
   languageName: node
   linkType: hard
 
-"@react-spring/rafz@npm:~9.3.0":
-  version: 9.3.0
-  resolution: "@react-spring/rafz@npm:9.3.0"
-  checksum: e382d177a6906ac4dda829a40d563f1c3b0e01dd308407bf73a74701ad9856294f1b0f473bf8b096880b45f9767e6701e8ac15b141644738c09fc2c525262c92
+"@react-spring/rafz@npm:~9.5.5":
+  version: 9.5.5
+  resolution: "@react-spring/rafz@npm:9.5.5"
+  checksum: a0e05c8bd2bee5996c12985dd502e05378ae46044fd09279f726bd10cd0d5037017f15040c4c171fb04a6cd31c90c4f61605629e5b09566765b0edafce091b7c
   languageName: node
   linkType: hard
 
-"@react-spring/shared@npm:~9.3.0":
-  version: 9.3.0
-  resolution: "@react-spring/shared@npm:9.3.0"
+"@react-spring/shared@npm:~9.5.5":
+  version: 9.5.5
+  resolution: "@react-spring/shared@npm:9.5.5"
   dependencies:
-    "@react-spring/rafz": ~9.3.0
-    "@react-spring/types": ~9.3.0
+    "@react-spring/rafz": ~9.5.5
+    "@react-spring/types": ~9.5.5
   peerDependencies:
-    react: ^16.8.0  || ^17.0.0
-  checksum: 61d403ebee6a9f95437ee03f98fdc184c04d86202c007a98f26766c76b0c9c094c9c85e3070fb721f4efc210e1cae8625eafcbfb9c7736bf56a535f6f2adfda5
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+  checksum: 5df013703b90eead6740f25b28599356b57a4f2a0002ff1ca7beaed581076c88d926f84c52de800052ee2ecfef870f51fced8fc0035b57312c6e0a28418b029e
   languageName: node
   linkType: hard
 
-"@react-spring/types@npm:~9.3.0":
-  version: 9.3.0
-  resolution: "@react-spring/types@npm:9.3.0"
-  checksum: 4a09f022f27880edc92a2a14d295b2d4d3b8d42e3ffcd1ae5291ffb7540d37e42ba1f695e65ce4fd476ced7259f06b76845f70983cb95c04fa5e2c7f4d3c444d
+"@react-spring/types@npm:~9.5.5":
+  version: 9.5.5
+  resolution: "@react-spring/types@npm:9.5.5"
+  checksum: 2bd314101f6d79f23816e87992ef442acc1dd86323a10ba5e613741090e6e096ee854e25a442c750dc7ea9b3954d1e945263c550d3bb4ac23588c9ec1d23c5da
   languageName: node
   linkType: hard
 
-"@react-spring/web@npm:^9.2.4":
-  version: 9.3.0
-  resolution: "@react-spring/web@npm:9.3.0"
+"@react-spring/web@npm:^9.2.4, @react-spring/web@npm:^9.4.5":
+  version: 9.5.5
+  resolution: "@react-spring/web@npm:9.5.5"
   dependencies:
-    "@react-spring/animated": ~9.3.0
-    "@react-spring/core": ~9.3.0
-    "@react-spring/shared": ~9.3.0
-    "@react-spring/types": ~9.3.0
+    "@react-spring/animated": ~9.5.5
+    "@react-spring/core": ~9.5.5
+    "@react-spring/shared": ~9.5.5
+    "@react-spring/types": ~9.5.5
   peerDependencies:
-    react: ^16.8.0  || ^17.0.0
-    react-dom: ^16.8.0  || ^17.0.0
-  checksum: 7e5d70b26566b17e62b4c58bd31de60172ca274853bb5155730360c890f3714ffe295018c6f4f232a567e02f006b7ea08a604085601cd45fff3df90915de79f7
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+  checksum: 01db4ad68305fbada3735c44a7972a3a8dcff630758bfbe75e48dffc27cf77c303f598f2be176b66d6bf4e61f66a38e64e007859e5fd369e662f829d26839499
   languageName: node
   linkType: hard
 
@@ -7017,7 +7046,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/lodash@npm:*, @types/lodash@npm:^4.14.172, @types/lodash@npm:^4.14.179":
+"@types/lodash@npm:*, @types/lodash@npm:^4.14.179":
   version: 4.14.179
   resolution: "@types/lodash@npm:4.14.179"
   checksum: 653e45c277e405577c1e4f5baeb0040589b805aa8dabea334c93e1ae44949f6071361754dbf933202de3fb73119f3ee12f317d0f0213168bb806d1ee7478b0ce
@@ -7126,6 +7155,13 @@ __metadata:
   version: 4.1.2
   resolution: "@types/npmlog@npm:4.1.2"
   checksum: 09a3395759651f0a867b5811ee33147803106684ff1f013ded27c632a2f8071766d95d862229feac112166b8ff9c6f3df49eb1e27875668a4e2e7fb5f579d3dd
+  languageName: node
+  linkType: hard
+
+"@types/offscreencanvas@npm:^2019.7.0":
+  version: 2019.7.0
+  resolution: "@types/offscreencanvas@npm:2019.7.0"
+  checksum: f10647cf8abf5c5313ac39a688866e824f04207b18fd03c2fa986a2d856f1c26dd11b04b3692fe64e6f1467b0d52579e8f4d0e532377d5c9065214bff4ebc0e7
   languageName: node
   linkType: hard
 
@@ -8343,14 +8379,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wordpress/a11y@npm:^3.10.0, @wordpress/a11y@npm:^3.13.0, @wordpress/a11y@npm:^3.2.1, @wordpress/a11y@npm:^3.2.4, @wordpress/a11y@npm:^3.7.0, @wordpress/a11y@npm:^3.9.0":
-  version: 3.13.0
-  resolution: "@wordpress/a11y@npm:3.13.0"
+"@wordpress/a11y@npm:^3.13.0, @wordpress/a11y@npm:^3.2.1, @wordpress/a11y@npm:^3.2.4, @wordpress/a11y@npm:^3.20.0, @wordpress/a11y@npm:^3.7.0, @wordpress/a11y@npm:^3.9.0":
+  version: 3.20.0
+  resolution: "@wordpress/a11y@npm:3.20.0"
   dependencies:
     "@babel/runtime": ^7.16.0
-    "@wordpress/dom-ready": ^3.13.0
-    "@wordpress/i18n": ^4.13.0
-  checksum: 506496a689fd5052e356a764dca6dcc17403b91531b94ea9ddc0844d29914f15a2ba2c4f69c71a64fe6e566ba70cd522ff2ad3807d6ff18761307d5d8b23b0f0
+    "@wordpress/dom-ready": ^3.20.0
+    "@wordpress/i18n": ^4.20.0
+  checksum: eb106fc653ec597037808507d4ecb0e72e0ea9e4bd53eb64dcffe1db77c34b4a4f2e9a0b7222ef1d8c790cd3ddf7cae8e4e5c3030cda32b02671be08565386a2
   languageName: node
   linkType: hard
 
@@ -8365,23 +8401,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wordpress/api-fetch@npm:^6.4.0, @wordpress/api-fetch@npm:^6.6.0":
-  version: 6.6.0
-  resolution: "@wordpress/api-fetch@npm:6.6.0"
+"@wordpress/api-fetch@npm:^6.17.0, @wordpress/api-fetch@npm:^6.4.0, @wordpress/api-fetch@npm:^6.6.0":
+  version: 6.17.0
+  resolution: "@wordpress/api-fetch@npm:6.17.0"
   dependencies:
     "@babel/runtime": ^7.16.0
-    "@wordpress/i18n": ^4.9.0
-    "@wordpress/url": ^3.10.0
-  checksum: e36375ae57b021bc517518861f9831b99a9fa9b3684ce06eb27eef67cd2dbd3624dca850c9b9929988607892bd4c86f9d4c4b30f89ec9ccb93f3c604332e43b0
+    "@wordpress/i18n": ^4.20.0
+    "@wordpress/url": ^3.21.0
+  checksum: a8df5753df9c4af748577c0299e52e0a944957b30afdc15bf1941d3b5e5fc8977efc1b327f048adc2d089c0e3644c157eb63caf32398d57fdd10632a48f44092
   languageName: node
   linkType: hard
 
-"@wordpress/autop@npm:^3.2.3, @wordpress/autop@npm:^3.9.0":
-  version: 3.9.0
-  resolution: "@wordpress/autop@npm:3.9.0"
+"@wordpress/autop@npm:^3.2.3, @wordpress/autop@npm:^3.20.0":
+  version: 3.20.0
+  resolution: "@wordpress/autop@npm:3.20.0"
   dependencies:
     "@babel/runtime": ^7.16.0
-  checksum: 51b6946b641df7d4591e84eefe99ea61487d1a86bfa96fd4ba45072eea3e0121d29341e17b3b569e5a6b29248e1d7cfc137a0a9295ec8bd50600e810f51d92a9
+  checksum: 5bf038a2fb1e74e6aa222d73c7b986d085ed06ac2ba792a1ea48dee45ea134da45d5fdf4273b0e251d65f9be5bb66b2a6ce2258f848d9cdfe4096bfce438b97d
   languageName: node
   linkType: hard
 
@@ -8428,12 +8464,62 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wordpress/blob@npm:^3.2.2, @wordpress/blob@npm:^3.7.0, @wordpress/blob@npm:^3.9.0":
-  version: 3.9.0
-  resolution: "@wordpress/blob@npm:3.9.0"
+"@wordpress/blob@npm:^3.2.2, @wordpress/blob@npm:^3.20.0, @wordpress/blob@npm:^3.7.0, @wordpress/blob@npm:^3.9.0":
+  version: 3.20.0
+  resolution: "@wordpress/blob@npm:3.20.0"
   dependencies:
     "@babel/runtime": ^7.16.0
-  checksum: 14e721171664ed50e6c7df5a8dc1d437db3edcaaf20bf04c0bd0c4a36b1076988106e9105fc84f6f0f7e6f7bd533e6818aaeef75dce1b5cd3dfb9888ab304206
+  checksum: d2b858ab914c86ec4b2e5f2d7a3dfa487932e072f35dd3ca36065e9dc4caab93b47c49c088e6f838f351adaa8f2e7b6b89b486dc89525bc43b513e98d037b013
+  languageName: node
+  linkType: hard
+
+"@wordpress/block-editor@npm:^10.3.0":
+  version: 10.3.0
+  resolution: "@wordpress/block-editor@npm:10.3.0"
+  dependencies:
+    "@babel/runtime": ^7.16.0
+    "@react-spring/web": ^9.4.5
+    "@wordpress/a11y": ^3.20.0
+    "@wordpress/api-fetch": ^6.17.0
+    "@wordpress/blob": ^3.20.0
+    "@wordpress/blocks": ^11.19.0
+    "@wordpress/components": ^21.3.0
+    "@wordpress/compose": ^5.18.0
+    "@wordpress/data": ^7.4.0
+    "@wordpress/date": ^4.20.0
+    "@wordpress/deprecated": ^3.20.0
+    "@wordpress/dom": ^3.20.0
+    "@wordpress/element": ^4.18.0
+    "@wordpress/hooks": ^3.20.0
+    "@wordpress/html-entities": ^3.20.0
+    "@wordpress/i18n": ^4.20.0
+    "@wordpress/icons": ^9.11.0
+    "@wordpress/is-shallow-equal": ^4.20.0
+    "@wordpress/keyboard-shortcuts": ^3.18.0
+    "@wordpress/keycodes": ^3.20.0
+    "@wordpress/notices": ^3.20.0
+    "@wordpress/rich-text": ^5.18.0
+    "@wordpress/shortcode": ^3.20.0
+    "@wordpress/style-engine": ^1.3.0
+    "@wordpress/token-list": ^2.20.0
+    "@wordpress/url": ^3.21.0
+    "@wordpress/warning": ^2.20.0
+    "@wordpress/wordcount": ^3.20.0
+    classnames: ^2.3.1
+    colord: ^2.7.0
+    diff: ^4.0.2
+    dom-scroll-into-view: ^1.2.1
+    inherits: ^2.0.3
+    lodash: ^4.17.21
+    react-autosize-textarea: ^7.1.0
+    react-easy-crop: ^4.5.1
+    rememo: ^4.0.0
+    remove-accents: ^0.4.2
+    traverse: ^0.6.6
+  peerDependencies:
+    react: ^17.0.0
+    react-dom: ^17.0.0
+  checksum: e190e44884639eaa80b3b27bb198158a7dff792a446d2e06cc14260eaf5a52e415642f47db773b7b943a9b8cc4596901a0fe4e576451766bb5c0b8ccc3418a7c
   languageName: node
   linkType: hard
 
@@ -8580,89 +8666,93 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wordpress/block-library@npm:^7.6.0":
-  version: 7.6.0
-  resolution: "@wordpress/block-library@npm:7.6.0"
+"@wordpress/block-library@npm:^7.17.0, @wordpress/block-library@npm:^7.6.0":
+  version: 7.17.0
+  resolution: "@wordpress/block-library@npm:7.17.0"
   dependencies:
     "@babel/runtime": ^7.16.0
-    "@wordpress/a11y": ^3.9.0
-    "@wordpress/api-fetch": ^6.6.0
-    "@wordpress/autop": ^3.9.0
-    "@wordpress/blob": ^3.9.0
-    "@wordpress/block-editor": ^9.1.0
-    "@wordpress/blocks": ^11.8.0
-    "@wordpress/components": ^19.11.0
-    "@wordpress/compose": ^5.7.0
-    "@wordpress/core-data": ^4.7.0
-    "@wordpress/data": ^6.9.0
-    "@wordpress/date": ^4.9.0
-    "@wordpress/deprecated": ^3.9.0
-    "@wordpress/dom": ^3.9.0
-    "@wordpress/element": ^4.7.0
-    "@wordpress/hooks": ^3.9.0
-    "@wordpress/html-entities": ^3.9.0
-    "@wordpress/i18n": ^4.9.0
-    "@wordpress/icons": ^9.0.0
-    "@wordpress/keycodes": ^3.9.0
-    "@wordpress/notices": ^3.9.0
-    "@wordpress/primitives": ^3.7.0
-    "@wordpress/reusable-blocks": ^3.7.0
-    "@wordpress/rich-text": ^5.7.0
-    "@wordpress/server-side-render": ^3.7.0
-    "@wordpress/url": ^3.10.0
-    "@wordpress/viewport": ^4.7.0
+    "@wordpress/a11y": ^3.20.0
+    "@wordpress/api-fetch": ^6.17.0
+    "@wordpress/autop": ^3.20.0
+    "@wordpress/blob": ^3.20.0
+    "@wordpress/block-editor": ^10.3.0
+    "@wordpress/blocks": ^11.19.0
+    "@wordpress/components": ^21.3.0
+    "@wordpress/compose": ^5.18.0
+    "@wordpress/core-data": ^5.3.0
+    "@wordpress/data": ^7.4.0
+    "@wordpress/date": ^4.20.0
+    "@wordpress/deprecated": ^3.20.0
+    "@wordpress/dom": ^3.20.0
+    "@wordpress/element": ^4.18.0
+    "@wordpress/hooks": ^3.20.0
+    "@wordpress/html-entities": ^3.20.0
+    "@wordpress/i18n": ^4.20.0
+    "@wordpress/icons": ^9.11.0
+    "@wordpress/keycodes": ^3.20.0
+    "@wordpress/notices": ^3.20.0
+    "@wordpress/primitives": ^3.18.0
+    "@wordpress/reusable-blocks": ^3.18.0
+    "@wordpress/rich-text": ^5.18.0
+    "@wordpress/server-side-render": ^3.18.0
+    "@wordpress/url": ^3.21.0
+    "@wordpress/viewport": ^4.18.0
+    change-case: ^4.1.2
     classnames: ^2.3.1
     colord: ^2.7.0
-    fast-average-color: 4.3.0
+    fast-average-color: ^9.1.1
     lodash: ^4.17.21
     memize: ^1.1.0
     micromodal: ^0.4.10
-    moment: ^2.22.1
+    remove-accents: ^0.4.2
   peerDependencies:
     react: ^17.0.0
     react-dom: ^17.0.0
-  checksum: 1109f092612de1d244b10f15cf092cbf956b149abf4691c288bbc67f26050adb1a96f3d1a84cb6cab3bb4a4c8fca1fa9c817ebddf8d556e1b65e75469220afee
+  checksum: 55df189e937ef14744ca2619133e370139e2781e07a7c1a5220d7b3213823bf4e4e3bb6de86c47b29bbabb834f01062ff6293acfea0be0b9a0467601bbfc4cc2
   languageName: node
   linkType: hard
 
-"@wordpress/block-serialization-default-parser@npm:^4.9.0":
-  version: 4.9.0
-  resolution: "@wordpress/block-serialization-default-parser@npm:4.9.0"
+"@wordpress/block-serialization-default-parser@npm:^4.20.0":
+  version: 4.20.0
+  resolution: "@wordpress/block-serialization-default-parser@npm:4.20.0"
   dependencies:
     "@babel/runtime": ^7.16.0
-  checksum: 3e6cfc6216a27661c2601964e86c8b973ae2b5a0539fccd7c2863271127648b3b47a8c715adb85cbd0bb50d74ba3c254b765da5dfa0dd26f482f10dc58e2d37e
+  checksum: 574c28b267492dfa00eeda5b0cfd8c83a5fd57ef9076b340c897f37103286bc1d98198671b1ed33d6d3b20a8753892b7d44f2684bd821be8a2c0814a700e7069
   languageName: node
   linkType: hard
 
-"@wordpress/blocks@npm:^11.1.5, @wordpress/blocks@npm:^11.6.0, @wordpress/blocks@npm:^11.8.0":
-  version: 11.8.0
-  resolution: "@wordpress/blocks@npm:11.8.0"
+"@wordpress/blocks@npm:^11.1.5, @wordpress/blocks@npm:^11.19.0, @wordpress/blocks@npm:^11.6.0, @wordpress/blocks@npm:^11.8.0":
+  version: 11.19.0
+  resolution: "@wordpress/blocks@npm:11.19.0"
   dependencies:
     "@babel/runtime": ^7.16.0
-    "@wordpress/autop": ^3.9.0
-    "@wordpress/blob": ^3.9.0
-    "@wordpress/block-serialization-default-parser": ^4.9.0
-    "@wordpress/compose": ^5.7.0
-    "@wordpress/data": ^6.9.0
-    "@wordpress/deprecated": ^3.9.0
-    "@wordpress/dom": ^3.9.0
-    "@wordpress/element": ^4.7.0
-    "@wordpress/hooks": ^3.9.0
-    "@wordpress/html-entities": ^3.9.0
-    "@wordpress/i18n": ^4.9.0
-    "@wordpress/is-shallow-equal": ^4.9.0
-    "@wordpress/shortcode": ^3.9.0
+    "@wordpress/autop": ^3.20.0
+    "@wordpress/blob": ^3.20.0
+    "@wordpress/block-serialization-default-parser": ^4.20.0
+    "@wordpress/compose": ^5.18.0
+    "@wordpress/data": ^7.4.0
+    "@wordpress/deprecated": ^3.20.0
+    "@wordpress/dom": ^3.20.0
+    "@wordpress/element": ^4.18.0
+    "@wordpress/hooks": ^3.20.0
+    "@wordpress/html-entities": ^3.20.0
+    "@wordpress/i18n": ^4.20.0
+    "@wordpress/is-shallow-equal": ^4.20.0
+    "@wordpress/shortcode": ^3.20.0
+    change-case: ^4.1.2
     colord: ^2.7.0
     hpq: ^1.3.0
+    is-plain-object: ^5.0.0
     lodash: ^4.17.21
     memize: ^1.1.0
-    rememo: ^3.0.0
+    rememo: ^4.0.0
+    remove-accents: ^0.4.2
     showdown: ^1.9.1
     simple-html-tokenizer: ^0.5.7
     uuid: ^8.3.0
   peerDependencies:
     react: ^17.0.0
-  checksum: d01627043d5142ce7e78f2c0156fafbd8ee065a69ebdfc37c8588728247301f0573333e77fb5a331c448d0d3540c1dac1a01926f1d242738e42e0366c772ca45
+  checksum: 26d36a4569ca18c9f4ebab726367af86157081ee22ed6427fbdfd1e77fcd2ec8f23c7ae2483242802673a0ef43c5b9c5f6681b74e38515f860173120dd3bbdec
   languageName: node
   linkType: hard
 
@@ -8773,6 +8863,59 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@wordpress/components@npm:^21.3.0":
+  version: 21.3.0
+  resolution: "@wordpress/components@npm:21.3.0"
+  dependencies:
+    "@babel/runtime": ^7.16.0
+    "@emotion/cache": ^11.7.1
+    "@emotion/css": ^11.7.1
+    "@emotion/react": ^11.7.1
+    "@emotion/serialize": ^1.0.2
+    "@emotion/styled": ^11.6.0
+    "@emotion/utils": ^1.0.0
+    "@floating-ui/react-dom": ^1.0.0
+    "@use-gesture/react": ^10.2.6
+    "@wordpress/a11y": ^3.20.0
+    "@wordpress/compose": ^5.18.0
+    "@wordpress/date": ^4.20.0
+    "@wordpress/deprecated": ^3.20.0
+    "@wordpress/dom": ^3.20.0
+    "@wordpress/element": ^4.18.0
+    "@wordpress/escape-html": ^2.20.0
+    "@wordpress/hooks": ^3.20.0
+    "@wordpress/i18n": ^4.20.0
+    "@wordpress/icons": ^9.11.0
+    "@wordpress/is-shallow-equal": ^4.20.0
+    "@wordpress/keycodes": ^3.20.0
+    "@wordpress/primitives": ^3.18.0
+    "@wordpress/rich-text": ^5.18.0
+    "@wordpress/warning": ^2.20.0
+    change-case: ^4.1.2
+    classnames: ^2.3.1
+    colord: ^2.7.0
+    date-fns: ^2.28.0
+    dom-scroll-into-view: ^1.2.1
+    downshift: ^6.0.15
+    framer-motion: ^6.2.8
+    gradient-parser: ^0.1.5
+    highlight-words-core: ^1.2.2
+    lodash: ^4.17.21
+    memize: ^1.1.0
+    re-resizable: ^6.4.0
+    react-colorful: ^5.3.1
+    reakit: ^1.3.8
+    remove-accents: ^0.4.2
+    use-lilius: ^2.0.1
+    uuid: ^8.3.0
+    valtio: ^1.7.0
+  peerDependencies:
+    react: ^17.0.0
+    react-dom: ^17.0.0
+  checksum: 5dd3d46c282e2e48f60893e9e6f2c474b69225bdd911ef392c836a064672a8ddb54baf7040534d7ab921a8940cceb720b7535985d19afb94eaf644c5bf59c131
+  languageName: node
+  linkType: hard
+
 "@wordpress/compose@npm:^3.24.5, @wordpress/compose@npm:^3.25.3":
   version: 3.25.3
   resolution: "@wordpress/compose@npm:3.25.3"
@@ -8794,26 +8937,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wordpress/compose@npm:^5.0.1, @wordpress/compose@npm:^5.0.7, @wordpress/compose@npm:^5.11.0, @wordpress/compose@npm:^5.5.0, @wordpress/compose@npm:^5.7.0":
-  version: 5.11.0
-  resolution: "@wordpress/compose@npm:5.11.0"
+"@wordpress/compose@npm:^5.0.1, @wordpress/compose@npm:^5.0.7, @wordpress/compose@npm:^5.11.0, @wordpress/compose@npm:^5.18.0, @wordpress/compose@npm:^5.5.0, @wordpress/compose@npm:^5.7.0":
+  version: 5.18.0
+  resolution: "@wordpress/compose@npm:5.18.0"
   dependencies:
     "@babel/runtime": ^7.16.0
-    "@types/lodash": ^4.14.172
     "@types/mousetrap": ^1.6.8
-    "@wordpress/deprecated": ^3.13.0
-    "@wordpress/dom": ^3.13.0
-    "@wordpress/element": ^4.11.0
-    "@wordpress/is-shallow-equal": ^4.13.0
-    "@wordpress/keycodes": ^3.13.0
-    "@wordpress/priority-queue": ^2.13.0
+    "@wordpress/deprecated": ^3.20.0
+    "@wordpress/dom": ^3.20.0
+    "@wordpress/element": ^4.18.0
+    "@wordpress/is-shallow-equal": ^4.20.0
+    "@wordpress/keycodes": ^3.20.0
+    "@wordpress/priority-queue": ^2.20.0
+    change-case: ^4.1.2
     clipboard: ^2.0.8
-    lodash: ^4.17.21
     mousetrap: ^1.6.5
     use-memo-one: ^1.1.1
   peerDependencies:
     react: ^17.0.0
-  checksum: 561bbbed104d9f51c88c4ba50375d6a4b58a9fdb96a3668df3181e7d22b091f92ed8e245c6105b8c1aa38c059aab969e66a0c768bb6d8c37bb465e586418996c
+  checksum: 2dfc0813342b8485a7b306fcd909ca0ac1578dffc2449add193918b44c4a448dec9d58b1d51c430947147e77b2e32a58af3bc85a8e7aad5dfbe4467a77fbcf37
   languageName: node
   linkType: hard
 
@@ -8839,6 +8981,33 @@ __metadata:
   peerDependencies:
     react: ^17.0.0
   checksum: a5d317289db7a79b74d02fdfae359aef51544357836f7f3da27cdde7649b45762c61cb1ef0f8feff700ec272e921c19561e6d85cf10aca9bc41f2559f0b80314
+  languageName: node
+  linkType: hard
+
+"@wordpress/core-data@npm:^5.3.0":
+  version: 5.3.0
+  resolution: "@wordpress/core-data@npm:5.3.0"
+  dependencies:
+    "@babel/runtime": ^7.16.0
+    "@wordpress/api-fetch": ^6.17.0
+    "@wordpress/blocks": ^11.19.0
+    "@wordpress/compose": ^5.18.0
+    "@wordpress/data": ^7.4.0
+    "@wordpress/deprecated": ^3.20.0
+    "@wordpress/element": ^4.18.0
+    "@wordpress/html-entities": ^3.20.0
+    "@wordpress/i18n": ^4.20.0
+    "@wordpress/is-shallow-equal": ^4.20.0
+    "@wordpress/url": ^3.21.0
+    change-case: ^4.1.2
+    equivalent-key-map: ^0.2.2
+    lodash: ^4.17.21
+    memize: ^1.1.0
+    rememo: ^4.0.0
+    uuid: ^8.3.0
+  peerDependencies:
+    react: ^17.0.0
+  checksum: a5e3398967693af3bce51222635da5049d327ffcfb8c1ad254454d2709845c2a301184f11560282ea28f1610caac3eac2962c0e4eef3ba1707f8920efaae3100
   languageName: node
   linkType: hard
 
@@ -8878,7 +9047,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wordpress/data@npm:^6.0.1, @wordpress/data@npm:^6.1.5, @wordpress/data@npm:^6.10.0, @wordpress/data@npm:^6.13.0, @wordpress/data@npm:^6.7.0, @wordpress/data@npm:^6.9.0":
+"@wordpress/data@npm:^6.0.1, @wordpress/data@npm:^6.1.5, @wordpress/data@npm:^6.7.0, @wordpress/data@npm:^6.9.0":
   version: 6.13.0
   resolution: "@wordpress/data@npm:6.13.0"
   dependencies:
@@ -8901,6 +9070,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@wordpress/data@npm:^7.4.0":
+  version: 7.4.0
+  resolution: "@wordpress/data@npm:7.4.0"
+  dependencies:
+    "@babel/runtime": ^7.16.0
+    "@wordpress/compose": ^5.18.0
+    "@wordpress/deprecated": ^3.20.0
+    "@wordpress/element": ^4.18.0
+    "@wordpress/is-shallow-equal": ^4.20.0
+    "@wordpress/priority-queue": ^2.20.0
+    "@wordpress/redux-routine": ^4.20.0
+    equivalent-key-map: ^0.2.2
+    is-plain-object: ^5.0.0
+    is-promise: ^4.0.0
+    lodash: ^4.17.21
+    redux: ^4.1.2
+    turbo-combine-reducers: ^1.0.2
+    use-memo-one: ^1.1.1
+  peerDependencies:
+    react: ^17.0.0
+  checksum: 737bcbcca9efccafedb09181409539aa5dcce34b2ab32aa537c9be353d21332a616bcec5b49cdd70e5b3a41363bd407540cf4b8be207a7d0493871b0056f2bdc
+  languageName: node
+  linkType: hard
+
 "@wordpress/date@npm:^3.13.1":
   version: 3.15.1
   resolution: "@wordpress/date@npm:3.15.1"
@@ -8912,14 +9105,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wordpress/date@npm:^4.13.0, @wordpress/date@npm:^4.2.1, @wordpress/date@npm:^4.2.3, @wordpress/date@npm:^4.7.0, @wordpress/date@npm:^4.9.0":
-  version: 4.13.0
-  resolution: "@wordpress/date@npm:4.13.0"
+"@wordpress/date@npm:^4.13.0, @wordpress/date@npm:^4.2.1, @wordpress/date@npm:^4.2.3, @wordpress/date@npm:^4.20.0, @wordpress/date@npm:^4.7.0, @wordpress/date@npm:^4.9.0":
+  version: 4.20.0
+  resolution: "@wordpress/date@npm:4.20.0"
   dependencies:
     "@babel/runtime": ^7.16.0
+    "@wordpress/deprecated": ^3.20.0
     moment: ^2.22.1
     moment-timezone: ^0.5.31
-  checksum: 2e245bece4efda7b783c800a55004dda5199f7c10b42892f8f14bf2885e747003bf3e5c96a5c575a37631107656a49780fae02900975a0683ba19ab187ae1a91
+  checksum: 2fdcecca29e5cbd02961bbf9bb092a8a87c459ba6ef119af6e27dd8a85ceae88446b394225a07934bf0f060fa330878318992e416cf54cc18c06bde22170784c
   languageName: node
   linkType: hard
 
@@ -8945,13 +9139,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wordpress/deprecated@npm:^3.13.0, @wordpress/deprecated@npm:^3.2.3, @wordpress/deprecated@npm:^3.7.0, @wordpress/deprecated@npm:^3.8.0, @wordpress/deprecated@npm:^3.9.0":
-  version: 3.13.0
-  resolution: "@wordpress/deprecated@npm:3.13.0"
+"@wordpress/deprecated@npm:^3.13.0, @wordpress/deprecated@npm:^3.2.3, @wordpress/deprecated@npm:^3.20.0, @wordpress/deprecated@npm:^3.7.0, @wordpress/deprecated@npm:^3.9.0":
+  version: 3.20.0
+  resolution: "@wordpress/deprecated@npm:3.20.0"
   dependencies:
     "@babel/runtime": ^7.16.0
-    "@wordpress/hooks": ^3.13.0
-  checksum: 9a62783134dabac4210e8001c34d6b9237a9657552cb8a482501133080fb7f885273580abcfe69cd05bfe27110292b2c49192408e8c7f56d0ec6c346da3ab68f
+    "@wordpress/hooks": ^3.20.0
+  checksum: 964eda1ed9de4582de8c179c3a8494b2c5d6c990e9c6d3947aaaf487ac50684d1e75a1d70da35dc091e20e3ee43e045f56a5ffe81fb889e295d24a42e41c542d
   languageName: node
   linkType: hard
 
@@ -8964,12 +9158,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wordpress/dom-ready@npm:^3.13.0, @wordpress/dom-ready@npm:^3.2.1, @wordpress/dom-ready@npm:^3.9.0":
-  version: 3.13.0
-  resolution: "@wordpress/dom-ready@npm:3.13.0"
+"@wordpress/dom-ready@npm:^3.2.1, @wordpress/dom-ready@npm:^3.20.0, @wordpress/dom-ready@npm:^3.9.0":
+  version: 3.20.0
+  resolution: "@wordpress/dom-ready@npm:3.20.0"
   dependencies:
     "@babel/runtime": ^7.16.0
-  checksum: 03b4b7db1b67115c3aef6c0f9bc3bca0a1e3d8445c449dd77d6703114ce132071b3ec87a0810cbe385947ebf4edbb043730d01f56e1937d0fda70075315b332c
+  checksum: 6034ef1b088011d16732d2cded5383656e2ab1dfb1b305ec92c9dd66e03dc117a581801b079ddf79b09182dc252112a3a58b0b7efacd78b8cdf96e644d840cc7
   languageName: node
   linkType: hard
 
@@ -8983,14 +9177,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wordpress/dom@npm:^3.13.0, @wordpress/dom@npm:^3.2.7, @wordpress/dom@npm:^3.7.0, @wordpress/dom@npm:^3.9.0":
-  version: 3.13.0
-  resolution: "@wordpress/dom@npm:3.13.0"
+"@wordpress/dom@npm:^3.13.0, @wordpress/dom@npm:^3.2.7, @wordpress/dom@npm:^3.20.0, @wordpress/dom@npm:^3.7.0, @wordpress/dom@npm:^3.9.0":
+  version: 3.20.0
+  resolution: "@wordpress/dom@npm:3.20.0"
   dependencies:
     "@babel/runtime": ^7.16.0
-    "@wordpress/deprecated": ^3.8.0
-    lodash: ^4.17.21
-  checksum: a5a00c12e9064916862e08c741f5ae9feca14a1a44f64634e61852542f2c0f71457214f124bbc3d93f66dcb7f27df8c8710fd3b501f4b2ed7bb287431d902ade
+    "@wordpress/deprecated": ^3.20.0
+  checksum: dffe0221055b1e3392f2b1dd247aaaf582d6b8065e48823fbca4bbdd20f31ad9046b4bdb93615cbf7d95a129f34c9a1e98ab21dfcfbd37faa2b0f5e2dc1a1a8c
   languageName: node
   linkType: hard
 
@@ -9074,91 +9267,92 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wordpress/edit-site@npm:^4.6.0":
-  version: 4.6.0
-  resolution: "@wordpress/edit-site@npm:4.6.0"
+"@wordpress/edit-site@npm:^4.17.0":
+  version: 4.17.0
+  resolution: "@wordpress/edit-site@npm:4.17.0"
   dependencies:
     "@babel/runtime": ^7.16.0
-    "@wordpress/a11y": ^3.9.0
-    "@wordpress/api-fetch": ^6.6.0
-    "@wordpress/block-editor": ^9.1.0
-    "@wordpress/block-library": ^7.6.0
-    "@wordpress/blocks": ^11.8.0
-    "@wordpress/components": ^19.11.0
-    "@wordpress/compose": ^5.7.0
-    "@wordpress/core-data": ^4.7.0
-    "@wordpress/data": ^6.9.0
-    "@wordpress/deprecated": ^3.9.0
-    "@wordpress/editor": ^12.8.0
-    "@wordpress/element": ^4.7.0
-    "@wordpress/hooks": ^3.9.0
-    "@wordpress/html-entities": ^3.9.0
-    "@wordpress/i18n": ^4.9.0
-    "@wordpress/icons": ^9.0.0
-    "@wordpress/interface": ^4.8.0
-    "@wordpress/keyboard-shortcuts": ^3.7.0
-    "@wordpress/keycodes": ^3.9.0
-    "@wordpress/media-utils": ^4.0.0
-    "@wordpress/notices": ^3.9.0
-    "@wordpress/plugins": ^4.7.0
-    "@wordpress/preferences": ^2.1.0
-    "@wordpress/reusable-blocks": ^3.7.0
-    "@wordpress/style-engine": ^0.8.0
-    "@wordpress/url": ^3.10.0
-    "@wordpress/viewport": ^4.7.0
+    "@wordpress/a11y": ^3.20.0
+    "@wordpress/api-fetch": ^6.17.0
+    "@wordpress/block-editor": ^10.3.0
+    "@wordpress/block-library": ^7.17.0
+    "@wordpress/blocks": ^11.19.0
+    "@wordpress/components": ^21.3.0
+    "@wordpress/compose": ^5.18.0
+    "@wordpress/core-data": ^5.3.0
+    "@wordpress/data": ^7.4.0
+    "@wordpress/deprecated": ^3.20.0
+    "@wordpress/editor": ^12.19.0
+    "@wordpress/element": ^4.18.0
+    "@wordpress/hooks": ^3.20.0
+    "@wordpress/html-entities": ^3.20.0
+    "@wordpress/i18n": ^4.20.0
+    "@wordpress/icons": ^9.11.0
+    "@wordpress/interface": ^4.19.0
+    "@wordpress/keyboard-shortcuts": ^3.18.0
+    "@wordpress/keycodes": ^3.20.0
+    "@wordpress/media-utils": ^4.11.0
+    "@wordpress/notices": ^3.20.0
+    "@wordpress/plugins": ^4.18.0
+    "@wordpress/preferences": ^2.12.0
+    "@wordpress/reusable-blocks": ^3.18.0
+    "@wordpress/style-engine": ^1.3.0
+    "@wordpress/url": ^3.21.0
+    "@wordpress/viewport": ^4.18.0
     classnames: ^2.3.1
     downloadjs: ^1.4.7
     history: ^5.1.0
     lodash: ^4.17.21
     react-autosize-textarea: ^7.1.0
-    rememo: ^3.0.0
+    rememo: ^4.0.0
   peerDependencies:
     react: ^17.0.0
     react-dom: ^17.0.0
-  checksum: fe1ea39e2a8a5fee9c42d5bd2ae58fc4eb8248d877f31f1af444fd1650c2a066eca3b1a934319779732fac10261f5998801b2201b2ce474a7056eb6852acd995
+  checksum: c9e4a9111387dca4c8bf7c67e91100d583c2b58d865981a91019ed39881a6e0b1784c683465c638340466995abdd07d7e19fb133245ff1405da87d78450dc96d
   languageName: node
   linkType: hard
 
-"@wordpress/editor@npm:^12.0.16, @wordpress/editor@npm:^12.8.0":
-  version: 12.8.0
-  resolution: "@wordpress/editor@npm:12.8.0"
+"@wordpress/editor@npm:^12.0.16, @wordpress/editor@npm:^12.19.0, @wordpress/editor@npm:^12.8.0":
+  version: 12.19.0
+  resolution: "@wordpress/editor@npm:12.19.0"
   dependencies:
     "@babel/runtime": ^7.16.0
-    "@wordpress/a11y": ^3.9.0
-    "@wordpress/api-fetch": ^6.6.0
-    "@wordpress/blob": ^3.9.0
-    "@wordpress/block-editor": ^9.1.0
-    "@wordpress/blocks": ^11.8.0
-    "@wordpress/components": ^19.11.0
-    "@wordpress/compose": ^5.7.0
-    "@wordpress/core-data": ^4.7.0
-    "@wordpress/data": ^6.9.0
-    "@wordpress/date": ^4.9.0
-    "@wordpress/deprecated": ^3.9.0
-    "@wordpress/element": ^4.7.0
-    "@wordpress/hooks": ^3.9.0
-    "@wordpress/html-entities": ^3.9.0
-    "@wordpress/i18n": ^4.9.0
-    "@wordpress/icons": ^9.0.0
-    "@wordpress/keyboard-shortcuts": ^3.7.0
-    "@wordpress/keycodes": ^3.9.0
-    "@wordpress/media-utils": ^4.0.0
-    "@wordpress/notices": ^3.9.0
-    "@wordpress/preferences": ^2.1.0
-    "@wordpress/reusable-blocks": ^3.7.0
-    "@wordpress/rich-text": ^5.7.0
-    "@wordpress/server-side-render": ^3.7.0
-    "@wordpress/url": ^3.10.0
-    "@wordpress/wordcount": ^3.9.0
+    "@wordpress/a11y": ^3.20.0
+    "@wordpress/api-fetch": ^6.17.0
+    "@wordpress/blob": ^3.20.0
+    "@wordpress/block-editor": ^10.3.0
+    "@wordpress/blocks": ^11.19.0
+    "@wordpress/components": ^21.3.0
+    "@wordpress/compose": ^5.18.0
+    "@wordpress/core-data": ^5.3.0
+    "@wordpress/data": ^7.4.0
+    "@wordpress/date": ^4.20.0
+    "@wordpress/deprecated": ^3.20.0
+    "@wordpress/element": ^4.18.0
+    "@wordpress/hooks": ^3.20.0
+    "@wordpress/html-entities": ^3.20.0
+    "@wordpress/i18n": ^4.20.0
+    "@wordpress/icons": ^9.11.0
+    "@wordpress/keyboard-shortcuts": ^3.18.0
+    "@wordpress/keycodes": ^3.20.0
+    "@wordpress/media-utils": ^4.11.0
+    "@wordpress/notices": ^3.20.0
+    "@wordpress/preferences": ^2.12.0
+    "@wordpress/reusable-blocks": ^3.18.0
+    "@wordpress/rich-text": ^5.18.0
+    "@wordpress/server-side-render": ^3.18.0
+    "@wordpress/url": ^3.21.0
+    "@wordpress/wordcount": ^3.20.0
     classnames: ^2.3.1
     lodash: ^4.17.21
     memize: ^1.1.0
     react-autosize-textarea: ^7.1.0
-    rememo: ^3.0.0
+    rememo: ^4.0.0
+    remove-accents: ^0.4.2
   peerDependencies:
     react: ^17.0.0
     react-dom: ^17.0.0
-  checksum: 7fb760f5b9f0f4fadd6fa31dd0ef3926a539d5de5cd856e24f685f0a5d99a691e6f9afb0613a8054a3d372861bbc5f894d3388527bb1396b37d0fa14dbac817f
+  checksum: ce41d87b9470f7cb20933ddbebc81e089b2b792e20b2b6126dfb021ec7e2fefdb4981d0cca74a7a20dfa2e7adee0f4df43369634f86f7566aea63bfe6fdeed60
   languageName: node
   linkType: hard
 
@@ -9192,18 +9386,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wordpress/element@npm:^4.0.1, @wordpress/element@npm:^4.0.4, @wordpress/element@npm:^4.1.1, @wordpress/element@npm:^4.11.0, @wordpress/element@npm:^4.12.0, @wordpress/element@npm:^4.5.0, @wordpress/element@npm:^4.7.0":
-  version: 4.12.0
-  resolution: "@wordpress/element@npm:4.12.0"
+"@wordpress/element@npm:^4.0.1, @wordpress/element@npm:^4.0.4, @wordpress/element@npm:^4.1.1, @wordpress/element@npm:^4.11.0, @wordpress/element@npm:^4.18.0, @wordpress/element@npm:^4.5.0, @wordpress/element@npm:^4.7.0":
+  version: 4.18.0
+  resolution: "@wordpress/element@npm:4.18.0"
   dependencies:
     "@babel/runtime": ^7.16.0
     "@types/react": ^17.0.37
     "@types/react-dom": ^17.0.11
-    "@wordpress/escape-html": ^2.14.0
-    lodash: ^4.17.21
+    "@wordpress/escape-html": ^2.20.0
+    change-case: ^4.1.2
+    is-plain-object: ^5.0.0
     react: ^17.0.2
     react-dom: ^17.0.2
-  checksum: 22162e567fc17cc1251b7581f49d54ed32ecdec98481d922e3dc6ca535d84dcf0695a7b15701ad6f74c884304d47544076593892294448afa2988056f604d359
+  checksum: d48240ab46f00344cc23f1c83b2c405046b49e2c59f3c604fae988b2263461c7c956f2e0d561f1ab8494b2d50cf6d344e6022de161df061098fd152b317bfa7a
   languageName: node
   linkType: hard
 
@@ -9238,12 +9433,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wordpress/escape-html@npm:^2.13.0, @wordpress/escape-html@npm:^2.14.0, @wordpress/escape-html@npm:^2.2.0, @wordpress/escape-html@npm:^2.2.1, @wordpress/escape-html@npm:^2.2.3, @wordpress/escape-html@npm:^2.9.0":
-  version: 2.14.0
-  resolution: "@wordpress/escape-html@npm:2.14.0"
+"@wordpress/escape-html@npm:^2.13.0, @wordpress/escape-html@npm:^2.2.0, @wordpress/escape-html@npm:^2.2.1, @wordpress/escape-html@npm:^2.2.3, @wordpress/escape-html@npm:^2.20.0, @wordpress/escape-html@npm:^2.9.0":
+  version: 2.20.0
+  resolution: "@wordpress/escape-html@npm:2.20.0"
   dependencies:
     "@babel/runtime": ^7.16.0
-  checksum: 88cd44de524346e95ab0eeaebc91afa4dee10e330b032a93b5106fa06ffd5568eb6bcab2597288a427ec4f0549d6ec8ef4840bb2b8cfc3e958f6643c2eea60cd
+  checksum: 860cd7a21c41b0542bd96fc30bc5080ebc73e9f609c5f89c23adc5e4ea1790a2302f6f4063d0d46f4c6163376370482e0878c20fa323fa72b4be32282a7fc21a
   languageName: node
   linkType: hard
 
@@ -9314,21 +9509,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wordpress/hooks@npm:^3.13.0, @wordpress/hooks@npm:^3.2.0, @wordpress/hooks@npm:^3.2.2, @wordpress/hooks@npm:^3.7.0, @wordpress/hooks@npm:^3.9.0":
-  version: 3.13.0
-  resolution: "@wordpress/hooks@npm:3.13.0"
+"@wordpress/hooks@npm:^3.13.0, @wordpress/hooks@npm:^3.2.0, @wordpress/hooks@npm:^3.2.2, @wordpress/hooks@npm:^3.20.0, @wordpress/hooks@npm:^3.7.0, @wordpress/hooks@npm:^3.9.0":
+  version: 3.20.0
+  resolution: "@wordpress/hooks@npm:3.20.0"
   dependencies:
     "@babel/runtime": ^7.16.0
-  checksum: 3594d5fe9ed39254ba2b58b7596062fe6fda73e2b8a07098069c899eb4c6b0e7b618db7775c6a129988631fb2fd6fbcfa543afc649f9ec1daab3997c2a900b23
+  checksum: 9a08d09ee1eef6b85d6ebde90c899063ba6c6d51e34132d70eb97f3563ff6b43569952d721b9fc2fce837e87f61705e3dcd47f72b33ec7cd3f52f2ec54e156a6
   languageName: node
   linkType: hard
 
-"@wordpress/html-entities@npm:^3.2.1, @wordpress/html-entities@npm:^3.2.3, @wordpress/html-entities@npm:^3.7.0, @wordpress/html-entities@npm:^3.9.0":
-  version: 3.9.0
-  resolution: "@wordpress/html-entities@npm:3.9.0"
+"@wordpress/html-entities@npm:^3.2.1, @wordpress/html-entities@npm:^3.2.3, @wordpress/html-entities@npm:^3.20.0, @wordpress/html-entities@npm:^3.7.0, @wordpress/html-entities@npm:^3.9.0":
+  version: 3.20.0
+  resolution: "@wordpress/html-entities@npm:3.20.0"
   dependencies:
     "@babel/runtime": ^7.16.0
-  checksum: bea6dc5a49eacbdf7bdd5aa4f6dc163a86ee67c4f09e287081fd43ce71236f77d661657e45a5a872f825f45bb4c1df92c1a7d754804b9bf05f1efa1791b4bce9
+  checksum: 6a47b4c818a996cf024d5fc3005c38cc14d1514825c66e6f9677ec6aacc691fde20498cf1f7b9385c3781370d8766cd2c7f5bc89413b8473fb0823ddfe262fcb
   languageName: node
   linkType: hard
 
@@ -9349,20 +9544,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wordpress/i18n@npm:^4.10.0, @wordpress/i18n@npm:^4.13.0, @wordpress/i18n@npm:^4.2.1, @wordpress/i18n@npm:^4.2.4, @wordpress/i18n@npm:^4.7.0, @wordpress/i18n@npm:^4.9.0":
-  version: 4.13.0
-  resolution: "@wordpress/i18n@npm:4.13.0"
+"@wordpress/i18n@npm:^4.10.0, @wordpress/i18n@npm:^4.13.0, @wordpress/i18n@npm:^4.2.1, @wordpress/i18n@npm:^4.2.4, @wordpress/i18n@npm:^4.20.0, @wordpress/i18n@npm:^4.7.0, @wordpress/i18n@npm:^4.9.0":
+  version: 4.20.0
+  resolution: "@wordpress/i18n@npm:4.20.0"
   dependencies:
     "@babel/runtime": ^7.16.0
-    "@wordpress/hooks": ^3.13.0
+    "@wordpress/hooks": ^3.20.0
     gettext-parser: ^1.3.1
-    lodash: ^4.17.21
     memize: ^1.1.0
     sprintf-js: ^1.1.1
     tannin: ^1.2.0
   bin:
     pot-to-php: tools/pot-to-php.js
-  checksum: 29e9cfa003358d262f23019fb26dea0ad1f2bf41ab2c13b146bb617725616cd40b0eaea163f95678bdda983994592e5ef17af01de26371add8e59a5b3673a9a5
+  checksum: ba1937257572e298a9b28cd0fdc675315ad801a38412853b1d1170af20a197500f5143687214761a4e47d57eb7492068fdc02bca71aa10324064f587e0050a75
   languageName: node
   linkType: hard
 
@@ -9421,39 +9615,38 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wordpress/icons@npm:^9.0.0, @wordpress/icons@npm:^9.4.0, @wordpress/icons@npm:^9.5.0":
-  version: 9.5.0
-  resolution: "@wordpress/icons@npm:9.5.0"
+"@wordpress/icons@npm:^9.0.0, @wordpress/icons@npm:^9.11.0, @wordpress/icons@npm:^9.4.0, @wordpress/icons@npm:^9.5.0":
+  version: 9.11.0
+  resolution: "@wordpress/icons@npm:9.11.0"
   dependencies:
     "@babel/runtime": ^7.16.0
-    "@wordpress/element": ^4.12.0
-    "@wordpress/primitives": ^3.12.0
-  checksum: 03e5885e79a20846ae0d906277afa6a159a1718acb647052bae5052d0ab49d2e78f475c93a7341ffcdee0ede55176fcaf87217bcb238980d1bad728e2f476412
+    "@wordpress/element": ^4.18.0
+    "@wordpress/primitives": ^3.18.0
+  checksum: 101063fb7d5ea60b63be65f00f54f858d63fb4edc326941181c77447818d005c85eab61873a57130dbbc0cb76ade818da847d7f01d4de520361855ed09020e0a
   languageName: node
   linkType: hard
 
-"@wordpress/interface@npm:^4.1.15, @wordpress/interface@npm:^4.8.0":
-  version: 4.8.0
-  resolution: "@wordpress/interface@npm:4.8.0"
+"@wordpress/interface@npm:^4.1.15, @wordpress/interface@npm:^4.19.0, @wordpress/interface@npm:^4.8.0":
+  version: 4.19.0
+  resolution: "@wordpress/interface@npm:4.19.0"
   dependencies:
     "@babel/runtime": ^7.16.0
-    "@wordpress/a11y": ^3.9.0
-    "@wordpress/components": ^19.11.0
-    "@wordpress/compose": ^5.7.0
-    "@wordpress/data": ^6.9.0
-    "@wordpress/deprecated": ^3.9.0
-    "@wordpress/element": ^4.7.0
-    "@wordpress/i18n": ^4.9.0
-    "@wordpress/icons": ^9.0.0
-    "@wordpress/plugins": ^4.7.0
-    "@wordpress/preferences": ^2.1.0
-    "@wordpress/viewport": ^4.7.0
+    "@wordpress/a11y": ^3.20.0
+    "@wordpress/components": ^21.3.0
+    "@wordpress/compose": ^5.18.0
+    "@wordpress/data": ^7.4.0
+    "@wordpress/deprecated": ^3.20.0
+    "@wordpress/element": ^4.18.0
+    "@wordpress/i18n": ^4.20.0
+    "@wordpress/icons": ^9.11.0
+    "@wordpress/plugins": ^4.18.0
+    "@wordpress/preferences": ^2.12.0
+    "@wordpress/viewport": ^4.18.0
     classnames: ^2.3.1
-    lodash: ^4.17.21
   peerDependencies:
     react: ^17.0.0
     react-dom: ^17.0.0
-  checksum: 2b77361bcfdb6ff1e61d26ad4804bf6701efb4c59418a6e0427857dcd74511c28888c83e195f0e2b25a04c5d49a3f52a8e19fd09826063a085a7c468303583be
+  checksum: fceba71108bf1f95e9f2aadbb99f157d749a61326818d877487fa0ba4b75486ddcd8d04b65559aeb55b915460e6ac1e89446fa9319a24349c04e7ed17c52a27c
   languageName: node
   linkType: hard
 
@@ -9466,12 +9659,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wordpress/is-shallow-equal@npm:^4.13.0, @wordpress/is-shallow-equal@npm:^4.2.1, @wordpress/is-shallow-equal@npm:^4.7.0, @wordpress/is-shallow-equal@npm:^4.9.0":
-  version: 4.13.0
-  resolution: "@wordpress/is-shallow-equal@npm:4.13.0"
+"@wordpress/is-shallow-equal@npm:^4.13.0, @wordpress/is-shallow-equal@npm:^4.2.1, @wordpress/is-shallow-equal@npm:^4.20.0, @wordpress/is-shallow-equal@npm:^4.7.0, @wordpress/is-shallow-equal@npm:^4.9.0":
+  version: 4.20.0
+  resolution: "@wordpress/is-shallow-equal@npm:4.20.0"
   dependencies:
     "@babel/runtime": ^7.16.0
-  checksum: 021285643f7d9c148ef21a819a849f21081622d90835271b8ea74ece6a52bcb852efc11b30304955cd9caefd1dbb5c2e78a4c2807e978a76ccfdea3a4780a371
+  checksum: b89d8d061eff2134e58a94da28268c520a10147f42c5500edacd9b4f61f916b4cf71ceb51ad2126cfd7603ef54cfed3742ed5b8edf006b94bba6184cdd9fc685
   languageName: node
   linkType: hard
 
@@ -9506,19 +9699,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wordpress/keyboard-shortcuts@npm:^3.0.7, @wordpress/keyboard-shortcuts@npm:^3.5.0, @wordpress/keyboard-shortcuts@npm:^3.7.0":
-  version: 3.7.0
-  resolution: "@wordpress/keyboard-shortcuts@npm:3.7.0"
+"@wordpress/keyboard-shortcuts@npm:^3.0.7, @wordpress/keyboard-shortcuts@npm:^3.18.0, @wordpress/keyboard-shortcuts@npm:^3.5.0, @wordpress/keyboard-shortcuts@npm:^3.7.0":
+  version: 3.18.0
+  resolution: "@wordpress/keyboard-shortcuts@npm:3.18.0"
   dependencies:
     "@babel/runtime": ^7.16.0
-    "@wordpress/data": ^6.9.0
-    "@wordpress/element": ^4.7.0
-    "@wordpress/keycodes": ^3.9.0
-    lodash: ^4.17.21
-    rememo: ^3.0.0
+    "@wordpress/data": ^7.4.0
+    "@wordpress/element": ^4.18.0
+    "@wordpress/keycodes": ^3.20.0
+    rememo: ^4.0.0
   peerDependencies:
     react: ^17.0.0
-  checksum: c519dfd25a14343111239d9f4f9d342c47154c671ba2f117230d333eb4ae889de3790a8da745d4df716e1c093fb9a57ab42488a3ab11624eb86d6caa8eca7b43
+  checksum: c5a197a592622edd9578c41907c049d85074120d612c9a34aaaef022be27522506255f13207670d4c4ac5888dc57304cee4d9ecfc46c8f000c19dc66b015189c
   languageName: node
   linkType: hard
 
@@ -9533,14 +9725,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wordpress/keycodes@npm:^3.10.0, @wordpress/keycodes@npm:^3.13.0, @wordpress/keycodes@npm:^3.2.1, @wordpress/keycodes@npm:^3.2.4, @wordpress/keycodes@npm:^3.7.0, @wordpress/keycodes@npm:^3.9.0":
-  version: 3.13.0
-  resolution: "@wordpress/keycodes@npm:3.13.0"
+"@wordpress/keycodes@npm:^3.10.0, @wordpress/keycodes@npm:^3.13.0, @wordpress/keycodes@npm:^3.2.1, @wordpress/keycodes@npm:^3.2.4, @wordpress/keycodes@npm:^3.20.0, @wordpress/keycodes@npm:^3.7.0, @wordpress/keycodes@npm:^3.9.0":
+  version: 3.20.0
+  resolution: "@wordpress/keycodes@npm:3.20.0"
   dependencies:
     "@babel/runtime": ^7.16.0
-    "@wordpress/i18n": ^4.13.0
+    "@wordpress/i18n": ^4.20.0
+    change-case: ^4.1.2
     lodash: ^4.17.21
-  checksum: b57e796bc1f35a3457e78119799f4009c80d36f7ab902ccfb85ffb306ee6cdc157069fd5f39e4f3a7ee74507e2cb65daf3f76f11c5efe9dc44e053f04652600a
+  checksum: b890476992acb910833be55164e2003b4916230491c51b51a8a820e0bc5abb95753d26fe387e2f14e1766a73f88c299de59ca12651b393f306ee2a37c034c17e
   languageName: node
   linkType: hard
 
@@ -9558,31 +9751,29 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wordpress/media-utils@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "@wordpress/media-utils@npm:4.0.0"
+"@wordpress/media-utils@npm:^4.0.0, @wordpress/media-utils@npm:^4.11.0":
+  version: 4.11.0
+  resolution: "@wordpress/media-utils@npm:4.11.0"
   dependencies:
     "@babel/runtime": ^7.16.0
-    "@wordpress/api-fetch": ^6.6.0
-    "@wordpress/blob": ^3.9.0
-    "@wordpress/element": ^4.7.0
-    "@wordpress/i18n": ^4.9.0
-    lodash: ^4.17.21
-  checksum: 5b7fca05ca298dddf7c2c5cc25d5cb02dd28b08bbcaf82fbac30faa560b0e663104eb7ebafe6177bb3a1a83ee8be1dbaf76501ec21b0e70575905bf87eb7d44b
+    "@wordpress/api-fetch": ^6.17.0
+    "@wordpress/blob": ^3.20.0
+    "@wordpress/element": ^4.18.0
+    "@wordpress/i18n": ^4.20.0
+  checksum: faa2e3a983c6499a69d0244c7ab28d497959274076c5d394ac5beaf85cea94229de28bf92b4f848350b70fd438180809a9b41cb7ed93086913cfb0257fa82d86
   languageName: node
   linkType: hard
 
-"@wordpress/notices@npm:^3.10.0, @wordpress/notices@npm:^3.2.8, @wordpress/notices@npm:^3.7.0, @wordpress/notices@npm:^3.9.0":
-  version: 3.10.0
-  resolution: "@wordpress/notices@npm:3.10.0"
+"@wordpress/notices@npm:^3.10.0, @wordpress/notices@npm:^3.2.8, @wordpress/notices@npm:^3.20.0, @wordpress/notices@npm:^3.7.0, @wordpress/notices@npm:^3.9.0":
+  version: 3.20.0
+  resolution: "@wordpress/notices@npm:3.20.0"
   dependencies:
     "@babel/runtime": ^7.16.0
-    "@wordpress/a11y": ^3.10.0
-    "@wordpress/data": ^6.10.0
-    lodash: ^4.17.21
+    "@wordpress/a11y": ^3.20.0
+    "@wordpress/data": ^7.4.0
   peerDependencies:
     react: ^17.0.0
-  checksum: 9a967a8eb603f3659f8e28fbcdf3a4fa2f8aa311e4337a7d2cb25231c16890b9ab2be07a685a0eb2b495d26f5850f9e257bddab0d5bfb831b7d7e94076b9515a
+  checksum: 6c43fa5f71ca4ac535b45857e0668fad44097c212ddaa396f69c8d748e14abf471bc9a444941b866df9b9937c2a2c4b45657f8a03ccaa3949ab1b399eab6e051
   languageName: node
   linkType: hard
 
@@ -9616,20 +9807,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wordpress/plugins@npm:^4.0.1, @wordpress/plugins@npm:^4.0.7, @wordpress/plugins@npm:^4.7.0":
-  version: 4.7.0
-  resolution: "@wordpress/plugins@npm:4.7.0"
+"@wordpress/plugins@npm:^4.0.1, @wordpress/plugins@npm:^4.0.7, @wordpress/plugins@npm:^4.18.0, @wordpress/plugins@npm:^4.7.0":
+  version: 4.18.0
+  resolution: "@wordpress/plugins@npm:4.18.0"
   dependencies:
     "@babel/runtime": ^7.16.0
-    "@wordpress/compose": ^5.7.0
-    "@wordpress/element": ^4.7.0
-    "@wordpress/hooks": ^3.9.0
-    "@wordpress/icons": ^9.0.0
-    lodash: ^4.17.21
+    "@wordpress/compose": ^5.18.0
+    "@wordpress/element": ^4.18.0
+    "@wordpress/hooks": ^3.20.0
+    "@wordpress/icons": ^9.11.0
     memize: ^1.1.0
   peerDependencies:
     react: ^17.0.0
-  checksum: 0bdf3658c9b3be120a3095e1e2905261f8468da13e9f3d09d4eb9f482ec01acb03378724048b9104ca3560a5ad2e3a56f95248bd3745f980492c34bedbbda780
+  checksum: 49364458861cf3ffe8927c372c1c817e9ad57f7abdec1f1cdcf245a5313d4e0b237d3322be321211f6bc295585b620a52c5f0e20c3769364be7df9d25a3d6b40
   languageName: node
   linkType: hard
 
@@ -9645,21 +9835,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wordpress/preferences@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "@wordpress/preferences@npm:2.1.0"
+"@wordpress/preferences@npm:^2.1.0, @wordpress/preferences@npm:^2.12.0":
+  version: 2.12.0
+  resolution: "@wordpress/preferences@npm:2.12.0"
   dependencies:
     "@babel/runtime": ^7.16.0
-    "@wordpress/a11y": ^3.9.0
-    "@wordpress/components": ^19.11.0
-    "@wordpress/data": ^6.9.0
-    "@wordpress/i18n": ^4.9.0
-    "@wordpress/icons": ^9.0.0
+    "@wordpress/a11y": ^3.20.0
+    "@wordpress/components": ^21.3.0
+    "@wordpress/data": ^7.4.0
+    "@wordpress/i18n": ^4.20.0
+    "@wordpress/icons": ^9.11.0
     classnames: ^2.3.1
   peerDependencies:
     react: ^17.0.0
     react-dom: ^17.0.0
-  checksum: e716c0a29ed40429bac87c7de0adcf2f09ed00e95fbffa6069b4d726e8fd699929b250fc22bc8a454728ce341c08461c7936e3cf678d11c3e87741af54d2a5bf
+  checksum: 22d5157a376082e77842cb1de965da90e52107aa44c2d3fea53f67109ed9c8f115e7b3d40bd7c21e58ea1268ea92d0c992f9d4b89bddc960038152fc800849da
   languageName: node
   linkType: hard
 
@@ -9694,14 +9884,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wordpress/primitives@npm:^3.0.1, @wordpress/primitives@npm:^3.0.4, @wordpress/primitives@npm:^3.1.1, @wordpress/primitives@npm:^3.11.0, @wordpress/primitives@npm:^3.12.0, @wordpress/primitives@npm:^3.5.0, @wordpress/primitives@npm:^3.7.0, @wordpress/primitives@npm:^3.8.0":
-  version: 3.12.0
-  resolution: "@wordpress/primitives@npm:3.12.0"
+"@wordpress/primitives@npm:^3.0.1, @wordpress/primitives@npm:^3.0.4, @wordpress/primitives@npm:^3.1.1, @wordpress/primitives@npm:^3.11.0, @wordpress/primitives@npm:^3.18.0, @wordpress/primitives@npm:^3.5.0, @wordpress/primitives@npm:^3.7.0, @wordpress/primitives@npm:^3.8.0":
+  version: 3.18.0
+  resolution: "@wordpress/primitives@npm:3.18.0"
   dependencies:
     "@babel/runtime": ^7.16.0
-    "@wordpress/element": ^4.12.0
+    "@wordpress/element": ^4.18.0
     classnames: ^2.3.1
-  checksum: 55b9bcb6a0cfa4405b8f45105251321173b396c4cb4263a89797939a4415cdc454743e7ff3779074c0437bf51a161875c6e2d2f4b793cc7b440ee4552124a262
+  checksum: 5090684e11d80d94fcf813dda71c0fcdadf036006509a448de54f7eb63ded6d668d7fa246b9f1f923b11268afac6c0aca4c1fd7f9cfb5d82055923cad6d607af
   languageName: node
   linkType: hard
 
@@ -9714,12 +9904,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wordpress/priority-queue@npm:^2.13.0":
-  version: 2.13.0
-  resolution: "@wordpress/priority-queue@npm:2.13.0"
+"@wordpress/priority-queue@npm:^2.13.0, @wordpress/priority-queue@npm:^2.20.0":
+  version: 2.20.0
+  resolution: "@wordpress/priority-queue@npm:2.20.0"
   dependencies:
     "@babel/runtime": ^7.16.0
-  checksum: 39909befa2c8f66684c82fbe436bafd1d6db018a5c8e803f14ed142500b9ea18dadfcc9f1cb659b1ab10f0bcaf7ba4dd62e8d9d731e094907a1eb272d2997bf1
+    requestidlecallback: ^0.3.0
+  checksum: 260e93b023e5bb3cbf4ffdd7858e0104b1838829270b1bd3e646de801ef75c7902473484305fd25c662d30985834bb397b748b80c89967439ca3c1cc8c1fb859
   languageName: node
   linkType: hard
 
@@ -9756,39 +9947,38 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wordpress/redux-routine@npm:^4.13.0":
-  version: 4.13.0
-  resolution: "@wordpress/redux-routine@npm:4.13.0"
+"@wordpress/redux-routine@npm:^4.13.0, @wordpress/redux-routine@npm:^4.20.0":
+  version: 4.20.0
+  resolution: "@wordpress/redux-routine@npm:4.20.0"
   dependencies:
     "@babel/runtime": ^7.16.0
+    is-plain-object: ^5.0.0
     is-promise: ^4.0.0
-    lodash: ^4.17.21
     rungen: ^0.3.2
   peerDependencies:
     redux: ">=4"
-  checksum: 5490599778378df687fdb94dea8fe6731c172f2811e17a4b6a811f3721f5598824e040e10da10e8d2345abe6cecbd3f590cabd88567386d0f9f78dbb2d50f6fb
+  checksum: 7932a96a8d7ff9637c6888a743d65f596506744f1103c7fbc20da63f9c798f6f11a058cb4db9732c214f67a5d0efa0e03956a04eab409dde19372a2ec6f1af3c
   languageName: node
   linkType: hard
 
-"@wordpress/reusable-blocks@npm:^3.0.19, @wordpress/reusable-blocks@npm:^3.7.0":
-  version: 3.7.0
-  resolution: "@wordpress/reusable-blocks@npm:3.7.0"
+"@wordpress/reusable-blocks@npm:^3.0.19, @wordpress/reusable-blocks@npm:^3.18.0":
+  version: 3.18.0
+  resolution: "@wordpress/reusable-blocks@npm:3.18.0"
   dependencies:
-    "@wordpress/block-editor": ^9.1.0
-    "@wordpress/blocks": ^11.8.0
-    "@wordpress/components": ^19.11.0
-    "@wordpress/core-data": ^4.7.0
-    "@wordpress/data": ^6.9.0
-    "@wordpress/element": ^4.7.0
-    "@wordpress/i18n": ^4.9.0
-    "@wordpress/icons": ^9.0.0
-    "@wordpress/notices": ^3.9.0
-    "@wordpress/url": ^3.10.0
-    lodash: ^4.17.21
+    "@wordpress/block-editor": ^10.3.0
+    "@wordpress/blocks": ^11.19.0
+    "@wordpress/components": ^21.3.0
+    "@wordpress/core-data": ^5.3.0
+    "@wordpress/data": ^7.4.0
+    "@wordpress/element": ^4.18.0
+    "@wordpress/i18n": ^4.20.0
+    "@wordpress/icons": ^9.11.0
+    "@wordpress/notices": ^3.20.0
+    "@wordpress/url": ^3.21.0
   peerDependencies:
     react: ^17.0.0
     react-dom: ^17.0.0
-  checksum: e0a469bfa7547db1b3d4772a203497c567d197c48359900daa297dc493278018a9fb2e81ef8ae1936fbda725265d44a65e8b28bdf9bc9113c19bf02588e6e2bd
+  checksum: 36b49d5a16566becb49129af56770febeb6ab4578d83ae98bdd0c7792aa6a6e9bacc7c3c12febe7e87a0656befaac7fdf0828d744223d64852016f940cc38a3a
   languageName: node
   linkType: hard
 
@@ -9812,24 +10002,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wordpress/rich-text@npm:^5.0.7, @wordpress/rich-text@npm:^5.11.0, @wordpress/rich-text@npm:^5.5.0, @wordpress/rich-text@npm:^5.7.0":
-  version: 5.11.0
-  resolution: "@wordpress/rich-text@npm:5.11.0"
+"@wordpress/rich-text@npm:^5.0.7, @wordpress/rich-text@npm:^5.11.0, @wordpress/rich-text@npm:^5.18.0, @wordpress/rich-text@npm:^5.5.0, @wordpress/rich-text@npm:^5.7.0":
+  version: 5.18.0
+  resolution: "@wordpress/rich-text@npm:5.18.0"
   dependencies:
     "@babel/runtime": ^7.16.0
-    "@wordpress/a11y": ^3.13.0
-    "@wordpress/compose": ^5.11.0
-    "@wordpress/data": ^6.13.0
-    "@wordpress/element": ^4.11.0
-    "@wordpress/escape-html": ^2.13.0
-    "@wordpress/i18n": ^4.13.0
-    "@wordpress/keycodes": ^3.13.0
-    lodash: ^4.17.21
+    "@wordpress/a11y": ^3.20.0
+    "@wordpress/compose": ^5.18.0
+    "@wordpress/data": ^7.4.0
+    "@wordpress/deprecated": ^3.20.0
+    "@wordpress/element": ^4.18.0
+    "@wordpress/escape-html": ^2.20.0
+    "@wordpress/i18n": ^4.20.0
+    "@wordpress/keycodes": ^3.20.0
     memize: ^1.1.0
     rememo: ^4.0.0
   peerDependencies:
     react: ^17.0.0
-  checksum: 132e79666c8e53498a3b687095f469122408b39a64e206b48eb2fc441a8067ce728d3b50dabbe4e125fc28cce29bcd1d7ccd6fcdcc86710dadca6625f54b52d4
+  checksum: 7e3634c52534c3643658b7490b7807381024b96b1abf0485c67b96e6ab355e05e1767b04f3b40efe7862aab58e305e13a0fd419cfcd94845973b3b0a02a1bc8b
   languageName: node
   linkType: hard
 
@@ -9901,36 +10091,35 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wordpress/server-side-render@npm:^3.0.17, @wordpress/server-side-render@npm:^3.7.0":
-  version: 3.7.0
-  resolution: "@wordpress/server-side-render@npm:3.7.0"
+"@wordpress/server-side-render@npm:^3.0.17, @wordpress/server-side-render@npm:^3.18.0, @wordpress/server-side-render@npm:^3.7.0":
+  version: 3.18.0
+  resolution: "@wordpress/server-side-render@npm:3.18.0"
   dependencies:
     "@babel/runtime": ^7.16.0
-    "@wordpress/api-fetch": ^6.6.0
-    "@wordpress/blocks": ^11.8.0
-    "@wordpress/components": ^19.11.0
-    "@wordpress/compose": ^5.7.0
-    "@wordpress/data": ^6.9.0
-    "@wordpress/deprecated": ^3.9.0
-    "@wordpress/element": ^4.7.0
-    "@wordpress/i18n": ^4.9.0
-    "@wordpress/url": ^3.10.0
+    "@wordpress/api-fetch": ^6.17.0
+    "@wordpress/blocks": ^11.19.0
+    "@wordpress/components": ^21.3.0
+    "@wordpress/compose": ^5.18.0
+    "@wordpress/data": ^7.4.0
+    "@wordpress/deprecated": ^3.20.0
+    "@wordpress/element": ^4.18.0
+    "@wordpress/i18n": ^4.20.0
+    "@wordpress/url": ^3.21.0
     lodash: ^4.17.21
   peerDependencies:
     react: ^17.0.0
     react-dom: ^17.0.0
-  checksum: 5964cb2c65d69ddbe135fb7816843ac4b57783ef33171aecfb15ce80632b9018d17d9a63bd224b7adac4eaebaca20358200a6508267807e1dbc292208d7b70e6
+  checksum: 0adb575adde0b71f22bc5a4533e613d56bd3eb96085421753f10fc526582dea7be6f2e42cbebe62beb8e1862d607da62a37c492ffbed58fbb87b328ee909b8f4
   languageName: node
   linkType: hard
 
-"@wordpress/shortcode@npm:^3.7.0, @wordpress/shortcode@npm:^3.9.0":
-  version: 3.9.0
-  resolution: "@wordpress/shortcode@npm:3.9.0"
+"@wordpress/shortcode@npm:^3.20.0, @wordpress/shortcode@npm:^3.7.0, @wordpress/shortcode@npm:^3.9.0":
+  version: 3.20.0
+  resolution: "@wordpress/shortcode@npm:3.20.0"
   dependencies:
     "@babel/runtime": ^7.16.0
-    lodash: ^4.17.21
     memize: ^1.1.0
-  checksum: c4b87038445005c8bcb2328237b5947bbf0328924e56d13607dfbb622bd56bcec6441a8fe138367c5b7db2b23b37badef188d75c8b499dcbe0beacfef296304f
+  checksum: cc49bb39d6bae532d3eb508d661d8e0029353176f119edef163487cea5e0f707c547e3b9ad2d8c8cd6a2f3150c9ef5db583168d5450aac4d4d317d55dfed4a94
   languageName: node
   linkType: hard
 
@@ -9954,6 +10143,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@wordpress/style-engine@npm:^1.3.0":
+  version: 1.3.0
+  resolution: "@wordpress/style-engine@npm:1.3.0"
+  dependencies:
+    "@babel/runtime": ^7.16.0
+    lodash: ^4.17.21
+  checksum: 09342d86968ce37fb50aff25bcaa619dcd4852a6d81357949810a820428079e53d73b0d558452ea78a7ac4f913e51528e16a9a6fca9be5b28c5403dcd52302c6
+  languageName: node
+  linkType: hard
+
 "@wordpress/stylelint-config@npm:^20.0.2":
   version: 20.0.3
   resolution: "@wordpress/stylelint-config@npm:20.0.3"
@@ -9966,37 +10165,35 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wordpress/token-list@npm:^2.7.0, @wordpress/token-list@npm:^2.9.0":
-  version: 2.9.0
-  resolution: "@wordpress/token-list@npm:2.9.0"
+"@wordpress/token-list@npm:^2.20.0, @wordpress/token-list@npm:^2.7.0, @wordpress/token-list@npm:^2.9.0":
+  version: 2.20.0
+  resolution: "@wordpress/token-list@npm:2.20.0"
   dependencies:
     "@babel/runtime": ^7.16.0
-    lodash: ^4.17.21
-  checksum: 22ba6445f7911ec31211b026265315c225c551aad87ca87c7d9ee69d92c2ebc00d769c65a733f244b2e3c6aa2a569dec28815fc2c154fb4f13dc5fdf4c531c50
+  checksum: 3aaba1fdcc26c31121a6391005e6d2fd297df46b96f890bac8a60903a39f108fc28f9610e92e00db864274637b9552e43c1fb95c59fb77217957bcc774abd647
   languageName: node
   linkType: hard
 
-"@wordpress/url@npm:^3.10.0, @wordpress/url@npm:^3.3.1, @wordpress/url@npm:^3.8.0":
-  version: 3.10.0
-  resolution: "@wordpress/url@npm:3.10.0"
+"@wordpress/url@npm:^3.10.0, @wordpress/url@npm:^3.21.0, @wordpress/url@npm:^3.3.1, @wordpress/url@npm:^3.8.0":
+  version: 3.21.0
+  resolution: "@wordpress/url@npm:3.21.0"
   dependencies:
     "@babel/runtime": ^7.16.0
-    lodash: ^4.17.21
-  checksum: 90ef36047c92f9035792604662e118b9c88de503781cd4519adf85f1ca32a482fce5cb00f0a71de96516e7124ccdc025d40a025921202cc3841ab6b89687592e
+    remove-accents: ^0.4.2
+  checksum: fafa4cf95d1565e1cb9e254bc7eedfa5fa6b9f1d9fa614c2709df0a1207ccaba11699fbbf104a4b93691c024b447cabfec59b63570da87721628287193d1d858
   languageName: node
   linkType: hard
 
-"@wordpress/viewport@npm:^4.0.7, @wordpress/viewport@npm:^4.7.0":
-  version: 4.7.0
-  resolution: "@wordpress/viewport@npm:4.7.0"
+"@wordpress/viewport@npm:^4.0.7, @wordpress/viewport@npm:^4.18.0, @wordpress/viewport@npm:^4.7.0":
+  version: 4.18.0
+  resolution: "@wordpress/viewport@npm:4.18.0"
   dependencies:
     "@babel/runtime": ^7.16.0
-    "@wordpress/compose": ^5.7.0
-    "@wordpress/data": ^6.9.0
-    lodash: ^4.17.21
+    "@wordpress/compose": ^5.18.0
+    "@wordpress/data": ^7.4.0
   peerDependencies:
     react: ^17.0.0
-  checksum: 467107bc3f673f3bc9c61dde9c194e869bdd1b3152f9bd6327a1c88ac700f4b9e1784901cf53d8c0eea4a44f65fe4c786a6dd252073f691fcb3e5a37e7aa86cd
+  checksum: 6a593d2a427654902db74bbf4c03bb6a4574055219d3e741f70e0164ac57a7785b2bc0162c26097b3e2e4353a68d9f7ed1e88679b52f6717880164f25122401c
   languageName: node
   linkType: hard
 
@@ -10007,20 +10204,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wordpress/warning@npm:^2.13.0, @wordpress/warning@npm:^2.2.2, @wordpress/warning@npm:^2.7.0, @wordpress/warning@npm:^2.9.0":
-  version: 2.13.0
-  resolution: "@wordpress/warning@npm:2.13.0"
-  checksum: f7f1fd837d157309889b1c8b3c91ff64d3f802e7492546af9aa39db2399ab69d25b3bc59f53e56fbaafc37d215b383440cd8ce419cbc96579dffdc68d778e16a
+"@wordpress/warning@npm:^2.13.0, @wordpress/warning@npm:^2.2.2, @wordpress/warning@npm:^2.20.0, @wordpress/warning@npm:^2.7.0, @wordpress/warning@npm:^2.9.0":
+  version: 2.20.0
+  resolution: "@wordpress/warning@npm:2.20.0"
+  checksum: ffe1eeed257ddce5c9b8f61ef276368fe36f61f81c12e14bfea6d25c035247adb1a5023c43172a110891b5d5f31f9bae0bf7015a37cb2dd366f64bc828d86011
   languageName: node
   linkType: hard
 
-"@wordpress/wordcount@npm:^3.7.0, @wordpress/wordcount@npm:^3.9.0":
-  version: 3.9.0
-  resolution: "@wordpress/wordcount@npm:3.9.0"
+"@wordpress/wordcount@npm:^3.20.0, @wordpress/wordcount@npm:^3.7.0, @wordpress/wordcount@npm:^3.9.0":
+  version: 3.20.0
+  resolution: "@wordpress/wordcount@npm:3.20.0"
   dependencies:
     "@babel/runtime": ^7.16.0
-    lodash: ^4.17.21
-  checksum: 737b1f97eaa10b0ac5bae8431b62fea892b08baf0a494cb97331261595904567b48d01bdd3103ab2de250f55f16339992e84f8e8df46971a120fd7ab76a1aaa7
+  checksum: 8b000087043a1f08d7b7b43e94b3669e57d5b4eb4574e8b1e27c9230c1cc359ee4bdf8190375dc5c6e65830fe7b55aa4f5cac38e96e4455742fb149283f0629e
   languageName: node
   linkType: hard
 
@@ -12810,13 +13006,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"camel-case@npm:^4.1.1":
-  version: 4.1.1
-  resolution: "camel-case@npm:4.1.1"
+"camel-case@npm:^4.1.1, camel-case@npm:^4.1.2":
+  version: 4.1.2
+  resolution: "camel-case@npm:4.1.2"
   dependencies:
-    pascal-case: ^3.1.1
-    tslib: ^1.10.0
-  checksum: d8113f24a3ac764a81a6ec7a5de5d339bcc749da741e6a088c8f1dc8768845ef5299ce37d94449a0608727ac0a7c33e9c47fecfa820a1ab2b4145c0f5129c584
+    pascal-case: ^3.1.2
+    tslib: ^2.0.3
+  checksum: bf9eefaee1f20edbed2e9a442a226793bc72336e2b99e5e48c6b7252b6f70b080fc46d8246ab91939e2af91c36cdd422e0af35161e58dd089590f302f8f64c8a
   languageName: node
   linkType: hard
 
@@ -12910,6 +13106,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"capital-case@npm:^1.0.4":
+  version: 1.0.4
+  resolution: "capital-case@npm:1.0.4"
+  dependencies:
+    no-case: ^3.0.4
+    tslib: ^2.0.3
+    upper-case-first: ^2.0.2
+  checksum: 6a034af73401f6e55d91ea35c190bbf8bda21714d4ea8bb8f1799311d123410a80f0875db4e3236dc3f97d74231ff4bf1c8783f2be13d7733c7d990c57387281
+  languageName: node
+  linkType: hard
+
 "capture-exit@npm:^2.0.0":
   version: 2.0.0
   resolution: "capture-exit@npm:2.0.0"
@@ -12992,6 +13199,26 @@ __metadata:
     ansi-styles: ^4.1.0
     supports-color: ^7.1.0
   checksum: 4a3fef5cc34975c898ffe77141450f679721df9dde00f6c304353fa9c8b571929123b26a0e4617bde5018977eb655b31970c297b91b63ee83bb82aeb04666880
+  languageName: node
+  linkType: hard
+
+"change-case@npm:^4.1.2":
+  version: 4.1.2
+  resolution: "change-case@npm:4.1.2"
+  dependencies:
+    camel-case: ^4.1.2
+    capital-case: ^1.0.4
+    constant-case: ^3.0.4
+    dot-case: ^3.0.4
+    header-case: ^2.0.4
+    no-case: ^3.0.4
+    param-case: ^3.0.4
+    pascal-case: ^3.1.2
+    path-case: ^3.0.4
+    sentence-case: ^3.0.4
+    snake-case: ^3.0.4
+    tslib: ^2.0.3
+  checksum: 95a6e48563cd393241ce18470c7310a8a050304a64b63addac487560ab039ce42b099673d1d293cc10652324d92060de11b5d918179fe3b5af2ee521fb03ca58
   languageName: node
   linkType: hard
 
@@ -13991,6 +14218,17 @@ __metadata:
   version: 2.0.2
   resolution: "consolidated-events@npm:2.0.2"
   checksum: d82df47cfd4d43289cdbc5c6d9a924f1445b1c753d36ee1250efa2ee008bca0bc72702ab2e9bda58e1deb8083dc45efdbe3deb363e094fcba7ec6b7b3589df53
+  languageName: node
+  linkType: hard
+
+"constant-case@npm:^3.0.4":
+  version: 3.0.4
+  resolution: "constant-case@npm:3.0.4"
+  dependencies:
+    no-case: ^3.0.4
+    tslib: ^2.0.3
+    upper-case: ^2.0.2
+  checksum: 91d54f18341fcc491ae66d1086642b0cc564be3e08984d7b7042f8b0a721c8115922f7f11d6a09f13ed96ff326eabae11f9d1eb0335fa9d8b6e39e4df096010e
   languageName: node
   linkType: hard
 
@@ -15048,6 +15286,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"date-fns@npm:^2.28.0, date-fns@npm:^2.29.2":
+  version: 2.29.3
+  resolution: "date-fns@npm:2.29.3"
+  checksum: aa9128c876ef69a05988029d6aa3d7e5c47a1e978f18b77b48126683d1a2e6605a16c3f5293ca9f4ca790d0755b5061fcea5b469f097871cd53f6590a5c1adc4
+  languageName: node
+  linkType: hard
+
 "date-format@npm:0.0.2":
   version: 0.0.2
   resolution: "date-format@npm:0.0.2"
@@ -15852,13 +16097,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dot-case@npm:^3.0.3":
-  version: 3.0.3
-  resolution: "dot-case@npm:3.0.3"
+"dot-case@npm:^3.0.4":
+  version: 3.0.4
+  resolution: "dot-case@npm:3.0.4"
   dependencies:
-    no-case: ^3.0.3
-    tslib: ^1.10.0
-  checksum: f4bbaa2f6cb5521f63bb0f6d7c79b902c7d618a9c51696f882e459257d17a4aee9db5d96d9a3fd2cc6d17264623509db0e1aa86bb7d478c5dd662f26e84d26db
+    no-case: ^3.0.4
+    tslib: ^2.0.3
+  checksum: 5b859ea65097a7ea870e2c91b5768b72ddf7fa947223fd29e167bcdff58fe731d941c48e47a38ec8aa8e43044c8fbd15cd8fa21689a526bc34b6548197cd5b05
   languageName: node
   linkType: hard
 
@@ -17692,6 +17937,15 @@ __metadata:
   version: 4.3.0
   resolution: "fast-average-color@npm:4.3.0"
   checksum: ee5a1a938614459963fd71247fbc3acab4c3d098522998677b120ac1c45e44d85ee033af5334aa5d29584a7f4a1885a2063cdc01d04357f6a6254b3748b67605
+  languageName: node
+  linkType: hard
+
+"fast-average-color@npm:^9.1.1":
+  version: 9.1.1
+  resolution: "fast-average-color@npm:9.1.1"
+  dependencies:
+    "@types/offscreencanvas": ^2019.7.0
+  checksum: 75ef0580e25f589faf26328cedd80b2ef67026cd81f565417fc363316b0b6e55e31ebcdd6bca1851e0b976d4aa9d99cb8ca6c2448a48bfef97c17c874a266da0
   languageName: node
   linkType: hard
 
@@ -19606,6 +19860,16 @@ __metadata:
   bin:
     he: bin/he
   checksum: a27d478befe3c8192f006cdd0639a66798979dfa6e2125c6ac582a19a5ebfec62ad83e8382e6036170d873f46e4536a7e795bf8b95bf7c247f4cc0825ccc8c17
+  languageName: node
+  linkType: hard
+
+"header-case@npm:^2.0.4":
+  version: 2.0.4
+  resolution: "header-case@npm:2.0.4"
+  dependencies:
+    capital-case: ^1.0.4
+    tslib: ^2.0.3
+  checksum: c9f295d9d8e38fa50679281fd70d80726962256e888a76c8e72e526453da7a1832dcb427caa716c1ad5d79841d4537301b90156fa30298fefd3d68f4ea2181bb
   languageName: node
   linkType: hard
 
@@ -23715,12 +23979,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lower-case@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "lower-case@npm:2.0.1"
+"lower-case@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "lower-case@npm:2.0.2"
   dependencies:
-    tslib: ^1.10.0
-  checksum: 3dad40e357d2a56e93e03b9dc1233c010a255dfd2dfc5b7203d351ca75944f4baa5f7ec9ede4ae99907548ef09eda56e6f52845e9607462f44436b50d0c83ffb
+    tslib: ^2.0.3
+  checksum: 3d925e090315cf7dc1caa358e0477e186ffa23947740e4314a7429b6e62d72742e0bbe7536a5ae56d19d7618ce998aba05caca53c2902bd5742fdca5fc57fd7b
   languageName: node
   linkType: hard
 
@@ -25416,13 +25680,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"no-case@npm:^3.0.3":
-  version: 3.0.3
-  resolution: "no-case@npm:3.0.3"
+"no-case@npm:^3.0.4":
+  version: 3.0.4
+  resolution: "no-case@npm:3.0.4"
   dependencies:
-    lower-case: ^2.0.1
-    tslib: ^1.10.0
-  checksum: ef23b5a5712e5f7d68eb4bc12c6e076709c86a9edfa30fb563adf53c4ab9be78f8fc24ee91240593aa2d4d79e3f901f838d2d27e4f7e3b45582d5b871d98f171
+    lower-case: ^2.0.2
+    tslib: ^2.0.3
+  checksum: 8ef545f0b3f8677c848f86ecbd42ca0ff3cd9dd71c158527b344c69ba14710d816d8489c746b6ca225e7b615108938a0bda0a54706f8c255933703ac1cf8e703
   languageName: node
   linkType: hard
 
@@ -25733,6 +25997,13 @@ __metadata:
   version: 6.1.0
   resolution: "normalize-url@npm:6.1.0"
   checksum: 95d948f9bdd2cfde91aa786d1816ae40f8262946e13700bf6628105994fe0ff361662c20af3961161c38a119dc977adeb41fc0b41b1745eb77edaaf9cb22db23
+  languageName: node
+  linkType: hard
+
+"normalize-wheel@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "normalize-wheel@npm:1.0.1"
+  checksum: 5daf4c97e39f36658a5263a6499bbc148676ae2bd85f12c8d03c46ffe7bc3c68d44564c00413d88d0457ac0d94450559bb1c24c2ce7ae0c107031f82d093ac06
   languageName: node
   linkType: hard
 
@@ -26601,13 +26872,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"param-case@npm:^3.0.3":
-  version: 3.0.3
-  resolution: "param-case@npm:3.0.3"
+"param-case@npm:^3.0.3, param-case@npm:^3.0.4":
+  version: 3.0.4
+  resolution: "param-case@npm:3.0.4"
   dependencies:
-    dot-case: ^3.0.3
-    tslib: ^1.10.0
-  checksum: c90d69d2fb9dbd157abebf85f1bf0ee7b5f4e3f24429ecc726f1d81a952fe858c3e4a7043e9da3b4f84a278b4e94e71aa90099cb7c244bd48e61fb73070eabea
+    dot-case: ^3.0.4
+    tslib: ^2.0.3
+  checksum: ccc053f3019f878eca10e70ec546d92f51a592f762917dafab11c8b532715dcff58356118a6f350976e4ab109e321756f05739643ed0ca94298e82291e6f9e76
   languageName: node
   linkType: hard
 
@@ -26813,13 +27084,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pascal-case@npm:^3.1.1":
-  version: 3.1.1
-  resolution: "pascal-case@npm:3.1.1"
+"pascal-case@npm:^3.1.2":
+  version: 3.1.2
+  resolution: "pascal-case@npm:3.1.2"
   dependencies:
-    no-case: ^3.0.3
-    tslib: ^1.10.0
-  checksum: d9f975e2720514224e58df96ec08628be6b5a29446e233c946b203c77e43f90080ad37d52a93eefd5e9c6d446bf86a233d9470af09173e20c093153a4bdfb0e2
+    no-case: ^3.0.4
+    tslib: ^2.0.3
+  checksum: 05ff7c344809fd272fc5030ae0ee3da8e4e63f36d47a1e0a4855ca59736254192c5a27b5822ed4bae96e54048eec5f6907713cfcfff7cdf7a464eaf7490786d8
   languageName: node
   linkType: hard
 
@@ -26841,6 +27112,16 @@ __metadata:
   version: 1.0.1
   resolution: "path-browserify@npm:1.0.1"
   checksum: 8b8c3fd5c66bd340272180590ae4ff139769e9ab79522e2eb82e3d571a89b8117c04147f65ad066dccfb42fcad902e5b7d794b3d35e0fd840491a8ddbedf8c66
+  languageName: node
+  linkType: hard
+
+"path-case@npm:^3.0.4":
+  version: 3.0.4
+  resolution: "path-case@npm:3.0.4"
+  dependencies:
+    dot-case: ^3.0.4
+    tslib: ^2.0.3
+  checksum: b6b14637228a558793f603aaeb2fcd981e738b8b9319421b713532fba96d75aa94024b9f6b9ae5aa33d86755144a5b36697d28db62ae45527dbd672fcc2cf0b7
   languageName: node
   linkType: hard
 
@@ -28233,6 +28514,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"proxy-compare@npm:2.3.0":
+  version: 2.3.0
+  resolution: "proxy-compare@npm:2.3.0"
+  checksum: ee21a793ad0746d706a228fac85c0a02dda12e38599b0bc0542b61f65705df93a3e4e01600a37c53dd69187c6e567f74f0edd7e8fc7f3caf6c63e7627b1ed69d
+  languageName: node
+  linkType: hard
+
 "proxy-from-env@npm:1.1.0, proxy-from-env@npm:^1.0.0, proxy-from-env@npm:^1.1.0":
   version: 1.1.0
   resolution: "proxy-from-env@npm:1.1.0"
@@ -28784,6 +29072,19 @@ __metadata:
     react: ">=16.4.0"
     react-dom: ">=16.4.0"
   checksum: 2483613b41fe457b2bb2628b6a2cda103d88d16fa73934077dd2da22d84ffa46c92df90121295b09a9f5b9ca83fad00615d7d58184759a324a8df5e52dac9616
+  languageName: node
+  linkType: hard
+
+"react-easy-crop@npm:^4.5.1":
+  version: 4.6.1
+  resolution: "react-easy-crop@npm:4.6.1"
+  dependencies:
+    normalize-wheel: ^1.0.1
+    tslib: 2.0.1
+  peerDependencies:
+    react: ">=16.4.0"
+    react-dom: ">=16.4.0"
+  checksum: aa08315bd64360b138e5126918b923e963514da39da6bbce73ae7a9c05104d59db0257a4fe7620b0af7ddf0dd080d65e64e5d8491fe215502ba3eeeb016bf251
   languageName: node
   linkType: hard
 
@@ -30794,6 +31095,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"requestidlecallback@npm:^0.3.0":
+  version: 0.3.0
+  resolution: "requestidlecallback@npm:0.3.0"
+  checksum: 68a2ff3154788643ccf96436cfaf8ad5bbe2f4d3f4b4d7858ec74681bf7d6a487d17df6a238130ff1e73d0a4a85bdc44b5f945eb79ef7d5552e23fc6288e795f
+  languageName: node
+  linkType: hard
+
 "require-directory@npm:^2.1.1":
   version: 2.1.1
   resolution: "require-directory@npm:2.1.1"
@@ -31580,6 +31888,17 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
+"sentence-case@npm:^3.0.4":
+  version: 3.0.4
+  resolution: "sentence-case@npm:3.0.4"
+  dependencies:
+    no-case: ^3.0.4
+    tslib: ^2.0.3
+    upper-case-first: ^2.0.2
+  checksum: 9a90527a51300cf5faea7fae0c037728f9ddcff23ac083883774c74d180c0a03c31aab43d5c3347512e8c1b31a0d4712512ec82beb71aa79b85149f9abeb5467
+  languageName: node
+  linkType: hard
+
 "serialize-error@npm:^2.1.0":
   version: 2.1.0
   resolution: "serialize-error@npm:2.1.0"
@@ -31982,6 +32301,16 @@ resolve@^2.0.0-next.3:
   version: 4.2.0
   resolution: "smart-buffer@npm:4.2.0"
   checksum: a16775323e1404dd43fabafe7460be13a471e021637bc7889468eb45ce6a6b207261f454e4e530a19500cc962c4cc5348583520843b363f4193cee5c00e1e539
+  languageName: node
+  linkType: hard
+
+"snake-case@npm:^3.0.4":
+  version: 3.0.4
+  resolution: "snake-case@npm:3.0.4"
+  dependencies:
+    dot-case: ^3.0.4
+    tslib: ^2.0.3
+  checksum: ab19a913969f58f4474fe9f6e8a026c8a2142a01f40b52b79368068343177f818cdfef0b0c6b9558f298782441d5ca8ed5932eb57822439fad791d866e62cecd
   languageName: node
   linkType: hard
 
@@ -34049,7 +34378,14 @@ swiper@4.5.1:
   languageName: node
   linkType: hard
 
-"tslib@npm:>=2.3.0, tslib@npm:^2.0.0, tslib@npm:^2.0.1, tslib@npm:^2.1.0, tslib@npm:^2.3.0":
+"tslib@npm:2.0.1":
+  version: 2.0.1
+  resolution: "tslib@npm:2.0.1"
+  checksum: 5f370da8ac0e9c7f2440a3fd8013682c042a8eeace93849a44a8d4252770e4830fce3201b0bc5a6045c7e28b80eaebe3a3b48e656aa7b4f9681b9a9d7263cfaf
+  languageName: node
+  linkType: hard
+
+"tslib@npm:>=2.3.0, tslib@npm:^2.0.0, tslib@npm:^2.0.1, tslib@npm:^2.0.3, tslib@npm:^2.1.0, tslib@npm:^2.3.0":
   version: 2.4.0
   resolution: "tslib@npm:2.4.0"
   checksum: eb19bda3ae545b03caea6a244b34593468e23d53b26bf8649fbc20fce43e9b21a71127fd6d2b9662c0fe48ee6ff668ead48fd00d3b88b2b716b1c12edae25b5d
@@ -34731,10 +35067,28 @@ swiper@4.5.1:
   languageName: node
   linkType: hard
 
+"upper-case-first@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "upper-case-first@npm:2.0.2"
+  dependencies:
+    tslib: ^2.0.3
+  checksum: ccad6a0b143310ebfba2b5841f30bef71246297385f1329c022c902b2b5fc5aee009faf1ac9da5ab3ba7f615b88f5dc1cd80461b18a8f38cb1d4c3eb92538ea9
+  languageName: node
+  linkType: hard
+
 "upper-case@npm:^1.1.1":
   version: 1.1.3
   resolution: "upper-case@npm:1.1.3"
   checksum: 3e4d3a90519915bb591db84d72610392518806d8287b8f7541d87642d30388f42b2def1ed2f687e5792ee025e8f7e17d3a0dcbd5b3b59e306ceb1f3b8121ef54
+  languageName: node
+  linkType: hard
+
+"upper-case@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "upper-case@npm:2.0.2"
+  dependencies:
+    tslib: ^2.0.3
+  checksum: 5ac176c9d3757abb71400df167f9abb46d63152d5797c630d1a9f083fbabd89711fb4b3dc6de06ff0138fe8946fa5b8518b4fcdae9ca8a3e341417075beae069
   languageName: node
   linkType: hard
 
@@ -34876,6 +35230,18 @@ swiper@4.5.1:
   languageName: node
   linkType: hard
 
+"use-lilius@npm:^2.0.1":
+  version: 2.0.3
+  resolution: "use-lilius@npm:2.0.3"
+  dependencies:
+    date-fns: ^2.29.2
+  peerDependencies:
+    react: "*"
+    react-dom: "*"
+  checksum: 4f1c1415a559531b62f6af3bc0886f7fcce010477b7938c9b355c79ba35ba613c9ad3d5cafb721f5f0e9b72601a79a5396335555f77ccfbd6f2c4b6c64a735d6
+  languageName: node
+  linkType: hard
+
 "use-memo-one@npm:^1.1.1":
   version: 1.1.2
   resolution: "use-memo-one@npm:1.1.2"
@@ -34893,6 +35259,15 @@ swiper@4.5.1:
   peerDependencies:
     react: ^16.8.0 || ^17.0.0
   checksum: 0de6185cd5890a0640cd08b616f9de7875c41d51e6570894eb2bb83fa48c6137eaa56c360edb8fb9f7f253b9705e103bca52fbcd9f86b03d07c6467d282758fc
+  languageName: node
+  linkType: hard
+
+"use-sync-external-store@npm:1.2.0":
+  version: 1.2.0
+  resolution: "use-sync-external-store@npm:1.2.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+  checksum: ac4814e5592524f242921157e791b022efe36e451fe0d4fd4d204322d5433a4fc300d63b0ade5185f8e0735ded044c70bcf6d2352db0f74d097a238cebd2da02
   languageName: node
   linkType: hard
 
@@ -35094,6 +35469,36 @@ swiper@4.5.1:
   version: 13.5.2
   resolution: "validator@npm:13.5.2"
   checksum: db5b14ae46c7f34b5f1e2f1bdd1ded58fa5fa5f57c0d6652e5bf13d4d2dab34243bc479c0bbb3bb63e750e34d4868fbb11ad208b93f88ca7dd910b505f01dc2d
+  languageName: node
+  linkType: hard
+
+"valtio@npm:^1.7.0":
+  version: 1.7.4
+  resolution: "valtio@npm:1.7.4"
+  dependencies:
+    proxy-compare: 2.3.0
+    use-sync-external-store: 1.2.0
+  peerDependencies:
+    "@babel/helper-module-imports": ">=7.12"
+    "@babel/types": ">=7.13"
+    aslemammad-vite-plugin-macro: ">=1.0.0-alpha.1"
+    babel-plugin-macros: ">=3.0"
+    react: ">=16.8"
+    vite: ">=2.8.6"
+  peerDependenciesMeta:
+    "@babel/helper-module-imports":
+      optional: true
+    "@babel/types":
+      optional: true
+    aslemammad-vite-plugin-macro:
+      optional: true
+    babel-plugin-macros:
+      optional: true
+    react:
+      optional: true
+    vite:
+      optional: true
+  checksum: e64f0e0002bd25dc9e8e61cd55a22507dfaed5f34079c56002282c63448d8f19cdfe78c68e515597c1d5bb43db11c801cd5fcd3b96a7688c3c6424e978ed5896
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
#### Proposed Changes

This PR updates `@automattic/design-preview` dependency of `@wordpress/edit-site` from `4.6.0` to `4.17.0`, which contains the fixes:
- https://github.com/WordPress/gutenberg/pull/43601
- https://github.com/WordPress/gutenberg/pull/44556

Which, in turn, fixes this UI issue for the `<DesignPreview />` component:
| Before | After |
| --- | --- |
| ![Screen Shot 2022-10-19 at 5 44 11 PM](https://user-images.githubusercontent.com/797888/196657111-41f92fe4-9053-4faf-957b-d9634ce1380c.png) | ![Screen Shot 2022-10-19 at 5 44 38 PM](https://user-images.githubusercontent.com/797888/196657125-ddca33d8-1989-4779-894a-529b57d1eb2f.png) |


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the design picker `setup/designSetup?siteSlug=${site_slug}`
* Preview any design with style variations.
* Ensure that the style preview doesn't have extra padding (happened previously for the theme "Pixl"). 

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

