### PR TITLE
Domains: Refactor `canSetAsPrimary` check into a function

### DIFF
--- a/client/lib/domains/utils/can-set-as-primary.ts
+++ b/client/lib/domains/utils/can-set-as-primary.ts
@@ -1,0 +1,16 @@
+import type { ResponseDomain } from 'calypso/lib/domains/types';
+
+export function canSetAsPrimary(
+	domain: ResponseDomain,
+	isManagingAllSites: boolean,
+	shouldUpgradeToMakePrimary: boolean
+): boolean {
+	return (
+		! isManagingAllSites &&
+		domain &&
+		domain.canSetAsPrimary &&
+		! domain.isPrimary &&
+		! shouldUpgradeToMakePrimary &&
+		! domain.aftermarketAuction
+	);
+}

--- a/client/my-sites/domains/domain-management/list/domain-row.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-row.jsx
@@ -20,6 +20,7 @@ import {
 } from 'calypso/lib/domains';
 import { type as domainTypes, domainInfoContext } from 'calypso/lib/domains/constants';
 import { getEmailForwardsCount, hasEmailForwards } from 'calypso/lib/domains/email-forwarding';
+import { canSetAsPrimary } from 'calypso/lib/domains/utils/can-set-as-primary';
 import { hasGSuiteWithUs, getGSuiteMailboxCount } from 'calypso/lib/gsuite';
 import { getMaxTitanMailboxCount, hasTitanMailWithUs } from 'calypso/lib/titan';
 import AutoRenewToggle from 'calypso/me/purchases/manage-purchase/auto-renew-toggle';
@@ -334,8 +335,17 @@ class DomainRow extends PureComponent {
 	};
 
 	renderEllipsisMenu() {
-		const { isLoadingDomainDetails, site, domain, showDomainDetails, disabled, isBusy, translate } =
-			this.props;
+		const {
+			disabled,
+			domain,
+			isBusy,
+			isLoadingDomainDetails,
+			isManagingAllSites,
+			shouldUpgradeToMakePrimary,
+			showDomainDetails,
+			site,
+			translate,
+		} = this.props;
 
 		if ( ! showDomainDetails ) {
 			return <div className="domain-row__action-cell"></div>;
@@ -365,7 +375,7 @@ class DomainRow extends PureComponent {
 							? translate( 'View transfer' )
 							: translate( 'View settings' ) }
 					</PopoverMenuItem>
-					{ this.canSetAsPrimary() && (
+					{ canSetAsPrimary( domain, isManagingAllSites, shouldUpgradeToMakePrimary ) && (
 						<PopoverMenuItem onClick={ this.makePrimary }>
 							<Icon icon={ home } size={ 18 } className="gridicon" viewBox="2 2 20 20" />
 							{ translate( 'Make primary site address' ) }
@@ -392,17 +402,6 @@ class DomainRow extends PureComponent {
 				</EllipsisMenu>
 				{ /* eslint-enable wpcalypso/jsx-classname-namespace */ }
 			</div>
-		);
-	}
-
-	canSetAsPrimary() {
-		const { domain, isManagingAllSites, shouldUpgradeToMakePrimary } = this.props;
-		return (
-			! isManagingAllSites &&
-			domain &&
-			domain.canSetAsPrimary &&
-			! domain.isPrimary &&
-			! shouldUpgradeToMakePrimary
 		);
 	}
 

--- a/client/my-sites/domains/domain-management/settings/set-as-primary/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/set-as-primary/index.tsx
@@ -5,6 +5,7 @@ import { useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import Accordion from 'calypso/components/domains/accordion';
 import { type } from 'calypso/lib/domains/constants';
+import { canSetAsPrimary } from 'calypso/lib/domains/utils/can-set-as-primary';
 import { isUnderDomainManagementAll } from 'calypso/my-sites/domains/paths';
 import { recordGoogleEvent, recordTracksEvent } from 'calypso/state/analytics/actions';
 import { NON_PRIMARY_DOMAINS_TO_FREE_USERS } from 'calypso/state/current-user/constants';
@@ -54,15 +55,7 @@ const SetAsPrimary = ( { domain, selectedSite }: SetAsPrimaryProps ) => {
 		! domain.isWpcomStagingDomain &&
 		! canSetPrimaryDomain;
 
-	const canSetAsPrimary =
-		! isManagingAllSites &&
-		domain &&
-		domain.canSetAsPrimary &&
-		! domain.isPrimary &&
-		! shouldUpgradeToMakeDomainPrimary &&
-		! domain.aftermarketAuction;
-
-	if ( ! canSetAsPrimary ) {
+	if ( ! canSetAsPrimary( domain, isManagingAllSites, shouldUpgradeToMakeDomainPrimary ) ) {
 		return null;
 	}
 


### PR DESCRIPTION
### Proposed Changes

This PR refactors the `canSetAsPrimary` check into a single function. That check was duplicated in `domain-row.jsx` and `set-as-primary/index.tsx`.

### Testing Instructions

- Build this branch locally or open the live Calypso link
- Go to the domains list page and look for a domain which can't be set as primary
- Click on the ellipsis button and ensure the "Set domain as primary" option isn't shown
- Go to the domain details page for that domain
- Ensure the "Set as primary" section is not shown

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
