### PR TITLE
Checkout: add renewal gift route

### DIFF
--- a/client/my-sites/checkout/checkout-main-wrapper.tsx
+++ b/client/my-sites/checkout/checkout-main-wrapper.tsx
@@ -41,6 +41,7 @@ export default function CheckoutMainWrapper( {
 	isLoggedOutCart,
 	isNoSiteCart,
 	isJetpackCheckout,
+	isGiftPurchase,
 	jetpackSiteSlug,
 	jetpackPurchaseToken,
 	isUserComingFromLoginForm,
@@ -57,6 +58,7 @@ export default function CheckoutMainWrapper( {
 	isLoggedOutCart?: boolean;
 	isNoSiteCart?: boolean;
 	isJetpackCheckout?: boolean;
+	isGiftPurchase?: boolean;
 	jetpackSiteSlug?: string;
 	jetpackPurchaseToken?: string;
 	isUserComingFromLoginForm?: boolean;
@@ -113,6 +115,7 @@ export default function CheckoutMainWrapper( {
 							isLoggedOutCart={ isLoggedOutCart }
 							isNoSiteCart={ isNoSiteCart }
 							isJetpackCheckout={ isJetpackCheckout }
+							isGiftPurchase={ isGiftPurchase }
 							jetpackSiteSlug={ jetpackSiteSlug }
 							jetpackPurchaseToken={ jetpackPurchaseToken }
 							isUserComingFromLoginForm={ isUserComingFromLoginForm }

--- a/client/my-sites/checkout/composite-checkout/components/checkout-main.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-main.tsx
@@ -87,6 +87,7 @@ export default function CheckoutMain( {
 	isComingFromUpsell,
 	isLoggedOutCart,
 	isNoSiteCart,
+	isGiftPurchase,
 	infoMessage,
 	isInModal,
 	onAfterPaymentComplete,
@@ -110,6 +111,7 @@ export default function CheckoutMain( {
 	isComingFromUpsell?: boolean;
 	isLoggedOutCart?: boolean;
 	isNoSiteCart?: boolean;
+	isGiftPurchase?: boolean;
 	isInModal?: boolean;
 	infoMessage?: JSX.Element;
 	// IMPORTANT NOTE: This will not be called for redirect payment methods like
@@ -179,6 +181,7 @@ export default function CheckoutMain( {
 		jetpackSiteSlug,
 		jetpackPurchaseToken,
 		source: productSourceFromUrl,
+		isGiftPurchase,
 	} );
 
 	const cartKey = useCartKey();

--- a/client/my-sites/checkout/composite-checkout/hooks/use-add-products-from-url.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-add-products-from-url.ts
@@ -11,6 +11,15 @@ const debug = debugFactory( 'calypso:composite-checkout:use-add-products-from-ur
 
 export type isPendingAddingProductsFromUrl = boolean;
 
+/**
+ * Product requests can be sent to checkout using various methods including URL
+ * or localStorage. Those requests are turned into `RequestCartProduct` objects
+ * by `usePrepareProductsForCart()` and then they are added to the cart by this
+ * hook.
+ *
+ * This hook will return true when its adding process is complete or if there is
+ * nothing to add.
+ */
 export default function useAddProductsFromUrl( {
 	isLoadingCart,
 	isCartPendingUpdate,

--- a/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
@@ -32,6 +32,17 @@ const initialPreparedProductsState = {
 	error: null,
 };
 
+/**
+ * Hook to collect requested products from places like the URL or localStorage
+ * and turn them into `RequestCartProduct` objects.
+ *
+ * Objects created by this hook will then be added to the cart by
+ * `useAddProductsFromUrl()`.
+ *
+ * Because this process may be async, the return value of this hook includes an
+ * `isLoading` property which should be true before using the `productsForCart`
+ * it produces.
+ */
 export default function usePrepareProductsForCart( {
 	productAliasFromUrl,
 	purchaseId: originalPurchaseId,

--- a/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
@@ -16,7 +16,7 @@ import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import getCartFromLocalStorage from '../lib/get-cart-from-local-storage';
 import useFetchProductsIfNotLoaded from './use-fetch-products-if-not-loaded';
 import useStripProductsFromUrl from './use-strip-products-from-url';
-import type { RequestCartProduct } from '@automattic/shopping-cart';
+import type { RequestCartProduct, RequestCartProductExtra } from '@automattic/shopping-cart';
 
 const debug = debugFactory( 'calypso:composite-checkout:use-prepare-products-for-cart' );
 
@@ -56,6 +56,7 @@ export default function usePrepareProductsForCart( {
 	jetpackSiteSlug,
 	jetpackPurchaseToken,
 	source,
+	isGiftPurchase,
 }: {
 	productAliasFromUrl: string | null | undefined;
 	purchaseId: string | number | null | undefined;
@@ -69,6 +70,7 @@ export default function usePrepareProductsForCart( {
 	jetpackSiteSlug?: string;
 	jetpackPurchaseToken?: string;
 	source?: string;
+	isGiftPurchase?: boolean;
 } ): PreparedProductsForCart {
 	const [ state, dispatch ] = useReducer( preparedProductsReducer, initialPreparedProductsState );
 
@@ -124,6 +126,7 @@ export default function usePrepareProductsForCart( {
 		productAlias: productAliasFromUrl,
 		dispatch,
 		addHandler,
+		isGiftPurchase,
 	} );
 	useNothingToAdd( { addHandler, dispatch } );
 
@@ -256,11 +259,13 @@ function useAddRenewalItems( {
 	productAlias,
 	dispatch,
 	addHandler,
+	isGiftPurchase,
 }: {
 	originalPurchaseId: string | number | null | undefined;
 	productAlias: string | null | undefined;
 	dispatch: ( action: PreparedProductsAction ) => void;
 	addHandler: AddHandler;
+	isGiftPurchase?: boolean;
 } ) {
 	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
 	const translate = useTranslate();
@@ -278,7 +283,11 @@ function useAddRenewalItems( {
 				if ( ! productSlug ) {
 					return null;
 				}
-				return createRenewalItemToAddToCart( productSlug, subscriptionId );
+				return createRenewalItemToAddToCart( {
+					productAlias: productSlug,
+					purchaseId: subscriptionId,
+					isGiftPurchase,
+				} );
 			} )
 			.filter( isValueTruthy );
 
@@ -299,7 +308,15 @@ function useAddRenewalItems( {
 		}
 		debug( 'preparing renewals requested in url', productsForCart );
 		dispatch( { type: 'RENEWALS_ADD', products: productsForCart } );
-	}, [ addHandler, translate, originalPurchaseId, productAlias, dispatch, selectedSiteSlug ] );
+	}, [
+		addHandler,
+		translate,
+		originalPurchaseId,
+		productAlias,
+		dispatch,
+		selectedSiteSlug,
+		isGiftPurchase,
+	] );
 }
 
 function useAddProductFromSlug( {
@@ -422,10 +439,15 @@ function getProductSlugFromAlias( productAlias: string ): string {
 	return decodedAlias;
 }
 
-function createRenewalItemToAddToCart(
-	productAlias: string,
-	purchaseId: string | number | undefined | null
-): RequestCartProduct | null {
+function createRenewalItemToAddToCart( {
+	productAlias,
+	purchaseId,
+	isGiftPurchase,
+}: {
+	productAlias: string;
+	purchaseId: string | number | undefined | null;
+	isGiftPurchase?: boolean;
+} ): RequestCartProduct | null {
 	const [ slug, meta ] = productAlias.split( ':' );
 	// Some product slugs contain slashes, so we decode them
 	const productSlug = decodeProductFromUrl( slug );
@@ -434,9 +456,10 @@ function createRenewalItemToAddToCart(
 		return null;
 	}
 
-	const renewalItemExtra = {
+	const renewalItemExtra: RequestCartProductExtra = {
 		purchaseId: String( purchaseId ),
 		purchaseType: 'renewal',
+		isGiftPurchase,
 	};
 	return {
 		// Some meta values include slashes, so we decode them

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -42,7 +42,7 @@ import { getProductSlugFromContext } from './utils';
 
 const debug = debugFactory( 'calypso:checkout-controller' );
 
-export function checkoutSiteless( context, next ) {
+export function checkoutJetpackSiteless( context, next ) {
 	const state = context.store.getState();
 	const isLoggedOut = ! isUserLoggedIn( state );
 	const { productSlug: product } = context.params;

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -38,7 +38,7 @@ import UpsellNudge, {
 	CONCIERGE_QUICKSTART_SESSION,
 	PROFESSIONAL_EMAIL_UPSELL,
 } from './upsell-nudge';
-import { getProductSlugFromContext } from './utils';
+import { getProductSlugFromContext, isContextJetpackSitelessCheckout } from './utils';
 
 const debug = debugFactory( 'calypso:checkout-controller' );
 
@@ -93,13 +93,7 @@ export function checkout( context, next ) {
 	const jetpackPurchaseToken = context.query.purchasetoken;
 	const jetpackPurchaseNonce = context.query.purchaseNonce;
 	const isUserComingFromLoginForm = context.query?.flow === 'coming_from_login';
-	const isUserComingFromPlansPage = [ 'jetpack-plans', 'jetpack-connect-plans' ].includes(
-		context.query?.source
-	);
-	const isJetpackCheckout =
-		context.pathname.includes( '/checkout/jetpack' ) &&
-		( isLoggedOut || isUserComingFromLoginForm || isUserComingFromPlansPage ) &&
-		( !! jetpackPurchaseToken || !! jetpackPurchaseNonce );
+	const isJetpackCheckout = isContextJetpackSitelessCheckout( context );
 	const jetpackSiteSlug = context.params.siteSlug;
 
 	const isGiftPurchase = context.pathname.includes( '/gift/' );
@@ -128,7 +122,7 @@ export function checkout( context, next ) {
 		return;
 	}
 
-	const product = getProductSlugFromContext( context, { isJetpackCheckout } );
+	const product = getProductSlugFromContext( context );
 
 	if ( 'thank-you' === product ) {
 		return;

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -102,13 +102,28 @@ export function checkout( context, next ) {
 		( !! jetpackPurchaseToken || !! jetpackPurchaseNonce );
 	const jetpackSiteSlug = context.params.siteSlug;
 
+	const isGiftPurchase = context.pathname.includes( '/gift/' );
+
 	// Do not use Jetpack checkout for Jetpack Anti Spam
 	if ( 'jetpack_anti_spam' === context.params.productSlug ) {
 		page( context.path.replace( '/checkout/jetpack', '/checkout' ) );
 		return;
 	}
 
-	if ( ! selectedSite && ! isDisallowedForSitePicker && ! isJetpackCheckout ) {
+	const shouldAllowNoSelectedSite = () => {
+		if ( isDisallowedForSitePicker ) {
+			return true;
+		}
+		if ( isJetpackCheckout ) {
+			return true;
+		}
+		if ( isGiftPurchase ) {
+			return true;
+		}
+		return false;
+	};
+
+	if ( ! selectedSite && ! shouldAllowNoSelectedSite() ) {
 		sites( context, next );
 		return;
 	}
@@ -168,6 +183,7 @@ export function checkout( context, next ) {
 				isLoggedOutCart={ isLoggedOutCart }
 				isNoSiteCart={ isNoSiteCart }
 				isJetpackCheckout={ isJetpackCheckout }
+				isGiftPurchase={ isGiftPurchase }
 				jetpackSiteSlug={ jetpackSiteSlug }
 				jetpackPurchaseToken={ jetpackPurchaseToken || jetpackPurchaseNonce }
 				isUserComingFromLoginForm={ isUserComingFromLoginForm }

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -128,9 +128,7 @@ export function checkout( context, next ) {
 		return;
 	}
 
-	const product = isJetpackCheckout
-		? context.params.productSlug
-		: getProductSlugFromContext( context );
+	const product = getProductSlugFromContext( context, { isJetpackCheckout } );
 
 	if ( 'thank-you' === product ) {
 		return;

--- a/client/my-sites/checkout/index.js
+++ b/client/my-sites/checkout/index.js
@@ -253,6 +253,9 @@ export default function () {
 		clientRender
 	);
 
+	// Gift purchases work logged-out, so do not include redirectLoggedOut or siteSelection.
+	page( '/checkout/:product/gift/:purchaseId', noSite, checkout, makeLayout, clientRender );
+
 	page(
 		'/checkout/:site/with-gsuite/:domain/:receiptId?',
 		redirectLoggedOut,

--- a/client/my-sites/checkout/index.js
+++ b/client/my-sites/checkout/index.js
@@ -11,7 +11,7 @@ import { loggedInSiteSelection, noSite, siteSelection } from 'calypso/my-sites/c
 import {
 	checkout,
 	checkoutPending,
-	checkoutSiteless,
+	checkoutJetpackSiteless,
 	checkoutThankYou,
 	licensingThankYouManualActivationInstructions,
 	licensingThankYouManualActivationLicenseKey,
@@ -27,11 +27,12 @@ import {
 export default function () {
 	page( '/checkout*', recordSiftScienceUser );
 
+	// Jetpack siteless checkout works logged-out, so do not include redirectLoggedOut or siteSelection.
 	page(
 		`/checkout/jetpack/:productSlug`,
 		setLocaleMiddleware(),
 		noSite,
-		checkoutSiteless,
+		checkoutJetpackSiteless,
 		makeLayout,
 		clientRender
 	);
@@ -92,6 +93,8 @@ export default function () {
 		clientRender
 	);
 
+	// The no-site post-checkout route is for purchases not tied to a site so do
+	// not include the `siteSelection` middleware.
 	page(
 		'/checkout/thank-you/no-site/pending/:orderId',
 		redirectLoggedOut,
@@ -100,6 +103,8 @@ export default function () {
 		clientRender
 	);
 
+	// The no-site post-checkout route is for purchases not tied to a site so do
+	// not include the `siteSelection` middleware.
 	page(
 		'/checkout/thank-you/no-site/:receiptId?',
 		redirectLoggedOut,

--- a/client/my-sites/checkout/index.js
+++ b/client/my-sites/checkout/index.js
@@ -253,8 +253,16 @@ export default function () {
 		clientRender
 	);
 
-	// Gift purchases work logged-out, so do not include redirectLoggedOut or siteSelection.
-	page( '/checkout/:product/gift/:purchaseId', noSite, checkout, makeLayout, clientRender );
+	// Gift purchases work without a site, so do not include the `siteSelection`
+	// middleware.
+	page(
+		'/checkout/:product/gift/:purchaseId',
+		redirectLoggedOut,
+		noSite,
+		checkout,
+		makeLayout,
+		clientRender
+	);
 
 	page(
 		'/checkout/:site/with-gsuite/:domain/:receiptId?',

--- a/client/my-sites/checkout/test/utils.js
+++ b/client/my-sites/checkout/test/utils.js
@@ -40,120 +40,146 @@ describe( 'getProductSlugFromContext', () => {
 		{
 			product: newProduct,
 			domainOrProduct: wpcomSiteSlug,
+			productSlug: undefined,
 			selectedSite: wpcomStagingSiteSlug,
 			expected: newProduct,
 		},
 		{
 			product: undefined,
 			domainOrProduct: wpcomSiteSlug,
+			productSlug: undefined,
 			selectedSite: wpcomStagingSiteSlug,
 			expected: '',
 		},
 		{
 			product: newProduct,
 			domainOrProduct: domainSiteSlug,
+			productSlug: undefined,
 			selectedSite: domainSiteSlug,
 			expected: newProduct,
 		},
 		{
 			product: domainSiteSlug,
 			domainOrProduct: newProduct,
+			productSlug: undefined,
 			selectedSite: domainSiteSlug,
 			expected: newProduct,
 		},
 		{
 			product: newProductWithDomain,
 			domainOrProduct: undefined,
+			productSlug: undefined,
 			selectedSite: domainSiteSlug,
 			expected: newProductWithDomain,
 		},
 		{
 			product: undefined,
 			domainOrProduct: newProductWithDomain,
+			productSlug: undefined,
 			selectedSite: domainSiteSlug,
 			expected: newProductWithDomain,
 		},
 		{
 			product: newProductWithDot,
 			domainOrProduct: undefined,
+			productSlug: undefined,
 			selectedSite: domainSiteSlug,
 			expected: newProductWithDot,
 		},
 		{
 			product: undefined,
 			domainOrProduct: newProductWithDot,
+			productSlug: undefined,
 			selectedSite: domainSiteSlug,
 			expected: newProductWithDot,
 		},
 		{
 			product: newProduct,
 			domainOrProduct: undefined,
+			productSlug: undefined,
 			selectedSite: undefined,
 			expected: '',
 		},
 		{
 			product: undefined,
 			domainOrProduct: newProduct,
+			productSlug: undefined,
 			selectedSite: undefined,
 			expected: newProduct,
 		},
 		{
 			product: undefined,
 			domainOrProduct: domainSiteSlug,
+			productSlug: undefined,
 			selectedSite: domainSiteSlug,
 			expected: '',
 		},
 		{
 			product: domainSiteSlug,
 			domainOrProduct: undefined,
+			productSlug: undefined,
 			selectedSite: domainSiteSlug,
 			expected: '',
 		},
 		{
 			product: newProduct,
 			domainOrProduct: undefined,
+			productSlug: undefined,
 			selectedSite: domainSiteSlug,
 			expected: newProduct,
 		},
 		{
 			product: undefined,
 			domainOrProduct: newProduct,
+			productSlug: undefined,
 			selectedSite: domainSiteSlug,
 			expected: newProduct,
 		},
 		{
 			product: subdomainSiteSlug,
 			domainOrProduct: newProduct,
+			productSlug: undefined,
 			selectedSite: subdomainSiteSlug,
 			expected: newProduct,
 		},
 		{
 			product: newProduct,
 			domainOrProduct: subdomainSiteSlug,
+			productSlug: undefined,
 			selectedSite: subdomainSiteSlug,
 			expected: newProduct,
 		},
 		{
 			product: undefined,
 			domainOrProduct: subdomainSiteSlug,
+			productSlug: undefined,
 			selectedSite: subdomainSiteSlug,
 			expected: '',
 		},
 		{
 			product: undefined,
 			domainOrProduct: subdomainSiteSlug,
+			productSlug: undefined,
 			selectedSite: domainSiteSlug,
 			expected: '',
 		},
 		{
 			product: undefined,
 			domainOrProduct: undefined,
+			productSlug: undefined,
 			selectedSite: domainSiteSlug,
 			expected: '',
 		},
+		{
+			product: undefined,
+			domainOrProduct: undefined,
+			productSlug: newProduct,
+			selectedSite: domainSiteSlug,
+			expected: newProduct,
+		},
 	] )(
-		`returns '$expected' when :product is '$product' and :domainOrProduct is '$domainOrProduct' and selected site is '$selectedSite'`,
-		( { product, domainOrProduct, selectedSite, expected } ) => {
+		`returns '$expected' when :product is '$product', :domainOrProduct is '$domainOrProduct', productSlug is '$productSlug', and selected site is '$selectedSite'`,
+		( { product, domainOrProduct, productSlug, selectedSite, expected } ) => {
 			const store = mockStore( {
 				ui: {
 					selectedSiteId: getSiteIdFromDomain( selectedSite ),
@@ -161,13 +187,19 @@ describe( 'getProductSlugFromContext', () => {
 				sites,
 			} );
 
-			const actual = getProductSlugFromContext( {
-				store,
-				params: {
-					domainOrProduct,
-					product,
+			const options = productSlug ? { isJetpackCheckout: true } : {};
+
+			const actual = getProductSlugFromContext(
+				{
+					store,
+					params: {
+						domainOrProduct,
+						product,
+						productSlug,
+					},
 				},
-			} );
+				options
+			);
 
 			expect( actual ).toEqual( expected );
 		}

--- a/client/my-sites/checkout/test/utils.js
+++ b/client/my-sites/checkout/test/utils.js
@@ -40,6 +40,7 @@ describe( 'getProductSlugFromContext', () => {
 		{
 			product: newProduct,
 			domainOrProduct: wpcomSiteSlug,
+			pathname: undefined,
 			productSlug: undefined,
 			selectedSite: wpcomStagingSiteSlug,
 			expected: newProduct,
@@ -47,6 +48,7 @@ describe( 'getProductSlugFromContext', () => {
 		{
 			product: undefined,
 			domainOrProduct: wpcomSiteSlug,
+			pathname: undefined,
 			productSlug: undefined,
 			selectedSite: wpcomStagingSiteSlug,
 			expected: '',
@@ -54,6 +56,7 @@ describe( 'getProductSlugFromContext', () => {
 		{
 			product: newProduct,
 			domainOrProduct: domainSiteSlug,
+			pathname: undefined,
 			productSlug: undefined,
 			selectedSite: domainSiteSlug,
 			expected: newProduct,
@@ -61,6 +64,7 @@ describe( 'getProductSlugFromContext', () => {
 		{
 			product: domainSiteSlug,
 			domainOrProduct: newProduct,
+			pathname: undefined,
 			productSlug: undefined,
 			selectedSite: domainSiteSlug,
 			expected: newProduct,
@@ -68,6 +72,7 @@ describe( 'getProductSlugFromContext', () => {
 		{
 			product: newProductWithDomain,
 			domainOrProduct: undefined,
+			pathname: undefined,
 			productSlug: undefined,
 			selectedSite: domainSiteSlug,
 			expected: newProductWithDomain,
@@ -75,6 +80,7 @@ describe( 'getProductSlugFromContext', () => {
 		{
 			product: undefined,
 			domainOrProduct: newProductWithDomain,
+			pathname: undefined,
 			productSlug: undefined,
 			selectedSite: domainSiteSlug,
 			expected: newProductWithDomain,
@@ -82,6 +88,7 @@ describe( 'getProductSlugFromContext', () => {
 		{
 			product: newProductWithDot,
 			domainOrProduct: undefined,
+			pathname: undefined,
 			productSlug: undefined,
 			selectedSite: domainSiteSlug,
 			expected: newProductWithDot,
@@ -89,6 +96,7 @@ describe( 'getProductSlugFromContext', () => {
 		{
 			product: undefined,
 			domainOrProduct: newProductWithDot,
+			pathname: undefined,
 			productSlug: undefined,
 			selectedSite: domainSiteSlug,
 			expected: newProductWithDot,
@@ -96,6 +104,7 @@ describe( 'getProductSlugFromContext', () => {
 		{
 			product: newProduct,
 			domainOrProduct: undefined,
+			pathname: undefined,
 			productSlug: undefined,
 			selectedSite: undefined,
 			expected: '',
@@ -103,6 +112,7 @@ describe( 'getProductSlugFromContext', () => {
 		{
 			product: undefined,
 			domainOrProduct: newProduct,
+			pathname: undefined,
 			productSlug: undefined,
 			selectedSite: undefined,
 			expected: newProduct,
@@ -110,6 +120,7 @@ describe( 'getProductSlugFromContext', () => {
 		{
 			product: undefined,
 			domainOrProduct: domainSiteSlug,
+			pathname: undefined,
 			productSlug: undefined,
 			selectedSite: domainSiteSlug,
 			expected: '',
@@ -117,6 +128,7 @@ describe( 'getProductSlugFromContext', () => {
 		{
 			product: domainSiteSlug,
 			domainOrProduct: undefined,
+			pathname: undefined,
 			productSlug: undefined,
 			selectedSite: domainSiteSlug,
 			expected: '',
@@ -124,6 +136,7 @@ describe( 'getProductSlugFromContext', () => {
 		{
 			product: newProduct,
 			domainOrProduct: undefined,
+			pathname: undefined,
 			productSlug: undefined,
 			selectedSite: domainSiteSlug,
 			expected: newProduct,
@@ -131,6 +144,7 @@ describe( 'getProductSlugFromContext', () => {
 		{
 			product: undefined,
 			domainOrProduct: newProduct,
+			pathname: undefined,
 			productSlug: undefined,
 			selectedSite: domainSiteSlug,
 			expected: newProduct,
@@ -138,6 +152,7 @@ describe( 'getProductSlugFromContext', () => {
 		{
 			product: subdomainSiteSlug,
 			domainOrProduct: newProduct,
+			pathname: undefined,
 			productSlug: undefined,
 			selectedSite: subdomainSiteSlug,
 			expected: newProduct,
@@ -145,6 +160,7 @@ describe( 'getProductSlugFromContext', () => {
 		{
 			product: newProduct,
 			domainOrProduct: subdomainSiteSlug,
+			pathname: undefined,
 			productSlug: undefined,
 			selectedSite: subdomainSiteSlug,
 			expected: newProduct,
@@ -152,6 +168,7 @@ describe( 'getProductSlugFromContext', () => {
 		{
 			product: undefined,
 			domainOrProduct: subdomainSiteSlug,
+			pathname: undefined,
 			productSlug: undefined,
 			selectedSite: subdomainSiteSlug,
 			expected: '',
@@ -159,6 +176,7 @@ describe( 'getProductSlugFromContext', () => {
 		{
 			product: undefined,
 			domainOrProduct: subdomainSiteSlug,
+			pathname: undefined,
 			productSlug: undefined,
 			selectedSite: domainSiteSlug,
 			expected: '',
@@ -166,6 +184,7 @@ describe( 'getProductSlugFromContext', () => {
 		{
 			product: undefined,
 			domainOrProduct: undefined,
+			pathname: undefined,
 			productSlug: undefined,
 			selectedSite: domainSiteSlug,
 			expected: '',
@@ -173,13 +192,22 @@ describe( 'getProductSlugFromContext', () => {
 		{
 			product: undefined,
 			domainOrProduct: undefined,
+			pathname: undefined,
 			productSlug: newProduct,
 			selectedSite: domainSiteSlug,
 			expected: newProduct,
 		},
+		{
+			product: undefined,
+			domainOrProduct: newProduct,
+			pathname: `/checkout/${ newProduct }/gift/1234`,
+			productSlug: undefined,
+			selectedSite: undefined,
+			expected: newProduct,
+		},
 	] )(
-		`returns '$expected' when :product is '$product', :domainOrProduct is '$domainOrProduct', productSlug is '$productSlug', and selected site is '$selectedSite'`,
-		( { product, domainOrProduct, productSlug, selectedSite, expected } ) => {
+		`returns '$expected' when :product is '$product', :domainOrProduct is '$domainOrProduct', productSlug is '$productSlug', pathname is '$pathname', and selected site is '$selectedSite'`,
+		( { product, domainOrProduct, productSlug, selectedSite, expected, pathname } ) => {
 			const store = mockStore( {
 				ui: {
 					selectedSiteId: getSiteIdFromDomain( selectedSite ),
@@ -191,6 +219,7 @@ describe( 'getProductSlugFromContext', () => {
 
 			const actual = getProductSlugFromContext(
 				{
+					pathname: pathname ?? '',
 					store,
 					params: {
 						domainOrProduct,

--- a/client/my-sites/checkout/test/utils.js
+++ b/client/my-sites/checkout/test/utils.js
@@ -281,18 +281,6 @@ describe( 'getProductSlugFromContext', () => {
 		{
 			context: createMockContext( {
 				params: {
-					product: undefined,
-					domainOrProduct: newProduct,
-					productSlug: undefined,
-				},
-				pathname: `/checkout/${ newProduct }/gift/1234`,
-			} ),
-			selectedSite: undefined,
-			expected: newProduct,
-		},
-		{
-			context: createMockContext( {
-				params: {
 					product: newProduct,
 					domainOrProduct: undefined,
 					productSlug: undefined,

--- a/client/my-sites/checkout/test/utils.js
+++ b/client/my-sites/checkout/test/utils.js
@@ -3,6 +3,23 @@ import { getProductSlugFromContext } from '../utils';
 
 const mockStore = configureStore();
 
+const emptyContext = {
+	params: {
+		domainOrProduct: undefined,
+		product: undefined,
+		productSlug: undefined,
+	},
+	pathname: '',
+	query: {},
+};
+
+function createMockContext( options ) {
+	return {
+		...emptyContext,
+		...options,
+	};
+}
+
 describe( 'getProductSlugFromContext', () => {
 	const domainSiteId = 1;
 	const wpcomSiteId = 2;
@@ -38,184 +55,256 @@ describe( 'getProductSlugFromContext', () => {
 
 	it.each( [
 		{
-			product: newProduct,
-			domainOrProduct: wpcomSiteSlug,
-			pathname: undefined,
-			productSlug: undefined,
+			context: createMockContext( {
+				params: {
+					product: newProduct,
+					domainOrProduct: wpcomSiteSlug,
+				},
+			} ),
 			selectedSite: wpcomStagingSiteSlug,
 			expected: newProduct,
 		},
 		{
-			product: undefined,
-			domainOrProduct: wpcomSiteSlug,
-			pathname: undefined,
-			productSlug: undefined,
+			context: createMockContext( {
+				params: {
+					product: undefined,
+					domainOrProduct: wpcomSiteSlug,
+					productSlug: undefined,
+				},
+			} ),
 			selectedSite: wpcomStagingSiteSlug,
 			expected: '',
 		},
 		{
-			product: newProduct,
-			domainOrProduct: domainSiteSlug,
-			pathname: undefined,
-			productSlug: undefined,
+			context: createMockContext( {
+				params: {
+					product: newProduct,
+					domainOrProduct: domainSiteSlug,
+					productSlug: undefined,
+				},
+			} ),
 			selectedSite: domainSiteSlug,
 			expected: newProduct,
 		},
 		{
-			product: domainSiteSlug,
-			domainOrProduct: newProduct,
-			pathname: undefined,
-			productSlug: undefined,
+			context: createMockContext( {
+				params: {
+					product: domainSiteSlug,
+					domainOrProduct: newProduct,
+					productSlug: undefined,
+				},
+			} ),
 			selectedSite: domainSiteSlug,
 			expected: newProduct,
 		},
 		{
-			product: newProductWithDomain,
-			domainOrProduct: undefined,
-			pathname: undefined,
-			productSlug: undefined,
+			context: createMockContext( {
+				params: {
+					product: newProductWithDomain,
+					domainOrProduct: undefined,
+					productSlug: undefined,
+				},
+			} ),
 			selectedSite: domainSiteSlug,
 			expected: newProductWithDomain,
 		},
 		{
-			product: undefined,
-			domainOrProduct: newProductWithDomain,
-			pathname: undefined,
-			productSlug: undefined,
+			context: createMockContext( {
+				params: {
+					product: undefined,
+					domainOrProduct: newProductWithDomain,
+					productSlug: undefined,
+				},
+			} ),
 			selectedSite: domainSiteSlug,
 			expected: newProductWithDomain,
 		},
 		{
-			product: newProductWithDot,
-			domainOrProduct: undefined,
-			pathname: undefined,
-			productSlug: undefined,
+			context: createMockContext( {
+				params: {
+					product: newProductWithDot,
+					domainOrProduct: undefined,
+					productSlug: undefined,
+				},
+			} ),
 			selectedSite: domainSiteSlug,
 			expected: newProductWithDot,
 		},
 		{
-			product: undefined,
-			domainOrProduct: newProductWithDot,
-			pathname: undefined,
-			productSlug: undefined,
+			context: createMockContext( {
+				params: {
+					product: undefined,
+					domainOrProduct: newProductWithDot,
+					productSlug: undefined,
+				},
+			} ),
 			selectedSite: domainSiteSlug,
 			expected: newProductWithDot,
 		},
 		{
-			product: newProduct,
-			domainOrProduct: undefined,
-			pathname: undefined,
-			productSlug: undefined,
+			context: createMockContext( {
+				params: {
+					product: newProduct,
+					domainOrProduct: undefined,
+					productSlug: undefined,
+				},
+			} ),
 			selectedSite: undefined,
 			expected: '',
 		},
 		{
-			product: undefined,
-			domainOrProduct: newProduct,
-			pathname: undefined,
-			productSlug: undefined,
+			context: createMockContext( {
+				params: {
+					product: undefined,
+					domainOrProduct: newProduct,
+					productSlug: undefined,
+				},
+			} ),
 			selectedSite: undefined,
 			expected: newProduct,
 		},
 		{
-			product: undefined,
-			domainOrProduct: domainSiteSlug,
-			pathname: undefined,
-			productSlug: undefined,
+			context: createMockContext( {
+				params: {
+					product: undefined,
+					domainOrProduct: domainSiteSlug,
+					productSlug: undefined,
+				},
+			} ),
 			selectedSite: domainSiteSlug,
 			expected: '',
 		},
 		{
-			product: domainSiteSlug,
-			domainOrProduct: undefined,
-			pathname: undefined,
-			productSlug: undefined,
+			context: createMockContext( {
+				params: {
+					product: domainSiteSlug,
+					domainOrProduct: undefined,
+					productSlug: undefined,
+				},
+			} ),
 			selectedSite: domainSiteSlug,
 			expected: '',
 		},
 		{
-			product: newProduct,
-			domainOrProduct: undefined,
-			pathname: undefined,
-			productSlug: undefined,
+			context: createMockContext( {
+				params: {
+					product: newProduct,
+					domainOrProduct: undefined,
+					productSlug: undefined,
+				},
+			} ),
 			selectedSite: domainSiteSlug,
 			expected: newProduct,
 		},
 		{
-			product: undefined,
-			domainOrProduct: newProduct,
-			pathname: undefined,
-			productSlug: undefined,
+			context: createMockContext( {
+				params: {
+					product: undefined,
+					domainOrProduct: newProduct,
+					productSlug: undefined,
+				},
+			} ),
 			selectedSite: domainSiteSlug,
 			expected: newProduct,
 		},
 		{
-			product: subdomainSiteSlug,
-			domainOrProduct: newProduct,
-			pathname: undefined,
-			productSlug: undefined,
+			context: createMockContext( {
+				params: {
+					product: subdomainSiteSlug,
+					domainOrProduct: newProduct,
+					productSlug: undefined,
+				},
+			} ),
 			selectedSite: subdomainSiteSlug,
 			expected: newProduct,
 		},
 		{
-			product: newProduct,
-			domainOrProduct: subdomainSiteSlug,
-			pathname: undefined,
-			productSlug: undefined,
+			context: createMockContext( {
+				params: {
+					product: newProduct,
+					domainOrProduct: subdomainSiteSlug,
+					productSlug: undefined,
+				},
+			} ),
 			selectedSite: subdomainSiteSlug,
 			expected: newProduct,
 		},
 		{
-			product: undefined,
-			domainOrProduct: subdomainSiteSlug,
-			pathname: undefined,
-			productSlug: undefined,
+			context: createMockContext( {
+				params: {
+					product: undefined,
+					domainOrProduct: subdomainSiteSlug,
+					productSlug: undefined,
+				},
+			} ),
 			selectedSite: subdomainSiteSlug,
 			expected: '',
 		},
 		{
-			product: undefined,
-			domainOrProduct: subdomainSiteSlug,
-			pathname: undefined,
-			productSlug: undefined,
+			context: createMockContext( {
+				params: {
+					product: undefined,
+					domainOrProduct: subdomainSiteSlug,
+					productSlug: undefined,
+				},
+			} ),
 			selectedSite: domainSiteSlug,
 			expected: '',
 		},
 		{
-			product: undefined,
-			domainOrProduct: undefined,
-			pathname: undefined,
-			productSlug: undefined,
+			context: createMockContext( {
+				params: {
+					product: undefined,
+					domainOrProduct: undefined,
+					productSlug: undefined,
+				},
+			} ),
 			selectedSite: domainSiteSlug,
 			expected: '',
 		},
 		{
-			product: undefined,
-			domainOrProduct: undefined,
-			pathname: undefined,
-			productSlug: newProduct,
+			context: createMockContext( {
+				params: {
+					product: undefined,
+					domainOrProduct: undefined,
+					productSlug: newProduct,
+				},
+				pathname: '/checkout/jetpack',
+				query: {
+					flow: 'coming_from_login',
+					purchasetoken: 'testtoken',
+				},
+			} ),
 			selectedSite: undefined,
 			expected: newProduct,
 		},
 		{
-			product: undefined,
-			domainOrProduct: newProduct,
-			pathname: `/checkout/${ newProduct }/gift/1234`,
-			productSlug: undefined,
+			context: createMockContext( {
+				params: {
+					product: undefined,
+					domainOrProduct: newProduct,
+					productSlug: undefined,
+				},
+				pathname: `/checkout/${ newProduct }/gift/1234`,
+			} ),
 			selectedSite: undefined,
 			expected: newProduct,
 		},
 		{
-			product: newProduct,
-			domainOrProduct: undefined,
-			pathname: `/checkout/${ newProduct }/gift/1234`,
-			productSlug: undefined,
+			context: createMockContext( {
+				params: {
+					product: newProduct,
+					domainOrProduct: undefined,
+					productSlug: undefined,
+				},
+				pathname: `/checkout/${ newProduct }/gift/1234`,
+			} ),
 			selectedSite: undefined,
 			expected: newProduct,
 		},
 	] )(
-		`returns '$expected' when :product is '$product', :domainOrProduct is '$domainOrProduct', productSlug is '$productSlug', pathname is '$pathname', and selected site is '$selectedSite'`,
-		( { product, domainOrProduct, productSlug, selectedSite, expected, pathname } ) => {
+		`returns '$expected' when params is '$context.params', path is '$context.pathname', query is '$context.query', and selected site is '$selectedSite'`,
+		( { context, selectedSite, expected } ) => {
 			const store = mockStore( {
 				ui: {
 					selectedSiteId: getSiteIdFromDomain( selectedSite ),
@@ -223,20 +312,10 @@ describe( 'getProductSlugFromContext', () => {
 				sites,
 			} );
 
-			const options = productSlug ? { isJetpackCheckout: true } : {};
-
-			const actual = getProductSlugFromContext(
-				{
-					pathname: pathname ?? '',
-					store,
-					params: {
-						domainOrProduct,
-						product,
-						productSlug,
-					},
-				},
-				options
-			);
+			const actual = getProductSlugFromContext( {
+				...context,
+				store,
+			} );
 
 			expect( actual ).toEqual( expected );
 		}

--- a/client/my-sites/checkout/test/utils.js
+++ b/client/my-sites/checkout/test/utils.js
@@ -205,6 +205,14 @@ describe( 'getProductSlugFromContext', () => {
 			selectedSite: undefined,
 			expected: newProduct,
 		},
+		{
+			product: newProduct,
+			domainOrProduct: undefined,
+			pathname: `/checkout/${ newProduct }/gift/1234`,
+			productSlug: undefined,
+			selectedSite: undefined,
+			expected: newProduct,
+		},
 	] )(
 		`returns '$expected' when :product is '$product', :domainOrProduct is '$domainOrProduct', productSlug is '$productSlug', pathname is '$pathname', and selected site is '$selectedSite'`,
 		( { product, domainOrProduct, productSlug, selectedSite, expected, pathname } ) => {

--- a/client/my-sites/checkout/test/utils.js
+++ b/client/my-sites/checkout/test/utils.js
@@ -194,7 +194,7 @@ describe( 'getProductSlugFromContext', () => {
 			domainOrProduct: undefined,
 			pathname: undefined,
 			productSlug: newProduct,
-			selectedSite: domainSiteSlug,
+			selectedSite: undefined,
 			expected: newProduct,
 		},
 		{

--- a/client/my-sites/checkout/utils.ts
+++ b/client/my-sites/checkout/utils.ts
@@ -47,7 +47,7 @@ export function getProductSlugFromContext(
 	}
 
 	if ( isGiftPurchase ) {
-		return domainOrProduct;
+		return domainOrProduct || product;
 	}
 
 	if ( ! domainOrProduct && ! product ) {

--- a/client/my-sites/checkout/utils.ts
+++ b/client/my-sites/checkout/utils.ts
@@ -40,12 +40,14 @@ export function getProductSlugFromContext( context: PageJS.Context ): string | u
 	const selectedSite = getSelectedSite( state );
 	const isGiftPurchase = pathname.includes( '/gift/' );
 
+	// Jetpack siteless checkout routes always use `:productSlug` in the path.
 	if ( isContextJetpackSitelessCheckout( context ) ) {
 		return productSlug;
 	}
 
+	// Gift purchase routes always use `:product` in the path.
 	if ( isGiftPurchase ) {
-		return domainOrProduct || product;
+		return product;
 	}
 
 	if ( ! domainOrProduct && ! product ) {

--- a/client/my-sites/checkout/utils.ts
+++ b/client/my-sites/checkout/utils.ts
@@ -25,10 +25,7 @@ import { getSelectedSite } from 'calypso/state/ui/selectors';
  * 5. `/checkout/example.com::blog/pro` (path contains a domain followed by a product)
  * 6. `/checkout/pro/example.com::blog` (path contains a product followed by a domain)
  */
-export function getProductSlugFromContext(
-	context: PageJS.Context,
-	options?: { isJetpackCheckout?: boolean }
-): string | undefined {
+export function getProductSlugFromContext( context: PageJS.Context ): string | undefined {
 	const { params, store, pathname } = context;
 	const {
 		domainOrProduct,
@@ -43,7 +40,7 @@ export function getProductSlugFromContext(
 	const selectedSite = getSelectedSite( state );
 	const isGiftPurchase = pathname.includes( '/gift/' );
 
-	if ( options?.isJetpackCheckout ) {
+	if ( isContextJetpackSitelessCheckout( context ) ) {
 		return productSlug;
 	}
 

--- a/client/my-sites/checkout/utils.ts
+++ b/client/my-sites/checkout/utils.ts
@@ -25,9 +25,10 @@ import { getSelectedSite } from 'calypso/state/ui/selectors';
  * 6. `/checkout/pro/example.com::blog` (path contains a product followed by a domain)
  */
 export function getProductSlugFromContext(
-	{ params, store }: PageJS.Context,
+	context: PageJS.Context,
 	options?: { isJetpackCheckout?: boolean }
 ): string | undefined {
+	const { params, store, pathname } = context;
 	const {
 		domainOrProduct,
 		product,
@@ -39,9 +40,14 @@ export function getProductSlugFromContext(
 	} = params;
 	const state = store.getState();
 	const selectedSite = getSelectedSite( state );
+	const isGiftPurchase = pathname.includes( '/gift/' );
 
 	if ( options?.isJetpackCheckout ) {
 		return productSlug;
+	}
+
+	if ( isGiftPurchase ) {
+		return domainOrProduct;
 	}
 
 	if ( ! domainOrProduct && ! product ) {

--- a/client/my-sites/checkout/utils.ts
+++ b/client/my-sites/checkout/utils.ts
@@ -24,13 +24,25 @@ import { getSelectedSite } from 'calypso/state/ui/selectors';
  * 5. `/checkout/example.com::blog/pro` (path contains a domain followed by a product)
  * 6. `/checkout/pro/example.com::blog` (path contains a product followed by a domain)
  */
-export function getProductSlugFromContext( { params, store }: PageJS.Context ): string {
+export function getProductSlugFromContext(
+	{ params, store }: PageJS.Context,
+	options?: { isJetpackCheckout?: boolean }
+): string | undefined {
 	const {
 		domainOrProduct,
 		product,
-	}: { domainOrProduct: string | undefined; product: string | undefined } = params;
+		productSlug,
+	}: {
+		domainOrProduct: string | undefined;
+		product: string | undefined;
+		productSlug: string | undefined;
+	} = params;
 	const state = store.getState();
 	const selectedSite = getSelectedSite( state );
+
+	if ( options?.isJetpackCheckout ) {
+		return productSlug;
+	}
 
 	if ( ! domainOrProduct && ! product ) {
 		return '';

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -416,13 +416,14 @@ export function noSite( context, next ) {
 	const hasSite = currentUser && currentUser.visible_site_count >= 1;
 	const isDomainOnlyFlow = context.query?.isDomainOnly === '1';
 	const isJetpackCheckoutFlow = context.pathname.includes( '/checkout/jetpack' );
+	const isGiftCheckoutFlow = context.pathname.includes( '/gift/' );
 
-	if ( ! isDomainOnlyFlow && ! isJetpackCheckoutFlow && hasSite ) {
+	if ( ! isDomainOnlyFlow && ! isJetpackCheckoutFlow && ! isGiftCheckoutFlow && hasSite ) {
 		siteSelection( context, next );
-	} else {
-		context.store.dispatch( setSelectedSiteId( null ) );
-		return next();
 	}
+
+	context.store.dispatch( setSelectedSiteId( null ) );
+	return next();
 }
 
 /*

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -420,6 +420,7 @@ export function noSite( context, next ) {
 
 	if ( ! isDomainOnlyFlow && ! isJetpackCheckoutFlow && ! isGiftCheckoutFlow && hasSite ) {
 		siteSelection( context, next );
+		return;
 	}
 
 	context.store.dispatch( setSelectedSiteId( null ) );

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -591,6 +591,7 @@ export interface ResponseCartProductExtra {
 export interface RequestCartProductExtra extends ResponseCartProductExtra {
 	purchaseId?: string;
 	isJetpackCheckout?: boolean;
+	isGiftPurchase?: boolean;
 	jetpackSiteSlug?: string;
 	jetpackPurchaseToken?: string;
 	auth_code?: string;


### PR DESCRIPTION
#### Proposed Changes

This PR adds a new checkout route of the form `/checkout/:productSlugs/gift/:purchaseIds` to enable gifting subscription renewals to other WordPress.com users (see pbOQVh-2wh-p2 for more details). An example URL might be `/checkout/business-bundle-monthly,dotblog_domain/gift/10000,100001` to gift two products.

The new route works similarly to the current route for adding a renewal to the cart, which is `/checkout/:productSlugs/renew/:purchaseIds/:domain`. Both routes will attempt to add renewal products to the cart, but the gift route will allow adding a renewal for a _different user_. The user purchasing the gift does not need to have a WordPress.com site but does need to have an account.

Fixes https://github.com/Automattic/payments-shilling/issues/1194

(Most of this work was already prepared in the POC https://github.com/Automattic/wp-calypso/pull/69639 by @dylanrevisited)

#### Testing Instructions

You'll need two accounts and make sure that the store is sandboxed.

- With account A, purchase a personal plan (or use an account which already owns a plan).
- With account B, go to the following URL: `/checkout/personal-bundle/gift/<ACCOUNT_A_SUBSCRIPTION_ID>`. You can use Store Admin to find the subscription ID of the account A's plan.
- Verify that you see the gift subscription in account B's shopping cart.
