### PR TITLE
Partner Portal: include "and" when more than one license is assigned in notifications

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-add-license-notification/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-add-license-notification/index.tsx
@@ -54,14 +54,14 @@ export default function SiteAddLicenseNotification() {
 		} );
 		const conjunction =
 			licenses.length > 2
-				? translate( `%(commaCharacter)s and`, {
+				? translate( '%(commaCharacter)s and ', {
 						args: {
 							commaCharacter,
 							comment:
 								'The final separator of a delimited list, such as ", and" in "Backup, Scan, and Boost."',
 						},
 				  } )
-				: translate( ' and', {
+				: translate( ' and ', {
 						args: {
 							comment:
 								'The way that two words are separated, such as " and" in "Backup and Scan". Note that the space here is important due to the way the final string is constructed.',
@@ -86,7 +86,7 @@ export default function SiteAddLicenseNotification() {
 			// We are not using the same translate method for plural form since we have different arguments.
 			return licenses.length > 1
 				? translate(
-						'{{strong}}%(initialLicenseList)s%(conjunction)s %(lastLicenseItem)s{{/strong}} ' +
+						'{{strong}}%(initialLicenseList)s%(conjunction)s%(lastLicenseItem)s{{/strong}} ' +
 							'were succesfully assigned to {{em}}%(selectedSite)s{{/em}}. ' +
 							'Please allow a few minutes for your features to activate.',
 						{
@@ -109,7 +109,7 @@ export default function SiteAddLicenseNotification() {
 		// We are not using the same translate method for plural form since we have different arguments.
 		return licenses.length > 1
 			? translate(
-					'An error occurred and your {{strong}}%(initialLicenseList)s%(conjunction)s %(lastLicenseItem)s{{/strong}} ' +
+					'An error occurred and your {{strong}}%(initialLicenseList)s%(conjunction)s%(lastLicenseItem)s{{/strong}} ' +
 						"weren't assigned to {{em}}%(selectedSite)s{{/em}}.",
 					{
 						args: multipleLicensesArgs,

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-add-license-notification/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-add-license-notification/index.tsx
@@ -4,6 +4,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import Notice from 'calypso/components/notice';
 import { setPurchasedLicense } from 'calypso/state/jetpack-agency-dashboard/actions';
 import { getPurchasedLicense } from 'calypso/state/jetpack-agency-dashboard/selectors';
+import { ProductInfo } from '../types';
 
 import './style.scss';
 
@@ -39,9 +40,7 @@ export default function SiteAddLicenseNotification() {
 		dispatch( setPurchasedLicense( license.selectedProducts.length ? license : undefined ) );
 	};
 
-	function getMessageArgs(
-		licenses: Array< { name: string; key: string; status: 'rejected' | 'fulfilled' } >
-	) {
+	function getMessageArgs( licenses: Array< ProductInfo > ) {
 		const licenseNames = licenses.map( ( license ) => license.name );
 		const lastItem = licenseNames.slice( -1 )[ 0 ];
 		const remainingItems = licenseNames.slice( 0, -1 );

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-add-license-notification/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-add-license-notification/index.tsx
@@ -39,52 +39,60 @@ export default function SiteAddLicenseNotification() {
 		dispatch( setPurchasedLicense( license.selectedProducts.length ? license : undefined ) );
 	};
 
+	function getMessageArgs(
+		licenses: Array< { name: string; key: string; status: 'rejected' | 'fulfilled' } >
+	) {
+		const licenseNames = licenses.map( ( license ) => license.name );
+		const lastItem = licenseNames.slice( -1 )[ 0 ];
+		const remainingItems = licenseNames.slice( 0, -1 );
+		return {
+			args: {
+				lastItem: lastItem,
+				selectedSite,
+				remainingItems: remainingItems.join( ', ' ),
+			},
+			components: {
+				strong: <strong />,
+				em: <em />,
+			},
+		};
+	}
+
 	return (
 		<>
 			{ assignedLicenses.length > 0 && (
 				<div className="site-add-license-notification__license-banner">
 					<Notice onDismissClick={ () => clearLicenses( 'fulfilled' ) } status="is-success">
-						{ translate(
-							'{{strong}}%(assignedLicenses)s{{/strong}} was succesfully assigned to {{em}}%(selectedSite)s{{/em}}. Please allow a few minutes for your features to activate.',
-							'{{strong}}%(assignedLicenses)s{{/strong}} were succesfully assigned to {{em}}%(selectedSite)s{{/em}}. Please allow a few minutes for your features to activate.',
-
-							{
-								count: assignedLicenses.length,
-								args: {
-									assignedLicenses: assignedLicenses
-										.map( ( license ) => license.name )
-										.join( ', ' ),
-									selectedSite,
-								},
-								components: {
-									strong: <strong />,
-									em: <em />,
-								},
-							}
-						) }
+						{
+							// We are not using the same translate method for plural form since we have different arguments.
+							assignedLicenses.length > 1
+								? translate(
+										'{{strong}}%(remainingItems)s and %(lastItem)s{{/strong}} were succesfully assigned to {{em}}%(selectedSite)s{{/em}}. Please allow a few minutes for your features to activate.',
+										getMessageArgs( assignedLicenses )
+								  )
+								: translate(
+										'{{strong}}%(lastItem)s{{/strong}} was succesfully assigned to {{em}}%(selectedSite)s{{/em}}. Please allow a few minutes for your features to activate.',
+										getMessageArgs( assignedLicenses )
+								  )
+						}
 					</Notice>
 				</div>
 			) }
 			{ rejectedLicenses.length > 0 && (
 				<div className="site-add-license-notification__license-banner">
 					<Notice onDismissClick={ () => clearLicenses( 'rejected' ) } status="is-error">
-						{ translate(
-							`An error occurred and your {{strong}}%(rejectedLicenses)s{{/strong}} wasn't assigned to {{em}}%(selectedSite)s{{/em}}.`,
-							`An error occurred and your {{strong}}%(rejectedLicenses)s{{/strong}} weren't assigned to {{em}}%(selectedSite)s{{/em}}.`,
-							{
-								count: rejectedLicenses.length,
-								args: {
-									rejectedLicenses: rejectedLicenses
-										.map( ( license ) => license.name )
-										.join( ', ' ),
-									selectedSite,
-								},
-								components: {
-									strong: <strong />,
-									em: <em />,
-								},
-							}
-						) }
+						{
+							// We are not using the same translate method for plural form since we have different arguments.
+							rejectedLicenses.length > 1
+								? translate(
+										`An error occurred and your {{strong}}%(remainingItems)s and %(lastItem)s{{/strong}} weren't assigned to {{em}}%(selectedSite)s{{/em}}.`,
+										getMessageArgs( rejectedLicenses )
+								  )
+								: translate(
+										`An error occurred and your {{strong}}%(lastItem)s{{/strong}} wasn't assigned to {{em}}%(selectedSite)s{{/em}}.`,
+										getMessageArgs( rejectedLicenses )
+								  )
+						}
 					</Notice>
 				</div>
 			) }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-add-license-notification/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-add-license-notification/index.tsx
@@ -58,13 +58,13 @@ export default function SiteAddLicenseNotification() {
 						args: {
 							commaCharacter,
 							comment:
-								'The final separator of a delimited list, such as ", and" in "Backup, Scan, and Boost."',
+								'The final separator of a delimited list, such as ", and " in "Backup, Scan, and Boost." Note that the spaces here are important due to the way the final string is constructed.',
 						},
 				  } )
 				: translate( ' and ', {
 						args: {
 							comment:
-								'The way that two words are separated, such as " and" in "Backup and Scan". Note that the space here is important due to the way the final string is constructed.',
+								'The way that two words are separated, such as " and " in "Backup and Scan". Note that the spaces here are important due to the way the final string is constructed.',
 						},
 				  } );
 		const multipleLicensesArgs = {

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-add-license-notification/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-add-license-notification/index.tsx
@@ -58,7 +58,7 @@ export default function SiteAddLicenseNotification() {
 						args: {
 							commaCharacter,
 							comment:
-								'The final separator of a delimited list, such as ", and " in "Backup, Scan, and Boost." Note that the spaces here are important due to the way the final string is constructed.',
+								'The final separator of a delimited list, such as ", and " in "Backup, Scan, and Boost". Note that the spaces here are important due to the way the final string is constructed.',
 						},
 				  } )
 				: translate( ' and ', {

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-add-license-notification/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-add-license-notification/index.tsx
@@ -42,14 +42,30 @@ export default function SiteAddLicenseNotification() {
 
 	function getMessageArgs( licenses: Array< ProductInfo > ) {
 		const licenseNames = licenses.map( ( license ) => license.name );
-		const lastItem = licenseNames.slice( -1 )[ 0 ];
-		const remainingItems = licenseNames.slice( 0, -1 );
+		const initialLicenseList = licenseNames.slice( 0, -1 );
+		const lastLicenseItem = licenseNames.slice( -1 )[ 0 ];
+		const commaCharacter = translate( ',' );
+		const conjunction =
+			licenses.length > 2
+				? translate( `%(commaCharacter)s and`, { args: { commaCharacter } } )
+				: translate( ' and' );
 		return {
 			args: {
-				lastItem: lastItem,
 				selectedSite,
-				remainingItems: remainingItems.join( ', ' ),
+				...( licenses.length > 1
+					? {
+							initialLicenseList: initialLicenseList.join( `${ commaCharacter } ` ),
+							lastLicenseItem: lastLicenseItem,
+							conjunction,
+					  }
+					: { licenseItem: lastLicenseItem } ),
 			},
+			...( licenses.length > 1 && {
+				comment: `%(initialLicenseList)s is a list of n-1 license names
+						seperated by a translated comma character, %(lastLicenseItem)
+						is the nth license name, and %(conjunction) is a translated "and"
+						text with or without a serial comma based on the licenses count`,
+			} ),
 			components: {
 				strong: <strong />,
 				em: <em />,
@@ -66,11 +82,11 @@ export default function SiteAddLicenseNotification() {
 							// We are not using the same translate method for plural form since we have different arguments.
 							assignedLicenses.length > 1
 								? translate(
-										'{{strong}}%(remainingItems)s and %(lastItem)s{{/strong}} were succesfully assigned to {{em}}%(selectedSite)s{{/em}}. Please allow a few minutes for your features to activate.',
+										'{{strong}}%(initialLicenseList)s%(conjunction)s %(lastLicenseItem)s{{/strong}} were succesfully assigned to {{em}}%(selectedSite)s{{/em}}. Please allow a few minutes for your features to activate.',
 										getMessageArgs( assignedLicenses )
 								  )
 								: translate(
-										'{{strong}}%(lastItem)s{{/strong}} was succesfully assigned to {{em}}%(selectedSite)s{{/em}}. Please allow a few minutes for your features to activate.',
+										'{{strong}}%(licenseItem)s{{/strong}} was succesfully assigned to {{em}}%(selectedSite)s{{/em}}. Please allow a few minutes for your features to activate.',
 										getMessageArgs( assignedLicenses )
 								  )
 						}
@@ -84,11 +100,11 @@ export default function SiteAddLicenseNotification() {
 							// We are not using the same translate method for plural form since we have different arguments.
 							rejectedLicenses.length > 1
 								? translate(
-										`An error occurred and your {{strong}}%(remainingItems)s and %(lastItem)s{{/strong}} weren't assigned to {{em}}%(selectedSite)s{{/em}}.`,
+										`An error occurred and your {{strong}}%(initialLicenseList)s%(conjunction)s %(lastLicenseItem)s{{/strong}} weren't assigned to {{em}}%(selectedSite)s{{/em}}.`,
 										getMessageArgs( rejectedLicenses )
 								  )
 								: translate(
-										`An error occurred and your {{strong}}%(lastItem)s{{/strong}} wasn't assigned to {{em}}%(selectedSite)s{{/em}}.`,
+										`An error occurred and your {{strong}}%(licenseItem)s{{/strong}} wasn't assigned to {{em}}%(selectedSite)s{{/em}}.`,
 										getMessageArgs( rejectedLicenses )
 								  )
 						}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-add-license-notification/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-add-license-notification/index.tsx
@@ -82,11 +82,15 @@ export default function SiteAddLicenseNotification() {
 							// We are not using the same translate method for plural form since we have different arguments.
 							assignedLicenses.length > 1
 								? translate(
-										'{{strong}}%(initialLicenseList)s%(conjunction)s %(lastLicenseItem)s{{/strong}} were succesfully assigned to {{em}}%(selectedSite)s{{/em}}. Please allow a few minutes for your features to activate.',
+										'{{strong}}%(initialLicenseList)s%(conjunction)s %(lastLicenseItem)s{{/strong}} ' +
+											'were succesfully assigned to {{em}}%(selectedSite)s{{/em}}. ' +
+											'Please allow a few minutes for your features to activate.',
 										getMessageArgs( assignedLicenses )
 								  )
 								: translate(
-										'{{strong}}%(licenseItem)s{{/strong}} was succesfully assigned to {{em}}%(selectedSite)s{{/em}}. Please allow a few minutes for your features to activate.',
+										'{{strong}}%(licenseItem)s{{/strong}} was succesfully assigned to ' +
+											'{{em}}%(selectedSite)s{{/em}}. Please allow a few minutes ' +
+											'for your features to activate.',
 										getMessageArgs( assignedLicenses )
 								  )
 						}
@@ -100,11 +104,13 @@ export default function SiteAddLicenseNotification() {
 							// We are not using the same translate method for plural form since we have different arguments.
 							rejectedLicenses.length > 1
 								? translate(
-										`An error occurred and your {{strong}}%(initialLicenseList)s%(conjunction)s %(lastLicenseItem)s{{/strong}} weren't assigned to {{em}}%(selectedSite)s{{/em}}.`,
+										'An error occurred and your {{strong}}%(initialLicenseList)s%(conjunction)s %(lastLicenseItem)s{{/strong}} ' +
+											"weren't assigned to {{em}}%(selectedSite)s{{/em}}.",
 										getMessageArgs( rejectedLicenses )
 								  )
 								: translate(
-										`An error occurred and your {{strong}}%(licenseItem)s{{/strong}} wasn't assigned to {{em}}%(selectedSite)s{{/em}}.`,
+										'An error occurred and your {{strong}}%(licenseItem)s{{/strong}} ' +
+											"wasn't assigned to {{em}}%(selectedSite)s{{/em}}.",
 										getMessageArgs( rejectedLicenses )
 								  )
 						}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
@@ -123,9 +123,11 @@ export type AgencyDashboardFilter = {
 	showOnlyFavorites: boolean;
 };
 
+export type ProductInfo = { name: string; key: string; status: 'rejected' | 'fulfilled' };
+
 export type PurchasedProductsInfo = {
 	selectedSite: string;
-	selectedProducts: Array< { name: string; key: string; status: 'rejected' | 'fulfilled' } >;
+	selectedProducts: Array< ProductInfo >;
 };
 
 export interface APIError {

--- a/client/jetpack-cloud/sections/partner-portal/hooks.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/hooks.tsx
@@ -414,13 +414,13 @@ export function useIssueMultipleLicenses(
 								args: {
 									commaCharacter,
 									comment:
-										'The final separator of a delimited list, such as ", and" in "Jetpack Backup, Jetpack Scan, and Jetpack Boost."',
+										'The final separator of a delimited list, such as ", and " in "Jetpack Backup, Jetpack Scan, and Jetpack Boost". Note that the spaces here are important due to the way the final string is constructed.',
 								},
 						  } )
 						: translate( ' and ', {
 								args: {
 									comment:
-										'The way that two words are separated, such as " and" in "Jetpack Backup and Jetpack Scan". Note that the space here is important due to the way the final string is constructed.',
+										'The way that two words are separated, such as " and " in "Jetpack Backup and Jetpack Scan". Note that the spaces here are important due to the way the final string is constructed.',
 								},
 						  } );
 

--- a/client/jetpack-cloud/sections/partner-portal/hooks.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/hooks.tsx
@@ -410,14 +410,14 @@ export function useIssueMultipleLicenses(
 				} );
 				const conjunction =
 					assignedLicenses.length > 2
-						? translate( `%(commaCharacter)s and`, {
+						? translate( '%(commaCharacter)s and ', {
 								args: {
 									commaCharacter,
 									comment:
 										'The final separator of a delimited list, such as ", and" in "Jetpack Backup, Jetpack Scan, and Jetpack Boost."',
 								},
 						  } )
-						: translate( ' and', {
+						: translate( ' and ', {
 								args: {
 									comment:
 										'The way that two words are separated, such as " and" in "Jetpack Backup and Jetpack Scan". Note that the space here is important due to the way the final string is constructed.',
@@ -433,7 +433,7 @@ export function useIssueMultipleLicenses(
 						// We are not using the same translate method for plural form since we have different arguments.
 						assignedLicenses.length > 1
 							? translate(
-									'{{strong}}%(initialLicenseList)s%(conjunction)s %(lastLicenseItem)s{{/strong}} were succesfully issued',
+									'{{strong}}%(initialLicenseList)s%(conjunction)s%(lastLicenseItem)s{{/strong}} were succesfully issued',
 									{
 										args: {
 											lastLicenseItem,


### PR DESCRIPTION
#### Proposed Changes

This PR makes changes to success & error notifications to include "and" when more than one license is assigned.

#### Testing Instructions

1. Run `git checkout update/assign-licenses-notification-text` and `yarn start-jetpack-cloud`
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Click on `Add +` on any site  -> Click on **Issue x new License** -> Include any other license -> Click on **Select License** -> Verify that you are being redirected to `/dashboard` and a notification is shown as below based on the scenario after the license is successfully assigned.

Success notification(1 license)

<img width="1530" alt="Screenshot 2022-11-09 at 10 17 48 AM" src="https://user-images.githubusercontent.com/10586875/201256885-97cab85a-e049-4660-b82f-87b86042c16f.png">

-----

Success notification(2 licenses)

<img width="1530" alt="Screenshot 2022-11-09 at 10 18 16 AM" src="https://user-images.githubusercontent.com/10586875/201256895-f33c784f-1b7b-4156-9c27-ca77199950bd.png">

-----

Success notification(3 licenses)

<img width="1530" alt="Screenshot 2022-11-09 at 10 20 19 AM" src="https://user-images.githubusercontent.com/10586875/201256907-62d8abf4-5f0b-4bea-9dc0-d7bb79e29522.png">

-----

Success notification(3 licenses) in licenses page

<img width="1034" alt="Screenshot 2022-11-09 at 10 47 21 AM" src="https://user-images.githubusercontent.com/10586875/201256943-0e8526c7-76ca-4d42-b475-1bc9af646691.png">

-----

Error notification(1 license)

<img width="1530" alt="Screenshot 2022-11-09 at 10 18 41 AM" src="https://user-images.githubusercontent.com/10586875/201256902-ce103b3b-4702-4ef0-8db2-09fabacc2741.png">

-----

Error notification(2 license)

<img width="1530" alt="Screenshot 2022-11-09 at 10 19 33 AM" src="https://user-images.githubusercontent.com/10586875/201256906-5df919b6-ffcd-48ed-863e-3f27f19d7d14.png">

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1203126240279377-as-1203126240279442 & 1203126240279377-as-1203126240279449