### PR TITLE
Components: Add a Highlight Cards component

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -32,6 +32,7 @@
 		"@automattic/search": "workspace:^",
 		"@automattic/typography": "workspace:^",
 		"@wordpress/base-styles": "^4.5.0",
+		"@wordpress/icons": "^9.11.0",
 		"classnames": "^2.3.1",
 		"enzyme": "^3.11.0",
 		"framer-motion": "6.2.8",

--- a/packages/components/src/highlight-cards/highlight-card.tsx
+++ b/packages/components/src/highlight-cards/highlight-card.tsx
@@ -1,0 +1,53 @@
+import { Icon, trendingDown, trendingUp } from '@wordpress/icons';
+import classNames from 'classnames';
+import { Card } from '../';
+
+export type HighlightCardProps = {
+	count: number | null;
+	heading: React.ReactNode;
+	icon: React.ReactNode;
+	onClick?: () => void;
+	previousCount?: number | null;
+};
+
+function subtract( a: number | null, b: number | null | undefined ): number | null {
+	return a === null || b === null || b === undefined ? null : a - b;
+}
+
+function percent( part: number | null, whole: number | null ) {
+	return part === null || whole === null ? null : Math.round( ( part / whole ) * 100 );
+}
+
+export default function HighlightCard( {
+	count,
+	previousCount,
+	icon,
+	heading,
+}: HighlightCardProps ) {
+	const difference = subtract( count, previousCount );
+	const percentage = Number.isFinite( difference )
+		? percent( Math.abs( difference as number ), count )
+		: null;
+	return (
+		<Card className="highlight-card">
+			<div className="highlight-card-icon">{ icon }</div>
+			<div className="highlight-card-heading">{ heading }</div>
+			<div className="highlight-card-count">
+				{ count }{ ' ' }
+				{ difference !== null ? (
+					<span
+						className={ classNames( 'highlight-card-difference', {
+							'highlight-card-difference--positive': difference < 0,
+							'highlight-card-difference--negative': difference > 0,
+						} ) }
+					>
+						{ difference < 0 && <Icon icon={ trendingDown } /> }
+						{ difference > 0 && <Icon icon={ trendingUp } /> }
+						{ Math.abs( difference ) }
+						{ percentage !== null && <> ({ percentage }%)</> }
+					</span>
+				) : null }
+			</div>
+		</Card>
+	);
+}

--- a/packages/components/src/highlight-cards/highlight-card.tsx
+++ b/packages/components/src/highlight-cards/highlight-card.tsx
@@ -54,10 +54,19 @@ export default function HighlightCard( {
 							'highlight-card-difference--negative': difference > 0,
 						} ) }
 					>
-						{ difference < 0 && <Icon icon={ trendingDown } /> }
-						{ difference > 0 && <Icon icon={ trendingUp } /> }
-						{ Math.abs( difference ) }
-						{ percentage !== null && <> ({ percentage }%)</> }
+						<span className="highlight-card-difference-icon" title={ String( difference ) }>
+							{ difference < 0 && <Icon icon={ trendingDown } /> }
+							{ difference > 0 && <Icon icon={ trendingUp } /> }
+						</span>
+						<span className="highlight-card-difference-absolute-value">
+							{ Math.abs( difference ) }
+						</span>
+						{ percentage !== null && (
+							<span className="highlight-card-difference-absolute-percentage">
+								{ ' ' }
+								({ percentage }%)
+							</span>
+						) }
 					</span>
 				) : null }
 			</div>

--- a/packages/components/src/highlight-cards/highlight-card.tsx
+++ b/packages/components/src/highlight-cards/highlight-card.tsx
@@ -33,7 +33,7 @@ export default function HighlightCard( {
 			<div className="highlight-card-icon">{ icon }</div>
 			<div className="highlight-card-heading">{ heading }</div>
 			<div className="highlight-card-count">
-				{ count }{ ' ' }
+				{ Number.isFinite( count ) ? count : '-' }{ ' ' }
 				{ difference !== null ? (
 					<span
 						className={ classNames( 'highlight-card-difference', {

--- a/packages/components/src/highlight-cards/highlight-card.tsx
+++ b/packages/components/src/highlight-cards/highlight-card.tsx
@@ -18,6 +18,14 @@ function percent( part: number | null, whole: number | null ) {
 	return part === null || whole === null ? null : Math.round( ( part / whole ) * 100 );
 }
 
+const FORMATTER = new Intl.NumberFormat( 'en-GB', {
+	notation: 'compact',
+	compactDisplay: 'short',
+} );
+function formatNumber( number: number | null ) {
+	return Number.isFinite( number ) ? FORMATTER.format( number as number ) : '-';
+}
+
 export default function HighlightCard( {
 	count,
 	previousCount,
@@ -33,7 +41,12 @@ export default function HighlightCard( {
 			<div className="highlight-card-icon">{ icon }</div>
 			<div className="highlight-card-heading">{ heading }</div>
 			<div className="highlight-card-count">
-				{ Number.isFinite( count ) ? count : '-' }{ ' ' }
+				<span
+					className="highlight-card-count-value"
+					title={ Number.isFinite( count ) ? String( count ) : undefined }
+				>
+					{ formatNumber( count ) }
+				</span>{ ' ' }
 				{ difference !== null ? (
 					<span
 						className={ classNames( 'highlight-card-difference', {

--- a/packages/components/src/highlight-cards/index.tsx
+++ b/packages/components/src/highlight-cards/index.tsx
@@ -1,9 +1,11 @@
 import { comment, Icon, navigation, people, starEmpty } from '@wordpress/icons';
+import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import './style.scss';
 import HighlightCard from './highlight-card';
 
 export type HighlightCardsProps = {
+	className?: string;
 	counts: {
 		comments: number | null;
 		likes: number | null;
@@ -22,10 +24,15 @@ export type HighlightCardsProps = {
 	onClickVisitors: string;
 };
 
-export default function HighlightCards( { counts, previousCounts }: HighlightCardsProps ) {
+export default function HighlightCards( {
+	className,
+	counts,
+	previousCounts,
+}: HighlightCardsProps ) {
 	const translate = useTranslate();
+
 	return (
-		<div className="highlight-cards">
+		<div className={ classNames( 'highlight-cards', className ?? null ) }>
 			<h1 className="highlight-cards-heading">
 				{ translate( '7-day highlights' ) }{ ' ' }
 				<small>{ translate( 'compared to the last seven days' ) }</small>

--- a/packages/components/src/highlight-cards/index.tsx
+++ b/packages/components/src/highlight-cards/index.tsx
@@ -1,4 +1,5 @@
 import { comment, Icon, navigation, people, starEmpty } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
 import './style.scss';
 import HighlightCard from './highlight-card';
 
@@ -22,36 +23,38 @@ export type HighlightCardsProps = {
 };
 
 export default function HighlightCards( { counts, previousCounts }: HighlightCardsProps ) {
+	const translate = useTranslate();
 	return (
 		<div className="highlight-cards">
 			<h1 className="highlight-cards-heading">
-				7-day highlights <small>compared to the last seven days</small>
+				{ translate( '7-day highlights' ) }{ ' ' }
+				<small>{ translate( 'compared to the last seven days' ) }</small>
 			</h1>
 
 			<div className="highlight-cards-list">
 				<HighlightCard
-					heading="Visitors"
+					heading={ translate( 'Visitors' ) }
 					icon={ <Icon icon={ people } /> }
-					count={ counts.visitors }
-					previousCount={ previousCounts.visitors }
+					count={ counts?.visitors ?? null }
+					previousCount={ previousCounts?.visitors ?? null }
 				/>
 				<HighlightCard
-					heading="Views"
+					heading={ translate( 'Views' ) }
 					icon={ <Icon icon={ navigation } /> }
-					count={ counts.views }
-					previousCount={ previousCounts.views }
+					count={ counts?.views ?? null }
+					previousCount={ previousCounts?.views ?? null }
 				/>
 				<HighlightCard
-					heading="Likes"
+					heading={ translate( 'Likes' ) }
 					icon={ <Icon icon={ starEmpty } /> }
-					count={ counts.likes }
-					previousCount={ previousCounts.likes }
+					count={ counts?.likes ?? null }
+					previousCount={ previousCounts?.likes ?? null }
 				/>
 				<HighlightCard
-					heading="Comments"
+					heading={ translate( 'Comments' ) }
 					icon={ <Icon icon={ comment } /> }
-					count={ counts.comments }
-					previousCount={ previousCounts.comments }
+					count={ counts?.comments ?? null }
+					previousCount={ previousCounts?.comments ?? null }
 				/>
 			</div>
 		</div>

--- a/packages/components/src/highlight-cards/index.tsx
+++ b/packages/components/src/highlight-cards/index.tsx
@@ -1,0 +1,59 @@
+import { comment, Icon, navigation, people, starEmpty } from '@wordpress/icons';
+import './style.scss';
+import HighlightCard from './highlight-card';
+
+export type HighlightCardsProps = {
+	counts: {
+		comments: number | null;
+		likes: number | null;
+		views: number | null;
+		visitors: number | null;
+	};
+	previousCounts: {
+		comments: number | null;
+		likes: number | null;
+		views: number | null;
+		visitors: number | null;
+	};
+	onClickComments: string;
+	onClickLikes: string;
+	onClickViews: string;
+	onClickVisitors: string;
+};
+
+export default function HighlightCards( { counts, previousCounts }: HighlightCardsProps ) {
+	return (
+		<div className="highlight-cards">
+			<h1 className="highlight-cards-heading">
+				7-day highlights <small>compared to the last seven days</small>
+			</h1>
+
+			<div className="highlight-cards-list">
+				<HighlightCard
+					heading="Visitors"
+					icon={ <Icon icon={ people } /> }
+					count={ counts.visitors }
+					previousCount={ previousCounts.visitors }
+				/>
+				<HighlightCard
+					heading="Views"
+					icon={ <Icon icon={ navigation } /> }
+					count={ counts.views }
+					previousCount={ previousCounts.views }
+				/>
+				<HighlightCard
+					heading="Likes"
+					icon={ <Icon icon={ starEmpty } /> }
+					count={ counts.likes }
+					previousCount={ previousCounts.likes }
+				/>
+				<HighlightCard
+					heading="Comments"
+					icon={ <Icon icon={ comment } /> }
+					count={ counts.comments }
+					previousCount={ previousCounts.comments }
+				/>
+			</div>
+		</div>
+	);
+}

--- a/packages/components/src/highlight-cards/stories/index.stories.jsx
+++ b/packages/components/src/highlight-cards/stories/index.stories.jsx
@@ -1,0 +1,27 @@
+import { action } from '@storybook/addon-actions';
+import HighlightCards from '../';
+
+export default { title: 'Highlight Cards' };
+
+const handleClick = action( 'click' );
+
+export const Default = () => (
+	<HighlightCards
+		counts={ {
+			comments: 45,
+			likes: 103,
+			views: 4673,
+			visitors: 1548,
+		} }
+		previousCounts={ {
+			comments: 50,
+			likes: 123,
+			views: 4073,
+			visitors: 1412,
+		} }
+		onClickComments={ handleClick }
+		onClickLikes={ handleClick }
+		onClickViews={ handleClick }
+		onClickVisitors={ handleClick }
+	/>
+);

--- a/packages/components/src/highlight-cards/stories/index.stories.jsx
+++ b/packages/components/src/highlight-cards/stories/index.stories.jsx
@@ -5,7 +5,7 @@ export default { title: 'Highlight Cards' };
 
 const handleClick = action( 'click' );
 
-export const Default = () => (
+const HighlightCardsVariations = ( props ) => (
 	<HighlightCards
 		counts={ {
 			comments: 45,
@@ -23,5 +23,24 @@ export const Default = () => (
 		onClickLikes={ handleClick }
 		onClickViews={ handleClick }
 		onClickVisitors={ handleClick }
+		{ ...props }
 	/>
+);
+
+export const Default = () => <HighlightCardsVariations />;
+
+export const WithPartialPreviousCounts = () => (
+	<HighlightCardsVariations
+		previousCounts={ {
+			comments: null,
+			likes: null,
+			views: 4073,
+			visitors: 1412,
+		} }
+	/>
+);
+export const WithoutPreviousCounts = () => <HighlightCardsVariations previousCounts={ null } />;
+
+export const WithoutCounts = () => (
+	<HighlightCardsVariations counts={ null } previousCounts={ null } />
 );

--- a/packages/components/src/highlight-cards/style.scss
+++ b/packages/components/src/highlight-cards/style.scss
@@ -1,0 +1,67 @@
+@import "../styles/typography";
+
+$header-font: Recoleta, sans-serif;
+
+.highlight-cards {
+	padding: 64px 0;
+	color: var(--studio-gray-100);
+	font-size: $font-body-small;
+}
+
+.highlight-cards-heading {
+	font-size: 32px; // stylelint-disable-line declaration-property-unit-allowed-list
+	font-weight: 400;
+	line-height: 40px;
+	font-family: $header-font;
+	small {
+		font-size: $font-body-small;
+	}
+}
+
+.highlight-cards-list {
+	display: flex;
+	flex-flow: row nowrap;
+
+	.highlight-card {
+		border-color: var(--studio-gray-5);
+		border-radius: 4px;
+		width: 100%;
+
+		margin-right: 24px;
+		&:last-child {
+			margin-right: 0;
+		}
+	}
+}
+
+.highlight-card-heading {
+	font-weight: 500;
+	line-height: 20px;
+	font-family: $header-font;
+}
+
+.highlight-card-count {
+	font-size: 36px; // stylelint-disable-line declaration-property-unit-allowed-list
+	font-weight: 400;
+	line-height: 40px;
+	display: flex;
+	align-items: flex-end;
+}
+
+.highlight-card-difference {
+	align-items: flex-end;
+	color: var(--studio-gray-20);
+	display: flex;
+	font-size: $font-body-small;
+	font-weight: 600;
+	line-height: 24px;
+	margin-left: 8px;
+	&.highlight-card-difference--positive {
+		color: var(--studio-red-50);
+		fill: var(--studio-red-50);
+	}
+	&.highlight-card-difference--negative {
+		color: var(--studio-green-50);
+		fill: var(--studio-green-50);
+	}
+}

--- a/packages/components/src/highlight-cards/style.scss
+++ b/packages/components/src/highlight-cards/style.scss
@@ -1,3 +1,4 @@
+@import "@wordpress/base-styles/breakpoints";
 @import "../styles/typography";
 
 $header-font: Recoleta, sans-serif;
@@ -26,6 +27,7 @@ $header-font: Recoleta, sans-serif;
 		border-color: var(--studio-gray-5);
 		border-radius: 4px;
 		width: 100%;
+		min-width: 200px; // Minimum mobile width
 
 		margin-right: 24px;
 		&:last-child {
@@ -63,5 +65,30 @@ $header-font: Recoleta, sans-serif;
 	&.highlight-card-difference--negative {
 		color: var(--studio-green-50);
 		fill: var(--studio-green-50);
+	}
+}
+.highlight-card-difference-icon {
+	display: flex;
+	align-content: flex-end;
+}
+
+@media ( max-width: $break-small ) {
+	.highlight-cards {
+		overflow-y: auto;
+	}
+
+	.card.highlight-card {
+		padding: 16px 24px;
+	}
+
+	.highlight-cards-heading {
+		display: flex;
+		flex-flow: column;
+	}
+
+	.highlight-card-icon,
+	.highlight-card-difference-absolute-value,
+	.highlight-card-difference-absolute-percentage {
+		display: none;
 	}
 }

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -27,3 +27,5 @@ export { LoadingPlaceholder } from './loading-placeholder';
 export { default as HorizontalBarList } from './horizontal-bar-list';
 export { default as HorizontalBarListItem } from './horizontal-bar-list/horizontal-bar-grid-item';
 export { default as StatsCard } from './horizontal-bar-list/stats-card';
+export { default as HighlightCards } from './highlight-cards';
+export { default as HighlightCard } from './highlight-cards/highlight-card';

--- a/yarn.lock
+++ b/yarn.lock
@@ -394,6 +394,7 @@ __metadata:
     "@testing-library/react": ^12.1.3
     "@testing-library/react-hooks": 7.0.2
     "@wordpress/base-styles": ^4.5.0
+    "@wordpress/icons": ^9.11.0
     classnames: ^2.3.1
     enzyme: ^3.11.0
     framer-motion: 6.2.8
@@ -9226,6 +9227,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@wordpress/element@npm:^4.18.0":
+  version: 4.18.0
+  resolution: "@wordpress/element@npm:4.18.0"
+  dependencies:
+    "@babel/runtime": ^7.16.0
+    "@types/react": ^17.0.37
+    "@types/react-dom": ^17.0.11
+    "@wordpress/escape-html": ^2.20.0
+    change-case: ^4.1.2
+    is-plain-object: ^5.0.0
+    react: ^17.0.2
+    react-dom: ^17.0.2
+  checksum: d48240ab46f00344cc23f1c83b2c405046b49e2c59f3c604fae988b2263461c7c956f2e0d561f1ab8494b2d50cf6d344e6022de161df061098fd152b317bfa7a
+  languageName: node
+  linkType: hard
+
 "@wordpress/env@npm:^4.7.0":
   version: 4.7.0
   resolution: "@wordpress/env@npm:4.7.0"
@@ -9263,6 +9280,15 @@ __metadata:
   dependencies:
     "@babel/runtime": ^7.16.0
   checksum: 88cd44de524346e95ab0eeaebc91afa4dee10e330b032a93b5106fa06ffd5568eb6bcab2597288a427ec4f0549d6ec8ef4840bb2b8cfc3e958f6643c2eea60cd
+  languageName: node
+  linkType: hard
+
+"@wordpress/escape-html@npm:^2.20.0":
+  version: 2.20.0
+  resolution: "@wordpress/escape-html@npm:2.20.0"
+  dependencies:
+    "@babel/runtime": ^7.16.0
+  checksum: 860cd7a21c41b0542bd96fc30bc5080ebc73e9f609c5f89c23adc5e4ea1790a2302f6f4063d0d46f4c6163376370482e0878c20fa323fa72b4be32282a7fc21a
   languageName: node
   linkType: hard
 
@@ -9448,6 +9474,17 @@ __metadata:
     "@wordpress/element": ^4.12.0
     "@wordpress/primitives": ^3.12.0
   checksum: 03e5885e79a20846ae0d906277afa6a159a1718acb647052bae5052d0ab49d2e78f475c93a7341ffcdee0ede55176fcaf87217bcb238980d1bad728e2f476412
+  languageName: node
+  linkType: hard
+
+"@wordpress/icons@npm:^9.11.0":
+  version: 9.11.0
+  resolution: "@wordpress/icons@npm:9.11.0"
+  dependencies:
+    "@babel/runtime": ^7.16.0
+    "@wordpress/element": ^4.18.0
+    "@wordpress/primitives": ^3.18.0
+  checksum: 101063fb7d5ea60b63be65f00f54f858d63fb4edc326941181c77447818d005c85eab61873a57130dbbc0cb76ade818da847d7f01d4de520361855ed09020e0a
   languageName: node
   linkType: hard
 
@@ -9721,6 +9758,17 @@ __metadata:
     "@wordpress/element": ^4.12.0
     classnames: ^2.3.1
   checksum: 55b9bcb6a0cfa4405b8f45105251321173b396c4cb4263a89797939a4415cdc454743e7ff3779074c0437bf51a161875c6e2d2f4b793cc7b440ee4552124a262
+  languageName: node
+  linkType: hard
+
+"@wordpress/primitives@npm:^3.18.0":
+  version: 3.18.0
+  resolution: "@wordpress/primitives@npm:3.18.0"
+  dependencies:
+    "@babel/runtime": ^7.16.0
+    "@wordpress/element": ^4.18.0
+    classnames: ^2.3.1
+  checksum: 5090684e11d80d94fcf813dda71c0fcdadf036006509a448de54f7eb63ded6d668d7fa246b9f1f923b11268afac6c0aca4c1fd7f9cfb5d82055923cad6d607af
   languageName: node
   linkType: hard
 
@@ -12840,6 +12888,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"camel-case@npm:^4.1.2":
+  version: 4.1.2
+  resolution: "camel-case@npm:4.1.2"
+  dependencies:
+    pascal-case: ^3.1.2
+    tslib: ^2.0.3
+  checksum: bf9eefaee1f20edbed2e9a442a226793bc72336e2b99e5e48c6b7252b6f70b080fc46d8246ab91939e2af91c36cdd422e0af35161e58dd089590f302f8f64c8a
+  languageName: node
+  linkType: hard
+
 "camelcase-css@npm:2.0.1":
   version: 2.0.1
   resolution: "camelcase-css@npm:2.0.1"
@@ -12930,6 +12988,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"capital-case@npm:^1.0.4":
+  version: 1.0.4
+  resolution: "capital-case@npm:1.0.4"
+  dependencies:
+    no-case: ^3.0.4
+    tslib: ^2.0.3
+    upper-case-first: ^2.0.2
+  checksum: 6a034af73401f6e55d91ea35c190bbf8bda21714d4ea8bb8f1799311d123410a80f0875db4e3236dc3f97d74231ff4bf1c8783f2be13d7733c7d990c57387281
+  languageName: node
+  linkType: hard
+
 "capture-exit@npm:^2.0.0":
   version: 2.0.0
   resolution: "capture-exit@npm:2.0.0"
@@ -13012,6 +13081,26 @@ __metadata:
     ansi-styles: ^4.1.0
     supports-color: ^7.1.0
   checksum: 4a3fef5cc34975c898ffe77141450f679721df9dde00f6c304353fa9c8b571929123b26a0e4617bde5018977eb655b31970c297b91b63ee83bb82aeb04666880
+  languageName: node
+  linkType: hard
+
+"change-case@npm:^4.1.2":
+  version: 4.1.2
+  resolution: "change-case@npm:4.1.2"
+  dependencies:
+    camel-case: ^4.1.2
+    capital-case: ^1.0.4
+    constant-case: ^3.0.4
+    dot-case: ^3.0.4
+    header-case: ^2.0.4
+    no-case: ^3.0.4
+    param-case: ^3.0.4
+    pascal-case: ^3.1.2
+    path-case: ^3.0.4
+    sentence-case: ^3.0.4
+    snake-case: ^3.0.4
+    tslib: ^2.0.3
+  checksum: 95a6e48563cd393241ce18470c7310a8a050304a64b63addac487560ab039ce42b099673d1d293cc10652324d92060de11b5d918179fe3b5af2ee521fb03ca58
   languageName: node
   linkType: hard
 
@@ -14011,6 +14100,17 @@ __metadata:
   version: 2.0.2
   resolution: "consolidated-events@npm:2.0.2"
   checksum: d82df47cfd4d43289cdbc5c6d9a924f1445b1c753d36ee1250efa2ee008bca0bc72702ab2e9bda58e1deb8083dc45efdbe3deb363e094fcba7ec6b7b3589df53
+  languageName: node
+  linkType: hard
+
+"constant-case@npm:^3.0.4":
+  version: 3.0.4
+  resolution: "constant-case@npm:3.0.4"
+  dependencies:
+    no-case: ^3.0.4
+    tslib: ^2.0.3
+    upper-case: ^2.0.2
+  checksum: 91d54f18341fcc491ae66d1086642b0cc564be3e08984d7b7042f8b0a721c8115922f7f11d6a09f13ed96ff326eabae11f9d1eb0335fa9d8b6e39e4df096010e
   languageName: node
   linkType: hard
 
@@ -15879,6 +15979,16 @@ __metadata:
     no-case: ^3.0.3
     tslib: ^1.10.0
   checksum: f4bbaa2f6cb5521f63bb0f6d7c79b902c7d618a9c51696f882e459257d17a4aee9db5d96d9a3fd2cc6d17264623509db0e1aa86bb7d478c5dd662f26e84d26db
+  languageName: node
+  linkType: hard
+
+"dot-case@npm:^3.0.4":
+  version: 3.0.4
+  resolution: "dot-case@npm:3.0.4"
+  dependencies:
+    no-case: ^3.0.4
+    tslib: ^2.0.3
+  checksum: 5b859ea65097a7ea870e2c91b5768b72ddf7fa947223fd29e167bcdff58fe731d941c48e47a38ec8aa8e43044c8fbd15cd8fa21689a526bc34b6548197cd5b05
   languageName: node
   linkType: hard
 
@@ -19626,6 +19736,16 @@ __metadata:
   bin:
     he: bin/he
   checksum: a27d478befe3c8192f006cdd0639a66798979dfa6e2125c6ac582a19a5ebfec62ad83e8382e6036170d873f46e4536a7e795bf8b95bf7c247f4cc0825ccc8c17
+  languageName: node
+  linkType: hard
+
+"header-case@npm:^2.0.4":
+  version: 2.0.4
+  resolution: "header-case@npm:2.0.4"
+  dependencies:
+    capital-case: ^1.0.4
+    tslib: ^2.0.3
+  checksum: c9f295d9d8e38fa50679281fd70d80726962256e888a76c8e72e526453da7a1832dcb427caa716c1ad5d79841d4537301b90156fa30298fefd3d68f4ea2181bb
   languageName: node
   linkType: hard
 
@@ -23744,6 +23864,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lower-case@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "lower-case@npm:2.0.2"
+  dependencies:
+    tslib: ^2.0.3
+  checksum: 3d925e090315cf7dc1caa358e0477e186ffa23947740e4314a7429b6e62d72742e0bbe7536a5ae56d19d7618ce998aba05caca53c2902bd5742fdca5fc57fd7b
+  languageName: node
+  linkType: hard
+
 "lowercase-keys@npm:^1.0.0, lowercase-keys@npm:^1.0.1":
   version: 1.0.1
   resolution: "lowercase-keys@npm:1.0.1"
@@ -25446,6 +25575,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"no-case@npm:^3.0.4":
+  version: 3.0.4
+  resolution: "no-case@npm:3.0.4"
+  dependencies:
+    lower-case: ^2.0.2
+    tslib: ^2.0.3
+  checksum: 8ef545f0b3f8677c848f86ecbd42ca0ff3cd9dd71c158527b344c69ba14710d816d8489c746b6ca225e7b615108938a0bda0a54706f8c255933703ac1cf8e703
+  languageName: node
+  linkType: hard
+
 "nocache@npm:^2.1.0":
   version: 2.1.0
   resolution: "nocache@npm:2.1.0"
@@ -26631,6 +26770,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"param-case@npm:^3.0.4":
+  version: 3.0.4
+  resolution: "param-case@npm:3.0.4"
+  dependencies:
+    dot-case: ^3.0.4
+    tslib: ^2.0.3
+  checksum: ccc053f3019f878eca10e70ec546d92f51a592f762917dafab11c8b532715dcff58356118a6f350976e4ab109e321756f05739643ed0ca94298e82291e6f9e76
+  languageName: node
+  linkType: hard
+
 "parent-module@npm:^1.0.0":
   version: 1.0.1
   resolution: "parent-module@npm:1.0.1"
@@ -26843,6 +26992,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pascal-case@npm:^3.1.2":
+  version: 3.1.2
+  resolution: "pascal-case@npm:3.1.2"
+  dependencies:
+    no-case: ^3.0.4
+    tslib: ^2.0.3
+  checksum: 05ff7c344809fd272fc5030ae0ee3da8e4e63f36d47a1e0a4855ca59736254192c5a27b5822ed4bae96e54048eec5f6907713cfcfff7cdf7a464eaf7490786d8
+  languageName: node
+  linkType: hard
+
 "pascalcase@npm:^0.1.1":
   version: 0.1.1
   resolution: "pascalcase@npm:0.1.1"
@@ -26861,6 +27020,16 @@ __metadata:
   version: 1.0.1
   resolution: "path-browserify@npm:1.0.1"
   checksum: 8b8c3fd5c66bd340272180590ae4ff139769e9ab79522e2eb82e3d571a89b8117c04147f65ad066dccfb42fcad902e5b7d794b3d35e0fd840491a8ddbedf8c66
+  languageName: node
+  linkType: hard
+
+"path-case@npm:^3.0.4":
+  version: 3.0.4
+  resolution: "path-case@npm:3.0.4"
+  dependencies:
+    dot-case: ^3.0.4
+    tslib: ^2.0.3
+  checksum: b6b14637228a558793f603aaeb2fcd981e738b8b9319421b713532fba96d75aa94024b9f6b9ae5aa33d86755144a5b36697d28db62ae45527dbd672fcc2cf0b7
   languageName: node
   linkType: hard
 
@@ -31591,6 +31760,17 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
+"sentence-case@npm:^3.0.4":
+  version: 3.0.4
+  resolution: "sentence-case@npm:3.0.4"
+  dependencies:
+    no-case: ^3.0.4
+    tslib: ^2.0.3
+    upper-case-first: ^2.0.2
+  checksum: 9a90527a51300cf5faea7fae0c037728f9ddcff23ac083883774c74d180c0a03c31aab43d5c3347512e8c1b31a0d4712512ec82beb71aa79b85149f9abeb5467
+  languageName: node
+  linkType: hard
+
 "serialize-error@npm:^2.1.0":
   version: 2.1.0
   resolution: "serialize-error@npm:2.1.0"
@@ -31993,6 +32173,16 @@ resolve@^2.0.0-next.3:
   version: 4.2.0
   resolution: "smart-buffer@npm:4.2.0"
   checksum: a16775323e1404dd43fabafe7460be13a471e021637bc7889468eb45ce6a6b207261f454e4e530a19500cc962c4cc5348583520843b363f4193cee5c00e1e539
+  languageName: node
+  linkType: hard
+
+"snake-case@npm:^3.0.4":
+  version: 3.0.4
+  resolution: "snake-case@npm:3.0.4"
+  dependencies:
+    dot-case: ^3.0.4
+    tslib: ^2.0.3
+  checksum: ab19a913969f58f4474fe9f6e8a026c8a2142a01f40b52b79368068343177f818cdfef0b0c6b9558f298782441d5ca8ed5932eb57822439fad791d866e62cecd
   languageName: node
   linkType: hard
 
@@ -34060,7 +34250,7 @@ swiper@4.5.1:
   languageName: node
   linkType: hard
 
-"tslib@npm:>=2.3.0, tslib@npm:^2.0.0, tslib@npm:^2.0.1, tslib@npm:^2.1.0, tslib@npm:^2.3.0":
+"tslib@npm:>=2.3.0, tslib@npm:^2.0.0, tslib@npm:^2.0.1, tslib@npm:^2.0.3, tslib@npm:^2.1.0, tslib@npm:^2.3.0":
   version: 2.4.0
   resolution: "tslib@npm:2.4.0"
   checksum: eb19bda3ae545b03caea6a244b34593468e23d53b26bf8649fbc20fce43e9b21a71127fd6d2b9662c0fe48ee6ff668ead48fd00d3b88b2b716b1c12edae25b5d
@@ -34742,10 +34932,28 @@ swiper@4.5.1:
   languageName: node
   linkType: hard
 
+"upper-case-first@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "upper-case-first@npm:2.0.2"
+  dependencies:
+    tslib: ^2.0.3
+  checksum: ccad6a0b143310ebfba2b5841f30bef71246297385f1329c022c902b2b5fc5aee009faf1ac9da5ab3ba7f615b88f5dc1cd80461b18a8f38cb1d4c3eb92538ea9
+  languageName: node
+  linkType: hard
+
 "upper-case@npm:^1.1.1":
   version: 1.1.3
   resolution: "upper-case@npm:1.1.3"
   checksum: 3e4d3a90519915bb591db84d72610392518806d8287b8f7541d87642d30388f42b2def1ed2f687e5792ee025e8f7e17d3a0dcbd5b3b59e306ceb1f3b8121ef54
+  languageName: node
+  linkType: hard
+
+"upper-case@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "upper-case@npm:2.0.2"
+  dependencies:
+    tslib: ^2.0.3
+  checksum: 5ac176c9d3757abb71400df167f9abb46d63152d5797c630d1a9f083fbabd89711fb4b3dc6de06ff0138fe8946fa5b8518b4fcdae9ca8a3e341417075beae069
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9212,22 +9212,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wordpress/element@npm:^4.0.1, @wordpress/element@npm:^4.0.4, @wordpress/element@npm:^4.1.1, @wordpress/element@npm:^4.11.0, @wordpress/element@npm:^4.12.0, @wordpress/element@npm:^4.5.0, @wordpress/element@npm:^4.7.0":
-  version: 4.12.0
-  resolution: "@wordpress/element@npm:4.12.0"
-  dependencies:
-    "@babel/runtime": ^7.16.0
-    "@types/react": ^17.0.37
-    "@types/react-dom": ^17.0.11
-    "@wordpress/escape-html": ^2.14.0
-    lodash: ^4.17.21
-    react: ^17.0.2
-    react-dom: ^17.0.2
-  checksum: 22162e567fc17cc1251b7581f49d54ed32ecdec98481d922e3dc6ca535d84dcf0695a7b15701ad6f74c884304d47544076593892294448afa2988056f604d359
-  languageName: node
-  linkType: hard
-
-"@wordpress/element@npm:^4.18.0":
+"@wordpress/element@npm:^4.0.1, @wordpress/element@npm:^4.0.4, @wordpress/element@npm:^4.1.1, @wordpress/element@npm:^4.11.0, @wordpress/element@npm:^4.18.0, @wordpress/element@npm:^4.5.0, @wordpress/element@npm:^4.7.0":
   version: 4.18.0
   resolution: "@wordpress/element@npm:4.18.0"
   dependencies:
@@ -9274,16 +9259,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wordpress/escape-html@npm:^2.13.0, @wordpress/escape-html@npm:^2.14.0, @wordpress/escape-html@npm:^2.2.0, @wordpress/escape-html@npm:^2.2.1, @wordpress/escape-html@npm:^2.2.3, @wordpress/escape-html@npm:^2.9.0":
-  version: 2.14.0
-  resolution: "@wordpress/escape-html@npm:2.14.0"
-  dependencies:
-    "@babel/runtime": ^7.16.0
-  checksum: 88cd44de524346e95ab0eeaebc91afa4dee10e330b032a93b5106fa06ffd5568eb6bcab2597288a427ec4f0549d6ec8ef4840bb2b8cfc3e958f6643c2eea60cd
-  languageName: node
-  linkType: hard
-
-"@wordpress/escape-html@npm:^2.20.0":
+"@wordpress/escape-html@npm:^2.13.0, @wordpress/escape-html@npm:^2.2.0, @wordpress/escape-html@npm:^2.2.1, @wordpress/escape-html@npm:^2.2.3, @wordpress/escape-html@npm:^2.20.0, @wordpress/escape-html@npm:^2.9.0":
   version: 2.20.0
   resolution: "@wordpress/escape-html@npm:2.20.0"
   dependencies:
@@ -9466,18 +9442,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wordpress/icons@npm:^9.0.0, @wordpress/icons@npm:^9.4.0, @wordpress/icons@npm:^9.5.0":
-  version: 9.5.0
-  resolution: "@wordpress/icons@npm:9.5.0"
-  dependencies:
-    "@babel/runtime": ^7.16.0
-    "@wordpress/element": ^4.12.0
-    "@wordpress/primitives": ^3.12.0
-  checksum: 03e5885e79a20846ae0d906277afa6a159a1718acb647052bae5052d0ab49d2e78f475c93a7341ffcdee0ede55176fcaf87217bcb238980d1bad728e2f476412
-  languageName: node
-  linkType: hard
-
-"@wordpress/icons@npm:^9.11.0":
+"@wordpress/icons@npm:^9.0.0, @wordpress/icons@npm:^9.11.0, @wordpress/icons@npm:^9.4.0, @wordpress/icons@npm:^9.5.0":
   version: 9.11.0
   resolution: "@wordpress/icons@npm:9.11.0"
   dependencies:
@@ -9750,18 +9715,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wordpress/primitives@npm:^3.0.1, @wordpress/primitives@npm:^3.0.4, @wordpress/primitives@npm:^3.1.1, @wordpress/primitives@npm:^3.11.0, @wordpress/primitives@npm:^3.12.0, @wordpress/primitives@npm:^3.5.0, @wordpress/primitives@npm:^3.7.0, @wordpress/primitives@npm:^3.8.0":
-  version: 3.12.0
-  resolution: "@wordpress/primitives@npm:3.12.0"
-  dependencies:
-    "@babel/runtime": ^7.16.0
-    "@wordpress/element": ^4.12.0
-    classnames: ^2.3.1
-  checksum: 55b9bcb6a0cfa4405b8f45105251321173b396c4cb4263a89797939a4415cdc454743e7ff3779074c0437bf51a161875c6e2d2f4b793cc7b440ee4552124a262
-  languageName: node
-  linkType: hard
-
-"@wordpress/primitives@npm:^3.18.0":
+"@wordpress/primitives@npm:^3.0.1, @wordpress/primitives@npm:^3.0.4, @wordpress/primitives@npm:^3.1.1, @wordpress/primitives@npm:^3.11.0, @wordpress/primitives@npm:^3.18.0, @wordpress/primitives@npm:^3.5.0, @wordpress/primitives@npm:^3.7.0, @wordpress/primitives@npm:^3.8.0":
   version: 3.18.0
   resolution: "@wordpress/primitives@npm:3.18.0"
   dependencies:
@@ -12878,17 +12832,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"camel-case@npm:^4.1.1":
-  version: 4.1.1
-  resolution: "camel-case@npm:4.1.1"
-  dependencies:
-    pascal-case: ^3.1.1
-    tslib: ^1.10.0
-  checksum: d8113f24a3ac764a81a6ec7a5de5d339bcc749da741e6a088c8f1dc8768845ef5299ce37d94449a0608727ac0a7c33e9c47fecfa820a1ab2b4145c0f5129c584
-  languageName: node
-  linkType: hard
-
-"camel-case@npm:^4.1.2":
+"camel-case@npm:^4.1.1, camel-case@npm:^4.1.2":
   version: 4.1.2
   resolution: "camel-case@npm:4.1.2"
   dependencies:
@@ -15969,16 +15913,6 @@ __metadata:
     domelementtype: ^2.2.0
     domhandler: ^4.2.0
   checksum: d58e2ae01922f0dd55894e61d18119924d88091837887bf1438f2327f32c65eb76426bd9384f81e7d6dcfb048e0f83c19b222ad7101176ad68cdc9c695b563db
-  languageName: node
-  linkType: hard
-
-"dot-case@npm:^3.0.3":
-  version: 3.0.3
-  resolution: "dot-case@npm:3.0.3"
-  dependencies:
-    no-case: ^3.0.3
-    tslib: ^1.10.0
-  checksum: f4bbaa2f6cb5521f63bb0f6d7c79b902c7d618a9c51696f882e459257d17a4aee9db5d96d9a3fd2cc6d17264623509db0e1aa86bb7d478c5dd662f26e84d26db
   languageName: node
   linkType: hard
 
@@ -23855,15 +23789,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lower-case@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "lower-case@npm:2.0.1"
-  dependencies:
-    tslib: ^1.10.0
-  checksum: 3dad40e357d2a56e93e03b9dc1233c010a255dfd2dfc5b7203d351ca75944f4baa5f7ec9ede4ae99907548ef09eda56e6f52845e9607462f44436b50d0c83ffb
-  languageName: node
-  linkType: hard
-
 "lower-case@npm:^2.0.2":
   version: 2.0.2
   resolution: "lower-case@npm:2.0.2"
@@ -25565,16 +25490,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"no-case@npm:^3.0.3":
-  version: 3.0.3
-  resolution: "no-case@npm:3.0.3"
-  dependencies:
-    lower-case: ^2.0.1
-    tslib: ^1.10.0
-  checksum: ef23b5a5712e5f7d68eb4bc12c6e076709c86a9edfa30fb563adf53c4ab9be78f8fc24ee91240593aa2d4d79e3f901f838d2d27e4f7e3b45582d5b871d98f171
-  languageName: node
-  linkType: hard
-
 "no-case@npm:^3.0.4":
   version: 3.0.4
   resolution: "no-case@npm:3.0.4"
@@ -26760,17 +26675,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"param-case@npm:^3.0.3":
-  version: 3.0.3
-  resolution: "param-case@npm:3.0.3"
-  dependencies:
-    dot-case: ^3.0.3
-    tslib: ^1.10.0
-  checksum: c90d69d2fb9dbd157abebf85f1bf0ee7b5f4e3f24429ecc726f1d81a952fe858c3e4a7043e9da3b4f84a278b4e94e71aa90099cb7c244bd48e61fb73070eabea
-  languageName: node
-  linkType: hard
-
-"param-case@npm:^3.0.4":
+"param-case@npm:^3.0.3, param-case@npm:^3.0.4":
   version: 3.0.4
   resolution: "param-case@npm:3.0.4"
   dependencies:
@@ -26979,16 +26884,6 @@ __metadata:
   version: 1.3.3
   resolution: "parseurl@npm:1.3.3"
   checksum: 90dd4760d6f6174adb9f20cf0965ae12e23879b5f5464f38e92fce8073354341e4b3b76fa3d878351efe7d01e617121955284cfd002ab087fba1a0726ec0b4f5
-  languageName: node
-  linkType: hard
-
-"pascal-case@npm:^3.1.1":
-  version: 3.1.1
-  resolution: "pascal-case@npm:3.1.1"
-  dependencies:
-    no-case: ^3.0.3
-    tslib: ^1.10.0
-  checksum: d9f975e2720514224e58df96ec08628be6b5a29446e233c946b203c77e43f90080ad37d52a93eefd5e9c6d446bf86a233d9470af09173e20c093153a4bdfb0e2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
#### Proposed Changes

<img width="1540" alt="image" src="https://user-images.githubusercontent.com/4044428/198420934-ce954845-d054-43ab-8484-63159c7f83ba.png">

Adds new `<HighlightCards>` and `<HighlightCard>` components for future use on the Stats dashboard.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this branch locally.
* Spin up Storybook via `yarn workspace @automattic/components run storybook`.
* Check the Highlight Cards stories. Ensure they behave as expected.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #69224
