### PR TITLE
`EditorMediaModal`: refactor tests to `@testing-library/react`

### DIFF
--- a/client/post-editor/media-modal/test/index.jsx
+++ b/client/post-editor/media-modal/test/index.jsx
@@ -76,9 +76,7 @@ describe( 'EditorMediaModal', () => {
 	} );
 
 	test( 'When `single` selection screen chosen should initialise with no items selected', () => {
-		const { container } = render(
-			<EditorMediaModal { ...baseProps } single={ true } view={ null } />
-		);
+		const { container } = render( <EditorMediaModal { ...baseProps } single view={ null } /> );
 		Modal.setAppElement( container );
 		expect( selectMediaItems ).toHaveBeenCalledWith( DUMMY_SITE.ID, [] );
 	} );

--- a/client/post-editor/media-modal/test/index.jsx
+++ b/client/post-editor/media-modal/test/index.jsx
@@ -1,8 +1,11 @@
 /**
  * @jest-environment jsdom
  */
-import { shallow } from 'enzyme';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { translate } from 'i18n-calypso';
+import Modal from 'react-modal';
+import MediaLibrary from 'calypso/my-sites/media-library';
 import { ModalViews } from 'calypso/state/ui/media-modal/constants';
 import { EditorMediaModal } from '../';
 
@@ -15,28 +18,15 @@ jest.mock(
 	} ),
 	{ virtual: true }
 );
-jest.mock( 'calypso/post-editor/media-modal/detail', () => ( {
-	default: require( 'calypso/components/empty-component' ),
+jest.mock( 'calypso/lib/accept', () => ( _, callback ) => {
+	callback?.( true );
+} );
+jest.mock( 'calypso/my-sites/media-library', () => ( {
+	__esModule: true,
+	default: jest.fn( () => null ),
 } ) );
-jest.mock( 'calypso/post-editor/media-modal/gallery', () =>
-	require( 'calypso/components/empty-component' )
-);
-jest.mock( 'calypso/post-editor/media-modal/markup', () => ( {
-	get: ( x ) => x,
-} ) );
-jest.mock( 'calypso/post-editor/media-modal/secondary-actions', () =>
-	require( 'calypso/components/empty-component' )
-);
-jest.mock( 'calypso/lib/accept', () =>
-	jest.fn( ( message, callback ) => {
-		if ( callback ) {
-			callback( true );
-		}
-	} )
-);
-jest.mock( 'calypso/my-sites/media-library', () =>
-	require( 'calypso/components/empty-component' )
-);
+jest.mock( 'calypso/blocks/image-editor', () => () => <div data-testid="image-editor" /> );
+jest.mock( '../detail', () => () => <div data-testid="media-modal-detail-base" /> );
 
 const mockV4 = jest.fn();
 jest.mock( 'uuid', () => ( {
@@ -70,6 +60,7 @@ describe( 'EditorMediaModal', () => {
 		selectMediaItems = jest.fn();
 		changeMediaSource = jest.fn();
 		baseProps = {
+			visible: true,
 			selectMediaItems,
 			site: DUMMY_SITE,
 			selectedItems: DUMMY_MEDIA,
@@ -85,194 +76,229 @@ describe( 'EditorMediaModal', () => {
 	} );
 
 	test( 'When `single` selection screen chosen should initialise with no items selected', () => {
-		shallow( <EditorMediaModal { ...baseProps } single={ true } view={ null } /> ).instance();
+		const { container } = render(
+			<EditorMediaModal { ...baseProps } single={ true } view={ null } />
+		);
+		Modal.setAppElement( container );
 		expect( selectMediaItems ).toHaveBeenCalledWith( DUMMY_SITE.ID, [] );
 	} );
 
-	test( 'should prompt to delete a single item from the list view', () => {
-		const media = DUMMY_MEDIA.slice( 0, 1 );
+	test( 'should prompt to delete a single item from the list view', async () => {
+		const user = userEvent.setup();
 
-		const tree = shallow(
-			<EditorMediaModal { ...baseProps } selectedItems={ media } />
-		).instance();
-		tree.deleteMedia();
-
-		return new Promise( ( resolve ) => {
-			process.nextTick( function () {
-				expect( deleteMedia ).toHaveBeenCalledWith(
-					DUMMY_SITE.ID,
-					media.map( ( { ID } ) => ID )
-				);
-				resolve();
-			} );
+		MediaLibrary.mockImplementationOnce( ( { onDeleteItem } ) => {
+			return <button onClick={ onDeleteItem }>Delete</button>;
 		} );
+
+		const media = DUMMY_MEDIA.slice( 0, 1 );
+		const props = { ...baseProps, selectedItems: media };
+		const { container } = render( <EditorMediaModal { ...props } /> );
+
+		Modal.setAppElement( container );
+
+		const btn = screen.getByRole( 'button', { name: 'Delete' } );
+		await user.click( btn );
+
+		expect( props.deleteMedia ).toHaveBeenCalledWith(
+			DUMMY_SITE.ID,
+			media.map( ( { ID } ) => ID )
+		);
 	} );
 
-	test( 'should prompt to delete multiple items from the list view', () => {
-		const tree = shallow( <EditorMediaModal { ...baseProps } /> ).instance();
-		tree.deleteMedia();
+	test( 'should prompt to delete multiple items from the list view', async () => {
+		const user = userEvent.setup();
 
-		return new Promise( ( resolve ) => {
-			process.nextTick( function () {
-				expect( deleteMedia ).toHaveBeenCalledWith(
-					DUMMY_SITE.ID,
-					DUMMY_MEDIA.map( ( { ID } ) => ID )
-				);
-				resolve();
-			} );
+		MediaLibrary.mockImplementationOnce( ( { onDeleteItem } ) => {
+			return <button onClick={ onDeleteItem }>Delete</button>;
 		} );
+
+		const props = { ...baseProps, selectedItems: DUMMY_MEDIA };
+		const { container } = render( <EditorMediaModal { ...props } /> );
+
+		Modal.setAppElement( container );
+
+		await user.click( screen.getByRole( 'button', { name: 'Delete' } ) );
+
+		expect( baseProps.deleteMedia ).toHaveBeenCalledWith(
+			DUMMY_SITE.ID,
+			DUMMY_MEDIA.map( ( { ID } ) => ID )
+		);
 	} );
 
 	test( 'should show no buttons if editing an image', () => {
-		const tree = shallow(
-			<EditorMediaModal
-				{ ...baseProps }
-				selectedItems={ [] }
-				view={ ModalViews.IMAGE_EDITOR }
-				setView={ spy }
-			/>
-		).instance();
+		const props = {
+			...baseProps,
+			selectedItems: [],
+			view: ModalViews.IMAGE_EDITOR,
+			setView: spy,
+		};
+		const { container } = render( <EditorMediaModal { ...props } /> );
 
-		const buttons = tree.getModalButtons();
+		Modal.setAppElement( container );
 
-		expect( buttons ).toBeUndefined();
+		expect( screen.getByTestId( 'image-editor' ) ).toBeVisible();
+		expect( screen.queryAllByRole( 'button' ) ).toHaveLength( 0 );
 	} );
 
 	test( 'should show a Copy to media library button when viewing external media (no selection)', () => {
-		const tree = shallow(
+		const { container } = render(
 			<EditorMediaModal
 				{ ...baseProps }
 				view={ ModalViews.DETAIL }
 				setView={ spy }
 				selectedItems={ [] }
+				source="external"
 			/>
-		).instance();
+		);
 
-		tree.setState( { source: 'external' } );
-		const buttons = tree.getModalButtons();
+		Modal.setAppElement( container );
 
-		expect( buttons.length ).toEqual( 2 );
-		expect( buttons[ 1 ].label ).toEqual( 'Copy to media library' );
+		expect( screen.getByTestId( 'media-modal-detail-base' ) ).toBeVisible();
+		expect( screen.getByRole( 'button', { name: /copy to media library/i } ) ).toBeVisible();
 	} );
 
 	test( 'should show a Copy to media library button when 1 external image is selected', () => {
-		const tree = shallow(
+		const { container } = render(
 			<EditorMediaModal
 				{ ...baseProps }
 				view={ ModalViews.DETAIL }
 				selectedItems={ DUMMY_MEDIA.slice( 0, 1 ) }
 				setView={ spy }
+				source="external"
 			/>
-		).instance();
+		);
 
-		tree.setState( { source: 'external' } );
-		const buttons = tree.getModalButtons();
+		Modal.setAppElement( container );
 
-		expect( buttons.length ).toEqual( 2 );
-		expect( buttons[ 1 ].label ).toEqual( 'Copy to media library' );
+		expect( screen.queryAllByRole( 'button' ) ).toHaveLength( 2 );
+		expect( screen.getByRole( 'button', { name: /copy to media library/i } ) ).toBeVisible();
 	} );
 
 	test( 'should show a copy button when 1 external video is selected', () => {
-		const tree = shallow(
+		const { container } = render(
 			<EditorMediaModal
 				{ ...baseProps }
 				view={ ModalViews.DETAIL }
 				selectedItems={ DUMMY_VIDEO_MEDIA }
 				setView={ spy }
+				source="external"
 			/>
-		).instance();
+		);
 
-		tree.setState( { source: 'external' } );
-		const buttons = tree.getModalButtons();
+		Modal.setAppElement( container );
 
-		expect( buttons.length ).toEqual( 2 );
-		expect( buttons[ 1 ].label ).toEqual( 'Copy to media library' );
+		expect( screen.queryAllByRole( 'button' ) ).toHaveLength( 2 );
+		expect( screen.getByRole( 'button', { name: /copy to media library/i } ) ).toBeVisible();
 	} );
 
 	test( 'should show a copy button when 2 or more external media are selected', () => {
-		const tree = shallow(
-			<EditorMediaModal { ...baseProps } view={ ModalViews.DETAIL } setView={ spy } />
-		).instance();
+		const { container } = render(
+			<EditorMediaModal
+				{ ...baseProps }
+				view={ ModalViews.DETAIL }
+				setView={ spy }
+				source="external"
+			/>
+		);
 
-		tree.setState( { source: 'external' } );
-		const buttons = tree.getModalButtons();
+		Modal.setAppElement( container );
 
-		expect( buttons.length ).toEqual( 2 );
-		expect( buttons[ 1 ].label ).toEqual( 'Copy to media library' );
+		expect( screen.queryAllByRole( 'button' ) ).toHaveLength( 2 );
+		expect( screen.getByRole( 'button', { name: /copy to media library/i } ) ).toBeVisible();
 	} );
 
 	test( 'should show a continue button when multiple images are selected', () => {
-		const tree = shallow(
-			<EditorMediaModal { ...baseProps } view={ ModalViews.DETAIL } setView={ spy } />
-		).instance();
+		const { container } = render(
+			<EditorMediaModal
+				{ ...baseProps }
+				view={ ModalViews.DETAIL }
+				setView={ spy }
+				selectedItems={ DUMMY_MEDIA }
+			/>
+		);
 
-		const buttons = tree.getModalButtons();
+		Modal.setAppElement( container );
 
-		expect( buttons[ 1 ].label ).toEqual( 'Continue' );
+		expect( screen.getByRole( 'button', { name: 'Continue' } ) ).toBeVisible();
 	} );
 
 	test( 'should show an insert button if none or one local items are selected', () => {
-		const tree = shallow(
+		const { container } = render(
 			<EditorMediaModal
 				{ ...baseProps }
 				view={ ModalViews.DETAIL }
 				setView={ spy }
 				selectedItems={ [] }
 			/>
-		).instance();
+		);
 
-		const buttons = tree.getModalButtons();
+		Modal.setAppElement( container );
 
-		expect( buttons[ 1 ].label ).toEqual( 'Insert' );
+		expect( screen.getByRole( 'button', { name: 'Insert' } ) ).toBeVisible();
 	} );
 
 	test( 'should show an insert button if multiple images are selected when gallery view is disabled', () => {
-		const tree = shallow(
+		const { container } = render(
 			<EditorMediaModal
 				{ ...baseProps }
 				view={ ModalViews.DETAIL }
 				setView={ spy }
 				galleryViewEnabled={ false }
 			/>
-		).instance();
+		);
 
-		const buttons = tree.getModalButtons();
+		Modal.setAppElement( container );
 
-		expect( buttons[ 1 ].label ).toEqual( 'Insert' );
+		expect( screen.getByRole( 'button', { name: 'Insert' } ) ).toBeVisible();
 	} );
 
 	describe( '#confirmSelection()', () => {
-		test( 'should close modal if viewing local media and button is pressed', () => {
-			const tree = shallow(
-				<EditorMediaModal { ...baseProps } view={ ModalViews.DETAIL } setView={ spy } />
-			).instance();
+		test( 'should close modal if viewing local media and button is pressed', async () => {
+			const user = userEvent.setup();
+			const { container } = render(
+				<EditorMediaModal
+					{ ...baseProps }
+					visible
+					view={ ModalViews.DETAIL }
+					setView={ spy }
+					selectedItems={ DUMMY_MEDIA }
+					galleryViewEnabled={ false }
+				/>
+			);
 
-			tree.confirmSelection();
+			Modal.setAppElement( container );
 
-			return new Promise( ( resolve ) => {
-				process.nextTick( () => {
-					expect( onClose ).toHaveBeenCalledWith( {
-						items: DUMMY_MEDIA,
-						settings: undefined,
-						type: 'media',
-					} );
+			await user.click( screen.getByRole( 'button', { name: 'Insert' } ) );
 
-					resolve();
-				} );
+			expect( onClose ).toHaveBeenCalledWith( {
+				items: DUMMY_MEDIA,
+				settings: undefined,
+				type: 'media',
 			} );
 		} );
 
-		test( 'should copy external media after loading WordPress library if 1 or more media are selected and button is pressed', () => {
+		test( 'should copy external media after loading WordPress library if 1 or more media are selected and button is pressed', async () => {
+			const user = userEvent.setup();
 			mockV4.mockImplementationOnce( () => '1' );
 			mockV4.mockImplementationOnce( () => '2' );
 
-			const tree = shallow(
-				<EditorMediaModal { ...baseProps } view={ ModalViews.DETAIL } setView={ spy } />
-			).instance();
+			const addExternalMedia = jest.fn();
 
-			tree.setState( { source: 'external' } );
-			tree.copyExternalAfterLoadingWordPressLibrary = onClose;
-			tree.confirmSelection();
+			const { container } = render(
+				<EditorMediaModal
+					{ ...baseProps }
+					view={ ModalViews.DETAIL }
+					setView={ spy }
+					source="external"
+					selectedItems={ DUMMY_MEDIA }
+					setQuery={ () => {} }
+					addExternalMedia={ addExternalMedia }
+				/>
+			);
+
+			Modal.setAppElement( container );
+
+			await user.click( screen.getByRole( 'button', { name: /copy to media library/i } ) );
 
 			// EditorMediaModal will generate transient ID for the media selected
 			// by using uniqueId, which increments its value within the same session.
@@ -281,41 +307,48 @@ describe( 'EditorMediaModal', () => {
 				Object.assign( {}, DUMMY_MEDIA[ 1 ], { ID: 'media-2', transient: true } ),
 			];
 
-			return new Promise( ( resolve ) => {
-				process.nextTick( () => {
-					expect( onClose ).toHaveBeenCalledWith( transientItems, 'external' );
-					resolve();
-				} );
-			} );
+			expect( addExternalMedia ).toHaveBeenCalledWith(
+				transientItems,
+				DUMMY_SITE,
+				undefined,
+				'external'
+			);
 		} );
 
-		test( 'should copy external after loading WordPress library if 1 video is selected and button is pressed', () => {
+		test( 'should copy external after loading WordPress library if 1 video is selected and button is pressed', async () => {
+			const user = userEvent.setup();
 			mockV4.mockImplementationOnce( () => '3' );
 
-			const tree = shallow(
+			const addExternalMedia = jest.fn();
+
+			const { container } = render(
 				<EditorMediaModal
 					{ ...baseProps }
 					selectedItems={ DUMMY_VIDEO_MEDIA }
 					view={ ModalViews.DETAIL }
 					setView={ spy }
+					source="external"
+					setQuery={ () => {} }
+					addExternalMedia={ addExternalMedia }
 				/>
-			).instance();
+			);
 
-			tree.setState( { source: 'external' } );
-			tree.copyExternalAfterLoadingWordPressLibrary = onClose;
-			tree.confirmSelection();
+			Modal.setAppElement( container );
+
+			await user.click( screen.getByRole( 'button', { name: /copy to media library/i } ) );
 
 			// EditorMediaModal will generate transient ID for the media selected
 			// by using uniqueId, which increments its value within the same session.
 			const transientItems = [
 				Object.assign( {}, DUMMY_VIDEO_MEDIA[ 0 ], { ID: 'media-3', transient: true } ),
 			];
-			return new Promise( ( resolve ) => {
-				process.nextTick( () => {
-					expect( onClose ).toHaveBeenCalledWith( transientItems, 'external' );
-					resolve();
-				} );
-			} );
+
+			expect( addExternalMedia ).toHaveBeenCalledWith(
+				transientItems,
+				DUMMY_SITE,
+				undefined,
+				'external'
+			);
 		} );
 	} );
 } );

--- a/client/post-editor/media-modal/test/index.jsx
+++ b/client/post-editor/media-modal/test/index.jsx
@@ -134,7 +134,7 @@ describe( 'EditorMediaModal', () => {
 		Modal.setAppElement( container );
 
 		expect( screen.getByTestId( 'image-editor' ) ).toBeVisible();
-		expect( screen.queryAllByRole( 'button' ) ).toHaveLength( 0 );
+		expect( screen.queryByRole( 'button' ) ).not.toBeInTheDocument();
 	} );
 
 	test( 'should show a Copy to media library button when viewing external media (no selection)', () => {
@@ -167,7 +167,7 @@ describe( 'EditorMediaModal', () => {
 
 		Modal.setAppElement( container );
 
-		expect( screen.queryAllByRole( 'button' ) ).toHaveLength( 2 );
+		expect( screen.getAllByRole( 'button' ) ).toHaveLength( 2 );
 		expect( screen.getByRole( 'button', { name: /copy to media library/i } ) ).toBeVisible();
 	} );
 
@@ -184,7 +184,7 @@ describe( 'EditorMediaModal', () => {
 
 		Modal.setAppElement( container );
 
-		expect( screen.queryAllByRole( 'button' ) ).toHaveLength( 2 );
+		expect( screen.getAllByRole( 'button' ) ).toHaveLength( 2 );
 		expect( screen.getByRole( 'button', { name: /copy to media library/i } ) ).toBeVisible();
 	} );
 
@@ -200,7 +200,7 @@ describe( 'EditorMediaModal', () => {
 
 		Modal.setAppElement( container );
 
-		expect( screen.queryAllByRole( 'button' ) ).toHaveLength( 2 );
+		expect( screen.getAllByRole( 'button' ) ).toHaveLength( 2 );
 		expect( screen.getByRole( 'button', { name: /copy to media library/i } ) ).toBeVisible();
 	} );
 

--- a/client/post-editor/media-modal/test/index.jsx
+++ b/client/post-editor/media-modal/test/index.jsx
@@ -94,8 +94,7 @@ describe( 'EditorMediaModal', () => {
 
 		Modal.setAppElement( container );
 
-		const btn = screen.getByRole( 'button', { name: 'Delete' } );
-		await user.click( btn );
+		await user.click( screen.getByRole( 'button', { name: 'Delete' } ) );
 
 		expect( props.deleteMedia ).toHaveBeenCalledWith(
 			DUMMY_SITE.ID,


### PR DESCRIPTION
#### Proposed Changes

* `EditorMediaModal`: refactor tests to `@testing-library/react`

#### Testing Instructions

* Verify unit tests still pass

Related to #63409 
