### PR TITLE
Update import to fix deprecation warning

### DIFF
--- a/apps/wpcom-block-editor/src/default/features/rich-text.js
+++ b/apps/wpcom-block-editor/src/default/features/rich-text.js
@@ -54,7 +54,7 @@ const RichTextJustifyButton = ( { blockId, isBlockJustified, updateBlockAttribut
 
 const ConnectedRichTextJustifyButton = compose(
 	withSelect( ( wpSelect ) => {
-		const selectedBlock = wpSelect( 'core/editor' ).getSelectedBlock();
+		const selectedBlock = wpSelect( 'core/block-editor' ).getSelectedBlock();
 		if ( ! selectedBlock ) {
 			return {};
 		}


### PR DESCRIPTION
#### Proposed Changes

* Retrieve `selectedBlock` from `core/block-editor` instead of `core/editor` to resolve the deprecation warning.

> `wp.data.select( 'core/editor' ).getSelectedBlock` is deprecated since version 5.3 and will be removed in version 6.2. Please use `wp.data.select( 'core/block-editor' ).getSelectedBlock` instead.

<img width="1511" alt="image" src="https://user-images.githubusercontent.com/10482592/199216577-1d848366-a1f2-4e8f-83f4-0b033bb02e45.png">



#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Sandbox a site and `widgets.wp.com` through your hosts file
* Checkout this branch
* Navigate to `calypso/apps/wpcom-block-editor` in the terminal
* Run `yarn dev --sync`
* Navigate to Appearance > Site Editor
* Open the browser console.
* Add a paragraph block to your page and click on the paragraph text (or click an existing paragraph block text). You should no longer see the `wp.data.select( 'core/editor' ).getSelectedBlock` is deprecated since version 5.3 ...` warning.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #55682
