### PR TITLE
Gifting: Add gifting terms of service item

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/checkout-terms.jsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-terms.jsx
@@ -1,5 +1,5 @@
 import { localize } from 'i18n-calypso';
-import { Component, Fragment } from 'react';
+import { Fragment } from 'react';
 import { hasRenewableSubscription } from 'calypso/lib/cart-values/cart-items';
 import AdditionalTermsOfServiceInCart from './additional-terms-of-service-in-cart';
 import BundledDomainNotice from './bundled-domain-notice';
@@ -7,6 +7,7 @@ import ConciergeRefundPolicy from './concierge-refund-policy';
 import DomainRegistrationAgreement from './domain-registration-agreement';
 import DomainRegistrationHsts from './domain-registration-hsts';
 import { EbanxTermsOfService } from './ebanx-terms-of-service';
+import { GiftingTermsOfService } from './gifting-terms-of-service';
 import { InternationalFeeNotice } from './international-fee-notice';
 import RefundPolicies from './refund-policies';
 import TermsOfService from './terms-of-service';
@@ -15,19 +16,12 @@ import TitanTermsOfService from './titan-terms-of-service';
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 
-class CheckoutTerms extends Component {
-	render() {
-		const { cart } = this.props;
+const CheckoutTerms = ( { translate, cart } ) => {
+	const renderGiftToS = () => <GiftingTermsOfService />;
+
+	const renderDefaultToS = () => {
 		return (
-			<Fragment>
-				<div className="checkout__terms" id="checkout-terms">
-					<strong>
-						{ this.props.translate( 'By checking out:', {
-							comment:
-								'Headline before a list of terms the customer is agreeing to on checkout. Screenshot: https://user-images.githubusercontent.com/1379730/55166390-66c09080-5145-11e9-9c13-6c1b3b693786.png',
-						} ) }
-					</strong>
-				</div>
+			<>
 				<TermsOfService hasRenewableSubscription={ hasRenewableSubscription( cart ) } />
 				<DomainRegistrationAgreement cart={ cart } />
 				<DomainRegistrationHsts cart={ cart } />
@@ -39,9 +33,22 @@ class CheckoutTerms extends Component {
 				<EbanxTermsOfService />
 				<InternationalFeeNotice />
 				<AdditionalTermsOfServiceInCart />
-			</Fragment>
+			</>
 		);
-	}
-}
+	};
+	return (
+		<Fragment>
+			<div className="checkout__terms" id="checkout-terms">
+				<strong>
+					{ translate( 'By checking out:', {
+						comment:
+							'Headline before a list of terms the customer is agreeing to on checkout. Screenshot: https://user-images.githubusercontent.com/1379730/55166390-66c09080-5145-11e9-9c13-6c1b3b693786.png',
+					} ) }
+				</strong>
+			</div>
+			{ cart.gift_details ? renderGiftToS() : renderDefaultToS() }
+		</Fragment>
+	);
+};
 
 export default localize( CheckoutTerms );

--- a/client/my-sites/checkout/composite-checkout/components/gifting-terms-of-service.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/gifting-terms-of-service.tsx
@@ -1,0 +1,9 @@
+import { translate } from 'i18n-calypso';
+import CheckoutTermsItem from 'calypso/my-sites/checkout/composite-checkout/components/checkout-terms-item';
+
+export const GiftingTermsOfService = () => {
+	const giftingTermsOfServiceText = translate(
+		`Gifting ipsum dolor sit amet, consectetur adipiscing elit. Morbi at consectetur dolor.`
+	);
+	return <CheckoutTermsItem>{ giftingTermsOfServiceText }</CheckoutTermsItem>;
+};


### PR DESCRIPTION
#### Proposed Changes
**Working draft, do not merge**

<img width="750" alt="image" src="https://user-images.githubusercontent.com/16580129/200708981-ff7bbbef-40a4-4b33-85a8-d00580913010.png">

This PR will add a gifting ToS item and also provide a conditional flow that loads the gifting terms of service when the product(s) in the cart are a gift.

Providing a separate terms of service group for gifts seems sensible since they fundamentally work and behave differently from a product being added to the customer's own account.

At this point, the gift terms of service text is **PLACEHOLDER** text and should be changed before merged.

Additionally, further discussion is needed to decide what existing terms of service components can be reused for gifts.

#### Testing Instructions
- sandbox the wpcom api
- go to http://calypso.localhost:3000/checkout/value_bundle/gift/1022400
- scroll to the bottom of checkout, you should only see the 'gifting lorem' text and no other terms of service
- go to any other site on your account and add a product
- go to checkout again, this time you should not see any 'gifting lorem' text, but instead just the usual terms of service text
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/payments-shilling/issues/1196
