### PR TITLE
Stats: Restoring new layout for Countries component

### DIFF
--- a/client/my-sites/stats/stats-countries/index.jsx
+++ b/client/my-sites/stats/stats-countries/index.jsx
@@ -16,7 +16,7 @@ class StatCountries extends Component {
 	};
 
 	render() {
-		const { summary, query, period } = this.props;
+		const { summary, query, period, showNewModules } = this.props;
 		const moduleStrings = statsStrings();
 
 		return (
@@ -28,6 +28,7 @@ class StatCountries extends Component {
 				summary={ summary }
 				moduleStrings={ moduleStrings.countries }
 				statType="statsCountryViews"
+				showNewModules={ showNewModules }
 			>
 				<Geochart query={ query } />
 			</StatsModule>


### PR DESCRIPTION
#### Proposed Changes

* Restoring new display for `Countries` and implementing feedback from #69942 

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to the main Stats page either on a local instance or the test URL from the comment below
* append `?flags=stats/new-stats-module-component` to the URL
* check that the list of countries in the `Countries` component displays with horizontal bars 
* navigate to the `Insights` page and make sure the page loads without errors
* make sure that the `Insights` page doesn't have any components with horizontal bars

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
