### PR TITLE
Partner Portal: redirect to licenses or assign licenses after issuing licenses when no site is selected

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/hooks.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/hooks.tsx
@@ -294,6 +294,8 @@ export function useIssueMultipleLicenses(
 		select: selectAlphaticallySortedProductOptions,
 	} );
 
+	const sites = useSelector( getSites ).length;
+
 	const paymentMethodRequired = useSelector( doesPartnerRequireAPaymentMethod );
 
 	const fromDashboard = getQueryArg( window.location.href, 'source' ) === 'dashboard';
@@ -378,6 +380,58 @@ export function useIssueMultipleLicenses(
 		} );
 		const issueLicensePromises = await Promise.allSettled( issueLicenseRequests );
 
+		if ( ! selectedSiteId ) {
+			let nextStep = partnerPortalBasePath( '/licenses' );
+			if ( sites > 0 ) {
+				nextStep = addQueryArgs(
+					{
+						products: selectedProducts.join( ',' ),
+					},
+					partnerPortalBasePath( '/assign-license' )
+				);
+			}
+
+			const assignedLicenses = selectedProducts
+				.map(
+					( product ) =>
+						products.data?.find( ( productOption ) => productOption.slug === product )?.name
+				)
+				.filter( ( license ) => license );
+
+			if ( assignedLicenses.length > 0 ) {
+				const lastItem = assignedLicenses.slice( -1 )[ 0 ];
+				const remainingItems = assignedLicenses.slice( 0, -1 );
+				const messageArgs = {
+					args: {
+						lastItem: lastItem,
+						remainingItems: remainingItems.join( ', ' ),
+					},
+					components: {
+						strong: <strong />,
+					},
+				};
+
+				dispatch(
+					successNotice(
+						// We are not using the same translate method for plural form since we have different arguments.
+						assignedLicenses.length > 1
+							? translate(
+									'{{strong}}%(remainingItems)s and %(lastItem)s{{/strong}} were succesfully issued',
+									messageArgs
+							  )
+							: translate(
+									'{{strong}}%(lastItem)s{{/strong}} was succesfully issued',
+									messageArgs
+							  ),
+						{
+							displayOnNextPage: true,
+						}
+					)
+				);
+			}
+			return page.redirect( nextStep );
+		}
+
 		const assignLicenseRequests: any = [];
 
 		const assignedProducts: Array< any > = [];
@@ -448,7 +502,9 @@ export function useIssueMultipleLicenses(
 		selectedSite,
 		fromDashboard,
 		issueLicense,
-		products?.data,
+		sites,
+		translate,
+		products.data,
 		assignLicense,
 	] );
 

--- a/client/jetpack-cloud/sections/partner-portal/hooks.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/hooks.tsx
@@ -378,14 +378,17 @@ export function useIssueMultipleLicenses(
 		selectedProducts.forEach( ( product ) => {
 			issueLicenseRequests.push( issueLicense.mutateAsync( { product } ) );
 		} );
-		const issueLicensePromises = await Promise.allSettled( issueLicenseRequests );
+		const issueLicensePromises: any[] = await Promise.allSettled( issueLicenseRequests );
 
 		if ( ! selectedSiteId ) {
 			let nextStep = partnerPortalBasePath( '/licenses' );
 			if ( sites > 0 ) {
+				const licenseKeys = issueLicensePromises
+					.filter( ( { status } ) => status === 'fulfilled' )
+					.map( ( { value } ) => value.license_key );
 				nextStep = addQueryArgs(
 					{
-						products: selectedProducts.join( ',' ),
+						products: licenseKeys.join( ',' ),
 					},
 					partnerPortalBasePath( '/assign-license' )
 				);


### PR DESCRIPTION
#### Proposed Changes

This PR makes the following changes when no site is selected.

- Redirect to `/licenses` when no sites are available when licenses are issued.
- Redirect to `/assign-license` when sites are available when licenses are issued.
- Show notifications for issued licenses. 

#### Testing Instructions

1. Run `git checkout update/issue-multiple-licenses-without-site-selection` and `yarn start-jetpack-cloud`
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Click on **Licensing** -> Click on **Issue New License** -> Select any license -> Click on **Select License** -> Verify that you are being redirected to `/assign-license` and notification is being shown as below

<img width="1345" alt="Screenshot 2022-11-09 at 10 14 05 AM" src="https://user-images.githubusercontent.com/10586875/200774326-8e15d0e9-4a46-4c4a-8eb2-4331f489b303.png">

<img width="1343" alt="Screenshot 2022-11-09 at 10 14 25 AM" src="https://user-images.githubusercontent.com/10586875/200774345-a46fde6e-2e79-4f84-b202-e3b428879905.png">


<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1203126240279377-as-1203311546423717