### PR TITLE
Theme Subscriptions: Update premium theme tooltip for third-party themes

### DIFF
--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -24,6 +24,8 @@ import {
 	doesThemeBundleSoftwareSet as getDoesThemeBundleSoftwareSet,
 	isSiteEligibleForBundledSoftware as getIsSiteEligibleForBundledSoftware,
 	isPremiumThemeAvailable as getIsPremiumThemeAvailable,
+	isExternallyManagedTheme as getIsExternallyManagedTheme,
+	isSiteEligibleForManagedExternalThemes as getIsSiteEligibleForManagedExternalThemes,
 } from 'calypso/state/themes/selectors';
 import { isThemePremium as getIsThemePremium } from 'calypso/state/themes/selectors/is-theme-premium';
 import { isThemePurchased } from 'calypso/state/themes/selectors/is-theme-purchased';
@@ -272,6 +274,8 @@ export class Theme extends Component {
 			translate,
 			doesThemeBundleSoftwareSet,
 			isSiteEligibleForBundledSoftware,
+			isExternallyManagedTheme,
+			isSiteEligibleForManagedExternalThemes,
 		} = this.props;
 
 		// Premium themes (non-bundled): Only require premium themes feature (Premium or higher plans)
@@ -282,6 +286,27 @@ export class Theme extends Component {
 
 		if ( didPurchaseTheme && ! isUsablePremiumTheme && ! isUsableBundledTheme ) {
 			return translate( 'You have purchased an annual subscription for this theme' );
+		} else if ( isExternallyManagedTheme && ! isSiteEligibleForManagedExternalThemes ) {
+			// This is a third-party theme but the user doesn't have an eligible plan.
+			return createInterpolateElement(
+				translate(
+					'This premium theme costs %(price)s per year and can only be purchased if you have the <Link>Business plan</Link> on your site.',
+					{
+						args: { price: theme.price },
+					}
+				),
+				{
+					Link: <LinkButton isLink onClick={ () => this.goToCheckout( 'business' ) } />,
+				}
+			);
+		} else if ( isExternallyManagedTheme && isSiteEligibleForManagedExternalThemes ) {
+			// This is a third-party theme and the user has an eligible plan.
+			return translate(
+				'This premium theme is only available while your current plan is active and costs %(price)s per year.',
+				{
+					args: { price: theme.price },
+				}
+			);
 		} else if ( isUsablePremiumTheme ) {
 			return translate( 'The premium theme is included in your plan.' );
 		} else if ( isUsableBundledTheme ) {
@@ -339,6 +364,7 @@ export class Theme extends Component {
 			didPurchaseTheme,
 			doesThemeBundleSoftwareSet,
 			isPremiumThemeAvailable,
+			isExternallyManagedTheme,
 		} = this.props;
 		const { name, description, screenshot } = theme;
 		const isActionable = this.props.screenshotClickUrl || this.props.onScreenshotClick;
@@ -392,8 +418,11 @@ export class Theme extends Component {
 		) : (
 			<div>
 				<div data-testid="upsell-header" className="theme__upsell-header">
-					{ ! doesThemeBundleSoftwareSet && translate( 'Premium theme' ) }
-					{ doesThemeBundleSoftwareSet && translate( 'WooCommerce theme' ) }
+					{ ( ! doesThemeBundleSoftwareSet || isExternallyManagedTheme ) &&
+						translate( 'Premium theme' ) }
+					{ doesThemeBundleSoftwareSet &&
+						! isExternallyManagedTheme &&
+						translate( 'WooCommerce theme' ) }
 				</div>
 				<div data-testid="upsell-message">{ this.getUpsellMessage() }</div>
 			</div>
@@ -530,6 +559,11 @@ export default connect(
 			siteSlug: getSiteSlug( state, siteId ),
 			didPurchaseTheme: isThemePurchased( state, theme.id, siteId ),
 			isPremiumThemeAvailable: getIsPremiumThemeAvailable( state, theme.id, siteId ),
+			isExternallyManagedTheme: getIsExternallyManagedTheme( state, theme.id ),
+			isSiteEligibleForManagedExternalThemes: getIsSiteEligibleForManagedExternalThemes(
+				state,
+				siteId
+			),
 		};
 	},
 	{ recordTracksEvent, setThemesBookmark, updateThemes }


### PR DESCRIPTION
#### Proposed Changes

When hovering over the ⭐️ icon for a theme in the showcase, we want to show different messages for third-party themes depending on if the user has a Business plan or not.

**Note: The copy for the tooltip may change so no string freeze yet.**

#### Testing Instructions

In order to test, we need to simulate a third-party theme. The easiest way to achieve this is to add the following to `0-sandbox.php` on your sandbox:

```
function test_theme_type( $theme ) {
	if ( $theme['id'] === 'varese' ) {
		$theme['theme_type'] = 'managed-external';
	}

	return $theme;
}

add_filter( 'wpcom_theme_api_meta', 'test_theme_type', 1000 );
```

This will make the Varese theme behave as if it were a third-party managed theme.

1. Apply the above change to your sandbox.
2. Sandbox `public-api.wordpress.com`.
3. Apply this PR to your local Calypso.
4. If using the calypso-live link below, you'll also need to enable the `themes/third-party-premium` flag.

**Free/Premium Test**
1. Create a free or premium site and go to `/theme/[site-slug]`.
1. Locate Varese and hover over the ⭐  icon. You should see something like the following:
![image](https://user-images.githubusercontent.com/917632/198731382-652fe270-a791-4d90-a92a-447441bfc20f.png)

**Business Test**
1. Create an Atomic site with a Business plan and go to `/theme/[site-slug]`.
1. Locate Varese and hover over the ⭐  icon. You should see something like the following:
![image](https://user-images.githubusercontent.com/917632/198731519-837bb442-3334-4e1d-a30f-5f306d93c425.png)


<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #69476
