### PR TITLE
Plugin Details: Update the padding top of the plugin information

### DIFF
--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -1,4 +1,5 @@
 import { useBreakpoint } from '@automattic/viewport-react';
+import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useMemo } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
@@ -305,7 +306,7 @@ function PluginDetails( props ) {
 				</Notice>
 			) }
 			<div className="plugin-details__page">
-				<div className="plugin-details__layout">
+				<div className={ classnames( 'plugin-details__layout', { 'is-logged-in': isLoggedIn } ) }>
 					<div className="plugin-details__header">
 						<PluginDetailsHeader plugin={ fullPlugin } isPlaceholder={ showPlaceholder } />
 					</div>

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -93,8 +93,13 @@ body.is-section-plugins.theme-default.color-scheme {
 	}
 }
 
+$layout-padding-top: 54px;
+$calypso-header-height: 31px;
 .plugin-details__layout {
-	padding-top: 54px;
+	padding-top: $layout-padding-top;
+	&:not(.is-logged-in) {
+		padding-top: calc($layout-padding-top - $calypso-header-height);
+	}
 
 	@include display-grid;
 	grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) 395px;


### PR DESCRIPTION
#### Proposed Changes

* Update the padding-top on the plugin information

#### Testing Instructions

* Go to the plugin details page(ex: `/plugins/woocommerce-bookings`) on a logged session
* On a new tab, open the same page but on a unlogged session
* Check if the distance from the breadcrumb header to the plugin info is the same on both pages: `54px`


| Logged in  | Logged out |
| ------------- | ------------- |
|<img width="902" alt="Screen Shot 2022-11-03 at 16 01 16" src="https://user-images.githubusercontent.com/5039531/199843402-48411d16-d752-436c-9cfe-cc22513612cf.png">|<img width="902" alt="Screen Shot 2022-11-03 at 16 02 12" src="https://user-images.githubusercontent.com/5039531/199843483-d889f8c8-57f2-4cab-b22c-1ab3495f1e4e.png">|


<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #69410