### PR TITLE
Agency Dashboard: Add issue license and cancel buttons

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@automattic/components';
 import { useMobileBreakpoint } from '@automattic/viewport-react';
-import { getQueryArg, removeQueryArgs } from '@wordpress/url';
+import { getQueryArg, removeQueryArgs, addQueryArgs } from '@wordpress/url';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
@@ -134,13 +134,13 @@ export default function SitesOverview() {
 	const isFavoritesTab = selectedTab.key === 'favorites';
 
 	const issueLicenseRedirectUrl = useMemo( () => {
-		// Convert the product type (e.g., backup, scan) to comma-separated product slugs
-		// that can be used to issue multiple licenses.
-		const commaSeparatedProductSlugs = selectedLicenses
-			?.map( ( type: string ) => getProductSlugFromProductType( type ) )
-			.join( ',' );
-
-		return `/partner-portal/issue-license/?site_id=${ selectedLicensesSiteId }&product_slug=${ commaSeparatedProductSlugs }&source=dashboard`;
+		return addQueryArgs( `/partner-portal/issue-license/`, {
+			site_id: selectedLicensesSiteId,
+			product_slug: selectedLicenses?.map( ( type: string ) =>
+				getProductSlugFromProductType( type )
+			),
+			source: 'dashboard',
+		} );
 	}, [ selectedLicensesSiteId, selectedLicenses ] );
 
 	const renderIssueLicenseButton = () => {
@@ -188,9 +188,7 @@ export default function SitesOverview() {
 									{ translate( 'Manage all your Jetpack sites from one location' ) }
 								</div>
 							</div>
-							<div className="sites-overview__page-licenses">
-								{ selectedLicensesCount > 0 && renderIssueLicenseButton() }
-							</div>
+							{ selectedLicensesCount > 0 && renderIssueLicenseButton() }
 						</div>
 						<SectionNav
 							applyUpdatedStyles

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
@@ -137,7 +137,7 @@ export default function SitesOverview() {
 		// Convert the product type (e.g., backup, scan) to comma-separated product slugs
 		// that can be used to issue multiple licenses.
 		const commaSeparatedProductSlugs = selectedLicenses
-			.map( ( type: string ) => getProductSlugFromProductType( type ) )
+			?.map( ( type: string ) => getProductSlugFromProductType( type ) )
 			.join( ',' );
 
 		return `/partner-portal/issue-license/?site_id=${ selectedLicensesSiteId }&product_slug=${ commaSeparatedProductSlugs }&source=dashboard`;

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
@@ -60,15 +60,18 @@
 	color: var(--studio-gray-60);
 	margin-bottom: 8px;
 }
-.sites-overview__page-licenses {
-	margin-left: auto;
-}
 .sites-overview__licenses-buttons {
+	margin-left: auto;
+
+	button,
+	a {
+		font-size: 1rem;
+	}
+
 	&-cancel {
 		text-decoration: underline;
 		padding: 2;
 		margin-inline-end: 32px;
-		font-size: 1rem;
 		text-underline-offset: 3px;
 	}
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
@@ -47,7 +47,8 @@
 .sites-overview__page-title-container {
 	display: none;
 	@include breakpoint-deprecated( ">660px" ) {
-		display: block;
+		display: flex;
+		align-items: center;
 	}
 }
 .sites-overview__page-title {
@@ -58,6 +59,18 @@
 	font-size: 0.875rem;
 	color: var(--studio-gray-60);
 	margin-bottom: 8px;
+}
+.sites-overview__page-licenses {
+	margin-left: auto;
+}
+.sites-overview__licenses-buttons {
+	&-cancel {
+		text-decoration: underline;
+		padding: 2;
+		margin-inline-end: 32px;
+		font-size: 1rem;
+		text-underline-offset: 3px;
+	}
 }
 .sites-overview__status-select-license,
 .sites-overview__status-unselect-license, {

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
@@ -409,3 +409,15 @@ export const formatSites = ( sites: Array< Site > = [] ): Array< SiteData > | []
 		};
 	} );
 };
+
+/**
+ * Returns the product slug that can be purchased from the dashboard.
+ */
+export const getProductSlugFromProductType = ( type: string ): string | undefined => {
+	const slugs: Record< string, string > = {
+		backup: 'jetpack-backup-t2',
+		scan: 'jetpack-scan',
+	};
+
+	return slugs[ type ];
+};


### PR DESCRIPTION
#### Proposed Changes

This PR adds `Issue new licenses` and `Cancel` buttons in the Dashboard, which should redirect users to the new UI where they can select multiple licenses.

**Note:** The mobile UI implementation is tracked in 1203126240279377-as-1203275821751173

**Screenshot**

![Screenshot 2022-11-01 at 12 27 50](https://user-images.githubusercontent.com/1749918/199213539-0a2c0be8-4495-4427-8854-86842fdcb656.png)

#### Testing Instructions
- Checkout this branch locally
- Run yarn `start-jetpack-cloud`
- Create a new JN site
- Connect Jetpack
- Visit http://jetpack.cloud.localhost:3000/dashboard
- Select backup or scan licenses (and also both) for any of your sites
- Verify that the `Issue new licenses` button will appear on the top and has the correct text (check plural vs singular)
- Verify that the `Cancel` button will reset your existing selection
- Select multiple licenses (e.g., backup and scan) for any of your sites
- Click the `Issue new licenses` button on the top
- Verify that you are redirected to the new UI for multiple licenses selection (WIP) and the URL contains both product slugs (comma-separated, e.g., `?site_id=1&product_slug=jetpack-backup-t2,jetpack-scan&source=dashboard`
- Visit the Jetpack Cloud live link (horizon environment) in this PR and verify this PR isn't causing any regression

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1203126240279377-as-1203126240279390