### PR TITLE
Fixed sorting of country list after translation

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/company-details-form/hooks/use-countries-and-states.ts
+++ b/client/jetpack-cloud/sections/partner-portal/company-details-form/hooks/use-countries-and-states.ts
@@ -104,6 +104,17 @@ export function useCountriesAndStates() {
 			isLabel: false,
 		} );
 
+		// Alphabetizes country list after translated.
+		countries.sort( ( { label: countryA }, { label: countryB } ) => {
+			if ( countryA < countryB ) {
+				return -1;
+			}
+			if ( countryA > countryB ) {
+				return 1;
+			}
+			return 0;
+		} );
+
 		return {
 			countryOptions: countries as Option[],
 			stateOptionsMap: stateOptions,

--- a/client/jetpack-cloud/sections/partner-portal/company-details-form/hooks/use-countries-and-states.ts
+++ b/client/jetpack-cloud/sections/partner-portal/company-details-form/hooks/use-countries-and-states.ts
@@ -52,7 +52,7 @@ export function useCountriesAndStates() {
 	const translate = useTranslate();
 
 	return useMemo( () => {
-		const countryOptions = <{ [ key: string ]: object }>{};
+		const countryOptions = <{ [ key: string ]: Option }>{};
 		const stateOptions = <{ [ key: string ]: Array< object > }>{};
 
 		Object.entries( countriesList ?? [] ).map( ( [ key, value ] ) => {


### PR DESCRIPTION
#### Proposed Changes

* This change will change the sorting of the country list when signing up as an agency. It was sorting based on the English name of the country, but this fix sorts the countries after it's been sorted.

#### Testing Instructions

- In an incognito window, go to http://jetpack.cloud.localhost:3000/agency/signup
- Sign up for a new account (or use a test WordPress.com account)
- This will land you at the "Tell Us More About You" page
- Open a different tab, and go to https://wordpress.com/me/account and change your default WordPress.com language to something other than English
- Hard refresh on the "Tell Us More About You" Jetpack cloud page. 

Note: You might have to delete the key from your browser console `Application > Storage > IndexedDB > calypso > calypso_store > query-state`

### Old Sorting Portuguese
<img src="https://user-images.githubusercontent.com/2293077/198038015-07b17ed4-2ee0-4031-91cd-d87cd576d024.png" width="400">


### New Sorting Portuguese
<img src="https://user-images.githubusercontent.com/2293077/198038581-b9c745c6-de80-48df-9653-d59ca8d909e6.png" width="400">

#### Pre-merge Checklist

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

Related to 1202619025189113-as-1202784660147867