### PR TITLE
Checkout: Remove edit button and show only longer term variants

### DIFF
--- a/client/lib/use-jit-callback/index.ts
+++ b/client/lib/use-jit-callback/index.ts
@@ -1,0 +1,37 @@
+import { useCallback, useRef, useLayoutEffect } from 'react';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type CallbackArgs = any[];
+
+export type CallbackFunction< Args extends CallbackArgs, ReturnValue > = (
+	...args: Args
+) => ReturnValue;
+
+/*
+ * Return a stable callback function whose identity does not change.
+ *
+ * Even if the dependencies of the callback argument change, the returned
+ * callback will keep the same identity. In effect, the returned callback will
+ * always use the most recent version of the variables in the callback's
+ * closure.
+ *
+ * This is a simple implementation of the (still-in-development at the time of
+ * this commit) `useEvent` hook: https://beta.reactjs.org/apis/react/useEvent
+ *
+ * See https://github.com/reactjs/rfcs/blob/useevent/text/0000-useevent.md for
+ * more explanation of why this is helpful.
+ */
+export function useJITCallback< Args extends CallbackArgs, ReturnValue >(
+	handler: CallbackFunction< Args, ReturnValue >
+): ( ...args: Args ) => ReturnValue {
+	const handlerRef = useRef( handler );
+
+	useLayoutEffect( () => {
+		handlerRef.current = handler;
+	} );
+
+	return useCallback( ( ...args: Args ): ReturnValue => {
+		const fn = handlerRef.current;
+		return fn( ...args );
+	}, [] );
+}

--- a/client/lib/use-stable-callback/index.ts
+++ b/client/lib/use-stable-callback/index.ts
@@ -21,7 +21,7 @@ export type CallbackFunction< Args extends CallbackArgs, ReturnValue > = (
  * See https://github.com/reactjs/rfcs/blob/useevent/text/0000-useevent.md for
  * more explanation of why this is helpful.
  */
-export function useJITCallback< Args extends CallbackArgs, ReturnValue >(
+export function useStableCallback< Args extends CallbackArgs, ReturnValue >(
 	handler: CallbackFunction< Args, ReturnValue >
 ): ( ...args: Args ) => ReturnValue {
 	const handlerRef = useRef( handler );

--- a/client/my-sites/checkout/composite-checkout/components/item-variation-picker/types.ts
+++ b/client/my-sites/checkout/composite-checkout/components/item-variation-picker/types.ts
@@ -6,6 +6,7 @@ export type WPCOMProductVariant = {
 	price: number;
 	pricePerMonth: number;
 	termIntervalInMonths: number;
+	termIntervalInDays: number;
 	currency: string;
 	productId: number;
 	productSlug: WPCOMProductSlug;

--- a/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
@@ -17,8 +17,9 @@ import { useSelector } from 'react-redux';
 import { hasDIFMProduct } from 'calypso/lib/cart-values/cart-items';
 import { isWcMobileApp } from 'calypso/lib/mobile-app';
 import {
-	useGetProductVariants,
 	canVariantBePurchased,
+	getVariantPlanProductSlugs,
+	useGetProductVariants,
 } from 'calypso/my-sites/checkout/composite-checkout/hooks/product-variants';
 import { getPlansBySiteId } from 'calypso/state/sites/plans/selectors/get-plans-by-site';
 import { ItemVariationPicker } from './item-variation-picker';
@@ -91,13 +92,11 @@ export function WPOrderReviewLineItems( {
 		products: responseCart.products,
 	} );
 
-	const [ initialVariantTerms ] = useState( () =>
-		responseCart.products.map( ( product ) => product.months_per_bill_period )
-	);
+	const [ initialProducts ] = useState( () => responseCart.products );
 
 	return (
 		<WPOrderReviewList className={ joinClasses( [ className, 'order-review-line-items' ] ) }>
-			{ responseCart.products.map( ( product, i ) => (
+			{ responseCart.products.map( ( product ) => (
 				<LineItemWrapper
 					key={ product.product_slug }
 					product={ product }
@@ -113,7 +112,12 @@ export function WPOrderReviewLineItems( {
 					onRemoveProductCancel={ onRemoveProductCancel }
 					hasPartnerCoupon={ hasPartnerCoupon }
 					isDisabled={ isDisabled }
-					initialVariantTerm={ initialVariantTerms[ i ] }
+					initialVariantTerm={
+						initialProducts.find( ( initialProduct ) => {
+							const variants = getVariantPlanProductSlugs( initialProduct.product_slug );
+							return variants.includes( product.product_slug );
+						} )?.months_per_bill_period
+					}
 				/>
 			) ) }
 			{ couponLineItem && (
@@ -170,7 +174,7 @@ function LineItemWrapper( {
 	onRemoveProductCancel?: ( label: string ) => void;
 	hasPartnerCoupon: boolean;
 	isDisabled: boolean;
-	initialVariantTerm: number | null;
+	initialVariantTerm: number | null | undefined;
 } ) {
 	const isRenewal = isWpComProductRenewal( product );
 	const isWooMobile = isWcMobileApp();

--- a/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
@@ -169,7 +169,19 @@ function LineItemWrapper( {
 		! isRenewal &&
 		! isPremiumPlanWithDIFMInTheCart( product, responseCart ) &&
 		! hasPartnerCoupon;
-	const variants = useGetProductVariants( siteId, product.product_slug );
+	const allVariants = useGetProductVariants( siteId, product.product_slug );
+	const currentVariant = allVariants.find(
+		( variant ) => variant.productId === product.product_id
+	);
+
+	// Only show term variants which are equal to or longer than the currently
+	// selected variant. See https://github.com/Automattic/wp-calypso/issues/69633
+	const variants = currentVariant
+		? allVariants.filter(
+				( variant ) => variant.termIntervalInMonths >= currentVariant.termIntervalInMonths
+		  )
+		: [];
+
 	const areThereVariants = variants.length > 1;
 
 	return (

--- a/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
@@ -1,4 +1,4 @@
-import { isPremium } from '@automattic/calypso-products';
+import { isJetpackPurchasableItem, isPremium } from '@automattic/calypso-products';
 import { FormStatus, useFormStatus } from '@automattic/composite-checkout';
 import {
 	canItemBeRemovedFromCart,
@@ -173,14 +173,24 @@ function LineItemWrapper( {
 	const currentVariant = allVariants.find(
 		( variant ) => variant.productId === product.product_id
 	);
+	const isJetpack = responseCart.products.some( ( product ) =>
+		isJetpackPurchasableItem( product.product_slug )
+	);
 
 	// Only show term variants which are equal to or longer than the currently
-	// selected variant. See https://github.com/Automattic/wp-calypso/issues/69633
-	const variants = currentVariant
-		? allVariants.filter(
-				( variant ) => variant.termIntervalInMonths >= currentVariant.termIntervalInMonths
-		  )
-		: [];
+	// selected variant for WordPress.com. See
+	// https://github.com/Automattic/wp-calypso/issues/69633
+	const variants = ( () => {
+		if ( ! currentVariant ) {
+			return [];
+		}
+		if ( isJetpack ) {
+			return allVariants;
+		}
+		return allVariants.filter(
+			( variant ) => variant.termIntervalInMonths >= currentVariant.termIntervalInMonths
+		);
+	} )();
 
 	const areThereVariants = variants.length > 1;
 

--- a/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
@@ -1,5 +1,5 @@
-import { isJetpackPurchasableItem, isPremium } from '@automattic/calypso-products';
-import { FormStatus, useFormStatus, Button } from '@automattic/composite-checkout';
+import { isPremium } from '@automattic/calypso-products';
+import { FormStatus, useFormStatus } from '@automattic/composite-checkout';
 import {
 	canItemBeRemovedFromCart,
 	getCouponLineItemFromCart,
@@ -12,8 +12,6 @@ import {
 	getPartnerCoupon,
 } from '@automattic/wpcom-checkout';
 import styled from '@emotion/styled';
-import { useTranslate } from 'i18n-calypso';
-import { useState } from 'react';
 import { hasDIFMProduct } from 'calypso/lib/cart-values/cart-items';
 import { isWcMobileApp } from 'calypso/lib/mobile-app';
 import { useGetProductVariants } from 'calypso/my-sites/checkout/composite-checkout/hooks/product-variants';
@@ -162,21 +160,17 @@ function LineItemWrapper( {
 	isDisabled: boolean;
 } ) {
 	const isRenewal = isWpComProductRenewal( product );
-	const shouldShowVariantSelector =
-		onChangePlanLength &&
-		! isRenewal &&
-		! isPremiumPlanWithDIFMInTheCart( product, responseCart ) &&
-		! hasPartnerCoupon;
-	const [ isEditingTerm, setEditingTerm ] = useState( false );
-	const variants = useGetProductVariants( siteId, product.product_slug );
-	const areThereVariants = variants.length > 1;
-
 	const isWooMobile = isWcMobileApp();
 	const isDeletable = canItemBeRemovedFromCart( product, responseCart ) && ! isWooMobile;
 
-	const isJetpack = responseCart.products.some( ( product ) =>
-		isJetpackPurchasableItem( product.product_slug )
-	);
+	const shouldShowVariantSelector =
+		onChangePlanLength &&
+		! isWooMobile &&
+		! isRenewal &&
+		! isPremiumPlanWithDIFMInTheCart( product, responseCart ) &&
+		! hasPartnerCoupon;
+	const variants = useGetProductVariants( siteId, product.product_slug );
+	const areThereVariants = variants.length > 1;
 
 	return (
 		<WPOrderReviewListItem key={ product.uuid }>
@@ -192,12 +186,7 @@ function LineItemWrapper( {
 				onRemoveProductClick={ onRemoveProductClick }
 				onRemoveProductCancel={ onRemoveProductCancel }
 			>
-				{ ! isJetpack &&
-					! isWooMobile &&
-					areThereVariants &&
-					shouldShowVariantSelector &&
-					! isEditingTerm && <TermVariantEditButton onClick={ () => setEditingTerm( true ) } /> }
-				{ areThereVariants && shouldShowVariantSelector && ( isJetpack || isEditingTerm ) && (
+				{ areThereVariants && shouldShowVariantSelector && (
 					<ItemVariationPicker
 						selectedItem={ product }
 						onChangeItemVariant={ onChangePlanLength }
@@ -207,27 +196,6 @@ function LineItemWrapper( {
 				) }
 			</LineItem>
 		</WPOrderReviewListItem>
-	);
-}
-
-const EditTerm = styled( Button )< { theme?: Theme } >`
-	display: inline-block;
-	width: auto;
-	font-size: 0.75rem;
-	color: ${ ( props ) => props.theme.colors.textColorLight };
-	margin-top: 4px;
-`;
-
-function TermVariantEditButton( { onClick }: { onClick: () => void } ) {
-	const translate = useTranslate();
-	return (
-		<EditTerm
-			buttonType="text-button"
-			onClick={ onClick }
-			aria-label={ translate( 'Change the billing term for this product' ) }
-		>
-			{ translate( 'Edit' ) }
-		</EditTerm>
 	);
 }
 

--- a/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
@@ -194,7 +194,7 @@ function LineItemWrapper( {
 	const activePlan = sitePlans?.data?.find( ( plan ) => plan.currentPlan );
 
 	const variants = useGetProductVariants( siteId, product.product_slug, ( variant ) => {
-		if ( ! canVariantBePurchased( variant, activePlan?.interval ) ) {
+		if ( ! canVariantBePurchased( variant, activePlan?.interval, activePlan?.productSlug ) ) {
 			return false;
 		}
 

--- a/client/my-sites/checkout/composite-checkout/hooks/product-variants.tsx
+++ b/client/my-sites/checkout/composite-checkout/hooks/product-variants.tsx
@@ -183,7 +183,7 @@ export function canVariantBePurchased(
 	return false;
 }
 
-function getVariantPlanProductSlugs( productSlug: string | undefined ): string[] {
+export function getVariantPlanProductSlugs( productSlug: string | undefined ): string[] {
 	const chosenPlan = getPlan( productSlug ?? '' )
 		? getPlan( productSlug ?? '' )
 		: getProductFromSlug( productSlug ?? '' );

--- a/client/my-sites/checkout/composite-checkout/hooks/product-variants.tsx
+++ b/client/my-sites/checkout/composite-checkout/hooks/product-variants.tsx
@@ -154,33 +154,46 @@ export function useGetProductVariants(
 
 export function canVariantBePurchased(
 	variant: WPCOMProductVariant,
-	activePlanRenewalInterval: number | undefined
+	activePlanRenewalInterval: number | undefined,
+	activePlanSlug: string | undefined
 ): boolean {
 	// Always allow the variant when the item added to the cart is not a plan.
 	if ( ! isPlan( variant ) ) {
 		return true;
 	}
 
-	// If this is a plan, does the site currently own a plan? If so, is the term
-	// of the variant lower than the term of the currently owned plan? If so, do
-	// not allow the variant because our backend does not support plan upgrades
-	// with term downgrades.
+	// If the variant is a plan and there is no active plan, always allow the variant.
 	if ( ! activePlanRenewalInterval || activePlanRenewalInterval < 1 ) {
 		return true;
 	}
+
+	// If the variant is a plan and the site has an active plan, only allow the
+	// variant if the term of the variant is longer than the term of the active
+	// plan. This is because our backend does not support plan upgrades which are
+	// term downgrades.
 	const variantRenewalInterval = variant.termIntervalInDays;
-	if ( activePlanRenewalInterval <= variantRenewalInterval ) {
-		return true;
+	if ( activePlanRenewalInterval > variantRenewalInterval ) {
+		debug(
+			'filtering out plan variant',
+			variant,
+			'with interval',
+			variantRenewalInterval,
+			'because it is a downgrade from',
+			activePlanRenewalInterval
+		);
+		return false;
 	}
-	debug(
-		'filtering out plan variant',
-		variant,
-		'with interval',
-		variantRenewalInterval,
-		'because it is a downgrade from',
-		activePlanRenewalInterval
-	);
-	return false;
+
+	// If the variant is a plan and the site has an active plan, only allow the
+	// variant it is not a variant of the active plan. In other words, do not
+	// show the variant picker when purchasing a term upgrade for the active
+	// plan. This is because such a case is already an upsell and does not
+	// benefit from a term picker.
+	if ( getVariantPlanProductSlugs( activePlanSlug ).includes( variant.productSlug ) ) {
+		return false;
+	}
+
+	return true;
 }
 
 export function getVariantPlanProductSlugs( productSlug: string | undefined ): string[] {

--- a/client/my-sites/checkout/composite-checkout/hooks/product-variants.tsx
+++ b/client/my-sites/checkout/composite-checkout/hooks/product-variants.tsx
@@ -17,7 +17,7 @@ import debugFactory from 'debug';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState, useMemo, useCallback } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
-import { useJITCallback } from 'calypso/lib/use-jit-callback';
+import { useStableCallback } from 'calypso/lib/use-stable-callback';
 import { requestPlans } from 'calypso/state/plans/actions';
 import { requestProductsList } from 'calypso/state/products-list/actions';
 import { computeProductsWithPrices } from 'calypso/state/products-list/selectors';
@@ -100,7 +100,7 @@ export function useGetProductVariants(
 ): WPCOMProductVariant[] {
 	const translate = useTranslate();
 	const reduxDispatch = useDispatch();
-	const filterCallbackMemoized = useJITCallback( filterCallback ?? fallbackFilter );
+	const filterCallbackMemoized = useStableCallback( filterCallback ?? fallbackFilter );
 
 	const sitePlans = useSelector( ( state ) => getPlansBySiteId( state, siteId ) );
 	const activePlan = sitePlans?.data?.find( ( plan ) => plan.currentPlan );

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout-variant-picker.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout-variant-picker.tsx
@@ -3,7 +3,7 @@
  */
 import { StripeHookProvider } from '@automattic/calypso-stripe';
 import { ShoppingCartProvider, createShoppingCartManagerClient } from '@automattic/shopping-cart';
-import { render, screen, within } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import nock from 'nock';
 import { Provider as ReduxProvider } from 'react-redux';
@@ -133,17 +133,12 @@ describe( 'CheckoutMain with a variant picker', () => {
 	} );
 
 	it.each( [
-		{ activePlan: 'none', cartPlan: 'yearly', expectedVariant: 'monthly' },
 		{ activePlan: 'none', cartPlan: 'yearly', expectedVariant: 'yearly' },
 		{ activePlan: 'none', cartPlan: 'yearly', expectedVariant: 'two-year' },
 		{ activePlan: 'yearly', cartPlan: 'yearly', expectedVariant: 'yearly' },
 		{ activePlan: 'yearly', cartPlan: 'yearly', expectedVariant: 'two-year' },
-		{ activePlan: 'monthly', cartPlan: 'yearly', expectedVariant: 'monthly' },
 		{ activePlan: 'monthly', cartPlan: 'yearly', expectedVariant: 'yearly' },
 		{ activePlan: 'monthly', cartPlan: 'yearly', expectedVariant: 'two-year' },
-		{ activePlan: 'monthly', cartPlan: 'two-year', expectedVariant: 'monthly' },
-		{ activePlan: 'monthly', cartPlan: 'two-year', expectedVariant: 'yearly' },
-		{ activePlan: 'monthly', cartPlan: 'two-year', expectedVariant: 'two-year' },
 	] )(
 		'renders the variant picker with a $expectedVariant variant when the cart contains a $cartPlan plan and the current plan is $activePlan',
 		async ( { activePlan, cartPlan, expectedVariant } ) => {
@@ -247,27 +242,6 @@ describe( 'CheckoutMain with a variant picker', () => {
 			expect(
 				within( variantItem ).getByText( `Save ${ discountPercentage }%` )
 			).toBeInTheDocument();
-		}
-	);
-
-	it.each( [ { activePlan: 'none', cartPlan: 'yearly', expectedVariant: 'monthly' } ] )(
-		'renders the $expectedVariant variant without a discount percentage for a $cartPlan plan when the current plan is $activePlan',
-		async ( { activePlan, cartPlan, expectedVariant } ) => {
-			getPlansBySiteId.mockImplementation( () => ( {
-				data: getActivePersonalPlanDataForType( activePlan ),
-			} ) );
-			const user = userEvent.setup();
-			const cartChanges = { products: [ getBusinessPlanForInterval( cartPlan ) ] };
-			render( <MyCheckout cartChanges={ cartChanges } /> );
-
-			const openVariantPicker = await screen.findByLabelText( 'Pick a product term' );
-			await user.click( openVariantPicker );
-
-			const variantItem = await screen.findByRole( 'option', {
-				name: getVariantItemTextForInterval( expectedVariant ),
-			} );
-
-			expect( within( variantItem ).queryByText( /Save \d+%/ ) ).not.toBeInTheDocument();
 		}
 	);
 

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout-variant-picker.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout-variant-picker.tsx
@@ -3,7 +3,7 @@
  */
 import { StripeHookProvider } from '@automattic/calypso-stripe';
 import { ShoppingCartProvider, createShoppingCartManagerClient } from '@automattic/shopping-cart';
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import nock from 'nock';
 import { Provider as ReduxProvider } from 'react-redux';
@@ -270,12 +270,12 @@ describe( 'CheckoutMain with a variant picker', () => {
 				( plan ) => plan.product_slug === variantSlug
 			);
 			const finalPrice = variantData.raw_price;
-			const variantInterval = variantData.bill_period;
+			const variantInterval = parseInt( variantData.bill_period, 10 );
 			const currentVariantData = getPlansItemsState().find(
 				( plan ) => plan.product_slug === currentVariantSlug
 			);
 			const currentVariantPrice = currentVariantData.raw_price;
-			const currentVariantInterval = currentVariantData.bill_period;
+			const currentVariantInterval = parseInt( currentVariantData.bill_period, 10 );
 			const intervalsInVariant = Math.round( variantInterval / currentVariantInterval );
 			const priceBeforeDiscount = currentVariantPrice * intervalsInVariant;
 

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout-variant-picker.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout-variant-picker.tsx
@@ -165,7 +165,10 @@ describe( 'CheckoutMain with a variant picker', () => {
 		}
 	);
 
-	it.each( [ { activePlan: 'yearly', cartPlan: 'yearly', expectedVariant: 'monthly' } ] )(
+	it.each( [
+		{ activePlan: 'yearly', cartPlan: 'yearly', expectedVariant: 'monthly' },
+		{ activePlan: 'none', cartPlan: 'yearly', expectedVariant: 'monthly' },
+	] )(
 		'renders the variant picker without a $expectedVariant variant when the cart contains a $cartPlan plan and the current plan is $activePlan',
 		async ( { activePlan, cartPlan, expectedVariant } ) => {
 			getPlansBySiteId.mockImplementation( () => ( {
@@ -187,7 +190,10 @@ describe( 'CheckoutMain with a variant picker', () => {
 		}
 	);
 
-	it.each( [ { activePlan: 'two-year', cartPlan: 'yearly' } ] )(
+	it.each( [
+		{ activePlan: 'two-year', cartPlan: 'yearly' },
+		{ activePlan: 'none', cartPlan: 'two-year' },
+	] )(
 		'does not render the variant picker when the cart contains a $cartPlan plan and the current plan is $activePlan',
 		async ( { activePlan, cartPlan } ) => {
 			getPlansBySiteId.mockImplementation( () => ( {

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout-variant-picker.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout-variant-picker.tsx
@@ -154,10 +154,6 @@ describe( 'CheckoutMain with a variant picker', () => {
 			const cartChanges = { products: [ getBusinessPlanForInterval( cartPlan ) ] };
 			render( <MyCheckout cartChanges={ cartChanges } /> );
 
-			const editLineItem = await screen.findByLabelText(
-				'Change the billing term for this product'
-			);
-			await user.click( editLineItem );
 			const openVariantPicker = await screen.findByLabelText( 'Pick a product term' );
 			await user.click( openVariantPicker );
 
@@ -180,10 +176,6 @@ describe( 'CheckoutMain with a variant picker', () => {
 			nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
 			render( <MyCheckout cartChanges={ cartChanges } /> );
 
-			const editLineItem = await screen.findByLabelText(
-				'Change the billing term for this product'
-			);
-			await user.click( editLineItem );
 			const openVariantPicker = await screen.findByLabelText( 'Pick a product term' );
 			await user.click( openVariantPicker );
 
@@ -205,9 +197,7 @@ describe( 'CheckoutMain with a variant picker', () => {
 			nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
 			render( <MyCheckout cartChanges={ cartChanges } /> );
 
-			await expect(
-				screen.findByLabelText( 'Change the billing term for this product' )
-			).toNeverAppear();
+			await expect( screen.findByLabelText( 'Pick a product term' ) ).toNeverAppear();
 		}
 	);
 
@@ -221,10 +211,6 @@ describe( 'CheckoutMain with a variant picker', () => {
 			const cartChanges = { products: [ getBusinessPlanForInterval( cartPlan ) ] };
 			render( <MyCheckout cartChanges={ cartChanges } /> );
 
-			const editLineItem = await screen.findByLabelText(
-				'Change the billing term for this product'
-			);
-			await user.click( editLineItem );
 			const openVariantPicker = await screen.findByLabelText( 'Pick a product term' );
 			await user.click( openVariantPicker );
 
@@ -268,10 +254,6 @@ describe( 'CheckoutMain with a variant picker', () => {
 			const cartChanges = { products: [ getBusinessPlanForInterval( cartPlan ) ] };
 			render( <MyCheckout cartChanges={ cartChanges } /> );
 
-			const editLineItem = await screen.findByLabelText(
-				'Change the billing term for this product'
-			);
-			await user.click( editLineItem );
 			const openVariantPicker = await screen.findByLabelText( 'Pick a product term' );
 			await user.click( openVariantPicker );
 
@@ -287,9 +269,7 @@ describe( 'CheckoutMain with a variant picker', () => {
 		const cartChanges = { products: [ domainProduct ] };
 		render( <MyCheckout cartChanges={ cartChanges } /> );
 
-		await expect(
-			screen.findByLabelText( 'Change the billing term for this product' )
-		).toNeverAppear();
+		await expect( screen.findByLabelText( 'Pick a product term' ) ).toNeverAppear();
 	} );
 
 	it.each( [
@@ -304,9 +284,7 @@ describe( 'CheckoutMain with a variant picker', () => {
 			const cartChanges = { products: [ getPersonalPlanForInterval( cartPlan ) ] };
 			render( <MyCheckout cartChanges={ cartChanges } /> );
 
-			await expect(
-				screen.findByLabelText( 'Change the billing term for this product' )
-			).toNeverAppear();
+			await expect( screen.findByLabelText( 'Pick a product term' ) ).toNeverAppear();
 		}
 	);
 
@@ -315,9 +293,7 @@ describe( 'CheckoutMain with a variant picker', () => {
 		const cartChanges = { products: [ currentPlanRenewal ] };
 		render( <MyCheckout cartChanges={ cartChanges } /> );
 
-		await expect(
-			screen.findByLabelText( 'Change the billing term for this product' )
-		).toNeverAppear();
+		await expect( screen.findByLabelText( 'Pick a product term' ) ).toNeverAppear();
 	} );
 
 	it( 'does not render the variant picker when userAgent is Woo mobile', async () => {

--- a/client/my-sites/checkout/composite-checkout/test/util/index.ts
+++ b/client/my-sites/checkout/composite-checkout/test/util/index.ts
@@ -96,6 +96,7 @@ export const domainProduct = {
 	item_original_cost_display: 'R$5',
 	item_subtotal_integer: 500,
 	item_subtotal_display: 'R$5',
+	bill_period: '365',
 	months_per_bill_period: 12,
 };
 
@@ -121,6 +122,7 @@ export const caDomainProduct = {
 	item_original_cost_display: 'R$5',
 	item_subtotal_integer: 500,
 	item_subtotal_display: 'R$5',
+	bill_period: '365',
 	months_per_bill_period: 12,
 };
 
@@ -139,6 +141,7 @@ export const gSuiteProduct = {
 	item_original_cost_display: 'R$5',
 	item_subtotal_integer: 500,
 	item_subtotal_display: 'R$5',
+	bill_period: '365',
 	months_per_bill_period: 12,
 };
 
@@ -163,6 +166,7 @@ export const domainTransferProduct = {
 	item_original_cost_display: 'R$5',
 	item_subtotal_integer: 500,
 	item_subtotal_display: 'R$5',
+	bill_period: '365',
 	months_per_bill_period: 12,
 };
 
@@ -183,6 +187,7 @@ export const planWithBundledDomain = {
 	item_original_cost_display: 'R$144',
 	item_subtotal_integer: 14400,
 	item_subtotal_display: 'R$144',
+	bill_period: '365',
 	months_per_bill_period: 12,
 };
 
@@ -202,6 +207,7 @@ export const planWithoutDomain = {
 	item_original_cost_display: 'R$144',
 	item_subtotal_integer: 14400,
 	item_subtotal_display: 'R$144',
+	bill_period: '365',
 	months_per_bill_period: 12,
 };
 
@@ -221,6 +227,7 @@ export const planWithoutDomainMonthly = {
 	item_original_cost_display: 'R$144',
 	item_subtotal_integer: 14400,
 	item_subtotal_display: 'R$144',
+	bill_period: '31',
 	months_per_bill_period: 1,
 };
 
@@ -240,6 +247,7 @@ export const planWithoutDomainBiannual = {
 	item_original_cost_display: 'R$144',
 	item_subtotal_integer: 14400,
 	item_subtotal_display: 'R$144',
+	bill_period: '730',
 	months_per_bill_period: 24,
 };
 
@@ -259,10 +267,11 @@ export const planLevel2 = {
 	item_original_cost_display: 'R$144',
 	item_subtotal_integer: 14400,
 	item_subtotal_display: 'R$144',
+	bill_period: '365',
 	months_per_bill_period: 12,
 };
 
-export const planLevel2Monthly = {
+export const planLevel2Monthly: ResponseCartProduct = {
 	...getEmptyResponseCartProduct(),
 	product_name: 'WordPress.com Business Monthly',
 	product_slug: 'business-bundle-monthly',
@@ -270,7 +279,6 @@ export const planLevel2Monthly = {
 	extra: {
 		context: 'signup',
 	},
-	free_trial: false,
 	meta: '',
 	product_id: 1018,
 	volume: 1,
@@ -278,10 +286,11 @@ export const planLevel2Monthly = {
 	item_original_cost_display: 'R$144',
 	item_subtotal_integer: 14400,
 	item_subtotal_display: 'R$144',
+	bill_period: '31',
 	months_per_bill_period: 1,
 };
 
-export const planLevel2Biannual = {
+export const planLevel2Biannual: ResponseCartProduct = {
 	...getEmptyResponseCartProduct(),
 	product_name: 'WordPress.com Business 2 Year',
 	product_slug: 'business-bundle-2y',
@@ -289,7 +298,6 @@ export const planLevel2Biannual = {
 	extra: {
 		context: 'signup',
 	},
-	free_trial: false,
 	meta: '',
 	product_id: 1028,
 	volume: 1,
@@ -297,6 +305,7 @@ export const planLevel2Biannual = {
 	item_original_cost_display: 'R$144',
 	item_subtotal_integer: 14400,
 	item_subtotal_display: 'R$144',
+	bill_period: '730',
 	months_per_bill_period: 24,
 };
 
@@ -372,6 +381,7 @@ function convertRequestProductToResponseProduct(
 					item_original_cost_display: 'R$144',
 					item_subtotal_integer: 14400,
 					item_subtotal_display: 'R$144',
+					bill_period: '365',
 					months_per_bill_period: 12,
 					item_tax: 0,
 					meta: product.meta,
@@ -390,6 +400,7 @@ function convertRequestProductToResponseProduct(
 					item_original_cost_display: 'R$0',
 					item_subtotal_integer: 0,
 					item_subtotal_display: 'R$0',
+					bill_period: '365',
 					months_per_bill_period: 12,
 					item_tax: 0,
 					meta: product.meta,
@@ -408,6 +419,7 @@ function convertRequestProductToResponseProduct(
 					item_original_cost_display: 'R$70',
 					item_subtotal_integer: 70,
 					item_subtotal_display: 'R$70',
+					bill_period: '365',
 					months_per_bill_period: 12,
 					item_tax: 0,
 					meta: product.meta,
@@ -426,6 +438,7 @@ function convertRequestProductToResponseProduct(
 					item_original_cost_display: 'R$70',
 					item_subtotal_integer: 70,
 					item_subtotal_display: 'R$70',
+					bill_period: '365',
 					months_per_bill_period: 12,
 					item_tax: 0,
 					meta: product.meta,
@@ -478,6 +491,7 @@ function convertRequestProductToResponseProduct(
 					item_original_cost_display: 'R$41',
 					item_subtotal_integer: 4100,
 					item_subtotal_display: 'R$41',
+					bill_period: '365',
 					months_per_bill_period: 12,
 					item_tax: 0,
 					meta: product.meta,
@@ -496,6 +510,7 @@ function convertRequestProductToResponseProduct(
 					item_original_cost_display: 'R$42',
 					item_subtotal_integer: 4200,
 					item_subtotal_display: 'R$42',
+					bill_period: '365',
 					months_per_bill_period: 12,
 					item_tax: 0,
 					meta: product.meta,
@@ -514,6 +529,7 @@ function convertRequestProductToResponseProduct(
 					item_original_cost_display: planLevel2.item_original_cost_display,
 					item_subtotal_integer: planLevel2.item_subtotal_integer,
 					item_subtotal_display: planLevel2.item_subtotal_display,
+					bill_period: planLevel2.bill_period,
 					months_per_bill_period: 12,
 					item_tax: 0,
 					meta: product.meta,
@@ -532,6 +548,7 @@ function convertRequestProductToResponseProduct(
 					item_original_cost_display: planLevel2Biannual.item_original_cost_display,
 					item_subtotal_integer: planLevel2Biannual.item_subtotal_integer,
 					item_subtotal_display: planLevel2Biannual.item_subtotal_display,
+					bill_period: planLevel2Biannual.bill_period,
 					months_per_bill_period: 24,
 					item_tax: 0,
 					meta: product.meta,
@@ -672,12 +689,25 @@ export function getVariantItemTextForInterval( type: string ) {
 	}
 }
 
+export function getPlanSubtitleTextForInterval( type: string ) {
+	switch ( type ) {
+		case 'monthly':
+			return /per month/;
+		case 'yearly':
+			return /per year/;
+		case 'two-year':
+			return /per two years/;
+		default:
+			throw new Error( `Unknown plan type '${ type }'` );
+	}
+}
+
 export function getPlansItemsState() {
 	return [
 		{
 			product_id: planWithoutDomain.product_id,
 			product_slug: planWithoutDomain.product_slug,
-			bill_period: 365,
+			bill_period: '365',
 			product_type: 'bundle',
 			available: true,
 			price: '$48',
@@ -687,7 +717,7 @@ export function getPlansItemsState() {
 		{
 			product_id: planWithoutDomainMonthly.product_id,
 			product_slug: planWithoutDomainMonthly.product_slug,
-			bill_period: 30,
+			bill_period: '31',
 			product_type: 'bundle',
 			available: true,
 			price: '$7',
@@ -697,7 +727,7 @@ export function getPlansItemsState() {
 		{
 			product_id: planWithoutDomainBiannual.product_id,
 			product_slug: planWithoutDomainBiannual.product_slug,
-			bill_period: 730,
+			bill_period: '730',
 			product_type: 'bundle',
 			available: true,
 			price: '$84',
@@ -707,7 +737,7 @@ export function getPlansItemsState() {
 		{
 			product_id: planLevel2.product_id,
 			product_slug: planLevel2.product_slug,
-			bill_period: 365,
+			bill_period: '365',
 			product_type: 'bundle',
 			available: true,
 			price: '$300',
@@ -717,7 +747,7 @@ export function getPlansItemsState() {
 		{
 			product_id: planLevel2Monthly.product_id,
 			product_slug: planLevel2Monthly.product_slug,
-			bill_period: 30,
+			bill_period: '30',
 			product_type: 'bundle',
 			available: true,
 			price: '$33',
@@ -727,7 +757,7 @@ export function getPlansItemsState() {
 		{
 			product_id: planLevel2Biannual.product_id,
 			product_slug: planLevel2Biannual.product_slug,
-			bill_period: 730,
+			bill_period: '730',
 			product_type: 'bundle',
 			available: true,
 			price: '$499',

--- a/client/my-sites/checkout/composite-checkout/test/util/index.ts
+++ b/client/my-sites/checkout/composite-checkout/test/util/index.ts
@@ -96,6 +96,7 @@ export const domainProduct = {
 	item_original_cost_display: 'R$5',
 	item_subtotal_integer: 500,
 	item_subtotal_display: 'R$5',
+	months_per_bill_period: 12,
 };
 
 export const caDomainProduct = {
@@ -120,6 +121,7 @@ export const caDomainProduct = {
 	item_original_cost_display: 'R$5',
 	item_subtotal_integer: 500,
 	item_subtotal_display: 'R$5',
+	months_per_bill_period: 12,
 };
 
 export const gSuiteProduct = {
@@ -137,6 +139,7 @@ export const gSuiteProduct = {
 	item_original_cost_display: 'R$5',
 	item_subtotal_integer: 500,
 	item_subtotal_display: 'R$5',
+	months_per_bill_period: 12,
 };
 
 export const domainTransferProduct = {
@@ -160,6 +163,7 @@ export const domainTransferProduct = {
 	item_original_cost_display: 'R$5',
 	item_subtotal_integer: 500,
 	item_subtotal_display: 'R$5',
+	months_per_bill_period: 12,
 };
 
 export const planWithBundledDomain = {
@@ -179,6 +183,7 @@ export const planWithBundledDomain = {
 	item_original_cost_display: 'R$144',
 	item_subtotal_integer: 14400,
 	item_subtotal_display: 'R$144',
+	months_per_bill_period: 12,
 };
 
 export const planWithoutDomain = {
@@ -197,6 +202,7 @@ export const planWithoutDomain = {
 	item_original_cost_display: 'R$144',
 	item_subtotal_integer: 14400,
 	item_subtotal_display: 'R$144',
+	months_per_bill_period: 12,
 };
 
 export const planWithoutDomainMonthly = {
@@ -215,6 +221,7 @@ export const planWithoutDomainMonthly = {
 	item_original_cost_display: 'R$144',
 	item_subtotal_integer: 14400,
 	item_subtotal_display: 'R$144',
+	months_per_bill_period: 1,
 };
 
 export const planWithoutDomainBiannual = {
@@ -233,6 +240,7 @@ export const planWithoutDomainBiannual = {
 	item_original_cost_display: 'R$144',
 	item_subtotal_integer: 14400,
 	item_subtotal_display: 'R$144',
+	months_per_bill_period: 24,
 };
 
 export const planLevel2 = {
@@ -251,6 +259,7 @@ export const planLevel2 = {
 	item_original_cost_display: 'R$144',
 	item_subtotal_integer: 14400,
 	item_subtotal_display: 'R$144',
+	months_per_bill_period: 12,
 };
 
 export const planLevel2Monthly = {
@@ -269,6 +278,7 @@ export const planLevel2Monthly = {
 	item_original_cost_display: 'R$144',
 	item_subtotal_integer: 14400,
 	item_subtotal_display: 'R$144',
+	months_per_bill_period: 1,
 };
 
 export const planLevel2Biannual = {
@@ -287,6 +297,7 @@ export const planLevel2Biannual = {
 	item_original_cost_display: 'R$144',
 	item_subtotal_integer: 14400,
 	item_subtotal_display: 'R$144',
+	months_per_bill_period: 24,
 };
 
 export const fetchStripeConfiguration = async () => stripeConfiguration;

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -502,8 +502,25 @@ export interface ResponseCartProduct {
 	is_sale_coupon_applied: boolean;
 	meta: string;
 	time_added_to_cart: number;
+
+	/**
+	 * The billing term in days in numeric format, but as a string.
+	 *
+	 * Typically one of '31' (monthly), '365' (annual), or '730' (biennial).
+	 *
+	 * Similar to `months_per_bill_period`.
+	 */
 	bill_period: string;
+
+	/**
+	 * The billing term in months in numeric format.
+	 *
+	 * Typically one of 1 (monthly), 12 (annual), or 24 (biennial).
+	 *
+	 * Similar to `bill_period`.
+	 */
 	months_per_bill_period: number | null;
+
 	volume: number;
 	quantity: number | null;
 	current_quantity: number | null;
@@ -511,7 +528,15 @@ export interface ResponseCartProduct {
 	item_tax: number;
 	product_type: string;
 	included_domain_purchase_amount: number;
+
+	/**
+	 * True if the product is a renewal.
+	 *
+	 * This does not get set for `RequestCartProduct` which instead uses
+	 * `extra.purchaseType` set to 'renewal'.
+	 */
 	is_renewal?: boolean;
+
 	subscription_id?: string;
 	introductory_offer_terms?: IntroductoryOfferTerms;
 
@@ -545,7 +570,19 @@ export interface ResponseCartProductExtra {
 	google_apps_users?: GSuiteProductUser[];
 	google_apps_registration_data?: DomainContactDetails;
 	receipt_for_domain?: number;
+
+	/**
+	 * Set to 'renewal' if requesting a renewal.
+	 *
+	 * Often this does not need to be explicitly set because the shopping cart
+	 * endpoint will automatically make a requested product into a renewal if the
+	 * product is already owned.
+	 *
+	 * This is not set for `ResponseCartProduct` objects which use `is_renewal`
+	 * instead.
+	 */
 	purchaseType?: string;
+
 	afterPurchaseUrl?: string;
 	isJetpackCheckout?: boolean;
 	is_marketplace_product?: boolean;


### PR DESCRIPTION
#### Proposed Changes

Monthly plan variants are being selected too frequently in checkout. To help with this, the term variant picker (for WordPress.com, not Jetpack) was hidden behind an "Edit" button in https://github.com/Automattic/wp-calypso/pull/68606. However, now longer term variants are not being selected often enough.

This PR removes the "Edit" button and alters the variant picker (again, for WordPress.com and not Jetpack since Jetpack has no other way to select a monthly plan) so that it will not display variants which have a shorter term than the item that was in the cart when checkout loaded. 

Fixes https://github.com/Automattic/wp-calypso/issues/69633

Note: there's also a plan to consider switching to radio buttons from the designs in https://github.com/Automattic/wp-calypso/pull/69494#issuecomment-1295315829 (we can reuse some of the code in https://github.com/Automattic/wp-calypso/pull/66027) but that will be done separately.

#### Screenshots

Before:
<img width="564" alt="Screen Shot 2022-11-02 at 6 21 35 PM" src="https://user-images.githubusercontent.com/2036909/199613821-1ba9f122-ab53-4708-aaba-0105395e1aca.png">

After:
<img width="568" alt="Screen Shot 2022-11-02 at 6 22 11 PM" src="https://user-images.githubusercontent.com/2036909/199613846-b881062b-0314-44da-9bbd-22317352e662.png">

Before:
<img width="567" alt="Screen Shot 2022-11-02 at 6 23 01 PM" src="https://user-images.githubusercontent.com/2036909/199613910-8e499cb0-542e-49c9-8295-745caf8730ea.png">

After:
<img width="567" alt="Screen Shot 2022-11-02 at 6 23 08 PM" src="https://user-images.githubusercontent.com/2036909/199613920-1bec1e7c-9084-454a-a200-efe9d5c260b8.png">

#### Testing Instructions

Unit tests are included but you can test manually by doing the following.

Test annual/biennial plans:

- Add a WordPress.com annual plan to your cart and visit checkout.
- Verify that underneath the plan is a variant picker (and no "Edit" button).
- Click on the variant picker and verify that you can see the annual option and the biennial option, but not the monthly option.
- Click to select the biennial option and wait for the cart to finish updating.
- Click on the variant picker and verify that you can _still_ see the annual option and the biennial option, but not the monthly option.
- Reload the checkout page.
- Verify that there is no variant picker visible.

Test monthly plans:

- Add a WordPress.com monthly plan to your cart and visit checkout.
- Verify that underneath the plan is a variant picker (and no "Edit" button).
- Click on the variant picker and verify that you can see the monthly, annual, and biennial options.
- Click to select the annual option and wait for the cart to finish updating.
- Click on the variant picker and verify that you can _still_ see the monthly, annual, and biennial options.
- Reload the checkout page.
- Click on the variant picker and verify that you can only the annual and biennial options, but not the monthly option.

Test Jetpack plans:

- Add a Jetpack annual plan to your cart (for a Jetpack site) and visit checkout.
- Verify that underneath the plan is a variant picker (and no "Edit" button).
- Click on the variant picker and verify that you can see the monthly, annual, and biennial options.
