### PR TITLE
Third-Party Premium Themes: Adding action to add the Third-Party Themes to the cart

### DIFF
--- a/client/state/themes/actions/add-external-managed-theme-to-cart.tsx
+++ b/client/state/themes/actions/add-external-managed-theme-to-cart.tsx
@@ -45,17 +45,25 @@ export function addExternalManagedThemeToCart( themeId: string, siteId: number )
 		}
 
 		const siteSlug = getSiteSlug( getState(), siteId );
-
-		const isSiteEligibleForManagedExternalThemes = getIsSiteEligibleForManagedExternalThemes(
-			getState(),
-			siteId
-		);
 		// TODO: use the marketplaceThemeProduct function from #69831
 		const externalManagedThemeProduct = {
 			product_slug: themeId,
 		};
 
+		/**
+		 * This holds the products that will be added to the cart. We always want to add the
+		 * theme product, but we only want to add the business plan if the site is not eligible
+		 */
 		const cartItems: Array< MinimalRequestCartProduct > = [ externalManagedThemeProduct ];
+
+		/**
+		 * If the site is not eligible for the external themes, means that it doesn't have a business plan.
+		 * We need to add the business plan to the cart.
+		 */
+		const isSiteEligibleForManagedExternalThemes = getIsSiteEligibleForManagedExternalThemes(
+			getState(),
+			siteId
+		);
 
 		if ( ! isSiteEligibleForManagedExternalThemes ) {
 			cartItems.push( { product_slug: PLAN_BUSINESS_MONTHLY } );

--- a/client/state/themes/actions/add-external-managed-theme-to-cart.tsx
+++ b/client/state/themes/actions/add-external-managed-theme-to-cart.tsx
@@ -21,6 +21,15 @@ const isLoadingCart = ( isLoading: boolean ) => ( dispatch: CalypsoDispatch ) =>
 	} );
 };
 
+/**
+ * Add the business plan and/or the external theme to the cart and redirect to checkout.
+ * This action also manages the loading state of the cart. We'll use it to lock the CTA
+ * button while the cart is being updated.
+ *
+ * @param themeId Theme ID to add to cart
+ * @param siteId
+ * @returns
+ */
 export function addExternalManagedThemeToCart( themeId: string, siteId: number ) {
 	return async ( dispatch: CalypsoDispatch, getState: AppState ) => {
 		const isExternallyManagedTheme = getIsExternallyManagedTheme( getState(), themeId );
@@ -29,9 +38,9 @@ export function addExternalManagedThemeToCart( themeId: string, siteId: number )
 			throw new Error( 'Theme is not externally managed' );
 		}
 
-		const isPurchased = isPremiumThemeAvailable( getState(), themeId, siteId );
+		const isThemePurchased = isPremiumThemeAvailable( getState(), themeId, siteId );
 
-		if ( isPurchased ) {
+		if ( isThemePurchased ) {
 			throw new Error( 'Theme is already purchased' );
 		}
 

--- a/client/state/themes/actions/add-external-managed-theme-to-cart.tsx
+++ b/client/state/themes/actions/add-external-managed-theme-to-cart.tsx
@@ -1,0 +1,74 @@
+import { PLAN_BUSINESS_MONTHLY } from '@automattic/calypso-products';
+import { MinimalRequestCartProduct } from '@automattic/shopping-cart';
+import { addQueryArgs } from '@wordpress/url';
+import page from 'page';
+import 'calypso/state/themes/init';
+import { cartManagerClient } from 'calypso/my-sites/checkout/cart-manager-client';
+import { getSiteSlug } from 'calypso/state/sites/selectors';
+import {
+	isExternallyManagedTheme as getIsExternallyManagedTheme,
+	isSiteEligibleForManagedExternalThemes as getIsSiteEligibleForManagedExternalThemes,
+	isPremiumThemeAvailable,
+} from 'calypso/state/themes/selectors';
+import { CalypsoDispatch } from 'calypso/state/types';
+import { AppState } from 'calypso/types';
+import { THEMES_LOADING_CART } from '../action-types';
+
+const isLoadingCart = ( isLoading: boolean ) => ( dispatch: CalypsoDispatch ) => {
+	dispatch( {
+		type: THEMES_LOADING_CART,
+		isLoading,
+	} );
+};
+
+export function addExternalManagedThemeToCart( themeId: string, siteId: number ) {
+	return async ( dispatch: CalypsoDispatch, getState: AppState ) => {
+		const isExternallyManagedTheme = getIsExternallyManagedTheme( getState(), themeId );
+
+		if ( ! isExternallyManagedTheme ) {
+			throw new Error( 'Theme is not externally managed' );
+		}
+
+		const isPurchased = isPremiumThemeAvailable( getState(), themeId, siteId );
+
+		if ( isPurchased ) {
+			throw new Error( 'Theme is already purchased' );
+		}
+
+		const siteSlug = getSiteSlug( getState(), siteId );
+
+		const isSiteEligibleForManagedExternalThemes = getIsSiteEligibleForManagedExternalThemes(
+			getState(),
+			siteId
+		);
+		// TODO: use the marketplaceThemeProduct function from #69831
+		const externalManagedThemeProduct = {
+			product_slug: themeId,
+		};
+
+		const cartItems: Array< MinimalRequestCartProduct > = [ externalManagedThemeProduct ];
+
+		if ( ! isSiteEligibleForManagedExternalThemes ) {
+			cartItems.push( { product_slug: PLAN_BUSINESS_MONTHLY } );
+		}
+
+		const { origin = 'https://wordpress.com' } =
+			typeof window !== 'undefined' ? window.location : {};
+
+		const redirectUrl = addQueryArgs( `/checkout/${ siteSlug }`, {
+			redirect_to: `${ origin }/theme/${ themeId }/${ siteSlug }`,
+		} );
+
+		dispatch( isLoadingCart( true ) );
+		const cartKey = await cartManagerClient.getCartKeyForSiteSlug( siteSlug as string );
+		cartManagerClient
+			.forCartKey( cartKey )
+			.actions.addProductsToCart( cartItems )
+			.then( () => {
+				page( redirectUrl );
+			} )
+			.finally( () => {
+				dispatch( isLoadingCart( false ) );
+			} );
+	};
+}

--- a/client/state/themes/actions/add-external-managed-theme-to-cart.tsx
+++ b/client/state/themes/actions/add-external-managed-theme-to-cart.tsx
@@ -45,6 +45,11 @@ export function addExternalManagedThemeToCart( themeId: string, siteId: number )
 		}
 
 		const siteSlug = getSiteSlug( getState(), siteId );
+
+		if ( ! siteSlug ) {
+			throw new Error( 'Site could not be found matching id ' + siteId );
+		}
+
 		// TODO: use the marketplaceThemeProduct function from #69831
 		const externalManagedThemeProduct = {
 			product_slug: themeId,
@@ -77,7 +82,7 @@ export function addExternalManagedThemeToCart( themeId: string, siteId: number )
 		} );
 
 		dispatch( isLoadingCart( true ) );
-		const cartKey = await cartManagerClient.getCartKeyForSiteSlug( siteSlug as string );
+		const cartKey = await cartManagerClient.getCartKeyForSiteSlug( siteSlug );
 		cartManagerClient
 			.forCartKey( cartKey )
 			.actions.addProductsToCart( cartItems )

--- a/client/state/themes/actions/index.js
+++ b/client/state/themes/actions/index.js
@@ -1,6 +1,7 @@
 export { acceptAutoLoadingHomepageWarning } from 'calypso/state/themes/actions/accept-auto-loading-homepage-warning';
 export { activate } from 'calypso/state/themes/actions/activate';
 export { activateTheme } from 'calypso/state/themes/actions/activate-theme';
+export { addExternalManagedThemeToCart } from 'calypso/state/themes/actions/add-external-managed-theme-to-cart';
 export { clearActivated } from 'calypso/state/themes/actions/clear-activated';
 export { clearThemeUpload } from 'calypso/state/themes/actions/clear-theme-upload';
 export { confirmDelete } from 'calypso/state/themes/actions/confirm-delete';


### PR DESCRIPTION
#### Proposed Changes

* Adds the `addExternalManagedThemeToCart` action that will be used on the `theme-options.js`. This action intends to add the business plan and/or the third-party theme products to the cart and then redirect the user to the checkout.

#### Testing Instructions

* The action is not being used it. I added a few unit tests so we can test it:
```bash
node 'node_modules/.bin/jest' './client/state/themes/test/actions.js' -c './test/client/jest.config.js' -t 'actions addExternalManagedThemeToCart'
```
alternate:
```
yarn run test-client ./client/state/themes/test/actions.js -t 'actions addExternalManagedThemeToCart'
```

Related to #69616
