### PR TITLE
DIFM Landing: Cleanup after pricing test

### DIFF
--- a/client/my-sites/marketing/do-it-for-me/difm-landing.tsx
+++ b/client/my-sites/marketing/do-it-for-me/difm-landing.tsx
@@ -17,15 +17,14 @@ import styled from '@emotion/styled';
 import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useRef, useState, useCallback } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 import AsyncLoad from 'calypso/components/async-load';
+import QueryProductsList from 'calypso/components/data/query-products-list';
 import FoldableFAQComponent from 'calypso/components/foldable-faq';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import scrollIntoViewport from 'calypso/lib/scroll-into-viewport';
 import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
-import { incrementCounter } from 'calypso/state/persistent-counter/actions';
-import { requestProductsList } from 'calypso/state/products-list/actions';
 import { getProductBySlug } from 'calypso/state/products-list/selectors';
 import { getSitePlan } from 'calypso/state/sites/selectors';
 import type { TranslateResult } from 'i18n-calypso';
@@ -235,7 +234,6 @@ export default function DIFMLanding( {
 	siteId?: number | null;
 } ) {
 	const translate = useTranslate();
-	const dispatch = useDispatch();
 
 	const product = useSelector( ( state ) => getProductBySlug( state, WPCOM_DIFM_LITE ) );
 	const productCost = product?.cost;
@@ -245,8 +243,6 @@ export default function DIFMLanding( {
 
 	const currencyCode = useSelector( getCurrentUserCurrencyCode );
 	const hasPriceDataLoaded = productCost && extraPageCost && currencyCode;
-
-	const [ isLoading, setIsLoading ] = useState( true );
 
 	const displayCost = hasPriceDataLoaded
 		? formatCurrency( productCost, currencyCode, { stripZeros: true } )
@@ -274,14 +270,6 @@ export default function DIFMLanding( {
 		}
 	}, [ isFAQSectionOpen ] );
 
-	useEffect( () => {
-		( async () => {
-			await dispatch( incrementCounter( 'VIEWED_DIFM_LANDING' ) );
-			await dispatch( requestProductsList( { type: 'all' } ) );
-			setIsLoading( false );
-		} )();
-	}, [ dispatch ] );
-
 	const planTitle = isEnabled( 'plans/pro-plan' )
 		? getPlan( PLAN_WPCOM_PRO )?.getTitle()
 		: getPlan( PLAN_PREMIUM )?.getTitle();
@@ -290,7 +278,7 @@ export default function DIFMLanding( {
 		'Hire a professional to set up your site for {{PriceWrapper}}%(displayCost)s{{/PriceWrapper}}{{sup}}*{{/sup}}',
 		{
 			components: {
-				PriceWrapper: isLoading ? <Placeholder /> : <span />,
+				PriceWrapper: ! hasPriceDataLoaded ? <Placeholder /> : <span />,
 				sup: <sup />,
 			},
 			args: {
@@ -335,6 +323,7 @@ export default function DIFMLanding( {
 
 	return (
 		<>
+			{ ! hasPriceDataLoaded && <QueryProductsList persist /> }
 			<Wrapper>
 				<ContentSection>
 					<Header align="left" headerText={ headerText } subHeaderText={ subHeaderText } />


### PR DESCRIPTION
#### Proposed Changes

* This is a partial revert of #66080 and #66294.  Now that the test has ended, the counter increment is no longer required, and we can directly show the product price if it's available in memory.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `setup/difmStartingPoint?siteSlug=<site slug>`.
* Confirm that the product price is shown correctly.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes? - NA
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) - NA
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)? - NA

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Automattic/martech#1121
