### PR TITLE
chore: add KitKat to CODEOWNERS for .github dir.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,6 +9,9 @@
 #
 # See https://help.github.com/en/articles/about-code-owners for details on the format of this file
 
+# Repository configuration
+.github @Automattic/kitkat
+
 # Comments management
 /client/my-sites/comment* @Automattic/serenity
 


### PR DESCRIPTION
#### Proposed Changes

This PR adds @Automattic/kitkat as one of the CODEOWNERS for the `.github` dir. This way, there is at least someone pinged to review changes to the repo configuration.

Context: https://github.com/Automattic/wp-calypso/pull/69385 and p1667320623445379-slack-C02DQP0FP

#### Testing Instructions

None required.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #