### PR TITLE
Stats: Update traffic section's background color

### DIFF
--- a/client/blocks/stats-navigation/style.scss
+++ b/client/blocks/stats-navigation/style.scss
@@ -1,4 +1,6 @@
 .stats-navigation {
+	box-shadow: inset 0 -1px 0 #0000000d;
+
 	.section-nav__panel {
 		padding-right: 0;
 

--- a/client/my-sites/stats/highlights-section/index.tsx
+++ b/client/my-sites/stats/highlights-section/index.tsx
@@ -33,15 +33,13 @@ export default function HighlightsSection( { siteId }: { siteId: number } ) {
 	);
 
 	return (
-		<div className="stats__highlights-section">
-			<HighlightCards
-				counts={ counts }
-				previousCounts={ previousCounts }
-				onClickComments={ () => null }
-				onClickLikes={ () => null }
-				onClickViews={ () => null }
-				onClickVisitors={ () => null }
-			/>
-		</div>
+		<HighlightCards
+			counts={ counts }
+			previousCounts={ previousCounts }
+			onClickComments={ () => null }
+			onClickLikes={ () => null }
+			onClickViews={ () => null }
+			onClickVisitors={ () => null }
+		/>
 	);
 }

--- a/client/my-sites/stats/modernized-chart-tabs-styles.scss
+++ b/client/my-sites/stats/modernized-chart-tabs-styles.scss
@@ -77,6 +77,7 @@ $yearBarChartBorderRadius: 4px;
 	// Main Chart
 	.chart {
 		padding-left: 20px;
+		background-color: #fdfdfd;
 
 		.chart__bar {
 			// Cancel the chart bar styles

--- a/client/my-sites/stats/modernized-chart-tabs-styles.scss
+++ b/client/my-sites/stats/modernized-chart-tabs-styles.scss
@@ -3,9 +3,13 @@
 $barChartBorderRadius: 2px;
 $yearBarChartBorderRadius: 4px;
 
+.stats > .stats--new-main-chart {
+	padding-top: 48px;
+}
+
 // For feature `stats/new-main-chart`
 .stats--new-main-chart {
-	background-color: var(--color-surface);
+	background-color: #fdfdfd;
 
 	// Common Legend options
 	.chart__legend {

--- a/client/my-sites/stats/modernized-page-header-styles.scss
+++ b/client/my-sites/stats/modernized-page-header-styles.scss
@@ -43,7 +43,7 @@
 	.stats-navigation {
 		.section-nav {
 			margin: 0;
-			box-shadow: none;
+			box-shadow: inset 0 -1px 0 #0000000d;
 		}
 
 		.section-nav-group__label {

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -216,7 +216,7 @@ class StatsSite extends Component {
 		} );
 
 		return (
-			<div>
+			<div className="stats">
 				<JetpackBackupCredsBanner event="stats-backup-credentials" />
 
 				<FormattedHeader
@@ -456,7 +456,7 @@ class StatsSite extends Component {
 		const mainWrapperClass = classNames( { 'stats--new-wrapper': isNewMainChart } );
 
 		return (
-			<Main className={ mainWrapperClass } wideLayout>
+			<Main className={ mainWrapperClass } fullWidthLayout>
 				<QueryKeyringConnections />
 				{ isJetpack && <QueryJetpackModules siteId={ siteId } /> }
 				<QuerySiteKeyrings siteId={ siteId } />

--- a/client/my-sites/stats/stats-period-header/style.scss
+++ b/client/my-sites/stats/stats-period-header/style.scss
@@ -5,8 +5,7 @@
 	flex-wrap: wrap;
 	align-items: center;
 	justify-content: center;
-	background-color: var(--color-surface);
-	margin: 48px 0 16px;
+	margin-bottom: 16px;
 
 	.period {
 		font-family: Recoleta, sans-serif;

--- a/client/my-sites/stats/style.scss
+++ b/client/my-sites/stats/style.scss
@@ -30,6 +30,18 @@
 	}
 }
 
+.stats .jetpack-colophon {
+	background-color: #fdfdfd;
+}
+
+.stats .stats-content-promo {
+	background-color: #fdfdfd;
+
+	.promo-card-block {
+		margin: 0;
+	}
+}
+
 .stats > * {
 	@media ( min-width: 660px ) {
 		padding: 0 32px;
@@ -38,7 +50,7 @@
 	// 272 is the --sidebar-width-max value that can't be used in media queries.
 	// 1224 is the max-width for the stats content
 	@media ( min-width: calc(272px + 1224px) ) {
-		padding: 0 calc(50% - 622px);
+		padding: 0 calc(50% - 612px);
 	}
 }
 
@@ -239,10 +251,16 @@
 // this overrides the default .layout__content that adds unwanted padding
 .is-section-stats .layout__content,
 .is-section-stats.theme-default .focus-content .layout__content {
-	padding: 79px 0 32px 0;
+	padding: 79px 0 0 0;
 
 	@media ( min-width: 783px ) {
-		padding: 79px 0 32px calc(var(--sidebar-width-max) + 1px);
+		padding: 79px 0 0 calc(var(--sidebar-width-max) + 1px);
+	}
+
+	.jetpack-colophon {
+		padding-top: 32px;
+		padding-bottom: 32px;
+		margin-top: 0;
 	}
 }
 

--- a/client/my-sites/stats/style.scss
+++ b/client/my-sites/stats/style.scss
@@ -30,6 +30,18 @@
 	}
 }
 
+.stats > * {
+	@media ( min-width: 660px ) {
+		padding: 0 32px;
+	}
+
+	// 272 is the --sidebar-width-max value that can't be used in media queries.
+	// 1224 is the max-width for the stats content
+	@media ( min-width: calc(272px + 1224px) ) {
+		padding: 0 calc(50% - 622px);
+	}
+}
+
 .old-stats-link .button .gridicon {
 	margin-bottom: -2px;
 	margin-left: 4px;
@@ -221,6 +233,16 @@
 
 	&::after {
 		display: none;
+	}
+}
+
+// this overrides the default .layout__content that adds unwanted padding
+.is-section-stats .layout__content,
+.is-section-stats.theme-default .focus-content .layout__content {
+	padding: 79px 0 32px 0;
+
+	@media ( min-width: 783px ) {
+		padding: 79px 0 32px calc(var(--sidebar-width-max) + 1px);
 	}
 }
 

--- a/packages/components/src/highlight-cards/style.scss
+++ b/packages/components/src/highlight-cards/style.scss
@@ -9,10 +9,17 @@ $vertical-margin: 32px;
 // Technically deprecated, but majority of Calypso still uses this.
 $custom-mobile-breakpoint: 660px;
 
+
+.stats > .highlight-cards {
+	padding-top: $vertical-margin;
+	padding-bottom: $vertical-margin;
+}
+
 .highlight-cards {
-	margin: $vertical-margin 0;
 	color: var(--studio-gray-100);
 	font-size: $font-body-small;
+	background-color: #fbfbfb;
+	box-shadow: inset 0 -1px 0 #0000000d;
 }
 
 .highlight-cards a.highlight-cards-heading-wrapper {


### PR DESCRIPTION
#### Proposed Changes

Updates the background colors for the traffic section in Stats.

Before:
![image](https://user-images.githubusercontent.com/6406071/202327362-48e6db28-e665-4455-97c3-16e5082c407e.png)

After:
![image](https://user-images.githubusercontent.com/6406071/202327401-535290d4-e462-47d0-bc04-d1b8480ec307.png)


#### Testing Instructions

1. Visit the Calypso Live link.
2. Visit the Stats page.
4. Confirm it matches the screenshot above.
5. Confirm it behaves appropriately on smaller screen sizes.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #69953
