### PR TITLE
Onboarding standalone installation: add tracking events

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/jetpack-standalone-activation-instructions.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-standalone-activation-instructions.tsx
@@ -1,8 +1,10 @@
 import { Button, Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import { useMemo } from 'react';
+import { useMemo, useCallback } from 'react';
+import { useDispatch } from 'react-redux';
 import ExternalLink from 'calypso/components/external-link';
 import { SelectorProduct } from 'calypso/my-sites/plans/jetpack-plans/types';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import JetpackInstructionList from './jetpack-instruction-list';
 import JetpackLicenseKeyClipboard from './jetpack-license-key-clipboard';
 import { getWPORGPluginLink } from './utils';
@@ -13,9 +15,26 @@ interface Props {
 }
 
 const JetpackStandaloneActivationInstructions: React.FC< Props > = ( { product, receiptId } ) => {
+	const dispatch = useDispatch();
 	const translate = useTranslate();
 
-	const wporgPluginLink = getWPORGPluginLink( product.productSlug );
+	const { productSlug } = product;
+	const wporgPluginLink = getWPORGPluginLink( productSlug );
+
+	const handleDownloadClick = useCallback( () => {
+		dispatch(
+			recordTracksEvent( 'calypso_siteless_checkout_manual_activation_download_link_click', {
+				product_slug: productSlug,
+			} )
+		);
+	}, [ dispatch, productSlug ] );
+	const handleLearnMoreClick = useCallback( () => {
+		dispatch(
+			recordTracksEvent( 'calypso_siteless_checkout_manual_activation_learn_more_link_click', {
+				product_slug: productSlug,
+			} )
+		);
+	}, [ dispatch, productSlug ] );
 
 	const items = useMemo(
 		() => [
@@ -25,7 +44,13 @@ const JetpackStandaloneActivationInstructions: React.FC< Props > = ( { product, 
 					components: {
 						strong: <strong />,
 						link: (
-							<Button plain href={ wporgPluginLink } target="_blank" rel="noreferrer noopener" />
+							<Button
+								plain
+								href={ wporgPluginLink }
+								onClick={ handleDownloadClick }
+								target="_blank"
+								rel="noreferrer noopener"
+							/>
 						),
 						icon: <Gridicon icon="external" size={ 16 } />,
 					},
@@ -49,7 +74,7 @@ const JetpackStandaloneActivationInstructions: React.FC< Props > = ( { product, 
 				),
 			},
 		],
-		[ translate, product, wporgPluginLink ]
+		[ translate, product, wporgPluginLink, handleDownloadClick ]
 	);
 
 	return (
@@ -62,6 +87,7 @@ const JetpackStandaloneActivationInstructions: React.FC< Props > = ( { product, 
 				<ExternalLink
 					href="https://jetpack.com/support/install-jetpack-and-connect-your-new-plan/"
 					icon
+					onClick={ handleLearnMoreClick }
 				>
 					{ translate( 'Learn more about how to install Jetpack %(pluginName)s', {
 						args: { pluginName: product.shortName },


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR adds tracking events to the _Download X_ and _Learn more about how to install X_ links, in the new Jetpack standalone plugin installation/activation page.

<img width="500" alt="Screen Shot 2022-10-25 at 4 25 21 PM" src="https://user-images.githubusercontent.com/1620183/197874763-d09bcb36-199c-470d-8337-f78fc8fee95f.png">


### Testing instructions

- Follow the instructions mentioned in #69275 
- Open the Network panel
- Check that clicking each of the two links mentioned above generates a tracking pixel request, and that the `product_slug` property matches the plugin you chose (see captures below).

### Screenshots

_CLickin_ Download X

<img width="711" alt="Screen Shot 2022-10-25 at 4 21 42 PM" src="https://user-images.githubusercontent.com/1620183/197874443-273b10e2-94f4-4a43-aa89-58ee9828664f.png">

_Clicking_ Learn more about how to install X
<img width="725" alt="Screen Shot 2022-10-25 at 4 21 51 PM" src="https://user-images.githubusercontent.com/1620183/197874448-cadcf4e9-ab0d-4451-a67c-f1898edd761e.png">



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203159154260052