### PR TITLE
themes: thanks-modal: Update the plugin bundle redirect url

### DIFF
--- a/client/my-sites/themes/thanks-modal.jsx
+++ b/client/my-sites/themes/thanks-modal.jsx
@@ -62,7 +62,7 @@ class ThanksModal extends Component {
 			// Redirect to plugin-bundle flow for themes including software (like woocommerce)
 			const { siteSlug, doesThemeBundleUsableSoftware } = this.props;
 			if ( doesThemeBundleUsableSoftware ) {
-				const dest = `/setup/?siteSlug=${ siteSlug }&flow=plugin-bundle`;
+				const dest = `/setup/plugin-bundle?siteSlug=${ siteSlug }`;
 				window.location.replace( dest );
 			}
 		}


### PR DESCRIPTION
#### Proposed Changes

* After #69561, we need to update any stepper urls including the query parameter `flow=xyz` to instead contain `/xyz` in the url somewhere.
  * This pr fixes the plugin bundle redirect after switching to a theme with bundled software.

#### Testing Instructions

* Have a simple site with a business plan that's on a basic theme like twentytwentytwo.
* Visit the theme showcase and find thriving artist.
* Pick thriving artist, activate it with the menu item in the three dots menu for the theme.
* You should see the "Do you want to change the homepage?" modal.
* Choose yes and press the button to continue.
* **Before This PR**: You will be redirect into the stepper plugin bundle flow and then directly back out of it again. It looks like you got redirected to the homepage.
* **After This PR**: You will be redirected into the stepper plugin bundle flow and stay there. You'll be at a screen asking you to fill out some store details.

This is the screen you should see
![2022-11-03_14-06](https://user-images.githubusercontent.com/937354/199812064-2480acc8-ce9d-4817-8fcb-b0d13119c2f1.png)

