### PR TITLE
Jetpack Licenses Selection Page: Disable selection of conflicting licenses

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/issue-multiple-licenses-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-multiple-licenses-form/index.tsx
@@ -33,9 +33,11 @@ export default function IssueMultipleLicensesForm( {
 
 	// If the user comes from the flow for adding a new payment method during an attempt to issue a license
 	// after the payment method is added, we will make an attempt to issue the chosen license automatically.
-	const defaultProducts = getQueryArg( window.location.href, 'products' )?.toString().split( ',' );
+	const defaultProductSlugs = getQueryArg( window.location.href, 'products' )
+		?.toString()
+		.split( ',' );
 
-	const [ selectedProductSlugs, setSelectedProductSlugs ] = useState( defaultProducts ?? [] );
+	const [ selectedProductSlugs, setSelectedProductSlugs ] = useState( defaultProductSlugs ?? [] );
 	const [ issueLicenses, isLoading ] = useIssueMultipleLicenses(
 		selectedProductSlugs,
 		selectedSite

--- a/client/jetpack-cloud/sections/partner-portal/issue-multiple-licenses-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-multiple-licenses-form/index.tsx
@@ -35,8 +35,11 @@ export default function IssueMultipleLicensesForm( {
 	// after the payment method is added, we will make an attempt to issue the chosen license automatically.
 	const defaultProducts = getQueryArg( window.location.href, 'products' )?.toString().split( ',' );
 
-	const [ selectedProducts, setSelectedProducts ] = useState( defaultProducts ?? [] );
-	const [ issueLicenses, isLoading ] = useIssueMultipleLicenses( selectedProducts, selectedSite );
+	const [ selectedProductSlugs, setSelectedProductSlugs ] = useState( defaultProducts ?? [] );
+	const [ issueLicenses, isLoading ] = useIssueMultipleLicenses(
+		selectedProductSlugs,
+		selectedSite
+	);
 
 	const onSelectProduct = useCallback(
 		( product ) => {
@@ -46,7 +49,7 @@ export default function IssueMultipleLicensesForm( {
 				} )
 			);
 
-			setSelectedProducts( ( previousValue ) => {
+			setSelectedProductSlugs( ( previousValue ) => {
 				const allProducts = [ ...previousValue ];
 
 				// A bundle cannot be combined with other products.
@@ -56,23 +59,39 @@ export default function IssueMultipleLicensesForm( {
 
 				! allProducts.includes( product.slug )
 					? allProducts.push( product.slug )
-					: allProducts.splice( selectedProducts.indexOf( product.slug ), 1 );
+					: allProducts.splice( selectedProductSlugs.indexOf( product.slug ), 1 );
 
 				return allProducts;
 			} );
 		},
-		[ dispatch, selectedProducts ]
+		[ dispatch, selectedProductSlugs ]
 	);
 
 	useEffect( () => {
 		// In the case of a bundle, we want to take the user immediately to the next step since
 		// they can't select any additional item after selecting a bundle.
-		if ( selectedProducts.find( ( product ) => isJetpackBundle( product ) ) ) {
+		if ( selectedProductSlugs.find( ( product ) => isJetpackBundle( product ) ) ) {
 			issueLicenses();
 		}
-	}, [ selectedProducts ] );
+	}, [ selectedProductSlugs, issueLicenses ] );
 
 	const selectedSiteDomain = selectedSite?.domain;
+
+	const disabledProductSlugs = selectedProductSlugs
+		// Get the product objects corresponding to the selected product slugs
+		.map( ( selectedProductSlug ) =>
+			allProducts?.find( ( product ) => product.slug === selectedProductSlug )
+		)
+		// Get all the product slugs of products within the same product family as the selected product
+		.flatMap( ( selectedProduct ) =>
+			allProducts
+				?.filter(
+					( product ) =>
+						product.family_slug === selectedProduct?.family_slug &&
+						selectedProduct.slug !== selectedProduct.slug
+				)
+				.map( ( product ) => product.slug )
+		);
 
 	return (
 		<div className="issue-multiple-licenses-form">
@@ -98,7 +117,7 @@ export default function IssueMultipleLicensesForm( {
 							<Button
 								primary
 								className="issue-multiple-licenses-form__select-license"
-								disabled={ ! selectedProducts.length }
+								disabled={ ! selectedProductSlugs.length }
 								busy={ isLoading }
 								onClick={ issueLicenses }
 							>
@@ -114,7 +133,8 @@ export default function IssueMultipleLicensesForm( {
 									key={ productOption.slug }
 									product={ productOption }
 									onSelectProduct={ onSelectProduct }
-									isSelected={ selectedProducts.includes( productOption.slug ) }
+									isSelected={ selectedProductSlugs.includes( productOption.slug ) }
+									isDisabled={ disabledProductSlugs.includes( productOption.slug ) }
 									tabIndex={ 100 + i }
 									suggestedProduct={ suggestedProduct }
 								/>

--- a/client/jetpack-cloud/sections/partner-portal/issue-multiple-licenses-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-multiple-licenses-form/index.tsx
@@ -88,7 +88,7 @@ export default function IssueMultipleLicensesForm( {
 				?.filter(
 					( product ) =>
 						product.family_slug === selectedProduct?.family_slug &&
-						selectedProduct.slug !== selectedProduct.slug
+						product.slug !== selectedProduct.slug
 				)
 				.map( ( product ) => product.slug )
 		);

--- a/client/jetpack-cloud/sections/partner-portal/license-product-card/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-product-card/index.tsx
@@ -33,6 +33,10 @@ export default function LicenseProductCard( props: Props ) {
 	const translate = useTranslate();
 
 	const onSelect = useCallback( () => {
+		if ( isDisabled ) {
+			return;
+		}
+
 		if ( isEnabled( 'jetpack/partner-portal-issue-multiple-licenses' ) ) {
 			onSelectProduct?.( product );
 		} else {

--- a/client/jetpack-cloud/sections/partner-portal/license-product-card/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-product-card/index.tsx
@@ -13,13 +13,22 @@ interface Props {
 	tabIndex: number;
 	product: APIProductFamilyProduct;
 	isSelected: boolean;
+	isDisabled?: boolean;
 	onSelectProduct: ( value: APIProductFamilyProduct | string ) => void | null;
 	suggestedProduct?: string | null;
 	isMultiSelect?: boolean;
 }
 
 export default function LicenseProductCard( props: Props ) {
-	const { tabIndex, product, isSelected, onSelectProduct, suggestedProduct, isMultiSelect } = props;
+	const {
+		tabIndex,
+		product,
+		isSelected,
+		isDisabled,
+		onSelectProduct,
+		suggestedProduct,
+		isMultiSelect,
+	} = props;
 	const productTitle = getProductTitle( product.name );
 	const translate = useTranslate();
 
@@ -62,6 +71,7 @@ export default function LicenseProductCard( props: Props ) {
 			className={ classNames( {
 				'license-product-card': true,
 				selected: isSelected,
+				disabled: isDisabled,
 			} ) }
 		>
 			<div className="license-product-card__inner">

--- a/client/jetpack-cloud/sections/partner-portal/license-product-card/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-product-card/index.tsx
@@ -68,6 +68,7 @@ export default function LicenseProductCard( props: Props ) {
 			role={ isMultiSelect ? 'checkbox' : 'radio' }
 			tabIndex={ tabIndex }
 			aria-checked={ isSelected }
+			aria-disabled={ isDisabled }
 			className={ classNames( {
 				'license-product-card': true,
 				selected: isSelected,

--- a/client/jetpack-cloud/sections/partner-portal/license-product-card/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/license-product-card/style.scss
@@ -6,7 +6,10 @@
 
 	&.disabled {
 		opacity: 0.5;
-		pointer-events: none;
+
+		.license-product-card__inner {
+			cursor: not-allowed;
+		}
 	}
 
 	@include break-xlarge {

--- a/client/jetpack-cloud/sections/partner-portal/license-product-card/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/license-product-card/style.scss
@@ -5,7 +5,7 @@
 	width: 100%;
 
 	&.disabled {
-		opacity: 0.4;
+		opacity: 0.5;
 		pointer-events: none;
 	}
 

--- a/client/jetpack-cloud/sections/partner-portal/license-product-card/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/license-product-card/style.scss
@@ -6,6 +6,7 @@
 
 	&.disabled {
 		opacity: 0.4;
+		pointer-events: none;
 	}
 
 	@include break-xlarge {

--- a/client/jetpack-cloud/sections/partner-portal/license-product-card/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/license-product-card/style.scss
@@ -4,6 +4,10 @@
 .license-product-card {
 	width: 100%;
 
+	&.disabled {
+		opacity: 0.4;
+	}
+
 	@include break-xlarge {
 		width: 50%;
 	}


### PR DESCRIPTION
#### Proposed Changes

This PR updates the Jetpack dashboard so that when a license is selected all conflicting licenses will be disabled.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Start up Jetpack Cloud and visit http://jetpack.cloud.localhost:3001/partner-portal/issue-license
2. Select either Backup 10GB or Backup 1TB and verify that the other is disabled.
3. Select all other products and verify that nothing gets disabled.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1203126240279377-as-1203126240279411