### PR TITLE
Dev Tools: Delay hiding menu to make it easier to click helpers

### DIFF
--- a/client/components/environment-badge/index.jsx
+++ b/client/components/environment-badge/index.jsx
@@ -1,5 +1,5 @@
 import { Gridicon } from '@automattic/components';
-import { string, node } from 'prop-types';
+import { node, string } from 'prop-types';
 import ExternalLink from 'calypso/components/external-link';
 
 import './style.scss';
@@ -43,6 +43,8 @@ export function DevDocsLink( { url } ) {
 }
 
 function EnvironmentBadge( { badge, feedbackURL, children } ) {
+	// Static HTML only is produced here. Event listeners get added in
+	// load-dev-helpers/index.js
 	return (
 		<div className="environment-badge">
 			{ children }

--- a/client/components/environment-badge/style.scss
+++ b/client/components/environment-badge/style.scss
@@ -5,7 +5,8 @@
 	right: 86px;
 	z-index: z-index("root", ".environment-badge");
 
-	&:hover .environment {
+	// The hovered class is toggled in load-dev-helpers/index.js
+	&.hovered .environment {
 		display: inline-block;
 
 		// hide everything inside each tab

--- a/client/lib/load-dev-helpers/index.js
+++ b/client/lib/load-dev-helpers/index.js
@@ -1,6 +1,21 @@
 import config from '@automattic/calypso-config';
+import { debounce } from 'lodash';
 
 export default function loadDevHelpers( reduxStore ) {
+	const badge = document.querySelector( '.environment-badge' );
+	if ( badge ) {
+		// We
+		const remove = debounce( () => {
+			badge.classList.remove( 'hovered' );
+		}, 500 );
+		badge.onmouseleave = remove;
+
+		badge.onmouseenter = () => {
+			remove.cancel();
+			badge.classList.add( 'hovered' );
+		};
+	}
+
 	// account settings helper requires a Redux store.
 	if ( reduxStore && config.isEnabled( 'dev/account-settings-helper' ) ) {
 		const el = document.querySelector( '.environment.is-account-settings' );

--- a/client/lib/load-dev-helpers/index.js
+++ b/client/lib/load-dev-helpers/index.js
@@ -4,7 +4,7 @@ import { debounce } from 'lodash';
 export default function loadDevHelpers( reduxStore ) {
 	const badge = document.querySelector( '.environment-badge' );
 	if ( badge ) {
-		// We
+		// Show/hide Dev Tools menu as mouse enters/leaves
 		const remove = debounce( () => {
 			badge.classList.remove( 'hovered' );
 		}, 500 );


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/69128

#### Proposed Changes

* Add a 500ms delay before closing the menu


https://user-images.githubusercontent.com/6851384/197086023-258d49d4-50bd-43ce-9ba8-0f6e9cdb3703.mp4



#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Try out the Calypso Live link. You should find it's more forgiving than before.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #