### PR TITLE
Add followed date to manage feed stream

### DIFF
--- a/client/blocks/reader-list-item/style.scss
+++ b/client/blocks/reader-list-item/style.scss
@@ -13,7 +13,7 @@
 	order: 3;
 	align-self: flex-end;
 	width: 100%;
-	margin-left: 44px;
+	margin-left: 52px;
 }
 
 .reader-list-item__byline {
@@ -86,6 +86,7 @@
 .reader-list-item__site-excerpt,
 .reader-list-item__site-url-timestamp {
 	display: block;
+	line-height: 18px;
 	max-height: 16px * 2.6;
 	overflow: hidden;
 	text-overflow: ellipsis;
@@ -113,7 +114,9 @@
 }
 
 .reader-list-item__site-title {
+	font-size: $font-body;
 	font-weight: 600;
+	line-height: 20px;
 }
 
 .reader-list-item__site-url-timestamp {
@@ -213,7 +216,7 @@
 }
 
 .reader-list-item__avatar {
-	min-width: 44px;
+	min-width: 52px;
 	order: 1;
 	flex: 0;
 }

--- a/client/blocks/reader-recommended-sites/style.scss
+++ b/client/blocks/reader-recommended-sites/style.scss
@@ -57,8 +57,8 @@
 		right: 16px;
 
 		@include breakpoint-deprecated( ">960px" ) {
-			top: 0;
-			right: 0;
+			top: 6px;
+			right: 5px;
 		}
 
 		.button {

--- a/client/blocks/reader-subscription-list-item/index.jsx
+++ b/client/blocks/reader-subscription-list-item/index.jsx
@@ -116,27 +116,37 @@ function ReaderSubscriptionListItem( {
 				) }
 				{ siteUrl && (
 					<div className="reader-subscription-list-item__site-url-timestamp">
-						<ExternalLink
-							href={ siteUrl }
-							className="reader-subscription-list-item__site-url"
-							onClick={ recordSiteUrlClick }
-							icon={ true }
-							iconSize={ 14 }
-						>
-							{ formatUrlForDisplay( siteUrl ) }
-						</ExternalLink>
-						{ showLastUpdatedDate && feed && feed.last_update && (
-							<span className="reader-subscription-list-item__timestamp">
-								{ translate( 'updated %s', { args: moment( feed.last_update ).fromNow() } ) }
-							</span>
-						) }
-						{ feed && feed.date_subscribed && (
-							<span className="reader-subscription-list-item__date-subscribed">
-								{ translate( 'followed %s', {
-									args: moment( feed.date_subscribed ).format( 'MMM YYYY' ),
-								} ) }
-							</span>
-						) }
+						<ul>
+							<li>
+								<ExternalLink
+									href={ siteUrl }
+									className="reader-subscription-list-item__site-url"
+									onClick={ recordSiteUrlClick }
+									icon={ true }
+									iconSize={ 14 }
+								>
+									{ formatUrlForDisplay( siteUrl ) }
+								</ExternalLink>
+							</li>
+							{ showLastUpdatedDate && feed && feed.last_update && (
+								<li>
+									<span className="reader-subscription-list-item__timestamp">
+										{ translate( 'updated %s', {
+											args: moment( feed.last_update ).fromNow(),
+										} ) }
+									</span>
+								</li>
+							) }
+							{ feed && feed.date_subscribed && (
+								<li>
+									<span className="reader-subscription-list-item__date-subscribed">
+										{ translate( 'followed %s', {
+											args: moment( feed.date_subscribed ).format( 'MMM YYYY' ),
+										} ) }
+									</span>
+								</li>
+							) }
+						</ul>
 					</div>
 				) }
 			</div>

--- a/client/blocks/reader-subscription-list-item/style.scss
+++ b/client/blocks/reader-subscription-list-item/style.scss
@@ -139,6 +139,15 @@
 	.external-link .gridicons-external {
 		margin-left: 4px;
 	}
+
+	ul {
+		display: flex;
+		justify-content: space-between;
+		list-style-type: disc;
+		color: var(--color-text-subtle);
+		margin: 0;
+		gap: 8px;
+	}
 }
 
 .reader-subscription-list-item__site-url {

--- a/client/blocks/reader-subscription-list-item/style.scss
+++ b/client/blocks/reader-subscription-list-item/style.scss
@@ -107,6 +107,7 @@
 }
 
 .reader-subscription-list-item__site-title {
+	font-size: $font-body;
 	font-weight: 600;
 }
 
@@ -147,6 +148,12 @@
 		color: var(--color-text-subtle);
 		margin: 0;
 		gap: 8px;
+		li {
+			margin-right: 4px;
+		}
+		li:first-child {
+			list-style: none;
+		}
 	}
 }
 
@@ -217,5 +224,5 @@
 }
 
 .reader-subscription-list-item__avatar {
-	min-width: 44px;
+	min-width: 52px;
 }

--- a/client/blocks/reader-subscription-list-item/style.scss
+++ b/client/blocks/reader-subscription-list-item/style.scss
@@ -67,8 +67,13 @@
 
 .reader-subscription-list-item__site-url,
 .reader-subscription-list-item__site-url:visited,
-.reader-subscription-list-item__timestamp {
+.reader-subscription-list-item__timestamp
+.reader-subscription-list-item__date-subscribed {
 	color: var(--color-text-subtle);
+}
+
+.reader-subscription-list-item__timestamp {
+	margin-right: 8px;
 }
 
 .reader-subscription-list-item__site-title,


### PR DESCRIPTION
This adds the followed date to the manage feed stream on Reader.

This PR also fixes a bug where the site icon is not available on external feeds.

### Before
<img width="752" alt="Screenshot 2022-11-17 at 11 20 21" src="https://user-images.githubusercontent.com/5560595/202434034-a072e23d-5238-45b3-8d8e-2815d927e3c8.png">

### After
<img width="753" alt="Screenshot 2022-11-17 at 12 02 56" src="https://user-images.githubusercontent.com/5560595/202441516-2fd85b8e-6d28-4dee-bc10-2f72fa376330.png">


Ref - https://github.com/Automattic/wp-calypso/issues/69665