### PR TITLE
Atomic Revival: Use dark variant of illustration for urgent atomic revival tasks

### DIFF
--- a/client/my-sites/customer-home/cards/tasks/revive-auto-reverted-atomic/index.tsx
+++ b/client/my-sites/customer-home/cards/tasks/revive-auto-reverted-atomic/index.tsx
@@ -1,7 +1,7 @@
 import { localizeUrl } from '@automattic/i18n-utils';
 import { translate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
-import disconnectedIllustration from 'calypso/assets/images/customer-home/disconnected.svg';
+import disconnectedIllustration from 'calypso/assets/images/customer-home/disconnected-dark.svg';
 import ExternalLinkWithTracking from 'calypso/components/external-link/with-tracking';
 import {
 	TASK_REACTIVATE_ATOMIC_TRANSFER,


### PR DESCRIPTION
#### Proposed Changes

#69501 set the atomic revival notices on My Home to use the dark "urgent" style. This PR changes the SVG illustration used for those tasks so that they too use the dark style.

**Before**
<img width="1060" alt="CleanShot 2022-11-02 at 15 25 22@2x" src="https://user-images.githubusercontent.com/1500769/199380794-4626ad9e-08e3-46e9-935e-9f18e3196707.png">


**After**
![after](https://user-images.githubusercontent.com/1500769/199380360-e2c0a10d-aa58-4d3a-abb8-17a0bb598d04.png)


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Assuming the D90984-code patch is applied, these should all show the dark illustration

* `/home/{{ site slug }}?view=VIEW_REACTIVATE_RESTORE_BACKUP`
* `/home/{{ site slug }}?view=VIEW_REACTIVATE_EXPIRED_PLAN`
* `/home/{{ site slug }}?view=VIEW_REACTIVATE_ATOMIC_TRANSFER`

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] ~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~
- [ ] ~Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?~
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~
- [ ] ~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/1096