### PR TITLE
Page Pattern: Fix site title, tagline and logo in the preview

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-button/index.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-button/index.ts
@@ -14,7 +14,9 @@ let handled = false;
 domReady( () => {
 	// If site launch options does not exist, stop.
 	const siteLaunchOptions = window.wpcomEditorSiteLaunch;
-	if ( ! siteLaunchOptions ) return;
+	if ( ! siteLaunchOptions ) {
+		return;
+	}
 
 	// Don't proceed if this function has already run
 	if ( handled ) {

--- a/apps/editing-toolkit/editing-toolkit-plugin/global-styles/src/global-styles-sidebar.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/global-styles/src/global-styles-sidebar.js
@@ -37,7 +37,7 @@ const PanelActionButtons = ( {
 			{ __( 'Reset', 'full-site-editing' ) }
 		</Button>
 		<Button
-			className={ 'global-styles-sidebar__publish-button' }
+			className="global-styles-sidebar__publish-button"
 			disabled={ ! hasLocalChanges }
 			isPrimary
 			onClick={ publishAction }
@@ -82,7 +82,7 @@ export default ( {
 			</PluginSidebarMoreMenuItem>
 			<PluginSidebar
 				icon={ typography }
-				name={ 'global-styles' }
+				name="global-styles"
 				title={ __( 'Global Styles', 'full-site-editing' ) }
 				className="global-styles-sidebar"
 			>
@@ -142,7 +142,7 @@ export default ( {
 						hasLocalChanges={ hasLocalChanges }
 						publishAction={ publish }
 						resetAction={ resetLocalChanges }
-						className={ 'global-styles-sidebar__panel-action-buttons' }
+						className="global-styles-sidebar__panel-action-buttons"
 					/>
 				</PanelBody>
 			</PluginSidebar>

--- a/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/class-starter-page-templates.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/class-starter-page-templates.php
@@ -185,7 +185,6 @@ class Starter_Page_Templates {
 				// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 				'screenAction' => isset( $_GET['new-homepage'] ) ? 'add' : $screen->action,
 				'stylesheet'   => get_stylesheet(),
-				'theme'        => normalize_theme_slug( get_stylesheet() ),
 				// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 				'locale'       => $this->get_verticals_locale(),
 			)

--- a/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/class-starter-page-templates.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/class-starter-page-templates.php
@@ -184,6 +184,7 @@ class Starter_Page_Templates {
 				'templates'    => array_merge( $default_templates, $page_templates ),
 				// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 				'screenAction' => isset( $_GET['new-homepage'] ) ? 'add' : $screen->action,
+				'stylesheet'   => get_stylesheet(),
 				'theme'        => normalize_theme_slug( get_stylesheet() ),
 				// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 				'locale'       => $this->get_verticals_locale(),

--- a/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/index.tsx
@@ -12,7 +12,6 @@ declare global {
 			templates?: PatternDefinition[];
 			locale?: string;
 			stylesheet?: string;
-			theme?: string;
 			screenAction?: string;
 			tracksUserData?: Parameters< typeof initializeTracksWithIdentity >[ 0 ];
 		};
@@ -25,7 +24,6 @@ const {
 	tracksUserData,
 	screenAction,
 	stylesheet,
-	theme,
 	locale,
 } = window.starterPageTemplatesConfig ?? {};
 
@@ -41,14 +39,7 @@ if ( screenAction === 'add' ) {
 // Always register ability to open from document sidebar.
 registerPlugin( 'page-patterns', {
 	render: () => {
-		return (
-			<PagePatternsPlugin
-				patterns={ patterns }
-				stylesheet={ stylesheet }
-				theme={ theme }
-				locale={ locale }
-			/>
-		);
+		return <PagePatternsPlugin patterns={ patterns } stylesheet={ stylesheet } locale={ locale } />;
 	},
 
 	// `registerPlugin()` types assume `icon` is mandatory however it isn't

--- a/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/index.tsx
@@ -11,6 +11,7 @@ declare global {
 		starterPageTemplatesConfig?: {
 			templates?: PatternDefinition[];
 			locale?: string;
+			stylesheet?: string;
 			theme?: string;
 			screenAction?: string;
 			tracksUserData?: Parameters< typeof initializeTracksWithIdentity >[ 0 ];
@@ -23,6 +24,7 @@ const {
 	templates: patterns = [],
 	tracksUserData,
 	screenAction,
+	stylesheet,
 	theme,
 	locale,
 } = window.starterPageTemplatesConfig ?? {};
@@ -39,7 +41,14 @@ if ( screenAction === 'add' ) {
 // Always register ability to open from document sidebar.
 registerPlugin( 'page-patterns', {
 	render: () => {
-		return <PagePatternsPlugin patterns={ patterns } theme={ theme } locale={ locale } />;
+		return (
+			<PagePatternsPlugin
+				patterns={ patterns }
+				stylesheet={ stylesheet }
+				theme={ theme }
+				locale={ locale }
+			/>
+		);
 	},
 
 	// `registerPlugin()` types assume `icon` is mandatory however it isn't

--- a/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/page-patterns-plugin.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/page-patterns-plugin.tsx
@@ -13,7 +13,6 @@ interface PagePatternsPluginProps {
 	patterns: PatternDefinition[];
 	locale?: string;
 	stylesheet?: string;
-	theme?: string;
 }
 
 export function PagePatternsPlugin( props: PagePatternsPluginProps ) {

--- a/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/page-patterns-plugin.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/page-patterns-plugin.tsx
@@ -12,6 +12,7 @@ const INSERTING_HOOK_NAMESPACE = 'automattic/full-site-editing/inserting-pattern
 interface PagePatternsPluginProps {
 	patterns: PatternDefinition[];
 	locale?: string;
+	stylesheet?: string;
 	theme?: string;
 }
 

--- a/packages/page-pattern-modal/src/components/page-pattern-modal.tsx
+++ b/packages/page-pattern-modal/src/components/page-pattern-modal.tsx
@@ -27,7 +27,6 @@ interface PagePatternModalProps {
 	siteInformation?: Record< string, string >;
 	patterns: PatternDefinition[];
 	stylesheet?: string;
-	theme?: string;
 	title?: string;
 	description?: string;
 }
@@ -303,7 +302,6 @@ class PagePatternModal extends Component< PagePatternModalProps, PagePatternModa
 				patterns={ filteredPatternsList }
 				onPatternSelect={ this.setPattern }
 				stylesheet={ this.props.stylesheet }
-				theme={ this.props.theme }
 				locale={ this.props.locale }
 				siteInformation={ this.props.siteInformation }
 			/>

--- a/packages/page-pattern-modal/src/components/page-pattern-modal.tsx
+++ b/packages/page-pattern-modal/src/components/page-pattern-modal.tsx
@@ -26,6 +26,7 @@ interface PagePatternModalProps {
 	onClose: () => void;
 	siteInformation?: Record< string, string >;
 	patterns: PatternDefinition[];
+	stylesheet?: string;
 	theme?: string;
 	title?: string;
 	description?: string;
@@ -301,6 +302,7 @@ class PagePatternModal extends Component< PagePatternModalProps, PagePatternModa
 				legendLabel={ groupTitle }
 				patterns={ filteredPatternsList }
 				onPatternSelect={ this.setPattern }
+				stylesheet={ this.props.stylesheet }
 				theme={ this.props.theme }
 				locale={ this.props.locale }
 				siteInformation={ this.props.siteInformation }

--- a/packages/page-pattern-modal/src/components/pattern-selector-control.tsx
+++ b/packages/page-pattern-modal/src/components/pattern-selector-control.tsx
@@ -15,6 +15,7 @@ interface PatternSelectorControlProps {
 	onPatternSelect: ( patternName: string ) => void;
 	siteInformation?: Record< string, string >;
 	patterns?: PatternDefinition[];
+	stylesheet?: string;
 	theme?: string;
 }
 
@@ -23,6 +24,7 @@ export const PatternSelectorControl = ( {
 	label,
 	legendLabel,
 	patterns = [],
+	stylesheet = '',
 	theme = 'maywood',
 	locale = 'en',
 	onPatternSelect = noop,
@@ -51,6 +53,7 @@ export const PatternSelectorControl = ( {
 							description={ description }
 							onSelect={ onPatternSelect }
 							patternPostID={ ID }
+							stylesheet={ stylesheet }
 							theme={ theme }
 							locale={ locale }
 						/>

--- a/packages/page-pattern-modal/src/components/pattern-selector-control.tsx
+++ b/packages/page-pattern-modal/src/components/pattern-selector-control.tsx
@@ -16,7 +16,6 @@ interface PatternSelectorControlProps {
 	siteInformation?: Record< string, string >;
 	patterns?: PatternDefinition[];
 	stylesheet?: string;
-	theme?: string;
 }
 
 export const PatternSelectorControl = ( {
@@ -25,7 +24,6 @@ export const PatternSelectorControl = ( {
 	legendLabel,
 	patterns = [],
 	stylesheet = '',
-	theme = 'maywood',
 	locale = 'en',
 	onPatternSelect = noop,
 	siteInformation = {},
@@ -54,7 +52,6 @@ export const PatternSelectorControl = ( {
 							onSelect={ onPatternSelect }
 							patternPostID={ ID }
 							stylesheet={ stylesheet }
-							theme={ theme }
 							locale={ locale }
 						/>
 					</li>

--- a/packages/page-pattern-modal/src/components/pattern-selector-item.tsx
+++ b/packages/page-pattern-modal/src/components/pattern-selector-item.tsx
@@ -21,7 +21,7 @@ const getPatternPreviewUrl = (
 	patternId: string
 ): string => {
 	const params = new URLSearchParams( {
-		wpcom_site: window._currentSiteId.toString(),
+		demo_site: window._currentSiteId.toString(),
 		stylesheet,
 		source_site: PATTERN_SOURCE_SITE,
 		pattern_id: patternId,

--- a/packages/page-pattern-modal/src/components/pattern-selector-item.tsx
+++ b/packages/page-pattern-modal/src/components/pattern-selector-item.tsx
@@ -6,25 +6,39 @@ interface PatternSelectorItemProps {
 	onSelect: ( value: string ) => void;
 	patternPostID: number | null;
 	title?: string;
+	stylesheet: string;
 	theme: string;
 	value?: string;
 }
 
+const PATTERN_PREVIEW_ENDPOINT = 'https://public-api.wordpress.com/wpcom/v2/block-previews/pattern';
+
+const PATTERN_SOURCE_SITE = 'dotcompatterns.wordpress.com';
+
+const getPatternPreviewUrl = (
+	stylesheet: string,
+	language: string,
+	patternId: string
+): string => {
+	const params = new URLSearchParams( {
+		wpcom_site: window._currentSiteId.toString(),
+		stylesheet,
+		source_site: PATTERN_SOURCE_SITE,
+		pattern_id: patternId,
+		language,
+	} );
+
+	return `${ PATTERN_PREVIEW_ENDPOINT }?${ params }`;
+};
+
 const PatternSelectorItem = ( props: PatternSelectorItemProps ) => {
-	const { value, onSelect, title, description, theme, locale, patternPostID } = props;
+	const { value, onSelect, title, description, stylesheet, locale, patternPostID } = props;
 
 	if ( title == null || value == null ) {
 		return null;
 	}
 
-	const designsEndpoint = 'https://public-api.wordpress.com/rest/v1/template/demo/';
-	const sourceSiteUrl = 'dotcompatterns.wordpress.com';
-
-	const previewUrl = `${ designsEndpoint }${ encodeURIComponent( theme ) }/${ encodeURIComponent(
-		sourceSiteUrl
-	) }/?post_id=${ encodeURIComponent( patternPostID ?? '' ) }&language=${ encodeURIComponent(
-		locale
-	) }`;
+	const previewUrl = getPatternPreviewUrl( stylesheet, locale, String( patternPostID ) );
 
 	const mShotsOptions = {
 		vpw: 1024,

--- a/packages/page-pattern-modal/src/components/pattern-selector-item.tsx
+++ b/packages/page-pattern-modal/src/components/pattern-selector-item.tsx
@@ -7,7 +7,6 @@ interface PatternSelectorItemProps {
 	patternPostID: number | null;
 	title?: string;
 	stylesheet: string;
-	theme: string;
 	value?: string;
 }
 

--- a/packages/page-pattern-modal/src/components/test/page-pattern-modal.tsx
+++ b/packages/page-pattern-modal/src/components/test/page-pattern-modal.tsx
@@ -29,6 +29,14 @@ const patterns = [
 	},
 ];
 
+beforeAll( () => {
+	window._currentSiteId = 123;
+} );
+
+afterAll( () => {
+	delete window._currentSiteId;
+} );
+
 let originalReact;
 beforeEach( () => {
 	// The component uses `@wordpress/element` but the test assumes the React


### PR DESCRIPTION
#### Proposed Changes

* Switch to the `block-previews/pattern` endpoint
* Pass `wpcom_site` to that endpoint and the site-related block will based on the site we passed

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Proxy <your_site> and widgets.wp.com to your sandbox
* run `cd apps/editing-toolkit && yarn dev --sync`. Or run `install-plugin.sh editing-toolkit fix/page-pattern-modal-preview` on your sandbox.
* Go to "Pages > Add New"
* When you see the page pattern modal, select "Link in bio" category
* Check the site title, tagline and logo are rendered correctly

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1666257227083559-slack-CRWCHQGUB