### PR TITLE
E2E (Atomic): Fix ETK

### DIFF
--- a/packages/calypso-e2e/src/lib/blocks/block-flows/timeline.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/timeline.ts
@@ -55,12 +55,12 @@ export class TimelineBlockFlow implements BlockFlow {
 	 */
 	async validateAfterPublish( context: PublishedPostContext ): Promise< void > {
 		const expectedFirstTextLocator = context.page.locator(
-			`text=${ this.configurationData.firstEntry }`
+			`main :text("${ this.configurationData.firstEntry }")` // 'main' needs to be specified due to the debug elements
 		);
 		await expectedFirstTextLocator.waitFor();
 
 		const expectedSecondTextLocator = context.page.locator(
-			`text=${ this.configurationData.secondEntry }`
+			`main :text("${ this.configurationData.secondEntry }")` // 'main' needs to be specified due to the debug elements
 		);
 		await expectedSecondTextLocator.waitFor();
 	}


### PR DESCRIPTION
Tracking issue: https://github.com/Automattic/wp-calypso/issues/65906

#### Proposed Changes

Make the following test compatible with the Atomic environment:

> specs/blocks/blocks__etk.ts: Blocks: ETK

#### Why was it failing 
The first and second entries in the **timeline** block are failing on Atomic because of multiple elements found. This is due to debugging elements on this page. More specific selectors were then defined.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

The fixed test should pass for both Simple and Atomic sites (production).

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
