### PR TITLE
Onboarding: Redirect to first step on expiration

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/index.tsx
@@ -100,7 +100,7 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 	};
 
 	// Redirect to first step screen if the goals/intent is empty
-	if ( ! [ 'goals', 'vertical', 'intent' ].includes( currentRoute ) && ! intent ) {
+	if ( ! [ 'goals', 'vertical', 'intent', 'processing' ].includes( currentRoute ) && ! intent ) {
 		const _path = ! search
 			? generatePath( '/' + stepPaths[ 0 ] )
 			: generatePath( '/' + stepPaths[ 0 ] + search );

--- a/client/landing/stepper/declarative-flow/internals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/index.tsx
@@ -101,7 +101,7 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 
 	// Redirect to first step screen if the goals/intent is empty
 	if ( ! [ 'goals', 'vertical', 'intent' ].includes( currentRoute ) && ! intent ) {
-		const _path = currentRoute.includes( '?' )
+		const _path = search
 			? generatePath( '/' + stepPaths[ 0 ] )
 			: generatePath( '/' + stepPaths[ 0 ] + search );
 

--- a/client/landing/stepper/declarative-flow/internals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/index.tsx
@@ -99,6 +99,15 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 		}
 	};
 
+	// Redirect to first step screen if the goals/intent is empty
+	if ( ! [ 'goals', 'vertical', 'intent' ].includes( currentRoute ) && ! intent ) {
+		const _path = currentRoute.includes( '?' )
+			? generatePath( '/' + stepPaths[ 0 ] )
+			: generatePath( '/' + stepPaths[ 0 ] + search );
+
+		history.push( _path, stepPaths );
+	}
+
 	return (
 		<>
 			<DocumentHead title={ getDocumentHeadTitle() } />

--- a/client/landing/stepper/declarative-flow/internals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/index.tsx
@@ -101,7 +101,7 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 
 	// Redirect to first step screen if the goals/intent is empty
 	if ( ! [ 'goals', 'vertical', 'intent' ].includes( currentRoute ) && ! intent ) {
-		const _path = search
+		const _path = ! search
 			? generatePath( '/' + stepPaths[ 0 ] )
 			: generatePath( '/' + stepPaths[ 0 ] + search );
 

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -122,6 +122,11 @@ export const siteSetupFlow: Flow = {
 			setStepProgress( flowProgress );
 		}
 
+		// Redirect to /goals or /intent screen if the goals/intent is empty
+		if ( verticalsStepEnabled && currentStep !== 'goals' && ! goals.length ) {
+			navigate( 'goals' );
+		}
+
 		const exitFlow = ( to: string ) => {
 			setPendingAction( () => {
 				/**

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -123,8 +123,11 @@ export const siteSetupFlow: Flow = {
 		}
 
 		// Redirect to /goals or /intent screen if the goals/intent is empty
-		if ( verticalsStepEnabled && currentStep !== 'goals' && ! goals.length ) {
-			navigate( 'goals' );
+		if ( ! [ 'goals', 'vertical', 'intent' ].includes( currentStep ) && ! intent ) {
+			if ( goalsStepEnabled ) {
+				return navigate( 'goals' );
+			}
+			return navigate( 'vertical' );
 		}
 
 		const exitFlow = ( to: string ) => {

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -122,14 +122,6 @@ export const siteSetupFlow: Flow = {
 			setStepProgress( flowProgress );
 		}
 
-		// Redirect to /goals or /intent screen if the goals/intent is empty
-		if ( ! [ 'goals', 'vertical', 'intent' ].includes( currentStep ) && ! intent ) {
-			if ( goalsStepEnabled ) {
-				return navigate( 'goals' );
-			}
-			return navigate( 'vertical' );
-		}
-
 		const exitFlow = ( to: string ) => {
 			setPendingAction( () => {
 				/**


### PR DESCRIPTION
## Proposed Changes

- Check the value of `intent` and redirect to first step when needed

## Testing Instructions

- Access the URL wordpress.com/setup/patternAssembler?siteSlug=[ YOUR SITE ]
- Confirm that the setup flow is redirect to /goals screen

## Reference
[Stepper Framework: Redirect to first step once the ONBOARD_STORE is expired #68467
](https://github.com/Automattic/wp-calypso/issues/68467)
[Pattern Assembler - Zoologist is used instead of Blank canvas when the onboarding data has expired #68374](https://github.com/Automattic/wp-calypso/issues/68374)
