### PR TITLE
Revert "Stats: Release horizontal bar chart modules (#69970)"

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -106,7 +106,7 @@
 		"stats/new-all-time-highlights": false,
 		"stats/new-annual-highlights": false,
 		"stats/new-main-chart": false,
-		"stats/new-stats-module-component": true,
+		"stats/new-stats-module-component": false,
 		"stats/show-traffic-highlights": true,
 		"stepper-woocommerce-poc": true,
 		"subscriber-csv-upload": true,

--- a/config/production.json
+++ b/config/production.json
@@ -126,7 +126,7 @@
 		"stats/new-all-time-highlights": false,
 		"stats/new-annual-highlights": false,
 		"stats/new-main-chart": false,
-		"stats/new-stats-module-component": true,
+		"stats/new-stats-module-component": false,
 		"stats/show-traffic-highlights": true,
 		"stepper-woocommerce-poc": true,
 		"subscriber-csv-upload": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -122,7 +122,7 @@
 		"stats/new-all-time-highlights": false,
 		"stats/new-annual-highlights": false,
 		"stats/new-main-chart": false,
-		"stats/new-stats-module-component": true,
+		"stats/new-stats-module-component": false,
 		"stats/show-traffic-highlights": true,
 		"stepper-woocommerce-poc": true,
 		"subscriber-csv-upload": true,

--- a/config/test.json
+++ b/config/test.json
@@ -91,7 +91,7 @@
 		"stats/new-all-time-highlights": false,
 		"stats/new-annual-highlights": false,
 		"stats/new-main-chart": false,
-		"stats/new-stats-module-component": true,
+		"stats/new-stats-module-component": false,
 		"stats/show-traffic-highlights": true,
 		"stepper-woocommerce-poc": true,
 		"themes/premium": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -130,7 +130,7 @@
 		"stats/new-all-time-highlights": false,
 		"stats/new-annual-highlights": false,
 		"stats/new-main-chart": false,
-		"stats/new-stats-module-component": true,
+		"stats/new-stats-module-component": false,
 		"stats/show-traffic-highlights": true,
 		"stepper-woocommerce-poc": true,
 		"subscriber-csv-upload": true,

--- a/packages/components/src/horizontal-bar-list/horizontal-bar-grid-item.tsx
+++ b/packages/components/src/horizontal-bar-list/horizontal-bar-grid-item.tsx
@@ -67,11 +67,12 @@ const HorizontalBarListItem = ( {
 	return (
 		<>
 			<li
-				className={ classnames( `${ BASE_CLASS_NAME }-item`, {
-					[ `${ BASE_CLASS_NAME }-item--indicated` ]: hasIndicator,
-					[ `${ BASE_CLASS_NAME }-item--link` ]: isLink || hasChildren,
-					[ `${ BASE_CLASS_NAME }-item--static` ]: isStatic,
-				} ) }
+				className={ classnames(
+					`${ BASE_CLASS_NAME }-item`,
+					isLink && `${ BASE_CLASS_NAME }-item--link`,
+					hasIndicator && `${ BASE_CLASS_NAME }-item--indicated`,
+					isStatic && `${ BASE_CLASS_NAME }-item--static`
+				) }
 				style={ {
 					[ `--${ BASE_CLASS_NAME }-fill` ]: `${ fillPercentage }%`,
 				} }

--- a/packages/components/src/horizontal-bar-list/style.scss
+++ b/packages/components/src/horizontal-bar-list/style.scss
@@ -55,7 +55,7 @@
 			width: var(--horizontal-bar-list-fill);
 			height: 100%;
 			content: "";
-			border-radius: 2px;
+			border-radius: $border-radius;
 			background-color: rgba(var(--color-primary-rgb), 15%);
 			position: absolute;
 			left: 0;


### PR DESCRIPTION
This reverts commit dcbaf6e02ed06d6dc85ceb00123390962c50fff9 from #69970.

During a pre-deploy check, I noticed none of the action buttons for the stats list items were being shown. Backing off on this commit until I can land these changes without the regression.