### PR TITLE
Pattern Assembler: Add starting point and courses screen

### DIFF
--- a/client/components/videos-ui/video-chapters.jsx
+++ b/client/components/videos-ui/video-chapters.jsx
@@ -10,77 +10,80 @@ const VideoChapters = ( {
 	onVideoPlayClick,
 	isPreloadAnimationState,
 } ) => {
-	return Object.entries( course?.videos ).map( ( data, i ) => {
-		const isVideoCompleted = data[ 0 ] in course.completions && course.completions[ data[ 0 ] ];
-		const videoInfo = data[ 1 ];
+	return (
+		<>
+			{ Object.entries( course?.videos ).map( ( [ videoSlug, videoInfo ], i ) => {
+				const isVideoCompleted = videoSlug in course.completions && course.completions[ videoSlug ];
 
-		return (
-			<div
-				key={ i }
-				className={ classNames( 'videos-ui__chapter', {
-					selected: isChapterSelected( i ),
-					preload: isPreloadAnimationState,
-				} ) }
-			>
-				<button
-					type="button"
-					className="videos-ui__chapter-accordion-toggle"
-					onClick={ () => onChapterSelected( i ) }
-				>
-					<span className="videos-ui__video-title">
-						{ i + 1 }. { videoInfo.title }{ ' ' }
-					</span>
-					<span className="videos-ui__duration">
-						{ moment.unix( videoInfo.duration_seconds ).format( 'm:ss' ) }
-					</span>
-					{ isVideoCompleted && (
-						<span className="videos-ui__completed-checkmark">
-							<Gridicon icon="checkmark" size={ 12 } />
-						</span>
-					) }
-					{ isChapterSelected( i ) && ! isVideoCompleted && (
-						<span className="videos-ui__status-icon">
-							<Gridicon icon="chevron-up" size={ 18 } />
-						</span>
-					) }
-					{ ! isChapterSelected( i ) && ! isVideoCompleted && (
-						<span className="videos-ui__status-icon">
-							<Gridicon icon="chevron-down" size={ 18 } />
-						</span>
-					) }
-				</button>
-				<div className="videos-ui__active-video-content">
-					<div>
-						<p>{ videoInfo.description } </p>
-						<Button
-							className={ classNames( 'videos-ui__button', {
-								'videos-ui__video-completed': isVideoCompleted,
-							} ) }
-							onClick={ () => onVideoPlayClick( data[ 0 ], videoInfo ) }
+				return (
+					<div
+						key={ i }
+						className={ classNames( 'videos-ui__chapter', {
+							selected: isChapterSelected( i ),
+							preload: isPreloadAnimationState,
+						} ) }
+					>
+						<button
+							type="button"
+							className="videos-ui__chapter-accordion-toggle"
+							onClick={ () => onChapterSelected( i ) }
 						>
-							<svg
-								width="12"
-								height="14"
-								viewBox="0 0 12 14"
-								fill="none"
-								xmlns="http://www.w3.org/2000/svg"
-							>
-								<path
-									d="M1.9165 1.75L10.0832 7L1.9165 12.25V1.75Z"
-									fill="#101517"
-									stroke="#101517"
-									strokeWidth="2"
-									strokeLinecap="round"
-									strokeLinejoin="round"
-								/>
-							</svg>
-							<span>{ translate( 'Play video' ) }</span>
-						</Button>
+							<span className="videos-ui__video-title">
+								{ i + 1 }. { videoInfo.title }{ ' ' }
+							</span>
+							<span className="videos-ui__duration">
+								{ moment.unix( videoInfo.duration_seconds ).format( 'm:ss' ) }
+							</span>
+							{ isVideoCompleted && (
+								<span className="videos-ui__completed-checkmark">
+									<Gridicon icon="checkmark" size={ 12 } />
+								</span>
+							) }
+							{ isChapterSelected( i ) && ! isVideoCompleted && (
+								<span className="videos-ui__status-icon">
+									<Gridicon icon="chevron-up" size={ 18 } />
+								</span>
+							) }
+							{ ! isChapterSelected( i ) && ! isVideoCompleted && (
+								<span className="videos-ui__status-icon">
+									<Gridicon icon="chevron-down" size={ 18 } />
+								</span>
+							) }
+						</button>
+						<div className="videos-ui__active-video-content">
+							<div>
+								<p>{ videoInfo.description } </p>
+								<Button
+									className={ classNames( 'videos-ui__button', {
+										'videos-ui__video-completed': isVideoCompleted,
+									} ) }
+									onClick={ () => onVideoPlayClick( videoSlug, videoInfo ) }
+								>
+									<svg
+										width="12"
+										height="14"
+										viewBox="0 0 12 14"
+										fill="none"
+										xmlns="http://www.w3.org/2000/svg"
+									>
+										<path
+											d="M1.9165 1.75L10.0832 7L1.9165 12.25V1.75Z"
+											fill="#101517"
+											stroke="#101517"
+											strokeWidth="2"
+											strokeLinecap="round"
+											strokeLinejoin="round"
+										/>
+									</svg>
+									<span>{ translate( 'Play video' ) }</span>
+								</Button>
+							</div>
+						</div>
 					</div>
-				</div>
-			</div>
-		);
-	} );
+				);
+			} ) }
+		</>
+	);
 };
 
 export default VideoChapters;

--- a/client/components/videos-ui/video-player.jsx
+++ b/client/components/videos-ui/video-player.jsx
@@ -7,7 +7,7 @@ const VideoPlayer = ( {
 	course,
 	onVideoPlayStatusChanged,
 	onVideoCompleted,
-	intent = undefined,
+	intent,
 } ) => {
 	const [ shouldCheckForVideoComplete, setShouldCheckForVideoComplete ] = useState( true );
 

--- a/client/data/courses/constants.ts
+++ b/client/data/courses/constants.ts
@@ -1,5 +1,5 @@
-export const COURSE_SLUGS: Readonly< { PAYMENTS_FEATURES: string; BLOGGING_QUICK_START: string } > =
-	Object.freeze( {
-		BLOGGING_QUICK_START: 'blogging-quick-start',
-		PAYMENTS_FEATURES: 'payments-features',
-	} );
+export const COURSE_SLUGS = {
+	BLOGGING_QUICK_START: 'blogging-quick-start',
+	PAYMENTS_FEATURES: 'payments-features',
+	SITE_EDITOR_QUICK_START: 'site-editor-quick-start',
+} as const;

--- a/client/data/courses/index.ts
+++ b/client/data/courses/index.ts
@@ -1,4 +1,5 @@
 export { COURSE_SLUGS } from './constants';
+export type { Course, CourseSlug, CourseVideo, VideoSlug } from './types';
 export { default as useCourseData } from './use-course-data';
 export { default as useCourseDetails } from './use-course-details';
 export { default as useCourseQuery } from './use-course-query';

--- a/client/data/courses/types.ts
+++ b/client/data/courses/types.ts
@@ -23,6 +23,8 @@ export interface Course {
 		action: string;
 		url: string;
 	};
-	videos: CourseVideo[];
+	videos: {
+		[ key: string ]: CourseVideo;
+	};
 	completions: { [ key in VideoSlug ]: boolean | boolean[] };
 }

--- a/client/data/courses/types.ts
+++ b/client/data/courses/types.ts
@@ -1,4 +1,8 @@
-export type CourseSlug = 'blogging-quick-start';
+import { COURSE_SLUGS } from './constants';
+
+type ValueOf< T > = T[ keyof T ];
+
+export type CourseSlug = ValueOf< typeof COURSE_SLUGS >;
 
 export type VideoSlug = string;
 

--- a/client/data/courses/use-course-details.ts
+++ b/client/data/courses/use-course-details.ts
@@ -14,7 +14,7 @@ interface CourseDetails {
 	headerSummary: string[];
 }
 
-const useCourseDetails = ( courseSlug: CourseSlug ): CourseDetails | undefined => {
+const useCourseDetails = ( courseSlug: CourseSlug ): CourseDetails => {
 	const translate = useTranslate();
 
 	if ( courseSlug === COURSE_SLUGS.BLOGGING_QUICK_START ) {
@@ -51,6 +51,12 @@ const useCourseDetails = ( courseSlug: CourseSlug ): CourseDetails | undefined =
 			],
 		};
 	}
+
+	return {
+		headerTitle: '',
+		headerSubtitle: '',
+		headerSummary: [],
+	};
 };
 
 export default useCourseDetails;

--- a/client/data/courses/use-course-details.ts
+++ b/client/data/courses/use-course-details.ts
@@ -6,8 +6,7 @@ import { useTranslate } from 'i18n-calypso';
  * Internal Dependencies
  */
 import { COURSE_SLUGS } from './constants';
-
-type CourseSlug = keyof typeof COURSE_SLUGS;
+import type { CourseSlug } from './types';
 
 interface CourseDetails {
 	headerTitle: string;
@@ -38,6 +37,17 @@ const useCourseDetails = ( courseSlug: CourseSlug ): CourseDetails | undefined =
 				translate( 'Accept donations or sell services' ),
 				translate( 'Setup paid, subscriber-only content' ),
 				translate( 'Run a fully featured ecommerce store' ),
+			],
+		};
+	} else if ( courseSlug === COURSE_SLUGS.SITE_EDITOR_QUICK_START ) {
+		return {
+			headerTitle: translate( 'Watch four videos.' ),
+			headerSubtitle: translate( 'Save yourself hours.' ),
+			headerSummary: [
+				translate( 'Learn the building blocks of site building' ),
+				translate( 'Understand how to add your style to your site' ),
+				translate( 'Upskill now to save hours later' ),
+				translate( 'Set yourself up for creative success' ),
 			],
 		};
 	}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/courses/footer.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/courses/footer.tsx
@@ -1,15 +1,19 @@
 import { Button } from '@automattic/components';
-import { useTranslate } from 'i18n-calypso';
 import React from 'react';
 
 interface Props {
+	description: string;
+	actionText: string;
 	isCourseComplete?: boolean;
-	onStartWriting: () => void;
+	onComplete: () => void;
 }
 
-const CoursesFooter: React.FC< Props > = ( { isCourseComplete, onStartWriting } ) => {
-	const translate = useTranslate();
-
+const CoursesFooter: React.FC< Props > = ( {
+	isCourseComplete,
+	description,
+	actionText,
+	onComplete,
+} ) => {
 	if ( ! isCourseComplete ) {
 		return null;
 	}
@@ -17,11 +21,9 @@ const CoursesFooter: React.FC< Props > = ( { isCourseComplete, onStartWriting } 
 	return (
 		<div className="courses__footer">
 			<div className="courses__footer-content">
-				{ translate(
-					"You did it! Now it's time to put your skills to work and draft your first post."
-				) }
-				<Button className="courses__footer-button" onClick={ onStartWriting }>
-					{ translate( 'Start writing' ) }
+				{ description }
+				<Button className="courses__footer-button" onClick={ onComplete }>
+					{ actionText }
 				</Button>
 			</div>
 		</div>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/courses/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/courses/index.tsx
@@ -46,8 +46,6 @@ const CoursesStep: Step = function CoursesStep( { navigation } ) {
 							onComplete={ () => submit?.() }
 						/>
 					) }
-					// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-					// @ts-ignore - It's not recognizing the property as optional
 					intent={ intent }
 				/>
 			}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/courses/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/courses/index.tsx
@@ -1,12 +1,12 @@
 import { StepContainer } from '@automattic/onboarding';
 import { useViewportMatch } from '@wordpress/compose';
 import { useSelect } from '@wordpress/data';
-import { useTranslate } from 'i18n-calypso';
 import VideosUi from 'calypso/components/videos-ui';
-import { COURSE_SLUGS, useCourseData } from 'calypso/data/courses';
+import { useCourseData } from 'calypso/data/courses';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import CoursesFooter from './footer';
+import useCourseInfo from './use-course-info';
 import type { Step } from '../../types';
 import './style.scss';
 
@@ -15,12 +15,11 @@ import './style.scss';
  */
 const CoursesStep: Step = function CoursesStep( { navigation } ) {
 	const { goBack, submit } = navigation;
-	const translate = useTranslate();
 	const isMobile = useViewportMatch( 'small', '<' );
-	const courseSlug = COURSE_SLUGS.BLOGGING_QUICK_START;
+	const intent = useSelect( ( select ) => select( ONBOARD_STORE ).getIntent() );
+	const { courseSlug, congratsText, skipText, actionText } = useCourseInfo( intent );
 	const { isCourseComplete } = useCourseData( courseSlug );
 	const hideSkip = isMobile && isCourseComplete;
-	const { getIntent } = useSelect( ( select ) => select( ONBOARD_STORE ) );
 
 	return (
 		<StepContainer
@@ -29,8 +28,8 @@ const CoursesStep: Step = function CoursesStep( { navigation } ) {
 			goNext={ () => submit?.() }
 			isFullLayout
 			hideFormattedHeader
-			skipLabelText={ translate( 'Draft your first post' ) }
-			nextLabelText={ translate( 'Start writing' ) }
+			skipLabelText={ skipText }
+			nextLabelText={ actionText }
 			hideSkip={ hideSkip }
 			hideNext={ ! hideSkip }
 			skipButtonAlign="top"
@@ -41,13 +40,15 @@ const CoursesStep: Step = function CoursesStep( { navigation } ) {
 					HeaderBar={ () => null }
 					FooterBar={ () => (
 						<CoursesFooter
+							description={ congratsText }
+							actionText={ actionText }
 							isCourseComplete={ isCourseComplete }
-							onStartWriting={ () => submit?.() }
+							onComplete={ () => submit?.() }
 						/>
 					) }
 					// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 					// @ts-ignore - It's not recognizing the property as optional
-					intent={ getIntent() }
+					intent={ intent }
 				/>
 			}
 			recordTracksEvent={ recordTracksEvent }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/courses/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/courses/style.scss
@@ -33,7 +33,7 @@ $grey-header: #151b1e;
 		}
 
 		.step-container__content {
-			padding-top: 60px;
+			padding-top: 68px;
 			background-color: $grey-header;
 
 			.videos-ui {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/courses/use-course-info.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/courses/use-course-info.tsx
@@ -1,0 +1,34 @@
+import { Onboard } from '@automattic/data-stores';
+import { useTranslate } from 'i18n-calypso';
+import { COURSE_SLUGS } from 'calypso/data/courses';
+
+const { SiteIntent } = Onboard;
+
+const useCourseInfo = ( siteIntent: string ) => {
+	const translate = useTranslate();
+
+	switch ( siteIntent ) {
+		case SiteIntent.Build: {
+			return {
+				courseSlug: COURSE_SLUGS.SITE_EDITOR_QUICK_START,
+				congratsText: translate(
+					"You did it! Now it's time to put your skills to work and customize your homepage."
+				),
+				skipText: translate( 'Customize your homepage' ),
+				actionText: translate( 'Start creating' ),
+			};
+		}
+		default: {
+			return {
+				courseSlug: COURSE_SLUGS.BLOGGING_QUICK_START,
+				congratsText: translate(
+					"You did it! Now it's time to put your skills to work and draft your first post."
+				),
+				skipText: translate( 'Draft your first post' ),
+				actionText: translate( 'Start writing' ),
+			};
+		}
+	}
+};
+
+export default useCourseInfo;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/index.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/index.ts
@@ -8,6 +8,7 @@ export { default as bloggerStartingPoint } from './blogger-starting-point';
 export { default as storeFeatures } from './store-features';
 export { default as designSetup } from './design-setup';
 export { default as patternAssembler } from './pattern-assembler';
+export { default as patternAssemblerStartingPoint } from './pattern-assembler-starting-point';
 export { default as import } from './import';
 export { default as importLight } from './import-light';
 export { default as importList } from './import-list';
@@ -57,6 +58,7 @@ export type StepPath =
 	| 'storeFeatures'
 	| 'designSetup'
 	| 'patternAssembler'
+	| 'patternAssemblerStartingPoint'
 	| 'import'
 	| 'importList'
 	| 'importLight'

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler-starting-point/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler-starting-point/index.tsx
@@ -7,36 +7,37 @@ import FormattedHeader from 'calypso/components/formatted-header';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { preventWidows } from 'calypso/lib/formatting';
 import { ONBOARD_STORE } from '../../../../stores';
-import useStartingPoints from './starting-points';
+import useStartingPoints from './use-starting-points';
 import type { Step } from '../../types';
 
-/**
- * The starting point step
- */
-const StartingPointStep: Step = function StartingPointStep( { navigation } ) {
+const PatternAssemblerStartingPointStep: Step = ( { navigation } ) => {
 	const { goBack, submit } = navigation;
 	const translate = useTranslate();
 	const headerText = translate( 'Nice job! Now it’s{{br}}{{/br}} time to get creative.', {
 		components: { br: <br /> },
 	} );
-	const subHeaderText = translate( "Don't worry. You can come back to these steps!" );
-	const intents = useStartingPoints();
+	const subHeaderText = translate(
+		'Continue to the WordPress Site Editor or take a few moments to learn the basics.'
+	);
+	const startingPoints = useStartingPoints();
 	const { setStartingPoint } = useDispatch( ONBOARD_STORE );
 
-	const submitIntent = ( startingPoint: string ) => {
+	const submitStartingPoint = ( startingPoint: string ) => {
 		const providedDependencies = { startingPoint };
-		recordTracksEvent( 'calypso_signup_starting_point_select', { starting_point: startingPoint } );
+		recordTracksEvent( 'calypso_signup_pa_starting_point_select', {
+			starting_point: startingPoint,
+		} );
 		setStartingPoint( startingPoint );
 		submit?.( providedDependencies, startingPoint );
 	};
 
 	return (
 		<StepContainer
-			stepName="blogger-starting-point"
+			stepName="pattern-assembler-starting-point"
 			headerImageUrl={ startingPointImageUrl }
 			goBack={ goBack }
 			skipLabelText={ translate( 'Skip to dashboard' ) }
-			goNext={ () => submitIntent( 'skip-to-my-home' ) }
+			goNext={ () => submitStartingPoint( 'skip-to-my-home' ) }
 			skipButtonAlign="top"
 			isHorizontalLayout={ true }
 			formattedHeader={
@@ -49,9 +50,9 @@ const StartingPointStep: Step = function StartingPointStep( { navigation } ) {
 			}
 			stepContent={
 				<IntentScreen
-					intents={ intents }
+					intents={ startingPoints }
 					intentsAlt={ [] }
-					onSelect={ submitIntent }
+					onSelect={ submitStartingPoint }
 					preventWidows={ preventWidows }
 				/>
 			}
@@ -60,4 +61,4 @@ const StartingPointStep: Step = function StartingPointStep( { navigation } ) {
 	);
 };
 
-export default StartingPointStep;
+export default PatternAssemblerStartingPointStep;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler-starting-point/use-starting-points.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler-starting-point/use-starting-points.tsx
@@ -1,0 +1,27 @@
+import { useTranslate } from 'i18n-calypso';
+import { write, play } from 'calypso/signup/icons';
+
+const useStartingPoints = () => {
+	const translate = useTranslate();
+
+	return [
+		{
+			key: 'siteEditor',
+			title: translate( 'Customize your homepage' ),
+			description: <p>{ translate( 'Edit your content and style your site' ) }</p>,
+			icon: write,
+			value: 'siteEditor',
+			actionText: translate( 'Start creating' ),
+		},
+		{
+			key: 'courses',
+			title: translate( 'Learn the basics' ),
+			description: <p>{ translate( 'Watch videos and be site building in minutes' ) }</p>,
+			icon: play,
+			value: 'courses',
+			actionText: translate( 'Start learning' ),
+		},
+	];
+};
+
+export default useStartingPoints;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -20,10 +20,13 @@ import './style.scss';
 
 const PatternAssembler: Step = ( { navigation } ) => {
 	const translate = useTranslate();
+	const patternAssemblerData = useSelect( ( select ) =>
+		select( ONBOARD_STORE ).getPatternAssemblerData()
+	);
 	const [ showPatternSelectorType, setShowPatternSelectorType ] = useState< string | null >( null );
-	const [ header, setHeader ] = useState< Pattern | null >( null );
-	const [ footer, setFooter ] = useState< Pattern | null >( null );
-	const [ sections, setSections ] = useState< Pattern[] >( [] );
+	const [ header, setHeader ] = useState< Pattern | null >( patternAssemblerData.header );
+	const [ footer, setFooter ] = useState< Pattern | null >( patternAssemblerData.footer );
+	const [ sections, setSections ] = useState< Pattern[] >( patternAssemblerData.sections );
 	const [ sectionPosition, setSectionPosition ] = useState< number | null >( null );
 	const incrementIndexRef = useRef( 0 );
 	const [ scrollToSelector, setScrollToSelector ] = useState< string | null >( null );
@@ -36,6 +39,7 @@ const PatternAssembler: Step = ( { navigation } ) => {
 	const siteSlug = useSiteSlugParam();
 	const siteId = useSiteIdParam();
 	const siteSlugOrId = siteSlug ? siteSlug : siteId;
+	const { setPatternAssemblerData } = useDispatch( ONBOARD_STORE );
 
 	useEffect( () => {
 		// Require to start the flow from the first step
@@ -277,6 +281,8 @@ const PatternAssembler: Step = ( { navigation } ) => {
 										.then( () => runThemeSetupOnSite( siteSlugOrId, design ) )
 										.then( () => reduxDispatch( requestActiveTheme( site?.ID || -1 ) ) )
 								);
+
+								setPatternAssemblerData( { header, sections, footer } );
 
 								trackEventContinue();
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -264,7 +264,7 @@ const PatternAssembler: Step = ( { navigation } ) => {
 								const stylesheet = design.recipe!.stylesheet!;
 								const theme = stylesheet?.split( '/' )[ 1 ] || design.theme;
 
-								setPendingAction( () =>
+								setPendingAction(
 									// We have to switch theme first. Otherwise, the unique suffix might append to
 									// the slug of newly created Home template if the current activated theme has
 									// modified Home template.

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/types.ts
@@ -1,5 +1,3 @@
-export type Pattern = {
-	id: number;
-	name: string;
-	key?: string;
-};
+import { Onboard } from '@automattic/data-stores';
+
+export type Pattern = Onboard.PatternAssemblerPattern;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
@@ -49,9 +49,14 @@ const ProcessingStep: Step = function ( props ) {
 
 	useEffect( () => {
 		( async () => {
-			if ( typeof action === 'function' ) {
+			if ( typeof action === 'function' || action instanceof Promise ) {
 				try {
-					const destination = await action();
+					let destination;
+					if ( typeof action === 'function' ) {
+						destination = await action();
+					} else {
+						destination = await action;
+					}
 					// Don't call submit() directly; instead, turn on a flag that signals we should call submit() next.
 					// This allows us to call the newest submit() created. Otherwise, we would be calling a submit()
 					// that is frozen from before we called action().

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -444,6 +444,9 @@ export const siteSetupFlow: Flow = {
 					return navigate( 'businessInfo' );
 
 				case 'courses':
+					if ( intent === SiteIntent.Build ) {
+						return navigate( 'patternAssemblerStartingPoint' );
+					}
 					return navigate( 'bloggerStartingPoint' );
 
 				case 'designSetup':
@@ -467,6 +470,9 @@ export const siteSetupFlow: Flow = {
 
 				case 'patternAssembler':
 					return navigate( 'designSetup' );
+
+				case 'patternAssemblerStartingPoint':
+					return navigate( 'patternAssembler' );
 
 				case 'editEmail':
 					return navigate( 'wooVerifyEmail' );

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -1,6 +1,7 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { Onboard } from '@automattic/data-stores';
 import { Design, isBlankCanvasDesign } from '@automattic/design-picker';
+import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import { useViewportMatch } from '@wordpress/compose';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useDispatch as reduxDispatch, useSelector } from 'react-redux';
@@ -43,6 +44,7 @@ export const siteSetupFlow: Flow = {
 			'options',
 			'designSetup',
 			'patternAssembler',
+			'patternAssemblerStartingPoint',
 			'bloggerStartingPoint',
 			'courses',
 			'storeFeatures',
@@ -85,6 +87,9 @@ export const siteSetupFlow: Flow = {
 			getCanonicalTheme( state, site?.ID || -1, currentThemeId )
 		);
 
+		const isEnglishLocale = useIsEnglishLocale();
+		const isEnabledPatternAssemblerStartingPoint =
+			isEnabled( 'site-setup/pa-starting-point' ) && isEnglishLocale;
 		const urlQueryParams = useQuery();
 		const isPluginBundleEligible = useIsPluginBundleEligible();
 		const isDesktop = useViewportMatch( 'large' );
@@ -184,7 +189,18 @@ export const siteSetupFlow: Flow = {
 					return navigate( 'processing' );
 
 				case 'patternAssembler':
+					if ( isEnabledPatternAssemblerStartingPoint ) {
+						return navigate( 'patternAssemblerStartingPoint' );
+					}
 					return navigate( 'processing' );
+
+				case 'patternAssemblerStartingPoint': {
+					const startingPoint = params[ 0 ];
+					if ( startingPoint === 'courses' ) {
+						return navigate( 'courses' );
+					}
+					return navigate( 'processing' );
+				}
 
 				case 'processing': {
 					const processingResult = params[ 0 ] as ProcessingResult;
@@ -354,7 +370,7 @@ export const siteSetupFlow: Flow = {
 				}
 
 				case 'courses': {
-					return exitFlow( `/post/${ siteSlug }` );
+					return navigate( 'processing' );
 				}
 
 				case 'vertical': {

--- a/client/landing/stepper/hooks/use-site-setup-flow-progress.ts
+++ b/client/landing/stepper/hooks/use-site-setup-flow-progress.ts
@@ -47,10 +47,16 @@ export function useSiteSetupFlowProgress(
 		case SiteIntent.Build: {
 			switch ( currentStep ) {
 				case 'designSetup':
-					middleProgress = { progress: 1, count: 3 };
+					middleProgress = { progress: 1, count: 5 };
 					break;
 				case 'patternAssembler':
-					middleProgress = { progress: 2, count: 3 };
+					middleProgress = { progress: 2, count: 5 };
+					break;
+				case 'patternAssemblerStartingPoint':
+					middleProgress = { progress: 3, count: 5 };
+					break;
+				case 'courses':
+					middleProgress = { progress: 4, count: 5 };
 					break;
 			}
 

--- a/config/development.json
+++ b/config/development.json
@@ -156,6 +156,7 @@
 		"signup/tailored-ecommerce": true,
 		"signup/woo-verify-email": false,
 		"site-indicator": true,
+		"site-setup/pa-starting-point": true,
 		"ssr/prefetch-timebox": false,
 		"stats/new-all-time-highlights": true,
 		"stats/new-annual-highlights": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -102,6 +102,7 @@
 		"signup/tailored-ecommerce": false,
 		"signup/woo-verify-email": false,
 		"site-indicator": true,
+		"site-setup/pa-starting-point": false,
 		"ssr/prefetch-timebox": true,
 		"stats/new-all-time-highlights": true,
 		"stats/new-annual-highlights": true,

--- a/config/production.json
+++ b/config/production.json
@@ -120,6 +120,7 @@
 		"signup/tailored-ecommerce": false,
 		"signup/woo-verify-email": false,
 		"site-indicator": true,
+		"site-setup/pa-starting-point": false,
 		"ssr/log-prefetch-errors": true,
 		"ssr/prefetch-timebox": true,
 		"ssr/sample-log-cache-misses": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -118,6 +118,7 @@
 		"signup/tailored-ecommerce": false,
 		"signup/woo-verify-email": false,
 		"site-indicator": true,
+		"site-setup/pa-starting-point": false,
 		"ssr/prefetch-timebox": true,
 		"stats/new-all-time-highlights": true,
 		"stats/new-annual-highlights": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -126,6 +126,7 @@
 		"signup/tailored-ecommerce": false,
 		"signup/woo-verify-email": false,
 		"site-indicator": true,
+		"site-setup/pa-starting-point": false,
 		"ssr/prefetch-timebox": true,
 		"stats/new-all-time-highlights": true,
 		"stats/new-annual-highlights": true,

--- a/packages/data-stores/src/onboard/actions.ts
+++ b/packages/data-stores/src/onboard/actions.ts
@@ -316,7 +316,9 @@ export const setStoreAddressValue = (
 } );
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const setPendingAction = ( pendingAction: undefined | ( () => Promise< any > ) ) => ( {
+export const setPendingAction = (
+	pendingAction: undefined | Promise< any > | ( () => Promise< any > )
+) => ( {
 	type: 'SET_PENDING_ACTION' as const,
 	pendingAction,
 } );

--- a/packages/data-stores/src/onboard/actions.ts
+++ b/packages/data-stores/src/onboard/actions.ts
@@ -7,6 +7,7 @@ import { CreateSiteParams, Visibility, NewSiteBlogDetails } from '../site/types'
 import { FeatureId } from '../wpcom-features/types';
 import { SiteGoal, STORE_KEY } from './constants';
 import type { State } from '.';
+import type { PatternAssemblerData } from './types';
 // somewhat hacky, but resolves the circular dependency issue
 import type { Design, FontPair, StyleVariation } from '@automattic/design-picker/src/types';
 
@@ -382,6 +383,11 @@ export const setEcommerceFlowRecurType = ( ecommerceFlowRecurType: string ) => (
 	ecommerceFlowRecurType,
 } );
 
+export const setPatternAssemblerData = ( payload: PatternAssemblerData ) => ( {
+	type: 'SET_PATTERN_ASSEMBLER_DATA' as const,
+	payload,
+} );
+
 export type OnboardAction = ReturnType<
 	| typeof addFeature
 	| typeof removeFeature
@@ -429,4 +435,5 @@ export type OnboardAction = ReturnType<
 	| typeof setVerticalId
 	| typeof setStoreLocationCountryCode
 	| typeof setEcommerceFlowRecurType
+	| typeof setPatternAssemblerData
 >;

--- a/packages/data-stores/src/onboard/constants.ts
+++ b/packages/data-stores/src/onboard/constants.ts
@@ -17,3 +17,11 @@ export enum SiteIntent {
 	WpAdmin = 'wpadmin',
 	Import = 'import', // deprecated
 }
+
+export const INITIAL_STATES = {
+	PATTERN_ASSEMBLER_DATA: {
+		header: null,
+		sections: [],
+		footer: null,
+	},
+};

--- a/packages/data-stores/src/onboard/index.ts
+++ b/packages/data-stores/src/onboard/index.ts
@@ -10,6 +10,7 @@ import type { SelectFromMap, DispatchFromMap } from '../mapped-types';
 export type { State };
 
 export { SiteGoal, SiteIntent } from './constants';
+export * from './types';
 export * as utils from './utils';
 let isRegistered = false;
 
@@ -53,6 +54,7 @@ export function register(): typeof STORE_KEY {
 			'verticalId',
 			'storeLocationCountryCode',
 			'ecommerceFlowRecurType',
+			'patternAssemblerData',
 		],
 	} );
 	isRegistered = true;

--- a/packages/data-stores/src/onboard/reducer.ts
+++ b/packages/data-stores/src/onboard/reducer.ts
@@ -306,10 +306,10 @@ const storeType: Reducer< string, OnboardAction > = ( state = '', action ) => {
 	return state;
 };
 
-const pendingAction: Reducer< undefined | ( () => Promise< any > ), OnboardAction > = (
-	state,
-	action
-) => {
+const pendingAction: Reducer<
+	undefined | Promise< any > | ( () => Promise< any > ),
+	OnboardAction
+> = ( state, action ) => {
 	if ( action.type === 'SET_PENDING_ACTION' ) {
 		return action.pendingAction;
 	}

--- a/packages/data-stores/src/onboard/reducer.ts
+++ b/packages/data-stores/src/onboard/reducer.ts
@@ -1,8 +1,9 @@
 import { combineReducers } from '@wordpress/data';
-import { SiteGoal } from './constants';
+import { SiteGoal, INITIAL_STATES } from './constants';
 import type { DomainSuggestion } from '../domain-suggestions/types';
 import type { FeatureId } from '../wpcom-features/types';
 import type { OnboardAction } from './actions';
+import type { PatternAssemblerData } from './types';
 // somewhat hacky, but resolves the circular dependency issue
 import type { Design, FontPair, StyleVariation } from '@automattic/design-picker/src/types';
 import type { Reducer } from 'redux';
@@ -407,6 +408,19 @@ const ecommerceFlowRecurType: Reducer< string, OnboardAction > = ( state = '', a
 	return state;
 };
 
+const patternAssemblerData: Reducer< PatternAssemblerData, OnboardAction > = (
+	state = INITIAL_STATES.PATTERN_ASSEMBLER_DATA,
+	action
+) => {
+	if ( action.type === 'SET_PATTERN_ASSEMBLER_DATA' ) {
+		return action.payload;
+	}
+	if ( action.type === 'RESET_ONBOARD_STORE' ) {
+		return INITIAL_STATES.PATTERN_ASSEMBLER_DATA;
+	}
+	return state;
+};
+
 const reducer = combineReducers( {
 	anchorPodcastId,
 	anchorEpisodeId,
@@ -444,6 +458,7 @@ const reducer = combineReducers( {
 	verticalId,
 	storeLocationCountryCode,
 	ecommerceFlowRecurType,
+	patternAssemblerData,
 } );
 
 export type State = ReturnType< typeof reducer >;

--- a/packages/data-stores/src/onboard/selectors.ts
+++ b/packages/data-stores/src/onboard/selectors.ts
@@ -55,3 +55,5 @@ export const hasSelectedDesignWithoutFonts = ( state: State ) =>
 	hasSelectedDesign( state ) && ! state.selectedFonts;
 
 export const getEditEmail = ( state: State ) => state.editEmail;
+
+export const getPatternAssemblerData = ( state: State ) => state.patternAssemblerData;

--- a/packages/data-stores/src/onboard/types.ts
+++ b/packages/data-stores/src/onboard/types.ts
@@ -1,0 +1,11 @@
+export type PatternAssemblerPattern = {
+	id: number;
+	name: string;
+	key?: string;
+};
+
+export type PatternAssemblerData = {
+	header: PatternAssemblerPattern | null;
+	sections: PatternAssemblerPattern[];
+	footer: PatternAssemblerPattern | null;
+};


### PR DESCRIPTION
#### Proposed Changes

* Use the `site-setup/pa-starting-point` flag to control the feature
* Implement Pattern Assembler Starting Point step
* Implement `useCourseInfo` to get different copies and courses based on the intent
* Add a new course slug, `site-editor-quick-start`, to fetch the videos for the Pattern Assembler
* Allow the `pendingAction` to be a promise so that we could send the requests in the background when the user is learning from the courses.

**TODOs**

- [ ] Check copies of the title and description for the new courses

**Demo if the user goes back and submit again, it still works well**

https://user-images.githubusercontent.com/13596067/202615855-7f77f4be-fc21-41e6-8634-f04d7da61d94.mov

**Screenshots**

![image](https://user-images.githubusercontent.com/13596067/200513950-a44f3c60-32dd-470e-83b5-bd926cf24979.png)

![image](https://user-images.githubusercontent.com/13596067/200734606-b13c0eed-8b80-4e10-8a89-7d19d863cec8.png)


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup/site-setup?siteSlug=<your_site>`
* Select "Promote myself or business" in the Goal step
* Select any vertical in the Vertical step
* Click the "Get started" button inside "Start with a blank canvas" in the Design Picker step
* Select any header/sections/footer in the Pattern Assembler step
* When you land on the Pattern Assembler Starting Point step,
  * Verify there are 2 actions - "Customize your homepage" and "Learn the basics"
  * Click on the top-left button, "Back", and you will go back to the Pattern Assembler step. Additionally, the selected header/sections/footer are still there.
  * Click on the "Start creating" button, and you will land on the site editor
  * Click on the "Start learning" button, and you will enter the Course step
* When you land on the Course step,
  * Click on the top-left button, "Back", and you will go back to the Pattern Assembler Starting Point step
  * Click on the top-right button, "Customize your homepage", and you will land on the site editor
  * Verify there are 4 videos
  * When you finish all of the videos, you will see the congrats footer, and you will land on the site editor when you click on the "Start creating" button

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/69175
