### PR TITLE
Update mentions of "site stats" with "Jetpack Stats" (retry)

### DIFF
--- a/client/blocks/disconnect-jetpack/index.jsx
+++ b/client/blocks/disconnect-jetpack/index.jsx
@@ -131,7 +131,7 @@ class DisconnectJetpack extends PureComponent {
 
 		features.push(
 			translate(
-				'{{icon/}} Site stats, related content, and sharing tools',
+				'{{icon/}} Jetpack Stats, related content, and sharing tools',
 				this.getIcon( 'stats-alt' )
 			)
 		);

--- a/client/blocks/jetpack-benefits/site-visits.tsx
+++ b/client/blocks/jetpack-benefits/site-visits.tsx
@@ -42,7 +42,7 @@ const JetpackBenefitsSiteVisits: React.FC< Props > = ( { siteId, statType, query
 	if ( isRequestingStats ) {
 		return (
 			<JetpackBenefitsCard
-				headline={ translate( 'Site Stats' ) }
+				headline={ translate( 'Jetpack Stats' ) }
 				stat={ translate( 'Loading' ) }
 				description={ translate( 'Getting visitors stat' ) }
 				placeholder={ true }
@@ -58,7 +58,7 @@ const JetpackBenefitsSiteVisits: React.FC< Props > = ( { siteId, statType, query
 	return (
 		<React.Fragment>
 			<JetpackBenefitsCard
-				headline={ translate( 'Site Stats' ) }
+				headline={ translate( 'Jetpack Stats' ) }
 				stat={ countVisits > 0 ? countVisits : null }
 				description={
 					countVisits > 0

--- a/client/lib/plans/features-list.js
+++ b/client/lib/plans/features-list.js
@@ -831,7 +831,7 @@ export const FEATURES_LIST = {
 	},
 	[ FEATURE_SITE_STATS ]: {
 		getSlug: () => FEATURE_SITE_STATS,
-		getTitle: () => i18n.translate( 'Site Stats and Analytics' ),
+		getTitle: () => i18n.translate( 'Jetpack Stats' ),
 		getDescription: () => i18n.translate( 'The most important metrics for your site.' ),
 	},
 	[ FEATURE_TRAFFIC_TOOLS ]: {

--- a/client/my-sites/plans/jetpack-plans/jetpack-free-card/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/jetpack-free-card/index.tsx
@@ -22,7 +22,7 @@ const useFreeItem = (): SelectorProduct => {
 			features: {
 				items: [
 					{ slug: 'not used', text: translate( 'Brute force attack protection' ) },
-					{ slug: 'not used', text: translate( 'Site stats' ) },
+					{ slug: 'not used', text: translate( 'Jetpack Stats' ) },
 					{ slug: 'not used', text: translate( 'Content Delivery Network' ) },
 					{ slug: 'not used', text: translate( 'Downtime monitoring' ) },
 					{ slug: 'not used', text: translate( 'Related posts' ) },

--- a/client/my-sites/site-settings/analytics/form-google-analytics-jetpack.jsx
+++ b/client/my-sites/site-settings/analytics/form-google-analytics-jetpack.jsx
@@ -171,7 +171,7 @@ const GoogleAnalyticsJetpackForm = ( {
 							<p>
 								{ translate(
 									'Google Analytics is a free service that complements our {{a}}built-in stats{{/a}} ' +
-										'with different insights into your traffic. WordPress.com stats and Google Analytics ' +
+										'with different insights into your traffic. Jetpack Stats and Google Analytics ' +
 										'use different methods to identify and track activity on your site, so they will ' +
 										'normally show slightly different totals for your visits, views, etc.',
 									{

--- a/client/my-sites/site-settings/analytics/form-google-analytics-simple.jsx
+++ b/client/my-sites/site-settings/analytics/form-google-analytics-simple.jsx
@@ -148,7 +148,7 @@ const GoogleAnalyticsSimpleForm = ( {
 							<p>
 								{ translate(
 									'Google Analytics is a free service that complements our {{a}}built-in stats{{/a}} ' +
-										'with different insights into your traffic. WordPress.com stats and Google Analytics ' +
+										'with different insights into your traffic. Jetpack Stats and Google Analytics ' +
 										'use different methods to identify and track activity on your site, so they will ' +
 										'normally show slightly different totals for your visits, views, etc.',
 									{

--- a/client/my-sites/site-settings/jetpack-site-stats.jsx
+++ b/client/my-sites/site-settings/jetpack-site-stats.jsx
@@ -118,7 +118,7 @@ class JetpackSiteStats extends Component {
 			<div className="site-settings__traffic-settings">
 				<QueryJetpackConnection siteId={ siteId } />
 
-				<SettingsSectionHeader title={ translate( 'Site stats' ) } />
+				<SettingsSectionHeader title={ translate( 'Jetpack Stats' ) } />
 
 				<FoldableCard
 					className="site-settings__foldable-card is-top-level"

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -335,9 +335,9 @@ class StatsSite extends Component {
 				illustration="/calypso/images/illustrations/illustration-404.svg"
 				title={ translate( 'Looking for stats?' ) }
 				line={ translate(
-					'Enable site stats to see detailed information about your traffic, likes, comments, and subscribers.'
+					'Enable Jetpack Stats to see detailed information about your traffic, likes, comments, and subscribers.'
 				) }
-				action={ translate( 'Enable Site Stats' ) }
+				action={ translate( 'Enable Jetpack Stats' ) }
 				actionCallback={ this.enableStatsModule }
 			/>
 		);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #68728. Retries landing changes from #69457. 

Only land this PR once [the translated strings percentage](https://translate.wordpress.com/localci/status/automattic/wp-calypso/revert/69490) reaches an acceptable threshold.

#### Proposed Changes

Updates mentions of "site stats" with "Jetpack Stats" as part of our rebranding effort (p1HpG7-icd-p2).

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure that the text changes look reasonable.
* Sample some of the changes below in a live branch. For example:
  * On a Jetpack site connected to your user account, disable the Stats module via `/wp-admin/admin.php?page=jetpack_modules&module_tag=Jetpack%20Stats`.
  * Navigate to `/stats/day/example.com` on a live branch.
  * Ensure you see the following visual:
  > <img width="976" alt="image" src="https://user-images.githubusercontent.com/4044428/197900496-8a777eaf-eab2-428c-92b3-627bbf8f75be.png">

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
