### PR TITLE
Increase default /themes query limit to 1000

### DIFF
--- a/client/components/themes-list/index.jsx
+++ b/client/components/themes-list/index.jsx
@@ -12,7 +12,6 @@ import InfiniteScroll from 'calypso/components/infinite-scroll';
 import Theme from 'calypso/components/theme';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { upsellCardDisplayed as upsellCardDisplayedAction } from 'calypso/state/themes/actions';
-import { DEFAULT_THEME_QUERY } from 'calypso/state/themes/constants';
 import { getThemesBookmark } from 'calypso/state/themes/themes-ui/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 
@@ -89,7 +88,7 @@ ThemesList.defaultProps = {
 	wpOrgThemes: [],
 	recordTracksEvent: noop,
 	fetchNextPage: noop,
-	placeholderCount: DEFAULT_THEME_QUERY.number,
+	placeholderCount: 20,
 	optionsGenerator: () => [],
 	getActionLabel: () => '',
 	isActive: () => false,

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -12,6 +12,7 @@ import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-t
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { getSiteSlug, isJetpackSite } from 'calypso/state/sites/selectors';
 import { setThemePreviewOptions } from 'calypso/state/themes/actions';
+import { DEFAULT_THEME_QUERY_LIMIT } from 'calypso/state/themes/constants';
 import {
 	arePremiumThemesEnabled,
 	getPremiumThemePrice,
@@ -249,7 +250,9 @@ export const ConnectedThemesSelection = connect(
 		// results and sends all of the themes at once. QueryManager is not expecting such behaviour
 		// and we ended up loosing all of the themes above number 20. Real solution will be pagination on
 		// Jetpack themes endpoint.
-		const number = ! [ 'wpcom', 'wporg' ].includes( sourceSiteId ) ? 2000 : 100;
+		const number = ! [ 'wpcom', 'wporg' ].includes( sourceSiteId )
+			? 2000
+			: DEFAULT_THEME_QUERY_LIMIT;
 		const query = {
 			search,
 			page,

--- a/client/state/themes/constants.js
+++ b/client/state/themes/constants.js
@@ -1,8 +1,10 @@
+export const DEFAULT_THEME_QUERY_LIMIT = 1000;
+
 export const DEFAULT_THEME_QUERY = {
 	search: '',
 	tier: '',
 	filter: '',
-	number: 20,
+	number: DEFAULT_THEME_QUERY_LIMIT,
 	offset: 0,
 	page: 1,
 };

--- a/client/state/themes/test/utils.js
+++ b/client/state/themes/test/utils.js
@@ -171,7 +171,7 @@ describe( 'utils', () => {
 		test( 'should exclude default values', () => {
 			const query = getNormalizedThemesQuery( {
 				page: 4,
-				number: 20,
+				number: 1000,
 			} );
 
 			expect( query ).toEqual( {


### PR DESCRIPTION
#### Proposed Changes

Currently, wordpress.com/themes (while being logged out) by default only shows 20 themes. This PR increases the default limit to 1000.

(Unfortunately, there is no way to just remove the limit without doing some refactoring on backend side.)

#### Testing Instructions

* Open an incognito window
* Go to /themes. IMPORTANT: If testing locally, kill Calypso first and rerun `yarn start` to reset the cached SSR data.
* Verify that more than 20 themes are shown.
* Play around with the filters (Free/Premium) and searches, make sure everything still works.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #70060
