### PR TITLE
Plugins: add inline help link to breadcrumb modal

### DIFF
--- a/client/my-sites/plugins/plans/index.tsx
+++ b/client/my-sites/plugins/plans/index.tsx
@@ -12,6 +12,7 @@ import ActionPanelLink from 'calypso/components/action-panel/link';
 import DocumentHead from 'calypso/components/data/document-head';
 import FixedNavigationHeader from 'calypso/components/fixed-navigation-header';
 import FormattedHeader from 'calypso/components/formatted-header';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 import MainComponent from 'calypso/components/main';
 import PromoSection, { Props as PromoSectionProps } from 'calypso/components/promo-section';
 import { Gridicon } from 'calypso/devdocs/design/playground-scope';
@@ -45,7 +46,12 @@ const Plans = ( { intervalType }: { intervalType: 'yearly' | 'monthly' } ) => {
 					href: `/plugins/${ selectedSite?.slug || '' }`,
 					id: 'plugins',
 					helpBubble: translate(
-						'Add new functionality and integrations to your site with plugins.'
+						'Add new functionality and integrations to your site with plugins. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+						{
+							components: {
+								learnMoreLink: <InlineSupportLink supportContext="plugins" showIcon={ false } />,
+							},
+						}
 					),
 				} )
 			);

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -9,6 +9,7 @@ import QueryProductsList from 'calypso/components/data/query-products-list';
 import QuerySiteFeatures from 'calypso/components/data/query-site-features';
 import EmptyContent from 'calypso/components/empty-content';
 import FixedNavigationHeader from 'calypso/components/fixed-navigation-header';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 import MainComponent from 'calypso/components/main';
 import Notice from 'calypso/components/notice';
 import NoticeAction from 'calypso/components/notice/notice-action';
@@ -201,7 +202,12 @@ function PluginDetails( props ) {
 					href: localizePath( `/plugins/${ selectedSite?.slug || '' }` ),
 					id: 'plugins',
 					helpBubble: translate(
-						'Add new functionality and integrations to your site with plugins.'
+						'Add new functionality and integrations to your site with plugins. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+						{
+							components: {
+								learnMoreLink: <InlineSupportLink supportContext="plugins" showIcon={ false } />,
+							},
+						}
 					),
 				} )
 			);

--- a/client/my-sites/plugins/plugins-navigation-header/index.jsx
+++ b/client/my-sites/plugins/plugins-navigation-header/index.jsx
@@ -10,6 +10,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useEffect, useMemo } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import FixedNavigationHeader from 'calypso/components/fixed-navigation-header';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 import { useLocalizedPlugins } from 'calypso/my-sites/plugins/utils';
 import { recordTracksEvent, recordGoogleEvent } from 'calypso/state/analytics/actions';
 import { appendBreadcrumb, resetBreadcrumbs } from 'calypso/state/breadcrumb/actions';
@@ -123,7 +124,12 @@ const PluginsNavigationHeader = ( { navigationHeaderRef, categoryName, category,
 					href: localizePath( `/plugins/${ selectedSite?.slug || '' }` ),
 					id: 'plugins',
 					helpBubble: translate(
-						'Add new functionality and integrations to your site with plugins.'
+						'Add new functionality and integrations to your site with plugins. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+						{
+							components: {
+								learnMoreLink: <InlineSupportLink supportContext="plugins" showIcon={ false } />,
+							},
+						}
 					),
 				} )
 			);


### PR DESCRIPTION
This PR returns the `InlineSupportLink` to the Plugins header. Thanks to @donalirl for noticing it was missing. 

props @JessBoctor 
Fixes: #66635
See: #60876

![plugins-learn-more](https://user-images.githubusercontent.com/942359/197271779-23124db7-c615-4271-82e7-76ddd4f5635e.gif)

**To test:**
- run the branch locally (or use calypso.live)
- visit "Plugins" in the sidebar
- verify that the "Plugins" breadcrumb navigation is show
- click the (?) in the navigation
- verify that the description is shown in a tool-tip and the "learn more" link is included in the description
- click "learn more"
- verify that the plugins support inline modal is shown
