### PR TITLE
Stats: Refactor title determination for post detail page

### DIFF
--- a/client/my-sites/stats/stats-post-detail/index.jsx
+++ b/client/my-sites/stats/stats-post-detail/index.jsx
@@ -14,11 +14,7 @@ import Main from 'calypso/components/main';
 import WebPreview from 'calypso/components/web-preview';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { decodeEntities, stripHTML } from 'calypso/lib/formatting';
-import {
-	getSitePost,
-	isRequestingSitePost,
-	getPostPreviewUrl,
-} from 'calypso/state/posts/selectors';
+import { getSitePost, getPostPreviewUrl } from 'calypso/state/posts/selectors';
 import hasNavigated from 'calypso/state/selectors/has-navigated';
 import {
 	getSiteOption,
@@ -41,7 +37,6 @@ class StatsPostDetail extends Component {
 		postId: PropTypes.number,
 		translate: PropTypes.func,
 		context: PropTypes.object,
-		isRequestingPost: PropTypes.bool,
 		isRequestingStats: PropTypes.bool,
 		countViews: PropTypes.number,
 		post: PropTypes.object,
@@ -81,10 +76,27 @@ class StatsPostDetail extends Component {
 		} );
 	};
 
+	getTitle() {
+		const { isLatestPostsHomepage, post, postFallback, translate } = this.props;
+
+		if ( isLatestPostsHomepage ) {
+			return translate( 'Home page / Archives' );
+		}
+
+		if ( typeof post?.title === 'string' && post.title.length ) {
+			return decodeEntities( stripHTML( post.title ) );
+		}
+
+		if ( typeof postFallback?.post_title === 'string' && postFallback.post_title.length ) {
+			return decodeEntities( stripHTML( postFallback.post_title ) );
+		}
+
+		return null;
+	}
+
 	render() {
 		const {
 			isLatestPostsHomepage,
-			isRequestingPost,
 			isRequestingStats,
 			countViews,
 			post,
@@ -95,23 +107,7 @@ class StatsPostDetail extends Component {
 			showViewLink,
 			previewUrl,
 		} = this.props;
-		const postOnRecord = post && post.title !== null;
 		const isLoading = isRequestingStats && ! countViews;
-		let title;
-
-		if ( postOnRecord ) {
-			if ( typeof post.title === 'string' && post.title.length ) {
-				title = decodeEntities( stripHTML( post.title ) );
-			}
-		}
-
-		if ( ! postOnRecord && ! isLatestPostsHomepage && ! isRequestingPost ) {
-			title = translate( "We don't have that post on record yet." );
-		}
-
-		if ( isLatestPostsHomepage ) {
-			title = translate( 'Home page / Archives' );
-		}
 
 		const postType = post && post.type !== null ? post.type : 'post';
 		let actionLabel;
@@ -140,7 +136,7 @@ class StatsPostDetail extends Component {
 					actionText={ showViewLink ? actionLabel : null }
 					actionOnClick={ showViewLink ? this.openPreview : null }
 				>
-					{ title }
+					{ this.getTitle() }
 				</HeaderCake>
 
 				<StatsPlaceholder isLoading={ isLoading } />
@@ -206,8 +202,9 @@ const connectComponent = connect( ( state, { postId } ) => {
 
 	return {
 		post: getSitePost( state, siteId, postId ),
+		// NOTE: Post object from the stats response does not conform to the data structure returned by getSitePost!
+		postFallback: getPostStat( state, siteId, postId, 'post' ),
 		isLatestPostsHomepage,
-		isRequestingPost: isRequestingSitePost( state, siteId, postId ),
 		countViews: getPostStat( state, siteId, postId, 'views' ),
 		isRequestingStats: isRequestingPostStats( state, siteId, postId ),
 		siteSlug: getSiteSlug( state, siteId ),


### PR DESCRIPTION
#### Proposed Changes

Fixes an issue where the header title wouldn't render properly due to a malformed response from a Jetpack site. Specifically, this will now:

- No longer render the "We don't have that post on record yet" message, which can be inaccurate.
- Uses the post object from the post stats endpoint when the post endpoint fails to return data.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

This is for a12s only.

* Spin up this change locally.
* Navigate to the Stats page for a Jetpack site on your local Calypso instance.
* Click on one of the posts under the "Posts & Pages" data table.
* Ensure that the page heading renders as expected, like so:
<img width="1070" alt="image" src="https://user-images.githubusercontent.com/4044428/197063448-b2d984e9-276f-476f-8357-2246fde255bc.png">

* Alternatively, check 7824-gh-Automattic/jpop-issues and SU into the affected site.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
