### PR TITLE
Stats: Apply minimum height to geochart component

### DIFF
--- a/client/my-sites/stats/geochart/style.scss
+++ b/client/my-sites/stats/geochart/style.scss
@@ -10,3 +10,9 @@
 		display: none;
 	}
 }
+
+.stats-geochart,
+.stats-geochart.stats-module__placeholder {
+	height: 100%;
+	min-height: 300px;
+}


### PR DESCRIPTION
#### Proposed Changes

<img width="1072" alt="image" src="https://user-images.githubusercontent.com/4044428/202057068-5606193a-ee1d-4010-b405-22869eeac731.png">

Applies a minimum height to the geochart component used in the countries module in the Stats Traffic page.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up this change in a Calypso live branch.
* Navigate to the Stats page and scroll down to the countries stats module.
* Ensure that the world map visualization renders at a reasonable size.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #70048.