### PR TITLE
This PR adds handling for the global cancel button in the Promote Post

### DIFF
--- a/client/components/blazepress-widget/index.tsx
+++ b/client/components/blazepress-widget/index.tsx
@@ -23,6 +23,7 @@ const BlazePressWidget = ( props: BlazePressPromotionProps ) => {
 	const { isVisible = false, onClose = () => {} } = props;
 	const [ isLoading, setIsLoading ] = useState( true );
 	const [ showCancelDialog, setShowCancelDialog ] = useState( false );
+	const [ showCancelButton, setShowCancelButton ] = useState( true );
 	const widgetContainer = useRef< HTMLDivElement >( null );
 	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
 	const translate = useTranslate() as BlazePressTranslatable;
@@ -33,6 +34,8 @@ const BlazePressWidget = ( props: BlazePressPromotionProps ) => {
 			window.scrollTo( 0, 0 );
 		}
 	}, [ isVisible ] );
+
+	const handleShowCancel = ( show: boolean ) => setShowCancelButton( show );
 
 	useEffect( () => {
 		isVisible &&
@@ -56,7 +59,8 @@ const BlazePressWidget = ( props: BlazePressPromotionProps ) => {
 						// eslint-disable-next-line wpcalypso/i18n-no-variables
 						return translate( original );
 					},
-					widgetContainer.current
+					widgetContainer.current,
+					handleShowCancel
 				);
 				setIsLoading( false );
 			} )();
@@ -90,15 +94,17 @@ const BlazePressWidget = ( props: BlazePressPromotionProps ) => {
 					<div className="blazepress-widget__header-bar">
 						<WordPressLogo />
 						<h2>{ translate( 'Advertising' ) }</h2>
-						<span
-							role="button"
-							className="blazepress-widget__cancel"
-							onKeyDown={ () => setShowCancelDialog( true ) }
-							tabIndex={ 0 }
-							onClick={ () => setShowCancelDialog( true ) }
-						>
-							{ translate( 'Cancel' ) }
-						</span>
+						{ showCancelButton && (
+							<span
+								role="button"
+								className="blazepress-widget__cancel"
+								onKeyDown={ () => setShowCancelDialog( true ) }
+								tabIndex={ 0 }
+								onClick={ () => setShowCancelDialog( true ) }
+							>
+								{ translate( 'Cancel' ) }
+							</span>
+						) }
 					</div>
 					<div
 						className={
@@ -106,7 +112,7 @@ const BlazePressWidget = ( props: BlazePressPromotionProps ) => {
 						}
 					>
 						<Dialog
-							isVisible={ showCancelDialog }
+							isVisible={ showCancelDialog && showCancelButton }
 							buttons={ cancelDialogButtons }
 							onClose={ () => setShowCancelDialog( false ) }
 						>

--- a/client/lib/promote-post/index.ts
+++ b/client/lib/promote-post/index.ts
@@ -25,6 +25,7 @@ declare global {
 				onClose?: () => void;
 				translateFn?: ( value: string, options?: any ) => string;
 				showDialog?: boolean;
+				setShowCancelButton?: ( show: boolean ) => void;
 			} ) => void;
 		};
 	}
@@ -46,7 +47,8 @@ export async function showDSP(
 	postId: number | string,
 	onClose: () => void,
 	translateFn: ( value: string, options?: any ) => string,
-	domNodeOrId?: HTMLElement | string | null
+	domNodeOrId?: HTMLElement | string | null,
+	setShowCancelButton?: ( show: boolean ) => void
 ) {
 	await loadDSPWidgetJS();
 	return new Promise( ( resolve, reject ) => {
@@ -65,6 +67,7 @@ export async function showDSP(
 				onClose: onClose,
 				translateFn: translateFn,
 				urn: `urn:wpcom:post:${ siteId }:${ postId || 0 }`,
+				setShowCancelButton: setShowCancelButton,
 			} );
 		} else {
 			reject( false );

--- a/client/my-sites/promote-post/main.tsx
+++ b/client/my-sites/promote-post/main.tsx
@@ -39,10 +39,10 @@ const queryPage = {
 	type: 'page',
 };
 
-function sortItemsByModifiedDate( items: Post[] ) {
+function sortItemsByPublishedDate( items: Post[] ) {
 	return items.slice( 0 ).sort( function ( a, b ) {
-		if ( a.modified && b.modified ) {
-			const dateCompare = Date.parse( b.modified ) - Date.parse( a.modified );
+		if ( a.date && b.date ) {
+			const dateCompare = Date.parse( b.date ) - Date.parse( a.date );
 			if ( 0 !== dateCompare ) {
 				return dateCompare;
 			}
@@ -142,7 +142,7 @@ export default function PromotedPosts( { tab }: Props ) {
 		);
 	}
 
-	const content = sortItemsByModifiedDate( [ ...( posts || [] ), ...( pages || [] ) ] );
+	const content = sortItemsByPublishedDate( [ ...( posts || [] ), ...( pages || [] ) ] );
 
 	const isLoading = isLoadingPage && isLoadingPost;
 


### PR DESCRIPTION
#### Proposed Changes
- Adds handling of the "cancel" button that appears in the Promote Post wrapper

#### Testing Instructions

- First we need to include the parallel Pr that enables this in the DSP-widget app
- Promote a post and go to the payment screen
- Once you create the payment the cancel button will be hidden


#### Pre-merge Checklist
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

Related to #
