### PR TITLE
Stats: Limiting new layout to Traffic page

### DIFF
--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -188,6 +188,8 @@ class StatsSite extends Component {
 
 		const query = memoizedQuery( period, endOf );
 
+		const showNewModules = config.isEnabled( 'stats/new-stats-module-component' );
+
 		// File downloads are not yet supported in Jetpack Stats
 		if ( ! isJetpack ) {
 			fileDownloadList = (
@@ -199,6 +201,7 @@ class StatsSite extends Component {
 					statType="statsFileDownloads"
 					showSummaryLink
 					useShortLabel={ true }
+					showNewModules={ showNewModules }
 				/>
 			);
 		}
@@ -331,6 +334,7 @@ class StatsSite extends Component {
 								query={ query }
 								statType="statsTopPosts"
 								showSummaryLink
+								showNewModules={ showNewModules }
 							/>
 							<StatsModule
 								path="searchterms"
@@ -339,6 +343,7 @@ class StatsSite extends Component {
 								query={ query }
 								statType="statsSearchTerms"
 								showSummaryLink
+								showNewModules={ showNewModules }
 							/>
 							{ fileDownloadList }
 						</div>
@@ -348,6 +353,7 @@ class StatsSite extends Component {
 								period={ this.props.period }
 								query={ query }
 								summary={ false }
+								showNewModules={ showNewModules }
 							/>
 							<StatsModule
 								path="clicks"
@@ -356,6 +362,7 @@ class StatsSite extends Component {
 								query={ query }
 								statType="statsClicks"
 								showSummaryLink
+								showNewModules={ showNewModules }
 							/>
 						</div>
 						<div className="stats__module-column">
@@ -366,6 +373,7 @@ class StatsSite extends Component {
 								query={ query }
 								statType="statsReferrers"
 								showSummaryLink
+								showNewModules={ showNewModules }
 							/>
 							<StatsModule
 								path="authors"
@@ -375,6 +383,7 @@ class StatsSite extends Component {
 								statType="statsTopAuthors"
 								className="stats__author-views"
 								showSummaryLink
+								showNewModules={ showNewModules }
 							/>
 							<StatsModule
 								path="videoplays"
@@ -383,6 +392,7 @@ class StatsSite extends Component {
 								query={ query }
 								statType="statsVideoPlays"
 								showSummaryLink
+								showNewModules={ showNewModules }
 							/>
 						</div>
 					</div>

--- a/client/my-sites/stats/stats-module/index.jsx
+++ b/client/my-sites/stats/stats-module/index.jsx
@@ -128,6 +128,7 @@ class StatsModule extends Component {
 			period,
 			translate,
 			useShortLabel,
+			showNewModules,
 		} = this.props;
 
 		const noData = data && this.state.loaded && ! data.length;
@@ -155,7 +156,8 @@ class StatsModule extends Component {
 			'is-refreshing': requesting && ! isLoading,
 		} );
 
-		const shouldShowNewModule = isEnabled( 'stats/new-stats-module-component' ) && ! summary;
+		const shouldShowNewModule =
+			showNewModules && isEnabled( 'stats/new-stats-module-component' ) && ! summary;
 
 		return (
 			<>


### PR DESCRIPTION
#### Proposed Changes

* limiting new layout add in #69915 to Stats' `Traffic` page

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to the main Stats page either on a local instance or the test URL from the comment below
* append `?flags=stats/new-stats-module-component` to the URL
* navigate to the `Insights` page and make sure the page loads without errors
* make sure that the `Insights` page doesn't have any components with horizontal bars

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
