### PR TITLE
Add a Back button in the pattern selector instead of using the flow Back button

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -161,7 +161,13 @@ const PatternAssembler: Step = ( { navigation } ) => {
 	};
 
 	const onBack = () => {
-		setShowPatternSelectorType( null );
+		const patterns = getPatterns();
+		recordTracksEvent( 'calypso_signup_bcpa_back_click', {
+			has_selected_patterns: patterns.length > 0,
+			pattern_count: patterns.length,
+		} );
+
+		goBack();
 	};
 
 	const stepContent = (
@@ -170,7 +176,7 @@ const PatternAssembler: Step = ( { navigation } ) => {
 				<PatternSelectorLoader
 					showPatternSelectorType={ showPatternSelectorType }
 					onSelect={ onSelect }
-					onBack={ onBack }
+					onBack={ () => setShowPatternSelectorType( null ) }
 				/>
 				{ ! showPatternSelectorType && (
 					<PatternLayout
@@ -260,7 +266,7 @@ const PatternAssembler: Step = ( { navigation } ) => {
 		<StepContainer
 			stepName="pattern-assembler"
 			hideBack={ showPatternSelectorType !== null }
-			goBack={ goBack }
+			goBack={ onBack }
 			goNext={ goNext }
 			isHorizontalLayout={ false }
 			hideSkip={ true }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -161,17 +161,7 @@ const PatternAssembler: Step = ( { navigation } ) => {
 	};
 
 	const onBack = () => {
-		if ( showPatternSelectorType ) {
-			setShowPatternSelectorType( null );
-		} else {
-			const patterns = getPatterns();
-			recordTracksEvent( 'calypso_signup_bcpa_back_click', {
-				has_selected_patterns: patterns.length > 0,
-				pattern_count: patterns.length,
-			} );
-
-			goBack();
-		}
+		setShowPatternSelectorType( null );
 	};
 
 	const stepContent = (
@@ -180,6 +170,7 @@ const PatternAssembler: Step = ( { navigation } ) => {
 				<PatternSelectorLoader
 					showPatternSelectorType={ showPatternSelectorType }
 					onSelect={ onSelect }
+					onBack={ onBack }
 				/>
 				{ ! showPatternSelectorType && (
 					<PatternLayout
@@ -268,7 +259,8 @@ const PatternAssembler: Step = ( { navigation } ) => {
 	return (
 		<StepContainer
 			stepName="pattern-assembler"
-			goBack={ onBack }
+			hideBack={ showPatternSelectorType !== null }
+			goBack={ goBack }
 			goNext={ goNext }
 			isHorizontalLayout={ false }
 			hideSkip={ true }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-selector-loader.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-selector-loader.tsx
@@ -5,12 +5,14 @@ import type { Pattern } from './types';
 
 type PatternSelectorLoaderProps = {
 	onSelect: ( selectedPattern: Pattern | null ) => void;
+	onBack: () => void;
 	showPatternSelectorType: string | null;
 };
 
 const PatternSelectorLoader = ( {
 	showPatternSelectorType,
 	onSelect,
+	onBack,
 }: PatternSelectorLoaderProps ) => {
 	const translate = useTranslate();
 
@@ -20,19 +22,22 @@ const PatternSelectorLoader = ( {
 				show={ showPatternSelectorType === 'header' }
 				patterns={ headerPatterns }
 				onSelect={ onSelect }
+				onBack={ onBack }
 				title={ translate( 'Choose a header' ) }
 			/>
 			<PatternSelector
 				show={ showPatternSelectorType === 'footer' }
 				patterns={ footerPatterns }
 				onSelect={ onSelect }
+				onBack={ onBack }
 				title={ translate( 'Choose a footer' ) }
 			/>
 			<PatternSelector
 				show={ showPatternSelectorType === 'section' }
 				patterns={ sectionPatterns }
 				onSelect={ onSelect }
-				title={ translate( 'Choose a section' ) }
+				onBack={ onBack }
+				title={ translate( 'Add a section' ) }
 			/>
 		</>
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-selector.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-selector.tsx
@@ -1,6 +1,8 @@
+import { Button, Gridicon } from '@automattic/components';
 import { useLocale } from '@automattic/i18n-utils';
 import { useSelect } from '@wordpress/data';
 import classnames from 'classnames';
+import { useTranslate } from 'i18n-calypso';
 import { useEffect, useRef } from 'react';
 import { ONBOARD_STORE } from '../../../../stores';
 import PatternPreviewAutoHeight from './pattern-preview-auto-height';
@@ -10,14 +12,16 @@ import type { Pattern } from './types';
 type PatternSelectorProps = {
 	patterns: Pattern[] | null;
 	onSelect: ( selectedPattern: Pattern | null ) => void;
+	onBack: () => void;
 	title: string | null;
 	show: boolean;
 };
 
-const PatternSelector = ( { patterns, onSelect, title, show }: PatternSelectorProps ) => {
+const PatternSelector = ( { patterns, onSelect, onBack, title, show }: PatternSelectorProps ) => {
 	const locale = useLocale();
 	const patternSelectorRef = useRef< HTMLDivElement >( null );
 	const selectedDesign = useSelect( ( select ) => select( ONBOARD_STORE ).getSelectedDesign() );
+	const translate = useTranslate();
 
 	useEffect( () => {
 		if ( show ) {
@@ -37,6 +41,9 @@ const PatternSelector = ( { patterns, onSelect, title, show }: PatternSelectorPr
 			ref={ patternSelectorRef }
 		>
 			<div className="pattern-selector__header">
+				<Button borderless={ true } title={ translate( 'Back' ) } onClick={ onBack }>
+					<Gridicon icon="chevron-left" size={ 16 } />
+				</Button>
 				<h1>{ title }</h1>
 			</div>
 			<div className="pattern-selector__body">

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
@@ -258,7 +258,7 @@ $font-family: "SF Pro Text", $sans;
 				top: 4px;
 				margin-right: 12px;
 				margin-left: 4px;
-				fill: #101517;
+				fill: var(--studio-gray-100);
 			}
 
 			h1 {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
@@ -241,11 +241,32 @@ $font-family: "SF Pro Text", $sans;
 			pointer-events: none;
 		}
 
-		.pattern-selector__header h1 {
-			font-family: $font-family;
-			font-size: $font-title-small;
-			font-weight: 500;
-			line-height: 26px;
+		.pattern-selector__header {
+			display: flex;
+
+			.button {
+				padding: 0;
+
+				&:hover svg {
+					fill: var(--color-neutral-70);
+				}
+			}
+
+			svg {
+				width: 16px;
+				height: 16px;
+				top: 4px;
+				margin-right: 12px;
+				margin-left: 4px;
+				fill: #101517;
+			}
+
+			h1 {
+				font-family: $font-family;
+				font-size: $font-title-small;
+				font-weight: 500;
+				line-height: 26px;
+			}
 		}
 
 		.pattern-selector__body {


### PR DESCRIPTION
#### Proposed Changes

* Hide the back button next to the logo when the pattern selector is opened 
* Add a back button with an icon and tooltip next to the pattern selector header
* Add a hover effect to change the icon color
* Translate the tooltip
* Keep the metrics for the flow back button
* Updated the header title when adding a section

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Access `/setup?siteSlug={Site slug}`
* Don't select any goal
* Click on the blank canvas CTA
* Check that the flow back button is next to the logo and it works
* Click on add a header
* Check that the new back button is now near the header and it works
* Check the hover effect and the tooltip on the new back button

|Before|After|
|-----|-----|
|<img width="344" alt="Screen Shot 2565-10-26 at 13 39 23" src="https://user-images.githubusercontent.com/1881481/197958343-7aadac40-394a-4239-a73f-0ef6a2a4ae69.png">|<img width="344" alt="Screen Shot 2565-10-26 at 13 38 52" src="https://user-images.githubusercontent.com/1881481/197958362-b6939126-886e-4ddd-b705-63e6234dd0ec.png">|

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/69406
