### PR TITLE
Fix pattern assembler CTA vertical spacing

### DIFF
--- a/packages/design-picker/src/components/style.scss
+++ b/packages/design-picker/src/components/style.scss
@@ -424,6 +424,10 @@
 				}
 			}
 
+			.pattern-assembler-cta-wrapper {
+				margin-top: 32px;
+			}
+
 			.design-button-container {
 				margin-top: 32px;
 


### PR DESCRIPTION
#### Proposed Changes

This PR fixes the issue introduced in #69549, where `row-gap: 0` caused the pattern assemble CTA to lose vertical spacing with the grid items above it.

| Before | After |
| --- | --- |
| ![Screen Shot 2022-11-01 at 7 21 41 PM](https://user-images.githubusercontent.com/797888/199222116-f4ee8e6b-f9cd-44f3-8bf0-fbec0ea923ee.png) | ![Screen Shot 2022-11-01 at 7 22 42 PM](https://user-images.githubusercontent.com/797888/199222257-ca1be86e-8434-44d8-999d-c7e110583940.png) |

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the Goals screen `/setup?siteSlug=${site_slug}` and select "Other".
* Click "Continue" in the vertical screen.
* Once you land in the design picker, ensure that there is vertical spacing between the pattern assembler CTA and the theme cards above it.
* Also test the mobile view.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

