### PR TITLE
Revert "Wraps promote products in a feature flag"

### DIFF
--- a/client/lib/promote-post/index.ts
+++ b/client/lib/promote-post/index.ts
@@ -136,21 +136,3 @@ export const usePromoteWidget = (): PromoteWidgetStatus => {
 	} );
 	return value;
 };
-
-/**
- * Hook to verify if we should enable the products in the
- *
- * @returns bool
- */
-export const useCanPromoteProducts = (): PromoteWidgetStatus => {
-	return useSelector( ( state ) => {
-		const userData = getCurrentUser( state );
-		if ( userData ) {
-			const originalSetting = userData[ 'can_promote_products' ];
-			if ( originalSetting !== undefined ) {
-				return originalSetting ? PromoteWidgetStatus.ENABLED : PromoteWidgetStatus.DISABLED;
-			}
-		}
-		return PromoteWidgetStatus.FETCHING;
-	} );
-};

--- a/client/lib/user/shared-utils/filter-user-object.js
+++ b/client/lib/user/shared-utils/filter-user-object.js
@@ -22,7 +22,6 @@ const allowedKeys = [
 	'primary_blog',
 	'primary_blog_is_jetpack',
 	'has_promote_widget',
-	'can_promote_products',
 	'has_jetpack_partner_access',
 	'jetpack_partner_types',
 	'primary_blog_url',

--- a/client/lib/user/user.d.ts
+++ b/client/lib/user/user.d.ts
@@ -36,7 +36,6 @@ export type OptionalUserData = {
 	site_count: number;
 	jetpack_site_count?: number;
 	has_promote_widget?: boolean;
-	can_promote_products?: boolean;
 	has_jetpack_partner_access?: boolean;
 	jetpack_partner_types?: string[];
 	social_login_connections: unknown;

--- a/client/my-sites/promote-post/main.tsx
+++ b/client/my-sites/promote-post/main.tsx
@@ -9,11 +9,7 @@ import FormattedHeader from 'calypso/components/formatted-header';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import Main from 'calypso/components/main';
 import useCampaignsQuery from 'calypso/data/promote-post/use-promote-post-campaigns-query';
-import {
-	usePromoteWidget,
-	PromoteWidgetStatus,
-	useCanPromoteProducts,
-} from 'calypso/lib/promote-post';
+import { usePromoteWidget, PromoteWidgetStatus } from 'calypso/lib/promote-post';
 import CampaignsList from 'calypso/my-sites/promote-post/components/campaigns-list';
 import { Post } from 'calypso/my-sites/promote-post/components/post-item';
 import PostsList from 'calypso/my-sites/promote-post/components/posts-list';
@@ -114,8 +110,6 @@ export default function PromotedPosts( { tab }: Props ) {
 		page( '/' );
 	}
 
-	const productsEnabled = useCanPromoteProducts() === PromoteWidgetStatus.ENABLED;
-
 	const subtitle = translate(
 		'Reach new readers and customers by promoting a post or a page on our network of millions blogs and web sites. {{learnMoreLink}}Learn more.{{/learnMoreLink}}',
 		{
@@ -193,9 +187,7 @@ export default function PromotedPosts( { tab }: Props ) {
 
 			<QueryPosts siteId={ selectedSiteId } query={ queryPost } postId={ null } />
 			<QueryPosts siteId={ selectedSiteId } query={ queryPage } postId={ null } />
-			{ productsEnabled && (
-				<QueryPosts siteId={ selectedSiteId } query={ queryProducts } postId={ null } />
-			) }
+			<QueryPosts siteId={ selectedSiteId } query={ queryProducts } postId={ null } />
 
 			{ selectedTab === 'posts' && <PostsList content={ content } isLoading={ isLoading } /> }
 		</Main>


### PR DESCRIPTION
This reverts commit e4c4062f9177b07f32e342a18815b991ae13e0d2.

#### Proposed Changes

This relates to #69748, where we allowed A12's to promote WooCommerce products,  we've ran some testing and are happy to open this up to the wider public.

#### Testing Instructions

Pre-requisites

- [ ] You have a WordPress.com account not linked to a8c
- [ ] You have a WooCommerce store linked to that account


**Testing**
- [ ] visit wordpress.com/advertising/`yoursite.co.uk` (where `yoursite.co.uk` has products)
- [ ] You should see products appear in the promote list
- [ ] You should be able to complete promotion with these

Example:
![Screenshot 2022-11-15 at 16 31 04](https://user-images.githubusercontent.com/6440498/201974040-a4c6e3f2-7970-4687-b5f8-864ddb3ec102.png)
![Screenshot 2022-11-15 at 16 31 44](https://user-images.githubusercontent.com/6440498/201974204-518ec34b-3cf9-4126-b5ab-566ab265e7a1.png)


<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
