### PR TITLE
Checkout: always use selected site for checkout masterbar UI

### DIFF
--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -258,7 +258,7 @@ class MasterbarLoggedIn extends Component {
 		const {
 			isCheckoutPending,
 			previousPath,
-			siteSlug,
+			currentSelectedSiteSlug,
 			isJetpackNotAtomic,
 			title,
 			loadHelpCenterIcon,
@@ -271,7 +271,7 @@ class MasterbarLoggedIn extends Component {
 				title={ title }
 				isJetpackNotAtomic={ isJetpackNotAtomic }
 				previousPath={ previousPath }
-				siteSlug={ siteSlug }
+				siteSlug={ currentSelectedSiteSlug }
 				isLeavingAllowed={ ! isCheckoutPending }
 				loadHelpCenterIcon={ loadHelpCenterIcon }
 			/>

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -582,7 +582,9 @@ export default connect(
 				? getSiteSlug( state, currentSelectedSiteId )
 				: undefined,
 			previousPath: getPreviousRoute( state ),
-			isJetpackNotAtomic: isJetpackSite( state, siteId ) && ! isAtomicSite( state, siteId ),
+			isJetpackNotAtomic:
+				isJetpackSite( state, currentSelectedSiteId ) &&
+				! isAtomicSite( state, currentSelectedSiteId ),
 			currentLayoutFocus: getCurrentLayoutFocus( state ),
 			hasDismissedThePopover: getPreference( state, MENU_POPOVER_PREFERENCE_KEY ),
 			isFetchingPrefs: isFetchingPreferences( state ),


### PR DESCRIPTION
#### Proposed Changes

This changes the checkout masterbar to use the currently selected site for its logic.

Previously this used the primary site as a fallback when the selected site was undefined but that makes the masterbar for siteless checkout (where an undefined site is expected) behave unpredictably.

Note: this changes the `isJetpackNotAtomic` prop for the whole masterbar component, but that prop is currently only used for the checkout masterbar so this change should be safe (and it's ambiguous anyway along with the other site-related props).

Before:

<img width="580" alt="jetpack-checkout-header" src="https://user-images.githubusercontent.com/2036909/201195103-f86d897e-8845-4545-af16-bacc5107a358.png">

After:

<img width="530" alt="wpcom-checkout-header" src="https://user-images.githubusercontent.com/2036909/201195117-2a7ec339-d47d-4391-bbbd-5336f395c2ec.png">


#### Testing Instructions

- Use an account which has a Jetpack site as the primary site.
- Add a gift purchase to your cart and visit checkout (eg: visit `/checkout/value_bundle/gift/1011844` when the API is sandboxed).
- Verify that you see the "calypso blue" ("WordPress.com") UI instead of the "calypso green" ("Jetpack") UI.

To protect against regressions:

- Visit a Jetpack site and add a product to your cart to visit checkout.
- Verify that you see the "calypso green" ("Jetpack") UI.
