### PR TITLE
Launchpad: Only Show Email Banner for Newsletter Flow & Add Unit Tests

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/step-content.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/step-content.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useSelector } from 'react-redux';
+import { NEWSLETTER_FLOW } from 'calypso/../packages/onboarding/src';
 import { useGetDomainsQuery } from 'calypso/data/domains/use-get-domains-query';
 import { NavigationControls } from 'calypso/landing/stepper/declarative-flow/internals/types';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
@@ -52,7 +53,8 @@ const StepContent = ( { siteSlug, submit, goNext, goToStep, flow }: StepContentP
 
 	useEffect( () => {
 		// check if the current user's email hasn't been verified yet
-		if ( email && ! isEmailVerified ) {
+		// only show the email banner for newsletter flow
+		if ( email && ! isEmailVerified && flow === NEWSLETTER_FLOW ) {
 			setShowEmailValidationBanner( true );
 		}
 	}, [ email, isEmailVerified ] );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/step-content.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/step-content.tsx
@@ -1,0 +1,191 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from 'react-query';
+import * as redux from 'react-redux';
+import { createReduxStore } from 'calypso/state';
+import { getInitialState, getStateFromCache } from 'calypso/state/initial-state';
+import initialReducer from 'calypso/state/reducer';
+import { setStore } from 'calypso/state/redux-store';
+import * as sendEmail from '../../../../../../../landing/stepper/hooks/use-send-email-verification';
+import EmailValidationBanner from '../email-validation-banner';
+import StepContent from '../step-content';
+
+const NEWSLETTER_FLOW = 'newsletter';
+const LINK_IN_BIO_FLOW = 'link-in-bio';
+
+const props = {
+	siteSlug: 'testsite.wordpress.com',
+	/* eslint-disable @typescript-eslint/no-empty-function */
+	submit: () => {},
+	goNext: () => {},
+	goToStep: () => {},
+	/* eslint-enable @typescript-eslint/no-empty-function */
+};
+
+jest.mock( 'react-router-dom', () => ( {
+	...jest.requireActual( 'react-router-dom' ),
+	useLocation: jest.fn().mockImplementation( () => ( {
+		pathname: '/setup/launchpad',
+		search: `?flow=newsletter&siteSlug=${ props.siteSlug }`,
+		hash: '',
+		state: undefined,
+	} ) ),
+} ) );
+
+const user = {
+	ID: 1234,
+	username: 'testUser',
+	email: 'testemail@wordpress.com',
+	email_verified: false,
+};
+
+function renderStepContent( emailVerified = false, flow: string ) {
+	const initialState = getInitialState( initialReducer, user.ID );
+	const reduxStore = createReduxStore(
+		{
+			...initialState,
+			currentUser: {
+				user: {
+					...user,
+					email_verified: emailVerified,
+				},
+			},
+		},
+		initialReducer
+	);
+	setStore( reduxStore, getStateFromCache( user.ID ) );
+	const queryClient = new QueryClient();
+
+	render(
+		<redux.Provider store={ reduxStore }>
+			<QueryClientProvider client={ queryClient }>
+				<StepContent { ...props } flow={ flow }>
+					<EmailValidationBanner />
+				</StepContent>
+			</QueryClientProvider>
+		</redux.Provider>
+	);
+}
+
+describe( 'EmailValidationBanner', () => {
+	describe( 'when the flow is newsletter', () => {
+		it( "shows the banner when the user's email is not verified", () => {
+			renderStepContent( false, NEWSLETTER_FLOW );
+
+			const emailValidationBanner = screen.queryByText(
+				/Make sure to validate the email we sent to testemail@wordpress.com in order to publish and share your posts./i
+			);
+
+			expect( emailValidationBanner ).toBeInTheDocument();
+		} );
+
+		it( "hides the banner when the user's email is verified", () => {
+			renderStepContent( true, NEWSLETTER_FLOW );
+
+			const emailValidationBanner = screen.queryByText(
+				/Make sure to validate the email we sent to testemail@wordpress.com in order to publish and share your posts./i
+			);
+
+			expect( emailValidationBanner ).not.toBeInTheDocument();
+		} );
+
+		it( 'change email link redirects to /me/account', () => {
+			renderStepContent( false, NEWSLETTER_FLOW );
+
+			expect( screen.getByRole( 'link', { name: 'change email address' } ) ).toHaveAttribute(
+				'href',
+				'/me/account'
+			);
+		} );
+
+		it( 'hides the banner when clicking the close button', () => {
+			renderStepContent( false, NEWSLETTER_FLOW );
+
+			const closeButton = screen.getByLabelText( 'close' );
+			const emailValidationBanner = screen.queryByText(
+				/Make sure to validate the email we sent to testemail@wordpress.com in order to publish and share your posts./i
+			);
+
+			expect( emailValidationBanner ).toBeInTheDocument();
+
+			fireEvent.click( closeButton );
+
+			expect( emailValidationBanner ).not.toBeInTheDocument();
+		} );
+
+		it( 'fires success notice action when resend is successful', async () => {
+			const dispatch = jest.fn();
+
+			jest.spyOn( redux, 'useDispatch' ).mockReturnValue( dispatch );
+
+			const useSendEmailVerification = jest.spyOn( sendEmail, 'useSendEmailVerification' );
+			useSendEmailVerification.mockImplementation( () => () => {
+				return Promise.resolve( {
+					success: true,
+				} );
+			} );
+
+			renderStepContent( false, NEWSLETTER_FLOW );
+
+			const resendEmailButton = screen.queryByText( /Resend email/i );
+
+			expect( resendEmailButton ).toBeInTheDocument();
+
+			await userEvent.click( resendEmailButton as HTMLElement );
+
+			expect( useSendEmailVerification ).toHaveBeenCalled();
+
+			await waitFor( () => {
+				expect(
+					dispatch.mock.calls[ 0 ][ 0 ].notice.text.includes(
+						'Verification email resent. Please check your inbox.'
+					)
+				).toBeTruthy();
+			} );
+		} );
+
+		it( 'fires error notice action when resend is unsuccessful', async () => {
+			const dispatch = jest.fn();
+
+			jest.spyOn( redux, 'useDispatch' ).mockReturnValue( dispatch );
+
+			const useSendEmailVerification = jest.spyOn( sendEmail, 'useSendEmailVerification' );
+			useSendEmailVerification.mockImplementation( () => () => {
+				return Promise.reject();
+			} );
+
+			renderStepContent( false, NEWSLETTER_FLOW );
+
+			const resendEmailButton = screen.queryByText( /Resend email/i );
+
+			expect( resendEmailButton ).toBeInTheDocument();
+
+			await userEvent.click( resendEmailButton as HTMLElement );
+
+			expect( useSendEmailVerification ).toHaveBeenCalled();
+
+			await waitFor( () => {
+				expect(
+					dispatch.mock.calls[ 0 ][ 0 ].notice.text.includes(
+						"Couldn't resend verification email. Please try again."
+					)
+				).toBeTruthy();
+			} );
+		} );
+	} );
+
+	describe( 'when the flow is NOT newsletter', () => {
+		it( "DOES NOT show the banner when the user's email is not verified", () => {
+			renderStepContent( false, LINK_IN_BIO_FLOW );
+
+			const emailValidationBanner = screen.queryByText(
+				/Make sure to validate the email we sent to testemail@wordpress.com in order to publish and share your posts./i
+			);
+
+			expect( emailValidationBanner ).not.toBeInTheDocument();
+		} );
+	} );
+} );


### PR DESCRIPTION
#### Proposed Changes
This PR is for only displaying the email validation banner on the newsletter flow.

It also lays the groundwork for testing the `step-content.tsx` component and adds tests for the `email-validation-banner.tsx`

#### Testing Instructions

##### Test banner showing for newsletter flow

1. Create a new WordPress account. (You can use [Temp Email](https://temp-mail.org/en/))
2. Create a new Launchpad site with the **newsletter flow**
3. Go to `http://calypso.localhost:3000/setup/newsletter/launchpad?siteSlug=YOUR_SITE_SLUG`
4. You **should see** the banner displayed on the top of the page

##### Test banner NOT showing for other flows

1. Create a new WordPress account. (You can use [Temp Email](https://temp-mail.org/en/))
2. Create a new Launchpad site with the **link-in-bio flow**
3. Go to `http://calypso.localhost:3000/setup/link-in-bio/launchpad?siteSlug=YOUR_SITE_SLUG`
4. You **should NOT see** the banner displayed on the top of the page


https://user-images.githubusercontent.com/20927667/201196912-00b85270-75a4-45d8-8f72-2af68f9a791a.mov

##### Run unit tests

Run `yarn test-client launchpad`. You should see all tests are passing:

<img width="1159" alt="image" src="https://user-images.githubusercontent.com/20927667/201191048-e50a7b4e-bfbc-483f-abb1-3ec0ca5c5024.png">

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #69551 
Fixes #69936 
