### PR TITLE
Stats: Fix the last query date section for empty content

### DIFF
--- a/client/my-sites/stats/stats-date-picker/index.jsx
+++ b/client/my-sites/stats/stats-date-picker/index.jsx
@@ -98,15 +98,18 @@ class StatsDatePicker extends Component {
 		const today = moment();
 		const date = moment( queryDate );
 		const isToday = today.isSame( date, 'day' );
+
 		return (
-			<span>
-				{ translate( '{{b}}Last update: %(time)s{{/b}} (Updates every 30 minutes)', {
-					args: { time: isToday ? date.format( 'LT' ) : date.fromNow() },
-					components: {
-						b: <span className="stats-date-picker__last-update" />,
-					},
-				} ) }
-			</span>
+			<div className="stats-date-picker__refresh-status">
+				<span className="stats-date-picker__update-date">
+					{ translate( '{{b}}Last update: %(time)s{{/b}} (Updates every 30 minutes)', {
+						args: { time: isToday ? date.format( 'LT' ) : date.fromNow() },
+						components: {
+							b: <span className="stats-date-picker__last-update" />,
+						},
+					} ) }
+				</span>
+			</div>
 		);
 	}
 
@@ -164,11 +167,7 @@ class StatsDatePicker extends Component {
 				) : (
 					<div className="stats-section-title">
 						<h3>{ sectionTitle }</h3>
-						{ showQueryDate && isAutoRefreshAllowedForQuery( query ) && (
-							<div className="stats-date-picker__refresh-status">
-								<span className="stats-date-picker__update-date">{ this.renderQueryDate() }</span>
-							</div>
-						) }
+						{ showQueryDate && isAutoRefreshAllowedForQuery( query ) && this.renderQueryDate() }
 					</div>
 				) }
 			</div>

--- a/client/my-sites/stats/wordads/index.jsx
+++ b/client/my-sites/stats/wordads/index.jsx
@@ -115,6 +115,12 @@ class WordAds extends Component {
 		}
 	};
 
+	isPrevArrowHidden = ( period, queryDate ) => {
+		return (
+			[ 'day', 'week' ].includes( period ) && moment( queryDate ).isSameOrBefore( '2018-10-01' )
+		);
+	};
+
 	render() {
 		const { canAccessAds, canUpgradeToUseWordAds, date, site, siteId, slug } = this.props;
 
@@ -188,10 +194,7 @@ class WordAds extends Component {
 									<StatsPeriodHeader>
 										<StatsPeriodNavigation
 											date={ queryDate }
-											hidePreviousArrow={
-												( 'day' === period || 'week' === period ) &&
-												moment( queryDate ).isSameOrBefore( '2018-10-01' )
-											} // @TODO is there a more elegant way to do this? Similar to in_array() for php?
+											hidePreviousArrow={ this.isPrevArrowHidden( period, queryDate ) }
 											hideNextArrow={ yesterday === queryDate }
 											period={ period }
 											url={ `/stats/ads/${ period }/${ slug }` }
@@ -241,10 +244,7 @@ class WordAds extends Component {
 									<StickyPanel className="stats__sticky-navigation">
 										<StatsPeriodNavigation
 											date={ queryDate }
-											hidePreviousArrow={
-												( 'day' === period || 'week' === period ) &&
-												moment( queryDate ).isSameOrBefore( '2018-10-01' )
-											} // @TODO is there a more elegant way to do this? Similar to in_array() for php?
+											hidePreviousArrow={ this.isPrevArrowHidden( period, queryDate ) }
 											hideNextArrow={ yesterday === queryDate }
 											period={ period }
 											url={ `/stats/ads/${ period }/${ slug }` }


### PR DESCRIPTION
#### Proposed Changes

<img width="1091" alt="截圖 2022-11-10 上午12 49 06" src="https://user-images.githubusercontent.com/6869813/200890854-d2787770-d211-4d11-975b-727b1982e813.png">

* Render the DOM of the last query date only when there is data.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up this change in a live branch. (The new feature flag `?flags=stats/new-main-chart` is optional)
* Navigate to the `Ads` page with `/stats/ads/day/${your-site}`.
* Ensure there is no empty section under the title of period navigation.
* Press the previous arrow button on the period navigation.
* Ensure the alignment of the whole period navigation is not moving.

| Before | After |
| --- | --- |
|![Large GIF (764x68)](https://user-images.githubusercontent.com/4044428/199857753-8578cb38-ba9a-4cd2-97b1-d732d36ba855.gif)| ![螢幕錄製 2022-11-10 上午12 40 37](https://user-images.githubusercontent.com/6869813/200889507-69ce8f4a-2491-4dda-a95d-b14c7755db71.gif) |

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #69781 
