### PR TITLE
Fix relative URLs in writing prompt notifications

### DIFF
--- a/apps/notifications/src/panel/boot/stylesheets/actions.scss
+++ b/apps/notifications/src/panel/boot/stylesheets/actions.scss
@@ -134,7 +134,34 @@
 }
 
 .wpnc__blogging_prompts_note {
-	.wpnc__action-link:only-child {
-		padding: 0;
+	svg.gridicons-bell-off {
+		position: absolute;
+		top: 10px;
+		right: 20px;
+
+		&:hover {
+			path.bell {
+				stroke: var(--color-link);
+			}
+
+			rect {
+				fill: var(--color-link);
+			}
+
+			g {
+				opacity: 1;
+			}
+		}
+	}
+
+	.wpnc__action-link {
+		&:only-child {
+			padding: 0;
+		}
+		&:hover {
+			svg.gridicons-pinned path {
+				fill: var(--color-link);
+			}
+		}
 	}
 }

--- a/apps/notifications/src/panel/boot/stylesheets/actions.scss
+++ b/apps/notifications/src/panel/boot/stylesheets/actions.scss
@@ -133,35 +133,3 @@
 	}
 }
 
-.wpnc__blogging_prompts_note {
-	svg.gridicons-bell-off {
-		position: absolute;
-		top: 10px;
-		right: 20px;
-
-		&:hover {
-			path.bell {
-				stroke: var(--color-link);
-			}
-
-			rect {
-				fill: var(--color-link);
-			}
-
-			g {
-				opacity: 1;
-			}
-		}
-	}
-
-	.wpnc__action-link {
-		&:only-child {
-			padding: 0;
-		}
-		&:hover {
-			svg.gridicons-pinned path {
-				fill: var(--color-link);
-			}
-		}
-	}
-}

--- a/apps/notifications/src/panel/boot/stylesheets/actions.scss
+++ b/apps/notifications/src/panel/boot/stylesheets/actions.scss
@@ -133,7 +133,7 @@
 	}
 }
 
-.wpnc__writing_prompts_note {
+.wpnc__blogging_prompts_note {
 	.wpnc__action-link:only-child {
 		padding: 0;
 	}

--- a/apps/notifications/src/panel/boot/stylesheets/main.scss
+++ b/apps/notifications/src/panel/boot/stylesheets/main.scss
@@ -820,6 +820,39 @@
 		padding-top: $wpnc__padding-small;
 	}
 
+	.wpnc__blogging_prompts_note {
+		svg.gridicons-bell-off {
+			position: absolute;
+			top: 10px;
+			right: 20px;
+
+			&:hover {
+				path.bell {
+					stroke: var(--color-link);
+				}
+
+				rect {
+					fill: var(--color-link);
+				}
+
+				g {
+					opacity: 1;
+				}
+			}
+		}
+
+		.wpnc__action-link {
+			&:only-child {
+				padding: 0;
+			}
+			&:hover {
+				svg.gridicons-pinned path {
+					fill: var(--color-link);
+				}
+			}
+		}
+	}
+
 	.wpnc__comment .wpnc__body .wpnc__body-content {
 		box-shadow: inset 4px 0 0 var(--color-neutral-0);
 		margin: 0 0 0 $wpnc__padding-medium;

--- a/apps/notifications/src/panel/boot/stylesheets/main.scss
+++ b/apps/notifications/src/panel/boot/stylesheets/main.scss
@@ -815,7 +815,7 @@
 	.wpnc__comment .wpnc__body .wpnc__body-content,
 	.wpnc__new_post .wpnc__body .wpnc__body-content,
 	.wpnc__automattcher .wpnc__body .wpnc__body-content,
-	.wpnc__writing_prompts_note .wpnc__body .wpnc__body-content {
+	.wpnc__blogging_prompts_note .wpnc__body .wpnc__body-content {
 		border-bottom: 1px solid var(--color-neutral-5);
 		padding-top: $wpnc__padding-small;
 	}

--- a/apps/notifications/src/panel/templates/button-answer-prompt.jsx
+++ b/apps/notifications/src/panel/templates/button-answer-prompt.jsx
@@ -9,12 +9,8 @@ import ActionButton from './action-button';
 // eslint-disable-next-line no-shadow
 const AnswerPromptButton = ( { answerPrompt, note, translate } ) => {
 	const { site: siteId } = note?.meta?.ids ?? {};
-	let host = document.location.host;
-	console.log( document );
-	console.log( host );
-	if ( host === 'widgets.wp.com' ) {
-		host = 'wordpress.com';
-	}
+	const host =
+		document.location.host === 'widgets.wp.com' ? 'wordpress.com' : document.location.host;
 	const newPostLink = document.location.protocol + '//' + host + getNewPostLink( note );
 	return (
 		<ActionButton

--- a/apps/notifications/src/panel/templates/button-answer-prompt.jsx
+++ b/apps/notifications/src/panel/templates/button-answer-prompt.jsx
@@ -9,6 +9,7 @@ import ActionButton from './action-button';
 // eslint-disable-next-line no-shadow
 const AnswerPromptButton = ( { answerPrompt, note, translate } ) => {
 	const { site: siteId } = note?.meta?.ids ?? {};
+	// Notifications are hosted on widgets.wp.com on WordPress.com
 	const host =
 		document.location.host === 'widgets.wp.com' ? 'wordpress.com' : document.location.host;
 	const newPostLink = document.location.protocol + '//' + host + getNewPostLink( note );

--- a/apps/notifications/src/panel/templates/button-answer-prompt.jsx
+++ b/apps/notifications/src/panel/templates/button-answer-prompt.jsx
@@ -10,6 +10,8 @@ import ActionButton from './action-button';
 const AnswerPromptButton = ( { answerPrompt, note, translate } ) => {
 	const { site: siteId } = note?.meta?.ids ?? {};
 	let host = document.location.host;
+	console.log( document );
+	console.log( host );
 	if ( host === 'widgets.wp.com' ) {
 		host = 'wordpress.com';
 	}

--- a/apps/notifications/src/panel/templates/button-answer-prompt.jsx
+++ b/apps/notifications/src/panel/templates/button-answer-prompt.jsx
@@ -9,8 +9,11 @@ import ActionButton from './action-button';
 // eslint-disable-next-line no-shadow
 const AnswerPromptButton = ( { answerPrompt, note, translate } ) => {
 	const { site: siteId } = note?.meta?.ids ?? {};
-	const newPostLink =
-		document.location.protocol + '//' + document.location.host + getNewPostLink( note );
+	let host = document.location.host;
+	if ( host === 'widgets.wp.com' ) {
+		host = 'wordpress.com';
+	}
+	const newPostLink = document.location.protocol + '//' + host + getNewPostLink( note );
 	return (
 		<ActionButton
 			{ ...{

--- a/apps/notifications/src/panel/templates/button-answer-prompt.jsx
+++ b/apps/notifications/src/panel/templates/button-answer-prompt.jsx
@@ -9,7 +9,10 @@ import ActionButton from './action-button';
 // eslint-disable-next-line no-shadow
 const AnswerPromptButton = ( { answerPrompt, note, translate } ) => {
 	const { site: siteId } = note?.meta?.ids ?? {};
-	const newPostLink = getNewPostLink( note );
+	const isLocalhost = document.location.hostname === 'calypso.localhost';
+	const newPostLink =
+		( isLocalhost ? 'http://calypso.localhost:3000' : 'https://wordpress.com' ) +
+		getNewPostLink( note );
 	return (
 		<ActionButton
 			{ ...{

--- a/apps/notifications/src/panel/templates/button-answer-prompt.jsx
+++ b/apps/notifications/src/panel/templates/button-answer-prompt.jsx
@@ -9,10 +9,8 @@ import ActionButton from './action-button';
 // eslint-disable-next-line no-shadow
 const AnswerPromptButton = ( { answerPrompt, note, translate } ) => {
 	const { site: siteId } = note?.meta?.ids ?? {};
-	const isLocalhost = document.location.hostname === 'calypso.localhost';
 	const newPostLink =
-		( isLocalhost ? 'http://calypso.localhost:3000' : 'https://wordpress.com' ) +
-		getNewPostLink( note );
+		document.location.protocol + '//' + document.location.host + getNewPostLink( note );
 	return (
 		<ActionButton
 			{ ...{

--- a/apps/notifications/src/panel/templates/summary-in-single.jsx
+++ b/apps/notifications/src/panel/templates/summary-in-single.jsx
@@ -72,12 +72,8 @@ class BloggingPromptHeader extends Component {
 		const icon = this.props.site.media[ 0 ];
 		const img_tag = <img src={ icon.url } height={ icon.height } width={ icon.width } alt="" />;
 		const home_url = this.props.site.ranges[ 0 ].url;
-		let host = document.location.host;
-		console.log( document );
-		console.log( host );
-		if ( host === 'widgets.wp.com' ) {
-			host = 'wordpress.com';
-		}
+		const host =
+			document.location.host === 'widgets.wp.com' ? 'wordpress.com' : document.location.host;
 		const settings_url =
 			document.location.protocol + '//' + host + '/me/notifications#' + withoutHttp( home_url );
 

--- a/apps/notifications/src/panel/templates/summary-in-single.jsx
+++ b/apps/notifications/src/panel/templates/summary-in-single.jsx
@@ -73,6 +73,8 @@ class BloggingPromptHeader extends Component {
 		const img_tag = <img src={ icon.url } height={ icon.height } width={ icon.width } alt="" />;
 		const home_url = this.props.site.ranges[ 0 ].url;
 		let host = document.location.host;
+		console.log( document );
+		console.log( host );
 		if ( host === 'widgets.wp.com' ) {
 			host = 'wordpress.com';
 		}

--- a/apps/notifications/src/panel/templates/summary-in-single.jsx
+++ b/apps/notifications/src/panel/templates/summary-in-single.jsx
@@ -72,9 +72,10 @@ class WritingPromptHeader extends Component {
 		const icon = this.props.site.media[ 0 ];
 		const img_tag = <img src={ icon.url } height={ icon.height } width={ icon.width } alt="" />;
 		const home_url = this.props.site.ranges[ 0 ].url;
-		const isLocalhost = document.location.hostname === 'calypso.localhost';
 		const settings_url =
-			( isLocalhost ? 'http://calypso.localhost:3000' : 'https://wordpress.com' ) +
+			document.location.protocol +
+			'//' +
+			document.location.host +
 			'/me/notifications#' +
 			withoutHttp( home_url );
 

--- a/apps/notifications/src/panel/templates/summary-in-single.jsx
+++ b/apps/notifications/src/panel/templates/summary-in-single.jsx
@@ -72,6 +72,7 @@ class BloggingPromptHeader extends Component {
 		const icon = this.props.site.media[ 0 ];
 		const img_tag = <img src={ icon.url } height={ icon.height } width={ icon.width } alt="" />;
 		const home_url = this.props.site.ranges[ 0 ].url;
+		// Notifications are hosted on widgets.wp.com on WordPress.com
 		const host =
 			document.location.host === 'widgets.wp.com' ? 'wordpress.com' : document.location.host;
 		const settings_url =

--- a/apps/notifications/src/panel/templates/summary-in-single.jsx
+++ b/apps/notifications/src/panel/templates/summary-in-single.jsx
@@ -67,7 +67,7 @@ class UserHeader extends Component {
 	}
 }
 
-class WritingPromptHeader extends Component {
+class BloggingPromptHeader extends Component {
 	render() {
 		const icon = this.props.site.media[ 0 ];
 		const img_tag = <img src={ icon.url } height={ icon.height } width={ icon.width } alt="" />;
@@ -160,9 +160,9 @@ class SummaryInSingle extends Component {
 					/>
 				);
 			}
-			if ( this.props.note.type === 'writing_prompts_note' ) {
+			if ( this.props.note.type === 'blogging_prompts_note' ) {
 				return (
-					<WritingPromptHeader
+					<BloggingPromptHeader
 						note={ this.props.note }
 						prompt={ this.props.note.header[ 1 ] }
 						url={ header_url }

--- a/apps/notifications/src/panel/templates/summary-in-single.jsx
+++ b/apps/notifications/src/panel/templates/summary-in-single.jsx
@@ -72,7 +72,11 @@ class WritingPromptHeader extends Component {
 		const icon = this.props.site.media[ 0 ];
 		const img_tag = <img src={ icon.url } height={ icon.height } width={ icon.width } alt="" />;
 		const home_url = this.props.site.ranges[ 0 ].url;
-		const settings_url = '/me/notifications#' + withoutHttp( home_url );
+		const isLocalhost = document.location.hostname === 'calypso.localhost';
+		const settings_url =
+			( isLocalhost ? 'http://calypso.localhost:3000' : 'https://wordpress.com' ) +
+			'/me/notifications#' +
+			withoutHttp( home_url );
 
 		const get_home_link = function ( classNames, children ) {
 			if ( home_url ) {

--- a/apps/notifications/src/panel/templates/summary-in-single.jsx
+++ b/apps/notifications/src/panel/templates/summary-in-single.jsx
@@ -72,12 +72,12 @@ class BloggingPromptHeader extends Component {
 		const icon = this.props.site.media[ 0 ];
 		const img_tag = <img src={ icon.url } height={ icon.height } width={ icon.width } alt="" />;
 		const home_url = this.props.site.ranges[ 0 ].url;
+		let host = document.location.host;
+		if ( host === 'widgets.wp.com' ) {
+			host = 'wordpress.com';
+		}
 		const settings_url =
-			document.location.protocol +
-			'//' +
-			document.location.host +
-			'/me/notifications#' +
-			withoutHttp( home_url );
+			document.location.protocol + '//' + host + '/me/notifications#' + withoutHttp( home_url );
 
 		const get_home_link = function ( classNames, children ) {
 			if ( home_url ) {

--- a/client/notifications/style.scss
+++ b/client/notifications/style.scss
@@ -153,7 +153,7 @@
 		}
 	}
 
-	.wpnc__writing_prompts_note {
+	.wpnc__blogging_prompts_note {
 		svg.gridicons-bell-off {
 			position: absolute;
 			top: 10px;

--- a/client/notifications/style.scss
+++ b/client/notifications/style.scss
@@ -175,6 +175,9 @@
 		}
 
 		.wpnc__action-link {
+			&:only-child {
+				padding: 0;
+			}
 			&:hover {
 				svg.gridicons-pinned path {
 					fill: var(--color-link);

--- a/client/notifications/style.scss
+++ b/client/notifications/style.scss
@@ -152,39 +152,6 @@
 			margin: auto;
 		}
 	}
-
-	.wpnc__blogging_prompts_note {
-		svg.gridicons-bell-off {
-			position: absolute;
-			top: 10px;
-			right: 20px;
-
-			&:hover {
-				path.bell {
-					stroke: var(--color-link);
-				}
-
-				rect {
-					fill: var(--color-link);
-				}
-
-				g {
-					opacity: 1;
-				}
-			}
-		}
-
-		.wpnc__action-link {
-			&:only-child {
-				padding: 0;
-			}
-			&:hover {
-				svg.gridicons-pinned path {
-					fill: var(--color-link);
-				}
-			}
-		}
-	}
 }
 
 #wpnc-panel.wide {


### PR DESCRIPTION
The links in the new writing prompt notifications do not work. They were using relative paths and it appears due to how the notifications are cached in widgets.wp.com, this is the host used for the links;

* Answer prompt link is `https://widgets.wp.com/post/{wordpress.com site}?answer_prompt={prompt ID}` when it should be `https://wordpress.com/post/{wordpress.com site}?answer_prompt={prompt ID}`
* Notification settings link is `https://widgets.wp.com/me/notifications#{wordpress.com site}` when it should be `https://wordpress.com/me/notifications#{wordpress.com site}`

This patch uses the host http://calypso.localhost:3000 if dev locally, otherwise uses https://wordpress.com

This is a follow up to https://github.com/Automattic/wp-calypso/pull/69352