### PR TITLE
Get only rewindable Activity Log items when cloning a site into a previous state

### DIFF
--- a/client/signup/steps/clone-point/index.jsx
+++ b/client/signup/steps/clone-point/index.jsx
@@ -9,7 +9,7 @@ import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import Pagination from 'calypso/components/pagination';
 import TileGrid from 'calypso/components/tile-grid';
 import Tile from 'calypso/components/tile-grid/tile';
-import useActivityLogQuery from 'calypso/data/activity-log/use-activity-log-query';
+import useRewindableActivityLogQuery from 'calypso/data/activity-log/use-rewindable-activity-log-query';
 import { applySiteOffset } from 'calypso/lib/site/timezone';
 import ActivityLogItem from 'calypso/my-sites/activity/activity-log-item';
 import StepWrapper from 'calypso/signup/step-wrapper';
@@ -184,7 +184,7 @@ class ClonePointStep extends Component {
 function withActivityLog( Inner ) {
 	return ( props ) => {
 		const { siteId } = props;
-		const { data: logs } = useActivityLogQuery( siteId, {}, { enabled: !! siteId } );
+		const { data: logs } = useRewindableActivityLogQuery( siteId, {}, { enabled: !! siteId } );
 		return <Inner { ...props } logs={ logs ?? [] } />;
 	};
 }


### PR DESCRIPTION
Given a limit of items retrieved from the ActivityLog, sites with many activities could miss some backup points.

This change makes to retrieve only rewindable Activities in step 4 of the clone restore process, where you can select a specific point for the clone. 

#### Proposed Changes

* Instead of retrieving all the activities, one retrieves rewindable activities. 

#### Testing Instructions

(feature only applies on self-hosted Jetpack sites)

* In Calypso Live, pick one of your self-hosted Jetpack site and go to Settings / General / Site tools / Clone
* Follow the steps (add the site information and credentials) up to the "Clone point" step and select "Clone previous state"
* You will see a list of Activities, and all the items shown be rewindable (they will have a button "Clone from here"). No items without that button will be on the lists

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)? (only apply for self-hosted Jetpack site)
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
