### PR TITLE
Fix alignment of accent color dropdown color swatch & label

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/accent-color-control/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/accent-color-control/style.scss
@@ -57,6 +57,7 @@
 		.select-dropdown__options .select-dropdown__item-text > svg {
 			vertical-align: middle;
 			margin-right: 8px;
+			margin-bottom: 3px;
 		}
 
 		.select-dropdown__item.is-selected {


### PR DESCRIPTION
#### Proposed Changes

Fixes the alignment of the color swatch & label in the accent color dropdown.

| Before | After |
|--------|------|
| <img width="384" alt="CleanShot 2022-11-03 at 17 04 22@2x" src="https://user-images.githubusercontent.com/528287/199773287-884fa585-4497-4f2c-8acd-08e2887701da.png"> | <img width="388" alt="CleanShot 2022-11-03 at 17 03 14@2x" src="https://user-images.githubusercontent.com/528287/199773308-92549a6a-de5d-494c-b9f8-565fccf42b25.png"> |


#### Testing Instructions

- Go to http://calypso.localhost:3000/setup/newsletterSetup?flow=newsletter

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
