### PR TITLE
Help Center: Missing minimized title

### DIFF
--- a/packages/help-center/src/components/help-center-header.tsx
+++ b/packages/help-center/src/components/help-center-header.tsx
@@ -82,7 +82,7 @@ const HelpCenterHeader = ( { isMinimized = false, onMinimize, onMaximize, onDism
 							<Route path="/inline-chat">{ __( 'Live Chat', __i18n_text_domain__ ) }</Route>
 							<Route path="/contact-form" component={ SupportModeTitle }></Route>
 							<Route path="/post" component={ ArticleTitle }></Route>
-							<Route path="/success">{ __( 'Messagge submitted', __i18n_text_domain__ ) }</Route>
+							<Route path="/success">{ __( 'Message Submitted', __i18n_text_domain__ ) }</Route>
 						</Switch>
 					) : (
 						__( 'Help Center', __i18n_text_domain__ )

--- a/packages/help-center/src/components/help-center-header.tsx
+++ b/packages/help-center/src/components/help-center-header.tsx
@@ -82,6 +82,7 @@ const HelpCenterHeader = ( { isMinimized = false, onMinimize, onMaximize, onDism
 							<Route path="/inline-chat">{ __( 'Live Chat', __i18n_text_domain__ ) }</Route>
 							<Route path="/contact-form" component={ SupportModeTitle }></Route>
 							<Route path="/post" component={ ArticleTitle }></Route>
+							<Route path="/success">{ __( 'Messagge submitted', __i18n_text_domain__ ) }</Route>
 						</Switch>
 					) : (
 						__( 'Help Center', __i18n_text_domain__ )
@@ -93,7 +94,7 @@ const HelpCenterHeader = ( { isMinimized = false, onMinimize, onMaximize, onDism
 				<div>
 					{ isMinimized ? (
 						<Button
-							className={ 'help-center-header__maximize' }
+							className="help-center-header__maximize"
 							label={ __( 'Maximize Help Center', __i18n_text_domain__ ) }
 							icon={ chevronUp }
 							tooltipPosition="top left"
@@ -101,7 +102,7 @@ const HelpCenterHeader = ( { isMinimized = false, onMinimize, onMaximize, onDism
 						/>
 					) : (
 						<Button
-							className={ 'help-center-header__minimize' }
+							className="help-center-header__minimize"
 							label={ __( 'Minimize Help Center', __i18n_text_domain__ ) }
 							icon={ lineSolid }
 							tooltipPosition="top left"
@@ -110,7 +111,7 @@ const HelpCenterHeader = ( { isMinimized = false, onMinimize, onMaximize, onDism
 					) }
 
 					<Button
-						className={ 'help-center-header__close' }
+						className="help-center-header__close"
 						label={ __( 'Close Help Center', __i18n_text_domain__ ) }
 						tooltipPosition="top left"
 						icon={ closeSmall }


### PR DESCRIPTION
#### Proposed Changes

* Added the title `Message submitted` to the minimized Help Center header when in `/success`.

Open to change for a better header title.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit Calypso live link
* Verify that in the success page ( for example after submitting a ticket ), the header shows the correct title when minimized

#### Screenshot

![image](https://user-images.githubusercontent.com/52076348/201939257-b3f5e088-f609-4d04-8d36-954363cc6d6c.png)


Related to #68590
Fixes #68590
