### PR TITLE
When registering patterns include postTypes

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
@@ -117,26 +117,20 @@ class Block_Patterns_From_API {
 					$viewport_width = $viewport_width < 320 ? 320 : $viewport_width;
 					$pattern_name   = self::PATTERN_NAMESPACE . $pattern['name'];
 					$block_types    = $this->utils->maybe_get_pattern_block_types_from_pattern_meta( $pattern );
-					$pattern_props  = array(
-						'title'         => $pattern['title'],
-						'description'   => $pattern['description'],
-						'content'       => $pattern['html'],
-						'viewportWidth' => $viewport_width,
-						'categories'    => array_keys(
-							$pattern['categories']
-						),
-						'isPremium'     => $is_premium,
-						'blockTypes'    => $block_types,
-					);
-
-					$post_types = $this->utils->get_pattern_post_types_from_pattern( $pattern_props );
-					if ( $post_types ) {
-						$pattern_props['postTypes'] = $post_types;
-					}
 
 					$results[ $pattern_name ] = register_block_pattern(
 						$pattern_name,
-						$pattern_props
+						array(
+							'title'         => $pattern['title'],
+							'description'   => $pattern['description'],
+							'content'       => $pattern['html'],
+							'viewportWidth' => $viewport_width,
+							'categories'    => array_keys(
+								$pattern['categories']
+							),
+							'isPremium'     => $is_premium,
+							'blockTypes'    => $block_types,
+						)
 					);
 				}
 			}

--- a/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
@@ -144,6 +144,8 @@ class Block_Patterns_From_API {
 
 		$this->update_core_patterns_with_wpcom_categories();
 
+		$this->update_pattern_post_types();
+
 		return $results;
 	}
 
@@ -255,6 +257,30 @@ class Block_Patterns_From_API {
 						$pattern_properties
 					);
 				}
+			}
+		}
+	}
+
+	/**
+	 * Ensure that all patterns with a blockType property are registered with appropriate postTypes.
+	 */
+	private function update_pattern_post_types() {
+		if ( ! class_exists( 'WP_Block_Patterns_Registry' ) ) {
+			return;
+		}
+		foreach ( \WP_Block_Patterns_Registry::get_instance()->get_all_registered() as $pattern ) {
+			if ( array_key_exists( 'postTypes', $pattern ) && $pattern['postTypes'] ) {
+				continue;
+			}
+
+			$post_types = $this->utils->get_pattern_post_types_from_pattern( $pattern );
+			if ( $post_types ) {
+				unregister_block_pattern( $pattern['name'] );
+
+				$pattern['postTypes'] = $post_types;
+				$pattern_name         = $pattern['name'];
+				unset( $pattern['name'] );
+				register_block_pattern( $pattern_name, $pattern );
 			}
 		}
 	}

--- a/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
@@ -117,20 +117,26 @@ class Block_Patterns_From_API {
 					$viewport_width = $viewport_width < 320 ? 320 : $viewport_width;
 					$pattern_name   = self::PATTERN_NAMESPACE . $pattern['name'];
 					$block_types    = $this->utils->maybe_get_pattern_block_types_from_pattern_meta( $pattern );
+					$pattern_props  = array(
+						'title'         => $pattern['title'],
+						'description'   => $pattern['description'],
+						'content'       => $pattern['html'],
+						'viewportWidth' => $viewport_width,
+						'categories'    => array_keys(
+							$pattern['categories']
+						),
+						'isPremium'     => $is_premium,
+						'blockTypes'    => $block_types,
+					);
+
+					$post_types = $this->utils->get_pattern_post_types_from_pattern( $pattern_props );
+					if ( $post_types ) {
+						$pattern_props['postTypes'] = $post_types;
+					}
 
 					$results[ $pattern_name ] = register_block_pattern(
 						$pattern_name,
-						array(
-							'title'         => $pattern['title'],
-							'description'   => $pattern['description'],
-							'content'       => $pattern['html'],
-							'viewportWidth' => $viewport_width,
-							'categories'    => array_keys(
-								$pattern['categories']
-							),
-							'isPremium'     => $is_premium,
-							'blockTypes'    => $block_types,
-						)
+						$pattern_props
 					);
 				}
 			}
@@ -253,4 +259,3 @@ class Block_Patterns_From_API {
 		}
 	}
 }
-

--- a/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-utils.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-utils.php
@@ -117,20 +117,27 @@ class Block_Patterns_Utils {
 	}
 
 	/**
-	 * Check for post type values in a pattern array
+	 * Return pattern post types based on the pattern's blockTypes.
 	 *
 	 * @param array $pattern A pattern array such as is passed to `register_block_pattern`.
 	 *
-	 * @return array $postTypes An array of post type names.
+	 * @return array $postTypes An array of post type names such as is passed to `register_block_pattern`.
 	 */
 	public function get_pattern_post_types_from_pattern( $pattern ) {
-		$post_types        = array();
+		$post_types = array_key_exists( 'postTypes', $pattern ) ? $pattern['postTypes'] : array();
+		if ( $post_types ) {
+			// If some postTypes are explicitly set then respect the pattern author's intent.
+			return $post_types;
+		}
+
 		$block_types       = array_key_exists( 'blockTypes', $pattern ) ? $pattern['blockTypes'] : array();
 		$block_types_count = count( $block_types );
-		// If all of a patterns blockTypes are template-parts then limit the
-		// postTypes to just the template related types.
+		// If all of a patterns blockTypes are template-parts then limit the postTypes to just
+		// the template related types and to pages - this is to avoid the pattern appearing in
+		// the inserter for posts and other post types. Pages are included because it's not unusual
+		// to use a blank template and add a specific header and footer to a page.
 		if ( $block_types_count && count( array_filter( $block_types, fn( $block_type) => preg_match( '#core/template-part/#', $block_type ) ) ) === $block_types_count ) {
-			$post_types = array( 'wp_template', 'wp_template_part' );
+			$post_types = array( 'wp_template', 'wp_template_part', 'page' );
 		}
 		return $post_types;
 	}

--- a/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-utils.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-utils.php
@@ -125,7 +125,7 @@ class Block_Patterns_Utils {
 	 */
 	public function get_pattern_post_types_from_pattern( $pattern ) {
 		$post_types        = array();
-		$block_types       = $pattern['blockTypes'];
+		$block_types       = array_key_exists( 'blockTypes', $pattern ) ? $pattern['blockTypes'] : array();
 		$block_types_count = count( $block_types );
 		// If all of a patterns blockTypes are template-parts then limit the
 		// postTypes to just the template related types.

--- a/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-utils.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-utils.php
@@ -115,4 +115,23 @@ class Block_Patterns_Utils {
 
 		return $block_types;
 	}
+
+	/**
+	 * Check for post type values in a pattern array
+	 *
+	 * @param array $pattern A pattern array such as is passed to `register_block_pattern`.
+	 *
+	 * @return array $postTypes An array of post type names.
+	 */
+	public function get_pattern_post_types_from_pattern( $pattern ) {
+		$post_types        = array();
+		$block_types       = $pattern['blockTypes'];
+		$block_types_count = count( $block_types );
+		// If all of a patterns blockTypes are template-parts then limit the
+		// postTypes to just the template related types.
+		if ( $block_types_count && count( array_filter( $block_types, fn( $block_type) => preg_match( '#core/template-part/#', $block_type ) ) ) === $block_types_count ) {
+			$post_types = array( 'wp_template', 'wp_template_part' );
+		}
+		return $post_types;
+	}
 }

--- a/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/test/class-block-patterns-utils-test.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/test/class-block-patterns-utils-test.php
@@ -63,7 +63,7 @@ class Block_Patterns_Utils_Test extends TestCase {
 	 * Tests that template-based post types are generated from block types
 	 */
 	public function test_should_return_post_types_from_pattern() {
-		$pattern = array( 'blockTypes' => 'core/template-part/header' );
+		$pattern = array( 'blockTypes' => array( 'core/template-part/header' ) );
 
 		$post_types = $this->utils->get_pattern_post_types_from_pattern( $pattern );
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/test/class-block-patterns-utils-test.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/test/class-block-patterns-utils-test.php
@@ -67,7 +67,7 @@ class Block_Patterns_Utils_Test extends TestCase {
 
 		$post_types = $this->utils->get_pattern_post_types_from_pattern( $pattern );
 
-		$this->assertEquals( array( 'wp_template', 'wp_template_part', 'post' ), $post_types );
+		$this->assertEquals( array( 'wp_template', 'wp_template_part', 'page' ), $post_types );
 	}
 
 	/**

--- a/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/test/class-block-patterns-utils-test.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/test/class-block-patterns-utils-test.php
@@ -21,7 +21,7 @@ class Block_Patterns_Utils_Test extends TestCase {
 	/**
 	 * Block_Patterns_Utils
 	 *
-	 * @var object
+	 * @var Block_Patterns_Utils
 	 */
 	protected $utils;
 
@@ -57,6 +57,26 @@ class Block_Patterns_Utils_Test extends TestCase {
 		$block_types  = $this->utils->maybe_get_pattern_block_types_from_pattern_meta( $test_pattern );
 
 		$this->assertEquals( array( 'core/template-part/footer' ), $block_types );
+	}
+
+	/**
+	 * Tests that template-based post types are generated from block types
+	 */
+	public function test_should_return_post_types_from_pattern() {
+		$pattern = array( 'blockTypes' => 'core/template-part/header' );
+
+		$post_types = $this->utils->get_pattern_post_types_from_pattern( $pattern );
+
+		$this->assertEquals( array( 'wp_template', 'wp_template_part' ), $post_types );
+	}
+
+	/**
+	 * Tests that template-based post types are not generated without block types
+	 */
+	public function test_should_return_empty_array_if_nothing_to_parse() {
+		$post_types = $this->utils->get_pattern_post_types_from_pattern( array() );
+
+		$this->assertEquals( array(), $post_types );
 	}
 
 	/**

--- a/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/test/class-block-patterns-utils-test.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/test/class-block-patterns-utils-test.php
@@ -67,7 +67,7 @@ class Block_Patterns_Utils_Test extends TestCase {
 
 		$post_types = $this->utils->get_pattern_post_types_from_pattern( $pattern );
 
-		$this->assertEquals( array( 'wp_template', 'wp_template_part' ), $post_types );
+		$this->assertEquals( array( 'wp_template', 'wp_template_part', 'post' ), $post_types );
 	}
 
 	/**
@@ -77,6 +77,20 @@ class Block_Patterns_Utils_Test extends TestCase {
 		$post_types = $this->utils->get_pattern_post_types_from_pattern( array() );
 
 		$this->assertEquals( array(), $post_types );
+	}
+
+	/**
+	 * Tests that existing postTypes are preserved without modification
+	 */
+	public function test_should_not_modify_existing_post_types() {
+		$pattern = array(
+			'blockTypes' => array( 'core/template-part/header' ),
+			'postTypes'  => array( 'post' ),
+		);
+
+		$post_types = $this->utils->get_pattern_post_types_from_pattern( $pattern );
+
+		$this->assertEquals( array( 'post' ), $post_types );
 	}
 
 	/**


### PR DESCRIPTION
#### Proposed Changes

When registering block patterns from APIs set the [`postTypes`](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-patterns/#register_block_pattern) pattern property to `wp_template` and `wp_template_part` for patterns that have a block_type of `core/template-part/*`.

The practical effect of this right now is that header and footer patterns from our pattern repositories will only be offered inside the site editor and not inside the post or page editor.

The downside is that header and footer categories will still exist, as core and themes generally don't seem to have enacted this change yet. I think this may make this change confusing with little gain, but we need to break the chicken/egg cycle somewhere


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to wordpress.com and create a new post
* Open the pattern selector (big plus top left)
* Change category to footers and see a big list including patterns like 'Simple centered footer'
* Apply the update using the instructions below
* You may also need to add `define('WP_DISABLE_PATTERN_CACHE',1);` to your 0-sandbox.php
* Refresh the page and open up the pattern selector again
* Note that there are fewer patterns under headers and footers. All of the dotcompatterns no longer appear including 'Simple centered footer'
* Open up the site-editor
* Open up the patterns, see that the full pattern list is in headers and footers again, including everything from dotcompatterns and  'Simple centered footer'
* Note that this only affect headers and footers

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #66628
