### PR TITLE
Adding displayAsLink to the banner component

### DIFF
--- a/client/blocks/upsell-nudge/index.jsx
+++ b/client/blocks/upsell-nudge/index.jsx
@@ -69,6 +69,7 @@ export const UpsellNudge = ( {
 	tracksDismissProperties,
 	tracksImpressionName,
 	tracksImpressionProperties,
+	displayAsLink,
 } ) => {
 	const shouldNotDisplay =
 		isVip ||
@@ -148,6 +149,7 @@ export const UpsellNudge = ( {
 			tracksDismissProperties={ tracksDismissProperties }
 			tracksImpressionName={ tracksImpressionName }
 			tracksImpressionProperties={ tracksImpressionProperties }
+			displayAsLink={ displayAsLink }
 		/>
 	);
 };

--- a/client/components/banner/index.jsx
+++ b/client/components/banner/index.jsx
@@ -68,6 +68,7 @@ export class Banner extends Component {
 		tracksDismissProperties: PropTypes.object,
 		customerType: PropTypes.string,
 		isSiteWPForTeams: PropTypes.bool,
+		displayAsLink: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -264,6 +265,7 @@ export class Banner extends Component {
 			jetpack,
 			isAtomic,
 			plan,
+			displayAsLink,
 		} = this.props;
 
 		// For P2 sites, only show banners if they have the 'p2-banner' class.
@@ -310,6 +312,7 @@ export class Banner extends Component {
 				className={ classes }
 				href={ ( disableHref || callToAction ) && ! forceHref ? null : this.getHref() }
 				onClick={ callToAction && ! forceHref ? null : this.handleClick }
+				displayAsLink={ displayAsLink }
 			>
 				{ dismissWithoutSavingPreference && (
 					<Gridicon icon="cross" className="banner__close-icon" onClick={ this.handleDismiss } />


### PR DESCRIPTION
#### Proposed Changes

The prop `displayAsLink` gives the card a hovering effect to let the users know it is clickable. We need this for the Third Party themes because the card won't have a link. We will need to use the onClick event to redirect the user to checkout.

* Accepts the card prop `displayAsLink` in the banner component.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this PR
* Navigate to `/theme/thriving-artist` on an incognito tab to ensure the banner continues working as expected.

<img width="953" alt="Screen Shot 2022-11-07 at 18 02 43" src="https://user-images.githubusercontent.com/1234758/200415052-d6ae3b3c-cbeb-4e41-aa6b-0316ca1beccb.png">


Related to #69616
