### PR TITLE
Draft of Notifications: Trash e2e fix utilizing REST API

### DIFF
--- a/packages/calypso-e2e/src/lib/components/notifications-component.ts
+++ b/packages/calypso-e2e/src/lib/components/notifications-component.ts
@@ -8,6 +8,7 @@ const selectors = {
 	// Comment actions
 	commentAction: ( action: string ) => `button.wpnc__action-link:has-text("${ action }"):visible`,
 	undoLocator: '.wpnc__undo-item',
+	undoLink: '.wpnc__undo-link',
 };
 /**
  * Component representing the notifications panel and notifications themselves.
@@ -42,11 +43,21 @@ export class NotificationsComponent {
 	 * @param {string} action Predefined list of strings that are accepted.
 	 * @returns {Promise<void>} No return value.
 	 */
-	async clickNotificationAction( action: 'Trash' ): Promise< void > {
+	async clickNotificationAction( action: string ): Promise< void > {
 		// we need to make sure we're in a specific notification view before proceeding with the individual action
 		const elementHandle = await this.page.waitForSelector( selectors.activeSingleViewPanel );
 		await elementHandle.waitForElementState( 'stable' );
 		await this.page.click( selectors.commentAction( action ) );
+	}
+
+	/**
+	 * Clicks the undo link to undo the previous action.
+	 *
+	 * @returns {Promise<void>} No return value.
+	 */
+	async clickUndo(): Promise< void > {
+		this.waitForUndoMessage();
+		await this.page.click( selectors.undoLink );
 	}
 
 	/**
@@ -64,6 +75,7 @@ export class NotificationsComponent {
 	 * @returns {Promise<void>} No return value.
 	 */
 	async waitForUndoMessageToDisappear(): Promise< void > {
+		this.waitForUndoMessage();
 		await this.page.waitForSelector( selectors.undoLocator, { state: 'hidden' } );
 	}
 }

--- a/packages/calypso-e2e/src/lib/components/notifications-component.ts
+++ b/packages/calypso-e2e/src/lib/components/notifications-component.ts
@@ -56,7 +56,7 @@ export class NotificationsComponent {
 	 * @returns {Promise<void>} No return value.
 	 */
 	async clickUndo(): Promise< void > {
-		this.waitForUndoMessage();
+		await this.waitForUndoMessage();
 		await this.page.click( selectors.undoLink );
 	}
 
@@ -75,7 +75,7 @@ export class NotificationsComponent {
 	 * @returns {Promise<void>} No return value.
 	 */
 	async waitForUndoMessageToDisappear(): Promise< void > {
-		this.waitForUndoMessage();
+		await this.waitForUndoMessage();
 		await this.page.waitForSelector( selectors.undoLocator, { state: 'hidden' } );
 	}
 }

--- a/packages/calypso-e2e/src/rest-api-client.ts
+++ b/packages/calypso-e2e/src/rest-api-client.ts
@@ -571,7 +571,6 @@ export class RestAPIClient {
 
 	/**
 	 * Gets the latest posts from blogs a user follows.
-	 * TODO: Find an elegant way to pass in query parameters for better filtering.
 	 *
 	 * @returns {Promise<ReaderResponse>} An Array of posts.
 	 * @throws {Error} If API responded with an error.

--- a/packages/calypso-e2e/src/rest-api-client.ts
+++ b/packages/calypso-e2e/src/rest-api-client.ts
@@ -172,68 +172,6 @@ export class RestAPIClient {
 		return response.json();
 	}
 
-	/**
-	 * Gets the latest of post from the blogs a user follows.
-	 *
-	 *
-	 * @returns {Promise<ReaderParams}.
-	 * @throws {Error} If API responded with an error.
-	 */
-	async getReaderFeed(): Promise< ReaderParams > {
-		const params: RequestParams = {
-			method: 'get',
-			headers: {
-				Authorization: await this.getAuthorizationHeader( 'bearer' ),
-				'Content-Type': this.getContentTypeHeader( 'json' ),
-			},
-		};
-
-		const response = await this.sendRequest( this.getRequestURL( '1.1', '/me/sites' ), params );
-
-		if ( response.hasOwnProperty( 'error' ) ) {
-			throw new Error(
-				`${ ( response as ErrorResponse ).error }: ${ ( response as ErrorResponse ).message }`
-			);
-		}
-
-		return response;
-	}
-
-	/**
-	 * Creates a comment on the given post.
-	 *
-	 * @param {number} siteID Target site ID.
-	 * @param {number} postID Target post ID.
-	 * @param {string} comment Details of the new comment.
-	 */
-	async createComment(
-		siteID: number,
-		postID: number,
-		comment: string
-	): Promise< NewCommentParams > {
-		const params: RequestParams = {
-			method: 'post',
-			headers: {
-				Authorization: await this.getAuthorizationHeader( 'bearer' ),
-				'Content-Type': this.getContentTypeHeader( 'json' ),
-			},
-			body: JSON.stringify( { content: comment } ),
-		};
-
-		const response = await this.sendRequest(
-			this.getRequestURL( '1.1', `/sites/${ siteID }/posts/${ postID }/replies/new` ),
-			params
-		);
-
-		if ( response.hasOwnProperty( 'error' ) ) {
-			throw new Error(
-				`${ ( response as ErrorResponse ).error }: ${ ( response as ErrorResponse ).message }`
-			);
-		}
-
-		return response;
-	}
-
 	/* Sites */
 
 	/**
@@ -633,6 +571,38 @@ export class RestAPIClient {
 		return await this.sendRequest( this.getRequestURL( '1.1', '/me/preferences' ), params );
 	}
 
+	/* Reader */
+
+	/**
+	 * Gets the latest posts from blogs a user follows.
+	 * TODO: Find an elegant way to pass in query parameters for better filtering.
+	 *
+	 * @returns {Promise<ReaderResponse>} An Array of posts.
+	 * @throws {Error} If API responded with an error.
+	 */
+	async getReaderFeed(): Promise< ReaderResponse > {
+		const params: RequestParams = {
+			method: 'get',
+			headers: {
+				Authorization: await this.getAuthorizationHeader( 'bearer' ),
+				'Content-Type': this.getContentTypeHeader( 'json' ),
+			},
+		};
+
+		const response = await this.sendRequest(
+			this.getRequestURL( '1.1', '/read/following' ),
+			params
+		);
+
+		if ( response.hasOwnProperty( 'error' ) ) {
+			throw new Error(
+				`${ ( response as ErrorResponse ).error }: ${ ( response as ErrorResponse ).message }`
+			);
+		}
+
+		return response;
+	}
+
 	/* Posts */
 
 	/**
@@ -653,6 +623,45 @@ export class RestAPIClient {
 
 		const response = await this.sendRequest(
 			this.getRequestURL( '1.1', `/sites/${ siteID }/posts/new` ),
+			params
+		);
+
+		if ( response.hasOwnProperty( 'error' ) ) {
+			throw new Error(
+				`${ ( response as ErrorResponse ).error }: ${ ( response as ErrorResponse ).message }`
+			);
+		}
+
+		return response;
+	}
+
+	/* Comments */
+
+	/**
+	 * Creates a comment on the given post.
+	 *
+	 * @param {number} siteID Target site ID.
+	 * @param {number} postID Target post ID.
+	 * @param {string} comment Details of the new comment.
+	 * @returns {Promise<NewCommentResponse>} Confirmation details of the new comment.
+	 * @throws {Error} If API responded with an error.
+	 */
+	async createComment(
+		siteID: number,
+		postID: number,
+		comment: string
+	): Promise< NewCommentResponse > {
+		const params: RequestParams = {
+			method: 'post',
+			headers: {
+				Authorization: await this.getAuthorizationHeader( 'bearer' ),
+				'Content-Type': this.getContentTypeHeader( 'json' ),
+			},
+			body: JSON.stringify( { content: comment } ),
+		};
+
+		const response = await this.sendRequest(
+			this.getRequestURL( '1.1', `/sites/${ siteID }/posts/${ postID }/replies/new` ),
 			params
 		);
 

--- a/packages/calypso-e2e/src/rest-api-client.ts
+++ b/packages/calypso-e2e/src/rest-api-client.ts
@@ -2,13 +2,7 @@ import fs from 'fs';
 import FormData from 'form-data';
 import fetch from 'node-fetch';
 import { SecretsManager } from './secrets';
-import {
-	BearerTokenErrorResponse,
-	NewCommentParams,
-	ReaderParams,
-	TestFile,
-	SettingsParams,
-} from './types';
+import { BearerTokenErrorResponse, TestFile, SettingsParams } from './types';
 import type { Roles } from './lib';
 import type {
 	AccountDetails,
@@ -24,11 +18,13 @@ import type {
 	NewSiteResponse,
 	NewSiteParams,
 	NewInviteResponse,
+	NewCommentResponse,
 	AllInvitesResponse,
 	DeleteInvitesResponse,
 	NewPostParams,
 	NewMediaResponse,
 	NewPostResponse,
+	ReaderResponse,
 	Invite,
 } from './types';
 import type { BodyInit, HeadersInit, RequestInit } from 'node-fetch';
@@ -662,6 +658,37 @@ export class RestAPIClient {
 
 		const response = await this.sendRequest(
 			this.getRequestURL( '1.1', `/sites/${ siteID }/posts/${ postID }/replies/new` ),
+			params
+		);
+
+		if ( response.hasOwnProperty( 'error' ) ) {
+			throw new Error(
+				`${ ( response as ErrorResponse ).error }: ${ ( response as ErrorResponse ).message }`
+			);
+		}
+
+		return response;
+	}
+
+	/**
+	 * Deletes a given comment from a site.
+	 *
+	 * @param {number} siteID Target site ID.
+	 * @param {number} commentID Target comment ID.
+	 * @returns {Promise< any >} Decoded JSON response.
+	 * @throws {Error} If API responded with an error.
+	 */
+	async deleteComment( siteID: number, commentID: number ): Promise< any > {
+		const params: RequestParams = {
+			method: 'post',
+			headers: {
+				Authorization: await this.getAuthorizationHeader( 'bearer' ),
+				'Content-Type': this.getContentTypeHeader( 'json' ),
+			},
+		};
+
+		const response = await this.sendRequest(
+			this.getRequestURL( '1.1', `/sites/${ siteID }/comments/${ commentID }/delete` ),
 			params
 		);
 

--- a/packages/calypso-e2e/src/types/rest-api-client.types.ts
+++ b/packages/calypso-e2e/src/types/rest-api-client.types.ts
@@ -155,10 +155,6 @@ export interface NewCommentResponse {
 	ID: number;
 }
 
-export interface DeleteCommentResponse {
-	ID: number;
-}
-
 /* Error Responses */
 
 export interface BearerTokenErrorResponse {

--- a/packages/calypso-e2e/src/types/rest-api-client.types.ts
+++ b/packages/calypso-e2e/src/types/rest-api-client.types.ts
@@ -29,10 +29,6 @@ export interface SettingsParams {
 	[ key: string ]: string | number;
 }
 
-export interface ReaderParams {
-	number: number;
-}
-
 export interface NewCommentParams {
 	content: string;
 }
@@ -155,9 +151,13 @@ export interface ReaderResponse {
 	posts: Array< ReaderMetadata >;
 }
 
-// export interface NewCommentResponse {
-// 	// TODO: Find a way to get the response status code
-// }
+export interface NewCommentResponse {
+	ID: number;
+}
+
+export interface DeleteCommentResponse {
+	ID: number;
+}
 
 /* Error Responses */
 

--- a/packages/calypso-e2e/src/types/rest-api-client.types.ts
+++ b/packages/calypso-e2e/src/types/rest-api-client.types.ts
@@ -30,12 +30,10 @@ export interface SettingsParams {
 }
 
 export interface ReaderParams {
-	postID: number;
-	siteID: number;
+	number: number;
 }
 
 export interface NewCommentParams {
-	ID: number;
 	content: string;
 }
 
@@ -143,6 +141,23 @@ export interface NewMediaResponse {
 	title: string;
 	file: string;
 }
+
+export interface ReaderMetadata {
+	ID: number;
+	site_ID: number;
+	author: {
+		ID: number;
+		login: string;
+	};
+}
+
+export interface ReaderResponse {
+	posts: Array< ReaderMetadata >;
+}
+
+// export interface NewCommentResponse {
+// 	// TODO: Find a way to get the response status code
+// }
 
 /* Error Responses */
 

--- a/packages/calypso-e2e/src/types/rest-api-client.types.ts
+++ b/packages/calypso-e2e/src/types/rest-api-client.types.ts
@@ -25,9 +25,18 @@ export interface NewPostParams {
 	title: string;
 	content?: string;
 }
-
 export interface SettingsParams {
 	[ key: string ]: string | number;
+}
+
+export interface ReaderParams {
+	postID: number;
+	siteID: number;
+}
+
+export interface NewCommentParams {
+	ID: number;
+	content: string;
 }
 
 /* Response Interfaces */

--- a/test/e2e/specs/infrastructure/notification__actions.ts
+++ b/test/e2e/specs/infrastructure/notification__actions.ts
@@ -18,7 +18,7 @@ declare const browser: Browser;
 describe( DataHelper.createSuiteTitle( 'Notifications' ), function () {
 	const commentingUser = 'commentingUser';
 	const notificationsUser = 'notificationsUser';
-	const comment = DataHelper.getRandomPhrase() + ' notifications-trash-spec';
+	const comment = DataHelper.getRandomPhrase() + ' notification-actions-spec';
 
 	let notificationsComponent: NotificationsComponent;
 	let restAPIClient: RestAPIClient;
@@ -44,7 +44,7 @@ describe( DataHelper.createSuiteTitle( 'Notifications' ), function () {
 		} );
 	} );
 
-	describe( `Trash comment as ${ notificationsUser }`, function () {
+	describe( `View notification as ${ notificationsUser }`, function () {
 		let page: Page;
 
 		beforeAll( async function () {
@@ -62,13 +62,57 @@ describe( DataHelper.createSuiteTitle( 'Notifications' ), function () {
 			notificationsComponent = new NotificationsComponent( page );
 			await notificationsComponent.clickNotification( comment );
 		} );
+	} );
 
-		it( 'Delete comment from notification', async function () {
+	describe( 'Approve comment from notification', function () {
+		it( 'Approve comment', async function () {
+			// TODO: Handle notifications that have been already approved.
+			await notificationsComponent.clickNotificationAction( 'Approve' );
+		} );
+
+		it( 'Unapprove comment', async function () {
+			await notificationsComponent.clickNotificationAction( 'Approved' );
+		} );
+	} );
+
+	describe( 'Like comment from notification', function () {
+		it( 'Like comment', async function () {
+			await notificationsComponent.clickNotificationAction( 'Like' );
+		} );
+
+		it( 'Unlike comment', async function () {
+			await notificationsComponent.clickNotificationAction( 'Liked' );
+		} );
+	} );
+
+	// TODO: Edit comment from notification.
+
+	describe( 'Mark comment as spam from notification', function () {
+		it( 'Mark comment as spam', async function () {
+			await notificationsComponent.clickNotificationAction( 'Spam' );
+		} );
+
+		it( 'Undo mark comment as spam', async function () {
+			await notificationsComponent.clickUndo();
+			// TODO: Assert comment was un-marked as spam.
+		} );
+	} );
+
+	describe( 'Trash comment from notification', function () {
+		it( 'Trash comment', async function () {
+			await notificationsComponent.clickNotificationAction( 'Trash' );
+		} );
+
+		it( 'Undo trash comment', async function () {
+			await notificationsComponent.clickUndo();
+			// TODO: Assert comment was not deleted.
+		} );
+
+		it( 'Trash comment again', async function () {
 			await notificationsComponent.clickNotificationAction( 'Trash' );
 		} );
 
 		it( 'Confirm comment is trashed', async function () {
-			await notificationsComponent.waitForUndoMessage();
 			await notificationsComponent.waitForUndoMessageToDisappear();
 		} );
 	} );


### PR DESCRIPTION
### Context
The purpose of this PR is to make the Notifications: Trash e2e test more reliable [#66144](https://github.com/Automattic/wp-calypso/issues/66144). At some point, this test was passing inconsistently and was tagged as quarantined. Although it passes more consistently now, the test could benefit from some changes, such as using the Wordpress.com REST API to set up the notification used for the test

### Completed Steps
- [x] Create a comment using the REST API to generate a notification for the "notification user."
- [x] Add additional actions that a user can perform on a notification (approve, like, mark as spam).
- [x] Add undo actions for each action above (e.g. un-approve).
- [x] Rename the test to better reflect all notification flows, not just trash.
- [x] Add a clean up method that deletes the test comment using the REST API. 
- [x] Un-quarantine the test. 

### Future Steps (Outside of Scope)
- [ ] Create the test post used for commenting if it's not found.
- [ ] Handle the case where there are multiple posts (right now it's just one test post).