### PR TITLE
Partner Portal: update the dependency array for useEffect to issue bundle licenses not to run infinitely

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/issue-multiple-licenses-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-multiple-licenses-form/index.tsx
@@ -75,7 +75,10 @@ export default function IssueMultipleLicensesForm( {
 		if ( selectedProductSlugs.find( ( product ) => isJetpackBundle( product ) ) ) {
 			issueLicenses();
 		}
-	}, [ selectedProductSlugs, issueLicenses ] );
+		// Do not update the dependency array with issueLicenses since
+		// it gets changed on every product change, which triggers this `useEffect` to run infinitely.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ selectedProductSlugs ] );
 
 	const selectedSiteDomain = selectedSite?.domain;
 


### PR DESCRIPTION
#### Proposed Changes

This PR fixes an issue with assigning bundle licenses. It updates the dependency array for useEffect to issue bundle licenses, not to run infinitely.

#### Testing Instructions

> **_NOTE:_** Make sure you have added at least one payment method by visiting **[payment-methods](http://jetpack.cloud.localhost:3000/partner-portal/payment-methods)**.

1. Run `git checkout fix/issue-bundle-license-flow` and `yarn start-jetpack-cloud`
2. Go to **[issue-license](http://jetpack.cloud.localhost:3001/partner-portal/issue-license)** page -> Open the dev tool, click on the network tab and set the network to offline -> Click on `Select` on any bundle -> Verify that only one API call is being made. Please ignore the success message, it will be **[fixed](1203126240279377-as-1203377005312982)**
3. Set the network to default or close the dev tool -> Go back and Click on `Select` on any bundle -> Verify that it is being issued and you are redirected to the assign license page. Assigning a license won't work since it is [WIP](https://github.com/Automattic/wp-calypso/pull/69873)


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1203126240279377-as-1203348126439713