### PR TITLE
Plugin Details: Update the automanaged verification to also check if a marketplace product was purchased

### DIFF
--- a/client/my-sites/plugins/plugin-autoupdate-toggle/index.jsx
+++ b/client/my-sites/plugins/plugin-autoupdate-toggle/index.jsx
@@ -59,7 +59,7 @@ export class PluginAutoUpdateToggle extends Component {
 	};
 
 	isAutoManaged = () =>
-		this.props.isMarketplaceProduct ||
+		( this.props.isMarketplaceProduct && this.props.productPurchase ) ||
 		PREINSTALLED_PLUGINS.includes( this.props.plugin.slug ) ||
 		AUTOMOMANAGED_PLUGINS.includes( this.props.plugin.slug );
 

--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -56,6 +56,7 @@ const PluginDetailsCTA = ( { plugin, isPlaceholder } ) => {
 	);
 	const softwareSlug = getSoftwareSlug( plugin, isMarketplaceProduct );
 	const purchases = useSelector( ( state ) => getSitePurchases( state, selectedSite?.ID ) );
+	const currentPurchase = getPluginPurchased( plugin, purchases, isMarketplaceProduct );
 
 	// Site type
 	const sites = useSelector( getSelectedOrAllSitesWithPlugins );
@@ -86,9 +87,7 @@ const PluginDetailsCTA = ( { plugin, isPlaceholder } ) => {
 	const isPluginInstalledOnsite =
 		sitesWithPlugins.length && ! requestingPluginsForSites ? !! sitePlugin : false;
 	const isPluginInstalledOnsiteWithSubscription =
-		isPluginInstalledOnsite && ! isMarketplaceProduct
-			? true
-			: getPluginPurchased( plugin, purchases, isMarketplaceProduct )?.active;
+		isPluginInstalledOnsite && ! isMarketplaceProduct ? true : currentPurchase?.active;
 	const sitesWithPlugin = useSelector( ( state ) =>
 		getSiteObjectsWithPlugin( state, siteIds, softwareSlug )
 	);
@@ -217,6 +216,7 @@ const PluginDetailsCTA = ( { plugin, isPlaceholder } ) => {
 						</span>
 					}
 					isMarketplaceProduct={ plugin.isMarketplaceProduct }
+					productPurchase={ currentPurchase }
 					wporg
 				/>
 			</div>

--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -168,7 +168,7 @@ const PluginDetailsCTA = ( { plugin, isPlaceholder } ) => {
 		return <PluginDetailsCTAPlaceholder />;
 	}
 
-	if ( isPluginInstalledOnsiteWithSubscription && sitePlugin ) {
+	if ( isPluginInstalledOnsite && sitePlugin ) {
 		// Check if already instlaled on the site
 		const activeText = translate( '{{span}}active{{/span}}', {
 			components: {

--- a/client/my-sites/plugins/plugin-details-CTA/manage-plugin-menu.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/manage-plugin-menu.jsx
@@ -47,6 +47,7 @@ export const ManagePluginMenu = ( { plugin } ) => {
 					site={ site }
 					menuItem
 					isMarketplaceProduct={ plugin.isMarketplaceProduct }
+					productPurchase={ currentPurchase }
 				/>
 			</EllipsisMenu>
 		</>

--- a/client/my-sites/plugins/plugin-remove-button/index.jsx
+++ b/client/my-sites/plugins/plugin-remove-button/index.jsx
@@ -211,8 +211,8 @@ class PluginRemoveButton extends Component {
 			return null;
 		}
 
-		if ( this.props.isMarketplaceProduct ) {
-			// Marketplace products are auto-managed.
+		if ( this.props.isMarketplaceProduct && this.props.productPurchase ) {
+			// Purchased Marketplace products are auto-managed.
 			return null;
 		}
 


### PR DESCRIPTION
#### Proposed Changes

* Show the *management area* on the sidebar for all installed plugins and not only plugins with subscriptions. This would also cover the uploaded marketplace plugins
* Update the auto-managed check to also verify if a marketplace product was purchased. An uploaded Marketplace product is not considered auto-managed.

#### Testing Instructions
##### Uploaded Plugin
* Upload a Markeplace plugin. Ex: `woocommerce-shipment-tracking`
* Go to the plugin details page of this plugin. Ex: `/plugins/woocommerce-shipment-tracking/{installed_site}`
* Check if the `Enable autoupdades.` option is possible to be changed
* Check if the `Remove` option is shown on the menu

##### Purchased Plugin
* Purchase a Marketplace plugin.
* Go to the plugin details page of this plugin. Ex: `/plugins/woocommerce-shipment-tracking/{installed_site}`
* Check if the `Enable autoupdades.` option is disabled to be changed and a message about automanaged plugins is shown
* Check if the `Remove` option is NOT shown on the menu and there is the option `Manage Subscription`

| Uploaded Plugin  | Purchased Plugin (automanaged) |
| ------------- | ------------- |
|<img width="943" alt="Screen Shot 2022-10-28 at 10 03 44" src="https://user-images.githubusercontent.com/5039531/198672959-0d012cf4-b0f7-434a-b102-27ee8cea7a20.png">|<img width="943" alt="Screen Shot 2022-10-28 at 09 58 13" src="https://user-images.githubusercontent.com/5039531/198673015-45bd1fee-e23b-486e-9bd8-12d994f01ca3.png">|

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #67840