### PR TITLE
Checkout: Hide plan upsells in Woo mobile webview

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
@@ -31,6 +31,7 @@ import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import * as React from 'react';
 import { useSelector } from 'react-redux';
+import { isWcMobileApp } from 'calypso/lib/mobile-app';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import { getSignupCompleteFlowName } from 'calypso/signup/storageUtils';
 import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
@@ -65,6 +66,7 @@ export default function WPCheckoutOrderSummary( {
 	);
 
 	const isCartUpdating = FormStatus.VALIDATING === formStatus;
+	const isWcMobile = isWcMobileApp();
 
 	const plan = responseCart.products.find( ( product ) => isPlan( product ) );
 	const hasMonthlyPlanInCart = Boolean( plan && isMonthly( plan?.product_slug ) );
@@ -84,7 +86,7 @@ export default function WPCheckoutOrderSummary( {
 					<CheckoutSummaryFeaturesWrapper siteId={ siteId } nextDomainIsFree={ nextDomainIsFree } />
 				) }
 			</CheckoutSummaryFeatures>
-			{ ! isCartUpdating && ! hasRenewalInCart && plan && hasMonthlyPlanInCart && (
+			{ ! isCartUpdating && ! hasRenewalInCart && ! isWcMobile && plan && hasMonthlyPlanInCart && (
 				<CheckoutSummaryAnnualUpsell plan={ plan } onChangePlanLength={ onChangePlanLength } />
 			) }
 			<CheckoutSummaryAmountWrapper>

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
@@ -32,6 +32,7 @@ import {
 	hasTransferProduct,
 } from 'calypso/lib/cart-values/cart-items';
 import { getGoogleMailServiceFamily } from 'calypso/lib/gsuite';
+import { isWcMobileApp } from 'calypso/lib/mobile-app';
 import useValidCheckoutBackUrl from 'calypso/my-sites/checkout/composite-checkout/hooks/use-valid-checkout-back-url';
 import { leaveCheckout } from 'calypso/my-sites/checkout/composite-checkout/lib/leave-checkout';
 import { prepareDomainContactValidationRequest } from 'calypso/my-sites/checkout/composite-checkout/types/wpcom-store-state';
@@ -243,6 +244,8 @@ export default function WPCheckout( {
 		return true;
 	};
 
+	const isWcMobile = isWcMobileApp();
+
 	if ( transactionStatus === TransactionStatus.COMPLETE ) {
 		debug( 'rendering post-checkout redirecting page' );
 		return (
@@ -311,7 +314,7 @@ export default function WPCheckout( {
 								onChangePlanLength={ changePlanLength }
 								nextDomainIsFree={ responseCart?.next_domain_is_free }
 							/>
-							<CheckoutSidebarPlanUpsell />
+							{ ! isWcMobile && <CheckoutSidebarPlanUpsell /> }
 							<SecondaryCartPromotions
 								responseCart={ responseCart }
 								addItemToCart={ addItemToCart }


### PR DESCRIPTION
#### Proposed Changes

At this time the Woo mobile apps are only creating stores with the monthly eCommerce plan. This makes it so upsells to annual and biennial plans are not visible when the userAgent is set for Woo mobile webview.

Additional context: https://github.com/Automattic/wp-calypso/pull/69595#issuecomment-1301550693

#### Testing Instructions

1. In Calypso Live, go to the plans screen for a test site that doesn't have a plan yet.
2. Select a monthly plan (eCommerce is our focus, but any plan will work here).
3. On the checkout screen, note the two upsells in the sidebar (or in the "Purchase Details" dropdown in mobile view)
    <img src="https://user-images.githubusercontent.com/916023/200085443-b75afeef-1bff-4389-8353-1e55accfb504.jpg" alt="Sidebar upsells" width="50%" />
4. Now change the userAgent of the browser to `wc-ios` or `wc-android` (I use [User-Agent Switcher](https://addons.mozilla.org/en-US/firefox/addon/uaswitcher/) in Firefox) and refresh the screen.
5. The two upsells should no longer render.

#### Pre-merge Checklist

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
