### PR TITLE
Pattern Assembler: Don't hard-coded stylesheet for the preview of pattern

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/constants.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/constants.ts
@@ -1,4 +1,3 @@
 export const PATTERN_SOURCE_SITE_ID = 174455321; // dotcompatterns
-export const STYLE_SHEET = 'pub/blank-canvas-blocks';
 export const PUBLIC_API_URL = 'https://public-api.wordpress.com';
 export const PREVIEW_PATTERN_URL = PUBLIC_API_URL + '/wpcom/v2/block-previews/pattern';

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-selector.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-selector.tsx
@@ -1,6 +1,8 @@
 import { useLocale } from '@automattic/i18n-utils';
+import { useSelect } from '@wordpress/data';
 import classnames from 'classnames';
 import { useEffect, useRef } from 'react';
+import { ONBOARD_STORE } from '../../../../stores';
 import PatternPreviewAutoHeight from './pattern-preview-auto-height';
 import { getPatternPreviewUrl, handleKeyboard } from './utils';
 import type { Pattern } from './types';
@@ -15,6 +17,7 @@ type PatternSelectorProps = {
 const PatternSelector = ( { patterns, onSelect, title, show }: PatternSelectorProps ) => {
 	const locale = useLocale();
 	const patternSelectorRef = useRef< HTMLDivElement >( null );
+	const selectedDesign = useSelect( ( select ) => select( ONBOARD_STORE ).getSelectedDesign() );
 
 	useEffect( () => {
 		if ( show ) {
@@ -41,7 +44,7 @@ const PatternSelector = ( { patterns, onSelect, title, show }: PatternSelectorPr
 					{ patterns?.map( ( item: Pattern, index: number ) => (
 						<PatternPreviewAutoHeight
 							key={ `${ index }-${ item.id }` }
-							url={ getPatternPreviewUrl( item.id, locale ) }
+							url={ getPatternPreviewUrl( item.id, locale, selectedDesign?.recipe?.stylesheet ) }
 							patternId={ item.id }
 							patternName={ item.name }
 						>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/utils.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/utils.ts
@@ -1,12 +1,12 @@
 import { addQueryArgs } from '@wordpress/url';
-import { PATTERN_SOURCE_SITE_ID, PREVIEW_PATTERN_URL, STYLE_SHEET } from './constants';
+import { PATTERN_SOURCE_SITE_ID, PREVIEW_PATTERN_URL } from './constants';
 
 export const encodePatternId = ( patternId: number ) =>
 	`${ patternId }-${ PATTERN_SOURCE_SITE_ID }`;
 
-export const getPatternPreviewUrl = ( id: number, language: string ) => {
+export const getPatternPreviewUrl = ( id: number, language: string, stylesheet?: string ) => {
 	return addQueryArgs( PREVIEW_PATTERN_URL, {
-		stylesheet: STYLE_SHEET,
+		stylesheet,
 		pattern_id: encodePatternId( id ),
 		language,
 	} );


### PR DESCRIPTION
#### Proposed Changes

* Use the stylesheet of the selected design for the preview of the pattern instead of a hard-coded one.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup?siteSlug=<your_site>`
* Select build intent
* When you land on the design picker, get started with a blank canvas and go to the PA step
* Preview any pattern, it should work as before

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
