### PR TITLE
Marketplace: Add uuid when redirecting SaaS products to vendors

### DIFF
--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -116,8 +116,17 @@ const PluginDetailsCTA = ( { plugin, isPlaceholder } ) => {
 		return pluginsPlansPageFlag ? pluginsPlansPage : `/checkout/${ siteSlug }/business`;
 	}, [ selectedSite?.slug ] );
 
-	const getRedirectToThirdPartyVendorHRef = useCallback( () => {
-		return `${ plugin.saas_landing_page }?uuid=${ currentUserId }+${ selectedSite?.ID }`;
+	const getSaasRedirectHRef = useCallback( () => {
+		if ( ! plugin.saas_landing_page ) {
+			return null;
+		}
+		try {
+			const saasRedirectUrl = new URL( plugin.saas_landing_page );
+			saasRedirectUrl.searchParams.append( 'uuid', `${ currentUserId }+${ selectedSite?.ID }` );
+			return saasRedirectUrl.toString();
+		} catch ( error ) {
+			return null;
+		}
 	}, [ currentUserId, plugin.saas_landing_page, selectedSite?.ID ] );
 	/*
 	 * Remove 'NO_BUSINESS_PLAN' holds if the INSTALL_PURCHASED_PLUGINS feature is present.
@@ -302,7 +311,7 @@ const PluginDetailsCTA = ( { plugin, isPlaceholder } ) => {
 						userCantManageTheSite={ userCantManageTheSite }
 						translate={ translate }
 						plugin={ plugin }
-						thirdPartyVendorHRef={ getRedirectToThirdPartyVendorHRef() }
+						saasRedirectHRef={ getSaasRedirectHRef() }
 					/>
 				</div>
 				{ ! isJetpackSelfHosted && ! isMarketplaceProduct && (
@@ -360,7 +369,7 @@ function PrimaryButton( {
 	userCantManageTheSite,
 	translate,
 	plugin,
-	thirdPartyVendorHRef,
+	saasRedirectHRef,
 } ) {
 	if ( ! isLoggedIn ) {
 		return (
@@ -380,7 +389,7 @@ function PrimaryButton( {
 			<Button
 				className="plugin-details-cta__install-button"
 				primary={ ! shouldUpgrade }
-				href={ thirdPartyVendorHRef }
+				href={ saasRedirectHRef }
 			>
 				{ translate( 'Get started' ) }
 				<Gridicon icon="external" />

--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -18,7 +18,7 @@ import PluginAutoupdateToggle from 'calypso/my-sites/plugins/plugin-autoupdate-t
 import { isCompatiblePlugin } from 'calypso/my-sites/plugins/plugin-compatibility';
 import { siteObjectsToSiteIds } from 'calypso/my-sites/plugins/utils';
 import { getEligibility } from 'calypso/state/automated-transfer/selectors';
-import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import { isUserLoggedIn, getCurrentUserId } from 'calypso/state/current-user/selectors';
 import { setBillingInterval } from 'calypso/state/marketplace/billing-interval/actions';
 import { getBillingInterval } from 'calypso/state/marketplace/billing-interval/selectors';
 import {
@@ -51,6 +51,8 @@ const PluginDetailsCTA = ( { plugin, isPlaceholder } ) => {
 
 	const selectedSite = useSelector( getSelectedSite );
 	const billingPeriod = useSelector( getBillingInterval );
+
+	const currentUserId = useSelector( getCurrentUserId );
 
 	const isMarketplaceProduct = useSelector( ( state ) =>
 		isMarketplaceProductSelector( state, plugin.slug )
@@ -113,6 +115,10 @@ const PluginDetailsCTA = ( { plugin, isPlaceholder } ) => {
 		const pluginsPlansPage = `/plugins/plans/yearly/${ siteSlug }`;
 		return pluginsPlansPageFlag ? pluginsPlansPage : `/checkout/${ siteSlug }/business`;
 	}, [ selectedSite?.slug ] );
+
+	const getRedirectToThirdPartyVendorHRef = useCallback( () => {
+		return `${ plugin.saas_landing_page }?uuid=${ currentUserId }+${ selectedSite?.ID }`;
+	}, [ currentUserId, plugin.saas_landing_page, selectedSite?.ID ] );
 	/*
 	 * Remove 'NO_BUSINESS_PLAN' holds if the INSTALL_PURCHASED_PLUGINS feature is present.
 	 *
@@ -296,6 +302,7 @@ const PluginDetailsCTA = ( { plugin, isPlaceholder } ) => {
 						userCantManageTheSite={ userCantManageTheSite }
 						translate={ translate }
 						plugin={ plugin }
+						thirdPartyVendorHRef={ getRedirectToThirdPartyVendorHRef() }
 					/>
 				</div>
 				{ ! isJetpackSelfHosted && ! isMarketplaceProduct && (
@@ -353,6 +360,7 @@ function PrimaryButton( {
 	userCantManageTheSite,
 	translate,
 	plugin,
+	thirdPartyVendorHRef,
 } ) {
 	if ( ! isLoggedIn ) {
 		return (
@@ -372,7 +380,7 @@ function PrimaryButton( {
 			<Button
 				className="plugin-details-cta__install-button"
 				primary={ ! shouldUpgrade }
-				href={ plugin.saas_landing_page }
+				href={ thirdPartyVendorHRef }
 			>
 				{ translate( 'Get started' ) }
 				<Gridicon icon="external" />


### PR DESCRIPTION
#### Proposed Changes

* Adds a `uuid` query parameter when redirecting users to purchase SaaS products
* The `uuid` will be a combination of user id and site id separated by a `+`: `uuid=<user_id>+<site_id>`

> **Note**: The separator `+` will be url-encoded to `%2B`

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Sandbox your API and make sure you have `define( 'USE_STORE_SANDBOX', true );` as explained PCYsg-IA-p2
* Select a site and search for the plugin `Test SaaS Product`, e.g. `/plugins/test-saas-product/<site_id>`
* Click on the `Get Started` button
* Make sure the URL contains a query param named `uuid` with the user id and the site id in the form `?uuid=<user_id>%2B<site_id>`


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to  #67657
Follo-up of the PR #68667 
