### PR TITLE
Onboarding standalone installation: Add standalone jetpack plugin support doc links.

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/jetpack-standalone-activation-instructions.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-standalone-activation-instructions.tsx
@@ -7,7 +7,7 @@ import { SelectorProduct } from 'calypso/my-sites/plans/jetpack-plans/types';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import JetpackInstructionList from './jetpack-instruction-list';
 import JetpackLicenseKeyClipboard from './jetpack-license-key-clipboard';
-import { getWPORGPluginLink } from './utils';
+import { getJetpackPluginSupportDocLink, getWPORGPluginLink } from './utils';
 
 interface Props {
 	product: SelectorProduct;
@@ -85,7 +85,7 @@ const JetpackStandaloneActivationInstructions: React.FC< Props > = ( { product, 
 
 			<p>
 				<ExternalLink
-					href="https://jetpack.com/support/install-jetpack-and-connect-your-new-plan/"
+					href={ getJetpackPluginSupportDocLink( product.productSlug ) }
 					icon
 					onClick={ handleLearnMoreClick }
 				>

--- a/client/my-sites/checkout/checkout-thank-you/utils.ts
+++ b/client/my-sites/checkout/checkout-thank-you/utils.ts
@@ -7,26 +7,52 @@ import {
 } from '@automattic/calypso-products';
 import { domainManagementEdit, domainManagementList } from 'calypso/my-sites/domains/paths';
 
-const setWPORGPluginSlug = ( productSlugs: ReadonlyArray< string >, wporgPluginSlug: string ) => {
-	return productSlugs.reduce(
-		( map, productSlug ) => ( { ...map, [ productSlug ]: wporgPluginSlug } ),
-		{}
-	);
+const buildKeyValuePairByProductSlugs = (
+	productSlugs: ReadonlyArray< string >,
+	value: string
+) => {
+	return productSlugs.reduce( ( map, productSlug ) => ( { ...map, [ productSlug ]: value } ), {} );
 };
 
 const WPORG_PLUGIN_SLUG_MAP: Record< string, string > = {
-	...setWPORGPluginSlug( JETPACK_BACKUP_PRODUCTS, 'jetpack-backup' ),
-	...setWPORGPluginSlug( JETPACK_BOOST_PRODUCTS, 'jetpack-boost' ),
-	...setWPORGPluginSlug( JETPACK_SOCIAL_PRODUCTS, 'jetpack-social' ),
-	...setWPORGPluginSlug( JETPACK_SEARCH_PRODUCTS, 'jetpack-search' ),
-	...setWPORGPluginSlug( JETPACK_VIDEOPRESS_PRODUCTS, 'jetpack-videopress' ),
-	// ...setWPORGPluginSlug( JETPACK_SCAN_PRODUCTS, 'jetpack-protect' ),
+	...buildKeyValuePairByProductSlugs( JETPACK_BACKUP_PRODUCTS, 'jetpack-backup' ),
+	...buildKeyValuePairByProductSlugs( JETPACK_BOOST_PRODUCTS, 'jetpack-boost' ),
+	...buildKeyValuePairByProductSlugs( JETPACK_SOCIAL_PRODUCTS, 'jetpack-social' ),
+	...buildKeyValuePairByProductSlugs( JETPACK_SEARCH_PRODUCTS, 'jetpack-search' ),
+	...buildKeyValuePairByProductSlugs( JETPACK_VIDEOPRESS_PRODUCTS, 'jetpack-videopress' ),
+};
+
+const JETPACK_SUPPORT_DOCS_MAP: Record< string, string > = {
+	...buildKeyValuePairByProductSlugs(
+		JETPACK_BACKUP_PRODUCTS,
+		'backup/the-jetpack-backup-plugin/getting-started-with-the-jetpack-backup-plugin/#installing-jetpack-backup'
+	),
+	...buildKeyValuePairByProductSlugs(
+		JETPACK_BOOST_PRODUCTS,
+		'performance/jetpack-boost/#how-to-install-jetpack-boost'
+	),
+	...buildKeyValuePairByProductSlugs(
+		JETPACK_SOCIAL_PRODUCTS,
+		'social/jetpack-social-plugin/#installing-jetpack-social'
+	),
+	...buildKeyValuePairByProductSlugs(
+		JETPACK_SEARCH_PRODUCTS,
+		'search/jetpack-search-plugin/#installing-jetpack-search-plugin'
+	),
 };
 
 export function getWPORGPluginLink( productSlug: string ): string {
 	const wporgPluginSlug = WPORG_PLUGIN_SLUG_MAP[ productSlug ];
 
 	return wporgPluginSlug ? `https://wordpress.org/plugins/${ wporgPluginSlug }/` : '';
+}
+
+export function getJetpackPluginSupportDocLink( productSlug: string ): string {
+	const supportDoc = JETPACK_SUPPORT_DOCS_MAP[ productSlug ];
+	const DEFAULT_SUPPORT_DOC_LINK =
+		'https://jetpack.com/support/install-jetpack-and-connect-your-new-plan/';
+
+	return supportDoc ? `https://jetpack.com/support/${ supportDoc }` : DEFAULT_SUPPORT_DOC_LINK;
 }
 
 export function getDomainManagementUrl(


### PR DESCRIPTION
#### Proposed Changes

* Update the thank you to redirect user to the correct plugin installation document instead of the classic Jetpack plugin installation support document.

#### Testing Instructions

1. Now run this branch by following the steps below (or you can use the Calypso live link commented on this PR)
    * Run `git fetch && git checkout add/jetpack-standalone-installation-support-docs-link`
    * Run `yarn start`
    
 2. Go to the following link http://calypso.localhost:3000/checkout/jetpack/thank-you/licensing-manual-activate-instructions/PRODUCT_SLUG or use the Calypso live link and append `/checkout/jetpack/thank-you/licensing-manual-activate-instructions/PRODUCT_SLUG?flags=jetpack/standalone-plugin-onboarding-update-v1`. Make sure you replace the PRODUCT_SLUG with actual product slug. refer to the table below.
 
 3. Confirm if the page redirects to the correct support documents when click the `Learn more about how to install **` link.
    
<img width="997" alt="Screen Shot 2022-10-28 at 5 11 44 PM" src="https://user-images.githubusercontent.com/56598660/198550860-4ff91a1d-1b87-47f5-86dc-9a3e36832609.png">


| Product Slug        | Support document  |
| ------------- |:-------------:| 
|  jetpack_backup_t1_yearly | https://jetpack.com/support/backup/the-jetpack-backup-plugin/getting-started-with-the-jetpack-backup-plugin/#installing-jetpack-backup  |
|  jetpack_boost_yearly | https://jetpack.com/support/performance/jetpack-boost/#how-to-install-jetpack-boost  |
|  jetpack_search_monthly | https://jetpack.com/support/search/jetpack-search-plugin/#installing-jetpack-search-plugin  |
|  jetpack_social_basic_yearly | https://jetpack.com/support/social/jetpack-social-plugin/#installing-jetpack-social  |

 
#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

