### PR TITLE
Style selection in design picker: Remove background color of sidebar

### DIFF
--- a/packages/design-preview/src/components/style.scss
+++ b/packages/design-preview/src/components/style.scss
@@ -24,7 +24,6 @@ $break-design-preview: 1024px;
 
 .design-preview__sidebar {
 	align-items: center;
-	background: #fff;
 	border-bottom: 1px solid rgb(0 0 0 / 5%);
 	box-shadow: -4px 0 8px rgb(0 0 0 / 7%);
 	box-sizing: border-box;


### PR DESCRIPTION
#### Proposed Changes

* Remove the background color on the design preview sidebar

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the unified design picker `/setup/designSetup?siteSlug=${site_slug}`
* Click on a theme with style variations to open the preview
* Check that the sidebar of the preview doesn't have a white background

|Before|After|
|-------|-----|
|<img width="369" alt="Screen Shot 2565-11-15 at 14 19 50" src="https://user-images.githubusercontent.com/1881481/201854797-6f69469c-6c4f-4e3f-af35-3da9a13ab5f1.png">|<img width="424" alt="Screen Shot 2565-11-15 at 14 16 40" src="https://user-images.githubusercontent.com/1881481/201854329-04612578-2dda-4d7a-a722-8fa27b6bf5f4.png">|


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/67066
