### PR TITLE
Pattern Assembler - Add header and footer template parts when no selection is made

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -264,12 +264,7 @@ const PatternAssembler: Step = ( { navigation } ) => {
 												stylesheet,
 												'home',
 												translate( 'Home' ),
-												createCustomHomeTemplateContent(
-													stylesheet,
-													!! header,
-													!! footer,
-													!! sections.length
-												)
+												createCustomHomeTemplateContent( stylesheet, !! header, !! footer )
 											)
 										)
 										.then( () => runThemeSetupOnSite( siteSlugOrId, design ) )

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -264,7 +264,12 @@ const PatternAssembler: Step = ( { navigation } ) => {
 												stylesheet,
 												'home',
 												translate( 'Home' ),
-												createCustomHomeTemplateContent( stylesheet, !! header, !! footer )
+												createCustomHomeTemplateContent(
+													stylesheet,
+													!! header,
+													!! footer,
+													!! sections.length
+												)
 											)
 										)
 										.then( () => runThemeSetupOnSite( siteSlugOrId, design ) )

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/utils.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/utils.ts
@@ -41,10 +41,12 @@ export function createCustomHomeTemplateContent(
 ) {
 	const content: string[] = [];
 	const noSelection = ! hasHeader && ! hasFooter && ! hasSections;
-	if ( hasHeader || noSelection ) {
+	if ( hasHeader ) {
 		content.push(
 			`<!-- wp:template-part {"slug":"header","tagName":"header","theme":"${ stylesheet }"} /-->`
 		);
+	} else if ( noSelection ) {
+		content.push( `<!-- wp:template-part {"area":"header","theme":"${ stylesheet }"} /-->` );
 	}
 
 	content.push( `
@@ -53,10 +55,12 @@ export function createCustomHomeTemplateContent(
 	</main>
 <!-- /wp:group -->` );
 
-	if ( hasFooter || noSelection ) {
+	if ( hasFooter ) {
 		content.push(
 			`<!-- wp:template-part {"slug":"footer","tagName":"footer","theme":"${ stylesheet }","className":"site-footer-container"} /-->`
 		);
+	} else if ( noSelection ) {
+		content.push( `<!-- wp:template-part {"area":"footer","theme":"${ stylesheet }"} /-->` );
 	}
 
 	return content.join( '\n' );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/utils.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/utils.ts
@@ -52,6 +52,7 @@ export function createCustomHomeTemplateContent(
 	content.push( `
 <!-- wp:group {"tagName":"main"} -->
 	<main class="wp-block-group">
+	<p></p>
 	</main>
 <!-- /wp:group -->` );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/utils.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/utils.ts
@@ -60,7 +60,7 @@ export function createCustomHomeTemplateContent(
 			`<!-- wp:template-part {"slug":"footer","tagName":"footer","theme":"${ stylesheet }","className":"site-footer-container"} /-->`
 		);
 	} else if ( noSelection ) {
-		content.push( `<!-- wp:template-part {"area":"footer","theme":"${ stylesheet }"} /-->` );
+		content.push( `<!-- wp:template-part {"area":"footer"} /-->` );
 	}
 
 	return content.join( '\n' );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/utils.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/utils.ts
@@ -50,6 +50,9 @@ export function createCustomHomeTemplateContent(
 	content.push( `
 <!-- wp:group {"tagName":"main"} -->
 	<main class="wp-block-group">
+	<!-- wp:paragraph -->
+	<p></p>
+	<!-- /wp:paragraph -->
 	</main>
 <!-- /wp:group -->` );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/utils.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/utils.ts
@@ -36,23 +36,20 @@ export const handleKeyboard =
 export function createCustomHomeTemplateContent(
 	stylesheet: string,
 	hasHeader: boolean,
-	hasFooter: boolean,
-	hasSections: boolean
+	hasFooter: boolean
 ) {
 	const content: string[] = [];
-	const noSelection = ! hasHeader && ! hasFooter && ! hasSections;
 	if ( hasHeader ) {
 		content.push(
 			`<!-- wp:template-part {"slug":"header","tagName":"header","theme":"${ stylesheet }"} /-->`
 		);
-	} else if ( noSelection ) {
+	} else {
 		content.push( `<!-- wp:template-part {"area":"header"} /-->` );
 	}
 
 	content.push( `
 <!-- wp:group {"tagName":"main"} -->
 	<main class="wp-block-group">
-	<p></p>
 	</main>
 <!-- /wp:group -->` );
 
@@ -60,7 +57,7 @@ export function createCustomHomeTemplateContent(
 		content.push(
 			`<!-- wp:template-part {"slug":"footer","tagName":"footer","theme":"${ stylesheet }","className":"site-footer-container"} /-->`
 		);
-	} else if ( noSelection ) {
+	} else {
 		content.push( `<!-- wp:template-part {"area":"footer"} /-->` );
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/utils.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/utils.ts
@@ -36,11 +36,12 @@ export const handleKeyboard =
 export function createCustomHomeTemplateContent(
 	stylesheet: string,
 	hasHeader: boolean,
-	hasFooter: boolean
+	hasFooter: boolean,
+	hasSections: boolean
 ) {
 	const content: string[] = [];
-
-	if ( hasHeader ) {
+	const noSelection = ! hasHeader && ! hasFooter && ! hasSections;
+	if ( hasHeader || noSelection ) {
 		content.push(
 			`<!-- wp:template-part {"slug":"header","tagName":"header","theme":"${ stylesheet }"} /-->`
 		);
@@ -52,7 +53,7 @@ export function createCustomHomeTemplateContent(
 	</main>
 <!-- /wp:group -->` );
 
-	if ( hasFooter ) {
+	if ( hasFooter || noSelection ) {
 		content.push(
 			`<!-- wp:template-part {"slug":"footer","tagName":"footer","theme":"${ stylesheet }","className":"site-footer-container"} /-->`
 		);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/utils.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/utils.ts
@@ -46,7 +46,7 @@ export function createCustomHomeTemplateContent(
 			`<!-- wp:template-part {"slug":"header","tagName":"header","theme":"${ stylesheet }"} /-->`
 		);
 	} else if ( noSelection ) {
-		content.push( `<!-- wp:template-part {"area":"header","theme":"${ stylesheet }"} /-->` );
+		content.push( `<!-- wp:template-part {"area":"header"} /-->` );
 	}
 
 	content.push( `


### PR DESCRIPTION
#### Proposed Changes

* Add header or footer template parts when no patterns are selected in these areas

The goal is educational and to avoid a blank screen without any pattern or template part in the editor.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Access `/setup?siteSlug=[ YOUR SITE ]`
* No select any goal or vertical
* Click on the BC CTA
* Don't add a header or footer and click on `Continue`
* Check that the template parts for the header and the footer are not displayed in the site preview but visible in the editor.

<img width="1728" alt="Screen Shot 2565-11-04 at 11 20 23" src="https://user-images.githubusercontent.com/1881481/199886718-110b7d9f-b753-4cbd-8ad0-51090cf1e077.png">


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Close https://github.com/Automattic/wp-calypso/issues/69734
