### PR TITLE
Launchpad: Update checklist item button content type 

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/checklist-item.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/checklist-item.tsx
@@ -49,7 +49,7 @@ const ChecklistItem = ( { task, isPrimaryAction }: { task: Task; isPrimaryAction
 							/>
 						</div>
 					) }
-					<p className="launchpad__checklist-item-text">{ title }</p>
+					<span className="launchpad__checklist-item-text">{ title }</span>
 					{ task.badgeText ? <Badge type="info-blue">{ task.badgeText }</Badge> : null }
 					{ shouldDisplayChevron && (
 						<Gridicon


### PR DESCRIPTION
Update checklist item button content type from paragraph `p` tag to span `span` tag

#### Proposed Changes

Update our button's `p` tag to a `span` tag to align with [HTML Button Element specification](https://html.spec.whatwg.org/multipage/form-elements.html#the-button-element). The `p` tag is considered Flow Content, which is not permitted content for the button element. Though the current implementation is functional, this change will ensure _should_ browsers enforce this in the future, our buttons will remain unaffected.

#### Testing Instructions

* Test the Launchpad flow in Newsletter and Link in Bio flows. No visual changes should be present. 
* Test the flow with a screenreader. No audible change should be present.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes? **N/A**
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)? **Tested in Simple sites**
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) **N/A**
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)? **N/A**
