### PR TITLE
Implement the tld-given variation of Link in Bio flow

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -127,6 +127,7 @@ class RegisterDomainStep extends Component {
 		showAlreadyOwnADomain: PropTypes.bool,
 		domainAndPlanUpsellFlow: PropTypes.bool,
 		useProvidedProductsList: PropTypes.bool,
+		managedSubdomains: PropTypes.string,
 	};
 
 	static defaultProps = {
@@ -1066,6 +1067,7 @@ class RegisterDomainStep extends Component {
 			only_wordpressdotcom: this.props.includeDotBlogSubdomain,
 			tld_weight_overrides: null,
 			vendor: 'dot',
+			managed_subdomains: this.props.managedSubdomains,
 			...this.getActiveFiltersForAPI(),
 		};
 

--- a/client/landing/stepper/declarative-flow/link-in-bio.ts
+++ b/client/landing/stepper/declarative-flow/link-in-bio.ts
@@ -5,6 +5,7 @@ import { useEffect } from 'react';
 import { recordFullStoryEvent } from 'calypso/lib/analytics/fullstory';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import wpcom from 'calypso/lib/wp';
+import { useQuery } from '../hooks/use-query';
 import { useSiteSlug } from '../hooks/use-site-slug';
 import { USER_STORE, ONBOARD_STORE } from '../stores';
 import { recordSubmitStep } from './internals/analytics/record-submit-step';
@@ -23,14 +24,11 @@ export const linkInBio: Flow = {
 		return [ 'intro', 'linkInBioSetup', 'patterns', 'processing', 'launchpad' ] as StepPath[];
 	},
 
-	useStepNavigation( _currentStep, navigate ) {
+	useSubmit( _currentStep, navigate ) {
 		const flowName = this.name;
-		const { setStepProgress } = useDispatch( ONBOARD_STORE );
-		const flowProgress = useFlowProgress( { stepName: _currentStep, flowName } );
-		setStepProgress( flowProgress );
-		const siteSlug = useSiteSlug();
 		const userIsLoggedIn = useSelect( ( select ) => select( USER_STORE ).isCurrentUserLoggedIn() );
 		const locale = useLocale();
+		const queryParams = useQuery();
 
 		// trigger guides on step movement, we don't care about failures or response
 		wpcom.req.post(
@@ -44,15 +42,17 @@ export const linkInBio: Flow = {
 			}
 		);
 
-		const getStartUrl = () => {
-			return locale && locale !== 'en'
-				? `/start/account/user/${ locale }?variationName=${ flowName }&pageTitle=Link%20in%20Bio&redirect_to=/setup/${ flowName }/patterns`
-				: `/start/account/user?variationName=${ flowName }&pageTitle=Link%20in%20Bio&redirect_to=/setup/${ flowName }/patterns`;
-		};
+		const tld = queryParams.get( 'tld' );
+		const newDomainSearch = queryParams.get( 'new' ); // be consistent with how the Domain step works
 
+		// for the standard Link in Bio flow
 		function submit( providedDependencies: ProvidedDependencies = {} ) {
+			const logInUrl =
+				locale && locale !== 'en'
+					? `/start/account/user/${ locale }?variationName=${ flowName }&pageTitle=Link%20in%20Bio&redirect_to=/setup/patterns?flow=${ flowName }`
+					: `/start/account/user?variationName=${ flowName }&pageTitle=Link%20in%20Bio&redirect_to=/setup/patterns?flow=${ flowName }`;
+
 			recordSubmitStep( providedDependencies, '', flowName, _currentStep );
-			const logInUrl = getStartUrl();
 
 			switch ( _currentStep ) {
 				case 'intro':
@@ -78,24 +78,84 @@ export const linkInBio: Flow = {
 			return providedDependencies;
 		}
 
+		// when there is a designated tld, the domain step will come first, hence altering the flow accordingly
+		function submitDomainFirst( providedDependencies: ProvidedDependencies = {} ) {
+			const logInUrl =
+				locale && locale !== 'en'
+					? `/start/link-in-bio-tld/${ locale }?variationName=${ flowName }&pageTitle=Link%20in%20Bio&tld=${ tld }&new=${ newDomainSearch }`
+					: `/start/link-in-bio-tld?variationName=${ flowName }&pageTitle=Link%20in%20Bio&tld=${ tld }&new=${ newDomainSearch }`;
+
+			recordSubmitStep( providedDependencies, '', flowName, _currentStep );
+
+			switch ( _currentStep ) {
+				case 'intro':
+					if ( userIsLoggedIn ) {
+						return window.location.assign(
+							`/start/link-in-bio-tld/domains?new=${ encodeURIComponent(
+								providedDependencies.siteTitle as string
+							) }&search=yes&hide_initial_query=yes`
+						);
+					}
+					return window.location.assign( logInUrl );
+
+				case 'patterns':
+					return navigate( 'linkInBioSetup' );
+
+				case 'linkInBioSetup':
+					return window.location.assign(
+						`/start/link-in-bio-tld/plans-link-in-bio?variationName=${ flowName }&pageTitle=Link%20in%20Bio&tld=${ tld }&new=${ newDomainSearch }`
+					);
+
+				case 'launchpad': {
+					return navigate( 'processing' );
+				}
+			}
+			return providedDependencies;
+		}
+
+		if ( tld ) {
+			return submitDomainFirst;
+		}
+
+		return submit;
+	},
+
+	useStepNavigation( _currentStep, navigate ) {
+		const flowName = this.name;
+		const { setStepProgress } = useDispatch( ONBOARD_STORE );
+		const flowProgress = useFlowProgress( { stepName: _currentStep, flowName } );
+		const siteSlug = useSiteSlug();
+
+		setStepProgress( flowProgress );
+
+		// trigger guides on step movement, we don't care about failures or response
+		wpcom.req.post(
+			'guides/trigger',
+			{
+				apiNamespace: 'wpcom/v2/',
+			},
+			{
+				flow: flowName,
+				step: _currentStep,
+			}
+		);
+
+		const submit = this.useSubmit( _currentStep, navigate );
+
 		const goBack = () => {
 			return;
 		};
-
 		const goNext = () => {
 			switch ( _currentStep ) {
 				case 'launchpad':
 					return window.location.assign( `/view/${ siteSlug }` );
-
 				default:
 					return navigate( 'intro' );
 			}
 		};
-
 		const goToStep = ( step: StepPath | `${ StepPath }?${ string }` ) => {
 			navigate( step );
 		};
-
 		return { goNext, goBack, goToStep, submit };
 	},
 };

--- a/client/landing/stepper/declarative-flow/link-in-bio.ts
+++ b/client/landing/stepper/declarative-flow/link-in-bio.ts
@@ -30,27 +30,14 @@ export const linkInBio: Flow = {
 		const locale = useLocale();
 		const queryParams = useQuery();
 
-		// trigger guides on step movement, we don't care about failures or response
-		wpcom.req.post(
-			'guides/trigger',
-			{
-				apiNamespace: 'wpcom/v2/',
-			},
-			{
-				flow: flowName,
-				step: _currentStep,
-			}
-		);
-
 		const tld = queryParams.get( 'tld' );
-		const newDomainSearch = queryParams.get( 'new' ); // be consistent with how the Domain step works
 
 		// for the standard Link in Bio flow
 		function submit( providedDependencies: ProvidedDependencies = {} ) {
 			const logInUrl =
 				locale && locale !== 'en'
-					? `/start/account/user/${ locale }?variationName=${ flowName }&pageTitle=Link%20in%20Bio&redirect_to=/setup/patterns?flow=${ flowName }`
-					: `/start/account/user?variationName=${ flowName }&pageTitle=Link%20in%20Bio&redirect_to=/setup/patterns?flow=${ flowName }`;
+					? `/start/account/user/${ locale }?variationName=${ flowName }&pageTitle=Link%20in%20Bio&redirect_to=/setup/${ flowName }/patterns`
+					: `/start/account/user?variationName=${ flowName }&pageTitle=Link%20in%20Bio&redirect_to=/setup/${ flowName }/patterns`;
 
 			recordSubmitStep( providedDependencies, '', flowName, _currentStep );
 
@@ -82,8 +69,8 @@ export const linkInBio: Flow = {
 		function submitDomainFirst( providedDependencies: ProvidedDependencies = {} ) {
 			const logInUrl =
 				locale && locale !== 'en'
-					? `/start/link-in-bio-tld/${ locale }?variationName=${ flowName }&pageTitle=Link%20in%20Bio&tld=${ tld }&new=${ newDomainSearch }`
-					: `/start/link-in-bio-tld?variationName=${ flowName }&pageTitle=Link%20in%20Bio&tld=${ tld }&new=${ newDomainSearch }`;
+					? `/start/link-in-bio-tld/${ locale }?variationName=${ flowName }&pageTitle=Link%20in%20Bio&tld=${ tld }`
+					: `/start/link-in-bio-tld?variationName=${ flowName }&pageTitle=Link%20in%20Bio&tld=${ tld }`;
 
 			recordSubmitStep( providedDependencies, '', flowName, _currentStep );
 
@@ -103,7 +90,7 @@ export const linkInBio: Flow = {
 
 				case 'linkInBioSetup':
 					return window.location.assign(
-						`/start/link-in-bio-tld/plans-link-in-bio?variationName=${ flowName }&pageTitle=Link%20in%20Bio&tld=${ tld }&new=${ newDomainSearch }`
+						`/start/link-in-bio-tld/plans-link-in-bio?variationName=${ flowName }&pageTitle=Link%20in%20Bio&tld=${ tld }`
 					);
 
 				case 'launchpad': {

--- a/client/landing/stepper/declarative-flow/link-in-bio.ts
+++ b/client/landing/stepper/declarative-flow/link-in-bio.ts
@@ -126,6 +126,7 @@ export const linkInBio: Flow = {
 			switch ( _currentStep ) {
 				case 'launchpad':
 					return window.location.assign( `/view/${ siteSlug }` );
+
 				default:
 					return navigate( 'intro' );
 			}

--- a/client/landing/stepper/declarative-flow/link-in-bio.ts
+++ b/client/landing/stepper/declarative-flow/link-in-bio.ts
@@ -36,6 +36,18 @@ export const linkInBio: Flow = {
 
 		const tld = queryParams.get( 'tld' );
 
+		// trigger guides on step movement, we don't care about failures or response
+		wpcom.req.post(
+			'guides/trigger',
+			{
+				apiNamespace: 'wpcom/v2/',
+			},
+			{
+				flow: flowName,
+				step: _currentStep,
+			}
+		);
+
 		// for the standard Link in Bio flow
 		const submitDefault = ( providedDependencies: ProvidedDependencies = {} ) => {
 			const logInUrl =
@@ -104,23 +116,12 @@ export const linkInBio: Flow = {
 			return providedDependencies;
 		};
 
-		// trigger guides on step movement, we don't care about failures or response
-		wpcom.req.post(
-			'guides/trigger',
-			{
-				apiNamespace: 'wpcom/v2/',
-			},
-			{
-				flow: flowName,
-				step: _currentStep,
-			}
-		);
-
 		const submit = tld ? submitDomainFirst : submitDefault;
 
 		const goBack = () => {
 			return;
 		};
+
 		const goNext = () => {
 			switch ( _currentStep ) {
 				case 'launchpad':
@@ -129,9 +130,11 @@ export const linkInBio: Flow = {
 					return navigate( 'intro' );
 			}
 		};
+
 		const goToStep = ( step: StepPath | `${ StepPath }?${ string }` ) => {
 			navigate( step );
 		};
+
 		return { goNext, goBack, goToStep, submit };
 	},
 };

--- a/client/my-sites/plan-features-comparison/util.ts
+++ b/client/my-sites/plan-features-comparison/util.ts
@@ -1,7 +1,7 @@
 import { IncompleteWPcomPlan } from '@automattic/calypso-products';
 import {
 	NEWSLETTER_FLOW,
-	LINK_IN_BIO_FLOW,
+	isLinkInBioFlow,
 	isNewsletterOrLinkInBioFlow,
 } from '@automattic/onboarding';
 
@@ -10,7 +10,7 @@ const newsletterFeatures = ( flowName: string, plan: IncompleteWPcomPlan ) => {
 };
 
 const linkInBioFeatures = ( flowName: string, plan: IncompleteWPcomPlan ) => {
-	return flowName === LINK_IN_BIO_FLOW && plan.getLinkInBioSignupFeatures;
+	return isLinkInBioFlow( flowName ) && plan.getLinkInBioSignupFeatures;
 };
 
 const signupFlowDefaultFeatures = (
@@ -50,7 +50,7 @@ const newsletterHighlightedFeatures = ( flowName: string, plan: IncompleteWPcomP
 };
 
 const linkInBioHighlightedFeatures = ( flowName: string, plan: IncompleteWPcomPlan ) => {
-	return flowName === LINK_IN_BIO_FLOW && plan.getLinkInBioHighlightedFeatures;
+	return isLinkInBioFlow( flowName ) && plan.getLinkInBioHighlightedFeatures;
 };
 
 export const getHighlightedFeatures = ( flowName: string, plan: IncompleteWPcomPlan ) => {
@@ -77,7 +77,7 @@ export const getPlanDescriptionForMobile = ( {
 		return plan.getNewsletterDescription();
 	}
 
-	if ( flowName === LINK_IN_BIO_FLOW && plan.getLinkInBioDescription ) {
+	if ( isLinkInBioFlow( LINK_IN_BIO_FLOW ) && plan.getLinkInBioDescription ) {
 		return plan.getLinkInBioDescription();
 	}
 

--- a/client/my-sites/plan-features-comparison/util.ts
+++ b/client/my-sites/plan-features-comparison/util.ts
@@ -77,7 +77,7 @@ export const getPlanDescriptionForMobile = ( {
 		return plan.getNewsletterDescription();
 	}
 
-	if ( isLinkInBioFlow( LINK_IN_BIO_FLOW ) && plan.getLinkInBioDescription ) {
+	if ( isLinkInBioFlow( flowName ) && plan.getLinkInBioDescription ) {
 		return plan.getLinkInBioDescription();
 	}
 

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -143,6 +143,9 @@ export function generateFlows( {
 		{
 			name: LINK_IN_BIO_TLD_FLOW,
 			steps: [ 'domains', 'user', 'plans-link-in-bio' ],
+			middleDestination: {
+				user: ( dependencies ) => `/setup/patterns?flow=link-in-bio&tld=${ dependencies.tld }`,
+			},
 			destination: ( dependencies ) =>
 				`/setup/launchpad?flow=link-in-bio&siteSlug=${ encodeURIComponent( dependencies.siteSlug ) }`,
 			description: 'Beginning of the flow to create a link in bio',
@@ -151,6 +154,7 @@ export function generateFlows( {
 			get pageTitle() {
 				return translate( 'Link in Bio' );
 			},
+			providesDependenciesInQuery: [ 'tld' ],
 			postCompleteCallback: setupSiteAfterCreation,
 		},
 		{

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -144,10 +144,10 @@ export function generateFlows( {
 			name: LINK_IN_BIO_TLD_FLOW,
 			steps: [ 'domains', 'user', 'plans-link-in-bio' ],
 			middleDestination: {
-				user: ( dependencies ) => `/setup/patterns?flow=link-in-bio&tld=${ dependencies.tld }`,
+				user: ( dependencies ) => `/setup/link-in-bio/patterns?tld=${ dependencies.tld }`,
 			},
 			destination: ( dependencies ) =>
-				`/setup/launchpad?flow=link-in-bio&siteSlug=${ encodeURIComponent( dependencies.siteSlug ) }`,
+				`/setup/link-in-bio/launchpad?siteSlug=${ encodeURIComponent( dependencies.siteSlug ) }`,
 			description: 'Beginning of the flow to create a link in bio',
 			lastModified: '2022-11-03',
 			showRecaptcha: true,

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -1,5 +1,9 @@
 import { isEnabled } from '@automattic/calypso-config';
-import { setupSiteAfterCreation } from '@automattic/onboarding';
+import {
+	LINK_IN_BIO_FLOW,
+	LINK_IN_BIO_TLD_FLOW,
+	setupSiteAfterCreation,
+} from '@automattic/onboarding';
 import { translate } from 'i18n-calypso';
 import { VIDEOPRESS_ONBOARDING_FLOW_STEPS } from './constants';
 
@@ -124,12 +128,25 @@ export function generateFlows( {
 			postCompleteCallback: setupSiteAfterCreation,
 		},
 		{
-			name: 'link-in-bio',
+			name: LINK_IN_BIO_FLOW,
 			steps: [ 'domains', 'plans-link-in-bio' ],
 			destination: ( dependencies ) =>
 				`/setup/link-in-bio/launchpad?siteSlug=${ encodeURIComponent( dependencies.siteSlug ) }`,
 			description: 'Beginning of the flow to create a link in bio',
 			lastModified: '2022-11-01',
+			showRecaptcha: true,
+			get pageTitle() {
+				return translate( 'Link in Bio' );
+			},
+			postCompleteCallback: setupSiteAfterCreation,
+		},
+		{
+			name: LINK_IN_BIO_TLD_FLOW,
+			steps: [ 'domains', 'user', 'plans-link-in-bio' ],
+			destination: ( dependencies ) =>
+				`/setup/launchpad?flow=link-in-bio&siteSlug=${ encodeURIComponent( dependencies.siteSlug ) }`,
+			description: 'Beginning of the flow to create a link in bio',
+			lastModified: '2022-11-03',
 			showRecaptcha: true,
 			get pageTitle() {
 				return translate( 'Link in Bio' );

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -5,7 +5,7 @@ import {
 	isDomainMapping,
 } from '@automattic/calypso-products';
 import { isBlankCanvasDesign } from '@automattic/design-picker';
-import { isNewsletterOrLinkInBioFlow } from '@automattic/onboarding';
+import { isNewsletterOrLinkInBioFlow, LINK_IN_BIO_TLD_FLOW } from '@automattic/onboarding';
 import debugModule from 'debug';
 import {
 	clone,
@@ -120,7 +120,13 @@ function removeLoadingScreenClassNamesFromBody() {
 }
 
 function showProgressIndicator( flowName ) {
-	const DISABLED_PROGRESS_INDICATOR_FLOWS = [ 'pressable-nux', 'setup-site', 'importer', 'domain' ];
+	const DISABLED_PROGRESS_INDICATOR_FLOWS = [
+		'pressable-nux',
+		'setup-site',
+		'importer',
+		'domain',
+		LINK_IN_BIO_TLD_FLOW,
+	];
 
 	return ! DISABLED_PROGRESS_INDICATOR_FLOWS.includes( flowName );
 }

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -583,7 +583,10 @@ class Signup extends Component {
 	// `nextFlowName` is an optional parameter used to redirect to another flow, i.e., from `main`
 	// to `ecommerce`. If not specified, the current flow (`this.props.flowName`) continues.
 	goToNextStep = ( nextFlowName = this.props.flowName ) => {
-		const flowSteps = flows.getFlow( nextFlowName, this.props.isLoggedIn ).steps;
+		const { steps: flowSteps, middleDestination } = flows.getFlow(
+			nextFlowName,
+			this.props.isLoggedIn
+		);
 		const currentStepIndex = flowSteps.indexOf( this.props.stepName );
 		const nextStepName = flowSteps[ currentStepIndex + 1 ];
 		const nextProgressItem = get( this.props.progress, nextStepName );
@@ -591,6 +594,13 @@ class Signup extends Component {
 
 		if ( nextFlowName !== this.props.flowName ) {
 			this.setState( { previousFlowName: this.props.flowName } );
+		}
+
+		const midPoint = middleDestination ? middleDestination[ this.props.stepName ] : null;
+
+		if ( midPoint ) {
+			page( midPoint( this.props.signupDependencies ) );
+			return;
 		}
 
 		this.goToStep( nextStepName, nextStepSection, nextFlowName );

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -158,7 +158,6 @@ class Signup extends Component {
 		resumingStep: undefined,
 		previousFlowName: null,
 		signupSiteName: null,
-		transitFromMidpoint: null,
 	};
 
 	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
@@ -606,10 +605,9 @@ class Signup extends Component {
 		const midPoint = middleDestination ? middleDestination[ this.props.stepName ] : null;
 
 		if ( midPoint ) {
-			this.setState( {
-				transitFromMidpoint: midPoint( this.props.signupDependencies ),
-			} );
-
+			// save the resuming point and then navigate away.
+			this.setState( { resumingStep: nextStepName } );
+			page( midPoint( this.props.signupDependencies ) );
 			return;
 		}
 
@@ -793,11 +791,6 @@ class Signup extends Component {
 			( this.getPositionInFlow() > 0 && this.props.progress.length === 0 ) ||
 			this.state.resumingStep
 		) {
-			return null;
-		}
-
-		if ( this.state.transitFromMidpoint ) {
-			page( this.state.transitFromMidpoint );
 			return null;
 		}
 

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -158,6 +158,7 @@ class Signup extends Component {
 		resumingStep: undefined,
 		previousFlowName: null,
 		signupSiteName: null,
+		transitFromMidpoint: null,
 	};
 
 	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
@@ -605,7 +606,10 @@ class Signup extends Component {
 		const midPoint = middleDestination ? middleDestination[ this.props.stepName ] : null;
 
 		if ( midPoint ) {
-			page( midPoint( this.props.signupDependencies ) );
+			this.setState( {
+				transitFromMidpoint: midPoint( this.props.signupDependencies ),
+			} );
+
 			return;
 		}
 
@@ -789,6 +793,11 @@ class Signup extends Component {
 			( this.getPositionInFlow() > 0 && this.props.progress.length === 0 ) ||
 			this.state.resumingStep
 		) {
+			return null;
+		}
+
+		if ( this.state.transitFromMidpoint ) {
+			page( this.state.transitFromMidpoint );
 			return null;
 		}
 

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -525,6 +525,11 @@ class DomainsStep extends Component {
 		}
 
 		const includeWordPressDotCom = this.props.includeWordPressDotCom ?? ! this.props.isDomainOnly;
+		const promoTlds = this.props?.queryObject?.tld?.split( ',' ) ?? [];
+
+		// the .link tld comes with the w.link subdomain from our partnership.
+		// see pau2Xa-4tC-p2#comment-12869 for more details
+		const managedSubdomains = promoTlds.includes( 'link' ) ? 'link' : null;
 
 		return (
 			<CalypsoShoppingCartProvider>
@@ -535,8 +540,9 @@ class DomainsStep extends Component {
 					onAddDomain={ this.handleAddDomain }
 					products={ this.props.productsList }
 					basePath={ this.props.path }
-					promoTlds={ this.props?.queryObject?.tld?.split( ',' ) }
+					promoTlds={ promoTlds }
 					mapDomainUrl={ this.getUseYourDomainUrl() }
+					managedSubdomains={ managedSubdomains }
 					transferDomainUrl={ this.getUseYourDomainUrl() }
 					useYourDomainUrl={ this.getUseYourDomainUrl() }
 					onAddMapping={ this.handleAddMapping.bind( this, 'domainForm' ) }

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -10,6 +10,7 @@ import { getUrlParts } from '@automattic/calypso-url';
 import { Button } from '@automattic/components';
 import {
 	LINK_IN_BIO_FLOW,
+	LINK_IN_BIO_TLD_FLOW,
 	NEWSLETTER_FLOW,
 	isNewsletterOrLinkInBioFlow,
 } from '@automattic/onboarding';
@@ -331,7 +332,7 @@ export class PlansStep extends Component {
 						{ components: { link: freePlanButton } }
 				  );
 		}
-		if ( flowName === LINK_IN_BIO_FLOW ) {
+		if ( flowName === LINK_IN_BIO_FLOW || flowName === LINK_IN_BIO_TLD_FLOW ) {
 			return hideFreePlan
 				? translate( 'Unlock a powerful bundle of features for your Link in Bio.' )
 				: translate(

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -9,8 +9,7 @@ import {
 import { getUrlParts } from '@automattic/calypso-url';
 import { Button } from '@automattic/components';
 import {
-	LINK_IN_BIO_FLOW,
-	LINK_IN_BIO_TLD_FLOW,
+	isLinkInBioFlow,
 	NEWSLETTER_FLOW,
 	isNewsletterOrLinkInBioFlow,
 } from '@automattic/onboarding';
@@ -332,7 +331,7 @@ export class PlansStep extends Component {
 						{ components: { link: freePlanButton } }
 				  );
 		}
-		if ( flowName === LINK_IN_BIO_FLOW || flowName === LINK_IN_BIO_TLD_FLOW ) {
+		if ( isLinkInBioFlow( flowName ) ) {
 			return hideFreePlan
 				? translate( 'Unlock a powerful bundle of features for your Link in Bio.' )
 				: translate(

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -104,12 +104,19 @@ export class UserStep extends Component {
 		recaptchaClientId: null,
 	};
 
-	componentDidUpdate() {
-		if ( this.props.step?.status === 'completed' ) {
+	shouldComponentUpdate( nextProps ) {
+		// This used to be done in componentDidUpdate. However, when the user step is the last we'd actually introduce one extra frame of SignupForm with a notice
+		// saying "Your account has already been created", by the code at line 903 of blocks/signup-form/index.jsx at the momemt of writing this.
+		// It had gone unnoticed since the processing screen would hide it.
+		// Now the link-in-bio-tld case introduce a chance that there is no processing screen, revealing the bug.
+		if ( nextProps.step?.status === 'completed' ) {
 			this.props.goToNextStep();
-			return;
+			return false;
 		}
+		return true;
+	}
 
+	componentDidUpdate() {
 		if ( this.userCreationCompletedAndHasHistory( this.props ) ) {
 			// It looks like the user just completed the User Registartion Step
 			// And clicked the back button. Lets redirect them to the this page but this time they will be logged in.

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -1,5 +1,6 @@
 import config from '@automattic/calypso-config';
 import { localizeUrl } from '@automattic/i18n-utils';
+import { LINK_IN_BIO_TLD_FLOW } from '@automattic/onboarding';
 import { isMobile } from '@automattic/viewport';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
@@ -536,8 +537,10 @@ export class UserStep extends Component {
 			return null; // return nothing so that we don't see the error message and the sign up form.
 		}
 
+		// TODO: decouple hideBack flag from the flow name.
 		return (
 			<StepWrapper
+				hideBack={ this.props.flowName === LINK_IN_BIO_TLD_FLOW }
 				flowName={ this.props.flowName }
 				stepName={ this.props.stepName }
 				headerText={ this.getHeaderText() }

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -105,19 +105,12 @@ export class UserStep extends Component {
 		recaptchaClientId: null,
 	};
 
-	shouldComponentUpdate( nextProps ) {
-		// This used to be done in componentDidUpdate. However, when the user step is the last we'd actually introduce one extra frame of SignupForm with a notice
-		// saying "Your account has already been created", by the code at line 903 of blocks/signup-form/index.jsx at the momemt of writing this.
-		// It had gone unnoticed since the processing screen would hide it.
-		// Now the link-in-bio-tld case introduce a chance that there is no processing screen, revealing the bug.
-		if ( nextProps.step?.status === 'completed' ) {
-			this.props.goToNextStep();
-			return false;
-		}
-		return true;
-	}
-
 	componentDidUpdate() {
+		if ( this.props.step?.status === 'completed' ) {
+			this.props.goToNextStep();
+			return;
+		}
+
 		if ( this.userCreationCompletedAndHasHistory( this.props ) ) {
 			// It looks like the user just completed the User Registartion Step
 			// And clicked the back button. Lets redirect them to the this page but this time they will be logged in.

--- a/client/signup/tailored-flow-processing-screen/index.jsx
+++ b/client/signup/tailored-flow-processing-screen/index.jsx
@@ -1,4 +1,4 @@
-import { NEWSLETTER_FLOW, LINK_IN_BIO_FLOW } from '@automattic/onboarding';
+import { NEWSLETTER_FLOW, LINK_IN_BIO_FLOW, LINK_IN_BIO_TLD_FLOW } from '@automattic/onboarding';
 import { useI18n } from '@wordpress/react-i18n';
 import PropTypes from 'prop-types';
 import { useRef, useState, useEffect } from 'react';
@@ -15,6 +15,7 @@ const useSteps = ( flowName ) => {
 
 	switch ( flowName ) {
 		case LINK_IN_BIO_FLOW:
+		case LINK_IN_BIO_TLD_FLOW:
 			steps = [
 				{ title: __( 'Great choices. Nearly there!' ) },
 				{ title: __( 'Shining and polishing your Bio' ) },

--- a/client/signup/tailored-flow-processing-screen/style.scss
+++ b/client/signup/tailored-flow-processing-screen/style.scss
@@ -4,7 +4,8 @@
 .signup {
 	&.is-newsletter,
 	&.is-link-in-bio,
-	&.is-import {
+	&.is-import
+	&.is-link-in-bio-tld {
 		.signup-header {
 			z-index: 1;
 
@@ -88,7 +89,8 @@
 		}
 	}
 
-	&.is-link-in-bio {
+	&.is-link-in-bio,
+	&.is-link-in-bio-tld {
 		.reskinned-processing-screen__container {
 			background-color: #d0cce3;
 			background-image:

--- a/client/signup/tailored-flow-processing-screen/style.scss
+++ b/client/signup/tailored-flow-processing-screen/style.scss
@@ -4,8 +4,8 @@
 .signup {
 	&.is-newsletter,
 	&.is-link-in-bio,
-	&.is-import
-	&.is-link-in-bio-tld {
+	&.is-link-in-bio-tld,
+	&.is-import {
 		.signup-header {
 			z-index: 1;
 

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -182,6 +182,7 @@
 		"with-add-ons",
 		"newsletter",
 		"link-in-bio",
+		"link-in-bio-tld",
 		"setup-site",
 		"account",
 		"do-it-for-me",

--- a/packages/onboarding/src/setup-tailored-site-after-creation.ts
+++ b/packages/onboarding/src/setup-tailored-site-after-creation.ts
@@ -3,7 +3,7 @@ import { Site, Onboard } from '@automattic/data-stores';
 import { select, dispatch } from '@wordpress/data';
 import wpcomRequest from 'wpcom-proxy-request';
 import { uploadAndSetSiteLogo } from './upload-and-set-site-logo';
-import { isNewsletterOrLinkInBioFlow, LINK_IN_BIO_FLOW } from './utils';
+import { isLinkInBioFlow, isNewsletterOrLinkInBioFlow, LINK_IN_BIO_FLOW } from './utils';
 
 const ONBOARD_STORE = Onboard.register();
 const SITE_STORE = Site.register( { client_id: '', client_secret: '' } );
@@ -64,6 +64,10 @@ export function setupSiteAfterCreation( { siteId, flowName }: SetupOnboardingSit
 
 	const setIntent = ( siteId: number, flow: string ) => {
 		if ( isNewsletterOrLinkInBioFlow( flow ) ) {
+			// link-in-bio and link-in-bio-tld are considered the same intent.
+			if ( isLinkInBioFlow( flow ) ) {
+				return setIntentOnSite( siteId.toString(), LINK_IN_BIO_FLOW );
+			}
 			return setIntentOnSite( siteId.toString(), flow );
 		}
 		return Promise.resolve();
@@ -79,7 +83,7 @@ export function setupSiteAfterCreation( { siteId, flowName }: SetupOnboardingSit
 	};
 
 	const setPattern = async ( siteId: number, flow: string ) => {
-		if ( flow === LINK_IN_BIO_FLOW ) {
+		if ( isLinkInBioFlow( flow ) ) {
 			await wpcomRequest( {
 				// since this is a new site, its safe to assume that homepage ID is 2
 				path: `/sites/${ siteId }/pages/2`,

--- a/packages/onboarding/src/utils/flows.ts
+++ b/packages/onboarding/src/utils/flows.ts
@@ -7,6 +7,13 @@ export const VIDEOPRESS_FLOW = 'videopress';
 export const IMPORT_FOCUSED_FLOW = 'import-focused';
 export const ECOMMERCE_FLOW = 'ecommerce';
 
+export const isLinkInBioFlow = ( flowName: string | null ) => {
+	return Boolean(
+		flowName &&
+			[ LINK_IN_BIO_FLOW, LINK_IN_BIO_TLD_FLOW, LINK_IN_BIO_POST_SETUP_FLOW ].includes( flowName )
+	);
+};
+
 export const isNewsletterOrLinkInBioFlow = ( flowName: string | null ) => {
 	return Boolean(
 		flowName &&

--- a/packages/onboarding/src/utils/flows.ts
+++ b/packages/onboarding/src/utils/flows.ts
@@ -1,6 +1,7 @@
 export const NEWSLETTER_FLOW = 'newsletter';
 export const NEWSLETTER_POST_SETUP_FLOW = 'newsletter-post-setup';
 export const LINK_IN_BIO_FLOW = 'link-in-bio';
+export const LINK_IN_BIO_TLD_FLOW = 'link-in-bio-tld';
 export const LINK_IN_BIO_POST_SETUP_FLOW = 'link-in-bio-post-setup';
 export const VIDEOPRESS_FLOW = 'videopress';
 export const IMPORT_FOCUSED_FLOW = 'import-focused';
@@ -13,6 +14,7 @@ export const isNewsletterOrLinkInBioFlow = ( flowName: string | null ) => {
 				NEWSLETTER_FLOW,
 				NEWSLETTER_POST_SETUP_FLOW,
 				LINK_IN_BIO_FLOW,
+				LINK_IN_BIO_TLD_FLOW,
 				LINK_IN_BIO_POST_SETUP_FLOW,
 			].includes( flowName )
 	);


### PR DESCRIPTION
## Proposed Changes
_This PR is based on https://github.com/Automattic/wp-calypso/pull/69887_

This PR implements the dotlink variation of Link in Bio flow required for the dotlink partnership project. The detailed project info can be found in pau2Xa-4tC-p2. 

The new flow interweaves a new signup flow on the classic signup framework, `/start/link-in-bio-tld`, and the Link in Bio Stepper flow, `/setup/link-in-bio`. Stricyly speaking it's a technical compromise that's complicated more than it should have. However, before we [move everything to Stepper](https://github.com/Automattic/wp-calypso/pull/68722), we will need to interweave the both frameworks in some ways. In this case, the flow goes as: 

domains(signup) -> user(signup) -> pattern(Stepper) -> link in bio site info(Stepper) -> plans(signup) -> processing screen(signup) -> *checkout(directed from the signup framework if the cart is not empty) -> launchpad(Stepper)

To make this work, this PR includes:

1. Add a new "middle destination" mechanism to the classic signup flow that redirects to other URLs after a certain step is completed.
2. A new flow on the classic signup framework, `link-in-bio-tld`, that provides `tld` dependency and transit to `link-in-bio` Stepper flow after the user step using the above "middle destination" mechanism.
3. Add this new `link-in-bio-tld` to various places like `link-in-bio` does, so they acts as close as possible. It's a clear indication that we should move away from determining these by the flow name, but it's not the right timing to do it. 
4. Update the `link-in-bio` Stepper flow so the step order varied when `tld` query parameter is given.
5. The domain step component now populates `link` as the `managedSubdomains` prop to the underlying domain registration subcomponent, so the `w.link` option will suppress `wordpress.com` free subomaind when the .link tld is given.
6. Hide the step UI for the `link-in-bio-tld` flow, since the following Stepper flow has its own progress indicator. It's not perfect, but at least it would be less confusing. See pau2Xa-4tC-p2#comment-12834.

Demonstration:

https://user-images.githubusercontent.com/1842898/201882048-8ac2e101-cf0a-4635-8397-5aad7b5d9888.mp4

## Testing Instructions

### Test the dotlink variation of Link in Bio flow
1. Open the calypso.live instance of this PR and go `/start/link-in-bio-tld?tld=link`. Note that if you test this by a local instance, you'd need to prepend `ENABLE_FEATURES=no-force-sympathy` to disable the sympathy mode to make it work. Interweaving the flows from two frameworks requires the browser persistence to make it work, even though it's not ideal. If the local store is cleared along the way, the user will be redirected to the domains step once again when they should arrive the plans step. That's the fallback mechanism of the signup framework when the signup progress is lost.
2. Go through the entire flow and make sure it works as expected.

### Test the original Link in Bio flow
Go to the original Link in Bio flow by accessing `/setup/link-in-bio`. It should work without being affected.


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
