### PR TITLE
Calypso server: log extra data for long requests

### DIFF
--- a/client/server/lib/performance-mark/index.js
+++ b/client/server/lib/performance-mark/index.js
@@ -1,0 +1,70 @@
+/**
+ * Updates the express request context with a new performance mark.
+ *
+ * This pushes a new "performance mark" object to the array of performance marks.
+ * This object includes the current time to note when this step of the pipeline
+ * started. We also update the previous mark with its duration. (E.g. we expect
+ * each mark to happen in serial, with the previous step ending as the new one begins.)
+ *
+ * Unfortunately, due to how express passes around the request object, this modifies
+ * the request context by reference.
+ *
+ * @param {object}  req      The express request object.
+ * @param {string}  markName A name for the marker being logged.
+ * @param {boolean} isChild  Optionally note this occured as part of a different mark.
+ */
+export default function performanceMark( req, markName, isChild = false ) {
+	if ( ! req.context ) {
+		return;
+	}
+
+	req.context.performanceMarks ??= [];
+
+	// Quick reference to the array for less verbosity.
+	const perfMarks = req.context.performanceMarks;
+	const currentTime = Date.now();
+	const newMark = { markName, startTime: currentTime };
+
+	// Create an array of steps on the active mark if necessary.
+	if ( isChild && perfMarks.length ) {
+		perfMarks[ perfMarks.length - 1 ].steps ??= [];
+	}
+
+	// If adding a child, we want to operate on the active marker's steps array.
+	// Otherwise, we're just adding a normal mark to the top-level array.
+	const targetArray =
+		isChild && perfMarks.length ? perfMarks[ perfMarks.length - 1 ].steps : perfMarks;
+
+	// Mark the duration of the previous marker if a mark exists to be updated.
+	finalizeDuration( targetArray, currentTime );
+
+	targetArray.push( newMark );
+}
+
+/**
+ * Finalize the duration of any active marks and return the final array of data.
+ *
+ * @param {object} req The express request object.
+ * @returns array The array of finalized performance marks.
+ */
+export function finalizePerfMarks( req ) {
+	// Do nothing if there are no marks.
+	if ( ! req?.context?.performanceMarks?.length ) {
+		return [];
+	}
+
+	finalizeDuration( req.context.performanceMarks, Date.now() );
+	return req.context.performanceMarks;
+}
+
+function finalizeDuration( markArr, currentTime ) {
+	if ( ! markArr?.length ) {
+		return;
+	}
+
+	const lastMarker = markArr[ markArr.length - 1 ];
+	lastMarker.duration ??= currentTime - lastMarker.startTime;
+
+	// Do the same thing to the active mark's step array.
+	finalizeDuration( lastMarker.steps, currentTime );
+}

--- a/client/server/lib/performance-mark/test/index.js
+++ b/client/server/lib/performance-mark/test/index.js
@@ -116,7 +116,7 @@ describe( 'performanceMark', () => {
 		expect( marks.length ).toBe( 4 );
 	} );
 
-	it( 'does not overrwrite durations', () => {
+	it( 'does not overwrite durations', () => {
 		const req = { context: {} };
 
 		performanceMark( req, 'parent-1' );

--- a/client/server/lib/performance-mark/test/index.js
+++ b/client/server/lib/performance-mark/test/index.js
@@ -1,0 +1,170 @@
+import performanceMark, { finalizePerfMarks } from '../';
+
+describe( 'performanceMark', () => {
+	beforeAll( () => {
+		jest.useFakeTimers();
+	} );
+
+	it( 'does nothing if the context has not been created', () => {
+		const req = {};
+		performanceMark( req, 'test-marker' );
+		expect( Object.keys( req ).length ).toBe( 0 );
+	} );
+
+	it( "creates the performance marks array if it doesn't exist", () => {
+		const req = { context: {} };
+		performanceMark( req, 'test-marker' );
+		expect( req.context.performanceMarks.length ).toBe( 1 );
+	} );
+
+	it( 'adds a new performance marker with the current time', () => {
+		const req = { context: {} };
+		performanceMark( req, 'test-1' );
+		expect( req.context.performanceMarks[ 0 ] ).toStrictEqual( {
+			markName: 'test-1',
+			startTime: Date.now(),
+		} );
+	} );
+
+	it( 'adds a new step to the current main mark as a child', () => {
+		const req = { context: {} };
+		performanceMark( req, 'parent-1' );
+		performanceMark( req, 'child-1', true );
+
+		const marks = req.context.performanceMarks;
+		expect( marks.length ).toBe( 1 );
+		expect( marks[ 0 ].steps.length ).toBe( 1 );
+		expect( marks[ 0 ].markName ).toBe( 'parent-1' );
+		expect( marks[ 0 ].steps[ 0 ].markName ).toBe( 'child-1' );
+	} );
+
+	it( 'updates the duration of a mark and its children', () => {
+		// Number of ms between some steps.
+		const duration1 = 5001;
+		const duration2 = 203;
+		const duration3 = 101;
+		const req = { context: {} };
+
+		performanceMark( req, 'parent-1' );
+		performanceMark( req, 'child-1', true );
+		jest.advanceTimersByTime( duration1 );
+		performanceMark( req, 'child-2', true );
+		jest.advanceTimersByTime( duration2 );
+		performanceMark( req, 'parent-2' );
+		jest.advanceTimersByTime( duration3 );
+		performanceMark( req, 'parent-3' );
+		performanceMark( req, 'child-3', true );
+
+		const marks = req.context.performanceMarks;
+		// The children are logged with the correct duration.
+		expect( marks[ 0 ].steps.length ).toBe( 2 );
+		expect( marks[ 0 ].steps[ 0 ].markName ).toBe( 'child-1' );
+		expect( marks[ 0 ].steps[ 0 ].duration ).toBe( duration1 );
+		expect( marks[ 0 ].steps[ 1 ].markName ).toBe( 'child-2' );
+		expect( marks[ 0 ].steps[ 1 ].duration ).toBe( duration2 );
+
+		// The first parent's duration ends up being the sum of the children's duration.
+		expect( marks[ 0 ].markName ).toBe( 'parent-1' );
+		expect( marks[ 0 ].duration ).toBe( duration1 + duration2 );
+
+		// The second parent has no children, and is just the interval between the second and third parents.
+		expect( marks[ 1 ].markName ).toBe( 'parent-2' );
+		expect( marks[ 1 ].duration ).toBe( duration3 );
+
+		// The third parent has an undefined duration because it's unfinished, despite having a child.
+		expect( marks[ 2 ].steps.length ).toBe( 1 );
+		expect( marks[ 2 ].markName ).toBe( 'parent-3' );
+		expect( marks[ 2 ].duration ).toBeUndefined();
+
+		expect( marks.length ).toBe( 3 );
+	} );
+
+	it( 'adds a new parent step as a parent', () => {
+		const req = { context: {} };
+
+		performanceMark( req, 'parent-1' );
+		performanceMark( req, 'child-1', true );
+		performanceMark( req, 'parent-2' );
+		performanceMark( req, 'parent-3' );
+
+		expect( req.context.performanceMarks.length ).toBe( 3 );
+	} );
+
+	it( 'only adds children to the appropriate steps', () => {
+		const req = { context: {} };
+
+		// First mark and some steps.
+		performanceMark( req, 'parent-1' );
+		performanceMark( req, 'child-1', true );
+		performanceMark( req, 'child-2', true );
+
+		// Second mark and no steps.
+		performanceMark( req, 'parent-2' );
+
+		// Third mark and one step.
+		performanceMark( req, 'parent-3' );
+		performanceMark( req, 'child-3', true );
+
+		// Fourth mark and no steps.
+		performanceMark( req, 'parent-4' );
+
+		const marks = req.context.performanceMarks;
+		expect( marks[ 0 ].steps.length ).toBe( 2 );
+		expect( marks[ 1 ].steps ).toBeUndefined();
+		expect( marks[ 2 ].steps.length ).toBe( 1 );
+		expect( marks[ 3 ].steps ).toBeUndefined();
+		expect( marks.length ).toBe( 4 );
+	} );
+
+	it( 'does not overrwrite durations', () => {
+		const req = { context: {} };
+
+		performanceMark( req, 'parent-1' );
+		performanceMark( req, 'child-1', true );
+		jest.advanceTimersByTime( 5 );
+		finalizePerfMarks( req );
+
+		expect( req.context.performanceMarks[ 0 ].duration ).toBe( 5 );
+		expect( req.context.performanceMarks[ 0 ].steps[ 0 ].duration ).toBe( 5 );
+
+		jest.advanceTimersByTime( 200 );
+		// Normally, this would update the duration of pending marks. Since they
+		// were already updated by finalizePerfMarks, it should do nothing.
+		performanceMark( req, 'test' );
+		expect( req.context.performanceMarks[ 0 ].duration ).toBe( 5 );
+		expect( req.context.performanceMarks[ 0 ].steps[ 0 ].duration ).toBe( 5 );
+	} );
+} );
+
+describe( 'finalizePerfMarks', () => {
+	it( 'returns an empty array of no marks exist', () => {
+		const req1 = {};
+		expect( finalizePerfMarks( req1 ) ).toStrictEqual( [] );
+
+		const req2 = { context: {} };
+		expect( finalizePerfMarks( req2 ) ).toStrictEqual( [] );
+
+		const req3 = { context: { performanceMarks: null } };
+		expect( finalizePerfMarks( req3 ) ).toStrictEqual( [] );
+
+		const req4 = { context: { performanceMarks: [] } };
+		expect( finalizePerfMarks( req4 ) ).toStrictEqual( [] );
+	} );
+
+	it( 'finalizes mark durations and returns the marks', () => {
+		const req = { context: {} };
+		performanceMark( req, 'test' );
+		performanceMark( req, 'test-child', true );
+		jest.advanceTimersByTime( 55 );
+
+		expect( req.context.performanceMarks[ 0 ].duration ).toBeUndefined();
+		expect( req.context.performanceMarks[ 0 ].steps[ 0 ].duration ).toBeUndefined();
+
+		const finalMarks = finalizePerfMarks( req );
+		// The by-ref update still works:
+		expect( req.context.performanceMarks[ 0 ].duration ).toBe( 55 );
+		expect( req.context.performanceMarks[ 0 ].steps[ 0 ].duration ).toBe( 55 );
+		expect( finalMarks[ 0 ].duration ).toBe( 55 );
+		expect( finalMarks[ 0 ].steps[ 0 ].duration ).toBe( 55 );
+	} );
+} );

--- a/client/server/middleware/logger.js
+++ b/client/server/middleware/logger.js
@@ -2,6 +2,7 @@ import config from '@automattic/calypso-config';
 import uaParser from 'ua-parser-js';
 import { v4 as uuidv4 } from 'uuid';
 import { getLogger } from 'calypso/server/lib/logger';
+import { finalizePerfMarks } from 'calypso/server/lib/performance-mark';
 
 const NS_TO_MS = 1e-6;
 
@@ -18,21 +19,35 @@ const logRequest = ( req, res, options ) => {
 	const { requestStart } = options;
 
 	const message = res.finished ? 'request finished' : 'request closed';
-
+	// Duration in ms.
+	const duration = Number(
+		( Number( process.hrtime.bigint() - requestStart ) * NS_TO_MS ).toFixed( 3 )
+	);
 	const fields = {
 		method: req.method,
 		status: res.statusCode,
 		length: res.get( 'content-length' ),
-		duration: Number(
-			( Number( process.hrtime.bigint() - requestStart ) * NS_TO_MS ).toFixed( 3 )
-		),
+		duration,
 		httpVersion: req.httpVersion,
 		rawUserAgent: req.get( 'user-agent' ),
 		remoteAddr: req.ip,
 		referrer: req.get( 'referer' ),
 	};
-
 	req.logger.info( fields, message );
+
+	// Requests which take longer than one second aren't performing well. We log
+	// extra performance data in this case to troubleshoot the cause.
+	if ( duration > 1000 ) {
+		req.logger.info(
+			// TODO: does warn not exist here for tests?
+			{
+				performanceMarks: finalizePerfMarks( req ),
+				didTimeout: duration > 49500, // A timeout occurs at 50s, so anything close to that is likely a timeout.
+				duration,
+			},
+			'long request duration'
+		);
+	}
 };
 
 export default () => {

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -29,6 +29,7 @@ import isSectionEnabled from 'calypso/sections-filter';
 import { serverRouter, getCacheKey } from 'calypso/server/isomorphic-routing';
 import analytics from 'calypso/server/lib/analytics';
 import isWpMobileApp from 'calypso/server/lib/is-wp-mobile-app';
+import performanceMark from 'calypso/server/lib/performance-mark/index.js';
 import {
 	serverRender,
 	renderJsx,
@@ -51,7 +52,6 @@ import middlewareAssets from '../middleware/assets.js';
 import middlewareCache from '../middleware/cache.js';
 import middlewareUnsupportedBrowser from '../middleware/unsupported-browser.js';
 import { logSectionResponse } from './analytics';
-
 const debug = debugFactory( 'calypso:pages' );
 
 const calypsoEnv = config( 'env_id' );
@@ -96,6 +96,8 @@ function setupLoggedInContext( req, res, next ) {
 }
 
 function getDefaultContext( request, response, entrypoint = 'entry-main' ) {
+	performanceMark( request, 'getDefaultContext' );
+
 	const geoIPCountryCode = request.headers[ 'x-geoip-country-code' ];
 	const showGdprBanner = shouldSeeGdprBanner(
 		request.cookies.country_code || geoIPCountryCode,
@@ -120,6 +122,7 @@ function getDefaultContext( request, response, entrypoint = 'entry-main' ) {
 	 * are considered logged out. This shouldn't cause issues because only one
 	 * user is using the cache in dev mode -- so cross-request pollution won't happen.
 	 */
+	performanceMark( request, 'get cached redux state', true );
 	const cachedServerState = request.context.isLoggedIn ? {} : stateCache.get( cacheKey ) || {};
 	const getCachedState = ( reducer, storageKey ) => {
 		const storedState = cachedServerState[ storageKey ];
@@ -130,6 +133,7 @@ function getDefaultContext( request, response, entrypoint = 'entry-main' ) {
 	};
 	const reduxStore = createReduxStore( getCachedState( initialReducer, 'root' ) );
 	setStore( reduxStore, getCachedState );
+	performanceMark( request, 'create basic options', true );
 
 	const devEnvironments = [ 'development', 'jetpack-cloud-development' ];
 	const isDebug = devEnvironments.includes( calypsoEnv ) || request.query.debug !== undefined;
@@ -149,6 +153,14 @@ function getDefaultContext( request, response, entrypoint = 'entry-main' ) {
 	const featuresHelper = config.isEnabled( 'dev/features-helper' );
 
 	const flags = ( request.query.flags || '' ).split( ',' );
+
+	performanceMark( request, 'getFilesForEntrypoint', true );
+	const entrypointFiles = request.getFilesForEntrypoint( entrypoint );
+
+	performanceMark( request, 'getAssets', true );
+	const manifests = request.getAssets().manifests;
+
+	performanceMark( request, 'assign context object', true );
 	const context = Object.assign( {}, request.context, {
 		commitSha: process.env.hasOwnProperty( 'COMMIT_SHA' ) ? process.env.COMMIT_SHA : '(unknown)',
 		compileDebug: process.env.NODE_ENV === 'development',
@@ -160,8 +172,8 @@ function getDefaultContext( request, response, entrypoint = 'entry-main' ) {
 		isWooDna: wooDnaConfig( request.query ).isWooDnaFlow(),
 		badge: false,
 		lang: config( 'i18n_default_locale_slug' ),
-		entrypoint: request.getFilesForEntrypoint( entrypoint ),
-		manifests: request.getAssets().manifests,
+		entrypoint: entrypointFiles,
+		manifests,
 		reactQueryDevtoolsHelper,
 		accountSettingsHelper,
 		authHelper,
@@ -185,6 +197,7 @@ function getDefaultContext( request, response, entrypoint = 'entry-main' ) {
 		isDebug,
 	};
 
+	performanceMark( request, 'setup environments', true );
 	if ( calypsoEnv === 'wpcalypso' ) {
 		context.badge = calypsoEnv;
 		context.devDocs = true;
@@ -234,11 +247,15 @@ const setupDefaultContext = ( entrypoint ) => ( req, res, next ) => {
 };
 
 function setUpLocalLanguageRevisions( req ) {
+	performanceMark( req, 'setUpLocalLanguageRevisions', true );
 	const rootPath = path.join( __dirname, '..', '..', '..' );
 	const langRevisionsPath = path.join( rootPath, 'public', 'languages', 'lang-revisions.json' );
+
+	performanceMark( req, 'read language file', true );
 	const langPromise = fs.promises
 		.readFile( langRevisionsPath, 'utf8' )
 		.then( ( languageRevisions ) => {
+			performanceMark( req, 'parse language file', true );
 			req.context.languageRevisions = JSON.parse( languageRevisions );
 
 			return languageRevisions;
@@ -253,6 +270,7 @@ function setUpLocalLanguageRevisions( req ) {
 }
 
 function setUpLoggedOutRoute( req, res, next ) {
+	performanceMark( req, 'setUpLoggedOutRoute', true );
 	res.set( {
 		'X-Frame-Options': 'SAMEORIGIN',
 	} );
@@ -264,7 +282,10 @@ function setUpLoggedOutRoute( req, res, next ) {
 	}
 
 	Promise.all( setupRequests )
-		.then( () => next() )
+		.then( () => {
+			performanceMark( req, 'done with setup requests', true );
+			next();
+		} )
 		.catch( ( error ) => next( error ) );
 }
 
@@ -491,6 +512,8 @@ function setUpCSP( req, res, next ) {
 }
 
 function setUpRoute( req, res, next ) {
+	performanceMark( req, 'setUpRoute' );
+
 	if ( req.context.isRouteSetup === true ) {
 		req.logger.warn(
 			{


### PR DESCRIPTION
### Proposed Changes
We want to better understand why long requests take so long. This PR times the duration of different steps of the server's pipeline and saves the data to logstash if requests take a long time. This is **not** meant for fine-grained profiling -- use the server profiler for that. This is to narrow down which middlewares or steps might be performing poorly when, say, a request times out.

This PR enables that by:

1. Creating a way to mark the current step the server is on
2. Keeping track of step durations -- marking the next step updates the duration of the previous one
3. Logs all of this data when requests take longer than 1 second.

This is implemented as an array on the context object. When you call `performanceMark`, it updates that array by reference. (Unfortunately, there is a fair bit of updating by reference because that's just how express passes around the request object. We mitigate complexity by keeping all logic in the same file.) You can also add a "child" to note several steps under the same top-level step.

Whenever a new step is added, the former step is updated with the time between the former step and the new step. If you need to note that a step "foo" is over, you can add a new mark like "post-foo", so that "foo" gets updated with a more accurate duration, and any extra stuff at the end goes under "post-foo"

One limitation of this approach is that it assumes all marks are added in serial. So durations would be incorrect if you logged multiple times in parallel. This can happen when multiple promises are executing at the same time. You just can't log marks under both with duration being correct. I think fixing this would make my approach more complicated, so I'm inclined to not fix it for the time being.

Question: Will logstash be ok with nested JSON data? I'm thinking it should be ok to try. It wouldn't impact production because logstash parses the logs from a text file outside of the server process.

### Testing Instructions
1. Run `yarn start` locally.
3. Open `calypso.localhost:3000/themes`. You should see a bunch of extra JSON data in the console for the first requests. (It likely takes over 1s since local caches are not primed yet.) If you don't see, it reduce the duration of the [if statement here](https://github.com/Automattic/wp-calypso/blob/e1c2edcff0efba42b646321c53b698dc2f595cac/client/server/middleware/logger.js#L40) to something minuscule.