### PR TITLE
Launchpad: Prevent tabbing to web preview element with keyboard

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/launchpad-site-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/launchpad-site-preview.tsx
@@ -43,8 +43,12 @@ const LaunchpadSitePreview = ( {
 		} );
 	}
 
+	function preventTabbingToIFrame(): void {
+		( document.querySelector( 'iframe.web-preview__frame' ) as HTMLIFrameElement ).tabIndex = -1;
+	}
+
 	return (
-		<div className="launchpad__site-preview-wrapper">
+		<div className="launchpad__site-preview-wrapper" onLoad={ preventTabbingToIFrame }>
 			<WebPreview
 				className="launchpad__-web-preview"
 				showDeviceSwitcher={ true }


### PR DESCRIPTION
#### Proposed Changes

* Add tabindex to iframe element to prevent tabbing to element with keyboard

Note: This fix resolves tabbing _to_ the iframe from the parent window, but it does not resolve interacting with the embedded content once focus enters the iframe window (eg. with a virtual cursor, or via the `skip-link` button). May want to revisit this part in a future PR. 

#### Testing Instructions

1. Checkout locally and navigate to Launchpad Final Steps screen (newsletter or link-in-bio flow is OK)
2. Tab through the page until you reach the preview section. The tab should skip over the iframe and you should not be allowed to enter the embedded content with the keyboard.

#### Pre-merge Checklist

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

Related to [Issue: LaunchPad - Site Preview is interactive with keyboard. #69483](https://github.com/Automattic/wp-calypso/issues/69483)
