### PR TITLE
Jetpack Agency Dashboard: issue license button on the agency dashboard on small screen devices

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@automattic/components';
+import { isWithinBreakpoint } from '@automattic/viewport';
 import { useMobileBreakpoint } from '@automattic/viewport-react';
 import { getQueryArg, removeQueryArgs, addQueryArgs } from '@wordpress/url';
 import classNames from 'classnames';
@@ -186,7 +187,9 @@ export default function SitesOverview() {
 									{ translate( 'Manage all your Jetpack sites from one location' ) }
 								</div>
 							</div>
-							{ selectedLicensesCount > 0 && renderIssueLicenseButton() }
+							{ isWithinBreakpoint( '>960px' ) &&
+								selectedLicensesCount > 0 &&
+								renderIssueLicenseButton() }
 						</div>
 						<SectionNav
 							applyUpdatedStyles
@@ -232,6 +235,11 @@ export default function SitesOverview() {
 					</div>
 				</div>
 			</div>
+			{ isWithinBreakpoint( '<960px' ) && selectedLicensesCount > 0 && (
+				<div className="sites-overview__issue-licenses-button-small-screen">
+					{ renderIssueLicenseButton() }
+				</div>
+			) }
 		</div>
 	);
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-card/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-card/index.tsx
@@ -4,6 +4,10 @@ import { useState, useCallback, MouseEvent, KeyboardEvent } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import useFetchTestConnection from 'calypso/data/agency-dashboard/use-fetch-test-connection';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import {
+	getSelectedLicenses,
+	getSelectedLicensesSiteId,
+} from 'calypso/state/jetpack-agency-dashboard/selectors';
 import { getIsPartnerOAuthTokenLoaded } from 'calypso/state/partner-portal/partner/selectors';
 import SiteActions from '../site-actions';
 import SiteErrorContent from '../site-error-content';
@@ -58,8 +62,24 @@ export default function SiteCard( { rows, columns }: Props ) {
 	const siteUrl = site.value.url;
 	const isFavorite = rows.isFavorite;
 
+	const selectedLicenses = useSelector( getSelectedLicenses );
+	const selectedLicensesSiteId = useSelector( getSelectedLicensesSiteId );
+
+	const currentSiteHasSelectedLicenses =
+		selectedLicensesSiteId === blogId && selectedLicenses?.length;
+
+	// We should disable the license selection for all sites, but the active one.
+	const shouldDisableLicenseSelection =
+		selectedLicenses?.length && ! currentSiteHasSelectedLicenses;
+
 	return (
-		<Card className="site-card__card" compact>
+		<Card
+			className={ classNames( 'site-card__card', {
+				'site-card__card-disabled': shouldDisableLicenseSelection,
+				'site-card__card-active': currentSiteHasSelectedLicenses,
+			} ) }
+			compact
+		>
 			<div className="site-card__header">
 				<span
 					className="site-card__title"

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-card/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-card/style.scss
@@ -3,6 +3,7 @@
 	vertical-align: middle;
 	margin-inline-start: 32px;
 }
+
 .site-card__header {
 	position: relative;
 	padding: 16px 16px 16px 8px;
@@ -11,14 +12,17 @@
 	display: flex;
 	align-items: center;
 }
+
 .site-card__title {
 	display: inline-flex;
 	align-items: center;
 	width: 100%;
 }
+
 .site-card__card.is-compact {
 	padding: 0;
 }
+
 .site-card__expanded-content {
 	padding: 0 0.3em;
 
@@ -26,22 +30,27 @@
 		display: flex;
 	}
 }
+
 .site-card__expanded-content-list {
 	margin: 0 -5px;
 	position: relative;
 	padding: 0.7em 1em;
 	opacity: 0.5;
 }
+
 .site-card__content-list-no-error {
 	opacity: 1;
+
 	&:nth-child(odd) {
 		background: var(--studio-gray-0);
 	}
 }
+
 .site-card__expanded-content-key {
 	font-size: 0.875rem;
 	display: flex;
 }
+
 .site-card__expanded-content-value {
 	position: absolute;
 	right: 16px;
@@ -49,9 +58,22 @@
 	transform: translateY(-50%);
 	display: flex;
 }
+
 .site-card__actions-small-screen {
 	cursor: pointer;
 	position: absolute;
 	right: 16px;
 	display: inline;
+}
+
+.site-card__card-disabled {
+	opacity: 0.5;
+	user-select: none;
+}
+
+.site-card__card-active {
+	border-width: 0 1px;
+	border-style: solid;
+	border-color: var(--studio-gray-5);
+	box-shadow: 0 0 20px rgba(0, 0, 0, 0.16);
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
@@ -68,7 +68,7 @@
 		font-size: 1rem;
 	}
 
-	&-cancel {
+	.sites-overview__licenses-buttons-cancel {
 		text-decoration: underline;
 		padding: 2;
 		margin-inline-end: 32px;
@@ -307,4 +307,29 @@
 	text-align: center;
 	font-size: 1.5rem;
 	margin-top: 16px;
+}
+
+.sites-overview__issue-licenses-button-small-screen {
+	position: fixed;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	padding: 1rem;
+	background: var(--studio-white);
+	box-shadow: 0 -1px 2px rgba(0, 0, 0, 0.12);
+	z-index: 20;
+
+	.sites-overview__licenses-buttons-issue-license {
+		width: 70%;
+		max-width: 275px;
+	}
+
+	@include break-mobile {
+		text-align: right;
+	}
+
+	@include breakpoint-deprecated( ">660px" ) {
+		left: var(--sidebar-width-min);
+		padding: 0.5rem;
+	}
 }


### PR DESCRIPTION
#### Proposed Changes

This PR includes the following changes.

- Add issue license and cancel button for devices <960px when a license is selected.
- Right-aligned buttons for devices >480px <960px, it'll be left-aligned for devices <480px.
- Highlight active cards and blur the other cards.

#### Testing Instructions

**Prerequisites**

Since this change is made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout update/dashboard-issue-license-on-mobile` and `yarn start-jetpack-cloud`
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3.  Click on `Add + ` on any site and verify that the buttons to issue licenses and cancel appear as shown below and work as expected.

<img width="1572" alt="Screenshot 2022-11-14 at 5 53 46 PM" src="https://user-images.githubusercontent.com/10586875/201659223-598e277c-d229-4332-a5f6-33851c704d4e.png">

4. Switch to tablet view using the dev tool and verify the buttons are shown as below and work as expected. Please note you might have to refresh the page and repeat step 3.

<img width="808" alt="Screenshot 2022-11-14 at 5 50 35 PM" src="https://user-images.githubusercontent.com/10586875/201658670-5bf9bdad-5d6a-4163-a831-2fb3a3d303ee.png">

6. Switch to mobile view and verify the buttons are shown and work as expected.

<img width="380" alt="Screenshot 2022-11-14 at 5 50 42 PM" src="https://user-images.githubusercontent.com/10586875/201658697-aae81a03-6c14-47cd-bf41-26f66310dd8f.png">

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1203126240279377-as-1203275821751173