### PR TITLE
Partner Portal: Hide the "Assign License" step on the stepper when a site is pre-selected

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/assign-license-step-progress/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/assign-license-step-progress/index.tsx
@@ -5,7 +5,9 @@ import { Fragment } from 'react';
 import { useSelector } from 'react-redux';
 import { doesPartnerRequireAPaymentMethod } from 'calypso/state/partner-portal/partner/selectors';
 import getSites from 'calypso/state/selectors/get-sites';
+import type { SiteDetails } from '@automattic/data-stores';
 import type { ReactChild } from 'react';
+
 import './style.scss';
 
 function getStepClassName( currentStep: number, step: number ): any {
@@ -41,9 +43,10 @@ interface Step {
 
 interface Props {
 	currentStep: StepKey;
+	selectedSite?: SiteDetails | null;
 }
 
-export default function AssignLicenseStepProgress( { currentStep }: Props ) {
+export default function AssignLicenseStepProgress( { currentStep, selectedSite }: Props ) {
 	const translate = useTranslate();
 	const paymentMethodRequired = useSelector( doesPartnerRequireAPaymentMethod );
 	const sites = useSelector( getSites ).length;
@@ -54,7 +57,7 @@ export default function AssignLicenseStepProgress( { currentStep }: Props ) {
 		steps.push( { key: 'addPaymentMethod', label: translate( 'Add Payment Method' ) } );
 	}
 
-	if ( sites > 0 ) {
+	if ( sites > 0 && ! selectedSite ) {
 		steps.push( { key: 'assignLicense', label: translate( 'Assign license' ) } );
 	}
 

--- a/client/jetpack-cloud/sections/partner-portal/controller.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/controller.tsx
@@ -121,7 +121,11 @@ export function paymentMethodListContext( context: PageJS.Context, next: () => v
 export function paymentMethodAddContext( context: PageJS.Context, next: () => void ): void {
 	context.header = <Header />;
 	context.secondary = <PartnerPortalSidebar path={ context.path } />;
-	context.primary = <PaymentMethodAdd />;
+	const { site_id: siteId } = context.query;
+	const state = context.store.getState();
+	const sites = getSites( state );
+	const selectedSite = siteId ? sites?.find( ( site ) => site?.ID === parseInt( siteId ) ) : null;
+	context.primary = <PaymentMethodAdd selectedSite={ selectedSite } />;
 	next();
 }
 

--- a/client/jetpack-cloud/sections/partner-portal/primary/issue-license/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/issue-license/index.tsx
@@ -28,7 +28,7 @@ export default function IssueLicense( { selectedSite, suggestedProduct }: Assign
 		<Main wideLayout className="issue-license">
 			<DocumentHead title={ translate( 'Issue a new License' ) } />
 			<SidebarNavigation />
-			<AssignLicenseStepProgress currentStep="issueLicense" />
+			<AssignLicenseStepProgress currentStep="issueLicense" selectedSite={ selectedSite } />
 			<CardHeading size={ 36 }>{ translate( 'Issue a new License' ) }</CardHeading>
 
 			{ isEnabled( 'jetpack/partner-portal-issue-multiple-licenses' ) ? (

--- a/client/jetpack-cloud/sections/partner-portal/primary/payment-method-add/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/payment-method-add/index.tsx
@@ -39,10 +39,11 @@ import { errorNotice, removeNotice, successNotice } from 'calypso/state/notices/
 import { doesPartnerRequireAPaymentMethod } from 'calypso/state/partner-portal/partner/selectors';
 import { fetchStoredCards } from 'calypso/state/partner-portal/stored-cards/actions';
 import getSites from 'calypso/state/selectors/get-sites';
+import type { SiteDetails } from '@automattic/data-stores';
 
 import './style.scss';
 
-function PaymentMethodAdd() {
+function PaymentMethodAdd( { selectedSite }: { selectedSite?: SiteDetails | null } ) {
 	const translate = useTranslate();
 	const reduxDispatch = useDispatch();
 	const paymentMethodRequired = useSelector( doesPartnerRequireAPaymentMethod );
@@ -198,8 +199,8 @@ function PaymentMethodAdd() {
 			<DocumentHead title={ translate( 'Payment Methods' ) } />
 			<SidebarNavigation />
 
-			{ ( !! returnQueryArg || product ) && (
-				<AssignLicenseStepProgress currentStep="addPaymentMethod" />
+			{ ( !! returnQueryArg || product || products ) && (
+				<AssignLicenseStepProgress currentStep="addPaymentMethod" selectedSite={ selectedSite } />
 			) }
 
 			<div className="payment-method-add__header">
@@ -279,13 +280,17 @@ function PaymentMethodAdd() {
 	);
 }
 
-export default function PaymentMethodAddWrapper() {
+export default function PaymentMethodAddWrapper( {
+	selectedSite,
+}: {
+	selectedSite?: SiteDetails | null;
+} ) {
 	const locale = useSelector( getCurrentUserLocale );
 
 	return (
 		<StripeHookProvider locale={ locale } fetchStripeConfiguration={ getStripeConfiguration }>
 			<StripeSetupIntentIdProvider fetchStipeSetupIntentId={ getStripeConfiguration }>
-				<PaymentMethodAdd />
+				<PaymentMethodAdd selectedSite={ selectedSite } />
 			</StripeSetupIntentIdProvider>
 		</StripeHookProvider>
 	);

--- a/client/jetpack-cloud/sections/partner-portal/types.ts
+++ b/client/jetpack-cloud/sections/partner-portal/types.ts
@@ -1,3 +1,5 @@
+import type { SiteDetails } from '@automattic/data-stores';
+
 export enum LicenseState {
 	Detached = 'detached',
 	Attached = 'attached',
@@ -23,6 +25,6 @@ export enum LicenseSortDirection {
 }
 
 export interface AssignLicenceProps {
-	selectedSite?: { ID: number; domain: string } | null;
+	selectedSite?: SiteDetails | null;
 	suggestedProduct?: string;
 }


### PR DESCRIPTION
#### Proposed Changes

This PR makes changes to the issue/assign license flow by hiding the **Assign License** step when a site is pre-selected. 

#### Testing Instructions

> **_NOTE:_** Make sure you don't have any payment method added by visiting http://jetpack.cloud.localhost:3000/partner-portal/payment-methods.

1. Run `git checkout update/hide-assign-license-step` and `yarn start-jetpack-cloud`
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Click on `Add +` on any site  -> Click on **Issue x new License**  -> Notice the `site_id` in the URL -> Verify that **Assign License** is not shown in **Issue new license** step -> Click on **Select License** -> Verify that **Assign License** is not shown in **Add Payment Method** step.

<table>
<tr>
<th>
Before
</th>
<th>
After
</th>
</tr>
<tr>
<td>
<img width="1047" alt="Screenshot 2022-11-17 at 11 42 07 AM" src="https://user-images.githubusercontent.com/10586875/202371911-81338247-6f79-4b55-ae8d-e2b0d9dfc056.png">
</td>
<td>
<img width="1084" alt="Screenshot 2022-11-17 at 11 41 23 AM" src="https://user-images.githubusercontent.com/10586875/202371884-f98ef0d7-056b-4d16-8159-2431ff99544b.png">
</td>
</tr>
</table>

4. Now, click on **Licensing** on the top nav and click **Issue New License** button -> Verify that **Assign License** is shown in **Issue new license** step -> Click on **Select License** -> Verify that **Assign License** is shown in  **Add Payment Method** step. You can also verify this by adding a dummy `site_id`.

<img width="1051" alt="Screenshot 2022-11-17 at 11 51 44 AM" src="https://user-images.githubusercontent.com/10586875/202371758-e66f0664-5fb5-48e4-9f42-8c9355ade582.png">


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1203126240279377-as-1203362674516741