### PR TITLE
KPI Dashboard: enable Allure in Pre-Release Tests

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -885,7 +885,7 @@ object PreReleaseE2ETests : BuildType({
 				# Issue call as matticbot.
 				# The GitHub Action workflow expects the filename of the most recent Allure report
 				# as param.
-				curl https://api.github.com/repos/Automattic/wp-calypso-test-results/actions/workflows/pages.yml/dispatches -X POST -H "Accept: application/vnd.github+json" -H "Authorization: Bearer %MATTICBOT_GITHUB_BEARER_TOKEN%" -d '{"ref":"trunk","inputs":{"allure_result_filename": "%build.counter%-%build.vcs.number%.tgz"}}'
+				curl https://api.github.com/repos/Automattic/wp-calypso-test-results/actions/workflows/generate-report.yml/dispatches -X POST -H "Accept: application/vnd.github+json" -H "Authorization: Bearer %MATTICBOT_GITHUB_BEARER_TOKEN%" -d '{"ref":"trunk","inputs":{"allure_result_filename": "%build.counter%-%build.vcs.number%.tgz"}}'
 			""".trimIndent()
 			conditions {
 				exists("env.ALLURE_RESULTS_PATH")

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -973,7 +973,7 @@ object KPIDashboardTests : BuildType({
 
 				tar cvfz %build.counter%-%build.vcs.number%.tgz allure-results
 
-				aws s3 sync %build.counter%-%build.vcs.number%.tgz %CALYPSO_E2E_DASHBOARD_AWS_S3_ROOT%
+				aws s3 cp %build.counter%-%build.vcs.number%.tgz %CALYPSO_E2E_DASHBOARD_AWS_S3_ROOT%
 			""".trimIndent()
 			dockerImage = "%docker_image_allure%"
 		}
@@ -982,7 +982,7 @@ object KPIDashboardTests : BuildType({
 			name = "Send webhook to start report generation"
 			executionMode = BuildStep.ExecutionMode.RUN_ON_FAILURE
 			scriptContent = """
-				curl https://api.github.com/repos/Automattic/wp-calypso-test-results/actions/workflows/pages.yml/dispatches -X POST -H "Accept: application/vnd.github+json" -H "Authorization: Bearer %MATTICBOT_GITHUB_BEARER_TOKEN%" -d '{"ref":"trunk","inputs":{"newest_allure_results": "%%build.counter%-%build.vcs.number%.tgz%"}}'
+				curl https://api.github.com/repos/Automattic/wp-calypso-test-results/actions/workflows/pages.yml/dispatches -X POST -H "Accept: application/vnd.github+json" -H "Authorization: Bearer %MATTICBOT_GITHUB_BEARER_TOKEN%" -d '{"ref":"trunk","inputs":{"allure_result_filename": "%build.counter%-%build.vcs.number%.tgz"}}'
 			""".trimIndent()
 			dockerImage = "%docker_image_e2e%"
 		}

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -861,8 +861,6 @@ object PreReleaseE2ETests : BuildType({
 			name = "Upload Allure results to S3"
 			executionMode = BuildStep.ExecutionMode.RUN_ON_FAILURE
 			scriptContent = """
-				set -ex
-
 				aws configure set aws_access_key_id %CALYPSO_E2E_DASHBOARD_AWS_S3_ACCESS_KEY_ID%
 				aws configure set aws_secret_access_key %CALYPSO_E2E_DASHBOARD_AWS_S3_SECRET_ACCESS_KEY%
 

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -4,6 +4,7 @@ import Settings
 import _self.bashNodeScript
 import _self.lib.customBuildType.E2EBuildType
 import _self.lib.utils.mergeTrunk
+import jetbrains.buildServer.configs.kotlin.v2019_2.BuildStepConditions
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildStep
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildSteps
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildType
@@ -37,7 +38,6 @@ object WebApp : Project({
 	buildType(AuthenticationE2ETests)
 	buildType(HelpCentreE2ETests)
 	buildType(KPIDashboardTests)
-	buildType(CalypsoPreReleaseDashboard)
 	buildType(QuarantinedE2ETests)
 })
 
@@ -775,18 +775,139 @@ fun playwrightPrBuildType( targetDevice: String, buildUuid: String ): E2EBuildTy
 	)
 }
 
-object PreReleaseE2ETests : E2EBuildType(
-	buildId = "calypso_WebApp_Calypso_E2E_Pre_Release",
-	buildUuid = "9c2f634f-6582-4245-bb77-fb97d9f16533",
-	buildName = "Pre-Release E2E Tests",
-	buildDescription = "Runs a pre-release suite of E2E tests against trunk on staging, intended to be run after PR merge, but before deployment to production.",
-	concurrentBuilds = 1,
-	testGroup = "calypso-release",
-	buildParams = {
+object PreReleaseE2ETests : BuildType({
+	id("calypso_WebApp_Calypso_E2E_Pre_Release")
+	uuid = "9c2f634f-6582-4245-bb77-fb97d9f16533"
+	name = "Pre-Release E2E Tests"
+	description = "Runs a pre-release suite of E2E tests against trunk on staging, intended to be run after PR merge, but before deployment to production."
+	artifactRules = """
+		logs => logs.tgz
+		screenshots => screenshots
+		trace => trace
+		allure-results => allure-results.tgz
+	"""
+
+	vcs {
+		root(Settings.WpCalypso)
+		cleanCheckout = true
+	}
+
+	params {
+		param("env.NODE_CONFIG_ENV", "test")
+		param("env.PLAYWRIGHT_BROWSERS_PATH", "0")
+		param("env.TEAMCITY_VERSION", "2021")
+		param("env.HEADLESS", "true")
+		param("env.LOCALE", "en")
 		param("env.VIEWPORT_NAME", "desktop")
 		param("env.CALYPSO_BASE_URL", "https://wpcalypso.wordpress.com")
-	},
-	buildFeatures = {
+		param("env.ALLURE_RESULTS_PATH", "allure-results")
+	}
+
+	steps {
+		bashNodeScript {
+			name = "Prepare environment"
+			scriptContent = """
+				# Install deps
+				yarn workspaces focus wp-e2e-tests @automattic/calypso-e2e
+
+				# Decrypt secrets
+				# Must do before build so the secrets are in the dist output
+				E2E_SECRETS_KEY="%E2E_SECRETS_ENCRYPTION_KEY_CURRENT%" yarn workspace @automattic/calypso-e2e decrypt-secrets
+
+				# Build packages
+				yarn workspace @automattic/calypso-e2e build
+			""".trimIndent()
+			dockerImage = "%docker_image_e2e%"
+		}
+
+		bashNodeScript {
+			name = "Run tests"
+			scriptContent = """
+				# Configure bash shell.
+				shopt -s globstar
+				set -x
+
+				# Enter testing directory.
+				cd test/e2e
+				mkdir temp
+
+				# Run suite.
+				xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --maxWorkers=%E2E_WORKERS% --group=calypso-release
+			"""
+			dockerImage = "%docker_image_e2e%"
+		}
+
+		bashNodeScript {
+			name = "Collect results"
+			executionMode = BuildStep.ExecutionMode.RUN_ON_FAILURE
+			scriptContent = """
+				set -x
+
+				mkdir -p screenshots
+				find test/e2e/results -type f \( -iname \*.webm -o -iname \*.png \) -print0 | xargs -r -0 mv -t screenshots
+
+				mkdir -p logs
+				find test/e2e/results -name '*.log' -print0 | xargs -r -0 mv -t logs
+
+				mkdir -p trace
+				find test/e2e/results -name '*.zip' -print0 | xargs -r -0 mv -t trace
+
+				mkdir -p allure-results
+				find test/e2e/allure-results -name '*.json' -print0 | xargs -r -0 mv -t allure-results
+			""".trimIndent()
+			dockerImage = "%docker_image_e2e%"
+		}
+
+		bashNodeScript {
+			name = "Upload Allure results to S3"
+			executionMode = BuildStep.ExecutionMode.RUN_ON_FAILURE
+			scriptContent = """
+				set -ex
+
+				aws configure set aws_access_key_id %CALYPSO_E2E_DASHBOARD_AWS_S3_ACCESS_KEY_ID%
+				aws configure set aws_secret_access_key %CALYPSO_E2E_DASHBOARD_AWS_S3_SECRET_ACCESS_KEY%
+
+				# Need to use -C to avoid creation of an unnecessary top level directory.
+				tar cvfz %build.counter%-%build.vcs.number%.tgz -C allure-results .
+
+				aws s3 cp %build.counter%-%build.vcs.number%.tgz %CALYPSO_E2E_DASHBOARD_AWS_S3_ROOT%
+			""".trimIndent()
+			conditions {
+				exists("env.ALLURE_RESULTS_PATH")
+				equals("teamcity.build.branch", "trunk")
+			}
+			dockerImage = "%docker_image_e2e%"
+		}
+
+		bashNodeScript {
+			name = "Send webhook to GitHub Actions"
+			executionMode = BuildStep.ExecutionMode.RUN_ON_FAILURE
+			scriptContent = """
+				# Issue call as matticbot.
+				# The GitHub Action workflow expects the filename of the most recent Allure report
+				# as param.
+				curl https://api.github.com/repos/Automattic/wp-calypso-test-results/actions/workflows/pages.yml/dispatches -X POST -H "Accept: application/vnd.github+json" -H "Authorization: Bearer %MATTICBOT_GITHUB_BEARER_TOKEN%" -d '{"ref":"trunk","inputs":{"allure_result_filename": "%build.counter%-%build.vcs.number%.tgz"}}'
+			""".trimIndent()
+			conditions {
+				exists("env.ALLURE_RESULTS_PATH")
+				equals("teamcity.build.branch", "trunk")
+			}
+			dockerImage = "%docker_image_e2e%"
+		}
+	}
+
+	features {
+		perfmon {
+		}
+		commitStatusPublisher {
+			vcsRootExtId = "${Settings.WpCalypso.id}"
+			publisher = github {
+				githubUrl = "https://api.github.com"
+				authType = personalToken {
+					token = "credentialsJSON:57e22787-e451-48ed-9fea-b9bf30775b36"
+				}
+			}
+		}
 		notifications {
 			notifierSettings = slackNotifier {
 				connection = "PROJECT_EXT_11"
@@ -802,7 +923,25 @@ object PreReleaseE2ETests : E2EBuildType(
 			buildProbablyHanging = true
 		}
 	}
-)
+
+	failureConditions {
+		executionTimeoutMin = 20
+		// Don't fail if the runner exists with a non zero code. This allows a build to pass if the failed tests have been muted previously.
+		nonZeroExitCode = false
+
+		// Fail if the number of passing tests is 50% or less than the last build. This will catch the case where the test runner crashes and no tests are run.
+		failOnMetricChange {
+			metric = BuildFailureOnMetric.MetricType.PASSED_TEST_COUNT
+			threshold = 50
+			units = BuildFailureOnMetric.MetricUnit.PERCENTS
+			comparison = BuildFailureOnMetric.MetricComparison.LESS
+			compareTo = build {
+				buildRule = lastSuccessful()
+			}
+		}
+	}
+
+})
 
 object AuthenticationE2ETests : E2EBuildType(
 	buildId = "calypso_WebApp_Calypso_E2E_Authentication",
@@ -879,201 +1018,18 @@ object HelpCentreE2ETests : E2EBuildType(
 	}
 )
 
-object KPIDashboardTests : BuildType({
-	id("calypso_WebApp_Calypso_E2E_KPI_Dashboard")
-	uuid = "441efac5-721a-4557-9448-9234e89fb6b1"
-	name = "Test build for KPI Dashboard project"
-	description = "Test build configuration for KPI dashboard."
-	artifactRules = """
-		logs => logs.tgz
-		screenshots => screenshots
-		trace => trace
-		allure-results => allure-results.tgz
-	""".trimIndent()
-
-	vcs {
-		root(Settings.WpCalypso)
-		cleanCheckout = true
-	}
-
-	params {
-		param("env.NODE_CONFIG_ENV", "test")
-		param("env.PLAYWRIGHT_BROWSERS_PATH", "0")
-		param("env.TEAMCITY_VERSION", "2021")
-		param("env.HEADLESS", "false")
-		param("env.LOCALE", "en")
-		param("env.DEBUG", "")
+object KPIDashboardTests : E2EBuildType(
+	buildId = "Calypso_E2E_KPI_Dashboard",
+	buildUuid = "441efac5-721a-4557-9448-9234e89fb6b1",
+	buildName = "Test build for KPI Dashboard project",
+	buildDescription = "Test build configuration for KPI dashboard.",
+	testGroup = "kpi",
+	buildParams = {
 		param("env.VIEWPORT_NAME", "desktop")
-		param("env.ALLURE_RESULTS_PATH", "allure-results")
-	}
-
-	steps {
-		bashNodeScript {
-			name = "Prepare environment"
-			scriptContent = """
-				# Install deps
-				yarn workspaces focus wp-e2e-tests @automattic/calypso-e2e
-
-				# Decrypt secrets
-				# Must do before build so the secrets are in the dist output
-				E2E_SECRETS_KEY="%E2E_SECRETS_ENCRYPTION_KEY_CURRENT%" yarn workspace @automattic/calypso-e2e decrypt-secrets
-
-				# Build packages
-				yarn workspace @automattic/calypso-e2e build
-			""".trimIndent()
-			dockerImage = "%docker_image_e2e%"
-		}
-
-		bashNodeScript {
-			name = "Run tests"
-			scriptContent = """
-				# Configure bash shell.
-				shopt -s globstar
-				set -x
-
-				# Enter testing directory.
-				cd test/e2e
-				mkdir temp
-
-				# Run suite.
-				xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --maxWorkers=%E2E_WORKERS% --group=kpi
-			"""
-			dockerImage = "%docker_image_e2e%"
-		}
-
-		bashNodeScript {
-			name = "Collect results"
-			executionMode = BuildStep.ExecutionMode.RUN_ON_FAILURE
-			scriptContent = """
-				set -x
-
-				mkdir -p screenshots
-				find test/e2e/results -type f \( -iname \*.webm -o -iname \*.png \) -print0 | xargs -r -0 mv -t screenshots
-
-				mkdir -p logs
-				find test/e2e/results -name '*.log' -print0 | xargs -r -0 mv -t logs
-
-				mkdir -p trace
-				find test/e2e/results -name '*.zip' -print0 | xargs -r -0 mv -t trace
-
-				mkdir -p allure-results
-				find test/e2e/allure-results -name '*.json' -print0 | xargs -r -0 mv -t allure-results
-			""".trimIndent()
-			dockerImage = "%docker_image_e2e%"
-		}
-
-		bashNodeScript {
-			name = "Upload Allure results to S3"
-			executionMode = BuildStep.ExecutionMode.RUN_ON_FAILURE
-			scriptContent = """
-				set -ex
-
-				aws configure set aws_access_key_id %CALYPSO_E2E_DASHBOARD_AWS_S3_ACCESS_KEY_ID%
-				aws configure set aws_secret_access_key %CALYPSO_E2E_DASHBOARD_AWS_S3_SECRET_ACCESS_KEY%
-
-				# Need to use -C to avoid creation of an unnecessary top level directory.
-				tar cvfz %build.counter%-%build.vcs.number%.tgz -C allure-results .
-
-				aws s3 cp %build.counter%-%build.vcs.number%.tgz %CALYPSO_E2E_DASHBOARD_AWS_S3_ROOT%
-			""".trimIndent()
-			dockerImage = "%docker_image_e2e%"
-		}
-
-		bashNodeScript {
-			name = "Send webhook to start report generation"
-			executionMode = BuildStep.ExecutionMode.RUN_ON_FAILURE
-			scriptContent = """
-				# Issue call as matticbot.
-				# The GitHub Action workflow expects the filename of the most recent Allure report
-				# as param.
-				curl https://api.github.com/repos/Automattic/wp-calypso-test-results/actions/workflows/pages.yml/dispatches -X POST -H "Accept: application/vnd.github+json" -H "Authorization: Bearer %MATTICBOT_GITHUB_BEARER_TOKEN%" -d '{"ref":"trunk","inputs":{"allure_result_filename": "%build.counter%-%build.vcs.number%.tgz"}}'
-			""".trimIndent()
-			dockerImage = "%docker_image_e2e%"
-		}
-	}
-
-	features {
-		perfmon {
-		}
-	}
-
-	failureConditions {
-		executionTimeoutMin = 20
-		// Don't fail if the runner exists with a non zero code. This allows a build to pass if the failed tests have been muted previously.
-		nonZeroExitCode = false
-
-		// Fail if the number of passing tests is 50% or less than the last build. This will catch the case where the test runner crashes and no tests are run.
-		failOnMetricChange {
-			metric = BuildFailureOnMetric.MetricType.PASSED_TEST_COUNT
-			threshold = 50
-			units = BuildFailureOnMetric.MetricUnit.PERCENTS
-			comparison = BuildFailureOnMetric.MetricComparison.LESS
-			compareTo = build {
-				buildRule = lastSuccessful()
-			}
-		}
-	}
-})
-
-object CalypsoPreReleaseDashboard : BuildType({
-	id("calypso_WebApp_Calypso_Dashboard_Pre_Release_Dashboard")
-	uuid = "e07c2ff3-2a9f-416e-9a03-637690334da8"
-	name = "Calypso Pre-Release Dashboard"
-	description = "Generate Dashboard for Pre-Release Tests"
-
-	params {
-		param("docker_image", "registry.a8c.com/calypso/ci-allure:latest")
-	}
-
-	vcs {
-		root(Settings.WpCalypso)
-		cleanCheckout = false
-	}
-
-	dependencies {
-		artifacts (KPIDashboardTests) {
-			artifactRules = """
-				allure-results.tgz!/*.json => allure-results
-			"""
-		}
-	}
-
-	triggers {
-	}
-
-	steps {
-		bashNodeScript {
-			name = "Install dependencies"
-			scriptContent = """
-
-				aws configure set aws_access_key_id %CALYPSO_E2E_DASHBOARD_AWS_S3_ACCESS_KEY_ID%
-				aws configure set aws_secret_access_key %CALYPSO_E2E_DASHBOARD_AWS_S3_SECRET_ACCESS_KEY%
-
-				export FIRST_RUN=false
-				if [ "$(aws s3 ls %CALYPSO_E2E_DASHBOARD_AWS_S3_ROOT% | wc -l)" -eq "0" ]; then
-					echo "Previous report not found."
-					export FIRST_RUN=true
-				else
-					echo "Found previous report."
-					mkdir %teamcity.build.checkoutDir%/previous_allure_report
-					aws s3 sync %CALYPSO_E2E_DASHBOARD_AWS_S3_ROOT%/ %teamcity.build.checkoutDir%/previous_allure_report
-				fi
-
-				# -------
-				mkdir %teamcity.build.checkoutDir%/new_allure_report
-				# Copy history trend from previous run
-				cp -R %teamcity.build.checkoutDir%/previous_allure_report/history %teamcity.build.checkoutDir%/allure-results
-				# Generate report
-				allure generate %teamcity.build.checkoutDir%/allure-results -o %teamcity.build.checkoutDir%/new_allure_report
-
-				aws s3 sync %teamcity.build.checkoutDir%/new_allure_report %CALYPSO_E2E_DASHBOARD_AWS_S3_ROOT% --delete
-
-				echo "Done"
-			""".trimIndent()
-			dockerImage = "%docker_image_allure%"
-		}
-	}
-})
+	},
+	buildFeatures = {
+	},
+)
 
 object QuarantinedE2ETests: E2EBuildType(
 	buildId = "calypso_WebApp_Quarantined_E2E_Tests",

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -87,6 +87,7 @@ project {
 		// Calypso dashboard AWS secrets for S3 bucket.
 		password("CALYPSO_E2E_DASHBOARD_AWS_S3_ACCESS_KEY_ID", "credentialsJSON:1f324549-3795-43e5-a8c2-fb81d6e7c15d", display = ParameterDisplay.HIDDEN)
 		password("CALYPSO_E2E_DASHBOARD_AWS_S3_SECRET_ACCESS_KEY", "credentialsJSON:782b4bde-b73d-4326-9970-5a79251bdf07", display = ParameterDisplay.HIDDEN)
+		password("MATTICBOT_GITHUB_BEARER_TOKEN", "credentialsJSON:34cb38a5-9124-41c4-8497-74ed6289d751", display = ParameterDisplay.HIDDEN, label = "Matticbot GitHub Bearer Token")
 		text("CALYPSO_E2E_DASHBOARD_AWS_S3_ROOT", "s3://a8c-calypso-e2e-reports", label = "Calypso E2E Dashboard S3 bucket root")
 
 	}

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -65,7 +65,6 @@ project {
 		text("env.CHILD_CONCURRENCY", "15", label = "Yarn child concurrency", description = "How many packages yarn builds in parallel", allowEmpty = true)
 		text("docker_image", "registry.a8c.com/calypso/base:latest", label = "Docker image", description = "Default Docker image used to run builds", allowEmpty = true)
 		text("docker_image_e2e", "registry.a8c.com/calypso/ci-e2e:latest", label = "Docker e2e image", description = "Docker image used to run e2e tests", allowEmpty = true)
-		text("docker_image_allure", "registry.a8c.com/calypso/ci-allure:latest", label = "Docker allure image", description = "Docker image used to generate Allure report", allowEmpty = true)
 		text("env.DOCKER_BUILDKIT", "1", label = "Enable Docker BuildKit", description = "Enables BuildKit (faster image generation). Values 0 or 1", allowEmpty = true)
 		password("mc_post_root", "credentialsJSON:2f764583-d399-4d5f-8ee1-06f68ef2e2a6", display = ParameterDisplay.HIDDEN )
 		password("mc_auth_secret", "credentialsJSON:5b1903f9-4b03-43ff-bba8-4a7509d07088", display = ParameterDisplay.HIDDEN)
@@ -167,20 +166,6 @@ object BuildBaseImages : BuildType({
 			param("dockerImage.platform", "linux")
 		}
 		dockerCommand {
-			name = "Build CI allure image"
-			commandType = build {
-				source = file {
-					path = "Dockerfile.base"
-				}
-				namesAndTags = """
-					registry.a8c.com/calypso/ci-allure:%image_tag%
-					registry.a8c.com/calypso/ci-allure:%build.number%
-				""".trimIndent()
-				commandArgs = "--target ci-allure"
-			}
-			param("dockerImage.platform", "linux")
-		}
-		dockerCommand {
 			name = "Push images"
 			commandType = push {
 				namesAndTags = """
@@ -190,8 +175,6 @@ object BuildBaseImages : BuildType({
 					registry.a8c.com/calypso/ci-e2e:%build.number%
 					registry.a8c.com/calypso/ci-wpcom:%image_tag%
 					registry.a8c.com/calypso/ci-wpcom:%build.number%
-					registry.a8c.com/calypso/ci-allure:%image_tag%
-					registry.a8c.com/calypso/ci-allure:%build.number%
 				""".trimIndent()
 			}
 		}

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -65,6 +65,7 @@ project {
 		text("env.CHILD_CONCURRENCY", "15", label = "Yarn child concurrency", description = "How many packages yarn builds in parallel", allowEmpty = true)
 		text("docker_image", "registry.a8c.com/calypso/base:latest", label = "Docker image", description = "Default Docker image used to run builds", allowEmpty = true)
 		text("docker_image_e2e", "registry.a8c.com/calypso/ci-e2e:latest", label = "Docker e2e image", description = "Docker image used to run e2e tests", allowEmpty = true)
+		text("docker_image_allure", "registry.a8c.com/calypso/ci-allure:latest", label = "Docker allure image", description = "Docker image used to generate Allure report", allowEmpty = true)
 		text("env.DOCKER_BUILDKIT", "1", label = "Enable Docker BuildKit", description = "Enables BuildKit (faster image generation). Values 0 or 1", allowEmpty = true)
 		password("mc_post_root", "credentialsJSON:2f764583-d399-4d5f-8ee1-06f68ef2e2a6", display = ParameterDisplay.HIDDEN )
 		password("mc_auth_secret", "credentialsJSON:5b1903f9-4b03-43ff-bba8-4a7509d07088", display = ParameterDisplay.HIDDEN)
@@ -165,6 +166,20 @@ object BuildBaseImages : BuildType({
 			param("dockerImage.platform", "linux")
 		}
 		dockerCommand {
+			name = "Build CI allure image"
+			commandType = build {
+				source = file {
+					path = "Dockerfile.base"
+				}
+				namesAndTags = """
+					registry.a8c.com/calypso/ci-allure:%image_tag%
+					registry.a8c.com/calypso/ci-allure:%build.number%
+				""".trimIndent()
+				commandArgs = "--target ci-allure"
+			}
+			param("dockerImage.platform", "linux")
+		}
+		dockerCommand {
 			name = "Push images"
 			commandType = push {
 				namesAndTags = """
@@ -174,6 +189,8 @@ object BuildBaseImages : BuildType({
 					registry.a8c.com/calypso/ci-e2e:%build.number%
 					registry.a8c.com/calypso/ci-wpcom:%image_tag%
 					registry.a8c.com/calypso/ci-wpcom:%build.number%
+					registry.a8c.com/calypso/ci-allure:%image_tag%
+					registry.a8c.com/calypso/ci-allure:%build.number%
 				""".trimIndent()
 			}
 		}

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -69,6 +69,7 @@ ENV DISPLAY=:99
 
 RUN apt-get update \
 	&& apt-get install -y --no-install-recommends \
+		awscli \
 		fonts-liberation \
 		# Install non-Latin fonts
 		fonts-noto-cjk \
@@ -88,6 +89,7 @@ RUN apt-get update \
 		libx11-xcb1 \
 		libxss1 \
 		libxtst6 \
+		openjdk-17-jre \
 		openssl \
 		xauth \
 		xvfb \

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -123,17 +123,3 @@ RUN wget http://mirrors.kernel.org/ubuntu/pool/main/libf/libffi/libffi6_3.2.1-8_
 RUN wget -O - https://sentry.io/get-cli/ | bash
 
 ENTRYPOINT [ "/bin/bash" ]
-
-#### ci-allure image
-#### This image is used to process Allure reports in Calypso.
-
-FROM base as ci-allure
-# RUN curl -L "https://github.com/allure-framework/allure2/releases/download/2.19.0/allure_2.19.0-1_all.deb" -o "allure.deb"
-
-# RUN ls -la .
-RUN apt-get update && \
-	# apt-get install -y --no-install-recommends software-properties-common awscli
-	apt-get install -y --no-install-recommends awscli openjdk-17-jre && \
-	npm install -g allure-commandline
-
-ENTRYPOINT [ "/bin/bash" ]

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -48,8 +48,8 @@ RUN apt-get update \
 	&& chmod 0440 /etc/sudoers.d/$user \
 	&& chown $UID /calypso \
 	&& rm -rf /var/lib/apt/lists/* \
-	&& apt autoremove --purge \
-	&& apt autoclean
+	&& apt-get autoremove --purge \
+	&& apt-get autoclean
 
 # Set bash as the default shell
 RUN rm /bin/sh && ln -s /bin/bash /bin/sh
@@ -67,8 +67,8 @@ ENV PUPPETEER_SKIP_DOWNLOAD=false
 ENV PLAYWRIGHT_SKIP_DOWNLOAD=false
 ENV DISPLAY=:99
 
-RUN apt update \
-	&& apt install -y --no-install-recommends \
+RUN apt-get update \
+	&& apt-get install -y --no-install-recommends \
 		fonts-liberation \
 		# Install non-Latin fonts
 		fonts-noto-cjk \
@@ -91,8 +91,8 @@ RUN apt update \
 		openssl \
 		xauth \
 		xvfb \
-	&& apt autoremove --purge \
-	&& apt autoclean \
+	&& apt-get autoremove --purge \
+	&& apt-get autoclean \
 	&& rm -rf /var/lib/apt/lists/*
 
 ENTRYPOINT [ "/bin/bash" ]
@@ -104,20 +104,34 @@ FROM base as ci-wpcom
 COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 COPY --from=cache --chown=$UID /calypso/composer.* /calypso/
 
-RUN apt update && \
-	apt install -y apt-transport-https wget
+RUN apt-get update && \
+	apt-get install -y apt-transport-https wget
 
 # libffi6 is no longer available from apt as of bullseye.
 RUN wget http://mirrors.kernel.org/ubuntu/pool/main/libf/libffi/libffi6_3.2.1-8_amd64.deb && \
 	dpkg -i libffi6_3.2.1-8_amd64.deb && \
 	wget https://packages.sury.org/php/apt.gpg -O /etc/apt/trusted.gpg.d/php-sury.gpg && \
 	echo "deb https://packages.sury.org/php/ buster main" > /etc/apt/sources.list.d/php-sury.list && \
-	apt update && \
- 	apt upgrade -y && \
-	apt install -y php7.4-cli php7.4-xml php7.4-mbstring docker-compose && \
+	apt-get update && \
+ 	apt-get upgrade -y && \
+	apt-get install -y php7.4-cli php7.4-xml php7.4-mbstring docker-compose && \
 	composer install
 
 # Install sentry-cli.
 RUN wget -O - https://sentry.io/get-cli/ | bash
+
+ENTRYPOINT [ "/bin/bash" ]
+
+#### ci-allure image
+#### This image is used to process Allure reports in Calypso.
+
+FROM base as ci-allure
+# RUN curl -L "https://github.com/allure-framework/allure2/releases/download/2.19.0/allure_2.19.0-1_all.deb" -o "allure.deb"
+
+# RUN ls -la .
+RUN apt-get update && \
+	# apt-get install -y --no-install-recommends software-properties-common awscli
+	apt-get install -y --no-install-recommends awscli openjdk-17-jre && \
+	npm install -g allure-commandline
 
 ENTRYPOINT [ "/bin/bash" ]


### PR DESCRIPTION
#### Proposed Changes

This PR enables the TeamCity portion of Allure report generation for Pre-Release Tests.

Project Thread: pciE2j-1mq-p2

Some context/motivation: p1666118860676899/1666118837.142499-slack-C1A1EKDGQ

**40kft overview**
@Automattic/kitkat wants to generate a dashboard, starting with the Pre-Release Tests, to track overall trends and statistics that are buried and difficult to access with TeamCity.

We decided to use the Allure framework to do this, similarly to how [Jetpack](https://automattic.github.io/jetpack-e2e-reports/) and [WooCommerce](https://woocommerce.github.io/woocommerce-test-reports/) has built their dashboards.

The Allure framework plugin was built in https://github.com/Automattic/wp-calypso/pull/67333 and lives in the `wp-calypso` repo. The only thing it is waiting for is to be hooked up to a test run.

Similar to Jetpack and WooCommerce, I created a new repo at [wp-calypso-test-results](https://github.com/Automattic/wp-calypso-test-results) and built a GitHub Action that will obtain and process the generated Allure data. The GitHub Action will then push up the generated report to GitHub Pages.

**What this PR does**
With the GitHub Actions live and waiting for data input, this PR connects the wiring on the TeamCity side. Once merged, changes in this PR will take effect and subsequent runs of the Pre-Release Test build will push new Allure data to the GitHub Action each time it is run.

**Architecture**

**TeamCity** ---pushes data---> **S3** ---is pulled by---> **GitHub Actions** ---pushes report to---> **GitHub Pages**

Key changes:
- re-define the Pre-Release Tests build configuration as a `BuildType`, not as `E2EBuildType`.
- remove unnecessary build configuration `CalypsoPreReleaseDashboard`.
- define new secrets in `settings.kts`.
- update all `apt` calls in Dockerfile.base to `apt-get`.
- install `awscli` in the `ci-e2e` image.

#### Testing Instructions

Ensure the following build configurations are passing:
  - [ ] Pre-Release Tests
  - [ ] Calypso E2E (desktop)
  - [ ] Code Style
  - [ ] Unit Tests
  - [ ] Build Base Image
  - [ ] Build Docker Image

Additionally, ensure the following are true:
  - [ ] The steps `Upload Allure results` and `Send webhook to GitHub Actions` is skipped.


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #69802.