### PR TITLE
Help Center: Fix missing icon in contact options notice

### DIFF
--- a/packages/help-center/src/components/help-center-contact-form.scss
+++ b/packages/help-center/src/components/help-center-contact-form.scss
@@ -190,9 +190,9 @@ section.contact-form-submit {
 		margin-left: 16px;
 	}
 
-	.dashicon {
+	.info-icon {
 		display: block;
-		color: var(--studio-orange-40);
+		fill: var(--studio-orange-40);
 		margin-top: 2px;
 	}
 	.components-external-link__icon {

--- a/packages/help-center/src/components/help-center-notice.tsx
+++ b/packages/help-center/src/components/help-center-notice.tsx
@@ -1,7 +1,8 @@
 import { localizeUrl, useLocale, getRelativeTimeString } from '@automattic/i18n-utils';
-import { ExternalLink, Icon } from '@wordpress/components';
+import { ExternalLink } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
+import { Icon, info } from '@wordpress/icons';
 import type { SupportTicket } from '../types';
 import type { AnalysisReport } from '@automattic/data-stores';
 import type { ReactNode } from 'react';
@@ -117,7 +118,7 @@ export function HelpCenterActiveTicketNotice( {
 							style: 'long',
 						} )
 					) }
-				</strong>
+				</strong>{ ' ' }
 				&nbsp;
 				{ __(
 					`Rest assured that we got your message and we'll be in touch as soon as we can.`,
@@ -132,7 +133,7 @@ export function HelpCenterNotice( { children }: { children: ReactNode } ) {
 	return (
 		<div className="help-center-notice__container">
 			<div>
-				<Icon icon="info-outline"></Icon>
+				<Icon icon={ info } className="info-icon"></Icon>
 			</div>
 			{ children }
 		</div>


### PR DESCRIPTION
#### Proposed Changes

Before:
![image](https://user-images.githubusercontent.com/52076348/201977971-b4c8fc71-7079-4b28-be03-fd9d9089e991.png)

After:
![image](https://user-images.githubusercontent.com/52076348/201978008-8d6805e3-72ae-412e-b8c7-34ce07383a2e.png)


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Submit a ticket
* Re open the contact options page, you should see the icon now




Related to #68588
Fixes #68588
