### PR TITLE
Enable Plugins Details page SSR

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -77,7 +77,7 @@
 		"plans/pro-plan": false,
 		"plans/starter-plan": false,
 		"plugins/ssr-categories": true,
-		"plugins/ssr-details": false,
+		"plugins/ssr-details": true,
 		"plugins/ssr-landing": true,
 		"post-editor/checkout-overlay": true,
 		"post-list/qr-code-link": false,

--- a/config/production.json
+++ b/config/production.json
@@ -90,7 +90,7 @@
 		"plans/pro-plan": false,
 		"plans/starter-plan": false,
 		"plugins/ssr-categories": true,
-		"plugins/ssr-details": false,
+		"plugins/ssr-details": true,
 		"plugins/ssr-landing": true,
 		"post-editor/checkout-overlay": true,
 		"post-list/qr-code-link": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -88,7 +88,7 @@
 		"plans/pro-plan": false,
 		"plans/starter-plan": false,
 		"plugins/ssr-categories": true,
-		"plugins/ssr-details": false,
+		"plugins/ssr-details": true,
 		"plugins/ssr-landing": true,
 		"post-editor/checkout-overlay": true,
 		"post-list/qr-code-link": true,


### PR DESCRIPTION
#### Proposed Changes

Similar to #69366 and #70064, this allows logged-out Plugins Details pages to be Server Side Rendered on production

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Log out and disable JS
* Go to a category page, ex: `/plugins/wordpress-seo-premium`, `/plugins/elementor`
* Make sure the Plugins Details content is rendered

* Log in and double-check for regressions in the Plugins section

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
