### PR TITLE
Generated designs: Update how generated designs are displayed to users

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/categories.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/categories.ts
@@ -23,12 +23,18 @@ function makeSortCategoryToTop( slug: string ) {
 const sortBlogToTop = makeSortCategoryToTop( CATEGORY_BLOG );
 const sortStoreToTop = makeSortCategoryToTop( CATEGORY_STORE );
 
-export function getCategorizationOptions( intent: string, showAllFilter: boolean ) {
+export function getCategorizationOptions(
+	intent: string,
+	showAllFilter: boolean,
+	showGeneratedDesignsFilter: boolean
+) {
 	const result = {
 		showAllFilter,
+		showGeneratedDesignsFilter,
 		defaultSelection: null,
 	} as {
 		showAllFilter: boolean;
+		showGeneratedDesignsFilter: boolean;
 		defaultSelection: string | null;
 		sort: ( a: Category, b: Category ) => 0 | 1 | -1;
 	};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/categories.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/categories.ts
@@ -26,15 +26,15 @@ const sortStoreToTop = makeSortCategoryToTop( CATEGORY_STORE );
 export function getCategorizationOptions(
 	intent: string,
 	showAllFilter: boolean,
-	showGeneratedDesignsFilter: boolean
+	generatedDesignsFilter: string
 ) {
 	const result = {
 		showAllFilter,
-		showGeneratedDesignsFilter,
+		generatedDesignsFilter,
 		defaultSelection: null,
 	} as {
 		showAllFilter: boolean;
-		showGeneratedDesignsFilter: boolean;
+		generatedDesignsFilter: string | null;
 		defaultSelection: string | null;
 		sort: ( a: Category, b: Category ) => 0 | 1 | -1;
 	};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/categories.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/categories.ts
@@ -26,7 +26,7 @@ const sortStoreToTop = makeSortCategoryToTop( CATEGORY_STORE );
 export function getCategorizationOptions(
 	intent: string,
 	showAllFilter: boolean,
-	generatedDesignsFilter: string
+	generatedDesignsFilter?: string
 ) {
 	const result = {
 		showAllFilter,
@@ -34,7 +34,7 @@ export function getCategorizationOptions(
 		defaultSelection: null,
 	} as {
 		showAllFilter: boolean;
-		generatedDesignsFilter: string | null;
+		generatedDesignsFilter?: string;
 		defaultSelection: string | null;
 		sort: ( a: Category, b: Category ) => 0 | 1 | -1;
 	};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/test/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/test/unified-design-picker.tsx
@@ -119,9 +119,9 @@ describe( 'UnifiedDesignPickerStep', () => {
 
 			await waitFor( () => {
 				expect( screen.getByText( 'Pick a design' ) ).toBeInTheDocument();
-				expect(
-					container.getElementsByClassName( 'unified-design-picker__standard-designs' )
-				).toHaveLength( 1 );
+				expect( container.getElementsByClassName( 'unified-design-picker__designs' ) ).toHaveLength(
+					1
+				);
 			} );
 		} );
 	} );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -134,7 +134,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 	const categorizationOptions = getCategorizationOptions(
 		intent,
 		true,
-		generatedDesigns.length > 0 && siteVertical?.title
+		generatedDesigns.length > 0 ? siteVertical?.title : undefined
 	);
 
 	const categorization = useCategorization( staticDesigns, categorizationOptions );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -126,7 +126,11 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 		}
 	}, [ hasTrackedView, generatedDesigns, staticDesigns ] );
 
-	const categorizationOptions = getCategorizationOptions( intent, true );
+	const categorizationOptions = getCategorizationOptions(
+		intent,
+		true,
+		generatedDesigns.length > 0
+	);
 	const categorization = useCategorization( staticDesigns, categorizationOptions );
 
 	// ********** Logic for selecting a design and style variation

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -134,7 +134,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 	const categorizationOptions = getCategorizationOptions(
 		intent,
 		true,
-		generatedDesigns.length > 0 ? siteVertical?.title : null
+		generatedDesigns.length > 0 && siteVertical?.title
 	);
 
 	const categorization = useCategorization( staticDesigns, categorizationOptions );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -21,6 +21,7 @@ import { useQuerySitePurchases } from 'calypso/components/data/query-site-purcha
 import FormattedHeader from 'calypso/components/formatted-header';
 import PremiumBadge from 'calypso/components/premium-badge';
 import WebPreview from 'calypso/components/web-preview/content';
+import { useSiteVerticalQueryById } from 'calypso/data/site-verticals';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { urlToSlug } from 'calypso/lib/url';
 import { usePremiumGlobalStyles } from 'calypso/state/sites/hooks/use-premium-global-styles';
@@ -82,6 +83,10 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 		)
 	);
 
+	// ********** Logic for vertical
+	const { data: siteVertical, isLoading: isLoadingSiteVertical } =
+		useSiteVerticalQueryById( siteVerticalId );
+
 	// ********** Logic for fetching designs
 	const selectStarterDesigns = ( allDesigns: StarterDesigns ) => {
 		const blankCanvasDesignOffset = allDesigns.static.designs.findIndex( isBlankCanvasDesign );
@@ -129,8 +134,9 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 	const categorizationOptions = getCategorizationOptions(
 		intent,
 		true,
-		generatedDesigns.length > 0
+		generatedDesigns.length > 0 ? siteVertical?.title : null
 	);
+
 	const categorization = useCategorization( staticDesigns, categorizationOptions );
 
 	// ********** Logic for selecting a design and style variation
@@ -434,8 +440,8 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 
 	// ********** Main render logic
 
-	// Don't render until we've fetched the designs from the backend.
-	if ( ! site || isLoadingDesigns ) {
+	// Don't render until we've done fetching all the data needed for initial render.
+	if ( ! site || isLoadingSiteVertical || isLoadingDesigns ) {
 		return null;
 	}
 

--- a/packages/design-picker/src/components/style.scss
+++ b/packages/design-picker/src/components/style.scss
@@ -426,6 +426,10 @@
 
 			.design-button-container {
 				margin-top: 32px;
+
+				&:first-child {
+					margin-top: 0;
+				}
 			}
 
 			.design-button-container--is-generated {
@@ -440,7 +444,7 @@
 			}
 
 			.design-button-container--is-generated--is-showing {
-				margin-top: 0;
+				margin-top: 32px;
 				max-height: none;
 
 				.theme-preview__container {

--- a/packages/design-picker/src/components/style.scss
+++ b/packages/design-picker/src/components/style.scss
@@ -343,24 +343,6 @@
 	display: flex;
 	font-size: $font-body-small;
 
-	&--is-generated {
-		max-height: 0;
-		overflow: hidden;
-
-		.theme-preview__container {
-			opacity: 0;
-			transition: opacity 1.5s ease-in-out;
-		}
-
-		&--is-showing {
-			max-height: none;
-
-			.theme-preview__container {
-				opacity: 1;
-			}
-		}
-	}
-
 	.design-picker__design-option {
 		flex: 1;
 	}
@@ -431,9 +413,39 @@
 
 	.design-picker__grid {
 		@supports ( display: grid ) {
+			row-gap: 0;
+
 			@include break-medium {
 				grid-template-columns: 1fr 1fr 1fr;
 				column-gap: 24px;
+
+				.design-button-container:nth-child(-n+3) {
+					margin-top: 0;
+				}
+			}
+
+			.design-button-container {
+				margin-top: 32px;
+			}
+
+			.design-button-container--is-generated {
+				margin-top: 0;
+				max-height: 0;
+				overflow: hidden;
+
+				.theme-preview__container {
+					opacity: 0;
+					transition: opacity 1.5s ease-in-out;
+				}
+			}
+
+			.design-button-container--is-generated--is-showing {
+				margin-top: 0;
+				max-height: none;
+
+				.theme-preview__container {
+					opacity: 1;
+				}
 			}
 		}
 	}
@@ -472,6 +484,23 @@
 
 	.components-button.is-pressed:active:hover {
 		color: var(--theme-base-color);
+	}
+
+	.unified-design-picker__designs {
+		min-height: 100vh;
+	}
+
+	.unified-design-picker__generated-designs {
+		max-height: 0;
+		overflow: hidden;
+
+		&.unified-design-picker__generated-designs--is-showing {
+			max-height: none;
+		}
+
+		.design-picker__grid {
+			padding-top: 32px;
+		}
 	}
 }
 

--- a/packages/design-picker/src/components/style.scss
+++ b/packages/design-picker/src/components/style.scss
@@ -343,6 +343,24 @@
 	display: flex;
 	font-size: $font-body-small;
 
+	&--is-generated {
+		max-height: 0;
+		overflow: hidden;
+
+		.theme-preview__container {
+			opacity: 0;
+			transition: opacity 1.5s ease-in-out;
+		}
+
+		&--is-showing {
+			max-height: none;
+
+			.theme-preview__container {
+				opacity: 1;
+			}
+		}
+	}
+
 	.design-picker__design-option {
 		flex: 1;
 	}
@@ -406,9 +424,11 @@
 .design-picker.design-picker__unified {
 	display: block;
 	padding-bottom: 200px;
+
 	.responsive-toolbar-group__dropdown .responsive-toolbar-group__grouped-list {
 		justify-content: flex-start;
 	}
+
 	.design-picker__grid {
 		@supports ( display: grid ) {
 			@include break-medium {
@@ -427,11 +447,6 @@
 
 	.design-picker__design-option > button {
 		cursor: pointer;
-	}
-
-	.unified-design-picker__subtitle {
-		color: #50575e;
-		margin-bottom: 30px;
 	}
 
 	.generated-design-thumbnail {
@@ -457,22 +472,6 @@
 
 	.components-button.is-pressed:active:hover {
 		color: var(--theme-base-color);
-	}
-
-	// Customize styles for generated designs
-	.unified-design-picker__generated-designs {
-		.design-picker__grid {
-			padding-bottom: 32px;
-		}
-	}
-
-	// Customize styles for standard designs
-	.unified-design-picker__standard-designs {
-		min-height: 100vh;
-
-		.unified-design-picker__subtitle {
-			margin-bottom: 14px;
-		}
 	}
 }
 

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -9,8 +9,10 @@ import { createInterpolateElement } from '@wordpress/element';
 import { sprintf, hasTranslation } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
+import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import {
+	SHOW_ALL_SLUG,
 	SHOW_GENERATED_DESIGNS_SLUG,
 	DEFAULT_VIEWPORT_WIDTH,
 	DEFAULT_VIEWPORT_HEIGHT,
@@ -217,7 +219,7 @@ const DesignButtonContainer: React.FC< DesignButtonContainerProps > = ( {
 
 interface GeneratedDesignButtonContainerProps {
 	locale: string;
-	designs: Design[];
+	design: Design;
 	verticalId?: string;
 	isShowing: boolean;
 	onPreview: ( design: Design ) => void;
@@ -260,6 +262,33 @@ const GeneratedDesignButtonContainer: React.FC< GeneratedDesignButtonContainerPr
 		</div>
 	);
 };
+
+interface GeneratedDesignPickerProps {
+	locale: string;
+	designs: Design[];
+	verticalId?: string;
+	onPreview: ( design: Design ) => void;
+}
+
+const GeneratedDesignPicker: React.FC< GeneratedDesignPickerProps > = ( {
+	locale,
+	designs,
+	verticalId,
+	onPreview,
+} ) => (
+	<div className="design-picker__grid">
+		{ designs.map( ( design ) => (
+			<GeneratedDesignButtonContainer
+				key={ `generated-design__${ design.slug }` }
+				design={ design }
+				locale={ locale }
+				verticalId={ verticalId }
+				isShowing
+				onPreview={ onPreview }
+			/>
+		) ) }
+	</div>
+);
 
 const wasThemePurchased = ( purchasedThemes: string[] | undefined, design: Design ) =>
 	purchasedThemes
@@ -370,7 +399,10 @@ const UnifiedDesignPicker: React.FC< UnifiedDesignPickerProps > = ( {
 	purchasedThemes,
 	currentPlanFeatures,
 } ) => {
+	const translate = useTranslate();
 	const hasCategories = !! categorization?.categories.length;
+	const hasGeneratedDesigns = generatedDesigns.length > 0;
+	const isShowAll = ! categorization?.selection || categorization?.selection === SHOW_ALL_SLUG;
 
 	return (
 		<div
@@ -399,6 +431,26 @@ const UnifiedDesignPicker: React.FC< UnifiedDesignPickerProps > = ( {
 					currentPlanFeatures={ currentPlanFeatures }
 				/>
 			</div>
+			{ hasGeneratedDesigns && (
+				<div
+					className={ classnames( 'unified-design-picker__generated-designs', {
+						'unified-design-picker__generated-designs--is-showing': isShowAll,
+					} ) }
+				>
+					<div>
+						<h3> { translate( 'Custom designs for your site' ) } </h3>
+						<p className="unified-design-picker__subtitle">
+							{ translate( 'Based on your input, these designs have been tailored for you.' ) }
+						</p>
+					</div>
+					<GeneratedDesignPicker
+						locale={ locale }
+						designs={ generatedDesigns }
+						verticalId={ verticalId }
+						onPreview={ onPreview }
+					/>
+				</div>
+			) }
 		</div>
 	);
 };

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -9,9 +9,9 @@ import { createInterpolateElement } from '@wordpress/element';
 import { sprintf, hasTranslation } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
-import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import {
+	SHOW_GENERATED_DESIGNS_SLUG,
 	DEFAULT_VIEWPORT_WIDTH,
 	DEFAULT_VIEWPORT_HEIGHT,
 	MOBILE_VIEWPORT_WIDTH,
@@ -204,7 +204,6 @@ const DesignButtonContainer: React.FC< DesignButtonContainerProps > = ( {
 	...props
 } ) => {
 	const isBlankCanvas = isBlankCanvasDesign( props.design );
-
 	if ( isBlankCanvas ) {
 		return <PatternAssemblerCta onButtonClick={ () => onSelect( props.design ) } />;
 	}
@@ -216,10 +215,131 @@ const DesignButtonContainer: React.FC< DesignButtonContainerProps > = ( {
 	);
 };
 
+interface GeneratedDesignButtonContainerProps {
+	locale: string;
+	designs: Design[];
+	verticalId?: string;
+	isShowing: boolean;
+	onPreview: ( design: Design ) => void;
+}
+
+const GeneratedDesignButtonContainer: React.FC< GeneratedDesignButtonContainerProps > = ( {
+	locale,
+	design,
+	verticalId,
+	isShowing,
+	onPreview,
+} ) => {
+	const isMobile = useViewportMatch( 'small', '<' );
+	const previewUrl = getDesignPreviewUrl( design, {
+		language: locale,
+		vertical_id: verticalId,
+		viewport_width: isMobile ? MOBILE_VIEWPORT_WIDTH : DEFAULT_VIEWPORT_WIDTH,
+		viewport_height: DEFAULT_VIEWPORT_HEIGHT,
+		use_screenshot_overrides: true,
+	} );
+
+	return (
+		<div
+			key={ `generated-design__${ design.slug }` }
+			className={ classnames( 'design-button-container', 'design-button-container--is-generated', {
+				'design-button-container--is-generated--is-showing': isShowing,
+			} ) }
+		>
+			<div className="design-picker__design-option">
+				<button className="generated-design-thumbnail" onClick={ () => onPreview( design ) }>
+					<span className="generated-design-thumbnail__image design-picker__image-frame design-picker__image-frame-no-header">
+						<ThemePreview
+							url={ previewUrl }
+							viewportWidth={ isMobile ? MOBILE_VIEWPORT_WIDTH : DEFAULT_VIEWPORT_WIDTH }
+							isFitHeight
+						/>
+					</span>
+				</button>
+			</div>
+		</div>
+	);
+};
+
 const wasThemePurchased = ( purchasedThemes: string[] | undefined, design: Design ) =>
 	purchasedThemes
 		? purchasedThemes.some( ( themeId ) => design?.recipe?.stylesheet?.endsWith( '/' + themeId ) )
 		: false;
+
+interface DesignPickerProps {
+	locale: string;
+	verticalId?: string;
+	onSelect: ( design: Design ) => void;
+	onPreview: ( design: Design, variation?: StyleVariation ) => void;
+	staticDesigns: Design[];
+	generatedDesigns: Design[];
+	categorization?: Categorization;
+	isPremiumThemeAvailable?: boolean;
+	onCheckout?: any;
+	purchasedThemes?: string[];
+	currentPlanFeatures?: string[];
+}
+
+const DesignPicker: React.FC< DesignPickerProps > = ( {
+	locale,
+	onSelect,
+	onPreview,
+	staticDesigns,
+	generatedDesigns,
+	categorization,
+	isPremiumThemeAvailable,
+	onCheckout,
+	verticalId,
+	purchasedThemes,
+	currentPlanFeatures,
+} ) => {
+	const hasCategories = !! categorization?.categories.length;
+	const filteredStaticDesigns = useMemo( () => {
+		if ( categorization?.selection ) {
+			return filterDesignsByCategory( staticDesigns, categorization.selection );
+		}
+
+		return staticDesigns;
+	}, [ staticDesigns, categorization?.selection ] );
+
+	return (
+		<div>
+			{ categorization && hasCategories && (
+				<UnifiedDesignPickerCategoryFilter
+					categories={ categorization.categories }
+					onSelect={ categorization.onSelect }
+					selectedSlug={ categorization.selection }
+				/>
+			) }
+			<div className="design-picker__grid">
+				{ filteredStaticDesigns.map( ( design ) => (
+					<DesignButtonContainer
+						key={ design.slug }
+						design={ design }
+						locale={ locale }
+						onSelect={ onSelect }
+						onPreview={ onPreview }
+						isPremiumThemeAvailable={ isPremiumThemeAvailable }
+						onCheckout={ onCheckout }
+						verticalId={ verticalId }
+						hasPurchasedTheme={ wasThemePurchased( purchasedThemes, design ) }
+						currentPlanFeatures={ currentPlanFeatures }
+					/>
+				) ) }
+				{ generatedDesigns.map( ( design ) => (
+					<GeneratedDesignButtonContainer
+						key={ `generated-design__${ design.slug }` }
+						design={ design }
+						locale={ locale }
+						verticalId={ verticalId }
+						isShowing={ categorization?.selection === SHOW_GENERATED_DESIGNS_SLUG }
+						onPreview={ onPreview }
+					/>
+				) ) }
+			</div>
+		</div>
+	);
+};
 
 export interface UnifiedDesignPickerProps {
 	locale: string;
@@ -236,115 +356,6 @@ export interface UnifiedDesignPickerProps {
 	currentPlanFeatures?: string[];
 }
 
-interface StaticDesignPickerProps {
-	locale: string;
-	verticalId?: string;
-	onSelect: ( design: Design ) => void;
-	onPreview: ( design: Design, variation?: StyleVariation ) => void;
-	designs: Design[];
-	categorization?: Categorization;
-	isPremiumThemeAvailable?: boolean;
-	onCheckout?: any;
-	purchasedThemes?: string[];
-	currentPlanFeatures?: string[];
-}
-
-interface GeneratedDesignPickerProps {
-	locale: string;
-	designs: Design[];
-	verticalId?: string;
-	onPreview: ( design: Design ) => void;
-}
-
-const StaticDesignPicker: React.FC< StaticDesignPickerProps > = ( {
-	locale,
-	onSelect,
-	onPreview,
-	designs,
-	categorization,
-	isPremiumThemeAvailable,
-	onCheckout,
-	verticalId,
-	purchasedThemes,
-	currentPlanFeatures,
-} ) => {
-	const hasCategories = !! categorization?.categories.length;
-
-	const filteredDesigns = useMemo( () => {
-		if ( categorization?.selection ) {
-			return filterDesignsByCategory( designs, categorization.selection );
-		}
-
-		return designs;
-	}, [ designs, categorization?.selection ] );
-
-	return (
-		<div>
-			{ categorization && hasCategories && (
-				<UnifiedDesignPickerCategoryFilter
-					categories={ categorization.categories }
-					onSelect={ categorization.onSelect }
-					selectedSlug={ categorization.selection }
-				/>
-			) }
-			<div className="design-picker__grid">
-				{ filteredDesigns.map( ( design ) => (
-					<DesignButtonContainer
-						key={ design.slug }
-						design={ design }
-						locale={ locale }
-						onSelect={ onSelect }
-						onPreview={ onPreview }
-						isPremiumThemeAvailable={ isPremiumThemeAvailable }
-						onCheckout={ onCheckout }
-						verticalId={ verticalId }
-						hasPurchasedTheme={ wasThemePurchased( purchasedThemes, design ) }
-						currentPlanFeatures={ currentPlanFeatures }
-					/>
-				) ) }
-			</div>
-		</div>
-	);
-};
-
-const GeneratedDesignPicker: React.FC< GeneratedDesignPickerProps > = ( {
-	locale,
-	designs,
-	verticalId,
-	onPreview,
-} ) => {
-	const isMobile = useViewportMatch( 'small', '<' );
-
-	return (
-		<div className="design-picker__grid">
-			{ designs.map( ( design ) => {
-				const previewUrl = getDesignPreviewUrl( design, {
-					language: locale,
-					vertical_id: verticalId,
-					viewport_width: isMobile ? MOBILE_VIEWPORT_WIDTH : DEFAULT_VIEWPORT_WIDTH,
-					viewport_height: DEFAULT_VIEWPORT_HEIGHT,
-					use_screenshot_overrides: true,
-				} );
-				return (
-					<div className="design-button-container" key={ `generated-design__${ design.slug }` }>
-						<div className="design-picker__design-option">
-							<button className="generated-design-thumbnail" onClick={ () => onPreview( design ) }>
-								<span className="generated-design-thumbnail__image design-picker__image-frame design-picker__image-frame-no-header">
-									<ThemePreview
-										url={ previewUrl }
-										viewportWidth={ isMobile ? MOBILE_VIEWPORT_WIDTH : DEFAULT_VIEWPORT_WIDTH }
-										isFitHeight
-									/>
-								</span>
-							</button>
-						</div>
-					</div>
-				);
-			} ) }
-		</div>
-	);
-};
-
 const UnifiedDesignPicker: React.FC< UnifiedDesignPickerProps > = ( {
 	locale,
 	onSelect,
@@ -360,8 +371,6 @@ const UnifiedDesignPicker: React.FC< UnifiedDesignPickerProps > = ( {
 	currentPlanFeatures,
 } ) => {
 	const hasCategories = !! categorization?.categories.length;
-	const translate = useTranslate();
-	const hasGeneratedDesigns = generatedDesigns.length > 0;
 
 	return (
 		<div
@@ -375,36 +384,13 @@ const UnifiedDesignPicker: React.FC< UnifiedDesignPickerProps > = ( {
 			) }
 		>
 			{ heading }
-			{ hasGeneratedDesigns && (
-				<div className="unified-design-picker__generated-designs">
-					<div>
-						<h3> { translate( 'Custom designs for your site' ) } </h3>
-						<p className="unified-design-picker__subtitle">
-							{ translate( 'Based on your input, these designs have been tailored for you.' ) }
-						</p>
-					</div>
-					<GeneratedDesignPicker
-						locale={ locale }
-						designs={ generatedDesigns }
-						onPreview={ onPreview }
-						verticalId={ verticalId }
-					/>
-				</div>
-			) }
-			<div className="unified-design-picker__standard-designs">
-				{ hasGeneratedDesigns && (
-					<div>
-						<h3> { translate( 'Selected themes for you' ) } </h3>
-						<p className="unified-design-picker__subtitle">
-							{ translate( 'Choose a starting theme. You can change it later.' ) }
-						</p>
-					</div>
-				) }
-				<StaticDesignPicker
+			<div className="unified-design-picker__designs">
+				<DesignPicker
 					locale={ locale }
 					onSelect={ onSelect }
 					onPreview={ onPreview }
-					designs={ staticDesigns }
+					staticDesigns={ staticDesigns }
+					generatedDesigns={ generatedDesigns }
 					categorization={ categorization }
 					verticalId={ verticalId }
 					isPremiumThemeAvailable={ isPremiumThemeAvailable }

--- a/packages/design-picker/src/constants.ts
+++ b/packages/design-picker/src/constants.ts
@@ -5,6 +5,7 @@ export const FONT_TITLES: Partial< Record< Font, string > > = {
 };
 
 export const SHOW_ALL_SLUG = 'CLIENT_ONLY_SHOW_ALL_SLUG';
+export const SHOW_GENERATED_DESIGNS_SLUG = 'CLIENT_ONLY_SHOW_GENERATED_DESIGNS_SLUG';
 
 /**
  * Pairings of fontFamilies

--- a/packages/design-picker/src/hooks/use-categorization.ts
+++ b/packages/design-picker/src/hooks/use-categorization.ts
@@ -1,6 +1,6 @@
 import { useI18n } from '@wordpress/react-i18n';
 import { useEffect, useMemo, useState } from 'react';
-import { SHOW_ALL_SLUG } from '../constants';
+import { SHOW_ALL_SLUG, SHOW_GENERATED_DESIGNS_SLUG } from '../constants';
 import { Category, Design } from '../types';
 import { gatherCategories } from '../utils';
 
@@ -13,12 +13,13 @@ export interface Categorization {
 interface UseCategorizationOptions {
 	defaultSelection: string | null;
 	showAllFilter: boolean;
+	showGeneratedDesignsFilter?: boolean;
 	sort?: ( a: Category, b: Category ) => number;
 }
 
 export function useCategorization(
 	designs: Design[],
-	{ defaultSelection, showAllFilter, sort }: UseCategorizationOptions
+	{ defaultSelection, showAllFilter, showGeneratedDesignsFilter, sort }: UseCategorizationOptions
 ): Categorization {
 	const { __ } = useI18n();
 
@@ -26,6 +27,13 @@ export function useCategorization(
 		const result = gatherCategories( designs );
 		if ( sort ) {
 			result.sort( sort );
+		}
+
+		if ( showGeneratedDesignsFilter ) {
+			result.unshift( {
+				name: __( 'Customized for You', __i18n_text_domain__ ),
+				slug: SHOW_GENERATED_DESIGNS_SLUG,
+			} );
 		}
 
 		if ( showAllFilter && designs.length ) {
@@ -36,7 +44,7 @@ export function useCategorization(
 		}
 
 		return result;
-	}, [ designs, showAllFilter, sort, __ ] );
+	}, [ designs, showAllFilter, showGeneratedDesignsFilter, sort, __ ] );
 
 	const [ selection, onSelect ] = useState< string | null >(
 		chooseDefaultSelection( categories, defaultSelection )

--- a/packages/design-picker/src/hooks/use-categorization.ts
+++ b/packages/design-picker/src/hooks/use-categorization.ts
@@ -13,13 +13,13 @@ export interface Categorization {
 interface UseCategorizationOptions {
 	defaultSelection: string | null;
 	showAllFilter: boolean;
-	showGeneratedDesignsFilter?: boolean;
+	generatedDesignsFilter: string | null;
 	sort?: ( a: Category, b: Category ) => number;
 }
 
 export function useCategorization(
 	designs: Design[],
-	{ defaultSelection, showAllFilter, showGeneratedDesignsFilter, sort }: UseCategorizationOptions
+	{ defaultSelection, showAllFilter, generatedDesignsFilter, sort }: UseCategorizationOptions
 ): Categorization {
 	const { __ } = useI18n();
 
@@ -29,9 +29,9 @@ export function useCategorization(
 			result.sort( sort );
 		}
 
-		if ( showGeneratedDesignsFilter ) {
+		if ( generatedDesignsFilter ) {
 			result.unshift( {
-				name: __( 'Customized for You', __i18n_text_domain__ ),
+				name: generatedDesignsFilter,
 				slug: SHOW_GENERATED_DESIGNS_SLUG,
 			} );
 		}
@@ -44,7 +44,7 @@ export function useCategorization(
 		}
 
 		return result;
-	}, [ designs, showAllFilter, showGeneratedDesignsFilter, sort, __ ] );
+	}, [ designs, showAllFilter, generatedDesignsFilter, sort, __ ] );
 
 	const [ selection, onSelect ] = useState< string | null >(
 		chooseDefaultSelection( categories, defaultSelection )

--- a/packages/design-picker/src/hooks/use-categorization.ts
+++ b/packages/design-picker/src/hooks/use-categorization.ts
@@ -13,7 +13,7 @@ export interface Categorization {
 interface UseCategorizationOptions {
 	defaultSelection: string | null;
 	showAllFilter: boolean;
-	generatedDesignsFilter: string | null;
+	generatedDesignsFilter?: string;
 	sort?: ( a: Category, b: Category ) => number;
 }
 


### PR DESCRIPTION
#### Proposed Changes

This PR de-emphasizes generated design by moving them into a new category filter titled "Customized for You". See below for reference.

| Before | After |
| --- | --- |
| ![Screen Shot 2022-10-28 at 1 43 07 PM](https://user-images.githubusercontent.com/797888/198511812-e2a5c635-df5c-44b8-b621-b56319cac5d3.png) | ![Screen Shot 2022-10-28 at 1 43 46 PM](https://user-images.githubusercontent.com/797888/198511900-067fd1ae-fda9-4601-bf75-aeea59415554.png) |

Additionally, we also show generated designs at the bottom of the category filter "Show All":
 ![Screen Shot 2022-10-28 at 3 16 22 PM](https://user-images.githubusercontent.com/797888/198526864-632574a4-0cc4-4453-8748-de9f268f63e3.png)


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to `setup?siteSlug=${site_slug}`
* Select either the Write ("Write & Publish") or Build ("Promote myself or business") flow in the Goals screen.
* Select any vertical from the featured vertical list. For instance, "Education".
* Ensure that when landing in the design picker, you see the "Customized for You" category filter.
* Ensure that category filter works as before.
* Ensure that the generated design preview/selection works as before.
* Ensure that the new category filter doesn't show up in the Sell ("Sell online") flow.
* Ensure that the mobile experience works as before.
 
#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #[69515](https://github.com/Automattic/wp-calypso/issues/69515)
