### PR TITLE
Site Editor: Add document actions dropdown tracks events

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/delegate-event-tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/delegate-event-tracking.js
@@ -15,6 +15,11 @@ import wpcomBlockPremiumContentPlanUpgrade from './wpcom-block-premium-content-p
 import wpcomBlockPremiumContentStripeConnect from './wpcom-block-premium-content-stripe-connect';
 import wpcomInserterInlineSearchTerm from './wpcom-inserter-inline-search-term';
 import wpcomInserterTabPanelSelected from './wpcom-inserter-tab-panel-selected';
+import {
+	wpcomSiteEditorDocumentActionsDropdownOpen,
+	wpcomSiteEditorDocumentActionsTemplateAreaClick,
+	wpcomSiteEditorDocumentActionsShowAllClick,
+} from './wpcom-site-editor-document-actions-dropdown-click';
 import wpcomSiteEditorExitClick from './wpcom-site-editor-exit-click';
 import {
 	wpcomTemplatePartChooseCapture,
@@ -67,6 +72,9 @@ const EVENTS_MAPPING = [
 	wpcomBlockEditorSaveClick(),
 	wpcomBlockEditorSaveDraftClick(),
 	wpcomSiteEditorExitClick(),
+	wpcomSiteEditorDocumentActionsDropdownOpen(),
+	wpcomSiteEditorDocumentActionsTemplateAreaClick(),
+	wpcomSiteEditorDocumentActionsShowAllClick(),
 ];
 const EVENTS_MAPPING_CAPTURE = EVENTS_MAPPING.filter( ( { capture } ) => capture );
 const EVENTS_MAPPING_NON_CAPTURE = EVENTS_MAPPING.filter( ( { capture } ) => ! capture );

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/delegate-event-tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/delegate-event-tracking.js
@@ -18,6 +18,7 @@ import wpcomInserterTabPanelSelected from './wpcom-inserter-tab-panel-selected';
 import {
 	wpcomSiteEditorDocumentActionsDropdownOpen,
 	wpcomSiteEditorDocumentActionsTemplateAreaClick,
+	wpcomSiteEditorDocumentActionsRevertClick,
 	wpcomSiteEditorDocumentActionsShowAllClick,
 } from './wpcom-site-editor-document-actions-dropdown-click';
 import wpcomSiteEditorExitClick from './wpcom-site-editor-exit-click';
@@ -74,6 +75,7 @@ const EVENTS_MAPPING = [
 	wpcomSiteEditorExitClick(),
 	wpcomSiteEditorDocumentActionsDropdownOpen(),
 	wpcomSiteEditorDocumentActionsTemplateAreaClick(),
+	wpcomSiteEditorDocumentActionsRevertClick(),
 	wpcomSiteEditorDocumentActionsShowAllClick(),
 ];
 const EVENTS_MAPPING_CAPTURE = EVENTS_MAPPING.filter( ( { capture } ) => capture );

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-site-editor-document-actions-dropdown-click.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-site-editor-document-actions-dropdown-click.js
@@ -41,14 +41,16 @@ export const wpcomSiteEditorDocumentActionsTemplateAreaClick = () => ( {
 			previousElementSiblingHTML?.includes( headerSVGSnippet ) ||
 			targetHTML?.includes( headerSVGSnippet )
 		) {
-			tracksRecordEvent( 'wpcom_site_editor_document_actions_header_click' );
-		}
-
-		if (
+			tracksRecordEvent( 'wpcom_site_editor_document_actions_template_area_click', {
+				template_area: 'Header',
+			} );
+		} else if (
 			previousElementSiblingHTML?.includes( footerSVGSnippet ) ||
 			targetHTML?.includes( footerSVGSnippet )
 		) {
-			tracksRecordEvent( 'wpcom_site_editor_document_actions_footer_click' );
+			tracksRecordEvent( 'wpcom_site_editor_document_actions_template_area_click', {
+				template_area: 'Footer',
+			} );
 		}
 	},
 } );

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-site-editor-document-actions-dropdown-click.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-site-editor-document-actions-dropdown-click.js
@@ -51,6 +51,10 @@ export const wpcomSiteEditorDocumentActionsTemplateAreaClick = () => ( {
 			tracksRecordEvent( 'wpcom_site_editor_document_actions_template_area_click', {
 				template_area: 'Footer',
 			} );
+		} else {
+			tracksRecordEvent( 'wpcom_site_editor_document_actions_template_area_click', {
+				template_area: 'Unknown',
+			} );
 		}
 	},
 } );

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-site-editor-document-actions-dropdown-click.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-site-editor-document-actions-dropdown-click.js
@@ -22,18 +22,18 @@ export const wpcomSiteEditorDocumentActionsTemplateAreaClick = () => ( {
 	selector: '.components-dropdown__content .edit-site-template-details__template-areas',
 	type: 'click',
 	handler: ( event ) => {
+		// There are no selectors that provide a distinction between the Header and Footer template
+		// area buttons. Because of this, we look at accompanying SVG icons to differentiate
+		// instead.
 		const headerSVGSnippet =
 			'M18.5 10.5H10v8h8a.5.5 0 00.5-.5v-7.5zm-10 0h-3V18a.5.5 0 00.5.5h2.5v-8zM6';
 		const footerSVGSnippet =
 			'M18 5.5h-8v8h8.5V6a.5.5 0 00-.5-.5zm-9.5 8h-3V6a.5.5 0 01.5-.5h2.5v8zM6';
+		const moreSVGSnippet = 'M13 19h-2v-2h2v2zm0-6h-2v-2h2v2zm0-6h-2V5h2v2z';
 
-		// There are no selectors that provide a distinction between the Header and Footer template
-		// area buttons. We could use text content instead, but that information is unreliable when
-		// the text is translated. Because of this, we look for accompanying SVG icons and derive
-		// information from that instead.
-
-		// The buttons have an icon AND text content. The user may click on either element. We check
-		// for both possibilities here.
+		// Looking at the target is not enough. Some buttons have an icon AND text content. We only
+		// care about the icon, but the user may click on either element. We check for both
+		// possibilities here when clicking on Header or Footer.
 		const targetHTML = event.target.innerHTML;
 		const previousElementSiblingHTML = event.target?.previousElementSibling?.innerHTML;
 
@@ -42,21 +42,37 @@ export const wpcomSiteEditorDocumentActionsTemplateAreaClick = () => ( {
 			targetHTML?.includes( headerSVGSnippet )
 		) {
 			tracksRecordEvent( 'wpcom_site_editor_document_actions_template_area_click', {
-				template_area: 'Header',
+				template_area: 'header',
 			} );
 		} else if (
 			previousElementSiblingHTML?.includes( footerSVGSnippet ) ||
 			targetHTML?.includes( footerSVGSnippet )
 		) {
 			tracksRecordEvent( 'wpcom_site_editor_document_actions_template_area_click', {
-				template_area: 'Footer',
+				template_area: 'footer',
+			} );
+		} else if ( targetHTML?.includes( moreSVGSnippet ) ) {
+			tracksRecordEvent( 'wpcom_site_editor_document_actions_template_area_click', {
+				template_area: 'more_options',
 			} );
 		} else {
 			tracksRecordEvent( 'wpcom_site_editor_document_actions_template_area_click', {
-				template_area: 'Unknown',
+				template_area: 'unknown',
 			} );
 		}
 	},
+} );
+
+/**
+ * Return the event definition object to track `wpcom-site-editor-document-actions-template-areas-item-more`.
+ *
+ * @returns {import('./types').DelegateEventHandler} event object definition.
+ */
+export const wpcomSiteEditorDocumentActionsRevertClick = () => ( {
+	id: 'wpcom-site-editor-document-actions-revert-click',
+	selector: '.components-dropdown__content .edit-site-template-details__revert',
+	type: 'click',
+	handler: () => tracksRecordEvent( 'wpcom_site_editor_document_actions_revert_click' ),
 } );
 
 /**

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-site-editor-document-actions-dropdown-click.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-site-editor-document-actions-dropdown-click.js
@@ -1,0 +1,66 @@
+import tracksRecordEvent from './track-record-event';
+
+/**
+ * Return the event definition object to track `wpcom-site-editor-document-actions-dropdown-clicks`.
+ *
+ * @returns {import('./types').DelegateEventHandler} event object definition.
+ */
+export const wpcomSiteEditorDocumentActionsDropdownOpen = () => ( {
+	id: 'wpcom-site-editor-document-actions-dropdown-open',
+	selector: '.components-dropdown .edit-site-document-actions__get-info',
+	type: 'click',
+	handler: () => tracksRecordEvent( 'wpcom_site_editor_document_actions_dropdown_open' ),
+} );
+
+/**
+ * Return the event definition object to track `wpcom-site-editor-document-actions-template-area-click`.
+ *
+ * @returns {import('./types').DelegateEventHandler} event object definition.
+ */
+export const wpcomSiteEditorDocumentActionsTemplateAreaClick = () => ( {
+	id: 'wpcom-site-editor-document-actions-template-area-click',
+	selector: '.components-dropdown__content .edit-site-template-details__template-areas',
+	type: 'click',
+	handler: ( event ) => {
+		const headerSVGSnippet =
+			'M18.5 10.5H10v8h8a.5.5 0 00.5-.5v-7.5zm-10 0h-3V18a.5.5 0 00.5.5h2.5v-8zM6';
+		const footerSVGSnippet =
+			'M18 5.5h-8v8h8.5V6a.5.5 0 00-.5-.5zm-9.5 8h-3V6a.5.5 0 01.5-.5h2.5v8zM6';
+
+		// There are no selectors that provide a distinction between the Header and Footer template
+		// area buttons. We could use text content instead, but that information is unreliable when
+		// the text is translated. Because of this, we look for accompanying SVG icons and derive
+		// information from that instead.
+
+		// The buttons have an icon AND text content. The user may click on either element. We check
+		// for both possibilities here.
+		const targetHTML = event.target.innerHTML;
+		const previousElementSiblingHTML = event.target?.previousElementSibling?.innerHTML;
+
+		if (
+			previousElementSiblingHTML?.includes( headerSVGSnippet ) ||
+			targetHTML?.includes( headerSVGSnippet )
+		) {
+			tracksRecordEvent( 'wpcom_site_editor_document_actions_header_click' );
+		}
+
+		if (
+			previousElementSiblingHTML?.includes( footerSVGSnippet ) ||
+			targetHTML?.includes( footerSVGSnippet )
+		) {
+			tracksRecordEvent( 'wpcom_site_editor_document_actions_footer_click' );
+		}
+	},
+} );
+
+/**
+ * Return the event definition object to track `wpcom-site-editor-document-actions-show-all-click`.
+ *
+ * @returns {import('./types').DelegateEventHandler} event object definition.
+ */
+export const wpcomSiteEditorDocumentActionsShowAllClick = () => ( {
+	id: 'wpcom-site-editor-document-actions-show-all-click',
+	selector: '.components-dropdown__content .edit-site-template-details__show-all-button',
+	type: 'click',
+	handler: () => tracksRecordEvent( 'wpcom_site_editor_document_actions_show_all_click' ),
+} );


### PR DESCRIPTION
### Proposed Changes

* Adds tracks events to document actions dropdown in the site editor

### GIFS

![2022-10-31 16 23 28](https://user-images.githubusercontent.com/5414230/199128114-450a46e4-e709-49ef-b57d-cc84a317398e.gif)

### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Install [Tracks Vig](https://github.com/Automattic/tracks-chrome-extension)
- Sandbox site and `widgets.wp.com`
- Checkout branch
- Navigate to `calypso/apps/wpcom-block-editor` in the terminal
- Run `yarn dev --sync`
- Navigate to Appearance > Editor (beta)
- Open Tracks Vig
- Ensure the following events are being recorded in Tracks Vig:
  - After clicking on the document actions dropdown icon `wpcom_site_editor_document_actions_dropdown_open`
  - After clicking on the Header template area button `wpcom_site_editor_document_actions_template_area_click`
  - After clicking on the Footer template area button `wpcom_site_editor_document_actions_template_area_click`
  - After clicking on the Browse All Templates button `wpcom_site_editor_document_actions_show_all_click`

### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/69630
