### PR TITLE
[WordAds] Update copy on privacy link caption

### DIFF
--- a/client/my-sites/earn/ads/form-settings.jsx
+++ b/client/my-sites/earn/ads/form-settings.jsx
@@ -404,7 +404,7 @@ class AdsFormSettings extends Component {
 							/>
 							<FormSettingExplanation>
 								{ translate(
-									'Adds a link to your privacy policy to the bottom of the sale opt-out notice popup (optional).'
+									'Adds a link to your privacy policy to the notice popup triggered by the do not sell link (optional).'
 								) }
 							</FormSettingExplanation>
 						</FormFieldset>


### PR DESCRIPTION
#### Proposed Changes

* This PR changes the "Adds a link to your privacy policy to the bottom of the sale opt-out notice popup (optional)." caption below the privacy link to "Adds a link to your privacy policy to the notice popup triggered by the do not sell link (optional)."

#### Testing Instructions
- On a premium site, navigate to the admin page
- In Tools -> Earn -> View ad dashboard -> Settings, scroll to the "Privacy and Consent"
- Activate the checkbox "Enable targeted advertising to site visitors in all US states."
- You should see the new copy updates highlighted in the screenshot below.
<img width="1076" alt="update" src="https://user-images.githubusercontent.com/9039613/201593893-80e996bc-3c8d-4d9b-af02-bf55861a52c6.png">


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
