### PR TITLE
Site Purchases: add a link to advertising campaigns

### DIFF
--- a/client/my-sites/purchases/subscriptions/account-level-advertising-links.tsx
+++ b/client/my-sites/purchases/subscriptions/account-level-advertising-links.tsx
@@ -1,0 +1,16 @@
+import { CompactCard } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import { useSelector } from 'react-redux';
+import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+
+export default function AccountLevelAdvertisingLinks() {
+	const translate = useTranslate();
+	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
+	return (
+		<>
+			<CompactCard href={ `/advertising/${ selectedSiteSlug }` }>
+				{ translate( 'View advertising campaigns' ) }
+			</CompactCard>
+		</>
+	);
+}

--- a/client/my-sites/purchases/subscriptions/account-level-advertising-links.tsx
+++ b/client/my-sites/purchases/subscriptions/account-level-advertising-links.tsx
@@ -9,7 +9,7 @@ export default function AccountLevelAdvertisingLinks() {
 	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
 	const shouldShowAdvertisingOption = usePromoteWidget() === PromoteWidgetStatus.ENABLED;
 
-	if ( ! shouldShowAdvertisingOption ) {
+	if ( ! shouldShowAdvertisingOption || ! selectedSiteSlug ) {
 		return null;
 	}
 

--- a/client/my-sites/purchases/subscriptions/account-level-advertising-links.tsx
+++ b/client/my-sites/purchases/subscriptions/account-level-advertising-links.tsx
@@ -1,11 +1,18 @@
 import { CompactCard } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
+import { PromoteWidgetStatus, usePromoteWidget } from 'calypso/lib/promote-post';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 
 export default function AccountLevelAdvertisingLinks() {
 	const translate = useTranslate();
 	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
+	const shouldShowAdvertisingOption = usePromoteWidget() === PromoteWidgetStatus.ENABLED;
+
+	if ( ! shouldShowAdvertisingOption ) {
+		return null;
+	}
+
 	return (
 		<>
 			<CompactCard href={ `/advertising/${ selectedSiteSlug }` }>

--- a/client/my-sites/purchases/subscriptions/index.tsx
+++ b/client/my-sites/purchases/subscriptions/index.tsx
@@ -4,6 +4,7 @@ import QueryStoredCards from 'calypso/components/data/query-stored-cards';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import AccountLevelAdvertisingLinks from './account-level-advertising-links';
 import AccountLevelPurchaseLinks from './account-level-purchase-links';
 import SubscriptionsContent from './subscriptions-content';
 
@@ -16,6 +17,7 @@ export default function Subscriptions() {
 			<QueryStoredCards />
 			<PageViewTracker path="/purchases/subscriptions" title="Subscriptions" />
 			<SubscriptionsContent />
+			{ ! isJetpackCloud() && <AccountLevelAdvertisingLinks /> }
 			{ ! isJetpackCloud() && <AccountLevelPurchaseLinks /> }
 		</div>
 	);


### PR DESCRIPTION
This adds a link to the site-level purchases list to guide users to the new promoted posts feature.

![Screen Shot 2022-10-25 at 12 33 03 PM](https://user-images.githubusercontent.com/942359/197878476-178609f2-0818-4382-8306-a2550397e111.png)

props @JessBoctor @spraveenitpro 
Fixes: https://github.com/Automattic/payments-shilling/issues/1185

**To test:**
- for a user with the Promoted Post feature enabled (currently any a11n)
- from the sidebar, visit Upgrades > Purchases
- verify that the link to "View advertising campaigns" is shown
- - for a user with the Promoted Post feature disabled
- from the sidebar, visit Upgrades > Purchases
- verify that the link to "View advertising campaigns" is not shown
