### PR TITLE
Update tasks to allow navigation back to launchpad

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -36,7 +36,7 @@ export function getEnhancedTasks(
 						title: translate( 'Personalize Newsletter' ),
 						actionDispatch: () => {
 							recordTaskClickTracksEvent( flow, task.completed, task.id );
-							window.location.replace(
+							window.location.assign(
 								`/setup/newsletterPostSetup?flow=newsletter-post-setup&siteSlug=${ siteSlug }`
 							);
 						},
@@ -47,7 +47,7 @@ export function getEnhancedTasks(
 						title: translate( 'Choose a Plan' ),
 						actionDispatch: () => {
 							recordTaskClickTracksEvent( flow, task.completed, task.id );
-							window.location.replace( `/plans/${ siteSlug }` );
+							window.location.assign( `/plans/${ siteSlug }` );
 						},
 						badgeText: translatedPlanName,
 					};
@@ -68,7 +68,7 @@ export function getEnhancedTasks(
 						title: translate( 'Write your first post' ),
 						actionDispatch: () => {
 							recordTaskClickTracksEvent( flow, task.completed, task.id );
-							window.location.replace( `/post/${ siteSlug }` );
+							window.location.assign( `/post/${ siteSlug }` );
 						},
 					};
 					break;
@@ -82,7 +82,7 @@ export function getEnhancedTasks(
 						title: translate( 'Personalize Link in Bio' ),
 						actionDispatch: () => {
 							recordTaskClickTracksEvent( flow, task.completed, task.id );
-							window.location.replace(
+							window.location.assign(
 								`/setup/linkInBioPostSetup?flow=link-in-bio-post-setup&siteSlug=${ siteSlug }`
 							);
 						},
@@ -94,7 +94,7 @@ export function getEnhancedTasks(
 						completed: linkInBioLinksEditCompleted,
 						actionDispatch: () => {
 							recordTaskClickTracksEvent( flow, linkInBioLinksEditCompleted, task.id );
-							window.location.replace( `/site-editor/${ siteSlug }` );
+							window.location.assign( `/site-editor/${ siteSlug }` );
 						},
 					};
 					break;
@@ -116,7 +116,7 @@ export function getEnhancedTasks(
 									// Waits for half a second so that the loading screen doesn't flash away too quickly
 									await new Promise( ( res ) => setTimeout( res, 500 ) );
 									recordTaskClickTracksEvent( flow, linkInBioSiteLaunchCompleted, task.id );
-									window.location.replace( `/home/${ siteSlug }` );
+									window.location.assign( `/home/${ siteSlug }` );
 								} );
 
 								submit?.();


### PR DESCRIPTION
#### Proposed Changes

* Update Launchpad task `window.location.replace` with 'window.location.assign` to fix browser history and allow proper navigation back to launchpad.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this PR (you can also use the calypso.live link below)
* Create a new link-in-bio & newsletter site (or use existing sites)
* Click through the checklist tasks items and check that the browser back button navigates back to the launchpad correctly.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #69666
