### PR TITLE
Stats: Release the All-time highlights section on the Insights page

### DIFF
--- a/client/my-sites/stats/stats-insights/index.jsx
+++ b/client/my-sites/stats/stats-insights/index.jsx
@@ -74,7 +74,7 @@ const StatsInsights = ( props ) => {
 					<div className="stats__module-list stats__module--unified">
 						<div className="stats__module-column">
 							<LatestPostSummary />
-							<MostPopular />
+							{ ! showAllTimeHighlights && <MostPopular /> }
 
 							<StatsModule
 								path="tags-categories"
@@ -90,7 +90,7 @@ const StatsInsights = ( props ) => {
 							<Followers path="followers" />
 						</div>
 						<div className="stats__module-column">
-							<AllTime />
+							{ ! showAllTimeHighlights && <AllTime /> }
 							<Comments path="comments" />
 							<StatsModule
 								path="publicize"

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -103,7 +103,7 @@
 		"signup/woo-verify-email": false,
 		"site-indicator": true,
 		"ssr/prefetch-timebox": true,
-		"stats/new-all-time-highlights": false,
+		"stats/new-all-time-highlights": true,
 		"stats/new-annual-highlights": true,
 		"stats/new-main-chart": true,
 		"stats/new-stats-module-component": true,

--- a/config/production.json
+++ b/config/production.json
@@ -123,7 +123,7 @@
 		"ssr/log-prefetch-errors": true,
 		"ssr/prefetch-timebox": true,
 		"ssr/sample-log-cache-misses": true,
-		"stats/new-all-time-highlights": false,
+		"stats/new-all-time-highlights": true,
 		"stats/new-annual-highlights": true,
 		"stats/new-main-chart": true,
 		"stats/new-stats-module-component": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -119,7 +119,7 @@
 		"signup/woo-verify-email": false,
 		"site-indicator": true,
 		"ssr/prefetch-timebox": true,
-		"stats/new-all-time-highlights": false,
+		"stats/new-all-time-highlights": true,
 		"stats/new-annual-highlights": true,
 		"stats/new-main-chart": true,
 		"stats/new-stats-module-component": true,

--- a/config/test.json
+++ b/config/test.json
@@ -88,7 +88,7 @@
 		"signup/social": true,
 		"site-indicator": true,
 		"ssr/prefetch-timebox": true,
-		"stats/new-all-time-highlights": false,
+		"stats/new-all-time-highlights": true,
 		"stats/new-annual-highlights": true,
 		"stats/new-main-chart": true,
 		"stats/new-stats-module-component": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -127,7 +127,7 @@
 		"signup/woo-verify-email": false,
 		"site-indicator": true,
 		"ssr/prefetch-timebox": true,
-		"stats/new-all-time-highlights": false,
+		"stats/new-all-time-highlights": true,
 		"stats/new-annual-highlights": true,
 		"stats/new-main-chart": true,
 		"stats/new-stats-module-component": true,


### PR DESCRIPTION
#### Proposed Changes

* Adds a new All-time highlights section between the new annual highlights and Posting activity sections at the top of the Insights page.
* Hides the existing `All-time posts, comments, views, and visitors` and `Most popular day and hour` modules at the bottom of the Insights page.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up this change with the Calypso Live link.
* Navigate to page `/stats/insights/${your-site}`.
* Ensure the new All-time highlights section is in line with the design.
* Ensure there are no original `All-time posts, comments, views, and visitors` and `Most popular day and hour` modules.

<img width="1072" alt="截圖 2022-11-17 下午12 37 13" src="https://user-images.githubusercontent.com/6869813/202579124-2cf22b1b-640d-4b58-8c56-d51ff2c64867.png">

<img width="1163" alt="截圖 2022-11-17 下午12 37 25" src="https://user-images.githubusercontent.com/6869813/202356661-6e4ecec7-91c3-4060-a767-d2c7051ae2ad.png">

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #69229 
