### PR TITLE
Support: Ensure chat closure notice shows for eligible users

### DIFF
--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -47,6 +47,7 @@ import {
 } from 'calypso/state/happychat/connection/actions';
 import getHappychatEnv from 'calypso/state/happychat/selectors/get-happychat-env';
 import getHappychatUserInfo from 'calypso/state/happychat/selectors/get-happychat-userinfo';
+import getSupportLevel from 'calypso/state/happychat/selectors/get-support-level';
 import hasHappychatLocalizedSupport from 'calypso/state/happychat/selectors/has-happychat-localized-support';
 import isHappychatUserEligible from 'calypso/state/happychat/selectors/is-happychat-user-eligible';
 import { openChat as openHappychat } from 'calypso/state/happychat/ui/actions';
@@ -564,6 +565,10 @@ class HelpContact extends Component {
 		const isUserAffectedByLiveChatClosure =
 			[ SUPPORT_FORUM, SUPPORT_UPWORK_TICKET ].indexOf( supportVariation ) === -1;
 
+		const hasAccessToLivechat = ! [ 'free', 'personal', 'starter' ].includes(
+			this.props.supportLevel
+		);
+
 		return (
 			<div>
 				{ activeSupportTicketCount > 0 && (
@@ -585,7 +590,7 @@ class HelpContact extends Component {
 							displayAt="2022-10-29 00:00Z"
 							closesAt="2022-11-05 00:00Z"
 							reopensAt="2022-11-14 07:00Z"
-							enabled={ this.props.isHappychatUserEligible }
+							enabled={ hasAccessToLivechat }
 						/>
 						<ChatHolidayClosureNotice
 							holidayName={ translate( 'Christmas', {
@@ -668,6 +673,7 @@ export default withDispatch( ( dispatch ) => {
 				hasMoreThanOneSite: getCurrentUserSiteCount( state ) > 1,
 				shouldStartHappychatConnection: ! isRequestingSites( state ) && isChatEligible,
 				isRequestingSites: isRequestingSites( state ),
+				supportLevel: getSupportLevel( state ),
 				supportVariation: getInlineHelpSupportVariation( state ),
 				shouldShowHelpCenterToUser: shouldShowHelpCenterToUser( getCurrentUserId( state ) ),
 				happychatEnv: getHappychatEnv( state ),

--- a/packages/help-center/src/components/help-center-contact-page.tsx
+++ b/packages/help-center/src/components/help-center-contact-page.tsx
@@ -4,6 +4,7 @@
  */
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Spinner, GMClosureNotice } from '@automattic/components';
+import { useSupportAvailability } from '@automattic/data-stores';
 import { Notice } from '@wordpress/components';
 import { useEffect } from '@wordpress/element';
 import { comment, Icon } from '@wordpress/icons';
@@ -42,6 +43,7 @@ export const HelpCenterContactPage: React.FC = () => {
 	const { data: tickets, isLoading: isLoadingTickets } = useActiveSupportTicketsQuery( email, {
 		staleTime: 30 * 60 * 1000,
 	} );
+	const { data: supportAvailability } = useSupportAvailability( 'CHAT' );
 	const isLoading = renderChat.isLoading || renderEmail.isLoading || isLoadingTickets;
 
 	useEffect( () => {
@@ -63,6 +65,10 @@ export const HelpCenterContactPage: React.FC = () => {
 		);
 	}
 
+	const hasAccessToLivechat = ! [ 'free', 'personal', 'starter' ].includes(
+		supportAvailability?.supportLevel || ''
+	);
+
 	return (
 		<div className="help-center-contact-page">
 			<BackButton />
@@ -73,7 +79,7 @@ export const HelpCenterContactPage: React.FC = () => {
 					displayAt="2022-10-29 00:00Z"
 					closesAt="2022-11-05 00:00Z"
 					reopensAt="2022-11-14 07:00Z"
-					enabled={ renderChat.render }
+					enabled={ hasAccessToLivechat }
 				/>
 				<div
 					className={ classnames( 'help-center-contact-page__boxes', {


### PR DESCRIPTION
As reported on P2: pbg9X-i2B-p2#comment-70116

The issue is that with the chat throttle set to 0%, no user is "eligible" for chat. So the notice is not shown.

To fix this, we need to look at the support level instead.

Not liking the duplicated code there, but this is a quickfix, plus we're going to be getting rid of the FAB soon enough (🤞).

#### Testing Instructions

Test in Help Center, see instructions from #69523.
Test in FAB, see instructions from #69475.

With this PR (and when the backend changes from D91755-code are merged), both Help Center and FAB should show the notice for eligible users (those that are not on Free, Personal or Starter plans).