### PR TITLE
Translate label and description of the Featured image email toggle

### DIFF
--- a/client/my-sites/site-settings/featured-image-toggle.jsx
+++ b/client/my-sites/site-settings/featured-image-toggle.jsx
@@ -1,9 +1,11 @@
 import { Card } from '@automattic/components';
 import { ToggleControl } from '@wordpress/components';
+import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
 
 const FeaturedImageTemplateToggle = ( props ) => {
-	const { isRequestingSettings, isSavingSettings, fields, handleAutosavingToggle } = props;
+	const { isRequestingSettings, isSavingSettings, fields, handleAutosavingToggle, translate } =
+		props;
 	const isDisabled = isRequestingSettings || isSavingSettings;
 	const settingName = 'featured_image_email_enabled';
 
@@ -11,19 +13,23 @@ const FeaturedImageTemplateToggle = ( props ) => {
 		<div className="featured-image-template-toggle-settings">
 			<SettingsSectionHeader
 				id="featured-image-template-toggle-header"
-				title="Featured Image" /* TODO: this will need to be translated */
+				title={ translate( 'Featured image' ) }
 			/>
 			<Card className="featured-image-template-toggle-card">
-				<ToggleControl /* TODO: Update props as needed. Currently the toggle does nothing */
+				<ToggleControl
 					checked={ !! fields[ settingName ] }
 					disabled={ isDisabled }
 					onChange={ handleAutosavingToggle( settingName ) }
-					label="Enable Featured image in the New Post email template" /* TODO: this will need to be translated */
+					label={ translate( 'Enable featured image on your new post emails' ) }
 				/>
+				<FormSettingExplanation>
+					{ translate(
+						"Includes your post's featured image in the email sent out to your readers."
+					) }
+				</FormSettingExplanation>
 			</Card>
 		</div>
 	);
 };
 
-/* TODO: connect export */
 export default FeaturedImageTemplateToggle;

--- a/client/my-sites/site-settings/form-writing.jsx
+++ b/client/my-sites/site-settings/form-writing.jsx
@@ -105,6 +105,7 @@ class SiteSettingsFormWriting extends Component {
 						isRequestingSettings={ isRequestingSettings }
 						handleAutosavingToggle={ handleAutosavingToggle }
 						fields={ fields }
+						translate={ translate }
 					/>
 				) }
 


### PR DESCRIPTION
#### Proposed Changes

The proposed changes update the copy of the Featured image email toggle to match the intended design (wdlTywgHNsHnVw1IMre1eQ-fi-221%3A4703).

The PR also encapsulates the strings in `translate` function so they can be sent for translation.

Before:
![Markup on 2022-10-28 at 10:18:22](https://user-images.githubusercontent.com/25105483/198550182-c0be6349-77bd-4b23-b31e-3b6ae1b2c75f.png)

After:
![Markup on 2022-10-28 at 10:29:37](https://user-images.githubusercontent.com/25105483/198550217-56fee0a2-3e84-473e-9073-a4117f32aed4.png)

The toggle is hidden behind a feature flag and not available in production yet. This means that the PR can be merged even before the translations are ready.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Navigate to _Settings → Writing_ in your Calypso development environment.
2. Review the Featured image toggle. It should match the intended design (wdlTywgHNsHnVw1IMre1eQ-fi-221%3A4703).
3. There should be no change to the toggle functionality - it should work as before.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #69554 