### PR TITLE
VideoPress Tailored Onboarding: Favor desktop site preview on the launchpad

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/launchpad-site-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/launchpad-site-preview.tsx
@@ -23,7 +23,7 @@ const LaunchpadSitePreview = ( {
 
 	if ( isVideoPressFlow ) {
 		const windowWidth = window.innerWidth;
-		defaultDevice = windowWidth >= 1430 ? DEVICE_TYPE.COMPUTER : DEVICE_TYPE.PHONE;
+		defaultDevice = windowWidth >= 1000 ? DEVICE_TYPE.COMPUTER : DEVICE_TYPE.PHONE;
 	}
 
 	function formatPreviewUrl() {


### PR DESCRIPTION
#### Proposed Changes

This PR reduces the threshold to display the mobile preview to 1000px instead of +- 1500px.

#### Testing Instructions

* Apply patch
* `yarn start`
* Go to `http://calypso.localhost:3000/setup/intro?flow=videopress`and complete the flow until launchpad
* Set your window size to very slightly bigger than when the launchpad wraps to the mobile layout (in the console, check window.innerWidth, it should be < 1000px)
* Refresh the page
* ✅ You should see the mobile preview
![Capture d’écran 2022-11-15 à 14 38 24](https://user-images.githubusercontent.com/1420594/201934967-7b3cbd2f-aa24-4624-9f2c-59d79b9fabf9.png)
* Make the window slightly larger (check window.innerWidth in the console, it should be >= 1000px)
* Refresh the page
* ✅ You should see the desktop preview
![Capture d’écran 2022-11-15 à 14 38 41](https://user-images.githubusercontent.com/1420594/201935120-f2916983-c43c-4ea0-b928-6b73ec8fcb37.png)

Fixes Automattic/greenhouse#1387
