### PR TITLE
Stats: Recover Traffic nested bar charts behind the new main chart feature

### DIFF
--- a/client/my-sites/stats/modernized-chart-tabs-styles.scss
+++ b/client/my-sites/stats/modernized-chart-tabs-styles.scss
@@ -14,52 +14,51 @@
 		}
 	}
 
-	.stats-module__placeholder.is-chart {
-		height: 228px;
-	}
-
 	// Common Legend options
 	.chart__legend {
-		margin: 0;
-	}
+		margin-bottom: 16px;
 
+		.chart__legend-options {
+			text-transform: none;
+		}
 
-	.chart__legend-options {
-		text-transform: none;
-	}
+		.chart__legend-option {
+			&:not(:first-child) {
+				margin-left: 24px;
+			}
+		}
 
-	.chart__legend-option {
-		&:not(:first-child) {
-			margin-left: 24px;
+		.chart__legend-label {
+			color: var(--studio-black);
+			font-size: $font-body-small;
+			font-weight: 400;
+			line-height: 18px;
+			padding: 0;
+
+			.chart__legend-checkbox {
+				width: 20px;
+				height: 20px;
+				background-color: var(--color-surface);
+				border: 1px solid var(--color-neutral-10);
+				border-radius: 2px;
+				margin-right: 8px;
+
+				&:checked::before {
+					margin: 3px auto;
+				}
+			}
+		}
+
+		.chart__legend-color {
+			width: 20px;
+			height: 20px;
+			margin: 0 8px 0 0;
+			border-radius: 4px;
 		}
 	}
 
-	.chart__legend-label {
-		color: var(--studio-black);
-		font-size: $font-body-small;
-		font-weight: 400;
-		line-height: 18px;
-		padding: 0;
-	}
-
-	.chart__legend-checkbox {
-		width: 20px;
-		height: 20px;
-		background-color: var(--color-surface);
-		border: 1px solid var(--color-neutral-10);
-		border-radius: 2px;
-		margin-right: 8px;
-
-		&:checked::before {
-			margin: 3px auto;
-		}
-	}
-
-	.chart__legend-color {
-		width: 20px;
-		height: 20px;
-		margin: 0 8px 0 0;
-		border-radius: 4px;
+	.stats-module__placeholder.is-chart {
+		height: 228px;
 	}
 
 	// Main Chart

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -252,7 +252,7 @@ class StatsSite extends Component {
 
 							<ChartTabs
 								activeTab={ getActiveTab( this.props.chartTab ) }
-								activeLegend={ [] }
+								activeLegend={ this.state.activeLegend }
 								availableLegend={ this.getAvailableLegend() }
 								onChangeLegend={ this.onChangeLegend }
 								barClick={ this.barClick }

--- a/client/my-sites/stats/stats-chart-tabs/index.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/index.jsx
@@ -110,6 +110,13 @@ class StatModuleChartTabs extends Component {
 		/* pass bars count as `key` to disable transitions between tabs with different column count */
 		return isNewFeatured ? (
 			<div className={ classNames( ...classes ) }>
+				<Legend
+					activeCharts={ this.props.activeLegend }
+					activeTab={ this.props.activeTab }
+					availableCharts={ this.props.availableLegend }
+					clickHandler={ this.onLegendClick }
+					tabs={ this.props.charts }
+				/>
 				{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace */ }
 				<StatsModulePlaceholder className="is-chart" isLoading={ isActiveTabLoading } />
 				<Chart

--- a/client/my-sites/stats/stats-chart-tabs/style.scss
+++ b/client/my-sites/stats/stats-chart-tabs/style.scss
@@ -245,6 +245,49 @@ ul.module-tabs {
 .chart-tabs--new-main-chart {
 	background-color: var(--studio-white);
 
+	// Legend options
+	.chart__legend {
+		margin-bottom: 16px;
+
+		.chart__legend-options {
+			text-transform: none;
+		}
+
+		.chart__legend-option {
+			&:not(:first-child) {
+				margin-left: 24px;
+			}
+		}
+
+		.chart__legend-label {
+			color: var(--studio-black);
+			font-size: $font-body-small;
+			font-weight: 400;
+			line-height: 18px;
+			padding: 0;
+
+			.chart__legend-checkbox {
+				width: 20px;
+				height: 20px;
+				background-color: var(--color-surface);
+				border: 1px solid var(--color-neutral-10);
+				border-radius: 2px;
+				margin-right: 8px;
+
+				&:checked::before {
+					margin: 3px auto;
+				}
+			}
+		}
+
+		.chart__legend-color {
+			width: 20px;
+			height: 20px;
+			margin: 0 8px 0 0;
+			border-radius: 4px;
+		}
+	}
+
 	.stats-module__placeholder.is-chart {
 		height: 228px;
 	}


### PR DESCRIPTION
#### Proposed Changes

This PR follows up on https://github.com/Automattic/wp-calypso/pull/69529#issuecomment-1301365801.

* Recover `Legend` options in the bar chart of the Traffic page behind the new feature flag `stats--new-main-chart`.
* Adjust and sync `.chart__legend` related styles.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Launch the _local_ development application or append `?flags=stats/new-main-chart` on URL of the Calypso Live link.
* Navigate to page `/stats/day/${your-site}`.
* Ensure the `Visitors`' nested bar charts are set back into the `Views` bar charts.

| Before | After |
| --- | --- |
| <img width="1093" alt="截圖 2022-11-07 上午2 43 53" src="https://user-images.githubusercontent.com/6869813/200189177-d6e351c0-7c1c-4f82-9326-f8fc55170229.png"> | <img width="1110" alt="截圖 2022-11-07 上午2 43 31" src="https://user-images.githubusercontent.com/6869813/200189188-fd292e02-87c4-4998-9db1-2b4800ced2d3.png"> |


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #69041 