### PR TITLE
Gifting: Add gift purchases to doNotStripProducts to preserve URL on refresh

### DIFF
--- a/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
@@ -132,7 +132,9 @@ export default function usePrepareProductsForCart( {
 
 	// Do not strip products from url until the URL has been parsed
 	const areProductsRetrievedFromUrl = ! state.isLoading && ! isInModal;
-	const doNotStripProducts = Boolean( ! areProductsRetrievedFromUrl || isJetpackCheckout );
+	const doNotStripProducts = Boolean(
+		! areProductsRetrievedFromUrl || isJetpackCheckout || isGiftPurchase
+	);
 	useStripProductsFromUrl( siteSlug, doNotStripProducts );
 
 	return state;


### PR DESCRIPTION
#### Proposed Changes

Added `isGiftPurchase` as a condition for doNotStripProducts, this should allow the gift URL to be preserved between page refreshes instead of the default behavior of falling back to the site picker.

#### Testing Instructions
- sandbox wpcom API
- go to http://calypso.localhost:3000/checkout/value_bundle/gift/1022400
- refresh page
- checkout with gift should load again without issue
- make notes if checkout does not load, or, if the site picker loads instead
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/payments-shilling/issues/1226
