### PR TITLE
Domains: Re-introduce removed illustration and strip www from use a domain I own query

### DIFF
--- a/client/components/domains/use-my-domain/domain-input.jsx
+++ b/client/components/domains/use-my-domain/domain-input.jsx
@@ -5,6 +5,7 @@ import { Icon } from '@wordpress/icons';
 import PropTypes from 'prop-types';
 import { useEffect, useRef } from 'react';
 import { connect } from 'react-redux';
+import illustration from 'calypso/assets/images/domains/domain.svg';
 import FormButton from 'calypso/components/forms/form-button';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormTextInput from 'calypso/components/forms/form-text-input';
@@ -16,6 +17,7 @@ function UseMyDomainInput( {
 	baseClassName,
 	domainName,
 	isBusy,
+	isSignupStep,
 	onChange,
 	onClear,
 	onNext,
@@ -69,6 +71,11 @@ function UseMyDomainInput( {
 		: '';
 	return (
 		<Card className={ baseClassName }>
+			{ ! isSignupStep && (
+				<div className={ baseClassName + '__domain-illustration' }>
+					<img src={ illustration } alt="" width={ 160 } />
+				</div>
+			) }
 			<div className={ baseClassName + '__domain-input' }>
 				<label>{ domainInputLabel }</label>
 				<FormFieldset className={ baseClassName + '__domain-input-fieldset' }>
@@ -126,6 +133,7 @@ UseMyDomainInput.propTypes = {
 	baseClassName: PropTypes.string.isRequired,
 	domainName: PropTypes.string.isRequired,
 	isBusy: PropTypes.bool,
+	isSignupStep: PropTypes.bool,
 	onChange: PropTypes.func.isRequired,
 	onClear: PropTypes.func.isRequired,
 	onNext: PropTypes.func.isRequired,

--- a/client/components/domains/use-my-domain/index.jsx
+++ b/client/components/domains/use-my-domain/index.jsx
@@ -111,7 +111,7 @@ function UseMyDomain( props ) {
 	}, [] );
 
 	const filterDomainName = useCallback( ( domain ) => {
-		return domain.replace( /(?:^http(?:s)?:)?(?:[/]*)([^/?]*)(?:.*)$/gi, '$1' );
+		return domain.replace( /(?:^http(?:s)?:)?(?:[/]*)(?:www\.)?([^/?]*)(?:.*)$/gi, '$1' );
 	}, [] );
 
 	const setTransferStepsAndLockStatus = useCallback(
@@ -250,6 +250,7 @@ function UseMyDomain( props ) {
 				baseClassName={ baseClassName }
 				domainName={ domainName }
 				isBusy={ isFetchingAvailability }
+				isSignupStep={ isSignupStep }
 				onChange={ onDomainNameChange }
 				onClear={ onClearInput }
 				onNext={ onNext }


### PR DESCRIPTION
#### Proposed Changes

* This PR re-introduces the illustration shown at the top of the Use a domain I own page when we're not in the signup flow and also will strip a `www.` subdomain from the beginning of the domain entered on the page.

#### Testing Instructions

- Visit Upgrades > Domains > Add a domain > Use a domain I own
- Enter a domain name like: www.example.com or http://www.example.com, make sure that the domain shown on the next page is just the root domain (example.com).
- Make sure that other subdomains are not stripped from the entry.

- Visit the same page in the signup flow.
- Make sure that the illustration is only shown in the `domains/add/use-my-domain` page and not in the signup flow.
- Make sure that a `www.` subdomain is still stripped from the query in signup.

Signup view:
<img width="1678" alt="Create_a_site_—_WordPress_com" src="https://user-images.githubusercontent.com/1379730/201752176-66414dce-9c19-42a5-ac87-5e60737ed438.png">

Logged-in view:
<img width="1386" alt="Use_A_Domain_I_Own_‹_A8C_Test_Site_—_WordPress_com" src="https://user-images.githubusercontent.com/1379730/201752302-9bea253f-da9f-423b-8ac2-8025d0f4f77d.png">
