### PR TITLE
Adding themes/subscription-purchases feature flag

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -173,6 +173,7 @@
 		"themes/atomic-homepage-replace": true,
 		"themes/plugin-bundling": true,
 		"themes/premium": true,
+		"themes/subscription-purchases": true,
 		"titan/iframe-control-panel": false,
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -117,6 +117,7 @@
 		"themes/atomic-homepage-replace": true,
 		"themes/plugin-bundling": true,
 		"themes/premium": true,
+		"themes/subscription-purchases": false,
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,
 		"upgrades/wpcom-monthly-plans": true,

--- a/config/production.json
+++ b/config/production.json
@@ -137,6 +137,7 @@
 		"themes/atomic-homepage-replace": true,
 		"themes/plugin-bundling": true,
 		"themes/premium": true,
+		"themes/subscription-purchases": false,
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,
 		"upgrades/wpcom-monthly-plans": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -134,6 +134,7 @@
 		"themes/atomic-homepage-replace": true,
 		"themes/plugin-bundling": true,
 		"themes/premium": true,
+		"themes/subscription-purchases": false,
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,
 		"upgrades/wpcom-monthly-plans": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -143,6 +143,7 @@
 		"themes/atomic-homepage-replace": true,
 		"themes/plugin-bundling": true,
 		"themes/premium": true,
+		"themes/subscription-purchases": false,
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,
 		"upgrades/wpcom-monthly-plans": true,


### PR DESCRIPTION
#### Proposed Changes

This PR adds a feature flag called `themes/subscription-purchases` and enables it in dev. This will be used as part of the implementation of subscription theme purchases (https://github.com/Automattic/wp-calypso/issues/68288).

#### Testing Instructions

N/A

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #68288
