### PR TITLE
Update primary nav global updates

### DIFF
--- a/client/blocks/app-promo/style.scss
+++ b/client/blocks/app-promo/style.scss
@@ -2,7 +2,7 @@
 	align-items: flex-start;
 	display: flex;
 	max-width: 300px;
-	margin: 10px;
+	margin: 16px;
 	padding: 3px;
 	overflow: hidden;
 	background-color: var(--color-surface);

--- a/client/blocks/site/index.jsx
+++ b/client/blocks/site/index.jsx
@@ -181,7 +181,7 @@ class Site extends Component {
 						defaultIcon={ this.props.isReskinned ? layout : null }
 						site={ site }
 						// eslint-disable-next-line no-nested-ternary
-						size={ this.props.compact ? 24 : this.props.isReskinned ? 50 : 32 }
+						size={ this.props.compact ? 24 : this.props.isReskinned ? 50 : 36 }
 					/>
 					<div className="site__info">
 						<div className="site__title">{ site.title }</div>

--- a/client/blocks/site/style.scss
+++ b/client/blocks/site/style.scss
@@ -130,6 +130,7 @@
 	font-size: $font-body-small;
 	font-weight: 400;
 	line-height: 1.3;
+	max-width: 95%;
 }
 
 .site__domain {

--- a/client/blocks/site/style.scss
+++ b/client/blocks/site/style.scss
@@ -154,8 +154,8 @@
 
 .site__home {
 	display: block;
-	width: 32px;
-	height: 32px;
+	width: 36px;
+	height: 36px;
 	text-align: center;
 	text-transform: none;
 	overflow: initial;

--- a/client/blocks/site/style.scss
+++ b/client/blocks/site/style.scss
@@ -113,7 +113,7 @@
 	width: 30px;
 	overflow: hidden;
 	align-self: flex-start;
-	margin-right: 8px;
+	margin-right: 16px;
 	flex: 0 0 auto;
 }
 

--- a/client/blocks/upsell-nudge/style.scss
+++ b/client/blocks/upsell-nudge/style.scss
@@ -4,7 +4,7 @@
 	border: 0;
 	border-radius: 2px;
 	color: var(--color-text-inverted);
-	margin: -4px 8px 8px;
+	margin: -4px 16px 8px;
 
 	a,
 	button {

--- a/client/blocks/upsell-nudge/style.scss
+++ b/client/blocks/upsell-nudge/style.scss
@@ -4,7 +4,7 @@
 	border: 0;
 	border-radius: 2px;
 	color: var(--color-text-inverted);
-	margin: -4px 16px 8px;
+	margin: 0 16px 16px;
 
 	a,
 	button {

--- a/client/components/site-selector/style.scss
+++ b/client/components/site-selector/style.scss
@@ -137,7 +137,7 @@
 }
 
 .site-selector .search {
-	margin: 8px;
+	margin: 8px 16px;
 	height: 33px;
 	max-height: 33px;
 	border: 1px solid var(--color-neutral-10);

--- a/client/components/site-selector/style.scss
+++ b/client/components/site-selector/style.scss
@@ -190,7 +190,7 @@
 	display: flex;
 	flex-direction: column;
 	gap: 8px;
-	padding: 8px;
+	padding: 8px 16px;
 	margin-top: auto;
 }
 

--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -191,7 +191,7 @@
 		height: 16px;
 		width: 16px;
 		position: absolute;
-		right: 21px;
+		right: 16px;
 		top: auto;
 	}
 }

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -173,6 +173,17 @@ body.is-focus-sites {
 			background: var(--color-sidebar-background);
 		}
 
+		&__sites::-webkit-scrollbar {
+			background-color: var(--color-sidebar-background);
+			width: 12px;
+		}
+
+		&__sites::-webkit-scrollbar-thumb {
+			background-color: var(--color-sidebar-text-alternative);
+			border-radius: 4px;
+			-webkit-box-shadow: inset 0 0 6px rgba(0, 0, 0, 0.11);
+		}
+
 		&__add-new-site {
 			border-color: var(--color-sidebar-border);
 

--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -175,7 +175,7 @@ $font-size: rem(14px);
 		.sidebar__menu-icon {
 			background-size: contain;
 			color: var(--color-sidebar-gridicon-fill);
-			margin-right: 8px;
+			margin-right: 16px;
 		}
 
 		img.sidebar__menu-icon {

--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -30,7 +30,7 @@
 }
 
 // Local Vars
-$sidebar-item-padding: 8px 0;
+$sidebar-item-padding: 11px 0;
 $font-size: rem(14px);
 
 .clear-secondary-layout-transitions {
@@ -125,7 +125,7 @@ $font-size: rem(14px);
 		.sidebar__expandable-title,
 		.sidebar__menu-link-text {
 			padding: $sidebar-item-padding;
-			max-height: 34px;
+			max-height: 40px;
 			box-sizing: border-box;
 		}
 

--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -76,11 +76,11 @@ $font-size: rem(14px);
 		}
 
 		.site__content {
-			padding: 10px 0 10px 8px;
+			padding: 10px 0 10px 16px;
 		}
 
 		.site__home {
-			left: 8px;
+			left: 16px;
 			top: 10px;
 		}
 
@@ -90,7 +90,7 @@ $font-size: rem(14px);
 			font-size: $font-size;
 			font-weight: 400;
 			line-height: 1.3;
-			padding: 0 0 0 8px;
+			padding: 0 0 0 16px;
 			color: var(--color-sidebar-text);
 			align-items: center;
 
@@ -140,7 +140,7 @@ $font-size: rem(14px);
 			padding: 7px 0 8px;
 
 			.sidebar__menu-link {
-				padding: 5px 12px;
+				padding: 5px 16px;
 				font-size: rem(13px);
 				line-height: 1.4;
 				font-weight: 400;
@@ -230,7 +230,7 @@ $font-size: rem(14px);
 		// Is togglable but closed
 		.sidebar__menu.is-togglable {
 			.sidebar__heading {
-				padding: 0 0 0 8px;
+				padding: 0 0 0 16px;
 				font-weight: 400;
 			}
 		}
@@ -363,20 +363,20 @@ $font-size: rem(14px);
 
 	.current-site__switch-sites .button.is-borderless {
 		color: var(--color-sidebar-text-alternative);
-		padding: 6px 8px 6px 36px;
+		padding: 6px 8px 6px 44px;
 	}
 
 	.current-site__switch-sites .button.is-borderless .gridicon {
 		height: 20px;
 		width: 20px;
 		top: 9px;
-		left: 8px;
+		left: 16px;
 	}
 
 	// client/blocks/site/style.scss
 	.site__content,
 	.all-sites .all-sites__content {
-		padding: 10px 0 10px 8px;
+		padding: 10px 0 10px 16px;
 	}
 
 	&.is-sidebar-collapsed {

--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -381,8 +381,8 @@ $font-size: rem(14px);
 
 	&.is-sidebar-collapsed {
 		.layout:not(.focus-sites) {
-			--sidebar-width-max: 36px;
-			--sidebar-width-min: 36px;
+			--sidebar-width-max: 52px;
+			--sidebar-width-min: 52px;
 		}
 
 		.sidebar__actions {
@@ -426,7 +426,7 @@ $font-size: rem(14px);
 
 		// client/my-sites/current-site/style.scss
 		.current-site__switch-sites .button.is-borderless {
-			height: 34px;
+			height: 44px;
 			padding: 0;
 		}
 
@@ -443,7 +443,7 @@ $font-size: rem(14px);
 		}
 
 		.sidebar .site__content {
-			padding: 10px 2px;
+			padding: 10px 2px 0;
 
 			.count {
 				margin: 0;
@@ -455,17 +455,17 @@ $font-size: rem(14px);
 		}
 
 		.site__home {
-			left: 2px;
+			left: 8px;
 		}
 
 		.sidebar .site .site-icon {
-			margin-bottom: 4px;
+			margin: 0 auto;
 		}
 
 		// client/blocks/upsell-nudge/style.scss
 		.upsell-nudge.banner.card.is-compact {
-			margin: 8px 3px 7px;
-			padding: 2px 12px 2px 4px;
+			margin: 8px 0 7px;
+			padding: 2px 16px;
 		}
 
 		.current-site__notices > .banner {

--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -166,7 +166,7 @@ $font-size: rem(14px);
 
 		.sidebar__inline-text {
 			position: absolute;
-			right: 20px;
+			right: 16px;
 			top: 50%;
 			transform: translateY(-50%);
 			opacity: 0.8;
@@ -279,7 +279,7 @@ $font-size: rem(14px);
 		}
 
 		.sidebar__menu.is-togglable .sidebar__expandable-arrow {
-			margin-right: 10px;
+			margin-right: 11px;
 		}
 
 		.notice {
@@ -562,7 +562,7 @@ $font-size: rem(14px);
 	}
 
 	.sidebar__sparkline {
-		margin-right: 8px;
+		margin-right: 16px;
 	}
 
 	// Reader specific styles

--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -72,11 +72,12 @@ $font-size: rem(14px);
 		box-sizing: border-box;
 
 		.sidebar__separator {
-			margin: 0 0 11px;
+			margin: 16px 0;
+			border-top: 1px solid var(--color-sidebar-border);
 		}
 
 		.site__content {
-			padding: 10px 0 10px 16px;
+			padding: 16px 0 16px 16px;
 		}
 
 		.site__home {
@@ -344,7 +345,6 @@ $font-size: rem(14px);
 	.upsell-nudge.banner.card.is-compact {
 		padding: 7px 12px 7px 4px;
 		line-height: 26px;
-		margin-top: 8px;
 	}
 
 	.upsell-nudge.banner.card.is-compact .banner__action {
@@ -363,13 +363,13 @@ $font-size: rem(14px);
 
 	.current-site__switch-sites .button.is-borderless {
 		color: var(--color-sidebar-text-alternative);
-		padding: 6px 8px 6px 44px;
+		padding: 11px 8px 11px 44px;
 	}
 
 	.current-site__switch-sites .button.is-borderless .gridicon {
 		height: 20px;
 		width: 20px;
-		top: 9px;
+		top: 14px;
 		left: 16px;
 	}
 

--- a/client/reader/sidebar/reader-sidebar-lists/style.scss
+++ b/client/reader/sidebar/reader-sidebar-lists/style.scss
@@ -1,6 +1,7 @@
 .sidebar__menu-item--create-reader-list-link {
 	.gridicon,
 	.sidebar__menu-item-title-text {
+		margin-right: 10px;
 		vertical-align: middle;
 	}
 }

--- a/client/reader/sidebar/style.scss
+++ b/client/reader/sidebar/style.scss
@@ -12,8 +12,8 @@
 	.reader-sidebar-tags__text-input {
 		background-color: transparent;
 		border: 0;
-		padding-left: 8px;
-		padding-right: 8px;
+		padding-left: 16px;
+		padding-right: 16px;
 		box-shadow: none;
 
 		.form-text-input {

--- a/client/reader/sidebar/style.scss
+++ b/client/reader/sidebar/style.scss
@@ -74,7 +74,7 @@
 	}
 
 	.sidebar__menu-item-siteicon {
-		margin-right: 15px;
+		margin-right: 16px;
 		position: relative;
 		flex-shrink: 0;
 	}


### PR DESCRIPTION
## Description

This PR explores updating the primary left nav styles across all screens.

![image](https://user-images.githubusercontent.com/5634774/199321121-16f29fcf-f3eb-4af0-b0f3-6cd6e09d60ed.png)

## List of changes

- Left and right padding increased from 8px to 16px
- Padding between icons and labels increased from 8px to 16px
- Style site selector scrollbar colors based on admin color scheme
- Site icon increased from 32x32 to 36x36.
- Row height updates from 34px to 40px
- Add clear divider lines
- Collapsed menu styles updated

## Known issues

- We added a clear separator line color using `--color-sidebar-border`, but I suspect this color variable might not be the right fit for some admin color schemes. We may want to go through each color scheme and create a new variable just for separator lines (across all color schemes).