### PR TITLE
Jetpack Search: don't change jetpack_search to wpcom_search

### DIFF
--- a/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
@@ -1,11 +1,4 @@
-import {
-	JETPACK_SEARCH_PRODUCTS,
-	PRODUCT_JETPACK_SEARCH,
-	PRODUCT_JETPACK_SEARCH_MONTHLY,
-	PRODUCT_WPCOM_SEARCH,
-	PRODUCT_WPCOM_SEARCH_MONTHLY,
-	getPlanByPathSlug,
-} from '@automattic/calypso-products';
+import { getPlanByPathSlug } from '@automattic/calypso-products';
 import { createRequestCartProduct } from '@automattic/shopping-cart';
 import { decodeProductFromUrl, isValueTruthy } from '@automattic/wpcom-checkout';
 import debugFactory from 'debug';
@@ -321,8 +314,6 @@ function useAddProductFromSlug( {
 		() =>
 			productAliasFromUrl
 				?.split( ',' )
-				// Special treatment for Jetpack Search products
-				.map( ( productAlias ) => getJetpackSearchForSite( productAlias, usesJetpackProducts ) )
 				// Get the product information if it exists, and keep a reference to
 				// its product alias which we may need to get additional information like
 				// the domain name or theme (eg: 'theme:ovation').
@@ -435,31 +426,6 @@ function createRenewalItemToAddToCart(
 		product_slug: productSlug,
 		extra: renewalItemExtra,
 	};
-}
-
-/*
- * Provides an special handling for search products: Always add Jetpack Search to
- * Jetpack sites and WPCOM Search to WordPress.com sites, regardless of
- * which slug was provided. This allows e.g. code on jetpack.com to
- * redirect to a valid checkout URL for a search purchase without worrying
- * about which type of site the user has.
- */
-function getJetpackSearchForSite( productAlias: string, usesJetpackProducts: boolean ): string {
-	if (
-		productAlias &&
-		JETPACK_SEARCH_PRODUCTS.includes( productAlias as typeof JETPACK_SEARCH_PRODUCTS[ number ] )
-	) {
-		if ( usesJetpackProducts ) {
-			productAlias = productAlias.includes( 'monthly' )
-				? PRODUCT_JETPACK_SEARCH_MONTHLY
-				: PRODUCT_JETPACK_SEARCH;
-		} else {
-			productAlias = productAlias.includes( 'monthly' )
-				? PRODUCT_WPCOM_SEARCH_MONTHLY
-				: PRODUCT_WPCOM_SEARCH;
-		}
-	}
-	return productAlias;
 }
 
 function createItemToAddToCart( {

--- a/client/my-sites/site-settings/search.jsx
+++ b/client/my-sites/site-settings/search.jsx
@@ -1,6 +1,5 @@
 import {
 	PRODUCT_JETPACK_SEARCH_MONTHLY,
-	PRODUCT_WPCOM_SEARCH_MONTHLY,
 	WPCOM_FEATURES_CLASSIC_SEARCH,
 	WPCOM_FEATURES_INSTANT_SEARCH,
 } from '@automattic/calypso-products';
@@ -108,11 +107,9 @@ class Search extends Component {
 	}
 
 	renderUpgradeNotice() {
-		const { siteIsJetpack, siteSlug, translate, hasClassicSearch } = this.props;
+		const { siteSlug, translate, hasClassicSearch } = this.props;
 
-		const href = siteIsJetpack
-			? `/checkout/${ siteSlug }/${ PRODUCT_JETPACK_SEARCH_MONTHLY }`
-			: `/checkout/${ siteSlug }/${ PRODUCT_WPCOM_SEARCH_MONTHLY }`;
+		const href = `/checkout/${ siteSlug }/${ PRODUCT_JETPACK_SEARCH_MONTHLY }`;
 
 		return (
 			<Fragment>
@@ -128,7 +125,7 @@ class Search extends Component {
 					href={ href }
 					event="calypso_jetpack_search_settings_upgrade_nudge"
 					feature={ WPCOM_FEATURES_INSTANT_SEARCH }
-					plan={ siteIsJetpack ? PRODUCT_JETPACK_SEARCH_MONTHLY : PRODUCT_WPCOM_SEARCH_MONTHLY }
+					plan={ PRODUCT_JETPACK_SEARCH_MONTHLY }
 					showIcon={ true }
 				/>
 			</Fragment>


### PR DESCRIPTION
#### Proposed Changes

Currently, when purchasing a Jetpack Search plan on wpcom site (simple or atomic), we automatically change the product slug from jetpack_search to wpcom_search, and from jetpack_search_monthly to wpcom_search_monthly.

In this PR I'm removing that swap, as we now want to use jetpack_search variant for both Jetpack and wpcom sites.

#### Testing Instructions

* Wait for backend changes to be released (or sandbox public-api with diff D90829-code applied, if you're from A8C).
* Visit `http://calypso.localhost:3000/checkout/<your-site>/jetpack_search`, where your-site is base URL of simple or atomic site.
* Verify that the purchased product is Jetpack Search, and not WPCOM Search (for instances in payments admin).
* Next, verify that the site with this plan behaves the same as with WPCOM Search, for both simple and atomic.

#### Pre-merge Checklist

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
