### PR TITLE
Improve gift thank you page copy to clipboard instruction

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/gift/gift-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/gift/gift-thank-you.tsx
@@ -55,7 +55,7 @@ export default function GiftThankYou( { site }: { site: number | string } ) {
 					stepKey: 'share_site',
 					stepTitle: translate( 'Share this site' ),
 					stepDescription: translate(
-						'Know someone else who would enjoy the site you just supported? Click the button below so you can send it to your friends.'
+						'Know someone else who would enjoy the site you just supported? Click the button to copy the link and share with friends.'
 					),
 					stepCta: (
 						<ClipboardButton


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/69976

#### Proposed Changes

* Improve gift thank you page copy to clipboard instruction

#### Testing Instructions

* http://calypso.localhost:3000/checkout/gift/thank-you/testing705633960.wordpress.com
* Confirm new copy is seen. "Know someone else who would enjoy the site you just supported? Click the button to copy the link and share with friends."

![Screenshot(3)](https://user-images.githubusercontent.com/811776/202087521-7bfd4582-5e25-4cea-9243-40c2c5c394b6.png)

