### PR TITLE
Fix component name typo in the Theme component

### DIFF
--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -13,7 +13,7 @@ import { Component, createRef } from 'react';
 import { connect } from 'react-redux';
 import InfoPopover from 'calypso/components/info-popover';
 import PulsingDot from 'calypso/components/pulsing-dot';
-import Tootlip from 'calypso/components/tooltip';
+import Tooltip from 'calypso/components/tooltip';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import { decodeEntities } from 'calypso/lib/formatting';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -450,13 +450,13 @@ export class Theme extends Component {
 						) }
 					</a>
 
-					<Tootlip
+					<Tooltip
 						context={ this.themeThumbnailRef.current }
 						isVisible={ this.state.descriptionTooltipVisible }
 						showDelay={ 1000 }
 					>
 						<div className="theme__tooltip">{ themeDescription }</div>
-					</Tootlip>
+					</Tooltip>
 
 					<div className="theme__info">
 						<h2 className="theme__info-title">{ name }</h2>


### PR DESCRIPTION
#### Proposed Changes

We were accidentally importing `Tooltip` as `Tootlip`. Everything functioned since `Tooltip` is exported as the default so it didn't matter what name we used but it seems like it's a good idea to name it properly.

#### Testing Instructions
1. Change to this branch
2. Go to `/theme` and verify the ⭐ tooltip still functions on premium themes.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
