### PR TITLE
Stats: Update Ads main chart styling

### DIFF
--- a/client/my-sites/stats/modernized-chart-tabs-styles.scss
+++ b/client/my-sites/stats/modernized-chart-tabs-styles.scss
@@ -1,0 +1,206 @@
+// For feature `stats/new-main-chart`
+.stats--new-main-chart {
+	background-color: var(--color-surface);
+
+	// Store Legend options
+	.store-stats-chart__top {
+		display: flex;
+		justify-content: end;
+		background-color: var(--color-surface);
+		padding-bottom: 16px;
+
+		.store-stats-chart__title {
+			display: none;
+		}
+	}
+
+	.stats-module__placeholder.is-chart {
+		height: 228px;
+	}
+
+	// Common Legend options
+	.chart__legend {
+		margin: 0;
+	}
+
+
+	.chart__legend-options {
+		text-transform: none;
+	}
+
+	.chart__legend-option {
+		&:not(:first-child) {
+			margin-left: 24px;
+		}
+	}
+
+	.chart__legend-label {
+		color: var(--studio-black);
+		font-size: $font-body-small;
+		font-weight: 400;
+		line-height: 18px;
+		padding: 0;
+	}
+
+	.chart__legend-checkbox {
+		width: 20px;
+		height: 20px;
+		background-color: var(--color-surface);
+		border: 1px solid var(--color-neutral-10);
+		border-radius: 2px;
+		margin-right: 8px;
+
+		&:checked::before {
+			margin: 3px auto;
+		}
+	}
+
+	.chart__legend-color {
+		width: 20px;
+		height: 20px;
+		margin: 0 8px 0 0;
+		border-radius: 4px;
+	}
+
+	// Main Chart
+	.chart {
+		padding: 0;
+
+		.chart__bar {
+			// Cancel the chart bar styles
+			&.is-weekend {
+				background: none;
+			}
+
+			&:hover {
+				background-color: rgba(var(--color-neutral-rgb), 0.1);
+
+				.chart__bar-section.is-bar {
+					background-color: var(--color-primary);
+				}
+			}
+
+			&.is-selected {
+				background-color: rgba(var(--color-primary-rgb), 0.1);
+
+				.chart__bar-section.is-bar {
+					background-color: var(--color-primary);
+				}
+
+				.chart__bar-section-inner {
+					background-color: var(--color-primary-dark);
+				}
+			}
+		}
+
+		.chart__bar-section {
+			background-color: var(--color-primary);
+			border-top-left-radius: 2px;
+			border-top-right-radius: 2px;
+		}
+
+		.chart__x-axis-label:not(.chart__x-axis-width-spacer) {
+			font-weight: 400;
+			line-height: 24px;
+			color: var(--color-neutral-40);
+		}
+	}
+
+	// Chart Tabs
+	.stats-tabs {
+		width: 100%;
+		display: flex;
+		flex-wrap: nowrap;
+		align-items: center;
+		padding: 24px 0 16px;
+		margin-bottom: 32px;
+		border: 0;
+
+		&.is-enabled {
+			background-color: var(--color-surface);
+		}
+
+		.stats-tab {
+			flex: 1;
+			width: auto;
+			border: 0;
+
+			&:not(:first-child) {
+				margin-left: 16px;
+			}
+
+			a {
+				display: block;
+				background-color: var(--color-neutral-0);
+				border: 1.5px solid transparent;
+				border-radius: 4px;
+				overflow: hidden;
+				color: var(--color-neutral-60);
+
+				&:hover {
+					background-color: var(--color-neutral-0);
+				}
+
+				.label {
+					font-size: $font-body-small;
+					line-height: 20px;
+					text-transform: none;
+					letter-spacing: -0.15px;
+				}
+
+				.value {
+					font-size: $font-title-small;
+					font-weight: 500;
+					line-height: 30px;
+				}
+
+				.store-stats-orders-chart__value.value {
+					display: block;
+				}
+
+				.delta {
+					justify-content: center;
+				}
+			}
+
+			&.is-low,
+			&.is-selected,
+			&.is-selected.is-low {
+				a {
+					&:hover {
+						color: var(--studio-black);
+
+						.label {
+							color: var(--studio-black);
+						}
+
+						.value {
+							color: var(--studio-black);
+						}
+					}
+
+					.value {
+						color: var(--studio-black);
+					}
+				}
+			}
+
+			&.is-selected,
+			&.is-selected.is-low {
+				a {
+					color: var(--studio-black);
+					border-color: var(--color-primary);
+					background-color: var(--color-surface);
+
+					.label {
+						color: var(--studio-black);
+					}
+
+					.value {
+						color: var(--studio-black);
+					}
+				}
+			}
+		}
+	}
+}

--- a/client/my-sites/stats/wordads-chart-tabs/index.jsx
+++ b/client/my-sites/stats/wordads-chart-tabs/index.jsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { Card } from '@automattic/components';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
@@ -116,31 +117,61 @@ class WordAdsChartTabs extends Component {
 	}
 
 	render() {
+		const isNewFeatured = config.isEnabled( 'stats/new-main-chart' );
+
 		const { siteId, query, isDataLoading } = this.props;
-		const classes = [ 'stats-module', 'is-chart-tabs', { 'is-loading': isDataLoading } ];
+		const classes = [
+			'is-chart-tabs',
+			{
+				'stats-module': ! isNewFeatured,
+				'is-loading': isDataLoading,
+			},
+		];
 
 		return (
 			<div>
 				{ siteId && <QuerySiteStats statType="statsAds" siteId={ siteId } query={ query } /> }
 
-				<Card className={ classNames( ...classes ) }>
-					<Legend
-						activeCharts={ this.props.activeLegend }
-						activeTab={ this.props.activeTab }
-						tabs={ this.props.charts }
-					/>
-					{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace */ }
-					<StatsModulePlaceholder className="is-chart" isLoading={ isDataLoading } />
-					<Chart barClick={ this.props.barClick } data={ this.buildChartData() } />
-					<StatTabs
-						data={ this.props.data }
-						tabs={ this.props.charts }
-						switchTab={ this.props.switchTab }
-						selectedTab={ this.props.chartTab }
-						activeIndex={ this.props.queryDate }
-						activeKey="period"
-					/>
-				</Card>
+				{ isNewFeatured ? (
+					<div className={ classNames( ...classes ) }>
+						{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace */ }
+						<StatsModulePlaceholder className="is-chart" isLoading={ isDataLoading } />
+						<Chart
+							barClick={ this.props.barClick }
+							data={ this.buildChartData() }
+							chartXPadding={ 0 }
+							minBarWidth={ 35 }
+						/>
+						<StatTabs
+							data={ this.props.data }
+							tabs={ this.props.charts }
+							switchTab={ this.props.switchTab }
+							selectedTab={ this.props.chartTab }
+							activeIndex={ this.props.queryDate }
+							activeKey="period"
+							iconSize={ 24 }
+						/>
+					</div>
+				) : (
+					<Card className={ classNames( ...classes ) }>
+						<Legend
+							activeCharts={ this.props.activeLegend }
+							activeTab={ this.props.activeTab }
+							tabs={ this.props.charts }
+						/>
+						{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace */ }
+						<StatsModulePlaceholder className="is-chart" isLoading={ isDataLoading } />
+						<Chart barClick={ this.props.barClick } data={ this.buildChartData() } />
+						<StatTabs
+							data={ this.props.data }
+							tabs={ this.props.charts }
+							switchTab={ this.props.switchTab }
+							selectedTab={ this.props.chartTab }
+							activeIndex={ this.props.queryDate }
+							activeKey="period"
+						/>
+					</Card>
+				) }
 			</div>
 		);
 	}

--- a/client/my-sites/stats/wordads/index.jsx
+++ b/client/my-sites/stats/wordads/index.jsx
@@ -1,3 +1,5 @@
+import config from '@automattic/calypso-config';
+import classNames from 'classnames';
 import { localize, translate, numberFormat } from 'i18n-calypso';
 import { find } from 'lodash';
 import moment from 'moment';
@@ -7,6 +9,7 @@ import { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import titlecase from 'to-title-case';
 import StatsNavigation from 'calypso/blocks/stats-navigation';
+import Intervals from 'calypso/blocks/stats-navigation/intervals';
 import DocumentHead from 'calypso/components/data/document-head';
 import EmptyContent from 'calypso/components/empty-content';
 import FormattedHeader from 'calypso/components/formatted-header';
@@ -23,6 +26,7 @@ import {
 	getSelectedSiteSlug,
 } from 'calypso/state/ui/selectors';
 import DatePicker from '../stats-date-picker';
+import StatsPeriodHeader from '../stats-period-header';
 import StatsPeriodNavigation from '../stats-period-navigation';
 import WordAdsChartTabs from '../wordads-chart-tabs';
 import WordAdsEarnings from './earnings';
@@ -126,6 +130,20 @@ class WordAds extends Component {
 			date: endOf.format( 'YYYY-MM-DD' ),
 		};
 
+		// For period option links
+		const wordads = {
+			label: 'Ads',
+			path: '/stats/ads',
+			showIntervals: true,
+		};
+
+		const slugPath = slug ? `/${ slug }` : '';
+		const pathTemplate = `${ wordads.path }/{{ interval }}${ slugPath }`;
+
+		// New feature gate
+		const isNewFeatured = config.isEnabled( 'stats/new-main-chart' );
+		const wrapperClasses = classNames( 'wordads', { 'stats--new-main-chart': isNewFeatured } );
+
 		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		return (
 			<Main wideLayout>
@@ -141,6 +159,7 @@ class WordAds extends Component {
 					subHeaderText={ translate( 'See how ads are performing on your site.' ) }
 					align="left"
 				/>
+
 				{ ! canAccessAds && (
 					<EmptyContent
 						illustration="/calypso/images/illustrations/illustration-404.svg"
@@ -153,6 +172,7 @@ class WordAds extends Component {
 						actionURL={ '/earn/ads-settings/' + slug }
 					/>
 				) }
+
 				{ canAccessAds && (
 					<Fragment>
 						<StatsNavigation
@@ -161,39 +181,86 @@ class WordAds extends Component {
 							siteId={ siteId }
 							slug={ slug }
 						/>
-						<div id="my-stats-content" className="wordads">
-							<WordAdsChartTabs
-								activeTab={ getActiveTab( this.props.chartTab ) }
-								activeLegend={ this.state.activeLegend }
-								availableLegend={ this.getAvailableLegend() }
-								onChangeLegend={ this.onChangeLegend }
-								barClick={ this.barClick }
-								switchTab={ this.switchChart }
-								charts={ CHARTS }
-								queryDate={ queryDate }
-								period={ this.props.period }
-								chartTab={ this.props.chartTab }
-							/>
-							<StickyPanel className="stats__sticky-navigation">
-								<StatsPeriodNavigation
-									date={ queryDate }
-									hidePreviousArrow={
-										( 'day' === period || 'week' === period ) &&
-										moment( queryDate ).isSameOrBefore( '2018-10-01' )
-									} // @TODO is there a more elegant way to do this? Similar to in_array() for php?
-									hideNextArrow={ yesterday === queryDate }
-									period={ period }
-									url={ `/stats/ads/${ period }/${ slug }` }
-								>
-									<DatePicker
-										period={ period }
-										date={ queryDate }
-										query={ query }
-										statsType="statsAds"
-										showQueryDate
+
+						<div id="my-stats-content" className={ wrapperClasses }>
+							{ isNewFeatured ? (
+								<>
+									<StatsPeriodHeader>
+										<StatsPeriodNavigation
+											date={ queryDate }
+											hidePreviousArrow={
+												( 'day' === period || 'week' === period ) &&
+												moment( queryDate ).isSameOrBefore( '2018-10-01' )
+											} // @TODO is there a more elegant way to do this? Similar to in_array() for php?
+											hideNextArrow={ yesterday === queryDate }
+											period={ period }
+											url={ `/stats/ads/${ period }/${ slug }` }
+										>
+											<DatePicker
+												period={ period }
+												date={ queryDate }
+												query={ query }
+												statsType="statsAds"
+												showQueryDate
+											/>
+										</StatsPeriodNavigation>
+										<Intervals
+											selected={ period }
+											pathTemplate={ pathTemplate }
+											compact={ false }
+										/>
+									</StatsPeriodHeader>
+
+									<WordAdsChartTabs
+										activeTab={ getActiveTab( this.props.chartTab ) }
+										activeLegend={ this.state.activeLegend }
+										availableLegend={ this.getAvailableLegend() }
+										onChangeLegend={ this.onChangeLegend }
+										barClick={ this.barClick }
+										switchTab={ this.switchChart }
+										charts={ CHARTS }
+										queryDate={ queryDate }
+										period={ this.props.period }
+										chartTab={ this.props.chartTab }
 									/>
-								</StatsPeriodNavigation>
-							</StickyPanel>
+								</>
+							) : (
+								<>
+									<WordAdsChartTabs
+										activeTab={ getActiveTab( this.props.chartTab ) }
+										activeLegend={ this.state.activeLegend }
+										availableLegend={ this.getAvailableLegend() }
+										onChangeLegend={ this.onChangeLegend }
+										barClick={ this.barClick }
+										switchTab={ this.switchChart }
+										charts={ CHARTS }
+										queryDate={ queryDate }
+										period={ this.props.period }
+										chartTab={ this.props.chartTab }
+									/>
+									<StickyPanel className="stats__sticky-navigation">
+										<StatsPeriodNavigation
+											date={ queryDate }
+											hidePreviousArrow={
+												( 'day' === period || 'week' === period ) &&
+												moment( queryDate ).isSameOrBefore( '2018-10-01' )
+											} // @TODO is there a more elegant way to do this? Similar to in_array() for php?
+											hideNextArrow={ yesterday === queryDate }
+											period={ period }
+											url={ `/stats/ads/${ period }/${ slug }` }
+										>
+											<DatePicker
+												period={ period }
+												date={ queryDate }
+												query={ query }
+												statsType="statsAds"
+												showQueryDate
+											/>
+										</StatsPeriodNavigation>
+									</StickyPanel>
+								</>
+							) }
+
 							<div className="stats__module-list stats__module-headerless--unified">
 								<WordAdsEarnings site={ site } />
 							</div>

--- a/client/my-sites/stats/wordads/style.scss
+++ b/client/my-sites/stats/wordads/style.scss
@@ -1,3 +1,5 @@
+@import "client/my-sites/stats/modernized-chart-tabs-styles.scss";
+
 @include breakpoint-deprecated( ">480px" ) {
 	.wordads .stats-tabs .stats-tab {
 		width: 33.33%;


### PR DESCRIPTION
#### Proposed Changes

* Introduce modernized chart tabs styles as a shared file.
* Adjust the structure and styles on the Stats `Ads` tab page to align with the new design.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up a `Jurassic Ninja` site and purchase `Jetpack Security` with the `Ads` settings enabled.

<img width="1050" alt="截圖 2022-11-03 下午10 24 15" src="https://user-images.githubusercontent.com/6869813/199746870-6378f8da-e8c5-44b5-a2f2-e654d4a9e82b.png">

* Launch the `local` development application.
* Navigate to the page with the JN site `/stats/ads/day/${jetpack-security-site}`.
* Ensure styling on the `Ads` tab page is aligned with the new version of the design.

<img width="1117" alt="截圖 2022-11-03 下午10 26 02" src="https://user-images.githubusercontent.com/6869813/199747212-cdfddc1c-392d-440f-8ddc-ab8edca3ba7e.png">

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #69041
