### PR TITLE
Site Switcher: Do not add site slug to the Add New Site link if it's null

### DIFF
--- a/client/components/site-selector/add-site.tsx
+++ b/client/components/site-selector/add-site.tsx
@@ -1,10 +1,10 @@
 import { Button } from '@automattic/components';
-import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import { FunctionComponent, useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { onboardingUrl } from 'calypso/lib/paths';
+import { addQueryArgs } from 'calypso/lib/url';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 
@@ -24,11 +24,14 @@ const SiteSelectorAddSite: FunctionComponent = () => {
 	return (
 		<Button
 			primary
-			href={ addQueryArgs( onboardingUrl(), {
-				ref: 'calypso-selector',
-				source: 'my-home',
-				siteSlug,
-			} ) }
+			href={ addQueryArgs(
+				{
+					ref: 'calypso-selector',
+					source: 'my-home',
+					siteSlug,
+				},
+				onboardingUrl()
+			) }
 			onClick={ recordAddNewSite }
 		>
 			{ translate( 'Add new site' ) }

--- a/client/components/site-selector/add-site.tsx
+++ b/client/components/site-selector/add-site.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@automattic/components';
+import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import { FunctionComponent, useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
@@ -23,7 +24,11 @@ const SiteSelectorAddSite: FunctionComponent = () => {
 	return (
 		<Button
 			primary
-			href={ `${ onboardingUrl() }?ref=calypso-selector&source=my-home&siteSlug=${ siteSlug }` }
+			href={ addQueryArgs( onboardingUrl(), {
+				ref: 'calypso-selector',
+				source: 'my-home',
+				siteSlug,
+			} ) }
 			onClick={ recordAddNewSite }
 		>
 			{ translate( 'Add new site' ) }


### PR DESCRIPTION
#### Proposed Changes

Fixes https://github.com/Automattic/wp-calypso/issues/69392 by using the `addQueryArgs` helper in https://github.com/Automattic/wp-calypso/blob/trunk/client/components/site-selector/add-site.tsx.

The site slug can be null if, for example, the user is seeing a multi-context page like the stats page. Using the helper automatically removes nullish values from the query parameters. 

#### Testing Instructions

1. Open Calypso with an account that has more than one site;
2. While having a site selected, click the Site Switcher and the `Add new site` button;
3. Check that the `siteSlug` in the URL is defined.

After that:

1. Click the `Stats` section in Calypso;
2. Click `Switch Sites` and select `View stats for all sites`;
3. Click `Switch Sites` again;
4. Click `Add new site` and verify that the target URL does not have the `siteSlug` defined as a query parameter.