### PR TITLE
Fix virtual Page UI on blank static page option

### DIFF
--- a/client/my-sites/pages/page-list.jsx
+++ b/client/my-sites/pages/page-list.jsx
@@ -269,6 +269,7 @@ class Pages extends Component {
 
 	renderVirtualHomePage() {
 		const { site, blockEditorSettings, translate } = this.props;
+
 		if ( ! this.showVirtualHomepage() ) {
 			return null;
 		}

--- a/client/my-sites/pages/page-list.jsx
+++ b/client/my-sites/pages/page-list.jsx
@@ -182,7 +182,7 @@ class Pages extends Component {
 	}
 
 	showBlogPostsPage() {
-		const { site, homepageType, isFSEActive } = this.props;
+		const { site, homepageType, homepageId, isFSEActive } = this.props;
 		const { search, status } = this.props.query;
 
 		return (
@@ -190,7 +190,7 @@ class Pages extends Component {
 				/** Blog posts page is for themes that don't support FSE */
 				! isFSEActive ) &&
 			site &&
-			homepageType === 'posts' &&
+			( homepageType === 'posts' || ( homepageType === 'page' && ! homepageId ) ) &&
 			/** Under the "Published" tab */
 			status === 'publish,private' &&
 			/** Without any search term */

--- a/client/my-sites/pages/page-list.jsx
+++ b/client/my-sites/pages/page-list.jsx
@@ -202,7 +202,8 @@ class Pages extends Component {
 	 * Show the virtual homepage
 	 */
 	showVirtualHomepage() {
-		const { site, homepageType, blockEditorSettings, isFSEActive, translate } = this.props;
+		const { site, homepageType, homepageId, blockEditorSettings, isFSEActive, translate } =
+			this.props;
 		const { search, status } = this.props.query;
 
 		return (
@@ -210,7 +211,7 @@ class Pages extends Component {
 			/** Virtual homepage is for themes that support FSE */
 			isFSEActive &&
 			site &&
-			homepageType === 'posts' &&
+			( homepageType === 'posts' || ( homepageType === 'page' && ! homepageId ) ) &&
 			blockEditorSettings?.home_template &&
 			/** Under the "Published" tab without any search term or the search term is matched */
 			( ( status === 'publish,private' && ! search ) ||
@@ -268,7 +269,6 @@ class Pages extends Component {
 
 	renderVirtualHomePage() {
 		const { site, blockEditorSettings, translate } = this.props;
-
 		if ( ! this.showVirtualHomepage() ) {
 			return null;
 		}


### PR DESCRIPTION
## Proposed Changes

* When Static page option is left blank, the page list should show virtual page Homepage
![image](https://user-images.githubusercontent.com/10071857/198513655-b7a83895-fce3-45bf-b6de-20d00c9a5131.png)

## Testings

* Update the homepage option in Settings->Reading
* Make sure to select `A static page (select below)` option in `Your homepage displays`
* Confirm that Homepage template is shown in the page list
![image](https://user-images.githubusercontent.com/10071857/198514101-19b8a56d-eb7d-49da-b5b0-878e3ba0036a.png)

## Reference
#69400
