### PR TITLE
Marketplace: checks if a plugin needs a subscription.

### DIFF
--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -184,7 +184,7 @@ const PluginDetailsCTA = ( { plugin, isPlaceholder } ) => {
 		return <PluginDetailsCTAPlaceholder />;
 	}
 
-	if ( isPluginInstalledOnsite && sitePlugin ) {
+	if ( isPluginInstalledOnsiteWithSubscription && sitePlugin ) {
 		// Check if already instlaled on the site
 		const activeText = translate( '{{span}}active{{/span}}', {
 			components: {


### PR DESCRIPTION
#### Proposed Changes

Reinstates the `isPluginInstalledOnsiteWithSubscription` condition check that was replaced in https://github.com/Automattic/wp-calypso/pull/69581/files#r1023793597

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

## Preinstalled plugin 
* Visit Jetpack plugin
* Make sure it appears as installed and active

## Freemium plugin 
* Install start booking free plugin
* Make sure it appears as installed and active
* Go to start booking premium plugin
* Make sure you can purchase it ( don't proceed with checking out )

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

