### PR TITLE
Pattern Assembler - Delayed pattern previews to use the API cache

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/delayed-render-hook.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/delayed-render-hook.tsx
@@ -1,0 +1,21 @@
+import { useState, useEffect } from 'react';
+
+type Props = {
+	children: JSX.Element;
+	waitBeforeShow?: number;
+};
+
+const Delayed = ( { children, waitBeforeShow = 200 }: Props ) => {
+	const [ isShown, setIsShown ] = useState( false );
+
+	useEffect( () => {
+		const timer = setTimeout( () => {
+			setIsShown( true );
+		}, waitBeforeShow );
+		return () => clearTimeout( timer );
+	}, [ waitBeforeShow ] );
+
+	return isShown ? children : null;
+};
+
+export default Delayed;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-selector-loader.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-selector-loader.tsx
@@ -1,4 +1,5 @@
 import { useTranslate } from 'i18n-calypso';
+import Delayed from './delayed-render-hook';
 import PatternSelector from './pattern-selector';
 import { headerPatterns, footerPatterns, sectionPatterns } from './patterns-data';
 import type { Pattern } from './types';
@@ -28,22 +29,26 @@ const PatternSelectorLoader = ( {
 				title={ translate( 'Choose a header' ) }
 				selectedPattern={ selectedPattern }
 			/>
-			<PatternSelector
-				show={ showPatternSelectorType === 'footer' }
-				patterns={ footerPatterns }
-				onSelect={ onSelect }
-				onBack={ onBack }
-				title={ translate( 'Choose a footer' ) }
-				selectedPattern={ selectedPattern }
-			/>
-			<PatternSelector
-				show={ showPatternSelectorType === 'section' }
-				patterns={ sectionPatterns }
-				onSelect={ onSelect }
-				onBack={ onBack }
-				title={ translate( 'Add a section' ) }
-				selectedPattern={ selectedPattern }
-			/>
+			<Delayed>
+				<PatternSelector
+					show={ showPatternSelectorType === 'footer' }
+					patterns={ footerPatterns }
+					onSelect={ onSelect }
+					onBack={ onBack }
+					title={ translate( 'Choose a footer' ) }
+					selectedPattern={ selectedPattern }
+				/>
+			</Delayed>
+			<Delayed>
+				<PatternSelector
+					show={ showPatternSelectorType === 'section' }
+					patterns={ sectionPatterns }
+					onSelect={ onSelect }
+					onBack={ onBack }
+					title={ translate( 'Add a section' ) }
+					selectedPattern={ selectedPattern }
+				/>
+			</Delayed>
 		</>
 	);
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-selector-loader.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-selector-loader.tsx
@@ -1,5 +1,4 @@
 import { useTranslate } from 'i18n-calypso';
-import Delayed from './delayed-render-hook';
 import PatternSelector from './pattern-selector';
 import { headerPatterns, footerPatterns, sectionPatterns } from './patterns-data';
 import type { Pattern } from './types';
@@ -29,26 +28,22 @@ const PatternSelectorLoader = ( {
 				title={ translate( 'Choose a header' ) }
 				selectedPattern={ selectedPattern }
 			/>
-			<Delayed waitBeforeShow={ 500 }>
-				<PatternSelector
-					show={ showPatternSelectorType === 'footer' }
-					patterns={ footerPatterns }
-					onSelect={ onSelect }
-					onBack={ onBack }
-					title={ translate( 'Choose a footer' ) }
-					selectedPattern={ selectedPattern }
-				/>
-			</Delayed>
-			<Delayed waitBeforeShow={ 500 }>
-				<PatternSelector
-					show={ showPatternSelectorType === 'section' }
-					patterns={ sectionPatterns }
-					onSelect={ onSelect }
-					onBack={ onBack }
-					title={ translate( 'Add a section' ) }
-					selectedPattern={ selectedPattern }
-				/>
-			</Delayed>
+			<PatternSelector
+				show={ showPatternSelectorType === 'footer' }
+				patterns={ footerPatterns }
+				onSelect={ onSelect }
+				onBack={ onBack }
+				title={ translate( 'Choose a footer' ) }
+				selectedPattern={ selectedPattern }
+			/>
+			<PatternSelector
+				show={ showPatternSelectorType === 'section' }
+				patterns={ sectionPatterns }
+				onSelect={ onSelect }
+				onBack={ onBack }
+				title={ translate( 'Add a section' ) }
+				selectedPattern={ selectedPattern }
+			/>
 		</>
 	);
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-selector-loader.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-selector-loader.tsx
@@ -29,7 +29,7 @@ const PatternSelectorLoader = ( {
 				title={ translate( 'Choose a header' ) }
 				selectedPattern={ selectedPattern }
 			/>
-			<Delayed>
+			<Delayed waitBeforeShow={ 500 }>
 				<PatternSelector
 					show={ showPatternSelectorType === 'footer' }
 					patterns={ footerPatterns }
@@ -39,7 +39,7 @@ const PatternSelectorLoader = ( {
 					selectedPattern={ selectedPattern }
 				/>
 			</Delayed>
-			<Delayed>
+			<Delayed waitBeforeShow={ 500 }>
 				<PatternSelector
 					show={ showPatternSelectorType === 'section' }
 					patterns={ sectionPatterns }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-selector.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-selector.tsx
@@ -6,12 +6,13 @@ import { useTranslate } from 'i18n-calypso';
 import { useEffect, useRef } from 'react';
 import { useSite } from '../../../../hooks/use-site';
 import { ONBOARD_STORE } from '../../../../stores';
+import Delayed from './delayed-render-hook';
 import PatternPreviewAutoHeight from './pattern-preview-auto-height';
 import { getPatternPreviewUrl, handleKeyboard } from './utils';
 import type { Pattern } from './types';
 
 type PatternSelectorProps = {
-	patterns: Pattern[] | null;
+	patterns: Pattern[];
 	onSelect: ( selectedPattern: Pattern | null ) => void;
 	onBack: () => void;
 	title: string | null;
@@ -32,6 +33,7 @@ const PatternSelector = ( {
 	const selectedDesign = useSelect( ( select ) => select( ONBOARD_STORE ).getSelectedDesign() );
 	const translate = useTranslate();
 	const site = useSite();
+	const [ firstPattern, ...restPatterns ] = patterns;
 
 	useEffect( () => {
 		if ( show ) {
@@ -39,6 +41,34 @@ const PatternSelector = ( {
 			patternSelectorRef.current?.removeAttribute( 'tabindex' );
 		}
 	}, [ show ] );
+
+	const renderPatterns = ( patternList: Pattern[] ) =>
+		patternList?.map( ( item: Pattern, index: number ) => (
+			<PatternPreviewAutoHeight
+				key={ `${ index }-${ item.id }` }
+				url={ getPatternPreviewUrl( {
+					id: item.id,
+					language: locale,
+					siteTitle: site?.name,
+					stylesheet: selectedDesign?.recipe?.stylesheet,
+				} ) }
+				patternId={ item.id }
+				patternName={ item.name }
+			>
+				<div
+					aria-label={ item.name }
+					tabIndex={ show ? 0 : -1 }
+					role="option"
+					title={ item.name }
+					aria-selected={ item.id === selectedPattern?.id }
+					className={ classnames( {
+						'pattern-selector__block-list--selected-pattern': item.id === selectedPattern?.id,
+					} ) }
+					onClick={ () => onSelect( item ) }
+					onKeyUp={ handleKeyboard( () => onSelect( item ) ) }
+				/>
+			</PatternPreviewAutoHeight>
+		) );
 
 	return (
 		<div
@@ -58,32 +88,10 @@ const PatternSelector = ( {
 			</div>
 			<div className="pattern-selector__body">
 				<div className="pattern-selector__block-list" role="listbox">
-					{ patterns?.map( ( item: Pattern, index: number ) => (
-						<PatternPreviewAutoHeight
-							key={ `${ index }-${ item.id }` }
-							url={ getPatternPreviewUrl( {
-								id: item.id,
-								language: locale,
-								siteTitle: site?.name,
-								stylesheet: selectedDesign?.recipe?.stylesheet,
-							} ) }
-							patternId={ item.id }
-							patternName={ item.name }
-						>
-							<div
-								aria-label={ item.name }
-								tabIndex={ show ? 0 : -1 }
-								role="option"
-								title={ item.name }
-								aria-selected={ item.id === selectedPattern?.id }
-								className={ classnames( {
-									'pattern-selector__block-list--selected-pattern': item.id === selectedPattern?.id,
-								} ) }
-								onClick={ () => onSelect( item ) }
-								onKeyUp={ handleKeyboard( () => onSelect( item ) ) }
-							/>
-						</PatternPreviewAutoHeight>
-					) ) }
+					{ renderPatterns( [ firstPattern ] ) }
+					<Delayed>
+						<>{ renderPatterns( restPatterns ) }</>
+					</Delayed>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
#### Proposed Changes

* Render the first pattern in each list (headers, sections, and footers) and then the rest after 200 ms. 
This ensures that the cache is created before rendering each group. 

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
* **Do not sandbox the API.** Use the API from the production servers.
* Open the Dev tools > Network to see the waterfall of requests. Filter them by `/pattern`. 
* Access `/setup/patternAssembler?siteSlug=[YOUR SITE]`
* Check that all patterns are rendered as expected with the full width of the iframe.
* Check that all the patterns don't load simultaneously but in a waterfall where there are three patterns requested first and then the rest.

<img width="104" alt="Screen Shot 2565-11-01 at 10 07 07" src="https://user-images.githubusercontent.com/1881481/199150145-3b7eb22c-b53c-4ee2-b4bc-b051b86edcf9.png">


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
