### PR TITLE
Pattern Assembler - Add an API param to optimize the previews by removing unnecessary assets

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/constants.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/constants.ts
@@ -2,3 +2,4 @@ export const PATTERN_SOURCE_SITE_ID = 174455321; // dotcompatterns
 export const PUBLIC_API_URL = 'https://public-api.wordpress.com';
 export const PREVIEW_PATTERN_URL = PUBLIC_API_URL + '/wpcom/v2/block-previews/pattern';
 export const SITE_TAGLINE = 'Site Tagline';
+export const REMOVE_ASSETS = true;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/constants.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/constants.ts
@@ -2,4 +2,3 @@ export const PATTERN_SOURCE_SITE_ID = 174455321; // dotcompatterns
 export const PUBLIC_API_URL = 'https://public-api.wordpress.com';
 export const PREVIEW_PATTERN_URL = PUBLIC_API_URL + '/wpcom/v2/block-previews/pattern';
 export const SITE_TAGLINE = 'Site Tagline';
-export const REMOVE_ASSETS = true;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-assembler-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-assembler-preview.tsx
@@ -11,7 +11,7 @@ import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useSite } from '../../../../hooks/use-site';
 import { ONBOARD_STORE } from '../../../../stores';
 import PreviewToolbar from '../design-setup/preview-toolbar';
-import { SITE_TAGLINE } from './constants';
+import { SITE_TAGLINE, REMOVE_ASSETS } from './constants';
 import { encodePatternId } from './utils';
 import type { Pattern } from './types';
 import type { Design } from '@automattic/design-picker';
@@ -81,6 +81,7 @@ const PatternAssemblerPreview = ( { header, sections = [], footer, scrollToSelec
 								disable_viewport_height: true,
 								site_title: site?.name,
 								site_tagline: SITE_TAGLINE,
+								remove_assets: REMOVE_ASSETS,
 						  } )
 						: 'about:blank'
 				}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-assembler-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-assembler-preview.tsx
@@ -11,7 +11,7 @@ import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useSite } from '../../../../hooks/use-site';
 import { ONBOARD_STORE } from '../../../../stores';
 import PreviewToolbar from '../design-setup/preview-toolbar';
-import { SITE_TAGLINE, REMOVE_ASSETS } from './constants';
+import { SITE_TAGLINE } from './constants';
 import { encodePatternId } from './utils';
 import type { Pattern } from './types';
 import type { Design } from '@automattic/design-picker';
@@ -81,7 +81,7 @@ const PatternAssemblerPreview = ( { header, sections = [], footer, scrollToSelec
 								disable_viewport_height: true,
 								site_title: site?.name,
 								site_tagline: SITE_TAGLINE,
-								remove_assets: REMOVE_ASSETS,
+								remove_assets: true,
 						  } )
 						: 'about:blank'
 				}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/utils.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/utils.ts
@@ -1,10 +1,5 @@
 import { addQueryArgs } from '@wordpress/url';
-import {
-	PATTERN_SOURCE_SITE_ID,
-	PREVIEW_PATTERN_URL,
-	SITE_TAGLINE,
-	REMOVE_ASSETS,
-} from './constants';
+import { PATTERN_SOURCE_SITE_ID, PREVIEW_PATTERN_URL, SITE_TAGLINE } from './constants';
 
 export const encodePatternId = ( patternId: number ) =>
 	`${ patternId }-${ PATTERN_SOURCE_SITE_ID }`;
@@ -26,7 +21,7 @@ export const getPatternPreviewUrl = ( {
 		site_title: siteTitle,
 		site_tagline: SITE_TAGLINE,
 		stylesheet,
-		remove_assets: REMOVE_ASSETS,
+		remove_assets: true,
 	} );
 };
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/utils.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/utils.ts
@@ -1,5 +1,10 @@
 import { addQueryArgs } from '@wordpress/url';
-import { PATTERN_SOURCE_SITE_ID, PREVIEW_PATTERN_URL, SITE_TAGLINE } from './constants';
+import {
+	PATTERN_SOURCE_SITE_ID,
+	PREVIEW_PATTERN_URL,
+	SITE_TAGLINE,
+	REMOVE_ASSETS,
+} from './constants';
 
 export const encodePatternId = ( patternId: number ) =>
 	`${ patternId }-${ PATTERN_SOURCE_SITE_ID }`;
@@ -21,6 +26,7 @@ export const getPatternPreviewUrl = ( {
 		site_title: siteTitle,
 		site_tagline: SITE_TAGLINE,
 		stylesheet,
+		remove_assets: REMOVE_ASSETS,
 	} );
 };
 

--- a/packages/design-picker/src/types.ts
+++ b/packages/design-picker/src/types.ts
@@ -126,6 +126,7 @@ export interface DesignPreviewOptions {
 	viewport_height?: number;
 	use_screenshot_overrides?: boolean;
 	disable_viewport_height?: boolean;
+	remove_assets?: boolean;
 }
 
 /** @deprecated used for Gutenboarding (/new flow) */

--- a/packages/design-picker/src/utils/designs.ts
+++ b/packages/design-picker/src/utils/designs.ts
@@ -34,6 +34,7 @@ export const getDesignPreviewUrl = (
 			: undefined,
 		source_site: 'patternboilerplates.wordpress.com',
 		use_screenshot_overrides: options.use_screenshot_overrides,
+		remove_assets: options.remove_assets,
 	} );
 
 	// The preview url is sometimes used in a `background-image: url()` CSS rule and unescaped


### PR DESCRIPTION
#### Proposed Changes
* Add an API param `remove_assets=true` to the preview API to remove unnecessary assets from previews

The final goal of this change is to optimize the load time of the site/pattern previews. While the load time saved thanks to this optimization is not huge while sandboxing the API, I believe it will improve more on production servers because they are faster. 

#### Testing Instructions
Test together with D91400-code
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Access `/setup?siteSlug=[YOUR SITE]`
* Open the Dev tools > Network
* Don't mark any goal
* Don't select any vertical
* Wait until all the assets are loaded
* Clean the list of network requests
* Click on the blank canvas CTA
* Wait until the number of requests stops 
* Check that the number of requests is fewer while the patterns still look and work as expected

**Before**

https://user-images.githubusercontent.com/1881481/199537883-ed8be262-d9b6-4499-ac20-e782cec3da64.mov

**After**

https://user-images.githubusercontent.com/1881481/199538611-b62d2388-b020-496d-bb65-971507fb9b56.mov

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #