### PR TITLE
Email open stats card in stats dashboard

### DIFF
--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -301,6 +301,13 @@ class StatsSite extends Component {
 					<div className="stats__module-list is-events stats__module--unified">
 						<div className="stats__module-column">
 							<StatsModule
+								path="emailsOpen"
+								moduleStrings={ moduleStrings.emailsOpenStats }
+								period={ this.props.period }
+								query={ query }
+								statType="statsEmailsOpen"
+							/>
+							<StatsModule
 								path="posts"
 								moduleStrings={ moduleStrings.posts }
 								period={ this.props.period }

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -302,11 +302,11 @@ class StatsSite extends Component {
 						<div className="stats__module-column">
 							{ config.isEnabled( 'newsletter/stats' ) && (
 								<StatsModule
-									path="emailsOpen"
-									moduleStrings={ moduleStrings.emailsOpenStats }
+									path="emailOpens"
+									moduleStrings={ moduleStrings.emailOpensStats }
 									period={ this.props.period }
 									query={ query }
-									statType="statsEmailsOpen"
+									statType="statsEmailOpens"
 								/>
 							) }
 							<StatsModule

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -300,13 +300,15 @@ class StatsSite extends Component {
 
 					<div className="stats__module-list is-events stats__module--unified">
 						<div className="stats__module-column">
-							<StatsModule
-								path="emailsOpen"
-								moduleStrings={ moduleStrings.emailsOpenStats }
-								period={ this.props.period }
-								query={ query }
-								statType="statsEmailsOpen"
-							/>
+							{ config.isEnabled( 'newsletter/stats' ) && (
+								<StatsModule
+									path="emailsOpen"
+									moduleStrings={ moduleStrings.emailsOpenStats }
+									period={ this.props.period }
+									query={ query }
+									statType="statsEmailsOpen"
+								/>
+							) }
 							<StatsModule
 								path="posts"
 								moduleStrings={ moduleStrings.posts }

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -300,7 +300,7 @@ class StatsSite extends Component {
 
 					<div className="stats__module-list is-events stats__module--unified">
 						<div className="stats__module-column">
-							{ config.isEnabled( 'newsletter/stats' ) && (
+							{ config.isEnabled( 'stats/newsletter' ) && (
 								<StatsModule
 									path="emailOpens"
 									moduleStrings={ moduleStrings.emailOpensStats }

--- a/client/my-sites/stats/stats-strings.js
+++ b/client/my-sites/stats/stats-strings.js
@@ -113,11 +113,11 @@ export default function () {
 		} ),
 	};
 
-	statsStrings.emailsOpenStats = {
-		title: translate( 'Emails open', { context: 'Stats: title of module' } ),
+	statsStrings.emailOpensStats = {
+		title: translate( 'Email opens', { context: 'Stats: title of module' } ),
 		item: translate( 'Title', { context: 'Stats: module row header for post title.' } ),
-		value: translate( 'Views', { context: 'Stats: module row header for number of post views.' } ),
-		empty: translate( 'No emails open', {
+		value: translate( 'Opens', { context: 'Stats: module row header for number of post views.' } ),
+		empty: translate( 'No email opens', {
 			context: 'Stats: Info box label when the Email Open module is empty',
 		} ),
 	};

--- a/client/my-sites/stats/stats-strings.js
+++ b/client/my-sites/stats/stats-strings.js
@@ -113,5 +113,14 @@ export default function () {
 		} ),
 	};
 
+	statsStrings.emailsOpenStats = {
+		title: translate( 'Emails open', { context: 'Stats: title of module' } ),
+		item: translate( 'Title', { context: 'Stats: module row header for post title.' } ),
+		value: translate( 'Views', { context: 'Stats: module row header for number of post views.' } ),
+		empty: translate( 'No emails open', {
+			context: 'Stats: Info box label when the Email Open module is empty',
+		} ),
+	};
+
 	return statsStrings;
 }

--- a/client/state/stats/lists/actions.js
+++ b/client/state/stats/lists/actions.js
@@ -33,6 +33,7 @@ const wpcomV1Endpoints = {
 	statsInsights: 'stats/insights',
 	statsFileDownloads: 'stats/file-downloads',
 	statsAds: 'wordads/stats',
+	statsEmailsOpen: 'stats/opens/emails',
 };
 
 const wpcomV2Endpoints = {

--- a/client/state/stats/lists/actions.js
+++ b/client/state/stats/lists/actions.js
@@ -33,7 +33,7 @@ const wpcomV1Endpoints = {
 	statsInsights: 'stats/insights',
 	statsFileDownloads: 'stats/file-downloads',
 	statsAds: 'wordads/stats',
-	statsEmailsOpen: 'stats/opens/emails',
+	statsEmailOpens: 'stats/opens/emails',
 };
 
 const wpcomV2Endpoints = {

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -946,4 +946,32 @@ export const normalizers = {
 			};
 		} );
 	},
+
+	/**
+	 * Returns a normalized statsEmailsOpen array, ready for use in stats-module
+	 *
+	 * @param   {object} data   Stats data
+	 * @param   {object} query  Stats query
+	 * @returns {Array}       Normalized stats data
+	 */
+	statsEmailsOpen( data, query = {} ) {
+		if ( ! data || ! query.period || ! query.date ) {
+			return [];
+		}
+		const { startOf } = rangeOfPeriod( query.period, query.date );
+		const emailsData = get( data, [ 'days', startOf, 'email_opens' ], [] );
+
+		return emailsData.map( ( { id, href, date, title, type, opens } ) => {
+			const record = {
+				id,
+				href,
+				date,
+				label: title,
+				type,
+				value: opens || '0',
+			};
+
+			return record;
+		} );
+	},
 };

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -948,20 +948,20 @@ export const normalizers = {
 	},
 
 	/**
-	 * Returns a normalized statsEmailsOpen array, ready for use in stats-module
+	 * Returns a normalized statsEmailOpens array, ready for use in stats-module
 	 *
 	 * @param   {object} data   Stats data
 	 * @param   {object} query  Stats query
 	 * @returns {Array}       Normalized stats data
 	 */
-	statsEmailsOpen( data, query = {} ) {
+	statsEmailOpens( data, query = {} ) {
 		if ( ! data || ! query.period || ! query.date ) {
 			return [];
 		}
 		const { startOf } = rangeOfPeriod( query.period, query.date );
-		const emailsData = get( data, [ 'days', startOf, 'email_opens' ], [] );
+		const emailOpensData = get( data, [ 'days', startOf, 'email_opens' ], [] );
 
-		return emailsData.map( ( { id, href, date, title, type, opens } ) => {
+		return emailOpensData.map( ( { id, href, date, title, type, opens } ) => {
 			const record = {
 				id,
 				href,

--- a/config/development.json
+++ b/config/development.json
@@ -171,6 +171,7 @@
 		"site-indicator": true,
 		"ssr/prefetch-timebox": false,
 		"stats/new-main-chart": true,
+		"stats/newsletter": false,
 		"stepper-woocommerce-poc": true,
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,
@@ -187,7 +188,6 @@
 		"upsell/concierge-session": true,
 		"woop": false,
 		"wordpress-action-search": false,
-		"wpcom-user-bootstrap": false,
-		"newsletter/stats": false
+		"wpcom-user-bootstrap": false
 	}
 }

--- a/config/development.json
+++ b/config/development.json
@@ -187,6 +187,7 @@
 		"upsell/concierge-session": true,
 		"woop": false,
 		"wordpress-action-search": false,
-		"wpcom-user-bootstrap": false
+		"wpcom-user-bootstrap": false,
+		"newsletter/stats": false
 	}
 }

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -131,7 +131,8 @@
 		"use-translation-chunks": true,
 		"woop": false,
 		"wordpress-action-search": false,
-		"wpcom-user-bootstrap": true
+		"wpcom-user-bootstrap": true,
+		"newsletter/stats": false
 	},
 	"siftscience_key": "a4f69f6759",
 	"oauth_client_id": "39911",

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -116,6 +116,7 @@
 		"site-indicator": true,
 		"ssr/prefetch-timebox": true,
 		"stats/new-main-chart": false,
+		"stats/newsletter": false,
 		"stepper-woocommerce-poc": true,
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,
@@ -131,8 +132,7 @@
 		"use-translation-chunks": true,
 		"woop": false,
 		"wordpress-action-search": false,
-		"wpcom-user-bootstrap": true,
-		"newsletter/stats": false
+		"wpcom-user-bootstrap": true
 	},
 	"siftscience_key": "a4f69f6759",
 	"oauth_client_id": "39911",

--- a/config/production.json
+++ b/config/production.json
@@ -153,7 +153,8 @@
 		"use-translation-chunks": true,
 		"woop": false,
 		"wordpress-action-search": false,
-		"wpcom-user-bootstrap": true
+		"wpcom-user-bootstrap": true,
+		"newsletter/stats": false
 	},
 	"siftscience_key": "a4f69f6759",
 	"oauth_client_id": "39911",

--- a/config/production.json
+++ b/config/production.json
@@ -137,6 +137,7 @@
 		"ssr/prefetch-timebox": true,
 		"ssr/sample-log-cache-misses": true,
 		"stats/new-main-chart": false,
+		"stats/newsletter": false,
 		"stepper-woocommerce-poc": true,
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,
@@ -153,8 +154,7 @@
 		"use-translation-chunks": true,
 		"woop": false,
 		"wordpress-action-search": false,
-		"wpcom-user-bootstrap": true,
-		"newsletter/stats": false
+		"wpcom-user-bootstrap": true
 	},
 	"siftscience_key": "a4f69f6759",
 	"oauth_client_id": "39911",

--- a/config/stage.json
+++ b/config/stage.json
@@ -149,7 +149,8 @@
 		"use-translation-chunks": true,
 		"woop": false,
 		"wordpress-action-search": false,
-		"wpcom-user-bootstrap": true
+		"wpcom-user-bootstrap": true,
+		"newsletter/stats": false
 	},
 	"siftscience_key": "e00e878351",
 	"oauth_client_id": "39911",

--- a/config/stage.json
+++ b/config/stage.json
@@ -133,6 +133,7 @@
 		"site-indicator": true,
 		"ssr/prefetch-timebox": true,
 		"stats/new-main-chart": false,
+		"stats/newsletter": false,
 		"stepper-woocommerce-poc": true,
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,
@@ -149,8 +150,7 @@
 		"use-translation-chunks": true,
 		"woop": false,
 		"wordpress-action-search": false,
-		"wpcom-user-bootstrap": true,
-		"newsletter/stats": false
+		"wpcom-user-bootstrap": true
 	},
 	"siftscience_key": "e00e878351",
 	"oauth_client_id": "39911",

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -141,6 +141,7 @@
 		"site-indicator": true,
 		"ssr/prefetch-timebox": true,
 		"stats/new-main-chart": false,
+		"stats/newsletter": false,
 		"stepper-woocommerce-poc": true,
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,
@@ -157,8 +158,7 @@
 		"use-translation-chunks": true,
 		"woop": false,
 		"wordpress-action-search": false,
-		"wpcom-user-bootstrap": true,
-		"newsletter/stats": false
+		"wpcom-user-bootstrap": true
 	},
 	"siftscience_key": "e00e878351",
 	"oauth_client_id": "39911",

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -157,7 +157,8 @@
 		"use-translation-chunks": true,
 		"woop": false,
 		"wordpress-action-search": false,
-		"wpcom-user-bootstrap": true
+		"wpcom-user-bootstrap": true,
+		"newsletter/stats": false
 	},
 	"siftscience_key": "e00e878351",
 	"oauth_client_id": "39911",


### PR DESCRIPTION
#### Proposed Changes

This PR adds a new card in the stats dashboard: the Emails Open tab. This tab indicates the number of people opening each email sent for new post. See the screenshot:

<img width="613" alt="Screenshot 2022-10-26 at 17 19 51" src="https://user-images.githubusercontent.com/3832570/198337237-deab0e0b-51fb-4f58-89e4-cb4b13f963ec.png">

It also adds a feature flag ('newsletter/stats') for shielding the development while this is done.

#### Testing Instructions

As the endpoint is returning mocked data at this point, the testing instructions are:

- pull this PR code locally
- start the development environment with `yarn start`
- go to your local calypso url (`http://calypso.localhost:3000` most likely?)
- go to the stats page
- you should see the `Emails open` card.
- stop the development environment.
- go to `config/development.json` and set the feature flag (`newsletter/stats`) to `false`
- start the development environment again (`yarn start`)
- go to the stats page again
- you shouldn't see the `Emails open` card anymore

Related to https://github.com/Automattic/wp-calypso/issues/69431
