### PR TITLE
Jetpack pricing: add link to GDPR page to FAQ

### DIFF
--- a/client/my-sites/plans/jetpack-plans/faq/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/faq/index.tsx
@@ -22,6 +22,19 @@ const jetpackGettingStartedLink = () => {
 	);
 };
 
+const jetpackGDPRLink = () => {
+	return (
+		<a
+			href="https://jetpack.com/gdpr/"
+			target="_blank"
+			rel="noopener noreferrer"
+			onClick={ () => {
+				recordTracksEvent( 'calypso_jetpack_faq_gdpr_click' );
+			} }
+		/>
+	);
+};
+
 const JetpackFAQ: FC = () => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
@@ -174,6 +187,22 @@ const JetpackFAQ: FC = () => {
 						'Jetpack’s free features are compatible with WordPress Multisite networks. Paid features' +
 							' also work with Multisite networks, but each site requires its own subscription. Jetpack Backup' +
 							' and Jetpack Scan are not currently compatible with Multisite networks.'
+					) }
+				</FoldableFAQ>
+				<FoldableFAQ
+					id="gdpr"
+					question={ translate( 'Does Jetpack comply with the GDPR?', {
+						comment:
+							'GDPR refers to the General Data Protection Regulation in effect in the European Union',
+					} ) }
+					onToggle={ onFaqToggle }
+					className="jetpack-faq__section"
+				>
+					{ translate(
+						'Jetpack understands the General Data Protection Regulation. {{link}}Read more about how Jetpack is committed to operating in accordance with the GDPR.{{/link}}',
+						{
+							components: { link: jetpackGDPRLink() },
+						}
 					) }
 				</FoldableFAQ>
 				<FoldableFAQ


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR adds a link to the Jetpack.com GDPR page to the FAQ of the Jetpack pricing page.

### Testing instructions

- Spin up Cloud, by running this branch locally or using the live link below
- Visit the pricing page
- Notice the  new item in the FAQ
- Check that it links to the GDPR page in Jetpack.com

### Screenshots

<img width="787" alt="Screen Shot 2022-11-02 at 3 49 20 PM" src="https://user-images.githubusercontent.com/1620183/199609060-24649128-6b11-4f7b-a4b0-4c4fa90339c5.png">

