### PR TITLE
BBE : WebsiteContent : Refactor add page descriptions to website content stage

### DIFF
--- a/client/signup/difm/constants.tsx
+++ b/client/signup/difm/constants.tsx
@@ -17,5 +17,24 @@ export const TESTIMONIALS_PAGE = 'TESTIMONIALS_PAGE';
 export const PRICING_PAGE = 'PRICING_PAGE';
 export const TEAM_PAGE = 'TEAM_PAGE';
 
+export type PageId =
+	| typeof HOME_PAGE
+	| typeof BLOG_PAGE
+	| typeof CONTACT_PAGE
+	| typeof ABOUT_PAGE
+	| typeof PHOTO_GALLERY_PAGE
+	| typeof SERVICE_SHOWCASE_PAGE
+	| typeof VIDEO_GALLERY_PAGE
+	| typeof PODCAST_PAGE
+	| typeof PORTFOLIO_PAGE
+	| typeof FAQ_PAGE
+	| typeof SITEMAP_PAGE
+	| typeof PROFILE_PAGE
+	| typeof MENU_PAGE
+	| typeof SERVICES_PAGE
+	| typeof TESTIMONIALS_PAGE
+	| typeof PRICING_PAGE
+	| typeof TEAM_PAGE;
+
 //The maximum number of pages allowed
 export const PAGE_LIMIT = 5;

--- a/client/signup/difm/constants.tsx
+++ b/client/signup/difm/constants.tsx
@@ -31,7 +31,7 @@ export type PageId =
 	| typeof PRICING_PAGE
 	| typeof TEAM_PAGE;
 
-export type DepricatedPageIds =
+export type DeprecatedPageIds =
 	| typeof SERVICE_SHOWCASE_PAGE
 	| typeof PODCAST_PAGE
 	| typeof SITEMAP_PAGE

--- a/client/signup/difm/constants.tsx
+++ b/client/signup/difm/constants.tsx
@@ -23,18 +23,20 @@ export type PageId =
 	| typeof CONTACT_PAGE
 	| typeof ABOUT_PAGE
 	| typeof PHOTO_GALLERY_PAGE
-	| typeof SERVICE_SHOWCASE_PAGE
 	| typeof VIDEO_GALLERY_PAGE
-	| typeof PODCAST_PAGE
 	| typeof PORTFOLIO_PAGE
 	| typeof FAQ_PAGE
-	| typeof SITEMAP_PAGE
-	| typeof PROFILE_PAGE
-	| typeof MENU_PAGE
 	| typeof SERVICES_PAGE
 	| typeof TESTIMONIALS_PAGE
 	| typeof PRICING_PAGE
 	| typeof TEAM_PAGE;
+
+export type DepricatedPageIds =
+	| typeof SERVICE_SHOWCASE_PAGE
+	| typeof PODCAST_PAGE
+	| typeof SITEMAP_PAGE
+	| typeof PROFILE_PAGE
+	| typeof MENU_PAGE;
 
 //The maximum number of pages allowed
 export const PAGE_LIMIT = 5;

--- a/client/signup/difm/translation-hooks.tsx
+++ b/client/signup/difm/translation-hooks.tsx
@@ -55,9 +55,12 @@ type TranslationContext =
 	| typeof BBE_ONBOARDING_PAGE_PICKER_STEP
 	| typeof BBE_WEBSITE_CONTENT_FILLING_STEP;
 
-export function useTranslatedPageDescriptions( pageId: PageId, context?: TranslationContext ) {
+export function useTranslatedPageDescriptions(
+	pageId: PageId,
+	context?: TranslationContext
+): TranslateResult {
 	const translate = useTranslate();
-	const defaultDescriptions: Partial< Record< PageId, TranslateResult > > = {
+	const defaultDescriptions: Record< PageId, TranslateResult > = {
 		[ HOME_PAGE ]: translate(
 			'An overview of you, your writing, or your business. What phrases would someone search on Google to find you? What can visitors expect on this site?'
 		),
@@ -97,7 +100,7 @@ export function useTranslatedPageDescriptions( pageId: PageId, context?: Transla
 		),
 	};
 
-	const contextBaseDescriptions = {
+	const contextBaseDescriptions: Record< TranslationContext, typeof defaultDescriptions > = {
 		[ BBE_ONBOARDING_PAGE_PICKER_STEP ]: {
 			...defaultDescriptions,
 		},
@@ -107,12 +110,12 @@ export function useTranslatedPageDescriptions( pageId: PageId, context?: Transla
 				'How would you introduce your journal entries/news-articles/chapters? Describe what readers can expect from your regularly published content!'
 			),
 			[ CONTACT_PAGE ]: translate(
-				'Visitors want to get in touch with you. How can they reach you?'
+				'Visitors want to get in touch with you. Do you have a message for them to say hello, and that it’s okay to get in touch? How can they reach you?'
 			),
 		},
 	};
 	if ( ! context ) {
-		return [ pageId ];
+		return defaultDescriptions[ pageId ];
 	}
 	return contextBaseDescriptions[ context ][ pageId ];
 }

--- a/client/signup/difm/translation-hooks.tsx
+++ b/client/signup/difm/translation-hooks.tsx
@@ -92,7 +92,7 @@ export function useTranslatedPageDescriptions(
 		),
 	};
 
-	const contextBaseDescriptions: Record< TranslationContext, typeof defaultDescriptions > = {
+	const contextualDescriptions: Record< TranslationContext, typeof defaultDescriptions > = {
 		[ BBE_ONBOARDING_PAGE_PICKER_STEP ]: {
 			...defaultDescriptions,
 		},
@@ -109,5 +109,5 @@ export function useTranslatedPageDescriptions(
 	if ( ! context ) {
 		return defaultDescriptions[ pageId ];
 	}
-	return contextBaseDescriptions[ context ][ pageId ];
+	return contextualDescriptions[ context ][ pageId ];
 }

--- a/client/signup/difm/translation-hooks.tsx
+++ b/client/signup/difm/translation-hooks.tsx
@@ -6,12 +6,8 @@ import {
 	ABOUT_PAGE,
 	PHOTO_GALLERY_PAGE,
 	VIDEO_GALLERY_PAGE,
-	PODCAST_PAGE,
 	PORTFOLIO_PAGE,
 	FAQ_PAGE,
-	SITEMAP_PAGE,
-	PROFILE_PAGE,
-	MENU_PAGE,
 	SERVICES_PAGE,
 	TESTIMONIALS_PAGE,
 	PRICING_PAGE,
@@ -27,19 +23,15 @@ import type { TranslateResult } from 'i18n-calypso';
  */
 export function useTranslatedPageTitles() {
 	const translate = useTranslate();
-	const pages: Record< string, TranslateResult > = {
+	const pages: Record< PageId, TranslateResult > = {
 		[ HOME_PAGE ]: translate( 'Home' ),
 		[ BLOG_PAGE ]: translate( 'Blog' ),
 		[ CONTACT_PAGE ]: translate( 'Contact' ),
 		[ ABOUT_PAGE ]: translate( 'About' ),
 		[ PHOTO_GALLERY_PAGE ]: translate( 'Photo Gallery' ),
 		[ VIDEO_GALLERY_PAGE ]: translate( 'Video Gallery' ),
-		[ PODCAST_PAGE ]: translate( 'Podcast' ),
 		[ PORTFOLIO_PAGE ]: translate( 'Portfolio' ),
 		[ FAQ_PAGE ]: translate( 'FAQ' ),
-		[ SITEMAP_PAGE ]: translate( 'Sitemap' ),
-		[ PROFILE_PAGE ]: translate( 'Profile' ),
-		[ MENU_PAGE ]: translate( 'Menu' ),
 		[ SERVICES_PAGE ]: translate( 'Services' ),
 		[ TESTIMONIALS_PAGE ]: translate( 'Testimonials' ),
 		[ PRICING_PAGE ]: translate( 'Pricing' ),

--- a/client/signup/difm/translation-hooks.tsx
+++ b/client/signup/difm/translation-hooks.tsx
@@ -107,10 +107,10 @@ export function useTranslatedPageDescriptions(
 		[ BBE_WEBSITE_CONTENT_FILLING_STEP ]: {
 			...defaultDescriptions,
 			[ BLOG_PAGE ]: translate(
-				'How would you introduce your journal entries/news-articles/chapters? Describe what readers can expect from your regularly published content!'
+				'Add a short description to explain what type of posts will appear on your blog. We will set up the page so this description appears above your posts; you can add the posts later with the editor.'
 			),
 			[ CONTACT_PAGE ]: translate(
-				'Visitors want to get in touch with you. Do you have a message for them to say hello, and that it’s okay to get in touch? How can they reach you?'
+				'This page will include a contact form. Optionally provide text to appear above the form to let visitors know other ways they can reach you.'
 			),
 		},
 	};

--- a/client/signup/difm/translation-hooks.tsx
+++ b/client/signup/difm/translation-hooks.tsx
@@ -17,6 +17,7 @@ import {
 	PRICING_PAGE,
 	TEAM_PAGE,
 } from 'calypso/signup/difm/constants';
+import type { PageId } from 'calypso/signup/difm/constants';
 import type { TranslateResult } from 'i18n-calypso';
 
 /**
@@ -47,9 +48,16 @@ export function useTranslatedPageTitles() {
 	return pages;
 }
 
-export function useTranslatedPageDescriptions() {
+// Requesting Contexts
+export const BBE_ONBOARDING_PAGE_PICKER_STEP = 'BBE_ONBOARDING_PAGE_PICKER_STEP';
+export const BBE_WEBSITE_CONTENT_FILLING_STEP = 'BBE_WEBSITE_CONTENT_FILLING_STEP';
+type TranslationContext =
+	| typeof BBE_ONBOARDING_PAGE_PICKER_STEP
+	| typeof BBE_WEBSITE_CONTENT_FILLING_STEP;
+
+export function useTranslatedPageDescriptions( pageId: PageId, context?: TranslationContext ) {
 	const translate = useTranslate();
-	const descriptions: Record< string, TranslateResult > = {
+	const defaultDescriptions: Partial< Record< PageId, TranslateResult > > = {
 		[ HOME_PAGE ]: translate(
 			'An overview of you, your writing, or your business. What phrases would someone search on Google to find you? What can visitors expect on this site?'
 		),
@@ -62,6 +70,7 @@ export function useTranslatedPageDescriptions() {
 		[ BLOG_PAGE ]: translate(
 			'Blog posts can be news stories, journal entries, or even recipes! We will set up the blog page and explain how you can add posts to your new site.'
 		),
+
 		[ PHOTO_GALLERY_PAGE ]: translate(
 			'A visual space to share pictures with your website visitors. Add a text summary to describe the gallery to your visitors.'
 		),
@@ -87,5 +96,23 @@ export function useTranslatedPageDescriptions() {
 			'Showcase a mini profile of each member of your business, with an image, name, and role description.'
 		),
 	};
-	return descriptions;
+
+	const contextBaseDescriptions = {
+		[ BBE_ONBOARDING_PAGE_PICKER_STEP ]: {
+			...defaultDescriptions,
+		},
+		[ BBE_WEBSITE_CONTENT_FILLING_STEP ]: {
+			...defaultDescriptions,
+			[ BLOG_PAGE ]: translate(
+				'How would you introduce your journal entries/news-articles/chapters? Describe what readers can expect from your regularly published content!'
+			),
+			[ CONTACT_PAGE ]: translate(
+				'Visitors want to get in touch with you. How can they reach you?'
+			),
+		},
+	};
+	if ( ! context ) {
+		return [ pageId ];
+	}
+	return contextBaseDescriptions[ context ][ pageId ];
 }

--- a/client/signup/steps/page-picker/index.tsx
+++ b/client/signup/steps/page-picker/index.tsx
@@ -36,6 +36,7 @@ import { saveSignupStep, submitSignupStep } from 'calypso/state/signup/progress/
 import { getSiteId } from 'calypso/state/sites/selectors';
 import ShoppingCartForDIFM from './shopping-cart-for-difm';
 import useCartForDIFM from './use-cart-for-difm';
+import type { PageId } from 'calypso/signup/difm/constants';
 import type { Dependencies } from 'calypso/signup/types';
 
 import './style.scss';
@@ -111,7 +112,7 @@ const PageCellBadge = styled.div`
 `;
 
 interface PageCellType {
-	pageId: string;
+	pageId: PageId;
 	selectedPages: string[];
 	onClick: ( pageId: string ) => void;
 	popular?: boolean;
@@ -126,7 +127,7 @@ function PageCell( { pageId, popular, required, selectedPages, onClick }: PageCe
 	const isDisabled =
 		! config.isEnabled( 'difm/allow-extra-pages' ) && PAGE_LIMIT <= totalSelections;
 	const title = useTranslatedPageTitles()[ pageId ];
-	const description = useTranslatedPageDescriptions()[ pageId ];
+	const description = useTranslatedPageDescriptions( pageId );
 
 	return (
 		<GridCellContainer isSelected={ isSelected } isClickDisabled={ isDisabled }>

--- a/client/signup/steps/website-content/index.tsx
+++ b/client/signup/steps/website-content/index.tsx
@@ -26,6 +26,7 @@ import { getSiteId } from 'calypso/state/sites/selectors';
 import { SiteId } from 'calypso/types';
 import { sectionGenerator } from './section-generator';
 import { usePollSiteForDIFMDetails } from './use-poll-site-for-difm-details';
+import type { PageId } from 'calypso/signup/difm/constants';
 
 import './style.scss';
 
@@ -76,7 +77,7 @@ interface WebsiteContentStepProps {
 	flowName: string;
 	stepName: string;
 	positionInFlow: string;
-	pageTitles: string[];
+	pageTitles: PageId[];
 	siteId: SiteId | null;
 }
 

--- a/client/signup/steps/website-content/section-generator.tsx
+++ b/client/signup/steps/website-content/section-generator.tsx
@@ -71,12 +71,6 @@ const generateWebsiteContentSections = (
 	const { translate, formValues, formErrors, onChangeField } = params;
 
 	const OPTIONAL_PAGES: Record< string, boolean > = { [ CONTACT_PAGE ]: true };
-	const PAGE_LABELS: Record< string, TranslateResult > = {
-		[ CONTACT_PAGE ]: translate(
-			"We'll add a standard contact form on this page, plus a comment box. " +
-				'If you would like text to appear above this form, please enter it below.'
-		),
-	};
 
 	const websiteContentSections = formValues.pages.map( ( page, index ) => {
 		const fieldNumber = elapsedSections + index + 1;
@@ -103,7 +97,6 @@ const generateWebsiteContentSections = (
 				<DisplayedPageComponent
 					page={ page }
 					formErrors={ formErrors }
-					label={ PAGE_LABELS[ page.id ] }
 					onChangeField={ onChangeField }
 				/>
 			),

--- a/client/signup/steps/website-content/section-types/contact-page-details.tsx
+++ b/client/signup/steps/website-content/section-types/contact-page-details.tsx
@@ -7,7 +7,10 @@ import {
 	HorizontalGrid,
 	ContactInformation,
 } from 'calypso/signup/accordion-form/form-components';
-import { ValidationErrors } from 'calypso/signup/accordion-form/types';
+import {
+	BBE_WEBSITE_CONTENT_FILLING_STEP,
+	useTranslatedPageDescriptions,
+} from 'calypso/signup/difm/translation-hooks';
 import {
 	MediaUploadData,
 	WordpressMediaUpload,
@@ -20,28 +23,18 @@ import {
 	imageUploadInitiated,
 } from 'calypso/state/signup/steps/website-content/actions';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
-import type { ContactPageData } from 'calypso/state/signup/steps/website-content/schema';
-import type { TranslateResult } from 'i18n-calypso';
+import { PageDetailsParams } from './default-page-details';
 
 export const CONTENT_SUFFIX = 'Content';
 export const IMAGE_PREFIX = 'Image';
 
-export function ContactPageDetails( {
-	page,
-	formErrors,
-	label,
-	onChangeField,
-}: {
-	page: ContactPageData;
-	formErrors: ValidationErrors;
-	label: TranslateResult | undefined;
-	onChangeField?: ( { target: { name, value } }: ChangeEvent< HTMLInputElement > ) => void;
-} ) {
+export function ContactPageDetails( { page, formErrors, onChangeField }: PageDetailsParams ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const site = useSelector( getSelectedSite );
 	const pageTitle = page.title;
 	const pageID = page.id;
+	const description = useTranslatedPageDescriptions( pageID, BBE_WEBSITE_CONTENT_FILLING_STEP );
 
 	const onMediaUploadFailed = ( { mediaIndex }: MediaUploadData ) => {
 		dispatch(
@@ -105,12 +98,7 @@ export function ContactPageDetails( {
 				onChange={ onFieldChanged }
 				value={ page.content }
 				error={ formErrors[ fieldName ] }
-				label={
-					label ||
-					translate( 'Please provide the text you want to appear on your %(pageTitle)s page.', {
-						args: { pageTitle },
-					} )
-				}
+				label={ description }
 			/>
 			<ContactInformation
 				displayEmailProps={ {

--- a/client/signup/steps/website-content/section-types/contact-page-details.tsx
+++ b/client/signup/steps/website-content/section-types/contact-page-details.tsx
@@ -22,13 +22,18 @@ import {
 	imageUploadFailed,
 	imageUploadInitiated,
 } from 'calypso/state/signup/steps/website-content/actions';
+import { ContactPageData } from 'calypso/state/signup/steps/website-content/schema';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import { PageDetailsParams } from './default-page-details';
 
 export const CONTENT_SUFFIX = 'Content';
 export const IMAGE_PREFIX = 'Image';
 
-export function ContactPageDetails( { page, formErrors, onChangeField }: PageDetailsParams ) {
+export function ContactPageDetails( {
+	page,
+	formErrors,
+	onChangeField,
+}: PageDetailsParams< ContactPageData > ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const site = useSelector( getSelectedSite );

--- a/client/signup/steps/website-content/section-types/contact-page-details.tsx
+++ b/client/signup/steps/website-content/section-types/contact-page-details.tsx
@@ -22,9 +22,9 @@ import {
 	imageUploadFailed,
 	imageUploadInitiated,
 } from 'calypso/state/signup/steps/website-content/actions';
-import { ContactPageData } from 'calypso/state/signup/steps/website-content/schema';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
-import { PageDetailsParams } from './default-page-details';
+import type { PageDetailsParams } from './default-page-details';
+import type { ContactPageData } from 'calypso/state/signup/steps/website-content/schema';
 
 export const CONTENT_SUFFIX = 'Content';
 export const IMAGE_PREFIX = 'Image';

--- a/client/signup/steps/website-content/section-types/default-page-details.tsx
+++ b/client/signup/steps/website-content/section-types/default-page-details.tsx
@@ -8,6 +8,10 @@ import {
 } from 'calypso/signup/accordion-form/form-components';
 import { ValidationErrors } from 'calypso/signup/accordion-form/types';
 import {
+	BBE_WEBSITE_CONTENT_FILLING_STEP,
+	useTranslatedPageDescriptions,
+} from 'calypso/signup/difm/translation-hooks';
+import {
 	imageRemoved,
 	imageUploaded,
 	imageUploadFailed,
@@ -38,11 +42,12 @@ export function DefaultPageDetails( {
 	const site = useSelector( getSelectedSite );
 	const pageTitle = page.title;
 	const pageID = page.id;
+	const description = useTranslatedPageDescriptions( pageID, BBE_WEBSITE_CONTENT_FILLING_STEP );
 
 	const onMediaUploadFailed = ( { mediaIndex }: MediaUploadData ) => {
 		dispatch(
 			imageUploadFailed( {
-				pageId: page.id,
+				pageId: pageID,
 				mediaIndex,
 			} )
 		);
@@ -101,12 +106,7 @@ export function DefaultPageDetails( {
 				onChange={ onContentChange }
 				value={ page.content }
 				error={ formErrors[ fieldName ] }
-				label={
-					label ||
-					translate( 'Please provide the text you want to appear on your %(pageTitle)s page.', {
-						args: { pageTitle },
-					} )
-				}
+				label={ label || description }
 			/>
 			<Label>
 				{ translate( 'Upload up to 3 images to be used on your %(pageTitle)s page.', {

--- a/client/signup/steps/website-content/section-types/default-page-details.tsx
+++ b/client/signup/steps/website-content/section-types/default-page-details.tsx
@@ -24,12 +24,16 @@ import type { PageData } from 'calypso/state/signup/steps/website-content/schema
 
 export const CONTENT_SUFFIX = 'Content';
 export const IMAGE_PREFIX = 'Image';
-export interface PageDetailsParams {
-	page: PageData;
+export interface PageDetailsParams< T > {
+	page: T;
 	formErrors: ValidationErrors;
 	onChangeField?: ( { target: { name, value } }: ChangeEvent< HTMLInputElement > ) => void;
 }
-export function DefaultPageDetails( { page, formErrors, onChangeField }: PageDetailsParams ) {
+export function DefaultPageDetails( {
+	page,
+	formErrors,
+	onChangeField,
+}: PageDetailsParams< PageData > ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const site = useSelector( getSelectedSite );

--- a/client/signup/steps/website-content/section-types/default-page-details.tsx
+++ b/client/signup/steps/website-content/section-types/default-page-details.tsx
@@ -21,22 +21,15 @@ import {
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import { MediaUploadData, WordpressMediaUpload } from '../wordpress-media-upload';
 import type { PageData } from 'calypso/state/signup/steps/website-content/schema';
-import type { TranslateResult } from 'i18n-calypso';
 
 export const CONTENT_SUFFIX = 'Content';
 export const IMAGE_PREFIX = 'Image';
-
-export function DefaultPageDetails( {
-	page,
-	formErrors,
-	label,
-	onChangeField,
-}: {
+export interface PageDetailsParams {
 	page: PageData;
 	formErrors: ValidationErrors;
-	label: TranslateResult | undefined;
 	onChangeField?: ( { target: { name, value } }: ChangeEvent< HTMLInputElement > ) => void;
-} ) {
+}
+export function DefaultPageDetails( { page, formErrors, onChangeField }: PageDetailsParams ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const site = useSelector( getSelectedSite );
@@ -106,7 +99,7 @@ export function DefaultPageDetails( {
 				onChange={ onContentChange }
 				value={ page.content }
 				error={ formErrors[ fieldName ] }
-				label={ label || description }
+				label={ description }
 			/>
 			<Label>
 				{ translate( 'Upload up to 3 images to be used on your %(pageTitle)s page.', {

--- a/client/signup/steps/website-content/use-poll-site-for-difm-details.ts
+++ b/client/signup/steps/website-content/use-poll-site-for-difm-details.ts
@@ -2,12 +2,12 @@ import config from '@automattic/calypso-config';
 import { useState, useRef, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { logToLogstash } from 'calypso/lib/logstash';
-import { PageId } from 'calypso/signup/difm/constants';
 import getDIFMLiteSitePageTitles from 'calypso/state/selectors/get-difm-lite-site-page-titles';
 import isDIFMLiteInProgress from 'calypso/state/selectors/is-difm-lite-in-progress';
 import isDIFMLiteWebsiteContentSubmitted from 'calypso/state/selectors/is-difm-lite-website-content-submitted';
 import { requestSite } from 'calypso/state/sites/actions';
 import { isRequestingSite } from 'calypso/state/sites/selectors';
+import type { PageId } from 'calypso/signup/difm/constants';
 import type { SiteId } from 'calypso/types';
 
 /**

--- a/client/signup/steps/website-content/use-poll-site-for-difm-details.ts
+++ b/client/signup/steps/website-content/use-poll-site-for-difm-details.ts
@@ -2,6 +2,7 @@ import config from '@automattic/calypso-config';
 import { useState, useRef, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { logToLogstash } from 'calypso/lib/logstash';
+import { PageId } from 'calypso/signup/difm/constants';
 import getDIFMLiteSitePageTitles from 'calypso/state/selectors/get-difm-lite-site-page-titles';
 import isDIFMLiteInProgress from 'calypso/state/selectors/is-difm-lite-in-progress';
 import isDIFMLiteWebsiteContentSubmitted from 'calypso/state/selectors/is-difm-lite-website-content-submitted';
@@ -36,7 +37,7 @@ export function usePollSiteForDIFMDetails(
 	maxTries = 10
 ): {
 	isPollingInProgress: boolean;
-	pageTitles: string[] | null;
+	pageTitles: PageId[] | null;
 	hasValidPurchase: boolean;
 } {
 	const [ retryCount, setRetryCount ] = useState( 0 );

--- a/client/state/selectors/get-difm-lite-site-page-titles.ts
+++ b/client/state/selectors/get-difm-lite-site-page-titles.ts
@@ -23,6 +23,6 @@ export default function getDIFMLiteSitePageTitles(
 		return null;
 	}
 
-	const pageId = site.options?.difm_lite_site_options?.selected_page_titles as PageId[];
-	return pageId ?? null;
+	const pageIds = site.options?.difm_lite_site_options?.selected_page_titles as PageId[];
+	return pageIds ?? null;
 }

--- a/client/state/selectors/get-difm-lite-site-page-titles.ts
+++ b/client/state/selectors/get-difm-lite-site-page-titles.ts
@@ -1,5 +1,5 @@
-import { PageId } from 'calypso/signup/difm/constants';
 import getRawSite from 'calypso/state/selectors/get-raw-site';
+import type { PageId } from 'calypso/signup/difm/constants';
 import type { AppState, SiteId } from 'calypso/types';
 
 /**

--- a/client/state/selectors/get-difm-lite-site-page-titles.ts
+++ b/client/state/selectors/get-difm-lite-site-page-titles.ts
@@ -1,3 +1,4 @@
+import { PageId } from 'calypso/signup/difm/constants';
 import getRawSite from 'calypso/state/selectors/get-raw-site';
 import type { AppState, SiteId } from 'calypso/types';
 
@@ -12,7 +13,7 @@ import type { AppState, SiteId } from 'calypso/types';
 export default function getDIFMLiteSitePageTitles(
 	state: AppState,
 	siteId: SiteId | null
-): string[] | null {
+): PageId[] | null {
 	if ( ! siteId ) {
 		return null;
 	}
@@ -22,5 +23,6 @@ export default function getDIFMLiteSitePageTitles(
 		return null;
 	}
 
-	return site.options?.difm_lite_site_options?.selected_page_titles ?? null;
+	const pageId = site.options?.difm_lite_site_options?.selected_page_titles as PageId[];
+	return pageId ?? null;
 }

--- a/client/state/signup/steps/website-content/schema.ts
+++ b/client/state/signup/steps/website-content/schema.ts
@@ -1,5 +1,5 @@
-import type { SiteId } from 'calypso/types';
 import { PageId } from 'calypso/signup/difm/constants';
+import type { SiteId } from 'calypso/types';
 
 export const schema = {
 	$schema: 'https://json-schema.org/draft/2020-12/schema',

--- a/client/state/signup/steps/website-content/schema.ts
+++ b/client/state/signup/steps/website-content/schema.ts
@@ -1,4 +1,6 @@
 import type { SiteId } from 'calypso/types';
+import { PageId } from 'calypso/signup/difm/constants';
+
 export const schema = {
 	$schema: 'https://json-schema.org/draft/2020-12/schema',
 	title: 'Website content schema',
@@ -88,7 +90,7 @@ export interface ImageData {
 }
 
 export interface PageData {
-	id: string;
+	id: PageId;
 	title: string;
 	content: string;
 	images: Array< ImageData >;

--- a/client/state/signup/steps/website-content/schema.ts
+++ b/client/state/signup/steps/website-content/schema.ts
@@ -1,4 +1,4 @@
-import { PageId } from 'calypso/signup/difm/constants';
+import type { PageId } from 'calypso/signup/difm/constants';
 import type { SiteId } from 'calypso/types';
 
 export const schema = {


### PR DESCRIPTION
### Proposed Changes

* Refactors page descriptions to be context aware. 
* Each page can have different descriptions based on the context.
* Adds below page descriptions to the website content collection stage with overrides for the contact and blog pages

### Where the changes will land

![image](https://user-images.githubusercontent.com/3422709/198208786-f222da68-ca6e-4dab-adc4-c7435dcafa1d.png)

---
### Change List of Descriptions at the Website Content Collection Stage

<kbd>
<img width="632" alt="Screenshot 2022-10-27 at 2 10 54 PM" src="https://user-images.githubusercontent.com/3422709/198258054-de2106e0-f02d-40b6-93d5-d829a3517b23.png">
</kbd>


### Testing Instructions

- Go to `/star/do-it-for-me` and continue through the flow
- On the page picker step select all pages
- Complete the DIFM purchase
- On the website content page make sure the descriptions are properly updated

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes Automattic/martech#1143
