### PR TITLE
Domains: Fix domain ownership verification flow redirection

### DIFF
--- a/client/components/domains/use-my-domain/utilities/connect-domain-action.js
+++ b/client/components/domains/use-my-domain/utilities/connect-domain-action.js
@@ -1,6 +1,7 @@
 import { __ } from '@wordpress/i18n';
 import page from 'page';
 import { stepSlug } from 'calypso/components/domains/connect-domain-step/constants';
+import { isSubdomain } from 'calypso/lib/domains';
 import wpcom from 'calypso/lib/wp';
 import { domainManagementList, domainMappingSetup } from 'calypso/my-sites/domains/paths';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
@@ -36,7 +37,12 @@ export const connectDomainAction =
 							}
 						)
 					);
-					const step = result.points_to_wpcom ? stepSlug.SUGGESTED_CONNECTED : '';
+					let step = '';
+					if ( result.points_to_wpcom ) {
+						step = isSubdomain( domain )
+							? stepSlug.SUBDOMAIN_SUGGESTED_CONNECTED
+							: stepSlug.SUGGESTED_CONNECTED;
+					}
 					page( domainMappingSetup( selectedSite.slug, domain, step, false, true ) );
 				} )
 				.catch( ( error ) => {


### PR DESCRIPTION
A page redirection error occurs when domain ownership verification is needed to connect a subdomain and the subdomain already points to WPCOM. In that scenario, at the end of the verification flow, the user is redirected to the beginning of the "Use a domain I own" flow due to a page slug error.

#### Proposed Changes

This PR updates the code to redirect the user to the correct domain connection flow step.

Before:

https://user-images.githubusercontent.com/5324818/198417302-d42a0af0-eb9f-46ba-bb93-97c3e0edbc1b.mp4

After:

https://user-images.githubusercontent.com/5324818/198417320-4d02e5f2-0071-4d8a-bde2-2b4382bb9f78.mp4

#### Testing Instructions

- Hack your backend's domain ownership verification code to always require auth code verification and to accept any auth code when connecting a domain
- Build this branch locally or open the live Calypso link
- Go to the "Use a domain I own" flow to add a new domain connection to a site
- Enter a subdomain that already points to WPCOM (e.g. `blog.leotaba.blog` - you can use that to test, just clean it up after testing 🙂)
- After the ownership verification steps, ensure you're shown the "Your subdomain is connected" page like in the video above
- Also, please try to connect a subdomain that doesn't point to WPCOM (e.g. `asdf.example.com`) and ensure you're taken to the start of the "Connect your subdomain" flow after ownership verification

#### Pre-merge Checklist

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

