### PR TITLE
Stats: Update page header and layout styling

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -246,6 +246,7 @@ class Layout extends Component {
 			'is-jetpack-mobile-flow': this.props.isJetpackMobileFlow,
 			'is-jetpack-woocommerce-flow': this.props.isJetpackWooCommerceFlow,
 			'is-jetpack-woo-dna-flow': this.props.isJetpackWooDnaFlow,
+			'is-stats-page': this.props.isStatsPage,
 			'is-wccom-oauth-flow': isWooOAuth2Client( this.props.oauth2Client ) && this.props.wccomFrom,
 		} );
 
@@ -399,6 +400,9 @@ export default withCurrentRoute(
 		].includes( sectionName );
 		const sidebarIsHidden = ! secondary || isWcMobileApp();
 		const chatIsDocked = ! [ 'reader', 'theme' ].includes( sectionName ) && ! sidebarIsHidden;
+		const isStatsPage =
+			( typeof sectionName === 'string' && sectionName?.includes( 'sectionName' ) ) ||
+			( typeof sectionJitmPath === 'string' && sectionJitmPath?.includes( 'stats' ) );
 
 		const userAllowedToHelpCenter =
 			config.isEnabled( 'calypso/help-center' ) &&
@@ -415,6 +419,7 @@ export default withCurrentRoute(
 			isEligibleForJITM,
 			oauth2Client,
 			wccomFrom,
+			isStatsPage,
 			isSupportSession: isSupportSession( state ),
 			sectionGroup,
 			sectionName,

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -246,7 +246,6 @@ class Layout extends Component {
 			'is-jetpack-mobile-flow': this.props.isJetpackMobileFlow,
 			'is-jetpack-woocommerce-flow': this.props.isJetpackWooCommerceFlow,
 			'is-jetpack-woo-dna-flow': this.props.isJetpackWooDnaFlow,
-			'is-stats-page': this.props.isStatsPage,
 			'is-wccom-oauth-flow': isWooOAuth2Client( this.props.oauth2Client ) && this.props.wccomFrom,
 		} );
 
@@ -400,9 +399,6 @@ export default withCurrentRoute(
 		].includes( sectionName );
 		const sidebarIsHidden = ! secondary || isWcMobileApp();
 		const chatIsDocked = ! [ 'reader', 'theme' ].includes( sectionName ) && ! sidebarIsHidden;
-		const isStatsPage =
-			( typeof sectionName === 'string' && sectionName?.includes( 'sectionName' ) ) ||
-			( typeof sectionJitmPath === 'string' && sectionJitmPath?.includes( 'stats' ) );
 
 		const userAllowedToHelpCenter =
 			config.isEnabled( 'calypso/help-center' ) &&
@@ -419,7 +415,6 @@ export default withCurrentRoute(
 			isEligibleForJITM,
 			oauth2Client,
 			wccomFrom,
-			isStatsPage,
 			isSupportSession: isSupportSession( state ),
 			sectionGroup,
 			sectionName,

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -193,7 +193,7 @@ class StatsSite extends Component {
 				<FormattedHeader
 					brandFont
 					className="stats__section-header"
-					headerText={ translate( 'Stats and Insights' ) }
+					headerText={ translate( 'Jetpack Stats' ) }
 					align="left"
 					subHeaderText={ translate(
 						"Learn more about the activity and behavior of your site's visitors. {{learnMoreLink}}Learn more{{/learnMoreLink}}.",
@@ -354,7 +354,7 @@ class StatsSite extends Component {
 				<QueryKeyringConnections />
 				{ isJetpack && <QueryJetpackModules siteId={ siteId } /> }
 				<QuerySiteKeyrings siteId={ siteId } />
-				<DocumentHead title={ translate( 'Stats and Insights' ) } />
+				<DocumentHead title={ translate( 'Jetpack Stats' ) } />
 				<PageViewTracker
 					path={ `/stats/${ period }/:site` }
 					title={ `Stats > ${ titlecase( period ) }` }

--- a/client/my-sites/stats/stats-insights/index.jsx
+++ b/client/my-sites/stats/stats-insights/index.jsx
@@ -34,12 +34,12 @@ const StatsInsights = ( props ) => {
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	return (
 		<Main wideLayout>
-			<DocumentHead title={ translate( 'Stats and Insights' ) } />
+			<DocumentHead title={ translate( 'Jetpack Stats' ) } />
 			<PageViewTracker path="/stats/insights/:site" title="Stats > Insights" />
 			<FormattedHeader
 				brandFont
 				className="stats__section-header"
-				headerText={ translate( 'Stats and Insights' ) }
+				headerText={ translate( 'Jetpack Stats' ) }
 				subHeaderText={ translate( "View your site's performance and learn from trends." ) }
 				align="left"
 			/>

--- a/client/my-sites/stats/style.scss
+++ b/client/my-sites/stats/style.scss
@@ -207,13 +207,10 @@
 	}
 }
 
-// Following styles are are mirrored at client/my-sites/store/style.scss.
-.is-stats-page {
-	background: var(--studio-white);
-}
-
 // Stats section scoped styles
-.is-stats-page { // stylelint-disable-line no-duplicate-selectors
+.is-section-stats {
+	background: var(--studio-white);
+
 	.followers-count .button {
 		@include breakpoint-deprecated( "<480px" ) {
 			display: none;

--- a/client/my-sites/stats/style.scss
+++ b/client/my-sites/stats/style.scss
@@ -207,8 +207,13 @@
 	}
 }
 
+// Following styles are are mirrored at client/my-sites/store/style.scss.
+.is-stats-page {
+	background: var(--studio-white);
+}
+
 // Stats section scoped styles
-.is-section-stats {
+.is-stats-page { // stylelint-disable-line no-duplicate-selectors
 	.followers-count .button {
 		@include breakpoint-deprecated( "<480px" ) {
 			display: none;

--- a/client/my-sites/stats/wordads/index.jsx
+++ b/client/my-sites/stats/wordads/index.jsx
@@ -137,7 +137,7 @@ class WordAds extends Component {
 				<FormattedHeader
 					brandFont
 					className="wordads__section-header"
-					headerText={ translate( 'Stats and Insights' ) }
+					headerText={ translate( 'Jetpack Stats' ) }
 					subHeaderText={ translate( 'See how ads are performing on your site.' ) }
 					align="left"
 				/>

--- a/client/my-sites/store/app/store-stats/index.js
+++ b/client/my-sites/store/app/store-stats/index.js
@@ -51,7 +51,7 @@ class StoreStats extends Component {
 				<FormattedHeader
 					brandFont
 					className="store-stats__section-header"
-					headerText={ translate( 'Stats and Insights' ) }
+					headerText={ translate( 'Jetpack Stats' ) }
 					align="left"
 					subHeaderText={ translate(
 						'Learn valuable insights about the purchases made on your store.'

--- a/client/my-sites/store/app/store-stats/store-stats-chart/style.scss
+++ b/client/my-sites/store/app/store-stats/store-stats-chart/style.scss
@@ -9,3 +9,7 @@
 		padding: 12px 19px 10px 20px;
 	}
 }
+
+.store-stats-orders-chart {
+	padding: 0;
+}

--- a/client/my-sites/store/style.scss
+++ b/client/my-sites/store/style.scss
@@ -172,3 +172,7 @@
 		}
 	}
 }
+
+.is-stats-page {
+	background: var(--studio-white);
+}

--- a/client/my-sites/store/style.scss
+++ b/client/my-sites/store/style.scss
@@ -44,6 +44,8 @@
 }
 
 .is-section-woocommerce {
+	background: var(--studio-white);
+
 	// overwrite notice styles due to sticky bar
 	.global-notices {
 		z-index: z-index("root", ".is-section-woocommerce .global-notices");
@@ -171,8 +173,4 @@
 			display: none;
 		}
 	}
-}
-
-.is-stats-page {
-	background: var(--studio-white);
 }


### PR DESCRIPTION
#### Proposed Changes

- Changes Stats page headers to "Jetpack Stats" per p1HpG7-icd-p2.
- Set Stats page backgrounds to white.
- (Bonus) Fixes incorrect padding for the chart in the Store tab.
<table>
<tr>
<td>Before
<td>After
</tr>
<tr>
<td><img width="1062" alt="image" src="https://user-images.githubusercontent.com/4044428/199102145-3d85e62c-a293-4bda-84b0-66990d133f24.png">
<td><img width="1067" alt="image" src="https://user-images.githubusercontent.com/4044428/199102095-fe121848-0f6a-41e1-bbe2-2579e9b6a877.png">
</tr>
</table>


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up the live branch and ensure that the headers now say "Jetpack Stats" like so:
  * <img width="1065" alt="image" src="https://user-images.githubusercontent.com/4044428/199102408-7b16fc0a-6689-41c0-8b31-7c8de5c207d4.png">
  * <img width="1065" alt="image" src="https://user-images.githubusercontent.com/4044428/199102431-70d00aa1-03ef-440d-8b69-bc8dd8999527.png">
  * <img width="1069" alt="image" src="https://user-images.githubusercontent.com/4044428/199102460-988e93a6-8a05-4ae8-a669-d235fb3b5aee.png">
  * <img width="1061" alt="image" src="https://user-images.githubusercontent.com/4044428/199102515-6dc18ddf-15a1-4d61-b9c1-1f5101184e4d.png">
* Ensure that the Store chart looks reasonable.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #69225.
