### PR TITLE
VideoPress onboarding: Add new options to old onboarding flow

### DIFF
--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -952,21 +952,16 @@ export function createWpForTeamsSite( callback, dependencies, stepData, reduxSto
 
 // Similar to createSite but also sets the site title and description
 export function createVideoPressSite( callback, dependencies, stepData, reduxStore ) {
-	const { site, themeSlugWithRepo, siteTitle = '', siteDescription = '' } = stepData;
-	const signupDependencies = getSignupDependencyStore( reduxStore.getState() );
+	const { site, siteTitle = '', siteDescription = '' } = stepData;
 	const locale = getLocaleSlug();
-
-	const theme =
-		dependencies?.themeSlugWithRepo ||
-		themeSlugWithRepo ||
-		get( signupDependencies, 'themeSlugWithRepo', false );
 
 	const data = {
 		blog_name: site,
 		blog_title: siteTitle,
 		public: Visibility.PublicNotIndexed,
 		options: {
-			theme,
+			theme: 'pub/twentytwentytwo',
+			site_vertical_name: 'videomaker',
 			timezone_string: guessTimezone(),
 			wpcom_public_coming_soon: 1,
 		},


### PR DESCRIPTION

#### Proposed Changes

* Add the correct `theme` and `site_vertical` properties to created site to ensure new post / homepage link creation works correctly
* test alongside D90682-code

#### Testing Instructions

<img width="351" alt="Screenshot 2022-11-08 at 6 07 59 PM" src="https://user-images.githubusercontent.com/4081020/200695984-0fb50b6e-2f9b-4fe3-9422-e9ef976defbc.png">
<img width="1592" alt="Screenshot 2022-11-08 at 6 08 06 PM" src="https://user-images.githubusercontent.com/4081020/200695991-18170c2a-824d-4d8a-b73c-55affc65f6a9.png">


<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* apply D90682-code to wpcom sandbox
* pull pr and `yarn && yarn start`
* visit `http://calypso.localhost:3000/start/videopress`
* complete the flow, the view the created site. The menu should only have the 4 basic options, and the homepage video links should point to the correct pages

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
