### PR TITLE
Enable SSR for Plugins Detail page

### DIFF
--- a/client/data/marketplace/use-wpcom-plugins-query.ts
+++ b/client/data/marketplace/use-wpcom-plugins-query.ts
@@ -79,6 +79,16 @@ const fetchWPCOMPlugin = ( slug: string ) => {
 	} );
 };
 
+export const getWPCOMPluginQueryParams = ( slug: string ): [ QueryKey, QueryFunction ] => {
+	const cacheKey = getCacheKey( slug + '-normalized' );
+	const fetchFn = () =>
+		fetchWPCOMPlugin( slug ).then( ( data: any ) =>
+			normalizePluginData( { detailsFetched: Date.now() }, data )
+		);
+
+	return [ cacheKey, fetchFn ];
+};
+
 /**
  * Returns a marketplace plugin data
  *
@@ -90,8 +100,7 @@ export const useWPCOMPlugin = (
 	slug: string,
 	{ enabled = true, staleTime = BASE_STALE_TIME, refetchOnMount = true }: UseQueryOptions = {}
 ): UseQueryResult< any > => {
-	return useQuery( getCacheKey( slug ), () => fetchWPCOMPlugin( slug ), {
-		select: ( data ) => normalizePluginData( { detailsFetched: Date.now() }, data ),
+	return useQuery( ...getWPCOMPluginQueryParams( slug ), {
 		enabled: enabled,
 		staleTime: staleTime,
 		refetchOnMount: refetchOnMount,

--- a/client/lib/plugins/utils.js
+++ b/client/lib/plugins/utils.js
@@ -140,6 +140,10 @@ export function extractAuthorUrl( authorElementSource ) {
 }
 
 export function extractScreenshots( screenshotsHtml ) {
+	if ( 'undefined' === typeof window ) {
+		return null;
+	}
+
 	const screenshotsDom = parseHtml( screenshotsHtml );
 
 	const list = screenshotsDom && screenshotsDom.querySelectorAll( 'li' );

--- a/client/my-sites/plugins/index.node.js
+++ b/client/my-sites/plugins/index.node.js
@@ -4,8 +4,14 @@ import { makeLayout, ssrSetupLocale } from 'calypso/controller';
 import { setHrefLangLinks, setLocalizedCanonicalUrl } from 'calypso/controller/localized-links';
 import { overrideSanitizeSectionRoot } from 'calypso/lib/plugins/sanitize-section-content';
 import { isEnabled } from 'calypso/server/config';
-import { browsePlugins } from './controller';
-import { fetchPlugins, fetchCategoryPlugins, skipIfLoggedIn } from './controller-logged-out';
+import { browsePlugins, browsePluginsOrPlugin } from './controller';
+import {
+	fetchPlugins,
+	fetchCategoryPlugins,
+	fetchPlugin,
+	validatePlugin,
+	skipIfLoggedIn,
+} from './controller-logged-out';
 
 export default function ( router ) {
 	const langParam = getLanguageRouteParam();
@@ -34,6 +40,20 @@ export default function ( router ) {
 			setHrefLangLinks,
 			setLocalizedCanonicalUrl,
 			browsePlugins,
+			makeLayout
+		);
+	}
+
+	if ( isEnabled( 'plugins/ssr-details' ) ) {
+		router(
+			`/${ langParam }/plugins/:plugin`,
+			skipIfLoggedIn,
+			validatePlugin,
+			ssrSetupLocale,
+			fetchPlugin,
+			setHrefLangLinks,
+			setLocalizedCanonicalUrl,
+			browsePluginsOrPlugin,
 			makeLayout
 		);
 	}

--- a/client/server/render/index.js
+++ b/client/server/render/index.js
@@ -248,7 +248,7 @@ export function serverRender( req, res ) {
 		performanceMark( req, 'redux store', true );
 		attachHead( context );
 
-		const isomorphicSubtrees = context.section?.isomorphic ? [ 'themes', 'ui' ] : [];
+		const isomorphicSubtrees = context.section?.isomorphic ? [ 'themes', 'ui', 'plugins' ] : [];
 		const initialClientStateTrees = [ 'documentHead', ...isomorphicSubtrees ];
 
 		// Send state to client
@@ -266,8 +266,12 @@ export function serverRender( req, res ) {
 		 * (like /es/themes), that applies to every user.
 		 */
 		if ( cacheKey ) {
-			const { documentHead, themes } = context.store.getState();
-			const serverState = serialize( context.store.getCurrentReducer(), { documentHead, themes } );
+			const { documentHead, themes, plugins } = context.store.getState();
+			const serverState = serialize( context.store.getCurrentReducer(), {
+				documentHead,
+				themes,
+				plugins,
+			} );
 			stateCache.set( cacheKey, serverState.get() );
 		}
 	}

--- a/client/state/plugins/wporg/reducer.js
+++ b/client/state/plugins/wporg/reducer.js
@@ -4,7 +4,7 @@ import {
 	PLUGINS_WPORG_PLUGIN_RECEIVE,
 	PLUGINS_WPORG_PLUGIN_REQUEST,
 } from 'calypso/state/action-types';
-import { combineReducers } from 'calypso/state/utils';
+import { combineReducers, withPersistence } from 'calypso/state/utils';
 
 function updatePluginState( state = {}, pluginSlug, attributes ) {
 	return Object.assign( {}, state, {
@@ -47,7 +47,7 @@ export function fetchingLists( state = {}, action ) {
 	return state;
 }
 
-export function items( state = {}, action ) {
+function itemsReducer( state = {}, action ) {
 	const { type, pluginSlug } = action;
 	switch ( type ) {
 		case PLUGINS_WPORG_PLUGIN_RECEIVE:
@@ -67,6 +67,10 @@ export function items( state = {}, action ) {
 			return state;
 	}
 }
+
+export const items = withPersistence( itemsReducer );
+
+// export const items = itemsReducer;
 
 export function listsPagination( state = {}, action ) {
 	const { category, pagination } = action;

--- a/config/development.json
+++ b/config/development.json
@@ -127,6 +127,7 @@
 		"plans/pro-plan": false,
 		"plans/starter-plan": false,
 		"plugins/ssr-categories": true,
+		"plugins/ssr-details": true,
 		"plugins/ssr-landing": true,
 		"post-editor/checkout-overlay": true,
 		"pre-cancellation-modal": false,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -78,6 +78,7 @@
 		"plans/pro-plan": false,
 		"plans/starter-plan": false,
 		"plugins/ssr-categories": false,
+		"plugins/ssr-details": false,
 		"plugins/ssr-landing": true,
 		"post-editor/checkout-overlay": true,
 		"pre-cancellation-modal": false,

--- a/config/production.json
+++ b/config/production.json
@@ -93,6 +93,7 @@
 		"plans/pro-plan": false,
 		"plans/starter-plan": false,
 		"plugins/ssr-categories": false,
+		"plugins/ssr-details": false,
 		"plugins/ssr-landing": true,
 		"post-editor/checkout-overlay": true,
 		"pre-cancellation-modal": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -91,6 +91,7 @@
 		"plans/pro-plan": false,
 		"plans/starter-plan": false,
 		"plugins/ssr-categories": false,
+		"plugins/ssr-details": false,
 		"plugins/ssr-landing": true,
 		"post-editor/checkout-overlay": true,
 		"press-this": true,

--- a/config/test.json
+++ b/config/test.json
@@ -70,6 +70,7 @@
 		"plans/pro-plan": false,
 		"plans/starter-plan": false,
 		"plugins/ssr-categories": true,
+		"plugins/ssr-details": true,
 		"plugins/ssr-landing": true,
 		"press-this": true,
 		"publicize-preview": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -100,6 +100,7 @@
 		"plans/pro-plan": false,
 		"plans/starter-plan": false,
 		"plugins/ssr-categories": true,
+		"plugins/ssr-details": true,
 		"plugins/ssr-landing": true,
 		"post-editor/checkout-overlay": true,
 		"press-this": true,


### PR DESCRIPTION
#### Proposed Changes

More info: p58i-d84-p2#comment-55362
This is a follow-up to #67747  and allows SSR rendering for logged-out Plugin Details pages. 
It contains a part from #66344 (reverted in #67573) and hides changes behind a `plugins/ssr-details` flag.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


* Log out and disable JavaScript
* Go to a few Plugin details pages, ex: 
  * `/plugins/wordpress-seo-premium` (marketplace plugin) 
  * `/plugins/elementor` (org plugin)

* Make sure the plugin details are rendered and (somewhat) match the version with JS enabled
NOTE: Breadcrumbs are not visible and aside content is collapsed 
<img width="320" alt="Screen Shot on 2022-11-02 at 14-05-16" src="https://user-images.githubusercontent.com/2749938/199485595-94beaee5-a45f-46c3-9f7e-a340d3d711eb.png">


* Log in, enable JS and double-check for regressions in the Plugins section

* To disable the feature flag run: `DISABLE_FEATURES=plugins/ssr-details yarn start`
* Refreshing the `/plugins/wordpress-seo-premium` and `/plugins/elementor` page should  only show the WordPress placeholder logo

<img width="320" alt="Screen Shot on 2022-11-02 at 14-07-52" src="https://user-images.githubusercontent.com/2749938/199486079-c31cbaa8-b4c3-49dc-a8c8-a290cc23519e.png">



#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
