### PR TITLE
Global Styles: Basic logging for gating global styles

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
@@ -172,6 +172,9 @@ function wpcom_track_global_styles( $blog_id, $post, $updated ) {
 		require_lib( 'tracks/client' );
 		tracks_record_event( get_current_user_id(), $event_name, $event_props );
 	}
+
+	// Delegate logging to the underlying infrastructure.
+	do_action( 'global_styles_log', $event_name );
 }
 add_action( 'save_post_wp_global_styles', 'wpcom_track_global_styles', 10, 3 );
 
@@ -184,12 +187,21 @@ function wpcom_global_styles_in_use() {
 	$user_cpt = WP_Theme_JSON_Resolver_Gutenberg::get_user_data_from_wp_global_styles( wp_get_theme() );
 
 	if ( ! isset( $user_cpt['post_content'] ) ) {
+		do_action( 'global_styles_log', 'global_styles_not_in_use' );
 		return false;
 	}
 
 	$global_style_keys = array_keys( json_decode( $user_cpt['post_content'], true ) ?? array() );
 
-	return count( array_diff( $global_style_keys, array( 'version', 'isGlobalStylesUserThemeJSON' ) ) ) > 0;
+	$global_styles_in_use = count( array_diff( $global_style_keys, array( 'version', 'isGlobalStylesUserThemeJSON' ) ) ) > 0;
+
+	if ( $global_styles_in_use ) {
+		do_action( 'global_styles_log', 'global_styles_in_use' );
+	} else {
+		do_action( 'global_styles_log', 'global_styles_not_in_use' );
+	}
+
+	return $global_styles_in_use;
 }
 
 /**


### PR DESCRIPTION
In order to determine changes in the volume of events being sent we need to be able to determine how/when they're originating.

#### Proposed Changes

* The GS gating and GS usage features will dispatch an action so that other systems can listen to them and log accordingly.
* I've avoided including the logging strategy discriminator inside Calypso since we would be leaking implementation details from other systems.
* Each infrastructure will need to implement a way of listening to and logging these actions.

#### Testing Instructions
* Install this version of ETK
* Apply D90711-code to your sandbox.
* Open the site editor and change some GS related styles.
* Save the styles.
* You should see your changes logged to kibana, the feature name is `global-styles-gate`

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #