### PR TITLE
Third-Party Themes: Add selector to get products by billing slug

### DIFF
--- a/packages/data-stores/src/products-list/selectors.ts
+++ b/packages/data-stores/src/products-list/selectors.ts
@@ -1,5 +1,7 @@
 import { select } from '@wordpress/data';
+import { filter, values } from 'lodash';
 import { STORE_KEY } from './constants';
+import { ProductsListItem } from './types';
 import type { State } from './reducer';
 
 export const getState = ( state: State ) => state;
@@ -19,4 +21,28 @@ export const getProductBySlug = ( _state: State, slug: string ) => {
 	}
 
 	return products?.[ slug ];
+};
+
+/**
+ * Returns an array of products that matches the specified billing product slug.
+ *
+ * @param _state the state object
+ * @param billingProductSlug the product slug to match
+ * @returns ProductsListItem[]|undefined an array of products that matches the specified billing product slug or undefined if the products list is not loaded yet
+ */
+export const getProductsByBillingSlug = (
+	_state: State,
+	billingProductSlug: string
+): ProductsListItem[] | undefined => {
+	if ( ! billingProductSlug ) {
+		return undefined;
+	}
+
+	const products = select( STORE_KEY ).getProductsList();
+
+	if ( ! products ) {
+		return undefined;
+	}
+
+	return filter( values( products ), { billing_product_slug: billingProductSlug } );
 };

--- a/packages/data-stores/src/products-list/selectors.ts
+++ b/packages/data-stores/src/products-list/selectors.ts
@@ -1,5 +1,4 @@
 import { select } from '@wordpress/data';
-import { filter, values } from 'lodash';
 import { STORE_KEY } from './constants';
 import { ProductsListItem } from './types';
 import type { State } from './reducer';
@@ -43,6 +42,7 @@ export const getProductsByBillingSlug = (
 	if ( ! products ) {
 		return undefined;
 	}
-
-	return filter( values( products ), { billing_product_slug: billingProductSlug } );
+	return Object.values( products ).filter(
+		( product ) => product.billing_product_slug === billingProductSlug
+	);
 };

--- a/packages/data-stores/src/products-list/test/selectors.ts
+++ b/packages/data-stores/src/products-list/test/selectors.ts
@@ -45,6 +45,26 @@ describe( 'selectors', () => {
 				price_tiers: [],
 				price_tier_slug: '',
 			},
+			wp_mp_theme_tsubaki_test_yearly: {
+				product_id: 3001,
+				product_name: 'Tsubaki Third-Party Test',
+				product_slug: 'wp_mp_theme_tsubaki_test_yearly',
+				description: '',
+				product_type: 'marketplace_theme',
+				available: true,
+				billing_product_slug: 'wp-mp-theme-tsubaki-test',
+				is_domain_registration: false,
+				cost_display: 'US$100.00',
+				combined_cost_display: 'US$100.00',
+				cost: 100,
+				cost_smallest_unit: 10000,
+				currency_code: 'USD',
+				price_tier_list: [],
+				price_tier_usage_quantity: null,
+				product_term: 'year',
+				price_tiers: [],
+				price_tier_slug: '',
+			},
 		};
 
 		( wpcomRequest as jest.Mock ).mockResolvedValue( apiResponse );
@@ -65,5 +85,8 @@ describe( 'selectors', () => {
 
 		expect( select( store ).getProductsList() ).toEqual( apiResponse );
 		expect( select( store ).getProductBySlug( 'free_plan' ) ).toEqual( apiResponse[ 'free_plan' ] );
+		expect( select( store ).getProductsByBillingSlug( 'wp-mp-theme-tsubaki-test' ) ).toEqual( [
+			apiResponse[ 'wp_mp_theme_tsubaki_test_yearly' ],
+		] );
 	} );
 } );

--- a/packages/data-stores/src/products-list/types.ts
+++ b/packages/data-stores/src/products-list/types.ts
@@ -7,6 +7,7 @@ export interface Dispatch {
 
 export interface ProductsListItem {
 	available: boolean;
+	billing_product_slug: string;
 	combined_cost_display: string;
 	cost: number;
 	currency_code: string;


### PR DESCRIPTION
#### Proposed Changes

* Adds a selector to get an array of products by the billing product slug. This will be used to define what will be the default billing cycle when checking out on the theme page.

#### Testing Instructions

* This selector will be used on #69616 
* Make sure the tests are passing:
```sh
node 'node_modules/.bin/jest' './packages/data-stores/src/products-list/test/selectors.ts' -c './packages/data-stores/jest.config.js' -t 'selectors'
```

Related to #69616
