### PR TITLE
SSH Keys: Prevent temporary 'Back' before 'Back to Hosting Config'

### DIFF
--- a/client/me/security-ssh-key/security-ssh-key.tsx
+++ b/client/me/security-ssh-key/security-ssh-key.tsx
@@ -11,7 +11,6 @@ import FormattedHeader from 'calypso/components/formatted-header';
 import HeaderCake from 'calypso/components/header-cake';
 import Main from 'calypso/components/main';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
-import { getQueryArgs } from 'calypso/lib/query-args';
 import twoStepAuthorization from 'calypso/lib/two-step-authorization';
 import ReauthRequired from 'calypso/me/reauth-required';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -22,6 +21,14 @@ import { ManageSSHKeys } from './manage-ssh-keys';
 import { useAddSSHKeyMutation } from './use-add-ssh-key-mutation';
 import { useDeleteSSHKeyMutation } from './use-delete-ssh-key-mutation';
 import { useSSHKeyQuery } from './use-ssh-key-query';
+
+interface SecuritySSHKeyQueryParams {
+	siteSlug?: string;
+	source?: string;
+}
+interface SecuritySSHKeyProps {
+	queryParams: SecuritySSHKeyQueryParams;
+}
 
 const SSHKeyLoadingPlaceholder = styled( LoadingPlaceholder )( {
 	':not(:last-child)': {
@@ -45,12 +52,11 @@ const noticeOptions = {
 
 const sshKeySaveFailureNoticeId = 'ssh-key-save-failure';
 
-export const SecuritySSHKey = () => {
+export const SecuritySSHKey = ( { queryParams }: SecuritySSHKeyProps ) => {
 	const { data, isLoading } = useSSHKeyQuery();
 	const dispatch = useDispatch();
 	const currentUser = useSelector( getCurrentUser );
 	const { __ } = useI18n();
-	const queryArgs = getQueryArgs();
 
 	const { addSSHKey, isLoading: isAdding } = useAddSSHKeyMutation( {
 		onMutate: () => {
@@ -102,7 +108,7 @@ export const SecuritySSHKey = () => {
 
 	const hasKeys = data && data.length > 0;
 	const redirectToHosting =
-		queryArgs.source && queryArgs.source === 'hosting-config' && queryArgs.siteSlug;
+		queryParams.source && queryParams.source === 'hosting-config' && queryParams.siteSlug;
 
 	return (
 		<Main wideLayout className="security">
@@ -114,7 +120,7 @@ export const SecuritySSHKey = () => {
 			<HeaderCake
 				backText={ redirectToHosting ? __( 'Back to Hosting Configuration' ) : __( 'Back' ) }
 				backHref={
-					redirectToHosting ? `/${ queryArgs.source }/${ queryArgs.siteSlug }` : '/me/security'
+					redirectToHosting ? `/${ queryParams.source }/${ queryParams.siteSlug }` : '/me/security'
 				}
 			>
 				{ __( 'SSH Key' ) }

--- a/client/me/security/controller.js
+++ b/client/me/security/controller.js
@@ -87,6 +87,6 @@ export function socialLogin( context, next ) {
 }
 
 export function sshKey( context, next ) {
-	context.primary = <SecuritySSHKey />;
+	context.primary = <SecuritySSHKey queryParams={ context.query } />;
 	next();
 }


### PR DESCRIPTION
From https://github.com/Automattic/wp-calypso/pull/69788#issuecomment-1307640956

## Proposed Changes

Switches to read query args directly from React, instead of `calypso/lib/query-args`, to prevent "Back" from temporarily displaying before "Back to Hosting Configuration". `calypso/lib/query-args` reads from `window.location.href`, which isn't updated until the end of the cycle.

## Testing Instructions

1. Remove your SSH key from your account if you already have one.
2. Navigate to `/hosting-config/<site>`.
3. Click on "Add an SSH key to your account" link.
4. Verify the "SSH Key" UI displays "Back to Hosting Configuration" instantly, instead of first showing "Back".

