### PR TITLE
Marketplace: Handle SaaS redirect url when no site is selected

### DIFF
--- a/client/lib/plugins/utils.js
+++ b/client/lib/plugins/utils.js
@@ -470,7 +470,7 @@ export const getPluginPurchased = ( plugin, purchases, isMarketplaceProduct ) =>
  * @returns The URL of the SaaS redirect page or null if it doesn't exist or is an invalid URL
  */
 export function getSaasRedirectUrl( plugin, userId, siteId ) {
-	if ( ! plugin.saas_landing_page ) {
+	if ( ! plugin?.saas_landing_page ) {
 		return null;
 	}
 	try {

--- a/client/lib/plugins/utils.js
+++ b/client/lib/plugins/utils.js
@@ -460,3 +460,24 @@ export const getPluginPurchased = ( plugin, purchases, isMarketplaceProduct ) =>
 		)
 	);
 };
+
+/**
+ * Gets the SaaS redirect URL of a plugin if it exits and is valid
+ *
+ * @param {plugin} plugin The plugin object  to read the SaaS redirect url from
+ * @param {number} userId The user id
+ * @param {number} siteId The site id
+ * @returns The URL of the SaaS redirect page or null if it doesn't exist or is an invalid URL
+ */
+export function getSaasRedirectUrl( plugin, userId, siteId ) {
+	if ( ! plugin.saas_landing_page ) {
+		return null;
+	}
+	try {
+		const saasRedirectUrl = new URL( plugin.saas_landing_page );
+		saasRedirectUrl.searchParams.append( 'uuid', `${ userId }+${ siteId }` );
+		return saasRedirectUrl.toString();
+	} catch ( error ) {
+		return null;
+	}
+}

--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -7,7 +7,7 @@ import {
 import { Gridicon, Button } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
-import { Fragment, useState, useCallback } from 'react';
+import { Fragment, useState, useCallback, useMemo } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import { getPluginPurchased, getSoftwareSlug, getSaasRedirectUrl } from 'calypso/lib/plugins/utils';
@@ -102,7 +102,7 @@ const PluginDetailsCTA = ( { plugin, isPlaceholder } ) => {
 		getEligibility( state, selectedSite?.ID )
 	);
 
-	const getUpgradeToBusinessHRef = useCallback( () => {
+	const upgradeToBusinessHRef = useMemo( () => {
 		const pluginsPlansPageFlag = isEnabled( 'plugins-plans-page' );
 
 		const siteSlug = selectedSite?.slug;
@@ -111,7 +111,7 @@ const PluginDetailsCTA = ( { plugin, isPlaceholder } ) => {
 		return pluginsPlansPageFlag ? pluginsPlansPage : `/checkout/${ siteSlug }/business`;
 	}, [ selectedSite?.slug ] );
 
-	const getSaasRedirectHRef = useCallback( () => {
+	const saasRedirectHRef = useMemo( () => {
 		return getSaasRedirectUrl( plugin, currentUserId, selectedSite?.ID );
 	}, [ currentUserId, plugin, selectedSite?.ID ] );
 	/*
@@ -296,7 +296,7 @@ const PluginDetailsCTA = ( { plugin, isPlaceholder } ) => {
 						userCantManageTheSite={ userCantManageTheSite }
 						translate={ translate }
 						plugin={ plugin }
-						saasRedirectHRef={ getSaasRedirectHRef() }
+						saasRedirectHRef={ saasRedirectHRef }
 					/>
 				</div>
 				{ ! isJetpackSelfHosted && ! isMarketplaceProduct && (
@@ -331,7 +331,7 @@ const PluginDetailsCTA = ( { plugin, isPlaceholder } ) => {
 					<div className="plugin-details-cta__upgrade-required-card">
 						<UpgradeRequiredContent translate={ translate } />
 						<Button
-							href={ getUpgradeToBusinessHRef() }
+							href={ upgradeToBusinessHRef }
 							className="plugin-details-cta__install-button"
 							primary
 							onClick={ () => {} }

--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -10,7 +10,7 @@ import { useTranslate } from 'i18n-calypso';
 import { Fragment, useState, useCallback } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
-import { getPluginPurchased, getSoftwareSlug } from 'calypso/lib/plugins/utils';
+import { getPluginPurchased, getSoftwareSlug, getSaasRedirectUrl } from 'calypso/lib/plugins/utils';
 import { userCan } from 'calypso/lib/site/utils';
 import BillingIntervalSwitcher from 'calypso/my-sites/marketplace/components/billing-interval-switcher';
 import { ManageSitePluginsDialog } from 'calypso/my-sites/plugins/manage-site-plugins-dialog';
@@ -117,17 +117,8 @@ const PluginDetailsCTA = ( { plugin, isPlaceholder } ) => {
 	}, [ selectedSite?.slug ] );
 
 	const getSaasRedirectHRef = useCallback( () => {
-		if ( ! plugin.saas_landing_page ) {
-			return null;
-		}
-		try {
-			const saasRedirectUrl = new URL( plugin.saas_landing_page );
-			saasRedirectUrl.searchParams.append( 'uuid', `${ currentUserId }+${ selectedSite?.ID }` );
-			return saasRedirectUrl.toString();
-		} catch ( error ) {
-			return null;
-		}
-	}, [ currentUserId, plugin.saas_landing_page, selectedSite?.ID ] );
+		return getSaasRedirectUrl( plugin, currentUserId, selectedSite?.ID );
+	}, [ currentUserId, plugin, selectedSite?.ID ] );
 	/*
 	 * Remove 'NO_BUSINESS_PLAN' holds if the INSTALL_PURCHASED_PLUGINS feature is present.
 	 *

--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -26,10 +26,7 @@ import {
 	getSiteObjectsWithPlugin,
 	getPluginOnSite,
 } from 'calypso/state/plugins/installed/selectors';
-import {
-	isMarketplaceProduct as isMarketplaceProductSelector,
-	isSaasProduct as isSaasProductSelector,
-} from 'calypso/state/products-list/selectors';
+import { isMarketplaceProduct as isMarketplaceProductSelector } from 'calypso/state/products-list/selectors';
 import { getSitePurchases } from 'calypso/state/purchases/selectors';
 import getSelectedOrAllSitesWithPlugins from 'calypso/state/selectors/get-selected-or-all-sites-with-plugins';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
@@ -59,8 +56,6 @@ const PluginDetailsCTA = ( { plugin, isPlaceholder } ) => {
 	);
 	const softwareSlug = getSoftwareSlug( plugin, isMarketplaceProduct );
 	const purchases = useSelector( ( state ) => getSitePurchases( state, selectedSite?.ID ) );
-
-	const isSaasProduct = useSelector( ( state ) => isSaasProductSelector( state, softwareSlug ) );
 
 	// Site type
 	const sites = useSelector( getSelectedOrAllSitesWithPlugins );
@@ -263,7 +258,7 @@ const PluginDetailsCTA = ( { plugin, isPlaceholder } ) => {
 		<Fragment>
 			<QuerySitePurchases siteId={ selectedSite?.ID } />
 			<div className="plugin-details-cta__container">
-				{ ! isSaasProduct && (
+				{ ! plugin.isSaasProduct && (
 					<div className="plugin-details-cta__price">
 						<PluginPrice plugin={ plugin } billingPeriod={ billingPeriod }>
 							{ ( { isFetching, price, period } ) =>
@@ -285,7 +280,7 @@ const PluginDetailsCTA = ( { plugin, isPlaceholder } ) => {
 						</PluginPrice>
 					</div>
 				) }
-				{ isMarketplaceProduct && ! isSaasProduct && (
+				{ isMarketplaceProduct && ! plugin.isSaasProduct && (
 					<BillingIntervalSwitcher
 						billingPeriod={ billingPeriod }
 						onChange={ ( interval ) => dispatch( setBillingInterval( interval ) ) }
@@ -295,7 +290,6 @@ const PluginDetailsCTA = ( { plugin, isPlaceholder } ) => {
 				<div className="plugin-details-cta__install">
 					<PrimaryButton
 						isLoggedIn={ isLoggedIn }
-						isSaasProduct={ isSaasProduct }
 						shouldUpgrade={ shouldUpgrade }
 						hasEligibilityMessages={ hasEligibilityMessages }
 						incompatiblePlugin={ incompatiblePlugin }
@@ -330,10 +324,10 @@ const PluginDetailsCTA = ( { plugin, isPlaceholder } ) => {
 						) }
 					</div>
 				) }
-				{ ! isSaasProduct && shouldUpgrade && isLoggedIn && (
+				{ ! plugin.isSaasProduct && shouldUpgrade && isLoggedIn && (
 					<UpgradeRequiredContent translate={ translate } />
 				) }
-				{ isSaasProduct && shouldUpgrade && isLoggedIn && (
+				{ plugin.isSaasProduct && shouldUpgrade && isLoggedIn && (
 					<div className="plugin-details-cta__upgrade-required-card">
 						<UpgradeRequiredContent translate={ translate } />
 						<Button
@@ -353,7 +347,6 @@ const PluginDetailsCTA = ( { plugin, isPlaceholder } ) => {
 
 function PrimaryButton( {
 	isLoggedIn,
-	isSaasProduct,
 	shouldUpgrade,
 	hasEligibilityMessages,
 	incompatiblePlugin,
@@ -375,7 +368,7 @@ function PrimaryButton( {
 			</Button>
 		);
 	}
-	if ( isSaasProduct ) {
+	if ( plugin.isSaasProduct ) {
 		return (
 			<Button
 				className="plugin-details-cta__install-button"

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -46,6 +46,7 @@ import {
 import {
 	isMarketplaceProduct as isMarketplaceProductSelector,
 	getProductsList,
+	isSaasProduct as isSaasProductSelector,
 } from 'calypso/state/products-list/selectors';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import canCurrentUserManagePlugins from 'calypso/state/selectors/can-current-user-manage-plugins';
@@ -125,6 +126,10 @@ function PluginDetails( props ) {
 		isMarketplaceProductSelector( state, props.pluginSlug )
 	);
 
+	const isSaasProduct = useSelector( ( state ) =>
+		isSaasProductSelector( state, props.pluginSlug )
+	);
+
 	// Fetch WPorg plugin data if needed
 	useEffect( () => {
 		if ( isProductListFetched && ! isMarketplaceProduct && ! isWporgPluginFetched ) {
@@ -152,15 +157,22 @@ function PluginDetails( props ) {
 			...wpComPluginData,
 			fetched: isWpComPluginFetched,
 		};
-
 		return {
 			...wpcomPlugin,
 			...wporgPlugin,
 			...plugin,
 			fetched: wpcomPlugin?.fetched || wporgPlugin?.fetched,
 			isMarketplaceProduct,
+			isSaasProduct,
 		};
-	}, [ plugin, wporgPlugin, wpComPluginData, isWpComPluginFetched, isMarketplaceProduct ] );
+	}, [
+		plugin,
+		wporgPlugin,
+		wpComPluginData,
+		isWpComPluginFetched,
+		isMarketplaceProduct,
+		isSaasProduct,
+	] );
 
 	const existingPlugin = useMemo( () => {
 		if (

--- a/client/my-sites/plugins/plugin-install-button/style.scss
+++ b/client/my-sites/plugins/plugin-install-button/style.scss
@@ -41,6 +41,10 @@
 			text-transform: uppercase;
 		}
 	}
+	.gridicon.gridicons-external {
+		margin-left: 5px;
+		top: 3px;
+	}
 }
 
 .plugin-install-button__warning {

--- a/client/my-sites/plugins/plugin-price/index.jsx
+++ b/client/my-sites/plugins/plugin-price/index.jsx
@@ -6,7 +6,6 @@ import {
 	getProductDisplayCost,
 	isProductsListFetching,
 	getProductsList,
-	isSaasProduct as isSaasProductSelector,
 } from 'calypso/state/products-list/selectors';
 
 export const PluginPrice = ( { plugin, billingPeriod, children } ) => {
@@ -17,7 +16,6 @@ export const PluginPrice = ( { plugin, billingPeriod, children } ) => {
 	const priceSlug = getProductSlugByPeriodVariation( variation, productList );
 	const price = useSelector( ( state ) => getProductDisplayCost( state, priceSlug ) );
 	const isFetching = useSelector( isProductsListFetching );
-	const isSaasProduct = useSelector( ( state ) => isSaasProductSelector( state, plugin?.slug ) );
 
 	const getPeriodText = ( periodValue ) => {
 		switch ( periodValue ) {
@@ -34,7 +32,6 @@ export const PluginPrice = ( { plugin, billingPeriod, children } ) => {
 		isFetching,
 		price,
 		period: getPeriodText( variationPeriod ),
-		isSaasProduct,
 	} );
 };
 

--- a/client/my-sites/plugins/plugins-browser-item/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-item/index.jsx
@@ -322,8 +322,8 @@ const InstalledInOrPricing = ( {
 	return (
 		<div className="plugins-browser-item__pricing">
 			<PluginPrice plugin={ plugin } billingPeriod={ IntervalLength.MONTHLY }>
-				{ ( { isFetching, price, period, isSaasProduct } ) => {
-					if ( isSaasProduct ) {
+				{ ( { isFetching, price, period } ) => {
+					if ( plugin.isSaasProduct ) {
 						// SaaS products do not display a price
 						return (
 							<>


### PR DESCRIPTION
#### Proposed Changes
 Adds a new button functionality when selecting `Manage sites` in a plugin details screen for SaaS products

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Sandbox the API and make sure you are using the test store. More information here PCYsg-IA-p2
* Navigate to `/plugins/test-saas-product` without a site selected
* Click on `Manage sites`
* Make sure the buttons are displayed with the `Get Started` text 
* Make sure when clicking the buttons, the site is redirected to the test URL with both the `userId` and `siteId` in the URL in the `uuuid` query param

##### Regression testing
* Navigate to another plugin without a site selected and make sure when clicking the `Manage sites` button, the dialog and buttons behave like in production. E.g. `/plugins/woocommerce-bookings` or `/plugins/woocommerce`
* Navigate to the `test saas product` plugin detail with a site selected and make sure it behaves like in production. Example URL is `/plugins/test-saas-product/<site_id>`

#### Screenshot
![CleanShot 2022-10-25 at 13 43 29@2x](https://user-images.githubusercontent.com/3519124/197764817-623203b0-5b4f-425a-a0f0-71fa38d597b0.png)


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixed #69329 