### PR TITLE
Partner Portal: fix error scenario during the issue license flow

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/hooks.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/hooks.tsx
@@ -379,12 +379,16 @@ export function useIssueMultipleLicenses(
 		} );
 		const issueLicensePromises: any[] = await Promise.allSettled( issueLicenseRequests );
 
+		const issuedLicenses = issueLicensePromises.filter( ( { status } ) => status === 'fulfilled' );
+
+		if ( ! issuedLicenses.length ) {
+			return;
+		}
+
 		if ( ! selectedSiteId ) {
 			let nextStep = partnerPortalBasePath( '/licenses' );
 			if ( sites > 0 ) {
-				const licenseKeys = issueLicensePromises
-					.filter( ( { status } ) => status === 'fulfilled' )
-					.map( ( { value } ) => value.license_key );
+				const licenseKeys = issuedLicenses.map( ( { value } ) => value.license_key );
 				nextStep = addQueryArgs(
 					{
 						products: licenseKeys.join( ',' ),
@@ -464,20 +468,18 @@ export function useIssueMultipleLicenses(
 
 		const assignedProducts: Array< any > = [];
 
-		issueLicensePromises.forEach( ( promise: any ) => {
-			const { status, value: license } = promise;
-			if ( status === 'fulfilled' ) {
-				const licenseKey = license.license_key;
-				const productSlug = licenseKey.split( '_' )[ 0 ];
-				const selectedProduct = products?.data?.find( ( p ) => p.slug === productSlug );
-				if ( selectedProduct ) {
-					assignedProducts.push( getProductTitle( selectedProduct.name ) );
-				}
-				if ( selectedSiteId ) {
-					assignLicenseRequests.push(
-						assignLicense.mutateAsync( { licenseKey, selectedSite: selectedSiteId } )
-					);
-				}
+		issuedLicenses.forEach( ( promise: any ) => {
+			const { value: license } = promise;
+			const licenseKey = license.license_key;
+			const productSlug = licenseKey.split( '_' )[ 0 ];
+			const selectedProduct = products?.data?.find( ( p ) => p.slug === productSlug );
+			if ( selectedProduct ) {
+				assignedProducts.push( getProductTitle( selectedProduct.name ) );
+			}
+			if ( selectedSiteId ) {
+				assignLicenseRequests.push(
+					assignLicense.mutateAsync( { licenseKey, selectedSite: selectedSiteId } )
+				);
 			}
 		} );
 


### PR DESCRIPTION
#### Proposed Changes

This PR fixes an issue with issue license flow, where it shows a success notification even when the request fails.

#### Testing Instructions

1. Run `git checkout fix/issue-license-error-scenario` and `yarn start-jetpack-cloud`
2. Go to **[issue-license](http://jetpack.cloud.localhost:3001/partner-portal/issue-license)** page -> Select a license(s) -> Open the dev tool, click on the network tab and set the network to offline so that the request fails -> Click on **Select License** -> Verify that an error message is shown and you are not redirected to the assign-license page.

<img width="1368" alt="Screenshot 2022-11-17 at 6 29 47 PM" src="https://user-images.githubusercontent.com/10586875/202453172-49d340d0-a47e-46b9-b7d8-947af2b3dd4c.png">

3. Set the network to default or close the dev tool -> Select a license(s) -> Click on **Select License**  -> Verify that it is being issued and you are redirected to the assign license page. Assigning a license won't work since it is [WIP](https://github.com/Automattic/wp-calypso/pull/69873)

<img width="1373" alt="Screenshot 2022-11-17 at 6 30 18 PM" src="https://user-images.githubusercontent.com/10586875/202453206-4a206b7a-6870-4912-bc0a-b98647675fbc.png">

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1203126240279377-as-1203377005312982