### PR TITLE
Adds `product` post type to the promoted posts tool

### DIFF
--- a/client/lib/promote-post/index.ts
+++ b/client/lib/promote-post/index.ts
@@ -136,3 +136,21 @@ export const usePromoteWidget = (): PromoteWidgetStatus => {
 	} );
 	return value;
 };
+
+/**
+ * Hook to verify if we should enable the products in the
+ *
+ * @returns bool
+ */
+export const useCanPromoteProducts = (): PromoteWidgetStatus => {
+	return useSelector( ( state ) => {
+		const userData = getCurrentUser( state );
+		if ( userData ) {
+			const originalSetting = userData[ 'can_promote_products' ];
+			if ( originalSetting !== undefined ) {
+				return originalSetting ? PromoteWidgetStatus.ENABLED : PromoteWidgetStatus.DISABLED;
+			}
+		}
+		return PromoteWidgetStatus.FETCHING;
+	} );
+};

--- a/client/lib/user/shared-utils/filter-user-object.js
+++ b/client/lib/user/shared-utils/filter-user-object.js
@@ -22,6 +22,7 @@ const allowedKeys = [
 	'primary_blog',
 	'primary_blog_is_jetpack',
 	'has_promote_widget',
+	'can_promote_products',
 	'has_jetpack_partner_access',
 	'jetpack_partner_types',
 	'primary_blog_url',

--- a/client/lib/user/user.d.ts
+++ b/client/lib/user/user.d.ts
@@ -36,6 +36,7 @@ export type OptionalUserData = {
 	site_count: number;
 	jetpack_site_count?: number;
 	has_promote_widget?: boolean;
+	can_promote_products?: boolean;
 	has_jetpack_partner_access?: boolean;
 	jetpack_partner_types?: string[];
 	social_login_connections: unknown;

--- a/client/my-sites/promote-post/main.tsx
+++ b/client/my-sites/promote-post/main.tsx
@@ -9,7 +9,11 @@ import FormattedHeader from 'calypso/components/formatted-header';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import Main from 'calypso/components/main';
 import useCampaignsQuery from 'calypso/data/promote-post/use-promote-post-campaigns-query';
-import { usePromoteWidget, PromoteWidgetStatus } from 'calypso/lib/promote-post';
+import {
+	usePromoteWidget,
+	PromoteWidgetStatus,
+	useCanPromoteProducts,
+} from 'calypso/lib/promote-post';
 import CampaignsList from 'calypso/my-sites/promote-post/components/campaigns-list';
 import { Post } from 'calypso/my-sites/promote-post/components/post-item';
 import PostsList from 'calypso/my-sites/promote-post/components/posts-list';
@@ -110,6 +114,8 @@ export default function PromotedPosts( { tab }: Props ) {
 		page( '/' );
 	}
 
+	const productsEnabled = useCanPromoteProducts() === PromoteWidgetStatus.ENABLED;
+
 	const subtitle = translate(
 		'Reach new readers and customers by promoting a post or a page on our network of millions blogs and web sites. {{learnMoreLink}}Learn more.{{/learnMoreLink}}',
 		{
@@ -187,7 +193,9 @@ export default function PromotedPosts( { tab }: Props ) {
 
 			<QueryPosts siteId={ selectedSiteId } query={ queryPost } postId={ null } />
 			<QueryPosts siteId={ selectedSiteId } query={ queryPage } postId={ null } />
-			<QueryPosts siteId={ selectedSiteId } query={ queryProducts } postId={ null } />
+			{ productsEnabled && (
+				<QueryPosts siteId={ selectedSiteId } query={ queryProducts } postId={ null } />
+			) }
 
 			{ selectedTab === 'posts' && <PostsList content={ content } isLoading={ isLoading } /> }
 		</Main>

--- a/client/my-sites/promote-post/main.tsx
+++ b/client/my-sites/promote-post/main.tsx
@@ -38,6 +38,11 @@ const queryPage = {
 	type: 'page',
 };
 
+const queryProducts = {
+	...queryPost,
+	type: 'product',
+};
+
 export type DSPMessage = {
 	errorCode?: string;
 };
@@ -73,11 +78,19 @@ export default function PromotedPosts( { tab }: Props ) {
 		return pages?.filter( ( page: any ) => ! page.password );
 	} );
 
+	const products = useSelector( ( state ) => {
+		const products = getPostsForQuery( state, selectedSiteId, queryProducts );
+		return products?.filter( ( product: any ) => ! product.password );
+	} );
+
 	const isLoadingPost = useSelector( ( state ) =>
 		isRequestingPostsForQuery( state, selectedSiteId, queryPost )
 	);
 	const isLoadingPage = useSelector( ( state ) =>
 		isRequestingPostsForQuery( state, selectedSiteId, queryPage )
+	);
+	const isLoadingProducts = useSelector( ( state ) =>
+		isRequestingPostsForQuery( state, selectedSiteId, queryProducts )
 	);
 
 	const campaigns = useCampaignsQuery( selectedSiteId ?? 0 );
@@ -140,9 +153,13 @@ export default function PromotedPosts( { tab }: Props ) {
 		);
 	}
 
-	const content = sortItemsByPublishedDate( [ ...( posts || [] ), ...( pages || [] ) ] );
+	const content = sortItemsByPublishedDate( [
+		...( posts || [] ),
+		...( pages || [] ),
+		...( products || [] ),
+	] );
 
-	const isLoading = isLoadingPage && isLoadingPost;
+	const isLoading = isLoadingPage && isLoadingPost && isLoadingProducts;
 
 	return (
 		<Main wideLayout className="promote-post">
@@ -170,6 +187,7 @@ export default function PromotedPosts( { tab }: Props ) {
 
 			<QueryPosts siteId={ selectedSiteId } query={ queryPost } postId={ null } />
 			<QueryPosts siteId={ selectedSiteId } query={ queryPage } postId={ null } />
+			<QueryPosts siteId={ selectedSiteId } query={ queryProducts } postId={ null } />
 
 			{ selectedTab === 'posts' && <PostsList content={ content } isLoading={ isLoading } /> }
 		</Main>

--- a/client/my-sites/promote-post/utils/index.ts
+++ b/client/my-sites/promote-post/utils/index.ts
@@ -13,6 +13,9 @@ export const getPostType = ( type: string ) => {
 		case 'page': {
 			return __( 'Page' );
 		}
+		case 'product': {
+			return __( 'Product' );
+		}
 		default:
 			return type;
 	}


### PR DESCRIPTION
#### Proposed Changes

* Add `product` as a valid post type for promoted posts

#### Testing Instructions

- [ ] First make sure you have a public WooCommerce store
- [ ] Visit `/advertising/site.co.uk`
- [ ] Ensure that you see your WC Store products
- [ ] Click Promote and ensure that the `title`,`snippet` & `image` are set ( assuming they are on the product)

![Screenshot 2022-11-03 at 16 37 40](https://user-images.githubusercontent.com/6440498/199780568-172c2994-52d4-46ed-9a30-e57efb9ec3e8.png)


![Screenshot 2022-11-03 at 16 35 27](https://user-images.githubusercontent.com/6440498/199779995-62183cfe-a748-4e9a-9a8a-27b99775ec35.png)


<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
