### PR TITLE
Global Styles: Show link in the launch banner to preview hidden styles

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
@@ -248,14 +248,12 @@ function wpcom_is_previewing_global_styles( ?int $user_id = null ) {
  * @return void
  */
 function wpcom_display_global_styles_banner_extra_tooltip() {
-	global $wp;
-	$location = home_url( $wp->request );
-
 	if ( wpcom_is_previewing_global_styles() ) {
-		$text = __( 'Hide premium styles', 'full-site-editing' );
+		$text     = __( 'Hide premium styles', 'full-site-editing' );
+		$location = remove_query_arg( 'preview-global-styles' );
 	} else {
 		$text     = __( 'Preview styles before upgrading', 'full-site-editing' );
-		$location = add_query_arg( 'preview-global-styles', '', $location );
+		$location = add_query_arg( 'preview-global-styles', '' );
 	}
 
 	?>

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
@@ -248,13 +248,14 @@ function wpcom_is_previewing_global_styles( ?int $user_id = null ) {
  * @return void
  */
 function wpcom_display_global_styles_banner_extra_tooltip() {
-	$location = get_home_url();
+	global $wp;
+	$location = home_url( $wp->request );
 
 	if ( wpcom_is_previewing_global_styles() ) {
 		$text = __( 'Hide premium styles', 'full-site-editing' );
 	} else {
-		$text      = __( 'Preview styles before upgrading', 'full-site-editing' );
-		$location .= '?preview-global-styles';
+		$text     = __( 'Preview styles before upgrading', 'full-site-editing' );
+		$location = add_query_arg( 'preview-global-styles', '', $location );
 	}
 
 	?>

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
@@ -113,7 +113,7 @@ add_action( 'enqueue_block_editor_assets', 'wpcom_global_styles_enqueue_scripts_
  * @return WP_Theme_JSON_Data|WP_Theme_JSON_Data_Gutenberg Filtered data.
  */
 function wpcom_block_global_styles_frontend( $theme_json ) {
-	if ( ! wpcom_should_limit_global_styles() ) {
+	if ( ! wpcom_should_limit_global_styles() || wpcom_is_previewing_global_styles() ) {
 		return $theme_json;
 	}
 
@@ -215,8 +215,50 @@ function wpcom_display_global_styles_banner( $custom_controls ) {
 		'tooltip_link_url'   => $upgrade_url,
 		'icon_path'          => 'M13 9h-2V7h2v2zm0 2h-2v6h2v-6zm-1-7c-4.411 0-8 3.589-8 8s3.589 8 8 8 8-3.589 8-8-3.589-8-8-8m0-2c5.523 0 10 4.477 10 10s-4.477 10-10 10S2 17.523 2 12 6.477 2 12 2z',
 		'icon_color'         => 'orange',
+		'extra_tooltip'      => 'toggle_global_styles',
 	);
 
 	return $custom_controls;
 }
 add_filter( 'wpcom_custom_launch_bar_controls', 'wpcom_display_global_styles_banner' );
+
+/**
+ * Checks if the necessary conditions are met in order to establish that the supplied user should be considered as previewing Global Styles.
+ *
+ * @param int|null $user_id User id to check.
+ *
+ * @return bool
+ */
+function wpcom_is_previewing_global_styles( ?int $user_id = null ) {
+	if ( null === $user_id ) {
+		$user_id = get_current_user_id();
+	}
+
+	if ( 0 === $user_id ) {
+		return false;
+	}
+
+	// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+	return isset( $_GET['preview-global-styles'] ) && user_can( $user_id, 'administrator' );
+}
+
+/**
+ * Renders the link for previewing global styles in the launch banner.
+ *
+ * @return void
+ */
+function wpcom_display_global_styles_banner_extra_tooltip() {
+	$location = get_home_url();
+
+	if ( wpcom_is_previewing_global_styles() ) {
+		$text = __( 'Hide premium styles', 'full-site-editing' );
+	} else {
+		$text      = __( 'Preview styles before upgrading', 'full-site-editing' );
+		$location .= '?preview-global-styles';
+	}
+
+	?>
+	<a class="launch-custom-link" href="<?php echo esc_url( $location ); ?>"><?php echo esc_html( $text ); ?></a>
+	<?php
+}
+add_action( 'launch_bar_extra_tooltip_toggle_global_styles', 'wpcom_display_global_styles_banner_extra_tooltip' );


### PR DESCRIPTION
#### Proposed Changes

* Added an action to register a link on the `Styles hidden` launch banner custom option.
* Created a function that determines if we should be previewing styles or not.
* The `wpcom_block_global_styles_frontend` function will now render global styles when the application is in the previewing global styles state.

#### Testing Instructions
You will also need to apply [this WPCOM DIFF](D90502-code) so that you can see the link styled correctly.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #