### PR TITLE
Store: Modify thank you card for Woo mobile

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/atomic-store-thank-you-card.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/atomic-store-thank-you-card.jsx
@@ -6,6 +6,7 @@ import { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import PlanThankYouCard from 'calypso/blocks/plan-thank-you-card';
 import { Interval, EVERY_FIVE_SECONDS } from 'calypso/lib/interval';
+import { isWcMobileApp } from 'calypso/lib/mobile-app';
 import wpcom from 'calypso/lib/wp';
 import { fetchCurrentUser } from 'calypso/state/current-user/actions';
 import {
@@ -87,6 +88,10 @@ class AtomicStoreThankYouCard extends Component {
 		const { isEmailVerified, translate, siteWooCommerceWizardUrl } = this.props;
 		const { resendStatus } = this.state;
 
+		if ( isWcMobileApp() ) {
+			return;
+		}
+
 		if ( ! isEmailVerified ) {
 			return (
 				<div className="checkout-thank-you__atomic-store-action-buttons">
@@ -116,6 +121,10 @@ class AtomicStoreThankYouCard extends Component {
 
 	renderDescription() {
 		const { emailAddress, isEmailVerified, translate } = this.props;
+
+		if ( isWcMobileApp() ) {
+			return translate( 'One moment while we create your store&hellip;' );
+		}
 
 		if ( ! isEmailVerified ) {
 			return (

--- a/client/my-sites/checkout/checkout-thank-you/atomic-store-thank-you-card.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/atomic-store-thank-you-card.jsx
@@ -89,7 +89,7 @@ class AtomicStoreThankYouCard extends Component {
 		const { resendStatus } = this.state;
 
 		if ( isWcMobileApp() ) {
-			return;
+			return <></>; // Non-empty return so that action default doesn't get applied instead.
 		}
 
 		if ( ! isEmailVerified ) {
@@ -123,7 +123,7 @@ class AtomicStoreThankYouCard extends Component {
 		const { emailAddress, isEmailVerified, translate } = this.props;
 
 		if ( isWcMobileApp() ) {
-			return translate( 'One moment while we create your store&hellip;' );
+			return translate( 'One moment while we create your store.' );
 		}
 
 		if ( ! isEmailVerified ) {


### PR DESCRIPTION
#### Proposed Changes

When setting up a new store via the Woo mobile app, the user can create a new wpcom account as part of the process if they don't have one yet, and then they need to add the ecommerce plan to their new site (other plans are not supported by the Woo mobile app). Once these steps are complete, the `AtomicStoreThankYouCard` component is displayed. However, when this renders in the Woo mobile app's webview, we don't want it to show a message about verifying email (because app creates a new account without email verification) and we don't want it to provide a "Create your store" button or any other CTA, as the mobile app will automatically redirect the screen once everything is set up. This change uses userAgent detection to conditionally modify the thankyou card component accordingly in the Woo mobile app webview.

Additional context: https://github.com/woocommerce/team-ghidorah/issues/109#4

#### Testing Instructions

1. Use the latest Calypso Live build ([currently](https://calypso.live/?image=registry.a8c.com/calypso/app:commit-b1e3a657a4dbfd8b5ed4545bd03303fbc0d3007a)).
2. Open the plans screen for one of your test sites that doesn't currently have a plan.
3. Change the userAgent of the browser to `wc-ios` or `wc-android` (I use [User-Agent Switcher](https://addons.mozilla.org/en-US/firefox/addon/uaswitcher/) in Firefox) and refresh the screen. The sidebar menu and top bar should no longer render (this is another effect of the Woo webview userAgent, but is not part of this PR).
4. Choose the Monthly eCommerce plan for the site and proceed through the checkout process.
5. Once the purchase is complete, and the site has been migrated to Atomic if necessary, you should see a green Thank You card. It should say "Thank you for your purchase" and then, simply "One moment while we create your store." It should _not_ mention email verification or have a clickable button to take you to your site.
  ![thankyou](https://user-images.githubusercontent.com/916023/199595324-2e9874ec-8b00-4ba6-9260-fbcff2d7b03e.jpg)

#### Pre-merge Checklist

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
