### PR TITLE
Editor Tracking: Update entity_context for template parts

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/features/utils.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/utils.js
@@ -39,14 +39,15 @@ const buildPropsFromContextBlock = ( block ) => {
 
 	if ( block?.name === 'core/template-part' ) {
 		const templatePartId = `${ block.attributes.theme }//${ block.attributes.slug }`;
-		const { getActiveBlockVariation } = select( 'core/blocks' );
 
-		if ( typeof getActiveBlockVariation === 'function' ) {
-			const variation = getActiveBlockVariation( block.name, block.attributes );
+		const entity = select( 'core' ).getEntityRecord(
+			'postType',
+			'wp_template_part',
+			templatePartId
+		);
 
-			if ( variation?.name ) {
-				context = `${ context }/${ variation.name }`;
-			}
+		if ( entity?.area && entity?.area !== 'uncategorized' ) {
+			context = `${ context }/${ entity.area }`;
 		}
 
 		return {


### PR DESCRIPTION
### Proposed Changes

When registering tracks events for the block editor, we sometimes set `entity_context` as meta for events. We discovered while fixing E2E tests that `entity_context` was not being determined correctly when adding blocks to template parts. See [this comment](https://github.com/Automattic/wp-calypso/pull/69154#discussion_r1001701389). 

This PR ensures the correct `entity_context` when adding blocks to template parts:
 - `entity_context` will be `core/template-part/header` when adding a block to a header template part (same as before). 
 - `entity_context` will be `core/template-part/footer` when adding a block to a footer template part (same as before).
 - `entity_context` will be `core/template-part` when adding a block to a generic template part. This is the situation being fixed. We had been adding the block variation to the end, such as  `core/template-part/some-block-variation`. But block variations were being incorrectly set for generic template parts.

### Testing Instructions

**Preparation**. You will need to be able to see tracks events in order to test. You have two options: 
- Option 1: Install and use the [Tracks Vigilante](https://github.com/Automattic/tracks-chrome-extension) Chrome extension.
- Option 2: Open Developer Tools > Network. Filter requests with `t.gif`. You'll find tracks event meta under payload for each request. 

**Testing**.

1. Sandbox the site domain you'll be testing, along with widgets.wp.com.

2. Checkout this branch, cd to apps/wpcom-block-editor, and run `yarn dev --sync`

3. Go to the site editor.

4. Test header template parts.
   - Insert any header template part (ie, header-centered or header-minimal)
   - Insert a block inside the header template part
   - Confirm that a tracks event fired for wpcom_block_inserted, with `entity_context` === `core/template-part/header`
   - If using Tracks Vigilante, the resulting event will look this (in this case, I inserted a page-list block):
![wpcom-block-inserted 2](https://user-images.githubusercontent.com/21228350/197603425-3d55db4d-53dd-4484-8cb2-a94742c0ed1b.png)


5. Test footer template parts. Repeat same sequence as Step 4 above, but entity context should now be `core/template-part/footer`. 

7. Test generic template parts.
   - Insert a straight Template Part block.
   - Within your new template part, click Start Blank to start a new template part. You'll be prompted to give your Template Part a name. 
   - Insert a block within your new Template Part. 
   - Confirm that a tracks event fired for wpcom_block_inserted, with `entity_context` === `core/template-part` (there should be no extra info appended to the end). 

### Related

Once merged, related E2E tests can be updated in https://github.com/Automattic/wp-calypso/pull/69154
