### PR TITLE
Update Welcome Tour slides in Site Editor to mention FSE

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-steps.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-steps.tsx
@@ -72,7 +72,7 @@ function getTourSteps(
 				descriptions: {
 					desktop: isSiteEditor
 						? __(
-								'Take this short, interactive tour to learn the fundamentals of the WordPress Full Site Editor.',
+								'Take this short, interactive tour to learn the fundamentals of the WordPress Site Editor.',
 								'full-site-editing'
 						  )
 						: __(
@@ -306,7 +306,7 @@ function getTourSteps(
 							descriptions: {
 								desktop: createInterpolateElement(
 									__(
-										'Design everything on your site - from the header right down to the footer - in the Full Site Editor. <link_to_fse_docs>Learn more</link_to_fse_docs>',
+										'Design everything on your site - from the header right down to the footer - in the Site Editor. <link_to_fse_docs>Learn more</link_to_fse_docs>',
 										'full-site-editing'
 									),
 									{
@@ -321,7 +321,7 @@ function getTourSteps(
 									}
 								),
 								mobile: __(
-									'Design everything on your site - from the header right down to the footer - in the Full Site Editor.',
+									'Design everything on your site - from the header right down to the footer - in the Site Editor.',
 									'full-site-editing'
 								),
 							},

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-steps.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-steps.tsx
@@ -70,10 +70,15 @@ function getTourSteps(
 			meta: {
 				heading: __( 'Welcome to WordPress!', 'full-site-editing' ),
 				descriptions: {
-					desktop: __(
-						'Take this short, interactive tour to learn the fundamentals of the WordPress editor.',
-						'full-site-editing'
-					),
+					desktop: isSiteEditor
+						? __(
+								'Take this short, interactive tour to learn the fundamentals of the WordPress Full Site Editor.',
+								'full-site-editing'
+						  )
+						: __(
+								'Take this short, interactive tour to learn the fundamentals of the WordPress editor.',
+								'full-site-editing'
+						  ),
 					mobile: null,
 				},
 				imgSrc: getTourAssets( isVideoMaker ? 'videomakerWelcome' : 'welcome' ),
@@ -299,12 +304,24 @@ function getTourSteps(
 						meta: {
 							heading: __( 'Edit your site', 'full-site-editing' ),
 							descriptions: {
-								desktop: __(
-									'Design everything on your site - from the header right down to the footer - using blocks.',
-									'full-site-editing'
+								desktop: createInterpolateElement(
+									__(
+										'Design everything on your site - from the header right down to the footer - in the Full Site Editor. <link_to_fse_docs>Learn more</link_to_fse_docs>',
+										'full-site-editing'
+									),
+									{
+										link_to_fse_docs: (
+											<ExternalLink
+												href={ localizeUrl(
+													'https://wordpress.com/support/full-site-editing/',
+													localeSlug
+												) }
+											/>
+										),
+									}
 								),
 								mobile: __(
-									'Design everything on your site - from the header right down to the footer - using blocks.',
+									'Design everything on your site - from the header right down to the footer - in the Full Site Editor.',
 									'full-site-editing'
 								),
 							},


### PR DESCRIPTION
#### Proposed Changes

This PR updates the description of slide 1 and 9 in the welcome guide tour of Site Editor, so that they explicitly mention FSE concepts.

| Before | After |
| -------|----- |
| <img width="399" alt="image" src="https://user-images.githubusercontent.com/1525580/198963615-64c03cb5-980b-4d36-b274-5444ab029cf6.png"> | <img width="398" alt="image" src="https://user-images.githubusercontent.com/1525580/199461632-2c288a97-3b38-48d0-b5d4-46f055563770.png"> |
| <img width="397" alt="image" src="https://user-images.githubusercontent.com/1525580/198964289-ffc02583-7c5d-4b3d-a783-139bf32449fa.png"> | <img width="396" alt="image" src="https://user-images.githubusercontent.com/1525580/199461741-a684d73d-b08b-4277-af81-4e816e5d6e06.png"> |

#### Testing Instructions

1. Sandbox your site (your site, not public-api).
2. Check out this PR locally.
3. Sync ETK to your sandbox:

       cd apps/editing-toolkit
       yarn dev --sync

1. Run Calypso locally.
5. Clear your welcome guide state as explained in this post: pbxlJb-2U0-p2
6. Open Site Editor - verify that Slide 1 and Slide 9 are updated as shown above.
7. Open Page Editor (e.g. create a new page) - verify that Slide 1 is NOT updated.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #69607