### PR TITLE
Pattern Assembler - UI updates - copy and max width

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -302,6 +302,7 @@ const PatternAssembler: Step = ( { navigation } ) => {
 			goBack={ onBack }
 			goNext={ goNext }
 			isHorizontalLayout={ false }
+			isFullLayout={ true }
 			hideSkip={ true }
 			stepContent={ stepContent }
 			recordTracksEvent={ recordTracksEvent }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-layout.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-layout.tsx
@@ -47,9 +47,10 @@ const PatternLayout = ( {
 				<h2>{ translate( 'Design your page' ) }</h2>
 				<p>
 					{ translate(
-						'Kick start the content on your page by picking your patterns. First choose a header for your page layout, then choose at least one section pattern, and finally choose your footer.'
+						'First choose a header for your page layout, then choose at least one section pattern, and finally choose your footer.'
 					) }
 				</p>
+				<p>{ translate( 'You can change this later.' ) }</p>
 			</div>
 			<div className="pattern-layout__body">
 				<ul>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-layout.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-layout.tsx
@@ -47,7 +47,7 @@ const PatternLayout = ( {
 				<h2>{ translate( 'Design your page' ) }</h2>
 				<p>
 					{ translate(
-						'First choose a header for your page layout, then choose at least one section pattern, and finally choose your footer.'
+						'First choose a header for your page layout, then choose at least one content pattern, and finally choose your footer.'
 					) }
 				</p>
 				<p>{ translate( 'You can change this later.' ) }</p>
@@ -106,8 +106,8 @@ const PatternLayout = ( {
 						<Button onClick={ () => onAddSection() }>
 							<span className="pattern-layout__add-icon">+</span>{ ' ' }
 							{ sections?.length
-								? translate( 'Add another section' )
-								: translate( 'Add a first section' ) }
+								? translate( 'Add another pattern' )
+								: translate( 'Add a first pattern' ) }
 						</Button>
 					</li>
 					{ footer ? (

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-selector-loader.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-selector-loader.tsx
@@ -41,7 +41,7 @@ const PatternSelectorLoader = ( {
 				patterns={ sectionPatterns }
 				onSelect={ onSelect }
 				onBack={ onBack }
-				title={ translate( 'Add a section' ) }
+				title={ translate( 'Add a pattern' ) }
 				selectedPattern={ selectedPattern }
 			/>
 		</>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/patterns-data.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/patterns-data.ts
@@ -7,46 +7,46 @@ const headerPatterns: Pattern[] = [
 	},
 	{
 		id: 5582,
-		name: 'Simple Header With Large Font Size',
+		name: 'Simple header with large font size',
 	},
 	{
 		id: 5605,
-		name: 'Header with Site Title and Vertical Navigation',
+		name: 'Header with site title and vertical navigation',
 	},
 	{
 		id: 5603,
-		name: 'Header with Site Title and Menu Button',
+		name: 'Header with site title and menu button',
 	},
 	{
 		id: 7914,
-		name: 'Header with Button',
+		name: 'Header with button',
 	},
 	{
 		id: 5588,
-		name: 'Simple Header',
+		name: 'Simple header',
 	},
 	{
 		id: 5601,
-		name: 'Simple Header With Tagline',
+		name: 'Simple header with tagline',
 	},
 	{
 		id: 5590,
-		name: 'Simple Header With Image Background',
+		name: 'Simple header with image background',
 	},
 	{
 		id: 5595,
-		name: 'Simple Header With Image',
+		name: 'Simple header with image',
 	},
 	{
 		id: 5593,
-		name: 'Simple Header With Dark background',
+		name: 'Simple header with dark background',
 	},
 ];
 
 const footerPatterns: Pattern[] = [
 	{
 		id: 5316,
-		name: 'Footer with Social Icons, Address, E-mail, and Telephone Number',
+		name: 'Footer with social icons, address, e-mail, and telephone number',
 	},
 	{
 		id: 5886,
@@ -74,7 +74,7 @@ const footerPatterns: Pattern[] = [
 	},
 	{
 		id: 5047,
-		name: 'Footer with Navigation, Contact Details, Social Links, and Subscription Form',
+		name: 'Footer with navigation, contact details, social links, and subscription form',
 	},
 	{
 		id: 5880,
@@ -109,7 +109,7 @@ const sectionPatterns: Pattern[] = [
 	},
 	{
 		id: 5691,
-		name: 'Three Logos, Heading, and Paragraphs',
+		name: 'Three logos, heading, and paragraphs',
 	},
 	{
 		id: 7143,
@@ -129,11 +129,11 @@ const sectionPatterns: Pattern[] = [
 	},
 	{
 		id: 1585,
-		name: 'Quote and Logos',
+		name: 'Quote and logos',
 	},
 	{
 		id: 789,
-		name: 'Numbered List',
+		name: 'Numbered list',
 	},
 	{
 		id: 5666,
@@ -145,7 +145,7 @@ const sectionPatterns: Pattern[] = [
 	},
 	{
 		id: 5663,
-		name: 'Large Headline',
+		name: 'Large headline',
 	},
 	{
 		id: 7140,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
@@ -13,16 +13,11 @@ $font-family: "SF Pro Text", $sans;
 	display: flex;
 	height: calc(100vh - 60px);
 	width: 100%;
-	justify-content: center;
 
 	.pattern-assembler__button {
 		width: 100%;
 		height: 40px;
 		border-radius: 4px;
-	}
-
-	.step-container {
-		max-width: 1440px;
 	}
 
 	.step-container__content {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
@@ -68,7 +68,7 @@ $font-family: "SF Pro Text", $sans;
 				line-height: 24px;
 				letter-spacing: -0.1px;
 				color: #50575e;
-				padding-bottom: 42px;
+				padding-bottom: 24px;
 			}
 		}
 


### PR DESCRIPTION
#### Proposed Changes

* Remove max width from PA.
* Reduce the intro text. 
* Replace the term `section` to use `pattern`.
* Remove capitalization of pattern titles.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Access `/start&siteSlug=[YOUR SITE]`
* Don't mark any goal or any vertical
* Click on the Blank canvas CTA
* Check that the Pattern Assembler is full width by resizing your browser.

<img width="2553" alt="Screen Shot 2565-11-07 at 15 04 02" src="https://user-images.githubusercontent.com/1881481/200257305-9e8f5785-ca88-4dfa-a1b0-4b9d726635ea.png">

* Check the intro text update
![image](https://user-images.githubusercontent.com/1881481/201827828-2b38611f-f527-4fbe-9387-1b8024a071c9.png)

* Click on `Add a first pattern` to check that the term `section` is removed
![image](https://user-images.githubusercontent.com/1881481/201827856-63383e1c-0c18-4270-8151-b2b4233c8644.png)

* Check that the pattern names have only the first character capitalized.

<img width="289" alt="Screen Shot 2565-11-15 at 11 47 33" src="https://user-images.githubusercontent.com/1881481/201828841-c4985fdd-f23a-4dd9-9e68-490169dc768f.png">


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/69817
