### PR TITLE
Pre Cancellation Modal - add tracking events

### DIFF
--- a/client/me/purchases/pre-cancellation-dialog/index.tsx
+++ b/client/me/purchases/pre-cancellation-dialog/index.tsx
@@ -9,6 +9,7 @@ import {
 	maybeWithinRefundPeriod,
 } from 'calypso/lib/purchases';
 import { CALYPSO_CONTACT } from 'calypso/lib/url/support';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import getPlanCancellationFeatures from './get-plan-cancellation-features';
 import type { Purchase } from 'calypso/lib/purchases/types';
 import './style.scss';
@@ -176,10 +177,16 @@ export const PreCancellationDialog = ( {
 	 * Click events, buttons tracking and action.
 	 */
 	const clickCancelPlan = () => {
+		recordTracksEvent( 'calypso_remove_purchase_cancellation_modal_cancel_plan_click', {
+			product_slug: productSlug,
+		} );
 		removePlan();
 	};
 
 	const clickCloseDialog = () => {
+		recordTracksEvent( 'calypso_remove_purchase_cancellation_modal_keep_plan_click', {
+			product_slug: productSlug,
+		} );
 		closeDialog();
 	};
 

--- a/client/me/purchases/pre-cancellation-dialog/index.tsx
+++ b/client/me/purchases/pre-cancellation-dialog/index.tsx
@@ -177,14 +177,14 @@ export const PreCancellationDialog = ( {
 	 * Click events, buttons tracking and action.
 	 */
 	const clickCancelPlan = () => {
-		recordTracksEvent( 'calypso_remove_purchase_cancellation_modal_cancel_plan_click', {
+		recordTracksEvent( 'calypso_pre_cancellation_modal_cancel_plan_click', {
 			product_slug: productSlug,
 		} );
 		removePlan();
 	};
 
 	const clickCloseDialog = () => {
-		recordTracksEvent( 'calypso_remove_purchase_cancellation_modal_keep_plan_click', {
+		recordTracksEvent( 'calypso_pre_cancellation_modal_keep_plan_click', {
 			product_slug: productSlug,
 		} );
 		closeDialog();

--- a/client/me/purchases/pre-cancellation-dialog/index.tsx
+++ b/client/me/purchases/pre-cancellation-dialog/index.tsx
@@ -179,6 +179,9 @@ export const PreCancellationDialog = ( {
 	const clickCancelPlan = () => {
 		recordTracksEvent( 'calypso_pre_cancellation_modal_cancel_plan', {
 			product_slug: productSlug,
+			has_domain: hasDomain ? true : false,
+			has_autorenew: isPurchaseAutoRenewing,
+			is_refundable: isPurchaseRefundable,
 		} );
 
 		removePlan();
@@ -187,6 +190,9 @@ export const PreCancellationDialog = ( {
 	const clickCloseDialog = () => {
 		recordTracksEvent( 'calypso_pre_cancellation_modal_keep_plan', {
 			product_slug: productSlug,
+			has_domain: hasDomain ? true : false,
+			has_autorenew: isPurchaseAutoRenewing,
+			is_refundable: isPurchaseRefundable,
 		} );
 		closeDialog();
 	};

--- a/client/me/purchases/pre-cancellation-dialog/index.tsx
+++ b/client/me/purchases/pre-cancellation-dialog/index.tsx
@@ -3,13 +3,13 @@ import cx from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { SiteExcerptData } from 'calypso/data/sites/site-excerpt-types';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import {
 	hasAmountAvailableToRefund,
 	isRefundable,
 	maybeWithinRefundPeriod,
 } from 'calypso/lib/purchases';
 import { CALYPSO_CONTACT } from 'calypso/lib/url/support';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import getPlanCancellationFeatures from './get-plan-cancellation-features';
 import type { Purchase } from 'calypso/lib/purchases/types';
 import './style.scss';
@@ -177,16 +177,12 @@ export const PreCancellationDialog = ( {
 	 * Click events, buttons tracking and action.
 	 */
 	const clickCancelPlan = () => {
-		recordTracksEvent( 'calypso_pre_cancellation_modal_cancel_plan_click', {
-			product_slug: productSlug,
-		} );
+		recordTracksEvent( 'calypso_pre_cancellation_modal_cancel_plan' );
 		removePlan();
 	};
 
 	const clickCloseDialog = () => {
-		recordTracksEvent( 'calypso_pre_cancellation_modal_keep_plan_click', {
-			product_slug: productSlug,
-		} );
+		recordTracksEvent( 'calypso_pre_cancellation_modal_keep_plan' );
 		closeDialog();
 	};
 

--- a/client/me/purchases/pre-cancellation-dialog/index.tsx
+++ b/client/me/purchases/pre-cancellation-dialog/index.tsx
@@ -177,12 +177,17 @@ export const PreCancellationDialog = ( {
 	 * Click events, buttons tracking and action.
 	 */
 	const clickCancelPlan = () => {
-		recordTracksEvent( 'calypso_pre_cancellation_modal_cancel_plan' );
+		recordTracksEvent( 'calypso_pre_cancellation_modal_cancel_plan', {
+			product_slug: productSlug,
+		} );
+
 		removePlan();
 	};
 
 	const clickCloseDialog = () => {
-		recordTracksEvent( 'calypso_pre_cancellation_modal_keep_plan' );
+		recordTracksEvent( 'calypso_pre_cancellation_modal_keep_plan', {
+			product_slug: productSlug,
+		} );
 		closeDialog();
 	};
 


### PR DESCRIPTION
#### Proposed Changes

Add tracking events to the Pre Cancellation Modal,

#### Feature Flags:
- URL query: ?flags=pre-cancellation-modal
- Shell command: ENABLE_FEATURES=pre-cancellation-modal yarn start

#### Testing Instructions
1. Visit the Calypso purchases page: http://calypso.localhost:3000/me/purchases
2. Select different plans and verify the Tracking events bound to the Pre Cancellation Modal buttons.

#### Screenshot
<img width="674" alt="Screenshot 2022-11-02 at 07 20 56" src="https://user-images.githubusercontent.com/5706607/199413183-c6ec54e5-6b8f-4b2b-8d3b-739456ab65bb.png">

#### Related to https://github.com/Automattic/martech/issues/1222
