### PR TITLE
Remove noads mentions from the checkout page

### DIFF
--- a/client/lib/cart-values/cart-items.ts
+++ b/client/lib/cart-values/cart-items.ts
@@ -22,7 +22,6 @@ import {
 	isJetpackPlan,
 	isJetpackProduct,
 	isMonthlyProduct,
-	isNoAds,
 	isP2Plus,
 	isPersonal,
 	isPlan,
@@ -441,12 +440,6 @@ export function customDesignItem(): MinimalRequestCartProduct {
 	};
 }
 
-export function noAdsItem(): MinimalRequestCartProduct {
-	return {
-		product_slug: 'no-adverts/no-adverts.php',
-	};
-}
-
 export function videoPressItem(): MinimalRequestCartProduct {
 	return {
 		product_slug: 'videopress',
@@ -539,10 +532,6 @@ function createRenewalCartItemFromProduct(
 
 	if ( isCustomDesign( product ) ) {
 		return customDesignItem();
-	}
-
-	if ( isNoAds( product ) ) {
-		return noAdsItem();
 	}
 
 	if ( isSiteRedirect( product ) ) {

--- a/client/lib/cart-values/test/cart-items.js
+++ b/client/lib/cart-values/test/cart-items.js
@@ -705,22 +705,6 @@ describe( 'getRenewalItemFromProduct()', () => {
 			} );
 		} );
 	} );
-	describe( 'isNoAds', () => {
-		test( 'should return the corresponding renewal item', () => {
-			expect(
-				getRenewalItemFromProduct(
-					buildPurchase( { product_slug: 'no-adverts/no-adverts.php', isRenewable: true } ),
-					properties
-				)
-			).toEqual( {
-				extra: {
-					purchaseId: 123,
-					purchaseType: 'renewal',
-				},
-				product_slug: 'no-adverts/no-adverts.php',
-			} );
-		} );
-	} );
 	describe( 'isCustomDesign', () => {
 		test( 'should return the corresponding renewal item', () => {
 			expect(

--- a/client/my-sites/add-ons/hooks/use-add-on-feature-slugs.ts
+++ b/client/my-sites/add-ons/hooks/use-add-on-feature-slugs.ts
@@ -1,10 +1,8 @@
 import {
 	PRODUCT_WPCOM_UNLIMITED_THEMES,
 	PRODUCT_WPCOM_CUSTOM_DESIGN,
-	PRODUCT_NO_ADS,
 	WPCOM_FEATURES_PREMIUM_THEMES,
 	WPCOM_FEATURES_CUSTOM_DESIGN,
-	WPCOM_FEATURES_NO_ADVERTS,
 } from '@automattic/calypso-products';
 
 /**
@@ -17,8 +15,6 @@ const useAddOnFeatureSlugs = ( addOnProductSlug: string ) => {
 			return [ WPCOM_FEATURES_PREMIUM_THEMES ];
 		case PRODUCT_WPCOM_CUSTOM_DESIGN:
 			return [ WPCOM_FEATURES_CUSTOM_DESIGN ];
-		case PRODUCT_NO_ADS:
-			return [ WPCOM_FEATURES_NO_ADVERTS ];
 		default:
 			return null;
 	}

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
@@ -4,7 +4,6 @@ import {
 	isDomainProduct,
 	isDomainTransfer,
 	isMonthly,
-	isNoAds,
 	isPlan,
 	isWpComBusinessPlan,
 	isWpComEcommercePlan,
@@ -277,10 +276,6 @@ function CheckoutSummaryFeaturesList( props: {
 	const plans = responseCart.products.filter( ( product ) => isPlan( product ) );
 	const hasPlanInCart = plans.length > 0;
 
-	const translate = useTranslate();
-
-	const hasNoAdsAddOn = responseCart.products.some( ( product ) => isNoAds( product ) );
-
 	return (
 		<CheckoutSummaryFeaturesListWrapper>
 			{ hasDomainsInCart &&
@@ -293,13 +288,6 @@ function CheckoutSummaryFeaturesList( props: {
 					hasDomainsInCart={ hasDomainsInCart }
 					nextDomainIsFree={ nextDomainIsFree }
 				/>
-			) }
-
-			{ hasNoAdsAddOn && (
-				<CheckoutSummaryFeaturesListItem>
-					<WPCheckoutCheckIcon id="features-list-support-text" />
-					{ translate( 'Remove ads from your site with the No Ads add-on' ) }
-				</CheckoutSummaryFeaturesListItem>
 			) }
 
 			{ ! hasPlanInCart && <CheckoutSummaryChatIfAvailable siteId={ siteId } /> }

--- a/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
@@ -397,9 +397,6 @@ function getProductSlugFromAlias( productAlias: string ): string {
 	if ( decodedAlias === 'domain-mapping' ) {
 		return 'domain_map';
 	}
-	if ( decodedAlias === 'no-ads' ) {
-		return 'no-adverts/no-adverts.php';
-	}
 	if ( decodedAlias === 'theme' ) {
 		return 'premium_theme';
 	}

--- a/packages/calypso-products/src/constants/wpcom.ts
+++ b/packages/calypso-products/src/constants/wpcom.ts
@@ -1,7 +1,6 @@
 export const GROUP_WPCOM = 'GROUP_WPCOM';
 
 // Products
-export const PRODUCT_NO_ADS = 'no-adverts/no-adverts.php';
 export const PRODUCT_WPCOM_SEARCH = 'wpcom_search';
 export const PRODUCT_WPCOM_SEARCH_MONTHLY = 'wpcom_search_monthly';
 export const PRODUCT_WPCOM_UNLIMITED_THEMES = 'unlimited_themes';

--- a/packages/calypso-products/src/is-add-on.ts
+++ b/packages/calypso-products/src/is-add-on.ts
@@ -1,9 +1,8 @@
 import { isCustomDesign } from './is-custom-design';
-import { isNoAds } from './is-no-ads';
 import { isUnlimitedThemes } from './is-unlimited-themes';
 import type { WithSnakeCaseSlug, WithCamelCaseSlug } from './types';
 
 export function isAddOn( product: WithSnakeCaseSlug | WithCamelCaseSlug ): boolean {
 	// Right now the definition of an "add-on" just comes from a hardcoded list.
-	return isCustomDesign( product ) || isNoAds( product ) || isUnlimitedThemes( product );
+	return isCustomDesign( product ) || isUnlimitedThemes( product );
 }

--- a/packages/calypso-products/src/is-no-ads.ts
+++ b/packages/calypso-products/src/is-no-ads.ts
@@ -1,7 +1,0 @@
-import { camelOrSnakeSlug } from './camel-or-snake-slug';
-import { PRODUCT_NO_ADS } from './constants';
-import type { WithCamelCaseSlug, WithSnakeCaseSlug } from './types';
-
-export function isNoAds( product: WithCamelCaseSlug | WithSnakeCaseSlug ): boolean {
-	return PRODUCT_NO_ADS === camelOrSnakeSlug( product );
-}

--- a/packages/calypso-products/src/product-values.ts
+++ b/packages/calypso-products/src/product-values.ts
@@ -77,7 +77,6 @@ export { isJetpackVideoPress } from './is-jetpack-videopress';
 export { default as isJetpackLegacyItem } from './is-jetpack-legacy-item';
 export { default as isJetpackPurchasableItem } from './is-jetpack-purchasable-item';
 export * from './is-monthly';
-export { isNoAds } from './is-no-ads';
 export { isPersonal } from './is-personal';
 export { isPlan } from './is-plan';
 export { isPremium } from './is-premium';

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -226,7 +226,7 @@ function WPNonProductLineItem( {
 					<DeleteButtonWrapper>
 						<DeleteButton
 							className="checkout-line-item__remove-product"
-							buttonType={ 'text-button' }
+							buttonType="text-button"
 							aria-label={ String(
 								translate( 'Remove %s from cart', {
 									args: label,
@@ -779,7 +779,7 @@ function PartnerLogo( { className }: { className?: string } ) {
 	return (
 		<LineItemMeta className={ joinClasses( [ className, 'jetpack-partner-logo' ] ) }>
 			<div>{ translate( 'Included in your IONOS plan' ) }</div>
-			<div className={ 'checkout-line-item__partner-logo-image' }>
+			<div className="checkout-line-item__partner-logo-image">
 				<IonosLogo />
 			</div>
 		</LineItemMeta>
@@ -947,7 +947,7 @@ function WPLineItem( {
 					<DeleteButtonWrapper>
 						<DeleteButton
 							className="checkout-line-item__remove-product"
-							buttonType={ 'text-button' }
+							buttonType="text-button"
 							aria-label={ String(
 								translate( 'Remove %s from cart', {
 									args: label,


### PR DESCRIPTION
Implements the request defined in pau2Xa-4vo-p2 to remove the No-Ads addon.

#### Proposed Changes

* Removes constants related to noads which should no longer be needed, since the feature is deprecated.
* Disallows adding a new noads addon to cart, if you directly navigate to `/checkout/{SITE_SLUG}/no-ads`.

As an fyi, the parent PR is https://github.com/Automattic/wp-calypso/pull/69463.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit `/checkout/{SITE_SLUG}/no-ads` and verify that you are not allowed to add the noads addon to cart.


