### PR TITLE
Fix theme preview options for bundled themes

### DIFF
--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -133,6 +133,9 @@ class ThemesSelection extends Component {
 					secondaryOption = null;
 				} else if ( this.props.isThemeActive( themeId ) ) {
 					defaultOption = options.customize;
+				} else if ( options.upgradePlanForBundledThemes ) {
+					defaultOption = options.upgradePlanForBundledThemes;
+					secondaryOption = null;
 				} else if ( options.purchase ) {
 					defaultOption = options.purchase;
 				} else if ( options.upgradePlan ) {


### PR DESCRIPTION
#### Proposed Changes

* This PR fixes a bug where clicking on the "Live demo" link in the logged-in theme showcase for a theme that includes bundled software (currently Thriving Artist or Tsubaki) would result in a white screen.
* The core issue was that the code responsible for setting up the CTA didn't have a case for bundled themes, which need to show a different CTA.
* This PR ensures that we correctly check for the bundled theme upgrade CTA before we launch the preview.

Thanks to @mikeicode for reporting this in p7DVsv-fH5-p2#comment-42716.

#### Testing Instructions

* While logged in on a site with the Premium, Personal or free plan, navigate to _Appearance_ -> _Themes_
* Click on the kebab menu for either Thriving Artist or Tsubaki, and click on the "Live demo" option
* Verify that the theme preview loads correctly
* Also verify that the "Live demo" link works correctly for other free and Premium themes, and shows the theme preview

#### Pre-merge Checklist

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ X ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?