### PR TITLE
Plans step FAQ: Remove english only check

### DIFF
--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -1,4 +1,4 @@
-import config, { isEnabled } from '@automattic/calypso-config';
+import { isEnabled } from '@automattic/calypso-config';
 import {
 	chooseDefaultCustomerType,
 	findPlansKeys,
@@ -463,20 +463,13 @@ export class PlansFeaturesMain extends Component {
 	}
 
 	mayRenderFAQ() {
-		const { isInSignup, titanMonthlyRenewalCost, showFAQ, locale } = this.props;
+		const { isInSignup, titanMonthlyRenewalCost, showFAQ } = this.props;
 
 		if ( ! showFAQ ) {
 			return;
 		}
 
 		if ( isInSignup ) {
-			const isEnglish = config( 'english_locales' ).includes( locale );
-
-			// Remove this check after translations are completed for the PlanFAQ component.
-			if ( ! isEnglish ) {
-				return null;
-			}
-
 			return <PlanFAQ titanMonthlyRenewalCost={ titanMonthlyRenewalCost } />;
 		}
 


### PR DESCRIPTION
#### Proposed Changes

* Removes the `en` only check, so that the FAQs will be visible in all locales. The translations are [now complete](https://github.com/Automattic/wp-calypso/pull/68957#issuecomment-1286638586) and it's safe to remove the `en` only check.


<img width="1234" alt="Screenshot 2022-10-21 at 1 36 38 PM" src="https://user-images.githubusercontent.com/1269602/197145893-baa039c1-b2f4-4cc8-a23f-481d2bed6c64.png">

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* In non-EN locales, check that the FAQ section is displayed in the signup flow plans step and is fully translated.

