### PR TITLE
E2E (Atomic): Fix Jetpack Earn

### DIFF
--- a/packages/calypso-e2e/src/lib/blocks/block-flows/pay-with-paypal.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/pay-with-paypal.ts
@@ -15,7 +15,8 @@ const selectors = {
 	email: `${ blockParentSelector } input[placeholder="Email"]`,
 
 	// Published
-	publishedPrice: ( price: number ) => `.jetpack-simple-payments-price :text("${ price }")`,
+	publishedName: ( name: string ) => `main .jetpack-simple-payments-title :text("${ name }")`, // 'main' needs to be specified due to the debug elements
+	publishedPrice: ( price: number ) => `main .jetpack-simple-payments-price :text("${ price }")`, // 'main' needs to be specified due to the debug elements
 };
 
 /**
@@ -65,7 +66,9 @@ export class PayWithPaypalBlockFlow implements BlockFlow {
 	 */
 	async validateAfterPublish( context: PublishedPostContext ): Promise< void > {
 		// Use quotes in selector to narrow down to an exact text node match for specificity.
-		const expectedNameLocator = context.page.locator( `text="${ this.configurationData.name }"` );
+		const expectedNameLocator = context.page.locator(
+			selectors.publishedName( this.configurationData.name )
+		);
 		expectedNameLocator.waitFor();
 
 		const expectedPriceLocator = context.page.locator(

--- a/test/e2e/specs/blocks/blocks__jetpack-earn.ts
+++ b/test/e2e/specs/blocks/blocks__jetpack-earn.ts
@@ -6,6 +6,7 @@ import {
 	PayWithPaypalBlockFlow,
 	OpenTableFlow,
 	PaymentsBlockFlow,
+	envVariables,
 } from '@automattic/calypso-e2e';
 import { createBlockTests } from './shared/block-smoke-testing';
 
@@ -18,7 +19,11 @@ const blockFlows: BlockFlow[] = [
 	new OpenTableFlow( {
 		restaurant: 'Miku Restaurant - Vancouver',
 	} ),
-	new PaymentsBlockFlow( { buttonText: 'Donate to Me' } ),
 ];
+
+// Stripe is not connected to this WordPress.com account, so skipping on Atomic
+if ( ! envVariables.TEST_ON_ATOMIC ) {
+	blockFlows.push( new PaymentsBlockFlow( { buttonText: 'Donate to Me' } ) );
+}
 
 createBlockTests( 'Blocks: Jetpack Earn', blockFlows );


### PR DESCRIPTION
Tracking issue: https://github.com/Automattic/wp-calypso/issues/65906

#### Proposed Changes

Make the following test compatible with the Atomic environment:
 
> specs/blocks/blocks__jetpack-earn.ts: Blocks: Jetpack Earn

### Why was it failing?

There is a block warning or error in the editor for the **Payment Button** in Atomic because Stripe is not connected to the user. In the meantime, we would skip the **Payment Button** block when testing on Atomic.

Context: p1666794081067859/1666793696.801109-slack-C1A1EKDGQ

The **published name** and **published price** for the Paypal block are also failing on Atomic because of multiple elements found. This is due to debugging elements on this page. More specific selectors were then defined.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

The fixed test should pass for both Simple and Atomic sites (production).

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #