### PR TITLE
Jetpack pricing: add link to GDPR page to footer

### DIFF
--- a/client/jetpack-cloud/sections/pricing/jpcom-footer/index.tsx
+++ b/client/jetpack-cloud/sections/pricing/jpcom-footer/index.tsx
@@ -123,6 +123,11 @@ const JetpackComFooter: React.FC = () => {
 						href: addQueryArgs( utmParams, 'https://automattic.com/privacy/' ),
 						trackId: 'privacy_policy',
 					},
+					{
+						label: translate( 'GDPR ' ),
+						href: addQueryArgs( utmParams, 'https://jetpack.com/gdpr/' ),
+						trackId: 'gdpr',
+					},
 					hideCaliforniaNotice
 						? null
 						: {

--- a/client/jetpack-cloud/sections/pricing/jpcom-footer/index.tsx
+++ b/client/jetpack-cloud/sections/pricing/jpcom-footer/index.tsx
@@ -124,7 +124,10 @@ const JetpackComFooter: React.FC = () => {
 						trackId: 'privacy_policy',
 					},
 					{
-						label: translate( 'GDPR ' ),
+						label: translate( 'GDPR', {
+							comment:
+								'GDPR refers to the General Data Protection Regulation in effect in the European Union',
+						} ),
 						href: addQueryArgs( utmParams, 'https://jetpack.com/gdpr/' ),
 						trackId: 'gdpr',
 					},


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR adds a link to the Jetpack.com GDPR page to the footer of the Jetpack pricing page.

### Testing instructions

- Spin up Cloud, by running this branch locally or using the live link below
- Visit the pricing page
- Notice the GDPR link in the _Legal_ section of the footer
- Check that it links to the GDPR page in Jetpack.com

### Screenshots

<img width="183" alt="Screen Shot 2022-11-02 at 2 33 20 PM" src="https://user-images.githubusercontent.com/1620183/199596584-cf42e975-a4d9-439d-97cb-18ce8be8c420.png">
