### PR TITLE
Add logs around SSR cache accesses

### DIFF
--- a/client/lib/analytics/statsd-utils.ts
+++ b/client/lib/analytics/statsd-utils.ts
@@ -65,13 +65,13 @@ export function createStatsdURL( calypsoSection: string, events: BeaconData[] | 
 /**
  * Logs server events to statsd. Uses superagent for server-side network requests
  * and can disable statsd events with the server_side_boom_analytics_enabled
- * config flag.
+ * config flag. Does nothing if called on the client.
  *
  * @param calypsoSection The Calypso section the event occurred under.
  * @param events List of events to send to the server.
  */
 export function logServerEvent( calypsoSection: string, events: BeaconData[] | BeaconData ) {
-	if ( config( 'server_side_boom_analytics_enabled' ) ) {
+	if ( typeof window === 'undefined' && config( 'server_side_boom_analytics_enabled' ) ) {
 		superagent.get( createStatsdURL( calypsoSection, events ) ).end();
 	}
 }

--- a/client/lib/analytics/statsd-utils.ts
+++ b/client/lib/analytics/statsd-utils.ts
@@ -71,6 +71,7 @@ export function createStatsdURL( calypsoSection: string, events: BeaconData[] | 
  * @param events List of events to send to the server.
  */
 export function logServerEvent( calypsoSection: string, events: BeaconData[] | BeaconData ) {
+	calypsoSection ??= 'unknown';
 	if ( typeof window === 'undefined' && config( 'server_side_boom_analytics_enabled' ) ) {
 		superagent.get( createStatsdURL( calypsoSection, events ) ).end();
 	}

--- a/client/lib/analytics/test/statsd-utils.js
+++ b/client/lib/analytics/test/statsd-utils.js
@@ -95,5 +95,11 @@ describe( 'StatsD Analytics Utils', () => {
 
 			expect( superagent.get ).not.toHaveBeenCalled();
 		} );
+
+		test( 'sets calypso section to unknown if undefined', () => {
+			config.mockReturnValue( true ); // server_side_boom_analytics_enabled
+			logServerEvent( undefined, { name: 'foo', type: 'counting' } );
+			expect( superagent.get ).toHaveBeenCalledWith( expect.stringContaining( 'u=unknown' ) );
+		} );
 	} );
 } );

--- a/client/my-sites/themes/controller.jsx
+++ b/client/my-sites/themes/controller.jsx
@@ -1,4 +1,5 @@
 import debugFactory from 'debug';
+import { logServerEvent } from 'calypso/lib/analytics/statsd-utils';
 import trackScrollPage from 'calypso/lib/track-scroll-page';
 import { requestThemes, requestThemeFilters } from 'calypso/state/themes/actions';
 import { DEFAULT_THEME_QUERY } from 'calypso/state/themes/constants';
@@ -56,6 +57,12 @@ export function fetchThemeData( context, next ) {
 	};
 
 	const themes = getThemesForQuery( context.store.getState(), siteId, query );
+
+	logServerEvent( 'themes', {
+		name: `ssr.get_themes_fetch_cache.${ themes ? 'hit' : 'miss' }`,
+		type: 'counting',
+	} );
+
 	if ( themes ) {
 		debug( 'found theme data in cache' );
 		return next();
@@ -66,8 +73,14 @@ export function fetchThemeData( context, next ) {
 
 export function fetchThemeFilters( context, next ) {
 	const { store } = context;
+	const hasFilters = Object.keys( getThemeFilters( store.getState() ) ).length > 0;
 
-	if ( Object.keys( getThemeFilters( store.getState() ) ).length > 0 ) {
+	logServerEvent( 'themes', {
+		name: `ssr.get_theme_filters_fetch_cache.${ hasFilters ? 'hit' : 'miss' }`,
+		type: 'counting',
+	} );
+
+	if ( hasFilters ) {
 		debug( 'found theme filters in cache' );
 		return next();
 	}

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -19,6 +19,7 @@ import { stringify } from 'qs';
 import superagent from 'superagent'; // Don't have Node.js fetch lib yet.
 import wooDnaConfig from 'calypso/jetpack-connect/woo-dna-config';
 import { STEPPER_SECTION_DEFINITION } from 'calypso/landing/stepper/section';
+import { logServerEvent } from 'calypso/lib/analytics/statsd-utils';
 import { shouldSeeGdprBanner } from 'calypso/lib/analytics/utils';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { isWooOAuth2Client } from 'calypso/lib/oauth2-clients';
@@ -126,6 +127,13 @@ function getDefaultContext( request, response, entrypoint = 'entry-main' ) {
 	const cachedServerState = request.context.isLoggedIn ? {} : stateCache.get( cacheKey ) || {};
 	const getCachedState = ( reducer, storageKey ) => {
 		const storedState = cachedServerState[ storageKey ];
+
+		logServerEvent( request.context.sectionName, {
+			// Note: "ssr" just categorizes the stat. It doesn't necessarily mean SSR was used for the request.
+			name: `ssr.global_redux_cache.${ storedState ? 'hit' : 'miss' }`,
+			type: 'counting',
+		} );
+
 		if ( ! storedState ) {
 			return undefined;
 		}

--- a/client/server/render/index.js
+++ b/client/server/render/index.js
@@ -8,6 +8,7 @@ import Lru from 'lru';
 import { createElement } from 'react';
 import ReactDomServer from 'react-dom/server';
 import superagent from 'superagent';
+import { logServerEvent } from 'calypso/lib/analytics/statsd-utils';
 import {
 	getLanguageFileUrl,
 	getLanguageManifestFileUrl,
@@ -82,6 +83,13 @@ function render( element, key, req ) {
 		debug( 'cache access for key', key );
 
 		let renderedLayout = markupCache.get( key );
+
+		logServerEvent( req.context.sectionName, {
+			// Note: "ssr" just categorizes the stat. It doesn't necessarily mean SSR was used for the request.
+			name: `ssr.markup_cache.${ key }.${ renderedLayout ? 'hit' : 'miss' }`,
+			type: 'counting',
+		} );
+
 		if ( ! renderedLayout ) {
 			bumpStat( 'calypso-ssr', 'loggedout-design-cache-miss' );
 			debug( 'cache miss for key', key );


### PR DESCRIPTION
### Proposed Changes
My ultimate goal is to build a Grafana dashboard around the caches related to the SSR pipeline. This will help us answer if cache is effectively utilized for most requests.

I'm building this on top of my statsd changes in #68068.

Each log follows the same format and uses a statsd counter. We log the total number of hits and the total number of misses, which summed together equal the total number of accesses.

```js
logServerEvent( sectionName, {
	name: `ssr.name_of_cache.${ dataExists ? 'hit' : 'miss' }`,
	type: 'counting',
} );
```

I added this in the following places:
- Themes fetch cache access. (Which happens during SSR of the themes page)
- Server redux cache. (Happens on every request)
- React SSR markup cache. (Happens every time we render SSR markup)

I also looked into adding this to /plugins, around the server-side react query stuff, but realized it would be more tricky than this, since there isn't a single place to check if the cache was accessed and missed as part of a fetch. (Open to suggestions on how to handle this)

#### Potential concerns:
This should add several extra fetch requests to the server with `superagent`, since we aren't throttling anything client side. I would prefer to not throttle anything, since there should be a level of throttling on the other end of the system anyway (in statsd or graphite or boom.gif). We just need to make sure this doesn't impact the server load itself. I don't _think_ it should, since the server never needs to wait for the `get` request to finish, but I wonder if there are any ways to optimize this.

### Testing instructions:
TBD. Not quite sure how to test this, other than smoke testing SSR. 