### PR TITLE
Marketplace: Remove search result highlights

### DIFF
--- a/client/my-sites/plugins/plugins-browser-item/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-item/index.jsx
@@ -175,7 +175,7 @@ const PluginsBrowserListElement = ( props ) => {
 			>
 				<div className="plugins-browser-item__info">
 					<PluginIcon image={ plugin.icon } isPlaceholder={ isPlaceholder } />
-					<div className="plugins-browser-item__title">text={ plugin.name }</div>
+					<div className="plugins-browser-item__title">{ plugin.name }</div>
 					{ variant === PluginsBrowserElementVariant.Extended && (
 						<>
 							<div className="plugins-browser-item__author">

--- a/client/my-sites/plugins/plugins-browser-item/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-item/index.jsx
@@ -1,7 +1,6 @@
 import { WPCOM_FEATURES_INSTALL_PLUGINS } from '@automattic/calypso-products';
 import { Gridicon } from '@automattic/components';
 import { useLocalizeUrl } from '@automattic/i18n-utils';
-import { TextHighlight } from '@wordpress/components';
 import { Icon, info } from '@wordpress/icons';
 import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
@@ -42,7 +41,6 @@ const PluginsBrowserListElement = ( props ) => {
 		plugin = {},
 		variant = PluginsBrowserElementVariant.Compact,
 		currentSites,
-		search,
 	} = props;
 
 	const translate = useTranslate();
@@ -177,16 +175,12 @@ const PluginsBrowserListElement = ( props ) => {
 			>
 				<div className="plugins-browser-item__info">
 					<PluginIcon image={ plugin.icon } isPlaceholder={ isPlaceholder } />
-					<div className="plugins-browser-item__title">
-						<TextHighlight text={ plugin.name } highlight={ search } />
-					</div>
+					<div className="plugins-browser-item__title">text={ plugin.name }</div>
 					{ variant === PluginsBrowserElementVariant.Extended && (
 						<>
 							<div className="plugins-browser-item__author">
 								{ translate( 'by ' ) }
-								<span className="plugins-browser-item__author-name">
-									<TextHighlight text={ plugin.author_name } highlight={ search } />
-								</span>
+								<span className="plugins-browser-item__author-name">{ plugin.author_name }</span>
 							</div>
 
 							<div className="plugins-browser-item__last-updated">
@@ -202,9 +196,7 @@ const PluginsBrowserListElement = ( props ) => {
 							</div>
 						</>
 					) }
-					<div className="plugins-browser-item__description">
-						<TextHighlight text={ plugin.short_description } highlight={ search } />
-					</div>
+					<div className="plugins-browser-item__description">{ plugin.short_description }</div>
 				</div>
 				{ isUntestedVersion && (
 					<div className="plugins-browser-item__untested-notice">


### PR DESCRIPTION
#### Proposed Changes
Remove search result highlights

#### Screenshots
| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/402286/197523398-d994f01e-d7eb-4a94-8c50-e41ff35846e5.png) | ![image](https://user-images.githubusercontent.com/402286/197523418-9c7db932-23c0-4413-898a-5108023c89dc.png) |


#### Testing Instructions

1. Go to [/plugins](http://calypso.localhost:3000/plugins).
2. Search for something (that has results).
3. Check the search_term is not highlighted on search results

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] ~~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~~
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~~
- [ ] ~~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~~


Fixes #67922
