### PR TITLE
Learn More links: Block Description for the Comments Block

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-description-links/src/block-links-map.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-description-links/src/block-links-map.ts
@@ -95,6 +95,8 @@ const blockLinks: { [ key: string ]: string } = {
 	'core/table-of-contents':
 		'https://wordpress.com/support/wordpress-editor/table-of-contents-block/',
 
+	'core/comments': 'https://wordpress.com/support/full-site-editing/theme-blocks/comments-block/',
+
 	/**
 	 * A8C and CO Blocks
 	 */


### PR DESCRIPTION
#### Proposed Changes

Add new documentation for the `Comments` block: `https://wordpress.com/support/full-site-editing/theme-blocks/comments-block/`

![image](https://user-images.githubusercontent.com/52076348/201947070-0ddd5373-5815-4541-8a32-8dddb5717a08.png)

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Checkout branch
- yarn dev --sync from apps/editing-toolkit
- Check that the new block has the Learn more link and it points to the correct destination.
- Check that support articles is localized.

Related to #69108
Fixes #69108
