### PR TITLE
Woo Onboarding MVP: Update/store profiler persistence

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/store-profiler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/store-profiler/index.tsx
@@ -12,7 +12,7 @@ import FormInput from 'calypso/components/forms/form-text-input';
 import useSiteVerticalsFeatured from 'calypso/data/site-verticals/use-site-verticals-featured';
 import { useCountriesAndStates } from 'calypso/jetpack-cloud/sections/partner-portal/company-details-form/hooks/use-countries-and-states';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import { USER_STORE, ONBOARD_STORE } from '../../../../stores';
+import { ONBOARD_STORE, USER_STORE } from '../../../../stores';
 import type { Step } from '../../types';
 import './style.scss';
 
@@ -50,7 +50,6 @@ const StoreProfiler: Step = function StoreProfiler( { navigation } ) {
 		);
 		return options;
 	}, [ verticals, translate ] );
-	// TODO: This may not be the right source for this info.
 	const countriesAndStates = useCountriesAndStates();
 	const countriesOptions = React.useMemo( () => {
 		return countriesAndStates.countryOptions.map( ( c ) => (

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/store-profiler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/store-profiler/index.tsx
@@ -10,22 +10,26 @@ import FormLabel from 'calypso/components/forms/form-label';
 import FormSelect from 'calypso/components/forms/form-select';
 import FormInput from 'calypso/components/forms/form-text-input';
 import useSiteVerticalsFeatured from 'calypso/data/site-verticals/use-site-verticals-featured';
-import { useCountries } from 'calypso/landing/stepper/hooks/use-countries';
+import { useCountriesAndStates } from 'calypso/jetpack-cloud/sections/partner-portal/company-details-form/hooks/use-countries-and-states';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import { SITE_STORE, USER_STORE } from '../../../../stores';
+import { USER_STORE, ONBOARD_STORE } from '../../../../stores';
 import type { Step } from '../../types';
 import './style.scss';
 
 const StoreProfiler: Step = function StoreProfiler( { navigation } ) {
 	const { goBack, goNext, submit } = navigation;
 	const [ siteTitle, setSiteTitle ] = React.useState( '' );
-	const [ vertical, setVertical ] = React.useState( '' );
-	const [ country, setCountry ] = React.useState( '' );
-	// const [ formTouched, setFormTouched ] = React.useState( false );
+	const [ verticalId, setVerticalId ] = React.useState( '' );
+	const [ storeCountryCode, setStoreCountryCode ] = React.useState( '' );
 	const translate = useTranslate();
 	const currentUser = useSelect( ( select ) => select( USER_STORE ).getCurrentUser() );
 	const newUser = useSelect( ( select ) => select( USER_STORE ).getNewUser() );
-	const site = { ID: 0 }; // TODO: how to we initialize new site programmatically?
+	const {
+		setSiteTitle: saveSiteTitleToStore,
+		setVerticalId: saveVerticalIdToStore,
+		setStoreLocationCountryCode: saveCountryCodeToStore,
+	} = useDispatch( ONBOARD_STORE );
+
 	const verticals = useSiteVerticalsFeatured();
 	const verticalsOptions = React.useMemo( () => {
 		const sorted = verticals.data?.sort( ( a, b ) => {
@@ -41,49 +45,44 @@ const StoreProfiler: Step = function StoreProfiler( { navigation } ) {
 		) );
 	}, [ verticals ] );
 	// TODO: This may not be the right source for this info.
-	const countries = useCountries();
+	const countriesAndStates = useCountriesAndStates();
 	const countriesOptions = React.useMemo( () => {
-		const data = countries.data as Record< string, string >;
-		console.log( data );
-		const options = [];
-		for ( const abbrev in data ) {
-			const country = data[ abbrev ];
-			options.push(
-				<option value={ abbrev } key={ abbrev }>
-					{ country }
-				</option>
-			);
-		}
-		return options;
-	}, [ countries ] );
-
-	const { saveSiteSettings } = useDispatch( SITE_STORE );
-	console.log( { currentUser, newUser } );
+		return countriesAndStates.countryOptions.map( ( c ) => (
+			<option value={ c.value } key={ c.value }>
+				{ c.label }
+			</option>
+		) );
+	}, [ countriesAndStates ] );
+	const isLoading = verticals.isLoading || ! countriesAndStates;
 
 	const handleSubmit = async ( event: React.FormEvent ) => {
 		event.preventDefault();
-		if ( site ) {
-			await saveSiteSettings( site.ID, {
-				blogname: siteTitle,
-			} );
+		if ( currentUser || newUser ) {
+			saveSiteTitleToStore( siteTitle );
+			saveVerticalIdToStore( verticalId );
+			saveCountryCodeToStore( storeCountryCode );
 			recordTracksEvent( 'calypso_signup_store_profiler_submit', {
 				has_site_title: !! siteTitle,
+				has_vertical: !! verticalId,
+				has_location: !! storeCountryCode,
 			} );
 
-			submit?.( { siteTitle } );
+			submit?.( {
+				siteTitle: siteTitle,
+				verticalId: verticalId,
+				storeLocationCountryCode: storeCountryCode,
+			} );
 		}
 	};
 	const onChange = ( event: React.FormEvent< HTMLInputElement | HTMLSelectElement > ) => {
-		if ( site ) {
-			// setFormTouched( true );
-
+		if ( currentUser || newUser ) {
 			switch ( event.currentTarget.name ) {
 				case 'siteTitle':
 					return setSiteTitle( event.currentTarget.value );
 				case 'siteVertical':
-					return setVertical( event.currentTarget.value );
+					return setVerticalId( event.currentTarget.value );
 				case 'siteCountry':
-					return setCountry( event.currentTarget.value );
+					return setStoreCountryCode( event.currentTarget.value );
 			}
 		}
 	};
@@ -92,7 +91,7 @@ const StoreProfiler: Step = function StoreProfiler( { navigation } ) {
 
 	const stepContent = (
 		<form className="store-profiler__form" onSubmit={ handleSubmit }>
-			<FormFieldset disabled={ ! site } className="store-profiler__form-fieldset">
+			<FormFieldset disabled={ isLoading } className="store-profiler__form-fieldset">
 				<FormLabel htmlFor="siteTitle" optional>
 					{ translate( 'Name of your store' ) }{ ' ' }
 				</FormLabel>
@@ -105,24 +104,39 @@ const StoreProfiler: Step = function StoreProfiler( { navigation } ) {
 				/>
 				{ siteTitleError && <FormInputValidation isError text={ siteTitleError } /> }
 			</FormFieldset>
-			<FormFieldset disabled={ ! site } className="store-profiler__form-fieldset">
+			<FormFieldset disabled={ isLoading } className="store-profiler__form-fieldset">
 				<FormLabel htmlFor="siteVertical" optional>
 					{ translate( 'In which industry does your store operate?' ) }{ ' ' }
 				</FormLabel>
-				<FormSelect name="siteVertical" id="siteVertical" value={ vertical } onChange={ onChange }>
+				<FormSelect
+					name="siteVertical"
+					id="siteVertical"
+					value={ verticalId }
+					onChange={ onChange }
+				>
 					{ verticalsOptions }
 				</FormSelect>
 			</FormFieldset>
-			<FormFieldset disabled={ ! site } className="store-profiler__form-fieldset">
+			<FormFieldset disabled={ isLoading } className="store-profiler__form-fieldset">
 				<FormLabel htmlFor="siteCountry" optional>
 					{ translate( 'Where will your business be located?' ) }{ ' ' }
 				</FormLabel>
-				<FormSelect name="siteCountry" id="siteCountry" value={ country } onChange={ onChange }>
+				<FormSelect
+					name="siteCountry"
+					id="siteCountry"
+					value={ storeCountryCode }
+					onChange={ onChange }
+				>
 					{ countriesOptions }
 				</FormSelect>
 			</FormFieldset>
 
-			<Button disabled={ ! site } className="store-profiler__submit-button" type="submit" primary>
+			<Button
+				disabled={ isLoading }
+				className="store-profiler__submit-button"
+				type="submit"
+				primary
+			>
 				{ translate( 'Continue' ) }
 			</Button>
 		</form>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/store-profiler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/store-profiler/index.tsx
@@ -38,12 +38,18 @@ const StoreProfiler: Step = function StoreProfiler( { navigation } ) {
 			}
 			return a.name > b.name ? 1 : -1;
 		} );
-		return sorted?.map( ( v ) => (
+		const options = sorted?.map( ( v ) => (
 			<option value={ v.id } key={ v.id }>
 				{ v.name }
 			</option>
 		) );
-	}, [ verticals ] );
+		options?.unshift(
+			<option value="" key="">
+				{ translate( '- Select Industry -' ) }
+			</option>
+		);
+		return options;
+	}, [ verticals, translate ] );
 	// TODO: This may not be the right source for this info.
 	const countriesAndStates = useCountriesAndStates();
 	const countriesOptions = React.useMemo( () => {

--- a/packages/data-stores/src/onboard/actions.ts
+++ b/packages/data-stores/src/onboard/actions.ts
@@ -314,6 +314,16 @@ export const setEditEmail = ( email: string ) => ( {
 	email,
 } );
 
+export const setVerticalId = ( verticalId: string ) => ( {
+	type: 'SET_VERTICAL_ID' as const,
+	verticalId,
+} );
+
+export const setStoreLocationCountryCode = ( storeLocationCountryCode: string ) => ( {
+	type: 'SET_STORE_LOCATION_COUNTRY_CODE' as const,
+	storeLocationCountryCode,
+} );
+
 export type OnboardAction = ReturnType<
 	| typeof addFeature
 	| typeof removeFeature
@@ -358,4 +368,6 @@ export type OnboardAction = ReturnType<
 	| typeof setSiteDescription
 	| typeof setSiteLogo
 	| typeof setSiteAccentColor
+	| typeof setVerticalId
+	| typeof setStoreLocationCountryCode
 >;

--- a/packages/data-stores/src/onboard/index.ts
+++ b/packages/data-stores/src/onboard/index.ts
@@ -50,6 +50,8 @@ export function register(): typeof STORE_KEY {
 			'siteLogo',
 			'siteAccentColor',
 			'storeType',
+			'verticalId',
+			'storeLocationCountryCode',
 		],
 	} );
 	isRegistered = true;

--- a/packages/data-stores/src/onboard/reducer.ts
+++ b/packages/data-stores/src/onboard/reducer.ts
@@ -377,6 +377,26 @@ const editEmail: Reducer< string, OnboardAction > = ( state = '', action ) => {
 	return state;
 };
 
+const verticalId: Reducer< string, OnboardAction > = ( state = '', action ) => {
+	if ( action.type === 'SET_VERTICAL_ID' ) {
+		return action.verticalId;
+	}
+	if ( action.type === 'RESET_ONBOARD_STORE' ) {
+		return '';
+	}
+	return state;
+};
+
+const storeLocationCountryCode: Reducer< string, OnboardAction > = ( state = '', action ) => {
+	if ( action.type === 'SET_STORE_LOCATION_COUNTRY_CODE' ) {
+		return action.storeLocationCountryCode;
+	}
+	if ( action.type === 'RESET_ONBOARD_STORE' ) {
+		return '';
+	}
+	return state;
+};
+
 const reducer = combineReducers( {
 	anchorPodcastId,
 	anchorEpisodeId,
@@ -411,6 +431,8 @@ const reducer = combineReducers( {
 	siteDescription,
 	siteLogo,
 	siteAccentColor,
+	verticalId,
+	storeLocationCountryCode,
 } );
 
 export type State = ReturnType< typeof reducer >;

--- a/packages/data-stores/src/onboard/selectors.ts
+++ b/packages/data-stores/src/onboard/selectors.ts
@@ -25,6 +25,8 @@ export const getProgressTitle = ( state: State ) => state.progressTitle;
 export const getStepProgress = ( state: State ) => state.stepProgress;
 export const getGoals = ( state: State ) => state.goals;
 export const getPatternContent = ( state: State ) => state.patternContent;
+export const getVerticalId = ( state: State ) => state.verticalId;
+export const getStoreLocationCountryCode = ( state: State ) => state.storeLocationCountryCode;
 export const getState = ( state: State ) => state;
 export const hasPaidDesign = ( state: State ): boolean => {
 	if ( ! state.selectedDesign ) {


### PR DESCRIPTION
#### Proposed Changes

* This PR updates the Store Profiler step introduced in #69634 to persist data from it into future steps of the flow. It also introduces two new keys on the onboarding store used to persist this data.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this branch to local Calypso.
* Edit the file `client/landing/stepper/declarative-flow/internals/steps-repository/design-carousel/index.tsx` to include the following:

```js
// add imports:
import { useSelect, useDispatch } from '@wordpress/data';
import { ONBOARD_STORE } from '../../../../stores';

// add in component function body
const siteTitle = useSelect( ( select ) => select( ONBOARD_STORE ).getSelectedSiteTitle() );
const verticalId = useSelect( ( select ) => select( ONBOARD_STORE ).getVerticalId() );
const storeLocationCountryCode = useSelect( ( select ) =>
    select( ONBOARD_STORE ).getStoreLocationCountryCode()
);
console.log( { siteTitle, verticalId, storeLocationCountryCode } );
```
* Navigate to `/setup?flow=ecommerce` and pass through the intro step to the store profiler step.
* Fill out the store profiler form - enter a store name, select a site vertical, and select a store country.
<img width="741" alt="image" src="https://user-images.githubusercontent.com/13437011/199612953-bae11844-46dd-402b-8f47-9a6bdd04a0bb.png">

* Navigate to the next step by pressing Continue.
* Verify that the console logs out the values that were entered in the previous step.

<img width="486" alt="image" src="https://user-images.githubusercontent.com/13437011/199613005-03d59ec8-2c8a-4400-a39b-479bd1ca4be5.png">


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #69386 
