### PR TITLE
Track favicon update from onboarding flows

### DIFF
--- a/packages/onboarding/src/upload-and-set-site-logo.ts
+++ b/packages/onboarding/src/upload-and-set-site-logo.ts
@@ -29,6 +29,7 @@ export async function uploadAndSetSiteLogo( siteId: string | number | undefined,
 			apiNamespace: 'wp/v2',
 			// we know the site doesn't have a logo nor an icon, let's set both
 			body: { site_logo: imageID, site_icon: imageID },
+			query: 'source=onboarding',
 			method: 'POST',
 		} );
 		return { logoResult, uploadResult };


### PR DESCRIPTION
#### Proposed Changes

* Add param source=onboarding on the request to save the favicon setting

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup/newsletterSetup?flow=newsletter`
* Upload a logo
* Open the network dev tools, and filter by `/settings` 
* Continue the flow, you choose a domain and a plan.
* Check that the request includes the query param `source=onboarding` 

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/889
