### PR TITLE
Update Gifting settings toggle WordPress.com text

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -664,7 +664,7 @@ export class SiteSettingsFormGeneral extends Component {
 							/>
 							<FormSettingExplanation>
 								{ translate(
-									"Allow a site visitor to cover the full cost of your site's WordPress plan."
+									"Allow a site visitor to cover the full cost of your site's WordPress.com plan."
 								) }
 							</FormSettingExplanation>
 						</CompactCard>


### PR DESCRIPTION
#### Proposed Changes

Following https://github.com/Automattic/wp-calypso/pull/69637#issuecomment-1300249158, we need to updated the Gifting settings toggle text.

> [Toggle] Allow a site visitor to gift site plan costs.
> Allow a site visitor to cover the full cost of your site's WordPress.com plan.

#### Testing Instructions

1. Using a site with Auto-Renew Off.
2. Go to `/settings/general/[your-site]?flags=subscription-gifting`.
3. Check the text and description of the Gifting Subscriptions section. (screenshot)

#### Screenshot
<img width="729" alt="image" src="https://user-images.githubusercontent.com/402286/199529122-0605b921-9b0d-4c8d-8383-fe3beb204bbb.png">

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] ~~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~~
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~~
- [ ] ~~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~~


Fixes https://github.com/Automattic/dotcom-forge/issues/1154
