### PR TITLE
Stats: Inline logic for title & message strings.

### DIFF
--- a/packages/components/src/promo-card/index.tsx
+++ b/packages/components/src/promo-card/index.tsx
@@ -15,37 +15,31 @@ export default function PromoCard( { className, isMobile }: PromoCardProps ) {
 	const components = {
 		a: <a href="https://wp.com/apps" />,
 	};
-	const getTitle = () => {
-		return translate( 'Bring your stats with you using the {{a}}Jetpack{{/a}} mobile app', {
-			components,
-		} );
-	};
-	const getMessage = () => {
-		let string;
-		if ( isMobile ) {
-			string = translate(
-				'Check your stats on-the-go and get real-time notifications with the Jetpack mobile app.'
-			);
-		} else {
-			string = translate(
-				'Visit {{a}}wp.com/app{{/a}} or scan the QR code to download the Jetpack mobile app.',
-				{ components }
-			);
-		}
-		return string;
-	};
-	// ToDo: Fix mobile logic.
+	// TODO: Fix mobile logic.
 	// Should this maybe come via a media query in the CSS?
 	// Also, does it make sense to push one app store over the other?
-	// Might make more sense to have a custom SVG image that goes to wp.com/app.
+	// Might make more sense to have a custom "app store" SVG image that goes to wp.com/app.
 	return (
 		<div className={ classNames( 'promo-card', className ?? null ) }>
 			<div className="promo-lhs">
 				<div className="promo-card__icons">
 					<WordPressJetpackSVG />
 				</div>
-				<p className="promo-card__title">{ getTitle() }</p>
-				<p className="promo-card__message">{ getMessage() }</p>
+				<p className="promo-card__title">
+					{ translate( 'Bring your stats with you using the {{a}}Jetpack{{/a}} mobile app', {
+						components,
+					} ) }
+				</p>
+				<p className="promo-card__message">
+					{ isMobile
+						? translate(
+								'Check your stats on-the-go and get real-time notifications with the Jetpack mobile app.'
+						  )
+						: translate(
+								'Visit {{a}}wp.com/app{{/a}} or scan the QR code to download the Jetpack mobile app.',
+								{ components }
+						  ) }
+				</p>
 			</div>
 			<div className="promo-rhs">
 				{ ! isMobile && <QRCodeSVG /> }


### PR DESCRIPTION
#### Proposed Changes

Addresses feedback in #69917 regarding title and message logic by moving the logic into the component tree.

Feedback: https://github.com/Automattic/wp-calypso/pull/69917#pullrequestreview-1176500349

No visual changes.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this branch locally.
* Spin up Storybook via `yarn workspace @automattic/components run storybook`.
* Check the PromoCard stories. Ensure they behave as expected.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #69230 