### PR TITLE
Agency Dashboard: Do not trigger API requests to the /test-connection endpoint on window refocus

### DIFF
--- a/client/data/agency-dashboard/use-fetch-test-connection.ts
+++ b/client/data/agency-dashboard/use-fetch-test-connection.ts
@@ -33,6 +33,8 @@ const useFetchTestConnection = (
 					)
 				),
 			enabled: isPartnerOAuthTokenLoaded,
+			refetchOnWindowFocus: false,
+			refetchOnMount: false,
 		}
 	);
 };


### PR DESCRIPTION
#### Proposed Changes

In https://github.com/Automattic/wp-calypso/pull/68837, we have implemented an improvement that will trigger a site audit if we detect a difference between the site health stored in the ES and the actual state.

This PR implements some optimizations (see my suggestion [here](https://github.com/Automattic/wp-calypso/pull/68837#issuecomment-1278894423)):
- Prevent React Query from automatically requesting fresh data for you in the background when your browser tab is on focus.
- Prevent React Query from automatically requesting fresh data when the component mounts, instead, we want to fetch data only on the initial rendering.

#### Testing Instructions
- Checkout this PR
- Run `yarn start-jetpack-cloud`
- Open your Dev Tools (Option + ⌘ + J), and choose the `Network` tab
- Visit http://jetpack.cloud.localhost:3000/dashboard
- Verify that API requests to the `/test-connection` endpoint are made for your website
- Switch to another browser tab and return back to the dashboard
- Verify that no further API requests to the `/test-connection` endpoint are made
- Click on `Manage sites` (on the top navigation), and then return back to the `Dashboard`
- Verify that no further API requests to the `/test-connection` endpoint are made


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1202619025189113-as-1203269403342686