### PR TITLE
Add blogging prompt setting

### DIFF
--- a/client/me/notification-settings/blogs-settings/blog.jsx
+++ b/client/me/notification-settings/blogs-settings/blog.jsx
@@ -66,6 +66,7 @@ class BlogSettings extends Component {
 			'achievement',
 			'mentions',
 			'scheduled_publicize',
+			'blogging_prompt',
 		];
 
 		if ( site.options.woocommerce_is_active ) {

--- a/client/me/notification-settings/settings-form/constants.js
+++ b/client/me/notification-settings/settings-form/constants.js
@@ -1,3 +1,3 @@
 export const NOTIFICATIONS_EXCEPTIONS = {
-	email: [ 'achievement', 'scheduled_publicize', 'store_order' ],
+	email: [ 'achievement', 'scheduled_publicize', 'store_order', 'blogging_prompt' ],
 };

--- a/client/me/notification-settings/settings-form/locales.js
+++ b/client/me/notification-settings/settings-form/locales.js
@@ -15,7 +15,7 @@ export const settingLabels = {
 	achievement: () => i18n.translate( 'Site achievements' ),
 	mentions: () => i18n.translate( 'Username mentions' ),
 	scheduled_publicize: () => i18n.translate( 'Post Publicized' ),
-
+	blogging_prompt: () => i18n.translate( 'Daily Writing Prompts' ),
 	store_order: () => i18n.translate( 'New order' ),
 };
 

--- a/client/me/notification-settings/settings-form/stream-options.jsx
+++ b/client/me/notification-settings/settings-form/stream-options.jsx
@@ -15,14 +15,19 @@ export default class extends PureComponent {
 		onToggle: PropTypes.func.isRequired,
 	};
 
+	// Assume a device stream if not timeline or email
+	isDeviceStream = () => {
+		return [ 'timeline', 'email' ].indexOf( this.props.stream ) === -1;
+	};
+
 	render() {
 		return (
 			<ul className="notification-settings-form-stream-options">
 				{ this.props.settingKeys.map( ( setting, index ) => {
 					const isException =
-						this.props.stream in NOTIFICATIONS_EXCEPTIONS &&
-						NOTIFICATIONS_EXCEPTIONS[ this.props.stream ].indexOf( setting ) >= 0;
-
+						( this.props.stream in NOTIFICATIONS_EXCEPTIONS &&
+							NOTIFICATIONS_EXCEPTIONS[ this.props.stream ].indexOf( setting ) >= 0 ) ||
+						( setting === 'blogging_prompt' && this.isDeviceStream() );
 					return (
 						<li className="notification-settings-form-stream-options__item" key={ index }>
 							{ isException ? null : (

--- a/client/me/notification-settings/settings-form/stream-options.jsx
+++ b/client/me/notification-settings/settings-form/stream-options.jsx
@@ -15,7 +15,7 @@ export default class extends PureComponent {
 		onToggle: PropTypes.func.isRequired,
 	};
 
-	// Assume a device stream if not timeline or email
+	// Assume this is a device stream if not timeline or email
 	isDeviceStream = () => {
 		return [ 'timeline', 'email' ].indexOf( this.props.stream ) === -1;
 	};


### PR DESCRIPTION
#### Proposed Changes

Works with D91865-code to add a blogging prompt setting to each site using existing infrastructure.

implements https://github.com/Automattic/wp-calypso/issues/69160

#### Testing Instructions
Apply D91865-code and head to the settings page

<img width="1054" alt="Screen Shot 2022-11-08 at 6 45 51 pm" src="https://user-images.githubusercontent.com/22446385/200517545-0dd05208-c04a-49bb-9a58-b79e3f190c72.png">
