### PR TITLE
Editor iframe: pass through answer_prompt query parameter

### DIFF
--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -802,6 +802,7 @@ const mapStateToProps = (
 		openSidebar: getQueryArg( window.location.href, 'openSidebar' ),
 		showDraftPostModal,
 		...pressThisData,
+		answer_prompt: getQueryArg( window.location.href, 'answer_prompt' ),
 	} );
 
 	// needed for loading the editor in SU sessions


### PR DESCRIPTION
#### Proposed Changes

* Pass through the `answer_prompt` query parameter to the iframed block editor, to allow responding to a writing prompt.

#### Testing Instructions

* Combined with https://github.com/Automattic/jetpack/pull/26680, see Simple site instructions in the PR description
* With that PR applied to a wpcom sandbox, visit the link for a new post in Calypso, like `http://calypso.localhost:3000/post/example.blog?answer_prompt=2129`
* You should see the specified prompt as a pullquote in the editor

<img width="954" alt="image" src="https://user-images.githubusercontent.com/1699996/202038817-cb807e24-a06f-4510-a5ac-e3a4cbcba9e8.png">


#### Pre-merge Checklist

- [ ] N/A [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] N/A Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] N/A Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] N/A For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
