### PR TITLE
Fix bad margins around `PromoCard` version of domain non-owner warning

### DIFF
--- a/client/my-sites/email/email-different-domain-owner-message/index.tsx
+++ b/client/my-sites/email/email-different-domain-owner-message/index.tsx
@@ -34,7 +34,7 @@ export const EmailDifferentDomainOwnerMessage = () => {
 				eventName="calypso_email_providers_nonowner_impression"
 				eventProperties={ { source: 'email-management', context: 'different-owners' } }
 			/>
-			<p className="email-non-domain-owner-message__non-owner-message">
+			<p className="email-non-domain-owner-message__text">
 				{ translate(
 					'Additional mailboxes can only be purchased by the owner of the domain and email subscriptions. ' +
 						'Please {{contactSupportLink}}contact support{{/contactSupportLink}} to make a purchase.',

--- a/client/my-sites/email/email-non-domain-owner-message/index.tsx
+++ b/client/my-sites/email/email-non-domain-owner-message/index.tsx
@@ -122,11 +122,11 @@ export const EmailNonDomainOwnerMessage = ( props: EmailNonDomainOwnerMessagePro
 	return (
 		<>
 			{ usePromoCard ? (
-				<PromoCard className="email-non-domain-owner-message__non-owner-notice">
+				<PromoCard className="email-non-domain-owner-message__promo-card">
 					<p>{ reasonText }</p>
 				</PromoCard>
 			) : (
-				<p className="email-non-domain-owner-message__non-owner-message">{ reasonText }</p>
+				<p className="email-non-domain-owner-message__text">{ reasonText }</p>
 			) }
 			<TrackComponentView
 				eventName="calypso_email_providers_nonowner_impression"

--- a/client/my-sites/email/email-non-domain-owner-message/style.scss
+++ b/client/my-sites/email/email-non-domain-owner-message/style.scss
@@ -1,4 +1,9 @@
-.email-non-domain-owner-message__non-owner-message {
+.email-non-domain-owner-message__promo-card {
+	margin-top: 16px;
+	padding-bottom: 0;
+}
+
+.email-non-domain-owner-message__text {
 	margin-top: 16px;
 	margin-bottom: 0;
 }

--- a/client/my-sites/email/email-non-owner-message/index.tsx
+++ b/client/my-sites/email/email-non-owner-message/index.tsx
@@ -96,7 +96,7 @@ export const EmailNonOwnerMessage = ( props: EmailNonOwnerMessageProps ) => {
 				eventName="calypso_email_providers_nonowner_impression"
 				eventProperties={ { source, context: 'email-different-owner' } }
 			/>
-			<p className="email-non-owner-message__non-owner-message">{ reasonText }</p>
+			<p className="email-non-owner-message__text">{ reasonText }</p>
 		</>
 	);
 };

--- a/client/my-sites/email/email-non-owner-message/style.scss
+++ b/client/my-sites/email/email-non-owner-message/style.scss
@@ -1,4 +1,4 @@
-.email-non-owner-message__non-owner-message {
+.email-non-owner-message__text {
 	margin-top: 16px;
 	margin-bottom: 0;
 }


### PR DESCRIPTION
#### Proposed Changes

This is a follow-up to #68435.

I encountered an issue with the margins around `EmailNonDomainOwnerMessage` when `usePromoCard === true`. This PR adds styling for that case.

I also took the opportunity to simplify some class names that seemed a tad repetitive.

| Before | After |
| - | - |
| ![before](https://user-images.githubusercontent.com/1101677/197995418-c985fe7d-feb6-4600-99f4-b2ff36574117.png) | ![after](https://user-images.githubusercontent.com/1101677/197995439-dc05bbfa-9360-43ff-a947-ab6db588df38.png) |

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Have a domain that you purchased with Store Sandbox
2. Disable Store Sandbox
3. Navigate to `/email/:domain/purchase/:site_slug`
4. Ensure that you see a warning about `Email service can only be purchased by the owner of {domain}` and that the margins around the warning look good

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
