### PR TITLE
BBE : WebsiteContent : cosmetic fixes for the form

### DIFF
--- a/client/signup/accordion-form/accordion-form-section.tsx
+++ b/client/signup/accordion-form/accordion-form-section.tsx
@@ -91,7 +91,8 @@ const SummaryLabel = styled( RequiredLabel )`
 const NextButton = styled( Button )`
 	box-shadow: 0px 1px 2px rgba( 0, 0, 0, 0.05 );
 	border-radius: 5px;
-	padding: 10px 64px;
+	padding: 10px 50px;
+	width: 177px;
 	.gridicon {
 		margin-left: 10px;
 	}

--- a/client/signup/accordion-form/form-components.tsx
+++ b/client/signup/accordion-form/form-components.tsx
@@ -3,20 +3,23 @@ import styled from '@emotion/styled';
 import { TranslateResult, useTranslate } from 'i18n-calypso';
 import { ChangeEvent } from 'react';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
-import FormLabel from 'calypso/components/forms/form-label';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import FormTextArea from 'calypso/components/forms/form-textarea';
 import SocialLogo from 'calypso/components/social-logo';
 
 // TODO: This probably should be moved out to a more suitable folder name like difm-components
-export const Label = styled( FormLabel )`
+export const Label = styled.label`
 	color: var( --studio-gray-50 );
-	font-weight: 500;
+	font-weight: 400;
+	font-size: 0.875rem;
 	cursor: inherit;
-	margin-bottom: 24px;
 `;
 
-export const SubLabel = styled( Label )`
+export const LabelContainer = styled.div`
+	margin-bottom: 12px;
+`;
+
+export const SubLabel = styled.label`
 	font-weight: 400;
 	text-decoration-line: none;
 	color: ${ ( props ) => ( props.color ? props.color : 'inherited' ) };
@@ -90,10 +93,24 @@ interface TextInputFieldProps {
 	onChange?: ( event: ChangeEvent< HTMLInputElement > ) => void;
 }
 
+export function TextInputLabel( {
+	inputName,
+	labelText,
+}: {
+	inputName?: string;
+	labelText?: TranslateResult;
+} ) {
+	return (
+		<LabelContainer>
+			<Label htmlFor={ inputName }>{ labelText }</Label>
+		</LabelContainer>
+	);
+}
+
 export function TextInputField( props: TextInputFieldProps ) {
 	return (
 		<FormFieldset>
-			<Label htmlFor={ props.name }>{ props.label }</Label>
+			<TextInputLabel inputName={ props.name } labelText={ props.label } />
 			{ props.sublabel && <SubLabel htmlFor={ props.name }>{ props.sublabel }</SubLabel> }
 			<TextInput { ...props } isError={ !! props.error } />
 			{ props.error && <FormInputValidation isError text={ props.error } /> }
@@ -108,7 +125,7 @@ interface TextAreaFieldProps extends TextInputFieldProps {
 export function TextAreaField( props: TextAreaFieldProps ) {
 	return (
 		<FormFieldset>
-			<Label htmlFor={ props.name }>{ props.label }</Label>
+			<TextInputLabel inputName={ props.name } labelText={ props.label } />
 			{ props.sublabel && <SubLabel htmlFor={ props.name }>{ props.sublabel }</SubLabel> }
 			<TextArea
 				{ ...props }

--- a/client/signup/accordion-form/form-components.tsx
+++ b/client/signup/accordion-form/form-components.tsx
@@ -15,6 +15,11 @@ export const Label = styled.label`
 	cursor: inherit;
 `;
 
+export const LabelLink = styled( Label )`
+	text-decoration: underline;
+	font-weight: bold;
+`;
+
 export const LabelContainer = styled.div`
 	margin-bottom: 12px;
 `;

--- a/client/signup/accordion-form/form-components.tsx
+++ b/client/signup/accordion-form/form-components.tsx
@@ -1,7 +1,7 @@
 import { FormInputValidation } from '@automattic/components';
 import styled from '@emotion/styled';
 import { TranslateResult, useTranslate } from 'i18n-calypso';
-import { ChangeEvent } from 'react';
+import { ChangeEvent, ReactChild } from 'react';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import FormTextArea from 'calypso/components/forms/form-textarea';
@@ -98,16 +98,16 @@ interface TextInputFieldProps {
 	onChange?: ( event: ChangeEvent< HTMLInputElement > ) => void;
 }
 
-export function TextInputLabel( {
+export function LabelBlock( {
 	inputName,
-	labelText,
+	children,
 }: {
 	inputName?: string;
-	labelText?: TranslateResult;
+	children: ReactChild | ReactChild[];
 } ) {
 	return (
 		<LabelContainer>
-			<Label htmlFor={ inputName }>{ labelText }</Label>
+			<Label htmlFor={ inputName }>{ children }</Label>
 		</LabelContainer>
 	);
 }
@@ -115,7 +115,7 @@ export function TextInputLabel( {
 export function TextInputField( props: TextInputFieldProps ) {
 	return (
 		<FormFieldset>
-			<TextInputLabel inputName={ props.name } labelText={ props.label } />
+			{ props.label && <LabelBlock inputName={ props.name }>{ props.label } </LabelBlock> }
 			{ props.sublabel && <SubLabel htmlFor={ props.name }>{ props.sublabel }</SubLabel> }
 			<TextInput { ...props } isError={ !! props.error } />
 			{ props.error && <FormInputValidation isError text={ props.error } /> }
@@ -130,7 +130,7 @@ interface TextAreaFieldProps extends TextInputFieldProps {
 export function TextAreaField( props: TextAreaFieldProps ) {
 	return (
 		<FormFieldset>
-			<TextInputLabel inputName={ props.name } labelText={ props.label } />
+			{ props.label && <LabelBlock inputName={ props.name }>{ props.label } </LabelBlock> }
 			{ props.sublabel && <SubLabel htmlFor={ props.name }>{ props.sublabel }</SubLabel> }
 			<TextArea
 				{ ...props }

--- a/client/signup/steps/website-content/section-types/contact-page-details.tsx
+++ b/client/signup/steps/website-content/section-types/contact-page-details.tsx
@@ -2,10 +2,10 @@ import { useTranslate } from 'i18n-calypso';
 import { ChangeEvent } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import {
-	Label,
 	TextAreaField,
 	HorizontalGrid,
 	ContactInformation,
+	TextInputLabel,
 } from 'calypso/signup/accordion-form/form-components';
 import {
 	BBE_WEBSITE_CONTENT_FILLING_STEP,
@@ -126,11 +126,15 @@ export function ContactPageDetails( {
 				} }
 				onChange={ onFieldChanged }
 			/>
-			<Label>
-				{ translate( 'Upload up to %(noOfImages)d images to be used on your %(pageTitle)s page.', {
-					args: { pageTitle, noOfImages: page.media.length },
-				} ) }
-			</Label>
+
+			<TextInputLabel
+				labelText={ translate(
+					'Upload up to %(noOfImages)d images to be used on your %(pageTitle)s page.',
+					{
+						args: { pageTitle, noOfImages: page.media.length },
+					}
+				) }
+			/>
 			<HorizontalGrid>
 				{ page.media.map( ( media, i ) => (
 					<WordpressMediaUpload

--- a/client/signup/steps/website-content/section-types/contact-page-details.tsx
+++ b/client/signup/steps/website-content/section-types/contact-page-details.tsx
@@ -5,7 +5,7 @@ import {
 	TextAreaField,
 	HorizontalGrid,
 	ContactInformation,
-	TextInputLabel,
+	LabelBlock,
 } from 'calypso/signup/accordion-form/form-components';
 import {
 	BBE_WEBSITE_CONTENT_FILLING_STEP,
@@ -127,14 +127,11 @@ export function ContactPageDetails( {
 				onChange={ onFieldChanged }
 			/>
 
-			<TextInputLabel
-				labelText={ translate(
-					'Upload up to %(noOfImages)d images to be used on your %(pageTitle)s page.',
-					{
-						args: { pageTitle, noOfImages: page.media.length },
-					}
-				) }
-			/>
+			<LabelBlock>
+				{ translate( 'Upload up to %(noOfImages)d images to be used on your %(pageTitle)s page.', {
+					args: { pageTitle, noOfImages: page.media.length },
+				} ) }
+			</LabelBlock>
 			<HorizontalGrid>
 				{ page.media.map( ( media, i ) => (
 					<WordpressMediaUpload

--- a/client/signup/steps/website-content/section-types/default-page-details.tsx
+++ b/client/signup/steps/website-content/section-types/default-page-details.tsx
@@ -2,9 +2,9 @@ import { useTranslate } from 'i18n-calypso';
 import { ChangeEvent } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import {
-	Label,
 	TextAreaField,
 	HorizontalGrid,
+	TextInputLabel,
 } from 'calypso/signup/accordion-form/form-components';
 import { ValidationErrors } from 'calypso/signup/accordion-form/types';
 import {
@@ -135,7 +135,7 @@ export function DefaultPageDetails( {
 				error={ formErrors[ fieldName ] }
 				label={ description }
 			/>
-			<Label>{ getMediaCaption() }</Label>
+			<TextInputLabel>{ getMediaCaption() }</TextInputLabel>
 			<HorizontalGrid>
 				{ page.media.map( ( media, i ) => (
 					<WordpressMediaUpload

--- a/client/signup/steps/website-content/section-types/default-page-details.tsx
+++ b/client/signup/steps/website-content/section-types/default-page-details.tsx
@@ -4,7 +4,7 @@ import { useSelector, useDispatch } from 'react-redux';
 import {
 	TextAreaField,
 	HorizontalGrid,
-	TextInputLabel,
+	LabelBlock,
 } from 'calypso/signup/accordion-form/form-components';
 import { ValidationErrors } from 'calypso/signup/accordion-form/types';
 import {
@@ -120,8 +120,8 @@ export function DefaultPageDetails( {
 			case 'VIDEO':
 				return videoCaption;
 			case 'IMAGE':
-				return imageCaption;
 			default:
+				return imageCaption;
 				break;
 		}
 	};
@@ -135,7 +135,7 @@ export function DefaultPageDetails( {
 				error={ formErrors[ fieldName ] }
 				label={ description }
 			/>
-			<TextInputLabel>{ getMediaCaption() }</TextInputLabel>
+			<LabelBlock>{ getMediaCaption() }</LabelBlock>
 			<HorizontalGrid>
 				{ page.media.map( ( media, i ) => (
 					<WordpressMediaUpload

--- a/client/signup/steps/website-content/section-types/feedback-section.tsx
+++ b/client/signup/steps/website-content/section-types/feedback-section.tsx
@@ -1,7 +1,7 @@
 import { useTranslate } from 'i18n-calypso';
 import { ChangeEvent } from 'react';
 import { useDispatch } from 'react-redux';
-import { TextAreaField, Label } from 'calypso/signup/accordion-form/form-components';
+import { TextAreaField, TextInputLabel } from 'calypso/signup/accordion-form/form-components';
 import { updateFeedback } from 'calypso/state/signup/steps/website-content/actions';
 import type { WebsiteContent } from 'calypso/state/signup/steps/website-content/schema';
 export function FeedbackSection( {
@@ -32,9 +32,11 @@ export function FeedbackSection( {
 					'Optional: Is there anything else you would like the site builder to know?'
 				) }
 			/>
-			<Label>
-				{ translate( 'Click Submit when you are finished providing content for all pages.' ) }
-			</Label>
+			<TextInputLabel
+				labelText={ translate(
+					'Click Submit when you are finished providing content for all pages.'
+				) }
+			/>
 		</>
 	);
 }

--- a/client/signup/steps/website-content/section-types/feedback-section.tsx
+++ b/client/signup/steps/website-content/section-types/feedback-section.tsx
@@ -1,7 +1,7 @@
 import { useTranslate } from 'i18n-calypso';
 import { ChangeEvent } from 'react';
 import { useDispatch } from 'react-redux';
-import { TextAreaField, TextInputLabel } from 'calypso/signup/accordion-form/form-components';
+import { TextAreaField, LabelBlock } from 'calypso/signup/accordion-form/form-components';
 import { updateFeedback } from 'calypso/state/signup/steps/website-content/actions';
 import type { WebsiteContent } from 'calypso/state/signup/steps/website-content/schema';
 export function FeedbackSection( {
@@ -32,11 +32,9 @@ export function FeedbackSection( {
 					'Optional: Is there anything else you would like the site builder to know?'
 				) }
 			/>
-			<TextInputLabel
-				labelText={ translate(
-					'Click Submit when you are finished providing content for all pages.'
-				) }
-			/>
+			<LabelBlock>
+				{ translate( 'Click Submit when you are finished providing content for all pages.' ) }
+			</LabelBlock>
 		</>
 	);
 }

--- a/client/signup/steps/website-content/section-types/logo-upload-section.tsx
+++ b/client/signup/steps/website-content/section-types/logo-upload-section.tsx
@@ -2,7 +2,7 @@ import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import { ChangeEvent } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
-import { Label, HorizontalGrid } from 'calypso/signup/accordion-form/form-components';
+import { HorizontalGrid, TextInputLabel } from 'calypso/signup/accordion-form/form-components';
 import {
 	MediaUploadData,
 	WordpressMediaUpload,
@@ -48,9 +48,11 @@ export function LogoUploadSection( {
 
 	return (
 		<LogoUploadSectionContainer>
-			<Label>
-				{ translate( 'Upload a logo for your website, transparent backgrounds work best.' ) }
-			</Label>
+			<TextInputLabel
+				labelText={ translate(
+					'Upload a logo for your website, transparent backgrounds work best.'
+				) }
+			/>
 			<HorizontalGrid>
 				<WordpressMediaUpload
 					media={ { mediaType: 'IMAGE', url: logoUrl } }

--- a/client/signup/steps/website-content/section-types/logo-upload-section.tsx
+++ b/client/signup/steps/website-content/section-types/logo-upload-section.tsx
@@ -2,7 +2,7 @@ import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import { ChangeEvent } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
-import { HorizontalGrid, TextInputLabel } from 'calypso/signup/accordion-form/form-components';
+import { HorizontalGrid, LabelBlock } from 'calypso/signup/accordion-form/form-components';
 import {
 	MediaUploadData,
 	WordpressMediaUpload,
@@ -48,11 +48,9 @@ export function LogoUploadSection( {
 
 	return (
 		<LogoUploadSectionContainer>
-			<TextInputLabel
-				labelText={ translate(
-					'Upload a logo for your website, transparent backgrounds work best.'
-				) }
-			/>
+			<LabelBlock>
+				{ translate( 'Upload a logo for your website, transparent backgrounds work best.' ) }
+			</LabelBlock>
 			<HorizontalGrid>
 				<WordpressMediaUpload
 					media={ { mediaType: 'IMAGE', url: logoUrl } }

--- a/client/signup/steps/website-content/wordpress-media-upload.tsx
+++ b/client/signup/steps/website-content/wordpress-media-upload.tsx
@@ -6,7 +6,7 @@ import { useTranslate } from 'i18n-calypso';
 import { ChangeEvent, MouseEvent, useState } from 'react';
 import { useAddMedia } from 'calypso/data/media/use-add-media';
 import { logToLogstash } from 'calypso/lib/logstash';
-import { Label, LabelLink, SubLabel } from 'calypso/signup/accordion-form/form-components';
+import { LabelLink, SubLabel } from 'calypso/signup/accordion-form/form-components';
 import { Media, MediaUploadType } from 'calypso/state/signup/steps/website-content/schema';
 import type { SiteDetails } from '@automattic/data-stores';
 

--- a/client/signup/steps/website-content/wordpress-media-upload.tsx
+++ b/client/signup/steps/website-content/wordpress-media-upload.tsx
@@ -6,7 +6,7 @@ import { useTranslate } from 'i18n-calypso';
 import { ChangeEvent, MouseEvent, useState } from 'react';
 import { useAddMedia } from 'calypso/data/media/use-add-media';
 import { logToLogstash } from 'calypso/lib/logstash';
-import { Label, SubLabel } from 'calypso/signup/accordion-form/form-components';
+import { Label, LabelLink, SubLabel } from 'calypso/signup/accordion-form/form-components';
 import { Media, MediaUploadType } from 'calypso/state/signup/steps/website-content/schema';
 import type { SiteDetails } from '@automattic/data-stores';
 
@@ -215,7 +215,7 @@ export function WordpressMediaUpload( {
 							/>
 						</CroppedImage>
 						{ mediaType === 'VIDEO' && <CroppedLabel>{ caption }</CroppedLabel> }
-						<Label>{ translate( 'Replace' ) }</Label>
+						<LabelLink>{ translate( 'Replace' ) }</LabelLink>
 					</FileSelectThumbnailContainer>
 				</>
 			);
@@ -231,7 +231,7 @@ export function WordpressMediaUpload( {
 					<FileSelectThumbnailContainer>
 						<FileInput type="file" onChange={ onPick } accept={ allowedFileTypesString } />
 						<MediaPlaceholder mediaType={ mediaType } />
-						<Label>{ translate( 'Choose file' ) }</Label>
+						<LabelLink>{ translate( 'Choose file' ) }</LabelLink>
 						<SubLabel color="red">{ translate( 'Image upload failed' ) }</SubLabel>
 					</FileSelectThumbnailContainer>
 				</>
@@ -244,7 +244,7 @@ export function WordpressMediaUpload( {
 					<FileSelectThumbnailContainer>
 						<FileInput type="file" onChange={ onPick } accept={ allowedFileTypesString } />
 						<MediaPlaceholder mediaType={ mediaType } />
-						<Label>{ translate( 'Choose file' ) }</Label>
+						<LabelLink>{ translate( 'Choose file' ) }</LabelLink>
 						{ /* <SubLabel>{ translate( 'or drag here')}</SubLabel> */ }
 					</FileSelectThumbnailContainer>
 				</>


### PR DESCRIPTION
### Proposed Changes
* The styles from existing components seem to be unpredictably overriding the style-component style. So there seem to be glitches appearing on the form - p1667396355239569/1667381030.756159-slack-C028NRBP2AU. So these components were shifted to native elements.
* ![image](https://user-images.githubusercontent.com/3422709/202634502-096e44a7-8f0d-42dc-a974-ee3593a6c2df.png)
* Fixes margin bottom, font weight, button width


### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go through DIFM flow
* Purchase DIFM
* On the website content page the UI should look like below
<img width="1482" alt="image" src="https://user-images.githubusercontent.com/3422709/202637466-b673578f-968b-40a4-91e4-f9939fabbc6f.png">

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes Automattic/martech#1228