### PR TITLE
Signup: Fixes styling for plans-site-selected step

### DIFF
--- a/client/signup/steps/plans/style.scss
+++ b/client/signup/steps/plans/style.scss
@@ -43,6 +43,7 @@
 .signup__step.is-plans-newsletter .formatted-header__subtitle .button.is-borderless,
 .signup__step.is-plans .formatted-header__subtitle .button.is-borderless,
 .signup__step.is-plans-launch .formatted-header__subtitle .button.is-borderless,
+.signup__step.is-plans-site-selected .formatted-header__subtitle .button.is-borderless,
 .signup__step.is-mailbox-plan .formatted-header__subtitle .button.is-borderless {
 	padding: 0;
 	color: inherit;

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -29,6 +29,7 @@ body.is-section-signup {
 		.signup__step.is-mailbox-plan .step-wrapper__navigation,
 		.signup__step.is-plans .step-wrapper__navigation,
 		.signup__step.is-domains .step-wrapper__navigation,
+		.signup__step.is-plans-site-selected .step-wrapper__navigation,
 		.signup__step.is-mailbox-domain .step-wrapper__navigation {
 			@include breakpoint-deprecated( "<660px" ) {
 				display: none;
@@ -804,6 +805,7 @@ body.is-section-signup.is-white-signup .layout:not(.dops):not(.is-wccom-oauth-fl
 	.signup__step.is-plans-newsletter,
 	.signup__step.is-plans-link-in-bio,
 	.signup__step.is-mailbox-plan,
+	.signup__step.is-plans-site-selected,
 	.signup__step.is-plans {
 		.formatted-header {
 			.formatted-header__title {
@@ -848,6 +850,7 @@ body.is-section-signup.is-white-signup .layout:not(.dops):not(.is-wccom-oauth-fl
 	.signup__step.is-plans-link-in-bio,
 	.signup__step.is-plans-newsletter,
 	.signup__step.is-mailbox-plan,
+	.signup__step.is-plans-site-selected,
 	.signup__step.is-plans {
 		.formatted-header__title {
 			font-weight: 500;


### PR DESCRIPTION
#### Proposed Changes

P2: pau2Xa-4yo-p2#comment-12835

This PR resolves a few styling issues for the `plans-site-selected` step by applying the same styles used for the `plans` step.

* Fixes padding and font for the `start with a free site` link.

|Before|After|
|---|---|
|<img width="184" alt="image" src="https://user-images.githubusercontent.com/5436027/199651312-5716050e-c973-470e-8436-64728b1aa7c8.png">|<img width="205" alt="image" src="https://user-images.githubusercontent.com/5436027/199651338-691933fc-e4ce-4d34-9191-ce7908ccf661.png">|

* Fixes padding and font for the subheader.

|Before|After|
|---|---|
|<img width="765" alt="image" src="https://user-images.githubusercontent.com/5436027/199651507-5c81b4e3-d384-458e-99e4-e259448a3e51.png">|<img width="699" alt="image" src="https://user-images.githubusercontent.com/5436027/199651531-7468ceb2-49d8-4242-a374-9571fc73665b.png">|

* Hides back button in mobile view

|Before|After|
|---|---|
|<img width="345" alt="image" src="https://user-images.githubusercontent.com/5436027/199651650-0a5cfc4b-09cc-4f96-9928-5b0f7031e1ab.png">|<img width="341" alt="image" src="https://user-images.githubusercontent.com/5436027/199651687-8d08b581-c02f-48bb-bbc9-0214ef47e391.png">|



#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/domain` and select any domain.
* On the next step, confirm that the page looks exactly the same as the one on https://wordpress.com/start/plans, with focus on the changes mentioned above.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes? -NA
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)? -NA
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) -NA
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)? -NA

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->