### PR TITLE
Woo Tailored Onboarding: Add action to switch theme

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-carousel/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-carousel/index.tsx
@@ -1,16 +1,51 @@
 import { StepContainer } from '@automattic/onboarding';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
 import AsyncLoad from 'calypso/components/async-load';
 import FormattedHeader from 'calypso/components/formatted-header';
+import { useSite } from 'calypso/landing/stepper/hooks/use-site';
+import { useSiteIdParam } from 'calypso/landing/stepper/hooks/use-site-id-param';
+import { useSiteSlugParam } from 'calypso/landing/stepper/hooks/use-site-slug-param';
+import { ONBOARD_STORE, SITE_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { reduxDispatch } from 'calypso/lib/redux-bridge';
+import { requestActiveTheme } from 'calypso/state/themes/actions';
 import type { Step } from '../../types';
 
 const DesignCarousel: Step = function DesignCarousel( { navigation } ) {
 	const { goNext, goBack, submit } = navigation;
 	const { __ } = useI18n();
 
-	function handleSubmit( design: any ) {
-		submit?.( design );
+	const selectedDesign = useSelect( ( select ) => select( ONBOARD_STORE ).getSelectedDesign() );
+	const { setSelectedDesign } = useDispatch( ONBOARD_STORE );
+	const { setThemeOnSite, installTheme } = useDispatch( SITE_STORE );
+	const { setPendingAction } = useDispatch( ONBOARD_STORE );
+
+	const site = useSite();
+	const siteSlug = useSiteSlugParam();
+	const siteId = useSiteIdParam();
+	const siteSlugOrId = siteId || siteSlug;
+	const isJetpackSite = useSelect( ( select ) => select( SITE_STORE ).isJetpackSite( site?.ID ) );
+
+	function pickDesign( _selectedDesign: any | undefined = selectedDesign ) {
+		setSelectedDesign( _selectedDesign );
+		if ( siteSlugOrId && _selectedDesign ) {
+			setPendingAction( async () => {
+				if ( isJetpackSite ) {
+					try {
+						await installTheme( siteSlugOrId, _selectedDesign.slug );
+					} catch ( e ) {
+						// TODO: Handle better theme already installed
+					}
+				}
+
+				await setThemeOnSite( siteSlugOrId, _selectedDesign.slug ).then( () =>
+					reduxDispatch( requestActiveTheme( site?.ID || -1 ) )
+				);
+				return { selectedDesign: _selectedDesign, siteSlug };
+			} );
+			submit?.();
+		}
 	}
 
 	return (
@@ -24,7 +59,7 @@ const DesignCarousel: Step = function DesignCarousel( { navigation } ) {
 				<AsyncLoad
 					require="@automattic/design-carousel"
 					placeholder={ null }
-					onPick={ handleSubmit }
+					onPick={ pickDesign }
 				/>
 			}
 			recordTracksEvent={ recordTracksEvent }

--- a/client/landing/stepper/declarative-flow/tailored-ecommerce-flow.ts
+++ b/client/landing/stepper/declarative-flow/tailored-ecommerce-flow.ts
@@ -17,7 +17,7 @@ export const ecommerceFlow: Flow = {
 			recordFullStoryEvent( 'calypso_signup_start_ecommerce', { flow: this.name } );
 		}, [] );
 
-		return [ 'intro', 'storeProfiler', 'designCarousel' ] as StepPath[];
+		return [ 'intro', 'storeProfiler', 'designCarousel', 'processing' ] as StepPath[];
 	},
 
 	useStepNavigation( _currentStepName, navigate ) {
@@ -48,7 +48,9 @@ export const ecommerceFlow: Flow = {
 				case 'storeProfiler':
 					return navigate( 'designCarousel' );
 				case 'designCarousel':
-					return navigate( 'designCarousel' );
+					return navigate( 'processing' );
+				case 'processing':
+					return navigate( 'intro' );
 			}
 			return providedDependencies;
 		}

--- a/packages/data-stores/src/site/actions.ts
+++ b/packages/data-stores/src/site/actions.ts
@@ -285,6 +285,14 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		yield saveSiteSettings( siteId, { blogdescription } );
 	}
 
+	function* installTheme( siteSlugOrId: string, themeSlug: string ) {
+		yield wpcomRequest( {
+			path: `/sites/${ siteSlugOrId }/themes/${ themeSlug }/install`,
+			apiVersion: '1.1',
+			method: 'POST',
+		} );
+	}
+
 	function* setThemeOnSite(
 		siteSlug: string,
 		theme: string,
@@ -588,6 +596,7 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		receiveNewSite,
 		receiveNewSiteFailed,
 		resetNewSiteFailed,
+		installTheme,
 		setThemeOnSite,
 		runThemeSetupOnSite,
 		setDesignOnSite,


### PR DESCRIPTION
#### Proposed Changes

* This PRs adds the code to switch the site's theme after a design is picked, including Atomic sites - that require installation.

#### Testing Instructions
* Make sure the flag `signup/tailored-ecommerce` is enabled in your environment
* Access `/setup/ecommerce/designCarousel?siteSlug=<simple-site-slug>`
![image](https://user-images.githubusercontent.com/3801502/200906828-20246c67-f19f-4fe3-b318-fb03294ee651.png)
* Click Continue
* Check that the theme was applied to the site
![image](https://user-images.githubusercontent.com/3801502/200907026-4e4e784a-85df-4157-bd05-fe83ff8b19fb.png)
* Repeat the process with an Atomic site
