### PR TITLE
Added Tracks event when product is selected on Dashboard

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
@@ -157,6 +157,17 @@ export default function SitesOverview() {
 					primary
 					className="sites-overview__licenses-buttons-issue-license"
 					href={ issueLicenseRedirectUrl }
+					onClick={ () =>
+						dispatch(
+							recordTracksEvent( 'calypso_jetpack_agency_dashboard_licenses_select', {
+								site_id: selectedLicensesSiteId,
+								products: selectedLicenses
+									?.map( ( type: string ) => getProductSlugFromProductType( type ) )
+									// If multiple products are selected, pass them as a comma-separated list.
+									.join( ',' ),
+							} )
+						)
+					}
 				>
 					{ translate( 'Issue %(numLicenses)d new license', 'Issue %(numLicenses)d new licenses', {
 						context: 'button label',

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content.tsx
@@ -67,6 +67,11 @@ export default function SiteStatusContent( {
 
 	const handleSelectLicenseAction = () => {
 		dispatch( selectLicense( siteId, type ) );
+		dispatch(
+			recordTracksEvent( 'calypso_jetpack_agency_dashboard_add_license', {
+				type: type,
+			} )
+		);
 	};
 
 	const handleDeselectLicenseAction = () => {

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content.tsx
@@ -67,11 +67,6 @@ export default function SiteStatusContent( {
 
 	const handleSelectLicenseAction = () => {
 		dispatch( selectLicense( siteId, type ) );
-		dispatch(
-			recordTracksEvent( 'calypso_jetpack_agency_dashboard_add_license', {
-				type: type,
-			} )
-		);
 	};
 
 	const handleDeselectLicenseAction = () => {


### PR DESCRIPTION
#### Proposed Changes

* Add Tracks event when product(s) is/are selected on Dashboard and the *Issue new licenses* button is selected.
* The tag captures both the siteID as well as the products that were added.

#### Testing Instructions

* Checkout PR and run Jetpack Cloud locally
* http://jetpack.cloud.localhost:3000/dashboard
* Use the `(+Add)` button to add Backup, Scan or both
* Using network tab or the Tracks Vigilante Chrome Extension, view to see if `calypso_jetpack_agency_dashboard_licenses_select`
* The tag will be captured once the green "Issue new licenses" button is selected.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1203126240279377-as-1203136066214509/f