### PR TITLE
Stats: Add title link to the Annual Highlights section

### DIFF
--- a/client/my-sites/stats/annual-highlights-section/index.tsx
+++ b/client/my-sites/stats/annual-highlights-section/index.tsx
@@ -2,6 +2,7 @@ import { AnnualHighlightCards } from '@automattic/components';
 import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import QuerySiteStats from 'calypso/components/data/query-site-stats';
+import { getSiteSlug } from 'calypso/state/sites/selectors';
 import { getSiteStatsNormalizedData } from 'calypso/state/stats/lists/selectors';
 import './style.scss';
 
@@ -53,6 +54,9 @@ export default function AnnualHighlightsSection( { siteId }: { siteId: number } 
 		};
 	}, [ year, followers, insights ] );
 
+	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) );
+	const viewMoreHref = siteSlug ? `/stats/annualstats/${ siteSlug }` : null;
+
 	return (
 		<div className="stats__annual-highlights-section">
 			{ siteId && (
@@ -61,7 +65,7 @@ export default function AnnualHighlightsSection( { siteId }: { siteId: number } 
 					<QuerySiteStats siteId={ siteId } statType="statsFollowers" query={ FOLLOWERS_QUERY } />
 				</>
 			) }
-			<AnnualHighlightCards counts={ counts } year={ year } />
+			<AnnualHighlightCards counts={ counts } titleHref={ viewMoreHref } year={ year } />
 		</div>
 	);
 }

--- a/packages/components/src/highlight-cards/annual-highlight-cards.tsx
+++ b/packages/components/src/highlight-cards/annual-highlight-cards.tsx
@@ -1,8 +1,8 @@
 import { comment, Icon, paragraph, people, postContent, starEmpty } from '@wordpress/icons';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import './style.scss';
 import HighlightCard from './highlight-card';
+import './style.scss';
 
 export type AnnualHighlightCardsProps = {
 	className?: string;
@@ -13,28 +13,35 @@ export type AnnualHighlightCardsProps = {
 		words: number | null;
 		followers: number | null;
 	};
+	titleHref?: string | null;
 	year?: string | number | null;
-	onClickComments?: ( event: MouseEvent ) => void;
-	onClickLikes?: ( event: MouseEvent ) => void;
-	onClickPosts?: ( event: MouseEvent ) => void;
-	onClickWords?: ( event: MouseEvent ) => void;
-	onClickFollowers?: ( event: MouseEvent ) => void;
 };
 
 export default function AnnualHighlightCards( {
 	className,
 	counts,
+	titleHref,
 	year,
 }: AnnualHighlightCardsProps ) {
 	const translate = useTranslate();
 
+	const header = (
+		<h1 className="highlight-cards-heading">
+			{ Number.isFinite( year )
+				? translate( '%(year)s in review', { args: { year } } )
+				: translate( 'Year in review' ) }
+		</h1>
+	);
+
 	return (
 		<div className={ classNames( 'highlight-cards', className ?? null ) }>
-			<h1 className="highlight-cards-heading">
-				{ Number.isFinite( year )
-					? translate( '%(year)s in review', { args: { year } } )
-					: translate( 'Year in review' ) }
-			</h1>
+			{ titleHref ? (
+				<a className="highlight-cards-heading-wrapper" href={ titleHref }>
+					{ header }
+				</a>
+			) : (
+				header
+			) }
 
 			<div className="highlight-cards-list">
 				<HighlightCard

--- a/packages/components/src/highlight-cards/style.scss
+++ b/packages/components/src/highlight-cards/style.scss
@@ -1,3 +1,4 @@
+@use "sass:math";
 @import "@wordpress/base-styles/breakpoints";
 @import "../styles/typography";
 
@@ -10,12 +11,21 @@ $vertical-margin: 32px;
 	font-size: $font-body-small;
 }
 
+.highlight-cards a.highlight-cards-heading-wrapper {
+	color: var(--color-text);
+	transition: color 100ms linear;
+	&:focus,
+	&:hover {
+		color: var(--color-link);
+	}
+}
+
 .highlight-cards-heading {
 	font-size: 32px; // stylelint-disable-line declaration-property-unit-allowed-list
 	font-weight: 400;
 	line-height: 40px;
 	font-family: $header-font;
-	margin-bottom: $vertical-margin / 2;
+	margin-bottom: math.div($vertical-margin, 2);
 	small {
 		font-size: $font-body-small;
 	}
@@ -32,7 +42,7 @@ $vertical-margin: 32px;
 		border-color: var(--studio-gray-5);
 		border-radius: 5px; // stylelint-disable-line scales/radii
 		width: 100%;
-		min-width: 200px; // Minimum mobile width
+		min-width: 180px; // Minimum mobile width
 		padding: 16px 24px;
 		margin-bottom: 0;
 


### PR DESCRIPTION
#### Proposed Changes

![Large GIF (1060x226)](https://user-images.githubusercontent.com/4044428/199835182-36c42e5d-4162-4d83-b104-02252726c20c.gif)

- Turns the heading into a link for the Annual Highlights section in the Insights page.

#### Testing Instructions

* Spin up this change in a live branch.
* Navigate to the Insights page (`/stats/insights/example.com`) and append `?flags=stats/new-annual-highlights` to the URL.
* Ensure that the heading is now a link for the Annual Highlights section.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #69227