### PR TITLE
BBE Content Form: Make Blog page optional

### DIFF
--- a/client/signup/steps/website-content/section-generator.tsx
+++ b/client/signup/steps/website-content/section-generator.tsx
@@ -1,4 +1,4 @@
-import { CONTACT_PAGE } from 'calypso/signup/difm/constants';
+import { BLOG_PAGE, CONTACT_PAGE } from 'calypso/signup/difm/constants';
 import {
 	ContactPageDetails,
 	FeedbackSection,
@@ -11,6 +11,7 @@ import type {
 	AccordionSectionProps,
 	SectionGeneratorReturnType,
 } from 'calypso/signup/accordion-form/types';
+import type { PageId } from 'calypso/signup/difm/constants';
 import type { TranslateResult } from 'i18n-calypso';
 
 interface SectionProcessedResult {
@@ -70,7 +71,10 @@ const generateWebsiteContentSections = (
 ): SectionProcessedResult => {
 	const { translate, formValues, formErrors, onChangeField } = params;
 
-	const OPTIONAL_PAGES: Record< string, boolean > = { [ CONTACT_PAGE ]: true };
+	const OPTIONAL_PAGES: Partial< Record< PageId, boolean > > = {
+		[ CONTACT_PAGE ]: true,
+		[ BLOG_PAGE ]: true,
+	};
 
 	const websiteContentSections = formValues.pages.map( ( page, index ) => {
 		const fieldNumber = elapsedSections + index + 1;


### PR DESCRIPTION
#### Proposed Changes
P2: pdh1Xd-1xQ-p2

* Makes the Blog page content field an optional field in the BBE content submission form.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/do-it-for-me` and proceed through the flow steps.
* On the page picker step, select the Blog page and complete checkout.
* On the content submission form, confirm that you can submit the form without adding any content for the Blog page field.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes Automattic/martech#1235