### PR TITLE
Checkout: Replace feature list with gift text for gift purchases

### DIFF
--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -316,6 +316,10 @@ export interface ResponseCart< P = ResponseCartProduct > {
 	 * Gift Details
 	 */
 	gift_details?: ResponseCartGiftDetails;
+
+	/**
+	 * True if the cart contains a purchase for a different user's site.
+	 */
 	is_gift_purchase?: boolean;
 
 	currency: string;


### PR DESCRIPTION
#### Proposed Changes

This replaces the checkout summary text (the sidebar at desktop widths), which is normally a list of features, with a block of text specific to gift purchases. This is because the normal feature list doesn't always make sense for a gift; it frequently mentions "your purchase" and "your support" but a gift purchaser won't have access to any of that.

The updated text now reads `You are showing your appreciation for %(siteSlug)s by gifting them their next subscription.`

Suggestions for different text are welcome!

Before:

<img width="922" alt="Screen Shot 2022-11-10 at 5 15 15 PM" src="https://user-images.githubusercontent.com/2036909/201217393-a941e1b7-831c-4b10-9a9d-99de08414179.png">

After:

<img width="926" alt="Screen Shot 2022-11-10 at 5 11 49 PM" src="https://user-images.githubusercontent.com/2036909/201217419-34fffcfb-3060-46fe-bc5d-ad617137b634.png">

Fixes https://github.com/Automattic/payments-shilling/issues/1221

#### Testing Instructions

- Add a gift to your cart (eg: `/checkout/value_bundle/gift/1011844`) and visit checkout.
- Verify that you see the modified sidebar text.