### PR TITLE
Update/subscribers label adjustments

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/subscribers/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/subscribers/index.tsx
@@ -30,6 +30,7 @@ const Subscribers: Step = function ( { navigation } ) {
 					{ site?.ID && (
 						<AddSubscriberForm
 							siteId={ site.ID }
+							isSiteOnFreePlan={ !! site?.plan?.is_free }
 							flowName="onboarding_subscribers"
 							submitBtnName={ __( 'Continue' ) }
 							onImportFinished={ handleSubmit }

--- a/client/my-sites/people/followers-list/followers.jsx
+++ b/client/my-sites/people/followers-list/followers.jsx
@@ -122,6 +122,9 @@ class Followers extends Component {
 		}
 
 		let emptyTitle;
+		const site = this.props.site;
+		const isSiteOnFreePlan = site && site.plan.is_free;
+
 		if ( this.siteHasNoFollowers() ) {
 			if ( 'email' === this.props.type ) {
 				if ( this.props.includeSubscriberImporter ) {
@@ -135,6 +138,7 @@ class Followers extends Component {
 							>
 								<AddSubscriberForm
 									siteId={ this.props.site.ID }
+									isSiteOnFreePlan={ isSiteOnFreePlan }
 									flowName="people"
 									showSubtitle={ true }
 									showCsvUpload={ isEnabled( 'subscriber-csv-upload' ) }

--- a/client/my-sites/people/people-add-subscribers/index.jsx
+++ b/client/my-sites/people/people-add-subscribers/index.jsx
@@ -42,6 +42,7 @@ class PeopleInvites extends PureComponent {
 	render() {
 		const { site, canViewPeople, translate } = this.props;
 		const siteId = site && site.ID;
+		const isSiteOnFreePlan = site && site.plan.is_free;
 
 		if ( siteId && ! canViewPeople ) {
 			return (
@@ -75,6 +76,7 @@ class PeopleInvites extends PureComponent {
 					>
 						<AddSubscriberForm
 							siteId={ this.props.site.ID }
+							isSiteOnFreePlan={ isSiteOnFreePlan }
 							flowName="people"
 							showTitle={ false }
 							showFormManualListLabel={ true }

--- a/packages/subscriber/src/components/add-form/index.tsx
+++ b/packages/subscriber/src/components/add-form/index.tsx
@@ -292,8 +292,7 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 
 	function renderImportCsvDisclaimerMsg() {
 		return (
-			isSelectedFileValid &&
-			selectedFile && (
+			( !! getValidEmails().length || ( isSelectedFileValid && selectedFile ) ) && (
 				<p className="add-subscriber__form--disclaimer">
 					{ createInterpolateElement(
 						sprintf(

--- a/packages/subscriber/src/components/add-form/index.tsx
+++ b/packages/subscriber/src/components/add-form/index.tsx
@@ -26,6 +26,7 @@ import './style.scss';
 
 interface Props {
 	siteId: number;
+	isSiteOnFreePlan?: boolean;
 	flowName?: string;
 	showTitle?: boolean;
 	showSubtitle?: boolean;
@@ -47,6 +48,7 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 	};
 	const {
 		siteId,
+		isSiteOnFreePlan,
 		flowName,
 		showTitle = true,
 		showSubtitle,
@@ -318,18 +320,24 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 	}
 
 	function renderImportCsvLabel() {
+		const ariaLabelMsg = isSiteOnFreePlan
+			? __(
+					'Or bring your mailing list up to 100 emails from other newsletter services by uploading a CSV file.'
+			  )
+			: __( 'Or bring your mailing list from other newsletter services by uploading a CSV file.' );
+
 		return (
 			isSelectedFileValid &&
 			! selectedFile && (
-				<label
-					aria-label={ __(
-						'Or bring your mailing list from other newsletter services by uploading a CSV file.'
-					) }
-				>
+				<label aria-label={ ariaLabelMsg }>
 					{ createInterpolateElement(
-						__(
-							'Or bring your mailing list from other newsletter services by <uploadBtn>uploading a CSV file.</uploadBtn>'
-						),
+						isSiteOnFreePlan
+							? __(
+									'Or bring your mailing list up to 100 emails from other newsletter services by <uploadBtn>uploading a CSV file.</uploadBtn>'
+							  )
+							: __(
+									'Or bring your mailing list from other newsletter services by <uploadBtn>uploading a CSV file.</uploadBtn>'
+							  ),
 						{ uploadBtn: formFileUploadElement }
 					) }
 				</label>

--- a/packages/subscriber/src/components/add-form/index.tsx
+++ b/packages/subscriber/src/components/add-form/index.tsx
@@ -298,7 +298,7 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 						sprintf(
 							/* translators: the first string variable shows CTA button name */
 							__(
-								'By clicking "%s", you represent that you\'ve obtained the appropriate consent to email each person on your list. <Button>Learn more</Button>'
+								'By clicking "%s", you represent that you\'ve obtained the appropriate consent to email each person. <Button>Learn more</Button>'
 							),
 							submitBtnName
 						),


### PR DESCRIPTION
#### Proposed Changes

* Shown disclaimer message for both, manual list and CSV
* Updated labels text depending on if a site is on a free plan or not

#### Testing Instructions

* Go to `/setup/subscribers?flow=newslatter&siteSlug={SLUG}`
* Check if there are described changes

#### Screenshots
<table>
<tr>
<td width="50%">Before</td>
<td width="50%">After</td>
</tr>

<tr>
<td width="50%">
<img width="432" alt="Screenshot 2022-10-21 at 12 31 53" src="https://user-images.githubusercontent.com/1241413/197176239-1e2ac660-a4c6-40ee-a12b-373c83ac7f7a.png">
</td>
<td width="50%">
<img src="https://user-images.githubusercontent.com/1241413/197176567-74664364-86a2-4dde-9957-20a25e4dc2af.jpg" />
</td>
</tr>

<tr>
<td width="50%">
<img width="379" alt="Screenshot 2022-10-21 at 12 32 33" src="https://user-images.githubusercontent.com/1241413/197176867-3a0e58bb-3cbe-4f56-9728-d7dc0a691156.png">

</td>
<td width="50%">
<img width="395" alt="Screenshot 2022-10-21 at 12 32 27" src="https://user-images.githubusercontent.com/1241413/197176907-f92a8b34-ca0b-4dbd-983a-fbd5cbaeed88.png">
</td>
</tr>

<tr>
<td>Free plan</td>
<td>Paid plan</td>
</tr>

<tr>
<td width="50%">
<img width="394" alt="Screenshot 2022-10-21 at 12 33 40" src="https://user-images.githubusercontent.com/1241413/197177034-6501a301-9507-4b42-b7ff-fd6a7807cbfd.png">

</td>
<td width="50%">
<img width="392" alt="Screenshot 2022-10-21 at 12 33 56" src="https://user-images.githubusercontent.com/1241413/197177051-c782163c-857a-4bbe-89a7-22102846db0f.png">
</td>
</tr>

</table>

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #69060
