### PR TITLE
Remove global redux cache log

### DIFF
--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -19,7 +19,6 @@ import { stringify } from 'qs';
 import superagent from 'superagent'; // Don't have Node.js fetch lib yet.
 import wooDnaConfig from 'calypso/jetpack-connect/woo-dna-config';
 import { STEPPER_SECTION_DEFINITION } from 'calypso/landing/stepper/section';
-import { logServerEvent } from 'calypso/lib/analytics/statsd-utils';
 import { shouldSeeGdprBanner } from 'calypso/lib/analytics/utils';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { isWooOAuth2Client } from 'calypso/lib/oauth2-clients';
@@ -127,12 +126,6 @@ function getDefaultContext( request, response, entrypoint = 'entry-main', sectio
 	const cachedServerState = request.context.isLoggedIn ? {} : stateCache.get( cacheKey ) || {};
 	const getCachedState = ( reducer, storageKey ) => {
 		const storedState = cachedServerState[ storageKey ];
-
-		logServerEvent( sectionName, {
-			// Note: "ssr" just categorizes the stat. It doesn't necessarily mean SSR was used for the request.
-			name: `ssr.global_redux_cache.${ storedState ? 'hit' : 'miss' }`,
-			type: 'counting',
-		} );
 
 		if ( ! storedState ) {
 			return undefined;

--- a/client/server/render/index.js
+++ b/client/server/render/index.js
@@ -86,7 +86,7 @@ function render( element, key, req ) {
 
 		logServerEvent( req.context.sectionName, {
 			// Note: "ssr" just categorizes the stat. It doesn't necessarily mean SSR was used for the request.
-			name: `ssr.markup_cache.${ key }.${ renderedLayout ? 'hit' : 'miss' }`,
+			name: `ssr.markup_cache.${ renderedLayout ? 'hit' : 'miss' }`,
 			type: 'counting',
 		} );
 


### PR DESCRIPTION
#### Proposed Changes
I added this in #69353. Removing now for two reasons:

1. It's not helpful because the cache is only really used in SSR pipelines. But we log it all the time. (So the cache hit rate is like 0.01%)
2. I think there are so many logs around here that it's impacting performance a little bit.

I'm also tweaking the `redux_cache` log because it isn't getting captured for some reason. Maybe the "key" contains invalid data or something.

#### Testing Instructions

CI
