### PR TITLE
Stats: Adjust tooltip styles in Stats

### DIFF
--- a/client/components/chart/style.scss
+++ b/client/components/chart/style.scss
@@ -372,6 +372,7 @@ $y-axis-padding: 0 20px 0 10px;
 		}
 	}
 
+	// @TODO Integrate styles with Stats
 	&.is-streak {
 		.popover__inner {
 			width: 160px;
@@ -400,6 +401,7 @@ $y-axis-padding: 0 20px 0 10px;
 }
 
 .chart__tooltip .module-content-list-item {
+	// @TODO Integrate styles with Stats
 	&.is-date-label {
 		font-size: $font-body-extra-small;
 		margin-bottom: 2px;
@@ -409,6 +411,7 @@ $y-axis-padding: 0 20px 0 10px;
 		padding-bottom: 2px;
 	}
 
+	// @TODO Integrate styles with Stats
 	&.is-published-item {
 		height: 19px;
 

--- a/client/my-sites/stats/stats-chart-tabs/utility.js
+++ b/client/my-sites/stats/stats-chart-tabs/utility.js
@@ -102,7 +102,7 @@ function addTooltipData( chartTab, item, period ) {
 				label: translate( 'Visitors' ),
 				value: numberFormat( item.data.visitors ),
 				className: 'is-visitors',
-				icon: 'user',
+				icon: 'multiple-users',
 			} );
 			tooltipData.push( {
 				label: translate( 'Views Per Visitor' ),

--- a/client/my-sites/stats/style.scss
+++ b/client/my-sites/stats/style.scss
@@ -31,12 +31,6 @@
 	margin-left: 4px;
 }
 
-.is-section-stats .followers-count .button {
-	@include breakpoint-deprecated( "<480px" ) {
-		display: none;
-	}
-}
-
 .stats-navigation__control {
 	margin-right: 16px;
 
@@ -163,7 +157,6 @@
 	}
 }
 
-
 .stats__parsely-banner {
 	display: flex;
 	font-size: $font-body-small;
@@ -211,5 +204,101 @@
 
 	&::after {
 		display: none;
+	}
+}
+
+// Stats section scoped styles
+.is-section-stats {
+	.followers-count .button {
+		@include breakpoint-deprecated( "<480px" ) {
+			display: none;
+		}
+	}
+
+	.tooltip.popover.chart__tooltip {
+		// Overwrite Tooltip styles
+		&.is-bottom-right,
+		&.is-bottom-left,
+		&.is-bottom {
+			.popover__arrow {
+				border-bottom-color: var(--color-neutral-100);
+			}
+		}
+
+		&.is-top,
+		&.is-top-left,
+		&.is-top-right {
+			.popover__arrow {
+				border-top-color: var(--color-neutral-100);
+			}
+		}
+
+		&.is-left {
+			.popover__arrow {
+				border-left-color: var(--color-neutral-100);
+			}
+		}
+
+		&.is-right {
+			.popover__arrow {
+				border-right-color: var(--color-neutral-100);
+			}
+		}
+
+		// Overwrite Tooltip styles
+		.popover__inner {
+			color: var(--color-text-inverted);
+			background: var(--color-neutral-100);
+			font-size: $font-body-small;
+			padding: 16px 24px;
+
+			// Overwrite Chart styles
+			ul {
+				li {
+					font-size: $font-body-small;
+					font-weight: 500;
+					line-height: 20px;
+					letter-spacing: -0.24px;
+					margin-bottom: 10px;
+
+					&:last-child {
+						margin-bottom: 0;
+					}
+
+					.value {
+						color: inherit;
+					}
+
+					.gridicon {
+						margin-right: 12px;
+					}
+				}
+			}
+		}
+
+		// Overwrite Chart styles
+		.module-content-list-item {
+			&.is-date-label {
+				font-weight: 600;
+				border-bottom: 0;
+			}
+
+			&.is-published {
+				margin-bottom: 4px;
+			}
+
+			&.is-published-item {
+				font-size: $font-body-extra-small;
+				margin-bottom: 4px;
+				padding-left: 30px;
+				text-decoration: underline;
+
+				.label {
+					color: inherit;
+					letter-spacing: inherit;
+					line-height: 20px;
+				}
+			}
+		}
 	}
 }

--- a/client/my-sites/stats/style.scss
+++ b/client/my-sites/stats/style.scss
@@ -288,15 +288,18 @@
 			}
 
 			&.is-published-item {
+				height: auto;
 				font-size: $font-body-extra-small;
-				margin-bottom: 4px;
+				margin-bottom: 0;
 				padding-left: 30px;
 				text-decoration: underline;
 
 				.label {
+					height: auto;
+					line-height: 20px;
 					color: inherit;
 					letter-spacing: inherit;
-					line-height: 20px;
+					word-break: break-word;
 				}
 			}
 		}


### PR DESCRIPTION
#### Proposed Changes

* Check the tooltip applied styles in the `Chart` component.
* Overwrite tooltip styles in Stats styles when necessary to improve the tooltip styling.
* Alter the Visitors icon in tooltips.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the page `Stats` for certain site `/stats/day/${your-site}`.
* Hover the bar chart of the day traffic.
* Ensure the tooltip displays with new styles in line with the Design.

| Before | After |
| --- | --- |
| <img width="1090" alt="截圖 2022-10-21 上午10 11 57" src="https://user-images.githubusercontent.com/6869813/197095367-73685ad0-387e-4a65-ac6b-09117a153b78.png"> | <img width="1137" alt="截圖 2022-10-21 上午10 49 22" src="https://user-images.githubusercontent.com/6869813/197100138-1ebead26-e8cf-4fa7-9c91-c73b8a4f242c.png"> |



#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #69178 
