### PR TITLE
Domains: Update / add focus styles and address tabbing behaviour for a11y

### DIFF
--- a/client/components/breadcrumb/index.tsx
+++ b/client/components/breadcrumb/index.tsx
@@ -68,6 +68,9 @@ const HelpBuble = styled( InfoPopover )`
 	& .gridicon {
 		color: var( --studio-gray-30 );
 	}
+	&:focus {
+		outline: thin dotted;
+	}
 `;
 
 const renderHelpBubble = ( item: Item ) => {

--- a/client/my-sites/domains/domain-management/list/domain-row.scss
+++ b/client/my-sites/domains/domain-management/list/domain-row.scss
@@ -196,9 +196,7 @@
 	}
 
 	.domain-row__domain-name {
-		overflow: hidden;
-		text-overflow: ellipsis;
-		white-space: nowrap;
+		padding: 1px;
 		font-size: $font-body;
 		font-weight: 500;
 
@@ -206,9 +204,13 @@
 			color: var(--studio-gray-90);
 			cursor: pointer;
 			font-weight: 500;
-		}
-		button:hover {
-			color: var(--color-link);
+			button:hover {
+				color: var(--color-link);
+			}
+
+			&:focus {
+				outline: thin dotted;
+			}
 		}
 
 		@include break-mobile {

--- a/client/my-sites/domains/domain-management/list/domain-row.scss
+++ b/client/my-sites/domains/domain-management/list/domain-row.scss
@@ -73,9 +73,9 @@
 
 .domain-row__mobile-container {
 	flex: 233 233 0;
-	overflow: hidden;
 	display: flex;
 	flex-basis: 100%;
+	max-width: 100%;
 }
 
 .domain-row__mobile-container2 {
@@ -204,7 +204,12 @@
 			color: var(--studio-gray-90);
 			cursor: pointer;
 			font-weight: 500;
-			button:hover {
+			text-overflow: ellipsis;
+			overflow: hidden;
+			white-space: nowrap;
+			max-width: 100%;
+
+			&:hover {
 				color: var(--color-link);
 			}
 

--- a/client/my-sites/domains/domain-management/list/domains-table-header.jsx
+++ b/client/my-sites/domains/domain-management/list/domains-table-header.jsx
@@ -130,6 +130,7 @@ class DomainsTableHeader extends PureComponent {
 								'is-sortable': column?.isSortable,
 							} ) }
 							data-column={ column.name }
+							tabindex={ column.label ? 0 : -1 }
 						>
 							{ column.label }{ ' ' }
 							{ column.bubble > 0 && (

--- a/client/my-sites/domains/domain-management/list/domains-table-header.jsx
+++ b/client/my-sites/domains/domain-management/list/domains-table-header.jsx
@@ -130,7 +130,7 @@ class DomainsTableHeader extends PureComponent {
 								'is-sortable': column?.isSortable,
 							} ) }
 							data-column={ column.name }
-							tabindex={ column.label ? 0 : -1 }
+							tabindex={ column?.isSortable ? 0 : -1 }
 						>
 							{ column.label }{ ' ' }
 							{ column.bubble > 0 && (

--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -215,6 +215,10 @@
 
 	.button-plain {
 		text-align: left;
+
+		&:focus {
+			outline: thin dotted;
+		}
 	}
 
 	.list__header-column {


### PR DESCRIPTION
#### Proposed Changes

* Fixes:
  - Inconsistent and cutoff focus styles
  - Losing focus indicator while tabbing through the experience
  - Tabbing to button with no content (no label)
  - Very long domain name not overflowing with text ellipsis

#### Testing Instructions

1. Ensure at least one of your sites has a custom domain, then go to Domains management page and tab through the page to observe current behaviour. https://wordpress.com/domains/manage
2. Checkout locally and navigate to Domains management page http://calypso.localhost:3000/domains/manage, then confirm:
    1. A thin dotted line appears for
        - Help Icon Button
        - Table’s column headers
        - Domain name
    2. Tab and focus indicator goes directly from email to domain name
    3. Domain name and three-dots icon button do not have their focus indicators cut off 
3. Open DevTools and modify your domain name to be something really, really, really long. The domain name should now be clipped with an ellipsis. Shrink and expand the browser to confirm that content is still responsive.


https://user-images.githubusercontent.com/102400653/198090983-29a68cdc-5934-48f2-a26c-0c491fbd9584.mp4


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?


Related to [Issue: Domain options 3 dots icon is difficult for accessibility and easy to misclick #56230](https://github.com/Automattic/wp-calypso/issues/56230)
