### PR TITLE
VideoPress Onboarding, text fixes on launchpad

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -130,7 +130,7 @@ export function getEnhancedTasks(
 				case 'videopress_setup':
 					taskData = {
 						completed: true,
-						title: translate( 'Set up your Video site' ),
+						title: translate( 'Set up your video site' ),
 					};
 					break;
 				case 'videopress_upload':
@@ -146,7 +146,7 @@ export function getEnhancedTasks(
 					break;
 				case 'videopress_launched':
 					taskData = {
-						title: translate( 'Launch Video site' ),
+						title: translate( 'Launch site' ),
 						completed: siteLaunchCompleted,
 						disabled: ! videoPressUploadCompleted,
 						actionDispatch: () => {
@@ -155,7 +155,7 @@ export function getEnhancedTasks(
 								const { launchSite } = dispatch( SITE_STORE );
 
 								setPendingAction( async () => {
-									setProgressTitle( __( 'Launching Video Site' ) );
+									setProgressTitle( __( 'Launching video site' ) );
 									await launchSite( site.ID );
 
 									// Waits for half a second so that the loading screen doesn't flash away too quickly

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/translations.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/translations.tsx
@@ -21,7 +21,8 @@ export function getLaunchpadTranslations( flow: string | null ): TranslatedLaunc
 			break;
 		case VIDEOPRESS_FLOW:
 			translatedStrings.flowName = translate( 'Video' );
-			translatedStrings.launchTitle = translate( 'Your Video site is ready to launch!' );
+			translatedStrings.title = translate( 'Your video site is ready!' );
+			translatedStrings.launchTitle = translate( 'Your video site is ready!' );
 			break;
 	}
 

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -643,7 +643,7 @@ class DomainsStep extends Component {
 			};
 			if ( VIDEOPRESS_FLOW === flowName ) {
 				return translate(
-					'Set your Video site apart with a custom domain. Not sure yet? {{span}}Decide later{{/span}}.',
+					'Set your video site apart with a custom domain. Not sure yet? {{span}}Decide later{{/span}}.',
 					{ components }
 				);
 			}


### PR DESCRIPTION
#### Proposed Changes

This PR updates the launchpad on the VideoPress flow to match changes described in Automattic/greenhouse#1390 .
It also updates occurrences of "Video site" to "video site" to stay consistent.

#### Testing Instructions

* Apply patch
* `yarn start`
* Go to `http://calypso.localhost:3000/setup/intro?flow=videopress`
* Follow the flow
* ✅ On site options, you should read "Set up your video site" instead of "Set up your Video site"
* ✅ On domain step, you should read "Set your video site apart ..." instead of "Set your Video site apart..."
* ✅ On launchpad step, your should read "Your video site is ready!" instead of "Your website is ready!"
* ✅ On launchpad, the button should read "Launch site" instead of "Launch Video site"

Fixes Automattic/greenhouse#1390 
