### PR TITLE
Enable SSR for Plugins Category pages

### DIFF
--- a/client/my-sites/plugins/controller-logged-out.js
+++ b/client/my-sites/plugins/controller-logged-out.js
@@ -65,9 +65,6 @@ const prefetchProductList = ( queryClient, store ) => {
 		} );
 };
 
-// const prefetchCategoryPlugins = ( queryClient, options ) =>
-// 	prefetchPluginsData( queryClient, getFetchWPORGInfinitePlugins( options ), true );
-
 const prefetchTimebox = ( prefetchPromises, context ) => {
 	const racingPromises = [ Promise.all( prefetchPromises ) ];
 	const isBot = context.res?.req?.useragent?.isBot;

--- a/client/my-sites/plugins/controller-logged-out.js
+++ b/client/my-sites/plugins/controller-logged-out.js
@@ -125,13 +125,17 @@ export async function fetchCategoryPlugins( context, next ) {
 		return next();
 	}
 
+	const categories = getCategories();
+	const category = getCategoryForPluginsBrowser( context );
+
+	const categoryTags = categories[ category || '' ]?.tags || [ category ];
+	const tag = categoryTags.join( ',' );
+
 	const options = {
 		...getQueryOptions( context ),
-		category: getCategoryForPluginsBrowser( context ),
+		category,
+		tag,
 	};
-	const categories = getCategories();
-	const categoryTags = categories[ options.category || '' ]?.tags || [ options.category ];
-	options.tag = categoryTags.join( ',' );
 
 	await prefetchTimebox(
 		[

--- a/client/my-sites/plugins/controller-logged-out.js
+++ b/client/my-sites/plugins/controller-logged-out.js
@@ -6,6 +6,8 @@ import {
 } from 'calypso/data/marketplace/use-wpcom-plugins-query';
 import wpcom from 'calypso/lib/wp';
 import { receiveProductsList } from 'calypso/state/products-list/actions';
+import { getCategories } from './categories/use-categories';
+import { getCategoryForPluginsBrowser } from './controller';
 
 const PREFETCH_TIMEOUT = 2000;
 const PREFETCH_TIMEOUT_BOTS = 10000;
@@ -41,6 +43,15 @@ const prefetchPopularPlugins = ( queryClient, options ) => {
 	);
 };
 
+const prefetchCategoryPlugins = ( queryClient, options ) => {
+	const infinite = true;
+	return prefetchPluginsData(
+		queryClient,
+		getESPluginsInfiniteQueryParams( { ...options, infinite }, infinite ),
+		true
+	);
+};
+
 const prefetchFeaturedPlugins = ( queryClient ) =>
 	prefetchPluginsData( queryClient, getWPCOMFeaturedPluginsQueryParams() );
 
@@ -53,6 +64,9 @@ const prefetchProductList = ( queryClient, store ) => {
 			return store.dispatch( receiveProductsList( productsList, type ) );
 		} );
 };
+
+// const prefetchCategoryPlugins = ( queryClient, options ) =>
+// 	prefetchPluginsData( queryClient, getFetchWPORGInfinitePlugins( options ), true );
 
 const prefetchTimebox = ( prefetchPromises, context ) => {
 	const racingPromises = [ Promise.all( prefetchPromises ) ];
@@ -100,6 +114,32 @@ export async function fetchPlugins( context, next ) {
 			prefetchPaidPlugins( queryClient, options ),
 			prefetchPopularPlugins( queryClient, options ),
 			prefetchFeaturedPlugins( queryClient, options ),
+		],
+		context
+	);
+
+	next();
+}
+
+export async function fetchCategoryPlugins( context, next ) {
+	const { queryClient } = context;
+
+	if ( ! context.isServerSide ) {
+		return next();
+	}
+
+	const options = {
+		...getQueryOptions( context ),
+		category: getCategoryForPluginsBrowser( context ),
+	};
+	const categories = getCategories();
+	const categoryTags = categories[ options.category || '' ]?.tags || [ options.category ];
+	options.tag = categoryTags.join( ',' );
+
+	await prefetchTimebox(
+		[
+			prefetchPaidPlugins( queryClient, options ),
+			prefetchCategoryPlugins( queryClient, options ),
 		],
 		context
 	);

--- a/client/my-sites/plugins/controller.js
+++ b/client/my-sites/plugins/controller.js
@@ -43,7 +43,7 @@ function renderPluginList( context, basePath ) {
 
 // The plugin browser can be rendered by the `/plugins/:plugin/:site_id?` route. In that case,
 // the `:plugin` param is actually the side ID or category.
-function getCategoryForPluginsBrowser( context ) {
+export function getCategoryForPluginsBrowser( context ) {
 	if ( context.params.plugin && includes( ALLOWED_CATEGORIES, context.params.plugin ) ) {
 		return context.params.plugin;
 	}

--- a/client/my-sites/plugins/index.node.js
+++ b/client/my-sites/plugins/index.node.js
@@ -5,7 +5,7 @@ import { setHrefLangLinks, setLocalizedCanonicalUrl } from 'calypso/controller/l
 import { overrideSanitizeSectionRoot } from 'calypso/lib/plugins/sanitize-section-content';
 import { isEnabled } from 'calypso/server/config';
 import { browsePlugins } from './controller';
-import { fetchPlugins, skipIfLoggedIn } from './controller-logged-out';
+import { fetchPlugins, fetchCategoryPlugins, skipIfLoggedIn } from './controller-logged-out';
 
 export default function ( router ) {
 	const langParam = getLanguageRouteParam();
@@ -18,6 +18,19 @@ export default function ( router ) {
 			skipIfLoggedIn,
 			ssrSetupLocale,
 			fetchPlugins,
+			setHrefLangLinks,
+			setLocalizedCanonicalUrl,
+			browsePlugins,
+			makeLayout
+		);
+	}
+
+	if ( isEnabled( 'plugins/ssr-categories' ) ) {
+		router(
+			`/${ langParam }/plugins/browse/:category`,
+			skipIfLoggedIn,
+			ssrSetupLocale,
+			fetchCategoryPlugins,
 			setHrefLangLinks,
 			setLocalizedCanonicalUrl,
 			browsePlugins,

--- a/config/development.json
+++ b/config/development.json
@@ -127,6 +127,7 @@
 		"plans/personal-plan": true,
 		"plans/pro-plan": false,
 		"plans/starter-plan": false,
+		"plugins/ssr-categories": true,
 		"plugins/ssr-landing": true,
 		"post-editor/checkout-overlay": true,
 		"pre-cancellation-modal": false,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -78,6 +78,7 @@
 		"plans/personal-plan": true,
 		"plans/pro-plan": false,
 		"plans/starter-plan": false,
+		"plugins/ssr-categories": false,
 		"plugins/ssr-landing": true,
 		"post-editor/checkout-overlay": true,
 		"pre-cancellation-modal": false,

--- a/config/production.json
+++ b/config/production.json
@@ -93,6 +93,7 @@
 		"plans/personal-plan": true,
 		"plans/pro-plan": false,
 		"plans/starter-plan": false,
+		"plugins/ssr-categories": false,
 		"plugins/ssr-landing": true,
 		"post-editor/checkout-overlay": true,
 		"pre-cancellation-modal": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -91,6 +91,7 @@
 		"plans/personal-plan": true,
 		"plans/pro-plan": false,
 		"plans/starter-plan": false,
+		"plugins/ssr-categories": false,
 		"plugins/ssr-landing": true,
 		"post-editor/checkout-overlay": true,
 		"press-this": true,

--- a/config/test.json
+++ b/config/test.json
@@ -69,6 +69,7 @@
 		"plans/personal-plan": true,
 		"plans/pro-plan": false,
 		"plans/starter-plan": false,
+		"plugins/ssr-categories": true,
 		"plugins/ssr-landing": true,
 		"press-this": true,
 		"publicize-preview": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -100,6 +100,7 @@
 		"plans/personal-plan": true,
 		"plans/pro-plan": false,
 		"plans/starter-plan": false,
+		"plugins/ssr-categories": true,
 		"plugins/ssr-landing": true,
 		"post-editor/checkout-overlay": true,
 		"press-this": true,


### PR DESCRIPTION
#### Proposed Changes

More info: p58i-d84-p2#comment-55362
This is a follow-up to #67747  and allows SSR rendering for logged-out Plugins Category pages. 
It contains a part from #66344 (reverted in #67573) and hides changes behind a `plugins/ssr-categories` flag.



#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Log out and disable JavaScript
* Go to a category page, ex: `/plugins/browse/seo`
* Make sure the plugins are rendered and match the version with JS enabled
<img width="320" alt="Screen Shot on 2022-11-01 at 13-22-19" src="https://user-images.githubusercontent.com/2749938/199222314-77e47f31-a42c-4141-94df-2ca76f4a91dd.png">

* Log in, enable JS and double-check for regressions in the Plugins section

* To disable the feature flag run: `DISABLE_FEATURES=plugins/ssr-categories yarn start `
* Refreshing the `/plugins/browse/seo` page should  only show the WordPress placeholder logo
<img width="320" alt="Screen Shot on 2022-11-01 at 13-43-18" src="https://user-images.githubusercontent.com/2749938/199225302-88c1c2f4-a7d4-4bee-88e8-8ce7dd624813.png">


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
