### PR TITLE
Jetpack Cloud Pricing | Fix client-side redirect on initial load

### DIFF
--- a/client/my-sites/plans/jetpack-plans/product-store/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/index.tsx
@@ -1,5 +1,5 @@
 import { TabPanel } from '@wordpress/components';
-import { useCallback, useEffect, useState, useMemo } from '@wordpress/element';
+import { useCallback, useEffect, useState, useMemo, useRef } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
 import { useDispatch, useSelector } from 'react-redux';
 import StoreFooter from 'calypso/jetpack-connect/store-footer';
@@ -34,6 +34,7 @@ const ProductStore: React.FC< ProductStoreProps > = ( {
 	const translate = useTranslate();
 	const siteId = useSelector( getSelectedSiteId );
 	const dispatch = useDispatch();
+	const didMount = useRef( false );
 
 	const [ currentView, setCurrentView ] = useState< ViewType >( () => {
 		return urlQueryArgs?.[ TAB_QUERY_PARAM ] && TABS.includes( urlQueryArgs[ TAB_QUERY_PARAM ] )
@@ -63,23 +64,20 @@ const ProductStore: React.FC< ProductStoreProps > = ( {
 
 	const showJetpackFree = useShowJetpackFree();
 
-	const tabs = useMemo(
-		() =>
-			TABS.map( ( name ) => {
-				const titles = {
-					products: translate( 'Products' ),
-					bundles: translate( 'Bundles' ),
-				};
-
-				return {
-					name,
-					title: titles[ name ],
-				};
-			} ),
-		[ translate ]
-	);
+	const tabs = useMemo( () => {
+		const titles = {
+			products: translate( 'Products' ),
+			bundles: translate( 'Bundles' ),
+		};
+		return TABS.map( ( name ) => ( { name, title: titles[ name ] } ) );
+	}, [ translate ] );
 
 	useEffect( () => {
+		if ( ! didMount.current ) {
+			didMount.current = true;
+			return;
+		}
+
 		const { location, history } = window;
 
 		history?.pushState?.(


### PR DESCRIPTION
Right now, on the initial page load, the URL changes from `/pricing` to `/pricing?view=bundles`

#### Proposed Changes

* This PR updates the logic to ensure that the URL does not change on initial page load.

#### Testing Instructions

- Do any one of these
    * Do this (Both Calypso Blue and Green)
        * Click on Jetpack Cloud live link below and wait for the redirect to complete, then goto `/pricing`
        * Click on Calypso live link below and wait for the redirect to complete, then goto `/plans/:site`
    * or boot up this PR
        * Run `git fetch && git checkout fix/jp-cloud-pricing-initial-redirect`
        * Run `yarn start` in one terminal window and `yarn start-jetpack-cloud` in another
        * Goto [http://jetpack.cloud.localhost:3001/pricing](http://jetpack.cloud.localhost:3001/pricing)
        * Goto `http://calypso.localhost:3000/plans/:site`
- Confirm that there is no URL change from `/pricing` to `/pricing?view=bundles`
- Switch the tab between Bundles and Products
- Confirm that the URL changes on switching the tab
- Follow the testing instructions given in
    - #68673
    - #69484
    - #69397

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes 1202858161751496-as-1203266987637593/f

| BEFORE | AFTER |
| - | - |
| <img width="390" alt="Screenshot 2022-11-01 at 4 12 59 PM" src="https://user-images.githubusercontent.com/18226415/199216147-d0fa1a23-2771-4150-b9d2-2412b6fa1b0a.png"> | <img width="313" alt="Screenshot 2022-11-01 at 4 13 16 PM" src="https://user-images.githubusercontent.com/18226415/199216118-892c39c8-f5e2-4bc0-85ec-df9a46868fea.png"> |

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203266987637593