### PR TITLE
Checkout: Remove special logic to show free payment method

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/checkout-main.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-main.tsx
@@ -372,7 +372,6 @@ export default function CheckoutMain( {
 		: filterAppropriatePaymentMethods( {
 				paymentMethodObjects,
 				allowedPaymentMethods,
-				responseCart,
 		  } );
 	debug( 'filtered payment method objects', paymentMethods );
 

--- a/client/my-sites/checkout/composite-checkout/lib/filter-appropriate-payment-methods.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/filter-appropriate-payment-methods.ts
@@ -1,29 +1,18 @@
-import { doesPurchaseHaveFullCredits } from '@automattic/wpcom-checkout';
 import isPaymentMethodEnabled from './is-payment-method-enabled';
 import { readCheckoutPaymentMethodSlug } from './translate-payment-method-names';
 import type { PaymentMethod } from '@automattic/composite-checkout';
-import type { ResponseCart } from '@automattic/shopping-cart';
 import type { CheckoutPaymentMethodSlug } from '@automattic/wpcom-checkout';
 
 export default function filterAppropriatePaymentMethods( {
 	paymentMethodObjects,
-	responseCart,
 	allowedPaymentMethods,
 }: {
 	paymentMethodObjects: PaymentMethod[];
 	allowedPaymentMethods: CheckoutPaymentMethodSlug[];
-	responseCart: ResponseCart;
 } ): PaymentMethod[] {
-	const isPurchaseFree =
-		responseCart.total_cost_integer === 0 || doesPurchaseHaveFullCredits( responseCart );
-
-	if ( isPurchaseFree ) {
-		return paymentMethodObjects.filter( ( methodObject ) => methodObject.id === 'free-purchase' );
-	}
-
 	return paymentMethodObjects.filter( ( methodObject ) => {
 		const slug = readCheckoutPaymentMethodSlug( methodObject.id );
-		if ( ! slug || slug === 'free-purchase' ) {
+		if ( ! slug ) {
 			return false;
 		}
 		return isPaymentMethodEnabled( slug, allowedPaymentMethods );

--- a/client/my-sites/checkout/composite-checkout/lib/is-payment-method-enabled.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/is-payment-method-enabled.ts
@@ -6,11 +6,6 @@ export default function isPaymentMethodEnabled(
 	slug: CheckoutPaymentMethodSlug,
 	allowedPaymentMethods: null | CheckoutPaymentMethodSlug[]
 ): boolean {
-	const alwaysEnabledPaymentMethods = [ 'free-purchase' ];
-	if ( alwaysEnabledPaymentMethods.includes( slug ) ) {
-		return true;
-	}
-
 	// Existing cards have unique slugs but here we need only know if existing
 	// cards are allowed.
 	if ( slug.startsWith( 'existingCard' ) ) {

--- a/client/my-sites/checkout/composite-checkout/test/util/index.ts
+++ b/client/my-sites/checkout/composite-checkout/test/util/index.ts
@@ -585,7 +585,15 @@ export function mockCartEndpoint( initialCart: ResponseCart, currency: string, l
 
 export function mockGetCartEndpointWith( initialCart: ResponseCart ) {
 	return async () => {
-		return initialCart;
+		const isFree =
+			initialCart.total_cost_integer === 0 ||
+			initialCart.credits_integer >= initialCart.total_cost_integer;
+		return {
+			...initialCart,
+			allowed_payment_methods: isFree
+				? [ 'WPCOM_Billing_WPCOM' ]
+				: [ 'WPCOM_Billing_PayPal_Express' ],
+		};
 	};
 }
 


### PR DESCRIPTION
#### Proposed Changes

Before D91110-code the backend provided the list of available payment methods always and never returned the free payment method. Deciding to show the free payment method was handled entirely on the frontend. 

After D91110-code, the backend (via the `/me/shopping-cart` endpoint) now returns _only_ the free payment method (and no other payment methods) if the purchase would be free. Therefore the frontend needs to only filter its payment methods based on what the backend returns. 

The frontend already does this filtering, so in this PR we remove the special case for free purchases.

See https://github.com/Automattic/payments-shilling/issues/1183

#### Screenshots

Free purchase:

<img width="571" alt="Screen Shot 2022-10-25 at 6 41 29 PM" src="https://user-images.githubusercontent.com/2036909/197895915-2b0738a0-7144-4f73-9784-eb8713645870.png">

Full credits:

<img width="571" alt="Screen Shot 2022-10-25 at 6 43 01 PM" src="https://user-images.githubusercontent.com/2036909/197895930-37d38527-3f7a-414a-ab8e-0e2814ea732c.png">


#### Testing Instructions

- Test neither method
  - With no coupon and no credits, add a product to your cart and visit checkout.
  - Continue to the final step of checkout and verify that you see several payment methods, none of which mentions "Free" or "Credits".
- Test free payment method
  - Add a product to your cart and visit checkout.
  - Add a coupon to your cart that gives a 100% discount.
  - Continue to the final step of checkout and verify that you see the "Free Purchase" payment method.
  - Click to complete the purchase and verify that the purchase is successful.
- Test full credits payment method
  - Add enough credits to your account to completely cover the cost of a purchase.
  - Add a product to your cart and visit checkout.
  - Continue to the final step of checkout and verify that you see the "WordPress.com Credits" payment method.
  - Click to complete the purchase and verify that the purchase is successful.