### PR TITLE
Show gifting toggle on has subscription-gifting feature & set defaut to false

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -1,9 +1,6 @@
 import { isEnabled } from '@automattic/calypso-config';
-import {
-	isDotComPlan,
-	PLAN_BUSINESS,
-	WPCOM_FEATURES_NO_WPCOM_BRANDING,
-} from '@automattic/calypso-products';
+import { PLAN_BUSINESS, WPCOM_FEATURES_NO_WPCOM_BRANDING } from '@automattic/calypso-products';
+import { WPCOM_FEATURES_SUBSCRIPTION_GIFTING } from '@automattic/calypso-products/src';
 import { Card, CompactCard, Button, Gridicon } from '@automattic/components';
 import { guessTimezone } from '@automattic/i18n-utils';
 import languages from '@automattic/languages';
@@ -40,7 +37,6 @@ import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 import { usePremiumGlobalStyles } from 'calypso/state/sites/hooks/use-premium-global-styles';
 import { launchSite } from 'calypso/state/sites/launch/actions';
-import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
 import {
 	getSiteOption,
 	isJetpackSite,
@@ -635,14 +631,14 @@ export class SiteSettingsFormGeneral extends Component {
 			isRequestingSettings,
 			isSavingSettings,
 			handleSubmitForm,
-			currentPlan,
+			hasSubscriptionGifting,
 		} = this.props;
 
 		if ( ! isEnabled( 'subscription-gifting' ) ) {
 			return;
 		}
 
-		if ( currentPlan && isDotComPlan( currentPlan ) && ! currentPlan?.autoRenew ) {
+		if ( hasSubscriptionGifting ) {
 			return (
 				<>
 					<div className="site-settings__gifting-container">
@@ -818,7 +814,7 @@ const connectComponent = connect( ( state ) => {
 		siteDomains: getDomainsBySiteId( state, siteId ),
 		siteIsJetpack: isJetpackSite( state, siteId ),
 		siteSlug: getSelectedSiteSlug( state ),
-		currentPlan: getCurrentPlan( state, siteId ),
+		hasSubscriptionGifting: siteHasFeature( state, siteId, WPCOM_FEATURES_SUBSCRIPTION_GIFTING ),
 	};
 }, mapDispatchToProps );
 
@@ -831,7 +827,7 @@ const getFormSettings = ( settings ) => {
 		blog_public: '',
 		wpcom_coming_soon: '',
 		wpcom_public_coming_soon: '',
-		wpcom_gifting_subscription: true,
+		wpcom_gifting_subscription: false,
 		admin_url: '',
 	};
 

--- a/packages/calypso-products/src/constants/features.ts
+++ b/packages/calypso-products/src/constants/features.ts
@@ -249,6 +249,7 @@ export const WPCOM_FEATURES_PRIORITY_SUPPORT = 'priority_support';
 export const WPCOM_FEATURES_REAL_TIME_BACKUPS = 'real-time-backups';
 export const WPCOM_FEATURES_SCAN = 'scan';
 export const WPCOM_FEATURES_SEO_PREVIEW_TOOLS = 'seo-preview-tools';
+export const WPCOM_FEATURES_SUBSCRIPTION_GIFTING = 'subscription-gifting';
 export const WPCOM_FEATURES_UPLOAD_AUDIO_FILES = 'upload-audio-files';
 export const WPCOM_FEATURES_UPLOAD_PLUGINS = 'upload-plugins';
 export const WPCOM_FEATURES_UPLOAD_VIDEO_FILES = 'upload-video-files';


### PR DESCRIPTION
In D92119-code we introduce a feature called 'subscription-gifting'. If a site has this feature we show the "Accept a gift subscription" settings panel in Settings -> General

![accept-gift-setting](https://user-images.githubusercontent.com/140841/201208303-60fc4ff0-173b-4d05-b6c0-506d4c835f8b.png)

This PR also sets the default value of that toggle to false.

#### Proposed Changes

* Use 'subscription-gifting' feature to determin if we should show the "Accept a gift subscription" settings panel in Settings -> General
* Set the default value of the "Accept a gift subscription" toggle to false.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Load this diff in your sandbox D92119-code
* Sandbox the API
* Checkout this PR branch
* Using a test site with a Personal plan or higher, go to: http://calypso.localhost:3000/settings/general/YOURTESTSITE.wpcomstaging.com?flags=subscription-gifting (Note the feature flag) You should see the "Accept a gift subscription" panel (pictured above).
* Using a Jetpack site, and a free site, go to the same page (be sure to include the feature flag). You should NOT see the "Accept a gift subscription" panel (pictured above).

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #