### PR TITLE
Updating link button and badges to use new purple styling.

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-domain/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-domain/style.scss
@@ -1,8 +1,11 @@
 $videopress-mobile-layout-width: 1200px;
+$videopress-link-color: #c377ff;
+$videopress-background: #010101;
 
 .videopress.choose-adomain {
 	--color-text-subtle: #a7aaad;
-	--studio-green-60: #1ed15a;
+	// Silly override, but easily replaces green with purple as desired for VideoPress flow
+	--studio-green-60: #c377ff;
 
 	.chooseADomain.is-wide-layout {
 		max-width: 1160px;
@@ -149,12 +152,12 @@ $videopress-mobile-layout-width: 1200px;
 
 		.domain-registration-suggestion__badges {
 			.badge--info-green {
-				background-color: #b8e6bf;
-				color: #00450c;
+				background-color: $videopress-link-color;
+				color: $videopress-background;
 			}
 			.badge--info-purple {
-				background-color: #e5cfe8;
-				color: #3c2861;
+				background-color: #646970;
+				color: #fff;
 			}
 		}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-plan/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-plan/style.scss
@@ -1,4 +1,6 @@
 $videopress-mobile-layout-width: 700px;
+$videopress-link-color: #c377ff;
+$videopress-background: #010101;
 
 .videopress {
 	.step-container__header {
@@ -51,8 +53,8 @@ $videopress-mobile-layout-width: 700px;
 			&.is-popular {
 				margin-top: 0;
 				.plan-item__badge {
-					background-color: #b8e6bf;
-					color: #00450c;
+					background-color: $videopress-link-color;
+					color: $videopress-background;
 					width: fit-content;
 					text-transform: none;
 					font-weight: 500;
@@ -90,7 +92,7 @@ $videopress-mobile-layout-width: 700px;
 
 				.plan-item__price-discount {
 					text-align: center;
-					color: #1ed15a;
+					color: $videopress-link-color;
 				}
 
 				.components-button.plan-item__select-button.is-primary {
@@ -122,7 +124,7 @@ $videopress-mobile-layout-width: 700px;
 
 					.plans-feature-list__item {
 						.plans-feature-list__item-bullet-icon {
-							color: #1ed15a;
+							color: $videopress-link-color;
 						}
 
 						&.plans-feature-list__item--requires-annual-disabled .plans-feature-list__item-bullet-icon {


### PR DESCRIPTION
#### Proposed Changes

* Fixes https://github.com/Automattic/greenhouse/issues/1370
* Updates styles for VideoPress onboarding to use purple coloring on domain and plan views:

<img width="660" alt="Screenshot 2022-11-08 at 8 57 13 AM" src="https://user-images.githubusercontent.com/789137/200614130-edde58f9-b0f2-4b8d-a101-f32b2393a01a.png">
<img width="1230" alt="Screenshot 2022-11-08 at 8 57 22 AM" src="https://user-images.githubusercontent.com/789137/200614154-f73aa18a-4b8f-4b20-9877-859467f80065.png">



#### Testing Instructions

* Start at http://calypso.localhost:3000/setup/intro?flow=videopress
* Proceed to the domain selection. It should be using the new purple styling and look nice!
* Same for the plans selection, should use purple accent color (no more green on page)

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
