### PR TITLE
Use the new gift thank you page

### DIFF
--- a/client/my-sites/checkout/get-thank-you-page-url/index.ts
+++ b/client/my-sites/checkout/get-thank-you-page-url/index.ts
@@ -237,10 +237,12 @@ export default function getThankYouPageUrl( {
 	// redirection to the ecommerce thank you page for ecommerce plan checkouts.
 	if ( cart?.is_gift_purchase ) {
 		debug( 'gift purchase cart.gift_details', cart?.gift_details );
+		// Missing receiver_blog_slug should never happen but if it's missing we incorrectly
+		// show a purchase thank you page for the users primary site instead.
 		if ( ! cart?.gift_details?.receiver_blog_slug ) {
 			throw new Error( 'Expected receiver_blog_slug in cart.gift_details, slug not found.' );
 		}
-		return `/checkout/gift/thank-you/${ cart?.gift_details?.receiver_blog_slug ?? 'no-site' }`;
+		return `/checkout/gift/thank-you/${ cart?.gift_details?.receiver_blog_slug }`;
 	}
 
 	// Manual renewals usually have a `redirectTo` but if they do not, return to

--- a/client/my-sites/checkout/get-thank-you-page-url/index.ts
+++ b/client/my-sites/checkout/get-thank-you-page-url/index.ts
@@ -233,6 +233,16 @@ export default function getThankYouPageUrl( {
 		return '/';
 	}
 
+	// Gift purchases need to bypass everything below, especially the updateUrlInCookie
+	// redirection to the ecommerce thank you page for ecommerce plan checkouts.
+	if ( cart?.is_gift_purchase ) {
+		debug( 'gift purchase cart.gift_details', cart?.gift_details );
+		if ( ! cart?.gift_details?.receiver_blog_slug ) {
+			throw new Error( 'Expected receiver_blog_slug in cart.gift_details, slug not found.' );
+		}
+		return `/checkout/gift/thank-you/${ cart?.gift_details?.receiver_blog_slug ?? 'no-site' }`;
+	}
+
 	// Manual renewals usually have a `redirectTo` but if they do not, return to
 	// the manage purchases page.
 	const firstRenewalInCart =

--- a/client/my-sites/checkout/get-thank-you-page-url/test/get-thank-you-page-url.ts
+++ b/client/my-sites/checkout/get-thank-you-page-url/test/get-thank-you-page-url.ts
@@ -1716,5 +1716,42 @@ describe( 'getThankYouPageUrl', () => {
 				'/checkout/jetpack/thank-you/licensing-auto-activate/jetpack_backup_daily?receiptId=80023&siteId=123456789'
 			);
 		} );
+
+		it( '/checkout/gift/thank-you/:site when gift purchase', () => {
+			const url = getThankYouPageUrl( {
+				...defaultArgs,
+				cart: {
+					...getEmptyResponseCart(),
+					products: [
+						{
+							...getEmptyResponseCartProduct(),
+							product_slug: PLAN_PERSONAL,
+						},
+					],
+					is_gift_purchase: true,
+					gift_details: { receiver_blog_slug: 'foo.bar' },
+				},
+			} );
+			expect( url ).toBe( '/checkout/gift/thank-you/foo.bar' );
+		} );
+
+		it( 'Error when gift purchase missing blog_slug', () => {
+			expect( () =>
+				getThankYouPageUrl( {
+					...defaultArgs,
+					cart: {
+						...getEmptyResponseCart(),
+						products: [
+							{
+								...getEmptyResponseCartProduct(),
+								product_slug: PLAN_PERSONAL,
+							},
+						],
+						is_gift_purchase: true,
+						gift_details: {},
+					},
+				} )
+			).toThrow();
+		} );
 	} );
 } );

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -316,6 +316,7 @@ export interface ResponseCart< P = ResponseCartProduct > {
 	 * Gift Details
 	 */
 	gift_details?: ResponseCartGiftDetails;
+	is_gift_purchase?: boolean;
 
 	currency: string;
 	allowed_payment_methods: string[];
@@ -595,6 +596,7 @@ export interface ResponseCartProductExtra {
 
 export interface ResponseCartGiftDetails {
 	receiver_blog_id: number;
+	receiver_blog_slug?: string;
 	receiver_blog_url?: string;
 }
 


### PR DESCRIPTION
#### Proposed Changes

* Re-routes gift purchases to a specific gift thank you page after checkout completes.

#### Testing Instructions

Per @sirbrillig's [instruction](https://github.com/Automattic/wp-calypso/pull/69729#issuecomment-1306421739):

- You'll need two accounts and make sure that the store is sandboxed.
- With account A, purchase a personal plan (or use an account which already owns a plan).
- With account B, go to the following URL: /checkout/personal-bundle/gift/<ACCOUNT_A_SUBSCRIPTION_ID>. You can use Store Admin to find the subscription ID of the account A's plan.
- Verify that you see the gift subscription in account B's shopping cart.
- Complete the purchase.

Alternatively, you can give yourself some free credits while using the store sandbox and purchase a gift bundle for my test site using this url: http://calypso.localhost:3000/checkout/personal-bundle/gift/848361


Unit tests:
```
yarn test-client client/my-sites/checkout/get-thank-you-page-url/test/get-thank-you-page-url.ts
```


https://user-images.githubusercontent.com/811776/200738656-0a0a0220-bffa-4c75-8a10-9beb0353e143.mp4



Fixes https://github.com/Automattic/payments-shilling/issues/1217
