### PR TITLE
Hide "Edit" and "Remove" buttons from the checkout line item when rendered in a Woo mobile webview

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
@@ -171,16 +171,18 @@ function LineItemWrapper( {
 	const variants = useGetProductVariants( siteId, product.product_slug );
 	const areThereVariants = variants.length > 1;
 
+	const isWooMobile = isWcMobileApp();
+	const isDeletable = canItemBeRemovedFromCart( product, responseCart ) && ! isWooMobile;
+
 	const isJetpack = responseCart.products.some( ( product ) =>
 		isJetpackPurchasableItem( product.product_slug )
 	);
-	const isWooMobile = isWcMobileApp();
 
 	return (
 		<WPOrderReviewListItem key={ product.uuid }>
 			<LineItem
 				product={ product }
-				hasDeleteButton={ canItemBeRemovedFromCart( product, responseCart ) }
+				hasDeleteButton={ isDeletable }
 				removeProductFromCart={ removeProductFromCart }
 				isSummary={ isSummary }
 				createUserAndSiteBeforeTransaction={ createUserAndSiteBeforeTransaction }

--- a/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
@@ -15,6 +15,7 @@ import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import { hasDIFMProduct } from 'calypso/lib/cart-values/cart-items';
+import { isWcMobileApp } from 'calypso/lib/mobile-app';
 import { useGetProductVariants } from 'calypso/my-sites/checkout/composite-checkout/hooks/product-variants';
 import { ItemVariationPicker } from './item-variation-picker';
 import type { OnChangeItemVariant } from './item-variation-picker';
@@ -173,6 +174,7 @@ function LineItemWrapper( {
 	const isJetpack = responseCart.products.some( ( product ) =>
 		isJetpackPurchasableItem( product.product_slug )
 	);
+	const isWooMobile = isWcMobileApp();
 
 	return (
 		<WPOrderReviewListItem key={ product.uuid }>
@@ -188,7 +190,7 @@ function LineItemWrapper( {
 				onRemoveProductClick={ onRemoveProductClick }
 				onRemoveProductCancel={ onRemoveProductCancel }
 			>
-				{ ! isJetpack && areThereVariants && shouldShowVariantSelector && ! isEditingTerm && (
+				{ ! isJetpack && ! isWooMobile && shouldShowVariantSelector && ! isEditingTerm && (
 					<TermVariantEditButton onClick={ () => setEditingTerm( true ) } />
 				) }
 				{ areThereVariants && shouldShowVariantSelector && ( isJetpack || isEditingTerm ) && (

--- a/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
@@ -192,9 +192,11 @@ function LineItemWrapper( {
 				onRemoveProductClick={ onRemoveProductClick }
 				onRemoveProductCancel={ onRemoveProductCancel }
 			>
-				{ ! isJetpack && ! isWooMobile && shouldShowVariantSelector && ! isEditingTerm && (
-					<TermVariantEditButton onClick={ () => setEditingTerm( true ) } />
-				) }
+				{ ! isJetpack &&
+					! isWooMobile &&
+					areThereVariants &&
+					shouldShowVariantSelector &&
+					! isEditingTerm && <TermVariantEditButton onClick={ () => setEditingTerm( true ) } /> }
 				{ areThereVariants && shouldShowVariantSelector && ( isJetpack || isEditingTerm ) && (
 					<ItemVariationPicker
 						selectedItem={ product }

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout-variant-picker.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout-variant-picker.tsx
@@ -27,6 +27,7 @@ import {
 	getPlansItemsState,
 	createTestReduxStore,
 	countryList,
+	mockUserAgent,
 } from './util';
 
 jest.mock( 'calypso/lib/analytics/utils/refresh-country-code-cookie-gdpr' );
@@ -310,6 +311,20 @@ describe( 'CheckoutMain with a variant picker', () => {
 	it( 'does not render the variant picker for a renewal of the current plan', async () => {
 		const currentPlanRenewal = { ...planWithoutDomain, extra: { purchaseType: 'renewal' } };
 		const cartChanges = { products: [ currentPlanRenewal ] };
+		render( <MyCheckout cartChanges={ cartChanges } /> );
+
+		await expect(
+			screen.findByLabelText( 'Change the billing term for this product' )
+		).toNeverAppear();
+	} );
+
+	it( 'does not render the variant picker when userAgent is Woo mobile', async () => {
+		getPlansBySiteId.mockImplementation( () => ( {
+			data: getActivePersonalPlanDataForType( 'none' ),
+		} ) );
+		const cartChanges = { products: [ getBusinessPlanForInterval( 'yearly' ) ] };
+
+		mockUserAgent( 'wc-ios' );
 		render( <MyCheckout cartChanges={ cartChanges } /> );
 
 		await expect(

--- a/client/my-sites/checkout/composite-checkout/test/util/index.ts
+++ b/client/my-sites/checkout/composite-checkout/test/util/index.ts
@@ -1063,3 +1063,11 @@ expect.extend( {
 		};
 	},
 } );
+
+export function mockUserAgent( agent ) {
+	Object.defineProperty( window.navigator, 'userAgent', {
+		get() {
+			return agent;
+		},
+	} );
+}


### PR DESCRIPTION
#### Proposed Changes

When a Woo mobile app user is going through the flow to set up a new store, they need to purchase the wpcom plan for ecommerce. During this step, the composite checkout has "Edit" and "Remove" buttons on the plan line item, but if the user interacts with either of these, it will break the flow. This change employs user agent detection to conditionally hide these buttons when the checkout is rendered in a Woo mobile app webview.

Additional context: https://github.com/woocommerce/team-ghidorah/issues/109#3

#### Testing Instructions

1. On calypso.live, proceed through the process of adding a plan to a site until you get to checkout step 2
2. The plan line item should have buttons to Edit and Remove from cart
  ![line-item-with-buttons](https://user-images.githubusercontent.com/916023/198776130-607c1cf1-933f-4428-97be-07508700bd4d.jpg)
3. Change the userAgent of the browser to `wc-ios` or `wc-android` (I use [User-Agent Switcher](https://addons.mozilla.org/en-US/firefox/addon/uaswitcher/) in Firefox)
4. Refresh the screen. Now the buttons should not render
  ![line-item-without-buttons](https://user-images.githubusercontent.com/916023/198777364-c6bcc72f-0c72-466b-863c-cdcc79852227.jpg)


#### Pre-merge Checklist

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
