### PR TITLE
Render Backup Add-on next to the backup plan in My Plan section 

### DIFF
--- a/client/my-sites/plans/current-plan/purchases-listing.jsx
+++ b/client/my-sites/plans/current-plan/purchases-listing.jsx
@@ -13,6 +13,7 @@ import {
 	PRODUCT_JETPACK_SCAN,
 	PRODUCT_JETPACK_BACKUP_REALTIME,
 	JETPACK_BACKUP_PRODUCTS,
+	JETPACK_BACKUP_ADDON_PRODUCTS,
 	TERM_MONTHLY,
 } from '@automattic/calypso-products';
 import { Button, Card, Gridicon } from '@automattic/components';
@@ -360,15 +361,41 @@ class PurchasesListing extends Component {
 		);
 	}
 
+	sortBackupProducts( products ) {
+		//create a new array with the backup products first then the add-ons
+		let backupIndex = -1;
+		const backupSortedArray = [];
+		const addOnProducts = [];
+		products.forEach( ( product ) => {
+			if ( JETPACK_BACKUP_ADDON_PRODUCTS.includes( product.productSlug ) ) {
+				if ( backupIndex === -1 ) {
+					addOnProducts.push( product );
+				} else {
+					backupSortedArray.splice( backupIndex + 1, 0, product );
+				}
+			} else if ( JETPACK_BACKUP_PRODUCTS.includes( product.productSlug ) ) {
+				backupSortedArray.push( product );
+				backupIndex = backupSortedArray.length - 1;
+				if ( addOnProducts.length ) {
+					backupSortedArray.push( ...addOnProducts );
+				}
+			} else {
+				backupSortedArray.push( product );
+			}
+		} );
+		return backupSortedArray;
+	}
+
 	renderProducts() {
 		const { translate } = this.props;
 
 		// Get all products and filter out falsy items.
-		const productPurchases = this.getProductPurchases();
-
+		let productPurchases = this.getProductPurchases();
 		if ( productPurchases.length === 0 ) {
 			return null;
 		}
+
+		productPurchases = this.sortBackupProducts( productPurchases );
 
 		return (
 			<Fragment>


### PR DESCRIPTION
#### Proposed Changes
* Make sure to render Backup addons next to backup plans in the My Plans section

#### Testing Instructions

*Note: This is an edge case - sometimes Backup Addons are rendered first and then the Backup plan. So, there is no proper way to test it, but make sure to refresh multiple times and confirm add-on are always rendered next to Backup*

* Create a JN site with Jetpack Backup 10GB product (or) Jetpack Security 10GB
* click on Jetpack Cloud live link below
    * Goto /backup
* or boot up this PR
   * Run git fetch && git checkout fix/backup-addon-order
   * Run yarn start-jetpack-cloud
   * Goto http://jetpack.cloud.localhost:3000/backup
* Simulate the Storage and purchase Add on by following the testing instructions in #69377
* After the purchase, navigate to WPCOM and switch to the JN site you created in Step 1 
* Go to **Upgrades -> Plans -> My Plan** from the side menu
* Make sure Add-on is always displayed below the Backup Plan as in the screenshot below
   <img width="1045" alt="Screenshot 2022-11-16 at 5 44 23 PM" src="https://user-images.githubusercontent.com/2027003/202178084-274f903b-124a-45d8-814b-ee2557d99e2a.png">

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
