### PR TITLE
Pricing page: update bundles copy

### DIFF
--- a/client/my-sites/plans/jetpack-plans/product-store/features-list/features.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/features-list/features.tsx
@@ -27,12 +27,12 @@ export function useBundleFeaturesList( planSlug: string ) {
 			slug: 'security',
 			title: translate( 'Security' ),
 			features: [
-				translate( 'Real-time backups as you edit' ),
+				translate( 'VaultPress Backup: Real-time backups as you edit' ),
 				translate( '10GB of cloud storage' ),
 				translate( '30-day activity log archive' ),
 				translate( 'Unlimited one-click restores from the last 30 days' ),
-				translate( 'Real-time malware scanning and one-click fixes' ),
-				translate( 'Comment and form spam protection (10k API calls/mo)' ),
+				translate( 'Scan: Real-time malware scanning and one-click fixes' ),
+				translate( 'Akismet: Comment and form spam protection (10k API calls/mo)' ),
 			],
 		},
 		{
@@ -47,7 +47,10 @@ export function useBundleFeaturesList( planSlug: string ) {
 			included: false,
 			slug: 'growth',
 			title: translate( 'Growth' ),
-			features: [ translate( 'CRM: with 30 extensions' ) ],
+			features: [
+				translate( 'Social: Basic with 1,000 shares/mo' ),
+				translate( 'CRM: with 30 extensions' ),
+			],
 		},
 	];
 
@@ -58,7 +61,7 @@ export function useBundleFeaturesList( planSlug: string ) {
 			slug: 'security',
 			title: translate( 'Security' ),
 			features: [
-				translate( 'Real-time backups as you edit' ),
+				translate( 'VaultPress Backup: Real-time backups as you edit' ),
 				translate( '{{b}}1TB (1,000GB){{/b}} of cloud storage', {
 					components: {
 						b: <b />,
@@ -74,8 +77,8 @@ export function useBundleFeaturesList( planSlug: string ) {
 						b: <b />,
 					},
 				} ),
-				translate( 'Real-time malware scanning and one-click fixes' ),
-				translate( 'Comment and form spam protection ({{b}}60k API calls/mo{{/b}})', {
+				translate( 'Scan: Real-time malware scanning and one-click fixes' ),
+				translate( 'Akismet: Comment and form spam protection ({{b}}60k API calls/mo{{/b}})', {
 					components: {
 						b: <b />,
 					},
@@ -98,7 +101,10 @@ export function useBundleFeaturesList( planSlug: string ) {
 			included: true,
 			slug: 'growth',
 			title: translate( 'Growth' ),
-			features: [ <b>{ translate( 'CRM: Entrepreneur with 30 extensions' ) }</b> ],
+			features: [
+				translate( 'Social: Basic with 1,000 shares/mo' ),
+				<b>{ translate( 'CRM: Entrepreneur with 30 extensions' ) }</b>,
+			],
 		},
 	];
 

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -1168,7 +1168,7 @@ const getPlanJetpackSecurityT1Details = (): IncompleteJetpackPlan => ( {
 		),
 	getLightboxDescription: () =>
 		translate(
-			'Easy-to-use, comprehensive WordPress site security including backups, malware scanning, and spam protection.'
+			'Easy-to-use, comprehensive WordPress site security including backups, malware scanning, and spam protection. Includes VaultPress Backup, Jetpack Scan, and Akismet Anti-spam.'
 		),
 	getPlanCardFeatures: () => [
 		FEATURE_JETPACK_PRODUCT_BACKUP,
@@ -1780,15 +1780,17 @@ export const PLANS_LIST: Record< string, Plan | JetpackPlan | WPComPlan > = {
 		getPathSlug: () => 'complete',
 		getProductId: () => 2014,
 		getWhatIsIncluded: () => [
-			translate( 'Real-time backups as you edit' ),
+			translate( 'VaultPress Backup: Real-time backups as you edit' ),
 			translate( '1TB (1,000GB) of cloud storage' ),
 			translate( '1-year activity log archive' ),
 			translate( 'Unlimited one-click restores from the last 1 year' ),
-			translate( 'Real-time malware scanning and one-click fixes' ),
-			translate( 'Comment and form spam protection (60k API calls/mo)' ),
-			translate( 'VideoPress with 1TB of ad-free video hosting' ),
-			translate( 'Site Search up to 100k records' ),
-			translate( 'CRM Entrepreneur' ),
+			translate( 'Scan: Real-time malware scanning and one-click fixes' ),
+			translate( 'Akismet: Comment and form spam protection (60k API calls/mo)' ),
+			translate( 'VideoPress: 1TB of ad-free video hosting' ),
+			translate( 'Boost: Automatic CSS generation' ),
+			translate( 'Site Search: Up to 100k records' ),
+			translate( 'Social: Basic with 1,000 shares/mo' ),
+			translate( 'CRM: Entrepreneur with 30 extensions' ),
 		],
 	},
 
@@ -1799,15 +1801,17 @@ export const PLANS_LIST: Record< string, Plan | JetpackPlan | WPComPlan > = {
 		getPathSlug: () => 'complete-monthly',
 		getProductId: () => 2015,
 		getWhatIsIncluded: () => [
-			translate( 'Real-time backups as you edit' ),
+			translate( 'VaultPress Backup: Real-time backups as you edit' ),
 			translate( '1TB (1,000GB) of cloud storage' ),
 			translate( '1-year activity log archive' ),
 			translate( 'Unlimited one-click restores from the last 1-year' ),
-			translate( 'Real-time malware scanning and one-click fixes' ),
-			translate( 'Comment and form spam protection (60k API calls/mo)' ),
-			translate( 'VideoPress with 1TB of ad-free video hosting' ),
-			translate( 'Site Search up to 100k records' ),
-			translate( 'CRM Entrepreneur' ),
+			translate( 'Scan: Real-time malware scanning and one-click fixes' ),
+			translate( 'Akismet: Comment and form spam protection (60k API calls/mo)' ),
+			translate( 'VideoPress: 1TB of ad-free video hosting' ),
+			translate( 'Boost: Automatic CSS generation' ),
+			translate( 'Site Search: Up to 100k records' ),
+			translate( 'Social: Basic with 1,000 shares/mo' ),
+			translate( 'CRM: Entrepreneur with 30 extensions' ),
 		],
 	},
 
@@ -1818,12 +1822,12 @@ export const PLANS_LIST: Record< string, Plan | JetpackPlan | WPComPlan > = {
 		getPathSlug: () => 'security-20gb-yearly',
 		getProductId: () => 2016,
 		getWhatIsIncluded: () => [
-			translate( 'Real-time backups as you edit' ),
+			translate( 'VaultPress Backup: Real-time backups as you edit' ),
 			translate( '10GB of cloud storage' ),
 			translate( '30-day activity log archive' ),
 			translate( 'Unlimited one-click restores from the last 30 days' ),
-			translate( 'Real-time malware scanning and one-click fixes' ),
-			translate( 'Comment and form spam protection (10k API calls/mo)' ),
+			translate( 'Scan: Real-time malware scanning and one-click fixes' ),
+			translate( 'Akismet: Comment and form spam protection (10k API calls/mo)' ),
 		],
 	},
 
@@ -1834,12 +1838,12 @@ export const PLANS_LIST: Record< string, Plan | JetpackPlan | WPComPlan > = {
 		getPathSlug: () => 'security-20gb-monthly',
 		getProductId: () => 2017,
 		getWhatIsIncluded: () => [
-			translate( 'Real-time backups as you edit' ),
+			translate( 'VaultPress Backup: Real-time backups as you edit' ),
 			translate( '10GB of cloud storage' ),
 			translate( '30-day activity log archive' ),
 			translate( 'Unlimited one-click restores from the last 30 days' ),
-			translate( 'Real-time malware scanning and one-click fixes' ),
-			translate( 'Comment and form spam protection (10k API calls/mo)' ),
+			translate( 'Scan: Real-time malware scanning and one-click fixes' ),
+			translate( 'Akismet: Comment and form spam protection (10k API calls/mo)' ),
 		],
 	},
 
@@ -1850,7 +1854,7 @@ export const PLANS_LIST: Record< string, Plan | JetpackPlan | WPComPlan > = {
 		getPathSlug: () => 'security-1tb-yearly',
 		getProductId: () => 2019,
 		getWhatIsIncluded: () => [
-			translate( 'Real-time backups as you edit' ),
+			translate( 'VaultPress Backup: Real-time backups as you edit' ),
 			translate( '{{strong}}1TB (1,000GB){{/strong}} of cloud storage', {
 				components: {
 					strong: <strong />,
@@ -1866,8 +1870,8 @@ export const PLANS_LIST: Record< string, Plan | JetpackPlan | WPComPlan > = {
 					strong: <strong />,
 				},
 			} ),
-			translate( 'Real-time malware scanning and one-click fixes' ),
-			translate( 'Comment and form spam protection (10k API calls/mo)' ),
+			translate( 'Scan: Real-time malware scanning and one-click fixes' ),
+			translate( 'Akismet: Comment and form spam protection (10k API calls/mo)' ),
 		],
 	},
 
@@ -1878,7 +1882,7 @@ export const PLANS_LIST: Record< string, Plan | JetpackPlan | WPComPlan > = {
 		getPathSlug: () => 'security-1tb-monthly',
 		getProductId: () => 2020,
 		getWhatIsIncluded: () => [
-			translate( 'Real-time backups as you edit' ),
+			translate( 'VaultPress Backup: Real-time backups as you edit' ),
 			translate( '{{strong}}1TB (1,000GB){{/strong}} of cloud storage', {
 				components: {
 					strong: <strong />,
@@ -1894,8 +1898,8 @@ export const PLANS_LIST: Record< string, Plan | JetpackPlan | WPComPlan > = {
 					strong: <strong />,
 				},
 			} ),
-			translate( 'Real-time malware scanning and one-click fixes' ),
-			translate( 'Comment and form spam protection (10k API calls/mo)' ),
+			translate( 'Scan: Real-time malware scanning and one-click fixes' ),
+			translate( 'Akismet: Comment and form spam protection (10k API calls/mo)' ),
 		],
 	},
 

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -1168,7 +1168,13 @@ const getPlanJetpackSecurityT1Details = (): IncompleteJetpackPlan => ( {
 		),
 	getLightboxDescription: () =>
 		translate(
-			'Easy-to-use, comprehensive WordPress site security including backups, malware scanning, and spam protection. Includes VaultPress Backup, Jetpack Scan, and Akismet Anti-spam.'
+			'Easy-to-use, comprehensive WordPress site security including backups, malware scanning, and spam protection.{{br/}}Includes VaultPress Backup, Jetpack Scan, and Akismet Anti-spam.',
+			{
+				components: {
+					br: <br />,
+				},
+				comment: '{{br/}} represents a line break',
+			}
 		),
 	getPlanCardFeatures: () => [
 		FEATURE_JETPACK_PRODUCT_BACKUP,


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR updates the copy of the Security and Complete plans, in the Bundles section.

### Implementation notes

Here's the list of updates:

#### Comparison table

- Real-time backups as you edit (both sides)
  -> VaultPress Backup: Real-time backups as you edit
- Real-time malware scanning and one-click fixes (both sides)
  -> Scan: Real-time malware scanning and one-click fixes
- Comment and form spam protection 
  -> Akismet Anti-spam: Comment and form spam protection (10k API calls/mo)
  -> Akismet Anti-spam: Comment and form spam protection (60k API calls/mo)
  If it doesn’t fit, remove the word ‘Anti-spam’
- Boost: Automatic CSS Generation
  -> Boost: Automatic CSS generation
- Add new row Under Growth (above CRM)
  - Social: Basic with 1,000 shares/mo
  - [Red x on left column, green check on right column]

#### Security modal
- [Underneath Easy-to-use paragraph]
  - Add “Includes VaultPress Backup, Jetpack Scan, and Akismet Anti-spam”
- Real-time backups as you edit
  -> VaultPress Backup: Real-time backups as you edit
- Real-time malware scanning and one-click fixes
  -> Scan: Real-time malware scanning and one-click fixes
- Comment and form spam protection
  -> Akismet Anti-spam: Comment and form spam protection (10k API calls/mo)

#### Complete modal
- Real-time backups as you edit
  -> VaultPress Backup: Real-time backups as you edit
- Real-time malware scanning and one-click fixes
  -> Scan: Real-time malware scanning and one-click fixes
- Comment and form spam protection 
  -> Akismet Anti-spam: Comment and form spam protection (10k API calls/mo)
- VideoPress with 1TB of ad-free video hosting
  -> VideoPress: 1TB of ad-free video hosting
- [Add row] Boost: Automatic CSS generation
- Site Search up to 100k records
  -> Site Search: Up to 100k records
- [Add row] Social: Basic with 1,000 shares/mo
- CRM Entrepreneur
  -> CRM: Entrepreneur with 30 extensions

### Testing instructions

- Spin up the pricing page, using a live link below, or by running this branch locally
- Check that the aforementioned updates are reflected in the page
