### PR TITLE
Pattern Assembler: Avoid uniquifying the slug of newly created Home template

### DIFF
--- a/packages/data-stores/src/site/actions.ts
+++ b/packages/data-stores/src/site/actions.ts
@@ -285,64 +285,78 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		yield saveSiteSettings( siteId, { blogdescription } );
 	}
 
-	function* setThemeOnSite( siteSlug: string, theme: string, styleVariationSlug?: string ) {
-		yield wpcomRequest( {
-			path: `/sites/${ siteSlug }/themes/mine`,
-			apiVersion: '1.1',
-			body: { theme: theme, style_variation_slug: styleVariationSlug, dont_change_homepage: true },
-			method: 'POST',
-		} );
-	}
-
-	function* setDesignOnSite( siteSlug: string, selectedDesign: Design, options?: DesignOptions ) {
-		const { theme, recipe } = selectedDesign;
-
+	function* setThemeOnSite(
+		siteSlug: string,
+		theme: string,
+		styleVariationSlug?: string,
+		keepHomepage = true
+	) {
 		yield wpcomRequest( {
 			path: `/sites/${ siteSlug }/themes/mine`,
 			apiVersion: '1.1',
 			body: {
-				theme: recipe?.stylesheet?.split( '/' )[ 1 ] || theme,
-				style_variation_slug: options?.styleVariation?.slug,
-				dont_change_homepage: true,
+				theme: theme,
+				style_variation_slug: styleVariationSlug,
+				dont_change_homepage: keepHomepage,
 			},
 			method: 'POST',
 		} );
+	}
+
+	function* runThemeSetupOnSite(
+		siteSlug: string,
+		selectedDesign: Design,
+		options?: DesignOptions
+	) {
+		const { recipe, verticalizable } = selectedDesign;
 
 		/*
 		 * Anchor themes are set up directly via Headstart on the server side
 		 * so exclude them from theme setup.
 		 */
 		const anchorDesigns = [ 'hannah', 'gilbert', 'riley' ];
-		if ( anchorDesigns.indexOf( selectedDesign.template ) < 0 ) {
-			const themeSetupOptions: ThemeSetupOptions = {
-				trim_content: true,
-			};
-
-			if ( selectedDesign.verticalizable ) {
-				themeSetupOptions.vertical_id = options?.verticalId;
-			}
-
-			if ( recipe?.pattern_ids ) {
-				themeSetupOptions.pattern_ids = recipe?.pattern_ids;
-			}
-
-			if ( recipe?.header_pattern_ids ) {
-				themeSetupOptions.header_pattern_ids = recipe?.header_pattern_ids;
-			}
-
-			if ( recipe?.footer_pattern_ids ) {
-				themeSetupOptions.footer_pattern_ids = recipe?.footer_pattern_ids;
-			}
-
-			const response: { blog: string } = yield wpcomRequest( {
-				path: `/sites/${ encodeURIComponent( siteSlug ) }/theme-setup`,
-				apiNamespace: 'wpcom/v2',
-				body: themeSetupOptions,
-				method: 'POST',
-			} );
-
-			return response;
+		if ( anchorDesigns.indexOf( selectedDesign.template ) >= 0 ) {
+			return;
 		}
+
+		const themeSetupOptions: ThemeSetupOptions = {
+			trim_content: true,
+		};
+
+		if ( verticalizable ) {
+			themeSetupOptions.vertical_id = options?.verticalId;
+		}
+
+		if ( recipe?.pattern_ids ) {
+			themeSetupOptions.pattern_ids = recipe?.pattern_ids;
+		}
+
+		if ( recipe?.header_pattern_ids ) {
+			themeSetupOptions.header_pattern_ids = recipe?.header_pattern_ids;
+		}
+
+		if ( recipe?.footer_pattern_ids ) {
+			themeSetupOptions.footer_pattern_ids = recipe?.footer_pattern_ids;
+		}
+
+		const response: { blog: string } = yield wpcomRequest( {
+			path: `/sites/${ encodeURIComponent( siteSlug ) }/theme-setup`,
+			apiNamespace: 'wpcom/v2',
+			body: themeSetupOptions,
+			method: 'POST',
+		} );
+
+		return response;
+	}
+
+	function* setDesignOnSite( siteSlug: string, selectedDesign: Design, options?: DesignOptions ) {
+		yield* setThemeOnSite(
+			siteSlug,
+			selectedDesign.recipe?.stylesheet?.split( '/' )[ 1 ] || selectedDesign.theme,
+			options?.styleVariation?.slug
+		);
+
+		return yield* runThemeSetupOnSite( siteSlug, selectedDesign, options );
 	}
 
 	function* createCustomTemplate(
@@ -575,6 +589,7 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		receiveNewSiteFailed,
 		resetNewSiteFailed,
 		setThemeOnSite,
+		runThemeSetupOnSite,
 		setDesignOnSite,
 		createCustomTemplate,
 		createSite,


### PR DESCRIPTION
#### Proposed Changes

This is for easy testing. If you go through the PA flow with the existing site, and that site has modified the Home template before, then wpcom will append the suffix to the slug of the newly created Home template to make it unique.

Therefore, this PR tries to

* Separate API calls via `setDesignOnSite` as followed and then wpcom won't append the suffix to the slug of the newly created Home template because of duplication.
  * Switch theme
  * Create a home template where its slug is `home`
  * Run theme setup
* Set the `dont_change_homepage` to false for PA flow to avoid copying the content of current Home template into the new Home template

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use a8c account
* Switch to a theme with the default Home template. ex. `pub/pendant`
* Modify the Home template
  ![image](https://user-images.githubusercontent.com/13596067/199394942-30834517-f291-45e7-a16e-6d482102c954.png)
* Go to `/setup?siteSlug=<your_site>`
* Select "Promote myself or business" goal
* When you enter the design picker, select blank canvas CTA
* Select any header, sections, or footer, and press the "Continue" button
* When you land on the site editor, you have to see the Home template with patterns selected in the previous step
  ![image](https://user-images.githubusercontent.com/13596067/199395238-dcfd055a-f467-4060-bfae-cbde11ba24bc.png)
* When you browse all templates, you will see the Home template, and your Index template is never modified.
  ![image](https://user-images.githubusercontent.com/13596067/199395297-51e0cafc-2b51-4825-9e0f-353ae1da7f25.png)

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/68550, https://github.com/Automattic/wp-calypso/pull/69613
