### PR TITLE
Update sale banner text for Jetpack Black Friday/Cyber Monday sale

### DIFF
--- a/client/jetpack-cloud/sections/pricing/sale-banner/index.tsx
+++ b/client/jetpack-cloud/sections/pricing/sale-banner/index.tsx
@@ -62,12 +62,9 @@ const SaleBanner: React.FC< Props > = ( { coupon } ) => {
 						<div>
 							<b>{ saleTitle }</b>
 							&nbsp;
-							{ translate(
-								'Get up to %(discount)d%% off your first year on all Jetpack products & plans.',
-								{
-									args: { discount: coupon.final_discount },
-								}
-							) }
+							{ translate( 'Take %(discount)d%% off all annual Jetpack bundles and products.', {
+								args: { discount: coupon.final_discount },
+							} ) }
 						</div>
 						<span className="sale-banner__countdown-timer">
 							{ translate( 'Sale ends in: %(days)dd %(hours)dh %(minutes)dm %(seconds)ss', {


### PR DESCRIPTION
#### Proposed Changes

This diff updates text according to the Black Friday sale comps

P2: pbNhbs-4ff-p2

#### Testing Instructions

1. Check out this branch via `git switch update/masterbar-sale-banner-text`
2. Follow these steps to set up your sandbox to enable the sale banner: 2e22c-pb
3. Go to http://jetpack.cloud.localhost:3000/pricing and confirm the text is correct
![image](https://user-images.githubusercontent.com/65001528/200702402-feeacf06-0401-4423-ac80-5bb756763748.png)

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?