### PR TITLE
Limit Global Styles: Block styles with new filter

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
@@ -131,6 +131,7 @@ function wpcom_block_global_styles_frontend( $theme_json ) {
 	return $theme_json;
 }
 add_filter( 'theme_json_user', 'wpcom_block_global_styles_frontend' );
+add_filter( 'wp_theme_json_data_user', 'wpcom_block_global_styles_frontend' );
 
 /**
  * Tracks when global styles are updated or reset after the post has actually been saved.


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/1091

#### Proposed Changes

Updates the filter used to block Global Styles to `wp_theme_json_data_user`, since WordPress has changed the `theme_json_user` filter to `wp_theme_json_data_user` (https://github.com/WordPress/wordpress-develop/pull/3443, https://github.com/WordPress/gutenberg/pull/44940).

#### Testing Instructions

- Go to https://wordpress.com/start and create a new free site
- Add the following blog stickers to the new site from the Blog RC:
  - `wpcom-limit-global-styles`
  - `gutenberg-edge`
- Install Gutenberg v14.4.0-rc.1 on your sandbox: `gbupgrade -v v14.4.0-rc.1`
- Sandbox the new site
- Go to Appearance > Editor
- Open the Global Styles sidebar
- Click on "Browse styles"
- Select a non-default variation
- Save the styles
- Visit the frontend
- Note how the styles from the non-default variation are visible
- Apply these changes to your sandbox
- Reload the frontend
- Make sure the styles from the non-default variation are hidden
