### PR TITLE
Plugin Details: Update the sidebar items for pre installed plugins

### DIFF
--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -102,13 +102,14 @@ const PluginDetailsCTA = ( { plugin, isPlaceholder } ) => {
 		getEligibility( state, selectedSite?.ID )
 	);
 
-	const upgradeToBusinessHRef = useMemo( () => {
+	const upgradeToBusinessHref = useMemo( () => {
 		const pluginsPlansPageFlag = isEnabled( 'plugins-plans-page' );
 
 		const siteSlug = selectedSite?.slug;
 
 		const pluginsPlansPage = `/plugins/plans/yearly/${ siteSlug }`;
-		return pluginsPlansPageFlag ? pluginsPlansPage : `/checkout/${ siteSlug }/business`;
+		const checkoutPage = siteSlug ? `/checkout/${ siteSlug }/business` : `/checkout/business`;
+		return pluginsPlansPageFlag ? pluginsPlansPage : checkoutPage;
 	}, [ selectedSite?.slug ] );
 
 	const saasRedirectHRef = useMemo( () => {
@@ -145,8 +146,23 @@ const PluginDetailsCTA = ( { plugin, isPlaceholder } ) => {
 			<div className="plugin-details-cta__container">
 				<div className="plugin-details-cta__price">{ translate( 'Free' ) }</div>
 				<span className="plugin-details-cta__preinstalled">
-					{ translate( '%s is automatically managed for you.', { args: plugin.name } ) }
+					{ selectedSite
+						? translate(
+								'%s is automatically managed for you. Upgrade your plan and get access to another 50,000 WordPress plugins to extend functionality for your site.',
+								{ args: plugin.name }
+						  )
+						: translate( '%s is automatically managed for you.', { args: plugin.name } ) }
 				</span>
+
+				{ selectedSite && (
+					<Button
+						href={ upgradeToBusinessHref }
+						className="plugin-details-cta__install-button"
+						primary
+					>
+						{ translate( 'Upgrade my plan' ) }
+					</Button>
+				) }
 			</div>
 		);
 	}
@@ -331,7 +347,7 @@ const PluginDetailsCTA = ( { plugin, isPlaceholder } ) => {
 					<div className="plugin-details-cta__upgrade-required-card">
 						<UpgradeRequiredContent translate={ translate } />
 						<Button
-							href={ upgradeToBusinessHRef }
+							href={ upgradeToBusinessHref }
 							className="plugin-details-cta__install-button"
 							primary
 							onClick={ () => {} }

--- a/client/my-sites/plugins/plugin-details-CTA/usps.tsx
+++ b/client/my-sites/plugins/plugin-details-CTA/usps.tsx
@@ -29,7 +29,7 @@ const StyledLi = styled.li`
 	color: var( --studio-gray-80 );
 	font-size: $font-body-small;
 	display: flex;
-	align-items: center;
+	align-items: flex-start;
 	margin: 5px 0;
 
 	.title {
@@ -40,7 +40,9 @@ const StyledLi = styled.li`
 	}
 
 	svg {
+		min-width: 16px;
 		margin-right: 8px;
+		margin-top: 4px;
 	}
 `;
 

--- a/client/my-sites/plugins/plugin-details-CTA/usps.tsx
+++ b/client/my-sites/plugins/plugin-details-CTA/usps.tsx
@@ -14,7 +14,10 @@ import PluginDetailsSidebarUSP from 'calypso/my-sites/plugins/plugin-details-sid
 import usePluginsSupportText from 'calypso/my-sites/plugins/use-plugins-support-text/';
 import { getBillingInterval } from 'calypso/state/marketplace/billing-interval/selectors';
 import { getProductDisplayCost } from 'calypso/state/products-list/selectors';
+import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { IAppState } from 'calypso/state/types';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
+import { PREINSTALLED_PLUGINS } from '../constants';
 
 const StyledUl = styled.ul`
 	margin-top: 20px;
@@ -61,6 +64,7 @@ const useRequiredPlan = ( shouldUpgrade: boolean ) => {
 };
 
 interface Props {
+	pluginSlug: string;
 	shouldUpgrade: boolean;
 	isFreePlan: boolean;
 	isMarketplaceProduct: boolean;
@@ -100,8 +104,17 @@ export const USPS: React.FC< Props > = ( { isMarketplaceProduct, billingPeriod }
 	);
 };
 
-export const PlanUSPS: React.FC< Props > = ( { shouldUpgrade, isFreePlan, billingPeriod } ) => {
+export const PlanUSPS: React.FC< Props > = ( {
+	pluginSlug,
+	shouldUpgrade,
+	isFreePlan,
+	billingPeriod,
+} ) => {
 	const translate = useTranslate();
+
+	const selectedSite = useSelector( getSelectedSite );
+	const isJetpack = useSelector( ( state ) => isJetpackSite( state, selectedSite?.ID ) );
+	const isPreInstalledPlugin = ! isJetpack && PREINSTALLED_PLUGINS.includes( pluginSlug );
 
 	const isAnnualPeriod = billingPeriod === IntervalLength.ANNUALLY;
 	const supportText = usePluginsSupportText();
@@ -139,10 +152,21 @@ export const PlanUSPS: React.FC< Props > = ( { shouldUpgrade, isFreePlan, billin
 			break;
 	}
 
+	const preInstalledPluginUSPS = [
+		translate( 'Remove WordPress.com ads' ),
+		translate( 'Collect payments' ),
+		translate( 'Earn ad revenue' ),
+		translate( 'Premium themes' ),
+		translate( 'Google Analytics integration' ),
+		translate( 'Advanced SEO (Search Engine Optimisation) tools' ),
+		translate( 'Automated site backups and one-click restore' ),
+		translate( 'SFTP (SSH File Transfer Protocol) and Database Access' ),
+	];
 	const filteredUSPS = [
 		...( isFreePlan && isAnnualPeriod ? [ translate( 'Free domain for one year' ) ] : [] ),
 		translate( 'Best-in-class hosting' ),
 		supportText,
+		...( isPreInstalledPlugin ? preInstalledPluginUSPS : [] ),
 	];
 
 	return (

--- a/client/my-sites/plugins/plugin-details-sidebar/index.jsx
+++ b/client/my-sites/plugins/plugin-details-sidebar/index.jsx
@@ -18,6 +18,7 @@ import { getSelectedSite } from 'calypso/state/ui/selectors';
 
 const PluginDetailsSidebar = ( {
 	plugin: {
+		slug,
 		active_installs,
 		tested,
 		isMarketplaceProduct = false,
@@ -89,6 +90,7 @@ const PluginDetailsSidebar = ( {
 
 			{ selectedSite && (
 				<PlanUSPS
+					pluginSlug={ slug }
 					shouldUpgrade={ shouldUpgrade }
 					isFreePlan={ isFreePlan }
 					isMarketplaceProduct={ isMarketplaceProduct }


### PR DESCRIPTION
#### Proposed Changes

Update the sidebar items displayed for pre-installed plugins when a site with a plan lower than Business is selected:
* Update the wording
* Add a plan upgrade CTA
* Show additional USPs

#### Testing Instructions
* Go to the Plugin details page of a pre-installed plugin with a lower than business plan site selected. Ex: `/plugins/jetpack/{free_site}`
* Check if its similar to what is displayed below and matches the layout HOg65lHD0QOfaq0QtzKQbC-fi-984%3A9629
* Select a business site and check the same
* Go to the page without a site selected and check the same. Ex: `/plugins/jetpack`

| No site selected | Business and higher |  Lower than business  |
| ------------- | ------------- | ------------- |
|<img width="830" alt="Screen Shot 2022-10-27 at 15 12 36" src="https://user-images.githubusercontent.com/5039531/198390136-7d4329e8-3e9e-4a01-8d8f-a7d62daecf0f.png">|<img width="830" alt="Screen Shot 2022-10-27 at 15 12 53" src="https://user-images.githubusercontent.com/5039531/198390227-cba1c702-52b7-4d6f-8ddb-0c3aa462b5f4.png">|<img width="830" alt="Screen Shot 2022-10-27 at 15 35 39" src="https://user-images.githubusercontent.com/5039531/198392734-d67e3a02-880f-48a7-9f68-2d930541497d.png">|


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #67994

cc: @vinimotaa 