### PR TITLE
Fix issue with missing Follower role for the private site

### DIFF
--- a/client/my-sites/people/invite-people/index.jsx
+++ b/client/my-sites/people/invite-people/index.jsx
@@ -407,17 +407,20 @@ class InvitePeople extends Component {
 			site,
 			translate,
 			needsVerification,
+			isAtomic,
 			isJetpack,
+			isPrivateSite: isPrivate,
 			showSSONotice,
 			includeSubscriberImporter,
 		} = this.props;
-		let includeFollower;
+
+		let includeFollower = isPrivate && ! isAtomic;
 		const includeSubscriber = ! includeSubscriberImporter;
 
 		if ( ! includeSubscriberImporter ) {
 			// Atomic private sites don't support Viewers/Followers.
 			// @see https://github.com/Automattic/wp-calypso/issues/43919
-			includeFollower = ! this.props.isAtomic;
+			includeFollower = ! isAtomic;
 		}
 
 		const inviteForm = (


### PR DESCRIPTION
#### Proposed Changes

* Fix issue with missing Follower role for the private site. For more details, see: https://github.com/Automattic/wp-calypso/issues/69650

#### Testing Instructions

* Make sure your testing site is private. (You can do it by go to Settings > Generals > Privacy )
* Head to `/people/new/${SITE_SLUG}`
* Check if there is a "Viewer" role in the list

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #69650
