### PR TITLE
Onboarding standalone installation: Do not display standalone plugin image in the thank you page if feature is not enabled.

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/utils.ts
+++ b/client/my-sites/checkout/checkout-thank-you/utils.ts
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import {
 	JETPACK_BACKUP_PRODUCTS,
 	JETPACK_BOOST_PRODUCTS,
@@ -74,7 +75,10 @@ export function getJetpackPluginSupportDocLink( productSlug: string ): string {
 }
 
 export function getJetpackPluginImage( productSlug: string ): string {
-	return JETPACK_PLUGIN_IMAGE_MAP[ productSlug ] ?? JetpackPluginImage;
+	return isEnabled( 'jetpack/standalone-plugin-onboarding-update-v1' ) &&
+		JETPACK_PLUGIN_IMAGE_MAP[ productSlug ]
+		? JETPACK_PLUGIN_IMAGE_MAP[ productSlug ]
+		: JetpackPluginImage;
 }
 
 export function getDomainManagementUrl(


### PR DESCRIPTION
#### Description
Right now the changes for the new onboarding  standalone installation is disabled in production but the changes for the specific standalone plugin images are already showing up.

<img width="1228" alt="Screen Shot 2022-11-10 at 3 25 01 PM" src="https://user-images.githubusercontent.com/56598660/201026548-d2589102-cecf-49ec-b668-de5f0a991787.png">


#### Proposed Changes

* Update the page to only display the specific standalone images when feature flag is enabled.

#### Testing Instructions

1. Use the the calypso Live link and append `/checkout/jetpack/thank-you/licensing-manual-activate-instructions/jetpack_backup_t1_yearly
`
2. Confirm that the thank you page displays the classic Jetpack plugin.
<img width="1227" alt="Screen Shot 2022-11-10 at 3 32 27 PM" src="https://user-images.githubusercontent.com/56598660/201027872-cc1c50e0-d001-4aaf-859f-c6c5532dc40a.png">


3. Now use the calypso live link and append `/checkout/jetpack/thank-you/licensing-manual-activate-instructions/jetpack_backup_t1_yearly?flags=jetpack/standalone-plugin-onboarding-update-v1`.

4. Confirm that the Backup plugin image is displayed.
<img width="1221" alt="Screen Shot 2022-11-10 at 3 33 24 PM" src="https://user-images.githubusercontent.com/56598660/201028001-37b1c262-8caa-4978-8ad3-0d9bd918b70f.png">

 
#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1203097885147382-as-1203159154260045