### PR TITLE
Launchpad: Refactor web preview tabbing prevention

### DIFF
--- a/client/components/web-preview/component.jsx
+++ b/client/components/web-preview/component.jsx
@@ -61,9 +61,12 @@ export class WebPreviewModal extends Component {
 		autoHeight: PropTypes.bool,
 		// Fixes the viewport width of the iframe if provided.
 		fixedViewportWidth: PropTypes.number,
+		// Prevents tabbing into the iframe.
+		disableTabbing: PropTypes.bool,
 	};
 
 	static defaultProps = {
+		disableTabbing: false,
 		showExternal: true,
 		showClose: true,
 		showSEO: true,

--- a/client/components/web-preview/content.jsx
+++ b/client/components/web-preview/content.jsx
@@ -348,7 +348,13 @@ export default class WebPreviewContent extends Component {
 	}
 
 	render() {
-		const { translate, toolbarComponent: ToolbarComponent, fetchpriority, autoHeight } = this.props;
+		const {
+			translate,
+			toolbarComponent: ToolbarComponent,
+			fetchpriority,
+			autoHeight,
+			disableTabbing,
+		} = this.props;
 		const isLoaded = this.state.loaded && ( ! autoHeight || this.state.viewport !== null );
 
 		const className = classNames( this.props.className, 'web-preview__inner', {
@@ -413,6 +419,7 @@ export default class WebPreviewContent extends Component {
 								title={ this.props.iframeTitle || translate( 'Preview' ) }
 								fetchpriority={ fetchpriority ? fetchpriority : undefined }
 								scrolling={ autoHeight ? 'no' : undefined }
+								tabIndex={ disableTabbing ? -1 : 0 }
 							/>
 						</div>
 					) }
@@ -431,6 +438,8 @@ export default class WebPreviewContent extends Component {
 WebPreviewContent.propTypes = {
 	// Additional elements to display below the toolbar
 	belowToolbar: PropTypes.element,
+	// Prevents tabbing into the iframe.
+	disableTabbing: PropTypes.bool,
 	// Display the preview
 	showPreview: PropTypes.bool,
 	// Show external link button

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/launchpad-site-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/launchpad-site-preview.tsx
@@ -51,6 +51,7 @@ const LaunchpadSitePreview = ( {
 		<div className="launchpad__site-preview-wrapper" onLoad={ preventTabbingToIFrame }>
 			<WebPreview
 				className="launchpad__-web-preview"
+				disableTabbing
 				showDeviceSwitcher={ true }
 				showPreview
 				showSEO={ true }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/launchpad-site-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/launchpad-site-preview.tsx
@@ -43,12 +43,8 @@ const LaunchpadSitePreview = ( {
 		} );
 	}
 
-	function preventTabbingToIFrame(): void {
-		( document.querySelector( 'iframe.web-preview__frame' ) as HTMLIFrameElement ).tabIndex = -1;
-	}
-
 	return (
-		<div className="launchpad__site-preview-wrapper" onLoad={ preventTabbingToIFrame }>
+		<div className="launchpad__site-preview-wrapper">
 			<WebPreview
 				className="launchpad__-web-preview"
 				disableTabbing


### PR DESCRIPTION
#### Proposed Changes

We implemented a fix to prevent tabbing into the web preview in launchpad ( see more [here](https://github.com/Automattic/wp-calypso/pull/69493) ). The fix relied on brittle classname selectors.

In this PR, we remove the classname selectors and, instead, use react props to toggle tab interaction for the web preview iframe. ( see @Addison-Stavlo 's comment [here](https://github.com/Automattic/wp-calypso/pull/69493#discussion_r1006919559) )

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Checkout locally and navigate to Launchpad Final Steps screen (newsletter or link-in-bio flow is OK)
2. Tab through the page until you reach the preview section. The tab should skip over the iframe and you should not be allowed to enter the embedded content with the keyboard.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/69493
