### PR TITLE
SSR markup cache short-circuit

### DIFF
--- a/client/controller/shared.js
+++ b/client/controller/shared.js
@@ -16,7 +16,12 @@ export function makeLayoutMiddleware( LayoutComponent ) {
 			primary,
 			secondary,
 			showGdprBanner,
+			hasLayout,
 		} = context;
+		// Layout exists in the cache; no need to do extra work which won't be used.
+		if ( hasLayout ) {
+			return next();
+		}
 
 		// On server, only render LoggedOutLayout when logged-out.
 		if ( ! ( context.isServerSide && isUserLoggedIn( context.store.getState() ) ) ) {

--- a/client/controller/shared.js
+++ b/client/controller/shared.js
@@ -16,10 +16,10 @@ export function makeLayoutMiddleware( LayoutComponent ) {
 			primary,
 			secondary,
 			showGdprBanner,
-			hasLayout,
+			cachedMarkup,
 		} = context;
-		// Layout exists in the cache; no need to do extra work which won't be used.
-		if ( hasLayout ) {
+		// Markup exists in the cache; no need to do extra work which won't be used.
+		if ( cachedMarkup ) {
 			return next();
 		}
 

--- a/client/my-sites/plugins/controller-logged-out.js
+++ b/client/my-sites/plugins/controller-logged-out.js
@@ -119,9 +119,9 @@ const prefetchTimebox = ( prefetchPromises, context ) => {
 };
 
 export async function fetchPlugins( context, next ) {
-	const { queryClient, store, isServerSide, hasLayout } = context;
+	const { queryClient, store, isServerSide, cachedMarkup } = context;
 
-	if ( ! isServerSide || hasLayout ) {
+	if ( ! isServerSide || cachedMarkup ) {
 		return next();
 	}
 

--- a/client/my-sites/plugins/controller-logged-out.js
+++ b/client/my-sites/plugins/controller-logged-out.js
@@ -119,9 +119,9 @@ const prefetchTimebox = ( prefetchPromises, context ) => {
 };
 
 export async function fetchPlugins( context, next ) {
-	const { queryClient, store } = context;
+	const { queryClient, store, isServerSide, hasLayout } = context;
 
-	if ( ! context.isServerSide ) {
+	if ( ! isServerSide || hasLayout ) {
 		return next();
 	}
 

--- a/client/my-sites/theme/controller.jsx
+++ b/client/my-sites/theme/controller.jsx
@@ -9,7 +9,7 @@ import ThemeNotFoundError from './theme-not-found-error';
 const debug = debugFactory( 'calypso:themes' );
 
 export function fetchThemeDetailsData( context, next ) {
-	if ( ! context.isServerSide || context.hasLayout ) {
+	if ( ! context.isServerSide || context.cachedMarkup ) {
 		return next();
 	}
 

--- a/client/my-sites/theme/controller.jsx
+++ b/client/my-sites/theme/controller.jsx
@@ -9,7 +9,7 @@ import ThemeNotFoundError from './theme-not-found-error';
 const debug = debugFactory( 'calypso:themes' );
 
 export function fetchThemeDetailsData( context, next ) {
-	if ( ! context.isServerSide ) {
+	if ( ! context.isServerSide || context.hasLayout ) {
 		return next();
 	}
 

--- a/client/my-sites/themes/controller.jsx
+++ b/client/my-sites/themes/controller.jsx
@@ -43,7 +43,7 @@ export function loggedOut( context, next ) {
 }
 
 export function fetchThemeData( context, next ) {
-	if ( ! context.isServerSide || context.hasLayout ) {
+	if ( ! context.isServerSide || context.cachedMarkup ) {
 		debug( 'Skipping theme data fetch' );
 		return next();
 	}
@@ -73,7 +73,7 @@ export function fetchThemeData( context, next ) {
 }
 
 export function fetchThemeFilters( context, next ) {
-	if ( context.hasLayout ) {
+	if ( context.cachedMarkup ) {
 		debug( 'Skipping theme filter data fetch' );
 		return next();
 	}

--- a/client/my-sites/themes/controller.jsx
+++ b/client/my-sites/themes/controller.jsx
@@ -43,7 +43,8 @@ export function loggedOut( context, next ) {
 }
 
 export function fetchThemeData( context, next ) {
-	if ( ! context.isServerSide ) {
+	if ( ! context.isServerSide || context.hasLayout ) {
+		debug( 'Skipping theme data fetch' );
 		return next();
 	}
 
@@ -72,6 +73,11 @@ export function fetchThemeData( context, next ) {
 }
 
 export function fetchThemeFilters( context, next ) {
+	if ( context.hasLayout ) {
+		debug( 'Skipping theme filter data fetch' );
+		return next();
+	}
+
 	const { store } = context;
 	const hasFilters = Object.keys( getThemeFilters( store.getState() ) ).length > 0;
 

--- a/client/server/isomorphic-routing/index.js
+++ b/client/server/isomorphic-routing/index.js
@@ -13,12 +13,16 @@ export function serverRouter( expressApp, setUpRoute, section ) {
 		expressApp.get(
 			route,
 			( req, res, next ) => {
-				if ( markupCache.get( getCacheKey( req ) ) ) {
-					debug( 'Markup for request exists!' );
-					req.context.hasLayout = true;
+				const markup = markupCache.get( getCacheKey( req ) );
+				if ( markup ) {
+					req.context.cachedMarkup = markup;
 				}
 				req.context.usedSSRHandler = true;
-				debug( `Using SSR pipeline for path: ${ req.path } with handler ${ route }` );
+				debug(
+					`Using SSR pipeline for path: ${
+						req.path
+					} with handler ${ route }. Cached layout: ${ !! markup }`
+				);
 				next();
 			},
 			setUpRoute,

--- a/client/server/isomorphic-routing/index.js
+++ b/client/server/isomorphic-routing/index.js
@@ -2,7 +2,7 @@ import debugFactory from 'debug';
 import { isEmpty } from 'lodash';
 import { stringify } from 'qs';
 import { setSectionMiddleware } from 'calypso/controller';
-import { serverRender, setShouldServerSideRender } from 'calypso/server/render';
+import { serverRender, setShouldServerSideRender, markupCache } from 'calypso/server/render';
 import { createQueryClientSSR } from 'calypso/state/query-client-ssr';
 import { setRoute } from 'calypso/state/route/actions';
 
@@ -13,6 +13,10 @@ export function serverRouter( expressApp, setUpRoute, section ) {
 		expressApp.get(
 			route,
 			( req, res, next ) => {
+				if ( markupCache.get( getCacheKey( req ) ) ) {
+					debug( 'Markup for request exists!' );
+					req.context.hasLayout = true;
+				}
 				req.context.usedSSRHandler = true;
 				debug( `Using SSR pipeline for path: ${ req.path } with handler ${ route }` );
 				next();

--- a/client/server/render/index.js
+++ b/client/server/render/index.js
@@ -93,6 +93,7 @@ function render( element, key, req ) {
 		 * This should not happen -- if it does, we need to investigate and fix it.
 		 */
 		if ( req.context.hasLayout && ! renderedLayout ) {
+			debug( 'SSR layout mismatch!' );
 			throw new Error( 'SSR layout cache mismatch!' );
 		}
 
@@ -342,7 +343,7 @@ function isServerSideRenderCompatible( context ) {
 	return Boolean(
 		context.section?.isomorphic &&
 			! context.user && // logged out only
-			context.layout
+			( context.layout || context.hasLayout ) // A layout was generated or we have one cached.
 	);
 }
 


### PR DESCRIPTION
### Themes middleware performance
After recent PRs to log more data for poor server performance () and to log data around cache accesses (), we've discovered a few things:

1. The timeout happens at some point during the "theme" controller middleware, after the setup route middleware and before the render middleware.
2. The "get themes" cache has only around 20-30% cache hit rate. So for about 70% of requests to `/themes`, we're doing network requests for themes data.
3. The markup cache (including for the themes section) has a very high hit rate (e.g. 80+%). We're only rendering anything for around `20%` of requests to `/themes`.

Therefore, a relatively high number of requests to `/themes` ultimately use the markup cache, but still request theme data. That can't be helping the poor response times for this route. If we already have the layout cached, why do we even need to do a network request if the data isn't used?
 
### A solution

To get around this, what if we just short-circuit if we know we have the markup ready to go? My proposal:

1. Firstly, if markup for the request already exists, we add it to the request context under `context.cachedMarkup`. We have all the data to get this before starting the route-specific middleware.
2. For many middlewares which ultimately only exist to create the markup, we call `next()` to skip the route if `context.cachedMarkup` is truthy.

However, I'm making a big assumption: **all of these middlewares have no impact on the data sent to the client if the markup already exists** This assumption might be false, and I'd appreciate if anyone could help answer that.

At the same time, I think this should be relatively safe because if SSR fails, the client can still render the page. (The entire pipeline is setup so that at any point, SSR can just _not_ happen and it will still work fine.)

### Testing

1. `DEBUG=calypso:themes,calypso:pages,calypso:server-render yarn start`
2. Access `calypso.localhost:3000/themes` in a private window (logged out)
3. At first, you should see "Using SSR pipeline for path" in the logs, with no reference to the layout.
4. Refresh the page -- this time the cache should be used.
5. You should see messages about the markup existing, as well as that we're skipping the theme data fetch


