### PR TITLE
Limit Global Styles: Open plans page in new tab

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/notice.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/notice.js
@@ -1,7 +1,7 @@
 /* global wpcomGlobalStyles */
 
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { Button, Notice } from '@wordpress/components';
+import { Button, ExternalLink, Notice } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { createInterpolateElement, useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -88,8 +88,7 @@ const GlobalStylesNotice = () => {
 				),
 				{
 					a: (
-						<Button
-							variant="link"
+						<ExternalLink
 							href={ wpcomGlobalStyles.upgradeUrl }
 							target="_blank"
 							onClick={ () =>

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/notice.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/notice.js
@@ -91,7 +91,7 @@ const GlobalStylesNotice = () => {
 						<Button
 							variant="link"
 							href={ wpcomGlobalStyles.upgradeUrl }
-							target="_top"
+							target="_blank"
 							onClick={ () =>
 								recordTracksEvent( 'calypso_global_styles_gating_notice_upgrade_click', {
 									context: 'site-editor',

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/notice.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/notice.scss
@@ -8,4 +8,12 @@
 	a {
 		display: inline;
 	}
+
+	.components-button.is-link {
+		color: var(--color-link);
+
+		&:hover {
+			color: var(--color-link-light);
+		}
+	}
 }


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/69247

#### Proposed Changes

We open now the plans page in a new tab when the user clicks on the "upgrade your plan" link.

<img width="180" alt="Screen Shot 2022-10-24 at 11 38 00" src="https://user-images.githubusercontent.com/1233880/197496737-edf82b75-37ee-4728-94c9-eb7efbc8fd16.png">

We were previously opening it in the same tab, but that displayed a "Are you sure you want to leave? Changes will be lost" warning. I considered to automatically save the changes and keep opening the page in the same tab, but finally refrained from doing so because the changes won't be public and the user showed interested in having them public which is why they clicked on the upgrade link before saving.

The site editor doesn't have the concept of drafts to save unpublished changes, so I think that opening the page on a separate tab is the best thing we can do.


#### Testing Instructions

- Apply these changes to your sandbox: `update/limit-gs-click-upgrade-new-tab`
- Go to https://wordpress.com/start and create a new free site
- Add the `wpcom-limit-global-styles` blog sticker to the new site from the Blog RC
- Sandbox the new site
- Go to Appearance > Editor
- Open the Global Styles sidebar
- Change some styles
- Click on the "Save" button
- Click on the "upgrade your plan" link 
- Make sure it opens the plans page in a new tab
