### PR TITLE
BBE : WebsiteContent : Bug fix for when accessing site logo url with stale data

### DIFF
--- a/client/signup/steps/website-content/section-generator.tsx
+++ b/client/signup/steps/website-content/section-generator.tsx
@@ -42,7 +42,10 @@ const generateLogoSection = (
 				component: (
 					<LogoUploadSection
 						sectionID={ LOGO_SECTION_ID }
-						logoUrl={ formValues.siteLogoSection.siteLogoUrl }
+						// The structure of the state tree changed and can generate errors for stale data where siteLogoUrl lived in the root of this state tree
+						// So the optional parameter was added to safegaurd for any errors.
+						// This should eventually be removed with a fix that prevents this type of bug
+						logoUrl={ formValues.siteLogoSection?.siteLogoUrl }
 					/>
 				),
 				showSkip: true,

--- a/client/state/signup/steps/website-content/schema.ts
+++ b/client/state/signup/steps/website-content/schema.ts
@@ -47,6 +47,8 @@ export const schema = {
 				siteLogoSection: {
 					type: 'object',
 					description: 'Props related to Uploading logo url',
+					additionalProperties: false,
+					required: [ 'siteLogoUrl' ],
 					properties: {
 						siteLogoUrl: {
 							type: 'string',
@@ -57,6 +59,8 @@ export const schema = {
 				feedbackSection: {
 					type: 'object',
 					description: 'Props related to generating feedback',
+					additionalProperties: false,
+					required: [ 'genericFeedback' ],
 					properties: {
 						genericFeedback: {
 							type: 'string',

--- a/client/state/signup/steps/website-content/schema.ts
+++ b/client/state/signup/steps/website-content/schema.ts
@@ -2,7 +2,8 @@ export const schema = {
 	$schema: 'https://json-schema.org/draft/2020-12/schema',
 	title: 'Website content schema',
 	type: 'object',
-	required: [ 'currentIndex', 'websiteContent' ],
+	additionalProperties: false,
+	required: [ 'currentIndex', 'websiteContent', 'imageUploadStates' ],
 	properties: {
 		currentIndex: {
 			type: 'number',
@@ -11,6 +12,8 @@ export const schema = {
 		websiteContent: {
 			type: 'object',
 			description: 'The content for the website',
+			additionalProperties: false,
+			required: [ 'pages', 'siteLogoSection', 'feedbackSection' ],
 			properties: {
 				pages: {
 					type: 'array',
@@ -47,17 +50,17 @@ export const schema = {
 					properties: {
 						siteLogoUrl: {
 							type: 'string',
-							description: 'Uploaded Logot url',
+							description: 'Uploaded Logo url',
 						},
 					},
 				},
 				feedbackSection: {
 					type: 'object',
-					description: 'Props related to Uploading logo url',
+					description: 'Props related to generating feedback',
 					properties: {
 						genericFeedback: {
 							type: 'string',
-							description: 'Uploaded Logot url',
+							description: 'General feedback provided about the site',
 						},
 					},
 				},

--- a/client/state/signup/steps/website-content/schema.ts
+++ b/client/state/signup/steps/website-content/schema.ts
@@ -41,9 +41,25 @@ export const schema = {
 						},
 					},
 				},
-				siteLogoUrl: {
-					type: 'string',
-					description: 'Uploaded Logot url',
+				siteLogoSection: {
+					type: 'object',
+					description: 'Props related to Uploading logo url',
+					properties: {
+						siteLogoUrl: {
+							type: 'string',
+							description: 'Uploaded Logot url',
+						},
+					},
+				},
+				feedbackSection: {
+					type: 'object',
+					description: 'Props related to Uploading logo url',
+					properties: {
+						genericFeedback: {
+							type: 'string',
+							description: 'Uploaded Logot url',
+						},
+					},
 				},
 			},
 		},

--- a/client/state/signup/steps/website-content/test/schema.ts
+++ b/client/state/signup/steps/website-content/test/schema.ts
@@ -3,9 +3,7 @@ import { initialState, schema } from '../schema';
 
 const initialTestState = {
 	currentIndex: 0,
-
 	websiteContent: {
-		siteLogoSection: { siteLogoUrl: '' },
 		pages: [
 			{
 				id: 'Home',
@@ -38,7 +36,11 @@ const initialTestState = {
 				],
 			},
 		],
+
+		siteLogoSection: { siteLogoUrl: '' },
+		feedbackSection: { genericFeedback: '' },
 	},
+	imageUploadStates: {},
 };
 
 describe( 'schema', () => {
@@ -48,7 +50,7 @@ describe( 'schema', () => {
 		} ).not.toThrow();
 	} );
 
-	test( 'Empty schema should be invalid', () => {
+	test( 'Empty object should be invalid', () => {
 		const isValidSchema = validator( schema )( {} );
 		expect( isValidSchema ).toBe( false );
 	} );


### PR DESCRIPTION
#### Proposed Changes

The state structure of siteLogoUrl was changed from a simple string to a string within an object in #69285. However stale data might break due to this restructuring since we do not entirely discard stale data on initialisation of the page in the view of saving content for user convenience.

This should be fixed by properly adding the schema definition for the state. But the optional param is also included for good measure.


#### Testing Instructions
- Create DIFM site `/start/do-it-for-me` and complete purchase
- In the website-content page there should not be any console errors.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
