### PR TITLE
Show a confirm prompt when the FSE plugin is deactivated on an unlaunched site

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/helpers.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/helpers.php
@@ -193,35 +193,3 @@ function populate_wp_template_data() {
 register_activation_hook( __FILE__, __NAMESPACE__ . '\populate_wp_template_data' );
 add_action( 'switch_theme', __NAMESPACE__ . '\populate_wp_template_data' );
 
-/**
- * Shows a confirm prompt when the plugin is about to be deactivated on a unlaunched site.
- *
- * This will filter the FSE actions on the plugin manager list to add the confirm
- * prompt on the click event of the action=deactivate.
- *
- * The option launch-status exists only on wpcom sites.
- */
-add_filter(
-	'plugin_action_links_full-site-editing/full-site-editing-plugin.php',
-	function ( $actions ) {
-		$unlaunched = get_option( 'launch-status' ) === 'unlaunched';
-
-		if ( $unlaunched ) {
-			$actions = array_map(
-				function ( $action ) {
-					$message = __( 'Disabling this plugin will make your site public.', 'full-site-editing' );
-					$confirm = "confirm('$message') ? null : event.preventDefault()";
-
-					return str_replace(
-						'<a href="plugins.php?action=deactivate',
-						"<a onclick=\"$confirm\" href=\"plugins.php?action=deactivate",
-						$action
-					);
-				},
-				$actions
-			);
-		}
-
-		return $actions;
-	}
-);

--- a/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/helpers.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/helpers.php
@@ -192,3 +192,36 @@ function populate_wp_template_data() {
 }
 register_activation_hook( __FILE__, __NAMESPACE__ . '\populate_wp_template_data' );
 add_action( 'switch_theme', __NAMESPACE__ . '\populate_wp_template_data' );
+
+/**
+ * Shows a confirm prompt when the plugin is about to be deactivated on a unlaunched site.
+ *
+ * This will filter the FSE actions on the plugin manager list to add the confirm
+ * prompt on the click event of the action=deactivate.
+ *
+ * The option launch-status exists only on wpcom sites.
+ */
+add_filter(
+	'plugin_action_links_full-site-editing/full-site-editing-plugin.php',
+	function ( $actions ) {
+		$unlaunched = get_option( 'launch-status' ) === 'unlaunched';
+
+		if ( $unlaunched ) {
+			$actions = array_map(
+				function ( $action ) {
+					$message = __( 'Disabling this plugin will make your site public.', 'full-site-editing' );
+					$confirm = "confirm('$message') ? null : event.preventDefault()";
+
+					return str_replace(
+						'<a href="plugins.php?action=deactivate',
+						"<a onclick=\"$confirm\" href=\"plugins.php?action=deactivate",
+						$action
+					);
+				},
+				$actions
+			);
+		}
+
+		return $actions;
+	}
+);

--- a/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/helpers.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/helpers.php
@@ -192,4 +192,3 @@ function populate_wp_template_data() {
 }
 register_activation_hook( __FILE__, __NAMESPACE__ . '\populate_wp_template_data' );
 add_action( 'switch_theme', __NAMESPACE__ . '\populate_wp_template_data' );
-

--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -444,7 +444,7 @@ add_action( 'plugins_loaded', __NAMESPACE__ . '\load_wpcom_global_styles' );
  * The option launch-status exists only on wpcom sites.
  */
 add_filter(
-	'plugin_action_links_plugin_action_links_full-site-editing/full-site-editing-plugin.php',
+	'plugin_action_links_' . plugin_basename( __FILE__ ),
 	function ( $actions ) {
 		$unlaunched = get_option( 'launch-status' ) === 'unlaunched';
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -442,28 +442,32 @@ add_action( 'plugins_loaded', __NAMESPACE__ . '\load_wpcom_global_styles' );
  * prompt on the click event of the action=deactivate.
  *
  * The option launch-status exists only on wpcom sites.
+ *
+ * @TODO: Remove after coming-soon is migrated to the new jetpack-mu-wpcom plugin
  */
-add_filter(
-	'plugin_action_links_' . plugin_basename( __FILE__ ),
-	function ( $actions ) {
-		$unlaunched = get_option( 'launch-status' ) === 'unlaunched';
+if ( has_action( 'plugins_loaded', 'Jetpack\Mu_Wpcom\load_coming_soon' ) === false ) {
+	add_filter(
+		'plugin_action_links_' . plugin_basename( __FILE__ ),
+		function ( $actions ) {
+			$unlaunched = get_option( 'launch-status' ) === 'unlaunched';
 
-		if ( $unlaunched ) {
-			$actions = array_map(
-				function ( $action ) {
-					$message = __( 'Disabling this plugin will make your site public.', 'full-site-editing' );
-					$confirm = "confirm('$message') ? null : event.preventDefault()";
+			if ( $unlaunched ) {
+				$actions = array_map(
+					function ( $action ) {
+						$message = __( 'Disabling this plugin will make your site public.', 'full-site-editing' );
+						$confirm = "confirm('$message') ? null : event.preventDefault()";
 
-					return str_replace(
-						'<a href="plugins.php?action=deactivate',
-						"<a onclick=\"$confirm\" href=\"plugins.php?action=deactivate",
-						$action
-					);
-				},
-				$actions
-			);
+						return str_replace(
+							'<a href="plugins.php?action=deactivate',
+							"<a onclick=\"$confirm\" href=\"plugins.php?action=deactivate",
+							$action
+						);
+					},
+					$actions
+				);
+			}
+
+			return $actions;
 		}
-
-		return $actions;
-	}
-);
+	);
+}

--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -434,3 +434,36 @@ function load_wpcom_global_styles() {
 	require_once __DIR__ . '/wpcom-global-styles/index.php';
 }
 add_action( 'plugins_loaded', __NAMESPACE__ . '\load_wpcom_global_styles' );
+
+/**
+ * Shows a confirm prompt when the plugin is about to be deactivated on a unlaunched site.
+ *
+ * This will filter the FSE actions on the plugin manager list to add the confirm
+ * prompt on the click event of the action=deactivate.
+ *
+ * The option launch-status exists only on wpcom sites.
+ */
+add_filter(
+	'plugin_action_links_plugin_action_links_full-site-editing/full-site-editing-plugin.php',
+	function ( $actions ) {
+		$unlaunched = get_option( 'launch-status' ) === 'unlaunched';
+
+		if ( $unlaunched ) {
+			$actions = array_map(
+				function ( $action ) {
+					$message = __( 'Disabling this plugin will make your site public.', 'full-site-editing' );
+					$confirm = "confirm('$message') ? null : event.preventDefault()";
+
+					return str_replace(
+						'<a href="plugins.php?action=deactivate',
+						"<a onclick=\"$confirm\" href=\"plugins.php?action=deactivate",
+						$action
+					);
+				},
+				$actions
+			);
+		}
+
+		return $actions;
+	}
+);


### PR DESCRIPTION
#### Proposed Changes

* Show a confirm prompt when the plugin is about to be deactivated on an unlaunched site.
* We add a filter in the file `dotcom-fse/helpers.php` that loads it when the plugin is activated, which covers our use case. Is there a better file to put this code?

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* In an atomic site, go to plugins > add new > upload and drop the plugin in this link [full-site-editing.zip](https://github.com/Automattic/wp-calypso/files/10204957/full-site-editing.zip). It is the FSE plugin downloaded from Teamcity, and then the zip file has been renamed.
* Click on `Deactivate` the plugin and you should see a prompt saying `Disabling this plugin will make your site public.`
* Click on `Confirm` to deactivate the plugin or on `Cancel`.
* Click on `Activate` and you should not see the prompt.
* Launch the site from the button `Launch site` in the General Settings UI  or from the launchpad in My Home.
  * Alternatively, you can use the URL `[your atomic site URL]/_cli` to run the command  `wp option set launch-status launched` but remember to refresh the installed plugins page. 
* Head to installed plugins `/wp-admin/plugins.php`. You might need to refresh the page if you had it open already.
* Click on `Deactivate` on the plugin WordPress.com Editing Toolkit. You should NOT see the prompt and the plugin will be deactivated immediately because your site is launched.

**Recording**
Test with `launch-status` as `unlaunched`:

https://user-images.githubusercontent.com/1881481/197182777-26a8118d-5cbb-4f02-9f56-e90afd111bdb.mov

Test with `launch-status` as `launched`:

https://user-images.githubusercontent.com/1881481/197183509-12c5e29b-4d6d-4f4e-bd35-6090b064683d.mov

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/68870