### PR TITLE
Onboarding standalone installation: Add Jetpack License key activation in the instruction page

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/jetpack-activation-instructions.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-activation-instructions.tsx
@@ -1,40 +1,42 @@
 import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
+import { useMemo } from 'react';
 import ExternalLink from 'calypso/components/external-link';
+import JetpackInstructionList from './jetpack-instruction-list';
 
 const JetpackActivationInstructions: React.FC = () => {
 	const translate = useTranslate();
+
+	const items = useMemo(
+		() => [
+			translate( 'Go to your WP Admin Dashboard and {{strong}}add a new plugin{{/strong}}.', {
+				components: { strong: <strong /> },
+			} ),
+			translate(
+				'Search for {{link}}{{strong}}Jetpack{{/strong}}{{/link}}, install and activate.',
+				{
+					components: {
+						strong: <strong />,
+						link: (
+							<Button
+								plain
+								href="https://wordpress.org/plugins/jetpack/"
+								target="_blank"
+								rel="noreferrer noopener"
+							/>
+						),
+					},
+				}
+			),
+		],
+		[ translate ]
+	);
 
 	return (
 		<>
 			<p>{ translate( "If you don't have Jetpack installed, follow these instructions:" ) }</p>
 
-			<ol className="licensing-thank-you-manual-activation-instructions__list">
-				<li className="licensing-thank-you-manual-activation-instructions__list-item">
-					{ translate( 'Go to your WP Admin Dashboard and {{strong}}add a new plugin{{/strong}}.', {
-						components: { strong: <strong /> },
-					} ) }
-				</li>
-
-				<li className="licensing-thank-you-manual-activation-instructions__list-item">
-					{ translate(
-						'Search for {{link}}{{strong}}Jetpack{{/strong}}{{/link}}, install and activate.',
-						{
-							components: {
-								strong: <strong />,
-								link: (
-									<Button
-										plain
-										href="https://wordpress.org/plugins/jetpack/"
-										target="_blank"
-										rel="noreferrer noopener"
-									/>
-								),
-							},
-						}
-					) }
-				</li>
-			</ol>
+			<JetpackInstructionList items={ items } />
 
 			<p>
 				<ExternalLink

--- a/client/my-sites/checkout/checkout-thank-you/jetpack-activation-instructions.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-activation-instructions.tsx
@@ -9,25 +9,34 @@ const JetpackActivationInstructions: React.FC = () => {
 
 	const items = useMemo(
 		() => [
-			translate( 'Go to your WP Admin Dashboard and {{strong}}add a new plugin{{/strong}}.', {
-				components: { strong: <strong /> },
-			} ),
-			translate(
-				'Search for {{link}}{{strong}}Jetpack{{/strong}}{{/link}}, install and activate.',
-				{
-					components: {
-						strong: <strong />,
-						link: (
-							<Button
-								plain
-								href="https://wordpress.org/plugins/jetpack/"
-								target="_blank"
-								rel="noreferrer noopener"
-							/>
-						),
-					},
-				}
-			),
+			{
+				id: 1,
+				content: translate(
+					'Go to your WP Admin Dashboard and {{strong}}add a new plugin{{/strong}}.',
+					{
+						components: { strong: <strong /> },
+					}
+				),
+			},
+			{
+				id: 2,
+				content: translate(
+					'Search for {{link}}{{strong}}Jetpack{{/strong}}{{/link}}, install and activate.',
+					{
+						components: {
+							strong: <strong />,
+							link: (
+								<Button
+									plain
+									href="https://wordpress.org/plugins/jetpack/"
+									target="_blank"
+									rel="noreferrer noopener"
+								/>
+							),
+						},
+					}
+				),
+			},
 		],
 		[ translate ]
 	);

--- a/client/my-sites/checkout/checkout-thank-you/jetpack-instruction-list.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-instruction-list.tsx
@@ -1,10 +1,10 @@
-import { FC, ReactNode } from 'react';
+import React, { ReactNode } from 'react';
 
 export interface JetpackInstructionListProps {
 	items: ReactNode[];
 }
 
-const JetpackInstructionList: FC< JetpackInstructionListProps > = ( { items } ) => {
+const JetpackInstructionList: React.FC< JetpackInstructionListProps > = ( { items } ) => {
 	return (
 		<ol className="jetpack-instruction-list">
 			{ items.map( ( item, index ) => (

--- a/client/my-sites/checkout/checkout-thank-you/jetpack-instruction-list.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-instruction-list.tsx
@@ -1,0 +1,19 @@
+import { FC, ReactNode } from 'react';
+
+export interface JetpackInstructionListProps {
+	items: ReactNode[];
+}
+
+const JetpackInstructionList: FC< JetpackInstructionListProps > = ( { items } ) => {
+	return (
+		<ol className="jetpack-instruction-list">
+			{ items.map( ( item, index ) => (
+				<li className="jetpack-instruction-list__item" key={ index }>
+					<span>{ item }</span>
+				</li>
+			) ) }
+		</ol>
+	);
+};
+
+export default JetpackInstructionList;

--- a/client/my-sites/checkout/checkout-thank-you/jetpack-instruction-list.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-instruction-list.tsx
@@ -1,15 +1,18 @@
 import React, { ReactNode } from 'react';
 
 export interface JetpackInstructionListProps {
-	items: ReactNode[];
+	items: {
+		id: number;
+		content: ReactNode;
+	}[];
 }
 
 const JetpackInstructionList: React.FC< JetpackInstructionListProps > = ( { items } ) => {
 	return (
 		<ol className="jetpack-instruction-list">
-			{ items.map( ( item, index ) => (
-				<li className="jetpack-instruction-list__item" key={ index }>
-					<span>{ item }</span>
+			{ items.map( ( { id, content } ) => (
+				<li className="jetpack-instruction-list__item" key={ id }>
+					<span>{ content }</span>
 				</li>
 			) ) }
 		</ol>

--- a/client/my-sites/checkout/checkout-thank-you/jetpack-license-key-clipboard.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-license-key-clipboard.tsx
@@ -1,0 +1,54 @@
+import classnames from 'classnames';
+import { useTranslate } from 'i18n-calypso';
+import React from 'react';
+import ClipboardButton from 'calypso/components/forms/clipboard-button';
+import FormTextInput from 'calypso/components/forms/form-text-input';
+
+export interface JetpackLicenseKeyClipboardProps {
+	copied: boolean;
+	disabled: boolean;
+	licenseKey: string;
+	loading: boolean;
+	onCopy?: () => void;
+}
+
+const JetpackLicenseKeyClipboard: React.FC< JetpackLicenseKeyClipboardProps > = ( {
+	copied,
+	disabled,
+	licenseKey,
+	loading,
+	onCopy,
+} ) => {
+	const translate = useTranslate();
+
+	return (
+		<>
+			<div className="jetpack-license-key-clipboard">
+				<label>
+					<strong>{ translate( 'Your license key' ) }</strong>
+				</label>
+				<div className="jetpack-license-key-clipboard__container">
+					<FormTextInput
+						className={ classnames( 'jetpack-license-key-clipboard__input', {
+							'is-loading': loading,
+						} ) }
+						value={ licenseKey }
+						readOnly
+					/>
+					<ClipboardButton
+						className="jetpack-license-key-clipboard__button"
+						text={ licenseKey }
+						onCopy={ onCopy }
+						compact
+						primary
+						disabled={ disabled || loading }
+					>
+						{ copied ? translate( 'Copied!' ) : translate( 'Copy', { context: 'verb' } ) }
+					</ClipboardButton>
+				</div>
+			</div>
+		</>
+	);
+};
+
+export default JetpackLicenseKeyClipboard;

--- a/client/my-sites/checkout/checkout-thank-you/jetpack-standalone-activation-instructions.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-standalone-activation-instructions.tsx
@@ -19,21 +19,35 @@ const JetpackStandaloneActivationInstructions: React.FC< Props > = ( { product, 
 
 	const items = useMemo(
 		() => [
-			translate( '{{link}}Download Jetpack %(pluginName)s.{{icon/}}{{/link}}', {
-				components: {
-					strong: <strong />,
-					link: <Button plain href={ wporgPluginLink } target="_blank" rel="noreferrer noopener" />,
-					icon: <Gridicon icon="external" size={ 16 } />,
-				},
-				args: { pluginName: product.shortName },
-			} ),
-			translate( 'Install and activate the plugin.' ),
-			translate( 'Go to {{strong}}Jetpack > Dashboard > My Jetpack{{/strong}}.', {
-				components: { strong: <strong /> },
-			} ),
-			translate(
-				'Click the “Activate license key” (at the bottom of the page) and enter the key below.'
-			),
+			{
+				id: 1,
+				content: translate( '{{link}}Download Jetpack %(pluginName)s.{{icon/}}{{/link}}', {
+					components: {
+						strong: <strong />,
+						link: (
+							<Button plain href={ wporgPluginLink } target="_blank" rel="noreferrer noopener" />
+						),
+						icon: <Gridicon icon="external" size={ 16 } />,
+					},
+					args: { pluginName: product.shortName },
+				} ),
+			},
+			{
+				id: 2,
+				content: translate( 'Install and activate the plugin.' ),
+			},
+			{
+				id: 3,
+				content: translate( 'Go to {{strong}}Jetpack > Dashboard > My Jetpack{{/strong}}.', {
+					components: { strong: <strong /> },
+				} ),
+			},
+			{
+				id: 4,
+				content: translate(
+					'Click the “Activate license key” (at the bottom of the page) and enter the key below.'
+				),
+			},
 		],
 		[ translate, product, wporgPluginLink ]
 	);

--- a/client/my-sites/checkout/checkout-thank-you/jetpack-standalone-activation-instructions.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-standalone-activation-instructions.tsx
@@ -19,7 +19,7 @@ const JetpackStandaloneActivationInstructions: React.FC< Props > = ( { product, 
 
 	const items = useMemo(
 		() => [
-			translate( '{{link}}Download Jetpack %(pluginName)s {{icon/}} {{/link}}', {
+			translate( '{{link}}Download Jetpack %(pluginName)s.{{icon/}}{{/link}}', {
 				components: {
 					strong: <strong />,
 					link: <Button plain href={ wporgPluginLink } target="_blank" rel="noreferrer noopener" />,
@@ -27,12 +27,12 @@ const JetpackStandaloneActivationInstructions: React.FC< Props > = ( { product, 
 				},
 				args: { pluginName: product.shortName },
 			} ),
-			translate( 'Install and activate the plugin' ),
-			translate( 'Go to {{strong}}Jetpack > Dashboard > My Jetpack{{/strong}}', {
+			translate( 'Install and activate the plugin.' ),
+			translate( 'Go to {{strong}}Jetpack > Dashboard > My Jetpack{{/strong}}.', {
 				components: { strong: <strong /> },
 			} ),
 			translate(
-				'Click the “activate license key” (at the bottom of the page) and enter the key below.'
+				'Click the “Activate license key” (at the bottom of the page) and enter the key below.'
 			),
 		],
 		[ translate, product, wporgPluginLink ]

--- a/client/my-sites/checkout/checkout-thank-you/jetpack-standalone-activation-instructions.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-standalone-activation-instructions.tsx
@@ -1,7 +1,9 @@
 import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
+import { useMemo } from 'react';
 import ExternalLink from 'calypso/components/external-link';
 import { SelectorProduct } from 'calypso/my-sites/plans/jetpack-plans/types';
+import JetpackInstructionList from './jetpack-instruction-list';
 import { getWPORGPluginLink } from './utils';
 
 interface Props {
@@ -13,40 +15,31 @@ const JetpackStandaloneActivationInstructions: React.FC< Props > = ( { product }
 
 	const wporgPluginLink = getWPORGPluginLink( product.productSlug );
 
+	const items = useMemo(
+		() => [
+			translate( 'Login to an existing Wordpress site as an administrator.' ),
+			translate( 'Go to {{strong}}Plugins > Add New{{/strong}} in the admin menu.', {
+				components: { strong: <strong /> },
+			} ),
+			translate(
+				'Search for {{link}}{{strong}}Jetpack %(pluginName)s{{/strong}}{{/link}}, install and activate.',
+				{
+					components: {
+						strong: <strong />,
+						link: (
+							<Button plain href={ wporgPluginLink } target="_blank" rel="noreferrer noopener" />
+						),
+					},
+					args: { pluginName: product.shortName },
+				}
+			),
+		],
+		[ translate, product, wporgPluginLink ]
+	);
+
 	return (
 		<>
-			<ol className="licensing-thank-you-manual-activation-instructions__list">
-				<li className="licensing-thank-you-manual-activation-instructions__list-item">
-					{ translate( 'Login to an existing Wordpress site as an administrator.' ) }
-				</li>
-
-				<li className="licensing-thank-you-manual-activation-instructions__list-item">
-					{ translate( 'Go to {{strong}}Plugins > Add New{{/strong}} in the admin menu.', {
-						components: { strong: <strong /> },
-					} ) }
-				</li>
-
-				<li className="licensing-thank-you-manual-activation-instructions__list-item">
-					{ translate(
-						'Search for {{link}}{{strong}}Jetpack %(pluginName)s{{/strong}}{{/link}}, install and activate.',
-						{
-							components: {
-								strong: <strong />,
-								link: (
-									<Button
-										plain
-										href={ wporgPluginLink }
-										target="_blank"
-										rel="noreferrer noopener"
-									/>
-								),
-							},
-							args: { pluginName: product.shortName },
-						}
-					) }
-				</li>
-			</ol>
-
+			<JetpackInstructionList items={ items } />
 			<p>
 				<ExternalLink
 					href="https://jetpack.com/support/install-jetpack-and-connect-your-new-plan/"

--- a/client/my-sites/checkout/checkout-thank-you/jetpack-standalone-activation-instructions.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-standalone-activation-instructions.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@automattic/components';
+import { Button, Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import ExternalLink from 'calypso/components/external-link';
@@ -17,21 +17,20 @@ const JetpackStandaloneActivationInstructions: React.FC< Props > = ( { product }
 
 	const items = useMemo(
 		() => [
-			translate( 'Login to an existing Wordpress site as an administrator.' ),
-			translate( 'Go to {{strong}}Plugins > Add New{{/strong}} in the admin menu.', {
+			translate( '{{link}}Download Jetpack %(pluginName)s {{icon/}} {{/link}}', {
+				components: {
+					strong: <strong />,
+					link: <Button plain href={ wporgPluginLink } target="_blank" rel="noreferrer noopener" />,
+					icon: <Gridicon icon="external" size={ 16 } />,
+				},
+				args: { pluginName: product.shortName },
+			} ),
+			translate( 'Install and activate the plugin' ),
+			translate( 'Go to {{strong}}Jetpack > Dashboard > My Jetpack{{/strong}}', {
 				components: { strong: <strong /> },
 			} ),
 			translate(
-				'Search for {{link}}{{strong}}Jetpack %(pluginName)s{{/strong}}{{/link}}, install and activate.',
-				{
-					components: {
-						strong: <strong />,
-						link: (
-							<Button plain href={ wporgPluginLink } target="_blank" rel="noreferrer noopener" />
-						),
-					},
-					args: { pluginName: product.shortName },
-				}
+				'Click the “activate license key” (at the bottom of the page) and enter the key below.'
 			),
 		],
 		[ translate, product, wporgPluginLink ]

--- a/client/my-sites/checkout/checkout-thank-you/jetpack-standalone-activation-instructions.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-standalone-activation-instructions.tsx
@@ -4,13 +4,15 @@ import { useMemo } from 'react';
 import ExternalLink from 'calypso/components/external-link';
 import { SelectorProduct } from 'calypso/my-sites/plans/jetpack-plans/types';
 import JetpackInstructionList from './jetpack-instruction-list';
+import JetpackLicenseKeyClipboard from './jetpack-license-key-clipboard';
 import { getWPORGPluginLink } from './utils';
 
 interface Props {
 	product: SelectorProduct;
+	receiptId: number;
 }
 
-const JetpackStandaloneActivationInstructions: React.FC< Props > = ( { product } ) => {
+const JetpackStandaloneActivationInstructions: React.FC< Props > = ( { product, receiptId } ) => {
 	const translate = useTranslate();
 
 	const wporgPluginLink = getWPORGPluginLink( product.productSlug );
@@ -37,8 +39,11 @@ const JetpackStandaloneActivationInstructions: React.FC< Props > = ( { product }
 	);
 
 	return (
-		<>
+		<div className="jetpack-standalone-activation-instructions">
 			<JetpackInstructionList items={ items } />
+
+			<JetpackLicenseKeyClipboard productSlug={ product.productSlug } receiptId={ receiptId } />
+
 			<p>
 				<ExternalLink
 					href="https://jetpack.com/support/install-jetpack-and-connect-your-new-plan/"
@@ -49,7 +54,7 @@ const JetpackStandaloneActivationInstructions: React.FC< Props > = ( { product }
 					} ) }
 				</ExternalLink>
 			</p>
-		</>
+		</div>
 	);
 };
 

--- a/client/my-sites/checkout/checkout-thank-you/licensing-thank-you-manual-activation-instructions.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/licensing-thank-you-manual-activation-instructions.tsx
@@ -12,14 +12,13 @@ import { isJetpackStandaloneProduct } from 'calypso/my-sites/plans/jetpack-plans
 import slugToSelectorProduct from 'calypso/my-sites/plans/jetpack-plans/slug-to-selector-product';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import JetpackActivationInstructions from './jetpack-activation-instructions';
+import { JetpackLicenseKeyProps } from './jetpack-license-key-clipboard';
 import JetpackStandaloneActivationInstructions from './jetpack-standalone-activation-instructions';
 
-interface Props {
-	productSlug: string | 'no_product';
-	receiptId: number;
-}
-
-const LicensingActivationInstructions: FC< Props > = ( { productSlug, receiptId } ) => {
+const LicensingActivationInstructions: FC< JetpackLicenseKeyProps > = ( {
+	productSlug,
+	receiptId,
+} ) => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
@@ -71,19 +70,24 @@ const LicensingActivationInstructions: FC< Props > = ( { productSlug, receiptId 
 				progressIndicatorTotal={ 3 }
 			>
 				{ jetpackStandaloneProduct ? (
-					<JetpackStandaloneActivationInstructions product={ jetpackStandaloneProduct } />
+					<JetpackStandaloneActivationInstructions
+						product={ jetpackStandaloneProduct }
+						receiptId={ receiptId }
+					/>
 				) : (
-					<JetpackActivationInstructions />
-				) }
+					<>
+						<JetpackActivationInstructions />
 
-				<Button
-					className="licensing-thank-you-manual-activation-instructions__button"
-					primary
-					disabled={ false }
-					onClick={ onContinue }
-				>
-					{ translate( 'Continue ' ) }
-				</Button>
+						<Button
+							className="licensing-thank-you-manual-activation-instructions__button"
+							primary
+							disabled={ false }
+							onClick={ onContinue }
+						>
+							{ translate( 'Continue ' ) }
+						</Button>
+					</>
+				) }
 			</LicensingActivation>
 		</>
 	);

--- a/client/my-sites/checkout/checkout-thank-you/licensing-thank-you-manual-activation-license-key.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/licensing-thank-you-manual-activation-license-key.tsx
@@ -1,28 +1,23 @@
 import { useTranslate } from 'i18n-calypso';
-import { FC, useCallback, useEffect, useState } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { FC } from 'react';
+import { useSelector } from 'react-redux';
 import licensingActivationPluginBanner from 'calypso/assets/images/jetpack/licensing-activation-plugin-banner.svg';
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import LicensingActivation from 'calypso/components/jetpack/licensing-activation';
-import useUserLicenseByReceiptQuery from 'calypso/data/jetpack-licensing/use-user-license-by-receipt-query';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import {
 	isProductsListFetching as getIsProductListFetching,
 	getProductName,
 } from 'calypso/state/products-list/selectors';
-import JetpackLicenseKeyClipboard from './jetpack-license-key-clipboard';
+import JetpackLicenseKeyClipboard, {
+	JetpackLicenseKeyProps,
+} from './jetpack-license-key-clipboard';
 
-interface Props {
-	productSlug: string | 'no_product';
-	receiptId: number;
-}
-
-const LicensingActivationInstructions: FC< Props > = ( { productSlug, receiptId } ) => {
+const LicensingActivationInstructions: FC< JetpackLicenseKeyProps > = ( {
+	productSlug,
+	receiptId,
+} ) => {
 	const translate = useTranslate();
-	const dispatch = useDispatch();
-
-	const [ isCopied, setCopied ] = useState( false );
 
 	const hasProductInfo = productSlug !== 'no_product';
 
@@ -31,34 +26,6 @@ const LicensingActivationInstructions: FC< Props > = ( { productSlug, receiptId 
 	);
 
 	const isProductListFetching = useSelector( ( state ) => getIsProductListFetching( state ) );
-
-	const {
-		data: dataLicense,
-		isError: isErrorFetchingLicense,
-		isLoading: isLoadingLicense,
-	} = useUserLicenseByReceiptQuery( receiptId );
-
-	const licenseKey =
-		! isErrorFetchingLicense && ! isLoadingLicense && dataLicense
-			? dataLicense[ 0 ].licenseKey
-			: '';
-
-	const onCopy = useCallback( () => {
-		setCopied( true );
-		dispatch(
-			recordTracksEvent( 'calypso_siteless_checkout_manual_activation_license_key_copy', {
-				product_slug: productSlug,
-				license_key: licenseKey,
-			} )
-		);
-	}, [ dispatch, licenseKey, productSlug ] );
-
-	useEffect( () => {
-		if ( isCopied ) {
-			const confirmationTimeout = setTimeout( () => setCopied( false ), 4000 );
-			return () => clearTimeout( confirmationTimeout );
-		}
-	}, [ isCopied ] );
 
 	return (
 		<>
@@ -91,13 +58,7 @@ const LicensingActivationInstructions: FC< Props > = ( { productSlug, receiptId 
 					) }
 				</p>
 
-				<JetpackLicenseKeyClipboard
-					copied={ isCopied }
-					disabled={ isErrorFetchingLicense || isLoadingLicense }
-					licenseKey={ licenseKey }
-					loading={ isLoadingLicense }
-					onCopy={ onCopy }
-				/>
+				<JetpackLicenseKeyClipboard productSlug={ productSlug } receiptId={ receiptId } />
 			</LicensingActivation>
 		</>
 	);

--- a/client/my-sites/checkout/checkout-thank-you/licensing-thank-you-manual-activation-license-key.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/licensing-thank-you-manual-activation-license-key.tsx
@@ -1,11 +1,8 @@
-import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { FC, useCallback, useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import licensingActivationPluginBanner from 'calypso/assets/images/jetpack/licensing-activation-plugin-banner.svg';
 import QueryProductsList from 'calypso/components/data/query-products-list';
-import ClipboardButton from 'calypso/components/forms/clipboard-button';
-import FormTextInput from 'calypso/components/forms/form-text-input';
 import LicensingActivation from 'calypso/components/jetpack/licensing-activation';
 import useUserLicenseByReceiptQuery from 'calypso/data/jetpack-licensing/use-user-license-by-receipt-query';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
@@ -14,6 +11,7 @@ import {
 	isProductsListFetching as getIsProductListFetching,
 	getProductName,
 } from 'calypso/state/products-list/selectors';
+import JetpackLicenseKeyClipboard from './jetpack-license-key-clipboard';
 
 interface Props {
 	productSlug: string | 'no_product';
@@ -92,30 +90,14 @@ const LicensingActivationInstructions: FC< Props > = ( { productSlug, receiptId 
 						}
 					) }
 				</p>
-				<div className="licensing-thank-you-manual-activation-license-key__key">
-					<label>
-						<strong>{ translate( 'Your license key' ) }</strong>
-					</label>
-					<div className="licensing-thank-you-manual-activation-license-key__clipboard">
-						<FormTextInput
-							className={ classnames( 'licensing-thank-you-manual-activation-license-key__input', {
-								'is-loading': isLoadingLicense,
-							} ) }
-							value={ licenseKey }
-							readOnly
-						/>
-						<ClipboardButton
-							className="licensing-thank-you-manual-activation-license-key__button"
-							text={ licenseKey }
-							onCopy={ onCopy }
-							compact
-							primary
-							disabled={ isErrorFetchingLicense || isLoadingLicense }
-						>
-							{ isCopied ? translate( 'Copied!' ) : translate( 'Copy', { context: 'verb' } ) }
-						</ClipboardButton>
-					</div>
-				</div>
+
+				<JetpackLicenseKeyClipboard
+					copied={ isCopied }
+					disabled={ isErrorFetchingLicense || isLoadingLicense }
+					licenseKey={ licenseKey }
+					loading={ isLoadingLicense }
+					onCopy={ onCopy }
+				/>
 			</LicensingActivation>
 		</>
 	);

--- a/client/my-sites/checkout/checkout-thank-you/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/style.scss
@@ -743,36 +743,6 @@
 	}
 }
 
-.licensing-thank-you-manual-activation-instructions__list {
-	margin: 0;
-
-	list-style: none;
-	counter-reset: item;
-}
-
-.licensing-thank-you-manual-activation-instructions__list-item {
-	margin-bottom: 1.5rem;
-
-	&::before {
-		content: counter(item);
-		counter-increment: item;
-
-		display: inline-flex;
-		justify-content: center;
-		align-items: center;
-
-		min-width: 1.75em;
-		height: 1.75em;
-		margin-inline-end: 0.75em;
-
-		background-color: var(--studio-jetpack-green-40);
-		border-radius: 50%; /* stylelint-disable-line declaration-property-unit-allowed-list */
-		color: var(--color-text-inverted);
-
-		font-weight: 700;
-	}
-}
-
 .licensing-activation .licensing-thank-you-manual-activation-instructions__button.button {
 	margin-top: 0;
 }
@@ -852,5 +822,35 @@
 	.jetpack-checkout-thank-you__sub-message-loading,
 	.jetpack-checkout-thank-you__email-message-loading {
 		@include placeholder( --color-neutral-20 );
+	}
+}
+
+.jetpack-instruction-list {
+	margin: 0;
+
+	list-style: none;
+	counter-reset: item;
+}
+
+.jetpack-instruction-list__item {
+	margin-bottom: 1.5rem;
+
+	&::before {
+		content: counter(item);
+		counter-increment: item;
+
+		display: inline-flex;
+		justify-content: center;
+		align-items: center;
+
+		min-width: 1.75em;
+		height: 1.75em;
+		margin-inline-end: 0.75em;
+
+		background-color: var(--studio-jetpack-green-40);
+		border-radius: 50%; /* stylelint-disable-line declaration-property-unit-allowed-list */
+		color: var(--color-text-inverted);
+
+		font-weight: 700;
 	}
 }

--- a/client/my-sites/checkout/checkout-thank-you/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/style.scss
@@ -836,6 +836,8 @@
 }
 
 .jetpack-instruction-list__item {
+	display: flex;
+	flex-direction: row;
 	margin-bottom: 1.5rem;
 
 	&::before {
@@ -856,4 +858,8 @@
 
 		font-weight: 700;
 	}
+}
+
+.jetpack-instruction-list__item .gridicon {
+	margin-bottom: -3px;
 }

--- a/client/my-sites/checkout/checkout-thank-you/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/style.scss
@@ -747,29 +747,28 @@
 	margin-top: 0;
 }
 
-.licensing-thank-you-manual-activation-license-key__key {
+.jetpack-license-key-clipboard {
 	margin-top: 40px;
 }
 
-.licensing-thank-you-manual-activation-license-key__clipboard {
+.jetpack-license-key-clipboard__container {
 	display: flex;
-
 	margin-top: 8px;
+}
 
-	.licensing-thank-you-manual-activation-license-key__input.form-text-input {
-		margin-right: 8px;
+.jetpack-license-key-clipboard__container .jetpack-license-key-clipboard__input.form-text-input {
+	margin-right: 8px;
 
-		background-color: var(--studio-gray-0);
+	background-color: var(--studio-gray-0);
 
-		border: none;
-	}
+	border: none;
 
-	.licensing-thank-you-manual-activation-license-key__input.form-text-input.is-loading {
+	&.is-loading {
 		@include placeholder( --color-neutral-20 );
 	}
 }
 
-.licensing-activation .licensing-thank-you-manual-activation-license-key__button.button {
+.licensing-activation .jetpack-license-key-clipboard__button.button {
 	margin-top: 0;
 	min-width: 100px;
 }

--- a/client/my-sites/checkout/checkout-thank-you/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/style.scss
@@ -768,6 +768,10 @@
 	}
 }
 
+.jetpack-standalone-activation-instructions .jetpack-license-key-clipboard {
+	margin: 32px 0 57.5px;
+}
+
 .licensing-activation .jetpack-license-key-clipboard__button.button {
 	margin-top: 0;
 	min-width: 100px;

--- a/client/my-sites/checkout/checkout-thank-you/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/style.scss
@@ -775,6 +775,8 @@
 .licensing-activation .jetpack-license-key-clipboard__button.button {
 	margin-top: 0;
 	min-width: 100px;
+	background-color: var(--studio-black);
+	color: var(--studio-white);
 }
 
 .jetpack-checkout-thank-you {
@@ -852,9 +854,9 @@
 		height: 1.75em;
 		margin-inline-end: 0.75em;
 
-		background-color: var(--studio-jetpack-green-40);
+		background-color: var(--studio-gray-5);
 		border-radius: 50%; /* stylelint-disable-line declaration-property-unit-allowed-list */
-		color: var(--color-text-inverted);
+		color: var(--color-text-black);
 
 		font-weight: 700;
 	}


### PR DESCRIPTION
## Description
In the new Jetpack standalone onboarding, the instruction page for activating the license key is now merged to the instruction page for installing and activating a Jetpack plugin. This is to simplify the instructions for installing and activating a standalone Jetpack product.


#### Proposed Changes

* Merged license key activation instructions in the activation instruction page.
* Code improvements
    * Add reusable **Jetpack instruction list** component.
    * Add reusable **Jetpack license key clipboard** component.

##### Current instructions (2 pages)
<img width="1223" alt="Screen Shot 2022-10-24 at 3 35 17 PM" src="https://user-images.githubusercontent.com/56598660/197472326-ed54474f-2769-432b-a586-261a05ae7db8.png">
<img width="1225" alt="Screen Shot 2022-10-20 at 3 02 20 PM" src="https://user-images.githubusercontent.com/56598660/197472355-4829f33f-824f-4e76-99c3-cccf4a3783a3.png">

##### New standalone instructions (1 page)
<img width="1219" alt="Screen Shot 2022-10-24 at 3 55 49 PM" src="https://user-images.githubusercontent.com/56598660/197475960-9b80db67-2413-42c0-a85c-a0858269aa50.png">

#### Testing Instructions

1. First we need to generate a **receipt ID** so we can properly verify the new screen.
    * Go to https://cloud.jetpack.com/pricing
    * Purchase a **Jetpack Social** 
    * Proceed to checkout and complete the payment
    * Once you land in the thank you page, copy the receipt ID in the URL. 
    
    <img width="1723" alt="Screen Shot 2022-10-24 at 3 46 40 PM" src="https://user-images.githubusercontent.com/56598660/197482629-70f4c1ff-aae5-4a7a-bd19-324e08948fa0.png">
    
2. Now run this branch by following the steps below (or you can use the Calypso live link commented on this PR)
    * Run `git fetch && git checkout add/new-instructions-for-activating-license`
    * Run `yarn start`

4. Confirm that the new instructions are displayed in the license key activation page for supported products. http://calypso.localhost:3000/checkout/jetpack/thank-you/licensing-manual-activate-instructions/PRODUCT_SLUG?receiptId=RECEIPT_ID or by using the Calypso live link below and appending `/checkout/jetpack/thank-you/licensing-manual-activate-instructions/PRODUCT_SLUG?receiptId=RECEIPT_ID&flags=jetpack/standalone-plugin-onboarding-update-v1`
   * make sure that you replace the PRODUCT_SLUG with a supported product slug (refer to the table below)
   * Make sure that you replace RECEIPT_ID with a valid receipt ID. Use the one you copied earlier.
   * Confirm the instruction includes activating of license key
  
     <img width="564" alt="Screen Shot 2022-10-24 at 4 01 21 PM" src="https://user-images.githubusercontent.com/56598660/197477417-66e5ab59-3275-4ac4-aee9-e4a3a3f48d72.png">
     
    * Confirm that there is no continue button below
     
    <img width="575" alt="Screen Shot 2022-10-24 at 4 02 22 PM" src="https://user-images.githubusercontent.com/56598660/197478003-6024b61d-e779-40b9-a366-ab61fc22d4b1.png">

5. Finally confirm that the non-support product slugs follow the existing onboarding (2 pages). Make sure you modify the PRODUCT_SLUG with the correct one. refer to the table below.
    
     | Product Slug        | New instructions  |
     | ------------- |:-------------:| 
     |  jetpack_boost_yearly | ✅  |
     | jetpack_boost_monthly | ✅  |
     | jetpack_backup | ✅  |
     | jetpack_backup_t1_yearly | ✅  |
     | jetpack_backup_t1_monthly | ✅  |
     | jetpack_backup_t2_yearly | ✅  |
     | jetpack_backup_t2_monthly | ✅  |
     | jetpack_backup_daily | ✅  |
     | jetpack_backup_realtime | ✅  |
     | jetpack_backup_daily_monthly | ✅  |
     | jetpack_backup_realtime_monthly | ✅  |
     | jetpack_scan | ❌  |
     | jetpack_scan_monthly | ❌  |
     | jetpack_scan_realtime | ❌  |
     | jetpack_scan_realtime_monthly | ❌  |
     | jetpack_anti_spam | ❌  |
     | jetpack_anti_spam_monthly | ❌  |
     | jetpack_search | ✅  |
     | jetpack_search_free | ✅  |
     | jetpack_search_monthly | ✅  |
     | jetpack_crm | ✅  |
     | jetpack_crm_monthly | ✅  |
     | jetpack_videopress | ❌  |
     | jetpack_videopress_monthly | ❌  |
     | jetpack_social_basic_yearly | ✅ |
     | jetpack_social_basic_monthly | ✅ |
     | jetpack_personal | ❌  |
     | jetpack_personal_monthly | ❌  |
     | jetpack_premium | ❌  |
     | jetpack_premium_monthly | ❌  |
     | jetpack_business | ❌  |
     | jetpack_business_monthly | ❌  |
     | jetpack_security_t1_yearly | ❌  |
     | jetpack_security_t1_monthly | ❌  |
     | jetpack_security_t2_yearly | ❌  |
     | jetpack_security_t2_monthly | ❌  |
     | jetpack_complete | ❌  |
     | jetpack_complete_monthly | ❌  |
     | jetpack_security_daily | ❌  |
     | jetpack_security_daily_monthly | ❌  |
     | jetpack_security_realtime | ❌  |
     | jetpack_security_realtime_monthly | ❌  |

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1203097885147382-as-1203171921722448