### PR TITLE
WPCOM SSH: Fix SSH key card styling for large breakpoint

### DIFF
--- a/client/components/ssh-key-card/index.tsx
+++ b/client/components/ssh-key-card/index.tsx
@@ -7,7 +7,10 @@ export const Root = styled( CompactCard )( {
 } );
 
 export const Details = styled.div( {
+	display: 'flex',
+	flexDirection: 'column',
 	marginRight: '1rem',
+	overflow: 'hidden',
 } );
 
 export const KeyName = styled.span( {
@@ -18,8 +21,6 @@ export const KeyName = styled.span( {
 } );
 
 export const PublicKey = styled.code( {
-	flex: 1,
-	position: 'relative',
 	overflow: 'hidden',
 	textOverflow: 'ellipsis',
 	whiteSpace: 'nowrap',

--- a/client/my-sites/hosting/sftp-card/ssh-key-card.tsx
+++ b/client/my-sites/hosting/sftp-card/ssh-key-card.tsx
@@ -1,3 +1,4 @@
+import styled from '@emotion/styled';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import i18n from 'i18n-calypso';
@@ -17,6 +18,18 @@ interface SshKeyCardProps {
 const noticeOptions = {
 	duration: 3000,
 };
+
+const MEDIA_QUERIES = {
+	wide: '@media screen and ( min-width: 1280px )',
+};
+
+const SSHKeyCardRoot = styled( SSHKeyCard.Root )( {
+	[ MEDIA_QUERIES.wide ]: {
+		'&&': {
+			paddingLeft: '24px',
+		},
+	},
+} );
 
 const sshKeyDetachFailureNoticeId = 'ssh-key-detach-failure';
 
@@ -54,7 +67,7 @@ function SshKeyCard( { deleteText, siteId, sshKey }: SshKeyCardProps ) {
 	);
 	const { sha256, user_login, name, attached_at } = sshKey;
 	return (
-		<SSHKeyCard.Root className="ssh-keys-card">
+		<SSHKeyCardRoot>
 			<SSHKeyCard.Details>
 				<SSHKeyCard.KeyName>
 					{ user_login }-{ name }
@@ -80,7 +93,7 @@ function SshKeyCard( { deleteText, siteId, sshKey }: SshKeyCardProps ) {
 			>
 				{ deleteText }
 			</SSHKeyCard.Button>
-		</SSHKeyCard.Root>
+		</SSHKeyCardRoot>
 	);
 }
 

--- a/client/my-sites/hosting/sftp-card/ssh-key-card.tsx
+++ b/client/my-sites/hosting/sftp-card/ssh-key-card.tsx
@@ -54,7 +54,7 @@ function SshKeyCard( { deleteText, siteId, sshKey }: SshKeyCardProps ) {
 	);
 	const { sha256, user_login, name, attached_at } = sshKey;
 	return (
-		<SSHKeyCard.Root>
+		<SSHKeyCard.Root className="ssh-keys-card">
 			<SSHKeyCard.Details>
 				<SSHKeyCard.KeyName>
 					{ user_login }-{ name }

--- a/client/my-sites/hosting/sftp-card/ssh-keys.scss
+++ b/client/my-sites/hosting/sftp-card/ssh-keys.scss
@@ -2,11 +2,12 @@
 	max-width: calc(100vw - 32px);
 }
 
-.hosting__main-layout-col .card.ssh-keys-card {
-	padding-left: 16px;
-	padding-right: 8px;
-	display: flex;
-	gap: 8px;
+@include breakpoint-deprecated( ">1280px" ) {
+	.hosting__main-layout-col {
+		.card.ssh-keys-card {
+			padding-left: 24px;
+		}
+	}
 }
 
 .ssh-keys__form {


### PR DESCRIPTION
Follow up from #69905

## Proposed Changes

Fixes SSH key card styling at large breakpoint, and removes some CSS that's no longer used.

### Before

<img width="774" alt="image" src="https://user-images.githubusercontent.com/36432/201681964-5e5a2be9-a3a9-4cc9-b965-2866ae275c84.png">

### After

<img width="747" alt="image" src="https://user-images.githubusercontent.com/36432/201681703-cf922513-14ca-4d77-9842-068329e2cf2c.png">

## Testing Instructions

1. Navigate to `/hosting-config/<site>`.
2. Make sure your browser is at least `1281px` wide.
3. Verify the SSH key card displays as expected.