### PR TITLE
Revert "Update mentions of "site stats" with "Jetpack Stats" (#69457)"

### DIFF
--- a/client/blocks/disconnect-jetpack/index.jsx
+++ b/client/blocks/disconnect-jetpack/index.jsx
@@ -131,7 +131,7 @@ class DisconnectJetpack extends PureComponent {
 
 		features.push(
 			translate(
-				'{{icon/}} Jetpack Stats, related content, and sharing tools',
+				'{{icon/}} Site stats, related content, and sharing tools',
 				this.getIcon( 'stats-alt' )
 			)
 		);

--- a/client/blocks/jetpack-benefits/site-visits.tsx
+++ b/client/blocks/jetpack-benefits/site-visits.tsx
@@ -42,7 +42,7 @@ const JetpackBenefitsSiteVisits: React.FC< Props > = ( { siteId, statType, query
 	if ( isRequestingStats ) {
 		return (
 			<JetpackBenefitsCard
-				headline={ translate( 'Jetpack Stats' ) }
+				headline={ translate( 'Site Stats' ) }
 				stat={ translate( 'Loading' ) }
 				description={ translate( 'Getting visitors stat' ) }
 				placeholder={ true }
@@ -58,7 +58,7 @@ const JetpackBenefitsSiteVisits: React.FC< Props > = ( { siteId, statType, query
 	return (
 		<React.Fragment>
 			<JetpackBenefitsCard
-				headline={ translate( 'Jetpack Stats' ) }
+				headline={ translate( 'Site Stats' ) }
 				stat={ countVisits > 0 ? countVisits : null }
 				description={
 					countVisits > 0

--- a/client/lib/plans/features-list.js
+++ b/client/lib/plans/features-list.js
@@ -831,7 +831,7 @@ export const FEATURES_LIST = {
 	},
 	[ FEATURE_SITE_STATS ]: {
 		getSlug: () => FEATURE_SITE_STATS,
-		getTitle: () => i18n.translate( 'Jetpack Stats' ),
+		getTitle: () => i18n.translate( 'Site Stats and Analytics' ),
 		getDescription: () => i18n.translate( 'The most important metrics for your site.' ),
 	},
 	[ FEATURE_TRAFFIC_TOOLS ]: {

--- a/client/my-sites/plans/jetpack-plans/jetpack-free-card/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/jetpack-free-card/index.tsx
@@ -22,7 +22,7 @@ const useFreeItem = (): SelectorProduct => {
 			features: {
 				items: [
 					{ slug: 'not used', text: translate( 'Brute force attack protection' ) },
-					{ slug: 'not used', text: translate( 'Jetpack Stats' ) },
+					{ slug: 'not used', text: translate( 'Site stats' ) },
 					{ slug: 'not used', text: translate( 'Content Delivery Network' ) },
 					{ slug: 'not used', text: translate( 'Downtime monitoring' ) },
 					{ slug: 'not used', text: translate( 'Related posts' ) },

--- a/client/my-sites/site-settings/jetpack-site-stats.jsx
+++ b/client/my-sites/site-settings/jetpack-site-stats.jsx
@@ -118,7 +118,7 @@ class JetpackSiteStats extends Component {
 			<div className="site-settings__traffic-settings">
 				<QueryJetpackConnection siteId={ siteId } />
 
-				<SettingsSectionHeader title={ translate( 'Jetpack Stats' ) } />
+				<SettingsSectionHeader title={ translate( 'Site stats' ) } />
 
 				<FoldableCard
 					className="site-settings__foldable-card is-top-level"

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -335,9 +335,9 @@ class StatsSite extends Component {
 				illustration="/calypso/images/illustrations/illustration-404.svg"
 				title={ translate( 'Looking for stats?' ) }
 				line={ translate(
-					'Enable Jetpack Stats to see detailed information about your traffic, likes, comments, and subscribers.'
+					'Enable site stats to see detailed information about your traffic, likes, comments, and subscribers.'
 				) }
-				action={ translate( 'Enable Jetpack Stats' ) }
+				action={ translate( 'Enable Site Stats' ) }
 				actionCallback={ this.enableStatsModule }
 			/>
 		);


### PR DESCRIPTION
This reverts commit ba131a327bbb3e33f75048c89582c8aba58db92e as suggested by @niranjan-uma-shankar [here](https://github.com/Automattic/wp-calypso/pull/69457#issuecomment-1291917787).
<!--
#### Proposed Changes

*
-->
#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure that the text changes look reasonable.

<!--
#### Pre-merge Checklist
-->
<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->
<!--
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
-->
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
<!--
Related to #
-->