### PR TITLE
Gifting: show gifted site name in Checkout

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-review.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-review.tsx
@@ -124,7 +124,11 @@ export default function WPCheckoutOrderReview( {
 		( product ) =>
 			isDomainTransfer( product ) || isDomainRegistration( product ) || isDomainMapping( product )
 	);
-	const domainUrl = primaryDomain ?? firstDomainProduct?.meta ?? siteUrl;
+	const domainUrl =
+		primaryDomain ??
+		firstDomainProduct?.meta ??
+		responseCart?.gift_details?.receiver_blog_url ??
+		siteUrl;
 
 	const removeCouponAndClearField = () => {
 		couponFieldStateProps.setCouponFieldValue( '' );

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -312,6 +312,11 @@ export interface ResponseCart< P = ResponseCartProduct > {
 	 */
 	credits_display: string;
 
+	/**
+	 * Gift Details
+	 */
+	gift_details?: ResponseCartGiftDetails;
+
 	currency: string;
 	allowed_payment_methods: string[];
 	coupon: string;
@@ -586,6 +591,11 @@ export interface ResponseCartProductExtra {
 	afterPurchaseUrl?: string;
 	isJetpackCheckout?: boolean;
 	is_marketplace_product?: boolean;
+}
+
+export interface ResponseCartGiftDetails {
+	receiver_blog_id: number;
+	receiver_blog_url?: string;
 }
 
 export interface RequestCartProductExtra extends ResponseCartProductExtra {


### PR DESCRIPTION
#### Proposed Changes

* Adds `gift_details` to `ResponseCart` (introduced in D90977-code)
* Updates the way the displayed site is determined
* Prioritizes using a domain name in the cart
* Uses `receiver_blog_url` from this response as a fall-through before using `siteUrl`

#### Testing Instructions

You'll need two accounts and make sure that the store is sandboxed.

* With account A, purchase a personal plan (or use an account which already owns a plan) and a `.live` domain name
* With account B, go to the following URL: `/checkout/personal-bundle/gift/<ACCOUNT_A_SUBSCRIPTION_ID>`. You can use Store Admin to find the subscription ID of the account A's plan.
* Verify the site name is account A's blog URL
* <img width="580" alt="Screen Shot 2022-11-07 at 11 09 38 AM" src="https://user-images.githubusercontent.com/38750/200424305-d6d59d74-02a9-4852-b574-3df192005bc1.png">
* With account B, go to the following URL: `/checkout/personal-bundle,dotlive_domain/gift/<ACCOUNT_A_PLAN_SUBSCRIPTION_ID>,<ACCOUNT_A_DOMAIN_SUBSCRIPTION_ID>`. You can use Store Admin to find the subscription ID of the account A's plan and .live domain.
* Verify the site name is the domain name added to the purchase
* <img width="577" alt="Screen Shot 2022-11-07 at 11 12 00 AM" src="https://user-images.githubusercontent.com/38750/200424428-ff6fc950-3c71-488d-9cf4-b81f60097642.png">


Fixes #1195
