### PR TITLE
Stats: Enable shares module for Jetpack sites

### DIFF
--- a/client/my-sites/stats/stats-insights/index.jsx
+++ b/client/my-sites/stats/stats-insights/index.jsx
@@ -15,7 +15,6 @@ import { getSuggestionsVendor } from 'calypso/lib/domains/suggestions';
 import AllTime from 'calypso/my-sites/stats/all-time/';
 import AnnualSiteStats from 'calypso/my-sites/stats/annual-site-stats';
 import MostPopular from 'calypso/my-sites/stats/most-popular';
-import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import AnnualHighlightsSection from '../annual-highlights-section';
 import LatestPostSummary from '../post-performance';
@@ -29,7 +28,7 @@ import statsStrings from '../stats-strings';
 import StatsViews from '../stats-views';
 
 const StatsInsights = ( props ) => {
-	const { isJetpack, siteId, siteSlug, translate } = props;
+	const { siteId, siteSlug, translate } = props;
 	const moduleStrings = statsStrings();
 
 	const showNewAnnualHighlights = config.isEnabled( 'stats/new-annual-highlights' );
@@ -79,7 +78,7 @@ const StatsInsights = ( props ) => {
 							/>
 
 							{ ! showNewAnnualHighlights && <AnnualSiteStats isWidget /> }
-							{ ! isJetpack && <StatShares siteId={ siteId } /> }
+							<StatShares siteId={ siteId } />
 						</div>
 						<div className="stats__module-column">
 							<Reach />
@@ -110,7 +109,6 @@ StatsInsights.propTypes = {
 const connectComponent = connect( ( state ) => {
 	const siteId = getSelectedSiteId( state );
 	return {
-		isJetpack: isJetpackSite( state, siteId ),
 		siteId,
 		siteSlug: getSelectedSiteSlug( state, siteId ),
 	};

--- a/client/my-sites/stats/stats-shares/index.jsx
+++ b/client/my-sites/stats/stats-shares/index.jsx
@@ -11,6 +11,7 @@ import {
 	hasSiteStatsQueryFailed,
 } from 'calypso/state/stats/lists/selectors';
 import ErrorPanel from '../stats-error';
+import StatsModulePlaceholder from '../stats-module/placeholder';
 import StatsTabs from '../stats-tabs';
 import StatsTab from '../stats-tabs/tab';
 
@@ -52,6 +53,7 @@ const StatShares = ( { siteId } ) => {
 								);
 							}
 						} ) }
+					<StatsModulePlaceholder isLoading={ isLoading } />
 					{ ! isLoading && ! siteStats?.stats.shares && (
 						<ErrorPanel message={ translate( 'No shares recorded' ) } />
 					) }


### PR DESCRIPTION
#### Proposed Changes

<img width="355" alt="image" src="https://user-images.githubusercontent.com/4044428/200672142-bd936882-d6c9-4aee-91c7-ccc915cd2e14.png">

Enable the Shares module within Stats Insights for Jetpack sites.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the live branch for this PR.
* Select a Jetpack site in the site selector.
* Navigate to Stats -> Insights.
* Ensure that the sharing module is visible.
* Ensure that the Sharing module shows a loader while loading.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.


Related to #
-->