### PR TITLE
SMP: update stats and useInView

### DIFF
--- a/client/components/activity-card-list/visible-days-limit-upsell/hooks.ts
+++ b/client/components/activity-card-list/visible-days-limit-upsell/hooks.ts
@@ -8,15 +8,13 @@ export const useTrackUpsellView = (
 ): RefObject< HTMLAnchorElement | HTMLButtonElement > => {
 	const dispatch = useDispatch();
 
-	const inViewCallback = useCallback( () => {
+	return useInView< HTMLAnchorElement | HTMLButtonElement >( () => {
 		dispatch(
 			recordTracksEvent( 'calypso_activitylog_visiblelimit_upsell_view', {
 				site_id: siteId ?? undefined,
 			} )
 		);
-	}, [ siteId ] );
-
-	return useInView< HTMLAnchorElement | HTMLButtonElement >( inViewCallback );
+	} );
 };
 
 export const useTrackUpgradeClick = ( siteId: number | null ): ( () => void ) => {

--- a/client/lib/use-in-view/index.ts
+++ b/client/lib/use-in-view/index.ts
@@ -41,7 +41,10 @@ export function useInView< T extends Element >( oneTimeCallback: () => void ): R
 		// When the effect is dismounted, stop observing
 		return () => {
 			observerRef.current?.disconnect?.();
-			if ( ! viewedRef.current ) {
+			if ( ! viewedRef.current && observerRef.current ) {
+				// This case prevents when the effect is dismounted and re-mounted due oneTimeCallback is not wrapped in useCallback
+				// We cannot show a warning, because it can be a valid use case.
+				// Valid case: When a component is unmounted and never was visible.
 				observerRef.current = undefined;
 			}
 		};

--- a/client/lib/use-in-view/index.ts
+++ b/client/lib/use-in-view/index.ts
@@ -1,13 +1,10 @@
 import { RefObject, useEffect, useRef } from 'react';
 
 export function useInView< T extends Element >( oneTimeCallback: () => void ): RefObject< T > {
-	const viewedRef = useRef( false );
 	const elementRef = useRef< T >( null );
 	const oneTimeCallbackRef = useRef< () => void >();
 
-	useEffect( () => {
-		oneTimeCallbackRef.current = oneTimeCallback;
-	}, [ oneTimeCallback ] );
+	oneTimeCallbackRef.current = oneTimeCallback;
 
 	useEffect( () => {
 		// We can't do anything without a valid reference to an element on the page
@@ -15,32 +12,28 @@ export function useInView< T extends Element >( oneTimeCallback: () => void ): R
 			return;
 		}
 
-		const handler = ( entries: IntersectionObserverEntry[] ) => {
-			// Only fire once per page load
-			if ( viewedRef.current ) {
-				return;
+		const observer = new IntersectionObserver(
+			( entries ) => {
+				const [ entry ] = entries;
+
+				if ( ! entry.isIntersecting ) {
+					return;
+				}
+
+				oneTimeCallbackRef.current?.();
+				observer.disconnect();
+			},
+			{
+				// Only fire the event when 100% of the element becomes visible
+				threshold: [ 1 ],
 			}
+		);
 
-			const [ entry ] = entries;
-			if ( ! entry.isIntersecting ) {
-				return;
-			}
-
-			oneTimeCallbackRef.current?.();
-			viewedRef.current = true;
-			// eslint-disable-next-line @typescript-eslint/no-use-before-define
-			observer.disconnect();
-		};
-
-		const observer = new IntersectionObserver( handler, {
-			// Only fire the event when 100% of the element becomes visible
-			threshold: [ 1 ],
-		} );
 		observer.observe( elementRef.current );
 
 		// When the effect is dismounted, stop observing
 		return () => observer.disconnect();
-	}, [ oneTimeCallbackRef, viewedRef, elementRef ] );
+	}, [] );
 
 	return elementRef;
 }

--- a/client/lib/use-in-view/index.ts
+++ b/client/lib/use-in-view/index.ts
@@ -28,8 +28,8 @@ export function useInView< T extends Element >( oneTimeCallback: () => void ): R
 			}
 
 			oneTimeCallback();
-
 			viewedRef.current = true;
+			observerRef.current?.disconnect?.();
 		};
 
 		observerRef.current = new IntersectionObserver( handler, {
@@ -39,7 +39,12 @@ export function useInView< T extends Element >( oneTimeCallback: () => void ): R
 		observerRef.current.observe( elementRef.current );
 
 		// When the effect is dismounted, stop observing
-		return () => observerRef.current?.disconnect?.();
+		return () => {
+			observerRef.current?.disconnect?.();
+			if ( ! viewedRef.current ) {
+				observerRef.current = undefined;
+			}
+		};
 	}, [ oneTimeCallback ] );
 
 	return elementRef;

--- a/client/lib/use-in-view/test/index.tsx
+++ b/client/lib/use-in-view/test/index.tsx
@@ -21,7 +21,7 @@ function TestComponent( {
 				( window as any ).intersectionObserverHandler();
 			} );
 		}
-	}, [ ref ] );
+	}, [ ref, totalTimesInView ] );
 
 	return <div ref={ ref } />;
 }
@@ -64,6 +64,16 @@ describe( 'useInView suite', () => {
 		let count = 0;
 		const callback = () => count++;
 		render( <TestComponent totalTimesInView={ 2 } callback={ callback } /> );
+		expect( count ).toBe( 1 );
+	} );
+
+	it( 'Component renders twice, first out view, second in view, event fires once', () => {
+		let count = 0;
+		// The callback is generated in each render, so it's a new function
+		const { rerender } = render(
+			<TestComponent totalTimesInView={ 0 } callback={ () => count++ } />
+		);
+		rerender( <TestComponent totalTimesInView={ 1 } callback={ () => count++ } /> );
 		expect( count ).toBe( 1 );
 	} );
 } );

--- a/client/lib/use-in-view/test/index.tsx
+++ b/client/lib/use-in-view/test/index.tsx
@@ -29,9 +29,15 @@ function TestComponent( {
 describe( 'useInView suite', () => {
 	beforeEach( () => {
 		( window as any ).IntersectionObserver = class IO {
+			disconnected = false;
+
 			constructor( private handler: ( entries: { isIntersecting: boolean }[] ) => void ) {
 				// expose the handler so it can be called in tests
 				( window as any ).intersectionObserverHandler = () => {
+					if ( this.disconnected ) {
+						return;
+					}
+
 					handler( [ { isIntersecting: true } ] );
 				};
 			}
@@ -41,6 +47,7 @@ describe( 'useInView suite', () => {
 			}
 
 			disconnect() {
+				this.disconnected = true;
 				return null;
 			}
 		};

--- a/client/sites-dashboard/components/sites-table-row.tsx
+++ b/client/sites-dashboard/components/sites-table-row.tsx
@@ -3,7 +3,7 @@ import { useSiteLaunchStatusLabel } from '@automattic/sites';
 import { css } from '@emotion/css';
 import styled from '@emotion/styled';
 import { useI18n } from '@wordpress/react-i18n';
-import { memo, useCallback, useState } from 'react';
+import { memo, useState } from 'react';
 import { useSelector } from 'react-redux';
 import StatsSparkline from 'calypso/blocks/stats-sparkline';
 import JetpackLogo from 'calypso/components/jetpack-logo';
@@ -99,8 +99,7 @@ export default memo( function SitesTableRow( { site }: SiteTableRowProps ) {
 	const { __ } = useI18n();
 	const translatedStatus = useSiteLaunchStatusLabel( site );
 	const [ inViewOnce, setInViewOnce ] = useState( false );
-	const setInViewOnceCallback = useCallback( () => setInViewOnce( true ), [] );
-	const ref = useInView< HTMLTableCellElement >( setInViewOnceCallback );
+	const ref = useInView< HTMLTableCellElement >( () => setInViewOnce( true ) );
 	const userId = useSelector( ( state ) => getCurrentUserId( state ) );
 
 	const isP2Site = site.options?.is_wpforteams_site;

--- a/client/sites-dashboard/components/sites-table-row.tsx
+++ b/client/sites-dashboard/components/sites-table-row.tsx
@@ -8,7 +8,7 @@ import { useSelector } from 'react-redux';
 import StatsSparkline from 'calypso/blocks/stats-sparkline';
 import JetpackLogo from 'calypso/components/jetpack-logo';
 import TimeSince from 'calypso/components/time-since';
-import { useInView } from 'calypso/lib/use-in-view/index';
+import { useInView } from 'calypso/lib/use-in-view';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import { displaySiteUrl, getDashboardUrl, isNotAtomicJetpack, MEDIA_QUERIES } from '../utils';
 import { SitesEllipsisMenu } from './sites-ellipsis-menu';
@@ -99,7 +99,7 @@ export default memo( function SitesTableRow( { site }: SiteTableRowProps ) {
 	const { __ } = useI18n();
 	const translatedStatus = useSiteLaunchStatusLabel( site );
 	const [ inViewOnce, setInViewOnce ] = useState( false );
-	const ref = useInView< HTMLTableDataCellElement >( () => setInViewOnce( true ) );
+	const ref = useInView< HTMLTableCellElement >( () => setInViewOnce( true ) );
 	const userId = useSelector( ( state ) => getCurrentUserId( state ) );
 
 	const isP2Site = site.options?.is_wpforteams_site;

--- a/client/sites-dashboard/components/sites-table-row.tsx
+++ b/client/sites-dashboard/components/sites-table-row.tsx
@@ -3,7 +3,7 @@ import { useSiteLaunchStatusLabel } from '@automattic/sites';
 import { css } from '@emotion/css';
 import styled from '@emotion/styled';
 import { useI18n } from '@wordpress/react-i18n';
-import { memo, useState } from 'react';
+import { memo, useCallback, useState } from 'react';
 import { useSelector } from 'react-redux';
 import StatsSparkline from 'calypso/blocks/stats-sparkline';
 import JetpackLogo from 'calypso/components/jetpack-logo';
@@ -99,7 +99,8 @@ export default memo( function SitesTableRow( { site }: SiteTableRowProps ) {
 	const { __ } = useI18n();
 	const translatedStatus = useSiteLaunchStatusLabel( site );
 	const [ inViewOnce, setInViewOnce ] = useState( false );
-	const ref = useInView< HTMLTableCellElement >( () => setInViewOnce( true ) );
+	const setInViewOnceCallback = useCallback( () => setInViewOnce( true ), [] );
+	const ref = useInView< HTMLTableCellElement >( setInViewOnceCallback );
 	const userId = useSelector( ( state ) => getCurrentUserId( state ) );
 
 	const isP2Site = site.options?.is_wpforteams_site;


### PR DESCRIPTION
- Fixes https://github.com/Automattic/dotcom-forge/issues/1097

#### Proposed Changes

The issue came from not using a `useCallback`, so the useInView `useEffect` was retriggered in every render, which disconnected the observer, and some callback Stats were not fired when the component was visible.

* Replace `react-intersection-observer` with our custom hook.
* Fix race condition on Stats and improve `useInView`  to fix and show Stats even on fast scrolling.

#### Testing Instructions

* Go to /sites
* Select the row mode (not grid)
* Click on refresh browser with the shift key pressed.
* Scroll fast the sites
* Observe the Stats are visible on every row

#### Pre-merge Checklist

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ x Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?


