### PR TITLE
add cancelSubscription action function

### DIFF
--- a/client/me/purchases/cancel-subscription/index.ts
+++ b/client/me/purchases/cancel-subscription/index.ts
@@ -2,15 +2,14 @@ import { hasAmountAvailableToRefund, isRefundable } from 'calypso/lib/purchases'
 import { cancelPurchaseAsync, cancelAndRefundPurchaseAsync } from 'calypso/lib/purchases/actions';
 import type { Purchase } from 'calypso/lib/purchases/types';
 
-export interface CancellationResponse {
+export interface PurchaseCancellationResponse {
 	status: boolean;
 	message: string;
 }
 
 export default async function cancelSubscriptionAsync(
-	purchase: Purchase /*,
-	// purchaseListUrl: string */
-): Promise< CancellationResponse > {
+	purchase: Purchase
+): Promise< PurchaseCancellationResponse > {
 	const isPlanRefundable = isRefundable( purchase );
 	const isPlanAutoRenewing = purchase?.isAutoRenewEnabled ?? false;
 
@@ -40,16 +39,16 @@ export default async function cancelSubscriptionAsync(
 		};
 
 		try {
-			const res = await cancelAndRefundPurchaseAsync( purchase.id, data );
-			if ( res.status === 'completed' ) {
+			const response = await cancelAndRefundPurchaseAsync( purchase.id, data );
+			if ( response.status === 'completed' ) {
 				return {
 					status: true,
 					message: 'cancel-and-refund',
 				};
 			}
-		} catch ( err ) {
+		} catch ( error ) {
 			return {
-				status: true,
+				status: false,
 				message: 'cancel-and-refund',
 			};
 		}
@@ -57,6 +56,6 @@ export default async function cancelSubscriptionAsync(
 
 	return {
 		status: false,
-		message: '',
+		message: 'remove-purchase',
 	};
 }

--- a/client/me/purchases/cancel-subscription/index.ts
+++ b/client/me/purchases/cancel-subscription/index.ts
@@ -1,0 +1,62 @@
+import { hasAmountAvailableToRefund, isRefundable } from 'calypso/lib/purchases';
+import { cancelPurchaseAsync, cancelAndRefundPurchaseAsync } from 'calypso/lib/purchases/actions';
+import type { Purchase } from 'calypso/lib/purchases/types';
+
+export interface CancellationResponse {
+	status: boolean;
+	message: string;
+}
+
+export default async function cancelSubscriptionAsync(
+	purchase: Purchase /*,
+	// purchaseListUrl: string */
+): Promise< CancellationResponse > {
+	const isPlanRefundable = isRefundable( purchase );
+	const isPlanAutoRenewing = purchase?.isAutoRenewEnabled ?? false;
+
+	// If AutoRenew disable AutoRenew.
+	if ( isPlanAutoRenewing ) {
+		// If the subscription is not refundable and auto-renew is on turn off auto-renew.
+		const disableAutoRenewResponse = await cancelPurchaseAsync( purchase.id );
+		if ( disableAutoRenewResponse ) {
+			return {
+				status: true,
+				message: 'auto-renew',
+			};
+		}
+
+		return {
+			status: false,
+			message: 'auto-renew',
+		};
+	}
+
+	// If refundable, cancel and refund.
+	if ( isPlanRefundable && hasAmountAvailableToRefund( purchase ) ) {
+		const data = {
+			confirm: true,
+			product_id: purchase.productId,
+			blog_id: purchase.siteId,
+		};
+
+		try {
+			const res = await cancelAndRefundPurchaseAsync( purchase.id, data );
+			if ( res.status === 'completed' ) {
+				return {
+					status: true,
+					message: 'cancel-and-refund',
+				};
+			}
+		} catch ( err ) {
+			return {
+				status: true,
+				message: 'cancel-and-refund',
+			};
+		}
+	}
+
+	return {
+		status: false,
+		message: '',
+	};
+}

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -59,6 +59,7 @@ import {
 	getDisplayName,
 	getPartnerName,
 	getRenewalPrice,
+	getSubscriptionEndDate,
 	handleRenewMultiplePurchasesClick,
 	handleRenewNowClick,
 	hasAmountAvailableToRefund,
@@ -77,7 +78,6 @@ import {
 	shouldRenderMonthlyRenewalOption,
 	getDIFMTieredPurchaseDetails,
 } from 'calypso/lib/purchases';
-import { disableAutoRenew, cancelAndRefundPurchase } from 'calypso/lib/purchases/actions';
 import { getPurchaseCancellationFlowType } from 'calypso/lib/purchases/utils';
 import { hasCustomDomain } from 'calypso/lib/site/utils';
 import { addQueryArgs } from 'calypso/lib/url';
@@ -94,7 +94,9 @@ import {
 	getCurrentUser,
 	getCurrentUserId,
 } from 'calypso/state/current-user/selectors';
+import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import { getProductsList } from 'calypso/state/products-list/selectors';
+import { clearPurchases } from 'calypso/state/purchases/actions';
 import {
 	getSitePurchases,
 	getByPurchaseId,
@@ -106,10 +108,12 @@ import getPrimaryDomainBySiteId from 'calypso/state/selectors/get-primary-domain
 import isDomainOnly from 'calypso/state/selectors/is-domain-only-site';
 import isSiteAtomic from 'calypso/state/selectors/is-site-automated-transfer';
 import { hasLoadedSiteDomains } from 'calypso/state/sites/domains/selectors';
+import { refreshSitePlans } from 'calypso/state/sites/plans/actions';
 import { getSitePlanRawPrice } from 'calypso/state/sites/plans/selectors';
 import { getSite, isRequestingSites } from 'calypso/state/sites/selectors';
 import { getCanonicalTheme } from 'calypso/state/themes/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import cancelSubscriptionAsync from '../cancel-subscription';
 import { cancelPurchase, managePurchase, purchasesRoot } from '../paths';
 import PurchaseSiteHeader from '../purchases-site/header';
 import RemovePurchase from '../remove-purchase';
@@ -122,7 +126,6 @@ import {
 import PurchaseNotice from './notices';
 import PurchasePlanDetails from './plan-details';
 import PurchaseMeta from './purchase-meta';
-
 import './style.scss';
 
 class ManagePurchase extends Component {
@@ -565,6 +568,66 @@ class ManagePurchase extends Component {
 		}
 	}
 
+	submitCancelSubscription = async () => {
+		const { purchase, translate } = this.props;
+		this.setState( { submitting: true } );
+
+		try {
+			const response = await cancelSubscriptionAsync( purchase );
+			const purchaseName = getName( purchase );
+			refreshSitePlans( purchase.siteId );
+			clearPurchases();
+
+			if ( response.status ) {
+				let success_message;
+				if ( response.message === 'auto-renew' ) {
+					success_message = translate( 'Auto-renewal has been turned off successfully.' );
+				}
+
+				if ( response.message === 'cancel-and-refund' ) {
+					const subscriptionEndDate = getSubscriptionEndDate( purchase );
+					success_message = translate(
+						'%(purchaseName)s was successfully cancelled. It will be available ' +
+							'for use until it expires on %(subscriptionEndDate)s.',
+						{
+							args: {
+								purchaseName,
+								subscriptionEndDate,
+							},
+						}
+					);
+				}
+
+				this.props.successNotice( success_message, { displayOnNextPage: true } );
+				page.redirect( this.props.purchaseListUrl );
+			} else {
+				let error_message;
+				if ( response.message === 'auto-renew' ) {
+					error_message = translate(
+						"We've failed to disable auto-renewal for you. Please try again."
+					);
+				}
+
+				if ( response.message === 'cancel-and-refund' ) {
+					error_message = translate(
+						'There was a problem canceling %(purchaseName)s. ' +
+							'Please try again later or contact support.',
+						{
+							args: { purchaseName },
+						}
+					);
+				}
+
+				this.props.errorNotice( error_message );
+			}
+		} catch ( error ) {
+			this.props.errorNotice( error.message );
+			this.closeDialog();
+		} finally {
+			this.setState( { submitting: false } );
+		}
+	};
+
 	renderCancelSurvey() {
 		const { purchase } = this.props;
 
@@ -575,84 +638,15 @@ class ManagePurchase extends Component {
 				linkedPurchases={ this.getActiveMarketplaceSubscriptions() }
 				isVisible={ this.state.isCancelSurveyVisible }
 				onClose={ this.closeDialog }
-				onClickFinalConfirm={ this.cancelSubscription }
+				onClickFinalConfirm={ this.submitCancelSubscription }
 				flowType={ getPurchaseCancellationFlowType( purchase ) }
 			/>
 		);
 	}
 
-	cancelSubscription = async () => {
-		const { purchase } = this.props;
-		const isPlanRefundable = isRefundable( purchase );
-		const isPlanAutoRenewing = purchase?.isAutoRenewEnabled ?? false;
-
-		this.setState( { submitting: true } );
-
-		if ( isPlanAutoRenewing ) {
-			// If the subscription is not refundable and auto-renew is on turn off auto-renew.
-			disableAutoRenew( purchase.id, ( success ) => {
-				const { translate } = this.props;
-
-				if ( success ) {
-					const successMessage = translate( 'Auto-renewal has been turned off successfully.' );
-
-					this.props.successNotice( successMessage, { displayOnNextPage: true } );
-
-					page.redirect( this.props.purchaseListUrl );
-
-					return;
-				}
-
-				const errorMessage = translate(
-					"We've failed to enable auto-renewal for you. Please try again."
-				);
-
-				this.props.errorNotice( errorMessage, { displayOnNextPage: true } );
-				this.setState( { submitting: false } );
-
-				return;
-			} );
-		}
-
-		if ( isPlanRefundable && hasAmountAvailableToRefund( purchase ) ) {
-			const data = {
-				confirm: true,
-				product_id: purchase.productId,
-				blog_id: purchase.siteId,
-			};
-
-			// If the subscription is refundable the subscription should be removed immediately.
-			cancelAndRefundPurchase( purchase.id, data, ( error ) => {
-				const { translate } = this.props;
-
-				if ( error ) {
-					this.props.errorNotice(
-						error.message ||
-							translate(
-								'Unable to cancel your purchase. Please try again later or contact support.'
-							)
-					);
-
-					return;
-				}
-
-				this.props.refreshSitePlans( purchase.siteId );
-				this.props.clearPurchases();
-
-				const successMessage = translate(
-					'You subscription was successfully cancelled and refunded.'
-				);
-
-				this.setState( { submitting: false } );
-
-				this.props.successNotice( successMessage, { displayOnNextPage: true } );
-
-				page.redirect( this.props.purchaseListUrl );
-
-				return;
-			} );
-		}
-
+	cancelSubscription = () => {
+		this.closeDialog();
+		page.redirect( this.props.purchaseListUrl );
 		return;
 	};
 
@@ -1257,5 +1251,7 @@ export default connect(
 	{
 		handleRenewNowClick,
 		handleRenewMultiplePurchasesClick,
+		errorNotice,
+		successNotice,
 	}
 )( localize( ManagePurchase ) );


### PR DESCRIPTION
#### Proposed Changes
Refactor of the `cancel subscription` action in the `ManagePurchase` component as a functional component.

#### Feature flag
?flags=pre-cancellation-modal

#### Testing Instructions
Test 1: auto renew
1. Connect to the Calypso page: http://calypso.localhost:3000/me/purchases
2. Select a subscription plan having auto renew on.
3. Click Cancel Plan
4. Verify the Pre Cancellation modal shows up
5. Confirm to cancel the plan
6. Verify the  cancellation survey show up
7. Verify at the end of the survey the auto renew is disabled, and the user is redirected to the purchases list page. A success notice should appear after the redirect confirming subscription the auto renew has been disabled.

Test 2: subscription in refund window.
1. Connect to the Calypso page: http://calypso.localhost:3000/me/purchases
2. Select a subscription plan in the refund window.
3. Click Cancel Plan
4. Verify the Pre Cancellation modal shows up
5. Confirm to cancel the plan
6. Verify the  cancellation survey show up
7. Verify at the end of the survey the subscription is Refunded and Cancelled, and the user is redirected to the purchases list page. A success notice should appear after the redirect confirming subscription has been cancelled.

#### Video
https://user-images.githubusercontent.com/5706607/204514050-9a45ada0-2dab-4378-b0e7-eec48a6dd290.mp4

Related to #1222

Note: 
Adapting the cancelSubscriptionAsync to the RemovePurchase turned out to be a dirty solution. I could create a second component just for the RemovePurchase component, but I don't think this would improve the state of the component. I have made several attempts in this direction, however I am open to advice in this regard.