### PR TITLE
Provide `themeSlugWithRepo` and `comingSoon` prop from the step data definition.

### DIFF
--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -205,7 +205,7 @@ export function generateSteps( {
 			providesDependencies: [ 'cartItem', 'themeSlugWithRepo' ],
 			fulfilledStepCallback: isPlanFulfilled,
 		},
-		// the only unique thing about plans-newsletter is that it provides themeSlugWithRepo and comingSoon dependencies
+
 		'plans-newsletter': {
 			stepName: 'plans',
 			apiRequestFunction: addPlanToCart,
@@ -213,9 +213,12 @@ export function generateSteps( {
 			optionalDependencies: [ 'emailItem' ],
 			providesDependencies: [ 'cartItem', 'themeSlugWithRepo', 'comingSoon' ],
 			fulfilledStepCallback: isPlanFulfilled,
+			props: {
+				themeSlugWithRepo: 'pub/lettre',
+				launchSite: true,
+			},
 		},
 
-		// the only unique thing about plans-link-in-bio is that it provides themeSlugWithRepo dependency
 		'plans-link-in-bio': {
 			stepName: 'plans',
 			apiRequestFunction: addPlanToCart,
@@ -223,6 +226,9 @@ export function generateSteps( {
 			optionalDependencies: [ 'emailItem' ],
 			providesDependencies: [ 'cartItem', 'themeSlugWithRepo' ],
 			fulfilledStepCallback: isPlanFulfilled,
+			props: {
+				themeSlugWithRepo: 'pub/lynx',
+			},
 		},
 
 		'plans-new': {

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -77,7 +77,15 @@ export class PlansStep extends Component {
 	}
 
 	onSelectPlan = ( cartItem ) => {
-		const { additionalStepData, stepSectionName, stepName, flowName } = this.props;
+		const {
+			additionalStepData,
+			stepSectionName,
+			stepName,
+			flowName,
+			themeSlugWithRepo,
+			launchSite,
+			goToNextStep,
+		} = this.props;
 
 		if ( cartItem ) {
 			this.props.recordTracksEvent( 'calypso_signup_plan_select', {
@@ -122,36 +130,24 @@ export class PlansStep extends Component {
 					this.props.submitSignupStep( step, {
 						cartItem,
 					} );
-					this.props.goToNextStep();
+					goToNextStep();
 				}
 			);
-		} else if ( flowName === 'newsletter' ) {
-			// newsletter flow always uses pub/lettre
-			// newsletter always needs the site launched
-			this.props.submitSignupStep( step, {
-				cartItem,
-				themeSlugWithRepo: 'pub/lettre',
-				comingSoon: 0,
-			} );
-			this.props.goToNextStep();
-		} else if ( flowName === LINK_IN_BIO_FLOW ) {
-			// link-in-bio flow always uses pub/lynx
-			this.props.submitSignupStep( step, {
-				cartItem,
-				themeSlugWithRepo: 'pub/lynx',
-			} );
-			this.props.goToNextStep();
-		} else {
-			const signupVals = { cartItem };
-
-			// Buying an eCommerce plan defaults to the pub/twentytwentytwo theme (All remaining flows)
-			if ( cartItem && isEcommerce( cartItem ) ) {
-				signupVals.themeSlugWithRepo = 'pub/twentytwentytwo';
-			}
-
-			this.props.submitSignupStep( step, signupVals );
-			this.props.goToNextStep();
+			return;
 		}
+
+		const signupVals = {
+			cartItem,
+			...( themeSlugWithRepo && { themeSlugWithRepo } ),
+			...( launchSite && { comingSoon: 0 } ),
+		};
+
+		if ( cartItem && isEcommerce( cartItem ) ) {
+			signupVals.themeSlugWithRepo = 'pub/twentytwentytwo';
+		}
+
+		this.props.submitSignupStep( step, signupVals );
+		goToNextStep();
 	};
 
 	getDomainName() {


### PR DESCRIPTION
#### Proposed Changes
_This PR is part of refactoring the signup flow code so that customization is less dependent on the flow name. See pau2Xa-4tC-p2#comment-12777 for more details._

This PR adds the functionality of supplying `themeSlugWithRepo` and `comingSoon` sign-up data through the corresponding props defined in `steps-pure.js`, instead of relying on the flow name. While `themeSlugWithRepo` is the same, `comingSoon` is connected to `launchSite`. That way the code for constructing the `signupVals object is consistent and it's also eaiser to understand in my opinion.

#### Testing Instructions

1. Create a site following the Link in Bio flow, `/setup/intro?flow=link-in-bio`, and make sure the resulting site uses the theme `lynx`.
2. Create a site following the Newsletter flow, `/setup/intro?flow=newsletter`, and make sure the resulting site uses the theme `lettre` and is launched by default.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
