### PR TITLE
Help Center: fix Help Center minimized state on iOS

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -45,6 +45,19 @@
 				"units": [ "px" ]
 			}
 		],
-		"unit-allowed-list": [ "%", "deg", "em", "fr", "ms", "px", "rem", "s", "vh", "vw", "svh" ]
+		"unit-allowed-list": [
+			"%",
+			"deg",
+			"em",
+			"fr",
+			"ms",
+			"px",
+			"rem",
+			"s",
+			"vh",
+			"vw",
+			"svh",
+			"dvh"
+		]
 	}
 }

--- a/packages/help-center/src/styles.scss
+++ b/packages/help-center/src/styles.scss
@@ -124,6 +124,10 @@ $head-foot-height: 50px;
 			&.is-minimized {
 				min-height: $head-foot-height;
 				top: calc(100vh - #{$head-foot-height});
+
+				@supports ( height: 100svh ) {
+					top: calc(100svh - #{$head-foot-height});
+				}
 			}
 		}
 

--- a/packages/help-center/src/styles.scss
+++ b/packages/help-center/src/styles.scss
@@ -125,8 +125,8 @@ $head-foot-height: 50px;
 				min-height: $head-foot-height;
 				top: calc(100vh - #{$head-foot-height});
 
-				@supports ( height: 100svh ) {
-					top: calc(100svh - #{$head-foot-height});
+				@supports ( height: 100dvh ) {
+					top: calc(100dvh - #{$head-foot-height});
 				}
 			}
 		}


### PR DESCRIPTION
#### Proposed Changes

* This uses `dvh` on iOS devices for positioning the Help Center when minimized. 
* This is needed because iOS doesn't consider its own UI components as limited to the viewport height.

Video on [`dvh`](https://youtu.be/Xy9ZXRRgpLk?t=982).

#### Testing Instructions

1. Go to my Home on iOS.
2. Minimize the Help Center.. 
3. Should be visible.

Context: p1668526222343279-slack-C02T4NVL4JJ