### PR TITLE
Stats: Apply actual data to All-time highlight cards

### DIFF
--- a/client/my-sites/stats/all-time-highlights-section/index.tsx
+++ b/client/my-sites/stats/all-time-highlights-section/index.tsx
@@ -20,6 +20,13 @@ type AllTimeData = {
 	viewsBestDayTotal: number;
 };
 
+type MostPopularData = {
+	day: string;
+	percent: number;
+	hour: string;
+	hourPercent: number;
+};
+
 const STATS_QUERY = {};
 
 const FORMATTER = new Intl.NumberFormat( 'en-GB' );
@@ -40,14 +47,21 @@ export default function AllTimeHighlightsSection( { siteId }: { siteId: number }
 
 	const isRequesting = useSelector( ( state ) =>
 		isRequestingSiteStatsForQuery( state, siteId, 'stats', STATS_QUERY )
+
+	const isInsightsRequesting = useSelector( ( state ) =>
+		isRequestingSiteStatsForQuery( state, siteId, 'statsInsights', {} )
 	);
 
 	const { comments, posts, views, visitors, viewsBestDay, viewsBestDayTotal } = useSelector(
 		( state ) => getSiteStatsNormalizedData( state, siteId, 'stats', STATS_QUERY ) || {}
 	) as AllTimeData;
 
+	const { day, percent, hour, hourPercent } = useSelector(
+		( state ) => getSiteStatsNormalizedData( state, siteId, 'statsInsights', {} ) || {}
+	) as MostPopularData;
 
 	const isLoading = isRequesting && ! views;
+	const isInsightsLoading = isInsightsRequesting && ! percent;
 
 	let bestViewsEverMonthDay;
 	let bestViewsEverYear;
@@ -81,19 +95,26 @@ export default function AllTimeHighlightsSection( { siteId }: { siteId: number }
 
 	const mostPopularTimeItems = {
 		id: 'mostPopularTime',
+		loading: isInsightsLoading,
 		heading: translate( 'Most popular time' ),
 		items: [
 			{
 				id: 'bestDay',
 				header: translate( 'Best day' ),
-				content: 'Thursday',
-				footer: translate( '%p% of views', { args: [ 25 ] } ),
+				content: day,
+				footer: translate( '%(percent)d%% of views', {
+					args: { percent: percent || 0 },
+					context: 'Stats: Percentage of views',
+				} ),
 			},
 			{
 				id: 'bestHour',
 				header: translate( 'Best hour' ),
-				content: '2 PM',
-				footer: translate( '%p% of views', { args: [ 18 ] } ),
+				content: hour,
+				footer: translate( '%(percent)d%% of views', {
+					args: { percent: hourPercent || 0 },
+					context: 'Stats: Percentage of views',
+				} ),
 			},
 		],
 	};
@@ -120,6 +141,7 @@ export default function AllTimeHighlightsSection( { siteId }: { siteId: number }
 	return (
 		<div className="stats__all-time-highlights-section">
 			{ siteId && <QuerySiteStats siteId={ siteId } statType="stats" query={ STATS_QUERY } /> }
+			{ siteId && <QuerySiteStats siteId={ siteId } statType="statsInsights" /> }
 
 			<div className="highlight-cards">
 				<h1 className="highlight-cards-heading">{ translate( 'All-time highlights' ) }</h1>

--- a/client/my-sites/stats/all-time-highlights-section/index.tsx
+++ b/client/my-sites/stats/all-time-highlights-section/index.tsx
@@ -102,7 +102,7 @@ export default function AllTimeHighlightsSection( { siteId }: { siteId: number }
 		},
 		{ id: 'visitors', icon: people, title: translate( 'Visitors' ), count: visitors },
 		{ id: 'posts', icon: postContent, title: translate( 'Posts' ), count: posts },
-		{ id: 'likes', icon: starEmpty, title: translate( 'Likes' ), count: 13092212 },
+		{ id: 'likes', icon: starEmpty, title: translate( 'Likes' ), count: 13092212, hidden: true },
 		{ id: 'comments', icon: commentContent, title: translate( 'Comments' ), count: comments },
 	];
 
@@ -166,22 +166,24 @@ export default function AllTimeHighlightsSection( { siteId }: { siteId: number }
 					<Card className="highlight-card">
 						<div className="highlight-card-heading">{ translate( 'All-time stats' ) }</div>
 						<div className="highlight-card-info-item-list">
-							{ infoItems.map( ( info ) => {
-								return (
-									<div key={ info.id } className="highlight-card-info-item">
-										<Icon icon={ info.icon } />
+							{ infoItems
+								.filter( ( i ) => ! i.hidden )
+								.map( ( info ) => {
+									return (
+										<div key={ info.id } className="highlight-card-info-item">
+											<Icon icon={ info.icon } />
 
-										<span className="highlight-card-info-item-title">{ info.title }</span>
+											<span className="highlight-card-info-item-title">{ info.title }</span>
 
-										<span
-											className="highlight-card-info-item-count"
-											title={ Number.isFinite( info.count ) ? String( info.count ) : undefined }
-										>
-											{ formatNumber( info.count ) }
-										</span>
-									</div>
-								);
-							} ) }
+											<span
+												className="highlight-card-info-item-count"
+												title={ Number.isFinite( info.count ) ? String( info.count ) : undefined }
+											>
+												{ formatNumber( info.count ) }
+											</span>
+										</div>
+									);
+								} ) }
 						</div>
 					</Card>
 

--- a/client/my-sites/stats/all-time-highlights-section/index.tsx
+++ b/client/my-sites/stats/all-time-highlights-section/index.tsx
@@ -1,4 +1,4 @@
-import { Card } from '@automattic/components';
+import { Card, PercentCalculator as percentCalculator } from '@automattic/components';
 import { Icon, people, postContent, starEmpty, commentContent } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
@@ -38,16 +38,6 @@ function formatNumber( number: number | null, isCompact = false ) {
 	const formatter = isCompact ? COMPACT_FORMATTER : FORMATTER;
 
 	return Number.isFinite( number ) ? formatter.format( number as number ) : '-';
-}
-
-function percentCalculator( part: number | null, whole: number | null ) {
-	if ( part === null || whole === null ) {
-		return null;
-	}
-
-	const divisor = whole === 0 ? 1 : whole;
-
-	return Math.round( ( part / divisor ) * 100 );
 }
 
 export default function AllTimeHighlightsSection( { siteId }: { siteId: number } ) {

--- a/client/my-sites/stats/all-time-highlights-section/index.tsx
+++ b/client/my-sites/stats/all-time-highlights-section/index.tsx
@@ -1,7 +1,6 @@
 import { Card } from '@automattic/components';
 import { Icon, people, postContent, starEmpty, commentContent } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
-import moment from 'moment';
 import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import QuerySiteStats from 'calypso/components/data/query-site-stats';
@@ -130,8 +129,14 @@ export default function AllTimeHighlightsSection( { siteId }: { siteId: number }
 		let bestViewsEverYear = '';
 
 		if ( viewsBestDay && ! isStatsLoading ) {
-			bestViewsEverMonthDay = moment( viewsBestDay ).format( 'MMMM D' );
-			bestViewsEverYear = moment( viewsBestDay ).format( 'YYYY' );
+			const theDay = new Date( viewsBestDay );
+			bestViewsEverMonthDay = theDay.toLocaleDateString( undefined, {
+				month: 'long',
+				day: 'numeric',
+			} );
+			bestViewsEverYear = theDay.toLocaleDateString( undefined, {
+				year: 'numeric',
+			} );
 		}
 
 		const bestViewsEverPercent = Number.isFinite( viewsBestDayTotal )

--- a/client/my-sites/stats/all-time-highlights-section/index.tsx
+++ b/client/my-sites/stats/all-time-highlights-section/index.tsx
@@ -2,6 +2,7 @@ import { Card } from '@automattic/components';
 import { Icon, people, postContent, starEmpty, commentContent } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import moment from 'moment';
+import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import QuerySiteStats from 'calypso/components/data/query-site-stats';
 import {
@@ -72,87 +73,93 @@ export default function AllTimeHighlightsSection( { siteId }: { siteId: number }
 	const isStatsLoading = isStatsRequesting && ! views;
 	const isInsightsLoading = isInsightsRequesting && ! percent;
 
-	let bestViewsEverMonthDay;
-	let bestViewsEverYear;
-
-	if ( viewsBestDay && ! isStatsLoading ) {
-		bestViewsEverMonthDay = moment( viewsBestDay ).format( 'MMMM D' );
-		bestViewsEverYear = moment( viewsBestDay ).format( 'YYYY' );
-	}
-
-	const bestViewsEverPercent = Number.isFinite( viewsBestDayTotal )
-		? percentCalculator( viewsBestDayTotal, views )
-		: 0;
-
-	const infoItems = [
-		{
-			id: 'views',
-			icon: (
-				<svg width="24" height="24" fill="none" xmlns="http://www.w3.org/2000/svg">
-					<path
-						fillRule="evenodd"
-						clipRule="evenodd"
-						d="m4 13 .67.336.003-.005a2.42 2.42 0 0 1 .094-.17c.071-.122.18-.302.329-.52.298-.435.749-1.017 1.359-1.598C7.673 9.883 9.498 8.75 12 8.75s4.326 1.132 5.545 2.293c.61.581 1.061 1.163 1.36 1.599a8.29 8.29 0 0 1 .422.689l.002.005L20 13l.67-.336v-.003l-.003-.005-.008-.015-.028-.052a9.752 9.752 0 0 0-.489-.794 11.6 11.6 0 0 0-1.562-1.838C17.174 8.617 14.998 7.25 12 7.25S6.827 8.618 5.42 9.957c-.702.669-1.22 1.337-1.563 1.839a9.77 9.77 0 0 0-.516.845l-.008.015-.002.005-.001.002v.001L4 13Zm8 3a3.5 3.5 0 1 0 0-7 3.5 3.5 0 0 0 0 7Z"
-						fill="#00101C"
-					/>
-				</svg>
-			),
-			title: translate( 'Views' ),
-			count: views,
-		},
-		{ id: 'visitors', icon: people, title: translate( 'Visitors' ), count: visitors },
-		{ id: 'posts', icon: postContent, title: translate( 'Posts' ), count: posts },
-		{ id: 'likes', icon: starEmpty, title: translate( 'Likes' ), count: 13092212, hidden: true },
-		{ id: 'comments', icon: commentContent, title: translate( 'Comments' ), count: comments },
-	];
-
-	const mostPopularTimeItems = {
-		id: 'mostPopularTime',
-		loading: isInsightsLoading,
-		heading: translate( 'Most popular time' ),
-		items: [
-			{
-				id: 'bestDay',
-				header: translate( 'Best day' ),
-				content: day,
-				footer: translate( '%(percent)d%% of views', {
-					args: { percent: percent || 0 },
-					context: 'Stats: Percentage of views',
-				} ),
-			},
-			{
-				id: 'bestHour',
-				header: translate( 'Best hour' ),
-				content: hour,
-				footer: translate( '%(percent)d%% of views', {
-					args: { percent: hourPercent || 0 },
-					context: 'Stats: Percentage of views',
-				} ),
-			},
-		],
-	};
-
-	const bestViewsEverItems = {
-		id: 'bestViewsEver',
-		heading: translate( 'Best views ever' ),
-		items: [
-			{
-				id: 'day',
-				header: translate( 'Day' ),
-				content: bestViewsEverMonthDay,
-				footer: bestViewsEverYear,
-			},
+	const infoItems = useMemo( () => {
+		return [
 			{
 				id: 'views',
-				header: translate( 'Views' ),
-				content: formatNumber( viewsBestDayTotal, true ),
-				footer: translate( '%(percent)d%% of views', {
-					args: { percent: bestViewsEverPercent || 0 },
-					context: 'Stats: Percentage of views',
-				} ),
+				icon: (
+					<svg width="24" height="24" fill="none" xmlns="http://www.w3.org/2000/svg">
+						<path
+							fillRule="evenodd"
+							clipRule="evenodd"
+							d="m4 13 .67.336.003-.005a2.42 2.42 0 0 1 .094-.17c.071-.122.18-.302.329-.52.298-.435.749-1.017 1.359-1.598C7.673 9.883 9.498 8.75 12 8.75s4.326 1.132 5.545 2.293c.61.581 1.061 1.163 1.36 1.599a8.29 8.29 0 0 1 .422.689l.002.005L20 13l.67-.336v-.003l-.003-.005-.008-.015-.028-.052a9.752 9.752 0 0 0-.489-.794 11.6 11.6 0 0 0-1.562-1.838C17.174 8.617 14.998 7.25 12 7.25S6.827 8.618 5.42 9.957c-.702.669-1.22 1.337-1.563 1.839a9.77 9.77 0 0 0-.516.845l-.008.015-.002.005-.001.002v.001L4 13Zm8 3a3.5 3.5 0 1 0 0-7 3.5 3.5 0 0 0 0 7Z"
+							fill="#00101C"
+						/>
+					</svg>
+				),
+				title: translate( 'Views' ),
+				count: views,
 			},
-		],
-	};
+			{ id: 'visitors', icon: people, title: translate( 'Visitors' ), count: visitors },
+			{ id: 'posts', icon: postContent, title: translate( 'Posts' ), count: posts },
+			{ id: 'likes', icon: starEmpty, title: translate( 'Likes' ), count: 13092212, hidden: true },
+			{ id: 'comments', icon: commentContent, title: translate( 'Comments' ), count: comments },
+		];
+	}, [ comments, posts, translate, views, visitors ] );
+
+	const mostPopularTimeItems = useMemo( () => {
+		return {
+			id: 'mostPopularTime',
+			loading: isInsightsLoading,
+			heading: translate( 'Most popular time' ),
+			items: [
+				{
+					id: 'bestDay',
+					header: translate( 'Best day' ),
+					content: day,
+					footer: translate( '%(percent)d%% of views', {
+						args: { percent: percent || 0 },
+						context: 'Stats: Percentage of views',
+					} ),
+				},
+				{
+					id: 'bestHour',
+					header: translate( 'Best hour' ),
+					content: hour,
+					footer: translate( '%(percent)d%% of views', {
+						args: { percent: hourPercent || 0 },
+						context: 'Stats: Percentage of views',
+					} ),
+				},
+			],
+		};
+	}, [ day, hour, hourPercent, isInsightsLoading, percent, translate ] );
+
+	const bestViewsEverItems = useMemo( () => {
+		let bestViewsEverMonthDay = '';
+		let bestViewsEverYear = '';
+
+		if ( viewsBestDay && ! isStatsLoading ) {
+			bestViewsEverMonthDay = moment( viewsBestDay ).format( 'MMMM D' );
+			bestViewsEverYear = moment( viewsBestDay ).format( 'YYYY' );
+		}
+
+		const bestViewsEverPercent = Number.isFinite( viewsBestDayTotal )
+			? percentCalculator( viewsBestDayTotal, views )
+			: 0;
+
+		return {
+			id: 'bestViewsEver',
+			heading: translate( 'Best views ever' ),
+			items: [
+				{
+					id: 'day',
+					header: translate( 'Day' ),
+					content: bestViewsEverMonthDay,
+					footer: bestViewsEverYear,
+				},
+				{
+					id: 'views',
+					header: translate( 'Views' ),
+					content: formatNumber( viewsBestDayTotal, true ),
+					footer: translate( '%(percent)d%% of views', {
+						args: { percent: bestViewsEverPercent || 0 },
+						context: 'Stats: Percentage of views',
+					} ),
+				},
+			],
+		};
+	}, [ isStatsLoading, translate, views, viewsBestDay, viewsBestDayTotal ] );
 
 	return (
 		<div className="stats__all-time-highlights-section">

--- a/client/my-sites/stats/stats-insights/index.jsx
+++ b/client/my-sites/stats/stats-insights/index.jsx
@@ -58,7 +58,7 @@ const StatsInsights = ( props ) => {
 			<div>
 				<div className="stats__module--insights-unified">
 					{ showNewAnnualHighlights && <AnnualHighlightsSection siteId={ siteId } /> }
-					{ showAllTimeHighlights && <AllTimelHighlightsSection /> }
+					{ showAllTimeHighlights && <AllTimelHighlightsSection siteId={ siteId } /> }
 					<PostingActivity />
 					<SectionHeader label={ translate( 'All-time views' ) } />
 					<StatsViews />

--- a/packages/components/src/highlight-cards/highlight-card.tsx
+++ b/packages/components/src/highlight-cards/highlight-card.tsx
@@ -14,7 +14,7 @@ function subtract( a: number | null, b: number | null | undefined ): number | nu
 	return a === null || b === null || b === undefined ? null : a - b;
 }
 
-function percent( part: number | null, whole: number | null ) {
+export function percentCalculator( part: number | null, whole: number | null ) {
 	if ( part === null || whole === null ) {
 		return null;
 	}
@@ -43,7 +43,7 @@ export default function HighlightCard( {
 }: HighlightCardProps ) {
 	const difference = subtract( count, previousCount );
 	const percentage = Number.isFinite( difference )
-		? percent( Math.abs( difference as number ), count )
+		? percentCalculator( Math.abs( difference as number ), count )
 		: null;
 	return (
 		<Card className="highlight-card">

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -33,5 +33,8 @@ export {
 } from './horizontal-bar-list';
 export { default as HighlightCards } from './highlight-cards';
 export { default as AnnualHighlightCards } from './highlight-cards/annual-highlight-cards';
-export { default as HighlightCard } from './highlight-cards/highlight-card';
+export {
+	default as HighlightCard,
+	percentCalculator as PercentCalculator,
+} from './highlight-cards/highlight-card';
 export { default as PromoCard } from './promo-card';


### PR DESCRIPTION
#### Proposed Changes

* Apply actual data from API `/stats` and `/stats/insights` to All-time highlight cards.
* Hide the `Likes` item of the All-time stats card since the data has not existed in the `/stats` API. I left a [comment on the related issue](https://github.com/Automattic/wp-calypso/issues/69229#issuecomment-1313978789).

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Launch the _local_ development application or append `?flags=stats/new-all-time-highlights` on URL of the Calypso Live link.
* Navigate to page `/stats/insights/${your-site}`.
* Ensure the data in All-time highlights are the same as the original modules.

| Original modules | All-time highlights |
| --- | --- |
| <img width="1095" alt="截圖 2022-11-14 下午11 47 33" src="https://user-images.githubusercontent.com/6869813/201704165-0721ebd3-4270-49d5-9d26-2d4aac8828d8.png"> | <img width="1086" alt="截圖 2022-11-14 下午11 47 21" src="https://user-images.githubusercontent.com/6869813/201704123-9835ef36-9550-48fa-a5ab-9257509a6ef0.png"> |

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #69229 
