### PR TITLE
Rename Backup to VaultPress Backup

### DIFF
--- a/client/components/jetpack/backup-getting-started/index.tsx
+++ b/client/components/jetpack/backup-getting-started/index.tsx
@@ -30,7 +30,7 @@ export default function BackupGettingStarted() {
 	const translate = useTranslate();
 	const videoPreviewProps: VideoPreviewProps = {
 		srcs: [ videoThumbnail, videoThumbnail2x ],
-		description: translate( 'Getting started with Jetpack Backup video thumbnail', {
+		description: translate( 'Getting started with Jetpack VaultPress Backup video thumbnail', {
 			textOnly: true,
 		} ),
 		timeLength: '2:55',
@@ -41,7 +41,7 @@ export default function BackupGettingStarted() {
 			<VideoPreview { ...videoPreviewProps } hiddenOn="mobile" />
 			<div className="backup-getting-started__content">
 				<div className="backup-getting-started__header">
-					{ preventWidows( translate( 'Getting started with Jetpack Backup' ) ) }
+					{ preventWidows( translate( 'Getting started with Jetpack VaultPress Backup' ) ) }
 				</div>
 				<p className="backup-getting-started__text">
 					{ preventWidows(

--- a/client/components/jetpack/daily-backup-status/status-card/backup-successful.jsx
+++ b/client/components/jetpack/daily-backup-status/status-card/backup-successful.jsx
@@ -76,7 +76,7 @@ const BackupSuccessful = ( { backup, selectedDate, lastBackupAttemptOnDate } ) =
 					<p className="status-card__multisite-warning-info">
 						{ preventWidows(
 							translate(
-								'Jetpack Backup for Multisite installations provides downloadable backups, no one-click restores. ' +
+								'Jetpack VaultPress Backup for Multisite installations provides downloadable backups, no one-click restores. ' +
 									'For more information {{ExternalLink}}visit our documentation page{{/ExternalLink}}.',
 								{
 									components: {

--- a/client/components/jetpack/sidebar/menu-items/index.jsx
+++ b/client/components/jetpack/sidebar/menu-items/index.jsx
@@ -60,7 +60,7 @@ export default ( { path, showIcons, tracksEventNames, expandSection } ) => {
 			{ isAdmin && ! isWPForTeamsSite && (
 				<SidebarItem
 					customIcon={ showIcons && <JetpackIcons icon="backup" /> }
-					label={ translate( 'Backup', {
+					label={ translate( 'VaultPress Backup', {
 						comment: 'Jetpack sidebar menu item',
 					} ) }
 					link={ backupPath( siteSlug ) }

--- a/client/components/jetpack/wpcom-business-at/index.tsx
+++ b/client/components/jetpack/wpcom-business-at/index.tsx
@@ -53,17 +53,17 @@ interface TransferFailureNoticeProps {
 }
 
 const content = {
-	documentHeadTitle: 'Activate Jetpack Backup now',
-	header: String( translate( 'Jetpack Backup' ) ),
+	documentHeadTitle: 'Activate Jetpack VaultPress Backup now',
+	header: String( translate( 'Jetpack VaultPress Backup' ) ),
 	primaryPromo: {
-		title: translate( 'Get time travel for your site with Jetpack Backup' ),
+		title: translate( 'Get time travel for your site with Jetpack VaultPress Backup' ),
 		image: { path: JetpackBackupSVG },
 		content: translate(
-			'Backup gives you granular control over your site, with the ability to restore it to any previous state, and export it at any time.'
+			'VaultPress Backup gives you granular control over your site, with the ability to restore it to any previous state, and export it at any time.'
 		),
 		promoCTA: {
-			text: translate( 'Activate Jetpack Backup now' ),
-			loadingText: translate( 'Activating Jetpack Backup' ),
+			text: translate( 'Activate Jetpack VaultPress Backup now' ),
+			loadingText: translate( 'Activating Jetpack VaultPress Backup' ),
 		},
 	},
 };

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
@@ -163,7 +163,7 @@ const getRowEventName = (
 const backupTooltips: StatusTooltip = {
 	failed: translate( 'Latest backup failed' ),
 	warning: translate( 'Latest backup completed with warnings' ),
-	inactive: translate( 'Add Jetpack Backup to this site' ),
+	inactive: translate( 'Add Jetpack VaultPress Backup to this site' ),
 	progress: translate( 'Backup in progress' ),
 	success: translate( 'Latest backup completed successfully' ),
 };

--- a/client/jetpack-cloud/sections/partner-portal/license-bundle-card-description/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-bundle-card-description/index.tsx
@@ -24,17 +24,21 @@ export default function LicenseBundleCardDescription( { product }: Props ) {
 			);
 			break;
 		case 'jetpack-security-t1':
-			textDescription = translate( 'Includes Backup 10GB, Scan Daily and Akismet Anti-spam.' );
+			textDescription = translate(
+				'Includes VaultPress Backup 10GB, Scan Daily and Akismet Anti-spam.'
+			);
 			features.push(
-				translate( 'Backup 10GB' ),
+				translate( 'VaultPress Backup 10GB' ),
 				translate( 'Scan Daily' ),
 				translate( 'Akismet Anti-spam*' )
 			);
 			break;
 		case 'jetpack-security-t2':
-			textDescription = translate( 'Includes Backup 1TB, Scan Daily and Akismet Anti-spam.' );
+			textDescription = translate(
+				'Includes VaultPress Backup 1TB, Scan Daily and Akismet Anti-spam.'
+			);
 			features.push(
-				translate( 'Backup 1TB' ),
+				translate( 'VaultPress Backup 1TB' ),
 				translate( 'Scan Daily' ),
 				translate( 'Akismet Anti-spam*' )
 			);

--- a/client/lib/plans/features-list.js
+++ b/client/lib/plans/features-list.js
@@ -1047,12 +1047,12 @@ export const FEATURES_LIST = {
 
 	[ FEATURE_BACKUP_REALTIME_V2 ]: {
 		getSlug: () => FEATURE_BACKUP_REALTIME_V2,
-		getTitle: () => i18n.translate( 'Backup (real-time, off-site)' ),
+		getTitle: () => i18n.translate( 'VaultPress Backup (real-time, off-site)' ),
 	},
 	[ FEATURE_PRODUCT_BACKUP_DAILY_V2 ]: {
 		getSlug: () => FEATURE_PRODUCT_BACKUP_DAILY_V2,
 		getIcon: () => 'cloud-upload',
-		getTitle: () => i18n.translate( 'All Backup Daily features' ),
+		getTitle: () => i18n.translate( 'All VaultPress Backup Daily features' ),
 		getDescription: () =>
 			i18n.translate(
 				'Automatic daily backups of your entire site, with unlimited, WordPress-optimized secure storage. {{link}}Learn more{{/link}}.',
@@ -1067,7 +1067,7 @@ export const FEATURES_LIST = {
 	[ FEATURE_PRODUCT_BACKUP_REALTIME_V2 ]: {
 		getSlug: () => FEATURE_PRODUCT_BACKUP_REALTIME_V2,
 		getIcon: () => 'cloud-upload',
-		getTitle: () => i18n.translate( 'Backup Real-time (off-site)' ),
+		getTitle: () => i18n.translate( 'VaultPress Backup Real-time (off-site)' ),
 		getDescription: () =>
 			i18n.translate(
 				'Real-time backups of your entire site and database with unlimited secure storage. {{link}}Learn more{{/link}}.',
@@ -1141,7 +1141,7 @@ export const FEATURES_LIST = {
 		getTitle: () => i18n.translate( 'Activity log: 1-year archive' ),
 		getDescription: () =>
 			i18n.translate(
-				'View every change to your site in the last year. Pairs with Backup to restore your site to any earlier version. {{link}}Learn more.{{/link}}',
+				'View every change to your site in the last year. Pairs with VaultPress Backup to restore your site to any earlier version. {{link}}Learn more.{{/link}}',
 				{
 					components: {
 						link: <ExternalLink icon href="https://jetpack.com/features/security/activity-log/" />,
@@ -1450,7 +1450,7 @@ export const FEATURES_LIST = {
 	},
 	[ FEATURE_JETPACK_PRODUCT_BACKUP ]: {
 		getSlug: () => FEATURE_JETPACK_PRODUCT_BACKUP,
-		getTitle: () => i18n.translate( 'All Backup features' ),
+		getTitle: () => i18n.translate( 'All VaultPress Backup features' ),
 	},
 	[ FEATURE_JETPACK_PRODUCT_VIDEOPRESS ]: {
 		getSlug: () => FEATURE_JETPACK_PRODUCT_VIDEOPRESS,
@@ -1458,7 +1458,7 @@ export const FEATURES_LIST = {
 	},
 	[ FEATURE_JETPACK_ALL_BACKUP_SECURITY_FEATURES ]: {
 		getSlug: () => FEATURE_JETPACK_ALL_BACKUP_SECURITY_FEATURES,
-		getTitle: () => i18n.translate( 'All Backup & Security features' ),
+		getTitle: () => i18n.translate( 'All VaultPress Backup & Security features' ),
 	},
 	[ FEATURE_JETPACK_REAL_TIME_CLOUD_BACKUPS ]: {
 		getSlug: () => FEATURE_JETPACK_REAL_TIME_CLOUD_BACKUPS,

--- a/client/my-sites/backup/backup-upsell/index.tsx
+++ b/client/my-sites/backup/backup-upsell/index.tsx
@@ -43,7 +43,7 @@ const BackupsMultisiteBody: FunctionComponent = () => {
 		<Upsell
 			headerText={ translate( 'WordPress multi-sites are not supported' ) }
 			bodyText={ translate(
-				"We're sorry, Jetpack Backup is not compatible with multisite WordPress installations at this time."
+				"We're sorry, Jetpack VaultPress Backup is not compatible with multisite WordPress installations at this time."
 			) }
 			iconComponent={ <BackupsUpsellIcon /> }
 		/>
@@ -115,7 +115,7 @@ const BackupsUpsellPage: FunctionComponent< UpsellComponentProps > = ( { reason 
 	}
 	return (
 		<Main className="backup-upsell" wideLayout>
-			<DocumentHead title="Backup" />
+			<DocumentHead title="VaultPress Backup" />
 			<SidebarNavigation />
 			<div className="backup-upsell__content">{ body }</div>
 		</Main>

--- a/client/my-sites/backup/main.jsx
+++ b/client/my-sites/backup/main.jsx
@@ -85,7 +85,7 @@ const BackupPage = ( { queryDate } ) => {
 				<TimeMismatchWarning siteId={ siteId } settingsUrl={ siteSettingsUrl } />
 				{ ! isJetpackCloud() && (
 					<FormattedHeader
-						headerText="Jetpack Backup"
+						headerText="Jetpack VaultPress Backup"
 						subHeaderText={ translate(
 							'Restore or download a backup of your site from a specific moment in time. {{learnMoreLink/}}',
 							{

--- a/client/my-sites/backup/wpcom-backup-upsell-placeholder.tsx
+++ b/client/my-sites/backup/wpcom-backup-upsell-placeholder.tsx
@@ -6,7 +6,11 @@ export default function WpcomBackupUpsellPlaceholder() {
 	const translate = useTranslate();
 	return (
 		<>
-			<FormattedHeader brandFont headerText={ translate( 'Jetpack Backup' ) } align="left" />
+			<FormattedHeader
+				brandFont
+				headerText={ translate( 'Jetpack VaultPress Backup' ) }
+				align="left"
+			/>
 			<WpcomUpsellPlaceholder />
 		</>
 	);

--- a/client/my-sites/backup/wpcom-backup-upsell.tsx
+++ b/client/my-sites/backup/wpcom-backup-upsell.tsx
@@ -38,7 +38,7 @@ const BackupMultisiteBody = () => {
 			<p>
 				{ preventWidows(
 					translate(
-						"We're sorry, Jetpack Backup is not compatible with multisite WordPress installations at this time."
+						"We're sorry, Jetpack VaultPress Backup is not compatible with multisite WordPress installations at this time."
 					)
 				) }
 			</p>
@@ -103,14 +103,16 @@ const BackupUpsellBody = () => {
 	return (
 		<>
 			<PromoCard
-				title={ preventWidows( translate( 'Get time travel for your site with Jetpack Backup' ) ) }
+				title={ preventWidows(
+					translate( 'Get time travel for your site with Jetpack VaultPress Backup' )
+				) }
 				image={ { path: JetpackBackupSVG } }
 				isPrimary
 			>
 				<p>
 					{ preventWidows(
 						translate(
-							'Backup gives you granular control over your site, with the ability to restore it to any previous state, and export it at any time.'
+							'VaultPress Backup gives you granular control over your site, with the ability to restore it to any previous state, and export it at any time.'
 						)
 					) }
 				</p>
@@ -118,7 +120,9 @@ const BackupUpsellBody = () => {
 				{ ! isAdmin && (
 					<Notice
 						status="is-warning"
-						text={ translate( 'Only site administrators can upgrade to access Backup.' ) }
+						text={ translate(
+							'Only site administrators can upgrade to access VaultPress Backup.'
+						) }
 						showDismiss={ false }
 					/>
 				) }
@@ -183,11 +187,11 @@ export default function WPCOMUpsellPage( { reason }: { reason: string } ) {
 	}
 	return (
 		<Main className="backup__main backup__wpcom-upsell">
-			<DocumentHead title="Jetpack Backup" />
-			<PageViewTracker path="/backup/:site" title="Backup" />
+			<DocumentHead title="Jetpack VaultPress Backup" />
+			<PageViewTracker path="/backup/:site" title="VaultPress Backup" />
 
 			<FormattedHeader
-				headerText={ translate( 'Jetpack Backup' ) }
+				headerText={ translate( 'Jetpack VaultPress Backup' ) }
 				id="backup-header"
 				align="left"
 				brandFont

--- a/client/my-sites/backup/wpcom-upsell.tsx
+++ b/client/my-sites/backup/wpcom-upsell.tsx
@@ -47,25 +47,27 @@ export default function WPCOMUpsellPage() {
 
 	return (
 		<Main className="backup__main backup__wpcom-upsell">
-			<DocumentHead title="Jetpack Backup" />
-			<PageViewTracker path="/backup/:site" title="Backup" />
+			<DocumentHead title="Jetpack VaultPress Backup" />
+			<PageViewTracker path="/backup/:site" title="VaultPress Backup" />
 
 			<FormattedHeader
-				headerText={ translate( 'Jetpack Backup' ) }
+				headerText={ translate( 'Jetpack VaultPress Backup' ) }
 				id="backup-header"
 				align="left"
 				brandFont
 			/>
 
 			<PromoCard
-				title={ preventWidows( translate( 'Get time travel for your site with Jetpack Backup' ) ) }
+				title={ preventWidows(
+					translate( 'Get time travel for your site with Jetpack VaultPress Backup' )
+				) }
 				image={ { path: JetpackBackupSVG } }
 				isPrimary
 			>
 				<p>
 					{ preventWidows(
 						translate(
-							'Backup gives you granular control over your site, with the ability to restore it to any previous state, and export it at any time.'
+							'VaultPress Backup gives you granular control over your site, with the ability to restore it to any previous state, and export it at any time.'
 						)
 					) }
 				</p>

--- a/client/my-sites/plans-features-main/jetpack-faq.jsx
+++ b/client/my-sites/plans-features-main/jetpack-faq.jsx
@@ -70,7 +70,7 @@ const JetpackFAQ = () => {
 				question={ translate( 'Does this work with a multisite network?' ) }
 				answer={ translate(
 					'Jetpack’s free features are compatible with WordPress Multisite networks. Paid features' +
-						' also work with Multisite networks, but each site requires its own subscription. Jetpack Backup' +
+						' also work with Multisite networks, but each site requires its own subscription. Jetpack VaultPress Backup' +
 						' and Jetpack Scan are not currently compatible with Multisite networks.'
 				) }
 			/>

--- a/client/my-sites/plans/current-plan/jetpack-checklist/index.tsx
+++ b/client/my-sites/plans/current-plan/jetpack-checklist/index.tsx
@@ -228,12 +228,12 @@ class JetpackChecklist extends PureComponent< Props & LocalizeProps > {
 					{ ( ( hasBackups && hasScan && isRewindAvailable ) || forceShowJetpackBackupTask ) && (
 						<Task
 							id="jetpack_rewind"
-							title={ translate( 'Backup and Scan' ) }
+							title={ translate( 'VaultPress Backup and Scan' ) }
 							description={ translate(
 								"Connect your site's server to Jetpack to perform backups, restores, and security scans."
 							) }
 							completedButtonText={ translate( 'Change', { context: 'verb' } ) }
-							completedTitle={ translate( 'You turned on Backup and Scan.' ) }
+							completedTitle={ translate( 'You turned on VaultPress Backup and Scan.' ) }
 							duration={ this.getDuration( 3 ) }
 							completed={ isRewindActive }
 							href={ settingsPath( siteSlug ) }

--- a/client/my-sites/plans/current-plan/purchases-listing.jsx
+++ b/client/my-sites/plans/current-plan/purchases-listing.jsx
@@ -250,9 +250,9 @@ class PurchasesListing extends Component {
 		const planHasScan = planHasFeature( plan.productSlug, PRODUCT_JETPACK_SCAN );
 
 		if ( planHasBackup && planHasScan ) {
-			serviceButtonText = translate( 'View Backup & Scan' );
+			serviceButtonText = translate( 'View VaultPress Backup & Scan' );
 		} else if ( planHasBackup ) {
-			serviceButtonText = translate( 'View Backup' );
+			serviceButtonText = translate( 'View VaultPress Backup' );
 		} else if ( planHasScan ) {
 			serviceButtonText = translate( 'View Scan' );
 		}

--- a/client/my-sites/plans/jetpack-plans/faq/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/faq/index.tsx
@@ -99,7 +99,7 @@ const JetpackFAQ: FC = () => {
 					className="jetpack-faq__section"
 				>
 					{ translate(
-						"If your site's VaultPress Backup storage limit is reached, your older backups will be deleted. Depending on the size of your site and your site's VaultPress Backup storage limit, your site's backup retention period may be reduced down to 7 days of your most recent backups. You will still be able to restore existing backups, but new site updates will not be backed up until you free up storage or upgrade your storage limit."
+						"If your site's backup storage limit is reached, your older backups will be deleted. Depending on the size of your site and your site's backup storage limit, your site's backup retention period may be reduced down to 7 days of your most recent backups. You will still be able to restore existing backups, but new site updates will not be backed up until you free up storage or upgrade your storage limit."
 					) }
 				</FoldableFAQ>
 				<FoldableFAQ

--- a/client/my-sites/plans/jetpack-plans/faq/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/faq/index.tsx
@@ -99,7 +99,7 @@ const JetpackFAQ: FC = () => {
 					className="jetpack-faq__section"
 				>
 					{ translate(
-						"If your site's Backup storage limit is reached, your older backups will be deleted. Depending on the size of your site and your site's Backup storage limit, your site's backup retention period may be reduced down to 7 days of your most recent backups. You will still be able to restore existing backups, but new site updates will not be backed up until you free up storage or upgrade your storage limit."
+						"If your site's VaultPress Backup storage limit is reached, your older backups will be deleted. Depending on the size of your site and your site's VaultPress Backup storage limit, your site's backup retention period may be reduced down to 7 days of your most recent backups. You will still be able to restore existing backups, but new site updates will not be backed up until you free up storage or upgrade your storage limit."
 					) }
 				</FoldableFAQ>
 				<FoldableFAQ
@@ -185,7 +185,7 @@ const JetpackFAQ: FC = () => {
 				>
 					{ translate(
 						'Jetpack’s free features are compatible with WordPress Multisite networks. Paid features' +
-							' also work with Multisite networks, but each site requires its own subscription. Jetpack Backup' +
+							' also work with Multisite networks, but each site requires its own subscription. Jetpack VaultPress Backup' +
 							' and Jetpack Scan are not currently compatible with Multisite networks.'
 					) }
 				</FoldableFAQ>

--- a/client/my-sites/plans/jetpack-plans/storage-pricing-header/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/storage-pricing-header/index.tsx
@@ -14,8 +14,8 @@ export const StoragePricingHeader = () => {
 					className="storage-pricing-header__title"
 					headerText={ preventWidows(
 						translate(
-							'Upgrade your Backup storage to %(storageAmount)dTB',
-							'Upgrade your Backup storage to %(storageAmount)dTB',
+							'Upgrade your VaultPress Backup storage to %(storageAmount)dTB',
+							'Upgrade your VaultPress Backup storage to %(storageAmount)dTB',
 							{
 								count: 1,
 								args: { storageAmount: 1 },

--- a/client/my-sites/scan/wpcom-upsell.tsx
+++ b/client/my-sites/scan/wpcom-upsell.tsx
@@ -34,7 +34,7 @@ export default function WPCOMScanUpsellPage() {
 
 	const promos = [
 		{
-			title: translate( 'Jetpack Backup' ),
+			title: translate( 'Jetpack VaultPress Backup' ),
 			body: translate(
 				'Granular control over your site, with the ability ' +
 					'to restore it to any previous state, and export it at any time.'

--- a/client/my-sites/sidebar/static-data/fallback-menu.js
+++ b/client/my-sites/sidebar/static-data/fallback-menu.js
@@ -342,7 +342,7 @@ export default function buildFallbackResponse( {
 				{
 					parent: 'jetpack',
 					slug: 'jetpack-backup',
-					title: translate( 'Backup' ),
+					title: translate( 'VaultPress Backup' ),
 					type: 'submenu-item',
 					url: `/backup/${ siteDomain }`,
 				},

--- a/client/my-sites/sidebar/static-data/jetpack-fallback-menu.js
+++ b/client/my-sites/sidebar/static-data/jetpack-fallback-menu.js
@@ -97,7 +97,7 @@ export default function jetpackMenu( { siteDomain } ) {
 				{
 					parent: 'jetpack',
 					slug: 'jetpack-backup',
-					title: translate( 'Backup' ),
+					title: translate( 'VaultPress Backup' ),
 					type: 'submenu-item',
 					url: `/backup/${ siteDomain }`,
 				},

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -1070,7 +1070,7 @@ const getPlanJetpackSecurityDailyDetails = (): IncompleteJetpackPlan => ( {
 	availableFor: ( plan ) => [ PLAN_JETPACK_FREE, ...JETPACK_LEGACY_PLANS ].includes( plan ),
 	getDescription: () =>
 		translate(
-			'All of the essential Jetpack Security features in one package including Backup, Scan, Akismet Anti-spam and more.'
+			'All of the essential Jetpack Security features in one package including VaultPress Backup, Scan, Akismet Anti-spam and more.'
 		),
 	getTagline: () => translate( 'Best for sites with occasional updates' ),
 	getPlanCardFeatures: () => [

--- a/packages/calypso-products/src/products-list.ts
+++ b/packages/calypso-products/src/products-list.ts
@@ -259,7 +259,7 @@ export const JETPACK_SITE_PRODUCTS_WITH_FEATURES: Record<
 		getStoreSlug: () => PRODUCT_JETPACK_ANTI_SPAM_MONTHLY,
 	},
 	[ PRODUCT_JETPACK_BACKUP_T1_YEARLY ]: {
-		product_name: translate( 'Backup' ),
+		product_name: translate( 'VaultPress Backup' ),
 		product_slug: PRODUCT_JETPACK_BACKUP_T1_YEARLY,
 		type: PRODUCT_JETPACK_BACKUP_T1_YEARLY,
 		term: TERM_ANNUALLY,
@@ -275,7 +275,7 @@ export const JETPACK_SITE_PRODUCTS_WITH_FEATURES: Record<
 		getStoreSlug: () => PRODUCT_JETPACK_BACKUP_T1_YEARLY,
 	},
 	[ PRODUCT_JETPACK_BACKUP_T1_MONTHLY ]: {
-		product_name: translate( 'Backup' ),
+		product_name: translate( 'VaultPress Backup' ),
 		product_slug: PRODUCT_JETPACK_BACKUP_T1_MONTHLY,
 		type: PRODUCT_JETPACK_BACKUP_T1_YEARLY,
 		term: TERM_MONTHLY,
@@ -291,7 +291,7 @@ export const JETPACK_SITE_PRODUCTS_WITH_FEATURES: Record<
 		getStoreSlug: () => PRODUCT_JETPACK_BACKUP_T1_MONTHLY,
 	},
 	[ PRODUCT_JETPACK_BACKUP_T2_YEARLY ]: {
-		product_name: translate( 'Backup' ),
+		product_name: translate( 'VaultPress Backup' ),
 		product_slug: PRODUCT_JETPACK_BACKUP_T2_YEARLY,
 		type: PRODUCT_JETPACK_BACKUP_T2_YEARLY,
 		term: TERM_ANNUALLY,
@@ -307,7 +307,7 @@ export const JETPACK_SITE_PRODUCTS_WITH_FEATURES: Record<
 		getStoreSlug: () => PRODUCT_JETPACK_BACKUP_T2_YEARLY,
 	},
 	[ PRODUCT_JETPACK_BACKUP_T2_MONTHLY ]: {
-		product_name: translate( 'Backup' ),
+		product_name: translate( 'VaultPress Backup' ),
 		product_slug: PRODUCT_JETPACK_BACKUP_T2_MONTHLY,
 		type: PRODUCT_JETPACK_BACKUP_T2_YEARLY,
 		term: TERM_MONTHLY,

--- a/packages/calypso-products/src/translations.tsx
+++ b/packages/calypso-products/src/translations.tsx
@@ -174,13 +174,13 @@ export const getJetpackProductsDisplayNames = (): Record< string, TranslateResul
 	} );
 
 	//Backup Add-on products
-	const backupAddon10gb = translate( 'Backup Add-on Storage (%(storageAmount)s)', {
+	const backupAddon10gb = translate( 'VaultPress Backup Add-on Storage (%(storageAmount)s)', {
 		args: { storageAmount: text10gb },
 	} );
-	const backupAddon100gb = translate( 'Backup Add-on Storage (%(storageAmount)s)', {
+	const backupAddon100gb = translate( 'VaultPress Backup Add-on Storage (%(storageAmount)s)', {
 		args: { storageAmount: text100gb },
 	} );
-	const backupAddon1tb = translate( 'Backup Add-on Storage (%(storageAmount)s)', {
+	const backupAddon1tb = translate( 'VaultPress Backup Add-on Storage (%(storageAmount)s)', {
 		args: { storageAmount: text1tb },
 	} );
 
@@ -287,9 +287,11 @@ export const getJetpackProductsTaglines = (): Record<
 	const socialTagLine = translate(
 		'Easily share your website content on your social media channels'
 	);
-	const backupAddonTagLine = translate( 'Additional storage for your Jetpack Backup plan.' );
+	const backupAddonTagLine = translate(
+		'Additional storage for your Jetpack VaultPress Backup plan.'
+	);
 	const backupAddonOwnedTagLine = translate(
-		'Your site has additional storage for Jetpack Backup.'
+		'Your site has additional storage for Jetpack VaultPress Backup.'
 	);
 	return {
 		[ PRODUCT_JETPACK_BACKUP_DAILY ]: {


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR updates the last references to `Backup` to `VaultPress Backup`.

It is a follow-up of #69954 and #69955.

Context: p1HpG7-j1R-p2

### Testing instructions

_Note: it's difficult to find all the places in the UI where these changes are reflected. Since only static strings are updated, reviewing the code should be sufficient._

- Review code, and check that only strings were updated.
- Check that no test is failing.
