### PR TITLE
Stats: Add All-time highlights section with mock data

### DIFF
--- a/client/my-sites/stats/all-time-highlights-section/index.tsx
+++ b/client/my-sites/stats/all-time-highlights-section/index.tsx
@@ -21,7 +21,21 @@ export default function AllTimeHighlightsSection() {
 	const translate = useTranslate();
 
 	const infoItems = [
-		{ id: 'views', icon: people, title: translate( 'Views' ), count: 47865778 },
+		{
+			id: 'views',
+			icon: (
+				<svg width="24" height="24" fill="none" xmlns="http://www.w3.org/2000/svg">
+					<path
+						fillRule="evenodd"
+						clipRule="evenodd"
+						d="m4 13 .67.336.003-.005a2.42 2.42 0 0 1 .094-.17c.071-.122.18-.302.329-.52.298-.435.749-1.017 1.359-1.598C7.673 9.883 9.498 8.75 12 8.75s4.326 1.132 5.545 2.293c.61.581 1.061 1.163 1.36 1.599a8.29 8.29 0 0 1 .422.689l.002.005L20 13l.67-.336v-.003l-.003-.005-.008-.015-.028-.052a9.752 9.752 0 0 0-.489-.794 11.6 11.6 0 0 0-1.562-1.838C17.174 8.617 14.998 7.25 12 7.25S6.827 8.618 5.42 9.957c-.702.669-1.22 1.337-1.563 1.839a9.77 9.77 0 0 0-.516.845l-.008.015-.002.005-.001.002v.001L4 13Zm8 3a3.5 3.5 0 1 0 0-7 3.5 3.5 0 0 0 0 7Z"
+						fill="#00101C"
+					/>
+				</svg>
+			),
+			title: translate( 'Views' ),
+			count: 47865778,
+		},
 		{ id: 'visitors', icon: people, title: translate( 'Visitors' ), count: 22787774 },
 		{ id: 'posts', icon: postContent, title: translate( 'Posts' ), count: 2582 },
 		{ id: 'likes', icon: starEmpty, title: translate( 'Likes' ), count: 13092212 },

--- a/client/my-sites/stats/all-time-highlights-section/index.tsx
+++ b/client/my-sites/stats/all-time-highlights-section/index.tsx
@@ -1,0 +1,121 @@
+import { Card } from '@automattic/components';
+import { Icon, people, postContent, starEmpty, commentContent } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
+
+import './style.scss';
+
+const FORMATTER = new Intl.NumberFormat( 'en-GB' );
+const COMPACT_FORMATTER = new Intl.NumberFormat( 'en-GB', {
+	notation: 'compact',
+	compactDisplay: 'short',
+	maximumFractionDigits: 1,
+} );
+
+function formatNumber( number: number | null, isCompact = false ) {
+	const formatter = isCompact ? COMPACT_FORMATTER : FORMATTER;
+
+	return Number.isFinite( number ) ? formatter.format( number as number ) : '-';
+}
+
+export default function AllTimeHighlightsSection() {
+	const translate = useTranslate();
+
+	const infoItems = [
+		{ id: 'views', icon: people, title: translate( 'Views' ), count: 47865778 },
+		{ id: 'visitors', icon: people, title: translate( 'Visitors' ), count: 22787774 },
+		{ id: 'posts', icon: postContent, title: translate( 'Posts' ), count: 2582 },
+		{ id: 'likes', icon: starEmpty, title: translate( 'Likes' ), count: 13092212 },
+		{ id: 'comments', icon: commentContent, title: translate( 'Comments' ), count: 45130 },
+	];
+
+	const mostPopularTimeItems = {
+		id: 'mostPopularTime',
+		heading: translate( 'Most popular time' ),
+		items: [
+			{
+				id: 'bestDay',
+				header: translate( 'Best day' ),
+				content: 'Thursday',
+				footer: translate( '%p% of views', { args: [ 25 ] } ),
+			},
+			{
+				id: 'bestHour',
+				header: translate( 'Best hour' ),
+				content: '2 PM',
+				footer: translate( '%p% of views', { args: [ 18 ] } ),
+			},
+		],
+	};
+
+	const bestViewsEverItems = {
+		id: 'bestViewsEver',
+		heading: translate( 'Best views ever' ),
+		items: [
+			{
+				id: 'day',
+				header: translate( 'Day' ),
+				content: 'June 23',
+				footer: 2022,
+			},
+			{
+				id: 'views',
+				header: translate( 'Views' ),
+				content: formatNumber( 32823, true ),
+				footer: translate( '%p% of views', { args: [ 25 ] } ),
+			},
+		],
+	};
+
+	return (
+		<div className="stats__all-time-highlights-section">
+			<div className="highlight-cards">
+				<h1 className="highlight-cards-heading">{ translate( 'All-time highlights' ) }</h1>
+
+				<div className="highlight-cards-list">
+					<Card className="highlight-card">
+						<div className="highlight-card-heading">{ translate( 'All-time stats' ) }</div>
+						<div className="highlight-card-info-item-list">
+							{ infoItems.map( ( info ) => {
+								return (
+									<div key={ info.id } className="highlight-card-info-item">
+										<Icon icon={ info.icon } />
+
+										<span className="highlight-card-info-item-title">{ info.title }</span>
+
+										<span
+											className="highlight-card-info-item-count"
+											title={ Number.isFinite( info.count ) ? String( info.count ) : undefined }
+										>
+											{ formatNumber( info.count ) }
+										</span>
+									</div>
+								);
+							} ) }
+						</div>
+					</Card>
+
+					{ [ mostPopularTimeItems, bestViewsEverItems ].map( ( card ) => {
+						return (
+							<Card key={ card.id } className="highlight-card">
+								<div className="highlight-card-heading">{ card.heading }</div>
+								<div className="highlight-card-detail-item-list">
+									{ card.items.map( ( item ) => {
+										return (
+											<div key={ item.id } className="highlight-card-detail-item">
+												<div className="highlight-card-detail-item-header">{ item.header }</div>
+
+												<div className="highlight-card-detail-item-content">{ item.content }</div>
+
+												<div className="highlight-card-detail-item-footer">{ item.footer }</div>
+											</div>
+										);
+									} ) }
+								</div>
+							</Card>
+						);
+					} ) }
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/client/my-sites/stats/all-time-highlights-section/style.scss
+++ b/client/my-sites/stats/all-time-highlights-section/style.scss
@@ -1,0 +1,80 @@
+$header-font: Recoleta, sans-serif;
+
+.stats__all-time-highlights-section {
+	margin: 32px 0;
+}
+
+.highlight-cards-list .highlight-card {
+	padding: 24px;
+}
+
+.highlight-card-heading {
+	font-family: inherit;
+	font-weight: 500;
+	font-size: $font-title-small;
+	line-height: 26px;
+	color: var(--color-neutral-100);
+	margin-bottom: 24px;
+}
+
+.highlight-card-info-item-list,
+.highlight-card-detail-item-list {
+	display: flex;
+	flex-direction: column;
+}
+
+.highlight-card-info-item {
+	flex: 1;
+	display: flex;
+	align-items: center;
+
+	&:not(:first-child) {
+		margin-top: 22px;
+	}
+}
+
+.highlight-card-info-item-title {
+	font-weight: 500;
+	font-size: $font-body-small;
+	line-height: 20px;
+	color: var(--color-neutral-100);
+	margin-left: 8px;
+}
+
+.highlight-card-info-item-count {
+	font-weight: 500;
+	font-size: $font-body;
+	line-height: 24px;
+	color: var(--studio-black);
+	margin-left: auto;
+}
+
+.highlight-card-detail-item {
+	&:not(:first-child) {
+		margin-top: 24px;
+	}
+}
+
+.highlight-card-detail-item-header {
+	font-weight: 500;
+	font-size: $font-body-small;
+	line-height: 20px;
+	color: var(--color-neutral-100);
+	margin-bottom: 8px;
+}
+
+.highlight-card-detail-item-content {
+	font-family: $header-font;
+	font-weight: 400;
+	font-size: $font-title-large;
+	line-height: 40px;
+	color: var(--color-neutral-100);
+}
+
+.highlight-card-detail-item-footer {
+	font-weight: 400;
+	font-size: $font-body-small;
+	line-height: 20px;
+	color: var(--color-neutral-60);
+	margin-top: 4px;
+}

--- a/client/my-sites/stats/stats-insights/index.jsx
+++ b/client/my-sites/stats/stats-insights/index.jsx
@@ -16,6 +16,7 @@ import AllTime from 'calypso/my-sites/stats/all-time/';
 import AnnualSiteStats from 'calypso/my-sites/stats/annual-site-stats';
 import MostPopular from 'calypso/my-sites/stats/most-popular';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import AllTimelHighlightsSection from '../all-time-highlights-section';
 import AnnualHighlightsSection from '../annual-highlights-section';
 import LatestPostSummary from '../post-performance';
 import PostingActivity from '../post-trends';
@@ -32,6 +33,7 @@ const StatsInsights = ( props ) => {
 	const moduleStrings = statsStrings();
 
 	const showNewAnnualHighlights = config.isEnabled( 'stats/new-annual-highlights' );
+	const showAllTimeHighlights = config.isEnabled( 'stats/new-all-time-highlights' );
 
 	const isNewMainChart = config.isEnabled( 'stats/new-main-chart' );
 
@@ -56,6 +58,7 @@ const StatsInsights = ( props ) => {
 			<div>
 				<div className="stats__module--insights-unified">
 					{ showNewAnnualHighlights && <AnnualHighlightsSection siteId={ siteId } /> }
+					{ showAllTimeHighlights && <AllTimelHighlightsSection /> }
 					<PostingActivity />
 					<SectionHeader label={ translate( 'All-time views' ) } />
 					<StatsViews />

--- a/client/my-sites/stats/stats-period-header/style.scss
+++ b/client/my-sites/stats/stats-period-header/style.scss
@@ -5,6 +5,10 @@
 	background-color: var(--color-surface);
 	margin: 48px 0 16px;
 
+	.period {
+		font-family: Recoleta, sans-serif;
+	}
+
 	.stats-period-navigation {
 		flex: 1;
 	}

--- a/config/client.json
+++ b/config/client.json
@@ -25,6 +25,7 @@
 	"readerFollowingSource",
 	"siftscience_key",
 	"signup_url",
+	"stats/new-all-time-highlights",
 	"stats/new-annual-highlights",
 	"stats/new-main-chart",
 	"stats/new-stats-module-component",

--- a/config/development.json
+++ b/config/development.json
@@ -158,6 +158,7 @@
 		"site-indicator": true,
 		"ssr/prefetch-timebox": false,
 		"stats/fixed-nav-headers": true,
+		"stats/new-all-time-highlights": true,
 		"stats/new-annual-highlights": true,
 		"stats/new-main-chart": true,
 		"stats/new-stats-module-component": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -107,6 +107,7 @@
 		"stats/new-main-chart": false,
 		"stats/new-stats-module-component": false,
 		"stats/show-traffic-highlights": false,
+		"stats/new-all-time-highlights": false,
 		"stats/new-annual-highlights": false,
 		"stepper-woocommerce-poc": true,
 		"subscriber-csv-upload": true,

--- a/config/production.json
+++ b/config/production.json
@@ -124,6 +124,7 @@
 		"ssr/prefetch-timebox": true,
 		"ssr/sample-log-cache-misses": true,
 		"stats/fixed-nav-headers": false,
+		"stats/new-all-time-highlights": false,
 		"stats/new-annual-highlights": false,
 		"stats/new-main-chart": false,
 		"stats/new-stats-module-component": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -120,6 +120,7 @@
 		"site-indicator": true,
 		"ssr/prefetch-timebox": true,
 		"stats/fixed-nav-headers": false,
+		"stats/new-all-time-highlights": false,
 		"stats/new-annual-highlights": false,
 		"stats/new-main-chart": false,
 		"stats/new-stats-module-component": false,

--- a/config/test.json
+++ b/config/test.json
@@ -89,6 +89,7 @@
 		"site-indicator": true,
 		"ssr/prefetch-timebox": true,
 		"stats/fixed-nav-headers": false,
+		"stats/new-all-time-highlights": false,
 		"stats/new-annual-highlights": false,
 		"stats/new-main-chart": false,
 		"stats/new-stats-module-component": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -128,6 +128,7 @@
 		"site-indicator": true,
 		"ssr/prefetch-timebox": true,
 		"stats/fixed-nav-headers": false,
+		"stats/new-all-time-highlights": false,
 		"stats/new-annual-highlights": false,
 		"stats/new-main-chart": false,
 		"stats/new-stats-module-component": false,


### PR DESCRIPTION
#### Proposed Changes

* Introduce the feature flag `stats/new-all-time-highlights` for all-time highlights.
* Add the `AllTimelHighlightsSection` component behind the feature flag.
* Adjust the `font-family` of StatsPeriodHeader.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Launch the _local_ development application or append `?flags=stats/new-all-time-highlights` on URL of the Calypso Live link.
* Navigate to page `/stats/insights/${your-site}`.
* Ensure the All-time highlights are in line with the design.

<img width="1104" alt="截圖 2022-11-11 上午4 10 09" src="https://user-images.githubusercontent.com/6869813/201196323-2023c9c7-9a2a-4406-bf09-d6043ba51f0e.png">

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #69229 
