### PR TITLE
(TeamCIty/WPCOM Atomic E2Es) Disable/parallel runs for wpcom atomic e2es, take 2

### DIFF
--- a/.teamcity/_self/projects/WPComTests.kt
+++ b/.teamcity/_self/projects/WPComTests.kt
@@ -92,7 +92,7 @@ fun gutenbergPlaywrightBuildType( targetDevice: String, buildUuid: String, atomi
 				// Overrides the inherited max workers settings and sets it to not run any tests in parallel.
 				// The reason for this is an inconsistent issue breaking the login in AT test sites when
 				// more than one test runs in parallel. Remove or set it to 16 after the issue is solved.
-				param("env.JEST_MAX_WORKERS", "1")
+				param("env.E2E_WORKERS", "1")
 			}
 			if (edge) {
 				param("env.GUTENBERG_EDGE", "true")


### PR DESCRIPTION
#### Proposed Changes

Follow-up to: https://github.com/Automattic/wp-calypso/pull/69858.

It seems `env.JEST_MAX_WORKERS` is not the setting that affects the Atomic E2E tests in production, but `E2E_WORKERS`. This PR fixes that. 

See https://github.com/Automattic/wp-calypso/pull/69858 and https://github.com/Automattic/wp-calypso/issues/69865 for more details.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
