### PR TITLE
Fix calypso_plugins_search_results_show / _page tracks events

### DIFF
--- a/client/data/marketplace/use-es-query.ts
+++ b/client/data/marketplace/use-es-query.ts
@@ -132,7 +132,11 @@ export const useESPluginsInfinite = (
 				return {
 					...data,
 					plugins: mapIndexResultsToPluginData( data.pages.flatMap( ( p ) => p.data.results ) ),
-					pagination: { results: data.pages[ 0 ]?.data?.total },
+					pagination: {
+						results: data.pages[ 0 ]?.data?.total,
+						pages: data?.pages || [],
+						page: data?.pageParams?.length || 0,
+					},
 				};
 			},
 			getNextPageParam: ( lastPage ) => {

--- a/client/my-sites/plugins/plugins-search-results-page/index.jsx
+++ b/client/my-sites/plugins/plugins-search-results-page/index.jsx
@@ -62,7 +62,7 @@ const PluginsSearchResultPage = ( {
 			);
 		}
 
-		if ( searchTerm && pluginsPagination ) {
+		if ( searchTerm && pluginsPagination.page ) {
 			dispatch(
 				recordTracksEvent( 'calypso_plugins_search_results_page', {
 					search_term: searchTerm,
@@ -72,7 +72,7 @@ const PluginsSearchResultPage = ( {
 				} )
 			);
 		}
-	}, [ searchTerm, pluginsPagination, dispatch, siteId ] );
+	}, [ searchTerm, pluginsPagination.page, pluginsPagination.results, dispatch, siteId ] );
 
 	if ( pluginsBySearchTerm.length > 0 || isFetchingPluginsBySearchTerm ) {
 		let title = translate( 'Search results for "%(searchTerm)s"', {


### PR DESCRIPTION
#### Proposed Changes

* Fixes the pagination response from `useESPluginsInfinite`
* Only record `calypso_plugins_search_results_show` once and pages for each page (once initially, then one more every time we scroll)

#### Testing Instructions

* View a /plugins search result e.g. http://calypso.localhost:3000/plugins/?s=email
* Enable tracks logging in web console by running: `localStorage.setItem( 'debug', 'calypso:analytics' );`
* Reload the page
* Filter console output to `calypso_plugins_search_results_`
* Should only see `_show` once
* And `_page` on new page results as you scroll the bottom of the page to load the next set of results

Before

https://user-images.githubusercontent.com/811776/196865843-5227f149-8bde-442a-8ca6-094e64ab8df1.mp4

After

https://user-images.githubusercontent.com/811776/196865850-cfb4b73d-3822-4075-9651-1bcd0a9ebd66.mp4


Fixes https://github.com/Automattic/wp-calypso/issues/68901
