### PR TITLE
Tailored Ecommerce Flow - Create skeleton flow w/ feature flag

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/index.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/index.ts
@@ -42,6 +42,7 @@ export { default as launchpad } from './launchpad';
 export { default as subscribers } from './subscribers';
 export { default as patterns } from './patterns';
 export { default as getCurrentThemeSoftwareSets } from './get-current-theme-software-sets';
+export { default as storeProfiler } from './store-profiler';
 
 export type StepPath =
 	| 'courses'
@@ -87,4 +88,5 @@ export type StepPath =
 	| 'intro'
 	| 'launchpad'
 	| 'subscribers'
-	| 'getCurrentThemeSoftwareSets';
+	| 'getCurrentThemeSoftwareSets'
+	| 'storeProfiler';

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/store-profiler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/store-profiler/index.tsx
@@ -1,0 +1,25 @@
+/* eslint-disable wpcalypso/jsx-classname-namespace */
+import { StepContainer } from '@automattic/onboarding';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import type { Step } from '../../types';
+
+const StoreProfilerStep: Step = function StoreProfilerStep( { navigation } ) {
+	const { goBack } = navigation;
+
+	const StoreProfilerStepContent: React.FC = () => {
+		return <p>Store Profiler Content TBA</p>;
+	};
+
+	return (
+		<StepContainer
+			stepName="store-profiler-step"
+			goBack={ goBack }
+			hideBack
+			isFullLayout
+			stepContent={ <StoreProfilerStepContent /> }
+			recordTracksEvent={ recordTracksEvent }
+		/>
+	);
+};
+
+export default StoreProfilerStep;

--- a/client/landing/stepper/declarative-flow/tailored-ecommerce-flow.ts
+++ b/client/landing/stepper/declarative-flow/tailored-ecommerce-flow.ts
@@ -1,0 +1,49 @@
+import { recordSubmitStep } from './internals/analytics/record-submit-step';
+import type { StepPath } from './internals/steps-repository';
+import type { Flow, ProvidedDependencies } from './internals/types';
+
+export const tailoredEcommerceFlow: Flow = {
+	name: 'tailored-ecommerce',
+
+	useSteps() {
+		return [ 'storeProfiler' ] as StepPath[];
+	},
+
+	useStepNavigation( currentStep, navigate ) {
+		const flowName = this.name;
+
+		function submit( providedDependencies: ProvidedDependencies = {} ) {
+			recordSubmitStep( providedDependencies, 'tailored-ecommerce', flowName, currentStep );
+
+			switch ( currentStep ) {
+				case 'storeProfiler':
+					return navigate( 'storeProfiler' );
+			}
+		}
+
+		const goBack = () => {
+			switch ( currentStep ) {
+				case 'storeProfiler':
+					return navigate( 'storeProfiler' );
+				default:
+					return navigate( 'storeProfiler' );
+			}
+		};
+
+		const goNext = () => {
+			switch ( currentStep ) {
+				case 'storeProfiler':
+					// @TODO this will need logic updates
+					return navigate( 'storeProfiler' );
+				default:
+					return navigate( 'storeProfiler' );
+			}
+		};
+
+		const goToStep = ( step: StepPath | `${ StepPath }?${ string }` ) => {
+			navigate( step );
+		};
+
+		return { goNext, goBack, goToStep, submit };
+	},
+};

--- a/client/landing/stepper/index.tsx
+++ b/client/landing/stepper/index.tsx
@@ -38,6 +38,7 @@ import { newsletterPostSetup } from './declarative-flow/newsletter-post-setup';
 import { pluginBundleFlow } from './declarative-flow/plugin-bundle-flow';
 import { podcasts } from './declarative-flow/podcasts';
 import { siteSetupFlow } from './declarative-flow/site-setup-flow';
+import { tailoredEcommerceFlow } from './declarative-flow/tailored-ecommerce-flow';
 import 'calypso/components/environment-badge/style.scss';
 import { useAnchorFmParams } from './hooks/use-anchor-fm-params';
 import { useQuery } from './hooks/use-query';
@@ -73,6 +74,9 @@ const availableFlows: Array< configurableFlows > = [
 	{ flowName: 'newsletter-post-setup', pathToFlow: newsletterPostSetup },
 	config.isEnabled( 'themes/plugin-bundling' )
 		? { flowName: 'plugin-bundle', pathToFlow: pluginBundleFlow }
+		: null,
+	config.isEnabled( 'signup/tailored-ecommerce' )
+		? { flowName: 'tailored-ecommerce', pathToFlow: tailoredEcommerceFlow }
 		: null,
 ].filter( ( item ) => item !== null ) as Array< configurableFlows >;
 

--- a/config/development.json
+++ b/config/development.json
@@ -165,6 +165,7 @@
 		"signup/social": true,
 		"signup/starting-point-courses": true,
 		"signup/stepper-flow": true,
+		"signup/tailored-ecommerce": true,
 		"signup/woo-verify-email": false,
 		"site-indicator": true,
 		"ssr/prefetch-timebox": false,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -109,6 +109,7 @@
 		"signup/social": true,
 		"signup/starting-point-courses": true,
 		"signup/stepper-flow": true,
+		"signup/tailored-ecommerce": false,
 		"signup/woo-verify-email": false,
 		"site-indicator": true,
 		"ssr/prefetch-timebox": true,

--- a/config/production.json
+++ b/config/production.json
@@ -128,6 +128,7 @@
 		"signup/social": true,
 		"signup/starting-point-courses": true,
 		"signup/stepper-flow": true,
+		"signup/tailored-ecommerce": false,
 		"signup/woo-verify-email": false,
 		"site-indicator": true,
 		"ssr/log-prefetch-errors": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -126,6 +126,7 @@
 		"signup/social": true,
 		"signup/starting-point-courses": true,
 		"signup/stepper-flow": true,
+		"signup/tailored-ecommerce": false,
 		"signup/woo-verify-email": false,
 		"site-indicator": true,
 		"ssr/prefetch-timebox": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -135,6 +135,7 @@
 		"signup/social": true,
 		"signup/starting-point-courses": true,
 		"signup/stepper-flow": true,
+		"signup/tailored-ecommerce": false,
 		"signup/woo-verify-email": false,
 		"site-indicator": true,
 		"ssr/prefetch-timebox": true,


### PR DESCRIPTION
#### Proposed Changes

* This PR adds the skeleton of a new `tailored-ecommerce-flow` path in Stepper, currently hidden behind the new feature flag (enabled in dev) `signup/tailored-ecommerce`.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this PR to local Calypso
* Navigate to `/setup?flow=tailored-ecommerce`
* Verify that you are taking to a placeholder step for the tailored ecommerce flow
* Disable the `signup/tailored-ecommerce` feature flag in development and restart Calypso
* Verify that going to the same path instead redirects you to the Calypso home screen.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #69386
