### PR TITLE
Checkout: Add biennial plan upsell to sidebar

### DIFF
--- a/client/components/promo-section/promo-card/cta.tsx
+++ b/client/components/promo-section/promo-card/cta.tsx
@@ -18,6 +18,8 @@ export interface CtaButton {
 	text: string | TranslateResult;
 	action: URL | ClickCallback | CtaAction;
 	component?: JSX.Element;
+	disabled?: boolean;
+	busy?: boolean;
 }
 
 export interface Props {
@@ -54,6 +56,8 @@ function buttonProps( button: CtaButton, isPrimary: boolean ) {
 	return {
 		className: 'promo-card__cta-button',
 		primary: isPrimary,
+		disabled: button.disabled ? true : false,
+		busy: button.busy ? true : false,
 		...actionProps,
 	};
 }

--- a/client/my-sites/checkout/composite-checkout/components/checkout-sidebar-plan-upsell/index.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-sidebar-plan-upsell/index.tsx
@@ -11,7 +11,10 @@ import PromoCardCTA from 'calypso/components/promo-section/promo-card/cta';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { useGetProductVariants } from '../../hooks/product-variants';
-import { getItemVariantDiscountPercentage } from '../item-variation-picker/variant-price';
+import {
+	getItemVariantCompareToPrice,
+	getItemVariantDiscountPercentage,
+} from '../item-variation-picker/variant-price';
 
 import './style.scss';
 
@@ -62,7 +65,15 @@ export function CheckoutSidebarPlanUpsell() {
 		replaceProductInCart( plan.uuid, newPlan );
 	};
 
+	const compareToPriceForVariantTerm = getItemVariantCompareToPrice(
+		biennialVariant,
+		currentVariant
+	);
 	const percentSavings = getItemVariantDiscountPercentage( biennialVariant, currentVariant );
+	if ( percentSavings === 0 ) {
+		debug( 'percent savings is too low', percentSavings );
+		return null;
+	}
 
 	const cardTitle = sprintf(
 		// translators: "percentSavings" is the savings percentage for the upgrade as a number, like '20' for '20%'.
@@ -82,6 +93,13 @@ export function CheckoutSidebarPlanUpsell() {
 					{ biennialVariant.variantLabel }
 				</div>
 				<div className="checkout-sidebar-plan-upsell__plan-grid-cell">
+					{ compareToPriceForVariantTerm && (
+						<del className="checkout-sidebar-plan-upsell__do-not-pay">
+							{ formatCurrency( compareToPriceForVariantTerm, currentVariant.currency, {
+								stripZeros: true,
+							} ) }
+						</del>
+					) }
 					{ formatCurrency( biennialVariant.price, biennialVariant.currency, {
 						stripZeros: true,
 					} ) }

--- a/client/my-sites/checkout/composite-checkout/components/checkout-sidebar-plan-upsell/index.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-sidebar-plan-upsell/index.tsx
@@ -26,7 +26,7 @@ export function CheckoutSidebarPlanUpsell() {
 	const { formStatus } = useFormStatus();
 	const reduxDispatch = useDispatch();
 	const isFormLoading = FormStatus.READY !== formStatus;
-	const { __ } = useI18n();
+	const { __, hasTranslation } = useI18n();
 	const cartKey = useCartKey();
 	const { responseCart, replaceProductInCart } = useShoppingCart( cartKey );
 	const siteId = useSelector( getSelectedSiteId );
@@ -93,6 +93,10 @@ export function CheckoutSidebarPlanUpsell() {
 		),
 		{ strong: createElement( 'strong' ) }
 	);
+
+	if ( ! hasTranslation( '<strong>Save %(percentSavings)d%%</strong> by paying for two years' ) ) {
+		return null;
+	}
 
 	return (
 		<PromoCard title={ cardTitle } className="checkout-sidebar-plan-upsell">

--- a/client/my-sites/checkout/composite-checkout/components/checkout-sidebar-plan-upsell/index.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-sidebar-plan-upsell/index.tsx
@@ -1,0 +1,82 @@
+import { isPlan } from '@automattic/calypso-products';
+import { FormStatus, useFormStatus } from '@automattic/composite-checkout';
+import { useShoppingCart } from '@automattic/shopping-cart';
+import debugFactory from 'debug';
+import { useTranslate } from 'i18n-calypso';
+import { useSelector } from 'react-redux';
+import PromoCard from 'calypso/components/promo-section/promo-card';
+import PromoCardCTA from 'calypso/components/promo-section/promo-card/cta';
+import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { useGetProductVariants } from '../../hooks/product-variants';
+
+import './style.scss';
+
+const debug = debugFactory( 'calypso:checkout-sidebar-plan-upsell' );
+
+export function CheckoutSidebarPlanUpsell() {
+	const { formStatus } = useFormStatus();
+	const isFormLoading = FormStatus.READY !== formStatus;
+	const translate = useTranslate();
+	const cartKey = useCartKey();
+	const { responseCart, replaceProductInCart } = useShoppingCart( cartKey );
+	const siteId = useSelector( getSelectedSiteId );
+	const plan = responseCart.products.find( ( product ) => isPlan( product ) );
+	const variants = useGetProductVariants( siteId ?? undefined, plan?.product_slug ?? '' );
+
+	if ( ! plan ) {
+		debug( 'no plan found in cart' );
+		return null;
+	}
+
+	const biennialVariant = variants?.find( ( product ) => product.termIntervalInMonths === 24 );
+	debug( 'plan in cart:', plan );
+
+	if ( ! biennialVariant ) {
+		debug( 'plan in cart has no biennial variant; variants are', variants );
+		return null;
+	}
+
+	if ( biennialVariant.productId === plan.product_id ) {
+		debug( 'plan in cart is already biennial' );
+		return null;
+	}
+
+	const onUpgradeClick = () => {
+		if ( isFormLoading ) {
+			return;
+		}
+		const newPlan = {
+			product_slug: biennialVariant.productSlug,
+			product_id: biennialVariant.productId,
+		};
+		debug( 'switching from', plan.product_slug, 'to', newPlan.product_slug );
+		replaceProductInCart( plan.uuid, newPlan );
+	};
+
+	return (
+		<PromoCard
+			title={ translate( 'Save 10% by paying for two years' ) }
+			className="checkout-sidebar-plan-upsell"
+		>
+			<div className="checkout-sidebar-plan-upsell__plan-grid">
+				<div className="checkout-sidebar-plan-upsell__plan-grid-cell">
+					{ translate( 'One year' ) }
+				</div>
+				<div className="checkout-sidebar-plan-upsell__plan-grid-cell">{ translate( '$60' ) }</div>
+				<div className="checkout-sidebar-plan-upsell__plan-grid-cell">
+					{ translate( 'Two years' ) }
+				</div>
+				<div className="checkout-sidebar-plan-upsell__plan-grid-cell">{ translate( '$108' ) }</div>
+			</div>
+			<PromoCardCTA
+				cta={ {
+					disabled: isFormLoading,
+					busy: isFormLoading,
+					text: translate( 'Switch to two year plan' ),
+					action: onUpgradeClick,
+				} }
+			/>
+		</PromoCard>
+	);
+}

--- a/client/my-sites/checkout/composite-checkout/components/checkout-sidebar-plan-upsell/index.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-sidebar-plan-upsell/index.tsx
@@ -5,10 +5,11 @@ import { useShoppingCart } from '@automattic/shopping-cart';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import debugFactory from 'debug';
-import { useSelector } from 'react-redux';
+import { useSelector, useDispatch } from 'react-redux';
 import PromoCard from 'calypso/components/promo-section/promo-card';
 import PromoCardCTA from 'calypso/components/promo-section/promo-card/cta';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { useGetProductVariants } from '../../hooks/product-variants';
 import {
@@ -22,6 +23,7 @@ const debug = debugFactory( 'calypso:checkout-sidebar-plan-upsell' );
 
 export function CheckoutSidebarPlanUpsell() {
 	const { formStatus } = useFormStatus();
+	const reduxDispatch = useDispatch();
 	const isFormLoading = FormStatus.READY !== formStatus;
 	const { __ } = useI18n();
 	const cartKey = useCartKey();
@@ -62,6 +64,13 @@ export function CheckoutSidebarPlanUpsell() {
 			product_id: biennialVariant.productId,
 		};
 		debug( 'switching from', plan.product_slug, 'to', newPlan.product_slug );
+		reduxDispatch(
+			recordTracksEvent( 'calypso_checkout_sidebar_upsell_click', {
+				upsell_type: 'biennial-plan',
+				switching_from: plan.product_slug,
+				switching_to: newPlan.product_slug,
+			} )
+		);
 		replaceProductInCart( plan.uuid, newPlan );
 	};
 

--- a/client/my-sites/checkout/composite-checkout/components/checkout-sidebar-plan-upsell/index.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-sidebar-plan-upsell/index.tsx
@@ -2,6 +2,7 @@ import { isPlan } from '@automattic/calypso-products';
 import { FormStatus, useFormStatus } from '@automattic/composite-checkout';
 import formatCurrency from '@automattic/format-currency';
 import { useShoppingCart } from '@automattic/shopping-cart';
+import { createElement, createInterpolateElement } from '@wordpress/element';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import debugFactory from 'debug';
@@ -84,11 +85,15 @@ export function CheckoutSidebarPlanUpsell() {
 		return null;
 	}
 
-	const cardTitle = sprintf(
-		// translators: "percentSavings" is the savings percentage for the upgrade as a number, like '20' for '20%'.
-		__( 'Save %(percentSavings)d%% by paying for two years' ),
-		{ percentSavings }
+	const cardTitle = createInterpolateElement(
+		sprintf(
+			// translators: "percentSavings" is the savings percentage for the upgrade as a number, like '20' for '20%'.
+			__( '<strong>Save %(percentSavings)d%%</strong> by paying for two years' ),
+			{ percentSavings }
+		),
+		{ strong: createElement( 'strong' ) }
 	);
+
 	return (
 		<PromoCard title={ cardTitle } className="checkout-sidebar-plan-upsell">
 			<div className="checkout-sidebar-plan-upsell__plan-grid">
@@ -118,7 +123,7 @@ export function CheckoutSidebarPlanUpsell() {
 				cta={ {
 					disabled: isFormLoading,
 					busy: isFormLoading,
-					text: __( 'Switch to two year plan' ),
+					text: __( 'Switch to a two year plan' ),
 					action: onUpgradeClick,
 				} }
 			/>

--- a/client/my-sites/checkout/composite-checkout/components/checkout-sidebar-plan-upsell/style.scss
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-sidebar-plan-upsell/style.scss
@@ -1,0 +1,25 @@
+.checkout-sidebar-plan-upsell {
+	margin-top: 24px;
+}
+
+.checkout-sidebar-plan-upsell .action-panel__title {
+	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
+	font-size: 14px;
+	font-weight: 600;
+}
+
+.checkout-sidebar-plan-upsell__plan-grid {
+	display: grid;
+	grid-template-rows: 1fr 1fr;
+	grid-template-columns: 1fr 1fr;
+	border-bottom: 1px solid #ccc;
+}
+
+.checkout-sidebar-plan-upsell__plan-grid > div:nth-child(even) {
+	text-align: right;
+}
+
+.checkout-sidebar-plan-upsell__plan-grid > div {
+	border-top: 1px solid #ccc;
+	padding: 0.5em 0;
+}

--- a/client/my-sites/checkout/composite-checkout/components/checkout-sidebar-plan-upsell/style.scss
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-sidebar-plan-upsell/style.scss
@@ -23,3 +23,14 @@
 	border-top: 1px solid #ccc;
 	padding: 0.5em 0;
 }
+
+.checkout-sidebar-plan-upsell__do-not-pay {
+	text-decoration: line-through;
+	margin-right: 8px;
+	color: #646970;
+
+	.rtl & {
+		margin-right: 0;
+		margin-left: 8px;
+	}
+}

--- a/client/my-sites/checkout/composite-checkout/components/checkout-sidebar-plan-upsell/style.scss
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-sidebar-plan-upsell/style.scss
@@ -2,17 +2,18 @@
 	margin-top: 24px;
 }
 
-.checkout-sidebar-plan-upsell .action-panel__title {
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
-	font-size: 14px;
-	font-weight: 600;
+.promo-card.checkout-sidebar-plan-upsell .action-panel__title {
+	color: var(--studio-blue-50);
+	display: block;
+	font-size: $font-title-medium;
+	font-weight: 400;
+	line-height: 1.2;
 }
 
 .checkout-sidebar-plan-upsell__plan-grid {
 	display: grid;
 	grid-template-rows: 1fr 1fr;
 	grid-template-columns: 1fr 1fr;
-	border-bottom: 1px solid #ccc;
 }
 
 .checkout-sidebar-plan-upsell__plan-grid > div:nth-child(even) {
@@ -22,6 +23,11 @@
 .checkout-sidebar-plan-upsell__plan-grid > div {
 	border-top: 1px solid #ccc;
 	padding: 0.5em 0;
+
+	&:nth-of-type(1),
+	&:nth-of-type(2) {
+		border-top: none;
+	}
 }
 
 .checkout-sidebar-plan-upsell__do-not-pay {
@@ -33,4 +39,8 @@
 		margin-right: 0;
 		margin-left: 8px;
 	}
+}
+
+.promo-card.checkout-sidebar-plan-upsell .button {
+	width: 100%;
 }

--- a/client/my-sites/checkout/composite-checkout/components/item-variation-picker/variant-price.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/item-variation-picker/variant-price.tsx
@@ -81,11 +81,10 @@ const DiscountPercentage: FunctionComponent< { percent: number } > = ( { percent
 	);
 };
 
-export const ItemVariantPrice: FunctionComponent< {
-	variant: WPCOMProductVariant;
-	compareTo?: WPCOMProductVariant;
-} > = ( { variant, compareTo } ) => {
-	const isMobile = useMobileBreakpoint();
+export function getItemVariantCompareToPrice(
+	variant: WPCOMProductVariant,
+	compareTo?: WPCOMProductVariant
+): number | undefined {
 	// This is the price that the compareTo variant would be if it was using the
 	// billing term of the variant. For example, if the price of the compareTo
 	// variant was 120 per year, and the variant we are displaying here is 5 per
@@ -95,11 +94,29 @@ export const ItemVariantPrice: FunctionComponent< {
 	const compareToPriceForVariantTerm = compareTo
 		? compareTo.pricePerMonth * variant.termIntervalInMonths
 		: undefined;
+	return compareToPriceForVariantTerm;
+}
+
+export function getItemVariantDiscountPercentage(
+	variant: WPCOMProductVariant,
+	compareTo?: WPCOMProductVariant
+): number {
+	const compareToPriceForVariantTerm = getItemVariantCompareToPrice( variant, compareTo );
 	// Extremely low "discounts" are possible if the price of the longer term has been rounded
 	// if they cannot be rounded to at least a percentage point we should not show them.
 	const discountPercentage = compareToPriceForVariantTerm
 		? Math.floor( 100 - ( variant.price / compareToPriceForVariantTerm ) * 100 )
 		: 0;
+	return discountPercentage;
+}
+
+export const ItemVariantPrice: FunctionComponent< {
+	variant: WPCOMProductVariant;
+	compareTo?: WPCOMProductVariant;
+} > = ( { variant, compareTo } ) => {
+	const isMobile = useMobileBreakpoint();
+	const compareToPriceForVariantTerm = getItemVariantCompareToPrice( variant, compareTo );
+	const discountPercentage = getItemVariantDiscountPercentage( variant, compareTo );
 	const formattedCurrentPrice = formatCurrency( variant.price, variant.currency, {
 		stripZeros: true,
 	} );

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
@@ -50,6 +50,7 @@ import badgeGenericSrc from './assets/icons/badge-generic.svg';
 import { CheckoutCompleteRedirecting } from './checkout-complete-redirecting';
 import CheckoutHelpLink from './checkout-help-link';
 import CheckoutNextSteps from './checkout-next-steps';
+import { CheckoutSidebarPlanUpsell } from './checkout-sidebar-plan-upsell';
 import { EmptyCart, shouldShowEmptyCartPage } from './empty-cart';
 import PaymentMethodStepContent from './payment-method-step';
 import SecondaryCartPromotions from './secondary-cart-promotions';
@@ -310,6 +311,7 @@ export default function WPCheckout( {
 								onChangePlanLength={ changePlanLength }
 								nextDomainIsFree={ responseCart?.next_domain_is_free }
 							/>
+							<CheckoutSidebarPlanUpsell />
 							<SecondaryCartPromotions
 								responseCart={ responseCart }
 								addItemToCart={ addItemToCart }

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout-variant-picker.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout-variant-picker.tsx
@@ -251,7 +251,9 @@ describe( 'CheckoutMain with a variant picker', () => {
 			const priceBeforeDiscount = currentVariantPrice * intervalsInVariant;
 
 			const discountPercentage = Math.floor( 100 - ( finalPrice / priceBeforeDiscount ) * 100 );
-			expect( screen.getByText( `Save ${ discountPercentage }%` ) ).toBeInTheDocument();
+			expect(
+				within( variantItem ).getByText( `Save ${ discountPercentage }%` )
+			).toBeInTheDocument();
 		}
 	);
 


### PR DESCRIPTION
#### Proposed Changes

This adds a checkout sidebar card which contains a two-year plan upsell.

![biennial-plan-upsell-sidebar](https://user-images.githubusercontent.com/2036909/198137042-7eb4f0af-8fcd-4fb9-a938-b15e66784cdd.png)

#### To do:

- [x] Fix mobile width padding.
- [x] Fix RTL alignment.
- [x] Test with monthly term.
- [x] Add analytics to upgrade button.

#### Testing Instructions

- Add a plan to your cart with an annual renewal term.
- Visit checkout.
- Verify that you see the new sidebar upsell and that its prices and percentages are correct.
- Click the button in the upsell and verify that the plan in the cart changes to the two-year variant.
- Verify that if the two-year variant is in the cart, the upsell does not appear.