### PR TITLE
Style selection: Fix style preview padding

### DIFF
--- a/packages/design-preview/src/components/style-variation.tsx
+++ b/packages/design-preview/src/components/style-variation.tsx
@@ -19,6 +19,23 @@ interface StyleVariationPreviewProps {
 	showGlobalStylesPremiumBadge: () => React.ReactNode;
 }
 
+// This is a temporary workaround until we can
+// upgrade @wordpress/edit-site to fix CSS issues.
+//
+// See: https://github.com/WordPress/gutenberg/pull/43601
+const OVERRIDE_CONFIG = {
+	styles: {
+		spacing: {
+			padding: {
+				bottom: 0,
+				left: 0,
+				right: 0,
+				top: 0,
+			},
+		},
+	},
+};
+
 const StyleVariationPreview: React.FC< StyleVariationPreviewProps > = ( {
 	variation,
 	base = {},
@@ -34,7 +51,10 @@ const StyleVariationPreview: React.FC< StyleVariationPreviewProps > = ( {
 				styles: variation.styles ?? {},
 			},
 			base,
-			merged: mergeBaseAndUserConfigs( base, variation ),
+			merged: mergeBaseAndUserConfigs(
+				mergeBaseAndUserConfigs( base, variation ),
+				OVERRIDE_CONFIG
+			),
 		};
 	}, [ variation, base ] );
 


### PR DESCRIPTION
#### Proposed Changes

This PR is a workaround solution to reset padding from global styles, which is applied to the style preview in an undesirable way. A better solution is to update `@wordpress/edit-site` to a newer version that solves this issue (WIP: #69272).

See screenshot for reference:
| Before | After |
| --- | --- |
| ![Screen Shot 2022-10-19 at 5 44 11 PM](https://user-images.githubusercontent.com/797888/196657111-41f92fe4-9053-4faf-957b-d9634ce1380c.png) | ![Screen Shot 2022-10-19 at 5 44 38 PM](https://user-images.githubusercontent.com/797888/196657125-ddca33d8-1989-4779-894a-529b57d1eb2f.png) |

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the design picker `setup/designSetup?siteSlug=${site_slug}`
* Preview any design with style variations.
* Ensure that the style preview doesn't have extra padding (happened previously for the theme "Pixl").

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

