### PR TITLE
E2E (Atomic): Fix Jetpack Other

### DIFF
--- a/packages/calypso-e2e/src/lib/blocks/block-flows/slideshow.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/slideshow.ts
@@ -45,8 +45,12 @@ export class SlideshowBlockFlow implements BlockFlow {
 			this.preparedImageFileNames.push( testFile.basename );
 
 			const fileInputLocator = context.editorLocator.locator( selectors.fileInput );
-			await fileInputLocator.setInputFiles( testFile.fullpath );
-
+			await Promise.all( [
+				fileInputLocator.setInputFiles( testFile.fullpath ),
+				context.page.waitForResponse(
+					( response ) => response.url().includes( 'media?' ) && response.ok()
+				),
+			] );
 			const uploadingIndicatorLocator = context.editorLocator
 				.locator( selectors.uploadingIndicator )
 				.last();

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/tiled-gallery.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/tiled-gallery.ts
@@ -10,7 +10,7 @@ const selectors = {
 	fileInput: `${ blockParentSelector } input[type=file]`,
 	uploadingIndicator: `${ blockParentSelector } .components-spinner`,
 	publishedImage: ( fileName: string ) =>
-		`.wp-block-jetpack-tiled-gallery img[src*="${ fileName }"]`,
+		`main .wp-block-jetpack-tiled-gallery img[src*="${ fileName }"]`, // 'main' needs to be specified due to the debug elements
 };
 
 /**


### PR DESCRIPTION
Tracking issue: https://github.com/Automattic/wp-calypso/issues/65906

#### Proposed Changes

Make the following test compatible with the Atomic environment:

> specs/blocks/blocks__jetpack-other.ts: Blocks: Other Jetpack Blocks: Validating blocks in published post.: Slideshow

Including the `Tiled Gallery` block as well. 

#### Why was it failing?

Waiting on the uploading (spinner) indicator when uploading an image is unreliable in Atomic. The spinner already disappeared but the image is still uploading. 

A wait for the request to complete is added to fix the issue. 

The validation of the `Tiled Gallery` block is also failing on Atomic because of multiple elements found. This is due to debugging elements on this page. More specific selectors were then defined.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

The fixed test should pass for both Simple and Atomic sites (production).

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
