### PR TITLE
Checkout: remove country code from payment method filter

### DIFF
--- a/client/lib/checkout/processor-specific.js
+++ b/client/lib/checkout/processor-specific.js
@@ -17,8 +17,7 @@ export function isEbanxCreditCardProcessingEnabledForCountry( countryCode, cart 
 		typeof PAYMENT_PROCESSOR_COUNTRIES_FIELDS[ countryCode ] !== 'undefined' &&
 		isPaymentMethodEnabled(
 			'ebanx',
-			cart.allowed_payment_methods?.map( translateWpcomPaymentMethodToCheckoutPaymentMethod ),
-			countryCode
+			cart.allowed_payment_methods?.map( translateWpcomPaymentMethodToCheckoutPaymentMethod )
 		)
 	);
 }

--- a/client/my-sites/checkout/composite-checkout/components/checkout-main.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-main.tsx
@@ -367,13 +367,11 @@ export default function CheckoutMain( {
 	const recaptchaClientId: number | undefined = useSelect( ( select ) =>
 		select( 'wpcom-checkout' )?.getRecaptchaClientId()
 	);
-	const countryCode: string = contactDetails?.countryCode?.value ?? '';
 
 	const paymentMethods = arePaymentMethodsLoading
 		? []
 		: filterAppropriatePaymentMethods( {
 				paymentMethodObjects,
-				countryCode,
 				allowedPaymentMethods,
 				responseCart,
 		  } );

--- a/client/my-sites/checkout/composite-checkout/lib/filter-appropriate-payment-methods.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/filter-appropriate-payment-methods.ts
@@ -7,12 +7,10 @@ import type { CheckoutPaymentMethodSlug } from '@automattic/wpcom-checkout';
 
 export default function filterAppropriatePaymentMethods( {
 	paymentMethodObjects,
-	countryCode,
 	responseCart,
 	allowedPaymentMethods,
 }: {
 	paymentMethodObjects: PaymentMethod[];
-	countryCode: string;
 	allowedPaymentMethods: CheckoutPaymentMethodSlug[];
 	responseCart: ResponseCart;
 } ): PaymentMethod[] {
@@ -39,6 +37,6 @@ export default function filterAppropriatePaymentMethods( {
 			if ( ! slug ) {
 				return false;
 			}
-			return isPaymentMethodEnabled( slug, allowedPaymentMethods, countryCode );
+			return isPaymentMethodEnabled( slug, allowedPaymentMethods );
 		} );
 }

--- a/client/my-sites/checkout/composite-checkout/lib/is-payment-method-enabled.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/is-payment-method-enabled.ts
@@ -4,8 +4,7 @@ import type { CheckoutPaymentMethodSlug } from '@automattic/wpcom-checkout';
 
 export default function isPaymentMethodEnabled(
 	slug: CheckoutPaymentMethodSlug,
-	allowedPaymentMethods: null | CheckoutPaymentMethodSlug[],
-	countryCode: string
+	allowedPaymentMethods: null | CheckoutPaymentMethodSlug[]
 ): boolean {
 	const alwaysEnabledPaymentMethods = [ 'full-credits', 'free-purchase' ];
 	if ( alwaysEnabledPaymentMethods.includes( slug ) ) {

--- a/client/my-sites/checkout/composite-checkout/lib/is-payment-method-enabled.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/is-payment-method-enabled.ts
@@ -17,12 +17,6 @@ export default function isPaymentMethodEnabled(
 		return true;
 	}
 
-	// Some country-specific payment methods should only be available if that
-	// country is selected in the contact information.
-	if ( slug === 'netbanking' && countryCode !== 'IN' ) {
-		return false;
-	}
-
 	// Redirect payments might not be possible in some cases - for example in the desktop app
 	if ( isRedirectPaymentMethod( slug ) && ! config.isEnabled( 'upgrades/redirect-payments' ) ) {
 		return false;


### PR DESCRIPTION
#### Proposed Changes

The function `isPaymentMethodEnabled()` is used to determine which payment methods are available in checkout. It includes a code block to disallow the `netbanking` (aka `WPCOM_Billing_Dlocal_Redirect_India_Netbanking`) payment method if the selected country code is not India. This block is unnecessary for two reasons:

1. Netbanking is currently disabled: pNPgK-5sc-p2
2. The shopping-cart and available payment method endpoints already filter payment methods by country code.

This PR removes the block. Because the block is removed, the function no longer needs a country code passed in, so the calls are also modified to remove the unused argument.

This is related to moving all payment method decisions to the backend (https://github.com/Automattic/payments-shilling/issues/1183).

#### Testing Instructions

- Verify that there are no uses of `isPaymentMethodEnabled()` which still pass a country code argument.
