### PR TITLE
change default view to bundles

### DIFF
--- a/client/my-sites/plans/jetpack-plans/product-store/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/index.tsx
@@ -38,7 +38,7 @@ const ProductStore: React.FC< ProductStoreProps > = ( {
 	const [ currentView, setCurrentView ] = useState< ViewType >( () => {
 		return urlQueryArgs?.[ TAB_QUERY_PARAM ] && TABS.includes( urlQueryArgs[ TAB_QUERY_PARAM ] )
 			? urlQueryArgs[ TAB_QUERY_PARAM ]
-			: TABS[ 0 ];
+			: TABS[ 1 ];
 	} );
 
 	const storeItemInfo = useStoreItemInfo( {


### PR DESCRIPTION
#### Proposed Changes


![Screen Shot 2022-10-24 at 2 50 13 PM](https://user-images.githubusercontent.com/12895386/197603477-d201ac91-75f1-45b9-b0ac-75ba30e99b86.png)

* We want the Jetpack pricing page to default to showing the bundles tab instead of the current behavior of showing the products tab
* See pedMtX-is-p2 for further context
* This PR changes the condition to update the array item from 0 to 1 when the pricing page is loaded without a query string

#### Testing Instructions

* visit the pricing page without a query string (eg http://jetpack.cloud.localhost:3000/pricing ) and verify the bundles tab showing and the address in the browser changed to http://jetpack.cloud.localhost:3000/pricing?view=bundles

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #