### PR TITLE
Third-Party Premium Themes: Externally Managed theme should be available only when purchased

### DIFF
--- a/client/state/themes/selectors/is-premium-theme-available.js
+++ b/client/state/themes/selectors/is-premium-theme-available.js
@@ -16,6 +16,9 @@ import 'calypso/state/themes/init';
  * @returns {boolean}         True if the premium theme is available for the given site
  */
 export function isPremiumThemeAvailable( state, themeId, siteId ) {
+	// TODO: We'll need to update this condition once we have a way to check
+	// whether the theme is subscribed to. This is related to the third-party premium
+	// themes project.
 	if ( isThemePurchased( state, themeId, siteId ) ) {
 		return true;
 	}

--- a/client/state/themes/selectors/is-premium-theme-available.js
+++ b/client/state/themes/selectors/is-premium-theme-available.js
@@ -1,6 +1,7 @@
 import { WPCOM_FEATURES_PREMIUM_THEMES } from '@automattic/calypso-products';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { doesThemeBundleSoftwareSet } from 'calypso/state/themes/selectors/does-theme-bundle-software-set';
+import { isExternallyManagedTheme } from 'calypso/state/themes/selectors/is-externally-managed-theme';
 import { isSiteEligibleForBundledSoftware } from 'calypso/state/themes/selectors/is-site-eligible-for-bundled-software';
 import { isThemePurchased } from 'calypso/state/themes/selectors/is-theme-purchased';
 
@@ -18,6 +19,14 @@ export function isPremiumThemeAvailable( state, themeId, siteId ) {
 	if ( isThemePurchased( state, themeId, siteId ) ) {
 		return true;
 	}
+
+	/**
+	 * If the theme is externally managed and is not purchased, it is not available.
+	 */
+	if ( isExternallyManagedTheme( state, themeId ) ) {
+		return false;
+	}
+
 	const hasPremiumThemesFeature = siteHasFeature( state, siteId, WPCOM_FEATURES_PREMIUM_THEMES );
 
 	/**

--- a/client/state/themes/test/selectors.js
+++ b/client/state/themes/test/selectors.js
@@ -2551,6 +2551,55 @@ describe( 'themes selectors', () => {
 				expect( isAvailable ).toBe( true );
 			} );
 		} );
+
+		test( "Should return false when the customer has a premium plan but didn't purchase a externally managed theme", () => {
+			const active = [ WPCOM_FEATURES_PREMIUM_THEMES ];
+			const isAvailable = isPremiumThemeAvailable(
+				{
+					sites: {
+						items: {
+							2916284: {},
+						},
+						plans: {
+							2916284: {
+								data: [
+									{
+										currentPlan: true,
+										productSlug: PLAN_PREMIUM,
+									},
+								],
+							},
+						},
+						features: {
+							2916284: {
+								data: {
+									active,
+								},
+							},
+						},
+					},
+					themes: {
+						queries: {
+							wpcom: new ThemeQueryManager( {
+								items: {
+									mood: {
+										...mood,
+										theme_type: 'managed-external',
+									},
+								},
+							} ),
+						},
+					},
+					purchases: {
+						data: [],
+					},
+				},
+				'mood',
+				2916284
+			);
+
+			expect( isAvailable ).toBe( false );
+		} );
 	} );
 
 	describe( 'getWpcomParentThemeId', () => {


### PR DESCRIPTION
#### Proposed Changes

* Third-party premium themes should be available only if it is purchased. This means that having the feature `WPCOM_FEATURES_PREMIUM_THEMES` is not enough to access the theme.
* Updates the logic of the `isPremiumThemeAvailable` to return false if the externally managed theme is not purchased.

#### Testing Instructions

* Since we don't have any third-party themes yet, I added unit tests that can be run by the following command:
```bash
yarn test-client client/state/themes/test/selectors.js
```

Related to #69468
