### PR TITLE
Pattern Assembler - Redirection to start the flow from the first step 

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -1,7 +1,7 @@
 import { StepContainer } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
-import { useState, useRef } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import { useDispatch as useReduxDispatch } from 'react-redux';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { requestActiveTheme } from 'calypso/state/themes/actions';
@@ -9,6 +9,7 @@ import { useSite } from '../../../../hooks/use-site';
 import { useSiteIdParam } from '../../../../hooks/use-site-id-param';
 import { useSiteSlugParam } from '../../../../hooks/use-site-slug-param';
 import { SITE_STORE, ONBOARD_STORE } from '../../../../stores';
+import { PA_THEME_SLUG } from './constants';
 import PatternAssemblerPreview from './pattern-assembler-preview';
 import PatternLayout from './pattern-layout';
 import PatternSelectorLoader from './pattern-selector-loader';
@@ -36,6 +37,13 @@ const PatternAssembler: Step = ( { navigation } ) => {
 	const siteSlug = useSiteSlugParam();
 	const siteId = useSiteIdParam();
 	const siteSlugOrId = siteSlug ? siteSlug : siteId;
+
+	useEffect( () => {
+		// Require to start the flow from the first step
+		if ( ! selectedDesign ) {
+			location.href = `/setup${ location.search }`;
+		}
+	} );
 
 	const getPatterns = () =>
 		[ header, ...sections, footer ].filter( ( pattern ) => pattern ) as Pattern[];
@@ -251,7 +259,7 @@ const PatternAssembler: Step = ( { navigation } ) => {
 							if ( siteSlugOrId ) {
 								const design = getDesign();
 								const stylesheet = design.recipe!.stylesheet!;
-								const theme = stylesheet?.split( '/' )[ 1 ] || design.theme;
+								const theme = stylesheet?.split( '/' )[ 1 ] || design.theme || PA_THEME_SLUG;
 
 								setPendingAction( () =>
 									// We have to switch theme first. Otherwise, the unique suffix might append to

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -42,7 +42,7 @@ const PatternAssembler: Step = ( { navigation } ) => {
 		if ( ! selectedDesign ) {
 			goToStep?.( 'goals' );
 		}
-	} );
+	}, [] );
 
 	const getPatterns = () =>
 		[ header, ...sections, footer ].filter( ( pattern ) => pattern ) as Pattern[];

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -9,7 +9,6 @@ import { useSite } from '../../../../hooks/use-site';
 import { useSiteIdParam } from '../../../../hooks/use-site-id-param';
 import { useSiteSlugParam } from '../../../../hooks/use-site-slug-param';
 import { SITE_STORE, ONBOARD_STORE } from '../../../../stores';
-import { PA_THEME_SLUG } from './constants';
 import PatternAssemblerPreview from './pattern-assembler-preview';
 import PatternLayout from './pattern-layout';
 import PatternSelectorLoader from './pattern-selector-loader';
@@ -28,7 +27,7 @@ const PatternAssembler: Step = ( { navigation } ) => {
 	const [ sectionPosition, setSectionPosition ] = useState< number | null >( null );
 	const incrementIndexRef = useRef( 0 );
 	const [ scrollToSelector, setScrollToSelector ] = useState< string | null >( null );
-	const { goBack, goNext, submit } = navigation;
+	const { goBack, goNext, submit, goToStep } = navigation;
 	const { setThemeOnSite, runThemeSetupOnSite, createCustomTemplate } = useDispatch( SITE_STORE );
 	const reduxDispatch = useReduxDispatch();
 	const { setPendingAction } = useDispatch( ONBOARD_STORE );
@@ -41,7 +40,7 @@ const PatternAssembler: Step = ( { navigation } ) => {
 	useEffect( () => {
 		// Require to start the flow from the first step
 		if ( ! selectedDesign ) {
-			location.href = `/setup${ location.search }`;
+			goToStep?.( 'goals' );
 		}
 	} );
 
@@ -259,7 +258,7 @@ const PatternAssembler: Step = ( { navigation } ) => {
 							if ( siteSlugOrId ) {
 								const design = getDesign();
 								const stylesheet = design.recipe!.stylesheet!;
-								const theme = stylesheet?.split( '/' )[ 1 ] || design.theme || PA_THEME_SLUG;
+								const theme = stylesheet?.split( '/' )[ 1 ] || design.theme;
 
 								setPendingAction( () =>
 									// We have to switch theme first. Otherwise, the unique suffix might append to


### PR DESCRIPTION
#### Proposed Changes

* Require to start the flow from the first step when the design prop is missing

The goal is to prevent errors because the design prop and others like the intent collected during previous steps are required.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Access directly to the PA `/setup/site-setup/patternAssembler?siteSlug=[ YOUR SITE ]`
* Check that you are redirected to the first step, which is the goals screen 
* No select any goal or vertical
* Click on the BC CTA
* Select patterns
* Click on continue
* Confirm that works as expected

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Close https://github.com/Automattic/wp-calypso/issues/68374
