### PR TITLE
Implement white login for all /log-in routes

### DIFF
--- a/client/blocks/login/error-notice.jsx
+++ b/client/blocks/login/error-notice.jsx
@@ -23,7 +23,6 @@ class ErrorNotice extends Component {
 		requestAccountError: PropTypes.object,
 		requestError: PropTypes.object,
 		twoFactorAuthRequestError: PropTypes.object,
-		isGutenboarding: PropTypes.bool.isRequired,
 		locale: PropTypes.string,
 	};
 
@@ -62,17 +61,10 @@ class ErrorNotice extends Component {
 	}
 
 	getSignupUrl() {
-		const { currentQuery, currentRoute, oauth2Client, locale, isGutenboarding } = this.props;
+		const { currentQuery, currentRoute, oauth2Client, locale } = this.props;
 		const { pathname } = getUrlParts( window.location.href );
 
-		return getSignupUrl(
-			currentQuery,
-			currentRoute,
-			oauth2Client,
-			locale,
-			pathname,
-			isGutenboarding
-		);
+		return getSignupUrl( currentQuery, currentRoute, oauth2Client, locale, pathname );
 	}
 
 	render() {

--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -50,7 +50,7 @@ class Login extends Component {
 		disableAutoFocus: PropTypes.bool,
 		isLinking: PropTypes.bool,
 		isJetpack: PropTypes.bool.isRequired,
-		isGutenboarding: PropTypes.bool.isRequired,
+		isWhiteLogin: PropTypes.bool.isRequired,
 		isJetpackWooCommerceFlow: PropTypes.bool.isRequired,
 		isManualRenewalImmediateLoginAttempt: PropTypes.bool,
 		linkingSocialService: PropTypes.string,
@@ -83,7 +83,7 @@ class Login extends Component {
 
 	static defaultProps = {
 		isJetpack: false,
-		isGutenboarding: false,
+		isWhiteLogin: false,
 		isJetpackWooCommerceFlow: false,
 	};
 
@@ -163,7 +163,7 @@ class Login extends Component {
 			page(
 				login( {
 					isJetpack: this.props.isJetpack,
-					isGutenboarding: this.props.isGutenboarding,
+					isWhiteLogin: this.props.isWhiteLogin,
 					// If no notification is sent, the user is using the authenticator for 2FA by default
 					twoFactorAuthType: authType,
 					locale: this.props.locale,
@@ -220,16 +220,8 @@ class Login extends Component {
 	};
 
 	getSignupUrl = () => {
-		const {
-			currentRoute,
-			oauth2Client,
-			currentQuery,
-			pathname,
-			locale,
-			isGutenboarding,
-			signupUrl,
-			isWoo,
-		} = this.props;
+		const { currentRoute, oauth2Client, currentQuery, pathname, locale, signupUrl, isWoo } =
+			this.props;
 
 		if ( signupUrl ) {
 			return signupUrl;
@@ -240,20 +232,13 @@ class Login extends Component {
 			return 'https://woocommerce.com/start/';
 		}
 
-		return getSignupUrl(
-			currentQuery,
-			currentRoute,
-			oauth2Client,
-			locale,
-			pathname,
-			isGutenboarding
-		);
+		return getSignupUrl( currentQuery, currentRoute, oauth2Client, locale, pathname );
 	};
 
 	renderHeader() {
 		const {
 			isJetpack,
-			isGutenboarding,
+			isWhiteLogin,
 			isJetpackWooCommerceFlow,
 			isP2Login,
 			wccomFrom,
@@ -450,7 +435,7 @@ class Login extends Component {
 			);
 		}
 
-		if ( isGutenboarding ) {
+		if ( isWhiteLogin ) {
 			preHeader = (
 				<div className="login__form-gutenboarding-wordpress-logo">
 					<svg
@@ -495,7 +480,7 @@ class Login extends Component {
 		const {
 			domain,
 			isJetpack,
-			isGutenboarding,
+			isWhiteLogin,
 			isP2Login,
 			privateSite,
 			twoFactorAuthType,
@@ -553,7 +538,7 @@ class Login extends Component {
 						require="calypso/blocks/login/two-factor-authentication/two-factor-content"
 						isBrowserSupported={ this.state.isBrowserSupported }
 						isJetpack={ isJetpack }
-						isGutenboarding={ isGutenboarding }
+						isWhiteLogin={ isWhiteLogin }
 						isWoo={ isWoo }
 						isPartnerSignup={ isPartnerSignup }
 						twoFactorAuthType={ twoFactorAuthType }
@@ -608,7 +593,7 @@ class Login extends Component {
 							socialService={ socialService }
 							socialServiceResponse={ socialServiceResponse }
 							domain={ domain }
-							isGutenboarding={ isGutenboarding }
+							isWhiteLogin={ isWhiteLogin }
 							isP2Login={ isP2Login }
 							locale={ locale }
 							userEmail={ userEmail }
@@ -632,7 +617,7 @@ class Login extends Component {
 				socialService={ socialService }
 				socialServiceResponse={ socialServiceResponse }
 				domain={ domain }
-				isGutenboarding={ isGutenboarding }
+				isWhiteLogin={ isWhiteLogin }
 				isP2Login={ isP2Login }
 				locale={ locale }
 				userEmail={ userEmail }
@@ -647,7 +632,7 @@ class Login extends Component {
 	}
 
 	render() {
-		const { isJetpack, oauth2Client, locale, isGutenboarding } = this.props;
+		const { isJetpack, oauth2Client, locale, isWhiteLogin } = this.props;
 		return (
 			<div
 				className={ classNames( 'login', {
@@ -657,7 +642,7 @@ class Login extends Component {
 			>
 				{ this.renderHeader() }
 
-				<ErrorNotice locale={ locale } isGutenboarding={ isGutenboarding } />
+				<ErrorNotice locale={ locale } isWhiteLogin={ isWhiteLogin } />
 
 				{ this.renderNotice() }
 

--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -163,7 +163,6 @@ class Login extends Component {
 			page(
 				login( {
 					isJetpack: this.props.isJetpack,
-					isWhiteLogin: this.props.isWhiteLogin,
 					// If no notification is sent, the user is using the authenticator for 2FA by default
 					twoFactorAuthType: authType,
 					locale: this.props.locale,

--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -479,7 +479,6 @@ class Login extends Component {
 		const {
 			domain,
 			isJetpack,
-			isWhiteLogin,
 			isP2Login,
 			privateSite,
 			twoFactorAuthType,
@@ -537,7 +536,6 @@ class Login extends Component {
 						require="calypso/blocks/login/two-factor-authentication/two-factor-content"
 						isBrowserSupported={ this.state.isBrowserSupported }
 						isJetpack={ isJetpack }
-						isWhiteLogin={ isWhiteLogin }
 						isWoo={ isWoo }
 						isPartnerSignup={ isPartnerSignup }
 						twoFactorAuthType={ twoFactorAuthType }
@@ -592,7 +590,6 @@ class Login extends Component {
 							socialService={ socialService }
 							socialServiceResponse={ socialServiceResponse }
 							domain={ domain }
-							isWhiteLogin={ isWhiteLogin }
 							isP2Login={ isP2Login }
 							locale={ locale }
 							userEmail={ userEmail }
@@ -616,7 +613,6 @@ class Login extends Component {
 				socialService={ socialService }
 				socialServiceResponse={ socialServiceResponse }
 				domain={ domain }
-				isWhiteLogin={ isWhiteLogin }
 				isP2Login={ isP2Login }
 				locale={ locale }
 				userEmail={ userEmail }
@@ -631,7 +627,7 @@ class Login extends Component {
 	}
 
 	render() {
-		const { isJetpack, oauth2Client, locale, isWhiteLogin } = this.props;
+		const { isJetpack, oauth2Client, locale } = this.props;
 		return (
 			<div
 				className={ classNames( 'login', {
@@ -641,7 +637,7 @@ class Login extends Component {
 			>
 				{ this.renderHeader() }
 
-				<ErrorNotice locale={ locale } isWhiteLogin={ isWhiteLogin } />
+				<ErrorNotice locale={ locale } />
 
 				{ this.renderNotice() }
 

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -76,7 +76,6 @@ export class LoginForm extends Component {
 		socialServiceResponse: PropTypes.object,
 		translate: PropTypes.func.isRequired,
 		userEmail: PropTypes.string,
-		isWhiteLogin: PropTypes.bool,
 		isPartnerSignup: PropTypes.bool,
 		locale: PropTypes.string,
 		showSocialLoginFormOnly: PropTypes.bool,

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -76,7 +76,7 @@ export class LoginForm extends Component {
 		socialServiceResponse: PropTypes.object,
 		translate: PropTypes.func.isRequired,
 		userEmail: PropTypes.string,
-		isGutenboarding: PropTypes.bool,
+		isWhiteLogin: PropTypes.bool,
 		isPartnerSignup: PropTypes.bool,
 		locale: PropTypes.string,
 		showSocialLoginFormOnly: PropTypes.bool,
@@ -544,7 +544,6 @@ export class LoginForm extends Component {
 			requestError,
 			socialAccountIsLinking: linkingSocialUser,
 			isJetpackWooCommerceFlow,
-			isGutenboarding,
 			isP2Login,
 			isJetpackWooDnaFlow,
 			wccomFrom,
@@ -561,7 +560,7 @@ export class LoginForm extends Component {
 
 		const signupUrl = this.props.signupUrl
 			? window.location.origin + pathWithLeadingSlash( this.props.signupUrl )
-			: getSignupUrl( currentQuery, currentRoute, oauth2Client, locale, pathname, isGutenboarding );
+			: getSignupUrl( currentQuery, currentRoute, oauth2Client, locale, pathname );
 
 		const socialToS = this.props.translate(
 			// To make any changes to this copy please speak to the legal team

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -186,7 +186,12 @@
 	}
 
 	.visit-site {
-		margin: -12px 0 24px;
+		margin: 12px 0 24px;
+		text-align: left;
+
+		@include break-mobile {
+			text-align: center;
+		}
 	}
 }
 

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -166,7 +166,9 @@ export default withCurrentRoute(
 		const isPartnerSignup = isPartnerSignupQuery( currentQuery );
 		const isPartnerSignupStart = currentRoute.startsWith( '/start/wpcc' );
 		const isReskinLoginRoute =
-			currentRoute.endsWith( 'log-in' ) && Boolean( currentQuery?.client_id ) === false;
+			currentRoute.startsWith( '/log-in' ) &&
+			! isJetpackLogin &&
+			Boolean( currentQuery?.client_id ) === false;
 		const isWhiteLogin = isReskinLoginRoute || ( isPartnerSignup && ! isPartnerSignupStart );
 		const isJetpackWooDnaFlow = wooDnaConfig( getInitialQueryArguments( state ) ).isWooDnaFlow();
 		const isP2Login = 'login' === sectionName && 'p2' === currentQuery?.from;

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -166,7 +166,7 @@ export default withCurrentRoute(
 		const isPartnerSignup = isPartnerSignupQuery( currentQuery );
 		const isPartnerSignupStart = currentRoute.startsWith( '/start/wpcc' );
 		const isWhiteLogin =
-			currentRoute.startsWith( '/log-in/new' ) || ( isPartnerSignup && ! isPartnerSignupStart );
+			currentRoute.startsWith( '/log-in' ) || ( isPartnerSignup && ! isPartnerSignupStart );
 		const isJetpackWooDnaFlow = wooDnaConfig( getInitialQueryArguments( state ) ).isWooDnaFlow();
 		const isP2Login = 'login' === sectionName && 'p2' === currentQuery?.from;
 		const noMasterbarForRoute =

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -165,9 +165,9 @@ export default withCurrentRoute(
 		const isJetpackLogin = currentRoute.startsWith( '/log-in/jetpack' );
 		const isPartnerSignup = isPartnerSignupQuery( currentQuery );
 		const isPartnerSignupStart = currentRoute.startsWith( '/start/wpcc' );
-		const isLoginRoute =
-			currentRoute.startsWith( '/log-in' ) && Boolean( currentQuery?.client_id ) === false;
-		const isWhiteLogin = isLoginRoute || ( isPartnerSignup && ! isPartnerSignupStart );
+		const isReskinLoginRoute =
+			currentRoute.endsWith( 'log-in' ) && Boolean( currentQuery?.client_id ) === false;
+		const isWhiteLogin = isReskinLoginRoute || ( isPartnerSignup && ! isPartnerSignupStart );
 		const isJetpackWooDnaFlow = wooDnaConfig( getInitialQueryArguments( state ) ).isWooDnaFlow();
 		const isP2Login = 'login' === sectionName && 'p2' === currentQuery?.from;
 		const noMasterbarForRoute =

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -165,13 +165,14 @@ export default withCurrentRoute(
 		const isJetpackLogin = currentRoute.startsWith( '/log-in/jetpack' );
 		const isPartnerSignup = isPartnerSignupQuery( currentQuery );
 		const isPartnerSignupStart = currentRoute.startsWith( '/start/wpcc' );
+		const isJetpackWooDnaFlow = wooDnaConfig( getInitialQueryArguments( state ) ).isWooDnaFlow();
+		const isP2Login = 'login' === sectionName && 'p2' === currentQuery?.from;
 		const isReskinLoginRoute =
 			currentRoute.startsWith( '/log-in' ) &&
 			! isJetpackLogin &&
+			! isP2Login &&
 			Boolean( currentQuery?.client_id ) === false;
 		const isWhiteLogin = isReskinLoginRoute || ( isPartnerSignup && ! isPartnerSignupStart );
-		const isJetpackWooDnaFlow = wooDnaConfig( getInitialQueryArguments( state ) ).isWooDnaFlow();
-		const isP2Login = 'login' === sectionName && 'p2' === currentQuery?.from;
 		const noMasterbarForRoute =
 			isJetpackLogin || ( isWhiteLogin && ! isPartnerSignup ) || isJetpackWooDnaFlow || isP2Login;
 		const isPopup = '1' === currentQuery?.is_popup;

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -165,8 +165,9 @@ export default withCurrentRoute(
 		const isJetpackLogin = currentRoute.startsWith( '/log-in/jetpack' );
 		const isPartnerSignup = isPartnerSignupQuery( currentQuery );
 		const isPartnerSignupStart = currentRoute.startsWith( '/start/wpcc' );
-		const isWhiteLogin =
-			currentRoute.startsWith( '/log-in' ) || ( isPartnerSignup && ! isPartnerSignupStart );
+		const isLoginRoute =
+			currentRoute.startsWith( '/log-in' ) && Boolean( currentQuery?.client_id ) === false;
+		const isWhiteLogin = isLoginRoute || ( isPartnerSignup && ! isPartnerSignupStart );
 		const isJetpackWooDnaFlow = wooDnaConfig( getInitialQueryArguments( state ) ).isWooDnaFlow();
 		const isP2Login = 'login' === sectionName && 'p2' === currentQuery?.from;
 		const noMasterbarForRoute =

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -143,7 +143,8 @@
 		line-height: 20px;
 	}
 
-	.button.is-primary {
+	.button.is-primary,
+	.login .button.is-primary {
 		background: $woo-purple-60;
 		border: none;
 		color: #fff;

--- a/client/lib/login/index.js
+++ b/client/lib/login/index.js
@@ -43,14 +43,7 @@ export function pathWithLeadingSlash( path ) {
 	return path ? `/${ path.replace( /^\/+/, '' ) }` : '';
 }
 
-export function getSignupUrl(
-	currentQuery,
-	currentRoute,
-	oauth2Client,
-	locale,
-	pathname,
-	isGutenboarding
-) {
+export function getSignupUrl( currentQuery, currentRoute, oauth2Client, locale, pathname ) {
 	let signupUrl = config( 'signup_url' );
 
 	const redirectTo = get( currentQuery, 'redirect_to', '' );
@@ -108,17 +101,6 @@ export function getSignupUrl(
 			oauth2Params.set( 'wccom-from', wccomFrom );
 		}
 		signupUrl = `${ signupUrl }/wpcc?${ oauth2Params.toString() }`;
-	}
-
-	if ( isGutenboarding ) {
-		const langFragment = locale && locale !== 'en' ? `/${ locale }` : '';
-		const defaultSignupUrl = `/new/plans${ langFragment }?signup`;
-		signupUrl = get( currentQuery, 'signup_url', defaultSignupUrl );
-
-		// Sanitize the url if it doesn't start with /new
-		if ( ! startsWith( signupUrl, '/new' ) ) {
-			signupUrl = defaultSignupUrl;
-		}
 	}
 
 	if ( oauth2Client && isJetpackCloudOAuth2Client( oauth2Client ) ) {

--- a/client/lib/paths/login/index.js
+++ b/client/lib/paths/login/index.js
@@ -4,8 +4,6 @@ import { addQueryArgs } from 'calypso/lib/url';
 /**
  * @param {{
 	isJetpack?: boolean;
-	isGutenboarding?: boolean;
-	isWhiteLogin?: boolean;
 	locale?: string;
 	redirectTo?: string;
 	twoFactorAuthType?: string;
@@ -24,8 +22,6 @@ import { addQueryArgs } from 'calypso/lib/url';
  */
 export function login( {
 	isJetpack = undefined,
-	isGutenboarding = undefined,
-	isWhiteLogin = undefined,
 	locale = undefined,
 	redirectTo = undefined,
 	twoFactorAuthType = undefined,
@@ -50,16 +46,12 @@ export function login( {
 		url += '/' + socialService + '/callback';
 	} else if ( twoFactorAuthType && isJetpack ) {
 		url += '/jetpack/' + twoFactorAuthType;
-	} else if ( twoFactorAuthType && ( isGutenboarding || isWhiteLogin ) ) {
-		url += '/new/' + twoFactorAuthType;
 	} else if ( twoFactorAuthType ) {
 		url += '/' + twoFactorAuthType;
 	} else if ( socialConnect ) {
 		url += '/social-connect';
 	} else if ( isJetpack ) {
 		url += '/jetpack';
-	} else if ( isGutenboarding || isWhiteLogin ) {
-		url += '/new';
 	} else if ( useMagicLink ) {
 		url += '/link';
 	} else if ( useQRCode ) {

--- a/client/lib/paths/login/test/index.js
+++ b/client/lib/paths/login/test/index.js
@@ -38,11 +38,6 @@ describe( 'login', () => {
 		expect( url ).toBe( '/log-in/jetpack?from=potato' );
 	} );
 
-	test( 'should return the login url for Gutenboarding specific login', () => {
-		const url = login( { isGutenboarding: true } );
-		expect( url ).toBe( '/log-in/new' );
-	} );
-
 	test( 'should return the login url with WooCommerce.com handler', () => {
 		const url = login( { oauth2ClientId: 12345, wccomFrom: 'testing' } );
 		expect( url ).toBe( '/log-in?client_id=12345&wccom-from=testing' );

--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -12,7 +12,7 @@ import WPLogin from './wp-login';
 
 const enhanceContextWithLogin = ( context ) => {
 	const {
-		params: { flow, isJetpack, isGutenboarding, socialService, twoFactorAuthType, action },
+		params: { flow, isJetpack, socialService, twoFactorAuthType, action },
 		path,
 		query,
 		isServerSide,
@@ -50,7 +50,9 @@ const enhanceContextWithLogin = ( context ) => {
 		<WPLogin
 			action={ action }
 			isJetpack={ isJetpack === 'jetpack' }
-			isGutenboarding={ isGutenboarding === 'new' }
+			isWhiteLogin={
+				Boolean( query?.client_id ) === false || Boolean( query?.oauth2_client_id ) === false
+			}
 			isP2Login={ query && query.from === 'p2' }
 			path={ path }
 			twoFactorAuthType={ twoFactorAuthType }

--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -45,15 +45,20 @@ const enhanceContextWithLogin = ( context ) => {
 	const socialServiceResponse = client_id
 		? { client_id, user_email, user_name, id_token, state }
 		: null;
+	const isJetpackLogin = isJetpack === 'jetpack';
+	const isP2Login = query && query.from === 'p2';
+	const isWhiteLogin =
+		! isJetpackLogin &&
+		! isP2Login &&
+		Boolean( query?.client_id ) === false &&
+		Boolean( query?.oauth2_client_id ) === false;
 
 	context.primary = (
 		<WPLogin
 			action={ action }
-			isJetpack={ isJetpack === 'jetpack' }
-			isWhiteLogin={
-				Boolean( query?.client_id ) === false || Boolean( query?.oauth2_client_id ) === false
-			}
-			isP2Login={ query && query.from === 'p2' }
+			isJetpack={ isJetpackLogin }
+			isWhiteLogin={ isWhiteLogin }
+			isP2Login={ isP2Login }
 			path={ path }
 			twoFactorAuthType={ twoFactorAuthType }
 			socialService={ socialService }

--- a/client/login/magic-login/index.jsx
+++ b/client/login/magic-login/index.jsx
@@ -55,7 +55,6 @@ class MagicLogin extends Component {
 
 		const loginParameters = {
 			isJetpack: this.props.isJetpackLogin,
-			isGutenboarding: true,
 			locale: this.props.locale,
 			emailAddress: this.props.query?.email_address,
 			signupUrl: this.props.query?.signup_url,
@@ -67,7 +66,7 @@ class MagicLogin extends Component {
 	renderLinks() {
 		const { isJetpackLogin, locale, showCheckYourEmail, translate } = this.props;
 
-		if ( showCheckYourEmail ) {
+		if ( showCheckYourEmail || this.props.query?.client_id ) {
 			return null;
 		}
 
@@ -77,7 +76,6 @@ class MagicLogin extends Component {
 		// paste somewhere else, their email address isn't included in it.
 		const loginParameters = {
 			isJetpack: isJetpackLogin,
-			isGutenboarding: true,
 			locale: locale,
 			signupUrl: this.props.query?.signup_url,
 		};

--- a/client/login/magic-login/index.jsx
+++ b/client/login/magic-login/index.jsx
@@ -1,6 +1,5 @@
 import config from '@automattic/calypso-config';
 import { Gridicon } from '@automattic/components';
-import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import page from 'page';
 import PropTypes from 'prop-types';
@@ -56,7 +55,7 @@ class MagicLogin extends Component {
 
 		const loginParameters = {
 			isJetpack: this.props.isJetpackLogin,
-			isGutenboarding: this.props.isGutenboardingLogin,
+			isGutenboarding: true,
 			locale: this.props.locale,
 			emailAddress: this.props.query?.email_address,
 			signupUrl: this.props.query?.signup_url,
@@ -66,8 +65,7 @@ class MagicLogin extends Component {
 	};
 
 	renderLinks() {
-		const { isJetpackLogin, isGutenboardingLogin, locale, showCheckYourEmail, translate } =
-			this.props;
+		const { isJetpackLogin, locale, showCheckYourEmail, translate } = this.props;
 
 		if ( showCheckYourEmail ) {
 			return null;
@@ -79,7 +77,7 @@ class MagicLogin extends Component {
 		// paste somewhere else, their email address isn't included in it.
 		const loginParameters = {
 			isJetpack: isJetpackLogin,
-			isGutenboarding: isGutenboardingLogin,
+			isGutenboarding: true,
 			locale: locale,
 			signupUrl: this.props.query?.signup_url,
 		};
@@ -133,13 +131,9 @@ class MagicLogin extends Component {
 		};
 
 		return (
-			<Main
-				className={ classNames( 'magic-login', 'magic-login__request-link', {
-					'is-white-login': this.props.isGutenboardingLogin,
-				} ) }
-			>
+			<Main className="magic-login magic-login__request-link is-white-login">
 				{ this.props.isJetpackLogin && <JetpackHeader /> }
-				{ this.props.isGutenboardingLogin && this.renderGutenboardingLogo() }
+				{ this.renderGutenboardingLogo() }
 
 				{ this.renderLocaleSuggestions() }
 
@@ -158,7 +152,6 @@ const mapState = ( state ) => ( {
 	query: getCurrentQueryArguments( state ),
 	showCheckYourEmail: getMagicLoginCurrentView( state ) === CHECK_YOUR_EMAIL_PAGE,
 	isJetpackLogin: getCurrentRoute( state ) === '/log-in/jetpack/link',
-	isGutenboardingLogin: getCurrentRoute( state )?.startsWith( '/log-in/new/link' ),
 } );
 
 const mapDispatch = {

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -261,6 +261,7 @@ export class Login extends Component {
 						isP2Login={ isP2Login }
 						signupUrl={ signupUrl }
 						usernameOrEmail={ this.state.usernameOrEmail }
+						oauth2ClientId={ this.props.oauth2Client?.id }
 					/>
 				) }
 				{ isLoginView && <TranslatorInvite path={ path } /> }

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -37,7 +37,7 @@ export class Login extends Component {
 		isLoggedIn: PropTypes.bool.isRequired,
 		isLoginView: PropTypes.bool,
 		isJetpack: PropTypes.bool.isRequired,
-		isGutenboarding: PropTypes.bool.isRequired,
+		isWhiteLogin: PropTypes.bool.isRequired,
 		isPartnerSignup: PropTypes.bool.isRequired,
 		locale: PropTypes.string.isRequired,
 		oauth2Client: PropTypes.object,
@@ -52,7 +52,7 @@ export class Login extends Component {
 		action: PropTypes.string,
 	};
 
-	static defaultProps = { isJetpack: false, isGutenboarding: false, isLoginView: true };
+	static defaultProps = { isJetpack: false, isWhiteLogin: false, isLoginView: true };
 
 	state = {
 		usernameOrEmail: '',
@@ -141,10 +141,10 @@ export class Login extends Component {
 	}
 
 	renderFooter() {
-		const { isJetpack, isGutenboarding, isP2Login, translate } = this.props;
+		const { isJetpack, isWhiteLogin, isP2Login, translate } = this.props;
 		const isOauthLogin = !! this.props.oauth2Client;
 
-		if ( isJetpack || isGutenboarding || isP2Login ) {
+		if ( isJetpack || isWhiteLogin || isP2Login ) {
 			return null;
 		}
 
@@ -221,7 +221,7 @@ export class Login extends Component {
 			domain,
 			isLoggedIn,
 			isJetpack,
-			isGutenboarding,
+			isWhiteLogin,
 			isP2Login,
 			oauth2Client,
 			privateSite,
@@ -257,7 +257,7 @@ export class Login extends Component {
 						locale={ locale }
 						privateSite={ privateSite }
 						twoFactorAuthType={ twoFactorAuthType }
-						isGutenboarding={ isGutenboarding }
+						isWhiteLogin={ isWhiteLogin }
 						isP2Login={ isP2Login }
 						signupUrl={ signupUrl }
 						usernameOrEmail={ this.state.usernameOrEmail }
@@ -275,7 +275,7 @@ export class Login extends Component {
 				privateSite={ privateSite }
 				clientId={ clientId }
 				isJetpack={ isJetpack }
-				isGutenboarding={ isGutenboarding }
+				isWhiteLogin={ isWhiteLogin }
 				isP2Login={ isP2Login }
 				oauth2Client={ oauth2Client }
 				socialService={ socialService }

--- a/client/login/wp-login/login-links.jsx
+++ b/client/login/wp-login/login-links.jsx
@@ -104,6 +104,7 @@ export class LoginLinks extends Component {
 			locale: this.props.locale,
 			twoFactorAuthType: 'link',
 			signupUrl: this.props.query?.signup_url,
+			oauth2ClientId: this.props.oauth2ClientId,
 		};
 
 		if ( this.props.currentRoute === '/log-in/jetpack' ) {

--- a/client/login/wp-login/login-links.jsx
+++ b/client/login/wp-login/login-links.jsx
@@ -108,8 +108,6 @@ export class LoginLinks extends Component {
 
 		if ( this.props.currentRoute === '/log-in/jetpack' ) {
 			loginParameters.twoFactorAuthType = 'jetpack/link';
-		} else if ( this.props.isGutenboarding ) {
-			loginParameters.twoFactorAuthType = 'new/link';
 		}
 
 		return login( loginParameters );
@@ -127,7 +125,7 @@ export class LoginLinks extends Component {
 		if (
 			isCrowdsignalOAuth2Client( this.props.oauth2Client ) ||
 			isJetpackCloudOAuth2Client( this.props.oauth2Client ) ||
-			this.props.isGutenboarding ||
+			this.props.isWhiteLogin ||
 			this.props.isP2Login ||
 			this.props.isPartnerSignup
 		) {
@@ -315,7 +313,6 @@ export class LoginLinks extends Component {
 		// Taken from client/layout/masterbar/logged-out.jsx
 		const {
 			currentRoute,
-			isGutenboarding,
 			isP2Login,
 			locale,
 			oauth2Client,
@@ -328,7 +325,7 @@ export class LoginLinks extends Component {
 		// use '?signup_url' if explicitly passed as URL query param
 		const signupUrl = this.props.signupUrl
 			? window.location.origin + pathWithLeadingSlash( this.props.signupUrl )
-			: getSignupUrl( query, currentRoute, oauth2Client, locale, pathname, isGutenboarding );
+			: getSignupUrl( query, currentRoute, oauth2Client, locale, pathname );
 
 		if ( isJetpackCloudOAuth2Client( oauth2Client ) && '/log-in/authenticator' !== currentRoute ) {
 			return null;


### PR DESCRIPTION
#### Proposed Changes

* Adds the white login background for all `/log-in` routes.

<img width="952" alt="Screenshot 2022-11-04 at 5 47 42 PM" src="https://user-images.githubusercontent.com/1269602/200085703-39d40e7a-9531-431d-bf39-43d29848fcd3.png">


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit `/log-in` and `/log-in/es` and verify that you see the white background for en and non-en locales.
* In the log-in page, click on the links "Email me a login link" and "Login via the mobile app" and verify that those show the white background.
* Login to an account that has 2FA enabled, and verify that the two factor authentication page using both push and authenticator have a white background.
* Verify that the white background is not seen in other Automattic product flows:
    - Go to akismet.com, click on the "Sign in" button, and in the page that opens replace wordpress.com with calypso.live host or calypso.localhost:3000 and verify that the log in page does not have a white background. Click on the links in that page for magic login etc. and verify that those too are unaffected.
    - Go to crowdsignal.com, click on the Log In link, replace wordpress.com with calypso link (live or localhost), and verify that the page does not have a white background. Click on the links in that page for magic login etc. and verify that those too are unaffected.
    - Visit woocommerce.com, click on the Login link, replace wordpress.com with calypso.live link and verify that the page does not have a white background and retains its custom Woo branding. Click on the links in that page for magic login etc. and verify that those too are unaffected.
    - Create a JP site with jurassic.ninja, setup Jetpack on a window that is not already logged in to WP.com, replace wordpress.com with calypso link, and verify that the login page retains its custom Jetpack branding. Click on the links in that page for magic login etc. and verify that those too are unaffected.
    - Verify that the login page on wordpress.com/p2 is unaffected.
* On a browser that is already logged in to WP.com, open calypso.localhost:3000/log-in again, you should see the "Continue as" user screen. Verify that this screen has the white background.
<img width="1664" alt="Screenshot 2022-11-04 at 6 02 47 PM" src="https://user-images.githubusercontent.com/1269602/200087024-03ab1989-13a0-475d-ba2a-d0e16215c29e.png">






