### PR TITLE
BBE: Copy changes for DIFM to BBE rebrand

### DIFF
--- a/client/blocks/site/index.jsx
+++ b/client/blocks/site/index.jsx
@@ -202,7 +202,7 @@ class Site extends Component {
 						) }
 						{ site.options && site.options.is_difm_lite_in_progress && (
 							<span className="site__badge site__badge-domain-only">
-								{ translate( 'Do It For Me' ) }
+								{ translate( 'Built By Express' ) }
 							</span>
 						) }
 						{ shouldShowPublicComingSoonSiteBadge && (

--- a/client/my-sites/marketing/do-it-for-me/difm-landing.tsx
+++ b/client/my-sites/marketing/do-it-for-me/difm-landing.tsx
@@ -408,7 +408,7 @@ export default function DIFMLanding( {
 						<FoldableFAQ
 							id="faq-1"
 							expanded={ true }
-							question={ translate( 'What is Do It For Me: Website Design Service?' ) }
+							question={ translate( 'What is Built By WordPress.com Express?' ) }
 						>
 							<p>
 								{ translate(

--- a/client/signup/steps/new-or-existing-site/index.tsx
+++ b/client/signup/steps/new-or-existing-site/index.tsx
@@ -11,6 +11,7 @@ import { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import difmImage from 'calypso/assets/images/difm/difm.svg';
 import QueryProductsList from 'calypso/components/data/query-products-list';
+import WordPressLogo from 'calypso/components/wordpress-logo';
 import { preventWidows } from 'calypso/lib/formatting';
 import useBranchSteps from 'calypso/signup/hooks/use-branch-steps';
 import StepWrapper from 'calypso/signup/step-wrapper';
@@ -43,7 +44,11 @@ export default function NewOrExistingSiteStep( props: Props ) {
 	const displayCost = useSelector( ( state ) => getProductDisplayCost( state, WPCOM_DIFM_LITE ) );
 	const isLoading = useSelector( isProductsListFetching );
 
-	const headerText = translate( 'Do It For Me' );
+	const headerText = translate( 'Built By {{wordPressLogo}}{{/wordPressLogo}} Express', {
+		components: {
+			wordPressLogo: <WordPressLogo size={ 48 } className="new-or-existing-site__wordpress-logo" />,
+		},
+	} );
 
 	const subHeaderText = translate(
 		'Get a professionally designed, mobile-optimized website in %(fulfillmentDays)d business days or less for a one-time fee of {{PriceWrapper}}%(displayCost)s{{/PriceWrapper}} plus an additional purchase of the %(plan)s plan.',

--- a/client/signup/steps/new-or-existing-site/style.scss
+++ b/client/signup/steps/new-or-existing-site/style.scss
@@ -1,7 +1,21 @@
+@import "@automattic/typography/styles/variables";
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
 .new-or-existing-site__placeholder {
 	padding: 0 20px;
 	animation: pulse-light 800ms ease-in-out infinite;
 	background-color: var(--color-neutral-10);
 	color: transparent;
 	min-height: $font-title-small;
+}
+
+.new-or-existing-site__wordpress-logo {
+	vertical-align: top;
+	height: 2.5rem;
+	width: 2.5rem;
+	@include break-mobile {
+		height: initial;
+		width: initial;
+	}
 }


### PR DESCRIPTION
#### Proposed Changes

P2: pdh1Xd-1s6-p2

* Changes product name on `/start/do-it-for-me`.
* Changes text in sidebar for BBE In-Progress sites.
* Changes product name in FAQ item on the BBE landing page.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/do-it-for-me`. Confirm that the product name looks like the following:

|Desktop|Mobile|
|---|---|
|<img width="1286" alt="image" src="https://user-images.githubusercontent.com/5436027/198271239-2c11cbee-ed4e-45f8-abf8-e8b60f4f3dfb.png">|<img width="346" alt="image" src="https://user-images.githubusercontent.com/5436027/198272258-3e9687da-55da-46e5-91a6-101a1b9c6e16.png">|


* Go to `/setup/difmStartingPoint?siteSlug=<site slug>`. Confirm that the product name in the FAQ item has been changed.
<img width="1288" alt="image" src="https://user-images.githubusercontent.com/5436027/198272467-eab09ce7-879c-45a5-b1b4-8b4b26d655c0.png">

* Go to `/home`. In the sidebar, if you have a site that is marked as BBE In-Progress, confirm that the name on the badge has changed:
<img width="258" alt="image" src="https://user-images.githubusercontent.com/5436027/198271477-634acea0-c4ab-4c4c-b9c3-92dbdafd3da2.png">


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes? - NA
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)? - NA
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) - NA
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)? - NA

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes Automattic/martech#1163
Fixes Automattic/martech#1164
Fixes Automattic/martech#1165