### PR TITLE
Goals Screen: Show BBE goal for EN and ES locales

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/goals.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/goals.tsx
@@ -5,6 +5,8 @@ import type { Goal } from './types';
 
 const SiteGoal = Onboard.SiteGoal;
 
+const DIFMSupportedLocales = [ ...englishLocales, 'es' ];
+
 // export const CALYPSO_BUILTBYEXPRESS_GOAL_TEXT_EXPERIMENT_NAME =
 // 	'calypso_builtbyexpress_goal_copy_change_202210';
 // export const VARIATION_CONTROL = 'control';
@@ -76,19 +78,13 @@ export const useGoals = (): Goal[] => {
 	];
 
 	/**
-	 * Hides the DIFM goal for all locales except English and es.
+	 * Hides the DIFM goal for all locales except English and ES.
 	 */
 	const hideDIFMGoalForUnsupportedLocales = ( { key }: Goal ) => {
-		if ( key !== SiteGoal.DIFM ) {
-			return true;
+		if ( key === SiteGoal.DIFM && ! DIFMSupportedLocales.includes( locale ) ) {
+			return false;
 		}
-		if ( englishLocales.includes( locale ) ) {
-			return true;
-		}
-		if ( 'es' === locale ) {
-			return true;
-		}
-		return false;
+		return true;
 	};
 
 	return goals.filter( hideDIFMGoalForUnsupportedLocales );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/goals.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/goals.tsx
@@ -1,5 +1,5 @@
 import { Onboard } from '@automattic/data-stores';
-import { useIsEnglishLocale } from '@automattic/i18n-utils';
+import { useLocale, englishLocales } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
 import type { Goal } from './types';
 
@@ -44,7 +44,7 @@ const useBBEGoal = () => {
 
 export const useGoals = (): Goal[] => {
 	const translate = useTranslate();
-	const isEnglishLocale = useIsEnglishLocale();
+	const locale = useLocale();
 	const builtByExpressGoalDisplayText = useBBEGoal();
 
 	const goals = [
@@ -75,12 +75,21 @@ export const useGoals = (): Goal[] => {
 		},
 	];
 
-	const hideDIFMGoalForNonEN = ( { key }: Goal ) => {
-		if ( key === SiteGoal.DIFM && ! isEnglishLocale ) {
-			return false;
+	/**
+	 * Hides the DIFM goal for all locales except English and es.
+	 */
+	const hideDIFMGoalForUnsupportedLocales = ( { key }: Goal ) => {
+		if ( key !== SiteGoal.DIFM ) {
+			return true;
 		}
-		return true;
+		if ( englishLocales.includes( locale ) ) {
+			return true;
+		}
+		if ( 'es' === locale ) {
+			return true;
+		}
+		return false;
 	};
 
-	return goals.filter( hideDIFMGoalForNonEN );
+	return goals.filter( hideDIFMGoalForUnsupportedLocales );
 };


### PR DESCRIPTION
#### Proposed Changes

P2: pdh1Xd-1w1-p2#comment-1733

Show the BBE (formerly DIFM) goal for EN and ES locales on the goals screen.

|EN|ES|Non EN/ES|
|---|---|---|
|<img width="1920" alt="image" src="https://user-images.githubusercontent.com/5436027/202111679-90b07919-b834-44e6-a4df-de10ac23fa35.png">|<img width="1920" alt="image" src="https://user-images.githubusercontent.com/5436027/202111752-8bc14473-90e8-4711-a415-9a457bc5da19.png">|<img width="1920" alt="image" src="https://user-images.githubusercontent.com/5436027/202111802-1f4cf441-3774-436b-bdfc-fa0dc07dd624.png">|




#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Change your locale to EN.
* Go to `/setup/site-setup/goals?siteSlug=<site slug`.
* Confirm that the BBE goal (Get a website quickly) is shown.
* Change your locale to ES and confirm the same.
* Change your locale to any other locale and confirm that the goal is not shown.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->