### PR TITLE
Add share code support to Coming Soon page

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/coming-soon.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/coming-soon.php
@@ -17,6 +17,10 @@ function should_show_coming_soon_page() {
 		return false;
 	}
 
+	if ( is_accessed_by_valid_share_link() ) {
+		return false;
+	}
+
 	$should_show = ( (int) get_option( 'wpcom_public_coming_soon' ) === 1 );
 
 	// Everyone from Administrator to Subscriber will be able to see the site.
@@ -29,6 +33,35 @@ function should_show_coming_soon_page() {
 	// Allow folks to hook into this method to set their own rules.
 	// We'll use to on WordPress.com to check further user privileges.
 	return apply_filters( 'a8c_show_coming_soon_page', $should_show );
+}
+
+/**
+ * Determines whether the coming soon page should be bypassed.
+ *
+ * It checks if share code is provided as GET parameter, or as a cookie.
+ * Then it validates the code against blog option, and if sharing code is valid,
+ * it allows bypassing the Coming Soon page.
+ *
+ * Finally, it sets a code in cookie and sets header that prevents robots from indexing.
+ *
+ * @return bool
+ */
+function is_accessed_by_valid_share_link() {
+	if ( isset( $_GET['share'] ) ) {
+		$share_code = $_GET['share'];
+	} elseif ( isset( $_COOKIE['share_code'] ) ) {
+		$share_code = $_COOKIE['share_code'];
+	}
+
+	// @todo validate $share_code value against blog option value
+	if ( '12345' !== $share_code ) {
+		return false;
+	}
+
+	setcookie( 'share_code', $share_code, time() + 3600, '/', false, is_ssl() );
+	header( 'X-Robots-Tag: noindex, nofollow' );
+
+	return true;
 }
 
 /**

--- a/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/coming-soon.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/coming-soon.php
@@ -19,6 +19,7 @@ function should_show_coming_soon_page() {
 
 	$share_code = get_share_code();
 	if ( is_accessed_by_valid_share_link( $share_code ) ) {
+		track_preview_link_event();
 		setcookie( 'wp_share_code', $share_code, time() + 3600, '/', false, is_ssl() );
 		return false;
 	}
@@ -91,6 +92,21 @@ function maybe_add_x_robots_headers( $headers ) {
 	return $headers;
 }
 add_filter( 'wp_headers', __NAMESPACE__ . '\maybe_add_x_robots_headers' );
+
+/**
+ * Track site preview event.
+ *
+ * @return void
+ */
+function track_preview_link_event() {
+	$event_name = 'wpcom_site_previewed';
+	if ( function_exists( 'wpcomsh_record_tracks_event' ) ) {
+		wpcomsh_record_tracks_event( $event_name, array() );
+	} else {
+		require_lib( 'tracks/client' );
+		tracks_record_event( get_current_user_id(), $event_name, array() );
+	}
+}
 
 /**
  * Renders a fallback coming soon page

--- a/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/coming-soon.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/coming-soon.php
@@ -51,10 +51,17 @@ function is_accessed_by_valid_share_link() {
 		$share_code = $_GET['share']; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 	} elseif ( isset( $_COOKIE['share_code'] ) ) {
 		$share_code = $_COOKIE['share_code'];
+	} else {
+		$share_code = '';
 	}
 
-	// @todo validate $share_code value against blog option value
-	if ( '12345' !== $share_code ) {
+	$preview_links_option = get_option( 'wpcom_public_preview_links' );
+
+	if ( ! is_array( $preview_links_option ) || ! count( $preview_links_option ) || ! $share_code ) {
+		return false;
+	}
+
+	if ( ! in_array( $share_code, array_column( $preview_links_option, 'code' ), true ) ) {
 		return false;
 	}
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/coming-soon.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/coming-soon.php
@@ -19,7 +19,7 @@ function should_show_coming_soon_page() {
 
 	$share_code = get_share_code();
 	if ( is_accessed_by_valid_share_link( $share_code ) ) {
-		setcookie( 'share_code', $share_code, time() + 3600, '/', false, is_ssl() );
+		setcookie( 'wp_share_code', $share_code, time() + 3600, '/', false, is_ssl() );
 		header( 'X-Robots-Tag: noindex, nofollow' );
 		return false;
 	}
@@ -46,8 +46,8 @@ function should_show_coming_soon_page() {
 function get_share_code() {
 	if ( isset( $_GET['share'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		return $_GET['share']; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-	} elseif ( isset( $_COOKIE['share_code'] ) ) {
-		return $_COOKIE['share_code'];
+	} elseif ( isset( $_COOKIE['wp_share_code'] ) ) {
+		return $_COOKIE['wp_share_code'];
 	}
 	return '';
 }

--- a/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/coming-soon.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/coming-soon.php
@@ -20,7 +20,6 @@ function should_show_coming_soon_page() {
 	$share_code = get_share_code();
 	if ( is_accessed_by_valid_share_link( $share_code ) ) {
 		setcookie( 'wp_share_code', $share_code, time() + 3600, '/', false, is_ssl() );
-		header( 'X-Robots-Tag: noindex, nofollow' );
 		return false;
 	}
 
@@ -78,6 +77,20 @@ function is_accessed_by_valid_share_link( $share_code ) {
 
 	return true;
 }
+
+/**
+ * Add X-Robots-Tag header to prevent from indexing page that includes share code.
+ *
+ * @param array $headers Headers.
+ * @return array Headers.
+ */
+function maybe_add_x_robots_headers( $headers ) {
+	if ( get_share_code() ) {
+		$headers['X-Robots-Tag'] = 'noindex, nofollow';
+	}
+	return $headers;
+}
+add_filter( 'wp_headers', __NAMESPACE__ . '\maybe_add_x_robots_headers' );
 
 /**
  * Renders a fallback coming soon page

--- a/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/coming-soon.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/coming-soon.php
@@ -47,8 +47,8 @@ function should_show_coming_soon_page() {
  * @return bool
  */
 function is_accessed_by_valid_share_link() {
-	if ( isset( $_GET['share'] ) ) {
-		$share_code = $_GET['share'];
+	if ( isset( $_GET['share'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$share_code = $_GET['share']; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 	} elseif ( isset( $_COOKIE['share_code'] ) ) {
 		$share_code = $_COOKIE['share_code'];
 	}

--- a/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/test/class-coming-soon-test.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/test/class-coming-soon-test.php
@@ -40,6 +40,7 @@ class Coming_Soon_Test extends TestCase {
 	 */
 	public function tearDown() {
 		self::delete_preview_links_parameters();
+		parent::tearDown();
 	}
 
 	/**

--- a/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/test/class-coming-soon-test.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/test/class-coming-soon-test.php
@@ -63,7 +63,7 @@ class Coming_Soon_Test extends TestCase {
 	 * Mock valid share code COOKIE request
 	 */
 	private static function set_valid_share_code_cookie_parameter() {
-		$_COOKIE['share_code'] = self::$preview_links[0]['code'];
+		$_COOKIE['wp_share_code'] = self::$preview_links[0]['code'];
 	}
 
 	/**
@@ -71,7 +71,7 @@ class Coming_Soon_Test extends TestCase {
 	 */
 	private static function delete_preview_links_parameters() {
 		unset( $_GET['share'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		unset( $_COOKIE['share_code'] );
+		unset( $_COOKIE['wp_share_code'] );
 	}
 
 	/**

--- a/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/test/class-coming-soon-test.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/test/class-coming-soon-test.php
@@ -36,6 +36,13 @@ class Coming_Soon_Test extends TestCase {
 	}
 
 	/**
+	 * Post-test actions.
+	 */
+	public function tearDown() {
+		self::delete_preview_links_parameters();
+	}
+
+	/**
 	 * Add coming soon options.
 	 */
 	private static function set_site_as_coming_soon() {
@@ -228,8 +235,6 @@ class Coming_Soon_Test extends TestCase {
 		$share_code = get_share_code();
 
 		$this->assertEquals( 'sharing-code', $share_code );
-
-		self::delete_preview_links_parameters();
 	}
 
 	/**
@@ -243,8 +248,6 @@ class Coming_Soon_Test extends TestCase {
 		$share_code = get_share_code();
 
 		$this->assertEquals( 'sharing-code', $share_code );
-
-		self::delete_preview_links_parameters();
 	}
 
 	/**


### PR DESCRIPTION
#### Proposed Changes

In this PR, I propose to add support for the Share Site links that allow bypassing the Coming Soon page.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
 
##### Simple site

1. Prepare a Coming Soon site and sandbox it
2. Get ETK from this PR deployed on the WPCOM sandbox, e.g.:

```
cd wp-calypso/
cd apps/editing-toolkit
yarn dev --sync
```

3. Use steps from D92828-code to set preview link for a Simple site, note the output
4. Try accessing the site in an incognito session, and confirm it serves the Coming Soon page
5. Access the site using the URL with appended code, e.g.:
https://SITE_SLUG.wordpress.com/?share=SHARE_CODE
6. Confirm that Coming Soon is not displayed anymore
7. Navigate through pages and confirm that they can be accessed
8. Remove `share_code` cookie to see Coming Soon again

##### Atomic site

1. Prepare an Atomic dev site
2. Get ETK from this PR deployed on the Atomic site, e.g.:

- Pack `editing-toolkit-plugin/` directory
- Disable and remove managed ETK plugin
- Upload the new one to the Atomic dev site and activate it
- disable auto-udpates for the plugin

3. Apply D92828-code on the WPCOM sandbox, and use steps from this diff to deploy `wpcomsh` and to set a preview link for an Atomic site, note the output
4. Try accessing the site in an incognito session, and confirm it serves the Coming Soon page
5. Access the site using the URL with appended code, e.g.:
https://SITE_SLUG.wpcomstaging.com/?share=SHARE_CODE
6. Confirm that Coming Soon is not displayed anymore
7. Navigate through pages and confirm that they can be accessed
8. Remove `share_code` cookie to see Coming Soon again

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1190-gh-Automattic/dotcom-forge