### PR TITLE
E2E (Atomic): Fix navbar tests

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/editor-page.ts
@@ -769,6 +769,7 @@ export class EditorPage {
 			this.page.waitForNavigation( { url: '**/home/**' } ),
 			this.page.waitForNavigation( { url: '**/posts/**' } ),
 			this.page.waitForNavigation( { url: '**/pages/**' } ),
+			this.page.waitForNavigation( { url: '**/wp-admin/edit**' } ),
 		] );
 		const actions: Promise< unknown >[] = [ navigationPromise ];
 


### PR DESCRIPTION
Tracking issue: https://github.com/Automattic/wp-calypso/issues/65906

#### Proposed Changes

Make the following test compatible with the Atomic environment:

> Return to Calypso dashboard
specs/editor/editor__navbar.ts: Editor: Navbar

#### Why was it failing?

When returning to the dashboard in an Atomic site, the view used is the classic WP-admin WordPress interface which then lands at `wp-admin/edit.php`

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* The fixed test should pass for both Simple and Atomic sites (production).

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
