### PR TITLE
Checkout: allow saved cards in checkout if saved cards are allowed by backend

### DIFF
--- a/client/my-sites/checkout/composite-checkout/lib/is-payment-method-enabled.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/is-payment-method-enabled.ts
@@ -12,9 +12,10 @@ export default function isPaymentMethodEnabled(
 		return true;
 	}
 
-	// If new cards are supported, so are existing cards.
-	if ( slug.startsWith( 'existingCard' ) && allowedPaymentMethods?.includes( 'card' ) ) {
-		return true;
+	// Existing cards have unique slugs but here we need only know if existing
+	// cards are allowed.
+	if ( slug.startsWith( 'existingCard' ) ) {
+		slug = 'existingCard';
 	}
 
 	// Some country-specific payment methods should only be available if that

--- a/client/my-sites/checkout/composite-checkout/lib/translate-payment-method-names.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/translate-payment-method-names.ts
@@ -102,6 +102,7 @@ export function translateCheckoutPaymentMethodToWpcomPaymentMethod(
 export function readWPCOMPaymentMethodClass( slug: string ): WPCOMPaymentMethod | null {
 	switch ( slug ) {
 		case 'WPCOM_Billing_WPCOM':
+		case 'WPCOM_Billing_MoneyPress_Stored':
 		case 'WPCOM_Billing_Ebanx':
 		case 'WPCOM_Billing_Dlocal_Redirect_India_Netbanking':
 		case 'WPCOM_Billing_PayPal_Direct':

--- a/packages/wpcom-checkout/src/types.ts
+++ b/packages/wpcom-checkout/src/types.ts
@@ -213,7 +213,8 @@ export type CheckoutPaymentMethodSlug =
 	| 'full-credits'
 	| 'stripe-three-d-secure'
 	| 'wechat'
-	| `existingCard${ string }`
+	| 'existingCard'
+	| `existingCard${ string }` // specific saved cards have unique slugs
 	| 'stripe' // a synonym for 'card'
 	| 'apple-pay' // a synonym for 'web-pay'
 	| 'google-pay'; // a synonym for 'web-pay'


### PR DESCRIPTION
#### Proposed Changes

The API endpoints (eg: the shopping-cart endpoint) used by checkout return `WPCOM_Billing_MoneyPress_Stored` if saved cards are allowed to be used as a payment method.

For some reason `isPaymentMethodEnabled()` ignored that value and relied on `WPCOM_Billing_Stripe_Payment_Method` which represents new cards.

In this PR we remove the unnecessary logic and instead make sure that we normalized saved card slugs.

This is related to moving all payment method decisions to the backend (https://github.com/Automattic/payments-shilling/issues/1183).

#### Testing Instructions

- Use a testing account which has at least one saved credit card.
- On this branch, add a product to your cart and visit checkout.
- Continue to the last step of checkout.
- Verify that all the account's saved credit cards are visible as available payment methods.