### PR TITLE
Plugin Details: Add a track event for the "Get started" button

### DIFF
--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -17,6 +17,7 @@ import { ManageSitePluginsDialog } from 'calypso/my-sites/plugins/manage-site-pl
 import PluginAutoupdateToggle from 'calypso/my-sites/plugins/plugin-autoupdate-toggle';
 import { isCompatiblePlugin } from 'calypso/my-sites/plugins/plugin-compatibility';
 import { siteObjectsToSiteIds } from 'calypso/my-sites/plugins/utils';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getEligibility } from 'calypso/state/automated-transfer/selectors';
 import { isUserLoggedIn, getCurrentUserId } from 'calypso/state/current-user/selectors';
 import { setBillingInterval } from 'calypso/state/marketplace/billing-interval/actions';
@@ -371,13 +372,24 @@ function PrimaryButton( {
 	plugin,
 	saasRedirectHRef,
 } ) {
+	const dispatch = useDispatch();
+	const onClick = useCallback( () => {
+		dispatch(
+			recordTracksEvent( 'calypso_plugin_details_get_started_click', {
+				plugin: plugin?.slug,
+				is_logged_in: isLoggedIn,
+				is_saas_product: plugin?.isSaasProduct,
+			} )
+		);
+	}, [ dispatch ] );
+
 	if ( ! isLoggedIn ) {
 		return (
 			<Button
 				type="a"
 				className="plugin-details-cta__install-button"
 				primary
-				onClick={ ( e ) => e.stopPropagation() }
+				onClick={ onClick }
 				href={ localizeUrl( 'https://wordpress.com/start/business' ) }
 			>
 				{ translate( 'Get started' ) }
@@ -390,6 +402,7 @@ function PrimaryButton( {
 				className="plugin-details-cta__install-button"
 				primary={ ! shouldUpgrade }
 				href={ saasRedirectHRef }
+				onClick={ onClick }
 			>
 				{ translate( 'Get started' ) }
 				<Gridicon icon="external" />


### PR DESCRIPTION
#### Proposed Changes

Plugin Details: Add a track event for the "Get started" button

#### Testing Instructions
* Use a incognito window to get a logged-out session
* On the browser console terminal enter `localStorage.setItem( 'debug', 'calypso:analytics*' )`
* Go to a plugin details page. Ex: `/plugins/woocommerce`
* Click on the `Get started` CTA
* After ~10min, check if you can find the event `calypso_plugin_details_get_started_click` logged on Track

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #69410
