### PR TITLE
DIFM: Fixes merge error on site content step

### DIFF
--- a/client/signup/steps/website-content/index.tsx
+++ b/client/signup/steps/website-content/index.tsx
@@ -23,6 +23,7 @@ import {
 	WebsiteContentStateModel,
 } from 'calypso/state/signup/steps/website-content/selectors';
 import { getSiteId } from 'calypso/state/sites/selectors';
+import { SiteId } from 'calypso/types';
 import { sectionGenerator } from './section-generator';
 import { usePollSiteForDIFMDetails } from './use-poll-site-for-difm-details';
 
@@ -76,6 +77,7 @@ interface WebsiteContentStepProps {
 	stepName: string;
 	positionInFlow: string;
 	pageTitles: string[];
+	siteId: SiteId | null;
 }
 
 function WebsiteContentStep( {
@@ -84,6 +86,7 @@ function WebsiteContentStep( {
 	submitSignupStep,
 	goToNextStep,
 	pageTitles,
+	siteId,
 }: WebsiteContentStepProps ) {
 	const [ formErrors, setFormErrors ] = useState< ValidationErrors >( {} );
 	const dispatch = useDispatch();
@@ -263,7 +266,9 @@ export default function WrapperWebsiteContent(
 			flowName={ flowName }
 			stepName={ stepName }
 			positionInFlow={ positionInFlow }
-			stepContent={ <WebsiteContentStep { ...props } pageTitles={ pageTitles } /> }
+			stepContent={
+				<WebsiteContentStep { ...props } pageTitles={ pageTitles } siteId={ siteId } />
+			}
 			goToNextStep={ false }
 			hideFormattedHeader={ false }
 			hideBack={ false }


### PR DESCRIPTION
#### Proposed Changes

* #69323 was based on an old version of trunk, and merging it caused a variable to be not defined. 

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/site-content-collection/website-content?siteSlug=<site slug>` and confirm that the form works correctly.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


