### PR TITLE
Pre Cancellation Modal - Screenshot Component and Restyle

### DIFF
--- a/client/me/purchases/pre-cancellation-dialog/index.tsx
+++ b/client/me/purchases/pre-cancellation-dialog/index.tsx
@@ -33,14 +33,12 @@ interface PreCancellationDialogProps {
  */
 interface FeaturesListProps {
 	productSlug: string | undefined;
-	subTitle: string | undefined;
 	domainFeature: JSX.Element | null;
 	isPurchaseRefundable: boolean;
 	isPurchaseAutoRenewing: boolean;
 }
 export const FeaturesList = ( {
 	productSlug,
-	subTitle,
 	domainFeature,
 	isPurchaseRefundable,
 	isPurchaseAutoRenewing,
@@ -53,7 +51,6 @@ export const FeaturesList = ( {
 
 	return (
 		<>
-			<p>{ subTitle }</p>
 			<ul
 				className={
 					'pre-cancellation-dialog__list-plan-features' +
@@ -113,39 +110,24 @@ interface RenderFooterTextProps {
 }
 
 export const RenderFooterText = ( { purchase }: RenderFooterTextProps ) => {
-	const { refundText } = purchase;
 	const translate = useTranslate();
 
 	return (
-		<div className="pre-cancellation-dialog--footer">
-			<div className="pre-cancellation-dialog--footer--support">
-				<strong className="pre-cancellation-dialog--footer--support-information">
-					{ ! isRefundable( purchase ) && maybeWithinRefundPeriod( purchase )
-						? translate(
-								'Have a question? Want to request a refund? {{contactLink}}Ask a Happiness Engineer!{{/contactLink}}',
-								{
-									components: {
-										contactLink: <a href={ CALYPSO_CONTACT } />,
-									},
-								}
-						  )
-						: translate(
-								'Have a question? {{contactLink}}Ask a Happiness Engineer!{{/contactLink}}',
-								{
-									components: {
-										contactLink: <a href={ CALYPSO_CONTACT } />,
-									},
-								}
-						  ) }
-				</strong>
-			</div>
-			<div className="pre-cancellation-dialog--footer--refund">
-				{ hasAmountAvailableToRefund( purchase ) &&
-					translate( '%(refundText)s to be refunded', {
-						args: { refundText },
-						context: 'refundText is of the form "[currency-symbol][amount]" i.e. "$20"',
-					} ) }
-			</div>
+		<div className="pre-cancellation-dialog--support">
+			{ ! isRefundable( purchase ) && maybeWithinRefundPeriod( purchase )
+				? translate(
+						'Have a question? Want to request a refund? {{contactLink}}Ask a Happiness Engineer!{{/contactLink}}',
+						{
+							components: {
+								contactLink: <a href={ CALYPSO_CONTACT } />,
+							},
+						}
+				  )
+				: translate( 'Have a question? {{contactLink}}Ask a Happiness Engineer!{{/contactLink}}', {
+						components: {
+							contactLink: <a href={ CALYPSO_CONTACT } />,
+						},
+				  } ) }
 		</div>
 	);
 };
@@ -175,13 +157,29 @@ export const PreCancellationDialog = ( {
 	const launchedStatus = site.launch_status === 'launched' ? true : false;
 	const shouldUseSiteThumbnail =
 		isComingSoon === false && isPrivate === false && launchedStatus === true;
-	const subTitle = translate( 'Subtitle' );
 
 	/**
 	 * Instantiate purchase variables.
 	 */
 	const isPurchaseRefundable = isRefundable( purchase );
 	const isPurchaseAutoRenewing = purchase.isAutoRenewEnabled;
+
+	/**
+	 * Determine dialog subtitle.
+	 */
+	const { refundText } = purchase;
+	const subTitle =
+		isPurchaseRefundable && hasAmountAvailableToRefund( purchase ) ? (
+			<div className="pre-cancellation-dialog--refund">
+				{ hasAmountAvailableToRefund( purchase ) &&
+					translate( '%(refundText)s to be refunded', {
+						args: { refundText },
+						context: 'refundText is of the form "[currency-symbol][amount]" i.e. "$20"',
+					} ) }
+			</div>
+		) : (
+			<>Subtitle</>
+		);
 
 	/**
 	 * Click events, buttons tracking and action.
@@ -220,14 +218,14 @@ export const PreCancellationDialog = ( {
 	 */
 	const buttons = [
 		{
-			action: 'cancel',
-			label: translate( 'Cancel my plan' ),
-			onClick: clickCancelPlan,
-		},
-		{
 			action: 'close',
 			label: translate( 'Keep my plan' ),
 			onClick: clickCloseDialog,
+		},
+		{
+			action: 'cancel',
+			label: translate( 'Cancel my plan' ),
+			onClick: clickCancelPlan,
 			isPrimary: true,
 		},
 	];
@@ -263,14 +261,13 @@ export const PreCancellationDialog = ( {
 							} ) }
 							align="left"
 						/>
+						<h2>{ subTitle }</h2>
 						<FeaturesList
 							productSlug={ productSlug }
-							subTitle={ subTitle }
 							domainFeature={ domainFeature }
 							isPurchaseRefundable={ isPurchaseRefundable }
 							isPurchaseAutoRenewing={ isPurchaseAutoRenewing }
 						/>
-						<RenderFooterText purchase={ purchase } />
 					</div>
 					{ shouldUseSiteThumbnail && (
 						<div className="pre-cancellation-dialog__grid-colmn">
@@ -282,6 +279,7 @@ export const PreCancellationDialog = ( {
 						</div>
 					) }
 				</div>
+				<RenderFooterText purchase={ purchase } />
 			</>
 		</Dialog>
 	);

--- a/client/me/purchases/pre-cancellation-dialog/index.tsx
+++ b/client/me/purchases/pre-cancellation-dialog/index.tsx
@@ -274,7 +274,7 @@ export const PreCancellationDialog = ( {
 							<SiteScreenshot
 								className="pre-cancellation-dialog__site-screenshot"
 								site={ site }
-								alt={ 'The screenshot of the site: ' + siteName }
+								alt={ translate( 'The screenshot of the site:' ) + ' ' + siteName }
 							/>
 						</div>
 					) }

--- a/client/me/purchases/pre-cancellation-dialog/index.tsx
+++ b/client/me/purchases/pre-cancellation-dialog/index.tsx
@@ -10,6 +10,7 @@ import {
 	maybeWithinRefundPeriod,
 } from 'calypso/lib/purchases';
 import { CALYPSO_CONTACT } from 'calypso/lib/url/support';
+import { SiteScreenshot } from '../site-screenshot';
 import getPlanCancellationFeatures from './get-plan-cancellation-features';
 import type { Purchase } from 'calypso/lib/purchases/types';
 import './style.scss';
@@ -163,13 +164,22 @@ export const PreCancellationDialog = ( {
 	wpcomURL,
 }: PreCancellationDialogProps ) => {
 	const translate = useTranslate();
-
 	/**
-	 * Instantiate site's plan variables.
+	 * Instantiate site's variables.
 	 */
+	const siteName = site.name ?? '';
 	const productSlug = site.plan?.product_slug;
 	const planLabel = site.plan?.product_name_short;
+	const isComingSoon = site.is_coming_soon;
+	const isPrivate = site.is_private;
+	const launchedStatus = site.launch_status === 'launched' ? true : false;
+	const shouldUseSiteThumbnail =
+		isComingSoon === false && isPrivate === false && launchedStatus === true;
 	const subTitle = translate( 'Subtitle' );
+
+	/**
+	 * Instantiate purchase variables.
+	 */
 	const isPurchaseRefundable = isRefundable( purchase );
 	const isPurchaseAutoRenewing = purchase.isAutoRenewEnabled;
 
@@ -231,6 +241,7 @@ export const PreCancellationDialog = ( {
 			className={ cx( {
 				'pre-cancellation-dialog': true,
 				'--with-domain-feature': domainFeature !== null,
+				'--with-screenshot': shouldUseSiteThumbnail,
 			} ) }
 			isVisible={ isDialogVisible }
 			onClose={ closeDialog }
@@ -261,6 +272,15 @@ export const PreCancellationDialog = ( {
 						/>
 						<RenderFooterText purchase={ purchase } />
 					</div>
+					{ shouldUseSiteThumbnail && (
+						<div className="pre-cancellation-dialog__grid-colmn">
+							<SiteScreenshot
+								className="pre-cancellation-dialog__site-screenshot"
+								site={ site }
+								alt={ siteName }
+							/>
+						</div>
+					) }
 				</div>
 			</>
 		</Dialog>

--- a/client/me/purchases/pre-cancellation-dialog/index.tsx
+++ b/client/me/purchases/pre-cancellation-dialog/index.tsx
@@ -274,7 +274,7 @@ export const PreCancellationDialog = ( {
 							<SiteScreenshot
 								className="pre-cancellation-dialog__site-screenshot"
 								site={ site }
-								alt={ siteName }
+								alt={ 'The screenshot of the site: ' + siteName }
 							/>
 						</div>
 					) }

--- a/client/me/purchases/pre-cancellation-dialog/index.tsx
+++ b/client/me/purchases/pre-cancellation-dialog/index.tsx
@@ -274,7 +274,11 @@ export const PreCancellationDialog = ( {
 							<SiteScreenshot
 								className="pre-cancellation-dialog__site-screenshot"
 								site={ site }
-								alt={ translate( 'The screenshot of the site:' ) + ' ' + siteName }
+								alt={ String(
+									translate( 'The screenshot of the site: %(site)s', {
+										args: { site: siteName },
+									} )
+								) }
 							/>
 						</div>
 					) }

--- a/client/me/purchases/pre-cancellation-dialog/style.scss
+++ b/client/me/purchases/pre-cancellation-dialog/style.scss
@@ -17,6 +17,18 @@ $modal-breakpoint-mobile: 480px;
 		}
 	}
 
+	.pre-cancellation-dialog__site-screenshot {
+		width: 365px;
+		height: 483px;
+		padding: 48px 24px;
+
+		&.site-thumbnail-loading {
+			background-color: transparent;
+			border: none;
+
+		}
+	}
+
 	& + .dialog__action-buttons {
 		&::before {
 			background: none;
@@ -52,6 +64,67 @@ $modal-breakpoint-mobile: 480px;
 
 		@media ( max-width: $modal-breakpoint-mobile ) {
 			padding: 48px 24px 0;
+		}
+	}
+
+	&.--with-screenshot {
+		max-width: 960px;
+
+		@media ( max-width: $modal-breakpoint-tablet ) {
+			max-width: 500px;
+		}
+
+		.pre-cancellation-dialog__grid {
+			display: grid;
+			grid-template-columns: 1fr 1fr;
+			vertical-align: middle;
+			text-align: center;
+
+			@media ( max-width: $modal-breakpoint-tablet ) {
+				display: block;
+			}
+
+			strong {
+				overflow-wrap: anywhere;
+			}
+		}
+
+		.pre-cancellation-dialog__grid-colmn:nth-child(2) {
+			background: #f0f0f0;
+			padding-bottom: 0;
+
+			@media ( max-width: $modal-breakpoint-tablet ) {
+				display: none;
+			}
+		}
+
+		& + .dialog__action-buttons {
+			margin-left: 48px;
+			margin-top: -92px;
+			margin-bottom: 52px;
+			border: none;
+			background: transparent;
+			text-align: left;
+			padding: 0;
+
+			&::before {
+				content: none;
+			}
+
+			button {
+				margin-left: 0;
+				margin-right: 10px;
+			}
+
+			@media ( max-width: $modal-breakpoint-tablet ) {
+				margin-left: 48px;
+				margin-top: 0;
+				margin-bottom: 48px;
+			}
+
+			@media ( max-width: $modal-breakpoint-mobile ) {
+				margin-right: 48px;
+			}
 		}
 	}
 

--- a/client/me/purchases/pre-cancellation-dialog/style.scss
+++ b/client/me/purchases/pre-cancellation-dialog/style.scss
@@ -34,9 +34,9 @@ $modal-breakpoint-mobile: 480px;
 			background: none;
 		}
 
-		margin-left: 48px;
+		margin-left: 38px;
 		margin-top: 32px;
-		margin-bottom: 48px;
+		margin-bottom: 92px;
 		border: none;
 		background: transparent;
 		text-align: left;
@@ -89,23 +89,16 @@ $modal-breakpoint-mobile: 480px;
 	.pre-cancellation-dialog--support {
 		font-size: $font-body-small;
 		position: absolute;
-		margin-top: -72px;
+		margin-top: 92px;
 		margin-left: 48px;
 
 		@media ( max-width: $modal-breakpoint-tablet ) {
-			margin-top: 82px;
-			margin-left: 0;
-			margin-right: 0;
-			text-align: center;
-			width: 100%;
+			margin-top: 92px;
 		}
 
 		@media ( max-width: $modal-breakpoint-mobile ) {
-			margin-top: 122px;
-			margin-left: 0;
-			margin-right: 0;
-			text-align: center;
-			width: 100%;
+			margin-top: 132px;
+			margin-left: 38px;
 		}
 	}
 
@@ -137,6 +130,13 @@ $modal-breakpoint-mobile: 480px;
 			}
 		}
 
+		.pre-cancellation-dialog--support {
+			@media ( min-width: $modal-breakpoint-tablet ) {
+				margin-top: -72px;
+				margin-left: 38px;
+			}
+		}
+
 		.pre-cancellation-dialog__grid-colmn:nth-child(2) {
 			background: #f0f0f0;
 			padding-bottom: 0;
@@ -147,7 +147,7 @@ $modal-breakpoint-mobile: 480px;
 		}
 
 		& + .dialog__action-buttons {
-			margin-left: 48px;
+			margin-left: 38px;
 			margin-top: -136px;
 			margin-bottom: 52px;
 			border: none;
@@ -167,7 +167,7 @@ $modal-breakpoint-mobile: 480px;
 			@media ( max-width: $modal-breakpoint-tablet ) {
 				margin-left: 48px;
 				margin-top: 24px;
-				margin-bottom: 92px;
+				margin-bottom: 102px;
 			}
 
 			@media ( max-width: $modal-breakpoint-mobile ) {

--- a/client/me/purchases/pre-cancellation-dialog/style.scss
+++ b/client/me/purchases/pre-cancellation-dialog/style.scss
@@ -52,7 +52,7 @@ $modal-breakpoint-mobile: 480px;
 		padding: 48px 48px 0;
 
 		.formatted-header__title {
-			font-size: 1.5rem;
+			font-size: 1.75rem;
 			font-weight: inherit;
 			margin-bottom: 0.75em;
 		}
@@ -67,8 +67,56 @@ $modal-breakpoint-mobile: 480px;
 		}
 	}
 
+	.pre-cancellation-dialog--refund {
+		font-size: $font-body-small;
+		margin: 0;
+		padding: 0 10px 5px 0;
+		margin-top: 20px;
+	}
+
+	.pre-cancellation-dialog__list-plan-features {
+		list-style-type: none;
+		margin: 10px 0;
+		text-align: left;
+
+		li {
+			display: grid;
+			grid-template-columns: 32px 1fr;
+			margin-bottom: 5px;
+		}
+	}
+
+	.pre-cancellation-dialog--support {
+		font-size: $font-body-small;
+		position: absolute;
+		margin-top: -72px;
+		margin-left: 48px;
+
+		@media ( max-width: $modal-breakpoint-tablet ) {
+			margin-top: 82px;
+			margin-left: 0;
+			margin-right: 0;
+			text-align: center;
+			width: 100%;
+		}
+
+		@media ( max-width: $modal-breakpoint-mobile ) {
+			margin-top: 122px;
+			margin-left: 0;
+			margin-right: 0;
+			text-align: center;
+			width: 100%;
+		}
+	}
+
+	.pre-cancellation-dialog__item-cross-small {
+		color: #e65054;
+		vertical-align: middle;
+		margin-right: 10px;
+	}
+
 	&.--with-screenshot {
-		max-width: 960px;
+		max-width: $modal-breakpoint-tablet;
 
 		@media ( max-width: $modal-breakpoint-tablet ) {
 			max-width: 500px;
@@ -100,7 +148,7 @@ $modal-breakpoint-mobile: 480px;
 
 		& + .dialog__action-buttons {
 			margin-left: 48px;
-			margin-top: -92px;
+			margin-top: -136px;
 			margin-bottom: 52px;
 			border: none;
 			background: transparent;
@@ -118,31 +166,13 @@ $modal-breakpoint-mobile: 480px;
 
 			@media ( max-width: $modal-breakpoint-tablet ) {
 				margin-left: 48px;
-				margin-top: 0;
-				margin-bottom: 48px;
+				margin-top: 24px;
+				margin-bottom: 92px;
 			}
 
 			@media ( max-width: $modal-breakpoint-mobile ) {
 				margin-right: 48px;
 			}
-		}
-	}
-
-	.pre-cancellation-dialog__item-cross-small {
-		color: #e65054;
-		vertical-align: middle;
-		margin-right: 10px;
-	}
-
-	.pre-cancellation-dialog__list-plan-features {
-		list-style-type: none;
-		margin: 0;
-		text-align: left;
-
-		li {
-			display: grid;
-			grid-template-columns: 32px 1fr;
-			margin-bottom: 5px;
 		}
 	}
 
@@ -154,33 +184,9 @@ $modal-breakpoint-mobile: 480px;
 			}
 		}
 
-		.pre-cancellation-dialog--footer {
-			margin-bottom: 98px;
-
-			@media ( max-width: $modal-breakpoint-tablet ) {
-				margin-bottom: 98px;
-			}
-
-			@media ( max-width: $modal-breakpoint-mobile ) {
-				margin-bottom: 58px;
-			}
-		}
-
 		& + .dialog__action-buttons {
 			margin-top: -67px;
 			margin-bottom: 27px;
 		}
-	}
-
-	.pre-cancellation-dialog--footer--refund {
-		color: var(--color-success);
-		font-size: $font-body-small;
-		margin: 0;
-		padding: 0 10px 5px 0;
-		margin-top: 20px;
-	}
-
-	.pre-cancellation-dialog--footer--support {
-		margin-top: 20px;
 	}
 }

--- a/client/me/purchases/site-screenshot/index.tsx
+++ b/client/me/purchases/site-screenshot/index.tsx
@@ -1,0 +1,59 @@
+import { SiteThumbnail, Spinner } from '@automattic/components';
+import { addQueryArgs } from '@wordpress/url';
+import { ComponentProps } from 'react';
+import { SiteExcerptData } from 'calypso/data/sites/site-excerpt-types';
+
+import './style.scss';
+
+interface SiteScreenshotProps extends ComponentProps< typeof SiteThumbnail > {
+	site: SiteExcerptData;
+	alt: string;
+}
+
+/**
+ * Create a site screenshot using mShots.
+ *
+ * @returns SiteThumbnail
+ */
+export const SiteScreenshot = ( { site, alt, ...props }: SiteScreenshotProps ) => {
+	const shouldUseScreenshot =
+		! site.is_coming_soon && ! site.is_private && site.launch_status === 'launched';
+
+	let siteUrl = site.URL;
+	if ( site.options?.updated_at ) {
+		const updatedAt = new Date( site.options.updated_at );
+		updatedAt.setMinutes( 0 );
+		updatedAt.setSeconds( 0 );
+		siteUrl = addQueryArgs( siteUrl, {
+			v: updatedAt.getTime() / 1000,
+
+			// This combination of flags stops free site headers and cookie banners from appearing.
+			iframe: true,
+			preview: true,
+			hide_banners: true,
+		} );
+	}
+
+	// mShots screenshot options.
+	const MShotsOptions = {
+		vpw: 1602,
+		vph: 2120,
+		w: 365,
+		screen_height: 2120,
+	};
+
+	return (
+		<SiteThumbnail
+			{ ...props }
+			mShotsUrl={ shouldUseScreenshot ? siteUrl : undefined }
+			className="site-screenshot"
+			alt={ alt }
+			bgColorImgUrl={ site.icon?.img }
+			mshotsOption={ MShotsOptions }
+			width={ 365 }
+			height={ 483 }
+		>
+			<Spinner className="site-screenshot__spinner" size={ 50 } />
+		</SiteThumbnail>
+	);
+};

--- a/client/me/purchases/site-screenshot/style.scss
+++ b/client/me/purchases/site-screenshot/style.scss
@@ -1,0 +1,12 @@
+.site-screenshot.site-thumbnail {
+	width: 365px;
+	height: 483px;
+	box-shadow: 0 0 10px rgba(0, 0, 0, 15%);
+	border: 1px solid #bbe0fa;
+	margin: auto;
+}
+
+.site-screenshot.site-thumbnail-loading {
+	background-color: transparent;
+	border: none;
+}


### PR DESCRIPTION
#### Description

Addition of the SiteScreenshot component used by the Pre Cancellation modal window.

The component makes use of mShots and in case the site is public, it generates a screenshot of the site's homepage which is shown in the Pre Cancellation modal window.

On small screens, the screenshot is hidden.

The screenshot is placed on the right side, contrary to how it was done in the previous work.

#### Feature flag
?flags=pre-cancellation-modal

#### Testing Instructions
The following steps should be performed with different WordPress.com sites. The site should use different themes, and different Privacy settings: Private, Coming Soon, Public. Privacy settings can be set at the URL /settings/general/<YOUR SITE AT WPCOM>

1. Visit the purchase page on Calypso: /me/purchases/<YOUR SITE>/<Purchase ID>?flags=pre-cancellation-modal
2. Click the cancel button to see the 
3. In case of using a public site, the screenshot should show up
4. Verify the screenshot is correctly generated
5. Verify the screenshot image is not blurry
6. Verify the Pre Cancellation Modal responsive behaviour for the following plans:
  1. Simple plan
  2. Subscription
  3. With domain
  4. Purchase in refund Window

#### Mobile Screen
<img width="538" alt="Screenshot 2022-11-01 at 08 33 39" src="https://user-images.githubusercontent.com/5706607/199182649-b6fe3949-38fb-4861-b67a-618f751b76d2.png">

#### Desktop Screen
<img width="1093" alt="Screenshot 2022-11-01 at 08 33 19" src="https://user-images.githubusercontent.com/5706607/199182694-cafcc118-af7e-4b35-bed7-3b83b4bb9d0b.png">

#### Video
https://user-images.githubusercontent.com/5706607/198693486-f75289cf-fcec-467a-b2ba-122acc31b100.mp4
