### PR TITLE
[WIP] Third-Party Themes: Add checkout information for the product

### DIFF
--- a/client/state/themes/selectors/get-theme-subscription-url.tsx
+++ b/client/state/themes/selectors/get-theme-subscription-url.tsx
@@ -1,0 +1,27 @@
+import { getSiteSlug } from 'calypso/state/sites/selectors';
+import { isExternallyManagedTheme } from 'calypso/state/themes/selectors/is-externally-managed-theme';
+import { isThemePremium } from 'calypso/state/themes/selectors/is-theme-premium';
+
+import 'calypso/state/themes/init';
+
+type BillingCycle = 'monthly' | 'yearly';
+
+/**
+ * Returns the URL for subscribing to the given theme for the given site.
+ *
+ * @param  {object}  state   Global state tree
+ * @param  {string}  themeId Theme ID
+ * @param  {number}  siteId  Site ID for which to buy the theme
+ * @returns {?string}         Theme purchase URL
+ */
+export function getThemeSubscriptionUrl(
+	state = {},
+	themeId: string,
+	siteId: number,
+	cycle: BillingCycle = 'monthly'
+): null | string {
+	if ( ! isExternallyManagedTheme( state, themeId ) || ! isThemePremium( state, themeId as any ) ) {
+		return null;
+	}
+	return `/checkout/${ getSiteSlug( state, siteId ) }/theme-${ cycle }:${ themeId }`;
+}


### PR DESCRIPTION
#### Proposed Changes

* Add the third-party premium theme checkout information to make it possible to add the products to the cart.
* Add the selector to generate the checkout URL.
* TBD

#### Testing Instructions

* TBD

Related to #69468
