### PR TITLE
Show notice if billing info is not US and currency is USD

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/checkout-terms.jsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-terms.jsx
@@ -18,6 +18,7 @@ import TitanTermsOfService from './titan-terms-of-service';
 class CheckoutTerms extends Component {
 	render() {
 		const { cart } = this.props;
+
 		return (
 			<Fragment>
 				<div className="checkout__terms" id="checkout-terms">
@@ -37,7 +38,7 @@ class CheckoutTerms extends Component {
 				<TitanTermsOfService cart={ cart } />
 				<ThirdPartyPluginsTermsOfService cart={ cart } />
 				<EbanxTermsOfService />
-				<InternationalFeeNotice />
+				<InternationalFeeNotice cart={ cart } />
 				<AdditionalTermsOfServiceInCart />
 			</Fragment>
 		);

--- a/client/my-sites/checkout/composite-checkout/components/international-fee-notice.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/international-fee-notice.tsx
@@ -1,14 +1,16 @@
+import { ResponseCart } from '@automattic/shopping-cart';
 import { useSelect } from '@wordpress/data';
 import { translate } from 'i18n-calypso';
 import CheckoutTermsItem from 'calypso/my-sites/checkout/composite-checkout/components/checkout-terms-item';
 import type { ManagedContactDetails } from '@automattic/wpcom-checkout';
 
-export const InternationalFeeNotice = () => {
+export const InternationalFeeNotice = ( { cart }: { cart: ResponseCart } ) => {
 	const contactInfo: ManagedContactDetails = useSelect( ( select ) =>
 		select( 'wpcom-checkout' ).getContactInfo()
 	);
+	const currency = cart.currency;
 
-	if ( contactInfo.countryCode?.value !== 'US' ) {
+	if ( contactInfo.countryCode?.value !== 'US' && currency === 'USD' ) {
 		const internationalFeeAgreement = translate(
 			`Your issuing bank may choose to charge an international transaction fee or a currency exchange fee. Your bank may be able to provide more information as to when this is necessary.`
 		);


### PR DESCRIPTION
In https://github.com/Automattic/wp-calypso/pull/68460, we added a new notice to Checkout's "ToS" area for users outside the US to caution about possible international transaction fees. This PR refines this logic to users outside of the US, attempting to pay with USD. While this doesn't cover all of the possible situations, it likely covers the most common occurrence and doesn't show the notice unnecessarily to non-US users. 

Fixes: https://github.com/Automattic/payments-shilling/issues/1212

**To test:**
- for a user with their currency set to USD
- add an item to your cart and visit checkout
- in the "Billing Information" step, select "United States" and enter a zip code
- verify that the international fee notice is not shown in the ToS area
-----
- in the "Billing Information" step, select a country that is not the united states and enter a postal code
- verify that the international fee notice is shown in the ToS area
-----
- switch your user's currency to a non-USD currency and reload Checkout
- verify that the international fee notice is not shown in the ToS area, regardless of billing location