### PR TITLE
Launchpad: Make copy to clipboard button keyboard navigable

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
@@ -125,18 +125,30 @@
 		padding-right: 12px;
 	}
 
+	// TODO: Fix layout shifting with this padding-right property
 	.launchpad__url-box-domain:hover > .launchpad__url-box-domain-text {
 		padding-right: 0;
 	}
 
 	.launchpad__url-box-domain:hover > .launchpad__clipboard-button {
-		display: block;
+		position: inherit;
+		top: 0;
+	}
+
+	.launchpad__url-box-domain-text + .launchpad__clipboard-button:focus {
+		padding-right: 0;
+	}
+
+	.launchpad__clipboard-button:focus {
+		position: inherit;
+		top: 0;
 	}
 
 	.launchpad__clipboard-button {
 		padding-left: 8px;
 		padding-right: 8px;
-		display: none;
+		position: absolute;
+		top: -1000em;
 		min-width: 34px;
 	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
@@ -125,18 +125,9 @@
 		padding-right: 12px;
 	}
 
-	// TODO: Fix layout shifting with this padding-right property
-	.launchpad__url-box-domain:hover > .launchpad__url-box-domain-text {
-		padding-right: 0;
-	}
-
 	.launchpad__url-box-domain:hover > .launchpad__clipboard-button {
 		position: inherit;
 		top: 0;
-	}
-
-	.launchpad__url-box-domain-text + .launchpad__clipboard-button:focus {
-		padding-right: 0;
 	}
 
 	.launchpad__clipboard-button:focus {


### PR DESCRIPTION
### Proposed Changes

* Copy to clipboard button is visually hidden but can be focused by keyboard

### GIF
![2022-10-31 11 41 11](https://user-images.githubusercontent.com/5414230/199084842-f83ebd39-cef2-4622-a1d6-55aafda75b5b.gif)

### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
* Check out this PR
* Create new, _**free**_ site through tailored flow https://wordpress.com/hp-2022-tailored-flows/
* Complete steps until at the Launchpad screen
* Verify that the clipboard button is keyboard navigable
* Repeat previous steps but with an excessively long domain name

### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/68967
