### PR TITLE
Licensing Portal: add new license multi-selection page

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/issue-multiple-licenses-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-multiple-licenses-form/index.tsx
@@ -9,6 +9,7 @@ import { selectAlphaticallySortedProductOptions } from 'calypso/jetpack-cloud/se
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import useProductsQuery from 'calypso/state/partner-portal/licenses/hooks/use-products-query';
 import type { IssueMultipleLicensesFormProps } from './types';
+
 import './style.scss';
 
 export default function IssueMultipleLicensesForm( {

--- a/client/jetpack-cloud/sections/partner-portal/issue-multiple-licenses-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-multiple-licenses-form/index.tsx
@@ -101,7 +101,7 @@ export default function IssueMultipleLicensesForm( {
 									product={ productOption }
 									onSelectProduct={ onSelectProduct }
 									isSelected={ productOption.slug === product }
-									tabIndex={ 100 + i }
+									tabIndex={ 100 + ( products?.length || 0 ) + i }
 								/>
 							) ) }
 					</div>

--- a/client/jetpack-cloud/sections/partner-portal/issue-multiple-licenses-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-multiple-licenses-form/index.tsx
@@ -1,11 +1,112 @@
+import { Button } from '@automattic/components';
+import { getQueryArg } from '@wordpress/url';
+import { useTranslate } from 'i18n-calypso';
+import { useCallback, useState } from 'react';
+import { useDispatch } from 'react-redux';
+import { useLicenseIssuing } from 'calypso/jetpack-cloud/sections/partner-portal/hooks';
+import LicenseProductCard from 'calypso/jetpack-cloud/sections/partner-portal/license-product-card';
+import { selectAlphaticallySortedProductOptions } from 'calypso/jetpack-cloud/sections/partner-portal/utils';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import useProductsQuery from 'calypso/state/partner-portal/licenses/hooks/use-products-query';
 import type { IssueMultipleLicensesFormProps } from './types';
+import './style.scss';
 
-const IssueMultipleLicensesForm: React.FC< IssueMultipleLicensesFormProps > = () => {
+export default function IssueMultipleLicensesForm( {
+	selectedSite,
+}: IssueMultipleLicensesFormProps ) {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+	const { data: allProducts, isLoading: isLoadingProducts } = useProductsQuery( {
+		select: selectAlphaticallySortedProductOptions,
+	} );
+
+	const bundles =
+		allProducts?.filter( ( { family_slug } ) => family_slug === 'jetpack-packs' ) || [];
+	const products =
+		allProducts?.filter( ( { family_slug } ) => family_slug !== 'jetpack-packs' ) || [];
+
+	const defaultProduct = ( getQueryArg( window.location.href, 'product' ) || '' ).toString();
+	const [ product, setProduct ] = useState( defaultProduct );
+	const [ issueLicense, isLoading ] = useLicenseIssuing( product, selectedSite );
+
+	const onSelectProduct = useCallback(
+		( value ) => {
+			dispatch(
+				recordTracksEvent( 'calypso_partner_portal_issue_license_product_select', {
+					product: value,
+				} )
+			);
+			setProduct( value );
+		},
+		[ setProduct ]
+	);
+
+	const selectedSiteDomain = selectedSite?.domain;
+
 	return (
-		<div>
-			<p>Hello there! 👋</p>
+		<div className="issue-multiple-licenses-form">
+			{ isLoadingProducts && <div className="issue-multiple-licenses-form__placeholder" /> }
+
+			{ ! isLoadingProducts && (
+				<>
+					<div className="issue-multiple-licenses-form__top">
+						<p className="issue-multiple-licenses-form__description">
+							{ selectedSiteDomain
+								? translate(
+										'Select the Jetpack products you would like to add to {{strong}}%(selectedSiteDomian)s{{/strong}}:',
+										{
+											args: { selectedSiteDomain },
+											components: { strong: <strong /> },
+										}
+								  )
+								: translate(
+										'Select the Jetpack products you would like to issue a new license for:'
+								  ) }
+						</p>
+						<div className="issue-multiple-licenses-form__controls">
+							<Button
+								primary
+								className="issue-multiple-licenses-form__select-license"
+								disabled={ ! product }
+								busy={ isLoading }
+								onClick={ issueLicense }
+							>
+								{ translate( 'Select License' ) }
+							</Button>
+						</div>
+					</div>
+					<div className="issue-multiple-licenses-form__bottom">
+						{ products &&
+							products.map( ( productOption, i ) => (
+								<LicenseProductCard
+									key={ productOption.slug }
+									product={ productOption }
+									onSelectProduct={ onSelectProduct }
+									isSelected={ productOption.slug === product }
+									tabIndex={ 100 + i }
+								/>
+							) ) }
+					</div>
+					<hr className="issue-multiple-licenses-form__separator" />
+					<p className="issue-multiple-licenses-form__description">
+						{ translate( 'Or select any of our {{strong}}recommended bundles{{/strong}}:', {
+							components: { strong: <strong /> },
+						} ) }
+					</p>
+					<div className="issue-multiple-licenses-form__bottom">
+						{ bundles &&
+							bundles.map( ( productOption, i ) => (
+								<LicenseProductCard
+									key={ productOption.slug }
+									product={ productOption }
+									onSelectProduct={ onSelectProduct }
+									isSelected={ productOption.slug === product }
+									tabIndex={ 100 + i }
+								/>
+							) ) }
+					</div>
+				</>
+			) }
 		</div>
 	);
-};
-
-export default IssueMultipleLicensesForm;
+}

--- a/client/jetpack-cloud/sections/partner-portal/issue-multiple-licenses-form/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/issue-multiple-licenses-form/style.scss
@@ -1,0 +1,71 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+@import "../mixins.scss";
+
+.issue-multiple-licenses-form {
+
+	p {
+		font-size: 1rem;
+	}
+
+	&__placeholder {
+		@include placeholder( --color-neutral-10 );
+
+		height: 43px;
+	}
+
+	.select-dropdown__container {
+		width: 100%;
+	}
+
+	&__actions {
+		display: flex;
+		justify-content: flex-end;
+		margin: 42px -10px 0;
+
+		> * {
+			margin: 0 10px;
+		}
+	}
+}
+
+.issue-multiple-licenses-form__controls {
+	@include licensing-portal-bottom-action-bar;
+}
+
+.issue-multiple-licenses-form__top {
+	display: flex;
+	justify-content: space-between;
+}
+
+.issue-multiple-licenses-form__bottom {
+	display: flex;
+	flex-wrap: wrap;
+
+	@include break-xlarge {
+		margin-left: -0.5rem;
+		margin-right: -0.5rem;
+	}
+}
+
+p.issue-multiple-licenses-form__description {
+	flex: 1 1 auto;
+	align-self: flex-end;
+	margin: 1rem 0;
+	font-size: 0.875rem;
+	color: #333;
+
+	@include breakpoint-deprecated( ">660px" ) {
+		margin-right: 1rem;
+	}
+}
+
+.issue-multiple-licenses-form__separator {
+	margin: 2rem 0;
+}
+
+.issue-multiple-licenses-form__select-license {
+	// :active introduces a 1px border but :focus introduces a 1.5px border which causes the button to move around.
+	border-width: 1.5px !important;
+	border-color: transparent;
+}

--- a/client/jetpack-cloud/sections/partner-portal/issue-multiple-licenses-form/types.ts
+++ b/client/jetpack-cloud/sections/partner-portal/issue-multiple-licenses-form/types.ts
@@ -1,3 +1,4 @@
 export type IssueMultipleLicensesFormProps = {
-	// Coming soon!
+	selectedSite?: { ID: number; domain: string } | null;
+	selectedProductSlugs?: string[];
 };

--- a/client/jetpack-cloud/sections/partner-portal/primary/issue-license/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/issue-license/index.tsx
@@ -32,7 +32,7 @@ export default function IssueLicense( { selectedSite, suggestedProduct }: Assign
 			<CardHeading size={ 36 }>{ translate( 'Issue a new License' ) }</CardHeading>
 
 			{ isEnabled( 'jetpack/partner-portal-issue-multiple-licenses' ) ? (
-				<IssueMultipleLicensesForm />
+				<IssueMultipleLicensesForm selectedSite={ selectedSite } selectedProductSlugs={ [] } />
 			) : (
 				<IssueLicenseForm selectedSite={ selectedSite } suggestedProduct={ suggestedProduct } />
 			) }

--- a/client/state/partner-portal/licenses/hooks/use-products-query.ts
+++ b/client/state/partner-portal/licenses/hooks/use-products-query.ts
@@ -28,9 +28,14 @@ function queryProducts(): Promise< APIProductFamily[] > {
 				.map( ( family ) => {
 					return {
 						...family,
-						products: family.products.filter( ( product ) => {
-							return exclude.indexOf( product.slug ) === -1;
-						} ),
+						products: family.products
+							.filter( ( product ) => {
+								return exclude.indexOf( product.slug ) === -1;
+							} )
+							.map( ( product ) => ( {
+								...product,
+								family_slug: family.slug,
+							} ) ),
 					};
 				} )
 				.filter( ( family ) => {

--- a/client/state/partner-portal/licenses/test/hooks.js
+++ b/client/state/partner-portal/licenses/test/hooks.js
@@ -140,6 +140,7 @@ describe( 'useProductsQuery', () => {
 				slug: 'jetpack-scan',
 				products: [
 					{
+						family_slug: 'jetpack-scan',
 						name: 'Jetpack Scan Daily',
 						product_id: 2106,
 						slug: 'jetpack-scan',
@@ -151,11 +152,13 @@ describe( 'useProductsQuery', () => {
 				slug: 'jetpack-backup',
 				products: [
 					{
+						family_slug: 'jetpack-backup',
 						name: 'Jetpack Backup (10GB)',
 						product_id: 2112,
 						slug: 'jetpack-backup-t1',
 					},
 					{
+						family_slug: 'jetpack-backup',
 						name: 'Jetpack Backup (1TB)',
 						product_id: 2114,
 						slug: 'jetpack-backup-t2',
@@ -167,6 +170,7 @@ describe( 'useProductsQuery', () => {
 				slug: 'jetpack-anti-spam',
 				products: [
 					{
+						family_slug: 'jetpack-anti-spam',
 						name: 'Jetpack Anti-Spam',
 						product_id: 2110,
 						slug: 'jetpack-anti-spam',
@@ -178,6 +182,7 @@ describe( 'useProductsQuery', () => {
 				slug: 'jetpack-videopress',
 				products: [
 					{
+						family_slug: 'jetpack-videopress',
 						name: 'Jetpack VideoPress',
 						product_id: 2116,
 						slug: 'jetpack-videopress',
@@ -189,16 +194,19 @@ describe( 'useProductsQuery', () => {
 				slug: 'jetpack-packs',
 				products: [
 					{
+						family_slug: 'jetpack-packs',
 						name: 'Jetpack Complete',
 						product_id: 2014,
 						slug: 'jetpack-complete',
 					},
 					{
+						family_slug: 'jetpack-packs',
 						name: 'Jetpack Security (10GB)',
 						product_id: 2016,
 						slug: 'jetpack-security-t1',
 					},
 					{
+						family_slug: 'jetpack-packs',
 						name: 'Jetpack Security (1TB)',
 						product_id: 2019,
 						slug: 'jetpack-security-t2',

--- a/client/state/partner-portal/types.ts
+++ b/client/state/partner-portal/types.ts
@@ -95,6 +95,7 @@ export interface APIProductFamilyProduct {
 	currency: string;
 	amount: number;
 	price_interval: string;
+	family_slug: string;
 }
 
 export interface APIProductFamily {


### PR DESCRIPTION
#### Proposed Changes

* Add a new license selection page that allows users to select multiple products simultaneously.

**Note**: this PR only deals with separating the options between products and bundles. The new product cards and multiple selections will come in a follow-up PR.

#### Testing Instructions

* Checkout this branch locally.
* Start Calypso with `yarn start-jetpack-cloud`.
* Visit `http://jetpack.cloud.localhost:3000/partner-portal/issue-license`.
* Verify that products and bundles are separated as shown in the screenshot.
* Visit the Jetpack Cloud live link (horizon environment) in this PR and verify this PR isn't causing any regression.


#### Demo – desktop

<img width="1504" alt="image" src="https://user-images.githubusercontent.com/3418513/199331152-82bc75e2-6863-40b1-ab90-9f7c77ec159e.png">

#### Demo – mobile
<img width="517" alt="image" src="https://user-images.githubusercontent.com/3418513/199331479-66343169-6a40-4128-877c-894146307638.png">

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1203126240279377-as-1203126240279425