### PR TITLE
Increase the font size of the soft-launch banner

### DIFF
--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -38,12 +38,11 @@
 
 .theme__sheet-bar-soft-launched {
 	color: var(--color-warning-80);
-	font-size: rem(7px);
+	font-size: 1.25rem;
 	font-weight: bold;
 	text-transform: uppercase;
 	background-color: var(--color-warning-20);
 	margin-left: 1rem;
-	margin-bottom: 0.75rem;
 }
 
 .theme__sheet-columns {


### PR DESCRIPTION
#### Proposed Changes

This increases the font size of the soft-launch banner on an individual theme page to make it easier to see.

#### Testing Instructions

1. Apply this PR.
2. Navigate to `/theme/tsubaki/[site-slug]` and verify you see something like the following:

![image](https://user-images.githubusercontent.com/917632/198661307-fce7ec28-1410-420b-81ad-5db15acf69ac.png)


<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
