### PR TITLE
Insights: Show Tags & Categories section  for Jetpack sites

### DIFF
--- a/client/my-sites/stats/stats-insights/index.jsx
+++ b/client/my-sites/stats/stats-insights/index.jsx
@@ -62,13 +62,13 @@ const StatsInsights = ( props ) => {
 						<div className="stats__module-column">
 							<LatestPostSummary />
 							<MostPopular />
-							{ ! isJetpack && (
-								<StatsModule
-									path="tags-categories"
-									moduleStrings={ moduleStrings.tags }
-									statType="statsTags"
-								/>
-							) }
+
+							<StatsModule
+								path="tags-categories"
+								moduleStrings={ moduleStrings.tags }
+								statType="statsTags"
+							/>
+
 							<AnnualSiteStats isWidget />
 							{ ! isJetpack && <StatShares siteId={ siteId } /> }
 						</div>


### PR DESCRIPTION
Fixes Automattic/jetpack/issues/12968

The check for Jetpack sites to decide if we should show this card goes back to the initial commit of wp-calypso as an open source projects. (~7 years ago). This is probably related to the fact that we weren't using the Jetpack Sync system at the time.

#### Proposed Changes

* Removes conditional rendering of Tags & Categories section in Insights page

#### Testing Instructions

* Visit `/stats/insights/:site-slug` for a Jetpack site and confirm you see the Tags & Categories card.

#### Pre-merge Checklist


- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
