### PR TITLE
Add link to gifting settings in auto renew dialog

### DIFF
--- a/client/me/purchases/manage-purchase/auto-renew-toggle/auto-renew-disabling-dialog/index.jsx
+++ b/client/me/purchases/manage-purchase/auto-renew-toggle/auto-renew-disabling-dialog/index.jsx
@@ -163,7 +163,6 @@ class AutoRenewDisablingDialog extends Component {
 					strong: <strong />,
 				},
 			}
-			}
 		);
 	}
 

--- a/client/me/purchases/manage-purchase/auto-renew-toggle/auto-renew-disabling-dialog/index.jsx
+++ b/client/me/purchases/manage-purchase/auto-renew-toggle/auto-renew-disabling-dialog/index.jsx
@@ -3,6 +3,7 @@ import {
 	isGSuiteOrGoogleWorkspace,
 	isPlan,
 	isTitanMail,
+	WPCOM_FEATURES_SUBSCRIPTION_GIFTING,
 } from '@automattic/calypso-products';
 import { Button, Dialog } from '@automattic/components';
 import { localize } from 'i18n-calypso';
@@ -12,6 +13,7 @@ import { connect } from 'react-redux';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import CancelAutoRenewalForm from 'calypso/components/marketing-survey/cancel-auto-renewal-form';
 import isSiteAtomic from 'calypso/state/selectors/is-site-automated-transfer';
+import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { getSite } from 'calypso/state/sites/selectors';
 import './style.scss';
 
@@ -240,7 +242,7 @@ class AutoRenewDisablingDialog extends Component {
 	};
 
 	renderGeneralDialog = () => {
-		const { isVisible, translate } = this.props;
+		const { isVisible, translate, hasSubscriptionGifting } = this.props;
 		const description = this.getCopy( this.getVariation() );
 
 		const buttons = [
@@ -268,7 +270,7 @@ class AutoRenewDisablingDialog extends Component {
 					{ translate( 'Turn off auto-renew' ) }
 				</h2>
 				<p>{ description }</p>
-				<p>{ this.getGiftingCopy() }</p>
+				{ hasSubscriptionGifting && <p>{ this.getGiftingCopy() }</p> }
 			</Dialog>
 		);
 	};
@@ -301,4 +303,9 @@ class AutoRenewDisablingDialog extends Component {
 export default connect( ( state, { purchase } ) => ( {
 	isAtomicSite: isSiteAtomic( state, purchase.siteId ),
 	selectedSite: getSite( state, purchase.siteId ),
+	hasSubscriptionGifting: siteHasFeature(
+		state,
+		purchase.siteId,
+		WPCOM_FEATURES_SUBSCRIPTION_GIFTING
+	),
 } ) )( localize( withLocalizedMoment( AutoRenewDisablingDialog ) ) );

--- a/client/me/purchases/manage-purchase/auto-renew-toggle/auto-renew-disabling-dialog/index.jsx
+++ b/client/me/purchases/manage-purchase/auto-renew-toggle/auto-renew-disabling-dialog/index.jsx
@@ -156,11 +156,13 @@ class AutoRenewDisablingDialog extends Component {
 		const { siteDomain, translate } = this.props;
 
 		return translate(
-			"Did you know: You can allow site visitors to help cover the full cost of your site's plan and domain by turning on gifting in {{a}}Settings > General{{/a}}.",
+			"{{strong}}Did you know:{{/strong}} You can allow site visitors to help cover the cost of your site's plan by enabling gift subscriptions in {{a}}Settings > General{{/a}}.",
 			{
 				components: {
 					a: <a href={ `/settings/general/${ siteDomain }` } />,
+					strong: <strong />,
 				},
+			}
 			}
 		);
 	}

--- a/client/me/purchases/manage-purchase/auto-renew-toggle/auto-renew-disabling-dialog/index.jsx
+++ b/client/me/purchases/manage-purchase/auto-renew-toggle/auto-renew-disabling-dialog/index.jsx
@@ -152,6 +152,19 @@ class AutoRenewDisablingDialog extends Component {
 		}
 	}
 
+	getGiftingCopy() {
+		const { siteDomain, translate } = this.props;
+
+		return translate(
+			"Did you know: You can allow site visitors to help cover the full cost of your site's plan and domain by turning on gifting in {{a}}Settings > General{{/a}}.",
+			{
+				components: {
+					a: <a href={ `/settings/general/${ siteDomain }` } />,
+				},
+			}
+		);
+	}
+
 	onClickAtomicFollowUpConfirm = () => {
 		this.props.onConfirm();
 		this.setState( {
@@ -254,6 +267,7 @@ class AutoRenewDisablingDialog extends Component {
 					{ translate( 'Turn off auto-renew' ) }
 				</h2>
 				<p>{ description }</p>
+				<p>{ this.getGiftingCopy() }</p>
 			</Dialog>
 		);
 	};


### PR DESCRIPTION
#### Proposed Changes

* Add a link in the auto renew dialog to point users to turn on their gifting banner.

![auto-renew](https://user-images.githubusercontent.com/6586048/202411710-9de5494c-760d-4c1d-833f-0c7c8cd2643e.png)


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Have auto renew turned on.
* Go to Upgrade > My Plan > Manage plan > Auto-renew is ON (or /purchases/subscriptions/:site/:subscription_id)
* Click on the link
* Should direct to Settings > General

Fixes #69927
