### PR TITLE
Theme Subscriptions: Add third-party theme options to the theme kebab menu

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -63,6 +63,8 @@ import {
 	getThemeForumUrl,
 	getThemeDemoUrl,
 	shouldShowTryAndCustomize,
+	isExternallyManagedTheme as getIsExternallyManagedTheme,
+	isSiteEligibleForManagedExternalThemes as getIsSiteEligibleForManagedExternalThemes,
 } from 'calypso/state/themes/selectors';
 import { getBackPath } from 'calypso/state/themes/themes-ui/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
@@ -552,6 +554,8 @@ class ThemeSheet extends Component {
 			isPurchased,
 			translate,
 			isBundledSoftwareSet,
+			isExternallyManagedTheme,
+			isSiteEligibleForManagedExternalThemes,
 		} = this.props;
 		if ( isActive ) {
 			// Customize site
@@ -565,7 +569,12 @@ class ThemeSheet extends Component {
 			if ( isPremium && ! isPurchased && ! isBundledSoftwareSet ) {
 				// purchase
 				return translate( 'Pick this design' );
-			} else if ( isPremium && ! isPurchased && isBundledSoftwareSet ) {
+			} else if (
+				isPremium &&
+				! isPurchased &&
+				( isBundledSoftwareSet ||
+					( isExternallyManagedTheme && ! isSiteEligibleForManagedExternalThemes ) )
+			) {
 				// upgrade plan
 				return translate( 'Upgrade to activate', {
 					comment:
@@ -847,6 +856,8 @@ const ThemeSheetWithOptions = ( props ) => {
 		demoUrl,
 		showTryAndCustomize,
 		isBundledSoftwareSet,
+		isExternallyManagedTheme,
+		isSiteEligibleForManagedExternalThemes,
 	} = props;
 
 	let defaultOption;
@@ -864,6 +875,8 @@ const ThemeSheetWithOptions = ( props ) => {
 		defaultOption = 'customize';
 	} else if ( needsJetpackPlanUpgrade ) {
 		defaultOption = 'upgradePlan';
+	} else if ( isExternallyManagedTheme && ! isSiteEligibleForManagedExternalThemes ) {
+		defaultOption = 'upgradePlanForExternallyManagedThemes';
 	} else if ( isPremium && ! isPurchased && ! isBundledSoftwareSet ) {
 		defaultOption = 'purchase';
 	} else if ( isPremium && ! isPurchased && isBundledSoftwareSet ) {
@@ -930,6 +943,11 @@ export default connect(
 			demoUrl: getThemeDemoUrl( state, id, siteId ),
 			isWPForTeamsSite: isSiteWPForTeams( state, siteId ),
 			softLaunched: theme?.soft_launched,
+			isExternallyManagedTheme: getIsExternallyManagedTheme( state, theme?.id ),
+			isSiteEligibleForManagedExternalThemes: getIsSiteEligibleForManagedExternalThemes(
+				state,
+				siteId
+			),
 		};
 	},
 	{

--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -27,6 +27,8 @@ import {
 	isThemePremium,
 	doesThemeBundleSoftwareSet,
 	shouldShowTryAndCustomize,
+	isExternallyManagedTheme,
+	isSiteEligibleForManagedExternalThemes,
 } from 'calypso/state/themes/selectors';
 
 const identity = ( theme ) => theme;
@@ -48,6 +50,31 @@ function getAllThemeOptions( { translate, isFSEActive } ) {
 			! isThemePremium( state, themeId ) || // Not a premium theme
 			isPremiumThemeAvailable( state, themeId, siteId ) || // Already purchased individually, or thru a plan
 			doesThemeBundleSoftwareSet( state, themeId ) || // Premium themes with bundled Software Sets cannot be purchased
+			isExternallyManagedTheme( state, themeId ) || // Third-party themes cannot be purchased
+			isThemeActive( state, themeId, siteId ), // Already active
+	};
+
+	const subscribe = {
+		label: translate( 'Subscribe', {
+			context: 'verb',
+		} ),
+		extendedLabel: translate( 'Subscribe to this design' ),
+		header: translate( 'Subscribe on:', {
+			context: 'verb',
+			comment: 'label for selecting a site for which to purchase a theme',
+		} ),
+		getUrl: () => {
+			// TODO - The checkout url will come later once the store product functionality is done on wpcom
+		},
+		hideForTheme: ( state, themeId, siteId ) =>
+			( isJetpackSite( state, siteId ) && ! isSiteWpcomAtomic( state, siteId ) ) || // No individual theme purchase on a JP site
+			! isUserLoggedIn( state ) || // Not logged in
+			! isThemePremium( state, themeId ) || // Not a premium theme
+			isPremiumThemeAvailable( state, themeId, siteId ) || // Already purchased individually, or thru a plan
+			doesThemeBundleSoftwareSet( state, themeId ) || // Premium themes with bundled Software Sets cannot be purchased ||
+			! isExternallyManagedTheme( state, themeId ) || // We're currently only subscribing to third-party themes
+			( isExternallyManagedTheme( state, themeId ) &&
+				! isSiteEligibleForManagedExternalThemes( state, siteId ) ) || // User must have appropriate plan to subscribe
 			isThemeActive( state, themeId, siteId ), // Already active
 	};
 
@@ -70,6 +97,7 @@ function getAllThemeOptions( { translate, isFSEActive } ) {
 			isSiteWpcomAtomic( state, siteId ) ||
 			! isUserLoggedIn( state ) ||
 			! isThemePremium( state, themeId ) ||
+			isExternallyManagedTheme( state, themeId ) ||
 			isThemeActive( state, themeId, siteId ) ||
 			isPremiumThemeAvailable( state, themeId, siteId ),
 	};
@@ -102,6 +130,33 @@ function getAllThemeOptions( { translate, isFSEActive } ) {
 			! isUserLoggedIn( state ) ||
 			! isThemePremium( state, themeId ) ||
 			! doesThemeBundleSoftwareSet( state, themeId ) ||
+			isExternallyManagedTheme( state, themeId ) ||
+			isThemeActive( state, themeId, siteId ) ||
+			isPremiumThemeAvailable( state, themeId, siteId ),
+	};
+
+	const upgradePlanForExternallyManagedThemes = {
+		label: translate( 'Upgrade to subscribe', {
+			comment: 'label prompting user to upgrade the WordPress.com plan to activate a certain theme',
+		} ),
+		extendedLabel: translate( 'Upgrade to subscribe', {
+			comment: 'label prompting user to upgrade the WordPress.com plan to activate a certain theme',
+		} ),
+		header: translate( 'Upgrade on:', {
+			context: 'verb',
+			comment: 'label for selecting a site for which to upgrade a plan',
+		} ),
+		getUrl: () => {
+			// TODO - The checkout url will come later once the store product functionality is done on wpcom
+		},
+		hideForTheme: ( state, themeId, siteId ) =>
+			isJetpackSite( state, siteId ) ||
+			isSiteWpcomAtomic( state, siteId ) ||
+			! isUserLoggedIn( state ) ||
+			! isThemePremium( state, themeId ) ||
+			! isExternallyManagedTheme( state, themeId ) ||
+			( isExternallyManagedTheme( state, themeId ) &&
+				isSiteEligibleForManagedExternalThemes( state, siteId ) ) ||
 			isThemeActive( state, themeId, siteId ) ||
 			isPremiumThemeAvailable( state, themeId, siteId ),
 	};
@@ -202,8 +257,10 @@ function getAllThemeOptions( { translate, isFSEActive } ) {
 		customize,
 		preview,
 		purchase,
+		subscribe,
 		upgradePlan,
 		upgradePlanForBundledThemes,
+		upgradePlanForExternallyManagedThemes,
 		activate,
 		tryandcustomize,
 		deleteTheme,

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -135,6 +135,9 @@ class ThemesSelection extends Component {
 					secondaryOption = null;
 				} else if ( this.props.isThemeActive( themeId ) ) {
 					defaultOption = options.customize;
+				} else if ( options.upgradePlanForExternallyManagedThemes ) {
+					defaultOption = options.upgradePlanForExternallyManagedThemes;
+					secondaryOption = null;
 				} else if ( options.upgradePlanForBundledThemes ) {
 					defaultOption = options.upgradePlanForBundledThemes;
 					secondaryOption = null;


### PR DESCRIPTION
#### Proposed Changes

This adds third-party theme options to the theme kebab menu.

**NOTE: At this time, checking out/subscribing isn't implemented. This functionality will be added later after we've made the appropriate backend updates.**

#### Testing Instructions

To test, you'll need to simulate a third-party theme by adding the following to `0-sandbox.php` on your sandbox, then sandboxing `public-api.wordpress.com`.

```
function test_theme_type( $theme ) {
	if ( $theme['id'] === 'varese' ) {
		$theme['theme_type'] = 'managed-external';
	}

	return $theme;
}

add_filter( 'wpcom_theme_api_meta', 'test_theme_type', 1000 );
```

#### Testing a Free site
- The simulated third-party theme should say "Upgrade to subscribe"
![image](https://user-images.githubusercontent.com/917632/199595718-72191103-403d-4a9d-ab69-2ea77845ca0d.png)

- Bundled themes should say "Upgrade to activate"
![image](https://user-images.githubusercontent.com/917632/199595636-e018bfd7-6748-4c03-9773-a9a37b7e5df4.png)

- Regular premium themes should say "Purchase"
![image](https://user-images.githubusercontent.com/917632/199595768-bc6dd382-4271-4202-a039-4aea9a6ccca2.png)

- Free themes should say "Activate"
![image](https://user-images.githubusercontent.com/917632/199595808-ec834a94-a010-4906-b9c4-475fbfd9ce6f.png)

#### Testing a Business plan site
- The simulated third-party theme should say "Subscribe"
![image](https://user-images.githubusercontent.com/917632/199596246-10de0d33-77df-4abd-b9ac-020a2a1d2b52.png)

All other theme types should read as described above.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #69470
