### PR TITLE
SSH Cards: Removed old @media rule; increase rule specificity.

### DIFF
--- a/client/my-sites/hosting/sftp-card/ssh-key-card.tsx
+++ b/client/my-sites/hosting/sftp-card/ssh-key-card.tsx
@@ -25,7 +25,7 @@ const MEDIA_QUERIES = {
 
 const SSHKeyCardRoot = styled( SSHKeyCard.Root )( {
 	[ MEDIA_QUERIES.wide ]: {
-		'&&': {
+		'&&&': {
 			paddingLeft: '24px',
 		},
 	},

--- a/client/my-sites/hosting/sftp-card/ssh-keys.scss
+++ b/client/my-sites/hosting/sftp-card/ssh-keys.scss
@@ -2,14 +2,6 @@
 	max-width: calc(100vw - 32px);
 }
 
-@include breakpoint-deprecated( ">1280px" ) {
-	.hosting__main-layout-col {
-		.card.ssh-keys-card {
-			padding-left: 24px;
-		}
-	}
-}
-
 .ssh-keys__form {
 	display: flex;
 	flex-direction: column;


### PR DESCRIPTION
Follow up of https://github.com/Automattic/wp-calypso/pull/69996

#### Proposed Changes

* Remove some CSS and tweak a CSS-in-JS selector so it overrides some styles correctly. See [here](https://github.com/Automattic/wp-calypso/pull/69996#discussion_r1022711034) for discussion. 

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Try it on Calypso Live using various screen widths below/above 1280px
* Make sure the padding is overridden at `>1281px` so it is `24px` and not `72px` like the parent component
* It should look like the "after" screenshot [here](https://github.com/Automattic/wp-calypso/pull/69996#issue-1448148147) for all screen widths. 

 
#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
