### PR TITLE
Update overall spend to "today" when a promoted post campaign has run for less than a day

### DIFF
--- a/client/my-sites/promote-post/utils/index.ts
+++ b/client/my-sites/promote-post/utils/index.ts
@@ -94,19 +94,24 @@ export const getCampaignOverallSpending = (
 	let daysRun = moment().diff( moment( start_date ), 'days' );
 	daysRun = daysRun > campaignDays ? campaignDays : daysRun;
 
-	/* translators: %1$s: Amount, %2$s: Days. eg: $3 over 2 days */
-	const overallSpending = sprintf( __( '$%1$s over %2$s days' ), totalBudgetUsed, daysRun );
-	return overallSpending;
+	const daysText = daysRun === 1 ? 'day' : 'days';
+
+	if ( daysRun > 0 ) {
+		/* translators: %1$s: Amount, %2$s: Days. Singular or plural: Day(s) eg: $3 over 2 days */
+		return sprintf( __( '$%1$s over %2$s %3$s' ), totalBudgetUsed, daysRun, daysText );
+	}
+
+	/* translators: %1$s: Amount, eg: $3 today */
+	return sprintf( __( '$%1$s today' ), totalBudgetUsed );
 };
 
 export const getCampaignClickthroughRate = ( clicks_total: number, impressions_total: number ) => {
 	const clickthroughRate = ( clicks_total * 100 ) / impressions_total || 0;
-	const formattedRate = clickthroughRate.toLocaleString( undefined, {
+	return clickthroughRate.toLocaleString( undefined, {
 		useGrouping: true,
 		minimumFractionDigits: 0,
 		maximumFractionDigits: 2,
 	} );
-	return formattedRate;
 };
 
 export const getCampaignDurationFormatted = ( start_date: string, end_date: string ) => {


### PR DESCRIPTION
#### Proposed Changes

Update wording on the promoted posts campaign overview tab.

**Why?**
In the campaign reporting for promoted posts, in the first 24hrs the campaign will report your spending over `0 days`

![image](https://user-images.githubusercontent.com/6440498/198348921-f9166fd6-5206-4f5b-acc6-43653bfe3365.png)

In these cases we will instead say "today". e.g. `$3.12 today`

Also adds pluralisation where necessary (` days !== 1`). As previously this always said days, regardless of how many.
Now: $3.12 over 1 day
Previous : $3.12 over 1 days


This PR updates this to handle 3 different scenarios:

**Less than 24 hrs**
![Screenshot 2022-10-27 at 17 26 00](https://user-images.githubusercontent.com/6440498/198348569-49d1ddcb-0946-4d34-8441-f00c2300897e.png)

**1 day**
![Screenshot 2022-10-27 at 17 24 55](https://user-images.githubusercontent.com/6440498/198348574-fb2285c0-cde6-4b68-9df3-255a5212aaac.png)

**More than one day**
![Screenshot 2022-10-27 at 17 25 37](https://user-images.githubusercontent.com/6440498/198348697-b1aeae78-5ce8-436b-bb49-c5eaeef51c7e.png)


#### Testing Instructions

Visit:
- [ ] Visit http://calypso.localhost:3000/advertising/yoursite.co.uk 
- [ ] Create a promoted posts campaign - expense this if you need to
- [ ] Check http://calypso.localhost:3000/advertising/yoursite.co.uk/campaigns and confirm you see `$0 today` and note `$0  over 0 days`

#### Pre-merge Checklist

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
