### PR TITLE
Data Stores: Add secondary WordPress domain to useSite() hook

### DIFF
--- a/packages/data-stores/src/site/selectors.ts
+++ b/packages/data-stores/src/site/selectors.ts
@@ -22,7 +22,11 @@ export const isNewSite = ( state: State ) => !! state.newSite.data;
 export const getSite = ( state: State, siteId: number | string ) => {
 	return (
 		state.sites[ siteId ] ||
-		Object.values( state.sites ).find( ( site ) => site && new URL( site.URL ).host === siteId )
+		Object.values( state.sites ).find( ( site ) => site && new URL( site.URL ).host === siteId ) ||
+		Object.values( state.sites ).find(
+			( site ) =>
+				site && site.options.unmapped_url && new URL( site.options.unmapped_url ).host === siteId
+		)
 	);
 };
 

--- a/packages/data-stores/src/site/selectors.ts
+++ b/packages/data-stores/src/site/selectors.ts
@@ -21,8 +21,11 @@ export const isNewSite = ( state: State ) => !! state.newSite.data;
  */
 export const getSite = ( state: State, siteId: number | string ) => {
 	return (
+		// Try matching numeric site ID
 		state.sites[ siteId ] ||
+		// Then try matching primary domain
 		Object.values( state.sites ).find( ( site ) => site && new URL( site.URL ).host === siteId ) ||
+		// Then try matching second domain
 		Object.values( state.sites ).find(
 			( site ) =>
 				site && site.options.unmapped_url && new URL( site.options.unmapped_url ).host === siteId

--- a/packages/data-stores/src/site/test/selectors.ts
+++ b/packages/data-stores/src/site/test/selectors.ts
@@ -92,6 +92,69 @@ describe( 'getSite', () => {
 		);
 	} );
 
+	it( 'resolves the state when called with ID', async () => {
+		const ID = 1;
+		const apiResponse = {
+			ID: 1,
+			name: 'My test site',
+			description: '',
+			URL: 'http://mytestsite12345.wordpress.com',
+		};
+
+		( wpcomRequest as jest.Mock ).mockResolvedValue( apiResponse );
+
+		const listenForStateUpdate = () => {
+			return new Promise( ( resolve ) => {
+				const unsubscribe = subscribe( () => {
+					unsubscribe();
+					resolve();
+				} );
+			} );
+		};
+
+		// First call returns undefined
+		expect( select( store ).getSite( ID ) ).toEqual( undefined );
+
+		// In first state update, the resolver starts resolving
+		// In the second update, the resolver is finished and we can read the result in state
+		await listenForStateUpdate();
+		await listenForStateUpdate();
+		expect( select( store ).getSite( ID ) ).toEqual( apiResponse );
+	} );
+
+	it( 'resolves the state when called with secondary wordpress domain', async () => {
+		const slug = 'mytestsite123456.wordpress.com';
+		const apiResponse = {
+			ID: 1,
+			name: 'My test site',
+			description: '',
+			URL: 'http://customdomain.com',
+			options: {
+				unmapped_url: 'http://mytestsite123456.wordpress.com',
+			},
+		};
+
+		( wpcomRequest as jest.Mock ).mockResolvedValue( apiResponse );
+
+		const listenForStateUpdate = () => {
+			return new Promise( ( resolve ) => {
+				const unsubscribe = subscribe( () => {
+					unsubscribe();
+					resolve();
+				} );
+			} );
+		};
+
+		// First call returns undefined
+		expect( select( store ).getSite( slug ) ).toEqual( undefined );
+
+		// In first state update, the resolver starts resolving
+		// In the second update, the resolver is finished and we can read the result in state
+		await listenForStateUpdate();
+		await listenForStateUpdate();
+		expect( select( store ).getSite( slug ) ).toEqual( apiResponse );
+	} );
+
 	it( 'resolves the state via an API call and caches the resolver on fail', async () => {
 		const slug = 'mytestsite12345.wordpress.com';
 		const apiResponse = {


### PR DESCRIPTION
### Proposed Changes

Resolves https://github.com/Automattic/wp-calypso/issues/69624

**Note:** This change fixes the issue above, but it is worth emphasizing that the useSite() hook is widely used elsewhere. I would appreciate extra thoughts and feedback on whether this change would risk any unanticipated issues elsewhere in the code base.

**Context:** For sites that have a primary custom domain, the Launchpad screen is failing to load if we pass the site's secondary *.wordpress.com domain as a query parameter. In these conditions, the useSite() hook is returning null because the getSite() selector tries to match against a numeric site ID or the site.URL property, which is the primary custom domain. The getSite() selector will not currently return a site if provided with a secondary, wordpress.com domain. 

**Proposed Fix:** I've adding a fallback. If there is no numeric site ID, and if there is no match for the primary domain at site.URL, the hook will check to see if site.options.unmapped_url matches, and if so, return the matching site.

### Testing Instructions

**1) Duplicate the issue.** I would recommend first trying to duplicate the issue. You can do this using the WordPress.com production or staging environment or Calypso trunk. Find a simple site that has a custom primary domain. Get that site's secondary *.wordpress.com domain, and load the following url: 

`https://wordpress.com/setup/launchpad?flow=link-in-bio&siteSlug=WORDPRESS_COM_DOMAIN`

You should Launchpad load like this, with empty sidebar and web preview stuck in loading: 
<img width="1505" alt="secondary wp domain" src="https://user-images.githubusercontent.com/21228350/199354787-18d37855-8b8c-4cc6-a333-d6caf7448bc9.png">

**2) Test the fix.** Now test the fix by: 
- Checking out this branch and running yarn and yarn start if needed. 
- For the same screen/url above where you duplicated the issue, replace `https://wordpress.com` with `http://calypso.localhost:3000`
- You should now see the Launchpad screen load correctly with sidebar content and web preview. 

**3) Test regressions.** We also want to ensure that the useSite hook continues to work as expected in conditions where it was working before. Two simple tests:
- Load the same Launchpad url above, but using the primary custom domain.
- Find a simple site without a custom domain, and load the launchpad url again with that domain.
