### PR TITLE
Add more granular response time metric to statsd

### DIFF
--- a/client/lib/analytics/statsd-utils.ts
+++ b/client/lib/analytics/statsd-utils.ts
@@ -1,21 +1,31 @@
 import config from '@automattic/calypso-config';
 import superagent from 'superagent';
 
-interface CountingBeacon {
+const IS_SERVER = typeof document === 'undefined';
+
+interface BeaconBase {
 	name: string;
+	isLegacy?: boolean;
+}
+
+interface CountingBeacon extends BeaconBase {
 	value?: number;
 	type: 'counting';
 }
 
-interface TimingBeacon {
-	name: string;
+interface TimingBeacon extends BeaconBase {
 	value: number;
 	type: 'timing';
 }
 
 export type BeaconData = CountingBeacon | TimingBeacon;
 
-function createBeacon( calypsoSection: string, { name, value, type }: BeaconData ) {
+/**
+ * Turns a beacon object into a string to send to boom.gif. The ultimate beacon
+ * has a format with hierarchy encoded. An example result is:
+ * "calypso.development.server.themes.$event:$value|$type"
+ */
+function createBeacon( calypsoSection: string, { name, value, type, isLegacy }: BeaconData ) {
 	const event = name.replace( '-', '_' );
 
 	// A counting event defaults to incrementing by one.
@@ -23,7 +33,13 @@ function createBeacon( calypsoSection: string, { name, value, type }: BeaconData
 		value ??= 1;
 	}
 
-	return `calypso.${ config( 'boom_analytics_key' ) }.${ calypsoSection }.${ event }:${ value }|${
+	// There is an old response time event we don't want to change, unfortunately...
+	// Otherwise, we want to encode "server" or "client" in the event.
+	const hierarchyString = isLegacy ? '' : `.${ IS_SERVER ? 'server' : 'client' }`;
+
+	return `calypso.${ config(
+		'boom_analytics_key'
+	) }${ hierarchyString }.${ calypsoSection }.${ event }:${ value }|${
 		type === 'timing' ? 'ms' : 'c'
 	}`;
 }

--- a/client/lib/analytics/test/statsd-utils.js
+++ b/client/lib/analytics/test/statsd-utils.js
@@ -29,9 +29,24 @@ describe( 'StatsD Analytics Utils', () => {
 			expect( sdUrl.searchParams.get( 'json' ) ).toEqual(
 				JSON.stringify( {
 					beacons: [
-						'calypso.development.my_section_name.response_time:100|ms',
-						'calypso.development.my_section_name.page_load:1|c',
+						'calypso.development.server.my_section_name.response_time:100|ms',
+						'calypso.development.server.my_section_name.page_load:1|c',
 					],
+				} )
+			);
+		} );
+
+		test( 'does not include server hierarchy in legacy events', () => {
+			const sdUrl = new URL(
+				createStatsdURL( 'my-section-name', {
+					name: 'test',
+					type: 'counting',
+					isLegacy: true,
+				} )
+			);
+			expect( sdUrl.searchParams.get( 'json' ) ).toEqual(
+				JSON.stringify( {
+					beacons: [ 'calypso.development.my_section_name.test:1|c' ],
 				} )
 			);
 		} );
@@ -48,7 +63,7 @@ describe( 'StatsD Analytics Utils', () => {
 			expect( sdUrl.searchParams.get( 'u' ) ).toEqual( 'my_section_name' );
 			expect( sdUrl.searchParams.get( 'json' ) ).toEqual(
 				JSON.stringify( {
-					beacons: [ 'calypso.development.my_section_name.response_time:100|ms' ],
+					beacons: [ 'calypso.development.server.my_section_name.response_time:100|ms' ],
 				} )
 			);
 		} );

--- a/client/server/isomorphic-routing/index.js
+++ b/client/server/isomorphic-routing/index.js
@@ -13,6 +13,7 @@ export function serverRouter( expressApp, setUpRoute, section ) {
 		expressApp.get(
 			route,
 			( req, res, next ) => {
+				req.context.usedSSRHandler = true;
 				debug( `Using SSR pipeline for path: ${ req.path } with handler ${ route }` );
 				next();
 			},

--- a/client/server/pages/analytics.js
+++ b/client/server/pages/analytics.js
@@ -12,10 +12,13 @@ const logAnalyticsThrottled = throttle( ( { sectionName, duration, loggedIn, use
 			name: 'response_time',
 			value: duration,
 			type: 'timing',
+			isLegacy: true,
 		},
 		// More granular response-time metric including SSR and auth status.
 		{
-			name: `loggedin_${ loggedIn }.ssr_${ usedSSRHandler }.response_time`,
+			name: `response_time.${
+				loggedIn ? 'logged-in' : 'logged-out'
+			}.ssr_pipeline_${ usedSSRHandler }`,
 			value: duration,
 			type: 'timing',
 		},

--- a/client/server/pages/test/analytics.js
+++ b/client/server/pages/test/analytics.js
@@ -78,12 +78,12 @@ describe( 'index', () => {
 
 				// Check the information sent to boom.gif.
 				expect(
-					includesBeacon( `reader.loggedin_true.ssr_false.response_time:${ THREE_SECONDS }` )
+					includesBeacon( `response_time.logged_in.ssr_pipeline_false:${ THREE_SECONDS }` )
 				).toBe( true );
 
 				// Double check the loggedin/ssr flags are set correctly.
 				expect(
-					includesBeacon( `reader.loggedin_false.ssr_true.response_time:${ THREE_SECONDS }` )
+					includesBeacon( `response_time.logged_out.ssr_pipeline_true:${ THREE_SECONDS }` )
 				).toBe( false );
 			} );
 

--- a/client/server/pages/test/analytics.js
+++ b/client/server/pages/test/analytics.js
@@ -5,6 +5,7 @@ import * as statsdUtils from 'calypso/lib/analytics/statsd-utils';
 import { logSectionResponse } from 'calypso/server/pages/analytics';
 
 const TWO_SECONDS = 2000;
+const THREE_SECONDS = 3000;
 
 const noop = () => {};
 
@@ -58,12 +59,32 @@ describe( 'index', () => {
 			test( 'logs response analytics', () => {
 				logSectionResponse( request, response, next );
 
-				// Move time forward and mock the "finish" event
+				// Move time forward and mock the "close" event
 				jest.advanceTimersByTime( TWO_SECONDS );
-				response.emit( 'finish' );
+				response.emit( 'close' );
 
 				// Check the information sent to boom.gif.
 				expect( includesBeacon( `reader.response_time:${ TWO_SECONDS }` ) );
+			} );
+
+			test( 'logs granular analytics', () => {
+				// Make the request authenticated
+				request.context.user = { foo: 'bar' };
+				logSectionResponse( request, response, next );
+
+				// Move time forward and mock the "close" event
+				jest.advanceTimersByTime( THREE_SECONDS );
+				response.emit( 'close' );
+
+				// Check the information sent to boom.gif.
+				expect(
+					includesBeacon( `reader.loggedin_true.ssr_false.response_time:${ THREE_SECONDS }` )
+				).toBe( true );
+
+				// Double check the loggedin/ssr flags are set correctly.
+				expect(
+					includesBeacon( `reader.loggedin_false.ssr_true.response_time:${ THREE_SECONDS }` )
+				).toBe( false );
 			} );
 
 			test( 'throttles calls to log analytics', () => {
@@ -74,14 +95,14 @@ describe( 'index', () => {
 				logSectionResponse( request, response, next );
 				logSectionResponse( request2, response2, next );
 
-				response.emit( 'finish' );
-				response2.emit( 'finish' );
+				response.emit( 'close' );
+				response2.emit( 'close' );
 
 				expect( statsdUtils.logServerEvent ).toBeCalledTimes( 1 );
 
 				jest.advanceTimersByTime( TWO_SECONDS );
-				response.emit( 'finish' );
-				response2.emit( 'finish' );
+				response.emit( 'close' );
+				response2.emit( 'close' );
 
 				expect( statsdUtils.logServerEvent ).toBeCalledTimes( 2 );
 				analyticsMock.mockRestore();


### PR DESCRIPTION
### Proposed Changes
Building off of the statsd refactor in #68068, add a new response time metric for the server which includes more granular data.

Essentially, I'd like to get extra data into our Calypso server response time dashboard. (Search for "calypso node response times" in Grafana to find it.) In particular, I'd like to visualize response time of SSR sections vs non-SSR sections and logged-in vs logged-out requests.

Periods in an event name are used to filter things. So we just need an event like this: `calypso.production.server.${section}.response_time.${logged-in|logged-out}.ssr_${true|false}.response_time:${value}`

Since this isn't backwards compatible with the existing dashboard queries (`calypso.production.${section}.response_time`), we add it as an extra event. (Which is now very easy to do thanks to the above refactor!) This adds no extra network requests.

Another subtle change is that we now log response time for "closed" requests, which includes requests which timeout. While not the most common type of request, they have an outsized impact on metrics, so we should be tracking them.

Finally, I also added "server" or "client into every statsd event. However, since we have this old event we don't want to change... I had to add an `isLegacy` flag to support that. I don't like that I had to do that, but I'm not sure we can add server/client for every event without it.

Double finally, let's definitely iterate on the statsd interface as we find improvements to make it even easier to send statsd events! No need to keep it static as it's only used in a couple places.

### Questions:
1. Is this the ideal format for this metric? Should we put `response_time` at the beginning? (yes, this is a better practice!)
2. How do we test that the data is sent? (in production, since there is no impact)
3. Should we change from request "finished" to request "closed" for the existing event? The problem is that we may see the response time numbers get worse, but that's just because we are collecting more data. (yes, we can annotate the dashboard.)
