### PR TITLE
Remove `react-intersection-observer` usage from devdocs

### DIFF
--- a/client/devdocs/design/search-collection.jsx
+++ b/client/devdocs/design/search-collection.jsx
@@ -1,11 +1,11 @@
 import { map, chunk } from 'lodash';
-import { Children } from 'react';
-import { InView } from 'react-intersection-observer';
+import { useState, Children } from 'react';
 import ReadmeViewer from 'calypso/components/readme-viewer';
 import ComponentPlayground from 'calypso/devdocs/design/component-playground';
 import Placeholder from 'calypso/devdocs/devdocs-async-load/placeholder';
 import { camelCaseToSlug, getComponentName } from 'calypso/devdocs/docs-example/util';
 import DocsExampleWrapper from 'calypso/devdocs/docs-example/wrapper';
+import { useInView } from 'calypso/lib/use-in-view';
 import { getExampleCodeFromComponent } from './playground-utils';
 
 const shouldShowInstance = ( example, filter, component ) => {
@@ -127,17 +127,23 @@ const Collection = ( {
 			{ map( chunk( examples.slice( examplesToMount ), examplesToMount ), ( exampleGroup ) => {
 				const groupKey = map( exampleGroup, ( example ) => example.key ).join( '_' );
 				return (
-					<InView key={ groupKey } triggerOnce>
-						{ ( { inView, ref } ) => (
-							<div ref={ ref }>
-								{ inView ? exampleGroup : <Placeholder count={ examplesToMount } /> }
-							</div>
-						) }
-					</InView>
+					<LazyExampleGroup
+						key={ groupKey }
+						exampleGroup={ exampleGroup }
+						examplesToMount={ examplesToMount }
+					/>
 				);
 			} ) }
 		</div>
 	);
 };
+
+function LazyExampleGroup( { exampleGroup, examplesToMount } ) {
+	const [ inView, setInView ] = useState( false );
+	const ref = useInView( () => setInView( true ) );
+	return (
+		<div ref={ ref }>{ inView ? exampleGroup : <Placeholder count={ examplesToMount } /> }</div>
+	);
+}
 
 export default Collection;

--- a/package.json
+++ b/package.json
@@ -199,7 +199,6 @@
 		"photon": "workspace:^",
 		"react": "^17.0.2",
 		"react-dom": "^17.0.2",
-		"react-intersection-observer": "^9.4.0",
 		"reakit-utils": "^0.15.1",
 		"redux": "^4.1.2",
 		"request": "^2.88.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -28867,15 +28867,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-intersection-observer@npm:^9.4.0":
-  version: 9.4.0
-  resolution: "react-intersection-observer@npm:9.4.0"
-  peerDependencies:
-    react: ^15.0.0 || ^16.0.0 || ^17.0.0|| ^18.0.0
-  checksum: abd076bbc0ed011c0a531deb6eacf27d05ff76c174b00c15cbe7a7bc064091f62813b7271bbfcee1bc3c90817a654075f35f9cbafa213ab547c7c92bdbf884aa
-  languageName: node
-  linkType: hard
-
 "react-is@npm:^16.12.0 || ^17.0.0, react-is@npm:^17.0.0, react-is@npm:^17.0.1, react-is@npm:^17.0.2":
   version: 17.0.2
   resolution: "react-is@npm:17.0.2"
@@ -36071,7 +36062,6 @@ swiper@4.5.1:
     prettier: "npm:wp-prettier@2.6.2"
     react: ^17.0.2
     react-dom: ^17.0.2
-    react-intersection-observer: ^9.4.0
     readline-sync: ^1.4.10
     reakit-utils: ^0.15.1
     recursive-copy: ^2.0.14


### PR DESCRIPTION
#### Proposed Changes

Removes the last use of the `react-intersection-observer` package and removes it from `package.json`.

The final use of `react-intersection-observer` was in `/devdocs`, chunking up the component galleries so they wouldn't try to render every component on page load (presumably that's quite slow).

This simplifies our dependency list, instead opting to factor out the code we'd already written into something reusable.
Discussion here https://github.com/Automattic/wp-calypso/pull/69119#issuecomment-1281714675
Interestingly the reason devdocs dropped its previous dependency (`react-lazily-render`) and moved to `react-intersection-observer` in #56154 was because `react-lazy-render` hadn't updated their peer dependency to React 17. That's exactly the sort of reason why I think we don't want too many React-related dependencies.

[Plus somehow it's managed to shave 3.5KB off the parsed size of some bundles 🤷‍♂️ ](https://github.com/Automattic/wp-calypso/pull/69469#issuecomment-1291717661)

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test the component galleries at `/devdocs/blocks` and `/devdocs/design`
* Notice how the scroll bar shrinks as you scroll down the page, that's because components are rendering as you scroll
* You should still be able to find any component/block by searching
* Confirm that there are no changes in behaviour between this branch and production https://wpcalypso.wordpress.com/devdocs/design

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
