### PR TITLE
E2E (Atomic): Skip widgets tests

### DIFF
--- a/test/e2e/specs/appearance/widgets__legacy-visibility.ts
+++ b/test/e2e/specs/appearance/widgets__legacy-visibility.ts
@@ -18,42 +18,47 @@ const accountName = getTestAccountByFeature( envToFeatureKey( envVariables ) );
 
 declare const browser: Browser;
 
-describe( DataHelper.createSuiteTitle( 'Widgets' ), function () {
-	let sidebarComponent: SidebarComponent;
-	let page: Page;
+// We're skipping for Atomic sites for now because the currently used theme
+// doesn't support widgets.
+skipDescribeIf( envVariables.TEST_ON_ATOMIC )(
+	DataHelper.createSuiteTitle( 'Widgets' ),
+	function () {
+		let sidebarComponent: SidebarComponent;
+		let page: Page;
 
-	beforeAll( async () => {
-		page = await browser.newPage();
+		beforeAll( async () => {
+			page = await browser.newPage();
 
-		const testAccount = new TestAccount( accountName );
-		await testAccount.authenticate( page );
-	} );
+			const testAccount = new TestAccount( accountName );
+			await testAccount.authenticate( page );
+		} );
 
-	it( 'Navigate to Appearance > Widgets', async function () {
-		sidebarComponent = new SidebarComponent( page );
-		await sidebarComponent.navigate( 'Appearance', 'Widgets' );
-	} );
+		it( 'Navigate to Appearance > Widgets', async function () {
+			sidebarComponent = new SidebarComponent( page );
+			await sidebarComponent.navigate( 'Appearance', 'Widgets' );
+		} );
 
-	it( 'Dismiss the Welcome modals', async function () {
-		const blockWidgetEditorComponent = new BlockWidgetEditorComponent( page );
-		await blockWidgetEditorComponent.dismissModals();
-	} );
+		it( 'Dismiss the Welcome modals', async function () {
+			const blockWidgetEditorComponent = new BlockWidgetEditorComponent( page );
+			await blockWidgetEditorComponent.dismissModals();
+		} );
 
-	// @todo: Refactor/Abstract these steps into a WidgetsEditor component
-	// Skipped for mobile due to https://github.com/Automattic/wp-calypso/issues/59960
-	skipDescribeIf( envVariables.VIEWPORT_NAME === 'mobile' )(
-		'Regression: Verify that the visibility option is present',
-		function () {
-			it( 'Insert a Legacy Widget', async function () {
-				await page.click( 'button[aria-label="Add block"]' );
-				await page.fill( 'input[placeholder="Search"]', 'Top Posts and Pages' );
-				await page.click( 'button.editor-block-list-item-legacy-widget\\/top-posts' );
-			} );
+		// @todo: Refactor/Abstract these steps into a WidgetsEditor component
+		// Skipped for mobile due to https://github.com/Automattic/wp-calypso/issues/59960
+		skipDescribeIf( envVariables.VIEWPORT_NAME === 'mobile' )(
+			'Regression: Verify that the visibility option is present',
+			function () {
+				it( 'Insert a Legacy Widget', async function () {
+					await page.click( 'button[aria-label="Add block"]' );
+					await page.fill( 'input[placeholder="Search"]', 'Top Posts and Pages' );
+					await page.click( 'button.editor-block-list-item-legacy-widget\\/top-posts' );
+				} );
 
-			it( 'Visibility options are shown for the Legacy Widget', async function () {
-				await page.click( 'a.button:text("Visibility")' );
-				await page.waitForSelector( 'div.widget-conditional' );
-			} );
-		}
-	);
-} );
+				it( 'Visibility options are shown for the Legacy Widget', async function () {
+					await page.click( 'a.button:text("Visibility")' );
+					await page.waitForSelector( 'div.widget-conditional' );
+				} );
+			}
+		);
+	}
+);


### PR DESCRIPTION
Tracking issue: https://github.com/Automattic/wp-calypso/issues/65906
Context: p1666700231937719-slack-C7YPUHBB2

### Proposed Changes

Skip the following tests in the Atomic environment:

> Navigate to Appearance > Widgets
> specs/appearance/widgets__legacy-visibility.ts: Widgets

### Why was it failing?

The theme used on our Atomic test sites does not support widgets. Changing a theme for a single test is not an option because it would have global implications, as we're running tests in parallel against the same account/site. Please follow p1666700231937719-slack-C7YPUHBB2 for more info.