### PR TITLE
Jetpack pricing page: fix product lightbox URL accessibility issue.

### DIFF
--- a/client/my-sites/plans/jetpack-plans/product-store/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/index.tsx
@@ -85,7 +85,8 @@ const ProductStore: React.FC< ProductStoreProps > = ( {
 		history?.pushState?.(
 			{},
 			'',
-			addQueryArgs( { [ TAB_QUERY_PARAM ]: currentView }, location.pathname + location.search )
+			addQueryArgs( { [ TAB_QUERY_PARAM ]: currentView }, location.pathname + location.search ) +
+				( location.hash ?? '' )
 		);
 	}, [ currentView ] );
 


### PR DESCRIPTION
### Description
Right now, when we have a hash fragment in the pricing page URL. It gets removed causing the product lightbox not accessible via URL. 

The issue was reported in Slack p1666641846003039-slack-C03V4PXKUGP.

#### Steps to Reproduce
* Go to https://cloud.jetpack.com/pricing
* Press any 'More about ***' link to display the product lightbox.

<img width="604" alt="Screen Shot 2022-10-26 at 10 28 33 PM" src="https://user-images.githubusercontent.com/56598660/198053781-4fb38cba-d168-4265-bd58-55acdcd8d260.png">

* Notice that the URL will append #PRODUCT_SLUG in the url.
<img width="525" alt="Screen Shot 2022-10-26 at 10 30 46 PM" src="https://user-images.githubusercontent.com/56598660/198054356-21019a05-8241-4055-b9c8-8748b944e0c0.png">

* Now refresh the page, **notice that the hash fragment is stripped out**. 


#### Proposed Changes

* Update the **useEffect** that is responsible for updating the `filter` query params when `currentView` state gets updated to include hash fragment when updating the URL.

#### Testing Instructions

1. Now run this branch by following the steps below (or you can use the Jetpack Cloud live link commented on this PR)
    * Run `git fetch && git checkout fix/product-lightbox-url-accessibility-not-working`
    * Run `yarn start-jetpack-cloud`

2. Goto http://jetpack.cloud.localhost:3000/pricing or use the Jetpack Cloud live link and append `/pricing`
3. Press any 'More about ***' link to display a product lightbox.
4. Confirm that the URL updates with the product slug as a hash fragment
5. Refresh the page, Confirm that the URL does not stripped out hash fragment. The product lightbox should display during load.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1666641846003039-slack-C03V4PXKUGP