### PR TITLE
Fix accessibility bug on "Manage Followed Blogs" page in reader

### DIFF
--- a/client/reader/components/reader-infinite-stream/index.jsx
+++ b/client/reader/components/reader-infinite-stream/index.jsx
@@ -137,6 +137,7 @@ class ReaderInfiniteStream extends Component {
 								scrollTop={ scrollTop }
 								width={ width }
 								items={ this.props.items } // passthrough-prop unused by the component except to signal a rerender
+								aria-readonly={ false }
 							/>
 						) }
 					</WindowScroller>


### PR DESCRIPTION
#### Proposed Changes

Fixes https://github.com/Automattic/wp-calypso/issues/16585

The `react-vertualized`, `Grid` component applies `aria-hidden` by default which was causing the table not to be accessible to screen readers.

`react-vertualized` has been updated and we can now pass `aria-hidden=false` to the component. 
https://github.com/bvaughn/react-virtualized/pull/744/files#diff-46fca11b791ccb59cb5f32d3759c09ce0b16be35ac4ae7747a53a52d1174eb96R254

This allows me to tab through the table where I couldn't before, it should also allow the screenreader to access this table now in safari, though I didn't test that directly. 

I couldn't reproduce the issue on the followers list page, I wonder if it has been fixed there already.

#### Testing Instructions
In safari, open the `/following/manage` page.
You should be able to tab through links in the table of followed sites

