### PR TITLE
Newsletter Flow: Fix Lettre primary color

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/accent-color-control/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/accent-color-control/index.tsx
@@ -28,7 +28,7 @@ export type AccentColor = {
 };
 
 enum COLORS {
-	Lettre = '#1D39EB',
+	Lettre = '#113AF5',
 	Black = '#000000',
 	VividRed = '#CF2E2E',
 	VividPurple = '#9B51E0',

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/index.tsx
@@ -14,7 +14,7 @@ import type { Step } from '../../types';
 import './style.scss';
 
 export const defaultAccentColor = {
-	hex: '#1D39EB',
+	hex: '#113AF5',
 	rgb: { r: 29, g: 57, b: 235 },
 	default: true,
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/index.tsx
@@ -15,7 +15,7 @@ import './style.scss';
 
 export const defaultAccentColor = {
 	hex: '#113AF5',
-	rgb: { r: 29, g: 57, b: 235 },
+	rgb: { r: 17, g: 58, b: 245 },
 	default: true,
 };
 


### PR DESCRIPTION
#### Proposed Changes

* Restore the Lettre theme's primary color code as defined by the Lettre theme.json.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run the Newsletter flow at `/setup/newsletterSetup?flow=newsletter`.
* In the accent color dropdown, inspect the Lettre color element and ensure the color code (converted to RGB) is correct.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #68408
