### PR TITLE
Marketplace: Show Gifting Toggle when Auto-Renew is off

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -659,7 +659,7 @@ export class SiteSettingsFormGeneral extends Component {
 								disabled={ isRequestingSettings || isSavingSettings }
 								className="site-settings__gifting-toggle"
 								label={ translate(
-									'Allow supporters to cover the WordPress plan to keep the site content up and running'
+									'Allow supporters to cover the WordPress plan to keep the site content up and running.'
 								) }
 								checked={ fields.wpcom_gifting_subscription }
 								onChange={ this.props.handleToggle( 'wpcom_gifting_subscription' ) }

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -658,15 +658,13 @@ export class SiteSettingsFormGeneral extends Component {
 							<ToggleControl
 								disabled={ isRequestingSettings || isSavingSettings }
 								className="site-settings__gifting-toggle"
-								label={ translate(
-									'Allow supporters to cover the WordPress plan to keep the site content up and running.'
-								) }
+								label={ translate( 'Allow a site visitor to gift site upgrade costs.' ) }
 								checked={ fields.wpcom_gifting_subscription }
 								onChange={ this.props.handleToggle( 'wpcom_gifting_subscription' ) }
 							/>
 							<FormSettingExplanation>
 								{ translate(
-									'Your readers will be able to pay for the WordPress subscription to keep the site and all the content that you have created up and running and available for everybody in the future.'
+									"Allow a site visitor to cover the full cost of your site's upgrades."
 								) }
 							</FormSettingExplanation>
 						</CompactCard>

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -36,6 +36,7 @@ import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 import { usePremiumGlobalStyles } from 'calypso/state/sites/hooks/use-premium-global-styles';
 import { launchSite } from 'calypso/state/sites/launch/actions';
+import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
 import {
 	getSiteOption,
 	isJetpackSite,
@@ -624,10 +625,18 @@ export class SiteSettingsFormGeneral extends Component {
 	}
 
 	giftOptions() {
-		const { translate, fields, isRequestingSettings, isSavingSettings, handleSubmitForm } =
-			this.props;
+		const {
+			translate,
+			fields,
+			isRequestingSettings,
+			isSavingSettings,
+			handleSubmitForm,
+			purchase,
+		} = this.props;
 
-		if ( ! isEnabled( 'subscription-gifting' ) ) {
+		const isAutorenewalEnabled = purchase?.autoRenew ?? false;
+
+		if ( ! isEnabled( 'subscription-gifting' ) || isAutorenewalEnabled ) {
 			return;
 		}
 
@@ -807,6 +816,7 @@ const connectComponent = connect( ( state ) => {
 		siteDomains: getDomainsBySiteId( state, siteId ),
 		siteIsJetpack: isJetpackSite( state, siteId ),
 		siteSlug: getSelectedSiteSlug( state ),
+		purchase: getCurrentPlan( state, siteId ),
 	};
 }, mapDispatchToProps );
 

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -1,5 +1,9 @@
 import { isEnabled } from '@automattic/calypso-config';
-import { PLAN_BUSINESS, WPCOM_FEATURES_NO_WPCOM_BRANDING } from '@automattic/calypso-products';
+import {
+	isDotComPlan,
+	PLAN_BUSINESS,
+	WPCOM_FEATURES_NO_WPCOM_BRANDING,
+} from '@automattic/calypso-products';
 import { Card, CompactCard, Button, Gridicon } from '@automattic/components';
 import { guessTimezone } from '@automattic/i18n-utils';
 import languages from '@automattic/languages';
@@ -631,45 +635,45 @@ export class SiteSettingsFormGeneral extends Component {
 			isRequestingSettings,
 			isSavingSettings,
 			handleSubmitForm,
-			purchase,
+			currentPlan,
 		} = this.props;
 
-		const isAutorenewalEnabled = purchase?.autoRenew ?? false;
-
-		if ( ! isEnabled( 'subscription-gifting' ) || isAutorenewalEnabled ) {
+		if ( ! isEnabled( 'subscription-gifting' ) ) {
 			return;
 		}
 
-		return (
-			<>
-				<div className="site-settings__gifting-container">
-					<SettingsSectionHeader
-						title={ translate( 'Accept a gift subscription' ) }
-						id="site-settings__gifting-header"
-						disabled={ isRequestingSettings || isSavingSettings }
-						isSaving={ isSavingSettings }
-						onButtonClick={ handleSubmitForm }
-						showButton
-					/>
-					<CompactCard className="site-settings__gifting-content">
-						<ToggleControl
+		if ( currentPlan && isDotComPlan( currentPlan ) && ! currentPlan?.autoRenew ) {
+			return (
+				<>
+					<div className="site-settings__gifting-container">
+						<SettingsSectionHeader
+							title={ translate( 'Accept a gift subscription' ) }
+							id="site-settings__gifting-header"
 							disabled={ isRequestingSettings || isSavingSettings }
-							className="site-settings__gifting-toggle"
-							label={ translate(
-								'Allow supporters to cover the WordPress plan to keep the site content up and running'
-							) }
-							checked={ fields.wpcom_gifting_subscription }
-							onChange={ this.props.handleToggle( 'wpcom_gifting_subscription' ) }
+							isSaving={ isSavingSettings }
+							onButtonClick={ handleSubmitForm }
+							showButton
 						/>
-						<FormSettingExplanation>
-							{ translate(
-								'Your readers will be able to pay for the WordPress subscription to keep the site and all the content that you have created up and running and available for everybody in the future.'
-							) }
-						</FormSettingExplanation>
-					</CompactCard>
-				</div>
-			</>
-		);
+						<CompactCard className="site-settings__gifting-content">
+							<ToggleControl
+								disabled={ isRequestingSettings || isSavingSettings }
+								className="site-settings__gifting-toggle"
+								label={ translate(
+									'Allow supporters to cover the WordPress plan to keep the site content up and running'
+								) }
+								checked={ fields.wpcom_gifting_subscription }
+								onChange={ this.props.handleToggle( 'wpcom_gifting_subscription' ) }
+							/>
+							<FormSettingExplanation>
+								{ translate(
+									'Your readers will be able to pay for the WordPress subscription to keep the site and all the content that you have created up and running and available for everybody in the future.'
+								) }
+							</FormSettingExplanation>
+						</CompactCard>
+					</div>
+				</>
+			);
+		}
 	}
 
 	render() {
@@ -816,7 +820,7 @@ const connectComponent = connect( ( state ) => {
 		siteDomains: getDomainsBySiteId( state, siteId ),
 		siteIsJetpack: isJetpackSite( state, siteId ),
 		siteSlug: getSelectedSiteSlug( state ),
-		purchase: getCurrentPlan( state, siteId ),
+		currentPlan: getCurrentPlan( state, siteId ),
 	};
 }, mapDispatchToProps );
 


### PR DESCRIPTION
#### Proposed Changes

Add a condition to show the Gifting subscriptions toggle only when Auto-renew is off.

#### Tasks
- [x] Must be behind a flag until https://github.com/Automattic/payments-shilling/issues/1165 is completed. (flag: `subscription-gifting`)
- [x] The toggle only will be visible for users with AUTO RENEW OFF (as soon as they turn it off) (If the user turns AUTO RENEW ON, we will hide the toggle)~ tracked here: https://github.com/Automattic/dotcom-forge/issues/1136

#### Testing Instructions

Simple sites

1. Make sure you are sandboxed.
3. Go to `/settings/general/[your-site]?flags=subscription-gifting` using a site with a paid plan.
4. If Auto-renew is enabled in `/purchases/subscriptions`, you should not see this toggle after `Footer credit`.
5. Turn off Auto-renew in `/purchases/subscriptions` and go back to settings. You should see the toggle.

Atomic sites
1. Checkout to [this branch](https://github.com/Automattic/jetpack/pull/27137) if not merged yet
2. Sync jetpack to a WoA test site: pb5gDS-1rQ-p2
3. Go to `/settings/general/[your-site]?flags=subscription-gifting` using a site with a paid plan.
4. Try toggling and saving the settings, they should persist

#### Screenshot

https://user-images.githubusercontent.com/6586048/198674572-14435c33-7ef7-4e23-a6a2-853fbd2c06f1.mp4

<img width="776" alt="image" src="https://user-images.githubusercontent.com/402286/198083193-3e7cfb46-fb5c-4cfa-b449-59100ff19199.png">

#### Pre-merge Checklist


- [ ] ~~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~~
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~~
- [ ] ~~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~~

Fixes https://github.com/Automattic/dotcom-forge/issues/1136