### PR TITLE
My Home: Update messaging for already launched sites and add icon to completed tasks action button

### DIFF
--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/current-task-item.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/current-task-item.jsx
@@ -47,6 +47,14 @@ const CurrentTaskItem = ( { currentTask, skipTask, startTask, useAccordionLayout
 								( currentTask.isCompleted && currentTask.actionDisableOnComplete )
 							}
 						>
+							{ currentTask.isCompleted && (
+								<Gridicon
+									aria-label={ translate( 'Task complete' ) }
+									className="site-setup-list__complete-icon"
+									icon="checkmark"
+									size={ 18 }
+								/>
+							) }
 							{ currentTask.actionText }
 						</Button>
 					) }

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/current-task-item.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/current-task-item.jsx
@@ -47,14 +47,15 @@ const CurrentTaskItem = ( { currentTask, skipTask, startTask, useAccordionLayout
 								( currentTask.isCompleted && currentTask.actionDisableOnComplete )
 							}
 						>
-							{ currentTask.isCompleted && (
-								<Gridicon
-									aria-label={ translate( 'Task complete' ) }
-									className="site-setup-list__complete-icon"
-									icon="checkmark"
-									size={ 18 }
-								/>
-							) }
+							{ currentTask.isCompleted &&
+								( currentTask.isDisabled || currentTask.actionDisableOnComplete ) && (
+									<Gridicon
+										aria-label={ translate( 'Task complete' ) }
+										className="site-setup-list__complete-icon"
+										icon="checkmark"
+										size={ 18 }
+									/>
+								) }
 							{ currentTask.actionText }
 						</Button>
 					) }

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
@@ -1,4 +1,5 @@
 import config from '@automattic/calypso-config';
+import { createInterpolateElement } from '@wordpress/element';
 import { translate } from 'i18n-calypso';
 import AnimatedIcon from 'calypso/components/animated-icon';
 import InlineSupportLink from 'calypso/components/inline-support-link';
@@ -126,7 +127,9 @@ export const getTask = (
 						<a href="/me/account">{ translate( 'Change' ) }</a>
 					</>
 				),
-				actionText: translate( 'Resend email' ),
+				actionText: task.isCompleted
+					? translate( 'Already confirmed' )
+					: translate( 'Resend email' ),
 				actionDispatch: verifyEmail,
 				actionDispatchArgs: [ { showGlobalNotices: true } ],
 			};
@@ -175,25 +178,40 @@ export const getTask = (
 				isSkippable: true,
 			};
 			break;
-		case CHECKLIST_KNOWN_TASKS.SITE_LAUNCHED:
+		case CHECKLIST_KNOWN_TASKS.SITE_LAUNCHED: {
+			const description = isBlogger
+				? translate(
+						"Ready for the big reveal? Right now, your blog is private and visible only to you. Launch your blog so that it's public for everyone."
+				  )
+				: translate(
+						"Your site is private and only visible to you. When you're ready, launch your site to make it public."
+				  );
+			const descriptionOnCompleted = createInterpolateElement(
+				/* translators: pressing <Link> will redirect user to Settings -> Privacy where they can change the site visibilidty */
+				translate(
+					'Your site is already live. You can change your site visibility in <Link>privacy options</Link> at any time.'
+				),
+				{
+					Link: <a href={ `/settings/general/${ siteSlug }#site-privacy-settings` } />,
+				}
+			);
+
+			const actionText = isBlogger ? translate( 'Launch blog' ) : translate( 'Launch site' );
+			const actionTextOnCompleted = translate( 'Already launched' );
+
 			taskData = {
 				timing: 1,
 				title: isBlogger
 					? translate( 'Launch your blog' )
 					: translate( 'Launch your site to the world' ),
-				description: isBlogger
-					? translate(
-							"Ready for the big reveal? Right now, your blog is private and visible only to you. Launch your blog so that it's public for everyone."
-					  )
-					: translate(
-							"Your site is private and only visible to you. When you're ready, launch your site to make it public."
-					  ),
-				actionText: isBlogger ? translate( 'Launch blog' ) : translate( 'Launch site' ),
+				description: task.isCompleted ? descriptionOnCompleted : description,
+				actionText: task.isCompleted ? actionTextOnCompleted : actionText,
 				actionDispatch: launchSiteOrRedirectToLaunchSignupFlow,
 				actionDispatchArgs: [ siteId, 'my-home' ],
 				actionDisableOnComplete: true,
 			};
 			break;
+		}
 		case CHECKLIST_KNOWN_TASKS.FRONT_PAGE_UPDATED:
 			taskData = {
 				timing: 20,

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/style.scss
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/style.scss
@@ -197,6 +197,10 @@
 		margin-top: 0;
 	}
 
+	.site-setup-list__complete-icon {
+		margin-right: 8px;
+	}
+
 	.site-setup-list__task-icon {
 		width: 67px;
 		height: 35px;


### PR DESCRIPTION
- Fixes: #69951
- Originally reported p1668163871099539-slack-C014TPFLP4Z

#### Proposed Changes

* Add a checkmark inside the button when a task is completed and disabled.
* Update the description and the button text for the launch site task when the site has already launched
* Update the button text for the email confirmation task

#### Testing Instructions

* Apply this PR to your local machine or use calypso live.
* Create a new site, it can be free.
* In the `Site setup` navigation click on `Launch your site to the world`.
* Observe the text and button match our current implementation on production.
* Click on Launch Site, and follow the process.
* In `My Home` click on `Site setup` and select the step `Launch your site to the world`.
* Observe that the description doesn't mention if the site is public or private.
* Observe that there is a link to privacy options.
* Observe the CTA is disabled, has a checkmark and says `Already launched`

**Video**

https://user-images.githubusercontent.com/779993/201952872-4e9e5daf-6f45-45a8-93ee-4d481732b7be.mp4




**Secreenshots: `Launch your site to the world`**

| **Before** | **After** |
|---|---|
| <img width="979" alt="Before: Launched" src="https://user-images.githubusercontent.com/779993/201953243-c1475133-6cd8-4063-8e34-c2ddd7535ebb.png"> | <img width="980" alt="Screenshot 2022-11-15 at 14 32 59" src="https://user-images.githubusercontent.com/779993/201955329-8c55af27-2263-47a6-ab8c-fb2abe02f9e2.png"> |

**Secreenshots: `Confirm your email address`**

| **Before** | **After** |
|---|---|
| <img width="956" alt="before-email-confirmed" src="https://user-images.githubusercontent.com/779993/201954368-b1627905-920c-46e4-a24f-8729aa3556d5.png"> | <img width="950" alt="after-email-confirmed" src="https://user-images.githubusercontent.com/779993/201954373-62d74fda-515c-41a1-89b2-feabcd46cdde.png"> |


#### Pre-merge Checklist

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->