### PR TITLE
Help Center: extend happychat to non-Simple sites

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-help-center.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-help-center.php
@@ -159,6 +159,10 @@ class Help_Center {
 		$controller = new WP_REST_Help_Center_Authenticate();
 		$controller->register_rest_route();
 
+		require_once __DIR__ . '/class-wp-rest-help-center-sibyl.php';
+		$controller = new WP_REST_Help_Center_Sibyl();
+		$controller->register_rest_route();
+
 		require_once __DIR__ . '/class-wp-rest-help-center-support-availability.php';
 		$controller = new WP_REST_Help_Center_Support_Availability();
 		$controller->register_rest_route();

--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-help-center.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-help-center.php
@@ -73,7 +73,6 @@ class Help_Center {
 	 */
 	public function enqueue_script() {
 		$script_dependencies = $this->asset_file['dependencies'];
-		$logo_id             = get_option( 'site_logo' );
 
 		wp_enqueue_script(
 			'help-center-script',
@@ -111,22 +110,42 @@ class Help_Center {
 			'help-center-script',
 			'helpCenterData',
 			array(
-				'currentSite' => array(
-					'ID'   => \Jetpack_Options::get_option( 'id' ),
-					'name' => get_bloginfo( 'name' ),
-					'url'  => get_bloginfo( 'url' ),
-					'logo' => array(
-						'id'    => $logo_id,
-						'sizes' => array(),
-						'url'   => wp_get_attachment_image_src( $logo_id, 'thumbnail' )[0],
-					),
-				),
+				'currentSite' => $this->get_current_site(),
 			)
 		);
 
 		wp_set_script_translations( 'help-center-script', 'full-site-editing' );
 	}
 
+	/**
+	 * Get current site details.
+	 */
+	public function get_current_site() {
+		$logo_id    = get_option( 'site_logo' );
+		$products   = wpcom_get_site_purchases();
+		$at_options = get_option( 'at_options' );
+		$plan       = array_pop(
+			array_filter(
+				$products,
+				function ( $product ) {
+					return 'bundle' === $product->product_type;
+				}
+			)
+		);
+
+		return array(
+			'ID'    => \Jetpack_Options::get_option( 'id' ),
+			'name'  => get_bloginfo( 'name' ),
+			'URL'   => get_bloginfo( 'url' ),
+			'plan'  => $plan->product_slug,
+			'is_at' => ! isset( $at_options ),
+			'logo'  => array(
+				'id'    => $logo_id,
+				'sizes' => array(),
+				'url'   => wp_get_attachment_image_src( $logo_id, 'thumbnail' )[0],
+			),
+		);
+	}
 	/**
 	 * Register the Help Center endpoints.
 	 */

--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-help-center.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-help-center.php
@@ -75,8 +75,6 @@ class Help_Center {
 		$script_dependencies = $this->asset_file['dependencies'];
 		$logo_id             = get_option( 'site_logo' );
 
-		l( wp_get_attachment_image_src( $logo_id, 'thumbnail' )[0] );
-
 		wp_enqueue_script(
 			'help-center-script',
 			plugins_url( 'dist/help-center.min.js', __FILE__ ),
@@ -111,15 +109,17 @@ class Help_Center {
 
 		wp_localize_script(
 			'help-center-script',
-			'currentSite',
+			'helpCenterData',
 			array(
-				'ID'   => \Jetpack_Options::get_option( 'id' ),
-				'name' => get_bloginfo( 'name' ),
-				'url'  => get_bloginfo( 'url' ),
-				'logo' => array(
-					'id'    => $logo_id,
-					'sizes' => array(),
-					'url'   => wp_get_attachment_image_src( $logo_id, 'thumbnail' )[0],
+				'currentSite' => array(
+					'ID'   => \Jetpack_Options::get_option( 'id' ),
+					'name' => get_bloginfo( 'name' ),
+					'url'  => get_bloginfo( 'url' ),
+					'logo' => array(
+						'id'    => $logo_id,
+						'sizes' => array(),
+						'url'   => wp_get_attachment_image_src( $logo_id, 'thumbnail' )[0],
+					),
 				),
 			)
 		);

--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-help-center.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-help-center.php
@@ -73,6 +73,9 @@ class Help_Center {
 	 */
 	public function enqueue_script() {
 		$script_dependencies = $this->asset_file['dependencies'];
+		$logo_id             = get_option( 'site_logo' );
+
+		l( wp_get_attachment_image_src( $logo_id, 'thumbnail' )[0] );
 
 		wp_enqueue_script(
 			'help-center-script',
@@ -108,9 +111,16 @@ class Help_Center {
 
 		wp_localize_script(
 			'help-center-script',
-			'helpCenterData',
+			'currentSite',
 			array(
-				'currentSiteId' => get_current_blog_id(),
+				'ID'   => \Jetpack_Options::get_option( 'id' ),
+				'name' => get_bloginfo( 'name' ),
+				'url'  => get_bloginfo( 'url' ),
+				'logo' => array(
+					'id'    => $logo_id,
+					'sizes' => array(),
+					'url'   => wp_get_attachment_image_src( $logo_id, 'thumbnail' )[0],
+				),
 			)
 		);
 
@@ -121,6 +131,10 @@ class Help_Center {
 	 * Register the Help Center endpoints.
 	 */
 	public function register_rest_api() {
+		require_once __DIR__ . '/class-wp-rest-help-center-authenticate.php';
+		$controller = new WP_REST_Help_Center_Authenticate();
+		$controller->register_rest_route();
+
 		require_once __DIR__ . '/class-wp-rest-help-center-support-availability.php';
 		$controller = new WP_REST_Help_Center_Support_Availability();
 		$controller->register_rest_route();

--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-help-center.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-help-center.php
@@ -121,6 +121,7 @@ class Help_Center {
 	 * Get current site details.
 	 */
 	public function get_current_site() {
+		$site       = \Jetpack_Options::get_option( 'id' );
 		$logo_id    = get_option( 'site_logo' );
 		$products   = wpcom_get_site_purchases();
 		$at_options = get_option( 'at_options' );
@@ -134,18 +135,22 @@ class Help_Center {
 		);
 
 		return array(
-			'ID'    => \Jetpack_Options::get_option( 'id' ),
-			'name'  => get_bloginfo( 'name' ),
-			'URL'   => get_bloginfo( 'url' ),
-			'plan'  => $plan->product_slug,
-			'is_at' => ! isset( $at_options ),
-			'logo'  => array(
+			'ID'              => $site,
+			'name'            => get_bloginfo( 'name' ),
+			'URL'             => get_bloginfo( 'url' ),
+			'plan'            => array(
+				'product_slug' => $plan->product_slug,
+			),
+			'is_wpcom_atomic' => boolval( $at_options ),
+			'jetpack'         => true === apply_filters( 'is_jetpack_site', false, $site ),
+			'logo'            => array(
 				'id'    => $logo_id,
 				'sizes' => array(),
 				'url'   => wp_get_attachment_image_src( $logo_id, 'thumbnail' )[0],
 			),
 		);
 	}
+
 	/**
 	 * Register the Help Center endpoints.
 	 */

--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-help-center.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-help-center.php
@@ -170,6 +170,10 @@ class Help_Center {
 		require_once __DIR__ . '/class-wp-rest-help-center-fetch-post.php';
 		$controller = new WP_REST_Help_Center_Fetch_Post();
 		$controller->register_rest_route();
+
+		require_once __DIR__ . '/class-wp-rest-help-center-ticket.php';
+		$controller = new WP_REST_Help_Center_Ticket();
+		$controller->register_rest_route();
 	}
 
 	/**

--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-wp-rest-help-center-authenticate.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-wp-rest-help-center-authenticate.php
@@ -41,7 +41,11 @@ class WP_REST_Help_Center_Authenticate extends \WP_REST_Controller {
 	 */
 	public function get_chat_authentication() {
 		$body = Client::wpcom_json_api_request_as_user(
-			'help/authenticate/chat'
+			'help/authenticate/chat',
+			'2',
+			array(
+				'method' => 'POST',
+			)
 		);
 
 		if ( is_wp_error( $body ) ) {

--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-wp-rest-help-center-authenticate.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-wp-rest-help-center-authenticate.php
@@ -17,9 +17,8 @@ class WP_REST_Help_Center_Authenticate extends \WP_REST_Controller {
 	 * WP_REST_Help_Center_Authenticate constructor.
 	 */
 	public function __construct() {
-		$this->namespace                       = 'help-center/';
-		$this->rest_base                       = 'authenticate';
-		$this->wpcom_is_site_specific_endpoint = false;
+		$this->namespace = 'help-center';
+		$this->rest_base = '/authenticate/chat';
 	}
 
 	/**
@@ -28,7 +27,7 @@ class WP_REST_Help_Center_Authenticate extends \WP_REST_Controller {
 	public function register_rest_route() {
 		register_rest_route(
 			$this->namespace,
-			$this->rest_base . '/chat',
+			$this->rest_base,
 			array(
 				'methods'             => \WP_REST_Server::CREATABLE,
 				'callback'            => array( $this, 'get_chat_authentication' ),
@@ -42,11 +41,7 @@ class WP_REST_Help_Center_Authenticate extends \WP_REST_Controller {
 	 */
 	public function get_chat_authentication() {
 		$body = Client::wpcom_json_api_request_as_user(
-			'help/authenticate/chat',
-			'2',
-			array(
-				'method' => 'POST',
-			)
+			'help/authenticate/chat'
 		);
 
 		if ( is_wp_error( $body ) ) {

--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-wp-rest-help-center-authenticate.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-wp-rest-help-center-authenticate.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * WP_REST_Help_Center_Authenticate file.
+ *
+ * @package A8C\FSE
+ */
+
+namespace A8C\FSE;
+
+use Automattic\Jetpack\Connection\Client;
+
+/**
+ * Class WP_REST_Help_Center_Authenticate.
+ */
+class WP_REST_Help_Center_Authenticate extends \WP_REST_Controller {
+	/**
+	 * WP_REST_Help_Center_Authenticate constructor.
+	 */
+	public function __construct() {
+		$this->namespace                       = 'help-center/';
+		$this->rest_base                       = 'authenticate';
+		$this->wpcom_is_site_specific_endpoint = false;
+	}
+
+	/**
+	 * Register available routes.
+	 */
+	public function register_rest_route() {
+		register_rest_route(
+			$this->namespace,
+			$this->rest_base . '/chat',
+			array(
+				'methods'             => \WP_REST_Server::CREATABLE,
+				'callback'            => array( $this, 'get_chat_authentication' ),
+				'permission_callback' => array( $this, 'permission_callback' ),
+			)
+		);
+	}
+
+	/**
+	 * Callback to authorize user for chat.
+	 */
+	public function get_chat_authentication() {
+		$body = Client::wpcom_json_api_request_as_user(
+			'help/authenticate/chat',
+			'2',
+			array(
+				'method' => 'POST',
+			)
+		);
+
+		if ( is_wp_error( $body ) ) {
+			return $body;
+		}
+		$response = json_decode( wp_remote_retrieve_body( $body ) );
+
+		return rest_ensure_response( $response );
+	}
+
+	/**
+	 * Callback to determine whether the user has permission to access.
+	 */
+	public function permission_callback() {
+		return is_user_logged_in();
+	}
+}

--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-wp-rest-help-center-authenticate.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-wp-rest-help-center-authenticate.php
@@ -53,7 +53,7 @@ class WP_REST_Help_Center_Authenticate extends \WP_REST_Controller {
 		}
 		$response = json_decode( wp_remote_retrieve_body( $body ) );
 
-		// Return happychat staging for proxied users. This value is not correct when retreiving from AT sites.
+		// Return happychat staging for proxied users. The URL returned from the API request is not correct when coming from atomic sites.
 		$is_proxied    = isset( $_SERVER['A8C_PROXIED_REQUEST'] ) ? sanitize_text_field( wp_unslash( $_SERVER['A8C_PROXIED_REQUEST'] ) ) : false || defined( 'A8C_PROXIED_REQUEST' ) && A8C_PROXIED_REQUEST;
 		$url           = $is_proxied ? 'https://happychat-io-staging.go-vip.co/customer' : 'https://happychat.io/customer';
 		$response->url = $url;

--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-wp-rest-help-center-authenticate.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-wp-rest-help-center-authenticate.php
@@ -53,6 +53,11 @@ class WP_REST_Help_Center_Authenticate extends \WP_REST_Controller {
 		}
 		$response = json_decode( wp_remote_retrieve_body( $body ) );
 
+		// Return happychat staging for proxied users. This value is not correct when retreiving from AT sites.
+		$is_proxied    = isset( $_SERVER['A8C_PROXIED_REQUEST'] ) ? sanitize_text_field( wp_unslash( $_SERVER['A8C_PROXIED_REQUEST'] ) ) : false || defined( 'A8C_PROXIED_REQUEST' ) && A8C_PROXIED_REQUEST;
+		$url           = $is_proxied ? 'https://happychat-io-staging.go-vip.co/customer' : 'https://happychat.io/customer';
+		$response->url = $url;
+
 		return rest_ensure_response( $response );
 	}
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-wp-rest-help-center-search.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-wp-rest-help-center-search.php
@@ -27,7 +27,7 @@ class WP_REST_Help_Center_Search extends \WP_REST_Controller {
 	public function register_rest_route() {
 		register_rest_route(
 			$this->namespace,
-			'/' . $this->rest_base,
+			$this->rest_base,
 			array(
 				'methods'             => \WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'get_search_results' ),

--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-wp-rest-help-center-sibyl.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-wp-rest-help-center-sibyl.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * WP_REST_Help_Center_Sibyl file.
+ *
+ * @package A8C\FSE
+ */
+
+namespace A8C\FSE;
+
+use Automattic\Jetpack\Connection\Client;
+
+/**
+ * Class WP_REST_Help_Center_Sibyl.
+ */
+class WP_REST_Help_Center_Sibyl extends \WP_REST_Controller {
+	/**
+	 * WP_REST_Help_Center_Sibyl constructor.
+	 */
+	public function __construct() {
+		$this->namespace = 'help-center';
+		$this->rest_base = '/sibyl';
+	}
+
+	/**
+	 * Register available routes.
+	 */
+	public function register_rest_route() {
+		register_rest_route(
+			$this->namespace,
+			$this->rest_base,
+			array(
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_sibyl_questions' ),
+				'permission_callback' => array( $this, 'permission_callback' ),
+			)
+		);
+	}
+
+	/**
+	 * Should return the sibyl articles.
+	 *
+	 * @param \WP_REST_Request $request The request sent to the API.
+	 *
+	 * @return WP_REST_Response
+	 */
+	public function get_sibyl_questions( \WP_REST_Request $request ) {
+		$query = $request['query'];
+		$site  = $request['site'];
+
+		$body = Client::wpcom_json_api_request_as_user(
+			'/help/sibyl?query=' . $query . '&site=' . $site
+		);
+
+		if ( is_wp_error( $body ) ) {
+			return $body;
+		}
+
+		$response = json_decode( wp_remote_retrieve_body( $body ) );
+
+		return rest_ensure_response( $response );
+	}
+
+	/**
+	 * Callback to determine whether the request can proceed.
+	 *
+	 * @return boolean
+	 */
+	public function permission_callback() {
+		return is_user_logged_in();
+	}
+}

--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-wp-rest-help-center-ticket.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-wp-rest-help-center-ticket.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * WP_REST_Help_Center_Ticket file.
+ *
+ * @package A8C\FSE
+ */
+
+namespace A8C\FSE;
+
+use Automattic\Jetpack\Connection\Client;
+
+/**
+ * Class WP_REST_Help_Center_Ticket.
+ */
+class WP_REST_Help_Center_Ticket extends \WP_REST_Controller {
+	/**
+	 * WP_REST_Help_Center_Ticket constructor.
+	 */
+	public function __construct() {
+		$this->namespace = 'help-center';
+		$this->rest_base = '/ticket';
+	}
+
+	/**
+	 * Register available routes.
+	 */
+	public function register_rest_route() {
+		register_rest_route(
+			$this->namespace,
+			$this->rest_base . '/new',
+			array(
+				'methods'             => \WP_REST_Server::CREATABLE,
+				'callback'            => array( $this, 'new_ticket' ),
+				'permission_callback' => array( $this, 'permission_callback' ),
+				'args'                => array(
+					'subject'          => array(
+						'type' => 'string',
+					),
+					'message'          => array(
+						'type' => 'string',
+					),
+					'locale'           => array(
+						'type'    => 'string',
+						'default' => 'en',
+					),
+					'is_chat_overflow' => array(
+						'type' => 'boolean',
+					),
+					'source'           => array(
+						'type' => 'string',
+					),
+					'blog_url'         => array(
+						'type' => 'string',
+					),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Should create a new ticket
+	 *
+	 * @param \WP_REST_Request $request    The request sent to the API.
+	 *
+	 * @return WP_REST_Response
+	 */
+	public function new_ticket( \WP_REST_Request $request ) {
+		$ticket = array(
+			'subject'          => $request['subject'],
+			'message'          => $request['message'],
+			'locale'           => $request['locale'],
+			'is_chat_overflow' => $request['is_chat_overflow'],
+			'source'           => $request['source'],
+			'blog_url'         => $request['blog_url'],
+		);
+
+		$body = Client::wpcom_json_api_request_as_user(
+			'/help/ticket/new',
+			'2',
+			array(
+				'method' => 'POST',
+			),
+			$ticket
+		);
+
+		if ( is_wp_error( $body ) ) {
+			return $body;
+		}
+
+		$response = json_decode( wp_remote_retrieve_body( $body ) );
+
+		return rest_ensure_response( $response );
+	}
+
+	/**
+	 * Callback to determine whether the request can proceed.
+	 *
+	 * @return boolean
+	 */
+	public function permission_callback() {
+		return is_user_logged_in();
+	}
+}

--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/CalypsoStateProvider.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/CalypsoStateProvider.js
@@ -37,8 +37,8 @@ const store = createStore(
 
 setStore( store );
 
-const helpCenterData = window.helpCenterData;
-helpCenterData && store.dispatch( setSelectedSiteId( helpCenterData.currentSiteId ) );
+const currentSite = window.helpCenterData.currentSite;
+currentSite && store.dispatch( setSelectedSiteId( currentSite.id ) );
 store.dispatch( setSection( { name: 'gutenberg-editor' } ) );
 
 i18n.configure( { defaultLocaleSlug: window.helpCenterLocale } );
@@ -56,7 +56,7 @@ export default function CalypsoStateProvider( { children } ) {
 	return (
 		<Provider store={ store }>
 			<>
-				<QuerySites siteId={ helpCenterData.currentSiteId } />
+				<QuerySites siteId={ currentSite.id } />
 				{ children }
 			</>
 		</Provider>

--- a/packages/data-stores/src/help-center/actions.ts
+++ b/packages/data-stores/src/help-center/actions.ts
@@ -1,5 +1,5 @@
 import { SiteDetails } from '../site';
-import { Location } from './types';
+import { Location, HelpCenterSite } from './types';
 
 export const setShowHelpCenter = ( show: boolean ) =>
 	( {
@@ -21,7 +21,7 @@ export const resetRouterState = () =>
 		index: undefined,
 	} as const );
 
-export const setSite = ( site: SiteDetails | undefined ) =>
+export const setSite = ( site: HelpCenterSite | undefined ) =>
 	( {
 		type: 'HELP_CENTER_SET_SITE',
 		site,
@@ -74,7 +74,7 @@ export const setUserDeclaredSite = ( site: SiteDetails | undefined ) =>
 		site,
 	} as const );
 
-export const startHelpCenterChat = function* ( site: SiteDetails, message: string ) {
+export const startHelpCenterChat = function* ( site: HelpCenterSite, message: string ) {
 	yield setRouterState( [ { pathname: '/inline-chat' } ], 0 );
 	yield setSite( site );
 	yield setMessage( message );

--- a/packages/data-stores/src/help-center/index.ts
+++ b/packages/data-stores/src/help-center/index.ts
@@ -31,3 +31,5 @@ declare module '@wordpress/data' {
 	function dispatch( key: typeof STORE_KEY ): DispatchFromMap< typeof actions >;
 	function select( key: typeof STORE_KEY ): SelectFromMap< typeof selectors >;
 }
+
+export type { HelpCenterSite } from './types';

--- a/packages/data-stores/src/help-center/reducer.ts
+++ b/packages/data-stores/src/help-center/reducer.ts
@@ -1,7 +1,7 @@
 import { combineReducers } from '@wordpress/data';
 import { SiteDetails } from '../site';
 import type { HelpCenterAction } from './actions';
-import type { Location } from './types';
+import type { Location, HelpCenterSite } from './types';
 import type { Reducer } from 'redux';
 
 const showHelpCenter: Reducer< boolean | undefined, HelpCenterAction > = ( state, action ) => {
@@ -20,7 +20,7 @@ const isMinimized: Reducer< boolean, HelpCenterAction > = ( state = false, actio
 	return state;
 };
 
-const site: Reducer< SiteDetails | undefined, HelpCenterAction > = ( state, action ) => {
+const site: Reducer< HelpCenterSite | undefined, HelpCenterAction > = ( state, action ) => {
 	if ( action.type === 'HELP_CENTER_RESET_STORE' ) {
 		return undefined;
 	} else if ( action.type === 'HELP_CENTER_SET_SITE' ) {

--- a/packages/data-stores/src/help-center/types.ts
+++ b/packages/data-stores/src/help-center/types.ts
@@ -5,3 +5,23 @@ export type Location = {
 	state?: unknown;
 	key?: string;
 };
+
+export interface SiteLogo {
+	id: number;
+	sizes: never[];
+	url: string;
+}
+
+export interface Plan {
+	product_slug: string;
+}
+
+export interface HelpCenterSite {
+	ID: number | string;
+	name: string;
+	URL: string;
+	plan: Plan;
+	is_wpcom_atomic: boolean;
+	jetpack: boolean;
+	logo: SiteLogo;
+}

--- a/packages/data-stores/src/index.ts
+++ b/packages/data-stores/src/index.ts
@@ -58,3 +58,4 @@ export { getContextResults } from './contextual-help/contextual-help';
 export { generateAdminSections } from './contextual-help/admin-sections';
 export type { LinksForSection } from './contextual-help/contextual-help';
 export * from './contextual-help/constants';
+export type { HelpCenterSite } from './help-center/types';

--- a/packages/data-stores/src/queries/use-site-analysis.ts
+++ b/packages/data-stores/src/queries/use-site-analysis.ts
@@ -1,4 +1,5 @@
 import { useDebounce } from 'use-debounce';
+import { HelpCenterSite } from '../help-center';
 import { SiteDetails } from '../site';
 import { useIsWpOrgSite } from './use-is-wporg-site';
 import { useUserSites } from './use-user-sites';
@@ -15,7 +16,7 @@ type ResultType =
 
 export type AnalysisReport = {
 	result: ResultType;
-	site?: SiteDetails;
+	site?: SiteDetails | HelpCenterSite;
 	siteURL: string | undefined;
 	isWpcom: boolean;
 };

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -128,7 +128,6 @@ export interface SiteDetails {
 	visible?: boolean;
 	wpcom_url?: string;
 	user_interactions?: string[];
-	is_at?: boolean;
 }
 
 export interface SiteDetailsCapabilities {

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -1,4 +1,5 @@
 import type { DispatchFromMap } from '../mapped-types';
+import type { Plan } from '../plans';
 import type { FeatureId } from '../wpcom-features';
 import type { ActionCreators } from './actions';
 
@@ -120,7 +121,7 @@ export interface SiteDetails {
 	name: string | undefined;
 	options: SiteDetailsOptions;
 	p2_thumbnail_elements?: P2ThumbnailElements | null;
-	plan?: SiteDetailsPlan;
+	plan?: Plan | SiteDetailsPlan;
 	products?: SiteDetailsPlan[];
 	single_user_site?: boolean;
 	site_owner?: number;
@@ -128,6 +129,7 @@ export interface SiteDetails {
 	visible?: boolean;
 	wpcom_url?: string;
 	user_interactions?: string[];
+	is_at?: boolean;
 }
 
 export interface SiteDetailsCapabilities {

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -101,7 +101,7 @@ export interface DifmLiteSiteOptions {
 
 // is_fse_active && is_fse_eligible properties have been deprecated and removed from SiteDetails interface
 export interface SiteDetails {
-	ID: number;
+	ID: number | string;
 	URL: string;
 	capabilities: SiteDetailsCapabilities;
 	description: string;

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -1,5 +1,4 @@
 import type { DispatchFromMap } from '../mapped-types';
-import type { Plan } from '../plans';
 import type { FeatureId } from '../wpcom-features';
 import type { ActionCreators } from './actions';
 
@@ -121,7 +120,7 @@ export interface SiteDetails {
 	name: string | undefined;
 	options: SiteDetailsOptions;
 	p2_thumbnail_elements?: P2ThumbnailElements | null;
-	plan?: Plan | SiteDetailsPlan;
+	plan?: SiteDetailsPlan;
 	products?: SiteDetailsPlan[];
 	single_user_site?: boolean;
 	site_owner?: number;

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -101,7 +101,7 @@ export interface DifmLiteSiteOptions {
 
 // is_fse_active && is_fse_eligible properties have been deprecated and removed from SiteDetails interface
 export interface SiteDetails {
-	ID: number | string;
+	ID: number;
 	URL: string;
 	capabilities: SiteDetailsCapabilities;
 	description: string;

--- a/packages/data-stores/src/support-queries/use-sibyl-query.ts
+++ b/packages/data-stores/src/support-queries/use-sibyl-query.ts
@@ -1,6 +1,6 @@
-import config from '@automattic/calypso-config';
+import { apiFetch } from '@wordpress/data-controls';
 import { useQuery } from 'react-query';
-import wpcomRequest from 'wpcom-proxy-request';
+import wpcomRequest, { canAccessWpcomApis } from 'wpcom-proxy-request';
 
 export type SupportArticleResult = {
 	id: string;
@@ -10,20 +10,29 @@ export type SupportArticleResult = {
 	link: string;
 };
 
-const wpcomSupportBlog = config( 'wpcom_support_blog' ) as string;
-const jetpackSupportBlog = config( 'jetpack_support_blog' ) as string;
+interface APIFetchOptions {
+	global: boolean;
+	path: string;
+}
 
 export function useSibylQuery( query: string, isJetpackSite: boolean, isAtomic: boolean ) {
-	const site = ! isJetpackSite || isAtomic ? wpcomSupportBlog : jetpackSupportBlog;
+	const site = ! isJetpackSite || isAtomic ? 'wpcom' : 'jpop';
 
 	return useQuery< SupportArticleResult[] >(
 		query,
 		async () =>
-			await wpcomRequest( {
-				path: '/help/qanda',
-				apiVersion: '1.1',
-				query: `query=${ encodeURIComponent( query ) }&site=${ encodeURIComponent( site ) }`,
-			} ),
+			canAccessWpcomApis()
+				? await wpcomRequest( {
+						path: 'help/sibyl',
+						apiNamespace: 'wpcom/v2/',
+						apiVersion: '2',
+						query: `query=${ encodeURIComponent( query ) }&site=${ site }`,
+				  } )
+				: ( ( await apiFetch( {
+						path: 'help-center/sibyl',
+						global: true,
+						query: `query=${ encodeURIComponent( query ) }&site=${ site }`,
+				  } as APIFetchOptions ) ) as SupportArticleResult[] ),
 		{
 			refetchOnWindowFocus: false,
 			keepPreviousData: true,

--- a/packages/data-stores/src/support-queries/use-sibyl-query.ts
+++ b/packages/data-stores/src/support-queries/use-sibyl-query.ts
@@ -1,4 +1,4 @@
-import { apiFetch } from '@wordpress/data-controls';
+import apiFetch, { APIFetchOptions } from '@wordpress/api-fetch';
 import { useQuery } from 'react-query';
 import wpcomRequest, { canAccessWpcomApis } from 'wpcom-proxy-request';
 
@@ -9,11 +9,6 @@ export type SupportArticleResult = {
 	description: string;
 	link: string;
 };
-
-interface APIFetchOptions {
-	global: boolean;
-	path: string;
-}
 
 export function useSibylQuery( query: string, isJetpackSite: boolean, isAtomic: boolean ) {
 	const site = ! isJetpackSite || isAtomic ? 'wpcom' : 'jpop';
@@ -29,9 +24,8 @@ export function useSibylQuery( query: string, isJetpackSite: boolean, isAtomic: 
 						query: `query=${ encodeURIComponent( query ) }&site=${ site }`,
 				  } )
 				: ( ( await apiFetch( {
-						path: 'help-center/sibyl',
+						path: `help-center/sibyl?query=${ encodeURIComponent( query ) }&site=${ site }`,
 						global: true,
-						query: `query=${ encodeURIComponent( query ) }&site=${ site }`,
 				  } as APIFetchOptions ) ) as SupportArticleResult[] ),
 		{
 			refetchOnWindowFocus: false,

--- a/packages/data-stores/src/support-queries/use-submit-support-ticket.ts
+++ b/packages/data-stores/src/support-queries/use-submit-support-ticket.ts
@@ -1,5 +1,6 @@
+import apiFetch, { APIFetchOptions } from '@wordpress/api-fetch';
 import { useMutation } from 'react-query';
-import wpcomRequest from 'wpcom-proxy-request';
+import wpcomRequest, { canAccessWpcomApis } from 'wpcom-proxy-request';
 
 type Ticket = {
 	subject: string;
@@ -13,11 +14,19 @@ type Ticket = {
 
 export function useSubmitTicketMutation() {
 	return useMutation( ( newTicket: Ticket ) =>
-		wpcomRequest( {
-			path: '/help/tickets/kayako/new',
-			apiVersion: '1.1',
-			method: 'POST',
-			body: newTicket,
-		} )
+		canAccessWpcomApis()
+			? wpcomRequest( {
+					path: 'help/ticket/new',
+					apiNamespace: 'wpcom/v2/',
+					apiVersion: '2',
+					method: 'POST',
+					body: newTicket,
+			  } )
+			: apiFetch( {
+					global: true,
+					path: '/help-center/ticket/new',
+					method: 'POST',
+					data: newTicket,
+			  } as APIFetchOptions )
 	);
 }

--- a/packages/data-stores/src/support-queries/use-support-availability.ts
+++ b/packages/data-stores/src/support-queries/use-support-availability.ts
@@ -1,10 +1,16 @@
+import apiFetch from '@wordpress/api-fetch';
 import { useQuery } from 'react-query';
-import wpcomRequest from 'wpcom-proxy-request';
+import wpcomRequest, { canAccessWpcomApis } from 'wpcom-proxy-request';
 import { OtherSupportAvailability, HappyChatAvailability } from './types';
 
 type ResponseType< T extends 'CHAT' | 'OTHER' > = T extends 'CHAT'
 	? HappyChatAvailability
 	: OtherSupportAvailability;
+
+interface APIFetchOptions {
+	global: boolean;
+	path: string;
+}
 
 export function useSupportAvailability< SUPPORT_TYPE extends 'CHAT' | 'OTHER' >(
 	supportType: SUPPORT_TYPE,
@@ -13,11 +19,16 @@ export function useSupportAvailability< SUPPORT_TYPE extends 'CHAT' | 'OTHER' >(
 	return useQuery< ResponseType< SUPPORT_TYPE >, typeof Error >(
 		supportType === 'OTHER' ? 'otherSupportAvailability' : 'chatSupportAvailability',
 		async () =>
-			await wpcomRequest( {
-				path: `help/eligibility/${ supportType === 'OTHER' ? 'all' : 'chat' }/mine`,
-				apiNamespace: 'wpcom/v2/',
-				apiVersion: '2',
-			} ),
+			canAccessWpcomApis()
+				? await wpcomRequest( {
+						path: `help/eligibility/${ supportType === 'OTHER' ? 'all' : 'chat' }/mine`,
+						apiNamespace: 'wpcom/v2/',
+						apiVersion: '2',
+				  } )
+				: await apiFetch( {
+						path: `help-center/support-availability/${ supportType === 'OTHER' ? 'all' : 'chat' }`,
+						global: true,
+				  } as APIFetchOptions ),
 		{
 			enabled,
 			refetchOnWindowFocus: false,

--- a/packages/data-stores/src/support-queries/use-support-availability.ts
+++ b/packages/data-stores/src/support-queries/use-support-availability.ts
@@ -14,10 +14,11 @@ interface APIFetchOptions {
 
 export function useSupportAvailability< SUPPORT_TYPE extends 'CHAT' | 'OTHER' >(
 	supportType: SUPPORT_TYPE,
+	plan: string,
 	enabled = true
 ) {
 	return useQuery< ResponseType< SUPPORT_TYPE >, typeof Error >(
-		supportType === 'OTHER' ? 'otherSupportAvailability' : 'chatSupportAvailability',
+		[ supportType === 'OTHER' ? 'otherSupportAvailability' : 'chatSupportAvailability', plan ],
 		async () =>
 			canAccessWpcomApis()
 				? await wpcomRequest( {
@@ -33,6 +34,7 @@ export function useSupportAvailability< SUPPORT_TYPE extends 'CHAT' | 'OTHER' >(
 			enabled,
 			refetchOnWindowFocus: false,
 			keepPreviousData: true,
+			staleTime: 6 * 60 * 60 * 1000, // 6 hours
 		}
 	);
 }

--- a/packages/data-stores/src/support-queries/use-support-availability.ts
+++ b/packages/data-stores/src/support-queries/use-support-availability.ts
@@ -14,11 +14,10 @@ interface APIFetchOptions {
 
 export function useSupportAvailability< SUPPORT_TYPE extends 'CHAT' | 'OTHER' >(
 	supportType: SUPPORT_TYPE,
-	plan: string,
 	enabled = true
 ) {
 	return useQuery< ResponseType< SUPPORT_TYPE >, typeof Error >(
-		[ supportType === 'OTHER' ? 'otherSupportAvailability' : 'chatSupportAvailability', plan ],
+		supportType === 'OTHER' ? 'otherSupportAvailability' : 'chatSupportAvailability',
 		async () =>
 			canAccessWpcomApis()
 				? await wpcomRequest( {

--- a/packages/happychat-connection/src/use-happychat-auth.ts
+++ b/packages/happychat-connection/src/use-happychat-auth.ts
@@ -11,20 +11,18 @@ interface APIFetchOptions {
 }
 
 export async function requestHappyChatAuth() {
-	if ( canAccessWpcomApis() ) {
-		return ( await wpcomRequest( {
-			path: '/help/authenticate/chat',
-			apiNamespace: 'wpcom/v2',
-			apiVersion: '2',
-			method: 'POST',
-		} ) ) as HappychatAuth;
-	}
-
-	return ( await apiFetch( {
-		path: '/help-center/authenticate/chat',
-		method: 'POST',
-		global: true,
-	} as APIFetchOptions ) ) as HappychatAuth;
+	return canAccessWpcomApis()
+		? ( ( await wpcomRequest( {
+				path: '/help/authenticate/chat',
+				apiNamespace: 'wpcom/v2',
+				apiVersion: '2',
+				method: 'POST',
+		  } ) ) as HappychatAuth )
+		: ( ( await apiFetch( {
+				path: '/help-center/authenticate/chat',
+				method: 'POST',
+				global: true,
+		  } as APIFetchOptions ) ) as HappychatAuth );
 }
 
 export default function useHappychatAuth( enabled = true ) {

--- a/packages/happychat-connection/src/use-happychat-auth.ts
+++ b/packages/happychat-connection/src/use-happychat-auth.ts
@@ -5,16 +5,26 @@ import type { HappychatAuth } from './types';
 
 export const happychatAuthQueryKey = 'getHappychatAuth-' + Date.now();
 
+interface APIFetchOptions {
+	global: boolean;
+	path: string;
+}
+
 export async function requestHappyChatAuth() {
-	return canAccessWpcomApis()
-		? ( ( await wpcomRequest( {
-				path: 'help/authenticate/chat',
-				apiNamespace: 'wpcom/v2/',
-				apiVersion: '2',
-		  } ) ) as HappychatAuth )
-		: ( ( await apiFetch( {
-				path: '/help-center/authenticate/chat',
-		  } ) ) as HappychatAuth );
+	if ( canAccessWpcomApis() ) {
+		return ( await wpcomRequest( {
+			path: '/help/authenticate/chat',
+			apiNamespace: 'wpcom/v2',
+			apiVersion: '2',
+			method: 'POST',
+		} ) ) as HappychatAuth;
+	}
+
+	return ( await apiFetch( {
+		path: '/help-center/authenticate/chat',
+		method: 'POST',
+		global: true,
+	} as APIFetchOptions ) ) as HappychatAuth;
 }
 
 export default function useHappychatAuth( enabled = true ) {

--- a/packages/happychat-connection/src/use-happychat-auth.ts
+++ b/packages/happychat-connection/src/use-happychat-auth.ts
@@ -1,51 +1,20 @@
+import apiFetch from '@wordpress/api-fetch';
 import { useQuery } from 'react-query';
-import wpcomRequest from 'wpcom-proxy-request';
-import type { HappychatSession, HappychatUser, User, HappychatAuth, Jwt } from './types';
+import wpcomRequest, { canAccessWpcomApis } from 'wpcom-proxy-request';
+import type { HappychatAuth } from './types';
 
 export const happychatAuthQueryKey = 'getHappychatAuth-' + Date.now();
 
 export async function requestHappyChatAuth() {
-	const user: User = await wpcomRequest( {
-		path: '/me',
-		apiVersion: '1.1',
-	} );
-
-	/**
-	 * The /happychat/session endpoint returns the right env (staging vs production) based on whether the user is proxied.
-	 *
-	 * @returns url The happychat endpoint URL based on if the connection is proxied (formerly happychat_url)
-	 * @returns session_id
-	 * @returns geo_location
-	 */
-	const { url, session_id, geo_location }: HappychatSession = await wpcomRequest( {
-		path: '/happychat/session',
-		apiVersion: '1.1',
-		method: 'POST',
-	} );
-
-	const happychatUser: HappychatUser = {
-		signer_user_id: user.ID,
-		groups: [ 'WP.com' ],
-		geoLocation: geo_location,
-		skills: {
-			product: [ 'WP.com' ],
-			language: [ user.language ],
-		},
-	};
-
-	/**
-	 * The /jwt/sign is used to sign JSON Web Token
-	 *
-	 * @returns {string} jwt JSON Web Token of signed payload
-	 */
-	const { jwt }: Jwt = await wpcomRequest( {
-		path: '/jwt/sign',
-		apiVersion: '1.1',
-		method: 'POST',
-		body: { payload: JSON.stringify( { user, session_id } ) },
-	} );
-
-	return { url, user: { jwt, ...happychatUser }, fullUser: user };
+	return canAccessWpcomApis()
+		? ( ( await wpcomRequest( {
+				path: 'help/authenticate/chat',
+				apiNamespace: 'wpcom/v2/',
+				apiVersion: '2',
+		  } ) ) as HappychatAuth )
+		: ( ( await apiFetch( {
+				path: '/help-center/authenticate/chat',
+		  } ) ) as HappychatAuth );
 }
 
 export default function useHappychatAuth( enabled = true ) {

--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -26,7 +26,7 @@ import { useSelector } from 'react-redux';
 import { useHistory, useLocation } from 'react-router-dom';
 import { useDebounce } from 'use-debounce';
 import { getCurrentUserEmail, getCurrentUserId } from 'calypso/state/current-user/selectors';
-import { getSectionName, getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { getSectionName } from 'calypso/state/ui/selectors';
 /**
  * Internal Dependencies
  */
@@ -196,8 +196,7 @@ export const HelpCenterContactForm = () => {
 
 	const formTitles = useFormTitles( mode );
 
-	const siteId = useSelector( getSelectedSiteId );
-	const currentSite = useSelect( ( select ) => select( SITE_STORE ).getSite( siteId ) );
+	const currentSite = selectedSite;
 
 	let ownershipResult: AnalysisReport = useSiteAnalysis(
 		// pass user email as query cache key
@@ -268,7 +267,7 @@ export const HelpCenterContactForm = () => {
 
 					recordTracksEvent( 'calypso_help_live_chat_begin', {
 						site_plan_product_id: supportSite ? supportSite.plan?.product_id : null,
-						is_automated_transfer: supportSite ? supportSite.options.is_automated_transfer : null,
+						is_automated_transfer: supportSite ? supportSite.options?.is_automated_transfer : null,
 						location: 'help-center',
 						section: sectionName,
 					} );

--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -254,18 +254,10 @@ export const HelpCenterContactForm = () => {
 			return;
 		}
 		const productSlug = ( supportSite as HelpCenterSite )?.plan.product_slug;
-		const {
-			productId,
-			productName,
-			productTerm,
-		}: any = () => {
-			const plan = getPlan( productSlug );
-			return {
-				productId: plan?.getProductId(),
-				productName: plan?.getTitle(),
-				productTerm: getPlanTermLabel( plan?.getTitle() as string, ( text ) => text ),
-			};
-		};
+		const plan = getPlan( productSlug );
+		const productId = plan?.getProductId();
+		const productName = plan?.getTitle();
+		const productTerm = getPlanTermLabel( productSlug, ( text ) => text );
 
 		switch ( mode ) {
 			case 'CHAT':

--- a/packages/help-center/src/components/help-center-contact-page.tsx
+++ b/packages/help-center/src/components/help-center-contact-page.tsx
@@ -111,17 +111,17 @@ export const HelpCenterContactPage: React.FC = () => {
 										</p>
 									</div>
 								</div>
-								{ renderChat.env === 'staging' && (
-									<Notice
-										status="warning"
-										actions={ [ { label: 'HUD', url: 'https://hud-staging.happychat.io/' } ] }
-										className="help-center-contact-page__staging-notice"
-										isDismissible={ false }
-									>
-										Using HappyChat staging
-									</Notice>
-								) }
 							</ConditionalLink>
+							{ renderChat.env === 'staging' && (
+								<Notice
+									status="warning"
+									actions={ [ { label: 'HUD', url: 'https://hud-staging.happychat.io/' } ] }
+									className="help-center-contact-page__staging-notice"
+									isDismissible={ false }
+								>
+									Using HappyChat staging
+								</Notice>
+							) }
 						</div>
 					) }
 

--- a/packages/help-center/src/components/help-center-sibyl-articles.tsx
+++ b/packages/help-center/src/components/help-center-sibyl-articles.tsx
@@ -8,9 +8,9 @@ import {
 	getContextResults,
 	RESULT_TOUR,
 	RESULT_VIDEO,
+	HelpCenterSite,
 } from '@automattic/data-stores';
 import { useLocale } from '@automattic/i18n-utils';
-import { useSelect } from '@wordpress/data';
 import { external, Icon, page } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { useMemo } from 'react';
@@ -25,7 +25,7 @@ export const SITE_STORE = 'automattic/site' as const;
 type Props = {
 	title?: string;
 	message?: string;
-	supportSite?: SiteDetails;
+	supportSite?: SiteDetails | HelpCenterSite;
 	articleCanNavigateBack?: boolean;
 };
 
@@ -95,12 +95,8 @@ export function SibylArticles( {
 	const { __ } = useI18n();
 	const locale = useLocale();
 
-	const isAtomic = Boolean(
-		useSelect( ( select ) => supportSite && select( SITE_STORE ).isSiteAtomic( supportSite?.ID ) )
-	);
-	const isJetpack = Boolean(
-		useSelect( ( select ) => select( SITE_STORE ).isJetpackSite( supportSite?.ID ) )
-	);
+	const isAtomic = Boolean( supportSite?.is_wpcom_atomic );
+	const isJetpack = Boolean( supportSite?.jetpack );
 
 	const [ debouncedMessage ] = useDebounce( message || '', 500 );
 

--- a/packages/help-center/src/components/help-center-sibyl-articles.tsx
+++ b/packages/help-center/src/components/help-center-sibyl-articles.tsx
@@ -101,7 +101,6 @@ export function SibylArticles( {
 	const [ debouncedMessage ] = useDebounce( message || '', 500 );
 
 	const { data: sibylArticles } = useSibylQuery( debouncedMessage, isJetpack, isAtomic );
-
 	const { data: intent } = useSiteIntent( supportSite?.ID );
 
 	const sectionName = useSelector( getSectionName );

--- a/packages/help-center/src/components/help-center.tsx
+++ b/packages/help-center/src/components/help-center.tsx
@@ -8,14 +8,13 @@ import { useHappychatAvailable } from '@automattic/happychat-connection';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { createPortal, useEffect, useRef } from '@wordpress/element';
 import { useSelector } from 'react-redux';
-import getIsSimpleSite from 'calypso/state/sites/selectors/is-simple-site';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 /**
  * Internal Dependencies
  */
 import { useHCWindowCommunicator } from '../happychat-window-communicator';
 import { useStillNeedHelpURL } from '../hooks/use-still-need-help-url';
-import { HELP_CENTER_STORE, USER_STORE } from '../stores';
+import { HELP_CENTER_STORE, USER_STORE, SITE_STORE } from '../stores';
 import { Container } from '../types';
 import HelpCenterContainer from './help-center-container';
 
@@ -46,17 +45,16 @@ const HelpCenter: React.FC< Container > = ( { handleClose, hidden } ) => {
 		}
 	}, [ data, setShowHelpCenter ] );
 
-	const { isSimpleSite } = useSelector( ( state ) => {
-		return {
-			siteId: getSelectedSiteId( state ),
-			isSimpleSite: getIsSimpleSite( state ),
-		};
-	} );
+	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
 
-	// prefetch the current site and user
-	setSite( window.helpCenterData.currentSite );
 	useSelect( ( select ) => select( USER_STORE ).getCurrentUser() );
-	useSupportAvailability( 'CHAT', isSimpleSite );
+
+	const currentSite = window?.helpCenterData?.currentSite;
+	const site = useSelect( ( select ) => select( SITE_STORE ).getSite( siteId ) );
+
+	setSite( currentSite ? currentSite : site );
+	useSupportAvailability( 'CHAT' );
+
 	useStillNeedHelpURL();
 
 	useEffect( () => {

--- a/packages/help-center/src/components/help-center.tsx
+++ b/packages/help-center/src/components/help-center.tsx
@@ -17,7 +17,6 @@ import { useHCWindowCommunicator } from '../happychat-window-communicator';
 import { useStillNeedHelpURL } from '../hooks/use-still-need-help-url';
 import { HELP_CENTER_STORE, USER_STORE } from '../stores';
 import { Container } from '../types';
-import { SITE_STORE } from './help-center-contact-form';
 import HelpCenterContainer from './help-center-container';
 
 import '../styles.scss';
@@ -28,6 +27,7 @@ const HelpCenter: React.FC< Container > = ( { handleClose, hidden } ) => {
 	const { data } = useHappychatAvailable( Boolean( chatStatus?.is_user_eligible ) );
 	const { setShowHelpCenter } = useDispatch( HELP_CENTER_STORE );
 	const { setUnreadCount } = useDispatch( HELP_CENTER_STORE );
+	const { setSite } = useDispatch( HELP_CENTER_STORE );
 
 	const { show, isMinimized } = useSelect( ( select ) => ( {
 		isMinimized: select( HELP_CENTER_STORE ).getIsMinimized(),
@@ -46,7 +46,7 @@ const HelpCenter: React.FC< Container > = ( { handleClose, hidden } ) => {
 		}
 	}, [ data, setShowHelpCenter ] );
 
-	const { siteId, isSimpleSite } = useSelector( ( state ) => {
+	const { isSimpleSite } = useSelector( ( state ) => {
 		return {
 			siteId: getSelectedSiteId( state ),
 			isSimpleSite: getIsSimpleSite( state ),
@@ -54,7 +54,7 @@ const HelpCenter: React.FC< Container > = ( { handleClose, hidden } ) => {
 	} );
 
 	// prefetch the current site and user
-	useSelect( ( select ) => select( SITE_STORE ).getSite( siteId ) );
+	setSite( window.helpCenterData.currentSite );
 	useSelect( ( select ) => select( USER_STORE ).getCurrentUser() );
 	useSupportAvailability( 'CHAT', isSimpleSite );
 	useStillNeedHelpURL();

--- a/packages/help-center/src/components/types.d.ts
+++ b/packages/help-center/src/components/types.d.ts
@@ -1,2 +1,5 @@
 // context here: https://wp.me/pbAok1-1Ao
 declare const __i18n_text_domain__: string;
+interface Window {
+	helpCenterData: any;
+}

--- a/packages/help-center/src/happychat-window-communicator.ts
+++ b/packages/help-center/src/happychat-window-communicator.ts
@@ -6,12 +6,10 @@ import { useHappychatAuth, happychatAuthQueryKey } from '@automattic/happychat-c
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect, useState } from '@wordpress/element';
 import { useQueryClient } from 'react-query';
-import { useSelector } from 'react-redux';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 /**
  * Internal Dependencies
  */
-import { HELP_CENTER_STORE, SITE_STORE } from './stores';
+import { HELP_CENTER_STORE } from './stores';
 
 /**
  * This hook is the bridge between HappyChat and Help Center.
@@ -23,10 +21,9 @@ import { HELP_CENTER_STORE, SITE_STORE } from './stores';
  */
 
 export function useHCWindowCommunicator( isMinimized: boolean ) {
-	const { selectedSite, subject, message, userDeclaredSite, iframe } = useSelect( ( select ) => {
+	const { supportSite, subject, message, iframe } = useSelect( ( select ) => {
 		return {
-			selectedSite: select( HELP_CENTER_STORE ).getSite(),
-			userDeclaredSite: select( HELP_CENTER_STORE ).getUserDeclaredSite(),
+			supportSite: select( HELP_CENTER_STORE ).getSite(),
 			subject: select( HELP_CENTER_STORE ).getSubject(),
 			message: select( HELP_CENTER_STORE ).getMessage(),
 			iframe: select( HELP_CENTER_STORE ).getIframe(),
@@ -35,14 +32,11 @@ export function useHCWindowCommunicator( isMinimized: boolean ) {
 	const queryClient = useQueryClient();
 	const [ unreadCount, setUnreadCount ] = useState( 0 );
 	const [ chatStatus, setChatStatus ] = useState( '' );
-	const siteId = useSelector( getSelectedSiteId );
-	const currentSite = useSelect( ( select ) => select( SITE_STORE ).getSite( siteId ), [ siteId ] );
 	const chatWindow = iframe?.contentWindow;
 	function happyChatPostMessage( message: Record< string, string > ) {
 		chatWindow?.postMessage( message, '*' );
 	}
 
-	const supportSite = selectedSite || userDeclaredSite || currentSite;
 	const { resetStore } = useDispatch( HELP_CENTER_STORE );
 	useHappychatAuth();
 

--- a/packages/help-center/src/hooks/use-help-search-query.ts
+++ b/packages/help-center/src/hooks/use-help-search-query.ts
@@ -30,7 +30,7 @@ export const useHelpSearchQuery = (
 				  } as APIFetchOptions ),
 		{
 			onSuccess: async ( data ) => {
-				if ( ! data[ 0 ].content ) {
+				if ( ! data[ 0 ]?.content ) {
 					const newData = await Promise.all(
 						data.map( async ( result: SearchResult ) => {
 							const article: { [ content: string ]: string } = canAccessWpcomApis()

--- a/packages/help-center/src/hooks/use-still-need-help-url.tsx
+++ b/packages/help-center/src/hooks/use-still-need-help-url.tsx
@@ -1,20 +1,12 @@
 /* eslint-disable no-restricted-imports */
 import { useSupportAvailability } from '@automattic/data-stores';
-import { canAccessWpcomApis } from 'wpcom-proxy-request';
 
 export function useStillNeedHelpURL() {
-	const { data: supportAvailability, isLoading } = useSupportAvailability(
-		'OTHER',
-		canAccessWpcomApis()
-	);
+	const { data: supportAvailability, isLoading } = useSupportAvailability( 'OTHER' );
 
 	// email support is available for all non-free users, let's use it as a proxy for free users
 	// TODO: check purchases instead
 	const isFreeUser = ! supportAvailability?.is_user_eligible_for_tickets;
-
-	if ( ! canAccessWpcomApis() ) {
-		return { url: 'https://wordpress.com/help/contact', isLoading };
-	}
 
 	if ( ! isFreeUser ) {
 		return { url: '/contact-options', isLoading };

--- a/packages/help-center/src/types.ts
+++ b/packages/help-center/src/types.ts
@@ -14,6 +14,7 @@ export interface Header {
 	onMaximize?: () => void;
 	onDismiss: () => void;
 }
+
 export interface SitePicker {
 	currentSite: SiteDetails | undefined;
 	onSelect: ( siteId: number | string ) => void;

--- a/packages/help-center/src/types.ts
+++ b/packages/help-center/src/types.ts
@@ -1,4 +1,4 @@
-import type { SiteDetails } from '@automattic/data-stores';
+import type { HelpCenterSite } from '@automattic/data-stores';
 import type { ReactElement } from 'react';
 
 export interface Container {
@@ -16,7 +16,7 @@ export interface Header {
 }
 
 export interface SitePicker {
-	currentSite: SiteDetails | undefined;
+	currentSite: HelpCenterSite | undefined;
 	onSelect: ( siteId: number | string ) => void;
 	siteId: string | number | null | undefined;
 	enabled: boolean;

--- a/packages/site-picker/src/index.tsx
+++ b/packages/site-picker/src/index.tsx
@@ -18,7 +18,7 @@ type ItemProps = {
 	mainItem?: boolean;
 	selected?: boolean;
 	onKeyDown?: React.KeyboardEventHandler< HTMLButtonElement >;
-	logo: { id: string; sizes: string[]; url: string } | undefined;
+	logo: SitePickerSite[ 'logo' ] | undefined;
 	id: string;
 	enabled?: boolean;
 };
@@ -67,16 +67,16 @@ const SitePickerItem: FC< ItemProps > = ( {
 };
 
 export type SitePickerSite = {
-	ID: number;
+	ID: number | string;
 	URL: string;
 	name: string | undefined;
-	logo: { id: string; sizes: string[]; url: string };
+	logo: { id: string | number; sizes: never[]; url: string };
 };
 
 export type Props = {
 	siteId: string | number | undefined | null;
 	options: ( SitePickerSite | undefined )[];
-	onPickSite: ( siteId: number ) => void;
+	onPickSite: ( siteId: number | string ) => void;
 	enabled: boolean;
 };
 


### PR DESCRIPTION
## Summary

This extends Help Center to be fully available in Atomic sites. We have extended the APIs to use the Jetpack built proxy request when the site does not have the ability to make requests directly to wpcom.

The big change was with the happychat auth signing. We combined all three requests for the authentication into a single new v2 API endpoint. This helps speed things up and allows us to use the Jetpack proxy as mentioned above.

## Testing

#### Steps

1. If you don't have one already, create a WoA site and make sure it is transferred to the Dev Pool - mission-control ⇢ /atomic/wpcom-dev-blogs/
2. Add the define to the wp-config.php of your dev site - `define( 'JETPACK__SANDBOX_DOMAIN', 'YOUR_SANDBOX_URL' );`
3. Deactivate Editing Toolkit but DONT delete it
4. [Upload the ETK plugin generated from TC](https://teamcity.a8c.com/repository/download/calypso_WPComPlugins_EditorToolKit/8916541:id/editing-toolkit.zip)

*Because the request is not being made through the proxy you will see the live Happychat not staging.*

Fixes #68583