### PR TITLE
Removing check for hideFreePlan, which now makes Free option availabl…

### DIFF
--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -321,7 +321,6 @@ export class PlansStep extends Component {
 			flowName,
 			hideFreePlan,
 			locale,
-			subHeaderText,
 			translate,
 			useEmailOnboardingSubheader,
 		} = this.props;
@@ -368,24 +367,16 @@ export class PlansStep extends Component {
 			);
 		}
 
-		if ( ! hideFreePlan ) {
-			if ( this.state.isDesktop ) {
-				return translate(
-					"Pick one that's right for you and unlock features that help you grow. Or {{link}}start with a free site{{/link}}.",
-					{ components: { link: freePlanButton } }
-				);
-			}
-
-			return translate( 'Choose a plan or {{link}}start with a free site{{/link}}.', {
-				components: { link: freePlanButton },
-			} );
-		}
-
 		if ( this.state.isDesktop ) {
-			return translate( "Pick one that's right for you and unlock features that help you grow." );
+			return translate(
+				"Pick one that's right for you and unlock features that help you grow. Or {{link}}start with a free site{{/link}}.",
+				{ components: { link: freePlanButton } }
+			);
 		}
 
-		return subHeaderText || translate( 'Choose a plan. Upgrade as you grow.' );
+		return translate( 'Choose a plan or {{link}}start with a free site{{/link}}.', {
+			components: { link: freePlanButton },
+		} );
 	}
 
 	isTailoredFlow() {


### PR DESCRIPTION
This PR makes the Free option available on the Plans step in the signup flow for all users, regardless of choices they made in prior steps.

Context for this change is available at p58i-cJS#comment-55928.

Note that the user will be taken to checkout if they select a paid domain so that they can purchase the domain they selected.

#### Proposed Changes

* Removes the hide free check on the subheader section of the PlansStep component

#### Testing Instructions

* Checkout this PR and start Calypso locally.
* Navigate to `/start` and begin signup
* Go through the flow using a variety of paths: selecting the skip option, selecting a free domain, and selecting a paid domain.
* Confirm that the Free option is available on the Plans step in all flows.
* Confirm that you're able to proceed through the flow as expected.
