### PR TITLE
Use stable color for .stats-sparkline__bar so bars are always visible.

### DIFF
--- a/client/sites-dashboard/components/sites-table-row.tsx
+++ b/client/sites-dashboard/components/sites-table-row.tsx
@@ -47,6 +47,10 @@ const Column = styled.td< { mobileHidden?: boolean } >`
 		${ ( props ) => props.mobileHidden && 'display: none;' };
 		padding-inline-end: 0;
 	}
+
+	.stats-sparkline__bar {
+		fill: var( --studio-gray-60 );
+	}
 `;
 
 const SiteListTile = styled( ListTile )`


### PR DESCRIPTION
#### Proposed Changes

* Use a stable `color` value for the `.stats-sparkline__bar`. By default it uses the Calypso theme variable `--color-stats-sparkline` which is sometimes the same colour as the `/sites` page background. 

This was flagged here https://github.com/Automattic/wp-calypso/pull/68731#issuecomment-1273197254 but looks it didn't get fixed before that PR was deployed. 

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Reproduce the issue with the Modern theme. Retry using the Calypso Live link. 

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
