### PR TITLE
Checkout: Hide contact validation errors during auto-completion

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/wp-contact-form.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-contact-form.tsx
@@ -1,7 +1,6 @@
 import { FormStatus, useFormStatus, useIsStepActive } from '@automattic/composite-checkout';
 import styled from '@emotion/styled';
 import { useSelect } from '@wordpress/data';
-import useCachedDomainContactDetails from '../hooks/use-cached-domain-contact-details';
 import ContactDetailsContainer from './contact-details-container';
 import type {
 	CountryListItem,
@@ -42,8 +41,6 @@ export default function WPContactForm( {
 	const { formStatus } = useFormStatus();
 	const isStepActive = useIsStepActive();
 	const isDisabled = ! isStepActive || formStatus !== FormStatus.READY;
-
-	useCachedDomainContactDetails( countriesList );
 
 	return (
 		<BillingFormFields>

--- a/client/my-sites/checkout/composite-checkout/hooks/use-cached-domain-contact-details.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-cached-domain-contact-details.ts
@@ -2,7 +2,7 @@ import { useSetStepComplete } from '@automattic/composite-checkout';
 import { getCountryPostalCodeSupport } from '@automattic/wpcom-checkout';
 import { useDispatch } from '@wordpress/data';
 import debugFactory from 'debug';
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useSelector, useDispatch as useReduxDispatch } from 'react-redux';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { requestContactDetailsCache } from 'calypso/state/domains/management/actions';
@@ -15,17 +15,24 @@ import type {
 
 const debug = debugFactory( 'calypso:composite-checkout:use-cached-domain-contact-details' );
 
-function useCachedContactDetails(): PossiblyCompleteDomainContactDetails | null {
+function useCachedContactDetails( {
+	shouldWait,
+}: {
+	shouldWait?: boolean;
+} ): PossiblyCompleteDomainContactDetails | null {
 	const reduxDispatch = useReduxDispatch();
 	const haveRequestedCachedDetails = useRef< 'not-started' | 'pending' | 'done' >( 'not-started' );
 	const cachedContactDetails = useSelector( getContactDetailsCache );
 	useEffect( () => {
+		if ( shouldWait ) {
+			return;
+		}
 		if ( haveRequestedCachedDetails.current === 'not-started' ) {
 			debug( 'requesting cached domain contact details' );
 			reduxDispatch( requestContactDetailsCache() );
 			haveRequestedCachedDetails.current = 'pending';
 		}
-	}, [ reduxDispatch ] );
+	}, [ reduxDispatch, shouldWait ] );
 	if ( haveRequestedCachedDetails.current === 'pending' && cachedContactDetails ) {
 		debug( 'cached domain contact details retrieved', cachedContactDetails );
 		haveRequestedCachedDetails.current = 'done';
@@ -33,14 +40,22 @@ function useCachedContactDetails(): PossiblyCompleteDomainContactDetails | null 
 	return cachedContactDetails;
 }
 
+/**
+ * Automatically attempt to populate the checkout contact form and complete the
+ * contact step (running validation as normal).
+ *
+ * Must be run inside a CheckoutStepGroup in order to have the ability to
+ * complete steps.
+ */
 function useCachedContactDetailsForCheckoutForm(
 	cachedContactDetails: PossiblyCompleteDomainContactDetails | null,
 	overrideCountryList?: CountryListItem[]
-): void {
+): { isComplete: boolean } {
 	const countriesList = useCountryList( overrideCountryList );
 	const reduxDispatch = useReduxDispatch();
 	const setStepCompleteStatus = useSetStepComplete();
 	const didFillForm = useRef( false );
+	const [ isComplete, setComplete ] = useState( false );
 
 	const arePostalCodesSupported =
 		countriesList.length && cachedContactDetails?.countryCode
@@ -92,6 +107,7 @@ function useCachedContactDetailsForCheckoutForm(
 				if ( didSkip ) {
 					reduxDispatch( recordTracksEvent( 'calypso_checkout_skip_to_last_step' ) );
 				}
+				setComplete( true );
 			} );
 	}, [
 		reduxDispatch,
@@ -101,15 +117,21 @@ function useCachedContactDetailsForCheckoutForm(
 		loadDomainContactDetailsFromCache,
 		countriesList,
 	] );
+
+	return { isComplete };
 }
 
 /**
  * Load cached contact details from the server and use them to populate the
  * checkout contact form and the shopping cart tax location.
  */
-export default function useCachedDomainContactDetails(
-	overrideCountryList?: CountryListItem[]
-): void {
-	const cachedContactDetails = useCachedContactDetails();
-	useCachedContactDetailsForCheckoutForm( cachedContactDetails, overrideCountryList );
+export default function useCachedDomainContactDetails( {
+	overrideCountryList,
+	shouldWait,
+}: {
+	overrideCountryList?: CountryListItem[];
+	shouldWait?: boolean;
+} ) {
+	const cachedContactDetails = useCachedContactDetails( { shouldWait } );
+	return useCachedContactDetailsForCheckoutForm( cachedContactDetails, overrideCountryList );
 }

--- a/client/my-sites/checkout/composite-checkout/test/checkout-contact-step.js
+++ b/client/my-sites/checkout/composite-checkout/test/checkout-contact-step.js
@@ -390,9 +390,14 @@ describe( 'Checkout contact step', () => {
 				screen.getByLabelText( /(Postal|ZIP) code/i ),
 				validContactDetails.postal_code
 			);
-			await user.click( await screen.findByText( 'Continue' ) );
 
-			// Wait for the validation to complete
+			// Do not await this click because we need to capture the 'Please wait'
+			// text that may only be visible very briefly. findByText('Please wait')
+			// will wait for it to appear.
+			user.click( await screen.findByText( 'Continue' ) );
+
+			// Wait for the validation to complete.
+			await screen.findAllByText( 'Please wait…' );
 			await waitForElementToBeRemoved( () => screen.queryAllByText( 'Please wait…' ) );
 
 			if ( complete === 'does' ) {

--- a/client/my-sites/checkout/composite-checkout/test/checkout-contact-step.js
+++ b/client/my-sites/checkout/composite-checkout/test/checkout-contact-step.js
@@ -255,7 +255,10 @@ describe( 'Checkout contact step', () => {
 		// Wait for the cart to load
 		await screen.findByText( 'Country' );
 
-		// Wait for the validation to complete, then check we've advanced to the next payment step
+		// Wait for the validation to complete.
+		await screen.findAllByText( 'Please wait…' );
+		await waitForElementToBeRemoved( () => screen.queryAllByText( 'Please wait…' ) );
+
 		expect( await screen.findByTestId( 'payment-method-step--visible' ) ).toBeInTheDocument();
 	} );
 

--- a/client/my-sites/checkout/composite-checkout/test/checkout-contact-step.js
+++ b/client/my-sites/checkout/composite-checkout/test/checkout-contact-step.js
@@ -255,11 +255,7 @@ describe( 'Checkout contact step', () => {
 		expect( screen.queryByTestId( 'payment-method-step--visible' ) ).not.toBeInTheDocument();
 	} );
 
-	/**
-	 * TODO: Restore these tests, which were failing for some reason on #64718
-	 */
-	/* eslint-disable jest/no-disabled-tests */
-	it.skip( 'autocompletes the contact step when there are valid cached details', async () => {
+	it( 'autocompletes the contact step when there are valid cached details', async () => {
 		mockCachedContactDetailsEndpoint( {
 			country_code: 'US',
 			postal_code: '10001',
@@ -269,12 +265,12 @@ describe( 'Checkout contact step', () => {
 		render( <MyCheckout cartChanges={ cartChanges } />, container );
 		// Wait for the cart to load
 		await screen.findByText( 'Country' );
-		// Wait for the validation to complete
-		await waitForElementToBeRemoved( () => screen.queryAllByText( 'Please wait…' ) );
-		expect( screen.queryByTestId( 'payment-method-step--visible' ) ).toBeInTheDocument();
+
+		// Wait for the validation to complete, then check we've advanced to the next payment step
+		expect( await screen.findByTestId( 'payment-method-step--visible' ) ).toBeInTheDocument();
 	} );
 
-	it.skip( 'does not autocomplete the contact step when there are invalid cached details', async () => {
+	it( 'does not autocomplete the contact step when there are invalid cached details', async () => {
 		mockCachedContactDetailsEndpoint( {
 			country_code: 'US',
 			postal_code: 'ABCD',
@@ -284,8 +280,6 @@ describe( 'Checkout contact step', () => {
 		render( <MyCheckout cartChanges={ cartChanges } />, container );
 		// Wait for the cart to load
 		await screen.findByText( 'Country' );
-		// Wait for the validation to complete
-		await waitForElementToBeRemoved( () => screen.queryAllByText( 'Please wait…' ) );
 		await expect( screen.findByTestId( 'payment-method-step--visible' ) ).toNeverAppear();
 	} );
 

--- a/client/my-sites/checkout/composite-checkout/test/checkout-contact-step.js
+++ b/client/my-sites/checkout/composite-checkout/test/checkout-contact-step.js
@@ -321,6 +321,10 @@ describe( 'Checkout contact step', () => {
 				};
 			} )();
 
+			mockCachedContactDetailsEndpoint( {
+				country_code: '',
+				postal_code: '',
+			} );
 			mockContactDetailsValidationEndpoint(
 				name === 'plan' ? 'tax' : name,
 				{

--- a/client/my-sites/checkout/composite-checkout/test/checkout-contact-step.js
+++ b/client/my-sites/checkout/composite-checkout/test/checkout-contact-step.js
@@ -272,6 +272,22 @@ describe( 'Checkout contact step', () => {
 		await expect( screen.findByTestId( 'payment-method-step--visible' ) ).toNeverAppear();
 	} );
 
+	it( 'does not show errors when autocompleting the contact step when there are invalid cached details', async () => {
+		mockCachedContactDetailsEndpoint( {
+			country_code: 'US',
+			postal_code: 'ABCD',
+		} );
+		mockContactDetailsValidationEndpoint( 'tax', {
+			success: false,
+			messages: { postal_code: [ 'Postal code error message' ] },
+		} );
+		const cartChanges = { products: [ planWithoutDomain ] };
+		render( <MyCheckout cartChanges={ cartChanges } />, container );
+		// Wait for the cart to load
+		await screen.findByText( 'Country' );
+		await expect( screen.findByText( 'Postal code error message' ) ).toNeverAppear();
+	} );
+
 	it.each( [
 		{ complete: 'does', valid: 'valid', name: 'plan', email: 'fails', logged: 'in' },
 		{ complete: 'does not', valid: 'invalid', name: 'plan', email: 'fails', logged: 'in' },

--- a/client/my-sites/checkout/composite-checkout/test/use-cached-domain-contact-details.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/use-cached-domain-contact-details.tsx
@@ -63,7 +63,7 @@ function MyTestContent( { countries }: { countries: CountryListItem[] } ) {
 	const { responseCart, reloadFromServer, updateLocation } = useShoppingCart(
 		initialCart.cart_key
 	);
-	useCachedDomainContactDetails( countries );
+	useCachedDomainContactDetails( { overrideCountryList: countries } );
 	const contactInfo: ManagedContactDetails = useSelect( ( select ) =>
 		select( 'wpcom-checkout' ).getContactInfo()
 	);

--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -153,7 +153,9 @@ Renders a list of the line items and their `displayValue` properties followed by
 
 ### CheckoutStep
 
-A checkout step. This should be a direct child of [CheckoutSteps](#CheckoutSteps) and is itself a wrapper for [CheckoutStepBody](#CheckoutStepBody). If you want to make something that looks like a step but is not connected to other steps, use a [CheckoutStepBody](#CheckoutStepBody) instead.
+A checkout step. This should be a **direct** child of [CheckoutSteps](#CheckoutSteps) and is itself a wrapper for [CheckoutStepBody](#CheckoutStepBody). If you want to make something that looks like a step but is not connected to other steps, use a [CheckoutStepBody](#CheckoutStepBody) instead.
+
+If you want to create a wrapper around a step, you must set the `isCheckoutStep` property of your wrapper component to identify it as a checkout step; otherwise it will be rendered without any step context and things will probably not work. Example: `function MyWrapper() { return <CheckoutStep /> }; MyWrapper.isCheckoutStep = true;`
 
 This component's props are:
 


### PR DESCRIPTION
#### Proposed Changes

When checkout loads, it fetches saved contact details from an API endpoint, pre-fills the contact form with those details, and attempts to auto-complete the contact details step. Since https://github.com/Automattic/wp-calypso/pull/64344, this process uses the same logic as if a user filled out the form and clicked "Continue" manually. However, there is a downside: the contact details will be validated by another API endpoint, and if they are invalid the user will see an error reported as soon as checkout loads. Since the user didn't actually take any action at this point, this UX can be confusing.

In this PR, we refactor the placement of the auto-completion code so that its validation call will not report any errors on failure.

Fixes https://github.com/Automattic/wp-calypso/issues/69211

Before this change, you might see a validation error like this when checkout first loads:

<img width="977" alt="validation-error" src="https://user-images.githubusercontent.com/2036909/201235660-6c218f93-0ae4-418d-bb69-29e953fe404f.png">


#### Testing Instructions

> **Note**
> Reviewing the code of this PR is probably easiest by reviewing each commit separately. The changes move large blocks of code around and can be hard to understand when viewed all at once.

There are unit tests for this behavior but you can test it manually as follows:

First test that successful validation still works:

- Make sure you have valid cached _domain_ contact details for a user (using a domain product will cause more fields to be visible). You can do this by visiting checkout when a domain product is in your cart, filling out the contact information step and pressing "Continue". Assuming they are valid, they will be saved for future visits to checkout.
- Add a _domain_ product to your cart and visit checkout (or reload if you are already there).
- Verify that you see the contact information step load before it is auto-completed.
- Verify that the active step is now the payment method step.

Next test that manual validation displays error messages:

- Add a _domain_ product to your cart and visit checkout.
- Click to edit the contact information step if it is not already active.
- Enter invalid contact information (eg: by clearing the "Last name" field).
- Press "Continue".
- Verify that you see a validation error.
- Verify that the active step is still the contact information step.

Finally, test that auto-completion does not display error messages:

- Apply D92139-code and sandbox the API. This will break the domain contact details validation endpoint.
- Add a _domain_ product to your cart and visit checkout.
- Verify that you see the contact information step load before it is auto-completed.
- Verify that you _do not see_ a validation error.
- Verify that the active step is still the contact information step.
