### PR TITLE
Receipts: Explicitly handle arrays when flattening in assembler

### DIFF
--- a/client/state/receipts/assembler.ts
+++ b/client/state/receipts/assembler.ts
@@ -74,5 +74,8 @@ function flattenPurchases(
 function flattenFailedPurchases(
 	purchases: RawFailedReceiptPurchases | Array< void >
 ): Array< RawFailedReceiptPurchase > {
+	if ( Array.isArray( purchases ) ) {
+		return [];
+	}
 	return Object.values( purchases ).flat();
 }

--- a/client/state/receipts/assembler.ts
+++ b/client/state/receipts/assembler.ts
@@ -61,6 +61,9 @@ export function createReceiptObject( data: RawReceiptData ): ReceiptData {
 function flattenPurchases(
 	purchases: RawReceiptPurchases | Array< void >
 ): Array< RawReceiptPurchase > {
+	if ( Array.isArray( purchases ) ) {
+		return [];
+	}
 	return Object.values( purchases ).flat();
 }
 


### PR DESCRIPTION
#### Proposed Changes

This improves the TypeScript type safety of the receipt assembler (converted to TS in https://github.com/Automattic/wp-calypso/pull/69107) by explicitly handling the case where PHP has converted an empty object to an empty array.

`Object.values([])` is valid JavaScript and returns `[]` just like `Object.values({})`, but apparently there's a TypeScript advantage in not doing that [as described here](https://github.com/Automattic/wp-calypso/pull/69107/files/f23faef6bd0a92d29a237c240f88dfa1d7fe134b#diff-2aeea09a7696725e2e8e75c79e43db511896daa8eb4a5a2eaf17df25cd3c1a41) by @pottedmeat.

#### Testing Instructions

Unit tests already cover this function, so no testing should be required.