### PR TITLE
Help Center: update resource title

### DIFF
--- a/packages/help-center/src/components/help-center-more-resources.tsx
+++ b/packages/help-center/src/components/help-center-more-resources.tsx
@@ -128,7 +128,7 @@ export const HelpCenterMoreResources = () => {
 				<li className="inline-help__resource-item">
 					<div className="inline-help__resource-cell">
 						<a
-							href={ localizeUrl( 'https://www.wordpress.com/support' ) }
+							href={ localizeUrl( 'https://wordpress.com/support' ) }
 							rel="noreferrer"
 							target="_blank"
 							className="inline-help__format-list-numbered"

--- a/packages/help-center/src/components/help-center-more-resources.tsx
+++ b/packages/help-center/src/components/help-center-more-resources.tsx
@@ -90,7 +90,7 @@ export const HelpCenterMoreResources = () => {
 							onClick={ () => trackMoreResourcesButtonClick( 'video' ) }
 						>
 							<Icon icon={ video } size={ 24 } />
-							<span>{ __( 'Video tutorials', __i18n_text_domain__ ) }</span>
+							<span>{ __( 'Video Tutorials', __i18n_text_domain__ ) }</span>
 							<Icon icon={ external } size={ 20 } />
 						</a>
 					</div>

--- a/packages/help-center/src/components/help-center-more-resources.tsx
+++ b/packages/help-center/src/components/help-center-more-resources.tsx
@@ -113,7 +113,7 @@ export const HelpCenterMoreResources = () => {
 				<li className="inline-help__resource-item">
 					<div className="inline-help__resource-cell">
 						<a
-							href={ localizeUrl( 'https://wordpress.com/learn/' ) }
+							href="https://wordpress.com/learn/"
 							rel="noreferrer"
 							target="_blank"
 							className="inline-help__desktop"

--- a/packages/help-center/src/components/help-center-more-resources.tsx
+++ b/packages/help-center/src/components/help-center-more-resources.tsx
@@ -113,14 +113,14 @@ export const HelpCenterMoreResources = () => {
 				<li className="inline-help__resource-item">
 					<div className="inline-help__resource-cell">
 						<a
-							href={ localizeUrl( 'https://wpcourses.com/?ref=wpcom-help-more-resources' ) }
+							href={ localizeUrl( 'https://wordpress.com/learn/' ) }
 							rel="noreferrer"
 							target="_blank"
 							className="inline-help__desktop"
-							onClick={ () => trackMoreResourcesButtonClick( 'courses' ) }
+							onClick={ () => trackMoreResourcesButtonClick( 'starting-guide' ) }
 						>
 							<Icon icon={ desktop } size={ 24 } />
-							<span>{ __( 'Courses', __i18n_text_domain__ ) }</span>
+							<span>{ __( 'Starting Guide', __i18n_text_domain__ ) }</span>
 							<Icon icon={ external } size={ 20 } />
 						</a>
 					</div>
@@ -132,10 +132,10 @@ export const HelpCenterMoreResources = () => {
 							rel="noreferrer"
 							target="_blank"
 							className="inline-help__format-list-numbered"
-							onClick={ () => trackMoreResourcesButtonClick( 'guides' ) }
+							onClick={ () => trackMoreResourcesButtonClick( 'support-documentation' ) }
 						>
 							<Icon icon={ formatListNumbered } size={ 24 } />
-							<span>{ __( 'Step-by-step guides', __i18n_text_domain__ ) }</span>
+							<span>{ __( 'Support Documentation', __i18n_text_domain__ ) }</span>
 							<Icon icon={ external } size={ 20 } />
 						</a>
 					</div>


### PR DESCRIPTION
## Proposed Changes

* Update some of the resources tabs

1. **Step by Step Guides ⇢ Support Documentation**
2. **Courses ⇢ Starting Guide** - also changed url to /learn and removed the localizeUrl because we do not have multiple languages it seems? For example https://wordpress.com/es/learn/ is a 404

## Testing Instructions

1. Pull branch and launch Calypso local
2. Open Help Center and check the changed tabs for spelling errors
4. Click the links to verify they go to the right places