### PR TITLE
Ensure Plugin breadcrumbs get rendered by the server

### DIFF
--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -247,8 +247,8 @@ function PluginDetails( props ) {
 	const breadcrumbs = useSelector( getBreadcrumbs );
 
 	useEffect( () => {
-		setBreadcrumbs( breadcrumbs.length !== 0 );
-	}, [ setBreadcrumbs, breadcrumbs.length ] );
+		setBreadcrumbs( ( breadcrumbs || [] ).length !== 0 );
+	}, [ setBreadcrumbs, breadcrumbs ] );
 
 	const getPageTitle = () => {
 		return translate( '%(pluginName)s Plugin', {

--- a/client/my-sites/plugins/plugins-navigation-header/index.jsx
+++ b/client/my-sites/plugins/plugins-navigation-header/index.jsx
@@ -162,8 +162,8 @@ const PluginsNavigationHeader = ( { navigationHeaderRef, categoryName, category,
 	const breadcrumbs = useSelector( getBreadcrumbs );
 
 	useEffect( () => {
-		setBreadcrumbs( breadcrumbs.length !== 0 );
-	}, [ setBreadcrumbs, breadcrumbs.length ] );
+		setBreadcrumbs( ( breadcrumbs || [] ).length !== 0 );
+	}, [ setBreadcrumbs, breadcrumbs ] );
 
 	return (
 		<FixedNavigationHeader

--- a/client/my-sites/plugins/plugins-navigation-header/index.jsx
+++ b/client/my-sites/plugins/plugins-navigation-header/index.jsx
@@ -5,9 +5,10 @@ import {
 } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
 import { useBreakpoint } from '@automattic/viewport-react';
+import { __ } from '@wordpress/i18n';
 import { Icon, upload } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback, useEffect, useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import FixedNavigationHeader from 'calypso/components/fixed-navigation-header';
 import InlineSupportLink from 'calypso/components/inline-support-link';
@@ -15,6 +16,7 @@ import { useLocalizedPlugins, useServerEffect } from 'calypso/my-sites/plugins/u
 import { recordTracksEvent, recordGoogleEvent } from 'calypso/state/analytics/actions';
 import { appendBreadcrumb, resetBreadcrumbs } from 'calypso/state/breadcrumb/actions';
 import { getBreadcrumbs } from 'calypso/state/breadcrumb/selectors';
+import getPreviousRoute from 'calypso/state/selectors/get-previous-route';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { getSiteAdminUrl, isJetpackSite } from 'calypso/state/sites/selectors';
@@ -113,57 +115,65 @@ const PluginsNavigationHeader = ( { navigationHeaderRef, categoryName, category,
 	}, [ jetpackNonAtomic, isJetpack, hasInstallPurchasedPlugins, hasManagePlugins ] );
 	const { localizePath } = useLocalizedPlugins();
 
-	const setBreadcrumbs = useCallback(
-		( isBreadcrumbsPopulated ) => {
-			if ( ! isBreadcrumbsPopulated || ( ! category && ! search ) ) {
-				dispatch( resetBreadcrumbs() );
-				dispatch(
-					appendBreadcrumb( {
-						label: translate( 'Plugins' ),
-						href: localizePath( `/plugins/${ selectedSite?.slug || '' }` ),
-						id: 'plugins',
-						helpBubble: translate(
-							'Add new functionality and integrations to your site with plugins. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
-							{
-								components: {
-									learnMoreLink: <InlineSupportLink supportContext="plugins" showIcon={ false } />,
-								},
-							}
-						),
-					} )
-				);
-			}
+	const setBreadcrumbs = ( breadcrumbs = [] ) => {
+		if ( breadcrumbs?.length === 0 || ( ! category && ! search ) ) {
+			dispatch( resetBreadcrumbs() );
+			dispatch(
+				appendBreadcrumb( {
+					label: __( 'Plugins' ),
+					href: localizePath( `/plugins/${ selectedSite?.slug || '' }` ),
+					id: 'plugins',
+					helpBubble: translate(
+						'Add new functionality and integrations to your site with plugins. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+						{
+							components: {
+								learnMoreLink: <InlineSupportLink supportContext="plugins" showIcon={ false } />,
+							},
+						}
+					),
+				} )
+			);
+		}
 
-			if ( category ) {
-				dispatch(
-					appendBreadcrumb( {
-						label: categoryName,
-						href: localizePath( `/plugins/browse/${ category }/${ selectedSite?.slug || '' }` ),
-						id: 'category',
-					} )
-				);
-			}
+		if ( category ) {
+			dispatch(
+				appendBreadcrumb( {
+					label: categoryName,
+					href: localizePath( `/plugins/browse/${ category }/${ selectedSite?.slug || '' }` ),
+					id: 'category',
+				} )
+			);
+		}
 
-			if ( search ) {
-				dispatch(
-					appendBreadcrumb( {
-						label: translate( 'Search Results' ),
-						href: localizePath( `/plugins/${ selectedSite?.slug || '' }?s=${ search }` ),
-						id: 'plugins-search',
-					} )
-				);
-			}
-		},
-		[ selectedSite?.slug, search, category, categoryName, dispatch, translate, localizePath ]
-	);
-	useServerEffect( setBreadcrumbs );
+		if ( search ) {
+			dispatch(
+				appendBreadcrumb( {
+					label: translate( 'Search Results' ),
+					href: localizePath( `/plugins/${ selectedSite?.slug || '' }?s=${ search }` ),
+					id: 'plugins-search',
+				} )
+			);
+		}
+	};
 
-	// We need to get the breadcrumbs here, after initial append dispatches on server.
+	const previousRoute = useSelector( getPreviousRoute );
+	useEffect( () => {
+		/* If translatations change, reset and update the breadcrumbs */
+		if ( ! previousRoute ) {
+			setBreadcrumbs();
+		}
+	}, [ translate ] );
+
+	useServerEffect( () => {
+		setBreadcrumbs();
+	} );
+
+	/* We need to get the breadcrumbs after the server has set them */
 	const breadcrumbs = useSelector( getBreadcrumbs );
 
 	useEffect( () => {
-		setBreadcrumbs( ( breadcrumbs || [] ).length !== 0 );
-	}, [ setBreadcrumbs, breadcrumbs ] );
+		setBreadcrumbs( breadcrumbs );
+	}, [ selectedSite?.slug, search, category, categoryName, dispatch, localizePath ] );
 
 	return (
 		<FixedNavigationHeader

--- a/client/my-sites/plugins/plugins-navigation-header/index.jsx
+++ b/client/my-sites/plugins/plugins-navigation-header/index.jsx
@@ -5,7 +5,6 @@ import {
 } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
 import { useBreakpoint } from '@automattic/viewport-react';
-import { __ } from '@wordpress/i18n';
 import { Icon, upload } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useMemo } from 'react';
@@ -120,7 +119,7 @@ const PluginsNavigationHeader = ( { navigationHeaderRef, categoryName, category,
 			dispatch( resetBreadcrumbs() );
 			dispatch(
 				appendBreadcrumb( {
-					label: __( 'Plugins' ),
+					label: translate( 'Plugins' ),
 					href: localizePath( `/plugins/${ selectedSite?.slug || '' }` ),
 					id: 'plugins',
 					helpBubble: translate(


### PR DESCRIPTION
#### Proposed Changes

The breadcrumbs only get updated on the component mount, which never gets run on the server.
This uses a server-tailored hook (useServerEffect) to ensure this code gets to run on the server and shows on logged-out SSR plugin pages. This approach was taken from #66344 (reverted in #67573).

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Log out and disable JavaScript
* Go to the following pages:
  * `/plugins`
  * `/plugins/browse/seo`
  * `/plugins/wordpress-seo-premium`
  * `/plugins/elementor`
* Make sure the pages rendered and the breadcrumb section is shown
* NOTE: The server doesn't know if the screen is mobile or desktop: therefore the mobile (ex. `< Back`) version will be rendered by default.
<img width="320" alt="Screen Shot on 2022-11-04 at 11-05-38" src="https://user-images.githubusercontent.com/2749938/199935279-99c8c57d-bac0-47d3-bffa-7d7310ccf3aa.png">
<img width="320" alt="Screen Shot on 2022-11-04 at 11-05-47" src="https://user-images.githubusercontent.com/2749938/199935275-73f18141-59ae-4ea3-ae75-798d1f7deb8c.png">
<img width="320" alt="Screen Shot on 2022-11-04 at 11-05-58" src="https://user-images.githubusercontent.com/2749938/199935272-e990dbaf-01f6-4819-8474-e27fc1e72a52.png">
<img width="320" alt="Screen Shot on 2022-11-04 at 11-06-17" src="https://user-images.githubusercontent.com/2749938/199935268-96c0c328-41f3-4389-b8f9-7f39fdad9ab9.png">

* Make sure that breadcrumbs get translated
* Log in, enable JS and double-check for regressions in the Plugins section


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
