### PR TITLE
[WIP] Limit Global Styles: Invalidate cache after change / during preview

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
@@ -304,11 +304,6 @@ function wpcom_invalidate_global_styles_cache() {
 		add_filter( 'pre_set_transient_' . $transient_name, '__return_false' );
 	}
 
-	add_action(
-		'save_post_wp_global_styles',
-		function () use ( $transient_name ) {
-			delete_transient( $transient_name );
-		}
-	);
+	add_action( 'save_post_wp_global_styles', fn() => delete_transient( $transient_name ) );
 }
 add_action( 'init', 'wpcom_invalidate_global_styles_cache' );

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
@@ -117,6 +117,10 @@ function wpcom_block_global_styles_frontend( $theme_json ) {
 		return $theme_json;
 	}
 
+	/*
+	 * Because Gutenberg overrides Core, the order in which we check the existence of
+	 * the classes below is important in order to give Gutenberg priority if available.
+	 */
 	if ( class_exists( 'WP_Theme_JSON_Data_Gutenberg' ) ) {
 		return new WP_Theme_JSON_Data_Gutenberg( array(), 'custom' );
 	} elseif ( class_exists( 'WP_Theme_JSON_Data' ) ) {
@@ -184,6 +188,11 @@ add_action( 'save_post_wp_global_styles', 'wpcom_track_global_styles', 10, 3 );
  */
 function wpcom_global_styles_in_use() {
 	$current_theme = wp_get_theme();
+
+	/*
+	 * Because Gutenberg overrides Core, the order in which we check the existence of
+	 * the classes below is important in order to give Gutenberg priority if available.
+	 */
 	if ( class_exists( 'WP_Theme_JSON_Resolver_Gutenberg' ) ) {
 		$user_cpt = WP_Theme_JSON_Resolver_Gutenberg::get_user_data_from_wp_global_styles( $current_theme );
 	} elseif ( class_exists( 'WP_Theme_JSON_Resolver' ) ) {

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
@@ -306,13 +306,13 @@ add_action( 'launch_bar_extra_tooltip_toggle_global_styles', 'wpcom_display_glob
  * Invalidates the cached Global Styles after changing them or when previewing them.
  */
 function wpcom_invalidate_global_styles_cache() {
-	$transient_name = 'gutenberg_global_styles_' . get_stylesheet();
+	$gutenberg_global_styles_transient_name = 'gutenberg_global_styles_' . get_stylesheet();
 
 	if ( wpcom_should_limit_global_styles() && wpcom_is_previewing_global_styles() ) {
-		add_filter( 'pre_transient_' . $transient_name, '__return_null' );
-		add_filter( 'pre_set_transient_' . $transient_name, '__return_false' );
+		add_filter( 'pre_transient_' . $gutenberg_global_styles_transient_name, '__return_null' );
+		add_filter( 'pre_set_transient_' . $gutenberg_global_styles_transient_name, '__return_false' );
 	}
 
-	add_action( 'save_post_wp_global_styles', fn() => delete_transient( $transient_name ) );
+	add_action( 'save_post_wp_global_styles', fn() => delete_transient( $gutenberg_global_styles_transient_name ) );
 }
 add_action( 'init', 'wpcom_invalidate_global_styles_cache' );


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/1151

#### Proposed Changes

This PR invalidates the cached Global Styles after they are changed or when previewing them, so we always show the styles expected by the user.

I also took the opportunity to remove the `theme_json_user` filter (since WP.com no longer loads the Gutenberg version that triggered it) and modify the `wpcom_global_styles_in_use` function to account for cases where Gutenberg does not provide a compat `WP_Theme_JSON_Resolver_Gutenberg` class. They are unrelated to cache issue, so I'm happy to move them to a separate PR.

#### Testing Instructions

- Apply these changes to your sandbox: `install-plugin.sh editing-toolkit fix/cache-global-styles`
- Go to https://wordpress.com/start and create a new free site
- Add the `wpcom-limit-global-styles` blog sticker to the new site from the Blog RC
- Sandbox the new site
- Go to Appearance > Editor
- Open the Global Styles sidebar
- Change some styles
- Click on the "Save" button
- Visit the frontend
- Make sure only the styles from the default theme variation are visible
- Preview the hidden styles using the "Styles hidden" action from the launchbar
- Make sure all the styles are immediately visible
- Make some more styles changes in the site editor
- Reload the frontend (and keep the `?preview-global-styles` param)
- Make sure the new style changes are immediately visible
- Remove the `?preview-global-styles` param
- Make sure only the styles from the default theme variation are visible
- Upgrade to a paid plan
- Make some more styles changes in the site editor
- Reload the frontend 
- Make sure the new style changes are immediately visible
