### PR TITLE
Plugin Management: fix the plugin site switcher url

### DIFF
--- a/client/my-sites/sidebar/static-data/all-sites-menu.js
+++ b/client/my-sites/sidebar/static-data/all-sites-menu.js
@@ -54,7 +54,7 @@ export default function allSitesMenu() {
 			title: translate( 'Plugins' ),
 			navigationLabel: translate( 'View plugins for all sites' ),
 			type: 'menu-item',
-			url: '/plugins',
+			url: '/plugins/manage',
 		},
 	];
 }


### PR DESCRIPTION
#### Proposed Changes

When on `/plugins/manage/:site_slug` if you click "Switch site" on the top left there is a button which says, "View plugins for all sites", which navigates to "/plugins". In Calypso Green this takes the user to a site selector which brings them back to `/plugins/manage/:site_slug`. In Calypso Blue this takes the user to a plugins marketplace.

Now that `/plugins/manage` exists it makes more sense to direct users there in both cases. This PR updates the URL to do that.

<img width="1115" alt="image" src="https://user-images.githubusercontent.com/42627630/199362611-71b45fc6-70fc-441c-a248-8212b4746d37.png">

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Spin up Jetpack Cloud and visit `http://jetpack.cloud.localhost:3001/plugins/manage/:site_slug`. Click "Switch site" in the top left, then click "View plugins for all sites". 
2. Verify that you are redirected to `http://jetpack.cloud.localhost:3001/plugins/manage`.
3. Spin up Calypso and visit `http://calypso.localhost:3001/plugins/:site_slug`. Click "Switch site" in the top left, then click "View plugins for all sites".
4. Verify that you are redirected to 'http://calypso.localhost:3001/plugins`.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1202619025189113-as-1203281903665252