### PR TITLE
Checkout: Add gift badge to gifted line items

### DIFF
--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -226,7 +226,7 @@ function WPNonProductLineItem( {
 					<DeleteButtonWrapper>
 						<DeleteButton
 							className="checkout-line-item__remove-product"
-							buttonType={ 'text-button' }
+							buttonType="text-button"
 							aria-label={ String(
 								translate( 'Remove %s from cart', {
 									args: label,
@@ -779,7 +779,7 @@ function PartnerLogo( { className }: { className?: string } ) {
 	return (
 		<LineItemMeta className={ joinClasses( [ className, 'jetpack-partner-logo' ] ) }>
 			<div>{ translate( 'Included in your IONOS plan' ) }</div>
-			<div className={ 'checkout-line-item__partner-logo-image' }>
+			<div className="checkout-line-item__partner-logo-image">
 				<IonosLogo />
 			</div>
 		</LineItemMeta>
@@ -947,7 +947,7 @@ function WPLineItem( {
 					<DeleteButtonWrapper>
 						<DeleteButton
 							className="checkout-line-item__remove-product"
-							buttonType={ 'text-button' }
+							buttonType="text-button"
 							aria-label={ String(
 								translate( 'Remove %s from cart', {
 									args: label,

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -102,6 +102,16 @@ export const CouponLineItem = styled( WPCouponLineItem )< {
 	}
 `;
 
+const GiftBadge = styled.span`
+	color: #234929;
+	background-color: #b8e6bf;
+	padding: 0 1em;
+	border-radius: 5px;
+	display: flex;
+	align-items: center;
+	font-size: small;
+`;
+
 const LineItemMeta = styled.div< { theme?: Theme } >`
 	color: ${ ( props ) => props.theme.colors.textColorLight };
 	font-size: 14px;
@@ -128,6 +138,8 @@ const LineItemTitle = styled.div< { theme?: Theme; isSummary?: boolean } >`
 	flex: 1;
 	word-break: break-word;
 	font-size: 16px;
+	display: flex;
+	gap: 0.5em;
 `;
 
 const LineItemPriceWrapper = styled.span< { theme?: Theme; isSummary?: boolean } >`
@@ -909,6 +921,7 @@ function WPLineItem( {
 		>
 			<LineItemTitle id={ itemSpanId } isSummary={ isSummary }>
 				{ label }
+				{ responseCart.is_gift_purchase && <GiftBadge>{ translate( 'Gift' ) }</GiftBadge> }
 			</LineItemTitle>
 			<span aria-labelledby={ itemSpanId } className="checkout-line-item__price">
 				<LineItemPrice

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -102,13 +102,17 @@ export const CouponLineItem = styled( WPCouponLineItem )< {
 	}
 `;
 
+const GiftBadgeWrapper = styled.span`
+	width: 100%;
+`;
+
 const GiftBadge = styled.span`
 	color: #234929;
 	background-color: #b8e6bf;
-	padding: 0 1em;
+	margin-bottom: 0.1em;
+	padding: 0.1em 0.8em;
 	border-radius: 5px;
-	display: flex;
-	align-items: center;
+	display: inline-block;
 	font-size: small;
 `;
 
@@ -919,9 +923,13 @@ function WPLineItem( {
 			data-e2e-product-slug={ productSlug }
 			data-product-type={ isPlan( product ) ? 'plan' : product.product_slug }
 		>
+			{ responseCart.is_gift_purchase && (
+				<GiftBadgeWrapper>
+					<GiftBadge>{ translate( 'Gift' ) }</GiftBadge>
+				</GiftBadgeWrapper>
+			) }
 			<LineItemTitle id={ itemSpanId } isSummary={ isSummary }>
 				{ label }
-				{ responseCart.is_gift_purchase && <GiftBadge>{ translate( 'Gift' ) }</GiftBadge> }
 			</LineItemTitle>
 			<span aria-labelledby={ itemSpanId } className="checkout-line-item__price">
 				<LineItemPrice


### PR DESCRIPTION
#### Proposed Changes

This PR adds a "Gift" badge to every line item which is a gift.

<img width="566" alt="Screen Shot 2022-11-10 at 1 56 44 PM" src="https://user-images.githubusercontent.com/2036909/201182452-9f973503-e4db-4f04-a16c-28a7653b5014.png">

Related to https://github.com/Automattic/payments-shilling/issues/1221 

#### Testing Instructions

- Add a gift purchase to your cart (instructions for gift purchases can be found in D92011-code).
- Verify that the Gift badge appears as in the screenshot.