### PR TITLE
VideoPress Tailored Onboarding: Style/Layout Fixes

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-plan/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-plan/style.scss
@@ -1,4 +1,5 @@
 $videopress-mobile-layout-width: 700px;
+$videopress-yellow: #ffe61c;
 $videopress-link-color: #c377ff;
 $videopress-background: #010101;
 
@@ -34,6 +35,7 @@ $videopress-background: #010101;
 
 		justify-content: center;
 		gap: 24px;
+		padding-bottom: 48px;
 
 		.plan-separator {
 			width: 1px;
@@ -48,20 +50,12 @@ $videopress-background: #010101;
 
 			min-width: auto;
 			flex-grow: unset;
-			margin-top: 46px;
+			margin-top: 0;
 
 			&.is-popular {
 				margin-top: 0;
 				.plan-item__badge {
-					background-color: $videopress-link-color;
-					color: $videopress-background;
-					width: fit-content;
-					text-transform: none;
-					font-weight: 500;
-					margin: auto;
-					border-radius: 4px;
-					padding: 0 10px;
-					margin-bottom: 22px;
+					display: none;
 				}
 			}
 
@@ -104,7 +98,7 @@ $videopress-background: #010101;
 
 					&:hover,
 					&:active {
-						background-color: #ffe61c;
+						background-color: $videopress-yellow;
 						color: #000;
 					}
 				}
@@ -112,8 +106,8 @@ $videopress-background: #010101;
 				&:not(.is-popular) {
 					.components-button.plan-item__select-button.is-primary {
 						background: none;
-						color: #fff;
-						border: solid 1px rgba(255, 255, 255, 0.2);
+						color: $videopress-yellow;
+						border: solid 1px $videopress-yellow;
 					}
 				}
 
@@ -128,7 +122,7 @@ $videopress-background: #010101;
 						}
 
 						&.plans-feature-list__item--requires-annual-disabled .plans-feature-list__item-bullet-icon {
-							color: #ffe61c;
+							color: $videopress-yellow;
 						}
 
 						.plans-feature-list__item-description {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/videomaker-setup/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/videomaker-setup/styles.scss
@@ -36,10 +36,9 @@ $font-family: "SF Pro Text", $sans;
 
 		button {
 			background-color: $videopress-theme-border-color;
-			outline: 10px solid $videopress-theme-border-color;
 			/* stylelint-disable-next-line scales/radii */
 			border-radius: 8px;
-			padding: 0;
+			padding: 8px;
 			margin: 0;
 			transition: all 0.2s ease-in-out;
 			transform: scale(1);
@@ -60,7 +59,6 @@ $font-family: "SF Pro Text", $sans;
 				transform: scale(1.05);
 				z-index: 1;
 				background-color: $videopress-theme-yellow;
-				outline: 8px solid $videopress-theme-yellow;
 			}
 		}
 


### PR DESCRIPTION
#### Proposed Changes

* Fixes a bug with the theme selection view on Safari
* Updates the plan selection view layout and coloring

Old:
<img width="783" alt="Screenshot 2022-11-11 at 10 39 45 AM" src="https://user-images.githubusercontent.com/789137/201397929-433330fc-846f-430c-8a16-f56b40088d9b.png">

New:
<img width="752" alt="Screenshot 2022-11-11 at 10 40 17 AM" src="https://user-images.githubusercontent.com/789137/201397985-32bf1917-6c38-40ec-b020-3fcd1cb556f5.png">


#### Testing Instructions

* Start testing at `/setup/videopress`
* In Safari, verify the theme selection has rounded corners around the buttons:

<img width="1089" alt="Screenshot 2022-11-11 at 10 41 50 AM" src="https://user-images.githubusercontent.com/789137/201398459-b25f7b9d-7ddf-40ec-bfc1-b6d9f869c78b.png">

* Proceed to the plan selection view, and verify the new styles and the view works as expected.


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
