### PR TITLE
Move `goToNextStep()` from `componentDidUpdate()` to `shouldComponentUpdate()` to prevent one extra render of the signup form.

### DIFF
--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -104,12 +104,19 @@ export class UserStep extends Component {
 		recaptchaClientId: null,
 	};
 
-	componentDidUpdate() {
-		if ( this.props.step?.status === 'completed' ) {
+	shouldComponentUpdate( nextProps ) {
+		// This used to be done in componentDidUpdate. However, when the user step is the last we'd actually introduce one extra frame of SignupForm with a notice
+		// saying "Your account has already been created", by the code at line 903 of blocks/signup-form/index.jsx at the momemt of writing this.
+		// It had gone unnoticed since the processing screen would hide it.
+		// Now the link-in-bio-tld case introduce a chance that there is no processing screen, revealing the bug.
+		if ( nextProps.step?.status === 'completed' ) {
 			this.props.goToNextStep();
-			return;
+			return false;
 		}
+		return true;
+	}
 
+	componentDidUpdate() {
 		if ( this.userCreationCompletedAndHasHistory( this.props ) ) {
 			// It looks like the user just completed the User Registartion Step
 			// And clicked the back button. Lets redirect them to the this page but this time they will be logged in.


### PR DESCRIPTION
#### Proposed Changes

This PR moves `goToNextStep()` from `componentDidUpdate()` to `shouldComponentUpdate()` to prevent one extra render of the signup form.

It's a tricky edge case that has been hidden by the processing screen for years, so this PR also adds a long-form explanation:


> This used to be done in componentDidUpdate. However, when the user step is the last we'd actually introduce one extra  frame of SignupForm with a notice saying "Your account has already been created", by the code at line 903 of  blocks/signup-form/index.jsx at the momemt of writing this.
> It had gone unnoticed since the processing screen would hide it.
> Now the link-in-bio-tld case introduce a chance that there is no processing screen, revealing the bug.

The following screencast were captured by hiding the processing screen.

Before:
https://user-images.githubusercontent.com/1842898/200034265-af50e89a-636d-435b-b019-6d8631eca794.mov

After:
https://user-images.githubusercontent.com/1842898/200034240-0f775769-16d1-4ab1-bf14-632a51b4e3f7.mov

#### Testing Instructions

1. We need to hide the processing screen to reveal the bug. The fastest way is to update the const [startLoadingScreen](https://github.com/Automattic/wp-calypso/blob/trunk/client/signup/main.jsx#L364) as `const startLoadingScreen = false;`
2. Go through `/setup/intro?flow=link-in-bio` flow and make sure you don't see the flashy frame after the user step like the screencast above.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
