### PR TITLE
Update license assignment page

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/assign-license-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/assign-license-form/index.tsx
@@ -50,6 +50,8 @@ export default function AssignLicenseForm( {
 	const [ selectedSite, setSelectedSite ] = useState( false );
 	const [ isSubmitting, setIsSubmitting ] = useState( false );
 	const licenseKey = getQueryArg( window.location.href, 'key' ) as string;
+	const licenseKeys = getQueryArg( window.location.href, 'keys' ) as string;
+	const licenseKeysArray = licenseKeys !== undefined ? licenseKeys.split( ',' ) : [ licenseKey ];
 	const onSelectSite = ( site: any ) => setSelectedSite( site );
 	const notificationId = 'partner-portal-assign-license-form';
 
@@ -133,7 +135,12 @@ export default function AssignLicenseForm( {
 						busy={ isSubmitting }
 						onClick={ onAssignLicense }
 					>
-						{ translate( 'Assign to website' ) }
+						{ translate( 'Assign %(numLicenses)d License', 'Assign %(numLicenses)d Licenses', {
+							count: licenseKeysArray.length,
+							args: {
+								numLicenses: licenseKeysArray.length,
+							},
+						} ) }
 					</Button>
 				</div>
 			</div>


### PR DESCRIPTION
Update the license assignment page to indicate the number of licenses that are being assigned.

#### Proposed Changes

* This PR changes the button in the licenses assignment page from "Assign to website" to "Assign x license" where the number of licenses being assigned is now indicated. The query param "keys" has been added and will be used as a comma separated list of keys if more than one key is being assigned. 

#### Testing Instructions
- Apply this PR
- Run yarn-start-jetpack-cloud
- Visit the unassigned licenses page at `http://jetpack.cloud.localhost:3000/partner-portal/licenses/unassigned` 
- Attempt to assign a license and ensure that the button now indicates the number of licenses being assigned in place of the previous "Assign to website". 
<img width="1163" alt="Screenshot 2022-11-02 at 7 25 13 PM" src="https://user-images.githubusercontent.com/1273880/199631900-4b0e75ee-41c3-4d73-a83e-20141ef0009d.png">

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--

Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
