### PR TITLE
Stats: Fix incorrect values for the annual highlights section

### DIFF
--- a/client/my-sites/stats/annual-highlights-section/index.tsx
+++ b/client/my-sites/stats/annual-highlights-section/index.tsx
@@ -48,10 +48,10 @@ export default function AnnualHighlightsSection( { siteId }: { siteId: number } 
 		return {
 			// TODO: Change `hasYearsData ? 0 : null` to `null` once insights API has been enhanced to
 			//       return `years` data even for inactive years. This is a temporary & hacky fix.
-			comments: currentYearData?.total_comments ?? hasYearsData ? 0 : null,
-			likes: currentYearData?.total_likes ?? hasYearsData ? 0 : null,
-			posts: currentYearData?.total_posts ?? hasYearsData ? 0 : null,
-			words: currentYearData?.total_words ?? hasYearsData ? 0 : null,
+			comments: currentYearData?.total_comments ?? ( hasYearsData ? 0 : null ),
+			likes: currentYearData?.total_likes ?? ( hasYearsData ? 0 : null ),
+			posts: currentYearData?.total_posts ?? ( hasYearsData ? 0 : null ),
+			words: currentYearData?.total_words ?? ( hasYearsData ? 0 : null ),
 			followers: followers?.total_wpcom ?? null,
 		};
 	}, [ year, followers, insights ] );


### PR DESCRIPTION
#### Proposed Changes

Fixes incorrect counts for the annual highlight section.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up a live branch for this PR and navigate to `/stats/insights/:siteSlug`.
* Ensure that the values for the annual highlights section are as expected.
* Compare to the current `wordpress.com/stats/insights/:siteSlug`, which shows zeroes for most counts.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #69863.
