### PR TITLE
Add option to redirect to campaigns tab

### DIFF
--- a/client/my-sites/promote-post/components/post-item/index.tsx
+++ b/client/my-sites/promote-post/components/post-item/index.tsx
@@ -3,6 +3,7 @@ import { CompactCard, Gridicon } from '@automattic/components';
 import './style.scss';
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import page from 'page';
 import { useState } from 'react';
 import { useQueryClient } from 'react-query';
 import { useDispatch, useSelector } from 'react-redux';
@@ -13,6 +14,7 @@ import { useRouteModal } from 'calypso/lib/route-modal';
 import PostRelativeTimeStatus from 'calypso/my-sites/post-relative-time-status';
 import { getPostType } from 'calypso/my-sites/promote-post/utils';
 import getPreviousRoute from 'calypso/state/selectors/get-previous-route';
+import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 
 export type Post = {
 	ID: number;
@@ -38,6 +40,7 @@ export default function PostItem( { post }: Props ) {
 	const [ loading, setLoading ] = useState( false );
 	const dispatch = useDispatch();
 	const queryClient = useQueryClient();
+	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
 	const keyValue = 'post-' + post.ID;
 	const { isModalOpen, value, openModal, closeModal } = useRouteModal(
 		'blazepress-widget',
@@ -46,10 +49,12 @@ export default function PostItem( { post }: Props ) {
 
 	const previousRoute = useSelector( getPreviousRoute );
 
-	const onCloseWidget = () => {
+	const onCloseWidget = ( redirectToCampaigns?: boolean ) => {
 		queryClient.invalidateQueries( [ 'promote-post-campaigns', post.site_ID ] );
 		setLoading( false );
-		if ( previousRoute ) {
+		if ( redirectToCampaigns ) {
+			page( `/advertising/${ selectedSiteSlug }/campaigns` );
+		} else if ( previousRoute ) {
 			closeModal();
 		} else {
 			goToOriginalEndpoint();


### PR DESCRIPTION
#### Proposed Changes

* For the last step, we want the "Go to campaigns" tab to work correctly: going to the campaigns tab rather than just close the modal. So here adding an optional parameter for that.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
