### PR TITLE
Design Preview: Fix title & logo overlap

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
@@ -219,6 +219,10 @@ $break-design-preview: 1024px;
 				margin: 16px 0 24px;
 				transform: translateY(-58px);
 				min-height: 42px;
+
+				#design-setup-header {
+					padding: 0 60px;
+				}
 			}
 		}
 


### PR DESCRIPTION
## Proposed Changes

* Remove title and logo overlapping for Design Preview between mobile and desktop
![image](https://user-images.githubusercontent.com/10071857/198174347-ea1aaa92-1516-42b1-b903-2b5322762371.png)
 

Related to [#68551](https://github.com/Automattic/wp-calypso/issues/68551)
