### PR TITLE
Support: Add chat closure for company meetup

### DIFF
--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -1,6 +1,6 @@
 import config from '@automattic/calypso-config';
 import { getPlanTermLabel } from '@automattic/calypso-products';
-import { Card } from '@automattic/components';
+import { Card, GMClosureNotice } from '@automattic/components';
 import { HelpCenter } from '@automattic/data-stores';
 import {
 	shouldShowHelpCenterToUser,
@@ -580,6 +580,12 @@ class HelpContact extends Component {
 							displayAt="2022-04-10 00:00Z"
 							closesAt="2022-04-17 00:00Z"
 							reopensAt="2022-04-18 07:00Z"
+						/>
+						<GMClosureNotice
+							displayAt="2022-10-29 00:00Z"
+							closesAt="2022-11-05 00:00Z"
+							reopensAt="2022-11-14 07:00Z"
+							enabled={ this.props.isHappychatUserEligible }
 						/>
 						<ChatHolidayClosureNotice
 							holidayName={ translate( 'Christmas', {


### PR DESCRIPTION
As requested on pdm0RZ-ni-p2

#### Proposed Changes

Use the component provided by @alshakero in https://github.com/Automattic/wp-calypso/pull/69523 in the old contact form/FAB.

<img width="335" alt="Screenshot 2022-10-28 at 19 15 32" src="https://user-images.githubusercontent.com/3392497/198715573-42b3f3bf-6f65-48b8-bc3a-2cdef9ec7f87.png">
<img width="345" alt="Screenshot 2022-10-28 at 19 15 40" src="https://user-images.githubusercontent.com/3392497/198715578-43f3b2db-69a8-4798-94f6-59059dc9195c.png">
<img width="336" alt="Screenshot 2022-10-28 at 19 16 32" src="https://user-images.githubusercontent.com/3392497/198715580-87c36510-a465-4d3a-86c9-f0a39f0f56c7.png">


#### Testing Instructions

See https://github.com/Automattic/wp-calypso/pull/69523. Make sure to disable the Help Center: `return false` in `shouldShowHelpCenterToUser` (`packages/help-center/src/utils.ts`).
