### PR TITLE
Marketplace: Fix sidebar margin in foldable content

### DIFF
--- a/client/my-sites/plugins/plugin-details-sidebar-usp/index.jsx
+++ b/client/my-sites/plugins/plugin-details-sidebar-usp/index.jsx
@@ -23,8 +23,8 @@ const Container = styled( FoldableCard )`
 		padding-right: 0;
 		${ ( props ) => ! props.showAsAccordion && 'display: none' };
 	}
-
-	&.is-expanded .foldable-card__content {
+	// Increase specificity to avoid conflicts with foldable-card styles
+	&&.is-expanded .foldable-card__content {
 		${ ( props ) => props.first && 'border-top: 0' };
 		${ ( props ) => props.showAsAccordion && 'border: 0' };
 		padding: ${ ( props ) => ( props.first ? '0 0 32px' : '32px 0' ) };


### PR DESCRIPTION
#### Proposed Changes

* [Increase the specificity](https://css-tricks.com/the-sass-ampersand/#aa-doubling-up-specificity) of `foldable-card` class in sidebar content to avoid conflicting with other CSS classes


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to any plugin with a site selected, e.g. `/plugins/wordpress-seo-premium/<site_id>` and make sure there is just one separator line below the button and the margins of the content are aligned with the top text

>**Note** The issue does not always reproduce. It might be required to go back and forth using the back navigation. If you cannot reproduce the issue, just make sure there is no differences between production and this branch

|Before | After|
|-------|------|
|![image](https://user-images.githubusercontent.com/3519124/198570823-15996772-8eab-4c5f-a958-10689edc009c.png)|  <img width="1601" alt="CleanShot 2022-10-28 at 12 57 17@2x" src="https://user-images.githubusercontent.com/3519124/198571541-18b83e99-cbd8-4a1b-8304-affc40ddd697.png">    |

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #68227 
