### PR TITLE
Stats: Pull site slug value from Redux state

### DIFF
--- a/client/my-sites/stats/stats-post-detail/index.jsx
+++ b/client/my-sites/stats/stats-post-detail/index.jsx
@@ -80,7 +80,7 @@ class StatsPostDetail extends Component {
 		const backLabel = localizedTabNames[ lastClickedTab ] || localizedTabNames.traffic;
 		let backLink = possibleBackLinks[ lastClickedTab ] || possibleBackLinks.traffic;
 		// Append the domain as needed.
-		const domain = this.props.path?.split( '/' ).pop();
+		const domain = this.props.siteSlug;
 		if ( domain?.length > 0 ) {
 			backLink += domain;
 		}

--- a/client/my-sites/stats/summary/index.jsx
+++ b/client/my-sites/stats/summary/index.jsx
@@ -13,7 +13,7 @@ import Main from 'calypso/components/main';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import AnnualSiteStats from 'calypso/my-sites/stats/annual-site-stats';
 import getMediaItem from 'calypso/state/selectors/get-media-item';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import Countries from '../stats-countries';
 import StatsModule from '../stats-module';
 import statsStringsFactory from '../stats-strings';
@@ -242,7 +242,7 @@ class StatsSummary extends Component {
 
 		// Append the site domain as needed.
 		const isFixedNavHeadersEnabled = config.isEnabled( 'stats/fixed-nav-headers' );
-		const domain = this.props.path?.split( '/' ).pop();
+		const domain = this.props.siteSlug;
 		if ( domain?.length > 0 ) {
 			backLink += domain;
 		}
@@ -280,6 +280,7 @@ export default connect( ( state, { context, postId } ) => {
 	const siteId = getSelectedSiteId( state );
 	return {
 		siteId: getSelectedSiteId( state ),
+		siteSlug: getSelectedSiteSlug( state, siteId ),
 		media: context.params.module === 'videodetails' ? getMediaItem( state, siteId, postId ) : false,
 	};
 } )( localize( StatsSummary ) );


### PR DESCRIPTION
Instead of performing string manipulation on the current path.

#### Proposed Changes

Minor update to how we generate the back links for the `FixedNavigationHeader` components. Now pulling the site slug from the Redux state.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Launch the Calypso Live link.
2. Select a site with recent activity from the Site Switcher.
3. Visit the Stats page.
4. Scroll down and click on the "Posts & pages" heading.
5. Confirm the back link brings you back to the Stats page.
6. Click on an individual post title under the "Posts & pages" heading.
7. Confirm the back link works correctly here too.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #69179.
