### PR TITLE
Marketplace: Update design of sidebar in SaaS product details

### DIFF
--- a/client/my-sites/plugins/plugin-details-CTA/style.scss
+++ b/client/my-sites/plugins/plugin-details-CTA/style.scss
@@ -89,6 +89,8 @@
 	background-color: var(--color-surface);
 	display: flex;
 	flex-direction: column;
+	border: 1px solid var(--color-neutral-10);
+	border-radius: 4px;
 
 	.button {
 		margin-top: 1rem;
@@ -97,7 +99,6 @@
 }
 .plugin-details-cta__upgrade-required {
 	display: flex;
-	align-items: center;
 
 	.plugin-details-cta__upgrade-required-icon {
 		color: var(--studio-orange-40);

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -97,7 +97,7 @@ body.is-section-plugins.theme-default.color-scheme {
 	padding-top: 54px;
 
 	@include display-grid;
-	grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) 350px;
+	grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) 395px;
 	grid-column-gap: 60px;
 	grid-template-areas:
 		"header header actions"


### PR DESCRIPTION
#### Proposed Changes

The following styles have been updated in the sidebar of product details:

##### In SaaS products:
* Border radius of the card component
* Added a border to the card component 
* Alignment of the small icon next to the text

##### In ALL products:
* The width of the sidebar has increased from 350px to 395px

||Before | After|
|-------|-------|------|
|Saas Product|       ![CleanShot 2022-10-25 at 16 39 34@2x](https://user-images.githubusercontent.com/3519124/197804871-0d3ae179-2b48-49e9-ae4d-af5d641c2b2d.png)          |              ![CleanShot 2022-10-25 at 16 39 14@2x](https://user-images.githubusercontent.com/3519124/197804916-6c5fb038-c001-4989-adb0-da97aec63996.png)     |
|Standard Product|         ![CleanShot 2022-10-25 at 16 39 58@2x](https://user-images.githubusercontent.com/3519124/197804775-b232228f-92c9-4413-a6c2-4405ea3e6409.png)     |![CleanShot 2022-10-25 at 16 40 06@2x](https://user-images.githubusercontent.com/3519124/197804609-daf271ea-408d-4fe5-99fd-856978efce56.png)|

Figma design can be found here f84fqtCG4pCnCh2Hq0But5-fi-5468%3A38057

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Sandbox the API and make sure you are using the test store. More info here PCYsg-IA-p2
* Navigate to the product details of the `Test Saas Product` on a site that requires an upgrade, e.g. `/plugins/test-saas-product/<free_site_id>`
* Make sure the changes in the sidebar look as expected
* Navigate to the product details of any other Marketplace or Free plugin and make sure the changes look as expected

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves #69328