### PR TITLE
Settings: add tracking for Start Over page

### DIFF
--- a/client/my-sites/site-settings/start-over.jsx
+++ b/client/my-sites/site-settings/start-over.jsx
@@ -8,6 +8,7 @@ import ActionPanelFigure from 'calypso/components/action-panel/figure';
 import ActionPanelFooter from 'calypso/components/action-panel/footer';
 import ActionPanelTitle from 'calypso/components/action-panel/title';
 import HeaderCake from 'calypso/components/header-cake';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { EMPTY_SITE } from 'calypso/lib/url/support';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 
@@ -18,6 +19,7 @@ const StartOver = ( { translate, selectedSiteSlug } ) => {
 			className="main main-column" // eslint-disable-line wpcalypso/jsx-classname-namespace
 			role="main"
 		>
+			<PageViewTracker path="/settings/start-over/:site" title="Settings > Start Over" />
 			<HeaderCake backHref={ '/settings/general/' + selectedSiteSlug }>
 				<h1>{ translate( 'Start Over' ) }</h1>
 			</HeaderCake>


### PR DESCRIPTION
#### Proposed Changes

We want to gauge how many organic views this page receives to determine customer demand. Currently, we are only tracking the views for https://wordpress.com/settings/start-over/ path, but that's not very useful since users can't reach it through the UI (only by typing the URL directly).

<img width="796" alt="Screenshot 2022-10-21 at 19 57 03" src="https://user-images.githubusercontent.com/1182160/197259331-541fcdd2-4cfe-4aec-b9ad-a708359c486b.png">

#### Testing Instructions

1. Run `localStorage.setItem( 'debug', 'calypso:analytics*' );` in your console.
2. Navigate to `Settings -> General` and click "Delete your content" at the bottom of the page.
3. Verify that the following entry appears in the console logs `calypso:analytics Recording event "calypso_page_view" with actual props` with path prop equal to `/settings/start-over/:site`.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
