### PR TITLE
WooCommerce Tailored Flow: Added design carousel component and step

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-carousel/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-carousel/index.tsx
@@ -1,0 +1,42 @@
+import { StepContainer } from '@automattic/onboarding';
+import { useI18n } from '@wordpress/react-i18n';
+import AsyncLoad from 'calypso/components/async-load';
+import FormattedHeader from 'calypso/components/formatted-header';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import type { Step } from '../../types';
+
+const DesignCarousel: Step = function DesignCarousel( { navigation } ) {
+	const { goNext, goBack, submit } = navigation;
+	const { __ } = useI18n();
+
+	function handleSubmit( design: any ) {
+		submit?.( design );
+	}
+
+	return (
+		<StepContainer
+			stepName="designCarousel"
+			goBack={ goBack }
+			goNext={ goNext }
+			shouldHideNavButtons
+			isFullLayout={ true }
+			stepContent={
+				<AsyncLoad
+					require="@automattic/design-carousel"
+					placeholder={ null }
+					onPick={ handleSubmit }
+				/>
+			}
+			recordTracksEvent={ recordTracksEvent }
+			formattedHeader={
+				<FormattedHeader
+					id="seller-step-header"
+					headerText={ __( 'Choose a design to start' ) }
+					align="center"
+				/>
+			}
+		/>
+	);
+};
+
+export default DesignCarousel;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/index.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/index.ts
@@ -43,6 +43,7 @@ export { default as subscribers } from './subscribers';
 export { default as patterns } from './patterns';
 export { default as getCurrentThemeSoftwareSets } from './get-current-theme-software-sets';
 export { default as storeProfiler } from './store-profiler';
+export { default as designCarousel } from './design-carousel';
 
 export type StepPath =
 	| 'courses'
@@ -89,4 +90,5 @@ export type StepPath =
 	| 'launchpad'
 	| 'subscribers'
 	| 'getCurrentThemeSoftwareSets'
+	| 'designCarousel'
 	| 'storeProfiler';

--- a/client/landing/stepper/declarative-flow/tailored-ecommerce-flow.ts
+++ b/client/landing/stepper/declarative-flow/tailored-ecommerce-flow.ts
@@ -1,3 +1,5 @@
+import { useDispatch } from '@wordpress/data';
+import { ONBOARD_STORE } from '../stores';
 import { recordSubmitStep } from './internals/analytics/record-submit-step';
 import type { StepPath } from './internals/steps-repository';
 import type { Flow, ProvidedDependencies } from './internals/types';
@@ -6,11 +8,15 @@ export const tailoredEcommerceFlow: Flow = {
 	name: 'tailored-ecommerce',
 
 	useSteps() {
-		return [ 'storeProfiler' ] as StepPath[];
+		return [ 'storeProfiler', 'designCarousel' ] as StepPath[];
 	},
 
 	useStepNavigation( currentStep, navigate ) {
 		const flowName = this.name;
+
+		// Leaving this as a placeholder for the actual logic
+		const { setStepProgress } = useDispatch( ONBOARD_STORE );
+		setStepProgress( { progress: 1, count: 4 } );
 
 		function submit( providedDependencies: ProvidedDependencies = {} ) {
 			recordSubmitStep( providedDependencies, 'tailored-ecommerce', flowName, currentStep );
@@ -18,6 +24,8 @@ export const tailoredEcommerceFlow: Flow = {
 			switch ( currentStep ) {
 				case 'storeProfiler':
 					return navigate( 'storeProfiler' );
+				case 'designCarousel':
+					return navigate( 'designCarousel' );
 			}
 		}
 
@@ -25,6 +33,8 @@ export const tailoredEcommerceFlow: Flow = {
 			switch ( currentStep ) {
 				case 'storeProfiler':
 					return navigate( 'storeProfiler' );
+				case 'designCarousel':
+					return navigate( 'designCarousel' );
 				default:
 					return navigate( 'storeProfiler' );
 			}
@@ -35,6 +45,8 @@ export const tailoredEcommerceFlow: Flow = {
 				case 'storeProfiler':
 					// @TODO this will need logic updates
 					return navigate( 'storeProfiler' );
+				case 'designCarousel':
+					return navigate( 'designCarousel' );
 				default:
 					return navigate( 'storeProfiler' );
 			}

--- a/package.json
+++ b/package.json
@@ -141,6 +141,7 @@
 		"@automattic/color-studio": "2.5.0",
 		"@automattic/components": "workspace:^",
 		"@automattic/data-stores": "workspace:^",
+		"@automattic/design-carousel": "workspace:^",
 		"@automattic/happychat-connection": "workspace:^",
 		"@automattic/help-center": "workspace:^",
 		"@automattic/i18n-utils": "workspace:^",

--- a/packages/design-carousel/.eslintrc.js
+++ b/packages/design-carousel/.eslintrc.js
@@ -1,0 +1,10 @@
+module.exports = {
+	overrides: [
+		{
+			files: [ '**/__tests__/**/*' ],
+			rules: {
+				'jest/no-mocks-import': 'off',
+			},
+		},
+	],
+};

--- a/packages/design-carousel/package.json
+++ b/packages/design-carousel/package.json
@@ -1,0 +1,61 @@
+{
+	"name": "@automattic/design-carousel",
+	"version": "1.0.0",
+	"description": "Theme/variation picker",
+	"homepage": "https://github.com/Automattic/wp-calypso",
+	"license": "GPL-2.0-or-later",
+	"author": "Automattic Inc.",
+	"main": "dist/cjs/index.js",
+	"module": "dist/esm/index.js",
+	"calypso:src": "src/index.tsx",
+	"sideEffects": [
+		"*.css",
+		"*.scss"
+	],
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/Automattic/wp-calypso.git",
+		"directory": "packages/design-carousel"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"bugs": "https://github.com/Automattic/wp-calypso/issues",
+	"types": "dist/types",
+	"scripts": {
+		"clean": "tsc --build ./tsconfig.json ./tsconfig-cjs.json --clean && rm -rf dist",
+		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json && copy-assets",
+		"prepack": "yarn run clean && yarn run build",
+		"watch": "tsc --build ./tsconfig.json --watch"
+	},
+	"dependencies": {
+		"@automattic/i18n-utils": "workspace:^",
+		"@automattic/onboarding": "workspace:^",
+		"classnames": "^2.3.1",
+		"react-query": "^3.32.1",
+		"tslib": "^2.3.0",
+		"utility-types": "^3.10.0",
+		"wpcom-proxy-request": "workspace:^"
+	},
+	"devDependencies": {
+		"@automattic/calypso-build": "workspace:^",
+		"@automattic/calypso-typescript-config": "workspace:^",
+		"postcss": "^8.4.5",
+		"react": "^17.0.2",
+		"react-dom": "^17.0.2",
+		"redux": "^4.1.2",
+		"typescript": "^4.7.4",
+		"webpack": "^5.68.0"
+	},
+	"peerDependencies": {
+		"@wordpress/data": "^6.7.0",
+		"@wordpress/element": "^4.5.0",
+		"@wordpress/i18n": "^4.7.0",
+		"debug": "^4.3.3",
+		"react": "^17.0.2",
+		"react-dom": "^17.0.2",
+		"reakit-utils": "^0.15.1",
+		"redux": "^4.1.2"
+	},
+	"private": true
+}

--- a/packages/design-carousel/src/index.tsx
+++ b/packages/design-carousel/src/index.tsx
@@ -1,0 +1,93 @@
+import { Gridicon } from '@automattic/components';
+import { useStarterDesignsQuery } from '@automattic/data-stores';
+import { useLocale } from '@automattic/i18n-utils';
+import { Button } from '@wordpress/components';
+import { Icon, chevronLeft, chevronRight } from '@wordpress/icons';
+import { useI18n } from '@wordpress/react-i18n';
+import React, { useEffect, useRef } from 'react';
+import Swiper from 'swiper';
+import { Item } from './item';
+import 'swiper/dist/css/swiper.css';
+
+type Props = { onPick: ( design: any ) => void };
+
+export default function DesignCarousel( { onPick }: Props ) {
+	const { __ } = useI18n();
+
+	const swiperInstance = useRef< Swiper | null >( null );
+
+	const locale = useLocale();
+
+	const { data: allDesigns } = useStarterDesignsQuery( {
+		vertical_id: '',
+		intent: 'sell',
+		_locale: locale,
+	} );
+
+	const staticDesigns = allDesigns?.static?.designs.slice( 0, 10 ) || [];
+
+	useEffect( () => {
+		if ( staticDesigns ) {
+			swiperInstance.current = new Swiper( '.swiper-container', {
+				autoHeight: true,
+				mousewheel: true,
+				keyboard: true,
+				threshold: 5,
+				slideToClickedSlide: true,
+				slidesPerView: 'auto',
+				spaceBetween: 20,
+				centeredSlides: true,
+				navigation: {
+					prevEl: '.design-carousel__carousel-nav-button--back',
+					nextEl: '.design-carousel__carousel-nav-button--next',
+				},
+			} );
+		}
+		return () => {
+			swiperInstance.current?.destroy();
+		};
+	}, [ staticDesigns ] );
+
+	if ( ! staticDesigns ) {
+		return null;
+	}
+
+	return (
+		<div className="design-carousel">
+			<div className="design-carousel__carousel swiper-container">
+				<div className="swiper-wrapper">
+					{ staticDesigns.map( ( design ) => (
+						<div
+							className="design-carousel__slide swiper-slide"
+							key={ `${ design.slug }-slide-item` }
+						>
+							<Item design={ design } />
+						</div>
+					) ) }
+				</div>
+				<div className="design-carousel__controls">
+					<button className="design-carousel__carousel-nav-button design-carousel__carousel-nav-button--back">
+						<Icon icon={ chevronLeft } />
+					</button>
+					<button className="design-carousel__carousel-nav-button design-carousel__carousel-nav-button--next">
+						<Icon icon={ chevronRight } />
+					</button>
+				</div>
+			</div>
+			<div className="design-carousel__cta">
+				<Button
+					className="design-carousel__select"
+					isPrimary
+					onClick={ () => {
+						if ( swiperInstance.current ) {
+							onPick( staticDesigns[ swiperInstance.current?.activeIndex ] );
+						}
+					} }
+				>
+					<span>{ __( 'Continue' ) }</span>
+					<Gridicon icon="heart" size={ 18 } />
+				</Button>
+			</div>
+		</div>
+	);
+}

--- a/packages/design-carousel/src/index.tsx
+++ b/packages/design-carousel/src/index.tsx
@@ -61,7 +61,8 @@ export default function DesignCarousel( { onPick }: Props ) {
 							className="design-carousel__slide swiper-slide"
 							key={ `${ design.slug }-slide-item` }
 						>
-							<Item design={ design } />
+							<Item design={ design } type="desktop" className="design-carousel__item-desktop" />
+							<Item design={ design } type="mobile" className="design-carousel__item-mobile" />
 						</div>
 					) ) }
 				</div>

--- a/packages/design-carousel/src/item.tsx
+++ b/packages/design-carousel/src/item.tsx
@@ -1,0 +1,36 @@
+/* eslint-disable wpcalypso/jsx-classname-namespace */
+import './styles.scss';
+import { MShotsImage } from '@automattic/onboarding';
+import cx from 'classnames';
+
+type Props = {
+	className?: string;
+	style?: React.CSSProperties;
+	design: any;
+};
+
+const getDesignPreviewUrl = ( design: any ): string => {
+	const params = new URLSearchParams( {
+		stylesheet: design.recipe?.stylesheet,
+		language: 'en',
+		viewport_height: '1040',
+		source_site: 'patternboilerplates.wordpress.com',
+		use_screenshot_overrides: 'true',
+		site_title: design.title,
+	} );
+
+	return `https://public-api.wordpress.com/wpcom/v2/block-previews/site?${ params }`;
+};
+
+export function Item( { style, design, className }: Props ) {
+	return (
+		<div style={ style } className={ cx( 'design-carousel__item', className ) }>
+			<MShotsImage
+				url={ getDesignPreviewUrl( design ) }
+				options={ { w: 1280, vpw: 1920, vph: 1280, format: 'png' } }
+				alt={ design.title }
+				aria-labelledby=""
+			/>
+		</div>
+	);
+}

--- a/packages/design-carousel/src/item.tsx
+++ b/packages/design-carousel/src/item.tsx
@@ -1,12 +1,13 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 import './styles.scss';
-import { MShotsImage } from '@automattic/onboarding';
+import { MShotsImage, MShotsOptions } from '@automattic/onboarding';
 import cx from 'classnames';
 
 type Props = {
 	className?: string;
 	style?: React.CSSProperties;
 	design: any;
+	type: 'desktop' | 'mobile';
 };
 
 const getDesignPreviewUrl = ( design: any ): string => {
@@ -22,12 +23,19 @@ const getDesignPreviewUrl = ( design: any ): string => {
 	return `https://public-api.wordpress.com/wpcom/v2/block-previews/site?${ params }`;
 };
 
-export function Item( { style, design, className }: Props ) {
+export function Item( { style, design, className, type }: Props ) {
+	// Default to mobile options
+	let options: MShotsOptions = { w: 400, vpw: 400, vph: 872, format: 'png' };
+
+	if ( type === 'desktop' ) {
+		options = { w: 1280, vpw: 1920, vph: 1280, format: 'png' };
+	}
+
 	return (
 		<div style={ style } className={ cx( 'design-carousel__item', className ) }>
 			<MShotsImage
 				url={ getDesignPreviewUrl( design ) }
-				options={ { w: 1280, vpw: 1920, vph: 1280, format: 'png' } }
+				options={ options }
 				alt={ design.title }
 				aria-labelledby=""
 			/>

--- a/packages/design-carousel/src/styles.scss
+++ b/packages/design-carousel/src/styles.scss
@@ -1,0 +1,153 @@
+/* stylelint-disable scss/at-import-no-partial-leading-underscore */
+@import "@wordpress/base-styles/_breakpoints";
+@import "@wordpress/base-styles/_mixins";
+
+$patterns: "17-2", "black", "ella-d", "link-cloud", "matt-smith", "ose-maiko", "purple", "yellow",
+	"biba", "chloe-currie", "emily", "luis-carvelleda", "mesh-gradient", "paul-nyberg", "tengfai";
+
+.design-carousel__item {
+	flex: 1;
+
+	// iPhone aspect ratio
+	aspect-ratio: 1.5;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	border-radius: 20px; /* stylelint-disable-line scales/radii */
+	box-shadow: 2px 2px 10px 0 rgb(66 68 90 / 23%);
+	transition: transform 0.4s ease-in-out, opacity 0.3s ease-in-out;
+	border: 0.6vh solid #fff;
+	margin: 20px 0;
+	cursor: pointer;
+	padding: 0;
+	overflow: hidden;
+	height: calc(65vh - 50px);
+	outline: none;
+
+	@media ( max-height: 375px ) {
+		aspect-ratio: 0.5;
+	}
+
+	// needed for iOS Safari. iOS has
+	@supports ( min-height: 65svh ) {
+		height: calc(65svh - 50px);
+	}
+
+	opacity: 0.5;
+	filter: blur(3px);
+
+	.mshots-image__container {
+		display: block;
+		height: 100%;
+		width: 100%;
+	}
+
+	.mshots-image-visible {
+		max-width: 100%;
+	}
+}
+
+.design-carousel__carousel {
+	/*!rtl:ignore*/
+	direction: ltr;
+
+	.design-carousel__slide {
+		width: auto;
+	}
+
+	.swiper-slide-active .design-carousel__item {
+		opacity: 1;
+		filter: blur(0);
+	}
+}
+
+.design-carousel__controls {
+	display: none;
+	position: absolute;
+	width: 100%;
+	top: calc(50% - 20px);
+	/*!rtl:ignore*/
+	direction: ltr;
+	padding: 20px;
+	box-sizing: border-box;
+	pointer-events: none;
+
+	@include break-small {
+		display: flex;
+		justify-content: space-between;
+	}
+}
+
+.design-carousel__carousel-nav-button {
+	width: 40px;
+	height: 40px;
+	background: #fff;
+	border: 1px solid #eee;
+	align-items: center;
+	// stylelint-disable-next-line declaration-property-unit-allowed-list
+	border-radius: 50%;
+	opacity: 0.5;
+	display: flex;
+	box-shadow: 1px 1px 3px 0 rgb(0 0 0 / 18%);
+	transition: opacity 0.3s ease-in-out;
+	pointer-events: all;
+	z-index: 2;
+
+	cursor: pointer;
+
+	&:hover {
+		opacity: 1;
+		fill: var(--studio-blue-50);
+	}
+
+	&.swiper-button-disabled {
+		visibility: hidden;
+		pointer-events: none;
+	}
+}
+
+.design-carousel:hover {
+	.design-carousel__carousel-nav-button {
+		opacity: 0.8;
+	}
+}
+
+.design-carousel__select {
+	display: flex;
+	justify-content: center;
+	text-align: center;
+	width: 100%;
+
+	@include break-small {
+		// seems like a magic number, but the button should be as wide as the designs
+		// and the designs width is tied to the viewport height
+		width: 28vh;
+	}
+
+	svg {
+		display: none;
+	}
+
+	use {
+		fill: #fff;
+	}
+
+	&:not(:disabled):hover {
+		svg {
+			display: inline;
+		}
+
+		span {
+			display: none;
+		}
+	}
+}
+
+.design-carousel__cta {
+	text-align: center;
+	margin: 10px 20px;
+
+	button {
+		display: inline-flex;
+	}
+}

--- a/packages/design-carousel/src/styles.scss
+++ b/packages/design-carousel/src/styles.scss
@@ -2,14 +2,30 @@
 @import "@wordpress/base-styles/_breakpoints";
 @import "@wordpress/base-styles/_mixins";
 
-$patterns: "17-2", "black", "ella-d", "link-cloud", "matt-smith", "ose-maiko", "purple", "yellow",
-	"biba", "chloe-currie", "emily", "luis-carvelleda", "mesh-gradient", "paul-nyberg", "tengfai";
+$patterns: "17-2", "black", "ella-d", "link-cloud", "matt-smith", "ose-maiko", "purple", "yellow", "biba",
+	"chloe-currie", "emily", "luis-carvelleda", "mesh-gradient", "paul-nyberg", "tengfai";
 
 .design-carousel__item {
 	flex: 1;
 
+	@include break-small {
+		aspect-ratio: 1.5;
+	}
+
+	&.design-carousel__item-mobile {
+		@include break-small {
+			display: none !important;
+		}
+	}
+	&.design-carousel__item-desktop {
+		display: none !important;
+		@include break-small {
+			display: flex !important;
+		}
+	}
+
 	// iPhone aspect ratio
-	aspect-ratio: 1.5;
+	aspect-ratio: 0.48;
 	display: flex;
 	align-items: center;
 	justify-content: center;
@@ -24,12 +40,12 @@ $patterns: "17-2", "black", "ella-d", "link-cloud", "matt-smith", "ose-maiko", "
 	height: calc(65vh - 50px);
 	outline: none;
 
-	@media ( max-height: 375px ) {
+	@media (max-height: 375px) {
 		aspect-ratio: 0.5;
 	}
 
 	// needed for iOS Safari. iOS has
-	@supports ( min-height: 65svh ) {
+	@supports (min-height: 65svh) {
 		height: calc(65svh - 50px);
 	}
 

--- a/packages/design-carousel/src/swiper.d.ts
+++ b/packages/design-carousel/src/swiper.d.ts
@@ -1,0 +1,9 @@
+declare module 'swiper' {
+	class Swiper {
+		activeIndex: number;
+		constructor( containerClass: string, options: unknown );
+		destroy(): void;
+	}
+
+	export default Swiper;
+}

--- a/packages/design-carousel/tsconfig-cjs.json
+++ b/packages/design-carousel/tsconfig-cjs.json
@@ -1,0 +1,7 @@
+{
+	"extends": "./tsconfig",
+	"compilerOptions": {
+		"module": "commonjs",
+		"outDir": "dist/cjs"
+	}
+}

--- a/packages/design-carousel/tsconfig.json
+++ b/packages/design-carousel/tsconfig.json
@@ -1,0 +1,16 @@
+{
+	"extends": "@automattic/calypso-typescript-config/ts-package.json",
+	"compilerOptions": {
+		"declarationDir": "dist/types",
+		"outDir": "dist/esm",
+		"rootDir": "src",
+		"types": []
+	},
+	"include": [ "src", "src/*.json" ],
+	"exclude": [ "**/__tests__/*", "**/__mocks__/*" ],
+	"references": [
+		{ "path": "../calypso-config" },
+		{ "path": "../js-utils" },
+		{ "path": "../onboarding" }
+	]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -480,6 +480,37 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@automattic/design-carousel@workspace:^, @automattic/design-carousel@workspace:packages/design-carousel":
+  version: 0.0.0-use.local
+  resolution: "@automattic/design-carousel@workspace:packages/design-carousel"
+  dependencies:
+    "@automattic/calypso-build": "workspace:^"
+    "@automattic/calypso-typescript-config": "workspace:^"
+    "@automattic/i18n-utils": "workspace:^"
+    "@automattic/onboarding": "workspace:^"
+    classnames: ^2.3.1
+    postcss: ^8.4.5
+    react: ^17.0.2
+    react-dom: ^17.0.2
+    react-query: ^3.32.1
+    redux: ^4.1.2
+    tslib: ^2.3.0
+    typescript: ^4.7.4
+    utility-types: ^3.10.0
+    webpack: ^5.68.0
+    wpcom-proxy-request: "workspace:^"
+  peerDependencies:
+    "@wordpress/data": ^6.7.0
+    "@wordpress/element": ^4.5.0
+    "@wordpress/i18n": ^4.7.0
+    debug: ^4.3.3
+    react: ^17.0.2
+    react-dom: ^17.0.2
+    reakit-utils: ^0.15.1
+    redux: ^4.1.2
+  languageName: unknown
+  linkType: soft
+
 "@automattic/design-picker@workspace:^, @automattic/design-picker@workspace:packages/design-picker":
   version: 0.0.0-use.local
   resolution: "@automattic/design-picker@workspace:packages/design-picker"
@@ -35945,6 +35976,7 @@ swiper@4.5.1:
     "@automattic/color-studio": 2.5.0
     "@automattic/components": "workspace:^"
     "@automattic/data-stores": "workspace:^"
+    "@automattic/design-carousel": "workspace:^"
     "@automattic/eslint-plugin-json": "workspace:^"
     "@automattic/happychat-connection": "workspace:^"
     "@automattic/help-center": "workspace:^"


### PR DESCRIPTION
This PR adds the Design Carousel component as a separate package and adds a wrapper Step to it in the `tailored-ecommerce` flow.

The new package was based on `@automattic/pattern-picker`. 

Testing: 

1. Make sure `signup/tailored-ecommerce` flag is enabled
2. Access the `tailored-ecommerce` flow: `/setup/designCarousel?flow=tailored-ecommerce`

![image](https://user-images.githubusercontent.com/3801502/198718439-e5d7d8ea-c75c-4044-8294-32041c14e7dd.png)

Mobile view:

![image](https://user-images.githubusercontent.com/3801502/199082270-88630870-4180-4db9-8fbe-f8e92fb4f5d3.png)


*When reviewing, notice that the new package had to be added to calypso as a new dependency.
*Even though the component is not fully ready it can be merged safely since it's behind a feature flag.

Related to #69399