### PR TITLE
Stats: Add mobile layout and interactions on the All-time highlights section

### DIFF
--- a/client/my-sites/stats/all-time-highlights-section/index.tsx
+++ b/client/my-sites/stats/all-time-highlights-section/index.tsx
@@ -162,7 +162,7 @@ export default function AllTimeHighlightsSection( { siteId }: { siteId: number }
 			{ siteId && <QuerySiteStats siteId={ siteId } statType="stats" query={ {} } /> }
 			{ siteId && <QuerySiteStats siteId={ siteId } statType="statsInsights" /> }
 
-			<div className="highlight-cards stats__all-time-highlights-mobile">
+			<div className="stats__all-time-highlights-mobile">
 				<h1 className="highlight-cards-heading">{ translate( 'Highlights' ) }</h1>
 				<DotPager>
 					<Card className="highlight-card">

--- a/client/my-sites/stats/all-time-highlights-section/index.tsx
+++ b/client/my-sites/stats/all-time-highlights-section/index.tsx
@@ -4,6 +4,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import QuerySiteStats from 'calypso/components/data/query-site-stats';
+import DotPager from 'calypso/components/dot-pager';
 import {
 	isRequestingSiteStatsForQuery,
 	getSiteStatsNormalizedData,
@@ -160,6 +161,56 @@ export default function AllTimeHighlightsSection( { siteId }: { siteId: number }
 		<div className="stats__all-time-highlights-section">
 			{ siteId && <QuerySiteStats siteId={ siteId } statType="stats" query={ {} } /> }
 			{ siteId && <QuerySiteStats siteId={ siteId } statType="statsInsights" /> }
+
+			<div className="highlight-cards stats__all-time-highlights-mobile">
+				<h1 className="highlight-cards-heading">{ translate( 'Highlights' ) }</h1>
+				<DotPager>
+					<Card className="highlight-card">
+						<div className="highlight-card-heading">{ translate( 'All-time stats' ) }</div>
+						<div className="highlight-card-info-item-list">
+							{ infoItems
+								.filter( ( i ) => ! i.hidden )
+								.map( ( info ) => {
+									return (
+										<div key={ info.id } className="highlight-card-info-item">
+											<Icon icon={ info.icon } />
+
+											<span className="highlight-card-info-item-title">{ info.title }</span>
+
+											<span
+												className="highlight-card-info-item-count"
+												title={ Number.isFinite( info.count ) ? String( info.count ) : undefined }
+											>
+												{ formatNumber( info.count ) }
+											</span>
+										</div>
+									);
+								} ) }
+						</div>
+					</Card>
+
+					{ [ mostPopularTimeItems, bestViewsEverItems ].map( ( card ) => {
+						return (
+							<Card key={ card.id } className="highlight-card">
+								<div className="highlight-card-heading">{ card.heading }</div>
+								<div className="highlight-card-detail-item-list">
+									{ card.items.map( ( item ) => {
+										return (
+											<div key={ item.id } className="highlight-card-detail-item">
+												<div className="highlight-card-detail-item-header">{ item.header }</div>
+
+												<div className="highlight-card-detail-item-content">{ item.content }</div>
+
+												<div className="highlight-card-detail-item-footer">{ item.footer }</div>
+											</div>
+										);
+									} ) }
+								</div>
+							</Card>
+						);
+					} ) }
+				</DotPager>
+			</div>
 
 			<div className="highlight-cards">
 				<h1 className="highlight-cards-heading">{ translate( 'All-time highlights' ) }</h1>

--- a/client/my-sites/stats/all-time-highlights-section/style.scss
+++ b/client/my-sites/stats/all-time-highlights-section/style.scss
@@ -9,30 +9,30 @@ $mobile-layout-breakpoint: $break-small;
 		@media ( max-width: $mobile-layout-breakpoint ) {
 			display: none;
 		}
+	}
 
-		&.stats__all-time-highlights-mobile {
-			display: none;
-			margin: 16px 0;
+	.stats__all-time-highlights-mobile {
+		display: none;
+		margin: 16px 0;
 
-			@media ( max-width: $mobile-layout-breakpoint ) {
-				display: block;
-			}
+		@media ( max-width: $mobile-layout-breakpoint ) {
+			display: block;
+		}
 
-			.highlight-cards-heading {
-				margin: 16px 16px 24px;
-			}
+		.highlight-cards-heading {
+			margin: 16px 16px 24px;
+		}
 
-			.dot-pager {
-				padding: 24px;
-				border: 1px var(--color-border-subtle);
-				border-style: solid none;
-			}
+		.dot-pager {
+			padding: 24px;
+			border: 1px var(--color-border-subtle);
+			border-style: solid none;
+		}
 
-			.card.highlight-card {
-				padding: 0;
-				margin: 0;
-				box-shadow: none;
-			}
+		.card.highlight-card {
+			padding: 0;
+			margin: 0;
+			box-shadow: none;
 		}
 	}
 

--- a/client/my-sites/stats/all-time-highlights-section/style.scss
+++ b/client/my-sites/stats/all-time-highlights-section/style.scss
@@ -6,6 +6,7 @@ $header-font: Recoleta, $sans;
 
 	.highlight-cards-list .highlight-card {
 		padding: 24px;
+		min-width: 320px;
 	}
 
 	.highlight-card-heading {

--- a/client/my-sites/stats/all-time-highlights-section/style.scss
+++ b/client/my-sites/stats/all-time-highlights-section/style.scss
@@ -1,8 +1,40 @@
 @import "@automattic/typography/styles/variables";
+@import "@wordpress/base-styles/breakpoints";
+
 $header-font: Recoleta, $sans;
+$mobile-layout-breakpoint: $break-small;
 
 .stats__all-time-highlights-section {
-	margin: 32px 0;
+	.highlight-cards {
+		@media ( max-width: $mobile-layout-breakpoint ) {
+			display: none;
+		}
+
+		&.stats__all-time-highlights-mobile {
+			display: none;
+			margin: 16px 0;
+
+			@media ( max-width: $mobile-layout-breakpoint ) {
+				display: block;
+			}
+
+			.highlight-cards-heading {
+				margin: 16px 16px 24px;
+			}
+
+			.dot-pager {
+				padding: 24px;
+				border: 1px var(--color-border-subtle);
+				border-style: solid none;
+			}
+
+			.card.highlight-card {
+				padding: 0;
+				margin: 0;
+				box-shadow: none;
+			}
+		}
+	}
 
 	.highlight-cards-list .highlight-card {
 		padding: 24px;


### PR DESCRIPTION
#### Proposed Changes

* Adjust the `min-width` to make the `.highlight-card` wider for horizontal scrolling in a narrower viewport.
* Add mobile highlights section with `DotPager` component to swipe cards.

> Due to [some layout issues](https://github.com/Automattic/wp-calypso/blob/dea365b99f707a95052d8e0e25b045b79ff238bf/client/my-sites/sidebar/style.scss#L677), we currently set the breakpoint to `600px` for mobile layouts.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Launch the _local_ development application or append `?flags=stats/new-all-time-highlights` on URL of the Calypso Live link.
* Navigate to page `/stats/insights/${your-site}`.
* Ensure the All-time highlight cards can be scrolled horizontally in a narrower viewport device.
* Ensure the content of the All-time highlight is displayed in the new layout that can be swiped by the control at the top of the card in the `width < 600px` viewport device.

<img width="800" alt="截圖 2022-11-16 下午10 51 50" src="https://user-images.githubusercontent.com/6869813/202218283-4b67b7fc-8354-4b00-8fd9-d7d412c2f037.png">

<img width="756" alt="截圖 2022-11-16 下午10 52 04" src="https://user-images.githubusercontent.com/6869813/202218587-88afcf42-8fb5-448b-9648-201236273ec7.png">


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #69229
