### PR TITLE
Limit Global Styles: Add unlock styles modal

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
@@ -95,6 +95,7 @@ function wpcom_global_styles_enqueue_scripts_and_styles() {
 		array(
 			'assetsUrl'  => plugins_url( 'dist/', __FILE__ ),
 			'upgradeUrl' => "$calypso_domain/plans/$site_slug",
+			'inUse'      => wpcom_global_styles_in_use(),
 		)
 	);
 	wp_enqueue_style(

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/modal.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/modal.js
@@ -13,7 +13,7 @@ import './modal.scss';
 const GlobalStylesModal = () => {
 	const params = new URLSearchParams( window.location.search );
 	const [ showUnlockStylesModal, setShowUnlockStylesModal ] = useState(
-		params.get( 'unlock-styles' )
+		params.get( 'unlock-styles' ) && wpcomGlobalStyles.inUse
 	);
 
 	const isVisible = useSelect(

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/modal.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/modal.js
@@ -23,6 +23,7 @@ const GlobalStylesModal = () => {
 			}
 
 			// Show unlock styles modal on load, but wait for the global styles to be ready.
+			// Otherwise, the modal will show up before the editor is visible.
 			const { getEditedPostId, getEditedPostType } = select( 'core/edit-site' );
 			if ( getEditedPostType() === undefined || getEditedPostId() === undefined ) {
 				return false;

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/modal.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/modal.js
@@ -79,8 +79,11 @@ const GlobalStylesModal = () => {
 	}, [ isVisible ] );
 
 	const closeModal = () => {
-		dismissModal();
-		setShowUnlockStylesModal( false );
+		if ( showUnlockStylesModal ) {
+			setShowUnlockStylesModal( false );
+		} else {
+			dismissModal();
+		}
 		recordTracksEvent( 'calypso_global_styles_gating_modal_dismiss', {
 			context: 'site-editor',
 		} );

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/modal.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/modal.js
@@ -93,6 +93,19 @@ const GlobalStylesModal = () => {
 		return null;
 	}
 
+	let title = __( 'A powerful new way to style your site', 'full-site-editing' );
+	let description = __(
+		"Change all of your site's fonts, colors and more. Available on any paid plan.",
+		'full-site-editing'
+	);
+	if ( showUnlockStylesModal ) {
+		title = __( 'Publish your new site styles', 'full-site-editing' );
+		description = __(
+			"To activate your site styles, and unlock advanced design customization tools, you'll need upgrade to a paid plan.",
+			'full-site-editing'
+		);
+	}
+
 	return (
 		<Modal
 			className="wpcom-global-styles-modal"
@@ -101,22 +114,8 @@ const GlobalStylesModal = () => {
 			shouldCloseOnClickOutside={ false }
 		>
 			<div className="wpcom-global-styles-modal__text">
-				<h1 className="wpcom-global-styles-modal__heading">
-					{ showUnlockStylesModal
-						? __( 'Publish your new site styles', 'full-site-editing' )
-						: __( 'A powerful new way to style your site', 'full-site-editing' ) }
-				</h1>
-				<p className="wpcom-global-styles-modal__description">
-					{ showUnlockStylesModal
-						? __(
-								"To activate your site styles, and unlock advanced design customization tools, you'll need upgrade to a paid plan.",
-								'full-site-editing'
-						  )
-						: __(
-								"Change all of your site's fonts, colors and more. Available on any paid plan.",
-								'full-site-editing'
-						  ) }
-				</p>
+				<h1 className="wpcom-global-styles-modal__heading">{ title }</h1>
+				<p className="wpcom-global-styles-modal__description">{ description }</p>
 				<div className="wpcom-global-styles-modal__actions">
 					<Button variant="secondary" onClick={ closeModal }>
 						{ __( 'Try it out', 'full-site-editing' ) }

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -79,6 +79,7 @@ interface Props {
 	stripeConnectSuccess: 'gutenberg' | null;
 	showDraftPostModal: boolean;
 	blockEditorSettings: BlockEditorSettings;
+	unlockStyles?: boolean;
 }
 
 interface CheckoutModalOptions extends RequestCart {
@@ -777,6 +778,7 @@ const mapStateToProps = (
 		showDraftPostModal,
 		pressThisData,
 		blockEditorSettings,
+		unlockStyles,
 	}: Props
 ) => {
 	const siteId = getSelectedSiteId( state );
@@ -802,6 +804,7 @@ const mapStateToProps = (
 		openSidebar: getQueryArg( window.location.href, 'openSidebar' ),
 		showDraftPostModal,
 		...pressThisData,
+		...( unlockStyles && { 'unlock-styles': true } ),
 	} );
 
 	// needed for loading the editor in SU sessions

--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -262,6 +262,7 @@ export const post = ( context, next ) => {
 export const siteEditor = ( context, next ) => {
 	const state = context.store.getState();
 	const siteId = getSelectedSiteId( state );
+	const unlockStyles = 'unlock-styles' in context.query;
 
 	context.primary = (
 		<CalypsoifyIframe
@@ -269,6 +270,7 @@ export const siteEditor = ( context, next ) => {
 			// It will force the component to remount completely when the Id changes.
 			key={ siteId }
 			editorType="site"
+			unlockStyles={ unlockStyles }
 		/>
 	);
 


### PR DESCRIPTION
Part of https://github.com/Automattic/dotcom-forge/issues/1057

#### Proposed Changes

Adds a new variant of the limited Global Styles modal that shows up when the `?unlock-styles` param is present.

<img width="400" alt="Screen Shot 2022-10-26 at 13 42 28" src="https://user-images.githubusercontent.com/1233880/198017625-5a5aaa48-4a7c-4c49-83d9-e9f8abb01c2c.png">

This modal will be presented to users who click on the "Activate advanced design customization tools" step of the launchpad (which will be implemented in a follow-up, see https://github.com/Automattic/dotcom-forge/issues/1057).


#### Testing Instructions

-  Apply these changes to your sandbox: `install-plugin.sh editing-toolkit add/global-styles-unlock-modal-param`
- Use the Calypso live link below and create a new free site
- Add the `wpcom-limit-global-styles` blog sticker to the new site from the Blog RC
- Sandbox the new site
- Go to `/site-editor/:slug?unlock-styles`
- Make sure the new modal shows up
- Make sure the Global Styles sidebar is automatically open
- Make sure you can dismiss the modal
