### PR TITLE
Limiting Global Styles: Release!

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
@@ -34,14 +34,7 @@ function wpcom_should_limit_global_styles( $blog_id = 0 ) {
 		return false;
 	}
 
-	// During the development stage, we only limit Global Styles on sites that have opted in via
-	// a blog sticker. This is a temporary check that will be removed as part of the public launch.
-	// Note that block stickers are not exposed by default to Atomic sites, so we're not limiting
-	// Global Styles on Atomic sites for now.
-	if ( ! function_exists( 'has_blog_sticker' ) ) {
-		return false;
-	}
-	return has_blog_sticker( 'wpcom-limit-global-styles', $blog_id );
+	return true;
 }
 
 /**

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
@@ -24,9 +24,8 @@ function wpcom_should_limit_global_styles( $blog_id = 0 ) {
 		}
 	}
 
-	// Do not limit Global Styles on sites created before we made it a paid feature. This cutoff
-	// blog ID needs to be updated as part of the public launch.
-	if ( $blog_id < 210494207 ) {
+	// Do not limit Global Styles on sites created before we made it a paid feature (2022-12-15).
+	if ( $blog_id < 213403000 ) {
 		return false;
 	}
 

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -63,6 +63,7 @@
 		"layout/query-selected-editor": true,
 		"layout/support-article-dialog": true,
 		"legal-updates-banner": false,
+		"limit-global-styles": true,
 		"livechat_solution": true,
 		"mailchimp": false,
 		"marketplace-domain-bundle": false,

--- a/config/production.json
+++ b/config/production.json
@@ -68,6 +68,7 @@
 		"layout/query-selected-editor": true,
 		"layout/support-article-dialog": true,
 		"legal-updates-banner": false,
+		"limit-global-styles": true,
 		"livechat_solution": true,
 		"login/magic-login": true,
 		"login/react-lost-password-screen": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -65,6 +65,7 @@
 		"layout/query-selected-editor": true,
 		"layout/support-article-dialog": true,
 		"legal-updates-banner": false,
+		"limit-global-styles": true,
 		"livechat_solution": true,
 		"login/magic-login": true,
 		"login/react-lost-password-screen": true,


### PR DESCRIPTION
#### Proposed Changes

* Add `limit-global-styles` feature to all environments.
* Remove the `wpcom-limit-global-styles` blog sticker check.
* **[TODO]** Update the blog ID check to the most recent one at launch time.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new free site.
  * Select a non-default style variation during the onboarding, or customize the Global Styles in the site editor.
  * ⚠️ Make sure the custom styles are not applied on the front end, and there are the expected notices and other functionalities to guide to an upgrade.
* Upgrade the site.
  * ⚠️ Make sure the custom styles are applied correctly.
* Select an old free test site.
  * ⚠️ Make sure the custom styles are applied correctly.
* Select an old paid test site.
  * ⚠️ Make sure the custom styles are applied correctly.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/798