### PR TITLE
E2E (Atomic): Fix Jetpack Grow: Premium Content

### DIFF
--- a/packages/calypso-e2e/src/lib/blocks/block-flows/contact-info.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/contact-info.ts
@@ -51,12 +51,12 @@ export class ContactInfoBlockFlow implements BlockFlow {
 		const numericOnlyPhoneNumber = this.configurationData.phoneNumber.replace( /\D/g, '' );
 
 		const expectedEmailLinkLocator = context.page.locator(
-			`[href="mailto:${ this.configurationData.email }"]`
+			`main [href="mailto:${ this.configurationData.email }"]`
 		);
 		await expectedEmailLinkLocator.waitFor();
 
 		const expectedPhoneLinkLocator = context.page.locator(
-			`[href="tel:${ numericOnlyPhoneNumber }"]`
+			`main [href="tel:${ numericOnlyPhoneNumber }"]`
 		);
 		await expectedPhoneLinkLocator.waitFor();
 	}

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/contact-info.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/contact-info.ts
@@ -51,11 +51,13 @@ export class ContactInfoBlockFlow implements BlockFlow {
 		const numericOnlyPhoneNumber = this.configurationData.phoneNumber.replace( /\D/g, '' );
 
 		const expectedEmailLinkLocator = context.page.locator(
+			// 'main' needs to be specified due to the debug elements
 			`main [href="mailto:${ this.configurationData.email }"]`
 		);
 		await expectedEmailLinkLocator.waitFor();
 
 		const expectedPhoneLinkLocator = context.page.locator(
+			// 'main' needs to be specified due to the debug elements
 			`main [href="tel:${ numericOnlyPhoneNumber }"]`
 		);
 		await expectedPhoneLinkLocator.waitFor();

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/whatsapp-button.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/whatsapp-button.ts
@@ -12,7 +12,7 @@ const selectors = {
 	buttonLabel: 'a.whatsapp-block__button',
 
 	// Published
-	block: 'div.wp-block-jetpack-whatsapp-button',
+	block: 'main div.wp-block-jetpack-whatsapp-button',
 };
 
 /**

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/whatsapp-button.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/whatsapp-button.ts
@@ -12,6 +12,7 @@ const selectors = {
 	buttonLabel: 'a.whatsapp-block__button',
 
 	// Published
+	// 'main' needs to be specified due to the debug elements
 	block: 'main div.wp-block-jetpack-whatsapp-button',
 };
 

--- a/test/e2e/specs/blocks/blocks__jetpack-grow.ts
+++ b/test/e2e/specs/blocks/blocks__jetpack-grow.ts
@@ -24,7 +24,7 @@ const blockFlows: BlockFlow[] = [
 
 // Interacting with the Premium Content toolbar is currently broken on mobile, so only adding for desktop:
 // https://github.com/Automattic/jetpack/issues/22745
-if ( envVariables.VIEWPORT_NAME === 'desktop' ) {
+if ( envVariables.VIEWPORT_NAME === 'desktop' && ! envVariables.TEST_ON_ATOMIC ) {
 	blockFlows.push(
 		new PremiumContentBlockFlow( {
 			subscriberTitle: DataHelper.getRandomPhrase(),

--- a/test/e2e/specs/blocks/blocks__jetpack-grow.ts
+++ b/test/e2e/specs/blocks/blocks__jetpack-grow.ts
@@ -24,6 +24,7 @@ const blockFlows: BlockFlow[] = [
 
 // Interacting with the Premium Content toolbar is currently broken on mobile, so only adding for desktop:
 // https://github.com/Automattic/jetpack/issues/22745
+// Stripe is not connected to this WordPress.com account, so skipping on Atomic
 if ( envVariables.VIEWPORT_NAME === 'desktop' && ! envVariables.TEST_ON_ATOMIC ) {
 	blockFlows.push(
 		new PremiumContentBlockFlow( {


### PR DESCRIPTION
Tracking issue: https://github.com/Automattic/wp-calypso/issues/65906

#### Proposed Changes

Make the following test compatible with the Atomic environment:

> There are no block warnings or errors in the editor
> specs/blocks/blocks__jetpack-grow.ts: Blocks: Jetpack Grow: Add and configure blocks in the editor: Premium Content

Including the following blocks as well: 

1. Contact Info
2. WhatsApp Button

#### Why was it failing? 

There is a block warning or error in the editor for Premium Content in Atomic because Stripe is not connected to the user. In the meantime, we would skip the **Premium Content** block when testing on Atomic. 

Context: p1666794081067859/1666793696.801109-slack-C1A1EKDGQ

The `Contact Info` and `WhatsApp Button` are also failing on Atomic because of multiple elements found. This is due to debugging elements on this page. More specific selectors were then defined. 

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

The fixed test should pass for both Simple and Atomic sites (production).

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->