### PR TITLE
Jetpack Cloud: Remove 'save up to X%' banner from pricing page

### DIFF
--- a/client/components/jetpack/intro-pricing-banner/index.tsx
+++ b/client/components/jetpack/intro-pricing-banner/index.tsx
@@ -16,7 +16,6 @@ import getIsRequestingIntroOffers from 'calypso/state/selectors/get-is-requestin
 import './style.scss';
 import guaranteeBadge from './14-day-badge.svg';
 import people from './people.svg';
-import rocket from './rocket.svg';
 
 interface Props {
 	productSlugs: string[];
@@ -67,18 +66,6 @@ const IntroPricingBanner: FunctionComponent< Props > = ( { productSlugs, siteId 
 			<div className={ `intro-pricing-banner ${ classModifier }` }>
 				{ ( discountPercentage > 0 || isLoading ) && (
 					<div className="intro-pricing-banner__content">
-						<div className="intro-pricing-banner__item">
-							<img className="intro-pricing-banner__item-icon" src={ rocket } alt="" />
-							<span className="intro-pricing-banner__item-label">
-								{ preventWidows(
-									translate( 'Get up to %(percent)d%% off your first year.', {
-										args: {
-											percent: discountPercentage,
-										},
-									} )
-								) }
-							</span>
-						</div>
 						<div className="intro-pricing-banner__item">
 							<img className="intro-pricing-banner__item-icon" src={ guaranteeBadge } alt="" />
 							<span className="intro-pricing-banner__item-label">


### PR DESCRIPTION
**WARNING:** DO NOT MERGE THIS PR UNTIL PRICING CHANGES ARE COMPLETE; SEE `p1HpG7-iuy-p2#comment-58439` OR CONSULT @Automattic/jetpack-origin.

#### Proposed Changes

* Remove the "Get up to X% off your first year" banner from the Jetpack.com pricing page.

Related to `p1HpG7-iuy-p2#comment-58439`.

#### Testing Instructions

* Visit the pricing page for Jetpack products, in both Calypso Blue and Calypso Green.
* Verify you no longer see the aforementioned banner (see screenshots).
* All other site behavior should be identical to what exists in production.

##### Before / after
<img width="350" alt="image" src="https://user-images.githubusercontent.com/670067/201200379-858cb6c9-f40f-4195-87da-0fcd132ccccf.png"> <img width="350" alt="image" src="https://user-images.githubusercontent.com/670067/201200317-40a070d5-14d6-4de6-9ef6-5c423fa8e2a8.png">

<img width="350" alt="image" src="https://user-images.githubusercontent.com/670067/201200598-273700ea-7d3b-49b5-9070-526ebf09fa13.png"> <img width="350" alt="image" src="https://user-images.githubusercontent.com/670067/201200537-681b38a6-d0c1-4674-888a-587f51cf156f.png">


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] ~~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~~
- [ ] ~~Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?~~
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~~
- [ ] ~~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~~
- [ ] ~~For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~~
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->