### PR TITLE
Partner Portal: redirect to licenses page when not via dashboard & show notifications

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/hooks.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/hooks.tsx
@@ -367,8 +367,7 @@ export function useIssueMultipleLicenses(
 				},
 				partnerPortalBasePath( '/payment-methods/add' )
 			);
-			page( nextStep );
-			return;
+			return page( nextStep );
 		}
 
 		const issueLicenseRequests: any[] = [];
@@ -440,12 +439,14 @@ export function useIssueMultipleLicenses(
 		if ( fromDashboard ) {
 			return page.redirect( '/dashboard' );
 		}
+		return page.redirect( partnerPortalBasePath( '/licenses' ) );
 	}, [
 		isLoading,
-		dispatch,
 		selectedProducts,
+		dispatch,
+		selectedSite?.ID,
+		selectedSite?.domain,
 		paymentMethodRequired,
-		selectedSite,
 		fromDashboard,
 		issueLicense,
 		products?.data,

--- a/client/jetpack-cloud/sections/partner-portal/primary/licenses/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/licenses/index.tsx
@@ -1,9 +1,11 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useDispatch, useSelector } from 'react-redux';
 import CardHeading from 'calypso/components/card-heading';
 import DocumentHead from 'calypso/components/data/document-head';
 import Main from 'calypso/components/main';
+import SiteAddLicenseNotification from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/site-add-license-notification';
 import SiteWelcomeBanner from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/site-welcome-banner';
 import LicenseList from 'calypso/jetpack-cloud/sections/partner-portal/license-list';
 import LicenseListContext from 'calypso/jetpack-cloud/sections/partner-portal/license-list-context';
@@ -17,6 +19,7 @@ import {
 } from 'calypso/jetpack-cloud/sections/partner-portal/types';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { showAgencyDashboard } from 'calypso/state/partner-portal/partner/selectors';
+
 import './style.scss';
 
 interface Props {
@@ -55,6 +58,9 @@ export default function Licenses( {
 			<DocumentHead title={ translate( 'Licenses' ) } />
 			<SidebarNavigation />
 			{ isAgencyUser && <SiteWelcomeBanner bannerKey="licenses-page" /> }
+			{ isEnabled( 'jetpack/partner-portal-issue-multiple-licenses' ) && (
+				<SiteAddLicenseNotification />
+			) }
 			<div className="licenses__header">
 				<CardHeading size={ 36 }>{ translate( 'Licenses' ) }</CardHeading>
 


### PR DESCRIPTION
#### Proposed Changes

This PR 
- Handles redirection to the licenses page when the license is assigned from the licenses or billing page(not from the dashboard)
- Shows notification(success & error) on the licenses page

This will be useful when assigning multiple licenses from the assign license page is completed.

#### Testing Instructions

1. Run `git checkout update/issue-multiple-licenses-from-licenses-page` and `yarn start-jetpack-cloud`
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Click on **Licensing** -> Click on **Issue New License** -> Append the URL with `?site_id={some-id}` -> Select any license -> Click on **Select License** -> Verify that you are redirected to the `licenses` page, and the notification is shown as below

<img width="1034" alt="Screenshot 2022-11-09 at 10 47 21 AM" src="https://user-images.githubusercontent.com/10586875/200749409-051fd503-375e-4cc9-ba51-99763a7541ad.png">

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1203126240279377-as-1203311546423726