### PR TITLE
Design Preview: Fix title & logo overlap - round 2

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
@@ -215,14 +215,10 @@ $break-design-preview: 1024px;
 				}
 			}
 
-			@include break-mobile {
+			@include break-small {
 				margin: 16px 0 24px;
 				transform: translateY(-58px);
 				min-height: 42px;
-
-				#design-setup-header {
-					padding: 0 60px;
-				}
 			}
 		}
 
@@ -230,7 +226,7 @@ $break-design-preview: 1024px;
 			height: calc(100vh - 245px);
 			margin-top: 74px;
 
-			@include break-mobile {
+			@include break-small {
 				height: calc(100vh - 225px);
 				margin-top: 32px;
 			}


### PR DESCRIPTION
## Proposed Changes

* Remove title and logo overlapping for Design Preview between mobile and desktop
![image](https://user-images.githubusercontent.com/10071857/198498946-100f5d8e-2413-4e19-a974-f80e83b5d990.png)
 
## Reference
Related to [#68551](https://github.com/Automattic/wp-calypso/issues/68551)
Override change on #69500