### PR TITLE
Update the Educational Footer design

### DIFF
--- a/client/components/feature-item/index.tsx
+++ b/client/components/feature-item/index.tsx
@@ -6,6 +6,7 @@ import './style.scss';
 interface FeatureItemProps {
 	header: ReactChild;
 	children: ReactChild;
+	dark?: boolean;
 }
 
 const FeatureItemContainer = styled.div`
@@ -18,28 +19,36 @@ const FeatureItemContainer = styled.div`
 	}
 `;
 
-const FeatureItemHeader = styled.div`
+interface FeatureItemHeaderProps {
+	dark?: boolean;
+}
+
+interface FeatureItemContentProps {
+	dark?: boolean;
+}
+
+const FeatureItemHeader = styled.div< FeatureItemHeaderProps >`
 	margin-bottom: 16px;
 	font-size: var( --scss-font-body );
 	font-weight: 500;
 	line-height: 24px;
-	color: var( --color-text-inverted );
+	color: var( --${ ( props ) => ( props.dark ? 'color-text-inverted' : 'color-text' ) } );
 `;
 
-const FeatureItemContent = styled.p`
+const FeatureItemContent = styled.p< FeatureItemContentProps >`
 	font-size: var( --scss-font-body-small );
 	font-weight: 400;
 	line-height: 22px;
-	color: var( --color-neutral-20 );
+	color: var( --${ ( props ) => ( props.dark ? 'color-neutral-20' : 'color-text' ) } );
 `;
 
 const FeatureItem = ( props: FeatureItemProps ) => {
-	const { header, children } = props;
+	const { header, children, dark } = props;
 
 	return (
 		<FeatureItemContainer>
-			<FeatureItemHeader>{ header }</FeatureItemHeader>
-			<FeatureItemContent>{ children }</FeatureItemContent>
+			<FeatureItemHeader dark={ dark }>{ header }</FeatureItemHeader>
+			<FeatureItemContent dark={ dark }>{ children }</FeatureItemContent>
 		</FeatureItemContainer>
 	);
 };

--- a/client/components/section/index.tsx
+++ b/client/components/section/index.tsx
@@ -18,7 +18,7 @@ interface SectionHeaderProps {
 	dark?: boolean;
 }
 
-const SectionContainer = styled.div< SectionContainerProps >`
+export const SectionContainer = styled.div< SectionContainerProps >`
 	::before {
 		box-sizing: border-box;
 		content: '';
@@ -38,6 +38,7 @@ const SectionHeader = styled.div< SectionHeaderProps >`
 	color: var( --${ ( props ) => ( props.dark ? 'color-text-inverted' : 'color-text' ) } );
 	font-weight: 400;
 	letter-spacing: -0.4px;
+	line-height: 1.2;
 	text-align: left;
 	font-size: var( --scss-font-title-large );
 `;
@@ -53,7 +54,7 @@ const SectionHeaderContainer = styled.div< SectionHeaderProps >`
 	@media ( max-width: 660px ) {
 		padding: 0 16px;
 	}
-	margin-bottom: 25px;
+	margin-bottom: 16px;
 	max-width: 377px;
 `;
 

--- a/client/my-sites/plugins/education-footer/index.tsx
+++ b/client/my-sites/plugins/education-footer/index.tsx
@@ -1,13 +1,15 @@
+import { Button } from '@automattic/components';
 import { useLocalizeUrl } from '@automattic/i18n-utils';
 import styled from '@emotion/styled';
 import { useI18n } from '@wordpress/react-i18n';
 import { useCallback } from 'react';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import FeatureItem from 'calypso/components/feature-item';
 import LinkCard from 'calypso/components/link-card';
-import Section from 'calypso/components/section';
+import Section, { SectionContainer } from 'calypso/components/section';
 import { preventWidows } from 'calypso/lib/formatting';
 import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 
 const ThreeColumnContainer = styled.div`
 	@media ( max-width: 660px ) {
@@ -47,32 +49,66 @@ const EducationFooterContainer = styled.div`
 	}
 `;
 
+const MarketplaceContainer = styled.div< { isloggedIn: boolean } >`
+	--color-accent: #117ac9;
+	--color-accent-60: #0e64a5;
+
+	.marketplace-cta {
+		min-width: 122px;
+		margin-bottom: 26px;
+
+		@media ( max-width: 660px ) {
+			margin-left: 16px;
+			margin-right: 16px;
+		}
+	}
+
+	${ ( { isloggedIn } ) =>
+		! isloggedIn &&
+		`${ SectionContainer } {
+		padding-bottom: 0;
+	}` }
+
+	${ SectionContainer }::before {
+		background-color: #f6f7f7;
+	}
+`;
+
 export const MarketplaceFooter = () => {
 	const { __ } = useI18n();
+	const isLoggedIn = useSelector( isUserLoggedIn );
 
 	return (
-		<Section
-			header={ preventWidows( __( 'You pick the plugin. We’ll take care of the rest.' ) ) }
-			dark
-		>
-			<ThreeColumnContainer>
-				<FeatureItem header={ __( 'Fully Managed' ) }>
-					{ __(
-						'Premium plugins are fully managed by the team at WordPress.com. No security patches. No update nags. It just works.'
+		<MarketplaceContainer isloggedIn={ isLoggedIn }>
+			<Section
+				header={ preventWidows( __( 'You pick the plugin. We’ll take care of the rest.' ) ) }
+			>
+				<>
+					{ ! isLoggedIn && (
+						<Button className="is-primary marketplace-cta" href="/start">
+							{ __( 'Get Started' ) }
+						</Button>
 					) }
-				</FeatureItem>
-				<FeatureItem header={ __( 'Thousands of plugins' ) }>
-					{ __(
-						'From WordPress.com premium plugins to thousands more community-authored plugins, we’ve got you covered.'
-					) }
-				</FeatureItem>
-				<FeatureItem header={ __( 'Flexible pricing' ) }>
-					{ __(
-						'Pay yearly and save. Or keep it flexible with monthly premium plugin pricing. It’s entirely up to you.'
-					) }
-				</FeatureItem>
-			</ThreeColumnContainer>
-		</Section>
+					<ThreeColumnContainer>
+						<FeatureItem header={ __( 'Fully Managed' ) }>
+							{ __(
+								'Premium plugins are fully managed by the team at WordPress.com. No security patches. No update nags. It just works.'
+							) }
+						</FeatureItem>
+						<FeatureItem header={ __( 'Thousands of plugins' ) }>
+							{ __(
+								'From WordPress.com premium plugins to thousands more community-authored plugins, we’ve got you covered.'
+							) }
+						</FeatureItem>
+						<FeatureItem header={ __( 'Flexible pricing' ) }>
+							{ __(
+								'Pay yearly and save. Or keep it flexible with monthly premium plugin pricing. It’s entirely up to you.'
+							) }
+						</FeatureItem>
+					</ThreeColumnContainer>
+				</>
+			</Section>
+		</MarketplaceContainer>
 	);
 };
 


### PR DESCRIPTION
#### Proposed Changes

This applies the latest changes to the Educational footer (context: pdgAPm-p2-yE#comment-573):
* switches to a grey background
* shows a CTA button for logged-out users
* needed to deploy before #67706 to avoid having two adjacent black sections.

<img width="420" alt="Screenshot on 2022-10-28 at 12-50-06" src="https://user-images.githubusercontent.com/2749938/198558228-ee767d0f-5c5d-4521-91a2-7c5f91ad7596.jpg">


#### Testing Instructions

* Logged in, go to `/plugins`
* The Footer should be properly rendered
<img width="420" alt="Screenshot on 2022-10-28 at 12-50-06" src="https://user-images.githubusercontent.com/2749938/198559444-a826eba1-a088-4313-b78a-289bc04b9f31.png">



* Log out and go to `/plugin`
* The Footer should be properly rendered
* Make sure the `Get Started` link points to the signup flow

<img width="420" alt="Screenshot on 2022-10-28 at 12-51-16" src="https://user-images.githubusercontent.com/2749938/198559492-87d18c49-381f-4892-83e7-c5424f39e301.png">

* Disable JS while logged out
* The Footer should be properly rendered by the server

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
