### PR TITLE
Support 'disassociated' retired themes

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -145,13 +145,9 @@ class ThemeSheet extends Component {
 		return !! this.props.screenshots;
 	};
 
-	isRemoved = () => {
-		// If a theme has been removed by a theme shop, then the theme will still exist and a8c will take over any support responsibilities.
-		return (
-			this.props?.taxonomies?.theme_status.filter( ( status ) => status.slug === 'removed' )
-				.length === 1
-		);
-	};
+	// If a theme has been removed by a theme shop, then the theme will still exist and a8c will take over any support responsibilities.
+	isRemoved = () =>
+		!! this.props.taxonomies?.theme_status?.find( ( status ) => status.slug === 'removed' );
 
 	onButtonClick = () => {
 		const { defaultOption, id } = this.props;

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -608,7 +608,7 @@ class ThemeSheet extends Component {
 					<Card>
 						<p>
 							{ this.props.translate(
-								'This theme has been renamed to reflect that limited support for it is now provided directly by WordPress.com. The theme will continue to work as before.'
+								'This theme has been renamed to reflect that support for it is now provided directly by WordPress.com. The theme will continue to work as before.'
 							) }
 						</p>
 					</Card>

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -796,9 +796,11 @@ class ThemeSheet extends Component {
 			} );
 		}
 
+		const isRemoved = this.isRemoved();
+
 		const className = classNames( 'theme__sheet', { 'is-with-upsell-banner': hasUpsellBanner } );
 		const columnsClassName = classNames( 'theme__sheet-columns', {
-			'is-removed': this.isRemoved(),
+			'is-removed': isRemoved,
 		} );
 
 		return (
@@ -834,7 +836,7 @@ class ThemeSheet extends Component {
 						{ ! retired && this.renderSectionContent( section ) }
 						{ retired && this.renderRetired() }
 					</div>
-					{ ! this.isRemoved() && (
+					{ ! isRemoved && (
 						<div className="theme__sheet-column-right">{ this.renderScreenshot() }</div>
 					) }
 				</div>

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -145,6 +145,14 @@ class ThemeSheet extends Component {
 		return !! this.props.screenshots;
 	};
 
+	isRemoved = () => {
+		// If a theme has been removed by a theme shop, then the theme will still exist and a8c will take over any support responsibilities.
+		return (
+			this.props?.taxonomies?.theme_status.filter( ( status ) => status.slug === 'removed' )
+				.length === 1
+		);
+	};
+
 	onButtonClick = () => {
 		const { defaultOption, id } = this.props;
 		defaultOption.action && defaultOption.action( id );
@@ -600,6 +608,15 @@ class ThemeSheet extends Component {
 					</Button>
 				</Card>
 
+				{ this.isRemoved() && (
+					<Card>
+						<p>
+							{ this.props.translate(
+								'This theme has been renamed to reflect that limited support for it is now provided directly by WordPress.com. The theme will continue to work as before.'
+							) }
+						</p>
+					</Card>
+				) }
 				<div className="theme__sheet-footer-line">
 					<Gridicon icon="my-sites" />
 				</div>
@@ -784,6 +801,9 @@ class ThemeSheet extends Component {
 		}
 
 		const className = classNames( 'theme__sheet', { 'is-with-upsell-banner': hasUpsellBanner } );
+		const columnsClassName = classNames( 'theme__sheet-columns', {
+			'is-removed': this.isRemoved(),
+		} );
 
 		return (
 			<Main className={ className }>
@@ -813,12 +833,14 @@ class ThemeSheet extends Component {
 				>
 					{ ! retired && ! hasWpOrgThemeUpsellBanner && ! isWPForTeamsSite && this.renderButton() }
 				</HeaderCake>
-				<div className="theme__sheet-columns">
+				<div className={ columnsClassName }>
 					<div className="theme__sheet-column-left">
 						{ ! retired && this.renderSectionContent( section ) }
 						{ retired && this.renderRetired() }
 					</div>
-					<div className="theme__sheet-column-right">{ this.renderScreenshot() }</div>
+					{ ! this.isRemoved() && (
+						<div className="theme__sheet-column-right">{ this.renderScreenshot() }</div>
+					) }
 				</div>
 				<ThemePreview belowToolbar={ previewUpsellBanner } />
 				<PerformanceTrackerStop />

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -55,6 +55,9 @@
 		flex-direction: column-reverse;
 	}
 }
+.theme__sheet-columns.is-removed {
+	justify-content: center;
+}
 
 .theme__sheet-column-left,
 .theme__sheet-column-right {


### PR DESCRIPTION
For a very small number of themes we have taken over maintenance and by request are renaming them to make it clear they're no longer related to the original authors. This change informs users what has happened.

See pdgAPm-rI-p2#comment-576 for discussion.

#### Testing Instructions

1. Add a relevant theme to a test site (A12s you can use the bottom form on the MC 'Premium Themes: Test Activation' tool, ping me for a good theme to test)
2. Go to the test site in calypso, navigate to Appearance -> Themes
3. At the top of the themes list press the 'info' button on the card showing your current theme
4. This takes you to /theme/<theme-slug>/<site>
5. Note that no screenshot is displayed. The retirement message is displayed and an additional message is displayed explaining the theme has been renamed.

It should look something like this:

![image](https://user-images.githubusercontent.com/93301/199522796-7140aba7-1d45-4aa8-a25a-bafbfc9bbf77.png)

Note that the wording is to be confirmed.

1. Change to a different retired theme, ensure the theme page continues to look as it does in production.
2. Change to a different active theme,  ensure the theme page continues to look as it does in production.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
