### PR TITLE
Sensei Domain onboarding screen

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-domain/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-domain/index.tsx
@@ -61,14 +61,13 @@ const SenseiDomain: Step = ( { navigation } ) => {
 						// vendor={ SENSEI_FLOW }
 						key="domainForm"
 						suggestion={ domainSuggestion }
-						domainsWithPlansOnly
+						domainsWithPlansOnly={ true }
 						isSignupStep={ true }
 						includeWordPressDotCom
 						onAddDomain={ onAddDomain }
 						onSkip={ onSkip }
 						products={ productsList }
 						useProvidedProductsList
-						showSkipButton
 						align="left"
 						isWideLayout={ true }
 					/>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-domain/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-domain/style.scss
@@ -3,15 +3,32 @@
 @import "@wordpress/base-styles/variables";
 
 $sensei-mobile-layout-width: 1200px;
+$sensei-color: #43af99;
 
 .sensei.sensei-domain {
-	--color-text-subtle: #a7aaad;
-	--studio-green-60: #1e8133;
-
+	.css-1l7urtg-Container {
+		height: auto;
+	}
+	.progress-bar__progress {
+		background-color: $sensei-color;
+	}
 	.sensei-domain.is-wide-layout {
 		max-width: 1160px;
 	}
+	.domain-search-results__domain-suggestions {
+		.card {
+			box-shadow: none;
+			border-bottom: 1px solid var(--color-border-subtle);
+			border-top: 1px solid #fff;
+			background: none;
+			margin: 0;
 
+			&:hover {
+				border-top: 1px solid #000;
+				border-bottom: 1px solid #000;
+			}
+		}
+	}
 	.domains__step-content {
 		display: flex;
 		margin-top: 50px;
@@ -180,7 +197,7 @@ $sensei-mobile-layout-width: 1200px;
 	}
 
 	.domain-suggestion {
-		margin-bottom: 10px;
+		// margin-bottom: 10px;
 
 		.domain-suggestion__action {
 			border-radius: 4px;
@@ -210,11 +227,19 @@ $sensei-mobile-layout-width: 1200px;
 		.domain-suggestion__action {
 			border: none;
 			border-radius: 4px;
-			background-color: #0675c4;
+			background-color: $sensei-color;
+			color: #000;
+
+			&:hover {
+				background: lighten($sensei-color, 10%);
+			}
 		}
-		.domain-product-price.is-free-domain .domain-product-price__price {
-			color: #8e9196;
-		}
+	}
+	.domain-product-price.is-free-domain .domain-product-price__price {
+		color: #8e9196;
+	}
+	.domain-product-price .domain-product-price__free-price {
+		color: $sensei-color;
 	}
 
 	.register-domain-step__next-page {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-domain/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-domain/style.scss
@@ -6,15 +6,18 @@ $sensei-mobile-layout-width: 1200px;
 $sensei-color: #43af99;
 
 .sensei.sensei-domain {
-	.css-1l7urtg-Container {
+	.step-container__content > div {
 		height: auto;
 	}
+
 	.progress-bar__progress {
 		background-color: $sensei-color;
 	}
+
 	.sensei-domain.is-wide-layout {
 		max-width: 1160px;
 	}
+
 	.domain-search-results__domain-suggestions {
 		.card {
 			box-shadow: none;
@@ -197,7 +200,6 @@ $sensei-color: #43af99;
 	}
 
 	.domain-suggestion {
-		// margin-bottom: 10px;
 
 		.domain-suggestion__action {
 			border-radius: 4px;
@@ -235,9 +237,11 @@ $sensei-color: #43af99;
 			}
 		}
 	}
+
 	.domain-product-price.is-free-domain .domain-product-price__price {
 		color: #8e9196;
 	}
+
 	.domain-product-price .domain-product-price__free-price {
 		color: $sensei-color;
 	}
@@ -251,6 +255,7 @@ $sensei-color: #43af99;
 	.badge {
 		box-sizing: content-box;
 	}
+
 	.domain-suggestion .premium-badge {
 		padding: 1px 10px;
 
@@ -260,9 +265,11 @@ $sensei-color: #43af99;
 	}
 }
 .search-filters__popover {
-	$accent-blue: #117ac9;
 	.button.is-primary {
-		background: $accent-blue;
-		border-color: $accent-blue;
+		background: $sensei-color;
+		border-color: $sensei-color;
+	}
+	.token-field__suggestion.is-selected {
+		background-color: darken($sensei-color, 10);
 	}
 }


### PR DESCRIPTION
## Sensei Onboarding domain screen

I already commited the main changes to the main `add/sensei-onboarding` branch here:
https://github.com/Automattic/wp-calypso/commit/905a1ff9d1620a4c01a9245b157379338f6d4e59
https://github.com/Automattic/wp-calypso/commit/49d7a37764e1f88829be6a6c3fe13783e8060496

I'm now going to work from this branch for the domain stuff, so adding changes as I go!

cc @dadish 

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
