### PR TITLE
Launchpad: Add checkmark icon to domain processing notification

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
@@ -139,11 +139,14 @@ const Sidebar = ( { sidebarDomain, siteSlug, submit, goNext, goToStep }: Sidebar
 					) }
 				</div>
 				{ isDomainSSLProcessing && (
-					<p>
-						{ translate(
-							'We are currently setting up your new domain! It may take a few minutes before it is ready.'
-						) }
-					</p>
+					<div className="launchpad__domain-notification">
+						<Gridicon className="launchpad__domain-checkmark-icon" icon="checkmark-circle" />
+						<p>
+							{ translate(
+								'We are currently setting up your new domain! It may take a few minutes before it is ready.'
+							) }
+						</p>
+					</div>
 				) }
 				<Checklist tasks={ enhancedTasks } />
 			</div>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
@@ -145,6 +145,20 @@
 	font-weight: 500;
 }
 
+.launchpad__domain-notification {
+	display: flex;
+	margin-bottom: 16px;
+
+	@include break-large {
+		margin-bottom: 10px;
+	}
+}
+
+.launchpad__domain-checkmark-icon {
+	flex: 0 0 36px;
+	fill: var(--studio-green-40);
+}
+
 .launchpad__domain-upgrade-badge {
 	&:hover {
 		background: var(--studio-blue-10);


### PR DESCRIPTION
#### Proposed Changes

* Adds checkmark icon to domain processing notification

<img width="1496" alt="Screen Shot 2022-10-26 at 4 52 54 PM" src="https://user-images.githubusercontent.com/5414230/198160263-ada0d40e-8918-4cb0-9955-3d6320db3d8c.png">

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this PR
* Create new site through tailored flow https://wordpress.com/hp-2022-tailored-flows/
* Make sure to switch out wordpress.com with calypso.localhost:3000
* Create a custom domain for the site
* Choose, at minimum, a personal plan ( so that we can make a custom domain the primary domain )
* Complete steps until at the Launchpad screen
* Verify that the domain ssl processing notification has a green checkmark icon

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/68967
