### PR TITLE
Bug: First Year Discount on Plans Not Displayed

### DIFF
--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -424,9 +424,9 @@ export class PlanFeaturesHeader extends Component {
 			return <div className={ classes } />;
 		}
 
-		if ( availableForPurchase && ! isLoggedInMonthlyPricing ) {
+		if ( availableForPurchase ) {
 			// Only multiply price by 12 for Jetpack plans where we sell both monthly and yearly
-			if ( isJetpack && ! isSiteAT && relatedMonthlyPlan ) {
+			if ( ! isLoggedInMonthlyPricing && isJetpack && ! isSiteAT && relatedMonthlyPlan ) {
 				return this.renderPriceGroup(
 					relatedMonthlyPlan.raw_price * 12,
 					discountPrice || rawPrice
@@ -436,7 +436,7 @@ export class PlanFeaturesHeader extends Component {
 			}
 		}
 
-		return this.renderPriceGroup( rawPrice, discountPrice );
+		return this.renderPriceGroup( rawPrice );
 	}
 
 	renderPriceGroup( fullPrice, discountedPrice = null ) {

--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -412,7 +412,6 @@ export class PlanFeaturesHeader extends Component {
 			discountPrice,
 			rawPrice,
 			relatedMonthlyPlan,
-			isFirstYearPromotionalDiscount,
 			isLoggedInMonthlyPricing,
 		} = this.props;
 
@@ -437,10 +436,7 @@ export class PlanFeaturesHeader extends Component {
 			}
 		}
 
-		if ( isFirstYearPromotionalDiscount ) {
-			return this.renderPriceGroup( rawPrice, discountPrice );
-		}
-		return this.renderPriceGroup( rawPrice );
+		return this.renderPriceGroup( rawPrice, discountPrice );
 	}
 
 	renderPriceGroup( fullPrice, discountedPrice = null ) {
@@ -610,16 +606,10 @@ export default connect( ( state, { planType, relatedMonthlyPlan } ) => {
 	const isYearly = !! relatedMonthlyPlan;
 	const relatedYearlyPlan = getPlanBySlug( state, getYearlyPlanByMonthly( planType ) );
 
-	const isFirstYearPromotionalDiscount =
-		isYearly &&
-		relatedYearlyPlan &&
-		'first_year_promotional_discounts' === relatedYearlyPlan.overridden_price_reason;
-
 	return {
 		currentSitePlan,
 		isSiteAT: isSiteAutomatedTransfer( state, selectedSiteId ),
 		isYearly,
-		isFirstYearPromotionalDiscount,
 		relatedYearlyPlan,
 		siteSlug: getSiteSlug( state, selectedSiteId ),
 		eligibleForWpcomMonthlyPlans: isEligibleForWpComMonthlyPlan( state, selectedSiteId ),


### PR DESCRIPTION
#### Proposed Changes

More info: pcNC1U-ix-p2
This addresses the missing first-year discount for certain currencies. The code on which this relied has been deprecated (D84961-code).
This PR addresses it by removing the related checks and passing the discount price to the relevant component.
<img width="420" alt="screenshot-2022-10-18-at-10 57 40-am" src="https://user-images.githubusercontent.com/2749938/199920616-e80f0de2-bb4a-4397-a231-726b1ed69e59.png">


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch your account to a first-year discounted currency (ex. INR, MXN or PHP)
* Go to the `/plans` page
* Make sure the discounted prices are shown

<img width="420" alt="Screen Shot on 2022-11-04 at 09-51-03" src="https://user-images.githubusercontent.com/2749938/199921070-33f42506-11cb-428b-bf95-6d8d0215a98d.png">

* Select a non-free plan
* The plans should show the pro-rated adjusted prices for the plan upgrades.
<img width="420" alt="Screen Shot on 2022-11-04 at 09-51-41" src="https://user-images.githubusercontent.com/2749938/199921237-2534b916-c388-4a09-aa92-cfd8eab25c06.png">

* The prices should match the ones from the checkout
<img width="320" alt="Screen Shot on 2022-11-04 at 09-54-01" src="https://user-images.githubusercontent.com/2749938/199921372-d182fa0a-c2d6-4bce-9823-88e4685c5d63.png">


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
