### PR TITLE
DIFM Content Form: Poll site API for DIFM data

### DIFF
--- a/client/signup/steps/website-content/index.tsx
+++ b/client/signup/steps/website-content/index.tsx
@@ -30,8 +30,6 @@ import './style.scss';
 
 const debug = debugFactory( 'calypso:difm' );
 
-const MAXTRIES = 10;
-
 const DialogContent = styled.div`
 	padding: 16px;
 	p {
@@ -214,7 +212,13 @@ export default function WrapperWebsiteContent(
 	);
 	const siteId = useSelector( ( state ) => getSiteId( state, queryObject.siteSlug as string ) );
 
-	const { hasValidPurchase, isPollingInProgress } = usePollSiteForDIFMDetails( siteId, MAXTRIES );
+	const urlParams = new URLSearchParams( window.location.search );
+	const isFromCheckout = 'purchase-success' === urlParams.get( 'notice' );
+	// If the user is coming from checkout, we can wait for a longer period to
+	// ensure that the WoA sync has completed.
+	const maxTries = isFromCheckout ? 30 : 10;
+
+	const { hasValidPurchase, isPollingInProgress } = usePollSiteForDIFMDetails( siteId, maxTries );
 
 	useEffect( () => {
 		if ( isPollingInProgress ) {

--- a/client/signup/steps/website-content/use-poll-site-for-difm-details.ts
+++ b/client/signup/steps/website-content/use-poll-site-for-difm-details.ts
@@ -36,6 +36,7 @@ export function usePollSiteForDIFMDetails(
 	maxTries = 10
 ): {
 	isPollingInProgress: boolean;
+	pageTitles: string[] | null;
 	hasValidPurchase: boolean;
 } {
 	const [ retryCount, setRetryCount ] = useState( 0 );
@@ -118,5 +119,6 @@ export function usePollSiteForDIFMDetails(
 	return {
 		isPollingInProgress,
 		hasValidPurchase: isPollingInProgress ? false : hasValidPurchase,
+		pageTitles,
 	};
 }

--- a/client/signup/steps/website-content/use-poll-site-for-difm-details.ts
+++ b/client/signup/steps/website-content/use-poll-site-for-difm-details.ts
@@ -1,0 +1,122 @@
+import config from '@automattic/calypso-config';
+import { useState, useRef, useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { logToLogstash } from 'calypso/lib/logstash';
+import getDIFMLiteSitePageTitles from 'calypso/state/selectors/get-difm-lite-site-page-titles';
+import isDIFMLiteInProgress from 'calypso/state/selectors/is-difm-lite-in-progress';
+import isDIFMLiteWebsiteContentSubmitted from 'calypso/state/selectors/is-difm-lite-website-content-submitted';
+import { requestSite } from 'calypso/state/sites/actions';
+import { isRequestingSite } from 'calypso/state/sites/selectors';
+import type { SiteId } from 'calypso/types';
+
+/**
+ * Hook that polls the /rest/v1.2/sites/<site fragment> API.
+ * It checks the site details for a valid DIFM purchase.
+ * A valid DIFM purchase has `.options.is_difm_lite_in_progress` set to `true`
+ * and `.options.difm_lite_site_options.pages` should be an array of strings.
+ * Also, `.options.difm_lite_site_options.is_website_content_submitted` should be
+ * `false/null` to indicate that the users has not submitted content yet.
+ *
+ *
+ * If the above conditions are met, the hook returns { isPollingInProgress: false, hasValidPurchase: true }.
+ * If the above conditions are not met, it retries the request maxTries times,
+ * with a linear backoff. If the conditions are still not met, the hook returns
+ * { isPollingInProgress: false, hasValidPurchase: false }.
+ * The default return value is { isPollingInProgress: true, hasValidPurchase: false }
+ *
+ * @param {(SiteId | null)} siteId The current site ID.
+ * @param {(number)} maxTries The max number of retries
+ * @returns {{
+ * 	isPollingInProgress: boolean;
+ * 	hasValidPurchase: boolean;
+ * }}
+ */
+export function usePollSiteForDIFMDetails(
+	siteId: SiteId | null,
+	maxTries = 10
+): {
+	isPollingInProgress: boolean;
+	hasValidPurchase: boolean;
+} {
+	const [ retryCount, setRetryCount ] = useState( 0 );
+	const [ isPollingInProgress, setIsPollingInProgress ] = useState( true );
+	const [ hasValidPurchase, setHasValidPurchase ] = useState( false );
+	const dispatch = useDispatch();
+
+	const isLoadingSiteInformation = useSelector( ( state ) =>
+		isRequestingSite( state, siteId as number )
+	);
+
+	const pageTitles = useSelector( ( state ) => getDIFMLiteSitePageTitles( state, siteId ) );
+	const isInProgress = useSelector( ( state ) => isDIFMLiteInProgress( state, siteId ) );
+	const isWebsiteContentSubmitted = useSelector( ( state ) =>
+		isDIFMLiteWebsiteContentSubmitted( state, siteId )
+	);
+
+	const timeout = useRef< number >();
+
+	useEffect( () => {
+		async function checkSite() {
+			if ( ! siteId ) {
+				return;
+			}
+
+			if ( isLoadingSiteInformation ) {
+				// A request is already in progress
+				return;
+			}
+
+			await dispatch( requestSite( siteId ) );
+
+			if ( isInProgress && isWebsiteContentSubmitted !== true ) {
+				setHasValidPurchase( true );
+			}
+
+			if ( pageTitles && pageTitles.length ) {
+				setIsPollingInProgress( false );
+			}
+		}
+
+		if ( isPollingInProgress && retryCount < maxTries ) {
+			// Only refresh 10 times
+			timeout.current = window.setTimeout( () => {
+				setRetryCount( ( retryCount ) => retryCount + 1 );
+				checkSite();
+			}, retryCount * 600 );
+		}
+
+		if ( retryCount === maxTries ) {
+			setIsPollingInProgress( false );
+			logToLogstash( {
+				feature: 'calypso_client',
+				message: 'BBEX Content Form: Max retries exceeded.',
+				severity: config( 'env_id' ) === 'production' ? 'error' : 'debug',
+				blog_id: siteId,
+				extra: {
+					isInProgress,
+					isWebsiteContentSubmitted,
+					pageTitles,
+				},
+			} );
+		}
+
+		return () => {
+			clearTimeout( timeout.current );
+		};
+	}, [
+		isPollingInProgress,
+		siteId,
+		retryCount,
+		dispatch,
+		isLoadingSiteInformation,
+		pageTitles,
+		isInProgress,
+		isWebsiteContentSubmitted,
+		maxTries,
+	] );
+
+	return {
+		isPollingInProgress,
+		hasValidPurchase: isPollingInProgress ? false : hasValidPurchase,
+	};
+}


### PR DESCRIPTION
#### Proposed Changes

For WoA sites, a background job copies data to the remote WoA site after purchase. Due to this, the correct DIFM data is not available immediately in the GET `/rest/v1.2/sites/<siteid>` endpoint response.

This PR adds a hook to the website content step that polls the endpoint and checks for DIFM-related data. A valid DIFM purchase has `.options.is_difm_lite_in_progress` set to `true`and `.options.difm_lite_site_options.pages` should be an array of strings.

If the above conditions are met, the hook returns `{ isLoading: false, hasValidPurchase: true }`.
If the above conditions are not met, it retries the request `MAXTRIES` times, with a linear backoff. If the conditions are still not met, the hook returns `{ isLoading: false, hasValidPurchase: false }`.
The default return value is `{ isLoading: true, hasValidPurchase: false }`.

This logic assumes that *most* users on this page will have a valid purchase and will have the best-case scenario - the form is shown after 1 request for simple sites and `n` requests for WoA sites (assuming data is synced within ~27 seconds).

Users without a valid purchase will have the worst-case scenario where the page would wait for ~27 seconds before redirecting to `/home`. IMO, this tradeoff is acceptable since this scenario can happen only if users manually visit this URL.



| Test Case | Result |
|---|---|
| Simple site with a valid purchase | Form is shown after the first request |
| Simple site without a valid purchase | Redirected to /home after 10 requests |
| Simple site with a valid purchase and content already submitted | Redirected to /home after 1 request |
| Atomic site with a valid purchase and data is in sync | Form is shown after the first request |
| Atomic site with a valid purchase and data is not in sync yet | Form is shown after `n` requests (after data sync happens) |
| Atomic site without a valid purchase | Redirected to /home after 10 requests |

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Testing WoA sites**
* Go to `/start/do-it-for-me/?flags=difm/allow-woa-sites`. Choose Existing site and in the site picker, select a WoA site.
* Go through the flow steps and complete the purchase.
* After purchase, you should see a loading screen and then see the form.

**Testing Simple sites**
* Follow the above steps, but select a simple site in the site picker.

**Testing Simple sites without a valid purchase**
* Go to `start/site-content-collection/website-content?siteSlug=<site slug>` for a site that does not have a DIFM purchase.
* Confirm that you are redirected to /home.

**Testing Simple sites with content already submitted**
* Go to `start/site-content-collection/website-content?siteSlug=<site slug>` for a site for which you have already submitted the content form.
* Confirm that you are redirected to /home.

#### Screenshots
**Loading Screen**
<img width="1518" alt="image" src="https://user-images.githubusercontent.com/5436027/198517366-6697d18d-b23c-4df6-9034-f184a1d89e4b.png">

**Error Screen**
<img width="1920" alt="image" src="https://user-images.githubusercontent.com/5436027/198518562-0af4af3b-2307-4997-ba08-924d64894ecf.png">


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes? - NA
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes Automattic/martech#1199
