### PR TITLE
Update Assign Later redirect

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/assign-license-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/assign-license-form/index.tsx
@@ -110,8 +110,12 @@ export default function AssignLicenseForm( {
 		assignLicense.mutate( { licenseKey, selectedSite } );
 	}, [ dispatch, licenseKey, selectedSite, assignLicense.mutate ] );
 
-	const onAssignLater = () =>
+	const onAssignLater = () => {
+		if ( licenseKeysArray.length > 1 ) {
+			page.redirect( '/partner-portal/licenses' );
+		}
 		page.redirect( addQueryArgs( { highlight: licenseKey }, '/partner-portal/licenses' ) );
+	};
 
 	return (
 		<div className="assign-license-form">


### PR DESCRIPTION
Update the assign later redirect to not highlight a license if there are multiple licenses being assigned.

#### Proposed Changes

* These changes update the Assign later button on on the licenses assignment page to no longer highlight a license if there are multiple licenses being assigned but the assign later option is selected

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this PR 
* Run yarn-start-jetpack-cloud
* Visit `http://jetpack.cloud.localhost:3000/partner-portal/licenses` and issue a new license
* Once the license is issued use the "Assign later" link and ensure that the page redirects to the licenses page with the just issued license highlighted
* VIsit `http://jetpack.cloud.localhost:3000/partner-portal/licenses` and attempt to assign the license again
* From the license assignment page update the query param in the url from "key" to "keys" and include a comma separated list of values
* Use the assign license page again and ensure that the page redirects to the license management page at `http://jetpack.cloud.localhost:3000/partner-portal/licenses` with no licenses highlighted

<img width="1163" alt="Screenshot 2022-11-02 at 7 25 13 PM" src="https://user-images.githubusercontent.com/1273880/200394649-50727165-b492-4055-9117-95426dfa24bb.png">



#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
