### PR TITLE
Onboarding standalone installation: copy and CSS tweaks

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/jetpack-standalone-activation-instructions.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-standalone-activation-instructions.tsx
@@ -45,7 +45,7 @@ const JetpackStandaloneActivationInstructions: React.FC< Props > = ( { product, 
 			{
 				id: 4,
 				content: translate(
-					'Click the “Activate license key” (at the bottom of the page) and enter the key below.'
+					'Click “Activate license key” (at the bottom of the page) and enter the key below.'
 				),
 			},
 		],

--- a/client/my-sites/checkout/checkout-thank-you/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/style.scss
@@ -842,6 +842,10 @@
 	flex-direction: row;
 	margin-bottom: 1.5rem;
 
+	strong {
+		font-weight: 700;
+	}
+
 	&::before {
 		content: counter(item);
 		counter-increment: item;


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR increases the font weight of the `strong` element in the instructions list, in the new Jetpack standalone plugin installation/activation page. It also removes an unwanted _the_ in the instructions copy.

### Testing instructions

- Follow the instructions mentioned in #69275 
- Check that the 2 aforementioned fixes are applied (see before/after below)

### Screenshots
Before            |  After
:-------------------------:|:-------------------------:
<img width="400" alt="Screen Shot 2022-10-25 at 4 25 21 PM" src="https://user-images.githubusercontent.com/1620183/197877232-d6ef2ef4-4177-4f37-b616-b6891913e06a.png">  |  <img width="400" alt="Screen Shot 2022-10-25 at 4 36 53 PM" src="https://user-images.githubusercontent.com/1620183/197877234-ab213477-4b5a-43f9-b8ab-a667ddf39909.png">




---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203239104540440