### PR TITLE
Redirect Add User button on followers tab to Email subscribers tab for simple site

### DIFF
--- a/client/my-sites/people/people-list-section-header/index.jsx
+++ b/client/my-sites/people/people-list-section-header/index.jsx
@@ -66,6 +66,12 @@ class PeopleListSectionHeader extends Component {
 		return startsWith( currentRoute, '/people/email-followers' );
 	}
 
+	isFollowersTab() {
+		const { currentRoute } = this.props;
+
+		return startsWith( currentRoute, '/people/followers' );
+	}
+
 	render() {
 		const { label, count, children, translate, includeSubscriberImporter } = this.props;
 		const siteLink = this.getAddLink();
@@ -73,7 +79,8 @@ class PeopleListSectionHeader extends Component {
 		const classes = classNames( this.props.className, 'people-list-section-header' );
 
 		const showInviteUserBtn =
-			( siteLink && ! this.isSubscribersTab() ) || ( siteLink && ! includeSubscriberImporter );
+			( siteLink && ! this.isSubscribersTab() && ! this.isFollowersTab() ) ||
+			( siteLink && ! includeSubscriberImporter );
 		const showAddSubscriberBtn =
 			addSubscriberLink && this.isSubscribersTab() && includeSubscriberImporter;
 

--- a/client/my-sites/people/people-list-section-header/index.jsx
+++ b/client/my-sites/people/people-list-section-header/index.jsx
@@ -37,6 +37,10 @@ class PeopleListSectionHeader extends Component {
 			return false;
 		}
 
+		if ( this.isFollowersTab() ) {
+			return '/people/email-followers/' + siteSlug;
+		}
+
 		return '/people/new/' + siteSlug;
 	}
 
@@ -79,8 +83,7 @@ class PeopleListSectionHeader extends Component {
 		const classes = classNames( this.props.className, 'people-list-section-header' );
 
 		const showInviteUserBtn =
-			( siteLink && ! this.isSubscribersTab() && ! this.isFollowersTab() ) ||
-			( siteLink && ! includeSubscriberImporter );
+			( siteLink && ! this.isSubscribersTab() ) || ( siteLink && ! includeSubscriberImporter );
 		const showAddSubscriberBtn =
 			addSubscriberLink && this.isSubscribersTab() && includeSubscriberImporter;
 

--- a/packages/subscriber/src/components/add-form/index.tsx
+++ b/packages/subscriber/src/components/add-form/index.tsx
@@ -372,6 +372,19 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 		);
 	}
 
+	function renderFollowerNoticeLabel() {
+		return (
+			isSelectedFileValid &&
+			! selectedFile && (
+				<label>
+					{ __(
+						"If you enter an email address that has a WordPress.com account, they'll become a follower."
+					) }
+				</label>
+			)
+		);
+	}
+
 	return (
 		<div className="add-subscriber">
 			{ ( showTitle || showSubtitle ) && (
@@ -426,7 +439,7 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 					{ ! includesHandledError() && renderImportCsvSelectedFileLabel() }
 					{ showCsvUpload && ! includesHandledError() && renderImportCsvLabel() }
 					{ showCsvUpload && ! includesHandledError() && renderImportCsvDisclaimerMsg() }
-
+					{ ! includesHandledError() && renderFollowerNoticeLabel() }
 					<NextButton
 						type="submit"
 						className="add-subscriber__form-submit-btn"


### PR DESCRIPTION
#### Proposed Changes

* Follow up on #69768 , as we have enabled the subscriber importers functionality now, it makes no sense to have the "Add User" button on the Followers tab because there's no way to see Followers roles on the invite page anymore. This PR removes the "Add User" button on the Followers tab.

#### Testing Instructions

* Navigate to `http://calypso.localhost:3000/people/followers/${SITE_SLUG}`.
* Click the Add User button and see if it redirects to Email Subscribers tab (http://calypso.localhost:3000/people/email-followers/${SITE_SLUG}).
* Also see if the notice label "If you enter an email address that has a WordPress.com account, they'll become a follower." shows at the bottom of the form.

Before:
![Screen Shot 2022-11-30 at 9 01 49 PM](https://user-images.githubusercontent.com/4074459/204803114-8b8a075b-5257-4320-aeea-be9d50177c32.png)


After:
![Screen Shot 2022-11-30 at 8 53 09 PM](https://user-images.githubusercontent.com/4074459/204803135-211640de-44ba-48d2-baf4-694453f6799e.png)


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #69768 
