### PR TITLE
Marketplace: Fix category localization

### DIFF
--- a/client/controller/ssr-setup-locale.js
+++ b/client/controller/ssr-setup-locale.js
@@ -1,5 +1,6 @@
 // eslint-disable-next-line import/no-nodejs-modules
 import { readFile } from 'fs/promises';
+import { defaultI18n } from '@wordpress/i18n';
 import { I18N } from 'i18n-calypso';
 import getAssetFilePath from 'calypso/lib/get-asset-file-path';
 import config from 'calypso/server/config';
@@ -12,6 +13,12 @@ export function ssrSetupLocaleMiddleware() {
 		function setLocaleData( localeData ) {
 			const i18n = new I18N();
 			i18n.setLocale( localeData );
+			if ( localeData ) {
+				defaultI18n.setLocaleData( localeData );
+			} else {
+				defaultI18n.resetLocaleData();
+			}
+
 			const localeSlug = i18n.getLocaleSlug();
 			const localeVariant = i18n.getLocaleVariant();
 			context.store.dispatch( { type: LOCALE_SET, localeSlug, localeVariant } );

--- a/client/data/marketplace/search-api.ts
+++ b/client/data/marketplace/search-api.ts
@@ -1,5 +1,5 @@
 import wpcom from 'calypso/lib/wp';
-import { categories } from 'calypso/my-sites/plugins/categories/use-categories';
+import { getCategories } from 'calypso/my-sites/plugins/categories/use-categories';
 import { RETURNABLE_FIELDS } from './constants';
 import type { SearchParams } from './types';
 
@@ -129,7 +129,7 @@ function getFilterbyAuthor( author: string ): {
 function getFilterByCategory( category: string ): {
 	bool: object;
 } {
-	const categoryTags = categories[ category ]?.tags;
+	const categoryTags = getCategories()[ category ]?.tags;
 
 	return {
 		bool: {

--- a/client/my-sites/plugins/categories/use-categories.tsx
+++ b/client/my-sites/plugins/categories/use-categories.tsx
@@ -36,7 +36,7 @@ export const ALLOWED_CATEGORIES = [
 	'onlinestore',
 ];
 
-export const categories: Record< string, Category > = {
+export const getCategories: () => Record< string, Category > = () => ( {
 	discover: {
 		menu: __( 'Discover' ),
 		title: __( 'Discover' ),
@@ -379,7 +379,7 @@ export const categories: Record< string, Category > = {
 			},
 		],
 	},
-};
+} );
 
 export function useCategories(
 	allowedCategories = ALLOWED_CATEGORIES
@@ -399,6 +399,6 @@ export function useCategories(
 	}
 
 	return Object.fromEntries(
-		Object.entries( categories ).filter( ( [ key ] ) => allowed.includes( key ) )
+		Object.entries( getCategories() ).filter( ( [ key ] ) => allowed.includes( key ) )
 	);
 }


### PR DESCRIPTION
#### Proposed Changes

This fixes the missing Marketplace category translations by:
* using a function to get the category data. This allows the translation functions to be executed when the correct locale and translation data has been resolved
* restores [previous changes](https://github.com/Automattic/wp-calypso/commit/408db777aca4b3a7c081da6b2db954b90ebcfa7e) to ensure `i18n` package receives translation data on the server. This is necessary once SSR is enabled for the Marketplace pages.

<img src="https://user-images.githubusercontent.com/2749938/197480632-bd5f85e7-a834-4924-aee9-b3a0ccafd5fc.png" width="420px" />


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* log out and go to a non-english version of the Marketplace. ex:`/ko/plugins`
* ensure the category links, titles and descriptions are getting translated
<img width="420" alt="Screenshot on 2022-10-24 at 11-25-54" src="https://user-images.githubusercontent.com/2749938/197481897-136e9504-33f5-4f31-a1cf-763e27e3269c.png">

* log out and do the same with different locales selected for your account
<img width="420" alt="Screenshot on 2022-10-24 at 11-27-57" src="https://user-images.githubusercontent.com/2749938/197482264-7b5d7402-f37b-4be4-b625-fed9849227fb.png">

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #69360
