### PR TITLE
Partner Portal: update issue license notification text

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/hooks.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/hooks.tsx
@@ -401,16 +401,16 @@ export function useIssueMultipleLicenses(
 				.filter( ( license ) => license );
 
 			if ( assignedLicenses.length > 0 ) {
-				const lastItem = assignedLicenses.slice( -1 )[ 0 ];
-				const remainingItems = assignedLicenses.slice( 0, -1 );
-				const messageArgs = {
-					args: {
-						lastItem: lastItem,
-						remainingItems: remainingItems.join( ', ' ),
-					},
-					components: {
-						strong: <strong />,
-					},
+				const initialLicenseList = assignedLicenses.slice( 0, -1 );
+				const lastLicenseItem = assignedLicenses.slice( -1 )[ 0 ];
+
+				const commaCharacter = translate( ',' );
+				const conjunction =
+					assignedLicenses.length > 2
+						? translate( `%(commaCharacter)s and`, { args: { commaCharacter } } )
+						: translate( ' and' );
+				const components = {
+					strong: <strong />,
 				};
 
 				dispatch(
@@ -418,13 +418,26 @@ export function useIssueMultipleLicenses(
 						// We are not using the same translate method for plural form since we have different arguments.
 						assignedLicenses.length > 1
 							? translate(
-									'{{strong}}%(remainingItems)s and %(lastItem)s{{/strong}} were succesfully issued',
-									messageArgs
+									'{{strong}}%(initialLicenseList)s%(conjunction)s %(lastLicenseItem)s{{/strong}} were succesfully issued',
+									{
+										args: {
+											lastLicenseItem,
+											conjunction,
+											initialLicenseList: initialLicenseList.join( ', ' ),
+										},
+										comment: `%(initialLicenseList)s is a list of n-1 license names
+											seperated by a translated comma character, %(lastLicenseItem)
+											is the nth license name, and %(conjunction) is a translated "and"
+											text with or without a serial comma based on the licenses count`,
+										components,
+									}
 							  )
-							: translate(
-									'{{strong}}%(lastItem)s{{/strong}} was succesfully issued',
-									messageArgs
-							  ),
+							: translate( '{{strong}}%(assignedLicense)s{{/strong}} was succesfully issued', {
+									args: {
+										assignedLicense: lastLicenseItem,
+									},
+									components,
+							  } ),
 						{
 							displayOnNextPage: true,
 						}

--- a/client/jetpack-cloud/sections/partner-portal/hooks.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/hooks.tsx
@@ -404,11 +404,26 @@ export function useIssueMultipleLicenses(
 				const initialLicenseList = assignedLicenses.slice( 0, -1 );
 				const lastLicenseItem = assignedLicenses.slice( -1 )[ 0 ];
 
-				const commaCharacter = translate( ',' );
+				const commaCharacter = translate( ',', {
+					comment:
+						'The character used to separate items in a list, such as the comma in "Jetpack Backup, Jetpack Scan, and Jetpack Boost".',
+				} );
 				const conjunction =
 					assignedLicenses.length > 2
-						? translate( `%(commaCharacter)s and`, { args: { commaCharacter } } )
-						: translate( ' and' );
+						? translate( `%(commaCharacter)s and`, {
+								args: {
+									commaCharacter,
+									comment:
+										'The final separator of a delimited list, such as ", and" in "Jetpack Backup, Jetpack Scan, and Jetpack Boost."',
+								},
+						  } )
+						: translate( ' and', {
+								args: {
+									comment:
+										'The way that two words are separated, such as " and" in "Jetpack Backup and Jetpack Scan". Note that the space here is important due to the way the final string is constructed.',
+								},
+						  } );
+
 				const components = {
 					strong: <strong />,
 				};
@@ -425,10 +440,8 @@ export function useIssueMultipleLicenses(
 											conjunction,
 											initialLicenseList: initialLicenseList.join( ', ' ),
 										},
-										comment: `%(initialLicenseList)s is a list of n-1 license names
-											seperated by a translated comma character, %(lastLicenseItem)
-											is the nth license name, and %(conjunction) is a translated "and"
-											text with or without a serial comma based on the licenses count`,
+										comment:
+											'%(initialLicenseList)s is a list of n-1 license names seperated by a translated comma character, %(lastLicenseItem) is the nth license name, and %(conjunction) is a translated "and" text with or without a serial comma based on the licenses count. An example is "Jetpack Backup, Jetpack Scan, and Jetpack Boost" where the initialLicenseList is "Jetpack Backup, Jetpack Scan", the conjunction is ", and", and the lastLicenseItem is "Jetpack Boost". An alternative example is "Jetpack Backup and Jetpack Scan", where initialLicenseList is "Jetpack Backup", conjunction is " and", and lastLienseItem is "Jetpack Boost".',
 										components,
 									}
 							  )


### PR DESCRIPTION
#### Proposed Changes

This PR makes some updates to the notification text during the issue license flow.

- Include a serial comma with the conjunction("and") where more than 2 licenses are issued.
- Translate comma
- Add a comment for the issue of multiple licenses translate messages
- Minor code refactor


#### Testing Instructions

1. Run `git checkout update/issue-license-notification-text` and `yarn start-jetpack-cloud`
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Click on **Licensing** -> Click on **Issue New License** -> Select any license -> Click on **Select License** -> Verify that you are being redirected to `/assign-license` and notification is being shown as below

**1 license**

<img width="519" alt="Screenshot 2022-11-15 at 12 54 41 PM" src="https://user-images.githubusercontent.com/10586875/201888406-e56aabf8-6554-42a5-8687-8ddcc8f6624d.png">

**2 licenses**

<img width="648" alt="Screenshot 2022-11-15 at 12 55 03 PM" src="https://user-images.githubusercontent.com/10586875/201888421-3bae8e3d-d975-4683-8302-6bafcaac4a9d.png">

**3 licenses**

<img width="718" alt="Screenshot 2022-11-15 at 12 55 20 PM" src="https://user-images.githubusercontent.com/10586875/201888429-22a444ea-4c38-483c-a912-885b1d87d179.png">

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1203126240279377-as-1203362674516728