### PR TITLE
Checkout: show biennial nudge for 'en' locale

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/checkout-sidebar-plan-upsell/index.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-sidebar-plan-upsell/index.tsx
@@ -1,6 +1,7 @@
 import { isPlan } from '@automattic/calypso-products';
 import { FormStatus, useFormStatus } from '@automattic/composite-checkout';
 import formatCurrency from '@automattic/format-currency';
+import { useLocale } from '@automattic/i18n-utils';
 import { useShoppingCart } from '@automattic/shopping-cart';
 import { createElement, createInterpolateElement } from '@wordpress/element';
 import { sprintf } from '@wordpress/i18n';
@@ -27,6 +28,7 @@ export function CheckoutSidebarPlanUpsell() {
 	const reduxDispatch = useDispatch();
 	const isFormLoading = FormStatus.READY !== formStatus;
 	const { __, hasTranslation } = useI18n();
+	const locale = useLocale();
 	const cartKey = useCartKey();
 	const { responseCart, replaceProductInCart } = useShoppingCart( cartKey );
 	const siteId = useSelector( getSelectedSiteId );
@@ -94,7 +96,11 @@ export function CheckoutSidebarPlanUpsell() {
 		{ strong: createElement( 'strong' ) }
 	);
 
-	if ( ! hasTranslation( '<strong>Save %(percentSavings)d%%</strong> by paying for two years' ) ) {
+	if (
+		'en' !== locale &&
+		! hasTranslation( '<strong>Save %(percentSavings)d%%</strong> by paying for two years' )
+	) {
+		debug( "not 'en' and does not have translation", locale );
 		return null;
 	}
 


### PR DESCRIPTION
In #69494 we added a sidebar nudge to Checkout for the biennial plan, and in c27a155 I added a guard to check for translations, but forgot to override the guard for the `en` locale. This PR overrides that logic to always show the nudge for the `en` locale.

The logic is a little awkward, but since we'll be removing it after translations are complete, it's not really worth abstracting.

**To test:**
- for an `en` user
- visit Checkout with a monthly or yearly plan that has a biennial term variant
- verify that the nudge is shown
- for a locale that hasn't been translate with [this job](https://translate.wordpress.com/deliverables/overview/7606775/) (e.g. `es`)
- visit Checkout with a monthly or yearly plan that has a biennial term variant
- verify that the nudge is not shown