### PR TITLE
Pattern Assembler: Update Home template if it's existed

### DIFF
--- a/packages/data-stores/src/site/actions.ts
+++ b/packages/data-stores/src/site/actions.ts
@@ -352,8 +352,21 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		title: string,
 		content: string
 	) {
+		const templateId = `${ stylesheet }//${ slug }`;
+		let existed = true;
+		try {
+			yield wpcomRequest( {
+				path: `/sites/${ encodeURIComponent( siteSlug ) }/templates/${ templateId }`,
+				apiNamespace: 'wp/v2',
+				method: 'GET',
+			} );
+		} catch {
+			existed = false;
+		}
+
+		const templatePath = `templates/${ existed ? templateId : '' }`;
 		yield wpcomRequest( {
-			path: `/sites/${ encodeURIComponent( siteSlug ) }/templates`,
+			path: `/sites/${ encodeURIComponent( siteSlug ) }/${ templatePath }`,
 			apiNamespace: 'wp/v2',
 			body: {
 				slug,


### PR DESCRIPTION
#### Proposed Changes

* For easy testing, check whether the home template exists or not first. If it exists, then update the Home template instead of creating the new one.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use a8c account
* Go to `/setup?siteSlug=<your_exisiting_site>`
* Select "Promote myself or business" goal
* When you enter the design picker, select blank canvas CTA
* Select any header, sections, or footer, and press the "Continue" button
* When you land on the site editor, you have to see the Home template with patterns selected in the previous step

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
