### PR TITLE
Promoted posts: update title and view external link

### DIFF
--- a/client/my-sites/promote-post/components/post-item/index.tsx
+++ b/client/my-sites/promote-post/components/post-item/index.tsx
@@ -1,5 +1,5 @@
 import { safeImageUrl } from '@automattic/calypso-url';
-import { CompactCard } from '@automattic/components';
+import { CompactCard, Gridicon } from '@automattic/components';
 import './style.scss';
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
@@ -59,9 +59,7 @@ export default function PostItem( { post }: Props ) {
 				<h1 // eslint-disable-line
 					className="post-item__title"
 				>
-					<a href={ post.URL } className="post-item__title-link">
-						{ post.title || __( 'Untitled' ) }
-					</a>
+					<span className="post-item__title-link">{ post.title || __( 'Untitled' ) }</span>
 				</h1>
 				<div className="post-item__meta">
 					<span className="post-item__meta-time-status">
@@ -76,7 +74,8 @@ export default function PostItem( { post }: Props ) {
 					<span className="post-item__post-type">{ getPostType( post.type ) }</span>
 					<span className="post-item__post-type">
 						<a href={ post.URL } className="post-item__title-view">
-							{ __( 'View' ) }
+							{ __( 'View' ) }{ ' ' }
+							<Gridicon icon="external" size={ 12 } className="post-item__external-icon" />
 						</a>
 					</span>
 				</div>

--- a/client/my-sites/promote-post/components/post-item/style.scss
+++ b/client/my-sites/promote-post/components/post-item/style.scss
@@ -44,16 +44,12 @@ $post-item-background-color: var(--color-surface);
 		vertical-align: bottom;
 	}
 
-	a.post-item__title-link,
-	a.post-item__title-link:visited {
+	.post-item__title-link,
+	.post-item__title-link:visited {
 		color: var(--color-neutral-70);
 		display: block;
 		padding-bottom: 2px;
 		padding-right: 8px;
-
-		&:hover {
-			color: var(--color-neutral-50);
-		}
 
 		.post-item__panel.is-untitled & {
 			color: var(--color-text-subtle);
@@ -64,7 +60,8 @@ $post-item-background-color: var(--color-surface);
 	a.post-item__title-view,
 	a.post-item__title-view:visited {
 		color: var(--color-neutral-70);
-		display: block;
+		display: flex;
+		align-items: center;
 
 		&:hover {
 			color: var(--color-neutral-50);
@@ -73,6 +70,10 @@ $post-item-background-color: var(--color-surface);
 		.post-item__panel.is-untitled & {
 			color: var(--color-text-subtle);
 			font-style: italic;
+		}
+
+		.post-item__external-icon {
+			margin-left: 2px;
 		}
 	}
 


### PR DESCRIPTION
#### Proposed Changes

* Disable links in the Titles
* Add icon to the view link

![image](https://user-images.githubusercontent.com/6070516/197691259-c3046b5d-5cdc-4416-ac41-b73e94ed07b5.png)


#### Testing Instructions
Test that title is no longer clickable and there is an external icon next to the View link.
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
