### PR TITLE
Stats: Adjust new page header

### DIFF
--- a/client/blocks/stats-navigation/index.js
+++ b/client/blocks/stats-navigation/index.js
@@ -54,6 +54,9 @@ class StatsNavigation extends Component {
 		const { label, showIntervals, path } = navItems[ selectedItem ];
 		const slugPath = slug ? `/${ slug }` : '';
 		const pathTemplate = `${ path }/{{ interval }}${ slugPath }`;
+
+		const isNewMainChart = config.isEnabled( 'stats/new-main-chart' );
+
 		return (
 			<div className="stats-navigation">
 				<SectionNav selectedText={ label }>
@@ -77,10 +80,12 @@ class StatsNavigation extends Component {
 								);
 							} ) }
 					</NavTabs>
-					{ showIntervals && <Intervals selected={ interval } pathTemplate={ pathTemplate } /> }
+					{ ! isNewMainChart && showIntervals && (
+						<Intervals selected={ interval } pathTemplate={ pathTemplate } />
+					) }
 					<FollowersCount />
 				</SectionNav>
-				{ showIntervals && (
+				{ ! isNewMainChart && showIntervals && (
 					<Intervals selected={ interval } pathTemplate={ pathTemplate } standalone />
 				) }
 			</div>

--- a/client/components/fixed-navigation-header/index.tsx
+++ b/client/components/fixed-navigation-header/index.tsx
@@ -50,38 +50,6 @@ const Container = styled.div`
 	}
 `;
 
-const ColContainer = styled.div`
-	display: flex;
-	flex-direction: column;
-	justify-content: center;
-	align-items: stretch;
-	min-height: 70px;
-
-	@media ( max-width: 660px ) {
-		min-height: 60px;
-	}
-
-	.main.is-wide-layout & {
-		max-width: 1040px;
-		margin: auto;
-	}
-
-	& > *:first-child:not( :only-child ) {
-		margin-top: 24px;
-	}
-`;
-
-const RowContainer = styled.div`
-	margin: 24px 0 0;
-	display: flex;
-	justify-content: space-between;
-	align-items: center;
-
-	&:only-child {
-		margin-top: 0;
-	}
-`;
-
 const ActionsContainer = styled.div`
 	display: flex;
 	align-items: center;
@@ -94,48 +62,20 @@ interface Props {
 	navigationItems: TBreadcrumbItem[];
 	mobileItem?: TBreadcrumbItem;
 	compactBreadcrumb?: boolean;
-	headerNode?: ReactNode;
-	tabListNode?: ReactNode;
 }
 
 const FixedNavigationHeader = React.forwardRef< HTMLElement, Props >( ( props, ref ) => {
-	const {
-		id,
-		className,
-		children,
-		navigationItems,
-		mobileItem,
-		compactBreadcrumb,
-		headerNode,
-		tabListNode,
-	} = props;
+	const { id, className, children, navigationItems, mobileItem, compactBreadcrumb } = props;
 	return (
 		<Header id={ id } className={ 'fixed-navigation-header__header ' + className } ref={ ref }>
-			{ ! headerNode && (
-				<Container>
-					<Breadcrumb
-						items={ navigationItems }
-						mobileItem={ mobileItem }
-						compact={ compactBreadcrumb }
-					/>
-					<ActionsContainer>{ children }</ActionsContainer>
-				</Container>
-			) }
-			{ headerNode && (
-				<ColContainer>
-					<Breadcrumb
-						items={ navigationItems }
-						mobileItem={ mobileItem }
-						compact={ compactBreadcrumb }
-					/>
-
-					<RowContainer>
-						{ headerNode }
-						<ActionsContainer>{ children }</ActionsContainer>
-					</RowContainer>
-					{ tabListNode }
-				</ColContainer>
-			) }
+			<Container>
+				<Breadcrumb
+					items={ navigationItems }
+					mobileItem={ mobileItem }
+					compact={ compactBreadcrumb }
+				/>
+				<ActionsContainer>{ children }</ActionsContainer>
+			</Container>
 		</Header>
 	);
 } );

--- a/client/components/fixed-navigation-header/index.tsx
+++ b/client/components/fixed-navigation-header/index.tsx
@@ -50,6 +50,38 @@ const Container = styled.div`
 	}
 `;
 
+const ColContainer = styled.div`
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	align-items: stretch;
+	min-height: 70px;
+
+	@media ( max-width: 660px ) {
+		min-height: 60px;
+	}
+
+	.main.is-wide-layout & {
+		max-width: 1040px;
+		margin: auto;
+	}
+
+	& > *:first-child:not( :only-child ) {
+		margin-top: 24px;
+	}
+`;
+
+const RowContainer = styled.div`
+	margin: 24px 0 0;
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+
+	&:only-child {
+		margin-top: 0;
+	}
+`;
+
 const ActionsContainer = styled.div`
 	display: flex;
 	align-items: center;
@@ -62,20 +94,48 @@ interface Props {
 	navigationItems: TBreadcrumbItem[];
 	mobileItem?: TBreadcrumbItem;
 	compactBreadcrumb?: boolean;
+	headerNode?: ReactNode;
+	tabListNode?: ReactNode;
 }
 
 const FixedNavigationHeader = React.forwardRef< HTMLElement, Props >( ( props, ref ) => {
-	const { id, className, children, navigationItems, mobileItem, compactBreadcrumb } = props;
+	const {
+		id,
+		className,
+		children,
+		navigationItems,
+		mobileItem,
+		compactBreadcrumb,
+		headerNode,
+		tabListNode,
+	} = props;
 	return (
 		<Header id={ id } className={ 'fixed-navigation-header__header ' + className } ref={ ref }>
-			<Container>
-				<Breadcrumb
-					items={ navigationItems }
-					mobileItem={ mobileItem }
-					compact={ compactBreadcrumb }
-				/>
-				<ActionsContainer>{ children }</ActionsContainer>
-			</Container>
+			{ ! headerNode && (
+				<Container>
+					<Breadcrumb
+						items={ navigationItems }
+						mobileItem={ mobileItem }
+						compact={ compactBreadcrumb }
+					/>
+					<ActionsContainer>{ children }</ActionsContainer>
+				</Container>
+			) }
+			{ headerNode && (
+				<ColContainer>
+					<Breadcrumb
+						items={ navigationItems }
+						mobileItem={ mobileItem }
+						compact={ compactBreadcrumb }
+					/>
+
+					<RowContainer>
+						{ headerNode }
+						<ActionsContainer>{ children }</ActionsContainer>
+					</RowContainer>
+					{ tabListNode }
+				</ColContainer>
+			) }
 		</Header>
 	);
 } );

--- a/client/my-sites/stats/modernized-page-header-styles.scss
+++ b/client/my-sites/stats/modernized-page-header-styles.scss
@@ -6,27 +6,30 @@
 	}
 
 	// FormattedHeader styles
-	.formatted-header.stats__section-header {
-		margin: 0;
-
-		.formatted-header__title {
-			margin-bottom: 4px;
-			font-weight: 500;
-			font-size: $font-title-small;
-			line-height: 26px;
-			color: var(--color-neutral-100);
-		}
-
-		.formatted-header__subtitle {
+	.formatted-header {
+		&.is-left-align,
+		&.is-right-align {
 			margin: 0;
-			font-weight: 400;
-			font-size: $font-body-small;
-			line-height: 20px;
-			color: var(--color-neutral-60);
-		}
 
-		.inline-support-link {
-			color: var(--color-primary);
+			.formatted-header__title {
+				margin-bottom: 4px;
+				font-weight: 500;
+				font-size: $font-title-small;
+				line-height: 26px;
+				color: var(--color-neutral-100);
+			}
+
+			.formatted-header__subtitle {
+				margin: 0;
+				font-weight: 400;
+				font-size: $font-body-small;
+				line-height: 20px;
+				color: var(--color-neutral-60);
+			}
+
+			.inline-support-link {
+				color: var(--color-primary);
+			}
 		}
 	}
 

--- a/client/my-sites/stats/modernized-page-header-styles.scss
+++ b/client/my-sites/stats/modernized-page-header-styles.scss
@@ -1,0 +1,94 @@
+// For page header styles behind feature `stats/new-main-chart`
+.stats--new-wrapper {
+	// Page layout
+	&.main {
+		padding-top: 82px;
+	}
+
+	// FormattedHeader styles
+	.formatted-header.stats__section-header {
+		margin: 0;
+
+		.formatted-header__title {
+			margin-bottom: 4px;
+			font-weight: 500;
+			font-size: $font-title-small;
+			line-height: 26px;
+			color: var(--color-neutral-100);
+		}
+
+		.formatted-header__subtitle {
+			margin: 0;
+			font-weight: 400;
+			font-size: $font-body-small;
+			line-height: 20px;
+			color: var(--color-neutral-60);
+		}
+
+		.inline-support-link {
+			color: var(--color-primary);
+		}
+	}
+
+	// StatsNavigation styles
+	.stats-navigation {
+		margin-top: 16px;
+
+		.section-nav {
+			margin: 0;
+			box-shadow: none;
+		}
+
+		.section-nav__panel {
+			padding: 0;
+		}
+
+		.section-nav-tab {
+			&:not(:first-child) {
+				margin-left: 16px;
+			}
+
+			.section-nav-tab__link {
+				padding: 8px 12px;
+				font-size: $font-body-small;
+				line-height: 20px;
+				color: var(--color-neutral-60);
+
+				&:hover {
+					color: var(--color-neutral-60);
+					background-color: var(--color-surface);
+				}
+			}
+
+			&.is-selected {
+				border-bottom-color: var(--color-neutral-100);
+
+				.section-nav-tab__link {
+					color: var(--color-neutral-100);
+				}
+			}
+		}
+
+		.followers-count {
+			.button {
+				font-weight: 400;
+				font-size: $font-body-small;
+				line-height: 24px;
+				color: var(--color-neutral-80);
+				margin: 0;
+				padding: 7px 12px;
+			}
+
+			.count {
+				padding: 0 8px;
+				margin-left: 6px;
+				border-radius: 2px;
+				border: 0;
+				background-color: var(--color-neutral-0);
+				font-weight: 500;
+				font-size: $font-body-extra-small;
+				line-height: 20px;
+			}
+		}
+	}
+}

--- a/client/my-sites/stats/modernized-page-header-styles.scss
+++ b/client/my-sites/stats/modernized-page-header-styles.scss
@@ -2,7 +2,7 @@
 .stats--new-wrapper {
 	// Page layout
 	&.main {
-		padding-top: 82px;
+		// padding-top: 82px;
 	}
 
 	// FormattedHeader styles

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -19,6 +19,7 @@ import QueryJetpackModules from 'calypso/components/data/query-jetpack-modules';
 import QueryKeyringConnections from 'calypso/components/data/query-keyring-connections';
 import QuerySiteKeyrings from 'calypso/components/data/query-site-keyrings';
 import EmptyContent from 'calypso/components/empty-content';
+import FixedNavigationHeader from 'calypso/components/fixed-navigation-header';
 import FormattedHeader from 'calypso/components/formatted-header';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import JetpackColophon from 'calypso/components/jetpack-colophon';
@@ -196,45 +197,50 @@ class StatsSite extends Component {
 		const traffic = {
 			label: translate( 'Traffic' ),
 			path: '/stats',
-			showIntervals: true,
 		};
 		const slugPath = slug ? `/${ slug }` : '';
 		const pathTemplate = `${ traffic.path }/{{ interval }}${ slugPath }`;
 
 		const showHighlights = config.isEnabled( 'stats/show-traffic-highlights' );
 
-		const isNewFeatured = config.isEnabled( 'stats/new-main-chart' );
-		const wrapperClasses = classNames( { 'stats--new-main-chart': isNewFeatured } );
+		const isNewMainChart = config.isEnabled( 'stats/new-main-chart' );
+		const wrapperClass = classNames( { 'stats--new-main-chart': isNewMainChart } );
 
 		return (
 			<div>
-				<JetpackBackupCredsBanner event="stats-backup-credentials" />
-				<FormattedHeader
-					brandFont
-					className="stats__section-header"
-					headerText={ translate( 'Jetpack Stats' ) }
-					align="left"
-					subHeaderText={ translate(
-						"Learn more about the activity and behavior of your site's visitors. {{learnMoreLink}}Learn more{{/learnMoreLink}}.",
-						{
-							components: {
-								learnMoreLink: <InlineSupportLink supportContext="stats" showIcon={ false } />,
-							},
-						}
-					) }
+				<FixedNavigationHeader
+					headerNode={
+						<FormattedHeader
+							brandFont
+							className="stats__section-header"
+							headerText={ translate( 'Jetpack Stats' ) }
+							align="left"
+							subHeaderText={ translate(
+								"Learn more about the activity and behavior of your site's visitors. {{learnMoreLink}}Learn more{{/learnMoreLink}}",
+								{
+									components: {
+										learnMoreLink: <InlineSupportLink supportContext="stats" showIcon={ false } />,
+									},
+								}
+							) }
+						/>
+					}
+					tabListNode={
+						<StatsNavigation
+							selectedItem="traffic"
+							interval={ period }
+							siteId={ siteId }
+							slug={ slug }
+						/>
+					}
 				/>
 
-				<StatsNavigation
-					selectedItem="traffic"
-					interval={ period }
-					siteId={ siteId }
-					slug={ slug }
-				/>
+				<JetpackBackupCredsBanner event="stats-backup-credentials" />
 
 				{ showHighlights && <HighlightsSection siteId={ siteId } /> }
 
-				<div id="my-stats-content" className={ wrapperClasses }>
-					{ isNewFeatured ? (
+				<div id="my-stats-content" className={ wrapperClass }>
+					{ isNewMainChart ? (
 						<>
 							<StatsPeriodHeader>
 								<StatsPeriodNavigation
@@ -417,8 +423,11 @@ class StatsSite extends Component {
 		// Necessary to properly configure the fixed navigation headers.
 		sessionStorage.setItem( 'jp-stats-last-tab', 'traffic' );
 
+		const isNewMainChart = config.isEnabled( 'stats/new-main-chart' );
+		const wrapperClass = classNames( { 'stats--new-wrapper': isNewMainChart } );
+
 		return (
-			<Main wideLayout>
+			<Main className={ wrapperClass } wideLayout>
 				<QueryKeyringConnections />
 				{ isJetpack && <QueryJetpackModules siteId={ siteId } /> }
 				<QuerySiteKeyrings siteId={ siteId } />

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -19,7 +19,6 @@ import QueryJetpackModules from 'calypso/components/data/query-jetpack-modules';
 import QueryKeyringConnections from 'calypso/components/data/query-keyring-connections';
 import QuerySiteKeyrings from 'calypso/components/data/query-site-keyrings';
 import EmptyContent from 'calypso/components/empty-content';
-import FixedNavigationHeader from 'calypso/components/fixed-navigation-header';
 import FormattedHeader from 'calypso/components/formatted-header';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import JetpackColophon from 'calypso/components/jetpack-colophon';
@@ -208,34 +207,29 @@ class StatsSite extends Component {
 
 		return (
 			<div>
-				<FixedNavigationHeader
-					headerNode={
-						<FormattedHeader
-							brandFont
-							className="stats__section-header"
-							headerText={ translate( 'Jetpack Stats' ) }
-							align="left"
-							subHeaderText={ translate(
-								"Learn more about the activity and behavior of your site's visitors. {{learnMoreLink}}Learn more{{/learnMoreLink}}",
-								{
-									components: {
-										learnMoreLink: <InlineSupportLink supportContext="stats" showIcon={ false } />,
-									},
-								}
-							) }
-						/>
-					}
-					tabListNode={
-						<StatsNavigation
-							selectedItem="traffic"
-							interval={ period }
-							siteId={ siteId }
-							slug={ slug }
-						/>
-					}
+				<JetpackBackupCredsBanner event="stats-backup-credentials" />
+
+				<FormattedHeader
+					brandFont
+					className="stats__section-header"
+					headerText={ translate( 'Jetpack Stats' ) }
+					align="left"
+					subHeaderText={ translate(
+						"Learn more about the activity and behavior of your site's visitors. {{learnMoreLink}}Learn more{{/learnMoreLink}}",
+						{
+							components: {
+								learnMoreLink: <InlineSupportLink supportContext="stats" showIcon={ false } />,
+							},
+						}
+					) }
 				/>
 
-				<JetpackBackupCredsBanner event="stats-backup-credentials" />
+				<StatsNavigation
+					selectedItem="traffic"
+					interval={ period }
+					siteId={ siteId }
+					slug={ slug }
+				/>
 
 				{ showHighlights && <HighlightsSection siteId={ siteId } /> }
 

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -424,10 +424,10 @@ class StatsSite extends Component {
 		sessionStorage.setItem( 'jp-stats-last-tab', 'traffic' );
 
 		const isNewMainChart = config.isEnabled( 'stats/new-main-chart' );
-		const wrapperClass = classNames( { 'stats--new-wrapper': isNewMainChart } );
+		const mainWrapperClass = classNames( { 'stats--new-wrapper': isNewMainChart } );
 
 		return (
-			<Main className={ wrapperClass } wideLayout>
+			<Main className={ mainWrapperClass } wideLayout>
 				<QueryKeyringConnections />
 				{ isJetpack && <QueryJetpackModules siteId={ siteId } /> }
 				<QuerySiteKeyrings siteId={ siteId } />

--- a/client/my-sites/stats/stats-insights/index.jsx
+++ b/client/my-sites/stats/stats-insights/index.jsx
@@ -34,6 +34,8 @@ const StatsInsights = ( props ) => {
 
 	const showNewAnnualHighlights = config.isEnabled( 'stats/new-annual-highlights' );
 
+	const isNewMainChart = config.isEnabled( 'stats/new-main-chart' );
+
 	// Track the last viewed tab.
 	// Necessary to properly configure the fixed navigation headers.
 	sessionStorage.setItem( 'jp-stats-last-tab', 'insights' );
@@ -41,7 +43,7 @@ const StatsInsights = ( props ) => {
 	// TODO: should be refactored into separate components
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	return (
-		<Main wideLayout>
+		<Main className={ isNewMainChart ? 'stats--new-wrapper' : undefined } wideLayout>
 			<DocumentHead title={ translate( 'Jetpack Stats' ) } />
 			<PageViewTracker path="/stats/insights/:site" title="Stats > Insights" />
 			<FormattedHeader

--- a/client/my-sites/stats/stats-period-header/style.scss
+++ b/client/my-sites/stats/stats-period-header/style.scss
@@ -3,7 +3,7 @@
 	align-items: center;
 	justify-content: space-between;
 	background-color: var(--color-surface);
-	padding: 16px 0;
+	margin: 48px 0 16px;
 
 	.stats-period-navigation {
 		flex: 1;

--- a/client/my-sites/stats/stats-period-header/style.scss
+++ b/client/my-sites/stats/stats-period-header/style.scss
@@ -4,7 +4,6 @@
 	justify-content: space-between;
 	background-color: var(--color-surface);
 	padding: 16px 0;
-	margin-top: 48px;
 
 	.stats-period-navigation {
 		flex: 1;

--- a/client/my-sites/stats/style.scss
+++ b/client/my-sites/stats/style.scss
@@ -1,5 +1,6 @@
 @import "client/my-sites/stats/modernized-tooltip-styles.scss";
 @import "client/my-sites/stats/modernized-chart-tabs-styles.scss";
+@import "client/my-sites/stats/modernized-page-header-styles.scss";
 
 // Module container
 @include breakpoint-deprecated( ">960px" ) {

--- a/client/my-sites/stats/wordads/index.jsx
+++ b/client/my-sites/stats/wordads/index.jsx
@@ -141,12 +141,15 @@ class WordAds extends Component {
 		const pathTemplate = `${ wordads.path }/{{ interval }}${ slugPath }`;
 
 		// New feature gate
-		const isNewFeatured = config.isEnabled( 'stats/new-main-chart' );
-		const wrapperClasses = classNames( 'wordads', { 'stats--new-main-chart': isNewFeatured } );
+		const isNewMainChart = config.isEnabled( 'stats/new-main-chart' );
+		const statsWrapperClass = classNames( 'wordads', { 'stats--new-main-chart': isNewMainChart } );
+		const mainWrapperClass = classNames( {
+			'stats--new-wrapper': isNewMainChart,
+		} );
 
 		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		return (
-			<Main wideLayout>
+			<Main className={ mainWrapperClass } wideLayout>
 				<DocumentHead title={ translate( 'WordAds Stats' ) } />
 				<PageViewTracker
 					path={ `/stats/ads/${ period }/:site` }
@@ -182,8 +185,8 @@ class WordAds extends Component {
 							slug={ slug }
 						/>
 
-						<div id="my-stats-content" className={ wrapperClasses }>
-							{ isNewFeatured ? (
+						<div id="my-stats-content" className={ statsWrapperClass }>
+							{ isNewMainChart ? (
 								<>
 									<StatsPeriodHeader>
 										<StatsPeriodNavigation

--- a/client/my-sites/stats/wordads/style.scss
+++ b/client/my-sites/stats/wordads/style.scss
@@ -1,5 +1,3 @@
-@import "client/my-sites/stats/modernized-chart-tabs-styles.scss";
-
 @include breakpoint-deprecated( ">480px" ) {
 	.wordads .stats-tabs .stats-tab {
 		width: 33.33%;

--- a/client/my-sites/store/app/store-stats/index.js
+++ b/client/my-sites/store/app/store-stats/index.js
@@ -9,7 +9,6 @@ import titlecase from 'to-title-case';
 import StatsNavigation from 'calypso/blocks/stats-navigation';
 import Intervals from 'calypso/blocks/stats-navigation/intervals';
 import QuerySiteStats from 'calypso/components/data/query-site-stats';
-import FixedNavigationHeader from 'calypso/components/fixed-navigation-header';
 import FormattedHeader from 'calypso/components/formatted-header';
 import JetpackColophon from 'calypso/components/jetpack-colophon';
 import Main from 'calypso/components/main';
@@ -71,27 +70,17 @@ class StoreStats extends Component {
 					<QuerySiteStats statType="statsOrders" siteId={ siteId } query={ orderQuery } />
 				) }
 
-				<FixedNavigationHeader
-					headerNode={
-						<FormattedHeader
-							brandFont
-							className="store-stats__section-header"
-							headerText={ translate( 'Jetpack Stats' ) }
-							align="left"
-							subHeaderText={ translate(
-								'Learn valuable insights about the purchases made on your store.'
-							) }
-						/>
-					}
-					tabListNode={
-						<StatsNavigation
-							selectedItem="store"
-							siteId={ siteId }
-							slug={ slug }
-							interval={ unit }
-						/>
-					}
+				<FormattedHeader
+					brandFont
+					className="store-stats__section-header"
+					headerText={ translate( 'Jetpack Stats' ) }
+					align="left"
+					subHeaderText={ translate(
+						'Learn valuable insights about the purchases made on your store.'
+					) }
 				/>
+
+				<StatsNavigation selectedItem="store" siteId={ siteId } slug={ slug } interval={ unit } />
 
 				<div id="my-stats-content" className={ statsWrapperClass }>
 					{ isNewMainChart ? (

--- a/client/my-sites/store/app/store-stats/index.js
+++ b/client/my-sites/store/app/store-stats/index.js
@@ -9,6 +9,7 @@ import titlecase from 'to-title-case';
 import StatsNavigation from 'calypso/blocks/stats-navigation';
 import Intervals from 'calypso/blocks/stats-navigation/intervals';
 import QuerySiteStats from 'calypso/components/data/query-site-stats';
+import FixedNavigationHeader from 'calypso/components/fixed-navigation-header';
 import FormattedHeader from 'calypso/components/formatted-header';
 import JetpackColophon from 'calypso/components/jetpack-colophon';
 import Main from 'calypso/components/main';
@@ -53,11 +54,14 @@ class StoreStats extends Component {
 		const pathTemplate = `${ store.path }/{{ interval }}${ slugPath }`;
 
 		// New feature gate
-		const isNewFeatured = config.isEnabled( 'stats/new-main-chart' );
-		const wrapperClasses = classNames( { 'stats--new-main-chart': isNewFeatured } );
+		const isNewMainChart = config.isEnabled( 'stats/new-main-chart' );
+		const statsWrapperClass = classNames( { 'stats--new-main-chart': isNewMainChart } );
+		const mainWrapperClass = classNames( 'store-stats', 'woocommerce', {
+			'stats--new-wrapper': isNewMainChart,
+		} );
 
 		return (
-			<Main className="store-stats woocommerce" wideLayout>
+			<Main className={ mainWrapperClass } wideLayout>
 				<PageViewTracker
 					path={ `/store/stats/orders/${ unit }/:site` }
 					title={ `Store > Stats > Orders > ${ titlecase( unit ) }` }
@@ -67,20 +71,30 @@ class StoreStats extends Component {
 					<QuerySiteStats statType="statsOrders" siteId={ siteId } query={ orderQuery } />
 				) }
 
-				<FormattedHeader
-					brandFont
-					className="store-stats__section-header"
-					headerText={ translate( 'Jetpack Stats' ) }
-					align="left"
-					subHeaderText={ translate(
-						'Learn valuable insights about the purchases made on your store.'
-					) }
+				<FixedNavigationHeader
+					headerNode={
+						<FormattedHeader
+							brandFont
+							className="store-stats__section-header"
+							headerText={ translate( 'Jetpack Stats' ) }
+							align="left"
+							subHeaderText={ translate(
+								'Learn valuable insights about the purchases made on your store.'
+							) }
+						/>
+					}
+					tabListNode={
+						<StatsNavigation
+							selectedItem="store"
+							siteId={ siteId }
+							slug={ slug }
+							interval={ unit }
+						/>
+					}
 				/>
 
-				<StatsNavigation selectedItem="store" siteId={ siteId } slug={ slug } interval={ unit } />
-
-				<div id="my-stats-content" class={ wrapperClasses }>
-					{ isNewFeatured ? (
+				<div id="my-stats-content" className={ statsWrapperClass }>
+					{ isNewMainChart ? (
 						<>
 							<StatsPeriodHeader>
 								<StatsPeriodNavigation

--- a/client/my-sites/store/style.scss
+++ b/client/my-sites/store/style.scss
@@ -1,4 +1,5 @@
 @import "client/my-sites/stats/modernized-tooltip-styles.scss";
+@import "client/my-sites/stats/modernized-page-header-styles.scss";
 
 .woocommerce {
 	@import "app/dashboard/style";


### PR DESCRIPTION
#### Proposed Changes

<img width="824" alt="截圖 2022-11-08 下午11 19 09" src="https://user-images.githubusercontent.com/6869813/200603600-e0f42a0c-5630-4ef5-a1eb-19e21c82fb8b.png">

* Update the `FixedNavigationHeader` component to be compatible with the new `Stats` page header and existing styles.
* Adjust the page header styling behind the `stats/new-main-chart` feature on the `Traffic` page.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Launch the _local_ development application or append `?flags=stats/new-main-chart` on URL of the Calypso Live link.
* Navigate to page `/stats/day/${your-site}`.
* Ensure the header styling works in line with the design.

| Before | After |
| --- | --- |
| <img width="1131" alt="截圖 2022-11-08 下午11 15 56" src="https://user-images.githubusercontent.com/6869813/200602845-427ace5a-aa07-4d4d-927b-626b4a6b0d82.png"> | <img width="1106" alt="截圖 2022-11-09 下午9 30 56" src="https://user-images.githubusercontent.com/6869813/200843116-7ac9de2d-eea3-4842-b0b0-717bd5e08fb3.png"> |

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #68974 
