### PR TITLE
Marketplace: Improving search states

### DIFF
--- a/client/my-sites/no-results/index.jsx
+++ b/client/my-sites/no-results/index.jsx
@@ -4,11 +4,17 @@ import './style.scss';
 
 export default function NoResults( props ) {
 	const translate = useTranslate();
-	const { image, text = translate( 'No results.' ) } = props;
+	const { image, text = translate( 'No results.' ), subtitle } = props;
 	return (
 		<div className="no-results">
 			{ image && <img className="no-results__img" src={ image } alt="" /> }
-			<span>{ text }</span>
+			{ ! subtitle && <span>{ text }</span> }
+			{ subtitle && (
+				<div className="no-results__titles">
+					<div className="no-results__title">{ text }</div>
+					{ subtitle && <div className="no-results__subtitle">{ subtitle }</div> }
+				</div>
+			) }
 		</div>
 	);
 }

--- a/client/my-sites/no-results/style.scss
+++ b/client/my-sites/no-results/style.scss
@@ -4,6 +4,22 @@
 	color: var(--color-neutral-50);
 	font-size: $font-body;
 	line-height: 56px;
+
+	.no-results__titles {
+		margin-bottom: 4px; // +20 from elements = 24 gap
+		color: var(--color-text);
+		line-height: 1.5;
+
+		.no-results__title {
+			@extend .wp-brand-font;
+			font-size: $font-title-medium;
+			font-weight: 500;
+		}
+
+		.no-results__subtitle {
+			font-size: $font-body-small;
+		}
+	}
 }
 
 .no-results__img {

--- a/client/my-sites/plugins/categories/index.tsx
+++ b/client/my-sites/plugins/categories/index.tsx
@@ -23,7 +23,7 @@ export type Plugin = {
 	icon: string;
 };
 
-const Categories = ( { selected }: { selected?: string } ) => {
+const Categories = ( { selected, noSelection }: { selected?: string; noSelection?: boolean } ) => {
 	const dispatch = useDispatch();
 	const getCategoryUrl = useGetCategoryUrl();
 
@@ -47,11 +47,12 @@ const Categories = ( { selected }: { selected?: string } ) => {
 	};
 
 	const current = selected ? categories.findIndex( ( { slug } ) => slug === selected ) : 0;
+	const activeIndex = noSelection ? -1 : current;
 
 	return (
 		<ResponsiveToolbarGroup
 			className="categories__menu"
-			initialActiveIndex={ current }
+			initialActiveIndex={ activeIndex }
 			onClick={ onClick }
 			hrefList={ categoryUrls }
 			forceSwipe={ 'undefined' === typeof window }

--- a/client/my-sites/plugins/plugins-browser-list/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-list/index.jsx
@@ -25,6 +25,7 @@ const PluginsBrowserList = ( {
 	browseAllLink,
 	size,
 	search,
+	noHeader,
 } ) => {
 	const renderPluginsViewList = () => {
 		const pluginsViewsList = plugins.map( ( plugin, n ) => {
@@ -86,7 +87,7 @@ const PluginsBrowserList = ( {
 
 	return (
 		<div className="plugins-browser-list">
-			{ ( title || subtitle || resultCount || browseAllLink ) && (
+			{ ! noHeader && ( title || subtitle || resultCount || browseAllLink ) && (
 				<PluginsResultsHeader
 					title={ title }
 					subtitle={ subtitle }

--- a/client/my-sites/plugins/plugins-browser-list/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-list/index.jsx
@@ -25,7 +25,7 @@ const PluginsBrowserList = ( {
 	browseAllLink,
 	size,
 	search,
-	noHeader,
+	noHeader = false,
 } ) => {
 	const renderPluginsViewList = () => {
 		const pluginsViewsList = plugins.map( ( plugin, n ) => {

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -163,7 +163,7 @@ const PluginsBrowser = ( { trackPageViews = true, category, search, hideHeader }
 				renderTitleInH1={ ! category }
 			/>
 
-			{ ! search && <Categories selected={ category } /> }
+			<Categories selected={ category } />
 			<div className="plugins-browser__main-container">{ renderList() }</div>
 			{ ! category && ! search && <EducationFooter /> }
 		</MainComponent>

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -163,7 +163,7 @@ const PluginsBrowser = ( { trackPageViews = true, category, search, hideHeader }
 				renderTitleInH1={ ! category }
 			/>
 
-			<Categories selected={ category } />
+			<Categories selected={ category } noSelection={ search ? true : false } />
 			<div className="plugins-browser__main-container">{ renderList() }</div>
 			{ ! category && ! search && <EducationFooter /> }
 		</MainComponent>

--- a/client/my-sites/plugins/plugins-browser/single-list-view/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/single-list-view/index.jsx
@@ -32,7 +32,7 @@ function isNotInstalled( plugin, installedPlugins ) {
 	);
 }
 
-const SingleListView = ( { category, plugins, isFetching, siteSlug, sites } ) => {
+const SingleListView = ( { category, plugins, isFetching, siteSlug, sites, noHeader } ) => {
 	const translate = useTranslate();
 
 	const siteId = useSelector( getSelectedSiteId );
@@ -75,6 +75,7 @@ const SingleListView = ( { category, plugins, isFetching, siteSlug, sites } ) =>
 			currentSites={ sites }
 			variant={ PluginsBrowserListVariant.Fixed }
 			extended
+			noHeader={ noHeader }
 		/>
 	);
 };

--- a/client/my-sites/plugins/plugins-browser/style.scss
+++ b/client/my-sites/plugins/plugins-browser/style.scss
@@ -37,8 +37,13 @@
 }
 
 .plugins-browser__no-results {
+	padding-top: 32px;
 	@include breakpoint-deprecated( "<660px" ) {
 		margin: 0 16px;
+	}
+
+	.plugins-browser-list {
+		padding-top: 0;
 	}
 }
 .plugins-browser__main-container {

--- a/client/my-sites/plugins/plugins-browser/test/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/test/index.jsx
@@ -109,7 +109,7 @@ describe( 'Search view', () => {
 
 	test( 'should show NoResults when there are no results', () => {
 		render( <PluginsBrowser { ...myProps } /> );
-		expect( screen.getByText( /no plugins match your search/i ) ).toBeVisible();
+		expect( screen.getByText( /no matches found/i ) ).toBeVisible();
 	} );
 	test( 'should show plugin list when there are results', () => {
 		mockPlugins = [ {} ];

--- a/client/my-sites/plugins/plugins-discovery-page/index.jsx
+++ b/client/my-sites/plugins/plugins-discovery-page/index.jsx
@@ -22,7 +22,7 @@ function filterPopularPlugins( popularPlugins = [], featuredPlugins = [] ) {
 	);
 }
 
-const PaidPluginsSection = ( props ) => {
+export const PaidPluginsSection = ( props ) => {
 	const { plugins: paidPlugins = [], isFetching: isFetchingPaidPlugins } = usePlugins( {
 		category: 'paid',
 	} );

--- a/client/my-sites/plugins/plugins-search-results-page/index.jsx
+++ b/client/my-sites/plugins/plugins-search-results-page/index.jsx
@@ -8,6 +8,7 @@ import { PluginsBrowserListVariant } from 'calypso/my-sites/plugins/plugins-brow
 import UpgradeNudge from 'calypso/my-sites/plugins/plugins-discovery-page/upgrade-nudge';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import ClearSearchButton from '../plugins-browser/clear-search-button';
+import { PaidPluginsSection } from '../plugins-discovery-page';
 import usePlugins from '../use-plugins';
 
 /**
@@ -142,11 +143,12 @@ const PluginsSearchResultPage = ( {
 		// eslint-disable-next-line wpcalypso/jsx-classname-namespace
 		<div className="plugins-browser__no-results">
 			<NoResults
-				text={ translate( 'No plugins match your search for {{searchTerm/}}.', {
-					textOnly: true,
-					components: { searchTerm: <em>{ searchTerm }</em> },
-				} ) }
+				text={ translate( 'No matches found' ) }
+				subtitle={ translate(
+					'Try using different keywords or check below our must-have premium plugins'
+				) }
 			/>
+			<PaidPluginsSection noHeader />
 		</div>
 	);
 };


### PR DESCRIPTION
#### Proposed Changes
Improve our existing search states.

#### Screenshots
![image](https://user-images.githubusercontent.com/402286/197286525-a6a4847b-3bad-4018-a863-38a4605c594e.png)

![image](https://user-images.githubusercontent.com/402286/197286550-b59f4af8-a5b5-4774-9550-6abe7e2f4cd6.png)

#### Testing Instructions

1. Go to [/plugins](http://calypso.localhost:3000/plugins).
2. Search for something (that has results).
3. Check the tasks below.
4. Repeat the process but search for something without results.

#### Tasks

- [x] Remove the existing (yellow) highlights of the query on the page.
- [x] Keep the categories in the main header allowing users to explore other plugins.
- [x] We follow [the same headline & description pattern](https://github.com/Automattic/wp-calypso/issues/67239) as we have on the landing page and categories.

###### When No Results
- [x] Add the headline of the page
- [x] Add the plugin categories to the main header allowing users to explore
- [x] List our top paid plugins in case of no search results

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] ~~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~~
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~~
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?


Fixes #68492
