### PR TITLE
Hosted Woo Onboarding: Add monthly recurrence query string

### DIFF
--- a/client/landing/stepper/declarative-flow/tailored-ecommerce-flow.ts
+++ b/client/landing/stepper/declarative-flow/tailored-ecommerce-flow.ts
@@ -9,6 +9,11 @@ import { recordSubmitStep } from './internals/analytics/record-submit-step';
 import type { StepPath } from './internals/steps-repository';
 import type { Flow, ProvidedDependencies } from './internals/types';
 
+export const ecommerceFlowRecurTypes = {
+	YEARLY: 'yearly',
+	MONTHLY: 'monthly',
+};
+
 export const ecommerceFlow: Flow = {
 	name: ECOMMERCE_FLOW,
 	useSteps() {

--- a/client/landing/stepper/index.tsx
+++ b/client/landing/stepper/index.tsx
@@ -38,12 +38,12 @@ import { newsletterPostSetup } from './declarative-flow/newsletter-post-setup';
 import { pluginBundleFlow } from './declarative-flow/plugin-bundle-flow';
 import { podcasts } from './declarative-flow/podcasts';
 import { siteSetupFlow } from './declarative-flow/site-setup-flow';
-import { ecommerceFlow } from './declarative-flow/tailored-ecommerce-flow';
+import { ecommerceFlow, ecommerceFlowRecurTypes } from './declarative-flow/tailored-ecommerce-flow';
 import { videopress } from './declarative-flow/videopress';
 import 'calypso/components/environment-badge/style.scss';
 import { useAnchorFmParams } from './hooks/use-anchor-fm-params';
 import { useQuery } from './hooks/use-query';
-import { USER_STORE } from './stores';
+import { ONBOARD_STORE, USER_STORE } from './stores';
 import type { Flow } from './declarative-flow/internals/types';
 
 function generateGetSuperProps() {
@@ -87,11 +87,13 @@ const availableFlows: Array< configurableFlows > = [
 
 const FlowSwitch: React.FC< { user: UserStore.CurrentUser | undefined } > = ( { user } ) => {
 	const { receiveCurrentUser } = useDispatch( USER_STORE );
+	const { setEcommerceFlowRecurType } = useDispatch( ONBOARD_STORE );
 	const location = useLocation();
 	const { anchorFmPodcastId } = useAnchorFmParams();
 
 	const flowNameFromParam = useQuery().get( 'flow' );
 	const flowNameFromPathName = location.pathname.split( '/' )[ 1 ];
+	const recurType = useQuery().get( 'recur' );
 	let flow = siteSetupFlow;
 
 	// keep supporting the `flow` query param for backwards compatibility
@@ -101,6 +103,15 @@ const FlowSwitch: React.FC< { user: UserStore.CurrentUser | undefined } > = ( { 
 
 	if ( anchorFmPodcastId ) {
 		flow = anchorFmFlow;
+	} else if ( flowNameFromPathName === ecommerceFlow.name ) {
+		flow = ecommerceFlow;
+		const isValidRecurType =
+			recurType && Object.values( ecommerceFlowRecurTypes ).includes( recurType );
+		if ( isValidRecurType ) {
+			setEcommerceFlowRecurType( recurType );
+		} else {
+			setEcommerceFlowRecurType( ecommerceFlowRecurTypes.YEARLY );
+		}
 	} else {
 		availableFlows.forEach( ( currentFlow ) => {
 			if ( currentFlow.flowName === flowNameFromPathName ) {

--- a/packages/data-stores/src/onboard/actions.ts
+++ b/packages/data-stores/src/onboard/actions.ts
@@ -377,6 +377,11 @@ export const setStoreLocationCountryCode = ( storeLocationCountryCode: string ) 
 	storeLocationCountryCode,
 } );
 
+export const setEcommerceFlowRecurType = ( ecommerceFlowRecurType: string ) => ( {
+	type: 'SET_ECOMMERCE_FLOW_RECUR_TYPE' as const,
+	ecommerceFlowRecurType,
+} );
+
 export type OnboardAction = ReturnType<
 	| typeof addFeature
 	| typeof removeFeature
@@ -423,4 +428,5 @@ export type OnboardAction = ReturnType<
 	| typeof setSiteAccentColor
 	| typeof setVerticalId
 	| typeof setStoreLocationCountryCode
+	| typeof setEcommerceFlowRecurType
 >;

--- a/packages/data-stores/src/onboard/index.ts
+++ b/packages/data-stores/src/onboard/index.ts
@@ -52,6 +52,7 @@ export function register(): typeof STORE_KEY {
 			'storeType',
 			'verticalId',
 			'storeLocationCountryCode',
+			'ecommerceFlowRecurType',
 		],
 	} );
 	isRegistered = true;

--- a/packages/data-stores/src/onboard/reducer.ts
+++ b/packages/data-stores/src/onboard/reducer.ts
@@ -397,6 +397,16 @@ const storeLocationCountryCode: Reducer< string, OnboardAction > = ( state = '',
 	return state;
 };
 
+const ecommerceFlowRecurType: Reducer< string, OnboardAction > = ( state = '', action ) => {
+	if ( action.type === 'SET_ECOMMERCE_FLOW_RECUR_TYPE' ) {
+		return action.ecommerceFlowRecurType;
+	}
+	if ( action.type === 'RESET_ONBOARD_STORE' ) {
+		return false;
+	}
+	return state;
+};
+
 const reducer = combineReducers( {
 	anchorPodcastId,
 	anchorEpisodeId,
@@ -433,6 +443,7 @@ const reducer = combineReducers( {
 	siteAccentColor,
 	verticalId,
 	storeLocationCountryCode,
+	ecommerceFlowRecurType,
 } );
 
 export type State = ReturnType< typeof reducer >;

--- a/packages/data-stores/src/onboard/reducer.ts
+++ b/packages/data-stores/src/onboard/reducer.ts
@@ -402,7 +402,7 @@ const ecommerceFlowRecurType: Reducer< string, OnboardAction > = ( state = '', a
 		return action.ecommerceFlowRecurType;
 	}
 	if ( action.type === 'RESET_ONBOARD_STORE' ) {
-		return false;
+		return '';
 	}
 	return state;
 };

--- a/packages/data-stores/src/onboard/selectors.ts
+++ b/packages/data-stores/src/onboard/selectors.ts
@@ -27,6 +27,7 @@ export const getGoals = ( state: State ) => state.goals;
 export const getPatternContent = ( state: State ) => state.patternContent;
 export const getVerticalId = ( state: State ) => state.verticalId;
 export const getStoreLocationCountryCode = ( state: State ) => state.storeLocationCountryCode;
+export const getEcommerceFlowRecurType = ( state: State ) => state.ecommerceFlowRecurType;
 export const getState = ( state: State ) => state;
 export const hasPaidDesign = ( state: State ): boolean => {
 	if ( ! state.selectedDesign ) {


### PR DESCRIPTION
#### Proposed Changes

* This PR adds support in the tailored ecommerce flow (in a way hopefully flexible enough for other flows that might need similar functionality in the future) for a `recur` query string parameter which can be either `"monthly"` or `"yearly"`, indicating which type of ecommerce plan the user should be directed to check out with.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this branch locally; verify that `signup/tailored-ecommerce` feature flag is enabled.
* Edit the file `client/landing/stepper/declarative-flow/tailored-ecommerce-flow.ts` to add the following:

```
const recurType = useSelect( ( select ) => select( ONBOARD_STORE ).getEcommerceFlowRecurType() );
console.log( recurType );
```

* Navigate to `/setup/ecommerce` and click through to the store profiler screen.
* Verify that the console logs the recur term `yearly`
* Navigate to `/setup/ecommerce?recur=monthly` and click through to the store profiler screen.
* Verify that the console logs the recur term `monthly`
* Navigate to `/setup/ecommerce?recur=yearly` and click through to the store profiler screen.
* Verify that the console logs the recur term `yearly`
* Navigate to `/setup/ecommerce?recur=asdfgasdfas` and click through to the store profiler screen.
* Verify that the console logs the recur term `yearly`

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #69386 
