### PR TITLE
Fix padding in add pages modal categories

### DIFF
--- a/packages/page-pattern-modal/src/styles/page-pattern-modal.scss
+++ b/packages/page-pattern-modal/src/styles/page-pattern-modal.scss
@@ -208,7 +208,6 @@ $sidebar-width-desktop: 324px;
 		position: fixed;
 		width: $sidebar-width;
 		padding-right: 22px;
-		overflow: hidden;
 		display: flex;
 		flex-direction: column;
 		top: 63px;

--- a/packages/page-pattern-modal/src/styles/page-pattern-modal.scss
+++ b/packages/page-pattern-modal/src/styles/page-pattern-modal.scss
@@ -239,6 +239,7 @@ $sidebar-width-desktop: 324px;
 	margin-top: 35px;
 	overflow: auto;
 	padding: 2px 0 2px 14px;
+	margin-left: -14px;
 
 	@media screen and ( min-width: $breakpoint-mobile ) {
 		display: block;

--- a/packages/page-pattern-modal/src/styles/page-pattern-modal.scss
+++ b/packages/page-pattern-modal/src/styles/page-pattern-modal.scss
@@ -235,7 +235,7 @@ $sidebar-width-desktop: 324px;
 .page-pattern-modal__category-list {
 	display: none;
 	margin: 0;
-	margin-top: 35px;
+	margin-top: 33px;
 	overflow: auto;
 	padding: 2px 0 2px 14px;
 	margin-left: -14px;

--- a/packages/page-pattern-modal/src/styles/page-pattern-modal.scss
+++ b/packages/page-pattern-modal/src/styles/page-pattern-modal.scss
@@ -238,6 +238,7 @@ $sidebar-width-desktop: 324px;
 	margin: 0;
 	margin-top: 35px;
 	overflow: auto;
+	padding: 2px 0 2px 14px;
 
 	@media screen and ( min-width: $breakpoint-mobile ) {
 		display: block;


### PR DESCRIPTION
#### Proposed Changes

* Increase the padding to show the border style when a category link is focused

The deployment of the ETK plugin is required because this CSS file is loaded from the ETK.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the modal to add a page (from the admin or the page editor)
* Click on the categories 
* Check the border of the link. It should be visible.

|Before|After|
|-------|-----|
|<img width="329" alt="Screen Shot 2565-10-20 at 16 29 27" src="https://user-images.githubusercontent.com/1881481/196916965-7428b36c-e577-4758-b706-6a38df1dfc7f.png">|<img width="325" alt="Screen Shot 2565-10-20 at 16 29 48" src="https://user-images.githubusercontent.com/1881481/196916706-1ec22eb3-cbe5-4b23-a61d-fa0d9393811e.png">|

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
