### PR TITLE
Bundled Themes: Add new with-business-theme flow

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -87,10 +87,10 @@ export function generateFlows( {
 		},
 		{
 			name: 'with-business-theme',
-			steps: [ 'domains-theme-preselected', 'plans-business', 'user' ],
+			steps: [ 'domains-theme-preselected', 'plans-business-monthly', 'user' ],
 			destination: getChecklistThemeDestination,
 			description: 'Preselect a theme to activate/buy from an external source',
-			lastModified: '2020-08-11',
+			lastModified: '2022-11-03',
 			showRecaptcha: true,
 		},
 		{

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -86,6 +86,14 @@ export function generateFlows( {
 			showRecaptcha: true,
 		},
 		{
+			name: 'with-business-theme',
+			steps: [ 'domains-theme-preselected', 'plans-business', 'user' ],
+			destination: getChecklistThemeDestination,
+			description: 'Preselect a theme to activate/buy from an external source',
+			lastModified: '2020-08-11',
+			showRecaptcha: true,
+		},
+		{
 			name: 'design-first',
 			steps: [
 				'template-first-themes',

--- a/client/state/themes/selectors/get-theme-signup-url.js
+++ b/client/state/themes/selectors/get-theme-signup-url.js
@@ -1,3 +1,4 @@
+import { doesThemeBundleSoftwareSet } from 'calypso/state/themes/selectors/does-theme-bundle-software-set';
 import { isThemePremium } from 'calypso/state/themes/selectors/is-theme-premium';
 
 import 'calypso/state/themes/init';
@@ -14,7 +15,11 @@ export function getThemeSignupUrl( state, themeId ) {
 		return null;
 	}
 
-	let url = '/start/with-theme?ref=calypshowcase&theme=' + themeId;
+	const flow = ! doesThemeBundleSoftwareSet( state, themeId )
+		? 'with-theme'
+		: 'with-business-theme';
+
+	let url = `/start/${ flow }?ref=calypshowcase&theme=${ themeId }`;
 
 	if ( isThemePremium( state, themeId ) ) {
 		url += '&premium=true';

--- a/client/state/themes/selectors/get-theme-signup-url.js
+++ b/client/state/themes/selectors/get-theme-signup-url.js
@@ -15,9 +15,7 @@ export function getThemeSignupUrl( state, themeId ) {
 		return null;
 	}
 
-	const flow = ! doesThemeBundleSoftwareSet( state, themeId )
-		? 'with-theme'
-		: 'with-business-theme';
+	const flow = doesThemeBundleSoftwareSet( state, themeId ) ? 'with-business-theme' : 'with-theme';
 
 	let url = `/start/${ flow }?ref=calypshowcase&theme=${ themeId }`;
 

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -198,6 +198,7 @@
 		"simple",
 		"woocommerce-install",
 		"with-theme",
+		"with-business-theme",
 		"free",
 		"personal",
 		"personal-monthly",


### PR DESCRIPTION
#### Proposed Changes

* Adds a new flow called `with-business-theme` to ensure users have the business plan when they select a bundled theme. We may also use this for the Third-Party themes project.
* Differentiate the redirect in the `getThemeSignupUrl` selector.

More context: p1667484678756799/1667420725.253399-slack-C0Q664T29

#### Testing Instructions

* Make sure you are not logged in.
* Navigate to `/theme/tsubaki`
* Click on the "Pick this design"
* You should be redirected to `/start/with-business-theme(...)`.
* Create a new account following the flow.
* Make sure the business plan is added to your cart.

You should also test a theme that is not bundled:

* Navigate to `/theme/cultivate`
* You should be redirected to `/start/with-theme(...)`.
