### PR TITLE
Help Center: fix happychat auth for 3PC users

### DIFF
--- a/packages/happychat-connection/src/index.ts
+++ b/packages/happychat-connection/src/index.ts
@@ -2,3 +2,4 @@ export { default } from './connection-async';
 export { default as buildConnection } from './connection';
 export { default as useHappychatAvailable } from './use-happychat-available';
 export { default as useHappychatAuth, requestHappyChatAuth } from './use-happychat-auth';
+export { happychatAuthQueryKey } from './use-happychat-auth';

--- a/packages/happychat-connection/src/use-happychat-auth.ts
+++ b/packages/happychat-connection/src/use-happychat-auth.ts
@@ -2,8 +2,6 @@ import { useQuery } from 'react-query';
 import wpcomRequest from 'wpcom-proxy-request';
 import type { HappychatSession, HappychatUser, User, HappychatAuth, Jwt } from './types';
 
-const key = Date.now();
-
 export async function requestHappyChatAuth() {
 	const user: User = await wpcomRequest( {
 		path: '/me',
@@ -49,7 +47,7 @@ export async function requestHappyChatAuth() {
 }
 
 export default function useHappychatAuth( enabled = true ) {
-	return useQuery< HappychatAuth >( 'getHappychatAuth' + key, requestHappyChatAuth, {
+	return useQuery< HappychatAuth >( 'getHappychatAuth', requestHappyChatAuth, {
 		staleTime: 10 * 60 * 1000, // 10 minutes
 		enabled,
 	} );

--- a/packages/happychat-connection/src/use-happychat-auth.ts
+++ b/packages/happychat-connection/src/use-happychat-auth.ts
@@ -2,6 +2,8 @@ import { useQuery } from 'react-query';
 import wpcomRequest from 'wpcom-proxy-request';
 import type { HappychatSession, HappychatUser, User, HappychatAuth, Jwt } from './types';
 
+export const happychatAuthQueryKey = 'getHappychatAuth-' + Date.now();
+
 export async function requestHappyChatAuth() {
 	const user: User = await wpcomRequest( {
 		path: '/me',
@@ -47,7 +49,7 @@ export async function requestHappyChatAuth() {
 }
 
 export default function useHappychatAuth( enabled = true ) {
-	return useQuery< HappychatAuth >( 'getHappychatAuth', requestHappyChatAuth, {
+	return useQuery< HappychatAuth >( happychatAuthQueryKey, requestHappyChatAuth, {
 		staleTime: 10 * 60 * 1000, // 10 minutes
 		enabled,
 	} );

--- a/packages/help-center/src/happychat-window-communicator.ts
+++ b/packages/help-center/src/happychat-window-communicator.ts
@@ -2,7 +2,7 @@
 /**
  * External Dependencies
  */
-import { useHappychatAuth } from '@automattic/happychat-connection';
+import { useHappychatAuth, happychatAuthQueryKey } from '@automattic/happychat-connection';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect, useState } from '@wordpress/element';
 import { useQueryClient } from 'react-query';
@@ -98,7 +98,7 @@ export function useHCWindowCommunicator( isMinimized: boolean ) {
 						break;
 
 					case 'happy-chat-authentication-data':
-						queryClient.fetchQuery( 'getHappychatAuth' ).then( ( auth ) => {
+						queryClient.fetchQuery( happychatAuthQueryKey ).then( ( auth ) => {
 							event.source?.postMessage(
 								{
 									type: 'happy-chat-authentication-data',


### PR DESCRIPTION
#### Proposed Changes

* In [this](https://github.com/Automattic/wp-calypso/blob/trunk/packages/help-center/src/happychat-window-communicator.ts#L101) line, we assumed the Happychat auth query will always have the key `getHappychatAuth`. But this [PR](https://github.com/Automattic/wp-calypso/blob/trunk/packages/help-center/src/happychat-window-communicator.ts) added a cache buster to reset the cache when the user refreshes the page. 
* This PR exports the key to remove this maintenance burden and prevent changing the key in the future from breaking this again.

#### Testing Instructions

1. Sandbox a site and start ETK.
2. Open the editor of the sandboxed site.
3. Block 3rd party cookies for that site.
4. Login to https://hud-staging.happychat.io/.
5. Open the Help Center and start a chat.
6. All should work.
