### PR TITLE
VideoPress Tailored Flow: Add custom VideoPress features list

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-plan/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-plan/index.tsx
@@ -1,6 +1,8 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 import { useLocale } from '@automattic/i18n-utils';
+import { isValueTruthy } from '@automattic/wpcom-checkout';
 import { useSelect, useDispatch } from '@wordpress/data';
+import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import React from 'react';
 import { Plans } from 'calypso/../packages/data-stores/src';
@@ -178,6 +180,29 @@ const ChooseAPlan: Step = function ChooseAPlan( { navigation, flow } ) {
 			submit?.();
 		};
 
+		const getVideoPressFeaturesList = ( plan: Plans.Plan ) => {
+			const isBusiness = 'business' === plan.periodAgnosticSlug;
+			return [
+				plan.storage && {
+					/* translators: A label displaying the amount of storage space available in the plan, eg: "13GB" or "200GB" */
+					name: sprintf( __( '%s storage space' ), plan.storage ),
+					requiresAnnuallyBilledPlan: false,
+				},
+				{ name: __( 'High-quality 4K video' ), requiresAnnuallyBilledPlan: false },
+				{ name: __( 'Ad-free video playback' ), requiresAnnuallyBilledPlan: false },
+				{ name: __( 'Video subtitles and chapters' ), requiresAnnuallyBilledPlan: false },
+				{ name: __( 'Background videos' ), requiresAnnuallyBilledPlan: false },
+				{ name: __( 'Private videos' ), requiresAnnuallyBilledPlan: false },
+				{ name: __( 'Adaptive video streaming' ), requiresAnnuallyBilledPlan: false },
+				isBusiness && {
+					name: __( 'Business features (incl. SEO)' ),
+					requiresAnnuallyBilledPlan: false,
+				},
+				isBusiness && { name: __( 'Upload themes' ), requiresAnnuallyBilledPlan: false },
+				isBusiness && { name: __( 'Install plugins' ), requiresAnnuallyBilledPlan: false },
+			].filter( isValueTruthy );
+		};
+
 		return (
 			<div className="plans-grid">
 				<PlansIntervalToggle
@@ -204,7 +229,7 @@ const ChooseAPlan: Step = function ChooseAPlan( { navigation, flow } ) {
 											slug={ plan.periodAgnosticSlug }
 											domain={ domain }
 											CTAVariation="NORMAL"
-											features={ plan.features ?? [] }
+											features={ getVideoPressFeaturesList( plan ) }
 											billingPeriod={ billingPeriod }
 											isPopular={ 'business' === plan.periodAgnosticSlug }
 											isFree={ plan.isFree }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-plan/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-plan/index.tsx
@@ -18,6 +18,7 @@ import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { domainRegistration } from 'calypso/lib/cart-values/cart-items';
 import { cartManagerClient } from 'calypso/my-sites/checkout/cart-manager-client';
 import type { Step } from '../../types';
+import type { PlanSimplifiedFeature } from 'calypso/../packages/data-stores/src/plans';
 
 import 'calypso/../packages/plans-grid/src/plans-grid/style.scss';
 import 'calypso/../packages/plans-grid/src/plans-table/style.scss';
@@ -181,11 +182,15 @@ const ChooseAPlan: Step = function ChooseAPlan( { navigation, flow } ) {
 		};
 
 		const getVideoPressFeaturesList = ( plan: Plans.Plan ) => {
-			const isBusiness = 'business' === plan.periodAgnosticSlug;
+			/* translators: A label displaying the amount of storage space available in the plan, eg: "13GB" or "200GB" */
+			const storageString = plan.storage ? sprintf( __( '%s storage space' ), plan.storage ) : null;
+
+			const filterStorageString = ( feature: PlanSimplifiedFeature ) =>
+				storageString !== feature.name;
+
 			return [
-				plan.storage && {
-					/* translators: A label displaying the amount of storage space available in the plan, eg: "13GB" or "200GB" */
-					name: sprintf( __( '%s storage space' ), plan.storage ),
+				null !== storageString && {
+					name: storageString,
 					requiresAnnuallyBilledPlan: false,
 				},
 				{ name: __( 'High-quality 4K video' ), requiresAnnuallyBilledPlan: false },
@@ -194,12 +199,7 @@ const ChooseAPlan: Step = function ChooseAPlan( { navigation, flow } ) {
 				{ name: __( 'Background videos' ), requiresAnnuallyBilledPlan: false },
 				{ name: __( 'Private videos' ), requiresAnnuallyBilledPlan: false },
 				{ name: __( 'Adaptive video streaming' ), requiresAnnuallyBilledPlan: false },
-				isBusiness && {
-					name: __( 'Business features (incl. SEO)' ),
-					requiresAnnuallyBilledPlan: false,
-				},
-				isBusiness && { name: __( 'Upload themes' ), requiresAnnuallyBilledPlan: false },
-				isBusiness && { name: __( 'Install plugins' ), requiresAnnuallyBilledPlan: false },
+				...( plan.features.filter( filterStorageString ) ?? [] ),
 			].filter( isValueTruthy );
 		};
 


### PR DESCRIPTION
#### Proposed Changes

* add a custom set of features to the videopress tailored flow's "Choose a plan" page

**Before**
<img width="625" alt="Screenshot 2022-11-14 at 5 01 03 PM" src="https://user-images.githubusercontent.com/4081020/201777159-9585fd04-d90d-4ed6-b1e5-2b1be36591a2.png">


**After**
<img width="653" alt="Screenshot 2022-11-14 at 4 15 24 PM" src="https://user-images.githubusercontent.com/4081020/201777106-959a8124-dc2b-4b6e-977f-ad3db1aaee59.png">

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* open the Calypso live link
* visit `/setup/videopress`
* complete the flow all the way to the "Choose a plan" page
* the Premium and Business plans should have the new video specific features with identical values except for `storage space` and the extra Business features (SEO, themes, plugins)

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/greenhouse/issues/1386

