### PR TITLE
Agency Dashboard: Trigger requests to the /test-connection endpoint on component mount

### DIFF
--- a/client/data/agency-dashboard/use-fetch-test-connection.ts
+++ b/client/data/agency-dashboard/use-fetch-test-connection.ts
@@ -34,7 +34,6 @@ const useFetchTestConnection = (
 				),
 			enabled: isPartnerOAuthTokenLoaded,
 			refetchOnWindowFocus: false,
-			refetchOnMount: false,
 		}
 	);
 };

--- a/client/data/agency-dashboard/use-fetch-test-connection.ts
+++ b/client/data/agency-dashboard/use-fetch-test-connection.ts
@@ -34,6 +34,9 @@ const useFetchTestConnection = (
 				),
 			enabled: isPartnerOAuthTokenLoaded,
 			refetchOnWindowFocus: false,
+			// We don't want to trigger another API request to the /test-connection endpoint for a given site
+			// five minutes after the first successful one.
+			staleTime: 1000 * 60 * 5,
 		}
 	);
 };


### PR DESCRIPTION
#### Proposed Changes

After shipping https://github.com/Automattic/wp-calypso/pull/69809, I realized that disabling requests on the component mount would prevent triggering the API requests to the `/test-connection` endpoint when the user navigates between pages in the dashboard (in case they have many sites).

This PR will solve that issue and will also set a `staleTime`, which specifies that we don't want to trigger another API requests five minutes after we had a successful one.

#### Testing Instructions
- Checkout this PR
- Run `yarn start-jetpack-cloud`
- Open your Dev Tools (Option + ⌘ + J), and choose the `Network` tab
- Visit http://jetpack.cloud.localhost:3000/dashboard
- Verify that API requests to the `/test-connection` endpoint are made for your website
- Switch to another browser tab and return back to the dashboard
- Verify that no further API requests to the `/test-connection` endpoint are made
- Wait about five minutes and then switch to the `Manage sites` (on the top navigation), then return to the `Dashboard`
- Verify that API requests to the `/test-connection` endpoint are made

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
