### PR TITLE
Thank you page for gifted purchases

### DIFF
--- a/client/components/thank-you/index.tsx
+++ b/client/components/thank-you/index.tsx
@@ -161,6 +161,7 @@ export const ThankYou = ( props: ThankYouProps ) => {
 		thankYouSubtitle,
 		thankYouImage,
 		thankYouNotice,
+		thankYouHeaderBody = null,
 	} = props;
 
 	const ThankYouTitleContainer = styled.div`
@@ -216,6 +217,7 @@ export const ThankYou = ( props: ThankYouProps ) => {
 						{ thankYouSubtitle && (
 							<h2 className="thank-you__header-subtitle">{ thankYouSubtitle }</h2>
 						) }
+						{ thankYouHeaderBody }
 					</ThankYouTitleContainer>
 				) }
 			</ThankYouHeader>

--- a/client/components/thank-you/types.ts
+++ b/client/components/thank-you/types.ts
@@ -47,5 +47,6 @@ export type ThankYouProps = {
 	};
 	thankYouTitle?: string | TranslateResult;
 	thankYouSubtitle?: string | TranslateResult;
+	thankYouHeaderBody?: React.ReactElement | null;
 	thankYouNotice?: ThankYouNoticeProps;
 };

--- a/client/my-sites/checkout/checkout-thank-you/gift/gift-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/gift/gift-thank-you.tsx
@@ -1,0 +1,113 @@
+import { Button, Card } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import { useQuery } from 'react-query';
+import { useSelector } from 'react-redux';
+import QueryProducts from 'calypso/components/data/query-products-list';
+import Main from 'calypso/components/main';
+import WordPressLogo from 'calypso/components/wordpress-logo';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import wpcom from 'calypso/lib/wp';
+import { isProductsListFetching, getProductName } from 'calypso/state/products-list/selectors';
+import type { FunctionComponent } from 'react';
+
+import './style.scss';
+
+interface Props {
+	site: number | string;
+	productSlug: string | 'no_product';
+	isUserlessCheckoutFlow: boolean;
+}
+
+interface Site {
+	name: string;
+	URL: string;
+}
+
+function useSiteQuery( siteId: string | number ) {
+	return useQuery< Site >(
+		[ 'unauthorized-site', siteId ],
+		() => wpcom.req.get( { path: `/sites/${ siteId }`, apiVersion: '1.2' } ),
+		{ meta: { persist: false } }
+	);
+}
+
+const GiftThankYou: FunctionComponent< Props > = ( {
+	site,
+	productSlug,
+	isUserlessCheckoutFlow = false,
+} ) => {
+	const translate = useTranslate();
+
+	const hasProductInfo = productSlug !== 'no_product';
+
+	const productName = useSelector( ( state ) =>
+		hasProductInfo ? getProductName( state, productSlug ) : null
+	);
+
+	const productListFetching = useSelector( isProductsListFetching );
+
+	const siteRequest = useSiteQuery( site );
+	const siteName = siteRequest.data?.name;
+	const siteUrl = siteRequest.data?.URL;
+	const isLoading = siteRequest.isLoading || productListFetching;
+
+	return (
+		<Main className="gift-thank-you">
+			<PageViewTracker
+				path="/checkout/gift/thank-you/:site/:product"
+				title="Checkout > Thank You"
+			/>
+			<Card className="gift-thank-you__card">
+				{ /*className="checkout-thank-you__wordpress-logo"*/ }
+				<WordPressLogo size={ 72 } />
+				{ hasProductInfo && <QueryProducts /> }
+				<h2 className="gift-thank-you__main-message">
+					{ /* the single space literal below is intentional for rendering purposes */ }
+					{ translate( 'Thank you for your purchase!' ) }{ ' ' }
+					{ String.fromCodePoint( 0x1f389 ) /* Celebration emoji 🎉 */ }
+				</h2>
+				{ hasProductInfo && ( isLoading || ( siteName && productName ) ) && (
+					<p
+						className={
+							isLoading ? 'gift-thank-you__sub-message-loading' : 'gift-thank-you__sub-message'
+						}
+					>
+						{ translate( '%(productName)s was added to your site %(siteName)s.', {
+							args: {
+								productName,
+								siteName,
+							},
+						} ) }
+					</p>
+				) }
+
+				{ isUserlessCheckoutFlow && (
+					<p
+						className={
+							isLoading ? 'gift-thank-you__email-message-loading' : 'gift-thank-you__email-message'
+						}
+					>
+						{ translate( 'We sent you an email with your receipt and further instructions.' ) }
+					</p>
+				) }
+
+				{ ( isLoading || ( siteName && siteUrl ) ) && (
+					<Button
+						className="gift-thank-you__button"
+						disabled={ isLoading }
+						href={ siteUrl }
+						primary
+					>
+						{ isLoading
+							? translate( 'Loading' )
+							: translate( 'Back to %s', {
+									args: siteName,
+							  } ) }
+					</Button>
+				) }
+			</Card>
+		</Main>
+	);
+};
+
+export default GiftThankYou;

--- a/client/my-sites/checkout/checkout-thank-you/gift/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/gift/style.scss
@@ -1,87 +1,49 @@
-.checkout-thank-you__wordpress-logo {
-	height: 180px;
-	width: 180px;
-	fill: var(--color-wpcom);
-	margin: 0 auto;
-	display: block;
-	transition: transform 0.8s cubic-bezier(0.075, 0.82, 0.165, 1);
-	transform: scale(0.13333);
-	transform-origin: 50% 0;
+// Global override, prevent grey around the no-sidebar layout padding
+.is-section-checkout-gift-thank-you {
+	background-color: var(--studio-white);
 
-	&.is-large {
-		transform: scale(1);
-	}
-}
-
-@mixin jetpack-primary-button() {
-	// button colors imported from packages/calypso-color-schemes/src/shared/color-schemes/_jetpack-cloud.scss
-	// background-color: var(--studio-jetpack-green-50);
-	// border-color: var(--studio-jetpack-green-50);
-	color: var(--color-text-inverted);
-
-	&:hover,
-	&:focus {
-		// background-color: var(--studio-jetpack-green-60);
-		// border-color: var(--studio-jetpack-green-60);
-		color: var(--color-text-inverted);
-	}
-
-	&[disabled],
-	&:disabled,
-	&.disabled {
-		color: var(--color-neutral-20);
-		background-color: var(--color-surface);
-		border-color: var(--color-neutral-5);
+	// Override and reset
+	.layout__content {
+		padding-top: 0;
+		margin-top: var(--masterbar-height);
 	}
 }
 
 .gift-thank-you {
-	.gift-thank-you__card,
-	.gift-thank-you__card-loading {
-		box-shadow: 0 0 40px 0 #00000014;
-
+	.button {
 		width: 100%;
-		max-width: none;
-		padding: 16px;
+	}
 
-		// @include break-mobile {
-		// 	width: auto;
-		// 	max-width: 650px;
-		// 	padding: 96px;
-		// }
+	.gift-thank-you__container {
+		margin-top: 0;
+	}
+	.gift-thank-you__header-body {
+		line-height: 28px;
+	}
+	.gift-thank-you__loader {
+		display: flex;
+		justify-content: center;
+		margin-top: 160px;
+	}
 
-		.gift-thank-you__main-message {
-			font-size: $font-headline-small;
-			font-weight: 700;
-			margin-bottom: 24px;
+	// Thankyou component overrides
+	.thank-you__header-title {
+		margin-bottom: 24px;
+	}
 
-			// @include break-mobile {
-			// font-size: $font-headline-medium;
-			// }
+	.thank-you__container-header {
+		padding-top: 50px;
+		@media screen and (max-width: 782px) {
+			padding-top: 30px;
 		}
-
-		.gift-thank-you__sub-message-loading,
-		.gift-thank-you__sub-message {
-			font-size: $font-title-medium;
-			font-weight: 500;
-			margin-bottom: 64px;
-		}
-
-		.gift-thank-you__email-message-loading,
-		.gift-thank-you__email-message {
-			margin-top: -32px;
-			margin-bottom: 64px;
-		}
-
-		.gift-thank-you__button,
-		.gift-thank-you__button:visited {
-			border-radius: calc(2px * 2);
-			@include jetpack-primary-button;
+		min-height: 0;
+		padding-bottom: 0;
+		img {
+			margin-bottom: 32px;
 		}
 	}
 
-	.gift-thank-you__sub-message-loading,
-	.gift-thank-you__email-message-loading {
-		@include placeholder(--color-neutral-20);
+	.thank-you__body {
+		margin-top: 69px;
 	}
 }

--- a/client/my-sites/checkout/checkout-thank-you/gift/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/gift/style.scss
@@ -1,0 +1,87 @@
+.checkout-thank-you__wordpress-logo {
+	height: 180px;
+	width: 180px;
+	fill: var(--color-wpcom);
+	margin: 0 auto;
+	display: block;
+	transition: transform 0.8s cubic-bezier(0.075, 0.82, 0.165, 1);
+	transform: scale(0.13333);
+	transform-origin: 50% 0;
+
+	&.is-large {
+		transform: scale(1);
+	}
+}
+
+@mixin jetpack-primary-button() {
+	// button colors imported from packages/calypso-color-schemes/src/shared/color-schemes/_jetpack-cloud.scss
+	// background-color: var(--studio-jetpack-green-50);
+	// border-color: var(--studio-jetpack-green-50);
+	color: var(--color-text-inverted);
+
+	&:hover,
+	&:focus {
+		// background-color: var(--studio-jetpack-green-60);
+		// border-color: var(--studio-jetpack-green-60);
+		color: var(--color-text-inverted);
+	}
+
+	&[disabled],
+	&:disabled,
+	&.disabled {
+		color: var(--color-neutral-20);
+		background-color: var(--color-surface);
+		border-color: var(--color-neutral-5);
+	}
+}
+
+.gift-thank-you {
+	.gift-thank-you__card,
+	.gift-thank-you__card-loading {
+		box-shadow: 0 0 40px 0 #00000014;
+
+		width: 100%;
+		max-width: none;
+		padding: 16px;
+
+		// @include break-mobile {
+		// 	width: auto;
+		// 	max-width: 650px;
+		// 	padding: 96px;
+		// }
+
+		.gift-thank-you__main-message {
+			font-size: $font-headline-small;
+			font-weight: 700;
+			margin-bottom: 24px;
+
+			// @include break-mobile {
+			// font-size: $font-headline-medium;
+			// }
+		}
+
+		.gift-thank-you__sub-message-loading,
+		.gift-thank-you__sub-message {
+			font-size: $font-title-medium;
+			font-weight: 500;
+			margin-bottom: 64px;
+		}
+
+		.gift-thank-you__email-message-loading,
+		.gift-thank-you__email-message {
+			margin-top: -32px;
+			margin-bottom: 64px;
+		}
+
+		.gift-thank-you__button,
+		.gift-thank-you__button:visited {
+			border-radius: calc(2px * 2);
+			@include jetpack-primary-button;
+		}
+	}
+
+	.gift-thank-you__sub-message-loading,
+	.gift-thank-you__email-message-loading {
+		@include placeholder(--color-neutral-20);
+	}
+}

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -30,6 +30,7 @@ import {
 import CalypsoShoppingCartProvider from './calypso-shopping-cart-provider';
 import CheckoutMainWrapper from './checkout-main-wrapper';
 import CheckoutThankYouComponent from './checkout-thank-you';
+import GiftThankYou from './checkout-thank-you/gift/gift-thank-you';
 import JetpackCheckoutThankYou from './checkout-thank-you/jetpack-checkout-thank-you';
 import CheckoutPending from './checkout-thank-you/pending';
 import UpsellNudge, {
@@ -453,6 +454,20 @@ export function jetpackCheckoutThankYou( context, next ) {
 
 	context.primary = (
 		<JetpackCheckoutThankYou
+			site={ context.params.site }
+			productSlug={ context.params.product }
+			isUserlessCheckoutFlow={ isUserlessCheckoutFlow }
+		/>
+	);
+
+	next();
+}
+
+export function giftThankYou( context, next ) {
+	const isUserlessCheckoutFlow = context.path.includes( '/checkout/gift' );
+
+	context.primary = (
+		<GiftThankYou
 			site={ context.params.site }
 			productSlug={ context.params.product }
 			isUserlessCheckoutFlow={ isUserlessCheckoutFlow }

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -464,17 +464,11 @@ export function jetpackCheckoutThankYou( context, next ) {
 }
 
 export function giftThankYou( context, next ) {
-	const isUserlessCheckoutFlow = context.path.includes( '/checkout/gift' );
-
-	context.primary = (
-		<GiftThankYou
-			site={ context.params.site }
-			productSlug={ context.params.product }
-			isUserlessCheckoutFlow={ isUserlessCheckoutFlow }
-		/>
-	);
-
-	next();
+	// Overriding section name here in order to apply a top level
+	// background via .is-section-checkout-gift-thank-you
+	context.section.name = 'checkout-gift-thank-you';
+	context.primary = <GiftThankYou site={ context.params.site } />;
+	next( context );
 }
 
 function getRememberedCoupon() {

--- a/client/my-sites/checkout/index.js
+++ b/client/my-sites/checkout/index.js
@@ -97,8 +97,8 @@ export default function () {
 	// The no-site post-checkout route is for purchases not tied to a site so do
 	// not include the `siteSelection` middleware.
 	page(
-		'/checkout/gift/thank-you/:site/:product',
-		// redirectLoggedOut,
+		'/checkout/gift/thank-you/:site',
+		redirectLoggedOut,
 		giftThankYou,
 		makeLayout,
 		clientRender

--- a/client/my-sites/checkout/index.js
+++ b/client/my-sites/checkout/index.js
@@ -18,6 +18,7 @@ import {
 	licensingThankYouAutoActivation,
 	licensingThankYouAutoActivationCompleted,
 	jetpackCheckoutThankYou,
+	giftThankYou,
 	redirectJetpackLegacyPlans,
 	redirectToSupportSession,
 	upsellNudge,
@@ -95,6 +96,14 @@ export default function () {
 
 	// The no-site post-checkout route is for purchases not tied to a site so do
 	// not include the `siteSelection` middleware.
+	page(
+		'/checkout/gift/thank-you/:site/:product',
+		// redirectLoggedOut,
+		giftThankYou,
+		makeLayout,
+		clientRender
+	);
+
 	page(
 		'/checkout/thank-you/no-site/pending/:orderId',
 		redirectLoggedOut,


### PR DESCRIPTION
Adding a thank you page for gift purchases https://github.com/Automattic/dotcom-forge/issues/1156

Borrowed impl from [jetpack-checkout-thank-you](https://github.com/Automattic/wp-calypso/blob/e81834887e4506b723afec34380b9b579aa7d510/client/my-sites/checkout/checkout-thank-you/jetpack-checkout-thank-you.tsx), and [marketplace-thank-you](https://github.com/Automattic/wp-calypso/blob/b861acf21449733c70426391383b4264866e9634/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx) pages.

#### Proposed Changes

* Add a new thank you page for gift purchases @  /checkout/gift/thank-you/:site

#### Testing Instructions

* We don't have a flow to test yet but we can test the page out on any site since we're bypassing user site data anyway.
* Visit the new thank you page http://calypso.localhost:3000/checkout/gift/thank-you/testing705633960.wordpress.com
* You should see the new page matching the figma: VJIo6mK2dL39bWYZpOrxre-fi-1502%3A27421

Regression checks:

* Confirm the marketplace plugin checkout page looks ok
* Confirm the standard checkout thank you page looks ok

Screenshot:
![Screenshot 2022-11-07 at 17-25-27 WordPress com](https://user-images.githubusercontent.com/811776/200239984-07136fda-3e60-4965-a61b-881db778c42c.png)


Related to https://github.com/Automattic/dotcom-forge/issues/1156
