### PR TITLE
Launchpad: Add copy to clipboard button unit tests

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
@@ -110,6 +110,7 @@ const Sidebar = ( { sidebarDomain, siteSlug, submit, goNext, goToStep }: Sidebar
 						{ showClipboardButton && (
 							<>
 								<ClipboardButton
+									aria-label={ translate( 'Copy URL' ) }
 									text={ siteSlug }
 									className="launchpad__clipboard-button"
 									borderless

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/sidebar.tsx
@@ -109,24 +109,54 @@ describe( 'Sidebar', () => {
 		expect( progressBar ).toBeVisible();
 	} );
 
-	it( 'does not show a custom domain setup notification for free wpcom domains', () => {
-		renderSidebar( {
-			...props,
-			sidebarDomain: buildDomainResponse( {
-				sslStatus: null,
-				isWPCOMDomain: true,
-			} ),
+	describe( 'when no custom domain has been purchased', () => {
+		it( 'shows a copy url to clipboard button', () => {
+			renderSidebar( {
+				...props,
+				sidebarDomain: buildDomainResponse( {
+					sslStatus: null,
+					isWPCOMDomain: true,
+				} ),
+			} );
+
+			const clipboardButton = screen.getByLabelText( /Copy URL/i );
+
+			expect( clipboardButton ).toBeInTheDocument();
 		} );
 
-		const domainProcessingNotification = screen.queryByText(
-			/We are currently setting up your new domain! It may take a few minutes before it is ready./i
-		);
+		it( 'does not show a custom domain setup notification for free wpcom domains', () => {
+			renderSidebar( {
+				...props,
+				sidebarDomain: buildDomainResponse( {
+					sslStatus: null,
+					isWPCOMDomain: true,
+				} ),
+			} );
 
-		expect( domainProcessingNotification ).not.toBeInTheDocument();
+			const domainProcessingNotification = screen.queryByText(
+				/We are currently setting up your new domain! It may take a few minutes before it is ready./i
+			);
+
+			expect( domainProcessingNotification ).not.toBeInTheDocument();
+		} );
 	} );
 
 	describe( 'when a custom domain has been purchased', () => {
 		describe( 'and the domain SSL is still being processed', () => {
+			it( 'does not show a copy url to clipboard button', () => {
+				renderSidebar( {
+					...props,
+					sidebarDomain: buildDomainResponse( {
+						sslStatus: 'pending',
+						isWPCOMDomain: false,
+					} ),
+				} );
+
+				const clipboardButton = screen.queryByLabelText( /Copy URL/i );
+
+				expect( clipboardButton ).not.toBeInTheDocument();
+			} );
+
 			it( 'shows a notification explaining that the domain is being set up', () => {
 				renderSidebar( {
 					...props,
@@ -145,12 +175,28 @@ describe( 'Sidebar', () => {
 		} );
 
 		describe( 'and the domain SSL has been activated', () => {
+			it( 'shows a copy url to clipboard button', () => {
+				renderSidebar( {
+					...props,
+					sidebarDomain: buildDomainResponse( {
+						sslStatus: 'active',
+						isWPCOMDomain: false,
+						isPrimary: true,
+					} ),
+				} );
+
+				const clipboardButton = screen.getByLabelText( /Copy URL/i );
+
+				expect( clipboardButton ).toBeInTheDocument();
+			} );
+
 			it( 'does not show a notification', () => {
 				renderSidebar( {
 					...props,
 					sidebarDomain: buildDomainResponse( {
 						sslStatus: 'active',
 						isWPCOMDomain: false,
+						isPrimary: true,
 					} ),
 				} );
 


### PR DESCRIPTION
#### Proposed Changes

* Adds an `aria-label` to the copy to clipboard button because there was no textual content in the button, only an svg icon. This led to a blank `aria-label` property by default for the button.
* Adds unit tests for launchpad copy to clipboard feature

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout branch
* Run `yarn test-client launchpad/test/sidebar` and verify that all unit tests pass

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
