### PR TITLE
Pattern Assembler - Enable signup/design-picker-pattern-assembler on Horizon

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -95,7 +95,7 @@
 		"settings/security/monitor": true,
 		"sign-in-with-apple": false,
 		"signup/anchor-fm": true,
-		"signup/design-picker-pattern-assembler": false,
+		"signup/design-picker-pattern-assembler": true,
 		"signup/design-picker-categories": true,
 		"signup/design-picker-premium-themes-checkout": true,
 		"signup/design-picker-use-featured-picks-buttons": true,


### PR DESCRIPTION
#### Proposed Changes

* Enable `signup/design-picker-pattern-assembler` on Horizon environment for testing

The goal is to test the Pattern Assembler flow, including creating a new site without needing to add `&flags=signup/design-picker-pattern-assembler`

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to [horizon.wordpress.com/start](https://horizon.wordpress.com/start) to pick a free domain and plan to create a new site
* Don't select any goals and any vertical and continue the flow
* Check that on the design picker step, you can see the Blank canvas CTA 

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


