### PR TITLE
Stats: Release the new main chart styling feature

### DIFF
--- a/client/components/chart/bar-tooltip.jsx
+++ b/client/components/chart/bar-tooltip.jsx
@@ -1,4 +1,3 @@
-import { Gridicon } from '@automattic/components';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
@@ -6,7 +5,7 @@ import { PureComponent } from 'react';
 export default class ChartBarTooltip extends PureComponent {
 	static propTypes = {
 		className: PropTypes.string,
-		icon: PropTypes.string,
+		icon: PropTypes.object,
 		label: PropTypes.string,
 		value: PropTypes.string,
 	};
@@ -17,7 +16,7 @@ export default class ChartBarTooltip extends PureComponent {
 				<span className="chart__tooltip-wrapper wrapper">
 					<span className="chart__tooltip-value value">{ this.props.value }</span>
 					<span className="chart__tooltip-label label">
-						{ this.props.icon && <Gridicon icon={ this.props.icon } size={ 18 } /> }
+						{ this.props.icon || null }
 						{ this.props.label }
 					</span>
 				</span>

--- a/client/my-sites/stats/modernized-chart-tabs-styles.scss
+++ b/client/my-sites/stats/modernized-chart-tabs-styles.scss
@@ -194,4 +194,11 @@
 			}
 		}
 	}
+
+	&.is-period-year {
+		.chart__bar-section {
+			border-top-left-radius: 4px;
+			border-top-right-radius: 4px;
+		}
+	}
 }

--- a/client/my-sites/stats/modernized-chart-tabs-styles.scss
+++ b/client/my-sites/stats/modernized-chart-tabs-styles.scss
@@ -1,3 +1,5 @@
+@import "@wordpress/base-styles/breakpoints";
+
 $barChartBorderRadius: 2px;
 $yearBarChartBorderRadius: 4px;
 
@@ -9,8 +11,16 @@ $yearBarChartBorderRadius: 4px;
 	.chart__legend {
 		margin-bottom: 16px;
 
+		@media ( max-width: $break-medium ) {
+			padding: 0 16px;
+		}
+
 		.chart__legend-options {
 			text-transform: none;
+
+			@media ( max-width: $break-mobile ) {
+				display: none;
+			}
 		}
 
 		.chart__legend-option {
@@ -54,7 +64,7 @@ $yearBarChartBorderRadius: 4px;
 
 	// Main Chart
 	.chart {
-		padding: 0;
+		padding-left: 20px;
 
 		.chart__bar {
 			// Cancel the chart bar styles
@@ -110,7 +120,7 @@ $yearBarChartBorderRadius: 4px;
 	.stats-tabs {
 		width: 100%;
 		display: flex;
-		flex-wrap: nowrap;
+		flex-wrap: wrap;
 		align-items: center;
 		padding: 24px 0 16px;
 		margin-bottom: 32px;
@@ -121,12 +131,18 @@ $yearBarChartBorderRadius: 4px;
 		}
 
 		.stats-tab {
-			flex: 1;
-			width: auto;
-			border: 0;
+			width: 100%;
 
-			&:not(:first-child) {
-				margin-left: 16px;
+			// Keep the original mobile stats-tabs styles
+			// Adjust new stats-tabs styling beyond the mobile layout
+			@media ( min-width: $break-mobile ) {
+				flex: 1;
+				width: auto;
+				border: 0;
+
+				&:not(:first-child) {
+					margin-left: 16px;
+				}
 			}
 
 			a {
@@ -136,6 +152,13 @@ $yearBarChartBorderRadius: 4px;
 				border-radius: 4px;
 				overflow: hidden;
 				color: var(--studio-black);
+				padding: 10px 0;
+
+				@media ( max-width: $break-mobile ) {
+					display: flex;
+					align-items: center;
+					justify-content: space-between;
+				}
 
 				&:hover {
 					color: var(--studio-black);
@@ -160,14 +183,25 @@ $yearBarChartBorderRadius: 4px;
 					font-size: $font-title-small;
 					font-weight: 500;
 					line-height: 30px;
-				}
+					margin-left: 0;
 
-				.store-stats-orders-chart__value.value {
-					display: block;
+					@media ( max-width: $break-mobile ) {
+						margin-left: auto;
+
+						// For mobile stats-tabs in Store page
+						&:not(.store-stats-orders-chart__value):not(:last-child) {
+							display: none;
+						}
+					}
 				}
 
 				.delta {
 					justify-content: center;
+
+					// For mobile stats-tabs in Store page
+					@media ( max-width: $break-mobile ) {
+						display: none;
+					}
 				}
 			}
 
@@ -195,6 +229,11 @@ $yearBarChartBorderRadius: 4px;
 					color: var(--studio-black);
 					border-color: var(--color-primary);
 					background-color: var(--color-surface);
+
+					// Keep the original mobile stats-tabs border styles
+					@media ( max-width: $break-mobile ) {
+						border-color: transparent;
+					}
 
 					.label {
 						color: var(--studio-black);

--- a/client/my-sites/stats/modernized-chart-tabs-styles.scss
+++ b/client/my-sites/stats/modernized-chart-tabs-styles.scss
@@ -17,6 +17,7 @@ $yearBarChartBorderRadius: 4px;
 
 		.chart__legend-options {
 			text-transform: none;
+			letter-spacing: inherit;
 
 			@media ( max-width: $break-mobile ) {
 				display: none;
@@ -35,6 +36,13 @@ $yearBarChartBorderRadius: 4px;
 			font-weight: 400;
 			line-height: 18px;
 			padding: 0;
+
+			&.is-selectable {
+				&:hover,
+				&:focus {
+					color: var(--studio-black);
+				}
+			}
 
 			.chart__legend-checkbox {
 				width: 20px;

--- a/client/my-sites/stats/modernized-chart-tabs-styles.scss
+++ b/client/my-sites/stats/modernized-chart-tabs-styles.scss
@@ -1,3 +1,6 @@
+$barChartBorderRadius: 2px;
+$yearBarChartBorderRadius: 4px;
+
 // For feature `stats/new-main-chart`
 .stats--new-main-chart {
 	background-color: var(--color-surface);
@@ -82,8 +85,13 @@
 
 		.chart__bar-section {
 			background-color: var(--color-primary);
-			border-top-left-radius: 2px;
-			border-top-right-radius: 2px;
+			border-top-left-radius: $barChartBorderRadius;
+			border-top-right-radius: $barChartBorderRadius;
+		}
+
+		.chart__bar-section-inner {
+			border-top-left-radius: $barChartBorderRadius;
+			border-top-right-radius: $barChartBorderRadius;
 		}
 
 		.chart__x-axis-label:not(.chart__x-axis-width-spacer) {
@@ -197,8 +205,13 @@
 
 	&.is-period-year {
 		.chart__bar-section {
-			border-top-left-radius: 4px;
-			border-top-right-radius: 4px;
+			border-top-left-radius: $yearBarChartBorderRadius;
+			border-top-right-radius: $yearBarChartBorderRadius;
+		}
+
+		.chart__bar-section-inner {
+			border-top-left-radius: $yearBarChartBorderRadius;
+			border-top-right-radius: $yearBarChartBorderRadius;
 		}
 	}
 }

--- a/client/my-sites/stats/modernized-chart-tabs-styles.scss
+++ b/client/my-sites/stats/modernized-chart-tabs-styles.scss
@@ -94,6 +94,11 @@ $yearBarChartBorderRadius: 4px;
 			border-top-right-radius: $barChartBorderRadius;
 		}
 
+		.chart__y-axis,
+		.chart__x-axis-width-spacer {
+			padding: 0 20px;
+		}
+
 		.chart__x-axis-label:not(.chart__x-axis-width-spacer) {
 			font-weight: 400;
 			line-height: 24px;

--- a/client/my-sites/stats/modernized-chart-tabs-styles.scss
+++ b/client/my-sites/stats/modernized-chart-tabs-styles.scss
@@ -122,13 +122,20 @@
 				border: 1.5px solid transparent;
 				border-radius: 4px;
 				overflow: hidden;
-				color: var(--color-neutral-60);
+				color: var(--studio-black);
 
 				&:hover {
+					color: var(--studio-black);
 					background-color: var(--color-neutral-0);
+
+					.label,
+					.value {
+						color: var(--studio-black);
+					}
 				}
 
 				.label {
+					color: var(--color-neutral-60);
 					font-size: $font-body-small;
 					line-height: 20px;
 					text-transform: none;
@@ -136,6 +143,7 @@
 				}
 
 				.value {
+					color: var(--studio-black);
 					font-size: $font-title-small;
 					font-weight: 500;
 					line-height: 30px;
@@ -164,10 +172,6 @@
 						.value {
 							color: var(--studio-black);
 						}
-					}
-
-					.value {
-						color: var(--studio-black);
 					}
 				}
 			}

--- a/client/my-sites/stats/modernized-page-header-styles.scss
+++ b/client/my-sites/stats/modernized-page-header-styles.scss
@@ -1,3 +1,5 @@
+@import "@wordpress/base-styles/breakpoints";
+
 // For page header styles behind feature `stats/new-main-chart`
 .stats--new-wrapper {
 	// Page layout
@@ -9,7 +11,11 @@
 	.formatted-header {
 		&.is-left-align,
 		&.is-right-align {
-			margin: 0;
+			margin: 0 0 16px 0;
+
+			@media ( max-width: $break-medium ) {
+				margin: 24px 16px 12px;
+			}
 
 			.formatted-header__title {
 				margin-bottom: 4px;
@@ -35,20 +41,30 @@
 
 	// StatsNavigation styles
 	.stats-navigation {
-		margin-top: 16px;
-
 		.section-nav {
 			margin: 0;
 			box-shadow: none;
 		}
 
+		.section-nav-group__label {
+			padding: 0;
+		}
+
 		.section-nav__panel {
 			padding: 0;
+
+			@media ( max-width: $break-medium ) {
+				padding: 0 16px;
+			}
 		}
 
 		.section-nav-tab {
 			&:not(:first-child) {
 				margin-left: 16px;
+
+				@media ( max-width: $break-mobile ) {
+					margin-left: 0;
+				}
 			}
 
 			.section-nav-tab__link {
@@ -56,6 +72,14 @@
 				font-size: $font-body-small;
 				line-height: 20px;
 				color: var(--color-neutral-60);
+
+				@media ( max-width: $break-medium ) {
+					padding: 8px 0;
+				}
+
+				@media ( max-width: $break-mobile ) {
+					padding: 8px;
+				}
 
 				&:hover {
 					color: var(--color-neutral-60);

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -227,7 +227,10 @@ class StatsSite extends Component {
 		const showHighlights = config.isEnabled( 'stats/show-traffic-highlights' );
 
 		const isNewMainChart = config.isEnabled( 'stats/new-main-chart' );
-		const wrapperClass = classNames( { 'stats--new-main-chart': isNewMainChart } );
+		const wrapperClass = classNames( {
+			'stats--new-main-chart': isNewMainChart,
+			'is-period-year': period === 'year',
+		} );
 
 		return (
 			<div>

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -1,5 +1,6 @@
 import config from '@automattic/calypso-config';
 import { getUrlParts } from '@automattic/calypso-url';
+import { Icon, people, starEmpty, commentContent } from '@wordpress/icons';
 import classNames from 'classnames';
 import { localize, translate } from 'i18n-calypso';
 import { find } from 'lodash';
@@ -72,22 +73,31 @@ const memoizedQuery = memoizeLast( ( period, endOf ) => ( {
 const CHART_VIEWS = {
 	attr: 'views',
 	legendOptions: [ 'visitors' ],
-	gridicon: 'visible',
+	icon: (
+		<svg className="gridicon" width="24" height="24" fill="none" xmlns="http://www.w3.org/2000/svg">
+			<path
+				fillRule="evenodd"
+				clipRule="evenodd"
+				d="m4 13 .67.336.003-.005a2.42 2.42 0 0 1 .094-.17c.071-.122.18-.302.329-.52.298-.435.749-1.017 1.359-1.598C7.673 9.883 9.498 8.75 12 8.75s4.326 1.132 5.545 2.293c.61.581 1.061 1.163 1.36 1.599a8.29 8.29 0 0 1 .422.689l.002.005L20 13l.67-.336v-.003l-.003-.005-.008-.015-.028-.052a9.752 9.752 0 0 0-.489-.794 11.6 11.6 0 0 0-1.562-1.838C17.174 8.617 14.998 7.25 12 7.25S6.827 8.618 5.42 9.957c-.702.669-1.22 1.337-1.563 1.839a9.77 9.77 0 0 0-.516.845l-.008.015-.002.005-.001.002v.001L4 13Zm8 3a3.5 3.5 0 1 0 0-7 3.5 3.5 0 0 0 0 7Z"
+				fill="#00101C"
+			/>
+		</svg>
+	),
 	label: translate( 'Views', { context: 'noun' } ),
 };
 const CHART_VISITORS = {
 	attr: 'visitors',
-	gridicon: 'multiple-users',
+	icon: <Icon className="gridicon" icon={ people } />,
 	label: translate( 'Visitors', { context: 'noun' } ),
 };
 const CHART_LIKES = {
 	attr: 'likes',
-	gridicon: 'star-outline',
+	icon: <Icon className="gridicon" icon={ starEmpty } />,
 	label: translate( 'Likes', { context: 'noun' } ),
 };
 const CHART_COMMENTS = {
 	attr: 'comments',
-	gridicon: 'comment',
+	icon: <Icon className="gridicon" icon={ commentContent } />,
 	label: translate( 'Comments', { context: 'noun' } ),
 };
 const CHARTS = [ CHART_VIEWS, CHART_VISITORS, CHART_LIKES, CHART_COMMENTS ];

--- a/client/my-sites/stats/stats-chart-tabs/index.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/index.jsx
@@ -131,7 +131,6 @@ class StatModuleChartTabs extends Component {
 					selectedTab={ this.props.chartTab }
 					activeIndex={ this.props.queryDate }
 					activeKey="period"
-					iconSize={ 24 }
 				/>
 			</div>
 		) : (

--- a/client/my-sites/stats/stats-chart-tabs/index.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/index.jsx
@@ -118,12 +118,7 @@ class StatModuleChartTabs extends Component {
 				/>
 				{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace */ }
 				<StatsModulePlaceholder className="is-chart" isLoading={ isActiveTabLoading } />
-				<Chart
-					barClick={ this.props.barClick }
-					data={ this.props.chartData }
-					chartXPadding={ 0 }
-					minBarWidth={ 35 }
-				/>
+				<Chart barClick={ this.props.barClick } data={ this.props.chartData } minBarWidth={ 35 } />
 				<StatTabs
 					data={ this.props.counts }
 					tabs={ this.props.charts }

--- a/client/my-sites/stats/stats-chart-tabs/utility.js
+++ b/client/my-sites/stats/stats-chart-tabs/utility.js
@@ -1,3 +1,11 @@
+import {
+	Icon,
+	people,
+	starEmpty,
+	commentContent,
+	chevronRight,
+	postContent,
+} from '@wordpress/icons';
 import classNames from 'classnames';
 import { numberFormat, translate } from 'i18n-calypso';
 import { capitalize } from 'lodash';
@@ -78,7 +86,7 @@ function addTooltipData( chartTab, item, period ) {
 				label: translate( 'Comments' ),
 				value: numberFormat( item.value ),
 				className: 'is-comments',
-				icon: 'comment',
+				icon: <Icon className="gridicon" icon={ commentContent } />,
 			} );
 			break;
 
@@ -87,7 +95,7 @@ function addTooltipData( chartTab, item, period ) {
 				label: translate( 'Likes' ),
 				value: numberFormat( item.value ),
 				className: 'is-likes',
-				icon: 'star',
+				icon: <Icon className="gridicon" icon={ starEmpty } />,
 			} );
 			break;
 
@@ -96,19 +104,34 @@ function addTooltipData( chartTab, item, period ) {
 				label: translate( 'Views' ),
 				value: numberFormat( item.data.views ),
 				className: 'is-views',
-				icon: 'visible',
+				icon: (
+					<svg
+						className="gridicon"
+						width="24"
+						height="24"
+						fill="none"
+						xmlns="http://www.w3.org/2000/svg"
+					>
+						<path
+							fillRule="evenodd"
+							clipRule="evenodd"
+							d="m4 13 .67.336.003-.005a2.42 2.42 0 0 1 .094-.17c.071-.122.18-.302.329-.52.298-.435.749-1.017 1.359-1.598C7.673 9.883 9.498 8.75 12 8.75s4.326 1.132 5.545 2.293c.61.581 1.061 1.163 1.36 1.599a8.29 8.29 0 0 1 .422.689l.002.005L20 13l.67-.336v-.003l-.003-.005-.008-.015-.028-.052a9.752 9.752 0 0 0-.489-.794 11.6 11.6 0 0 0-1.562-1.838C17.174 8.617 14.998 7.25 12 7.25S6.827 8.618 5.42 9.957c-.702.669-1.22 1.337-1.563 1.839a9.77 9.77 0 0 0-.516.845l-.008.015-.002.005-.001.002v.001L4 13Zm8 3a3.5 3.5 0 1 0 0-7 3.5 3.5 0 0 0 0 7Z"
+							fill="#fff"
+						/>
+					</svg>
+				),
 			} );
 			tooltipData.push( {
 				label: translate( 'Visitors' ),
 				value: numberFormat( item.data.visitors ),
 				className: 'is-visitors',
-				icon: 'multiple-users',
+				icon: <Icon className="gridicon" icon={ people } />,
 			} );
 			tooltipData.push( {
 				label: translate( 'Views Per Visitor' ),
 				value: numberFormat( item.data.views / item.data.visitors, { decimals: 2 } ),
 				className: 'is-views-per-visitor',
-				icon: 'chevron-right',
+				icon: <Icon className="gridicon" icon={ chevronRight } />,
 			} );
 
 			if ( item.data.post_titles && item.data.post_titles.length ) {
@@ -118,7 +141,7 @@ function addTooltipData( chartTab, item, period ) {
 						label: translate( 'Posts Published' ),
 						value: numberFormat( item.data.post_titles.length ),
 						className: 'is-published-nolist',
-						icon: 'posts',
+						icon: <Icon className="gridicon" icon={ postContent } />,
 					} );
 				} else {
 					tooltipData.push( {
@@ -128,7 +151,7 @@ function addTooltipData( chartTab, item, period ) {
 								count: item.data.post_titles.length,
 							} ) + ':',
 						className: 'is-published',
-						icon: 'posts',
+						icon: <Icon className="gridicon" icon={ postContent } />,
 						value: '',
 					} );
 					item.data.post_titles.forEach( ( post_title ) => {

--- a/client/my-sites/stats/stats-period-header/style.scss
+++ b/client/my-sites/stats/stats-period-header/style.scss
@@ -1,7 +1,10 @@
+@import "@wordpress/base-styles/breakpoints";
+
 .stats__period-header {
 	display: flex;
+	flex-wrap: wrap;
 	align-items: center;
-	justify-content: space-between;
+	justify-content: center;
 	background-color: var(--color-surface);
 	margin: 48px 0 16px;
 
@@ -11,11 +14,17 @@
 
 	.stats-period-navigation {
 		flex: 1;
+		min-width: 320px;
+		padding: 0 24px 0 0;
+		margin: 0;
+
+		@media ( max-width: $break-mobile ) {
+			margin: 16px 0;
+			min-width: unset;
+		}
 	}
 
 	.segmented-control {
-		margin-left: 24px;
-
 		&.is-primary {
 			.segmented-control__item.is-selected {
 				.segmented-control__link {
@@ -48,5 +57,33 @@
 		color: var(--studio-black);
 		width: 100px;
 		box-sizing: border-box;
+
+		@media ( max-width: $break-mobile ) {
+			width: auto;
+		}
+	}
+
+	// Make the content break line earlier than 660px
+	@media ( max-width: $break-large ) {
+		.stats-period-navigation {
+			margin: 0 0 24px 0;
+			padding: 0;
+		}
+
+		.segmented-control {
+			width: 100%;
+		}
+
+		.segmented-control__link {
+			width: unset;
+		}
+	}
+
+	@media ( max-width: $break-medium ) {
+		padding: 0 16px;
+	}
+
+	@media ( max-width: $break-mobile ) {
+		margin-top: 0;
 	}
 }

--- a/client/my-sites/stats/stats-period-navigation/index.jsx
+++ b/client/my-sites/stats/stats-period-navigation/index.jsx
@@ -1,5 +1,6 @@
 import config from '@automattic/calypso-config';
 import { Gridicon } from '@automattic/components';
+import { Icon, arrowLeft, arrowRight } from '@wordpress/icons';
 import classNames from 'classnames';
 import { localize, withRtl } from 'i18n-calypso';
 import { flowRight } from 'lodash';
@@ -80,7 +81,7 @@ class StatsPeriodNavigation extends PureComponent {
 					href={ `${ url }${ previousDayQuery }` }
 					onClick={ this.handleClickPrevious }
 				>
-					<Gridicon icon="arrow-left" size={ 24 } />
+					<Icon className="gridicon" icon={ arrowLeft } />
 				</a>
 				<a
 					className={ classNames( 'stats-period-navigation__next', {
@@ -89,7 +90,7 @@ class StatsPeriodNavigation extends PureComponent {
 					href={ `${ url }${ nextDayQuery }` }
 					onClick={ this.handleClickNext }
 				>
-					<Gridicon icon="arrow-right" size={ 24 } />
+					<Icon className="gridicon" icon={ arrowRight } />
 				</a>
 			</div>
 		) : (

--- a/client/my-sites/stats/stats-period-navigation/style.scss
+++ b/client/my-sites/stats/stats-period-navigation/style.scss
@@ -6,7 +6,6 @@
 	padding: 0 20px;
 
 	.stats-period-navigation__children {
-		text-align: center;
 		flex-grow: 1;
 	}
 
@@ -30,18 +29,12 @@
 
 	// For feature `stats/new-main-chart`
 	&.stats-period-navigation--new-main-chart {
-		margin: 0;
-		padding: 0;
-		align-items: center;
-
-		.stats-period-navigation__children {
-			text-align: left;
-		}
 
 		.stats-section-title {
 			font-size: $font-title-large;
 			line-height: 40px;
 			color: var(--studio-gray-100);
+			text-align: left;
 		}
 
 		.stats-date-picker__refresh-status {

--- a/client/my-sites/stats/stats-period-navigation/style.scss
+++ b/client/my-sites/stats/stats-period-navigation/style.scss
@@ -55,6 +55,11 @@
 			// Icon size 24x24
 			width: 24px;
 			height: 24px;
+
+			&.is-disabled {
+				visibility: visible;
+				opacity: 0.2;
+			}
 		}
 
 		.stats-period-navigation__next {

--- a/client/my-sites/stats/stats-period-navigation/style.scss
+++ b/client/my-sites/stats/stats-period-navigation/style.scss
@@ -52,6 +52,7 @@
 			&.is-disabled {
 				visibility: visible;
 				opacity: 0.2;
+				pointer-events: none;
 			}
 		}
 

--- a/client/my-sites/stats/stats-tabs/index.jsx
+++ b/client/my-sites/stats/stats-tabs/index.jsx
@@ -17,21 +17,11 @@ class StatsTabs extends Component {
 		switchTab: PropTypes.func,
 		tabs: PropTypes.array,
 		borderless: PropTypes.bool,
-		iconSize: PropTypes.number,
 	};
 
 	render() {
-		const {
-			children,
-			data,
-			activeIndex,
-			activeKey,
-			tabs,
-			switchTab,
-			selectedTab,
-			borderless,
-			iconSize,
-		} = this.props;
+		const { children, data, activeIndex, activeKey, tabs, switchTab, selectedTab, borderless } =
+			this.props;
 		let statsTabs;
 
 		if ( data && ! children ) {
@@ -43,7 +33,7 @@ class StatsTabs extends Component {
 
 				const tabOptions = {
 					attr: tab.attr,
-					gridicon: tab.gridicon,
+					icon: tab.icon,
 					className: tab.className,
 					label: tab.label,
 					loading: ! hasData,
@@ -51,7 +41,6 @@ class StatsTabs extends Component {
 					tabClick: switchTab,
 					value: hasData ? activeData[ tab.attr ] : null,
 					format: tab.format,
-					iconSize,
 				};
 
 				return <StatTab key={ tabOptions.attr } { ...tabOptions } />;

--- a/client/my-sites/stats/stats-tabs/tab.jsx
+++ b/client/my-sites/stats/stats-tabs/tab.jsx
@@ -1,4 +1,3 @@
-import { Gridicon } from '@automattic/components';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -9,8 +8,7 @@ class StatsTabsTab extends Component {
 
 	static propTypes = {
 		className: PropTypes.string,
-		gridicon: PropTypes.string,
-		iconSize: PropTypes.number,
+		icon: PropTypes.object,
 		href: PropTypes.string,
 		label: PropTypes.string,
 		loading: PropTypes.bool,
@@ -39,29 +37,18 @@ class StatsTabsTab extends Component {
 	};
 
 	render() {
-		const {
-			className,
-			compact,
-			children,
-			gridicon,
-			iconSize = 18,
-			href,
-			label,
-			loading,
-			selected,
-			tabClick,
-			value,
-		} = this.props;
+		const { className, compact, children, icon, href, label, loading, selected, tabClick, value } =
+			this.props;
 
 		const tabClass = classNames( 'stats-tab', className, {
 			'is-selected': selected,
 			'is-loading': loading,
 			'is-low': ! value,
 			'is-compact': compact,
-			'no-icon': ! gridicon,
+			'no-icon': ! icon,
 		} );
 
-		const tabIcon = gridicon ? <Gridicon icon={ gridicon } size={ iconSize } /> : null;
+		const tabIcon = icon ? icon : null;
 		const tabLabel = <span className="stats-tabs__label label">{ label }</span>;
 		const tabValue = <span className="stats-tabs__value value">{ this.ensureValue( value ) }</span>;
 		const hasClickAction = href || tabClick;

--- a/client/my-sites/stats/wordads-chart-tabs/index.jsx
+++ b/client/my-sites/stats/wordads-chart-tabs/index.jsx
@@ -1,5 +1,6 @@
 import config from '@automattic/calypso-config';
 import { Card } from '@automattic/components';
+import { Icon, chartBar, trendingUp } from '@wordpress/icons';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import { flowRight } from 'lodash';
@@ -64,19 +65,34 @@ class WordAdsChartTabs extends Component {
 					label: this.props.translate( 'Ads Served' ),
 					value: this.props.numberFormat( item.data.impressions ),
 					className: 'is-impressions',
-					icon: 'visible',
+					icon: (
+						<svg
+							className="gridicon"
+							width="24"
+							height="24"
+							fill="none"
+							xmlns="http://www.w3.org/2000/svg"
+						>
+							<path
+								fillRule="evenodd"
+								clipRule="evenodd"
+								d="m4 13 .67.336.003-.005a2.42 2.42 0 0 1 .094-.17c.071-.122.18-.302.329-.52.298-.435.749-1.017 1.359-1.598C7.673 9.883 9.498 8.75 12 8.75s4.326 1.132 5.545 2.293c.61.581 1.061 1.163 1.36 1.599a8.29 8.29 0 0 1 .422.689l.002.005L20 13l.67-.336v-.003l-.003-.005-.008-.015-.028-.052a9.752 9.752 0 0 0-.489-.794 11.6 11.6 0 0 0-1.562-1.838C17.174 8.617 14.998 7.25 12 7.25S6.827 8.618 5.42 9.957c-.702.669-1.22 1.337-1.563 1.839a9.77 9.77 0 0 0-.516.845l-.008.015-.002.005-.001.002v.001L4 13Zm8 3a3.5 3.5 0 1 0 0-7 3.5 3.5 0 0 0 0 7Z"
+								fill="#fff"
+							/>
+						</svg>
+					),
 				} );
 				tooltipData.push( {
 					label: this.props.translate( 'Avg. CPM' ),
 					value: '$ ' + this.props.numberFormat( item.data.cpm, { decimals: 2 } ),
 					className: 'is-cpm',
-					icon: 'stats-alt',
+					icon: <Icon className="gridicon" icon={ chartBar } />,
 				} );
 				tooltipData.push( {
 					label: this.props.translate( 'Revenue' ),
 					value: '$ ' + this.props.numberFormat( item.data.revenue, { decimals: 2 } ),
 					className: 'is-revenue',
-					icon: 'money',
+					icon: <Icon className="gridicon" icon={ trendingUp } />,
 				} );
 				break;
 		}

--- a/client/my-sites/stats/wordads-chart-tabs/index.jsx
+++ b/client/my-sites/stats/wordads-chart-tabs/index.jsx
@@ -155,7 +155,6 @@ class WordAdsChartTabs extends Component {
 						<Chart
 							barClick={ this.props.barClick }
 							data={ this.buildChartData() }
-							chartXPadding={ 0 }
 							minBarWidth={ 35 }
 						/>
 						<StatTabs

--- a/client/my-sites/stats/wordads/index.jsx
+++ b/client/my-sites/stats/wordads/index.jsx
@@ -156,7 +156,6 @@ class WordAds extends Component {
 		const wordads = {
 			label: 'Ads',
 			path: '/stats/ads',
-			showIntervals: true,
 		};
 
 		const slugPath = slug ? `/${ slug }` : '';
@@ -164,7 +163,10 @@ class WordAds extends Component {
 
 		// New feature gate
 		const isNewMainChart = config.isEnabled( 'stats/new-main-chart' );
-		const statsWrapperClass = classNames( 'wordads', { 'stats--new-main-chart': isNewMainChart } );
+		const statsWrapperClass = classNames( 'wordads', {
+			'stats--new-main-chart': isNewMainChart,
+			'is-period-year': period === 'year',
+		} );
 		const mainWrapperClass = classNames( {
 			'stats--new-wrapper': isNewMainChart,
 		} );

--- a/client/my-sites/stats/wordads/index.jsx
+++ b/client/my-sites/stats/wordads/index.jsx
@@ -1,4 +1,5 @@
 import config from '@automattic/calypso-config';
+import { Icon, chartBar, trendingUp } from '@wordpress/icons';
 import classNames from 'classnames';
 import { localize, translate, numberFormat } from 'i18n-calypso';
 import { find } from 'lodash';
@@ -49,18 +50,33 @@ const CHARTS = [
 	{
 		attr: 'impressions',
 		legendOptions: [ 'impressions' ],
-		gridicon: 'visible',
+		icon: (
+			<svg
+				className="gridicon"
+				width="24"
+				height="24"
+				fill="none"
+				xmlns="http://www.w3.org/2000/svg"
+			>
+				<path
+					fillRule="evenodd"
+					clipRule="evenodd"
+					d="m4 13 .67.336.003-.005a2.42 2.42 0 0 1 .094-.17c.071-.122.18-.302.329-.52.298-.435.749-1.017 1.359-1.598C7.673 9.883 9.498 8.75 12 8.75s4.326 1.132 5.545 2.293c.61.581 1.061 1.163 1.36 1.599a8.29 8.29 0 0 1 .422.689l.002.005L20 13l.67-.336v-.003l-.003-.005-.008-.015-.028-.052a9.752 9.752 0 0 0-.489-.794 11.6 11.6 0 0 0-1.562-1.838C17.174 8.617 14.998 7.25 12 7.25S6.827 8.618 5.42 9.957c-.702.669-1.22 1.337-1.563 1.839a9.77 9.77 0 0 0-.516.845l-.008.015-.002.005-.001.002v.001L4 13Zm8 3a3.5 3.5 0 1 0 0-7 3.5 3.5 0 0 0 0 7Z"
+					fill="#00101C"
+				/>
+			</svg>
+		),
 		label: translate( 'Ads Served' ),
 	},
 	{
 		attr: 'cpm',
-		gridicon: 'stats-alt',
+		icon: <Icon className="gridicon" icon={ chartBar } />,
 		label: translate( 'Average CPM' ),
 		format: formatCurrency,
 	},
 	{
 		attr: 'revenue',
-		gridicon: 'money',
+		icon: <Icon className="gridicon" icon={ trendingUp } />,
 		label: translate( 'Revenue' ),
 		format: formatCurrency,
 	},

--- a/client/my-sites/store/app/store-stats/constants.js
+++ b/client/my-sites/store/app/store-stats/constants.js
@@ -1,3 +1,4 @@
+import { Icon, currencyDollar, shipping, percent } from '@wordpress/icons';
 import { translate } from 'i18n-calypso';
 
 const sparkWidgetList1 = [
@@ -120,7 +121,23 @@ export const chartTabs = [
 		type: 'currency',
 		tabLabel: translate( 'Gross Sales' ),
 		availableCharts: [ 'net_sales' ],
-		gridicon: 'credit-card',
+		icon: (
+			<svg
+				className="gridicon"
+				width="25"
+				height="25"
+				viewBox="0 0 25 25"
+				fill="none"
+				xmlns="http://www.w3.org/2000/svg"
+			>
+				<path
+					fillRule="evenodd"
+					clipRule="evenodd"
+					d="M6 10V8H19V10H6ZM6 13V17H19V13H6ZM4.5 7.5C4.5 6.94772 4.94772 6.5 5.5 6.5H19.5C20.0523 6.5 20.5 6.94772 20.5 7.5V17.5C20.5 18.0523 20.0523 18.5 19.5 18.5H5.5C4.94772 18.5 4.5 18.0523 4.5 17.5V7.5Z"
+					fill="black"
+				/>
+			</svg>
+		),
 	},
 	{
 		label: translate( 'Net Sales' ),
@@ -128,21 +145,21 @@ export const chartTabs = [
 		isHidden: false,
 		availableCharts: [],
 		type: 'currency',
-		gridicon: 'money',
+		icon: <Icon className="gridicon" icon={ currencyDollar } />,
 	},
 	{
 		label: translate( 'Orders' ),
 		attr: 'orders',
 		type: 'number',
 		availableCharts: [],
-		gridicon: 'shipping',
+		icon: <Icon className="gridicon" icon={ shipping } />,
 	},
 	{
 		label: translate( 'Avg. Order Value' ),
 		attr: 'avg_order_value',
 		type: 'currency',
 		availableCharts: [],
-		gridicon: 'special-character',
+		icon: <Icon className="gridicon" icon={ percent } />,
 	},
 ];
 

--- a/client/my-sites/store/app/store-stats/index.js
+++ b/client/my-sites/store/app/store-stats/index.js
@@ -47,14 +47,16 @@ class StoreStats extends Component {
 		const store = {
 			label: translate( 'Store' ),
 			path: '/store/stats/orders',
-			showIntervals: true,
 		};
 		const slugPath = slug ? `/${ slug }` : '';
 		const pathTemplate = `${ store.path }/{{ interval }}${ slugPath }`;
 
 		// New feature gate
 		const isNewMainChart = config.isEnabled( 'stats/new-main-chart' );
-		const statsWrapperClass = classNames( { 'stats--new-main-chart': isNewMainChart } );
+		const statsWrapperClass = classNames( {
+			'stats--new-main-chart': isNewMainChart,
+			'is-period-year': unit === 'year',
+		} );
 		const mainWrapperClass = classNames( 'store-stats', 'woocommerce', {
 			'stats--new-wrapper': isNewMainChart,
 		} );

--- a/client/my-sites/store/app/store-stats/store-stats-chart/index.js
+++ b/client/my-sites/store/app/store-stats/store-stats-chart/index.js
@@ -163,7 +163,6 @@ class StoreStatsChart extends Component {
 					loading={ isLoading }
 					data={ chartData }
 					barClick={ this.barClick }
-					chartXPadding={ 0 }
 					minBarWidth={ 35 }
 				/>
 				{ ! isLoading &&

--- a/client/my-sites/store/app/store-stats/store-stats-chart/index.js
+++ b/client/my-sites/store/app/store-stats/store-stats-chart/index.js
@@ -1,5 +1,6 @@
 import config from '@automattic/calypso-config';
 import { Card } from '@automattic/components';
+import { Icon, currencyDollar } from '@wordpress/icons';
 import classNames from 'classnames';
 import { findIndex, find } from 'lodash';
 import page from 'page';
@@ -84,12 +85,30 @@ class StoreStatsChart extends Component {
 			{
 				value,
 				label: selectedTab.label,
+				icon: (
+					<svg
+						className="gridicon"
+						width="25"
+						height="25"
+						viewBox="0 0 25 25"
+						fill="none"
+						xmlns="http://www.w3.org/2000/svg"
+					>
+						<path
+							fillRule="evenodd"
+							clipRule="evenodd"
+							d="M6 10V8H19V10H6ZM6 13V17H19V13H6ZM4.5 7.5C4.5 6.94772 4.94772 6.5 5.5 6.5H19.5C20.0523 6.5 20.5 6.94772 20.5 7.5V17.5C20.5 18.0523 20.0523 18.5 19.5 18.5H5.5C4.94772 18.5 4.5 18.0523 4.5 17.5V7.5Z"
+							fill="#fff"
+						/>
+					</svg>
+				),
 			},
 		];
 		activeCharts.forEach( ( attr ) => {
 			data.push( {
 				value: formatValue( item[ attr ], selectedTab.type, item.currency ),
 				label: find( tabs, ( tab ) => tab.attr === attr ).label,
+				icon: <Icon className="gridicon" icon={ currencyDollar } />,
 			} );
 		} );
 		return data;
@@ -155,7 +174,6 @@ class StoreStatsChart extends Component {
 						selectedDate,
 						unit,
 						tabClick: this.tabClick,
-						iconSize: 24,
 					} ) }
 			</div>
 		) : (

--- a/client/my-sites/store/app/store-stats/store-stats-orders-chart/index.js
+++ b/client/my-sites/store/app/store-stats/store-stats-orders-chart/index.js
@@ -26,15 +26,7 @@ class StoreStatsOrdersChart extends Component {
 		slug: PropTypes.string,
 	};
 
-	renderTabs = ( {
-		chartData,
-		selectedIndex,
-		selectedTabIndex,
-		selectedDate,
-		unit,
-		tabClick,
-		iconSize,
-	} ) => {
+	renderTabs = ( { chartData, selectedIndex, selectedTabIndex, selectedDate, unit, tabClick } ) => {
 		const { deltas, moment } = this.props;
 		return (
 			<Tabs data={ chartData }>
@@ -60,8 +52,7 @@ class StoreStatsOrdersChart extends Component {
 							label={ tab.tabLabel || tab.label }
 							selected={ tabIndex === selectedTabIndex }
 							tabClick={ tabClick }
-							iconSize={ iconSize }
-							gridicon={ iconSize && tab.gridicon }
+							icon={ tab.icon }
 						>
 							<span className="store-stats-orders-chart__value value">
 								{ formatValue( value, tab.type, itemChartData.data.currency ) }

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -105,7 +105,7 @@
 		"ssr/prefetch-timebox": true,
 		"stats/new-all-time-highlights": false,
 		"stats/new-annual-highlights": false,
-		"stats/new-main-chart": false,
+		"stats/new-main-chart": true,
 		"stats/new-stats-module-component": false,
 		"stats/show-traffic-highlights": false,
 		"stepper-woocommerce-poc": true,

--- a/config/production.json
+++ b/config/production.json
@@ -125,7 +125,7 @@
 		"ssr/sample-log-cache-misses": true,
 		"stats/new-all-time-highlights": false,
 		"stats/new-annual-highlights": false,
-		"stats/new-main-chart": false,
+		"stats/new-main-chart": true,
 		"stats/new-stats-module-component": false,
 		"stats/show-traffic-highlights": false,
 		"stepper-woocommerce-poc": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -121,7 +121,7 @@
 		"ssr/prefetch-timebox": true,
 		"stats/new-all-time-highlights": false,
 		"stats/new-annual-highlights": false,
-		"stats/new-main-chart": false,
+		"stats/new-main-chart": true,
 		"stats/new-stats-module-component": false,
 		"stats/show-traffic-highlights": false,
 		"stepper-woocommerce-poc": true,

--- a/config/test.json
+++ b/config/test.json
@@ -90,7 +90,7 @@
 		"ssr/prefetch-timebox": true,
 		"stats/new-all-time-highlights": false,
 		"stats/new-annual-highlights": false,
-		"stats/new-main-chart": false,
+		"stats/new-main-chart": true,
 		"stats/new-stats-module-component": false,
 		"stats/show-traffic-highlights": false,
 		"stepper-woocommerce-poc": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -129,7 +129,7 @@
 		"ssr/prefetch-timebox": true,
 		"stats/new-all-time-highlights": false,
 		"stats/new-annual-highlights": false,
-		"stats/new-main-chart": false,
+		"stats/new-main-chart": true,
 		"stats/new-stats-module-component": false,
 		"stats/show-traffic-highlights": false,
 		"stepper-woocommerce-poc": true,


### PR DESCRIPTION
#### Proposed Changes

<img width="1121" alt="截圖 2022-11-12 上午1 31 52" src="https://user-images.githubusercontent.com/6869813/201396544-cbcf1ab5-84b9-4e3c-9d05-da4d5b04b029.png">

---

<img width="1144" alt="截圖 2022-11-12 上午1 09 57" src="https://user-images.githubusercontent.com/6869813/201395255-4451a663-b397-4549-80c7-8df75352a406.png">

---

<img width="1117" alt="截圖 2022-11-12 上午1 10 04" src="https://user-images.githubusercontent.com/6869813/201395288-ef624f28-9e4c-4991-89b0-52eccf887f83.png">

---

* Releases the new main chart styling on `Traffic`, `Store`, and `Ads` pages.
* Update chart tab and tooltip icons with `@wordpress/icons`.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up this change in a live branch.
* Navigate to the `Traffic`, `Store`, and `Ads` tab pages on Stats.
* Ensure the new styling of the main chart, chart tabs, and page header is displayed.

> Note: The instructions to show the Store and Ads pages can be found at https://github.com/Automattic/wp-calypso/pull/69661 and https://github.com/Automattic/wp-calypso/pull/69743.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #69041
Related to #68974 
