### PR TITLE
Updates the click behavior on promoted post campaigns list

### DIFF
--- a/client/my-sites/promote-post/components/campaign-item/index.tsx
+++ b/client/my-sites/promote-post/components/campaign-item/index.tsx
@@ -170,7 +170,12 @@ export default function CampaignItem( { campaign }: Props ) {
 				<p>{ __( 'Please try again later or contact support if the problem persists.' ) }</p>
 			</Dialog>
 
-			<FoldableCard header={ header } hideSummary={ true } className="campaign-item__foldable-card">
+			<FoldableCard
+				clickableHeader
+				header={ header }
+				hideSummary={ true }
+				className="campaign-item__foldable-card"
+			>
 				{ campaignStatus === 'rejected' && moderation_reason && (
 					<Notice isDismissible={ false } className="campaign-item__notice" status="warning">
 						<Gridicon className="campaign-item__notice-icon" icon="info-outline" />


### PR DESCRIPTION
#### Proposed Changes

* This PR changes the click behavior in the Promoted post campaign list page to be the entire header, instead of just the fold/collapse icon.

#### Testing Instructions

**Note:** To test this is necessary to have run a campaign previously. If you don't have a campaign, you can create one by promoting one of your post/pages. (the first tab of the advertising promoted page).

* Go to the advertising section for a public blog
* Go to the Campaigns tab
* Verify that you can collapse/expand each campaign by clicking on the header.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
