### PR TITLE
Plugin details: Add a notice for free plugins on the logged out experience

### DIFF
--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -288,7 +288,7 @@ const PluginDetailsCTA = ( { plugin, isPlaceholder } ) => {
 												<span className="plugin-details-cta__period">{ period }</span>
 											</>
 										) : (
-											translate( 'Free' )
+											<FreePrice />
 										) }
 									</>
 								)
@@ -404,6 +404,22 @@ function PrimaryButton( {
 			disabled={ incompatiblePlugin || userCantManageTheSite }
 		/>
 	);
+}
+
+function FreePrice() {
+	const translate = useTranslate();
+	const isLoggedIn = useSelector( isUserLoggedIn );
+
+	if ( ! isLoggedIn ) {
+		return (
+			<>
+				{ translate( 'Free' ) }
+				<span className="plugin-details-cta__notice">{ translate( 'on Business plan' ) }</span>
+			</>
+		);
+	}
+
+	return translate( 'Free' );
 }
 
 function UpgradeRequiredContent( { translate } ) {

--- a/client/my-sites/plugins/plugin-details-CTA/style.scss
+++ b/client/my-sites/plugins/plugin-details-CTA/style.scss
@@ -35,7 +35,8 @@
 	@extend %placeholder;
 }
 
-.plugin-details-cta__period {
+.plugin-details-cta__period,
+.plugin-details-cta__notice {
 	font-family: $sans;
 	font-size: $font-body-extra-small;
 	color: var(--studio-gray-50);

--- a/client/my-sites/plugins/plugin-details-CTA/style.scss
+++ b/client/my-sites/plugins/plugin-details-CTA/style.scss
@@ -40,7 +40,7 @@
 	font-family: $sans;
 	font-size: $font-body-extra-small;
 	color: var(--studio-gray-50);
-	padding-left: 3px;
+	padding-left: 8px;
 }
 
 .plugin-details-cta__uprade-required {


### PR DESCRIPTION
#### Proposed Changes

Add the text `on Business plan` for logged-out users on the Plugin Details page. 

#### Testing Instructions

* Go to a Free plugin details page (ex: `/plugins/mailpoet`). You can use an incognito window for that.
* Check if the text `on Business plan` is shown next to the `Free` text.

| Before  | After |
| ------------- | ------------- |
|<img width="316" alt="Screen Shot 2022-11-03 at 10 55 11" src="https://user-images.githubusercontent.com/5039531/199786482-27de672c-745e-4fa9-b2f2-d5228b01266b.png">|<img width="325" alt="Screen Shot 2022-11-04 at 08 19 39" src="https://user-images.githubusercontent.com/5039531/199998212-49a8dc7e-b529-403e-b2fd-c56166d3f61c.png">|


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #69410 
