### PR TITLE
BBE: Update copy on in-progress page

### DIFF
--- a/client/my-sites/marketing/do-it-for-me/difm-lite-in-progress.tsx
+++ b/client/my-sites/marketing/do-it-for-me/difm-lite-in-progress.tsx
@@ -95,7 +95,20 @@ function DIFMLiteInProgress( { siteId }: DIFMLiteInProgressProps ) {
 		<EmptyContent
 			title={ translate( 'Website content not submitted' ) }
 			line={ translate(
-				'Please provide the necessary information for the creation of your website. To access click on the button below.'
+				'Please provide the necessary information for the creation of your website. To access click on the button below.{{br}}{{/br}}' +
+					'{{SupportLink}}Contact support{{/SupportLink}} if you have any questions.',
+				{
+					components: {
+						br: <br />,
+						SupportLink: (
+							<a
+								href={ `mailto:builtby+express@wordpress.com?subject=${ encodeURIComponent(
+									`I need help with my site: ${ primaryDomain.domain }`
+								) }` }
+							/>
+						),
+					},
+				}
 			) }
 			action={ translate( 'Add content to your website' ) }
 			actionURL={ `/start/site-content-collection/website-content?siteSlug=${ slug }` }

--- a/client/my-sites/marketing/do-it-for-me/difm-lite-in-progress.tsx
+++ b/client/my-sites/marketing/do-it-for-me/difm-lite-in-progress.tsx
@@ -64,13 +64,20 @@ function DIFMLiteInProgress( { siteId }: DIFMLiteInProgressProps ) {
 
 	return isWebsiteContentSubmitted ? (
 		<EmptyContent
-			title={ translate( 'Our experts are building your site' ) }
+			title={ translate( 'Your content submission was successful!' ) }
 			line={ translate(
-				'Your content submission was successful!{{br}}{{/br}}' +
-					'Your website is now being built. We will send you an email within %d business days with details about your new site.',
+				"We are currently building your site and will send you an email when it's ready, within %d business days.{{br}}{{/br}}" +
+					'{{SupportLink}}Contact support{{/SupportLink}} if you have any questions.',
 				{
 					components: {
 						br: <br />,
+						SupportLink: (
+							<a
+								href={ `mailto:builtby+express@wordpress.com?subject=${ encodeURIComponent(
+									`I need help with my site: ${ primaryDomain.domain }`
+								) }` }
+							/>
+						),
 					},
 					args: [ 4 ],
 				}


### PR DESCRIPTION
#### Proposed Changes

Context: pdh1Xd-1zo-p2#comment-1738

* Updates the copy on the BBE in-progress page.
* Also adds a contact support link.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/do-it-for-me` and complete the purchase.
* Do not submit the form. Instead, visit `/home`.
* Confirm that you see a "Contact Support" link:
<img width="1651" alt="image" src="https://user-images.githubusercontent.com/5436027/203763550-d40c2c47-1e42-4273-836b-e55b11bcd776.png">

* After submitting the content form, visit `/home`. Confirm that the screen looks like this:
<img width="1649" alt="image" src="https://user-images.githubusercontent.com/5436027/202438028-b9c6785d-7869-44c9-a0ad-31b783eecd8d.png">

* Clicking on the "Contact Support" link should open an email client, with the subject "I need help with my site: <domain>"


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes Automattic/martech#1255