### PR TITLE
Add FAQ entry for multiyear pricing

### DIFF
--- a/client/my-sites/plans/jetpack-plans/faq/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/faq/index.tsx
@@ -130,6 +130,19 @@ const JetpackFAQ: FC = () => {
 					) }
 				</FoldableFAQ>
 				<FoldableFAQ
+					id="multiyear-plans"
+					question={ translate( 'Do you have discounts for multi-year plans?' ) }
+					onToggle={ onFaqToggle }
+					className="jetpack-faq__section"
+				>
+					{ translate(
+						"We currently do not offer multi-year subscriptions or discounts for Jetpack products. However if you're an Enterprise, {{helpLink}}contact us{{/helpLink}}.",
+						{
+							components: { helpLink: getHelpLink( 'multiyear-questions' ) },
+						}
+					) }
+				</FoldableFAQ>
+				<FoldableFAQ
 					id="wpcom-account"
 					question={ translate( 'Why do I need a WordPress.com account?' ) }
 					onToggle={ onFaqToggle }


### PR DESCRIPTION

![Screen Shot 2022-10-26 at 7 33 00 AM](https://user-images.githubusercontent.com/12895386/198015835-db5516c8-3508-4496-baed-a74bba9d48f5.png)


#### Proposed Changes

* per 1202858161751496-as-1203136959907407 this PR will add a question to the FAQ at https://jetpack.com/pricing?view=products#multiyear-plans-faq
* As requested in the card, there are unique IDs that will be sent to the same tracks events the other questions use

#### Testing Instructions

* Load the PR and then launch http://jetpack.cloud.localhost:3000/pricing?view=products#multiyear-plans-faq verify there is now a question titled "Do you have discounts for multi-year plans?" and it expands properly, the contact us link works and that no other FAQ entries are broken.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - 0-as-1203136959907407