### PR TITLE
get-teamcity-artifact-url: Update default value for `buildType`

### DIFF
--- a/bin/get-teamcity-artifact-url
+++ b/bin/get-teamcity-artifact-url
@@ -7,7 +7,7 @@ const yargs = require( 'yargs' );
 
 const args = yargs
 	.default( 'branch', 'trunk' )
-	.default( 'buildType', 'calypso_Translate' )
+	.default( 'buildType', 'calypso_calypso_WebApp_Translate' )
 	.required( 'artifact', 'Set the artifact file path.' ).argv;
 
 const url = `https://teamcity.a8c.com/repository/download/${ args.buildType }/.lastSuccessful/${ args.artifact }?guest=1&branch=${ args.branch }`;


### PR DESCRIPTION
The ID for `Translate` build type has been changed in https://github.com/Automattic/wp-calypso/pull/69269.

#### Proposed Changes

* Update default value for `buildType` argument

#### Testing Instructions

* Run `node bin/get-teamcity-artifact-url --artifact="calypso-strings.pot"` and check if the generated link is valid.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

