### PR TITLE
Fix 2FA signup link for woo 2fa screen

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -1,7 +1,7 @@
 import config from '@automattic/calypso-config';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
-import { capitalize, get } from 'lodash';
+import { capitalize, get, isEmpty } from 'lodash';
 import page from 'page';
 import PropTypes from 'prop-types';
 import { Component, Fragment } from 'react';
@@ -145,6 +145,20 @@ class Login extends Component {
 	handleTwoFactorRequested = ( authType ) => {
 		if ( this.props.onTwoFactorRequested ) {
 			this.props.onTwoFactorRequested( authType );
+		} else if ( this.props.isWoo ) {
+			page(
+				login( {
+					isJetpack: this.props.isJetpack,
+					isGutenboarding: this.props.isGutenboarding,
+					// If no notification is sent, the user is using the authenticator for 2FA by default
+					twoFactorAuthType: authType,
+					locale: this.props.locale,
+					isPartnerSignup: this.props.isPartnerSignup,
+					// Pass oauth2 and redirectTo query params so that we can get the correct signup url for the user
+					oauth2ClientId: this.props.oauth2Client?.id,
+					redirectTo: this.props.redirectTo,
+				} )
+			);
 		} else {
 			page(
 				login( {
@@ -221,8 +235,8 @@ class Login extends Component {
 			return signupUrl;
 		}
 
-		if ( isWoo && ! currentQuery ) {
-			// In 2fa screens, we don't have currentQuery
+		if ( isWoo && isEmpty( currentQuery ) ) {
+			// if query is empty, return to the woo start flow
 			return 'https://woocommerce.com/start/';
 		}
 


### PR DESCRIPTION
#### Proposed Changes

* Pass `oauth2ClientId` and `redirectTo` params to **Woo's** 2fa screen to fix the invalid signup url

The previous fix broke Jetpack SSO because there is a specific redirect logic for jetpack sso [in this line](https://github.com/Automattic/wp-calypso/blob/trunk/client/lib/paths/login/index.js#L80-L81).

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Follow the instructions on https://github.com/Automattic/wp-calypso/pull/68959

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

100-gh-woocommerce/team-ghidorah

