### PR TITLE
CI: prevent double-tarring situation of artifact files.

### DIFF
--- a/.teamcity/_self/lib/customBuildType/E2EBuildType.kt
+++ b/.teamcity/_self/lib/customBuildType/E2EBuildType.kt
@@ -73,7 +73,7 @@ open class E2EBuildType(
 		maxRunningBuilds = concurrentBuilds
 
 		artifactRules = """
-			logs.tgz => logs.tgz
+			logs => logs.tgz
 			screenshots => screenshots
 			trace => trace
 		""".trimIndent()
@@ -150,7 +150,7 @@ open class E2EBuildType(
 					find test/e2e/results -type f \( -iname \*.webm -o -iname \*.png \) -print0 | xargs -r -0 mv -t screenshots
 
 					mkdir -p logs
-					find test/e2e/ -name '*.log' -print0 | xargs -r -0 tar cvfz logs.tgz
+					find test/e2e/results -name '*.log' -print0 | xargs -r -0 mv -t logs
 
 					mkdir -p trace
 					find test/e2e/results -name '*.zip' -print0 | xargs -r -0 mv -t trace


### PR DESCRIPTION
#### Proposed Changes

This PR updates the `artifactRules` of E2EBuildType as well as the artifact collection process in order to prevent the "double-tarring" situation of artifact rules.

Key changes:
- do not tar matching files in the artifact collection process; instead, collec them into the directory.
- specify in the artifactRules that resulting files should be tarred

Context: 
This change arose as part of the KPI dashboard project: pciE2j-1mq-p2

#### Testing Instructions

Trigger any build that will generate an artifact. As a result of this change, double-tarring of files is stopped and the directory structure of the extracted logs are flattened.

Before:
![image](https://user-images.githubusercontent.com/6549265/197307019-49a57f96-59c0-4e24-8841-371ad6dcdd0f.png)

After:
![image](https://user-images.githubusercontent.com/6549265/197307416-0deb77ce-9460-4d91-b9aa-d5adee8fe502.png)

Note in the **before** image, there are two layers of `logs.tgz` that does not exist in the **after**.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #