### PR TITLE
Revert "Fix 2FA signup link for wpcc flow"

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -154,8 +154,6 @@ class Login extends Component {
 					twoFactorAuthType: authType,
 					locale: this.props.locale,
 					isPartnerSignup: this.props.isPartnerSignup,
-					oauth2ClientId: this.props.oauth2Client?.id,
-					redirectTo: this.props.redirectTo,
 				} )
 			);
 		}


### PR DESCRIPTION
Reverts Automattic/wp-calypso#68959 due to a bug when using jestpack sso

## Test instructions

1. Use a vip site 
2. Make sure your wpcom 2fa is enabled
3. Sign in with wpcom account
4. Change the url host with your local site host
5. Confirm you can login to the site