### PR TITLE
Woo Tailored Onboarding: Added responsive variation preview

### DIFF
--- a/packages/design-carousel/package.json
+++ b/packages/design-carousel/package.json
@@ -29,6 +29,7 @@
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},
 	"dependencies": {
+		"@automattic/design-picker": "workspace:^",
 		"@automattic/i18n-utils": "workspace:^",
 		"@automattic/onboarding": "workspace:^",
 		"classnames": "^2.3.1",

--- a/packages/design-carousel/src/item.tsx
+++ b/packages/design-carousel/src/item.tsx
@@ -1,18 +1,18 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 import './styles.scss';
-import { MShotsImage, MShotsOptions } from '@automattic/onboarding';
+import { ThemePreview, Design } from '@automattic/design-picker';
 import cx from 'classnames';
 
 type Props = {
 	className?: string;
 	style?: React.CSSProperties;
-	design: any;
-	type: 'desktop' | 'mobile';
+	design: Design;
+	inlineCss?: string;
 };
 
-const getDesignPreviewUrl = ( design: any ): string => {
+const getDesignPreviewUrl = ( design: Design ): string => {
 	const params = new URLSearchParams( {
-		stylesheet: design.recipe?.stylesheet,
+		stylesheet: design.recipe?.stylesheet || '',
 		language: 'en',
 		viewport_height: '1040',
 		source_site: 'patternboilerplates.wordpress.com',
@@ -23,22 +23,13 @@ const getDesignPreviewUrl = ( design: any ): string => {
 	return `https://public-api.wordpress.com/wpcom/v2/block-previews/site?${ params }`;
 };
 
-export function Item( { style, design, className, type }: Props ) {
-	// Default to mobile options
-	let options: MShotsOptions = { w: 400, vpw: 400, vph: 872, format: 'png' };
-
-	if ( type === 'desktop' ) {
-		options = { w: 1280, vpw: 1920, vph: 1280, format: 'png' };
-	}
+export function Item( { style, design, className, inlineCss }: Props ) {
+	const url = getDesignPreviewUrl( design );
 
 	return (
 		<div style={ style } className={ cx( 'design-carousel__item', className ) }>
-			<MShotsImage
-				url={ getDesignPreviewUrl( design ) }
-				options={ options }
-				alt={ design.title }
-				aria-labelledby=""
-			/>
+			<ThemePreview url={ url } inlineCss={ inlineCss } />
+			<div className="design-carousel__item-overlay"></div>
 		</div>
 	);
 }

--- a/packages/design-carousel/src/styles.scss
+++ b/packages/design-carousel/src/styles.scss
@@ -6,26 +6,8 @@ $patterns: "17-2", "black", "ella-d", "link-cloud", "matt-smith", "ose-maiko", "
 	"chloe-currie", "emily", "luis-carvelleda", "mesh-gradient", "paul-nyberg", "tengfai";
 
 .design-carousel__item {
+	aspect-ratio: 1.5;
 	flex: 1;
-
-	@include break-small {
-		aspect-ratio: 1.5;
-	}
-
-	&.design-carousel__item-mobile {
-		@include break-small {
-			display: none !important;
-		}
-	}
-	&.design-carousel__item-desktop {
-		display: none !important;
-		@include break-small {
-			display: flex !important;
-		}
-	}
-
-	// iPhone aspect ratio
-	aspect-ratio: 0.48;
 	display: flex;
 	align-items: center;
 	justify-content: center;
@@ -37,8 +19,17 @@ $patterns: "17-2", "black", "ella-d", "link-cloud", "matt-smith", "ose-maiko", "
 	cursor: pointer;
 	padding: 0;
 	overflow: hidden;
-	height: calc(65vh - 50px);
+	height: calc(75vh - 50px);
+	max-width: 90vw;
 	outline: none;
+
+	.design-carousel__item-overlay {
+		position: absolute;
+		top: 0;
+		bottom: 0;
+		left: 0;
+		right: 0;
+	}
 
 	@media (max-height: 375px) {
 		aspect-ratio: 0.5;

--- a/yarn.lock
+++ b/yarn.lock
@@ -487,6 +487,7 @@ __metadata:
   dependencies:
     "@automattic/calypso-build": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
+    "@automattic/design-picker": "workspace:^"
     "@automattic/i18n-utils": "workspace:^"
     "@automattic/onboarding": "workspace:^"
     classnames: ^2.3.1


### PR DESCRIPTION
#### Proposed Changes

Changed `design-carousel` component to show responsive style variation previews .

#### Testing Instructions
* It requires D91720-code so we don't need an extra request for each theme.
* Access  `/setup/ecommerce/designCarousel`
* You should see the 4 style variations of "Twenty twenty-two" and the previews should be responsive.

Ex:

![image](https://user-images.githubusercontent.com/3801502/200059299-28e23633-0c97-4c16-a8d4-538544874eed.png)
![image](https://user-images.githubusercontent.com/3801502/200059456-2b378707-0165-4bbb-a06d-328e6c804853.png)
![image](https://user-images.githubusercontent.com/3801502/200062647-fb663ad3-81ea-4b15-80ed-818dbdfd9185.png)
