### PR TITLE
Fixed post checkout upsell for BBE

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/checkout-next-steps.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-next-steps.tsx
@@ -2,6 +2,7 @@ import { Gridicon } from '@automattic/components';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
+import { hasDIFMProduct } from 'calypso/lib/cart-values/cart-items';
 import type { ResponseCart } from '@automattic/shopping-cart';
 import type { TranslateResult } from 'i18n-calypso';
 import type { ReactChild } from 'react';
@@ -76,33 +77,35 @@ const NextStepIcon = styled( BaseIcon )`
 export default function CheckoutNextSteps( { responseCart, headerText }: Props ) {
 	const translate = useTranslate();
 
-	const steps: NextStepsStep[] = useMemo(
-		() => [
-			{
-				text: translate( 'Submit business information' ),
-				icon: <CompletedStepIcon />,
-			},
-			{
-				text: translate( 'Choose a design' ),
-				icon: <CompletedStepIcon />,
-			},
-			{
-				text: <b>{ translate( 'Checkout' ) }</b>,
-				icon: <CurrentStepIcon />,
-			},
-			{
-				text: translate( 'Submit content for new site' ),
-				icon: <NextStepIcon />,
-			},
-			{
-				text: translate( 'Receive your finished site in under %d business days!', {
-					args: [ 4 ],
-				} ),
-				icon: <NextStepIcon />,
-			},
-		],
-		[ responseCart, translate ]
-	);
+	const steps: NextStepsStep[] = useMemo( () => {
+		if ( hasDIFMProduct( responseCart ) ) {
+			return [
+				{
+					text: translate( 'Submit business information' ),
+					icon: <CompletedStepIcon />,
+				},
+				{
+					text: translate( 'Choose a design' ),
+					icon: <CompletedStepIcon />,
+				},
+				{
+					text: <b>{ translate( 'Checkout' ) }</b>,
+					icon: <CurrentStepIcon />,
+				},
+				{
+					text: translate( 'Submit content for new site' ),
+					icon: <NextStepIcon />,
+				},
+				{
+					text: translate( 'Receive your finished site in under %d business days!', {
+						args: [ 4 ],
+					} ),
+					icon: <NextStepIcon />,
+				},
+			];
+		}
+		return [];
+	}, [ responseCart, translate ] );
 
 	return steps && steps.length ? (
 		<CheckoutNextStepsWrapper>

--- a/client/my-sites/checkout/composite-checkout/components/checkout-next-steps.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-next-steps.tsx
@@ -2,7 +2,6 @@ import { Gridicon } from '@automattic/components';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
-import { hasDIFMProduct } from 'calypso/lib/cart-values/cart-items';
 import type { ResponseCart } from '@automattic/shopping-cart';
 import type { TranslateResult } from 'i18n-calypso';
 import type { ReactChild } from 'react';
@@ -77,35 +76,33 @@ const NextStepIcon = styled( BaseIcon )`
 export default function CheckoutNextSteps( { responseCart, headerText }: Props ) {
 	const translate = useTranslate();
 
-	const steps: NextStepsStep[] = useMemo( () => {
-		if ( hasDIFMProduct( responseCart ) ) {
-			return [
-				{
-					text: translate( 'Submit business information' ),
-					icon: <CompletedStepIcon />,
-				},
-				{
-					text: translate( 'Choose a design' ),
-					icon: <CompletedStepIcon />,
-				},
-				{
-					text: <b>{ translate( 'Checkout' ) }</b>,
-					icon: <CurrentStepIcon />,
-				},
-				{
-					text: translate( 'Submit content for new site' ),
-					icon: <NextStepIcon />,
-				},
-				{
-					text: translate( 'Receive your finished site in under %d business days!', {
-						args: [ 4 ],
-					} ),
-					icon: <NextStepIcon />,
-				},
-			];
-		}
-		return [];
-	}, [ responseCart, translate ] );
+	const steps: NextStepsStep[] = useMemo(
+		() => [
+			{
+				text: translate( 'Submit business information' ),
+				icon: <CompletedStepIcon />,
+			},
+			{
+				text: translate( 'Choose a design' ),
+				icon: <CompletedStepIcon />,
+			},
+			{
+				text: <b>{ translate( 'Checkout' ) }</b>,
+				icon: <CurrentStepIcon />,
+			},
+			{
+				text: translate( 'Submit content for new site' ),
+				icon: <NextStepIcon />,
+			},
+			{
+				text: translate( 'Receive your finished site in under %d business days!', {
+					args: [ 4 ],
+				} ),
+				icon: <NextStepIcon />,
+			},
+		],
+		[ responseCart, translate ]
+	);
 
 	return steps && steps.length ? (
 		<CheckoutNextStepsWrapper>

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
@@ -30,6 +30,7 @@ import {
 	hasGoogleApps,
 	hasDomainRegistration,
 	hasTransferProduct,
+	hasDIFMProduct,
 } from 'calypso/lib/cart-values/cart-items';
 import { getGoogleMailServiceFamily } from 'calypso/lib/gsuite';
 import { isWcMobileApp } from 'calypso/lib/mobile-app';
@@ -290,6 +291,8 @@ export default function WPCheckout( {
 		);
 	}
 
+	const isDIFMInCart = hasDIFMProduct( responseCart );
+
 	return (
 		<CheckoutStepGroup
 			stepAreaHeader={
@@ -314,14 +317,14 @@ export default function WPCheckout( {
 								onChangePlanLength={ changePlanLength }
 								nextDomainIsFree={ responseCart?.next_domain_is_free }
 							/>
-							{ ! isWcMobile && <CheckoutSidebarPlanUpsell /> }
+							{ ! isWcMobile && ! isDIFMInCart && <CheckoutSidebarPlanUpsell /> }
 							<SecondaryCartPromotions
 								responseCart={ responseCart }
 								addItemToCart={ addItemToCart }
 								isCartPendingUpdate={ isCartPendingUpdate }
 							/>
 							<CheckoutHelpLink />
-							<CheckoutNextSteps responseCart={ responseCart } />
+							{ isDIFMInCart && <CheckoutNextSteps responseCart={ responseCart } /> }
 						</CheckoutSummaryBody>
 					</CheckoutErrorBoundary>
 				</CheckoutSummaryArea>

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
@@ -324,7 +324,7 @@ export default function WPCheckout( {
 								isCartPendingUpdate={ isCartPendingUpdate }
 							/>
 							<CheckoutHelpLink />
-							{ isDIFMInCart && <CheckoutNextSteps responseCart={ responseCart } /> }
+							<CheckoutNextSteps responseCart={ responseCart } />
 						</CheckoutSummaryBody>
 					</CheckoutErrorBoundary>
 				</CheckoutSummaryArea>


### PR DESCRIPTION
#### Proposed Changes

* The checkout steps from BBE are pushed down out of view due to the plan upsell section.
* This change hides the upsell section when BBE is in the basket

![image](https://user-images.githubusercontent.com/3422709/201856588-b61da5d2-31aa-4f35-baa7-bc69a32304e2.png)

#### Testing Instructions
 - Go through the DIFM flow `start/do-it-for-me`
 - Purchase DIFM and go to checkout
 - Make sure the upsell above is not visible
 
<img width="1422" alt="image" src="https://user-images.githubusercontent.com/3422709/201857200-f8ed55bf-8af8-4668-878c-77e6acafb09d.png">


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
