### PR TITLE
Switch Themes: Don't keep homepage in the onboarding flow

### DIFF
--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -436,7 +436,7 @@ export function setDesignOnSite( callback, { siteSlug, selectedDesign } ) {
 	const { theme } = selectedDesign;
 
 	wpcom.req
-		.post( `/sites/${ siteSlug }/themes/mine`, { theme, dont_change_homepage: true } )
+		.post( `/sites/${ siteSlug }/themes/mine`, { theme, dont_change_homepage: false } )
 		.then( () =>
 			wpcom.req.post( {
 				path: `/sites/${ siteSlug }/theme-setup`,

--- a/packages/data-stores/src/site/actions.ts
+++ b/packages/data-stores/src/site/actions.ts
@@ -289,7 +289,7 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		yield wpcomRequest( {
 			path: `/sites/${ siteSlug }/themes/mine`,
 			apiVersion: '1.1',
-			body: { theme: theme, style_variation_slug: styleVariationSlug, dont_change_homepage: true },
+			body: { theme: theme, style_variation_slug: styleVariationSlug, dont_change_homepage: false },
 			method: 'POST',
 		} );
 	}
@@ -303,7 +303,7 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 			body: {
 				theme: recipe?.stylesheet?.split( '/' )[ 1 ] || theme,
 				style_variation_slug: options?.styleVariation?.slug,
-				dont_change_homepage: true,
+				dont_change_homepage: false,
 			},
 			method: 'POST',
 		} );


### PR DESCRIPTION
#### Proposed Changes

* After we deployed D89996-code, wpcom will keep the Home template content when we call the `/theme/mine` API with `dont_change_homepage: true` to switch the theme. However, when the user goes through the onboarding flow, we don't need to persist the Home template. As a result, change the default value to `false`.

Another way is to use [isNewSite ](https://github.com/Automattic/wp-calypso/blob/91ab1b589e9c8483566dfa45b1072cb6a319a16e/client/state/sites/selectors/is-new-site.js#L13) to check the site is newly created site. If yes, then we don't need to persist the home page. If not, we can keep the homepage content in case the user enters the onboarding flow again by accident.

Any thoughts?

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start` to create a new site and enter the onboarding flow.
* Select "Promote myself or business" goal at the goal step
* Select designs with the Home template, ex. Pendant
* When you land on the site editor, browser all templates and ensure your template is not modified.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #