### PR TITLE
Launchpad: Add unit tests for email validation banner

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/step-content.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/step-content.tsx
@@ -1,0 +1,112 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen, fireEvent } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from 'react-query';
+import { Provider as ReduxProvider } from 'react-redux';
+import { createReduxStore } from 'calypso/state';
+import { getInitialState, getStateFromCache } from 'calypso/state/initial-state';
+import initialReducer from 'calypso/state/reducer';
+import { setStore } from 'calypso/state/redux-store';
+import EmailValidationBanner from '../email-validation-banner';
+import StepContent from '../step-content';
+
+const props = {
+	siteSlug: 'testsite.wordpress.com',
+	/* eslint-disable @typescript-eslint/no-empty-function */
+	submit: () => {},
+	goNext: () => {},
+	goToStep: () => {},
+	/* eslint-enable @typescript-eslint/no-empty-function */
+};
+
+jest.mock( 'react-router-dom', () => ( {
+	...jest.requireActual( 'react-router-dom' ),
+	useLocation: jest.fn().mockImplementation( () => ( {
+		pathname: '/setup/launchpad',
+		search: `?flow=newsletter&siteSlug=${ props.siteSlug }`,
+		hash: '',
+		state: undefined,
+	} ) ),
+} ) );
+
+const user = {
+	ID: 1234,
+	username: 'testUser',
+	email: 'testemail@wordpress.com',
+	email_verified: false,
+};
+
+function renderStepContent( emailVerified = false ) {
+	const initialState = getInitialState( initialReducer, user.ID );
+	const reduxStore = createReduxStore(
+		{
+			...initialState,
+			currentUser: {
+				user: {
+					...user,
+					email_verified: emailVerified,
+				},
+			},
+		},
+		initialReducer
+	);
+	setStore( reduxStore, getStateFromCache( user.ID ) );
+	const queryClient = new QueryClient();
+
+	render(
+		<ReduxProvider store={ reduxStore }>
+			<QueryClientProvider client={ queryClient }>
+				<StepContent { ...props }>
+					<EmailValidationBanner />
+				</StepContent>
+			</QueryClientProvider>
+		</ReduxProvider>
+	);
+}
+
+describe( 'EmailValidationBanner', () => {
+	it( "shows the banner when the user's email is not verified", () => {
+		renderStepContent( false );
+
+		const emailValidationBanner = screen.queryByText(
+			/Make sure to validate the email we sent to testemail@wordpress.com in order to publish and share your posts./i
+		);
+
+		expect( emailValidationBanner ).toBeInTheDocument();
+	} );
+
+	it( "hides the banner when the user's email is verified", () => {
+		renderStepContent( true );
+
+		const emailValidationBanner = screen.queryByText(
+			/Make sure to validate the email we sent to testemail@wordpress.com in order to publish and share your posts./i
+		);
+
+		expect( emailValidationBanner ).not.toBeInTheDocument();
+	} );
+
+	it( 'change email link redirects to /me/account', () => {
+		renderStepContent( false );
+
+		expect( screen.getByRole( 'link', { name: 'change email address' } ) ).toHaveAttribute(
+			'href',
+			'/me/account'
+		);
+	} );
+
+	it( 'hides the banner when clicking the close button', () => {
+		renderStepContent( false );
+
+		const closeButton = screen.getByLabelText( 'close' );
+		const emailValidationBanner = screen.queryByText(
+			/Make sure to validate the email we sent to testemail@wordpress.com in order to publish and share your posts./i
+		);
+
+		expect( emailValidationBanner ).toBeInTheDocument();
+
+		fireEvent.click( closeButton );
+
+		expect( emailValidationBanner ).not.toBeInTheDocument();
+	} );
+} );


### PR DESCRIPTION
#### Summary
This PR lays the groundwork for testing the `step-content.tsx` component and adds tests for the `email-validation-banner.tsx`

#### Testing Instructions

Run `yarn test-client launchpad`. You should see all tests are passing:

<img width="1167" alt="image" src="https://user-images.githubusercontent.com/20927667/200521303-97c745e2-d205-49e5-84d0-634ce90672fc.png">

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #69551