### PR TITLE
Store: Refactor `Sparkline` tests to RTL

### DIFF
--- a/client/my-sites/store/components/d3/sparkline/test/__snapshots__/index.jsx.snap
+++ b/client/my-sites/store/components/d3/sparkline/test/__snapshots__/index.jsx.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Sparkline should have className if provided, as well as sparkline class 1`] = `
+<div>
+  <div
+    class="d3-base sparkline test__foobar"
+  />
+</div>
+`;
+
+exports[`Sparkline should have sparkline class 1`] = `
+<div>
+  <div
+    class="d3-base sparkline"
+  />
+</div>
+`;

--- a/client/my-sites/store/components/d3/sparkline/test/index.jsx
+++ b/client/my-sites/store/components/d3/sparkline/test/index.jsx
@@ -1,25 +1,27 @@
-import { shallow } from 'enzyme';
+/**
+ * @jest-environment jsdom
+ */
+import { render } from '@testing-library/react';
 import Sparkline from '../index';
 
 describe( 'Sparkline', () => {
-	const shallowWithoutLifecycle = ( arg ) => shallow( arg, { disableLifecycleMethods: true } );
-
 	test( 'should allow data to be set.', () => {
 		const sparkline = <Sparkline data={ [ 1, 2, 3, 4, 5 ] } />;
 		expect( sparkline.props.data ).toEqual( [ 1, 2, 3, 4, 5 ] );
 	} );
 
 	test( 'should have sparkline class', () => {
-		const sparkline = shallowWithoutLifecycle( <Sparkline data={ [ 1, 2, 3, 4, 5 ] } /> );
-		expect( sparkline.find( '.sparkline' ) ).toHaveLength( 1 );
+		const { container } = render( <Sparkline data={ [ 1, 2, 3, 4, 5 ] } /> );
+
+		expect( container ).toMatchSnapshot();
 	} );
 
 	test( 'should have className if provided, as well as sparkline class', () => {
-		const sparkline = shallowWithoutLifecycle(
+		const { container } = render(
 			<Sparkline data={ [ 1, 2, 3, 4, 5 ] } className="test__foobar" />
 		);
-		expect( sparkline.find( '.test__foobar' ) ).toHaveLength( 1 );
-		expect( sparkline.find( '.sparkline' ) ).toHaveLength( 1 );
+
+		expect( container ).toMatchSnapshot();
 	} );
 
 	test( 'should have a default aspectRatio of 4.5', () => {


### PR DESCRIPTION
#### Proposed Changes

This PR refactors the `Sparkline` tests to use `@testing-library/react`. We're only migrating away from `enzyme` and keeping the rest of the tests intact. They're not exactly very valuable, but I'm happy to keep them as they are for now.

#### Testing Instructions

Verify tests still pass: `yarn run test-client client/my-sites/store/components/d3/sparkline/test/index.jsx`

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #63409
