### PR TITLE
VideoPress Tailored Onboarding: Fix saving site description

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-plan/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-plan/index.tsx
@@ -40,6 +40,9 @@ const ChooseAPlan: Step = function ChooseAPlan( { navigation, flow } ) {
 
 	const currentUser = useSelect( ( select ) => select( USER_STORE ).getCurrentUser() );
 	const domain = useSelect( ( select ) => select( ONBOARD_STORE ).getSelectedDomain() );
+	const siteDescription = useSelect( ( select ) =>
+		select( ONBOARD_STORE ).getSelectedSiteDescription()
+	);
 	const getPlanProduct = useSelect( ( select ) => select( PLANS_STORE ).getPlanProduct );
 	const { getNewSite } = useSelect( ( select ) => select( SITE_STORE ) );
 
@@ -122,7 +125,10 @@ const ChooseAPlan: Step = function ChooseAPlan( { navigation, flow } ) {
 				const newSite = getNewSite();
 				setSelectedSite( newSite?.blogid );
 				setIntentOnSite( newSite?.site_slug as string, flow as string );
-				saveSiteSettings( newSite?.blogid as number, { launchpad_screen: 'full' } );
+				saveSiteSettings( newSite?.blogid as number, {
+					launchpad_screen: 'full',
+					blogdescription: siteDescription,
+				} );
 
 				const planObject = supportedPlans.find(
 					( plan ) => plan.productIds.indexOf( planId as number ) >= 0


### PR DESCRIPTION
#### Proposed Changes

* Fixes a bug where the site description was not being saved properly after creating the new Videomaker site.

#### Testing Instructions

* Start at `/setup/videopress`.
* Add a title and description to the site.
* Finish the flow.
* You should see the description set on the site when you're at the launchpad.
* Repeat the signup, but don't set a description. After the site is created the description should be empty in the FSE.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
