### PR TITLE
Site Editor: dashboard link compat for Gutenberg 14.5

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/class-wpcom-block-editor-nav-sidebar.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/class-wpcom-block-editor-nav-sidebar.php
@@ -23,6 +23,7 @@ class WPCOM_Block_Editor_Nav_Sidebar {
 	 */
 	public function __construct() {
 		add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_script_and_style' ), 100 );
+		add_filter( 'block_editor_settings_all', array( $this, 'add_wpcom_dashboard_link' ) );
 	}
 
 	/**
@@ -84,6 +85,18 @@ class WPCOM_Block_Editor_Nav_Sidebar {
 			array(),
 			filemtime( plugin_dir_path( __FILE__ ) . $style_path )
 		);
+	}
+
+	/**
+	 * Point the dashboard link to wordpress.com in the editor sidebar for Gutenberg 14.5 compat
+	 *
+	 * @param array $settings Editor settings.
+	 * @return array Updated Editor settings.
+	 */
+	public function add_wpcom_dashboard_link( $settings ) {
+		$site_slug                               = preg_replace( '|^https?:\/\/|', '', home_url() );
+		$settings['__experimentalDashboardLink'] = 'https://wordpress.com/home/' . $site_slug;
+		return $settings;
 	}
 }
 add_action( 'init', array( __NAMESPACE__ . '\WPCOM_Block_Editor_Nav_Sidebar', 'init' ) );


### PR DESCRIPTION
Gutenberg 14.5 has removed the slotfill we formerly used for the dashboard link override, instead introducing a `__experimentalDashboardLink` setting.

#### Proposed Changes

* add filter for dashboard link

#### Testing Instructions

### WPCOM Simple

* to test on a sandboxed site, ensure it is running Gutenberg `dev` by adding a `gutenberg-edge` blog sticker to it (`wp blog-stickers add --sticker=gutenberg-edge --who=YOURUSERNAME --url=YOURBLOGURL.wordpress.com`)
* `yarn dev --sync` to sync this to your sandbox
* Navigate to the site editor and ensure that the `< Dashboard` link in the nav sidebar returns you to Calypso **My Home** rather than `wp-admin/index.php`

<img width="696" alt="Screen Shot 2022-11-10 at 10 06 26" src="https://user-images.githubusercontent.com/195089/201147541-5e75d531-6576-4fd0-8265-14db84482593.png">

### Atomic

* ensure that Gutenberg is up-to-date to v14.5 (just released)
* build this plugin and run it (process up to you at this point)
* Navigate to the site editor and ensure that the `< Dashboard` link in the nav sidebar returns you to Calypso **My Home** rather than `wp-admin/index.php`

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] **n/a** For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Supersedes Automattic/jetpack#27226
