### PR TITLE
Theme Showcase: Callout soft launched themes

### DIFF
--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -50,6 +50,7 @@ export class Theme extends Component {
 			taxonomies: PropTypes.object,
 			update: PropTypes.object,
 			price: PropTypes.any,
+			soft_launched: PropTypes.bool,
 		} ),
 		// If true, highlight this theme as active
 		active: PropTypes.bool,
@@ -90,6 +91,7 @@ export class Theme extends Component {
 		isUpdating: PropTypes.bool,
 		isUpdated: PropTypes.bool,
 		errorOnUpdate: PropTypes.bool,
+		softLaunched: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -309,6 +311,16 @@ export class Theme extends Component {
 		);
 	}
 
+	softLaunchedBanner = () => {
+		return (
+			<>
+				{ this.props.softLaunched && (
+					<div className="theme__info-soft-launched-banner">Soft Launched</div>
+				) }
+			</>
+		);
+	};
+
 	render() {
 		const {
 			active,
@@ -457,6 +469,8 @@ export class Theme extends Component {
 					>
 						<div className="theme__tooltip">{ themeDescription }</div>
 					</Tooltip>
+
+					{ this.softLaunchedBanner() }
 
 					<div className="theme__info">
 						<h2 className="theme__info-title">{ name }</h2>

--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -312,10 +312,12 @@ export class Theme extends Component {
 	}
 
 	softLaunchedBanner = () => {
+		const { translate } = this.props;
+
 		return (
 			<>
 				{ this.props.softLaunched && (
-					<div className="theme__info-soft-launched-banner">Soft Launched</div>
+					<div className="theme__info-soft-launched-banner">{ translate( 'Soft Launched' ) }</div>
 				) }
 			</>
 		);

--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -317,7 +317,12 @@ export class Theme extends Component {
 		return (
 			<>
 				{ this.props.softLaunched && (
-					<div className="theme__info-soft-launched-banner">{ translate( 'Soft Launched' ) }</div>
+					<div className="theme__info-soft-launched">
+						<div className="theme__info-soft-launched-banner">{ translate( 'Soft Launched' ) }</div>
+						<div className="theme__info-soft-launched-tooltip">
+							{ translate( 'This theme is only visible to Automattic employees.' ) }
+						</div>
+					</div>
 				) }
 			</>
 		);

--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -318,9 +318,8 @@ export class Theme extends Component {
 			<>
 				{ this.props.softLaunched && (
 					<div className="theme__info-soft-launched">
-						<div className="theme__info-soft-launched-banner">{ translate( 'Soft Launched' ) }</div>
-						<div className="theme__info-soft-launched-tooltip">
-							{ translate( 'This theme is only visible to Automattic employees.' ) }
+						<div className="theme__info-soft-launched-banner">
+							{ translate( 'Available to A8C-only' ) }
 						</div>
 					</div>
 				) }

--- a/client/components/theme/style.scss
+++ b/client/components/theme/style.scss
@@ -404,15 +404,37 @@ $theme-info-height: 54px;
 	max-width: 300px;
 }
 
-.theme__info-soft-launched-banner {
+.theme__info-soft-launched {
 	position: absolute;
 	top: 28px;
 	left: -8px;
 	z-index: 100000;
-	background-color: var(--color-warning-20);
-	color: var(--color-warning-80);
-	font-size: rem(7px);
-	font-weight: bold;
-	text-transform: uppercase;
-	transform: rotate(315deg);
+
+	.theme__info-soft-launched-banner {
+		background-color: var(--color-warning-20);
+		color: var(--color-warning-80);
+		font-size: rem(7px);
+		font-weight: bold;
+		text-transform: uppercase;
+		transform: rotate(315deg);
+
+	}
+
+	.theme__info-soft-launched-tooltip {
+		display: none;
+		position: absolute;
+		top: 0;
+		left: 0;
+		font-size: rem(7px);
+		width: 225px;
+		margin-left: 2rem;
+		background: var(--color-surface);
+		padding: 4px;
+		border-radius: 2px;
+		border: 1px solid var(--color-border-subtle);
+	}
+
+	&:hover .theme__info-soft-launched-tooltip {
+		display: block;
+	}
 }

--- a/client/components/theme/style.scss
+++ b/client/components/theme/style.scss
@@ -406,8 +406,8 @@ $theme-info-height: 54px;
 
 .theme__info-soft-launched {
 	position: absolute;
-	top: 28px;
-	left: -8px;
+	top: 36px;
+	left: -12px;
 	z-index: 100000;
 
 	.theme__info-soft-launched-banner {
@@ -418,23 +418,5 @@ $theme-info-height: 54px;
 		text-transform: uppercase;
 		transform: rotate(315deg);
 
-	}
-
-	.theme__info-soft-launched-tooltip {
-		display: none;
-		position: absolute;
-		top: 0;
-		left: 0;
-		font-size: rem(7px);
-		width: 225px;
-		margin-left: 2rem;
-		background: var(--color-surface);
-		padding: 4px;
-		border-radius: 2px;
-		border: 1px solid var(--color-border-subtle);
-	}
-
-	&:hover .theme__info-soft-launched-tooltip {
-		display: block;
 	}
 }

--- a/client/components/theme/style.scss
+++ b/client/components/theme/style.scss
@@ -403,3 +403,16 @@ $theme-info-height: 54px;
 .theme__tooltip {
 	max-width: 300px;
 }
+
+.theme__info-soft-launched-banner {
+	position: absolute;
+	top: 28px;
+	left: -8px;
+	z-index: 100000;
+	background-color: var(--color-warning-20);
+	color: var(--color-warning-80);
+	font-size: rem(7px);
+	font-weight: bold;
+	text-transform: uppercase;
+	transform: rotate(315deg);
+}

--- a/client/components/theme/style.scss
+++ b/client/components/theme/style.scss
@@ -408,7 +408,6 @@ $theme-info-height: 54px;
 	position: absolute;
 	top: 36px;
 	left: -12px;
-	z-index: 100000;
 
 	.theme__info-soft-launched-banner {
 		background-color: var(--color-warning-20);

--- a/client/components/themes-list/index.jsx
+++ b/client/components/themes-list/index.jsx
@@ -118,6 +118,7 @@ function ThemeBlock( props ) {
 			upsellUrl={ props.upsellUrl }
 			bookmarkRef={ bookmarkRef }
 			siteId={ siteId }
+			softLaunched={ theme.soft_launched }
 		/>
 	);
 }

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -103,6 +103,7 @@ class ThemeSheet extends Component {
 		siteSlug: PropTypes.string,
 		backPath: PropTypes.string,
 		isWpcomTheme: PropTypes.bool,
+		softLaunched: PropTypes.bool,
 		defaultOption: PropTypes.shape( {
 			label: PropTypes.string,
 			action: PropTypes.func,
@@ -193,7 +194,7 @@ class ThemeSheet extends Component {
 	};
 
 	renderBar = () => {
-		const { author, name, translate } = this.props;
+		const { author, name, translate, softLaunched } = this.props;
 
 		const placeholder = <span className="theme__sheet-placeholder">loading.....</span>;
 		const title = name || placeholder;
@@ -201,7 +202,10 @@ class ThemeSheet extends Component {
 
 		return (
 			<div className="theme__sheet-bar">
-				<span className="theme__sheet-bar-title">{ title }</span>
+				<span className="theme__sheet-bar-title">
+					{ title }
+					{ softLaunched && <span className="theme__sheet-bar-soft-launched">Soft Launched</span> }
+				</span>
 				<span className="theme__sheet-bar-tag">{ tag }</span>
 			</div>
 		);
@@ -921,6 +925,7 @@ export default connect(
 			canonicalUrl: localizeUrl( englishUrl, getLocaleSlug(), false ).replace( /\/$/, '' ),
 			demoUrl: getThemeDemoUrl( state, id, siteId ),
 			isWPForTeamsSite: isSiteWPForTeams( state, siteId ),
+			softLaunched: theme?.soft_launched,
 		};
 	},
 	{

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -205,7 +205,11 @@ class ThemeSheet extends Component {
 				<span className="theme__sheet-bar-title">
 					{ title }
 					{ softLaunched && (
-						<span className="theme__sheet-bar-soft-launched">{ translate( 'Soft Launched' ) }</span>
+						<button title={ translate( 'This theme is only visible to Automattic employees' ) }>
+							<span className="theme__sheet-bar-soft-launched">
+								{ translate( 'Soft Launched' ) }
+							</span>
+						</button>
 					) }
 				</span>
 				<span className="theme__sheet-bar-tag">{ tag }</span>

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -205,11 +205,9 @@ class ThemeSheet extends Component {
 				<span className="theme__sheet-bar-title">
 					{ title }
 					{ softLaunched && (
-						<button title={ translate( 'This theme is only visible to Automattic employees' ) }>
-							<span className="theme__sheet-bar-soft-launched">
-								{ translate( 'Soft Launched' ) }
-							</span>
-						</button>
+						<span className="theme__sheet-bar-soft-launched">
+							{ translate( 'Available to A8C-only' ) }
+						</span>
 					) }
 				</span>
 				<span className="theme__sheet-bar-tag">{ tag }</span>

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -204,7 +204,9 @@ class ThemeSheet extends Component {
 			<div className="theme__sheet-bar">
 				<span className="theme__sheet-bar-title">
 					{ title }
-					{ softLaunched && <span className="theme__sheet-bar-soft-launched">Soft Launched</span> }
+					{ softLaunched && (
+						<span className="theme__sheet-bar-soft-launched">{ translate( 'Soft Launched' ) }</span>
+					) }
 				</span>
 				<span className="theme__sheet-bar-tag">{ tag }</span>
 			</div>

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -44,6 +44,7 @@
 	background-color: var(--color-warning-20);
 	margin-left: 1rem;
 	margin-bottom: 0.75rem;
+	cursor: pointer;
 }
 
 .theme__sheet-columns {

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -44,7 +44,6 @@
 	background-color: var(--color-warning-20);
 	margin-left: 1rem;
 	margin-bottom: 0.75rem;
-	cursor: pointer;
 }
 
 .theme__sheet-columns {

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -36,6 +36,16 @@
 	padding-left: 25px;
 }
 
+.theme__sheet-bar-soft-launched {
+	color: var(--color-warning-80);
+	font-size: rem(7px);
+	font-weight: bold;
+	text-transform: uppercase;
+	background-color: var(--color-warning-20);
+	margin-left: 1rem;
+	margin-bottom: 0.75rem;
+}
+
 .theme__sheet-columns {
 	display: flex;
 	flex-direction: row;


### PR DESCRIPTION
#### Proposed Changes

Adds a visual callout when viewing a soft-launched theme in the showcase. The callout is only visible when logged in with an A8C (since soft-launched themes won't appear at all for non-A8C accounts).

![image](https://user-images.githubusercontent.com/917632/197282761-39168bb0-f214-495a-bed5-aa34db5aa81f.png)

![image](https://user-images.githubusercontent.com/917632/197282787-8c956bd8-78a4-4628-8127-6f870fabad4c.png)


#### Testing Instructions

1. Apply D90272-code to your sandbox and sandbox `public-api.wordpress.com`.
2. Visit `/themes/[site-slug]` and verify that Tsubaki and Lettre have the soft-launch badge. All of the other themes should appear normally.
3. Visit `/theme/tsubaki/[site-slug]` and verify that the soft-launch badge appears next to the theme title.
4. Visit a non-soft-launched theme (eg `/theme/varese/[site-slug]`) and verify the soft-launch badge doesn't appear. 

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #69137