### PR TITLE
Normalize server performance marks for logstash

### DIFF
--- a/client/controller/localized-links.js
+++ b/client/controller/localized-links.js
@@ -1,6 +1,7 @@
 import config from '@automattic/calypso-config';
 import { localizeUrl, getLanguageSlugs } from '@automattic/i18n-utils';
 import { getLocaleSlug } from 'i18n-calypso';
+import performanceMark from 'calypso/server/lib/performance-mark';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { setDocumentHeadLink } from 'calypso/state/document-head/actions';
 
@@ -21,6 +22,7 @@ const getLocalizedCanonicalUrl = ( path, locale ) => {
 };
 
 export const setLocalizedCanonicalUrl = ( context, next ) => {
+	performanceMark( context, 'setLocalizedCanonicalUrl' );
 	if ( ! context.isServerSide || isUserLoggedIn( context.store.getState() ) ) {
 		next();
 		return;
@@ -41,6 +43,7 @@ export const setHrefLangLinks = ( context, next ) => {
 		next();
 		return;
 	}
+	performanceMark( context, 'setHrefLangLinks' );
 
 	const langCodes = [ 'x-default', 'en', ...config( 'magnificent_non_en_locales' ) ];
 	const hrefLangBlock = langCodes.map( ( hrefLang ) => {

--- a/client/my-sites/themes/controller.jsx
+++ b/client/my-sites/themes/controller.jsx
@@ -1,6 +1,7 @@
 import debugFactory from 'debug';
 import { logServerEvent } from 'calypso/lib/analytics/statsd-utils';
 import trackScrollPage from 'calypso/lib/track-scroll-page';
+import performanceMark from 'calypso/server/lib/performance-mark';
 import { requestThemes, requestThemeFilters } from 'calypso/state/themes/actions';
 import { DEFAULT_THEME_QUERY } from 'calypso/state/themes/constants';
 import { getThemeFilters, getThemesForQuery } from 'calypso/state/themes/selectors';
@@ -31,6 +32,7 @@ export function getProps( context ) {
 }
 
 export function loggedOut( context, next ) {
+	performanceMark( context, 'loggedOut' );
 	if ( context.isServerSide && Object.keys( context.query ).length > 0 ) {
 		// Don't server-render URLs with query params
 		return next();
@@ -47,6 +49,7 @@ export function fetchThemeData( context, next ) {
 		debug( 'Skipping theme data fetch' );
 		return next();
 	}
+	performanceMark( context, 'fetchThemeData' );
 
 	const siteId = 'wpcom';
 	const query = {
@@ -77,6 +80,7 @@ export function fetchThemeFilters( context, next ) {
 		debug( 'Skipping theme filter data fetch' );
 		return next();
 	}
+	performanceMark( context, 'fetchThemeFilters' );
 
 	const { store } = context;
 	const hasFilters = Object.keys( getThemeFilters( store.getState() ) ).length > 0;

--- a/client/my-sites/themes/controller.jsx
+++ b/client/my-sites/themes/controller.jsx
@@ -32,7 +32,7 @@ export function getProps( context ) {
 }
 
 export function loggedOut( context, next ) {
-	performanceMark( context, 'loggedOut' );
+	performanceMark( context, 'themesLoggedOut' );
 	if ( context.isServerSide && Object.keys( context.query ).length > 0 ) {
 		// Don't server-render URLs with query params
 		return next();

--- a/client/my-sites/themes/validate-filters.js
+++ b/client/my-sites/themes/validate-filters.js
@@ -1,5 +1,6 @@
 import page from 'page';
 import { composeHandlers } from 'calypso/controller/shared';
+import performanceMark from 'calypso/server/lib/performance-mark';
 import {
 	getThemeFilterStringFromTerm,
 	getThemeFilterTerm,
@@ -10,6 +11,7 @@ import { fetchThemeFilters } from './controller';
 
 // Reorder and remove invalid filters to redirect to canonical URL
 export function validateFilters( context, next ) {
+	performanceMark( context, 'validateFilters' );
 	if ( ! context.params.filter ) {
 		return next();
 	}
@@ -39,6 +41,7 @@ export function validateFilters( context, next ) {
 }
 
 export function validateVertical( context, next ) {
+	performanceMark( context, 'fetchThemeFilters' );
 	const { vertical } = context.params;
 	const { store } = context;
 

--- a/client/my-sites/themes/validate-filters.js
+++ b/client/my-sites/themes/validate-filters.js
@@ -11,7 +11,7 @@ import { fetchThemeFilters } from './controller';
 
 // Reorder and remove invalid filters to redirect to canonical URL
 export function validateFilters( context, next ) {
-	performanceMark( context, 'validateFilters' );
+	performanceMark( context, 'validateThemeFilters' );
 	if ( ! context.params.filter ) {
 		return next();
 	}

--- a/client/server/isomorphic-routing/index.js
+++ b/client/server/isomorphic-routing/index.js
@@ -26,7 +26,7 @@ export function serverRouter( expressApp, setUpRoute, section ) {
 				);
 				next();
 			},
-			setUpRoute, // Here?
+			setUpRoute,
 			combineMiddlewares(
 				setSectionMiddleware( section ),
 				setRouteMiddleware,
@@ -34,7 +34,7 @@ export function serverRouter( expressApp, setUpRoute, section ) {
 				...middlewares
 			),
 			// Regular serverRender when there are no errors.
-			serverRender, // And here?
+			serverRender,
 
 			// Capture the error. This assumes that any of the previous middlewares
 			// have changed req.context to include info about the error, and serverRender

--- a/client/server/isomorphic-routing/index.js
+++ b/client/server/isomorphic-routing/index.js
@@ -66,8 +66,6 @@ function setRouteMiddleware( context, next ) {
 
 function combineMiddlewares( ...middlewares ) {
 	return function ( req, res, expressNext ) {
-		performanceMark( req.context, 'combining middlewares' );
-
 		req.context = getEnhancedContext( req, res );
 		applyMiddlewares(
 			req.context,

--- a/client/server/lib/performance-mark/index.ts
+++ b/client/server/lib/performance-mark/index.ts
@@ -9,11 +9,11 @@ type PartialContext = {
 	performanceMarks?: PerformanceMark[];
 };
 
-type LogastshMark = {
+type LogstashMark = {
 	total_duration: number;
 } & Record< string, number >;
 
-type LogsatshPerfMarks = Record< string, LogastshMark >;
+type LogstashPerfMarks = Record< string, LogstashMark >;
 
 /**
  * Updates the express request context with a new performance mark.
@@ -75,7 +75,7 @@ export default function performanceMark(
  * @param context The request.context object.
  * @returns object The normalized mark data for logstash in object format.
  */
-export function finalizePerfMarks( context: PartialContext ): LogsatshPerfMarks {
+export function finalizePerfMarks( context: PartialContext ): LogstashPerfMarks {
 	// Do nothing if there are no marks.
 	if ( ! context?.performanceMarks?.length ) {
 		return {};
@@ -85,7 +85,7 @@ export function finalizePerfMarks( context: PartialContext ): LogsatshPerfMarks 
 
 	// Logstash cannot accept arrays, so we transform our array into a more
 	// friendly structure for it.
-	return context.performanceMarks.reduce( ( marks: LogsatshPerfMarks, mark ) => {
+	return context.performanceMarks.reduce( ( marks: LogstashPerfMarks, mark ) => {
 		const markKey = markNameToKey( mark.markName );
 		// A mark like "setup request" becomes "0_setup_request"
 		marks[ markKey ] = {

--- a/client/server/lib/performance-mark/test/index.js
+++ b/client/server/lib/performance-mark/test/index.js
@@ -183,16 +183,16 @@ describe( 'finalizePerfMarks', () => {
 
 		const finalMarks = finalizePerfMarks( req.context );
 		// First mark has one child:
-		expect( finalMarks[ '0_test' ].total_duration ).toBe( 55 );
-		expect( finalMarks[ '0_test' ][ '0_test_child' ] ).toBe( 55 );
+		expect( finalMarks.test.total_duration ).toBe( 55 );
+		expect( finalMarks.test.test_child ).toBe( 55 );
 
 		// Second mark has two children indexed correctly:
-		expect( finalMarks[ '1_another_test' ].total_duration ).toBe( 1005 );
-		expect( finalMarks[ '1_another_test' ][ '0_another_test_child' ] ).toBe( 1000 );
-		expect( finalMarks[ '1_another_test' ][ '1_test_child_once_more' ] ).toBe( 3 );
+		expect( finalMarks.another_test.total_duration ).toBe( 1005 );
+		expect( finalMarks.another_test.another_test_child ).toBe( 1000 );
+		expect( finalMarks.another_test.test_child_once_more ).toBe( 3 );
 
 		// Third mark has no children and just a total duration:
-		expect( finalMarks[ '2_another_mark' ].total_duration ).toBe( 70 );
-		expect( Object.keys( finalMarks[ '2_another_mark' ] ).length ).toBe( 1 );
+		expect( finalMarks.another_mark.total_duration ).toBe( 70 );
+		expect( Object.keys( finalMarks.another_mark ).length ).toBe( 1 );
 	} );
 } );

--- a/client/server/lib/performance-mark/test/index.js
+++ b/client/server/lib/performance-mark/test/index.js
@@ -7,31 +7,31 @@ describe( 'performanceMark', () => {
 
 	it( 'does nothing if the context has not been created', () => {
 		const req = {};
-		performanceMark( req, 'test-marker' );
+		performanceMark( req.context, 'test-marker' );
 		expect( Object.keys( req ).length ).toBe( 0 );
 	} );
 
 	it( "creates the performance marks array if it doesn't exist", () => {
-		const req = { context: {} };
-		performanceMark( req, 'test-marker' );
-		expect( req.context.performanceMarks.length ).toBe( 1 );
+		const context = {};
+		performanceMark( context, 'test-marker' );
+		expect( context.performanceMarks.length ).toBe( 1 );
 	} );
 
 	it( 'adds a new performance marker with the current time', () => {
-		const req = { context: {} };
-		performanceMark( req, 'test-1' );
-		expect( req.context.performanceMarks[ 0 ] ).toStrictEqual( {
+		const context = {};
+		performanceMark( context, 'test-1' );
+		expect( context.performanceMarks[ 0 ] ).toStrictEqual( {
 			markName: 'test-1',
 			startTime: Date.now(),
 		} );
 	} );
 
 	it( 'adds a new step to the current main mark as a child', () => {
-		const req = { context: {} };
-		performanceMark( req, 'parent-1' );
-		performanceMark( req, 'child-1', true );
+		const context = {};
+		performanceMark( context, 'parent-1' );
+		performanceMark( context, 'child-1', true );
 
-		const marks = req.context.performanceMarks;
+		const marks = context.performanceMarks;
 		expect( marks.length ).toBe( 1 );
 		expect( marks[ 0 ].steps.length ).toBe( 1 );
 		expect( marks[ 0 ].markName ).toBe( 'parent-1' );
@@ -43,19 +43,19 @@ describe( 'performanceMark', () => {
 		const duration1 = 5001;
 		const duration2 = 203;
 		const duration3 = 101;
-		const req = { context: {} };
+		const context = {};
 
-		performanceMark( req, 'parent-1' );
-		performanceMark( req, 'child-1', true );
+		performanceMark( context, 'parent-1' );
+		performanceMark( context, 'child-1', true );
 		jest.advanceTimersByTime( duration1 );
-		performanceMark( req, 'child-2', true );
+		performanceMark( context, 'child-2', true );
 		jest.advanceTimersByTime( duration2 );
-		performanceMark( req, 'parent-2' );
+		performanceMark( context, 'parent-2' );
 		jest.advanceTimersByTime( duration3 );
-		performanceMark( req, 'parent-3' );
-		performanceMark( req, 'child-3', true );
+		performanceMark( context, 'parent-3' );
+		performanceMark( context, 'child-3', true );
 
-		const marks = req.context.performanceMarks;
+		const marks = context.performanceMarks;
 		// The children are logged with the correct duration.
 		expect( marks[ 0 ].steps.length ).toBe( 2 );
 		expect( marks[ 0 ].steps[ 0 ].markName ).toBe( 'child-1' );
@@ -80,35 +80,35 @@ describe( 'performanceMark', () => {
 	} );
 
 	it( 'adds a new parent step as a parent', () => {
-		const req = { context: {} };
+		const context = {};
 
-		performanceMark( req, 'parent-1' );
-		performanceMark( req, 'child-1', true );
-		performanceMark( req, 'parent-2' );
-		performanceMark( req, 'parent-3' );
+		performanceMark( context, 'parent-1' );
+		performanceMark( context, 'child-1', true );
+		performanceMark( context, 'parent-2' );
+		performanceMark( context, 'parent-3' );
 
-		expect( req.context.performanceMarks.length ).toBe( 3 );
+		expect( context.performanceMarks.length ).toBe( 3 );
 	} );
 
 	it( 'only adds children to the appropriate steps', () => {
-		const req = { context: {} };
+		const context = {};
 
 		// First mark and some steps.
-		performanceMark( req, 'parent-1' );
-		performanceMark( req, 'child-1', true );
-		performanceMark( req, 'child-2', true );
+		performanceMark( context, 'parent-1' );
+		performanceMark( context, 'child-1', true );
+		performanceMark( context, 'child-2', true );
 
 		// Second mark and no steps.
-		performanceMark( req, 'parent-2' );
+		performanceMark( context, 'parent-2' );
 
 		// Third mark and one step.
-		performanceMark( req, 'parent-3' );
-		performanceMark( req, 'child-3', true );
+		performanceMark( context, 'parent-3' );
+		performanceMark( context, 'child-3', true );
 
 		// Fourth mark and no steps.
-		performanceMark( req, 'parent-4' );
+		performanceMark( context, 'parent-4' );
 
-		const marks = req.context.performanceMarks;
+		const marks = context.performanceMarks;
 		expect( marks[ 0 ].steps.length ).toBe( 2 );
 		expect( marks[ 1 ].steps ).toBeUndefined();
 		expect( marks[ 2 ].steps.length ).toBe( 1 );
@@ -117,50 +117,49 @@ describe( 'performanceMark', () => {
 	} );
 
 	it( 'does not overwrite durations', () => {
-		const req = { context: {} };
+		const context = {};
 
-		performanceMark( req, 'parent-1' );
-		performanceMark( req, 'child-1', true );
+		performanceMark( context, 'parent-1' );
+		performanceMark( context, 'child-1', true );
 		jest.advanceTimersByTime( 5 );
-		finalizePerfMarks( req );
+		finalizePerfMarks( context );
 
-		expect( req.context.performanceMarks[ 0 ].duration ).toBe( 5 );
-		expect( req.context.performanceMarks[ 0 ].steps[ 0 ].duration ).toBe( 5 );
+		expect( context.performanceMarks[ 0 ].duration ).toBe( 5 );
+		expect( context.performanceMarks[ 0 ].steps[ 0 ].duration ).toBe( 5 );
 
 		jest.advanceTimersByTime( 200 );
 		// Normally, this would update the duration of pending marks. Since they
 		// were already updated by finalizePerfMarks, it should do nothing.
-		performanceMark( req, 'test' );
-		expect( req.context.performanceMarks[ 0 ].duration ).toBe( 5 );
-		expect( req.context.performanceMarks[ 0 ].steps[ 0 ].duration ).toBe( 5 );
+		performanceMark( context, 'test' );
+		expect( context.performanceMarks[ 0 ].duration ).toBe( 5 );
+		expect( context.performanceMarks[ 0 ].steps[ 0 ].duration ).toBe( 5 );
 	} );
 } );
 
 describe( 'finalizePerfMarks', () => {
 	it( 'returns an empty object of no marks exist', () => {
-		const req1 = {};
-		expect( finalizePerfMarks( req1 ) ).toStrictEqual( {} );
+		expect( finalizePerfMarks( {} ) ).toStrictEqual( {} );
 
 		const req2 = { context: {} };
-		expect( finalizePerfMarks( req2 ) ).toStrictEqual( {} );
+		expect( finalizePerfMarks( req2.context ) ).toStrictEqual( {} );
 
 		const req3 = { context: { performanceMarks: null } };
-		expect( finalizePerfMarks( req3 ) ).toStrictEqual( {} );
+		expect( finalizePerfMarks( req3.context ) ).toStrictEqual( {} );
 
 		const req4 = { context: { performanceMarks: [] } };
-		expect( finalizePerfMarks( req4 ) ).toStrictEqual( {} );
+		expect( finalizePerfMarks( req4.context ) ).toStrictEqual( {} );
 	} );
 
 	it( 'finalizes mark durations and returns the marks', () => {
 		const req = { context: {} };
-		performanceMark( req, 'test' );
-		performanceMark( req, 'test child', true );
+		performanceMark( req.context, 'test' );
+		performanceMark( req.context, 'test child', true );
 		jest.advanceTimersByTime( 55 );
 
 		expect( req.context.performanceMarks[ 0 ].duration ).toBeUndefined();
 		expect( req.context.performanceMarks[ 0 ].steps[ 0 ].duration ).toBeUndefined();
 
-		const finalMarks = finalizePerfMarks( req );
+		const finalMarks = finalizePerfMarks( req.context );
 		// The by-ref update still works:
 		expect( req.context.performanceMarks[ 0 ].duration ).toBe( 55 );
 		expect( req.context.performanceMarks[ 0 ].steps[ 0 ].duration ).toBe( 55 );
@@ -170,19 +169,19 @@ describe( 'finalizePerfMarks', () => {
 
 	it( 'returns a array normalized to an object for logstash', () => {
 		const req = { context: {} };
-		performanceMark( req, 'test' );
-		performanceMark( req, 'test child', true );
+		performanceMark( req.context, 'test' );
+		performanceMark( req.context, 'test child', true );
 		jest.advanceTimersByTime( 55 );
-		performanceMark( req, 'another test' );
+		performanceMark( req.context, 'another test' );
 		jest.advanceTimersByTime( 2 );
-		performanceMark( req, 'another test child', true );
+		performanceMark( req.context, 'another test child', true );
 		jest.advanceTimersByTime( 1000 );
-		performanceMark( req, 'test child once more', true );
+		performanceMark( req.context, 'test child once more', true );
 		jest.advanceTimersByTime( 3 );
-		performanceMark( req, 'another-mark' );
+		performanceMark( req.context, 'another-mark' );
 		jest.advanceTimersByTime( 70 );
 
-		const finalMarks = finalizePerfMarks( req );
+		const finalMarks = finalizePerfMarks( req.context );
 		// First mark has one child:
 		expect( finalMarks[ '0_test' ].total_duration ).toBe( 55 );
 		expect( finalMarks[ '0_test' ][ '0_test_child' ] ).toBe( 55 );

--- a/client/server/lib/performance-mark/test/index.js
+++ b/client/server/lib/performance-mark/test/index.js
@@ -6,6 +6,7 @@ describe( 'performanceMark', () => {
 	} );
 
 	it( 'does nothing if the context has not been created', () => {
+		//
 		const req = {};
 		performanceMark( req.context, 'test-marker' );
 		expect( Object.keys( req ).length ).toBe( 0 );
@@ -163,8 +164,8 @@ describe( 'finalizePerfMarks', () => {
 		// The by-ref update still works:
 		expect( req.context.performanceMarks[ 0 ].duration ).toBe( 55 );
 		expect( req.context.performanceMarks[ 0 ].steps[ 0 ].duration ).toBe( 55 );
-		expect( finalMarks[ '0_test' ].total_duration ).toBe( 55 );
-		expect( finalMarks[ '0_test' ][ '0_test_child' ] ).toBe( 55 );
+		expect( finalMarks.test.total_duration ).toBe( 55 );
+		expect( finalMarks.test.test_child ).toBe( 55 );
 	} );
 
 	it( 'returns a array normalized to an object for logstash', () => {

--- a/client/server/middleware/logger.js
+++ b/client/server/middleware/logger.js
@@ -43,11 +43,11 @@ const logRequest = ( req, res, options ) => {
 
 	// Requests which take longer than one second aren't performing well. We log
 	// extra performance data in this case to troubleshoot the cause.
-	if ( duration > 1000 ) {
+	if ( duration > 2 ) {
 		req.logger.info(
 			// TODO: does warn not exist here for tests?
 			{
-				performanceMarks: finalizePerfMarks( req ),
+				performanceMarks: finalizePerfMarks( req.context ),
 				didTimeout: duration > 49500, // A timeout occurs at 50s, so anything close to that is likely a timeout.
 				duration,
 			},

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -29,7 +29,7 @@ import isSectionEnabled from 'calypso/sections-filter';
 import { serverRouter, getCacheKey } from 'calypso/server/isomorphic-routing';
 import analytics from 'calypso/server/lib/analytics';
 import isWpMobileApp from 'calypso/server/lib/is-wp-mobile-app';
-import performanceMark from 'calypso/server/lib/performance-mark/index.js';
+import performanceMark from 'calypso/server/lib/performance-mark/index';
 import {
 	serverRender,
 	renderJsx,

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -96,7 +96,7 @@ function setupLoggedInContext( req, res, next ) {
 }
 
 function getDefaultContext( request, response, entrypoint = 'entry-main', sectionName ) {
-	performanceMark( request, 'getDefaultContext' );
+	performanceMark( request.context, 'getDefaultContext' );
 
 	const geoIPCountryCode = request.headers[ 'x-geoip-country-code' ];
 	const showGdprBanner = shouldSeeGdprBanner(
@@ -122,7 +122,7 @@ function getDefaultContext( request, response, entrypoint = 'entry-main', sectio
 	 * are considered logged out. This shouldn't cause issues because only one
 	 * user is using the cache in dev mode -- so cross-request pollution won't happen.
 	 */
-	performanceMark( request, 'get cached redux state', true );
+	performanceMark( request.context, 'get cached redux state', true );
 	const cachedServerState = request.context.isLoggedIn ? {} : stateCache.get( cacheKey ) || {};
 	const getCachedState = ( reducer, storageKey ) => {
 		const storedState = cachedServerState[ storageKey ];
@@ -134,7 +134,7 @@ function getDefaultContext( request, response, entrypoint = 'entry-main', sectio
 	};
 	const reduxStore = createReduxStore( getCachedState( initialReducer, 'root' ) );
 	setStore( reduxStore, getCachedState );
-	performanceMark( request, 'create basic options', true );
+	performanceMark( request.context, 'create basic options', true );
 
 	const devEnvironments = [ 'development', 'jetpack-cloud-development' ];
 	const isDebug = devEnvironments.includes( calypsoEnv ) || request.query.debug !== undefined;
@@ -155,13 +155,13 @@ function getDefaultContext( request, response, entrypoint = 'entry-main', sectio
 
 	const flags = ( request.query.flags || '' ).split( ',' );
 
-	performanceMark( request, 'getFilesForEntrypoint', true );
+	performanceMark( request.context, 'getFilesForEntrypoint', true );
 	const entrypointFiles = request.getFilesForEntrypoint( entrypoint );
 
-	performanceMark( request, 'getAssets', true );
+	performanceMark( request.context, 'getAssets', true );
 	const manifests = request.getAssets().manifests;
 
-	performanceMark( request, 'assign context object', true );
+	performanceMark( request.context, 'assign context object', true );
 	const context = Object.assign( {}, request.context, {
 		commitSha: process.env.hasOwnProperty( 'COMMIT_SHA' ) ? process.env.COMMIT_SHA : '(unknown)',
 		compileDebug: process.env.NODE_ENV === 'development',
@@ -198,7 +198,7 @@ function getDefaultContext( request, response, entrypoint = 'entry-main', sectio
 		isDebug,
 	};
 
-	performanceMark( request, 'setup environments', true );
+	performanceMark( request.context, 'setup environments', true );
 	if ( calypsoEnv === 'wpcalypso' ) {
 		context.badge = calypsoEnv;
 		context.devDocs = true;
@@ -248,15 +248,15 @@ const setupDefaultContext = ( entrypoint, sectionName ) => ( req, res, next ) =>
 };
 
 function setUpLocalLanguageRevisions( req ) {
-	performanceMark( req, 'setUpLocalLanguageRevisions', true );
+	performanceMark( req.context, 'setUpLocalLanguageRevisions', true );
 	const rootPath = path.join( __dirname, '..', '..', '..' );
 	const langRevisionsPath = path.join( rootPath, 'public', 'languages', 'lang-revisions.json' );
 
-	performanceMark( req, 'read language file', true );
+	performanceMark( req.context, 'read language file', true );
 	const langPromise = fs.promises
 		.readFile( langRevisionsPath, 'utf8' )
 		.then( ( languageRevisions ) => {
-			performanceMark( req, 'parse language file', true );
+			performanceMark( req.context, 'parse language file', true );
 			req.context.languageRevisions = JSON.parse( languageRevisions );
 
 			return languageRevisions;
@@ -271,7 +271,7 @@ function setUpLocalLanguageRevisions( req ) {
 }
 
 function setUpLoggedOutRoute( req, res, next ) {
-	performanceMark( req, 'setUpLoggedOutRoute', true );
+	performanceMark( req.context, 'setUpLoggedOutRoute', true );
 	res.set( {
 		'X-Frame-Options': 'SAMEORIGIN',
 	} );
@@ -284,7 +284,7 @@ function setUpLoggedOutRoute( req, res, next ) {
 
 	Promise.all( setupRequests )
 		.then( () => {
-			performanceMark( req, 'done with setup requests', true );
+			performanceMark( req.context, 'done with setup requests', true );
 			next();
 		} )
 		.catch( ( error ) => next( error ) );
@@ -513,7 +513,7 @@ function setUpCSP( req, res, next ) {
 }
 
 function setUpRoute( req, res, next ) {
-	performanceMark( req, 'setUpRoute' );
+	performanceMark( req.context, 'setUpRoute' );
 
 	if ( req.context.isRouteSetup === true ) {
 		req.logger.warn(

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -284,7 +284,7 @@ function setUpLoggedOutRoute( req, res, next ) {
 
 	Promise.all( setupRequests )
 		.then( () => {
-			performanceMark( req.context, 'done with setup requests', true );
+			performanceMark( req.context, 'done with loggedOut setup requests', true );
 			next();
 		} )
 		.catch( ( error ) => next( error ) );

--- a/client/server/render/index.js
+++ b/client/server/render/index.js
@@ -227,7 +227,7 @@ export function attachBuildTimestamp( context ) {
 }
 
 export function serverRender( req, res ) {
-	performanceMark( req, 'serverRender' );
+	performanceMark( req.context, 'serverRender' );
 	const context = req.context;
 
 	let cacheKey = false;
@@ -235,18 +235,18 @@ export function serverRender( req, res ) {
 	attachI18n( context );
 
 	if ( shouldServerSideRender( context ) ) {
-		performanceMark( req, 'render layout', true );
+		performanceMark( req.context, 'render layout', true );
 		cacheKey = getCacheKey( req );
 		debug( `SSR render with cache key ${ cacheKey }.` );
 
 		context.renderedLayout = render( context.layout, req.error?.message ?? cacheKey, req );
 	}
 
-	performanceMark( req, 'dehydrateQueryClient', true );
+	performanceMark( req.context, 'dehydrateQueryClient', true );
 	context.initialQueryState = dehydrateQueryClient( context.queryClient );
 
 	if ( context.store ) {
-		performanceMark( req, 'redux store', true );
+		performanceMark( req.context, 'redux store', true );
 		attachHead( context );
 
 		const isomorphicSubtrees = context.section?.isomorphic ? [ 'themes', 'ui', 'plugins' ] : [];
@@ -276,13 +276,13 @@ export function serverRender( req, res ) {
 			stateCache.set( cacheKey, serverState.get() );
 		}
 	}
-	performanceMark( req, 'final render', true );
+	performanceMark( req.context, 'final render', true );
 	context.clientData = config.clientData;
 
 	attachBuildTimestamp( context );
 
 	res.send( renderJsx( 'index', context ) );
-	performanceMark( req, 'post-sending JSX' );
+	performanceMark( req.context, 'post-sending JSX' );
 }
 
 /**


### PR DESCRIPTION
#### Proposed Changes
Follow-up for #69402 -- see that for testing instructions and more context.

Re: pMz3w-ggj-p2, it turns out that logstash cannot accept arrays, and transforms them into objects which aren't very readable. I've updated this PR to transform our array data into something more friendly. Each performance mark is ~prefixed with the array index~ (edit, this would cause our index to have too many properties) and contains a "total_duration" property in ms. Additionally, each step maps to its duration in ms. We no longer include start time. 

See comments on the p2 for more info, but we have to be careful about the number of keys we add to the index, so I've tried to make all the keys as static as possible. (So no more indexing.)

It looks like this in logstash now: (I hope order is somewhat preserved, but not sure if it's guaranteed.)

```json
{
	"performanceMarks": {
		"getDefaultContext": {
			"total_duration": 226,
			"get_cached_redux_state": 22,
			"create_basic_options": 0,
			"getFilesForEntrypoint": 1,
			"getAssets": 0,
			"assign_context_object": 0,
			"setup_environments": 203
		},
		"setUpRoute": {
			"total_duration": 1,
			"setUpLoggedOutRoute": 0,
			"done_with_setup_requests": 1
		},
		"serverRender": {
			"total_duration": 12,
			"dehydrateQueryClient": 0,
			"redux_store": 0,
			"final_render": 12
		},
		"post_sending_JSX": {
			"total_duration": 1
		}
	}
}
```

For example, we can tell that the get default context performance mark took the longest, and its "setup environments" step was the main culprit at 203ms. (The cause is getting the branch name/commit from then local system via exec)

I also added a few more improvements:
- Added types to the main file
- Refactored to use `context` instead of `request`. This way, we can log marks for some of the "client-side" middlewares which only accept context.
- Added a ton more performance marks in the theme middlewares. (This is where the timeout is happening)