### PR TITLE
Plugin Details: Make the plugin content section to start right after the header

### DIFF
--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -102,6 +102,7 @@ body.is-section-plugins.theme-default.color-scheme {
 	grid-template-areas:
 		"header header actions"
 		"content content actions";
+	grid-auto-rows: auto 1fr;
 
 	@include breakpoint-deprecated( "<1280px" ) {
 		grid-template-areas:


### PR DESCRIPTION

#### Proposed Changes

Update the layout to make the content section use all the free space besides what is needed for the header.

#### Testing Instructions
* Go to a plugin with a short description. Ex: `/plugins/visualcomposer-wpcom/{site}`
* Check if the content is close to the header and not too far away from it as below.

| Before  | After |
| ------------- | ------------- |
|<img width="1104" alt="Screen Shot 2022-10-20 at 15 22 04" src="https://user-images.githubusercontent.com/5039531/197051479-d61d50fc-eb48-40b5-8b05-41db4a59eb40.png">|<img width="1104" alt="Screen Shot 2022-10-20 at 15 24 28" src="https://user-images.githubusercontent.com/5039531/197051515-8385c141-84c6-4ef3-b0a3-06d94cda0c0e.png">|


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
