### PR TITLE
Licensing Portal: create new component for bundles (Security and Complete) V2

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/issue-multiple-licenses-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-multiple-licenses-form/index.tsx
@@ -13,7 +13,6 @@ import {
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import useProductsQuery from 'calypso/state/partner-portal/licenses/hooks/use-products-query';
 import type { IssueMultipleLicensesFormProps } from './types';
-import type { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
 
 import './style.scss';
 
@@ -36,7 +35,7 @@ export default function IssueMultipleLicensesForm( {
 	const [ issueLicense, isLoading ] = useLicenseIssuing( product, selectedSite );
 
 	const onSelectProduct = useCallback(
-		( product: APIProductFamilyProduct ) => {
+		( product ) => {
 			dispatch(
 				recordTracksEvent( 'calypso_partner_portal_issue_license_product_select', {
 					product: product.slug,

--- a/client/jetpack-cloud/sections/partner-portal/issue-multiple-licenses-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-multiple-licenses-form/index.tsx
@@ -4,6 +4,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useCallback, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { useLicenseIssuing } from 'calypso/jetpack-cloud/sections/partner-portal/hooks';
+import LicenseBundleCard from 'calypso/jetpack-cloud/sections/partner-portal/license-bundle-card';
 import LicenseProductCard from 'calypso/jetpack-cloud/sections/partner-portal/license-product-card';
 import { selectAlphaticallySortedProductOptions } from 'calypso/jetpack-cloud/sections/partner-portal/utils';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -97,7 +98,7 @@ export default function IssueMultipleLicensesForm( {
 					<div className="issue-multiple-licenses-form__bottom">
 						{ bundles &&
 							bundles.map( ( productOption, i ) => (
-								<LicenseProductCard
+								<LicenseBundleCard
 									key={ productOption.slug }
 									product={ productOption }
 									onSelectProduct={ onSelectProduct }

--- a/client/jetpack-cloud/sections/partner-portal/issue-multiple-licenses-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-multiple-licenses-form/index.tsx
@@ -1,15 +1,19 @@
 import { Button } from '@automattic/components';
 import { getQueryArg } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { useLicenseIssuing } from 'calypso/jetpack-cloud/sections/partner-portal/hooks';
 import LicenseBundleCard from 'calypso/jetpack-cloud/sections/partner-portal/license-bundle-card';
 import LicenseProductCard from 'calypso/jetpack-cloud/sections/partner-portal/license-product-card';
-import { selectAlphaticallySortedProductOptions } from 'calypso/jetpack-cloud/sections/partner-portal/utils';
+import {
+	isJetpackBundle,
+	selectAlphaticallySortedProductOptions,
+} from 'calypso/jetpack-cloud/sections/partner-portal/utils';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import useProductsQuery from 'calypso/state/partner-portal/licenses/hooks/use-products-query';
 import type { IssueMultipleLicensesFormProps } from './types';
+import type { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
 
 import './style.scss';
 
@@ -32,16 +36,24 @@ export default function IssueMultipleLicensesForm( {
 	const [ issueLicense, isLoading ] = useLicenseIssuing( product, selectedSite );
 
 	const onSelectProduct = useCallback(
-		( value ) => {
+		( product: APIProductFamilyProduct ) => {
 			dispatch(
 				recordTracksEvent( 'calypso_partner_portal_issue_license_product_select', {
-					product: value,
+					product: product.slug,
 				} )
 			);
-			setProduct( value );
+			setProduct( product.slug );
 		},
-		[ setProduct ]
+		[ dispatch, setProduct ]
 	);
+
+	useEffect( () => {
+		// In the case of a bundle, we want to take the user immediately to the next step since
+		// they can't select any additional item after selecting a bundle.
+		if ( isJetpackBundle( product ) ) {
+			issueLicense();
+		}
+	}, [ issueLicense, product ] );
 
 	const selectedSiteDomain = selectedSite?.domain;
 
@@ -102,7 +114,6 @@ export default function IssueMultipleLicensesForm( {
 									key={ productOption.slug }
 									product={ productOption }
 									onSelectProduct={ onSelectProduct }
-									isSelected={ productOption.slug === product }
 									tabIndex={ 100 + ( products?.length || 0 ) + i }
 								/>
 							) ) }

--- a/client/jetpack-cloud/sections/partner-portal/license-bundle-card-description/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-bundle-card-description/index.tsx
@@ -1,6 +1,6 @@
 import { useTranslate } from 'i18n-calypso';
 import GreenCheckmark from 'calypso/assets/images/jetpack/jetpack-green-checkmark.svg';
-import type { APIProductFamilyProduct } from '../../../../state/partner-portal/types';
+import type { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
 
 import './style.scss';
 

--- a/client/jetpack-cloud/sections/partner-portal/license-bundle-card-description/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-bundle-card-description/index.tsx
@@ -1,0 +1,66 @@
+import { ExternalLink } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import GreenCheckmark from 'calypso/assets/images/jetpack/jetpack-green-checkmark.svg';
+import type { APIProductFamilyProduct } from '../../../../state/partner-portal/types';
+
+import './style.scss';
+
+interface Props {
+	product: APIProductFamilyProduct;
+}
+
+export default function LicenseBundleCardDescription( { product }: Props ) {
+	const translate = useTranslate();
+
+	let textDescription = '';
+	const features = [];
+
+	switch ( product.slug ) {
+		case 'jetpack-complete':
+			textDescription = translate( 'Includes all Security 1TB and full Jetpack package.' );
+			features.push(
+				translate( 'All Security products' ),
+				translate( '1TB cloud storage' ),
+				translate( 'Full Jetpack package' )
+			);
+			break;
+		case 'jetpack-security-t1':
+			textDescription = translate( 'Includes Backup 10GB, Scan Daily and Anti-spam.' );
+			features.push(
+				translate( 'Backup 10GB' ),
+				translate( 'Scan Daily' ),
+				translate( 'Anti-spam*' )
+			);
+			break;
+		case 'jetpack-security-t2':
+			textDescription = translate( 'Includes Backup 1TB, Scan Daily and Anti-spam.' );
+			features.push(
+				translate( 'Backup 1TB' ),
+				translate( 'Scan Daily' ),
+				translate( 'Anti-spam*' )
+			);
+			break;
+	}
+
+	return (
+		<div className="license-bundle-card-description">
+			<p className="license-bundle-card-description__text">
+				{ textDescription }
+				<ExternalLink
+					className="license-bundle-card-description__learn-more"
+					href="https://jetpack.com"
+				>
+					{ translate( 'Learn more' ) }
+				</ExternalLink>
+			</p>
+			<ul className="license-bundle-card-description__list">
+				{ features.map( ( feature ) => (
+					<li key={ feature }>
+						<img src={ GreenCheckmark } alt={ translate( 'included' ) } />
+						{ feature }
+					</li>
+				) ) }
+			</ul>
+		</div>
+	);
+}

--- a/client/jetpack-cloud/sections/partner-portal/license-bundle-card-description/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-bundle-card-description/index.tsx
@@ -1,4 +1,3 @@
-import { ExternalLink } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import GreenCheckmark from 'calypso/assets/images/jetpack/jetpack-green-checkmark.svg';
 import type { APIProductFamilyProduct } from '../../../../state/partner-portal/types';
@@ -44,15 +43,7 @@ export default function LicenseBundleCardDescription( { product }: Props ) {
 
 	return (
 		<div className="license-bundle-card-description">
-			<p className="license-bundle-card-description__text">
-				{ textDescription }
-				<ExternalLink
-					className="license-bundle-card-description__learn-more"
-					href="https://jetpack.com"
-				>
-					{ translate( 'Learn more' ) }
-				</ExternalLink>
-			</p>
+			<p className="license-bundle-card-description__text">{ textDescription }</p>
 			<ul className="license-bundle-card-description__list">
 				{ features.map( ( feature ) => (
 					<li key={ feature }>

--- a/client/jetpack-cloud/sections/partner-portal/license-bundle-card-description/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/license-bundle-card-description/style.scss
@@ -1,0 +1,47 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
+.license-bundle-card-description {
+	margin-top: 0.5rem;
+}
+
+.license-bundle-card-description__text {
+	display: none;
+
+	margin: 0;
+
+	@include break-xlarge {
+		display: block;
+	}
+}
+
+.license-bundle-card-description__learn-more,
+a.license-bundle-card-description__learn-more,
+a.license-bundle-card-description__learn-more:visited {
+	margin-left: 0.25rem;
+
+	color: var(--studio-gray-60);
+	text-decoration: underline;
+}
+
+.license-bundle-card-description__list {
+	display: block;
+
+	margin: 0.5rem 0 0;
+
+	list-style: none;
+
+	@include break-xlarge {
+		display: none;
+	}
+}
+
+.license-bundle-card-description__list li {
+	display: flex;
+
+	margin-top: 0.5rem;
+}
+
+.license-bundle-card-description__list li img {
+	margin-right: 0.75rem;
+}

--- a/client/jetpack-cloud/sections/partner-portal/license-bundle-card-description/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/license-bundle-card-description/style.scss
@@ -15,15 +15,6 @@
 	}
 }
 
-.license-bundle-card-description__learn-more,
-a.license-bundle-card-description__learn-more,
-a.license-bundle-card-description__learn-more:visited {
-	margin-left: 0.25rem;
-
-	color: var(--studio-gray-60);
-	text-decoration: underline;
-}
-
 .license-bundle-card-description__list {
 	display: block;
 

--- a/client/jetpack-cloud/sections/partner-portal/license-bundle-card/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-bundle-card/index.tsx
@@ -1,7 +1,6 @@
 import { Button } from '@automattic/components';
 import formatCurrency from '@automattic/format-currency';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback } from 'react';
 import LicenseBundleCardDescription from 'calypso/jetpack-cloud/sections/partner-portal/license-bundle-card-description';
 import { APIProductFamilyProduct } from '../../../../state/partner-portal/types';
 import { getProductTitle } from '../utils';
@@ -11,7 +10,7 @@ import './style.scss';
 interface Props {
 	tabIndex: number;
 	product: APIProductFamilyProduct;
-	onSelectProduct: ( value: string ) => void | null;
+	onSelectProduct: ( value: APIProductFamilyProduct ) => void | null;
 }
 
 export default function LicenseBundleCard( props: Props ) {
@@ -19,9 +18,9 @@ export default function LicenseBundleCard( props: Props ) {
 	const productTitle = getProductTitle( product.name );
 	const translate = useTranslate();
 
-	const onSelect = useCallback( () => {
-		onSelectProduct?.( product.slug );
-	}, [ onSelectProduct, product.slug ] );
+	const onSelect = () => {
+		onSelectProduct( product );
+	};
 
 	return (
 		<div className="license-bundle-card">

--- a/client/jetpack-cloud/sections/partner-portal/license-bundle-card/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-bundle-card/index.tsx
@@ -1,0 +1,55 @@
+import { Button } from '@automattic/components';
+import formatCurrency from '@automattic/format-currency';
+import { useTranslate } from 'i18n-calypso';
+import { useCallback } from 'react';
+import LicenseBundleCardDescription from 'calypso/jetpack-cloud/sections/partner-portal/license-bundle-card-description';
+import { APIProductFamilyProduct } from '../../../../state/partner-portal/types';
+import { getProductTitle } from '../utils';
+
+import './style.scss';
+
+interface Props {
+	tabIndex: number;
+	product: APIProductFamilyProduct;
+	onSelectProduct: ( value: string ) => void | null;
+}
+
+export default function LicenseBundleCard( props: Props ) {
+	const { tabIndex, product, onSelectProduct } = props;
+	const productTitle = getProductTitle( product.name );
+	const translate = useTranslate();
+
+	const onSelect = useCallback( () => {
+		onSelectProduct?.( product.slug );
+	}, [ onSelectProduct, product.slug ] );
+
+	return (
+		<div className="license-bundle-card">
+			<div className="license-bundle-card__details">
+				<h3 className="license-bundle-card__title">{ productTitle }</h3>
+				<LicenseBundleCardDescription product={ product } />
+				<div className="license-bundle-card__pricing">
+					<div className="license-bundle-card__price">
+						{ formatCurrency( product.amount, product.currency ) }
+					</div>
+					<div className="license-bundle-card__price-interval">
+						{ product.price_interval === 'day' && translate( '/USD per license per day' ) }
+						{ product.price_interval === 'month' && translate( '/USD per license per month' ) }
+					</div>
+				</div>
+			</div>
+			<Button
+				primary
+				className="license-bundle-card__select-license"
+				onClick={ onSelect }
+				tabIndex={ tabIndex }
+			>
+				{ translate( 'Select' ) }
+			</Button>
+		</div>
+	);
+}
+
+LicenseBundleCard.defaultProps = {
+	onSelectProduct: null,
+};

--- a/client/jetpack-cloud/sections/partner-portal/license-bundle-card/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/license-bundle-card/style.scss
@@ -1,0 +1,116 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
+.license-bundle-card {
+	box-sizing: border-box;
+
+	display: flex;
+	justify-content: space-between;
+	align-items: flex-end;
+
+	width: 100%;
+
+	margin: 0.5rem 0;
+	padding: 1.5rem;
+
+	border: 1px solid var(--studio-gray-10);
+	border-radius: 4px;
+
+	cursor: pointer;
+	user-select: none;
+
+	@include break-xlarge {
+		display: block;
+
+		width: calc(50% - 1rem);
+
+		margin: 0.5rem;
+		padding: 1.75rem;
+	}
+
+	@include break-wide {
+		width: calc(33.33% - 1rem);
+	}
+}
+
+.license-bundle-card__details {
+	display: flex;
+	flex-direction: column;
+
+	@include break-xlarge {
+		flex-direction: row;
+		flex-wrap: wrap;
+		justify-content: stretch;
+		align-items: center;
+	}
+}
+
+.license-bundle-card__title {
+	flex: 1 0 auto;
+	white-space: nowrap;
+	font-size: 1.5rem;
+	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
+	line-height: 1.5rem;
+	color: var(--studio-gray-80);
+}
+
+@mixin license-bundle-card-block__pricing {
+	flex-basis: 100%;
+	margin: 1rem 0 0;
+	text-align: left;
+}
+
+@mixin license-bundle-card-line__pricing {
+	flex-basis: auto;
+}
+
+.license-bundle-card__pricing {
+	white-space: nowrap;
+	@include license-bundle-card-block__pricing;
+
+	@include break-mobile {
+		@include license-bundle-card-line__pricing;
+	}
+
+	@include breakpoint-deprecated( ">660px" ) {
+		@include license-bundle-card-block__pricing;
+	}
+
+	@include break-medium {
+		@include license-bundle-card-line__pricing;
+	}
+
+	@include break-xlarge {
+		@include license-bundle-card-block__pricing;
+	}
+}
+
+.license-bundle-card__price {
+	margin-bottom: 0.25rem;
+	font-size: 1.25rem;
+	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
+	line-height: 1.5rem;
+	font-weight: 600;
+	color: var(--studio-gray-80);
+
+	@include break-xlarge {
+		font-size: 1.5rem;
+		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
+		line-height: 1.75rem;
+		font-weight: 700;
+		color: var(--studio-black);
+	}
+}
+
+.license-bundle-card__price-interval {
+	font-size: 0.75rem;
+	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
+	line-height: 0.875rem;
+	font-weight: 400;
+	color: var(--studio-gray-60);
+}
+
+.license-bundle-card__select-license {
+	font-size: 1rem;
+	margin-top: 1rem;
+}

--- a/client/jetpack-cloud/sections/partner-portal/license-bundle-card/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/license-bundle-card/style.scss
@@ -16,7 +16,6 @@
 	border: 1px solid var(--studio-gray-10);
 	border-radius: 4px;
 
-	cursor: pointer;
 	user-select: none;
 
 	@include break-xlarge {

--- a/client/jetpack-cloud/sections/partner-portal/license-product-card/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-product-card/index.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { Gridicon } from '@automattic/components';
 import formatCurrency from '@automattic/format-currency';
 import classNames from 'classnames';
@@ -11,7 +12,7 @@ interface Props {
 	tabIndex: number;
 	product: APIProductFamilyProduct;
 	isSelected: boolean;
-	onSelectProduct: ( value: APIProductFamilyProduct ) => void | null;
+	onSelectProduct: ( value: APIProductFamilyProduct | string ) => void | null;
 	suggestedProduct?: string | null;
 }
 
@@ -21,8 +22,12 @@ export default function LicenseProductCard( props: Props ) {
 	const translate = useTranslate();
 
 	const onSelect = useCallback( () => {
-		onSelectProduct?.( product );
-	}, [ onSelectProduct ] );
+		if ( isEnabled( 'jetpack/partner-portal-issue-multiple-licenses' ) ) {
+			onSelectProduct?.( product );
+		} else {
+			onSelectProduct?.( product.slug );
+		}
+	}, [ onSelectProduct, product ] );
 
 	const onKeyDown = useCallback(
 		( e: any ) => {

--- a/client/jetpack-cloud/sections/partner-portal/license-product-card/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-product-card/index.tsx
@@ -11,7 +11,7 @@ interface Props {
 	tabIndex: number;
 	product: APIProductFamilyProduct;
 	isSelected: boolean;
-	onSelectProduct: ( value: string ) => void | null;
+	onSelectProduct: ( value: APIProductFamilyProduct ) => void | null;
 	suggestedProduct?: string | null;
 }
 
@@ -21,7 +21,7 @@ export default function LicenseProductCard( props: Props ) {
 	const translate = useTranslate();
 
 	const onSelect = useCallback( () => {
-		onSelectProduct?.( product.slug );
+		onSelectProduct?.( product );
 	}, [ onSelectProduct ] );
 
 	const onKeyDown = useCallback(

--- a/client/jetpack-cloud/sections/partner-portal/utils.ts
+++ b/client/jetpack-cloud/sections/partner-portal/utils.ts
@@ -192,3 +192,10 @@ export function selectAlphaticallySortedProductOptions(
 ): APIProductFamilyProduct[] {
 	return sortBy( selectProductOptions( families ), ( product ) => product.name );
 }
+
+export function isJetpackBundle( product: APIProductFamilyProduct | string ) {
+	if ( typeof product === 'string' ) {
+		return [ 'jetpack-complete', 'jetpack-security-t1', 'jetpack-security-t2' ].includes( product );
+	}
+	return product.family_slug === 'jetpack-packs';
+}

--- a/client/jetpack-cloud/sections/partner-portal/utils.ts
+++ b/client/jetpack-cloud/sections/partner-portal/utils.ts
@@ -193,9 +193,11 @@ export function selectAlphaticallySortedProductOptions(
 	return sortBy( selectProductOptions( families ), ( product ) => product.name );
 }
 
+export const JETPACK_BUNDLES = [ 'jetpack-complete', 'jetpack-security-t1', 'jetpack-security-t2' ];
+
 export function isJetpackBundle( product: APIProductFamilyProduct | string ) {
 	if ( typeof product === 'string' ) {
-		return [ 'jetpack-complete', 'jetpack-security-t1', 'jetpack-security-t2' ].includes( product );
+		return JETPACK_BUNDLES.includes( product );
 	}
 	return product.family_slug === 'jetpack-packs';
 }


### PR DESCRIPTION
#### Proposed Changes

**Context**: this is an improved version of https://github.com/Automattic/wp-calypso/pull/69720, which introduced a bug that prevents users from selecting a product.

* Create a new React component for bundles. The main difference between this component and the product one lies in that the newer one mentions the features included in the bundle.

**Note**: the PR does not include the following:
- Updates to product cards.
- The label with the discount since [getting this data is not straightforward](p1667416219504959-slack-C039K7CD119).
- The summary/total of the products about to be purchased.

#### Demo – desktop

<img width="1042" alt="image" src="https://user-images.githubusercontent.com/3418513/199772738-06c606b7-f3d9-4414-afc3-e0914078b8f2.png">

#### Demo – mobile

<img width="447" alt="image" src="https://user-images.githubusercontent.com/3418513/199772847-29e5dbdf-35cb-4cea-88bd-3b3caac62f91.png">


#### Testing Instructions

* Check out this branch locally.
* Start Calypso with `yarn start-jetpack-cloud`.
* Visit `http://jetpack.cloud.localhost:3000/partner-portal/issue-license`.
* Verify that products and bundles are separated as shown in the screenshot.
* Verify that bundles include a short description of their features (check this on mobile and desktop).
* Verify that you can issue and assign a bundle license to a site.
* Visit the Jetpack Cloud live link (horizon environment) in this PR and verify this PR isn't causing any regression.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1203126240279377-as-1203126240279418