### PR TITLE
Stats: Fix chart rendering and adjust period header content

### DIFF
--- a/client/components/chart/index.jsx
+++ b/client/components/chart/index.jsx
@@ -197,7 +197,6 @@ Chart.propTypes = {
 	data: PropTypes.array,
 	isPlaceholder: PropTypes.bool,
 	isRtl: PropTypes.bool,
-	loading: PropTypes.bool,
 	minBarWidth: PropTypes.number,
 	minTouchBarWidth: PropTypes.number,
 	numberFormat: PropTypes.func,

--- a/client/my-sites/stats/stats-chart-tabs/index.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/index.jsx
@@ -96,11 +96,20 @@ class StatModuleChartTabs extends Component {
 		const isNewFeatured = config.isEnabled( 'stats/new-main-chart' );
 
 		const { isActiveTabLoading } = this.props;
-		const classes = [ 'stats-module', 'is-chart-tabs', { 'is-loading': isActiveTabLoading } ];
+
+		//TODO Try to retire `.stats-module` and replace it with `.is-chart-tabs`.
+		const classes = [
+			'is-chart-tabs',
+			{
+				'is-loading': isActiveTabLoading,
+				'stats-module': ! isNewFeatured,
+				'chart-tabs--new-main-chart': isNewFeatured,
+			},
+		];
 
 		/* pass bars count as `key` to disable transitions between tabs with different column count */
 		return isNewFeatured ? (
-			<div className="chart-tabs--new-main-chart">
+			<div className={ classNames( ...classes ) }>
 				{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace */ }
 				<StatsModulePlaceholder className="is-chart" isLoading={ isActiveTabLoading } />
 				<Chart

--- a/client/my-sites/stats/stats-chart-tabs/index.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/index.jsx
@@ -106,7 +106,6 @@ class StatModuleChartTabs extends Component {
 				<Chart
 					barClick={ this.props.barClick }
 					data={ this.props.chartData }
-					loading={ isActiveTabLoading }
 					chartXPadding={ 0 }
 					minBarWidth={ 35 }
 				/>
@@ -131,11 +130,7 @@ class StatModuleChartTabs extends Component {
 				/>
 				{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace */ }
 				<StatsModulePlaceholder className="is-chart" isLoading={ isActiveTabLoading } />
-				<Chart
-					barClick={ this.props.barClick }
-					data={ this.props.chartData }
-					loading={ isActiveTabLoading }
-				/>
+				<Chart barClick={ this.props.barClick } data={ this.props.chartData } />
 				<StatTabs
 					data={ this.props.counts }
 					tabs={ this.props.charts }

--- a/client/my-sites/stats/stats-chart-tabs/style.scss
+++ b/client/my-sites/stats/stats-chart-tabs/style.scss
@@ -1,6 +1,7 @@
 // Module Tabs
 // (currently only used for the bar chart module at the top)
 
+//TODO This className seems not to be used
 ul.module-tabs {
 	@include clear-fix;
 	border-top: 1px solid var(--color-neutral-0);
@@ -231,9 +232,22 @@ ul.module-tabs {
 	}
 }
 
+.is-chart-tabs {
+	&.is-loading {
+		// Extract .stats-module.is-loading from StatsModulePlaceholder
+		.chart {
+			display: none;
+		}
+	}
+}
+
 // For feature `stats/new-main-chart`
 .chart-tabs--new-main-chart {
 	background-color: var(--studio-white);
+
+	.stats-module__placeholder.is-chart {
+		height: 228px;
+	}
 
 	// Main Chart
 	.chart {

--- a/client/my-sites/stats/stats-date-picker/index.jsx
+++ b/client/my-sites/stats/stats-date-picker/index.jsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { localize } from 'i18n-calypso';
 import { flowRight, get } from 'lodash';
 import PropTypes from 'prop-types';
@@ -111,11 +112,13 @@ class StatsDatePicker extends Component {
 	};
 
 	render() {
+		const isNewFeatured = config.isEnabled( 'stats/new-main-chart' );
+
 		/* eslint-disable wpcalypso/jsx-classname-namespace*/
 		const { summary, translate, query, showQueryDate, isActivity } = this.props;
 		const isSummarizeQuery = get( query, 'summarize' );
 
-		const sectionTitle = isActivity
+		let sectionTitle = isActivity
 			? translate( 'Activity for {{period/}}', {
 					components: {
 						period: (
@@ -142,6 +145,14 @@ class StatsDatePicker extends Component {
 					comment:
 						'Example: "Stats for December 7", "Stats for December 8 - December 14", "Stats for December", "Stats for 2014"',
 			  } );
+
+		if ( isNewFeatured ) {
+			sectionTitle = (
+				<span className="period">
+					<span className="date">{ this.dateForDisplay() }</span>
+				</span>
+			);
+		}
 
 		return (
 			<div>

--- a/client/my-sites/stats/stats-date-picker/index.jsx
+++ b/client/my-sites/stats/stats-date-picker/index.jsx
@@ -58,14 +58,17 @@ class StatsDatePicker extends Component {
 		const localizedDate = moment( momentDate.format( 'YYYY-MM-DD' ) );
 		let formattedDate;
 
+		const isNewFeatured = config.isEnabled( 'stats/new-main-chart' );
+		// ll is a date localized with abbreviated Month by momentjs
+		const weekPeriodFormat = isNewFeatured ? 'll' : 'LL';
+
 		switch ( period ) {
 			case 'week':
 				formattedDate = translate( '%(startDate)s - %(endDate)s', {
 					context: 'Date range for which stats are being displayed',
 					args: {
-						// LL is a date localized by momentjs
-						startDate: localizedDate.startOf( 'week' ).add( 1, 'd' ).format( 'LL' ),
-						endDate: localizedDate.endOf( 'week' ).add( 1, 'd' ).format( 'LL' ),
+						startDate: localizedDate.startOf( 'week' ).add( 1, 'd' ).format( weekPeriodFormat ),
+						endDate: localizedDate.endOf( 'week' ).add( 1, 'd' ).format( weekPeriodFormat ),
 					},
 				} );
 				break;

--- a/client/my-sites/stats/stats-period-navigation/style.scss
+++ b/client/my-sites/stats/stats-period-navigation/style.scss
@@ -32,7 +32,7 @@
 	&.stats-period-navigation--new-main-chart {
 		margin: 0;
 		padding: 0;
-		align-items: baseline;
+		align-items: center;
 
 		.stats-period-navigation__children {
 			text-align: left;

--- a/client/my-sites/stats/stats-period-navigation/style.scss
+++ b/client/my-sites/stats/stats-period-navigation/style.scss
@@ -44,9 +44,17 @@
 			color: var(--studio-gray-100);
 		}
 
+		.stats-date-picker__refresh-status {
+			font-size: $font-body-small;
+			line-height: 16px;
+		}
+
 		.stats-period-navigation__previous,
 		.stats-period-navigation__next {
 			color: #1e1e1e;
+			// Icon size 24x24
+			width: 24px;
+			height: 24px;
 		}
 
 		.stats-period-navigation__next {

--- a/client/my-sites/stats/wordads-chart-tabs/index.jsx
+++ b/client/my-sites/stats/wordads-chart-tabs/index.jsx
@@ -131,11 +131,7 @@ class WordAdsChartTabs extends Component {
 					/>
 					{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace */ }
 					<StatsModulePlaceholder className="is-chart" isLoading={ isDataLoading } />
-					<Chart
-						barClick={ this.props.barClick }
-						data={ this.buildChartData() }
-						loading={ isDataLoading }
-					/>
+					<Chart barClick={ this.props.barClick } data={ this.buildChartData() } />
 					<StatTabs
 						data={ this.props.data }
 						tabs={ this.props.charts }


### PR DESCRIPTION
#### Proposed Changes

* Remove the unused prop `loading` in the `Chart` component.
* Refactor classes of the `ChartTabs` component to avoid the unexpected empty section (`StatsModulePlaceholder`) when loading.
* Adjust period header content styles.
* Remove header text `Stats for `.
* Abbreviate the `months` for the `week` period.


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Launch the `local` development application.
* Navigate to page `/stats/week/${your-site}`.
* Ensure styling on the `Traffic` tab page is aligned with the new version of Design.

| Before | After |
| --- | --- |
| <img width="1113" alt="截圖 2022-11-01 下午3 23 52" src="https://user-images.githubusercontent.com/6869813/199181017-93bd93dd-6594-4bf4-b671-98d17d89f9b3.png"> | <img width="1099" alt="截圖 2022-11-01 下午3 17 10" src="https://user-images.githubusercontent.com/6869813/199181262-0790e3c8-a4cf-423e-be69-418be2734680.png"> |


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #69602 
