### PR TITLE
Ensure we always have a fallback subheader in /start signup flows

### DIFF
--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -140,22 +140,10 @@ export class UserStep extends Component {
 		}
 	}
 
-	getSubHeaderText() {
-		const {
-			flowName,
-			oauth2Client,
-			positionInFlow,
-			translate,
-			userLoggedIn,
-			wccomFrom,
-			isReskinned,
-			sectionName,
-			from,
-			locale,
-		} = this.props;
+	getLoginUrl() {
+		const { oauth2Client, wccomFrom, isReskinned, sectionName, from, locale } = this.props;
 
-		let subHeaderText = this.props.subHeaderText;
-		const loginUrl = login( {
+		return login( {
 			isJetpack: 'jetpack-connect' === sectionName,
 			from,
 			redirectTo: getRedirectToAfterLoginUrl( this.props ),
@@ -165,6 +153,22 @@ export class UserStep extends Component {
 			isWhiteLogin: isReskinned,
 			signupUrl: window.location.pathname + window.location.search,
 		} );
+	}
+
+	getSubHeaderText() {
+		const {
+			flowName,
+			oauth2Client,
+			positionInFlow,
+			translate,
+			userLoggedIn,
+			wccomFrom,
+			isReskinned,
+		} = this.props;
+
+		const loginUrl = this.getLoginUrl();
+
+		let subHeaderText = this.props.subHeaderText;
 
 		if ( [ 'wpcc', 'crowdsignal' ].includes( flowName ) && oauth2Client ) {
 			if ( isWooOAuth2Client( oauth2Client ) && wccomFrom ) {
@@ -228,6 +232,21 @@ export class UserStep extends Component {
 		}
 
 		return subHeaderText;
+	}
+
+	getFallbackSubHeaderText() {
+		const { isReskinned, positionInFlow, translate, userLoggedIn } = this.props;
+
+		if ( isReskinned && positionInFlow !== 0 && ! userLoggedIn ) {
+			return translate(
+				"Let's create your WordPress.com account. Have an account? {{a}}Log in{{/a}}",
+				{
+					components: { a: <a href={ this.getLoginUrl() } rel="noopener noreferrer" /> },
+				}
+			);
+		}
+
+		return undefined;
 	}
 
 	initGoogleRecaptcha() {
@@ -537,6 +556,7 @@ export class UserStep extends Component {
 				subHeaderText={ this.getSubHeaderText() }
 				positionInFlow={ this.props.positionInFlow }
 				fallbackHeaderText={ this.props.translate( 'Create your account.' ) }
+				fallbackSubHeaderText={ this.getFallbackSubHeaderText() }
 				stepContent={ this.renderSignupForm() }
 			/>
 		);


### PR DESCRIPTION
#### Proposed Changes

* This PR ensures that we always have a way for users to log in when they reach the user step in the `/start` signup flows, by adding the following fallback subheader to the user step when the step is reskinned and the user isn't logged in:
> Let's create your WordPress.com account. Have an account? [Log in](#)
* This is admittedly a broad change, so it will need some eyes to make sure we're not doing anything hugely detrimental. However, it should help avoid the issues raised in #70091, where users don't have a way to log in if they already have an account.

##### Screenshot

**Before**

<img width="1252" alt="image" src="https://user-images.githubusercontent.com/87168/202440658-41c1f8dd-f0dc-4ba5-b8d5-c4e5f809d3cd.png">


**After**

<img width="1132" alt="Screenshot 2022-11-17 at 13 49 27" src="https://user-images.githubusercontent.com/3376401/202438935-7214ebc0-0fa2-4412-8f19-116e5df1b16f.png">

#### Testing Instructions

* Try to replicate #70091, but sign in rather than trying to create an existing account
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #70091
