### PR TITLE
If no user is found in DSP interpret it as no campaigns found

### DIFF
--- a/client/my-sites/promote-post/components/campaigns-list/index.tsx
+++ b/client/my-sites/promote-post/components/campaigns-list/index.tsx
@@ -23,9 +23,11 @@ const noCampaignListMessage = translate(
 export default function CampaignsList( {
 	isLoading,
 	isError,
+	hasLocalUser,
 	campaigns,
 }: {
 	isLoading: boolean;
+	hasLocalUser: boolean;
 	isError: boolean;
 	campaigns: Campaign[];
 } ) {
@@ -33,7 +35,7 @@ export default function CampaignsList( {
 
 	const isEmpty = ! memoCampaigns.length;
 
-	if ( isError ) {
+	if ( isError && hasLocalUser ) {
 		return (
 			<Notice status="is-error" icon="mention">
 				{ noCampaignListMessage }

--- a/client/my-sites/promote-post/main.tsx
+++ b/client/my-sites/promote-post/main.tsx
@@ -38,6 +38,10 @@ const queryPage = {
 	type: 'page',
 };
 
+export type DSPMessage = {
+	errorCode?: string;
+};
+
 function sortItemsByPublishedDate( items: Post[] ) {
 	return items.slice( 0 ).sort( function ( a, b ) {
 		if ( a.date && b.date ) {
@@ -50,6 +54,8 @@ function sortItemsByPublishedDate( items: Post[] ) {
 		return b.ID - a.ID;
 	} );
 }
+
+const ERROR_NO_LOCAL_USER = 'no_local_user';
 
 export default function PromotedPosts( { tab }: Props ) {
 	const selectedTab = tab === 'campaigns' ? 'campaigns' : 'posts';
@@ -75,7 +81,10 @@ export default function PromotedPosts( { tab }: Props ) {
 	);
 
 	const campaigns = useCampaignsQuery( selectedSiteId ?? 0 );
-	const { isLoading: campaignsIsLoading, data: campaignsData, isError } = campaigns;
+	const { isLoading: campaignsIsLoading, isError, error: campaignError } = campaigns;
+	const { data: campaignsData } = campaigns;
+
+	const hasLocalUser = ( campaignError as DSPMessage )?.errorCode !== ERROR_NO_LOCAL_USER;
 
 	const translate = useTranslate();
 
@@ -152,6 +161,7 @@ export default function PromotedPosts( { tab }: Props ) {
 			<PromotePostTabBar tabs={ tabs } selectedTab={ selectedTab } />
 			{ selectedTab === 'campaigns' && (
 				<CampaignsList
+					hasLocalUser={ hasLocalUser }
 					isError={ isError }
 					isLoading={ campaignsIsLoading }
 					campaigns={ campaignsData || [] }

--- a/config/development.json
+++ b/config/development.json
@@ -24,7 +24,7 @@
 	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
 	"olark_chat_identity": "7089-503-10-5123",
 	"dsp_stripe_pub_key": "pk_live_51LYYzQF53KN4RFN0ePTwefdm7seki4pRuc4a19gPMGUba5mzuosz0IBR0cp4T57FiBgxK911ky0LNwlX2IHbm0SS00uPHEQNBO",
-	"dsp_widget_js_src": "http://localhost:3004/widget.js",
+	"dsp_widget_js_src": "https://widgets.wp.com/promote/widget.js",
 	"features": {
 		"ad-tracking": false,
 		"calypso/help-center": true,

--- a/config/development.json
+++ b/config/development.json
@@ -24,7 +24,7 @@
 	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
 	"olark_chat_identity": "7089-503-10-5123",
 	"dsp_stripe_pub_key": "pk_live_51LYYzQF53KN4RFN0ePTwefdm7seki4pRuc4a19gPMGUba5mzuosz0IBR0cp4T57FiBgxK911ky0LNwlX2IHbm0SS00uPHEQNBO",
-	"dsp_widget_js_src": "https://widgets.wp.com/promote/widget.js",
+	"dsp_widget_js_src": "http://localhost:3004/widget.js",
 	"features": {
 		"ad-tracking": false,
 		"calypso/help-center": true,


### PR DESCRIPTION
#### Proposed Changes
- When the user doesn't have a DSP user it was throwing an error when opening the campaign list. This PR will interpret when the user doesn't have a DSP account and will display the campaign list as empty instead of showing an error

#### Testing Instructions
- Go to campaign list with a fresh user that doesn't have opened the promote post tool
- The campaign list should display as empty

#### Pre-merge Checklist

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?


Related to #
