### PR TITLE
Domains: Prevent newly registerd domains that do not point to WPCOM to be set as primary

### DIFF
--- a/client/lib/domains/resolve-domain-status.tsx
+++ b/client/lib/domains/resolve-domain-status.tsx
@@ -4,6 +4,7 @@ import moment from 'moment';
 import { modeType, stepSlug } from 'calypso/components/domains/connect-domain-step/constants';
 import { isSubdomain } from 'calypso/lib/domains';
 import { isExpiringSoon } from 'calypso/lib/domains/utils/is-expiring-soon';
+import { isRecentlyRegistered } from 'calypso/lib/domains/utils/is-recently-registered';
 import { shouldRenderExpiringCreditCard, handleRenewNowClick } from 'calypso/lib/purchases';
 import {
 	SETTING_PRIMARY_DOMAIN,
@@ -434,7 +435,7 @@ export function resolveDomainStatus(
 				};
 			}
 
-			if ( domain.pendingRegistration ) {
+			if ( isRecentlyRegistered( domain.registrationDate ) || domain.pendingRegistration ) {
 				let noticeText;
 				if ( domain.isPrimary ) {
 					noticeText = translate(

--- a/client/lib/domains/utils/is-recently-registered-and-does-not-point-to-wpcom.ts
+++ b/client/lib/domains/utils/is-recently-registered-and-does-not-point-to-wpcom.ts
@@ -1,0 +1,6 @@
+import { isRecentlyRegistered } from 'calypso/lib/domains/utils/is-recently-registered';
+import type { ResponseDomain } from 'calypso/lib/domains/types';
+
+export function isRecentlyRegisteredAndDoesNotPointToWpcom( domain: ResponseDomain ): boolean {
+	return ! isRecentlyRegistered( domain.registrationDate ) && ! domain.pointsToWpcom;
+}

--- a/client/lib/domains/utils/is-recently-registered-and-does-not-point-to-wpcom.ts
+++ b/client/lib/domains/utils/is-recently-registered-and-does-not-point-to-wpcom.ts
@@ -1,6 +1,14 @@
 import { isRecentlyRegistered } from 'calypso/lib/domains/utils/is-recently-registered';
 import type { ResponseDomain } from 'calypso/lib/domains/types';
 
+/**
+ * Checks if the domain was registered recently (less than 24 hours ago) and does not
+ * point to WPCOM.
+ *
+ * @param domain
+ * @returns boolean
+ */
 export function isRecentlyRegisteredAndDoesNotPointToWpcom( domain: ResponseDomain ): boolean {
-	return ! isRecentlyRegistered( domain.registrationDate ) && ! domain.pointsToWpcom;
+	const DAY_IN_MINUTES = 24 * 60;
+	return isRecentlyRegistered( domain.registrationDate, DAY_IN_MINUTES ) && ! domain.pointsToWpcom;
 }

--- a/client/lib/domains/utils/is-recently-registered-and-does-not-point-to-wpcom.ts
+++ b/client/lib/domains/utils/is-recently-registered-and-does-not-point-to-wpcom.ts
@@ -2,13 +2,11 @@ import { isRecentlyRegistered } from 'calypso/lib/domains/utils/is-recently-regi
 import type { ResponseDomain } from 'calypso/lib/domains/types';
 
 /**
- * Checks if the domain was registered recently (less than 24 hours ago) and does not
- * point to WPCOM.
+ * Checks if the domain was registered recently and does not point to WPCOM.
  *
  * @param domain
  * @returns boolean
  */
 export function isRecentlyRegisteredAndDoesNotPointToWpcom( domain: ResponseDomain ): boolean {
-	const DAY_IN_MINUTES = 24 * 60;
-	return isRecentlyRegistered( domain.registrationDate, DAY_IN_MINUTES ) && ! domain.pointsToWpcom;
+	return isRecentlyRegistered( domain.registrationDate ) && ! domain.pointsToWpcom;
 }

--- a/client/my-sites/domains/domain-management/list/domain-row.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-row.jsx
@@ -377,7 +377,7 @@ class DomainRow extends PureComponent {
 							: translate( 'View settings' ) }
 					</PopoverMenuItem>
 					{ canSetAsPrimary( domain, isManagingAllSites, shouldUpgradeToMakePrimary ) &&
-						isRecentlyRegisteredAndDoesNotPointToWpcom( domain ) && (
+						! isRecentlyRegisteredAndDoesNotPointToWpcom( domain ) && (
 							<PopoverMenuItem onClick={ this.makePrimary }>
 								<Icon icon={ home } size={ 18 } className="gridicon" viewBox="2 2 20 20" />
 								{ translate( 'Make primary site address' ) }

--- a/client/my-sites/domains/domain-management/list/domain-row.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-row.jsx
@@ -21,6 +21,7 @@ import {
 import { type as domainTypes, domainInfoContext } from 'calypso/lib/domains/constants';
 import { getEmailForwardsCount, hasEmailForwards } from 'calypso/lib/domains/email-forwarding';
 import { canSetAsPrimary } from 'calypso/lib/domains/utils/can-set-as-primary';
+import { isRecentlyRegisteredAndDoesNotPointToWpcom } from 'calypso/lib/domains/utils/is-recently-registered-and-does-not-point-to-wpcom';
 import { hasGSuiteWithUs, getGSuiteMailboxCount } from 'calypso/lib/gsuite';
 import { getMaxTitanMailboxCount, hasTitanMailWithUs } from 'calypso/lib/titan';
 import AutoRenewToggle from 'calypso/me/purchases/manage-purchase/auto-renew-toggle';
@@ -375,12 +376,13 @@ class DomainRow extends PureComponent {
 							? translate( 'View transfer' )
 							: translate( 'View settings' ) }
 					</PopoverMenuItem>
-					{ canSetAsPrimary( domain, isManagingAllSites, shouldUpgradeToMakePrimary ) && (
-						<PopoverMenuItem onClick={ this.makePrimary }>
-							<Icon icon={ home } size={ 18 } className="gridicon" viewBox="2 2 20 20" />
-							{ translate( 'Make primary site address' ) }
-						</PopoverMenuItem>
-					) }
+					{ canSetAsPrimary( domain, isManagingAllSites, shouldUpgradeToMakePrimary ) &&
+						isRecentlyRegisteredAndDoesNotPointToWpcom( domain ) && (
+							<PopoverMenuItem onClick={ this.makePrimary }>
+								<Icon icon={ home } size={ 18 } className="gridicon" viewBox="2 2 20 20" />
+								{ translate( 'Make primary site address' ) }
+							</PopoverMenuItem>
+						) }
 					{ domain.type === domainTypes.MAPPED && domain.isEligibleForInboundTransfer && (
 						<PopoverMenuItem
 							href={ domainUseMyDomain(

--- a/client/my-sites/domains/domain-management/settings/set-as-primary/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/set-as-primary/index.tsx
@@ -6,6 +6,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import Accordion from 'calypso/components/domains/accordion';
 import { type } from 'calypso/lib/domains/constants';
 import { canSetAsPrimary } from 'calypso/lib/domains/utils/can-set-as-primary';
+import { isRecentlyRegisteredAndDoesNotPointToWpcom } from 'calypso/lib/domains/utils/is-recently-registered-and-does-not-point-to-wpcom';
 import { isUnderDomainManagementAll } from 'calypso/my-sites/domains/paths';
 import { recordGoogleEvent, recordTracksEvent } from 'calypso/state/analytics/actions';
 import { NON_PRIMARY_DOMAINS_TO_FREE_USERS } from 'calypso/state/current-user/constants';
@@ -85,6 +86,8 @@ const SetAsPrimary = ( { domain, selectedSite }: SetAsPrimaryProps ) => {
 		}
 	};
 
+	const shouldDisableSetAsPrimaryButton = isRecentlyRegisteredAndDoesNotPointToWpcom( domain );
+
 	return (
 		<div className="set-as-primary">
 			<Accordion
@@ -101,7 +104,26 @@ const SetAsPrimary = ( { domain, selectedSite }: SetAsPrimaryProps ) => {
 						},
 					} ) }
 				</p>
-				<Button onClick={ handleSetPrimaryDomainClick } busy={ isSettingPrimaryDomain }>
+				{ shouldDisableSetAsPrimaryButton && (
+					<p className="set-as-primary__content">
+						{ translate(
+							"{{strong}}%(domainName)s{{/strong}} is still activating, so you can't set it as primary just yet.",
+							{
+								args: {
+									domainName: selectedSite.domain,
+								},
+								components: {
+									strong: <strong />,
+								},
+							}
+						) }
+					</p>
+				) }
+				<Button
+					onClick={ handleSetPrimaryDomainClick }
+					busy={ isSettingPrimaryDomain }
+					disabled={ shouldDisableSetAsPrimaryButton }
+				>
 					{ translate( 'Set this domain as primary' ) }
 				</Button>
 			</Accordion>

--- a/client/my-sites/domains/domain-management/settings/set-as-primary/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/set-as-primary/index.tsx
@@ -110,7 +110,7 @@ const SetAsPrimary = ( { domain, selectedSite }: SetAsPrimaryProps ) => {
 							"{{strong}}%(domainName)s{{/strong}} is still activating, so you can't set it as primary just yet.",
 							{
 								args: {
-									domainName: selectedSite.domain,
+									domainName: domain.name,
 								},
 								components: {
 									strong: <strong />,

--- a/client/my-sites/domains/domain-management/settings/set-as-primary/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/set-as-primary/index.tsx
@@ -1,5 +1,6 @@
 import { FEATURE_SET_PRIMARY_CUSTOM_DOMAIN } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
+import { Icon, info } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
@@ -105,19 +106,27 @@ const SetAsPrimary = ( { domain, selectedSite }: SetAsPrimaryProps ) => {
 					} ) }
 				</p>
 				{ shouldDisableSetAsPrimaryButton && (
-					<p className="set-as-primary__content">
-						{ translate(
-							"{{strong}}%(domainName)s{{/strong}} is still activating, so you can't set it as primary just yet.",
-							{
-								args: {
-									domainName: domain.name,
-								},
-								components: {
-									strong: <strong />,
-								},
-							}
-						) }
-					</p>
+					<div className="set-as-primary__notice">
+						<Icon
+							icon={ info }
+							size={ 18 }
+							className="set-as-primary__notice-icon gridicon"
+							viewBox="2 2 20 20"
+						/>
+						<div className="set-as-primary__notice-message">
+							{ translate(
+								"{{strong}}%(domainName)s{{/strong}} is still activating, so you can't set it as primary just yet.",
+								{
+									args: {
+										domainName: domain.name,
+									},
+									components: {
+										strong: <strong />,
+									},
+								}
+							) }
+						</div>
+					</div>
 				) }
 				<Button
 					onClick={ handleSetPrimaryDomainClick }

--- a/client/my-sites/domains/domain-management/settings/style.scss
+++ b/client/my-sites/domains/domain-management/settings/style.scss
@@ -177,4 +177,30 @@ body.edit__body-white.theme-default.color-scheme {
 		margin-top: 4px;
 		margin-bottom: 0;
 	}
+
+	.set-as-primary__notice {
+		flex-basis: 100%;
+		background-color: var(--studio-gray-0);
+		display: flex;
+		align-items: center;
+		padding: 5px;
+		margin-top: 12px;
+		margin-bottom: 24px;
+		gap: 8px;
+		border-radius: 2px;
+
+		.set-as-primary__notice-icon.gridicon {
+			align-self: flex-start;
+			min-width: 18px;
+			fill: var(--studio-orange-40);
+			transform: rotate(180deg);
+			position: relative;
+		}
+
+		.set-as-primary__notice-message {
+			font-weight: 400;
+			font-size: $font-body-small;
+			color: var(--studio-gray-80);
+		}
+	}
 }


### PR DESCRIPTION
### Proposed Changes

This PR disables the "Set as primary" option for domains that were registered recently (less than 30 minutes ago) and do not point to the WPCOM infrastructure. This should prevent sites from ending up broken inadvertently.

### Testing Instructions

- Build this branch locally or open the live Calypso link
- Find a domain that was recently registered and go to the domains list page
- Ensure the "Set as primary" option is not shown
- Check the domain management page
- Ensure the "Set as primary" section is shown, but the "Set as primary" button is disabled and an explanation about that is shown, like in the following screenshot

<img width="543" alt="Screen Shot 2022-11-09 at 16 22 34" src="https://user-images.githubusercontent.com/5324818/200963391-9cb96d3f-0502-4973-bf5d-bd6a2e7bc251.png">

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

