### PR TITLE
Simplify and fix the onClose handler when creating a campaign

### DIFF
--- a/client/components/blazepress-widget/index.tsx
+++ b/client/components/blazepress-widget/index.tsx
@@ -3,19 +3,23 @@ import { Dialog } from '@automattic/components';
 import { TranslateOptionsText, useTranslate } from 'i18n-calypso';
 import page from 'page';
 import { useEffect, useRef, useState } from 'react';
+import { useQueryClient } from 'react-query';
 import { useSelector } from 'react-redux';
 import { BlankCanvas } from 'calypso/components/blank-canvas';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import WordPressLogo from 'calypso/components/wordpress-logo';
 import { showDSP, usePromoteWidget, PromoteWidgetStatus } from 'calypso/lib/promote-post';
 import './style.scss';
-import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import { useRouteModal } from 'calypso/lib/route-modal';
+import getPreviousRoute from 'calypso/state/selectors/get-previous-route';
+import { getSiteSlug } from 'calypso/state/sites/selectors';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 
 export type BlazePressPromotionProps = {
 	isVisible: boolean;
 	siteId: string | number;
 	postId: string | number;
-	onClose: () => void;
+	keyValue: string;
 };
 
 type BlazePressTranslatable = ( original: string, extra?: TranslateOptionsText ) => string;
@@ -26,14 +30,19 @@ export function goToOriginalEndpoint() {
 }
 
 const BlazePressWidget = ( props: BlazePressPromotionProps ) => {
-	// eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function
-	const { isVisible = false, onClose = () => {} } = props;
+	// eslint-disable-next-line @typescript-eslint/no-empty-function
+	const { isVisible = false, keyValue, siteId } = props;
 	const [ isLoading, setIsLoading ] = useState( true );
 	const [ showCancelDialog, setShowCancelDialog ] = useState( false );
 	const [ showCancelButton, setShowCancelButton ] = useState( true );
 	const widgetContainer = useRef< HTMLDivElement >( null );
 	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
 	const translate = useTranslate() as BlazePressTranslatable;
+	const previousRoute = useSelector( getPreviousRoute );
+	const selectedSiteId = useSelector( getSelectedSiteId );
+	const siteSlug = useSelector( ( state ) => getSiteSlug( state, selectedSiteId ) );
+	const { closeModal } = useRouteModal( 'blazepress-widget', keyValue );
+	const queryClient = useQueryClient();
 
 	// Scroll to top on initial load regardless of previous page position
 	useEffect( () => {
@@ -43,6 +52,19 @@ const BlazePressWidget = ( props: BlazePressPromotionProps ) => {
 	}, [ isVisible ] );
 
 	const handleShowCancel = ( show: boolean ) => setShowCancelButton( show );
+
+	const onClose = ( goToCampaigns?: boolean ) => {
+		if ( goToCampaigns ) {
+			page( `/advertising/${ siteSlug }/campaigns` );
+		} else {
+			queryClient && queryClient.invalidateQueries( [ 'promote-post-campaigns', siteId ] );
+			if ( previousRoute ) {
+				closeModal();
+			} else {
+				goToOriginalEndpoint();
+			}
+		}
+	};
 
 	useEffect( () => {
 		isVisible &&

--- a/client/my-sites/pages/page/page-ellipsis-menu-wrapper.js
+++ b/client/my-sites/pages/page/page-ellipsis-menu-wrapper.js
@@ -1,16 +1,12 @@
-import { useQueryClient } from 'react-query';
 import { useSelector } from 'react-redux';
-import BlazePressWidget, { goToOriginalEndpoint } from 'calypso/components/blazepress-widget';
+import BlazePressWidget from 'calypso/components/blazepress-widget';
 import { useRouteModal } from 'calypso/lib/route-modal';
 import { getPost } from 'calypso/state/posts/selectors';
-import getPreviousRoute from 'calypso/state/selectors/get-previous-route';
 
 const PageEllipsisMenuWrapper = ( { children, globalId } ) => {
 	const keyValue = globalId;
-	const { isModalOpen, value, closeModal } = useRouteModal( 'blazepress-widget', keyValue );
+	const { isModalOpen, value } = useRouteModal( 'blazepress-widget', keyValue );
 	const post = useSelector( ( state ) => getPost( state, globalId ) );
-	const { queryClient } = useQueryClient();
-	const previousRoute = useSelector( getPreviousRoute );
 
 	return (
 		<>
@@ -19,15 +15,7 @@ const PageEllipsisMenuWrapper = ( { children, globalId } ) => {
 					isVisible={ isModalOpen && value === keyValue }
 					siteId={ post.site_ID }
 					postId={ post.ID }
-					onClose={ () => {
-						queryClient &&
-							queryClient.invalidateQueries( [ 'promote-post-campaigns', post.site_ID ] );
-						if ( previousRoute ) {
-							closeModal();
-						} else {
-							goToOriginalEndpoint();
-						}
-					} }
+					keyValue={ globalId }
 				/>
 			) }
 			{ children }

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/index.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/index.jsx
@@ -1,15 +1,11 @@
 import PropTypes from 'prop-types';
 import { Children, cloneElement } from 'react';
-import { useQueryClient } from 'react-query';
 import { useSelector } from 'react-redux';
-import BlazePressWidget, { goToOriginalEndpoint } from 'calypso/components/blazepress-widget';
+import BlazePressWidget from 'calypso/components/blazepress-widget';
 import EllipsisMenu from 'calypso/components/ellipsis-menu';
 import PopoverMenuSeparator from 'calypso/components/popover-menu/separator';
 import { useRouteModal } from 'calypso/lib/route-modal';
 import { getPost } from 'calypso/state/posts/selectors';
-import getPreviousRoute from 'calypso/state/selectors/get-previous-route';
-import { getSiteSlug } from 'calypso/state/sites/selectors';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import PostActionsEllipsisMenuComments from './comments';
 import PostActionsEllipsisMenuCopyLink from './copy-link';
 import PostActionsEllipsisMenuDuplicate from './duplicate';
@@ -27,12 +23,8 @@ export default function PostActionsEllipsisMenu( { globalId, includeDefaultActio
 	let actions = [];
 
 	const keyValue = globalId;
-	const { isModalOpen, value, closeModal } = useRouteModal( 'blazepress-widget', keyValue );
+	const { isModalOpen, value } = useRouteModal( 'blazepress-widget', keyValue );
 	const post = useSelector( ( state ) => getPost( state, globalId ) );
-	const queryClient = useQueryClient();
-	const selectedSiteId = useSelector( getSelectedSiteId );
-	const siteSlug = useSelector( ( state ) => getSiteSlug( state, selectedSiteId ) );
-	const previousRoute = useSelector( getPreviousRoute );
 
 	if ( includeDefaultActions ) {
 		actions.push(
@@ -66,15 +58,6 @@ export default function PostActionsEllipsisMenu( { globalId, includeDefaultActio
 					isVisible={ isModalOpen && value === keyValue }
 					siteId={ post.site_ID }
 					postId={ post.ID }
-					onClose={ () => {
-						queryClient &&
-							queryClient.invalidateQueries( [ 'promote-post-campaigns', post.site_ID ] );
-						if ( previousRoute ) {
-							closeModal();
-						} else if ( siteSlug ) {
-							goToOriginalEndpoint();
-						}
-					} }
 				/>
 			) }
 			<EllipsisMenu position="bottom left" disabled={ ! globalId }>

--- a/client/my-sites/promote-post/components/campaign-item/style.scss
+++ b/client/my-sites/promote-post/components/campaign-item/style.scss
@@ -101,7 +101,6 @@
 
 		.campaign-item__target-value a {
 			word-break: break-all;
-			color: var(--color-text);
 		}
 	}
 

--- a/client/my-sites/promote-post/components/post-item/index.tsx
+++ b/client/my-sites/promote-post/components/post-item/index.tsx
@@ -3,18 +3,14 @@ import { CompactCard, Gridicon } from '@automattic/components';
 import './style.scss';
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import page from 'page';
 import { useState } from 'react';
-import { useQueryClient } from 'react-query';
-import { useDispatch, useSelector } from 'react-redux';
-import BlazePressWidget, { goToOriginalEndpoint } from 'calypso/components/blazepress-widget';
+import { useDispatch } from 'react-redux';
+import BlazePressWidget from 'calypso/components/blazepress-widget';
 import { recordDSPEntryPoint } from 'calypso/lib/promote-post';
 import resizeImageUrl from 'calypso/lib/resize-image-url';
 import { useRouteModal } from 'calypso/lib/route-modal';
 import PostRelativeTimeStatus from 'calypso/my-sites/post-relative-time-status';
 import { getPostType } from 'calypso/my-sites/promote-post/utils';
-import getPreviousRoute from 'calypso/state/selectors/get-previous-route';
-import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 
 export type Post = {
 	ID: number;
@@ -37,29 +33,10 @@ type Props = {
 };
 
 export default function PostItem( { post }: Props ) {
-	const [ loading, setLoading ] = useState( false );
+	const [ loading ] = useState( false );
 	const dispatch = useDispatch();
-	const queryClient = useQueryClient();
-	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
 	const keyValue = 'post-' + post.ID;
-	const { isModalOpen, value, openModal, closeModal } = useRouteModal(
-		'blazepress-widget',
-		keyValue
-	);
-
-	const previousRoute = useSelector( getPreviousRoute );
-
-	const onCloseWidget = ( redirectToCampaigns?: boolean ) => {
-		queryClient.invalidateQueries( [ 'promote-post-campaigns', post.site_ID ] );
-		setLoading( false );
-		if ( redirectToCampaigns ) {
-			page( `/advertising/${ selectedSiteSlug }/campaigns` );
-		} else if ( previousRoute ) {
-			closeModal();
-		} else {
-			goToOriginalEndpoint();
-		}
-	};
+	const { isModalOpen, value, openModal } = useRouteModal( 'blazepress-widget', keyValue );
 
 	const onClickPromote = async () => {
 		openModal();
@@ -108,7 +85,7 @@ export default function PostItem( { post }: Props ) {
 					isVisible={ isModalOpen && value === keyValue }
 					siteId={ post.site_ID }
 					postId={ post.ID }
-					onClose={ onCloseWidget }
+					keyValue={ keyValue }
 				/>
 				<Button
 					isPrimary={ true }

--- a/client/my-sites/stats/stats-list/action-promote.jsx
+++ b/client/my-sites/stats/stats-list/action-promote.jsx
@@ -1,8 +1,7 @@
 import { Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import { useQueryClient } from 'react-query';
 import { useSelector, useDispatch } from 'react-redux';
-import BlazePressWidget, { goToOriginalEndpoint } from 'calypso/components/blazepress-widget';
+import BlazePressWidget from 'calypso/components/blazepress-widget';
 import { gaRecordEvent } from 'calypso/lib/analytics/ga';
 import {
 	recordDSPEntryPoint,
@@ -10,7 +9,6 @@ import {
 	PromoteWidgetStatus,
 } from 'calypso/lib/promote-post';
 import { useRouteModal } from 'calypso/lib/route-modal';
-import getPreviousRoute from 'calypso/state/selectors/get-previous-route';
 import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 const PromotePost = ( props ) => {
@@ -18,16 +16,11 @@ const PromotePost = ( props ) => {
 
 	const translate = useTranslate();
 	const dispatch = useDispatch();
-	const queryClient = useQueryClient();
 
 	const keyValue = 'post-' + postId;
-	const { isModalOpen, value, openModal, closeModal } = useRouteModal(
-		'blazepress-widget',
-		keyValue
-	);
+	const { isModalOpen, value, openModal } = useRouteModal( 'blazepress-widget', keyValue );
 
 	const selectedSiteId = useSelector( getSelectedSiteId );
-	const previousRoute = useSelector( getPreviousRoute );
 
 	const site = useSelector( getSelectedSite );
 	const { is_private, is_coming_soon } = site;
@@ -55,15 +48,7 @@ const PromotePost = ( props ) => {
 						isVisible={ isModalOpen && value === keyValue }
 						siteId={ selectedSiteId }
 						postId={ postId }
-						onClose={ () => {
-							queryClient.invalidateQueries( [ 'promote-post-campaigns', selectedSiteId ] );
-							if ( previousRoute ) {
-								closeModal();
-							} else {
-								goToOriginalEndpoint();
-							}
-							onToggleVisibility( false );
-						} }
+						keyValue={ keyValue }
 					/>
 					<button
 						onClick={ showDSPWidget }

--- a/config/development.json
+++ b/config/development.json
@@ -24,7 +24,7 @@
 	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
 	"olark_chat_identity": "7089-503-10-5123",
 	"dsp_stripe_pub_key": "pk_live_51LYYzQF53KN4RFN0ePTwefdm7seki4pRuc4a19gPMGUba5mzuosz0IBR0cp4T57FiBgxK911ky0LNwlX2IHbm0SS00uPHEQNBO",
-	"dsp_widget_js_src": "http://localhost:3004/widget.js",
+	"dsp_widget_js_src": "https://widgets.wp.com/promote/widget.js",
 	"features": {
 		"ad-tracking": false,
 		"calypso/help-center": true,

--- a/config/development.json
+++ b/config/development.json
@@ -24,7 +24,7 @@
 	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
 	"olark_chat_identity": "7089-503-10-5123",
 	"dsp_stripe_pub_key": "pk_live_51LYYzQF53KN4RFN0ePTwefdm7seki4pRuc4a19gPMGUba5mzuosz0IBR0cp4T57FiBgxK911ky0LNwlX2IHbm0SS00uPHEQNBO",
-	"dsp_widget_js_src": "https://widgets.wp.com/promote/widget.js",
+	"dsp_widget_js_src": "http://localhost:3004/widget.js",
 	"features": {
 		"ad-tracking": false,
 		"calypso/help-center": true,


### PR DESCRIPTION
#### Proposed Changes

* This pr simplifies the way the onClose handler is called when  PromotePost page is closed or the user clicks in "Go To Campaigns"

#### Testing Instructions

* Go to post list, page list, stats page or promote post page and promote a post from there
* If the user clicks on "cancel" in the promote post page it should keep the user in the page where the user promoted a post
* If the user clicks on "Go to campaigns" button after creating a campaign the user should be sent to the Campaigns tab in the Promote Post page

#### Pre-merge Checklist

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

Related to #
