### PR TITLE
Fix woo login screen long email CSS issue

### DIFF
--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -438,6 +438,11 @@
 				color: $gray-60;
 				grid-area: email;
 				margin-bottom: 0;
+				text-overflow: ellipsis;
+				width: 100%;
+				overflow: hidden;
+				white-space: nowrap;
+				text-align: left;
 			}
 
 		}


### PR DESCRIPTION
#### Proposed Changes

* Update CSS style to fix the long email out of the box issue

Before:

![Screen Shot 2022-10-27 at 11 51 12](https://user-images.githubusercontent.com/4344253/198187127-a87ed14f-c00f-445d-a896-88e09145e408.png)


After:

![Screen Shot 2022-10-27 at 11 44 54](https://user-images.githubusercontent.com/4344253/198186590-cc1006fe-4d99-45c7-98cf-dc894f26fd2b.png)


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Make sure you're logged in with your WP account
2. Go to 
  https:/[your-local-calypso-host]/log-in?client_id=50916&redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%2F%3Fresponse_type%3Dcode%26client_id%3D50916%26state%3D48147b787fc13d521a37bbf0e6782961fac97660463c735e93fa9a858485097b%26redirect_uri%3Dhttps%253A%252F%252Fwoocommerce.com%252Fwc-api%252Fwpcom-signin%253Fnext%253Dmy-dashboard%26blog_id%3D0%26wpcom_connect%3D1%26authorize%3D1%26wccom-from%26calypso_env%3Dproduction%26from-calypso%3D1 
  OR
  https://container-nervous-hofstadter.calypso.live/log-in?client_id=50916&redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%2F%3Fresponse_type%3Dcode%26client_id%3D50916%26state%3D48147b787fc13d521a37bbf0e6782961fac97660463c735e93fa9a858485097b%26redirect_uri%3Dhttps%253A%252F%252Fwoocommerce.com%252Fwc-api%252Fwpcom-signin%253Fnext%253Dmy-dashboard%26blog_id%3D0%26wpcom_connect%3D1%26authorize%3D1%26wccom-from%26calypso_env%3Dproduction%26from-calypso%3D1
4. Open dev console and enter `document.querySelector('.continue-as-user__email').textContent = 'loooooooooooooooooooooooooooooooong@example.com''`
5. Confirm that email does not overflow out of the box.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
105-gh-woocommerce/team-ghidorah