### PR TITLE
Jetpack Pricing: rename Backup and Anti-spam

### DIFF
--- a/client/my-sites/plans/jetpack-plans/plan-upgrade/test/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/plan-upgrade/test/index.tsx
@@ -67,7 +67,8 @@ describe( '<PlanUpgradeSection />', () => {
 		);
 
 		const sectionHeader = screen.getByRole( 'heading', { level: 2 } );
-		expect( sectionHeader.outerHTML ).toContain( 'Anti-spam &amp; Backup' );
+		expect( sectionHeader.outerHTML ).toContain( 'Anti-spam' );
+		expect( sectionHeader.outerHTML ).toContain( 'Backup' );
 
 		const productHeaders = screen.getAllByRole( 'heading', { level: 3 } );
 

--- a/client/my-sites/plans/jetpack-plans/product-store/simple-item-card/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/simple-item-card/style.scss
@@ -35,6 +35,7 @@
 .simple-item-card__header {
 	display: flex;
 	flex-direction: row;
+	column-gap: 1em;
 	font-size: $font-body-small;
 	justify-content: space-between;
 	align-items: flex-start;
@@ -49,10 +50,6 @@
 	line-height: rem(29px);
 	margin-bottom: 0 !important;
 	color: var(--studio-gray-100);
-	display: flex;
-	flex-direction: row;
-	gap: 0.5rem;
-	align-items: center;
 }
 
 .simple-item-card__cta {

--- a/packages/calypso-products/src/translations.tsx
+++ b/packages/calypso-products/src/translations.tsx
@@ -98,8 +98,16 @@ export const getJetpackProductsShortNames = (): Record< string, TranslateResult 
 		[ PRODUCT_JETPACK_SEARCH_MONTHLY ]: translate( 'Search' ),
 		[ PRODUCT_WPCOM_SEARCH ]: translate( 'Search' ),
 		[ PRODUCT_WPCOM_SEARCH_MONTHLY ]: translate( 'Search' ),
-		[ PRODUCT_JETPACK_ANTI_SPAM ]: translate( 'Akismet Anti-Spam' ),
-		[ PRODUCT_JETPACK_ANTI_SPAM_MONTHLY ]: translate( 'Akismet Anti-Spam' ),
+		[ PRODUCT_JETPACK_ANTI_SPAM ]: translate( 'Akismet {{s}}Anti-Spam{{/s}}', {
+			components: {
+				s: <span style={ { whiteSpace: 'nowrap' } } />,
+			},
+		} ),
+		[ PRODUCT_JETPACK_ANTI_SPAM_MONTHLY ]: translate( 'Akismet {{s}}Anti-Spam{{/s}}', {
+			components: {
+				s: <span style={ { whiteSpace: 'nowrap' } } />,
+			},
+		} ),
 		[ PRODUCT_JETPACK_VIDEOPRESS ]: translate( 'VideoPress' ),
 		[ PRODUCT_JETPACK_VIDEOPRESS_MONTHLY ]: translate( 'VideoPress' ),
 		[ PRODUCT_JETPACK_SOCIAL_BASIC ]: translate( 'Social' ),
@@ -136,7 +144,11 @@ export const getJetpackProductsDisplayNames = (): Record< string, TranslateResul
 		</>
 	);
 	const videoPress = translate( 'VideoPress' );
-	const antiSpam = translate( 'Akismet Anti-Spam' );
+	const antiSpam = translate( 'Akismet {{s}}Anti-Spam{{/s}}', {
+		components: {
+			s: <span style={ { whiteSpace: 'nowrap' } } />,
+		},
+	} );
 	const boost = translate( 'Boost' );
 	const social = translate( 'Social' );
 
@@ -226,7 +238,11 @@ export const getJetpackProductsCallToAction = (): Record< string, TranslateResul
 	const search = translate( 'Get Site Search' );
 	const scan = translate( 'Get Scan' );
 	const videoPress = translate( 'Get VideoPress' );
-	const antiSpam = translate( 'Get Akismet Anti-Spam' );
+	const antiSpam = translate( 'Get Akismet {{s}}Anti-Spam{{/s}}', {
+		components: {
+			s: <span style={ { whiteSpace: 'nowrap' } } />,
+		},
+	} );
 	const boost = translate( 'Get Boost' );
 	const social = translate( 'Get Social' );
 

--- a/packages/calypso-products/src/translations.tsx
+++ b/packages/calypso-products/src/translations.tsx
@@ -52,30 +52,33 @@ import type { TranslateResult } from 'i18n-calypso';
 // Translatable strings
 export const getJetpackProductsShortNames = (): Record< string, TranslateResult > => {
 	return {
-		[ PRODUCT_JETPACK_BACKUP_DAILY ]: translate( 'Backup {{em}}Daily{{/em}}', {
+		[ PRODUCT_JETPACK_BACKUP_DAILY ]: translate( 'VaultPress Backup {{em}}Daily{{/em}}', {
 			components: {
 				em: createElement( 'em' ),
 			},
 		} ),
-		[ PRODUCT_JETPACK_BACKUP_DAILY_MONTHLY ]: translate( 'Backup {{em}}Daily{{/em}}', {
+		[ PRODUCT_JETPACK_BACKUP_DAILY_MONTHLY ]: translate( 'VaultPress Backup {{em}}Daily{{/em}}', {
 			components: {
 				em: createElement( 'em' ),
 			},
 		} ),
-		[ PRODUCT_JETPACK_BACKUP_REALTIME ]: translate( 'Backup {{em}}Real-time{{/em}}', {
+		[ PRODUCT_JETPACK_BACKUP_REALTIME ]: translate( 'VaultPress Backup {{em}}Real-time{{/em}}', {
 			components: {
 				em: createElement( 'em', { style: { whiteSpace: 'nowrap' } } ),
 			},
 		} ),
-		[ PRODUCT_JETPACK_BACKUP_REALTIME_MONTHLY ]: translate( 'Backup {{em}}Real-time{{/em}}', {
-			components: {
-				em: createElement( 'em', { style: { whiteSpace: 'nowrap' } } ),
-			},
-		} ),
-		[ PRODUCT_JETPACK_BACKUP_T1_YEARLY ]: translate( 'Backup' ),
-		[ PRODUCT_JETPACK_BACKUP_T1_MONTHLY ]: translate( 'Backup' ),
-		[ PRODUCT_JETPACK_BACKUP_T2_YEARLY ]: translate( 'Backup' ),
-		[ PRODUCT_JETPACK_BACKUP_T2_MONTHLY ]: translate( 'Backup' ),
+		[ PRODUCT_JETPACK_BACKUP_REALTIME_MONTHLY ]: translate(
+			'VaultPress Backup {{em}}Real-time{{/em}}',
+			{
+				components: {
+					em: createElement( 'em', { style: { whiteSpace: 'nowrap' } } ),
+				},
+			}
+		),
+		[ PRODUCT_JETPACK_BACKUP_T1_YEARLY ]: translate( 'VaultPress Backup' ),
+		[ PRODUCT_JETPACK_BACKUP_T1_MONTHLY ]: translate( 'VaultPress Backup' ),
+		[ PRODUCT_JETPACK_BACKUP_T2_YEARLY ]: translate( 'VaultPress Backup' ),
+		[ PRODUCT_JETPACK_BACKUP_T2_MONTHLY ]: translate( 'VaultPress Backup' ),
 		[ PRODUCT_JETPACK_BOOST ]: translate( 'Boost' ),
 		[ PRODUCT_JETPACK_BOOST_MONTHLY ]: translate( 'Boost' ),
 		[ PRODUCT_JETPACK_SCAN_REALTIME ]: translate( 'Scan {{em}}Real-time{{/em}}', {
@@ -95,8 +98,8 @@ export const getJetpackProductsShortNames = (): Record< string, TranslateResult 
 		[ PRODUCT_JETPACK_SEARCH_MONTHLY ]: translate( 'Search' ),
 		[ PRODUCT_WPCOM_SEARCH ]: translate( 'Search' ),
 		[ PRODUCT_WPCOM_SEARCH_MONTHLY ]: translate( 'Search' ),
-		[ PRODUCT_JETPACK_ANTI_SPAM ]: translate( 'Anti-spam' ),
-		[ PRODUCT_JETPACK_ANTI_SPAM_MONTHLY ]: translate( 'Anti-spam' ),
+		[ PRODUCT_JETPACK_ANTI_SPAM ]: translate( 'Akismet Anti-Spam' ),
+		[ PRODUCT_JETPACK_ANTI_SPAM_MONTHLY ]: translate( 'Akismet Anti-Spam' ),
 		[ PRODUCT_JETPACK_VIDEOPRESS ]: translate( 'VideoPress' ),
 		[ PRODUCT_JETPACK_VIDEOPRESS_MONTHLY ]: translate( 'VideoPress' ),
 		[ PRODUCT_JETPACK_SOCIAL_BASIC ]: translate( 'Social' ),
@@ -105,22 +108,22 @@ export const getJetpackProductsShortNames = (): Record< string, TranslateResult 
 };
 
 export const getJetpackProductsDisplayNames = (): Record< string, TranslateResult > => {
-	const backupDaily = translate( 'Backup {{em}}Daily{{/em}}', {
+	const backupDaily = translate( 'VaultPress Backup {{em}}Daily{{/em}}', {
 		components: {
 			em: <em />,
 		},
 	} );
 	const backupRealtime = (
 		<>
-			{ translate( 'Backup {{em}}Real-time{{/em}}', {
+			{ translate( 'VaultPress Backup {{em}}Real-time{{/em}}', {
 				components: {
 					em: <em style={ { whiteSpace: 'nowrap' } } />,
 				},
 			} ) }
 		</>
 	);
-	const backupT1 = translate( 'Backup' );
-	const backupT2 = translate( 'Backup' );
+	const backupT1 = translate( 'VaultPress Backup' );
+	const backupT2 = translate( 'VaultPress Backup' );
 	const search = translate( 'Site Search' );
 	const scan = translate( 'Scan' );
 	const scanRealtime = (
@@ -133,7 +136,7 @@ export const getJetpackProductsDisplayNames = (): Record< string, TranslateResul
 		</>
 	);
 	const videoPress = translate( 'VideoPress' );
-	const antiSpam = translate( 'Anti-spam' );
+	const antiSpam = translate( 'Akismet Anti-Spam' );
 	const boost = translate( 'Boost' );
 	const social = translate( 'Social' );
 
@@ -204,26 +207,26 @@ export const getJetpackProductsDisplayNames = (): Record< string, TranslateResul
 };
 
 export const getJetpackProductsCallToAction = (): Record< string, TranslateResult > => {
-	const backupDaily = translate( 'Get Backup {{em}}Daily{{/em}}', {
+	const backupDaily = translate( 'Get VaultPress Backup {{em}}Daily{{/em}}', {
 		components: {
 			em: <em />,
 		},
 	} );
 	const backupRealtime = (
 		<>
-			{ translate( 'Get Backup {{em}}Real-time{{/em}}', {
+			{ translate( 'Get VaultPress Backup {{em}}Real-time{{/em}}', {
 				components: {
 					em: <em style={ { whiteSpace: 'nowrap' } } />,
 				},
 			} ) }
 		</>
 	);
-	const backupT1 = translate( 'Get Backup' );
-	const backupT2 = translate( 'Get Backup' );
+	const backupT1 = translate( 'Get VaultPress Backup' );
+	const backupT2 = translate( 'Get VaultPress Backup' );
 	const search = translate( 'Get Site Search' );
 	const scan = translate( 'Get Scan' );
 	const videoPress = translate( 'Get VideoPress' );
-	const antiSpam = translate( 'Get Anti-spam' );
+	const antiSpam = translate( 'Get Akismet Anti-Spam' );
 	const boost = translate( 'Get Boost' );
 	const social = translate( 'Get Social' );
 

--- a/packages/calypso-products/src/translations.tsx
+++ b/packages/calypso-products/src/translations.tsx
@@ -98,12 +98,12 @@ export const getJetpackProductsShortNames = (): Record< string, TranslateResult 
 		[ PRODUCT_JETPACK_SEARCH_MONTHLY ]: translate( 'Search' ),
 		[ PRODUCT_WPCOM_SEARCH ]: translate( 'Search' ),
 		[ PRODUCT_WPCOM_SEARCH_MONTHLY ]: translate( 'Search' ),
-		[ PRODUCT_JETPACK_ANTI_SPAM ]: translate( 'Akismet {{s}}Anti-Spam{{/s}}', {
+		[ PRODUCT_JETPACK_ANTI_SPAM ]: translate( 'Akismet {{s}}Anti-spam{{/s}}', {
 			components: {
 				s: <span style={ { whiteSpace: 'nowrap' } } />,
 			},
 		} ),
-		[ PRODUCT_JETPACK_ANTI_SPAM_MONTHLY ]: translate( 'Akismet {{s}}Anti-Spam{{/s}}', {
+		[ PRODUCT_JETPACK_ANTI_SPAM_MONTHLY ]: translate( 'Akismet {{s}}Anti-spam{{/s}}', {
 			components: {
 				s: <span style={ { whiteSpace: 'nowrap' } } />,
 			},
@@ -144,7 +144,7 @@ export const getJetpackProductsDisplayNames = (): Record< string, TranslateResul
 		</>
 	);
 	const videoPress = translate( 'VideoPress' );
-	const antiSpam = translate( 'Akismet {{s}}Anti-Spam{{/s}}', {
+	const antiSpam = translate( 'Akismet {{s}}Anti-spam{{/s}}', {
 		components: {
 			s: <span style={ { whiteSpace: 'nowrap' } } />,
 		},
@@ -238,7 +238,7 @@ export const getJetpackProductsCallToAction = (): Record< string, TranslateResul
 	const search = translate( 'Get Site Search' );
 	const scan = translate( 'Get Scan' );
 	const videoPress = translate( 'Get VideoPress' );
-	const antiSpam = translate( 'Get Akismet {{s}}Anti-Spam{{/s}}', {
+	const antiSpam = translate( 'Get Akismet {{s}}Anti-spam{{/s}}', {
 		components: {
 			s: <span style={ { whiteSpace: 'nowrap' } } />,
 		},


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR renames the following products in the Jetpack pricing page:

- `Backup` > `VaultPress Backup`
- `Anti-spam` > `Akismet Anti-spam`

Context: p1HpG7-j1R-p2

### Implementation notes

Mentions in the navigation and footer will be renamed in a separate PR.

### Testing instructions

- Spin up the pricing page, using a live link below, or by running this branch locally
- Check that all mentions of Backup and Anti-spam respect the new branding
- Check that design is not broken on mobile devices

### Screenshots

#### VaultPress Backup
<img width="500" alt="Screen Shot 2022-11-11 at 10 35 29 AM" src="https://user-images.githubusercontent.com/1620183/201374279-b1292da4-85a7-4e92-92e9-30de9bb1168f.png">
<img width="500" alt="Screen Shot 2022-11-11 at 10 35 43 AM" src="https://user-images.githubusercontent.com/1620183/201374284-6426b526-4698-4e2c-b95e-4eb7750ee94e.png">
<img width="500" alt="Screen Shot 2022-11-11 at 10 35 21 AM" src="https://user-images.githubusercontent.com/1620183/201374271-1ba5ecab-0efe-4749-b416-861317fde168.png">

#### Akismet Anti-spam

_Note: `Anti-spam` should have a lowercase `s`. The following screenshots haven't been updated accordingly._

<img width="500" alt="Screen Shot 2022-11-11 at 10 37 30 AM" src="https://user-images.githubusercontent.com/1620183/201374285-56881953-988e-4f5c-927a-ed30f3b5af01.png">
<img width="500" alt="Screen Shot 2022-11-11 at 10 37 35 AM" src="https://user-images.githubusercontent.com/1620183/201374286-82d0323b-fed6-43ff-bf84-d9b8135c3a34.png">