### PR TITLE
Domains: Add loading state to domain connection flow options

### DIFF
--- a/client/components/domains/use-my-domain/transfer-or-connect/index.jsx
+++ b/client/components/domains/use-my-domain/transfer-or-connect/index.jsx
@@ -60,6 +60,8 @@ function DomainTransferOrConnect( {
 
 	const handleTransfer = () => {
 		recordTransferButtonClickInUseYourDomain( domain );
+		setActionClicked( true );
+
 		onTransfer( { domain, selectedSite, transferDomainUrl }, () => setActionClicked( false ) );
 	};
 

--- a/client/components/domains/use-my-domain/transfer-or-connect/option-content.jsx
+++ b/client/components/domains/use-my-domain/transfer-or-connect/option-content.jsx
@@ -89,7 +89,7 @@ export default function OptionContent( {
 			</div>
 			<div className="option-content__action">
 				{ onSelect && (
-					<Button primary={ primary } disabled={ disabled } onClick={ onSelect }>
+					<Button primary={ primary } disabled={ disabled } onClick={ onSelect } busy={ disabled }>
 						{ __( 'Select' ) }
 					</Button>
 				) }


### PR DESCRIPTION
#### Proposed Changes
This PR adds the loading state to both transfer and connect buttons in the domain connection flow.

#### Preview
##### Before

https://user-images.githubusercontent.com/18705930/198382426-b40b23f5-28ca-4367-a5c6-f2c978ec6f77.mov



##### After


https://user-images.githubusercontent.com/18705930/198382444-abd630c7-f70a-4b54-9045-99805d1e126e.mov



#### Testing Instructions
- Go to Upgrades > Domains > Add a domain > Use a domain I own;
- Type a testing domain and wait for the next step;
- In the next step, select either transfer or connect and ensure that the buttons will have their "loading state" toggled once clicked.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] (N/A) [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [X] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] (N/A) Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] (N/A) Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
