### PR TITLE
design-carousel: remove 'any' type

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-carousel/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-carousel/index.tsx
@@ -11,6 +11,7 @@ import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { reduxDispatch } from 'calypso/lib/redux-bridge';
 import { requestActiveTheme } from 'calypso/state/themes/actions';
 import type { Step } from '../../types';
+import type { Design } from '@automattic/design-picker/src/types';
 
 const DesignCarousel: Step = function DesignCarousel( { navigation } ) {
 	const { goNext, goBack, submit } = navigation;
@@ -27,7 +28,7 @@ const DesignCarousel: Step = function DesignCarousel( { navigation } ) {
 	const siteSlugOrId = siteId || siteSlug;
 	const isJetpackSite = useSelect( ( select ) => select( SITE_STORE ).isJetpackSite( site?.ID ) );
 
-	function pickDesign( _selectedDesign: any | undefined = selectedDesign ) {
+	function pickDesign( _selectedDesign: Design | undefined = selectedDesign ) {
 		setSelectedDesign( _selectedDesign );
 		if ( siteSlugOrId && _selectedDesign ) {
 			setPendingAction( async () => {

--- a/packages/design-carousel/src/index.tsx
+++ b/packages/design-carousel/src/index.tsx
@@ -8,8 +8,9 @@ import React, { useEffect, useRef } from 'react';
 import Swiper from 'swiper';
 import { Item } from './item';
 import 'swiper/dist/css/swiper.css';
+import type { Design } from '@automattic/design-picker/src/types';
 
-type Props = { onPick: ( design: any ) => void };
+type Props = { onPick: ( design: Design ) => void };
 
 export default function DesignCarousel( { onPick }: Props ) {
 	const { __ } = useI18n();


### PR DESCRIPTION
#### Proposed Changes

* No functional changes
* In typescript annotations, change `any` to `Design`


#### Testing Instructions

* Automated tests should pass

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
