### PR TITLE
Signup: Fix styling issues on plans step

### DIFF
--- a/client/signup/steps/plans/style.scss
+++ b/client/signup/steps/plans/style.scss
@@ -39,12 +39,7 @@
 	margin-top: 25px;
 }
 
-.signup__step.is-plans-link-in-bio .formatted-header__subtitle .button.is-borderless,
-.signup__step.is-plans-newsletter .formatted-header__subtitle .button.is-borderless,
-.signup__step.is-plans .formatted-header__subtitle .button.is-borderless,
-.signup__step.is-plans-launch .formatted-header__subtitle .button.is-borderless,
-.signup__step.is-plans-site-selected .formatted-header__subtitle .button.is-borderless,
-.signup__step.is-mailbox-plan .formatted-header__subtitle .button.is-borderless {
+.signup__step .plans.plans-step .formatted-header__subtitle .button.is-borderless {
 	padding: 0;
 	color: inherit;
 	font-size: inherit;

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -24,13 +24,7 @@ body.is-section-signup {
 		* This is done because the there is usally already a back button displayed to the user (Browser back button)
 		* and the current back button is redundent.
 		*/
-		.signup__step.is-plans-link-in-bio .step-wrapper__navigation,
-		.signup__step.is-plans-newsletter .step-wrapper__navigation,
-		.signup__step.is-mailbox-plan .step-wrapper__navigation,
-		.signup__step.is-plans .step-wrapper__navigation,
-		.signup__step.is-domains .step-wrapper__navigation,
-		.signup__step.is-plans-site-selected .step-wrapper__navigation,
-		.signup__step.is-mailbox-domain .step-wrapper__navigation {
+		.signup__step .plans.plans-step .step-wrapper__navigation {
 			@include breakpoint-deprecated( "<660px" ) {
 				display: none;
 			}
@@ -798,26 +792,23 @@ body.is-section-signup.is-white-signup .layout:not(.dops):not(.is-wccom-oauth-fl
 		}
 	}
 
-	.signup__step.is-domains,
-	.signup__step.is-mailbox-domain,
-	.signup__step.is-emails,
-	.signup__step.is-mailbox,
-	.signup__step.is-plans-newsletter,
-	.signup__step.is-plans-link-in-bio,
-	.signup__step.is-mailbox-plan,
-	.signup__step.is-plans-site-selected,
-	.signup__step.is-plans {
+	.signup__step .plans.plans-step {
 		.formatted-header {
 			.formatted-header__title {
 				font-size: 2.25rem;
 				/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 				line-height: 2.5rem;
-
+				font-weight: 500;
 				@include break-mobile {
 					font-size: 2.75rem;
 					/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 					line-height: 3rem;
 				}
+			}
+
+			.formatted-header__subtitle button.is-borderless {
+				font-weight: 500;
+				color: var(--studio-gray-90);
 			}
 		}
 	}
@@ -843,21 +834,6 @@ body.is-section-signup.is-white-signup .layout:not(.dops):not(.is-wccom-oauth-fl
 
 		.formatted-header__title {
 			text-align: start;
-		}
-	}
-
-	.signup__step.is-plans-link-in-bio,
-	.signup__step.is-plans-newsletter,
-	.signup__step.is-mailbox-plan,
-	.signup__step.is-plans-site-selected,
-	.signup__step.is-plans {
-		.formatted-header__title {
-			font-weight: 500;
-		}
-
-		.formatted-header__subtitle button.is-borderless {
-			font-weight: 500;
-			color: var(--studio-gray-90);
 		}
 	}
 


### PR DESCRIPTION
#### Proposed Changes

P2: pdKhl6-Jm-p2#comment-1162

This PR solves the same issue solved by #69728, but for all steps that use the plans step component. The current implementation applies styling based on selectors that use the name of the step. (eg: `signup__step.is-plans-link-in-bio`, `.signup__step.is-plans-launch`, etc.). If a new step is added that is based on the plans step component, the corresponding selector needs to be added in 4 different places. This is a leaky abstraction and can lead to bugs. 

In this PR, we replace all selectors of the type `.signup__step.is-<step name>` with a single `.signup__step .plans.plans-step` selector, where `<step name>` utilizes the plans step component. 

The specific styling issues that are fixed are described in #69728.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/import/` and select any domain.
* On the next step, confirm that the page looks exactly the same as the one on https://wordpress.com/start/plans, with a focus on the changes mentioned in #69728.
* Repeat this for a few flows that use the plans step:
  * Launch flow
  * /start
  * /start/domain
  * /start/onboarding-with-email
  * /setup/link-in-bio/intro

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->