### PR TITLE
Agency Dashboard: Add tracks event when selected products are different

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/hooks.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/hooks.tsx
@@ -1,5 +1,6 @@
 import { getQueryArg } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
+import { isEqual } from 'lodash';
 import page from 'page';
 import { useCallback, useEffect, useState } from 'react';
 import { useQuery, UseQueryOptions } from 'react-query';
@@ -286,7 +287,8 @@ export function useLicenseIssuing(
  */
 export function useIssueMultipleLicenses(
 	selectedProducts: Array< string >,
-	selectedSite?: { ID: number; domain: string } | null
+	selectedSite?: { ID: number; domain: string } | null,
+	suggestedProducts?: Array< string > = []
 ): [ () => void, boolean ] {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
@@ -357,6 +359,16 @@ export function useIssueMultipleLicenses(
 				products: selectedProducts.join( ',' ),
 			} )
 		);
+
+		// Track a custom event when the user is trying to purchase a product different than
+		// the one chosen by the dashboard.
+		if ( suggestedProducts?.length && ! isEqual( selectedProducts, suggestedProducts ) ) {
+			dispatch(
+				recordTracksEvent(
+					'calypso_partner_portal_issue_mutiple_licenses_changed_selection_after_dashboard_visit'
+				)
+			);
+		}
 
 		const selectedSiteId = selectedSite?.ID;
 

--- a/client/jetpack-cloud/sections/partner-portal/hooks.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/hooks.tsx
@@ -288,7 +288,7 @@ export function useLicenseIssuing(
 export function useIssueMultipleLicenses(
 	selectedProducts: Array< string >,
 	selectedSite?: { ID: number; domain: string } | null,
-	suggestedProducts?: Array< string > = []
+	suggestedProducts: Array< string > = []
 ): [ () => void, boolean ] {
 	const translate = useTranslate();
 	const dispatch = useDispatch();

--- a/client/jetpack-cloud/sections/partner-portal/issue-multiple-licenses-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-multiple-licenses-form/index.tsx
@@ -37,10 +37,17 @@ export default function IssueMultipleLicensesForm( {
 		?.toString()
 		.split( ',' );
 
+	// We need the suggested products (i.e., the products chosen from the dashboard) to properly
+	// track if the user purchases a different set of products.
+	const suggestedProductSlugs = getQueryArg( window.location.href, 'product_slug' )
+		?.toString()
+		.split( ',' );
+
 	const [ selectedProductSlugs, setSelectedProductSlugs ] = useState( defaultProductSlugs ?? [] );
 	const [ issueLicenses, isLoading ] = useIssueMultipleLicenses(
 		selectedProductSlugs,
-		selectedSite
+		selectedSite,
+		suggestedProductSlugs
 	);
 
 	const onSelectProduct = useCallback(


### PR DESCRIPTION
#### Proposed Changes

* This PR adds a track event when the user selects another set of products, different than the initial one selected on the dashboard page.

#### Testing Instructions

- Checkout this branch locally
- Run `yarn start-jetpack-cloud`
- Visit http://jetpack.cloud.localhost:3000/dashboard
- Click the `Add` button on backup or scan (or both)
- Click the `Issue N licenses` button
- Change the selected products (e.g., if you have selected a backup license, unselect it and select another product)
- Using the Network tab (Dev Tools) or the [Tracks Vigilante Chrome Extension](p7H4VZ-3cB-p2), verify that the `calypso_partner_portal_issue_mutiple_licenses_changed_selection_after_dashboard_visit` event is tracked
- Visit the dashboard again
- Repeat the above steps, but this time don't change the initial selection.
- Verify that the custom event is not tracked this time

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1203126240279377-as-1203136066214512