### PR TITLE
Free Onboarding flow: Remove plans and domains pages WIP

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -71,7 +71,9 @@ export function generateFlows( {
 		},
 		{
 			name: 'free',
-			steps: [ 'user', 'domains' ],
+			steps: isEnabled( 'signup/free-onboarding-flow' )
+				? [ 'user', 'auto-site-generation' ]
+				: [ 'user', 'domains' ],
 			destination: getSignupDestination,
 			description: 'Create an account and a blog and default to the free plan.',
 			lastModified: '2020-08-11',

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -1,5 +1,6 @@
 const stepNameToModuleName = {
 	'add-ons': 'add-ons',
+	'auto-site-generation': 'auto-site-generation',
 	'clone-start': 'clone-start',
 	'clone-destination': 'clone-destination',
 	'clone-credentials': 'clone-credentials',

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -737,6 +737,18 @@ export function generateSteps( {
 			providesDependencies: [ 'cartItem' ],
 		},
 
+		'auto-site-generation': {
+			stepName: 'auto-site-generation',
+			props: {
+				headerText: i18n.translate( 'Automatic site generation' ),
+			},
+			apiRequestFunction: () => {},
+			fulfilledStepCallback: () => {},
+			// Audit need for dependencies
+			// dependencies: [ 'siteSlug' ],
+			// providesDependencies: [ 'cartItem' ],
+		},
+
 		'difm-site-picker': {
 			stepName: 'difm-site-picker',
 			props: {

--- a/client/signup/steps/auto-site-generation/index.jsx
+++ b/client/signup/steps/auto-site-generation/index.jsx
@@ -1,0 +1,109 @@
+import { localize } from 'i18n-calypso';
+import { Component } from 'react';
+import { connect } from 'react-redux';
+import EmailSignupTitanCard from 'calypso/components/emails/email-signup-titan-card';
+import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
+import StepWrapper from 'calypso/signup/step-wrapper';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { getSignupDependencyStore } from 'calypso/state/signup/dependency-store/selectors';
+import { saveSignupStep, submitSignupStep } from 'calypso/state/signup/progress/actions';
+import './style.scss';
+
+class AutoSiteGeneration extends Component {
+	componentDidMount() {
+		// Do awesome site generation stuff here
+	}
+
+	handleSkip = () => {
+		const { flowName, stepName } = this.props;
+
+		this.props.recordTracksEvent( 'calypso_signup_skip_step', {
+			section: 'signup',
+			flow: flowName,
+			step: stepName,
+		} );
+
+		// Handle goToNextStep stuff here
+	};
+
+	renderStepContent() {
+		const { hideSkip, signupDependencies, step, stepSectionName, translate } = this.props;
+
+		// Replace content with whatever is decided upon by the design team
+		return (
+			<div className="emails__email-suggestion-content-container">
+				<div
+					key={ step + stepSectionName }
+					className="emails__step-content emails__step-content-email-step"
+				>
+					<div className="emails__register-email-step">
+						<CalypsoShoppingCartProvider>
+							<EmailSignupTitanCard
+								siteUrl={ signupDependencies.domainItem?.meta }
+								addButtonTitle={ translate( 'Add' ) }
+								skipButtonTitle={ translate( 'Skip' ) }
+								hideSkip={ hideSkip }
+								// onAddButtonClick={ this.handleAddEmail }
+								onSkipButtonClick={ this.handleSkip }
+							/>
+						</CalypsoShoppingCartProvider>
+					</div>
+				</div>
+			</div>
+		);
+	}
+
+	render() {
+		const {
+			backUrl = '/',
+			flowName,
+			hideSkip = false,
+			positionInFlow,
+			stepName,
+			translate,
+		} = this.props;
+
+		const headerText = translate( 'Generating your free site' );
+		const subHeaderText = translate( 'Free site auto-generation subheader text' );
+
+		// Audit the props passed to StepWrapper
+		return (
+			<StepWrapper
+				flowName={ flowName }
+				stepName={ stepName }
+				backUrl={ backUrl }
+				positionInFlow={ positionInFlow }
+				headerText={ headerText }
+				subHeaderText={ subHeaderText }
+				isExternalBackUrl={ false }
+				fallbackHeaderText={ headerText }
+				fallbackSubHeaderText={ subHeaderText }
+				stepContent={ this.renderStepContent() }
+				allowBackFirstStep={ !! backUrl }
+				backLabelText={ translate( 'Back' ) }
+				hideSkip={ hideSkip }
+				goToNextStep={ this.handleSkip }
+				skipHeadingText={ translate( 'Not sure yet?' ) }
+				skipLabelText={ translate( 'C' ) }
+				skipButtonAlign="bottom"
+				align="left"
+				isWideLayout={ true }
+			/>
+		);
+	}
+}
+
+// Audit the connections
+export default connect(
+	( state ) => {
+		const signupDependencies = getSignupDependencyStore( state );
+		return {
+			signupDependencies,
+		};
+	},
+	{
+		recordTracksEvent,
+		saveSignupStep,
+		submitSignupStep,
+	}
+)( localize( AutoSiteGeneration ) );

--- a/config/development.json
+++ b/config/development.json
@@ -155,6 +155,7 @@
 		"signup/design-picker-premium-themes-checkout": true,
 		"signup/design-picker-use-featured-picks-buttons": true,
 		"signup/ftm-flow-non-en": true,
+		"signup/free-onboarding-flow": true,
 		"signup/goals-step": true,
 		"signup/goals-step-2": true,
 		"signup/hero-flow-non-en": true,


### PR DESCRIPTION
#### Proposed Changes

*

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/69921
