### PR TITLE
Avoid logging static requests in dev mode

### DIFF
--- a/client/server/lib/is-static-request/index.ts
+++ b/client/server/lib/is-static-request/index.ts
@@ -1,0 +1,24 @@
+type PartialReq = {
+	originalUrl: string;
+};
+
+const STATIC_PATHS = [
+	'/calypso/',
+	'/service-worker',
+	'/nostats.js',
+	'/version',
+	'/__webpack_hmr',
+];
+
+/**
+ * Returns true if the request is to a static file, like JS bundles.
+ *
+ * @param req The express request object
+ */
+export default function isStaticRequest( req: PartialReq ) {
+	if ( ! req?.originalUrl ) {
+		return false;
+	}
+
+	return STATIC_PATHS.some( ( path ) => req.originalUrl.startsWith( path ) );
+}

--- a/client/server/lib/is-static-request/test/index.js
+++ b/client/server/lib/is-static-request/test/index.js
@@ -1,0 +1,18 @@
+import isStaticRequest from '..';
+
+describe( 'isStaticRequest', () => {
+	it( "returns false if original URL doesn't exist", () => {
+		expect( isStaticRequest( {} ) ).toBe( false );
+		expect( isStaticRequest( null ) ).toBe( false );
+	} );
+
+	it( 'returns true if original URL is static', () => {
+		expect( isStaticRequest( { originalUrl: '/calypso/hello' } ) ).toBe( true );
+		expect( isStaticRequest( { originalUrl: '/__webpack_hmr' } ) ).toBe( true );
+	} );
+
+	it( 'returns false if original URL is not static', () => {
+		expect( isStaticRequest( { originalUrl: '/home' } ) ).toBe( false );
+		expect( isStaticRequest( { originalUrl: '/post/xyz.wordpress.com' } ) ).toBe( false );
+	} );
+} );

--- a/client/server/middleware/logger.js
+++ b/client/server/middleware/logger.js
@@ -1,6 +1,7 @@
 import config from '@automattic/calypso-config';
 import uaParser from 'ua-parser-js';
 import { v4 as uuidv4 } from 'uuid';
+import isStaticRequest from 'calypso/server/lib/is-static-request';
 import { getLogger } from 'calypso/server/lib/logger';
 import { finalizePerfMarks } from 'calypso/server/lib/performance-mark';
 
@@ -17,6 +18,11 @@ const parseUA = ( rawUA ) => {
 
 const logRequest = ( req, res, options ) => {
 	const { requestStart } = options;
+
+	// Let's not log static file requests in dev mode, since it adds a ton of unhelpful noise.
+	if ( process.env.NODE_ENV === 'development' && isStaticRequest( req ) ) {
+		return;
+	}
 
 	const message = res.finished ? 'request finished' : 'request closed';
 	// Duration in ms.

--- a/client/server/middleware/profiler.js
+++ b/client/server/middleware/profiler.js
@@ -2,6 +2,7 @@ const fs = require( 'fs' );
 const path = require( 'path' );
 const chalk = require( 'chalk' );
 const v8Profiler = require( 'v8-profiler-next' );
+const { default: isStaticRequest } = require( 'calypso/server/lib/is-static-request' );
 
 /**
  * This should be dynamically imported:
@@ -30,15 +31,7 @@ module.exports = () => {
 	return ( req, res, next ) => {
 		// Avoid profiling certain requests (like for static files) and don't
 		// start profiling if we already are.
-		if (
-			isProfiling ||
-			! req.originalUrl.startsWith( '/' ) ||
-			req.originalUrl.startsWith( '/calypso/' ) ||
-			req.originalUrl.startsWith( '/service-worker' ) ||
-			req.originalUrl.startsWith( '/nostats.js' ) ||
-			req.originalUrl.startsWith( '/version' ) ||
-			req.originalUrl.startsWith( '/__webpack_hmr' )
-		) {
+		if ( isProfiling || ! req.originalUrl.startsWith( '/' ) || isStaticRequest( req ) ) {
 			next();
 			return;
 		}

--- a/client/server/middleware/test/logger.js
+++ b/client/server/middleware/test/logger.js
@@ -177,4 +177,43 @@ describe( 'Logger middleware', () => {
 			} )
 		);
 	} );
+
+	it( 'Does not log static requests in dev mode', () => {
+		const oldNodeEnv = process.env.NODE_ENV;
+		process.env.NODE_ENV = 'development';
+		simulateRequest( {
+			req: fakeRequest( {
+				url: '/calypso/abc',
+			} ),
+			res: fakeResponse(),
+		} );
+		process.env.NODE_ENV = oldNodeEnv;
+		expect( requestLogger.info ).not.toBeCalled();
+	} );
+
+	it( 'Does not log non-static requests in dev mode', () => {
+		const oldNodeEnv = process.env.NODE_ENV;
+		process.env.NODE_ENV = 'development';
+		simulateRequest( {
+			req: fakeRequest( {
+				url: '/home',
+			} ),
+			res: fakeResponse(),
+		} );
+		process.env.NODE_ENV = oldNodeEnv;
+		expect( requestLogger.info ).toBeCalled();
+	} );
+
+	it( 'Does log static requests in non-dev mode', () => {
+		const oldNodeEnv = process.env.NODE_ENV;
+		process.env.NODE_ENV = 'foo';
+		simulateRequest( {
+			req: fakeRequest( {
+				url: '/calypso/abc',
+			} ),
+			res: fakeResponse(),
+		} );
+		process.env.NODE_ENV = oldNodeEnv;
+		expect( requestLogger.info ).toBeCalled();
+	} );
 } );


### PR DESCRIPTION
#### Proposed Changes
When running Calypso locally, the terminal log is very verbose and therefore unhelpful. I'm often looking for one or two items in the log (such as from debug), but they can be hard to find because the log is overwhelmed with requests to JS bundles.

I propose to avoid logging these static requests in dev mode, and just log the main request. This will make it easier to debug errors and log output which occur near that "main request" but often get hidden by the other request logs.

#### Testing Instructions
Run calypso locally and verify that the terminal log is less verbose.