### PR TITLE
Revert "Revert "Introduce the custom callback mechanism upon a sign-up flow completion.""

### DIFF
--- a/client/lib/signup/flow-controller.ts
+++ b/client/lib/signup/flow-controller.ts
@@ -86,7 +86,7 @@ function progressStoreListener(
 	};
 }
 
-type OnCompleteCallback = ( dependencies: Dependencies, destination: string ) => void;
+type OnCompleteCallback = ( dependencies: Dependencies, destination: string ) => Promise< void >;
 
 interface SignupFlowControllerOptions {
 	flowName: string;
@@ -344,7 +344,7 @@ export default class SignupFlowController {
 			this._assertFlowProvidedRequiredDependencies();
 			// deferred to ensure that the onComplete function is called after the stores have
 			// emitted their final change events.
-			defer( () => this._onComplete( dependencies, this._destination( dependencies ) ) );
+			this._onComplete( dependencies, this._destination( dependencies ) );
 		}
 	}
 

--- a/client/lib/signup/flow-controller.ts
+++ b/client/lib/signup/flow-controller.ts
@@ -344,7 +344,7 @@ export default class SignupFlowController {
 			this._assertFlowProvidedRequiredDependencies();
 			// deferred to ensure that the onComplete function is called after the stores have
 			// emitted their final change events.
-			this._onComplete( dependencies, this._destination( dependencies ) );
+			defer( () => this._onComplete( dependencies, this._destination( dependencies ) ) );
 		}
 	}
 

--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -5,7 +5,6 @@ import { Site } from '@automattic/data-stores';
 import { isBlankCanvasDesign } from '@automattic/design-picker';
 import { guessTimezone, getLanguage } from '@automattic/i18n-utils';
 import { mapRecordKeysRecursively, camelToSnakeCase } from '@automattic/js-utils';
-import { setupSiteAfterCreation, isTailoredSignupFlow } from '@automattic/onboarding';
 import debugFactory from 'debug';
 import { defer, difference, get, includes, isEmpty, pick, startsWith } from 'lodash';
 import { recordRegistration } from 'calypso/lib/analytics/signup';
@@ -298,29 +297,16 @@ export function createSiteWithCart( callback, dependencies, stepData, reduxStore
 				domainItem,
 				themeItem,
 			};
-			if ( isTailoredSignupFlow( flowToCheck ) ) {
-				setupSiteAfterCreation( { siteId, flowName: flowToCheck } ).then( () => {
-					processItemCart(
-						providedDependencies,
-						newCartItems,
-						callback,
-						reduxStore,
-						siteSlug,
-						isFreeThemePreselected,
-						themeSlugWithRepo
-					);
-				} );
-			} else {
-				processItemCart(
-					providedDependencies,
-					newCartItems,
-					callback,
-					reduxStore,
-					siteSlug,
-					isFreeThemePreselected,
-					themeSlugWithRepo
-				);
-			}
+
+			processItemCart(
+				providedDependencies,
+				newCartItems,
+				callback,
+				reduxStore,
+				siteSlug,
+				isFreeThemePreselected,
+				themeSlugWithRepo
+			);
 		}
 	);
 }

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -1,4 +1,5 @@
 import { isEnabled } from '@automattic/calypso-config';
+import { setupSiteAfterCreation } from '@automattic/onboarding';
 import { translate } from 'i18n-calypso';
 import { VIDEOPRESS_ONBOARDING_FLOW_STEPS } from './constants';
 
@@ -115,11 +116,12 @@ export function generateFlows( {
 			destination: ( dependencies ) =>
 				`/setup/newsletter/subscribers?siteSlug=${ dependencies.siteSlug }`,
 			description: 'Beginning of the flow to create a newsletter',
-			lastModified: '2022-08-15',
+			lastModified: '2022-11-01',
 			showRecaptcha: true,
 			get pageTitle() {
 				return translate( 'Newsletter' );
 			},
+			postCompleteCallback: setupSiteAfterCreation,
 		},
 		{
 			name: 'link-in-bio',
@@ -127,11 +129,12 @@ export function generateFlows( {
 			destination: ( dependencies ) =>
 				`/setup/link-in-bio/launchpad?siteSlug=${ encodeURIComponent( dependencies.siteSlug ) }`,
 			description: 'Beginning of the flow to create a link in bio',
-			lastModified: '2022-08-16',
+			lastModified: '2022-11-01',
 			showRecaptcha: true,
 			get pageTitle() {
 				return translate( 'Link in Bio' );
 			},
+			postCompleteCallback: setupSiteAfterCreation,
 		},
 		{
 			name: 'import',
@@ -286,8 +289,9 @@ export function generateFlows( {
 					dependencies.siteSlug
 				) }`,
 			description: 'VideoPress signup flow',
-			lastModified: '2022-07-06',
+			lastModified: '2022-11-01',
 			showRecaptcha: true,
+			postCompleteCallback: setupSiteAfterCreation,
 		},
 		{
 			name: 'videopress-account',

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -291,6 +291,7 @@ class Signup extends Component {
 				this.props.locale
 			);
 			this.handleLogin( this.props.signupDependencies, stepUrl, false );
+			this.handleDestination( this.props.signupDependencies, stepUrl );
 		}
 	}
 
@@ -323,6 +324,15 @@ class Signup extends Component {
 		}
 	}
 
+	handlePostFlowCallbacks = async ( dependencies ) => {
+		const flow = flows.getFlow( this.props.flowName, this.props.isLoggedIn );
+
+		if ( flow.postCompleteCallback ) {
+			const siteId = dependencies && dependencies.siteId;
+			await flow.postCompleteCallback( { siteId, flowName: this.props.flowName } );
+		}
+	};
+
 	handleSignupFlowControllerCompletion = async ( dependencies, destination ) => {
 		const filteredDestination = getDestination(
 			destination,
@@ -338,7 +348,13 @@ class Signup extends Component {
 			setSignupCompleteFlowName( this.props.flowName );
 		}
 
-		return this.handleFlowComplete( dependencies, filteredDestination );
+		this.handleFlowComplete( dependencies, filteredDestination );
+
+		this.handleLogin( dependencies, filteredDestination );
+
+		await this.handlePostFlowCallbacks( dependencies );
+
+		this.handleDestination( dependencies, filteredDestination );
 	};
 
 	startTrackingForBusinessSite() {
@@ -467,9 +483,26 @@ class Signup extends Component {
 			startingPoint,
 			isBlankCanvas: isBlankCanvasDesign( dependencies.selectedDesign ),
 		} );
-
-		this.handleLogin( dependencies, destination );
 	};
+
+	handleDestination( dependencies, destination ) {
+		if ( this.props.isLoggedIn ) {
+			// don't use page.js for external URLs (eg redirect to new site after signup)
+			if ( /^https?:\/\//.test( destination ) ) {
+				return ( window.location.href = destination );
+			}
+
+			// deferred in case the user is logged in and the redirect triggers a dispatch
+			defer( () => {
+				debug( `Redirecting you to "${ destination }"` );
+				window.location.href = destination;
+			} );
+
+			return;
+		}
+
+		window.location.href = destination;
+	}
 
 	handleLogin( dependencies, destination, resetSignupFlowController = true ) {
 		const { isLoggedIn: userIsLoggedIn, progress } = this.props;
@@ -483,19 +516,6 @@ class Signup extends Component {
 			}
 		}
 
-		if ( userIsLoggedIn ) {
-			// don't use page.js for external URLs (eg redirect to new site after signup)
-			if ( /^https?:\/\//.test( destination ) ) {
-				return ( window.location.href = destination );
-			}
-
-			// deferred in case the user is logged in and the redirect triggers a dispatch
-			defer( () => {
-				debug( `Redirecting you to "${ destination }"` );
-				window.location.href = destination;
-			} );
-		}
-
 		const isRegularOauth2ClientSignup =
 			dependencies.oauth2_client_id && ! progress?.[ 'oauth2-user' ]?.service; // service is set for social signup (e.g. Google, Apple)
 		// If the user is not logged in, we need to log them in first.
@@ -505,7 +525,6 @@ class Signup extends Component {
 		if ( ! userIsLoggedIn && ( config.isEnabled( 'oauth' ) || isRegularOauth2ClientSignup ) ) {
 			debug( `Handling oauth login` );
 			oauthToken.setToken( dependencies.bearer_token );
-			window.location.href = destination;
 			return;
 		}
 
@@ -519,7 +538,6 @@ class Signup extends Component {
 				isEmpty( username ) &&
 				'onboarding-registrationless' === this.props.flowName
 			) {
-				window.location.href = destination;
 				return;
 			}
 
@@ -530,6 +548,8 @@ class Signup extends Component {
 					username: dependencies.username,
 					redirectTo: this.loginRedirectTo( destination ),
 				} );
+
+				return;
 			}
 		}
 	}

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -501,7 +501,10 @@ class Signup extends Component {
 			return;
 		}
 
-		window.location.href = destination;
+		// When this state is available, it will be the login form component's job to handle the redirect.
+		if ( ! this.state.redirectTo ) {
+			window.location.href = destination;
+		}
 	}
 
 	handleLogin( dependencies, destination, resetSignupFlowController = true ) {


### PR DESCRIPTION
## Summary
This PR is revived from https://github.com/Automattic/wp-calypso/pull/69647, since the it was reverted due to a pre-release e2e test failure. 

The reason is that the refactored `handleDestination()` wasn't semantically equivalent to how it used to be in two cases:

1. When `redirectTo` state was set. 
2.  There used to be a `defer()` call when `this._onComplete()` is called.

This PR addresses these two in https://github.com/Automattic/wp-calypso/pull/69887/commits/cb45c8594a38b08333f1eacfa9d104e6e1d3480e and has confirmed the fix by making sure the previously failed E2E test work locally. From my testing, the only contributing factor should be the 1st item, but I've brought back the `defer()` as well to match the original logic as close as possible.

## Test instructions

1. Test instructions in https://github.com/Automattic/wp-calypso/pull/69647 should all pass.
2. The test that it peviously broke was `specs/onboarding/ftme__sell.ts` at the picking the personal plan step. Following the setup instructions for running e2e tests locally and confirm the "picking a personal plan" step passes by running `CALYPSO_BASE_URL='http://calypso.localhost:3000' yarn jest specs/onboarding/ftme__sell.ts` in `tests/e2e` directory. Note that there will still be some steps failed, but that also happens in `trunk` so those shouldn't be an issue:
 
<img width="497" alt="image" src="https://user-images.githubusercontent.com/1842898/201959623-231e2008-e40c-41de-9dc1-0c5da12aaadd.png">
