### PR TITLE
Plugins SSR: make sure plugins collection is rendered

### DIFF
--- a/client/my-sites/plugins/controller-logged-out.js
+++ b/client/my-sites/plugins/controller-logged-out.js
@@ -1,9 +1,9 @@
 import config from '@automattic/calypso-config';
+import { getESPluginsInfiniteQueryParams } from 'calypso/data/marketplace/use-es-query';
 import {
 	getWPCOMFeaturedPluginsQueryParams,
 	getWPCOMPluginsQueryParams,
 } from 'calypso/data/marketplace/use-wpcom-plugins-query';
-import { getWPORGPluginsQueryParams } from 'calypso/data/marketplace/use-wporg-plugin-query';
 import wpcom from 'calypso/lib/wp';
 import { receiveProductsList } from 'calypso/state/products-list/actions';
 
@@ -32,11 +32,14 @@ const prefetchPaidPlugins = ( queryClient, options ) =>
 		getWPCOMPluginsQueryParams( 'all', options.search, options.tag )
 	);
 
-const prefetchPopularPlugins = ( queryClient, options ) =>
-	prefetchPluginsData(
+const prefetchPopularPlugins = ( queryClient, options ) => {
+	const infinite = true;
+	return prefetchPluginsData(
 		queryClient,
-		getWPORGPluginsQueryParams( { ...options, category: 'popular' } )
+		getESPluginsInfiniteQueryParams( { ...options, category: 'popular', infinite }, infinite ),
+		true
 	);
+};
 
 const prefetchFeaturedPlugins = ( queryClient ) =>
 	prefetchPluginsData( queryClient, getWPCOMFeaturedPluginsQueryParams() );

--- a/client/my-sites/plugins/plugins-browser/collection-list-view/index.tsx
+++ b/client/my-sites/plugins/plugins-browser/collection-list-view/index.tsx
@@ -9,6 +9,7 @@ import { PluginsBrowserListVariant } from 'calypso/my-sites/plugins/plugins-brow
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { useServerEffect } from '../../utils';
 
 export default function CollectionListView( {
 	category,
@@ -28,9 +29,14 @@ export default function CollectionListView( {
 	const categories = useCategories( [ category ] );
 
 	const plugins = useRef< Array< Plugin > >();
-	useEffect( () => {
+
+	const setPlugins = () => {
 		plugins.current = shuffle( categories[ category ].preview.slice( 0, 6 ) );
-	}, [ categories, category ] );
+	};
+	useEffect( setPlugins, [ categories, category ] );
+	useServerEffect( setPlugins ); // This is needed to ensure this runs on the server.
+
+	plugins.current = shuffle( categories[ category ].preview.slice( 0, 6 ) );
 
 	if ( isJetpackSelfHosted ) {
 		return null;

--- a/client/my-sites/plugins/utils.js
+++ b/client/my-sites/plugins/utils.js
@@ -149,3 +149,9 @@ export function handleUpdatePlugins( plugins, updateAction, pluginsOnSites ) {
 		sites: [ ...updatedSites ].join( ',' ),
 	} );
 }
+
+export function useServerEffect( fn ) {
+	if ( 'undefined' === typeof window ) {
+		fn();
+	}
+}


### PR DESCRIPTION
#### Proposed Changes

This updates the SSR prefetches for the Plugins Landing page to render the new 'monetization', 'business' and 'onlinestore' collections.


#### Testing Instructions

* Log out and disable JavaScript
* Go to `/plugins`
* Make sure all plugins are rendered by the server
<img width="320" alt="Screenshot on 2022-10-21 at 12-04-14" src="https://user-images.githubusercontent.com/2749938/197158055-032dfa75-58de-4589-ac14-f56b6a2a7ec7.png">
* Double-check logged in and with JavaScript enabled scenarios don't show regressions

