### PR TITLE
Update translation string for Search lightbox

### DIFF
--- a/packages/calypso-products/src/translations.tsx
+++ b/packages/calypso-products/src/translations.tsx
@@ -723,7 +723,7 @@ export const getJetpackProductsWhatIsIncluded = (): Record< string, Array< Trans
 	const searchIncludesInfo = [
 		translate( 'Instant search, filtering, and indexing' ),
 		translate( 'Highly relevant search results' ),
-		translate( 'Support for 29 languages' ),
+		translate( 'Supports 38 languages' ),
 		translate( 'Quick and accurate spelling correction' ),
 	];
 	const boostIncludesInfo = [


### PR DESCRIPTION
#### Proposed Changes

This PR updates a simple line to match other places.

#### Testing Instructions

- Navigate to live link for this PR for cloud.jetpack
- Open lightbox (by hitting 'More about ...') button on site search product and observe the line represented correctly. It should be `Supports 38 languages`

Related to #
p7pQDF-7v2-p2#comment-21898