### PR TITLE
Remove premium label from accent color picker

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/accent-color-control/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/accent-color-control/index.tsx
@@ -9,10 +9,8 @@ import classNames from 'classnames';
 import { Dispatch, SetStateAction, useState, useRef } from 'react';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
-import PremiumBadge from 'calypso/components/premium-badge';
 import { SelectDropdownForwardingRef as SelectDropdown } from 'calypso/components/select-dropdown';
 import { tip } from 'calypso/signup/icons';
-import { usePremiumGlobalStyles } from 'calypso/state/sites/hooks/use-premium-global-styles';
 import './style.scss';
 import ColorSwatch from './color-swatch';
 
@@ -68,7 +66,6 @@ const AccentColorControl = ( { accentColor, setAccentColor }: AccentColorControl
 	const [ customColor, setCustomColor ] = useState< AccentColor | null >( null );
 	const [ colorPickerOpen, setColorPickerOpen ] = useState< boolean >( false );
 	const accentColorRef = useRef< HTMLInputElement >( null );
-	const { shouldLimitGlobalStyles } = usePremiumGlobalStyles();
 
 	const handlePredefinedColorSelect = ( { value }: { value: string } ) => {
 		if ( value === 'custom' ) {
@@ -129,14 +126,6 @@ const AccentColorControl = ( { accentColor, setAccentColor }: AccentColorControl
 					{ hasTranslation( 'Favorite color' ) || locale === 'en'
 						? __( 'Favorite color' )
 						: __( 'Accent color' ) }
-					{ shouldLimitGlobalStyles && (
-						<PremiumBadge
-							className="accent-color-control__premium-badge"
-							tooltipText={ __(
-								'Upgrade to a paid plan for color changes to take effect and to unlock the advanced design customization'
-							) }
-						/>
-					) }
 				</FormLabel>
 
 				<SelectDropdown


### PR DESCRIPTION
#### Proposed Changes
This PR removes the Premium label from the Newsletter flow's site accent color picker.

| Before | After |
|--------|------|
| <img width="394" alt="CleanShot 2022-11-03 at 16 31 05@2x" src="https://user-images.githubusercontent.com/528287/199768962-619451f8-c489-4e16-963b-1ae566224378.png">  | <img width="394" alt="CleanShot 2022-11-03 at 16 37 06@2x" src="https://user-images.githubusercontent.com/528287/199768307-f438c45c-9be1-475b-ba3e-d5e1b8bb87e4.png"> |

Discussion: p1666598269553399-slack-C02TCEHP3HA

#### Testing Instructions

- Go to http://calypso.localhost:3000/setup/newsletterSetup?flow=newsletter

#### Pre-merge Checklist

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?