### PR TITLE
Introduce the custom callback mechanism upon a sign-up flow completion.

### DIFF
--- a/client/lib/signup/flow-controller.ts
+++ b/client/lib/signup/flow-controller.ts
@@ -86,7 +86,7 @@ function progressStoreListener(
 	};
 }
 
-type OnCompleteCallback = ( dependencies: Dependencies, destination: string ) => void;
+type OnCompleteCallback = ( dependencies: Dependencies, destination: string ) => Promise< void >;
 
 interface SignupFlowControllerOptions {
 	flowName: string;
@@ -344,7 +344,7 @@ export default class SignupFlowController {
 			this._assertFlowProvidedRequiredDependencies();
 			// deferred to ensure that the onComplete function is called after the stores have
 			// emitted their final change events.
-			defer( () => this._onComplete( dependencies, this._destination( dependencies ) ) );
+			this._onComplete( dependencies, this._destination( dependencies ) );
 		}
 	}
 

--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -5,7 +5,6 @@ import { Site } from '@automattic/data-stores';
 import { isBlankCanvasDesign } from '@automattic/design-picker';
 import { guessTimezone, getLanguage } from '@automattic/i18n-utils';
 import { mapRecordKeysRecursively, camelToSnakeCase } from '@automattic/js-utils';
-import { setupSiteAfterCreation, isTailoredSignupFlow } from '@automattic/onboarding';
 import debugFactory from 'debug';
 import { defer, difference, get, includes, isEmpty, pick, startsWith } from 'lodash';
 import { CALYPSO_BUILTBYEXPRESS_GOAL_TEXT_EXPERIMENT_NAME } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/goals/goals';
@@ -296,29 +295,16 @@ export function createSiteWithCart( callback, dependencies, stepData, reduxStore
 				domainItem,
 				themeItem,
 			};
-			if ( isTailoredSignupFlow( flowToCheck ) ) {
-				setupSiteAfterCreation( { siteId, flowName: flowToCheck } ).then( () => {
-					processItemCart(
-						providedDependencies,
-						newCartItems,
-						callback,
-						reduxStore,
-						siteSlug,
-						isFreeThemePreselected,
-						themeSlugWithRepo
-					);
-				} );
-			} else {
-				processItemCart(
-					providedDependencies,
-					newCartItems,
-					callback,
-					reduxStore,
-					siteSlug,
-					isFreeThemePreselected,
-					themeSlugWithRepo
-				);
-			}
+
+			processItemCart(
+				providedDependencies,
+				newCartItems,
+				callback,
+				reduxStore,
+				siteSlug,
+				isFreeThemePreselected,
+				themeSlugWithRepo
+			);
 		}
 	);
 }

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -1,4 +1,5 @@
 import { isEnabled } from '@automattic/calypso-config';
+import { setupSiteAfterCreation } from '@automattic/onboarding';
 import { translate } from 'i18n-calypso';
 import { VIDEOPRESS_ONBOARDING_FLOW_STEPS } from './constants';
 
@@ -115,11 +116,12 @@ export function generateFlows( {
 			destination: ( dependencies ) =>
 				`/setup/subscribers?flow=newsletter&siteSlug=${ dependencies.siteSlug }`,
 			description: 'Beginning of the flow to create a newsletter',
-			lastModified: '2022-08-15',
+			lastModified: '2022-11-01',
 			showRecaptcha: true,
 			get pageTitle() {
 				return translate( 'Newsletter' );
 			},
+			postCompleteCallback: setupSiteAfterCreation,
 		},
 		{
 			name: 'link-in-bio',
@@ -129,11 +131,12 @@ export function generateFlows( {
 					dependencies.siteSlug
 				) }`,
 			description: 'Beginning of the flow to create a link in bio',
-			lastModified: '2022-08-16',
+			lastModified: '2022-11-01',
 			showRecaptcha: true,
 			get pageTitle() {
 				return translate( 'Link in Bio' );
 			},
+			postCompleteCallback: setupSiteAfterCreation,
 		},
 		{
 			name: 'with-add-ons',
@@ -273,8 +276,9 @@ export function generateFlows( {
 			steps: VIDEOPRESS_ONBOARDING_FLOW_STEPS,
 			destination: ( dependencies ) => `/site-editor/${ dependencies.siteSlug }`,
 			description: 'VideoPress signup flow',
-			lastModified: '2022-07-06',
+			lastModified: '2022-11-01',
 			showRecaptcha: true,
+			postCompleteCallback: setupSiteAfterCreation,
 		},
 		{
 			// When adding steps, make sure that signup campaign ref's continue to work.


### PR DESCRIPTION
#### Proposed Changes

This PR introduces `flowCompleteCallback` prop to the signup flows. The callback will be called upon flow completion. 
With this addtion, `setupSiteAfterCreation()` for a VideoPress site, a Newsletter site, and a Link in Bio site, has been moved to the flow completion callback.

This is a required feature for the dotlink Link in Bio partnership project for two reasons:

1. Currently `setupSiteAfterCreation()` is being called in `createSiteWithCart()`. If we want to move the domain step upfront, it won't work because various of Link in Bio steps haven't been performed yet at that point.
2. It currently works, but it relies on the implication that the first `/account` flow will log the user in on completion, since `setupSiteAfterCreation()` uses many API calls that requires an authorization token. That means, if we move the domains step upfront, those API calls will fail.

By introducing this callback mechanism, we can also further reduce places we rely on the flow name to perform custom logics.

#### Testing Instructions

1. Go through the Link in Bio flow(/setup/intro?flow=link-in-bio) and create a site. If you see a preview like below, it means the setup function is properly called:
<img width="1113" alt="image" src="https://user-images.githubusercontent.com/1842898/199175007-1cf7e523-bb89-4eb8-a9e3-b118ff4f803c.png">

2. Go through the Newsletter flow(/setup/intro?flow=newsletter) and create a site. If you see a site preview like below, the setup function is preperly called:
<img width="1216" alt="image" src="https://user-images.githubusercontent.com/1842898/199174539-b07b1e4d-fcfb-4db7-bcee-d64b3c188840.png">

3. Go through the Video press flow and create a site. The site title should be properly assigned:
<img width="866" alt="image" src="https://user-images.githubusercontent.com/1842898/199175406-7939b99e-d4b7-4158-8f4a-f7cd2b402028.png">


4. Go through some other signup flows. They shouldn't be affected.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
