### PR TITLE
CI: try using finishBuildTrigger only for CalypsoPreReleaseDashboard.

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -1006,13 +1006,11 @@ object CalypsoPreReleaseDashboard : BuildType({
 				allure-results.tgz!*.json => allure-results
 			"""
 		}
-		snapshot ( KPIDashboardTests) {
-		}
 	}
 
 	triggers {
 		finishBuildTrigger {
-	    	buildType = "KPIDashboardTests"
+			buildType = "calypso_WebApp_Calypso_E2E_KPI_Dashboard"
 			branchFilter = "+:trunk"
 		}
 	}


### PR DESCRIPTION
#### Proposed Changes

This PR experiments with the finishBuildTrigger for the `CalypsoPreReleaseDashboard` build configuration.

Context: 
There are different ways to trigger builds in TeamCity, and the most common ones are `finishBuildTrigger` and `snapshotDependency`. They work in different ways which is nicely summarized in this [SO post](https://stackoverflow.com/questions/33247474/what-is-the-difference-between-snapshot-dependency-and-finished-build-trigger-in).

With this PR, I want to try updating the finishedBuildTrigger so that it is possible to do a "push" operation in order to trigger the `CalypsoPreReleaseDashboard` task.

#### Testing Instructions

Ensure that any build configurations pass.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
