### PR TITLE
Fixes a problem with the header on iOS for the promoted post widget page

### DIFF
--- a/client/components/blazepress-widget/style.scss
+++ b/client/components/blazepress-widget/style.scss
@@ -7,7 +7,6 @@ $headerHeight: 72px;
 	display: flex;
 	flex-direction: column;
 	z-index: 1001;
-	height: 100%;
 
 	.blazepress-widget__header-bar {
 		align-items: center;


### PR DESCRIPTION
#### Proposed Changes

* This PR fixes a behavior with the header on the promoted post widget for iOS. The expected result after the change is that the Navigational header should be on top of the page. On iOS, we had a styling problem that made the header hidden.

#### Testing Instructions

* Go to the advertising section for a public blog
* Promote a post or a page
* After the promoted post widget loads, verify that the header with the navigational steps is displayed

Verify that you have the same result with Android/iPhone and Web.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
