### PR TITLE
Fix/do not display product included when renewing products on free plan

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/prepurchase-notices/index.jsx
+++ b/client/my-sites/checkout/composite-checkout/components/prepurchase-notices/index.jsx
@@ -167,8 +167,13 @@ const PrePurchaseNotices = () => {
 	}
 
 	// We're attempting to buy Jetpack Backup individually,
-	// but this site already has a plan that includes it
-	if ( currentSitePlan && cartProductThatOverlapsSitePlan ) {
+	// but this site already has a plan that includes it.
+	// ignore the error on free plans as they do not include any paid features
+	if (
+		currentSitePlan &&
+		cartProductThatOverlapsSitePlan &&
+		! currentSitePlan.product_slug === 'jetpack_free'
+	) {
 		return (
 			<SitePlanIncludesCartProductNotice
 				plan={ currentSitePlan }

--- a/client/my-sites/checkout/composite-checkout/components/prepurchase-notices/index.jsx
+++ b/client/my-sites/checkout/composite-checkout/components/prepurchase-notices/index.jsx
@@ -172,7 +172,7 @@ const PrePurchaseNotices = () => {
 	if (
 		currentSitePlan &&
 		cartProductThatOverlapsSitePlan &&
-		! currentSitePlan.product_slug === 'jetpack_free'
+		currentSitePlan.product_slug !== 'jetpack_free'
 	) {
 		return (
 			<SitePlanIncludesCartProductNotice


### PR DESCRIPTION
#### Proposed Changes
<img width="612" alt="Screen Shot 2022-11-15 at 11 26 32 AM" src="https://user-images.githubusercontent.com/12895386/201972989-b40cf1f3-e460-4ce4-ad54-ae7ad09184e0.png">



* This is a workaround fix for an edge case where a user on Jetpack Free renews a standalone backup plan, the cart renders an error notifying the user that their plan includes backups.
* The root cause is somewhere the features attributes for jetpack_free list backups and backups daily as features. It is unclear where this feature is listed and due to this being a small issue, a workaround was implemented instead that suppresses the message if the user is on jetpack_free
* Reference: 1202858161751496-as-1203336850718744

#### Testing Instructions

* You will need a Jetpack site with a recently expired legacy backup plan.  You can add backups daily or other plan and manually set the expiration date in store admin if you have access.
* Use the live link and select your test site then go to your subscriptions (you can add purchases/subscriptions/:site to the live link URL to go straight there)
* Click renew next to the expired or nearly-expired backup plan.
* You should not see the message shown in the screenshot above

Extra testing:
* Add a valid new plan like complete or security to the same site and repeat the test.  You should now see the warning correctly.

#### Pre-merge Checklist


- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203336850718744