### PR TITLE
Purchases: Jetpack Plans - Hide remove option until plan is canceled

### DIFF
--- a/client/lib/purchases/index.ts
+++ b/client/lib/purchases/index.ts
@@ -6,7 +6,6 @@ import {
 	isDomainRegistration,
 	isDomainTransfer,
 	isGSuiteOrGoogleWorkspace,
-	isJetpackPlan,
 	isMonthlyProduct,
 	isPlan,
 	isThemePurchase,
@@ -640,7 +639,6 @@ export function isRemovable( purchase: Purchase ): boolean {
 	}
 
 	return (
-		isJetpackPlan( purchase ) ||
 		isExpiring( purchase ) ||
 		isExpired( purchase ) ||
 		( isDomainTransfer( purchase ) && isPurchaseCancelable( purchase ) ) ||


### PR DESCRIPTION
#### Proposed Changes

As noted in [this issue](https://github.com/Automattic/wp-calypso/issues/68049), Jetpack plans will show the Cancel AND the Remove options when outside of the refund window. We should only show the remove option after a plan has been canceled.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* See David's steps here https://github.com/Automattic/wp-calypso/issues/68049
* Repeat steps above to ensure that Remove only shows after plan has been canceled

Fixes: #68049
