### PR TITLE
components/theme: Use isPremiumTheme to determine premium status, not theme.price

### DIFF
--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -373,7 +373,7 @@ export class Theme extends Component {
 		} );
 
 		const themeNeedsPurchase = isPremiumTheme && ! hasPremiumThemesFeature && ! didPurchaseTheme;
-		const showUpsell = upsellUrl && theme.price && ! active;
+		const showUpsell = upsellUrl && isPremiumTheme && ! active;
 		const priceClass = classNames( 'theme__badge-price', {
 			'theme__badge-price-upgrade': ! themeNeedsPurchase,
 			'theme__badge-price-upsell': showUpsell,

--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -265,6 +265,27 @@ export class Theme extends Component {
 		}
 	};
 
+	parseThemePrice = ( price ) => {
+		/*
+		theme.price on "Recommended" themes tab
+		Premium theme: "$50"
+		Free theme:    undefined
+
+		theme.price on Trending themes tab
+		Premium theme: { value: 50, currency: "USD", display: "<abbr title=\"United States Dollars\">US$</abbr>50" }
+		Free theme:    { value: 0, currency: "USD", display: "Free" }
+
+		Try to correctly parse the price for both cases.
+		*/
+		if ( typeof price === 'object' && 'display' in price ) {
+			let parsedThemePrice = price.display;
+			// Remove all html tags from the price string
+			parsedThemePrice = parsedThemePrice.replace( /(<([^>]+)>)/gi, '' );
+			return parsedThemePrice;
+		}
+		return price;
+	};
+
 	getUpsellMessage() {
 		const {
 			hasPremiumThemesFeature,
@@ -283,6 +304,8 @@ export class Theme extends Component {
 		const isUsableBundledTheme =
 			doesThemeBundleSoftwareSet && hasPremiumThemesFeature && isSiteEligibleForBundledSoftware;
 
+		const parsedThemePrice = this.parseThemePrice( theme.price );
+
 		if ( didPurchaseTheme && ! isUsablePremiumTheme && ! isUsableBundledTheme ) {
 			return translate( 'You have purchased an annual subscription for this theme' );
 		} else if ( isExternallyManagedTheme && ! isSiteEligibleForManagedExternalThemes ) {
@@ -291,7 +314,7 @@ export class Theme extends Component {
 				translate(
 					'This premium theme costs %(price)s per year and can only be purchased if you have the <Link>Business plan</Link> on your site.',
 					{
-						args: { price: theme.price },
+						args: { price: parsedThemePrice },
 					}
 				),
 				{
@@ -303,7 +326,7 @@ export class Theme extends Component {
 			return translate(
 				'This premium theme is only available while your current plan is active and costs %(price)s per year.',
 				{
-					args: { price: theme.price },
+					args: { price: parsedThemePrice },
 				}
 			);
 		} else if ( isUsablePremiumTheme ) {
@@ -326,7 +349,7 @@ export class Theme extends Component {
 					'This premium theme is included in the <Link>Premium plan</Link>, or you can purchase individually for %(price)s a year'
 				),
 				{
-					price: theme.price,
+					price: parsedThemePrice,
 				}
 			),
 			{

--- a/client/components/theme/test/premium-popover.jsx
+++ b/client/components/theme/test/premium-popover.jsx
@@ -33,6 +33,7 @@ describe( 'Theme', () => {
 		translate: ( string ) => string,
 		setThemesBookmark: () => {},
 		onScreenshotClick: () => {},
+		isPremiumTheme: true,
 	};
 
 	function renderWithState( content ) {


### PR DESCRIPTION
 #### Proposed Changes

* When determining if we should show the premium theme "upsell", use isPremiumTheme to determine premium status, not theme.price

**This is to fix a bug where all themes in the trending tab incorrectly display as premium.**

I moved away from `theme.price` because it was unreliable, but only on one side of the `signup/seller-upgrade-modal` feature-flag: e5e270bcee3a408b08f91b9743d59bcb75102162.
Now the  `signup/seller-upgrade-modal` feature-flag is on, so we're back to using price.
This is applying a fix to remove the dependence of checking `theme.price` for premium status on the other side of the flag.

The fix here is slightly different from e5e270bcee3a408b08f91b9743d59bcb75102162 because we're now displaying the star in different circumstances, that is, when the theme is premium and you have it, and when the theme is premium and you don't have it.

```
theme.price on "Recommended" themes tab
 Premium theme: "$50"
 Free theme:    undefined

 theme.price on Trending themes tab
 Premium theme: { value: 50, currency: "USD", display: "<abbr title=\"United States Dollars\">US$</abbr>50" }
 Free theme:    { value: 0, currency: "USD", display: "Free" }
```

#### Testing Instructions

##### Unit Test

`yarn run test-client client/components/theme/test/premium-popover.jsx`

##### Manual Inspection

* Visit `/themes/<YOURSITE>` on both free and business plan sites
* Check the recommended, trending, and all themes tabs
* Only certain themes should have the star that indicates they're premium themes, not all

**Incorrect behavior: All Themes display as premium on trending tab**
![image](https://user-images.githubusercontent.com/937354/202246724-c0df4029-a96e-4aee-b60d-8f7c9b953edd.png)

**Correct behavior: Only some themes display as premium**
![2022-11-16_11-08](https://user-images.githubusercontent.com/937354/202246835-1ccb2003-6781-499e-ae53-a073abad6a4e.png)

**Stars are green if your site has access to premium themes (for example, business plan), grey if not**

More generally, the premium theme star display and tooltip should "make sense" under all circumstances.

