### PR TITLE
Theme Showcase: New component ThemesToolbarGroup

### DIFF
--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -64,6 +64,7 @@ class ThemeShowcase extends Component {
 		this.bookmarkRef = createRef();
 		this.tabTiers = this.getTabTiers( props );
 		this.tabFilters = this.getTabFilters( props );
+		this.tabSubjectTermTable = this.getSubjectTermTable( props );
 		this.state = {
 			tabFilter: this.tabFilters.ALL,
 		};
@@ -176,6 +177,15 @@ class ThemeShowcase extends Component {
 		};
 	};
 
+	getSubjectTermTable = ( { filterToTermTable } ) => {
+		return Object.keys( filterToTermTable )
+			.filter( ( key ) => key.indexOf( 'subject:' ) !== -1 )
+			.reduce( ( obj, key ) => {
+				obj[ key ] = filterToTermTable[ key ];
+				return obj;
+			}, {} );
+	};
+
 	scrollToSearchInput = () => {
 		if ( ! this.props.loggedOutComponent && this.scrollRef && this.scrollRef.current ) {
 			// If you are a larger screen where the theme info is displayed horizontally.
@@ -284,10 +294,20 @@ class ThemeShowcase extends Component {
 		}
 
 		if ( isNewSearchAndFilter ) {
-			const url = this.constructUrl( {
-				filter: this.props.filterToTermTable[ `subject:${ tabFilter.key }` ],
-			} );
-			page( url );
+			const { filter, search, filterToTermTable } = this.props;
+			const subjectTerm = filterToTermTable[ `subject:${ tabFilter.key }` ];
+			const subjectFilters = Object.values( this.tabSubjectTermTable );
+			const filterWithoutSubjects = filter
+				.split( '+' )
+				.filter( ( key ) => ! subjectFilters.includes( key ) )
+				.join( '+' );
+
+			const newFilter =
+				tabFilter.key !== this.tabFilters.ALL.key
+					? [ filterWithoutSubjects, subjectTerm ].join( '+' )
+					: filterWithoutSubjects;
+
+			page( this.constructUrl( { filter: newFilter, searchString: search } ) );
 		}
 
 		this.setState( { tabFilter }, callback );

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -18,6 +18,7 @@ import SearchThemes from 'calypso/components/search-themes';
 import SectionNav from 'calypso/components/section-nav';
 import NavItem from 'calypso/components/section-nav/item';
 import NavTabs from 'calypso/components/section-nav/tabs';
+import SimplifiedSegmentedControl from 'calypso/components/segmented-control/simplified';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { buildRelativeSearchUrl } from 'calypso/lib/build-url';
 import AutoLoadingHomepageModal from 'calypso/my-sites/themes/auto-loading-homepage-modal';
@@ -60,6 +61,7 @@ class ThemeShowcase extends Component {
 		super( props );
 		this.scrollRef = createRef();
 		this.bookmarkRef = createRef();
+		this.tabTiers = this.getTabTiers( props );
 		this.tabFilters = this.getTabFilters( props );
 		this.state = {
 			tabFilter:
@@ -125,6 +127,15 @@ class ThemeShowcase extends Component {
 			this.scrollToSearchInput();
 		}
 	}
+
+	getTabTiers = () => {
+		const { translate } = this.props;
+		return [
+			{ value: 'all', label: translate( 'All' ) },
+			{ value: 'free', label: translate( 'Free' ) },
+			{ value: 'premium', label: translate( 'Premium' ) },
+		];
+	};
 
 	getTabFilters = () => {
 		const { subjects = {}, translate } = this.props;
@@ -452,17 +463,26 @@ class ThemeShowcase extends Component {
 					) }
 					{ isLoggedIn &&
 						( isNewSearchAndFilter ? (
-							<ThemesToolbarGroup
-								items={ Object.values( this.tabFilters ).filter( ( tabFilter ) =>
-									this.shouldShowTab( tabFilter.key )
-								) }
-								selectedKey={ this.state.tabFilter.key }
-								onSelect={ ( key ) =>
-									this.onFilterClick(
-										Object.values( this.tabFilters ).find( ( tabFilter ) => tabFilter.key === key )
-									)
-								}
-							/>
+							<div className="theme__filters">
+								<ThemesToolbarGroup
+									items={ Object.values( this.tabFilters ).filter( ( tabFilter ) =>
+										this.shouldShowTab( tabFilter.key )
+									) }
+									selectedKey={ this.state.tabFilter.key }
+									onSelect={ ( key ) =>
+										this.onFilterClick(
+											Object.values( this.tabFilters ).find(
+												( tabFilter ) => tabFilter.key === key
+											)
+										)
+									}
+								/>
+								<SimplifiedSegmentedControl
+									initialSelected={ tier || 'all' }
+									options={ this.tabTiers }
+									onSelect={ this.onTierSelect }
+								/>
+							</div>
 						) : (
 							<SectionNav
 								className="themes__section-nav"

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -66,7 +66,7 @@ class ThemeShowcase extends Component {
 		this.tabFilters = this.getTabFilters( props );
 		this.tabSubjectTermTable = this.getSubjectTermTable( props );
 		this.state = {
-			tabFilter: this.tabFilters.ALL,
+			tabFilter: this.getTabFilterFromUrl( props.filter ),
 		};
 	}
 
@@ -186,6 +186,26 @@ class ThemeShowcase extends Component {
 			}, {} );
 	};
 
+	getTabFilterFromUrl = ( filterString ) => {
+		const matches = Object.values( this.tabSubjectTermTable ).filter(
+			( value ) => filterString.indexOf( value ) >= 0
+		);
+
+		let tabFilter = this.tabFilters.ALL;
+		if ( ! matches.length ) {
+			return tabFilter;
+		}
+
+		const filterKey = matches[ matches.length - 1 ].split( ':' ).pop();
+		Object.values( this.tabFilters ).map( ( filter ) => {
+			if ( filter.key === filterKey ) {
+				tabFilter = filter;
+			}
+		} );
+
+		return tabFilter;
+	};
+
 	scrollToSearchInput = () => {
 		if ( ! this.props.loggedOutComponent && this.scrollRef && this.scrollRef.current ) {
 			// If you are a larger screen where the theme info is displayed horizontally.
@@ -213,13 +233,15 @@ class ThemeShowcase extends Component {
 
 		const filters = searchBoxContent.match( filterRegex ) || [];
 		const validFilters = filters.map( ( filter ) => filterToTermTable[ filter ] );
+		const filterString = compact( validFilters ).join( '+' );
 
 		const url = this.constructUrl( {
-			filter: compact( validFilters ).join( '+' ),
+			filter: filterString,
 			// Strip filters and excess whitespace
 			searchString: searchBoxContent.replace( filterRegex, '' ).replace( /\s+/g, ' ' ).trim(),
 		} );
-		this.setState( { tabFilter: this.tabFilters.ALL } );
+
+		this.setState( { tabFilter: this.getTabFilterFromUrl( filterString ) } );
 		page( url );
 		this.scrollToSearchInput();
 	};

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -133,6 +133,7 @@ class ThemeShowcase extends Component {
 				Object.entries( subjects ).map( ( [ key, filter ] ) => [ key, { key, text: filter.name } ] )
 			)
 		);
+		const isNewSearchAndFilter = config.isEnabled( 'themes/showcase-i4/search-and-filter' );
 
 		return {
 			RECOMMENDED: {
@@ -152,10 +153,10 @@ class ThemeShowcase extends Component {
 			},
 			ALL: {
 				key: 'all',
-				text: translate( 'All Themes' ),
+				text: isNewSearchAndFilter ? translate( 'All' ) : translate( 'All Themes' ),
 				order: 4,
 			},
-			...subjectFilters,
+			...( isNewSearchAndFilter && subjectFilters ),
 		};
 	};
 
@@ -277,6 +278,9 @@ class ThemeShowcase extends Component {
 					( this.props.isJetpackSite && ! this.props.isAtomicSite ) ||
 					( this.props.isAtomicSite && this.props.siteCanInstallThemes )
 				);
+			// There are not enough themes in this filter.
+			case this.tabFilters.newsletter?.key:
+				return false;
 		}
 
 		return true;
@@ -446,40 +450,43 @@ class ThemeShowcase extends Component {
 							select={ this.onTierSelect }
 						/>
 					) }
-					{ isLoggedIn && (
-						<SectionNav className="themes__section-nav" selectedText={ this.state.tabFilter.text }>
-							<NavTabs>
-								{ Object.values( this.tabFilters )
-									.sort( ( a, b ) => a.order - b.order )
-									.map(
-										( tabFilter ) =>
-											this.shouldShowTab( tabFilter.key ) && (
-												<NavItem
-													key={ tabFilter.key }
-													onClick={ () => this.onFilterClick( tabFilter ) }
-													selected={ tabFilter.key === this.state.tabFilter.key }
-													count={ this.notificationCount( tabFilter.key ) }
-												>
-													{ tabFilter.text }
-												</NavItem>
-											)
-									) }
-							</NavTabs>
-						</SectionNav>
-					) }
-					{ isLoggedIn && (
-						<ThemesToolbarGroup
-							items={ Object.values( this.tabFilters ).filter( ( tabFilter ) =>
-								this.shouldShowTab( tabFilter.key )
-							) }
-							selectedKey={ this.state.tabFilter.key }
-							onSelect={ ( key ) =>
-								this.onFilterClick(
-									Object.values( this.tabFilters ).find( ( tabFilter ) => tabFilter.key === key )
-								)
-							}
-						/>
-					) }
+					{ isLoggedIn &&
+						( isNewSearchAndFilter ? (
+							<ThemesToolbarGroup
+								items={ Object.values( this.tabFilters ).filter( ( tabFilter ) =>
+									this.shouldShowTab( tabFilter.key )
+								) }
+								selectedKey={ this.state.tabFilter.key }
+								onSelect={ ( key ) =>
+									this.onFilterClick(
+										Object.values( this.tabFilters ).find( ( tabFilter ) => tabFilter.key === key )
+									)
+								}
+							/>
+						) : (
+							<SectionNav
+								className="themes__section-nav"
+								selectedText={ this.state.tabFilter.text }
+							>
+								<NavTabs>
+									{ Object.values( this.tabFilters )
+										.sort( ( a, b ) => a.order - b.order )
+										.map(
+											( tabFilter ) =>
+												this.shouldShowTab( tabFilter.key ) && (
+													<NavItem
+														key={ tabFilter.key }
+														onClick={ () => this.onFilterClick( tabFilter ) }
+														selected={ tabFilter.key === this.state.tabFilter.key }
+														count={ this.notificationCount( tabFilter.key ) }
+													>
+														{ tabFilter.text }
+													</NavItem>
+												)
+										) }
+								</NavTabs>
+							</SectionNav>
+						) ) }
 					{ this.renderBanner() }
 					{ this.renderThemes( themeProps ) }
 					{ siteId && <QuerySitePlans siteId={ siteId } /> }

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -2,7 +2,7 @@ import config from '@automattic/calypso-config';
 import { FEATURE_INSTALL_THEMES } from '@automattic/calypso-products';
 import cookie from 'cookie';
 import { localize } from 'i18n-calypso';
-import { compact, pickBy, shuffle } from 'lodash';
+import { compact, pickBy } from 'lodash';
 import page from 'page';
 import PropTypes from 'prop-types';
 import { createRef, Component } from 'react';
@@ -139,9 +139,7 @@ class ThemeShowcase extends Component {
 
 	getTabFilters = ( { subjects = {}, translate } ) => {
 		const subjectFilters = Object.fromEntries(
-			shuffle(
-				Object.entries( subjects ).map( ( [ key, filter ] ) => [ key, { key, text: filter.name } ] )
-			)
+			Object.entries( subjects ).map( ( [ key, filter ] ) => [ key, { key, text: filter.name } ] )
 		);
 		const isNewSearchAndFilter = config.isEnabled( 'themes/showcase-i4/search-and-filter' );
 

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -28,6 +28,7 @@ import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
 import {
+	arePremiumThemesEnabled,
 	getActiveTheme,
 	getCanonicalTheme,
 	getThemeFilterTerms,
@@ -128,8 +129,7 @@ class ThemeShowcase extends Component {
 		}
 	}
 
-	getTabTiers = () => {
-		const { translate } = this.props;
+	getTabTiers = ( { translate } ) => {
 		return [
 			{ value: 'all', label: translate( 'All' ) },
 			{ value: 'free', label: translate( 'Free' ) },
@@ -137,8 +137,7 @@ class ThemeShowcase extends Component {
 		];
 	};
 
-	getTabFilters = () => {
-		const { subjects = {}, translate } = this.props;
+	getTabFilters = ( { subjects = {}, translate } ) => {
 		const subjectFilters = Object.fromEntries(
 			shuffle(
 				Object.entries( subjects ).map( ( [ key, filter ] ) => [ key, { key, text: filter.name } ] )
@@ -379,6 +378,7 @@ class ThemeShowcase extends Component {
 			filterString,
 			isMultisite,
 			locale,
+			premiumThemesEnabled,
 		} = this.props;
 		const tier = this.props.tier || '';
 
@@ -477,11 +477,14 @@ class ThemeShowcase extends Component {
 										)
 									}
 								/>
-								<SimplifiedSegmentedControl
-									initialSelected={ tier || 'all' }
-									options={ this.tabTiers }
-									onSelect={ this.onTierSelect }
-								/>
+								{ premiumThemesEnabled && ! isMultisite && (
+									<SimplifiedSegmentedControl
+										key={ tier }
+										initialSelected={ tier || 'all' }
+										options={ this.tabTiers }
+										onSelect={ this.onTierSelect }
+									/>
+								) }
 							</div>
 						) : (
 							<SectionNav
@@ -537,6 +540,7 @@ const mapStateToProps = ( state, { siteId, filter, tier, vertical } ) => {
 		description: getThemeShowcaseDescription( state, { filter, tier, vertical } ),
 		title: getThemeShowcaseTitle( state, { filter, tier, vertical } ),
 		subjects: getThemeFilterTerms( state, 'subject' ) || {},
+		premiumThemesEnabled: arePremiumThemesEnabled( state, siteId ),
 		filterString: prependThemeFilterKeys( state, filter ),
 		filterToTermTable: getThemeFilterToTermTable( state ),
 		themesBookmark: getThemesBookmark( state ),

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -186,7 +186,7 @@ class ThemeShowcase extends Component {
 			}, {} );
 	};
 
-	getTabFilterFromUrl = ( filterString ) => {
+	getTabFilterFromUrl = ( filterString = '' ) => {
 		const matches = Object.values( this.tabSubjectTermTable ).filter(
 			( value ) => filterString.indexOf( value ) >= 0
 		);

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -316,7 +316,7 @@ class ThemeShowcase extends Component {
 		}
 
 		if ( isNewSearchAndFilter ) {
-			const { filter, search, filterToTermTable } = this.props;
+			const { filter = '', search, filterToTermTable } = this.props;
 			const subjectTerm = filterToTermTable[ `subject:${ tabFilter.key }` ];
 			const subjectFilters = Object.values( this.tabSubjectTermTable );
 			const filterWithoutSubjects = filter

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -86,7 +86,7 @@
 	justify-content: center;
 	padding: 16px 0 24px;
 
-	@include breakpoint-deprecated( ">660px" ) {
+	@include break-small {
 		flex-direction: row;
 		padding: 24px 0 32px;
 	}

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -77,6 +77,54 @@
 	}
 }
 
+.theme__filters {
+	align-items: center;
+	display: flex;
+	flex-direction: column;
+	flex-wrap: wrap;
+	gap: 24px;
+	justify-content: center;
+	padding: 16px 0 24px;
+
+	@include breakpoint-deprecated( ">660px" ) {
+		flex-direction: row;
+		padding: 24px 0 32px;
+	}
+
+	.themes-toolbar-group {
+		height: 28px;
+		max-width: 100%;
+		flex: 1;
+	}
+
+	.segmented-control {
+		background-color: var(--studio-gray-0);
+		border-radius: 4px;
+		box-sizing: border-box;
+		height: 28px;
+		padding: 4px;
+
+		.segmented-control__item {
+			&.is-selected {
+				.segmented-control__link {
+					background-color: var(--color-surface);
+					box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+					color: var(--color-neutral-100);
+				}
+			}
+
+			.segmented-control__link {
+				color: var(--color-neutral-60);
+				border: 0;
+				border-radius: 4px;
+				font-size: 0.875rem;
+				line-height: 20px;
+				padding: 0 16px;
+			}
+		}
+	}
+}
+
 .theme-showcase__all-themes-title {
 	font-weight: 600;
 }

--- a/client/my-sites/themes/themes-toolbar-group/index.tsx
+++ b/client/my-sites/themes/themes-toolbar-group/index.tsx
@@ -9,7 +9,7 @@ interface ThemesToolbarGroupProps {
 	onSelect: ( selectedSlug: string | null ) => void;
 }
 
-const ThemeToolbarGroup: React.FC< ThemesToolbarGroupProps > = ( {
+const ThemesToolbarGroup: React.FC< ThemesToolbarGroupProps > = ( {
 	items,
 	selectedKey,
 	onSelect,
@@ -33,4 +33,4 @@ const ThemeToolbarGroup: React.FC< ThemesToolbarGroupProps > = ( {
 	);
 };
 
-export default ThemeToolbarGroup;
+export default ThemesToolbarGroup;

--- a/client/my-sites/themes/themes-toolbar-group/index.tsx
+++ b/client/my-sites/themes/themes-toolbar-group/index.tsx
@@ -1,5 +1,5 @@
 import { ResponsiveToolbarGroup } from '@automattic/components';
-import { useEffect, useState } from 'react';
+import { useMemo } from 'react';
 import type { ThemesToolbarGroupItem } from './types';
 import './style.scss';
 
@@ -14,11 +14,14 @@ const ThemesToolbarGroup: React.FC< ThemesToolbarGroupProps > = ( {
 	selectedKey,
 	onSelect,
 } ) => {
-	const [ activeIndex, setActiveIndex ] = useState< number >( 0 );
-	useEffect( () => {
-		const selectedKeyIndex = items.findIndex( ( { key } ) => key === selectedKey );
-		setActiveIndex( Math.max( selectedKeyIndex, 0 ) );
-	}, [ items, selectedKey ] );
+	const activeIndex = useMemo(
+		() =>
+			Math.max(
+				items.findIndex( ( { key } ) => key === selectedKey ),
+				0
+			),
+		[ items, selectedKey ]
+	);
 
 	return (
 		<ResponsiveToolbarGroup

--- a/client/my-sites/themes/themes-toolbar-group/index.tsx
+++ b/client/my-sites/themes/themes-toolbar-group/index.tsx
@@ -24,7 +24,6 @@ const ThemeToolbarGroup: React.FC< ThemesToolbarGroupProps > = ( {
 		<ResponsiveToolbarGroup
 			className="themes-toolbar-group"
 			initialActiveIndex={ activeIndex }
-			rootMargin="0px 32px"
 			onClick={ ( index: number ) => onSelect( items[ index ]?.key ) }
 		>
 			{ items.map( ( item ) => (

--- a/client/my-sites/themes/themes-toolbar-group/index.tsx
+++ b/client/my-sites/themes/themes-toolbar-group/index.tsx
@@ -1,0 +1,37 @@
+import { ResponsiveToolbarGroup } from '@automattic/components';
+import { useEffect, useState } from 'react';
+import type { ThemesToolbarGroupItem } from './types';
+import './style.scss';
+
+interface ThemesToolbarGroupProps {
+	items: ThemesToolbarGroupItem[];
+	selectedKey: string | null;
+	onSelect: ( selectedSlug: string | null ) => void;
+}
+
+const ThemeToolbarGroup: React.FC< ThemesToolbarGroupProps > = ( {
+	items,
+	selectedKey,
+	onSelect,
+} ) => {
+	const [ activeIndex, setActiveIndex ] = useState< number >( 0 );
+	useEffect( () => {
+		const selectedKeyIndex = items.findIndex( ( { key } ) => key === selectedKey );
+		setActiveIndex( Math.max( selectedKeyIndex, 0 ) );
+	}, [ items, selectedKey ] );
+
+	return (
+		<ResponsiveToolbarGroup
+			className="themes-toolbar-group"
+			initialActiveIndex={ activeIndex }
+			rootMargin="0px 32px"
+			onClick={ ( index: number ) => onSelect( items[ index ]?.key ) }
+		>
+			{ items.map( ( item ) => (
+				<span key={ `themes-toolbar-group-item-${ item.key }` }>{ item.text }</span>
+			) ) }
+		</ResponsiveToolbarGroup>
+	);
+};
+
+export default ThemeToolbarGroup;

--- a/client/my-sites/themes/themes-toolbar-group/style.scss
+++ b/client/my-sites/themes/themes-toolbar-group/style.scss
@@ -1,11 +1,18 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 
+.themes-toolbar-group.responsive-toolbar-group__swipe,
 .themes-toolbar-group.responsive-toolbar-group__dropdown {
+	&.responsive-toolbar-group__dropdown {
+		padding: 24px 0;
+	}
+
+	.responsive-toolbar-group__swipe-list,
 	.responsive-toolbar-group__grouped-list {
 		display: flex;
 		gap: 4px;
 		justify-content: flex-start;
+		padding: 0;
 
 		> div {
 			&:first-of-type {
@@ -18,13 +25,8 @@
 		}
 	}
 
-	.responsive-toolbar-group__button-item {
-		border-radius: 4px;
-		font-size: 1rem;
-		line-height: 24px;
-	}
-
 	.components-toolbar {
+		background-color: transparent;
 		min-height: 32px;
 
 		.components-button {
@@ -41,7 +43,7 @@
 			}
 
 			&:focus-visible::before {
-				box-shadow: 0 0 0 2px var(--color-primary-light);
+				box-shadow: inset 0 0 0 2px var(--color-primary-light);
 			}
 
 			&.is-pressed {
@@ -54,7 +56,7 @@
 		}
 	}
 
-	.components-popover__content {
+	.components-dropdown__content {
 		border-radius: 4px;
 
 		.components-menu-group > div {

--- a/client/my-sites/themes/themes-toolbar-group/style.scss
+++ b/client/my-sites/themes/themes-toolbar-group/style.scss
@@ -1,0 +1,74 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
+.themes-toolbar-group.responsive-toolbar-group__dropdown {
+	.responsive-toolbar-group__grouped-list {
+		display: flex;
+		gap: 4px;
+		justify-content: flex-start;
+
+		> div {
+			&:first-of-type {
+				margin-left: 0;
+			}
+
+			&:last-of-type {
+				margin-right: 0;
+			}
+		}
+	}
+
+	.responsive-toolbar-group__button-item {
+		border-radius: 4px;
+		font-size: 1rem;
+		line-height: 24px;
+	}
+
+	.components-toolbar {
+		min-height: 32px;
+
+		.components-button {
+			color: var(--color-neutral-60);
+			font-size: 1rem;
+			height: 32px;
+			line-height: 24px;
+			padding: 4px 12px;
+
+			&::before {
+				border-radius: 4px;
+				left: 0;
+				right: 0;
+			}
+
+			&:focus-visible::before {
+				box-shadow: 0 0 0 2px var(--color-primary-light);
+			}
+
+			&.is-pressed {
+				color: var(--color-text-inverted);
+
+				&::before {
+					background-color: var(--color-neutral-80);
+				}
+			}
+		}
+	}
+
+	.components-popover__content {
+		border-radius: 4px;
+
+		.components-menu-group > div {
+			display: flex;
+			flex-direction: column;
+			gap: 4px;
+		}
+
+		.responsive-toolbar-group__menu-item {
+			border-radius: 4px;
+
+			&.is-selected {
+				background-color: var(--color-neutral-80);
+			}
+		}
+	}
+}

--- a/client/my-sites/themes/themes-toolbar-group/style.scss
+++ b/client/my-sites/themes/themes-toolbar-group/style.scss
@@ -3,6 +3,10 @@
 
 .themes-toolbar-group.responsive-toolbar-group__swipe,
 .themes-toolbar-group.responsive-toolbar-group__dropdown {
+	&.responsive-toolbar-group__swipe {
+		padding: 16px 0;
+	}
+
 	&.responsive-toolbar-group__dropdown {
 		padding: 24px 0;
 	}

--- a/client/my-sites/themes/themes-toolbar-group/style.scss
+++ b/client/my-sites/themes/themes-toolbar-group/style.scss
@@ -3,14 +3,9 @@
 
 .themes-toolbar-group.responsive-toolbar-group__swipe,
 .themes-toolbar-group.responsive-toolbar-group__dropdown {
-	&.responsive-toolbar-group__swipe {
-		padding: 16px 0;
-	}
+	padding: 0;
 
-	&.responsive-toolbar-group__dropdown {
-		padding: 24px 0;
-	}
-
+	.responsive-toolbar-group__full-list,
 	.responsive-toolbar-group__swipe-list,
 	.responsive-toolbar-group__grouped-list {
 		display: flex;
@@ -31,23 +26,30 @@
 
 	.components-toolbar {
 		background-color: transparent;
-		min-height: 32px;
+		border: 0;
+		min-height: 28px;
 
 		.components-button {
 			color: var(--color-neutral-60);
 			font-size: 1rem;
-			height: 32px;
+			height: 28px;
 			line-height: 24px;
 			padding: 4px 12px;
 
 			&::before {
+				transition: background-color 0.15s ease-in-out;
 				border-radius: 4px;
+				height: 28px;
 				left: 0;
 				right: 0;
 			}
 
 			&:focus-visible::before {
 				box-shadow: inset 0 0 0 2px var(--color-primary-light);
+			}
+
+			&:not(.is-pressed):hover::before {
+				background-color: var(--studio-gray-0);
 			}
 
 			&.is-pressed {

--- a/client/my-sites/themes/themes-toolbar-group/types.ts
+++ b/client/my-sites/themes/themes-toolbar-group/types.ts
@@ -1,0 +1,4 @@
+export interface ThemesToolbarGroupItem {
+	key: string;
+	text: string;
+}


### PR DESCRIPTION
#### Proposed Changes

This PR updates the filter toolbar group below the search component as per design spec in 0EogtxvlmxMGcnEEaMVECv-fi-1259%3A37689. More details are written in #69925.

This PR also moves the pricing filter next to the `<ThemesToolbarGroup />` component, its behavior is unchanged from the one in production. To be specific - when users click on "Free" or "Premium", the `<ThemesToolbarGroup />` is set to "All".

| Before | After |
| --- | --- |
| ![Screen Shot 2022-11-16 at 1 46 30 PM](https://user-images.githubusercontent.com/797888/202094057-4a14b99d-374e-4735-a7fc-b514a3ca12fb.png) | ![Screen Shot 2022-11-18 at 11 34 21 AM](https://user-images.githubusercontent.com/797888/202610956-af4deb82-c7d8-4b58-9119-d565f624dcef.png) |

Note that currently, the contrast between the pricing filter component and the background is not good. A separate PR will be created to revamp the Theme Showcase layout aesthetically fit the new components.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the Themes Showcase `/themes/${site_slug}`
  * If using calypso.live, the flag `themes/showcase-i4/search-and-filter` is required.
* Ensure that the filter result set is the same as `wordpress.com/themes/${site_slug}`.
* Ensure that the old filter component works as it used to.
  * Disable the new component via flag, i.e.: `/themes/${site_slug}?flags=-themes/showcase-i4/search-and-filter`
* Ensure that the pricing filter component works as it used to. 
  * Disable the new component via flag, i.e.: `/themes/${site_slug}?flags=-themes/showcase-i4/search-and-filter`

Note that there are 2 filters we deliberately filter out:
1. "Recommended" & "Trending" - Not shown due to being conceptually outdated.
2. "My Themes" - Not shown for simple sites.
3. "Newsletter" - Not shown due to lack of themes.

#### Pre-merge Checklist
<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #69925