### PR TITLE
Pattern Assembler - Show selected pattern when replacing it

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -170,6 +170,20 @@ const PatternAssembler: Step = ( { navigation } ) => {
 		goBack();
 	};
 
+	const getSelectedPattern = () => {
+		if ( 'header' === showPatternSelectorType ) {
+			return header;
+		}
+		if ( 'footer' === showPatternSelectorType ) {
+			return footer;
+		}
+		if ( 'section' === showPatternSelectorType && sectionPosition !== null ) {
+			return sections[ sectionPosition ];
+		}
+
+		return null;
+	};
+
 	const stepContent = (
 		<div className="pattern-assembler__wrapper">
 			<div className="pattern-assembler__sidebar">
@@ -177,6 +191,7 @@ const PatternAssembler: Step = ( { navigation } ) => {
 					showPatternSelectorType={ showPatternSelectorType }
 					onSelect={ onSelect }
 					onBack={ () => setShowPatternSelectorType( null ) }
+					selectedPattern={ getSelectedPattern() }
 				/>
 				{ ! showPatternSelectorType && (
 					<PatternLayout

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-selector-loader.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-selector-loader.tsx
@@ -7,12 +7,14 @@ type PatternSelectorLoaderProps = {
 	onSelect: ( selectedPattern: Pattern | null ) => void;
 	onBack: () => void;
 	showPatternSelectorType: string | null;
+	selectedPattern: Pattern | null;
 };
 
 const PatternSelectorLoader = ( {
 	showPatternSelectorType,
 	onSelect,
 	onBack,
+	selectedPattern,
 }: PatternSelectorLoaderProps ) => {
 	const translate = useTranslate();
 
@@ -24,6 +26,7 @@ const PatternSelectorLoader = ( {
 				onSelect={ onSelect }
 				onBack={ onBack }
 				title={ translate( 'Choose a header' ) }
+				selectedPattern={ selectedPattern }
 			/>
 			<PatternSelector
 				show={ showPatternSelectorType === 'footer' }
@@ -31,6 +34,7 @@ const PatternSelectorLoader = ( {
 				onSelect={ onSelect }
 				onBack={ onBack }
 				title={ translate( 'Choose a footer' ) }
+				selectedPattern={ selectedPattern }
 			/>
 			<PatternSelector
 				show={ showPatternSelectorType === 'section' }
@@ -38,6 +42,7 @@ const PatternSelectorLoader = ( {
 				onSelect={ onSelect }
 				onBack={ onBack }
 				title={ translate( 'Add a section' ) }
+				selectedPattern={ selectedPattern }
 			/>
 		</>
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-selector.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-selector.tsx
@@ -15,9 +15,17 @@ type PatternSelectorProps = {
 	onBack: () => void;
 	title: string | null;
 	show: boolean;
+	selectedPattern: Pattern | null;
 };
 
-const PatternSelector = ( { patterns, onSelect, onBack, title, show }: PatternSelectorProps ) => {
+const PatternSelector = ( {
+	patterns,
+	onSelect,
+	onBack,
+	title,
+	show,
+	selectedPattern,
+}: PatternSelectorProps ) => {
 	const locale = useLocale();
 	const patternSelectorRef = useRef< HTMLDivElement >( null );
 	const selectedDesign = useSelect( ( select ) => select( ONBOARD_STORE ).getSelectedDesign() );
@@ -60,7 +68,10 @@ const PatternSelector = ( { patterns, onSelect, onBack, title, show }: PatternSe
 								tabIndex={ show ? 0 : -1 }
 								role="option"
 								title={ item.name }
-								aria-selected={ false }
+								aria-selected={ item.id === selectedPattern?.id }
+								className={ classnames( {
+									'pattern-selector__block-list--selected-pattern': item.id === selectedPattern?.id,
+								} ) }
 								onClick={ () => onSelect( item ) }
 								onKeyUp={ handleKeyboard( () => onSelect( item ) ) }
 							/>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
@@ -246,6 +246,8 @@ $font-family: "SF Pro Text", $sans;
 
 			.button {
 				padding: 0;
+				width: 25px;
+				margin-right: 10px;
 
 				&:hover svg {
 					fill: var(--color-neutral-70);
@@ -308,6 +310,10 @@ $font-family: "SF Pro Text", $sans;
 
 				&:not(:last-child) {
 					margin-bottom: 16px;
+				}
+
+				&.pattern-selector__block-list--selected-pattern {
+					box-shadow: 0 0 0 2px var(--studio-gray);
 				}
 
 				&:focus,


### PR DESCRIPTION
#### Proposed Changes

* Show the selected pattern when replacing it
* Minor CSS fix for the back button when it's focused

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Access `/setup?siteSlug={Site slug}`
* Don't select any goal
* Click on the blank canvas CTA
* Check that the flow back button is next to the logo and it works
* Click on add a header, a section, and a footer, then replace them
* Check that there is a dark border around the pattern that is being replaced
<img width="311" alt="Screen Shot 2565-10-28 at 17 37 11" src="https://user-images.githubusercontent.com/1881481/198568038-d86a1dc1-3553-437c-b9cb-75dbe4768c3c.png">

https://user-images.githubusercontent.com/1881481/198567706-b19b9f13-fd6e-4a14-b893-01d87bc8af46.mov



#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/69362
