### PR TITLE
Enable Zendesk pre-sales chat on signup and checkout

### DIFF
--- a/client/components/zendesk-chat/index.jsx
+++ b/client/components/zendesk-chat/index.jsx
@@ -1,0 +1,18 @@
+import { useEffect } from 'react';
+
+const ZendeskChat = ( { chatId } ) => {
+	useEffect( () => {
+		if ( chatId ) {
+			const script = document.createElement( 'script' );
+			script.src = 'https://static.zdassets.com/ekr/snippet.js?key=' + chatId;
+			script.type = 'text/javascript';
+			script.id = 'ze-snippet';
+
+			document.body.appendChild( script );
+		}
+	}, [ chatId ] );
+
+	return null;
+};
+
+export default ZendeskChat;

--- a/client/components/zendesk-chat/index.jsx
+++ b/client/components/zendesk-chat/index.jsx
@@ -8,11 +8,11 @@ const ZendeskChat = ( { chatId } ) => {
 			script.type = 'text/javascript';
 			script.id = 'ze-snippet';
 
-			document.body.appendChild( script );
+			document.getElementById( 'zendesk-chat-container' ).appendChild( script );
 		}
 	}, [ chatId ] );
 
-	return null;
+	return <div id="zendesk-chat-container" />;
 };
 
 export default ZendeskChat;

--- a/client/components/zendesk-chat/index.jsx
+++ b/client/components/zendesk-chat/index.jsx
@@ -5,13 +5,13 @@ const ZendeskChat = ( { chatId } ) => {
 		if ( ! chatId ) {
 			return;
 		}
-			const script = document.createElement( 'script' );
-			script.src = 'https://static.zdassets.com/ekr/snippet.js?key=' + chatId;
-			script.type = 'text/javascript';
-			script.id = 'ze-snippet';
 
-			document.getElementById( 'zendesk-chat-container' ).appendChild( script );
-		}
+		const script = document.createElement( 'script' );
+		script.src = 'https://static.zdassets.com/ekr/snippet.js?key=' + chatId;
+		script.type = 'text/javascript';
+		script.id = 'ze-snippet';
+
+		document.getElementById( 'zendesk-chat-container' ).appendChild( script );
 	}, [ chatId ] );
 
 	return <div id="zendesk-chat-container" />;

--- a/client/components/zendesk-chat/index.jsx
+++ b/client/components/zendesk-chat/index.jsx
@@ -2,7 +2,9 @@ import { useEffect } from 'react';
 
 const ZendeskChat = ( { chatId } ) => {
 	useEffect( () => {
-		if ( chatId ) {
+		if ( ! chatId ) {
+			return;
+		}
 			const script = document.createElement( 'script' );
 			script.src = 'https://static.zdassets.com/ekr/snippet.js?key=' + chatId;
 			script.type = 'text/javascript';

--- a/client/my-sites/checkout/composite-checkout/components/checkout-help-link.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-help-link.tsx
@@ -182,7 +182,7 @@ export default function CheckoutHelpLink() {
 	} );
 	const presalesEligiblePlanLabel = getHighestWpComPlanLabel( plans );
 	const isPresalesChatEligible = presalesChatAvailable && presalesEligiblePlanLabel;
-	const zendeskChatKey = config( 'zendesk_chat_key' );
+	const zendeskPresalesChatKey = config( 'zendesk_presales_chat_key' );
 	const isPresalesZendeskChatEligible = presalesZendeskChatAvailable && isEnglishLocale;
 
 	const userAllowedToHelpCenter = !! (
@@ -216,7 +216,7 @@ export default function CheckoutHelpLink() {
 		<CheckoutHelpLinkWrapper>
 			<QuerySupportTypes />
 			{ ! shouldRenderPaymentChatButton && ! supportVariationDetermined && <LoadingButton /> }
-			{ shouldRenderZendeskChatButton && <ZendeskChat chatId={ zendeskChatKey } /> }
+			{ shouldRenderZendeskChatButton && <ZendeskChat chatId={ zendeskPresalesChatKey } /> }
 			{ shouldRenderPaymentChatButton ? (
 				<PaymentChatButton
 					plan={ presalesEligiblePlanLabel }

--- a/client/my-sites/checkout/composite-checkout/components/checkout-help-link.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-help-link.tsx
@@ -207,7 +207,6 @@ export default function CheckoutHelpLink() {
 
 	const hasDirectSupport = supportVariation !== SUPPORT_FORUM;
 
-	// Only show the zendesk presales chat button (when available) if user is not elligible for regular chat.
 	const shouldRenderZendeskChatButton =
 		isPresalesZendeskChatEligible && ! isPresalesChatEligible && ! hasDirectSupport;
 

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -743,12 +743,11 @@ class Signup extends Component {
 	shouldShowZendeskPresalesChat() {
 		const isEnglishLocale = config( 'english_locales' ).includes( getLocaleSlug() ?? '' );
 
-		// Zendesk presales chat is only open in signup between 15 and 23 UTC, Monday through Friday.
 		const currentTime = new Date();
 		return (
 			isEnglishLocale &&
 			currentTime.getUTCHours() >= 15 &&
-			currentTime.getUTCHours() < 23 &&
+			currentTime.getUTCHours() < 21 &&
 			currentTime.getUTCDay() !== 0 &&
 			currentTime.getUTCDay() !== 6
 		);

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -7,6 +7,7 @@ import {
 import { isBlankCanvasDesign } from '@automattic/design-picker';
 import { isNewsletterOrLinkInBioFlow } from '@automattic/onboarding';
 import debugModule from 'debug';
+import { getLocaleSlug } from 'i18n-calypso';
 import {
 	clone,
 	defer,
@@ -28,6 +29,7 @@ import { connect } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
 import QuerySiteDomains from 'calypso/components/data/query-site-domains';
 import LocaleSuggestions from 'calypso/components/locale-suggestions';
+import ZendeskChat from 'calypso/components/zendesk-chat';
 import { addHotJarScript } from 'calypso/lib/analytics/hotjar';
 import {
 	recordSignupStart,
@@ -760,6 +762,8 @@ class Signup extends Component {
 		}
 
 		const isReskinned = isReskinnedFlow( this.props.flowName );
+		const zendeskChatKey = config( 'zendesk_chat_key' );
+		const isEnglishLocale = config( 'english_locales' ).includes( getLocaleSlug() ?? '' );
 
 		return (
 			<>
@@ -794,6 +798,7 @@ class Signup extends Component {
 						/>
 					) }
 				</div>
+				{ isEnglishLocale && <ZendeskChat chatId={ zendeskChatKey } /> }
 			</>
 		);
 	}

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -762,7 +762,7 @@ class Signup extends Component {
 		}
 
 		const isReskinned = isReskinnedFlow( this.props.flowName );
-		const zendeskChatKey = config( 'zendesk_chat_key' );
+		const zendeskChatKey = config( 'zendesk_presales_chat_key' );
 		const isEnglishLocale = config( 'english_locales' ).includes( getLocaleSlug() ?? '' );
 
 		return (

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -743,9 +743,15 @@ class Signup extends Component {
 	shouldShowZendeskPresalesChat() {
 		const isEnglishLocale = config( 'english_locales' ).includes( getLocaleSlug() ?? '' );
 
-		// Zendesk presales chat is only open in signup between 15 and 23 UTC;
+		// Zendesk presales chat is only open in signup between 15 and 23 UTC, Monday through Friday.
 		const currentTime = new Date();
-		return isEnglishLocale && currentTime.getUTCHours() >= 15 && currentTime.getUTCHours() < 23;
+		return (
+			isEnglishLocale &&
+			currentTime.getUTCHours() >= 15 &&
+			currentTime.getUTCHours() < 23 &&
+			currentTime.getUTCDay() !== 0 &&
+			currentTime.getUTCDay() !== 6
+		);
 	}
 
 	getPageTitle() {

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -740,6 +740,14 @@ class Signup extends Component {
 		}
 	}
 
+	shouldShowZendeskPresalesChat() {
+		const isEnglishLocale = config( 'english_locales' ).includes( getLocaleSlug() ?? '' );
+
+		// Zendesk presales chat is only open in signup between 15 and 23 UTC;
+		const currentTime = new Date();
+		return isEnglishLocale && currentTime.getUTCHours() >= 15 && currentTime.getUTCHours() < 23;
+	}
+
 	getPageTitle() {
 		if ( isNewsletterOrLinkInBioFlow( this.props.flowName ) ) {
 			return this.props.pageTitle;
@@ -763,7 +771,7 @@ class Signup extends Component {
 
 		const isReskinned = isReskinnedFlow( this.props.flowName );
 		const zendeskChatKey = config( 'zendesk_presales_chat_key' );
-		const isEnglishLocale = config( 'english_locales' ).includes( getLocaleSlug() ?? '' );
+		const shouldShowZendeskPresalesChat = this.shouldShowZendeskPresalesChat();
 
 		return (
 			<>
@@ -798,7 +806,7 @@ class Signup extends Component {
 						/>
 					) }
 				</div>
-				{ isEnglishLocale && <ZendeskChat chatId={ zendeskChatKey } /> }
+				{ shouldShowZendeskPresalesChat && <ZendeskChat chatId={ zendeskChatKey } /> }
 			</>
 		);
 	}

--- a/client/state/happychat/selectors/is-presales-chat-available.js
+++ b/client/state/happychat/selectors/is-presales-chat-available.js
@@ -1,5 +1,3 @@
-import { get } from 'lodash';
-
 import 'calypso/state/happychat/init';
 
 /**
@@ -9,5 +7,5 @@ import 'calypso/state/happychat/init';
  * @returns {boolean}        true, when presales is available
  */
 export default function isPresalesChatAvailable( state ) {
-	return get( state, 'happychat.user.availability.presale', false );
+	return state.happychat?.user?.availability?.presale ?? false;
 }

--- a/client/state/happychat/selectors/is-presales-zendesk-chat-available.js
+++ b/client/state/happychat/selectors/is-presales-zendesk-chat-available.js
@@ -1,0 +1,13 @@
+import { get } from 'lodash';
+
+import 'calypso/state/happychat/init';
+
+/**
+ * Returns if presales zendesk chat is available.
+ *
+ * @param   {object}  state  Global state tree
+ * @returns {boolean}        true, when presales_zendesk is available
+ */
+export default function isPresalesZendeskChatAvailable( state ) {
+	return get( state, 'happychat.user.availability.presale_zendesk', false );
+}

--- a/client/state/happychat/selectors/is-presales-zendesk-chat-available.js
+++ b/client/state/happychat/selectors/is-presales-zendesk-chat-available.js
@@ -1,5 +1,3 @@
-import { get } from 'lodash';
-
 import 'calypso/state/happychat/init';
 
 /**
@@ -9,5 +7,5 @@ import 'calypso/state/happychat/init';
  * @returns {boolean}        true, when presales_zendesk is available
  */
 export default function isPresalesZendeskChatAvailable( state ) {
-	return get( state, 'happychat.user.availability.presale_zendesk', false );
+	return state.happychat?.user?.availability?.presale_zendesk ?? false;
 }

--- a/client/state/happychat/selectors/test/is-presales-zendesk-chat-available.js
+++ b/client/state/happychat/selectors/test/is-presales-zendesk-chat-available.js
@@ -1,0 +1,28 @@
+import isPresalesZendeskChatAvailable from '../is-presales-zendesk-chat-available';
+
+describe( '#isPresalesZendeskChatAvailable()', () => {
+	test( 'should return false if presales zendesk chat is not available', () => {
+		const isPresaleZendeskAvailable = isPresalesZendeskChatAvailable( {
+			happychat: {
+				user: {
+					availability: {
+						presale_zendesk: false,
+					},
+				},
+			},
+		} );
+		expect( isPresaleZendeskAvailable ).toBe( false );
+	} );
+	test( 'should return true if presales zendesk chat is available', () => {
+		const isPresaleZendeskAvailable = isPresalesZendeskChatAvailable( {
+			happychat: {
+				user: {
+					availability: {
+						presale_zendesk: true,
+					},
+				},
+			},
+		} );
+		expect( isPresaleZendeskAvailable ).toBe( true );
+	} );
+} );

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -37,6 +37,7 @@
 	"olark_chat_identity": false,
 	"dsp_stripe_pub_key": "pk_live_51LYYzQF53KN4RFN0ePTwefdm7seki4pRuc4a19gPMGUba5mzuosz0IBR0cp4T57FiBgxK911ky0LNwlX2IHbm0SS00uPHEQNBO",
 	"dsp_widget_js_src": "https://widgets.wp.com/promote/widget.js",
+	"zendesk_chat_key": false,
 	"upwork_support_locales": [
 		"de",
 		"de-at",

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -37,7 +37,7 @@
 	"olark_chat_identity": false,
 	"dsp_stripe_pub_key": "pk_live_51LYYzQF53KN4RFN0ePTwefdm7seki4pRuc4a19gPMGUba5mzuosz0IBR0cp4T57FiBgxK911ky0LNwlX2IHbm0SS00uPHEQNBO",
 	"dsp_widget_js_src": "https://widgets.wp.com/promote/widget.js",
-	"zendesk_chat_key": false,
+	"zendesk_presales_chat_key": false,
 	"upwork_support_locales": [
 		"de",
 		"de-at",

--- a/config/development.json
+++ b/config/development.json
@@ -25,6 +25,7 @@
 	"olark_chat_identity": "7089-503-10-5123",
 	"dsp_stripe_pub_key": "pk_live_51LYYzQF53KN4RFN0ePTwefdm7seki4pRuc4a19gPMGUba5mzuosz0IBR0cp4T57FiBgxK911ky0LNwlX2IHbm0SS00uPHEQNBO",
 	"dsp_widget_js_src": "https://widgets.wp.com/promote/widget.js",
+	"zendesk_chat_key": "216bf91d-f10f-4f66-bf65-a0cba220cd38",
 	"features": {
 		"ad-tracking": false,
 		"calypso/help-center": true,

--- a/config/development.json
+++ b/config/development.json
@@ -25,7 +25,7 @@
 	"olark_chat_identity": "7089-503-10-5123",
 	"dsp_stripe_pub_key": "pk_live_51LYYzQF53KN4RFN0ePTwefdm7seki4pRuc4a19gPMGUba5mzuosz0IBR0cp4T57FiBgxK911ky0LNwlX2IHbm0SS00uPHEQNBO",
 	"dsp_widget_js_src": "https://widgets.wp.com/promote/widget.js",
-	"zendesk_chat_key": "216bf91d-f10f-4f66-bf65-a0cba220cd38",
+	"zendesk_presales_chat_key": "216bf91d-f10f-4f66-bf65-a0cba220cd38",
 	"features": {
 		"ad-tracking": false,
 		"calypso/help-center": true,

--- a/config/production.json
+++ b/config/production.json
@@ -15,6 +15,7 @@
 	"olark_chat_identity": "7089-503-10-5123",
 	"dsp_stripe_pub_key": "pk_live_51LYYzQF53KN4RFN0ePTwefdm7seki4pRuc4a19gPMGUba5mzuosz0IBR0cp4T57FiBgxK911ky0LNwlX2IHbm0SS00uPHEQNBO",
 	"dsp_widget_js_src": "https://widgets.wp.com/promote/widget.js",
+	"zendesk_chat_key": "216bf91d-f10f-4f66-bf65-a0cba220cd38",
 	"features": {
 		"ad-tracking": true,
 		"bilmur-script": true,

--- a/config/production.json
+++ b/config/production.json
@@ -15,7 +15,7 @@
 	"olark_chat_identity": "7089-503-10-5123",
 	"dsp_stripe_pub_key": "pk_live_51LYYzQF53KN4RFN0ePTwefdm7seki4pRuc4a19gPMGUba5mzuosz0IBR0cp4T57FiBgxK911ky0LNwlX2IHbm0SS00uPHEQNBO",
 	"dsp_widget_js_src": "https://widgets.wp.com/promote/widget.js",
-	"zendesk_chat_key": "216bf91d-f10f-4f66-bf65-a0cba220cd38",
+	"zendesk_presales_chat_key": "216bf91d-f10f-4f66-bf65-a0cba220cd38",
 	"features": {
 		"ad-tracking": true,
 		"bilmur-script": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -13,6 +13,7 @@
 	"olark_chat_identity": "7089-503-10-5123",
 	"dsp_stripe_pub_key": "pk_live_51LYYzQF53KN4RFN0ePTwefdm7seki4pRuc4a19gPMGUba5mzuosz0IBR0cp4T57FiBgxK911ky0LNwlX2IHbm0SS00uPHEQNBO",
 	"dsp_widget_js_src": "https://widgets.wp.com/promote/widget.js",
+	"zendesk_chat_key": "216bf91d-f10f-4f66-bf65-a0cba220cd38",
 	"features": {
 		"ad-tracking": false,
 		"calypso/help-center": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -13,7 +13,7 @@
 	"olark_chat_identity": "7089-503-10-5123",
 	"dsp_stripe_pub_key": "pk_live_51LYYzQF53KN4RFN0ePTwefdm7seki4pRuc4a19gPMGUba5mzuosz0IBR0cp4T57FiBgxK911ky0LNwlX2IHbm0SS00uPHEQNBO",
 	"dsp_widget_js_src": "https://widgets.wp.com/promote/widget.js",
-	"zendesk_chat_key": "216bf91d-f10f-4f66-bf65-a0cba220cd38",
+	"zendesk_presales_chat_key": "216bf91d-f10f-4f66-bf65-a0cba220cd38",
 	"features": {
 		"ad-tracking": false,
 		"calypso/help-center": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -13,6 +13,7 @@
 	"olark_chat_identity": "7089-503-10-5123",
 	"dsp_stripe_pub_key": "pk_live_51LYYzQF53KN4RFN0ePTwefdm7seki4pRuc4a19gPMGUba5mzuosz0IBR0cp4T57FiBgxK911ky0LNwlX2IHbm0SS00uPHEQNBO",
 	"dsp_widget_js_src": "https://widgets.wp.com/promote/widget.js",
+	"zendesk_chat_key": "216bf91d-f10f-4f66-bf65-a0cba220cd38",
 	"features": {
 		"ad-tracking": false,
 		"calypso/help-center": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -13,7 +13,7 @@
 	"olark_chat_identity": "7089-503-10-5123",
 	"dsp_stripe_pub_key": "pk_live_51LYYzQF53KN4RFN0ePTwefdm7seki4pRuc4a19gPMGUba5mzuosz0IBR0cp4T57FiBgxK911ky0LNwlX2IHbm0SS00uPHEQNBO",
 	"dsp_widget_js_src": "https://widgets.wp.com/promote/widget.js",
-	"zendesk_chat_key": "216bf91d-f10f-4f66-bf65-a0cba220cd38",
+	"zendesk_presales_chat_key": "216bf91d-f10f-4f66-bf65-a0cba220cd38",
 	"features": {
 		"ad-tracking": false,
 		"calypso/help-center": true,


### PR DESCRIPTION
#### Proposed Changes

* This enables a Zendesk pre-sales chat widget on signup and checkout. 
* For checkout, the ZD chat will be shown to users who don't currently have access to live chat, and depends on the availability set on the dotcom side.
* For signup, the ZD chat will be shown between 15:00 and 23:00 UTC, Monday through Friday.

**TODOs:**
* Conditionally load in signup based on flow (i.e: do not display on "new site for existing user" flow).

#### Testing Instructions
- Visit checkout for a user with no access to live chat (i.e, not having an existing plan) and make sure the zendesk widget is visible
- Visit signup and check that the zendesk widget is visible (replace the current time in `Signup.shouldShowZendeskPresalesChat()` if necessary)  

#### Screenshots

*Signup*:
<img width="400" alt="Screenshot 2022-11-09 at 13 25 43" src="https://user-images.githubusercontent.com/844866/200822236-7a2f590e-240d-4ef3-ab40-cfbc57de1dba.png">



#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?

