### PR TITLE
Update Backup and Anti-spam names in pricing nav

### DIFF
--- a/client/jetpack-cloud/sections/pricing/jpcom-footer/index.tsx
+++ b/client/jetpack-cloud/sections/pricing/jpcom-footer/index.tsx
@@ -49,24 +49,54 @@ const JetpackComFooter: React.FC = () => {
 				category: translate( 'WordPress Plugins' ),
 				items: [
 					{
+						label: translate( 'Akismet Anti-spam' ),
+						href: 'https://wordpress.org/plugins/akismet/',
+						trackId: 'jetpack_antispam',
+					},
+					{
 						label: translate( 'Jetpack' ),
-						href: 'https://jetpack.com/',
+						href: 'https://wordpress.org/plugins/jetpack/',
 						trackId: 'jetpack',
 					},
 					{
-						label: translate( 'Jetpack Backup' ),
-						href: 'https://jetpack.com/upgrade/backup/',
-						trackId: 'jetpack_backup',
+						label: translate( 'Jetpack Boost' ),
+						href: 'https://wordpress.org/plugins/jetpack-boost/',
+						trackId: 'jetpack_boost',
 					},
 					{
 						label: translate( 'Jetpack CRM' ),
-						href: addQueryArgs( utmParams, 'https://jetpackcrm.com/' ),
+						href: 'https://wordpress.org/plugins/zero-bs-crm/',
 						trackId: 'jetpack_crm',
 					},
 					{
-						label: translate( 'Jetpack Boost' ),
-						href: 'https://jetpack.com/boost/',
-						trackId: 'jetpack_boost',
+						label: translate( 'Jetpack Protect' ),
+						href: 'https://wordpress.org/plugins/jetpack-protect/',
+						trackId: 'jetpack_protect',
+					},
+					{
+						label: translate( 'Jetpack Search' ),
+						href: 'https://wordpress.org/plugins/jetpack-search/',
+						trackId: 'jetpack_search',
+					},
+					{
+						label: translate( 'Jetpack Social' ),
+						href: 'https://wordpress.org/plugins/jetpack-social/',
+						trackId: 'jetpack_social',
+					},
+					{
+						label: translate( 'Jetpack VideoPress' ),
+						href: 'https://wordpress.org/plugins/jetpack-videopress/',
+						trackId: 'jetpack_videopress',
+					},
+					{
+						label: translate( 'VaultPress Backup' ),
+						href: 'https://wordpress.org/plugins/jetpack-backup/',
+						trackId: 'jetpack_backup',
+					},
+					{
+						label: translate( 'WP Super Cache' ),
+						href: 'https://wordpress.org/plugins/wp-super-cache/',
+						trackId: 'wp_supercache',
 					},
 				],
 			},

--- a/client/jetpack-cloud/sections/pricing/jpcom-masterbar/index.tsx
+++ b/client/jetpack-cloud/sections/pricing/jpcom-masterbar/index.tsx
@@ -51,7 +51,7 @@ const JetpackComMasterbar: React.FC< Props > = ( { pathname } ) => {
 						href: `${ JETPACK_COM_BASE_URL }/features/security/`,
 						items: [
 							{
-								label: translate( 'Backup' ),
+								label: translate( 'VaultPress' ),
 								tagline: translate( 'Save every change in real-time' ),
 								href: `${ JETPACK_COM_BASE_URL }/upgrade/backup/`,
 							},
@@ -61,7 +61,7 @@ const JetpackComMasterbar: React.FC< Props > = ( { pathname } ) => {
 								href: `${ JETPACK_COM_BASE_URL }/upgrade/scan/`,
 							},
 							{
-								label: translate( 'Anti-spam' ),
+								label: translate( 'Akismet' ),
 								tagline: translate( 'Stop comment and form spam' ),
 								href: `${ JETPACK_COM_BASE_URL }/upgrade/anti-spam/`,
 							},


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR renames Backup and Anti-spam in the Jetpack pricing page navigation and footer. It also updates the _WordPress Plugins_ section of the footer.

Context: p1HpG7-j1R-p2

### Testing instructions

- Spin up the pricing page in Cloud, using the live link below, or by running this branch locally
- Check that Backup and Anti-spam respect the new branding in the navigation
- Check that the _WordPress Plugins_ section of the footer looks like the capture below, and that links direct to the proper page in wordpress.org
- Check that design is not broken on mobile devices

### Screenshots

#### Navigation
<img width="1082" alt="Screen Shot 2022-11-11 at 11 15 00 AM" src="https://user-images.githubusercontent.com/1620183/201383918-b54aa963-044d-4ac9-a45a-80ef675ffe69.png">


#### Footer
<img width="191" alt="Screen Shot 2022-11-11 at 11 29 22 AM" src="https://user-images.githubusercontent.com/1620183/201385729-5fafbba0-61b9-4c77-a862-c73820b574b3.png">

