### PR TITLE
Help Center: Fix error with missing title when minimizing Sybil

### DIFF
--- a/packages/help-center/src/components/help-center-header.tsx
+++ b/packages/help-center/src/components/help-center-header.tsx
@@ -10,7 +10,9 @@ import type { Header } from '../types';
 
 export function ArticleTitle() {
 	const location = useLocation();
-	const { title } = location.state;
+	const { search } = useLocation();
+	const params = new URLSearchParams( search );
+	const title = location.state?.title || params.get( 'title' ) || '';
 
 	return (
 		<>
@@ -93,7 +95,7 @@ const HelpCenterHeader = ( { isMinimized = false, onMinimize, onMaximize, onDism
 				<div>
 					{ isMinimized ? (
 						<Button
-							className={ 'help-center-header__maximize' }
+							className="help-center-header__maximize"
 							label={ __( 'Maximize Help Center', __i18n_text_domain__ ) }
 							icon={ chevronUp }
 							tooltipPosition="top left"
@@ -101,7 +103,7 @@ const HelpCenterHeader = ( { isMinimized = false, onMinimize, onMaximize, onDism
 						/>
 					) : (
 						<Button
-							className={ 'help-center-header__minimize' }
+							className="help-center-header__minimize"
 							label={ __( 'Minimize Help Center', __i18n_text_domain__ ) }
 							icon={ lineSolid }
 							tooltipPosition="top left"
@@ -110,7 +112,7 @@ const HelpCenterHeader = ( { isMinimized = false, onMinimize, onMaximize, onDism
 					) }
 
 					<Button
-						className={ 'help-center-header__close' }
+						className="help-center-header__close"
 						label={ __( 'Close Help Center', __i18n_text_domain__ ) }
 						tooltipPosition="top left"
 						icon={ closeSmall }

--- a/packages/help-center/src/components/help-center-search-results.tsx
+++ b/packages/help-center/src/components/help-center-search-results.tsx
@@ -24,8 +24,8 @@ import hasCancelableUserPurchases from 'calypso/state/selectors/has-cancelable-u
 import { useSiteOption } from 'calypso/state/sites/hooks';
 import { getSectionName } from 'calypso/state/ui/selectors';
 import { useHelpSearchQuery } from '../hooks/use-help-search-query';
-import { SearchResult } from '../types';
 import PlaceholderLines from './placeholder-lines';
+import type { SearchResult } from '../types';
 
 interface SearchResultsSection {
 	type: string;


### PR DESCRIPTION
Add a default string to avoid error

#### Proposed Changes

`location.state` seems to be undefined in `https://github.com/Automattic/wp-calypso/blob/trunk/packages/help-center/src/components/help-center-header.tsx#L13`, when we try to minimize an article from the Sybil articles.

In that case indeed we do not use `history`, so we have no `location.state`. So it breaks when searching for the title in `location.state`. But we have the title in `{ search } = useLocation()`, so we can provide it as a fallback.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check live link.
* Open help center, click on one of the `Recommended Resources` and try to minimize the Help Center.
* Page should not break and title should be showing



Related to #69997
Fixes #69997