### PR TITLE
Checkout: Use radio button variant picker for wpcom and hide line item price

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/item-variation-picker/index.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/item-variation-picker/index.tsx
@@ -1,8 +1,14 @@
 import { FunctionComponent } from 'react';
 import { ItemVariationDropDown } from './item-variation-dropdown';
+import { ItemVariationRadioButtons } from './item-variation-radio-buttons';
 import type { ItemVariationPickerProps } from './types';
 
-export const ItemVariationPicker: FunctionComponent< ItemVariationPickerProps > = ( props ) => {
+export const ItemVariationPicker: FunctionComponent<
+	ItemVariationPickerProps & { type: 'dropdown' | 'radio' }
+> = ( props ) => {
+	if ( props.type === 'radio' ) {
+		return <ItemVariationRadioButtons { ...props } />;
+	}
 	return <ItemVariationDropDown { ...props } />;
 };
 

--- a/client/my-sites/checkout/composite-checkout/components/item-variation-picker/item-variation-radio-buttons.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/item-variation-picker/item-variation-radio-buttons.tsx
@@ -1,0 +1,90 @@
+import { RadioButton } from '@automattic/composite-checkout';
+import styled from '@emotion/styled';
+import { useTranslate } from 'i18n-calypso';
+import { FunctionComponent } from 'react';
+import { ItemVariantPrice } from './variant-price';
+import type { ItemVariationPickerProps, WPCOMProductVariant, OnChangeItemVariant } from './types';
+import type { ResponseCartProduct } from '@automattic/shopping-cart';
+
+const TermOptions = styled.ul`
+	flex-basis: 100%;
+	margin: 20px 0 0;
+	padding: 0;
+`;
+
+const TermOptionsItem = styled.li`
+	margin: 8px 0 0;
+	padding: 0;
+	list-style: none;
+
+	:first-of-type {
+		margin-top: 0;
+	}
+`;
+
+interface ProductVariantProps {
+	productVariant: WPCOMProductVariant;
+	selectedItem: ResponseCartProduct;
+	onChangeItemVariant: OnChangeItemVariant;
+	isDisabled: boolean;
+	compareTo?: WPCOMProductVariant;
+}
+
+const ProductVariant: FunctionComponent< ProductVariantProps > = ( {
+	productVariant,
+	selectedItem,
+	onChangeItemVariant,
+	isDisabled,
+	compareTo,
+} ) => {
+	const translate = useTranslate();
+	const { variantLabel, productSlug, productId } = productVariant;
+	const selectedProductSlug = selectedItem.product_slug;
+	const isChecked = productSlug === selectedProductSlug;
+
+	return (
+		<TermOptionsItem>
+			<RadioButton
+				name={ productSlug + variantLabel }
+				id={ productSlug + variantLabel }
+				value={ productSlug }
+				checked={ isChecked }
+				disabled={ isDisabled }
+				onChange={ () => {
+					! isDisabled && onChangeItemVariant( selectedItem.uuid, productSlug, productId );
+				} }
+				ariaLabel={ translate( 'Select a different term length' ) as string }
+				label={ <ItemVariantPrice variant={ productVariant } compareTo={ compareTo } /> }
+				children={ [] }
+			/>
+		</TermOptionsItem>
+	);
+};
+
+export const ItemVariationRadioButtons: FunctionComponent< ItemVariationPickerProps > = ( {
+	selectedItem,
+	onChangeItemVariant,
+	isDisabled,
+	variants,
+} ) => {
+	if ( variants.length < 2 ) {
+		return null;
+	}
+
+	const compareTo = variants[ 0 ];
+
+	return (
+		<TermOptions className="item-variation-picker">
+			{ variants.map( ( productVariant: WPCOMProductVariant ) => (
+				<ProductVariant
+					key={ productVariant.productSlug + productVariant.variantLabel }
+					selectedItem={ selectedItem }
+					onChangeItemVariant={ onChangeItemVariant }
+					isDisabled={ isDisabled }
+					productVariant={ productVariant }
+					compareTo={ compareTo }
+				/>
+			) ) }
+		</TermOptions>
+	);
+};

--- a/client/my-sites/checkout/composite-checkout/components/item-variation-picker/types.ts
+++ b/client/my-sites/checkout/composite-checkout/components/item-variation-picker/types.ts
@@ -5,6 +5,7 @@ export type WPCOMProductSlug = string;
 export type WPCOMProductVariant = {
 	price: number;
 	pricePerMonth: number;
+	pricePerYear: number;
 	termIntervalInMonths: number;
 	termIntervalInDays: number;
 	currency: string;

--- a/client/my-sites/checkout/composite-checkout/components/item-variation-picker/variant-price.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/item-variation-picker/variant-price.tsx
@@ -23,10 +23,6 @@ const Discount = styled.span`
 
 const Price = styled.span`
 	color: #646970;
-
-	.item-variant-option--selected & {
-		color: #fff;
-	}
 `;
 
 const Variant = styled.div`
@@ -37,10 +33,6 @@ const Variant = styled.div`
 	justify-content: space-between;
 	line-height: 20px;
 	width: 100%;
-
-	.item-variant-option--selected & {
-		color: #fff;
-	}
 `;
 
 const Label = styled.span`

--- a/client/my-sites/checkout/composite-checkout/components/item-variation-picker/variant-price.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/item-variation-picker/variant-price.tsx
@@ -5,16 +5,15 @@ import { FunctionComponent } from 'react';
 import type { WPCOMProductVariant } from './types';
 
 const Discount = styled.span`
-	color: ${ ( props ) => props.theme.colors.discount };
+	color: #234929;
 	display: block;
+	background-color: #b8e6bf;
+	padding: 0 1em;
+	border-radius: 4px;
 
 	.rtl & {
 		margin-right: 0;
 		margin-left: 8px;
-	}
-
-	.item-variant-option--selected & {
-		color: #b8e6bf;
 	}
 
 	@media ( max-width: 660px ) {

--- a/client/my-sites/checkout/composite-checkout/components/item-variation-picker/variant-price.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/item-variation-picker/variant-price.tsx
@@ -62,10 +62,7 @@ const Variant = styled.div`
 
 const Label = styled.span`
 	display: flex;
-	// MOBILE_BREAKPOINT is <480px, used in useMobileBreakpoint
-	@media ( max-width: 480px ) {
-		flex-direction: column;
-	}
+	flex-direction: column;
 `;
 
 const DiscountPercentage: FunctionComponent< { percent: number } > = ( { percent } ) => {

--- a/client/my-sites/checkout/composite-checkout/components/item-variation-picker/variant-price.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/item-variation-picker/variant-price.tsx
@@ -22,7 +22,7 @@ const Discount = styled.span`
 `;
 
 const Price = styled.span`
-	color: #646970;
+	color: #000;
 `;
 
 const Variant = styled.div`

--- a/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
@@ -226,7 +226,6 @@ function LineItemWrapper( {
 				onRemoveProduct={ onRemoveProduct }
 				onRemoveProductClick={ onRemoveProductClick }
 				onRemoveProductCancel={ onRemoveProductCancel }
-				hidePrice={ ! isJetpack && areThereVariants && shouldShowVariantSelector }
 			>
 				{ areThereVariants && shouldShowVariantSelector && (
 					<ItemVariationPicker

--- a/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
@@ -233,6 +233,7 @@ function LineItemWrapper( {
 						onChangeItemVariant={ onChangePlanLength }
 						isDisabled={ isDisabled }
 						variants={ variants }
+						type={ isJetpack ? 'dropdown' : 'radio' }
 					/>
 				) }
 			</LineItem>

--- a/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
@@ -226,6 +226,7 @@ function LineItemWrapper( {
 				onRemoveProduct={ onRemoveProduct }
 				onRemoveProductClick={ onRemoveProductClick }
 				onRemoveProductCancel={ onRemoveProductCancel }
+				hidePrice={ ! isJetpack && areThereVariants && shouldShowVariantSelector }
 			>
 				{ areThereVariants && shouldShowVariantSelector && (
 					<ItemVariationPicker

--- a/client/my-sites/checkout/composite-checkout/hooks/product-variants.tsx
+++ b/client/my-sites/checkout/composite-checkout/hooks/product-variants.tsx
@@ -3,6 +3,7 @@ import {
 	findPlansKeys,
 	findProductKeys,
 	getBillingMonthsForTerm,
+	getBillingYearsForTerm,
 	getPlan,
 	getProductFromSlug,
 	getTermDuration,
@@ -125,7 +126,9 @@ export function useGetProductVariants(
 					: variant.priceFinal || variant.priceFull;
 
 			const termIntervalInMonths = getBillingMonthsForTerm( variant.plan.term );
+			const termIntervalInYears = getBillingYearsForTerm( variant.plan.term );
 			const pricePerMonth = price / termIntervalInMonths;
+			const pricePerYear = price / termIntervalInYears;
 
 			return {
 				variantLabel: getTermText( variant.plan.term, translate ),
@@ -135,6 +138,7 @@ export function useGetProductVariants(
 				termIntervalInMonths: getBillingMonthsForTerm( variant.plan.term ),
 				termIntervalInDays: getTermDuration( variant.plan.term ) ?? 0,
 				pricePerMonth,
+				pricePerYear,
 				currency: variant.product.currency_code,
 			};
 		},

--- a/packages/calypso-products/src/main.ts
+++ b/packages/calypso-products/src/main.ts
@@ -485,6 +485,17 @@ export function getBillingMonthsForTerm( term: string ): number {
 	throw new Error( `Unknown term: ${ term }` );
 }
 
+export function getBillingYearsForTerm( term: string ): number {
+	if ( term === TERM_MONTHLY ) {
+		return 0;
+	} else if ( term === TERM_ANNUALLY ) {
+		return 1;
+	} else if ( term === TERM_BIENNIALLY ) {
+		return 2;
+	}
+	throw new Error( `Unknown term: ${ term }` );
+}
+
 export function plansLink(
 	urlString: string,
 	siteSlug: string | undefined | null,

--- a/packages/composite-checkout/src/components/radio-button.tsx
+++ b/packages/composite-checkout/src/components/radio-button.tsx
@@ -106,8 +106,9 @@ const Label = styled.label< LabelProps & React.LabelHTMLAttributes< HTMLLabelEle
 	display: flex;
 	flex-wrap: wrap;
 	justify-content: space-between;
-	align-items: flex-start;
+	align-items: center;
 	font-size: 14px;
+	height: 72px;
 
 	.rtl & {
 		padding: 16px 40px 16px 14px;
@@ -124,7 +125,7 @@ const Label = styled.label< LabelProps & React.LabelHTMLAttributes< HTMLLabelEle
 		content: '';
 		border: 1px solid ${ ( props ) => props.theme.colors.borderColor };
 		border-radius: 100%;
-		top: 19px;
+		top: 28px;
 		left: 16px;
 		position: absolute;
 		background: ${ ( props ) => props.theme.colors.surface };
@@ -143,7 +144,7 @@ const Label = styled.label< LabelProps & React.LabelHTMLAttributes< HTMLLabelEle
 		height: 8px;
 		content: '';
 		border-radius: 100%;
-		top: 23px;
+		top: 32px;
 		left: 20px;
 		position: absolute;
 		background: ${ getRadioColor };

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -840,6 +840,7 @@ function WPLineItem( {
 	onRemoveProduct,
 	onRemoveProductClick,
 	onRemoveProductCancel,
+	hidePrice,
 }: PropsWithChildren< {
 	product: ResponseCartProduct;
 	className?: string;
@@ -852,6 +853,7 @@ function WPLineItem( {
 	onRemoveProduct?: ( label: string ) => void;
 	onRemoveProductClick?: ( label: string ) => void;
 	onRemoveProductCancel?: ( label: string ) => void;
+	hidePrice?: boolean;
 } > ) {
 	const id = product.uuid;
 	const translate = useTranslate();
@@ -911,12 +913,14 @@ function WPLineItem( {
 				{ label }
 			</LineItemTitle>
 			<span aria-labelledby={ itemSpanId } className="checkout-line-item__price">
-				<LineItemPrice
-					isDiscounted={ isDiscounted }
-					actualAmount={ actualAmountDisplay }
-					originalAmount={ originalAmountDisplay }
-					isSummary={ isSummary }
-				/>
+				{ ! hidePrice && (
+					<LineItemPrice
+						isDiscounted={ isDiscounted }
+						actualAmount={ actualAmountDisplay }
+						originalAmount={ originalAmountDisplay }
+						isSummary={ isSummary }
+					/>
+				) }
 			</span>
 
 			{ product && ! containsPartnerCoupon && (

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -226,7 +226,7 @@ function WPNonProductLineItem( {
 					<DeleteButtonWrapper>
 						<DeleteButton
 							className="checkout-line-item__remove-product"
-							buttonType={ 'text-button' }
+							buttonType="text-button"
 							aria-label={ String(
 								translate( 'Remove %s from cart', {
 									args: label,
@@ -779,7 +779,7 @@ function PartnerLogo( { className }: { className?: string } ) {
 	return (
 		<LineItemMeta className={ joinClasses( [ className, 'jetpack-partner-logo' ] ) }>
 			<div>{ translate( 'Included in your IONOS plan' ) }</div>
-			<div className={ 'checkout-line-item__partner-logo-image' }>
+			<div className="checkout-line-item__partner-logo-image">
 				<IonosLogo />
 			</div>
 		</LineItemMeta>
@@ -902,7 +902,6 @@ function WPLineItem( {
 		products: [ product ],
 	} );
 
-	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	return (
 		<div
 			className={ joinClasses( [ className, 'checkout-line-item' ] ) }
@@ -951,7 +950,7 @@ function WPLineItem( {
 					<DeleteButtonWrapper>
 						<DeleteButton
 							className="checkout-line-item__remove-product"
-							buttonType={ 'text-button' }
+							buttonType="text-button"
 							aria-label={ String(
 								translate( 'Remove %s from cart', {
 									args: label,
@@ -992,5 +991,4 @@ function WPLineItem( {
 			) }
 		</div>
 	);
-	/* eslint-enable wpcalypso/jsx-classname-namespace */
 }


### PR DESCRIPTION
#### Proposed Changes

This is an attempt at implementing the UI outlined in https://github.com/Automattic/wp-calypso/issues/65968#issuecomment-1309159411

#### To do

- [x] Hide line item price.
- [x] Use radio buttons.
- [ ] Move "Save 20%" inside variant to a badge.
- [x] Remove crossed-out price (for variant comparison) inside variant.
- [ ] Add cart item discount and crossed-out price to selected (only?) variant price (eg: first year discount).
- [x] Add per-year (or per-month?) price as subtext inside variant.

#### Testing Instructions

TBD