### PR TITLE
New selector to check if a site is eligible for third-party themes

### DIFF
--- a/client/state/themes/selectors/index.js
+++ b/client/state/themes/selectors/index.js
@@ -53,6 +53,7 @@ export { isRequestingTheme } from 'calypso/state/themes/selectors/is-requesting-
 export { isRequestingThemesForQuery } from 'calypso/state/themes/selectors/is-requesting-themes-for-query';
 export { isRequestingThemesForQueryIgnoringPage } from 'calypso/state/themes/selectors/is-requesting-themes-for-query-ignoring-page';
 export { isSiteEligibleForBundledSoftware } from 'calypso/state/themes/selectors/is-site-eligible-for-bundled-software';
+export { isSiteEligibleForManagedExternalThemes } from 'calypso/state/themes/selectors/is-site-eligible-for-managed-external-themes';
 export { isThemeActive } from 'calypso/state/themes/selectors/is-theme-active';
 export { isThemeGutenbergFirst } from 'calypso/state/themes/selectors/is-theme-gutenberg-first';
 export { isThemePremium } from 'calypso/state/themes/selectors/is-theme-premium';

--- a/client/state/themes/selectors/is-site-eligible-for-managed-external-themes.js
+++ b/client/state/themes/selectors/is-site-eligible-for-managed-external-themes.js
@@ -1,0 +1,19 @@
+import { FEATURE_WOOP, WPCOM_FEATURES_ATOMIC } from '@automattic/calypso-products';
+import siteHasFeature from 'calypso/state/selectors/site-has-feature';
+
+import 'calypso/state/themes/init';
+
+/**
+ * Returns true if the site specified has the features needed to use
+ * software bundled with themes (like woo-on-plans).
+ *
+ * @param {object} state Global state tree
+ * @param {number} siteId Site ID
+ * @returns {boolean} True if the site is able to used bundled software.
+ */
+export function isSiteEligibleForManagedExternalThemes( state, siteId ) {
+	return (
+		siteHasFeature( state, siteId, FEATURE_WOOP ) &&
+		siteHasFeature( state, siteId, WPCOM_FEATURES_ATOMIC )
+	);
+}

--- a/client/state/themes/test/selectors.js
+++ b/client/state/themes/test/selectors.js
@@ -1,9 +1,11 @@
 import {
+	FEATURE_WOOP,
 	PLAN_FREE,
 	PLAN_PREMIUM,
 	PLAN_BUSINESS,
 	PLAN_ECOMMERCE,
 	WPCOM_FEATURES_PREMIUM_THEMES,
+	WPCOM_FEATURES_ATOMIC,
 } from '@automattic/calypso-products';
 import ThemeQueryManager from 'calypso/lib/query-manager/theme';
 import {
@@ -45,6 +47,7 @@ import {
 	areRecommendedThemesLoading,
 	shouldShowTryAndCustomize,
 	isExternallyManagedTheme,
+	isSiteEligibleForManagedExternalThemes,
 } from '../selectors';
 
 const twentyfifteen = {
@@ -2594,6 +2597,44 @@ describe( 'themes selectors', () => {
 			);
 			expect( parentId ).toEqual( 'superhero' );
 		} );
+	} );
+
+	test( 'has managed-external theme features', () => {
+		const isSiteEligible = isSiteEligibleForManagedExternalThemes(
+			{
+				sites: {
+					features: {
+						1234: {
+							data: {
+								active: [ FEATURE_WOOP, WPCOM_FEATURES_ATOMIC ],
+							},
+						},
+					},
+				},
+			},
+			1234
+		);
+
+		expect( isSiteEligible ).toEqual( true );
+	} );
+
+	test( 'does not have managed-external theme features', () => {
+		const isSiteEligible = isSiteEligibleForManagedExternalThemes(
+			{
+				sites: {
+					features: {
+						1234: {
+							data: {
+								active: [ 'i-can-has-feature' ],
+							},
+						},
+					},
+				},
+			},
+			1234
+		);
+
+		expect( isSiteEligible ).toEqual( false );
 	} );
 } );
 


### PR DESCRIPTION
#### Proposed Changes

This is a new selector which checks to see if a site is eligible to active third-party (externally managed themes). We check by looking for FEATURE_WOOP and WPCOM_FEATURES_ATOMIC

#### Testing Instructions

Run 
```
yarn test-client client/state/themes/test/selectors.js
```

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
