### PR TITLE
Stats: use `features` object in production.json to align features of Jetpack Stats

### DIFF
--- a/apps/stats/filter-json-config-loader.js
+++ b/apps/stats/filter-json-config-loader.js
@@ -5,13 +5,13 @@
  * @returns filtered content of source file.
  */
 export default function loader( source ) {
-	const configObject = JSON.parse( source );
+	const sourceObject = JSON.parse( source );
 	const targetObject = {};
 	const options = this.getOptions();
-	if ( options.keys.length > 0 ) {
+	if ( options.keys && options.keys.length > 0 ) {
 		let key;
 		for ( key of options.keys ) {
-			targetObject[ key ] = configObject[ key ] ?? null;
+			targetObject[ key ] = sourceObject[ key ];
 		}
 	}
 

--- a/apps/stats/filter-json-config-loader.js
+++ b/apps/stats/filter-json-config-loader.js
@@ -1,5 +1,5 @@
 /**
- * The loader parses a config file and filters out the keys needed by the app, so that we don't exopse the whole config file.
+ * The loader parses a config file and filters out the keys needed by the app, so that we don't load the whole config file.
  *
  * @param {*} source Content of source file.
  * @returns filtered content of source file.

--- a/apps/stats/filter-json-config-loader.js
+++ b/apps/stats/filter-json-config-loader.js
@@ -1,0 +1,19 @@
+/**
+ * The loader parses a config file and filters out the keys needed by the app, so that we don't exopse the whole config file.
+ *
+ * @param {*} source Content of source file.
+ * @returns filtered content of source file.
+ */
+export default function loader( source ) {
+	const configObject = JSON.parse( source );
+	const targetObject = {};
+	const options = this.getOptions();
+	if ( options.keys.length > 0 ) {
+		let key;
+		for ( key of options.keys ) {
+			targetObject[ key ] = configObject[ key ] ?? null;
+		}
+	}
+
+	return `export default ${ JSON.stringify( targetObject ) }`;
+}

--- a/apps/stats/src/app.jsx
+++ b/apps/stats/src/app.jsx
@@ -13,6 +13,8 @@ import { setStore } from 'calypso/state/redux-store';
 import sites from 'calypso/state/sites/reducer';
 import { setLocale as setLocaleAction } from 'calypso/state/ui/language/actions';
 import { combineReducers, addReducerEnhancer } from 'calypso/state/utils';
+// The JSON is filtered with only `features` object with `apps/stats/filter-json-config-loader.js` to avoid leak of credentials etc.
+import productionConfig from '../../../config/production.json';
 import { setupContextMiddleware } from './page-middleware/setup-context';
 import registerStatsPages from './routes';
 
@@ -25,6 +27,10 @@ const setLocale = ( dispatch ) => {
 };
 
 async function AppBoot() {
+	// Use feature locks for Calypso production `config/production.json`.
+	window.configData = window.configData || {};
+	window.configData.features = productionConfig.features;
+
 	const siteId = config( 'blog_id' );
 
 	const rootReducer = combineReducers( {

--- a/apps/stats/src/app.jsx
+++ b/apps/stats/src/app.jsx
@@ -13,7 +13,7 @@ import { setStore } from 'calypso/state/redux-store';
 import sites from 'calypso/state/sites/reducer';
 import { setLocale as setLocaleAction } from 'calypso/state/ui/language/actions';
 import { combineReducers, addReducerEnhancer } from 'calypso/state/utils';
-// The JSON is filtered with only `features` object with `apps/stats/filter-json-config-loader.js`.
+// The JSON is filtered by `apps/stats/filter-json-config-loader.js`.
 import productionConfig from '../../../config/production.json';
 import { setupContextMiddleware } from './page-middleware/setup-context';
 import registerStatsPages from './routes';

--- a/apps/stats/src/app.jsx
+++ b/apps/stats/src/app.jsx
@@ -13,7 +13,7 @@ import { setStore } from 'calypso/state/redux-store';
 import sites from 'calypso/state/sites/reducer';
 import { setLocale as setLocaleAction } from 'calypso/state/ui/language/actions';
 import { combineReducers, addReducerEnhancer } from 'calypso/state/utils';
-// The JSON is filtered with only `features` object with `apps/stats/filter-json-config-loader.js` to avoid leak of credentials etc.
+// The JSON is filtered with only `features` object with `apps/stats/filter-json-config-loader.js`.
 import productionConfig from '../../../config/production.json';
 import { setupContextMiddleware } from './page-middleware/setup-context';
 import registerStatsPages from './routes';

--- a/apps/stats/webpack.config.js
+++ b/apps/stats/webpack.config.js
@@ -83,6 +83,10 @@ module.exports = {
 				) }' as *;`,
 			} ),
 			FileConfig.loader(),
+			{
+				test: /^\.\.\/\.\.\/\.\.\/config\/production\.json$/,
+				use: { loader: './filter-json-config-loader', options: { keys: [ 'features' ] } },
+			},
 		],
 	},
 	resolve: {


### PR DESCRIPTION
#### Proposed Changes
The PR adds a loader `apps/stats/filter-json-config-loader.js` which picks with the passed in `keys` from a JSON file, so that we do not bundle the whole file.

The PR also leverages the loader to load only the `features` object from `config/production.json`. By doing this, we don't have to manually manage the feature locks in Jetpack Stats.

#### Testing Instructions
- Run `cd apps/stats`
- Run `STATS_PACKAGE_PATH=/path/to/jetpack/projects/packages/stats-admin yarn dev` <- replace path
- Open https://your-jetpack-site.com/wp-admin/admin.php?page=stats&calypso_stats=1
- Ensure most pages work
- Open dev console, enter `window.configData`
- Ensure you do NOT see any sensitive data, e.g. `wpcom_signup_key`

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
