### PR TITLE
Themes: Show wp.org results when there is no wp.com results to show

### DIFF
--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -408,8 +408,8 @@ export class Theme extends Component {
 		);
 
 		const fit = '479,360';
-		const themeImgSrc = photon( screenshot, { fit } );
-		const themeImgSrcDoubleDpi = photon( screenshot, { fit, zoom: 2 } );
+		const themeImgSrc = photon( screenshot, { fit } ) || screenshot;
+		const themeImgSrcDoubleDpi = photon( screenshot, { fit, zoom: 2 } ) || screenshot;
 		const e2eThemeName = name.toLowerCase().replace( /\s+/g, '-' );
 
 		const bookmarkRef = this.props.bookmarkRef ? { ref: this.props.bookmarkRef } : {};

--- a/client/components/themes-list/index.jsx
+++ b/client/components/themes-list/index.jsx
@@ -127,14 +127,7 @@ function ThemeBlock( props ) {
 }
 
 function Empty( props ) {
-	const {
-		wpOrgThemes,
-		emptyContent,
-		searchTerm,
-		upsellCardDisplayed,
-		translate,
-		recordTracksEvent,
-	} = props;
+	const { emptyContent, searchTerm, upsellCardDisplayed, translate, recordTracksEvent } = props;
 	const selectedSite = useSelector( getSelectedSite );
 	const shouldUpgradeToInstallThemes = useSelector(
 		( state ) => ! siteHasFeature( state, selectedSite?.ID, FEATURE_INSTALL_THEMES )
@@ -169,16 +162,7 @@ function Empty( props ) {
 	return shouldUpgradeToInstallThemes ? (
 		<div className="themes-list__empty-container">
 			<div className="themes-list">
-				{ wpOrgThemes?.length ? (
-					wpOrgThemes.map( ( theme, index ) => (
-						<ThemeBlock
-							key={ 'theme-block' + index }
-							theme={ theme }
-							index={ index }
-							{ ...props }
-						/>
-					) )
-				) : (
+				{ <WPOrgMatchingThemes { ...props } /> || (
 					<div className="themes-list__not-found-text">
 						{ translate( 'No themes match your search' ) }
 					</div>
@@ -214,6 +198,30 @@ function Empty( props ) {
 			title={ translate( 'Sorry, no themes found.' ) }
 			line={ translate( 'Try a different search or more filters?' ) }
 		/>
+	);
+}
+
+function WPOrgMatchingThemes( props ) {
+	const { wpOrgThemes, searchTerm } = props;
+
+	const matchingThemes =
+		wpOrgThemes?.filter(
+			( wpOrgTheme ) =>
+				wpOrgTheme?.name?.toLowerCase() === searchTerm.toLowerCase() ||
+				wpOrgTheme?.id?.toLowerCase() === searchTerm.toLowerCase()
+		) || [];
+
+	if ( matchingThemes.length === 0 ) {
+		return null;
+	}
+
+	return (
+		<>
+			{ matchingThemes.map( ( theme, index ) => (
+				<ThemeBlock key={ 'theme-block' + index } theme={ theme } index={ index } { ...props } />
+			) ) }
+			<TrailingItems />
+		</>
 	);
 }
 

--- a/client/components/themes-list/index.jsx
+++ b/client/components/themes-list/index.jsx
@@ -4,7 +4,7 @@ import { localize } from 'i18n-calypso';
 import { isEmpty, times } from 'lodash';
 import page from 'page';
 import PropTypes from 'prop-types';
-import { useCallback, useEffect } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 import { connect, useSelector } from 'react-redux';
 import proThemesBanner from 'calypso/assets/images/themes/pro-themes-banner.svg';
 import EmptyContent from 'calypso/components/empty-content';
@@ -127,22 +127,21 @@ function ThemeBlock( props ) {
 }
 
 function Empty( props ) {
-	const { emptyContent, searchTerm, upsellCardDisplayed, translate, recordTracksEvent } = props;
+	const { wpOrgThemes, emptyContent, searchTerm, upsellCardDisplayed, translate } = props;
 	const selectedSite = useSelector( getSelectedSite );
 	const shouldUpgradeToInstallThemes = useSelector(
 		( state ) => ! siteHasFeature( state, selectedSite?.ID, FEATURE_INSTALL_THEMES )
 	);
 
-	const onUpgradeClick = useCallback( () => {
-		recordTracksEvent( 'calypso_themeshowcase_search_empty_results_upgrade_plan', {
-			site_plan: selectedSite?.plan?.product_slug,
-			search_term: searchTerm,
-		} );
-
-		return page(
-			`/checkout/${ selectedSite.slug }/${ PLAN_BUSINESS }?redirect_to=/themes/${ selectedSite.slug }`
-		);
-	}, [ selectedSite, searchTerm ] );
+	const matchingThemes = useMemo(
+		() =>
+			wpOrgThemes?.filter(
+				( wpOrgTheme ) =>
+					wpOrgTheme?.name?.toLowerCase() === searchTerm.toLowerCase() ||
+					wpOrgTheme?.id?.toLowerCase() === searchTerm.toLowerCase()
+			) || [],
+		[ wpOrgThemes, searchTerm ]
+	);
 
 	useEffect( () => {
 		if ( shouldUpgradeToInstallThemes && ! emptyContent ) {
@@ -161,67 +160,84 @@ function Empty( props ) {
 
 	return shouldUpgradeToInstallThemes ? (
 		<div className="themes-list__empty-container">
-			<div className="themes-list">
-				{ <WPOrgMatchingThemes { ...props } /> || (
-					<div className="themes-list__not-found-text">
-						{ translate( 'No themes match your search' ) }
-					</div>
-				) }
-			</div>
-
-			<div className="themes-list__upgrade-section-wrapper">
-				<div className="themes-list__upgrade-section-title">
-					{ translate( 'Use any theme on WordPress.com' ) }
+			{ matchingThemes.length ? (
+				<WPOrgMatchingThemes matchingThemes={ matchingThemes } { ...props } />
+			) : (
+				<div className="themes-list__not-found-text">
+					{ translate( 'No themes match your search' ) }
 				</div>
-				<div className="themes-list__upgrade-section-subtitle">
-					{ translate(
-						'Have a theme in mind that we don’t show here? Unlock the ability to use any theme, including Astra, with a Business plan.'
-					) }
-				</div>
-
-				<Button primary className="themes-list__upgrade-section-cta" onClick={ onUpgradeClick }>
-					{ translate( 'Upgrade your plan' ) }
-				</Button>
-
-				<div className="themes-list__themes-images">
-					<img
-						src={ proThemesBanner }
-						alt={ translate(
-							'Themes banner featuring Astra, Neve, GeneratePress, and Hestia theme'
-						) }
-					/>
-				</div>
-			</div>
+			) }
+			<PlanUpgradeCTA
+				selectedSite={ selectedSite }
+				searchTerm={ searchTerm }
+				translate={ translate }
+			/>
 		</div>
 	) : (
-		<EmptyContent
-			title={ translate( 'Sorry, no themes found.' ) }
-			line={ translate( 'Try a different search or more filters?' ) }
-		/>
+		<>
+			{ matchingThemes.length ? (
+				<WPOrgMatchingThemes matchingThemes={ matchingThemes } { ...props } />
+			) : (
+				<EmptyContent
+					title={ translate( 'Sorry, no themes found.' ) }
+					line={ translate( 'Try a different search or more filters?' ) }
+				/>
+			) }
+		</>
 	);
 }
 
 function WPOrgMatchingThemes( props ) {
-	const { wpOrgThemes, searchTerm } = props;
-
-	const matchingThemes =
-		wpOrgThemes?.filter(
-			( wpOrgTheme ) =>
-				wpOrgTheme?.name?.toLowerCase() === searchTerm.toLowerCase() ||
-				wpOrgTheme?.id?.toLowerCase() === searchTerm.toLowerCase()
-		) || [];
-
-	if ( matchingThemes.length === 0 ) {
-		return null;
-	}
+	const { matchingThemes } = props;
 
 	return (
 		<>
-			{ matchingThemes.map( ( theme, index ) => (
-				<ThemeBlock key={ 'theme-block' + index } theme={ theme } index={ index } { ...props } />
-			) ) }
-			<TrailingItems />
+			<div className="themes-list">
+				{ matchingThemes.map( ( theme, index ) => (
+					<ThemeBlock key={ 'theme-block' + index } theme={ theme } index={ index } { ...props } />
+				) ) }
+				<TrailingItems />
+			</div>
 		</>
+	);
+}
+
+function PlanUpgradeCTA( { selectedSite, searchTerm, translate, recordTracksEvent } ) {
+	const onUpgradeClick = useCallback( () => {
+		recordTracksEvent( 'calypso_themeshowcase_search_empty_results_upgrade_plan', {
+			site_plan: selectedSite?.plan?.product_slug,
+			search_term: searchTerm,
+		} );
+
+		return page(
+			`/checkout/${ selectedSite.slug }/${ PLAN_BUSINESS }?redirect_to=/themes/${ selectedSite.slug }`
+		);
+	}, [ selectedSite, searchTerm ] );
+
+	return (
+		<div className="themes-list__upgrade-section-wrapper">
+			<div className="themes-list__upgrade-section-title">
+				{ translate( 'Use any theme on WordPress.com' ) }
+			</div>
+			<div className="themes-list__upgrade-section-subtitle">
+				{ translate(
+					'Have a theme in mind that we don’t show here? Unlock the ability to use any theme, including Astra, with a Business plan.'
+				) }
+			</div>
+
+			<Button primary className="themes-list__upgrade-section-cta" onClick={ onUpgradeClick }>
+				{ translate( 'Upgrade your plan' ) }
+			</Button>
+
+			<div className="themes-list__themes-images">
+				<img
+					src={ proThemesBanner }
+					alt={ translate(
+						'Themes banner featuring Astra, Neve, GeneratePress, and Hestia theme'
+					) }
+				/>
+			</div>
+		</div>
 	);
 }
 

--- a/client/components/themes-list/index.jsx
+++ b/client/components/themes-list/index.jsx
@@ -36,6 +36,8 @@ export const ThemesList = ( props ) => {
 				translate={ props.translate }
 				recordTracksEvent={ props.recordTracksEvent }
 				upsellCardDisplayed={ props.upsellCardDisplayed }
+				wpOrgThemes={ props.wpOrgThemes }
+				{ ...props }
 			/>
 		);
 	}
@@ -55,6 +57,7 @@ export const ThemesList = ( props ) => {
 
 ThemesList.propTypes = {
 	themes: PropTypes.array.isRequired,
+	wpOrgThemes: PropTypes.array,
 	emptyContent: PropTypes.element,
 	loading: PropTypes.bool.isRequired,
 	recordTracksEvent: PropTypes.func.isRequired,
@@ -83,6 +86,7 @@ ThemesList.defaultProps = {
 	loading: false,
 	searchTerm: '',
 	themes: [],
+	wpOrgThemes: [],
 	recordTracksEvent: noop,
 	fetchNextPage: noop,
 	placeholderCount: DEFAULT_THEME_QUERY.number,
@@ -122,7 +126,15 @@ function ThemeBlock( props ) {
 	);
 }
 
-function Empty( { emptyContent, searchTerm, upsellCardDisplayed, translate, recordTracksEvent } ) {
+function Empty( props ) {
+	const {
+		wpOrgThemes,
+		emptyContent,
+		searchTerm,
+		upsellCardDisplayed,
+		translate,
+		recordTracksEvent,
+	} = props;
 	const selectedSite = useSelector( getSelectedSite );
 	const shouldUpgradeToInstallThemes = useSelector(
 		( state ) => ! siteHasFeature( state, selectedSite?.ID, FEATURE_INSTALL_THEMES )
@@ -156,8 +168,21 @@ function Empty( { emptyContent, searchTerm, upsellCardDisplayed, translate, reco
 
 	return shouldUpgradeToInstallThemes ? (
 		<div className="themes-list__empty-container">
-			<div className="themes-list__not-found-text">
-				{ translate( 'No themes match your search' ) }
+			<div className="themes-list">
+				{ wpOrgThemes?.length ? (
+					wpOrgThemes.map( ( theme, index ) => (
+						<ThemeBlock
+							key={ 'theme-block' + index }
+							theme={ theme }
+							index={ index }
+							{ ...props }
+						/>
+					) )
+				) : (
+					<div className="themes-list__not-found-text">
+						{ translate( 'No themes match your search' ) }
+					</div>
+				) }
 			</div>
 
 			<div className="themes-list__upgrade-section-wrapper">

--- a/client/my-sites/themes/single-site-jetpack.jsx
+++ b/client/my-sites/themes/single-site-jetpack.jsx
@@ -106,6 +106,7 @@ const ConnectedSingleSiteJetpack = connectOptions( ( props ) => {
 							source="wpcom"
 							emptyContent={ emptyContent }
 							upsellUrl={ upsellUrl }
+							forceWpOrgSearch
 						/>
 					</div>
 				) }

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -341,6 +341,7 @@ class ThemeShowcase extends Component {
 		];
 
 		const themeProps = {
+			forceWpOrgSearch: true,
 			filter: filter,
 			vertical: this.props.vertical,
 			siteId: this.props.siteId,

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -51,11 +51,13 @@ class ThemesSelection extends Component {
 		source: PropTypes.oneOfType( [ PropTypes.number, PropTypes.oneOf( [ 'wpcom', 'wporg' ] ) ] ),
 		themes: PropTypes.array,
 		themesCount: PropTypes.number,
+		forceWpOrgSearch: PropTypes.bool,
 	};
 
 	static defaultProps = {
 		emptyContent: null,
 		showUploadButton: true,
+		forceWpOrgSearch: false,
 	};
 
 	componentDidMount() {
@@ -159,9 +161,13 @@ class ThemesSelection extends Component {
 		return (
 			<div className="themes__selection">
 				<QueryThemes query={ query } siteId={ source } />
+				{ this.props.forceWpOrgSearch && source !== 'wporg' && (
+					<QueryThemes query={ query } siteId="wporg" />
+				) }
 				<ThemesList
 					upsellUrl={ upsellUrl }
 					themes={ this.props.customizedThemesList || this.props.themes }
+					wpOrgThemes={ this.props.wpOrgThemes }
 					fetchNextPage={ this.fetchNextPage }
 					recordTracksEvent={ this.props.recordTracksEvent }
 					onMoreButtonClick={ this.recordSearchResultsClick }
@@ -209,6 +215,7 @@ export const ConnectedThemesSelection = connect(
 			vertical,
 			siteId,
 			source,
+			forceWpOrgSearch,
 			isLoading: isCustomizedThemeListLoading,
 		}
 	) => {
@@ -246,6 +253,10 @@ export const ConnectedThemesSelection = connect(
 		};
 
 		const themes = getThemesForQueryIgnoringPage( state, sourceSiteId, query ) || [];
+		const wpOrgThemes =
+			forceWpOrgSearch && sourceSiteId !== 'wporg'
+				? getThemesForQueryIgnoringPage( state, 'wporg', query ) || []
+				: [];
 
 		return {
 			query,
@@ -267,6 +278,7 @@ export const ConnectedThemesSelection = connect(
 			// redundant AJAX requests, we're not rendering these query components locally.
 			getPremiumThemePrice: bindGetPremiumThemePrice( state, siteId ),
 			filterString: prependThemeFilterKeys( state, query.filter ),
+			wpOrgThemes,
 		};
 	},
 	{ setThemePreviewOptions, recordGoogleEvent, recordTracksEvent }


### PR DESCRIPTION
#### Proposed Changes

* Query WP.org themes and show them when there are no WP.com results to show
  * The name or id of the theme should be the same as the searched 
* Add a fallback for screenshot images when it cannot be handled by `photon`

#### Testing Instructions
* Go to Themes page with a free site: `/themes/{free_site}`
* Search for an option that returns no results in WP.com but returns in WP.org. Ex: `astra`
* It should show the wp.org cards above the plan upgrade CTA card

| Before  | After |
| ------------- | ------------- |
|<img width="1266" alt="Screen Shot 2022-10-25 at 21 37 34" src="https://user-images.githubusercontent.com/5039531/197923502-d4a0c848-08f6-43f6-99f4-bc6ef0da2fd3.png">|<img width="1266" alt="Screen Shot 2022-10-25 at 16 58 15" src="https://user-images.githubusercontent.com/5039531/197923864-983f088c-0145-4027-8974-bf38cb63032d.png">|

* Search for a theme that doesn't returns anything on WP.com or WP.org. Ex: `abc`
* It should show the message `"No themes match your search"` as the **Before** version above

---

* Go to Themes page with a Business or ecommerce site: `/themes/{business_site}`
* Search for an option that returns no results in WP.com but returns in WP.org. Ex: `astral`
* It should show the wp.org cards 

| Before  | After |
| ------------- | ------------- |
|<img width="1230" alt="Screen Shot 2022-10-26 at 11 54 20" src="https://user-images.githubusercontent.com/5039531/198087845-e84172e2-509f-4499-ad97-8062f311eace.png">|<img width="1266" alt="Screen Shot 2022-10-26 at 11 43 41" src="https://user-images.githubusercontent.com/5039531/198087908-178fae5b-e24a-4019-ab74-b128285bed3e.png">|


* Search for a theme that doesn't returns anything on WP.com or WP.org. Ex: `abc`
* It should show the message `"Sorry, no themes found."` as the **Before** version above

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #69382
