### PR TITLE
Checkout: allow Jetpack siteless checkout to add multiple products in cart

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/checkout-main.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-main.tsx
@@ -138,7 +138,6 @@ export default function CheckoutMain( {
 	const createUserAndSiteBeforeTransaction =
 		Boolean( isLoggedOutCart || isNoSiteCart ) && ! isJetpackCheckout;
 	const reduxDispatch = useDispatch();
-	const isJetpackSitelessCheckout = isJetpackCheckout && ! jetpackSiteSlug;
 	const updatedSiteSlug = isJetpackCheckout ? jetpackSiteSlug : siteSlug;
 
 	const showErrorMessageBriefly = useCallback(
@@ -202,7 +201,6 @@ export default function CheckoutMain( {
 	const isInitialCartLoading = useAddProductsFromUrl( {
 		isLoadingCart,
 		isCartPendingUpdate,
-		isJetpackSitelessCheckout,
 		productsForCart,
 		areCartProductsPreparing,
 		couponCodeFromUrl,

--- a/client/my-sites/checkout/composite-checkout/hooks/use-add-products-from-url.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-add-products-from-url.ts
@@ -23,7 +23,6 @@ export type isPendingAddingProductsFromUrl = boolean;
 export default function useAddProductsFromUrl( {
 	isLoadingCart,
 	isCartPendingUpdate,
-	isJetpackSitelessCheckout,
 	productsForCart,
 	areCartProductsPreparing,
 	couponCodeFromUrl,
@@ -33,7 +32,6 @@ export default function useAddProductsFromUrl( {
 }: {
 	isLoadingCart: boolean;
 	isCartPendingUpdate: boolean;
-	isJetpackSitelessCheckout: boolean;
 	productsForCart: RequestCartProduct[];
 	areCartProductsPreparing: boolean;
 	couponCodeFromUrl: string | null | undefined;
@@ -109,7 +107,6 @@ export default function useAddProductsFromUrl( {
 		applyCoupon,
 		productsForCart,
 		addProductsToCart,
-		isJetpackSitelessCheckout,
 		replaceProductsInCart,
 	] );
 

--- a/client/my-sites/checkout/composite-checkout/hooks/use-add-products-from-url.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-add-products-from-url.ts
@@ -90,19 +90,7 @@ export default function useAddProductsFromUrl( {
 		debug( 'adding initial products to cart', productsForCart );
 		const cartPromises = [];
 		if ( productsForCart.length > 0 ) {
-			// The siteless checkout backend cannot handle multiple product checkout yet,
-			// so therefore we only want one product in the cart (The most recently selected).
-			if ( isJetpackSitelessCheckout ) {
-				debug(
-					'siteless checkout: replacing the cart with the most recently selected product',
-					productsForCart[ productsForCart.length - 1 ]
-				);
-				cartPromises.push(
-					replaceProductsInCart( [ productsForCart[ productsForCart.length - 1 ] ] )
-				);
-			} else {
-				cartPromises.push( addProductsToCart( productsForCart ) );
-			}
+			cartPromises.push( addProductsToCart( productsForCart ) );
 		}
 		debug( 'adding initial coupon to cart', couponCodeFromUrl );
 		if ( couponCodeFromUrl ) {

--- a/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
@@ -4,8 +4,6 @@ import { decodeProductFromUrl, isValueTruthy } from '@automattic/wpcom-checkout'
 import debugFactory from 'debug';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useMemo, useReducer } from 'react';
-import { useSelector } from 'react-redux';
-import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import getCartFromLocalStorage from '../lib/get-cart-from-local-storage';
 import useFetchProductsIfNotLoaded from './use-fetch-products-if-not-loaded';
 import useStripProductsFromUrl from './use-strip-products-from-url';
@@ -262,7 +260,6 @@ function useAddRenewalItems( {
 	addHandler: AddHandler;
 	isGiftPurchase?: boolean;
 } ) {
-	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
 	const translate = useTranslate();
 
 	useEffect( () => {
@@ -303,15 +300,7 @@ function useAddRenewalItems( {
 		}
 		debug( 'preparing renewals requested in url', productsForCart );
 		dispatch( { type: 'RENEWALS_ADD', products: productsForCart } );
-	}, [
-		addHandler,
-		translate,
-		originalPurchaseId,
-		productAlias,
-		dispatch,
-		selectedSiteSlug,
-		isGiftPurchase,
-	] );
+	}, [ addHandler, translate, originalPurchaseId, productAlias, dispatch, isGiftPurchase ] );
 }
 
 function useAddProductFromSlug( {
@@ -351,7 +340,7 @@ function useAddProductFromSlug( {
 					const productSlug = getProductSlugFromAlias( productAlias );
 					return { productSlug, productAlias };
 				} ) ?? [],
-		[ usesJetpackProducts, productAliasFromUrl ]
+		[ productAliasFromUrl ]
 	);
 
 	useEffect( () => {


### PR DESCRIPTION
#### Proposed Changes

This removes the guard added in https://github.com/Automattic/wp-calypso/pull/54811 which prevented the Jetpack siteless checkout shopping cart having multiple products because there is currently a project underway to support just that (p1HpG7-iLN-p2).

Fixes https://github.com/Automattic/wp-calypso/issues/69632 (see pNPgK-6bD-p2 where this was reported as a bug)

**Note:** in the PR which added this block, it seems that the intent may have been to prevent the cart containing more than one Jetpack product at the same time, rather than _adding_ more than one Jetpack product at the same time. This is a subtle difference, but an important one because in the former case, a user may be adding single products more than once (see test instructions in https://github.com/Automattic/wp-calypso/pull/54811). If we still want to support that behavior, a better way may be to update the shopping cart validator on the backend to replace one Jetpack product with another after the cart is created (it's also more reliable that way). cc @elliottprogrammer **Update:** This was completed in D92589-code

#### Screenshots

Before:
<img width="356" alt="Screen Shot 2022-10-31 at 5 07 27 PM" src="https://user-images.githubusercontent.com/2036909/199111049-b942824a-e5bb-4c30-b570-c749fd21da73.png">

After:
<img width="359" alt="Screen Shot 2022-10-31 at 5 08 12 PM" src="https://user-images.githubusercontent.com/2036909/199111000-bd1ad86d-1c67-40f9-885b-51489c598ce9.png">

A cart with multiple Jetpack products (probably not desirable, but IMO that should be fixed on the backend):
<img width="453" alt="Screen Shot 2022-11-01 at 12 59 58 PM" src="https://user-images.githubusercontent.com/2036909/199292362-c089c6c0-800f-479f-af13-cbe1cef52cd0.png">

#### Testing Instructions

- Open the Network tab of your browser's devtools.
- Visit `/checkout/jetpack/jetpack-boost,jetpack-scan`.
- Verify that a POST request is made to `/me/shopping-cart` and that it contains a `products` array with two items. (Note: the products will not actually be added because that support is not yet available on the backend.)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - 0-as-1203286153446976