### PR TITLE
Enable Zendesk pre-sales chat in Checkout

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/checkout-help-link.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-help-link.tsx
@@ -175,7 +175,8 @@ export default function CheckoutHelpLink() {
 	};
 
 	const zendeskPresalesChatKey: string | false = config( 'zendesk_presales_chat_key' );
-	const isPresalesZendeskChatEligible = presalesZendeskChatAvailable && isEnglishLocale && zendeskPresalesChatKey;
+	const isPresalesZendeskChatEligible =
+		presalesZendeskChatAvailable && isEnglishLocale && zendeskPresalesChatKey;
 
 	const hasDirectSupport = supportVariation !== SUPPORT_FORUM;
 

--- a/client/my-sites/checkout/composite-checkout/components/checkout-help-link.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-help-link.tsx
@@ -9,8 +9,8 @@ import { useDispatch as useDataStoreDispatch } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector, useDispatch } from 'react-redux';
 import QuerySupportTypes from 'calypso/blocks/inline-help/inline-help-query-support-types';
+import AsyncLoad from 'calypso/components/async-load';
 import HappychatButtonUnstyled from 'calypso/components/happychat/button';
-import ZendeskChat from 'calypso/components/zendesk-chat-widget';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import getSupportLevel from 'calypso/state/happychat/selectors/get-support-level';
@@ -185,7 +185,10 @@ export default function CheckoutHelpLink() {
 			<QuerySupportTypes />
 			{ ! isPresalesZendeskChatEligible && ! supportVariationDetermined && <LoadingButton /> }
 			{ isPresalesZendeskChatEligible ? (
-				<ZendeskChat chatId={ zendeskPresalesChatKey } />
+				<AsyncLoad
+					require="calypso/components/zendesk-chat-widget"
+					chatKey={ zendeskPresalesChatKey }
+				/>
 			) : (
 				supportVariationDetermined && (
 					<CheckoutSummaryHelpButton onClick={ handleHelpButtonClicked }>

--- a/client/my-sites/checkout/composite-checkout/components/checkout-help-link.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-help-link.tsx
@@ -175,7 +175,7 @@ export default function CheckoutHelpLink() {
 	};
 
 	const zendeskPresalesChatKey: string | false = config( 'zendesk_presales_chat_key' );
-	const isPresalesZendeskChatEligible = presalesZendeskChatAvailable && isEnglishLocale;
+	const isPresalesZendeskChatEligible = presalesZendeskChatAvailable && isEnglishLocale && zendeskPresalesChatKey;
 
 	const hasDirectSupport = supportVariation !== SUPPORT_FORUM;
 

--- a/client/my-sites/checkout/composite-checkout/components/checkout-help-link.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-help-link.tsx
@@ -186,7 +186,7 @@ export default function CheckoutHelpLink() {
 			{ ! isPresalesZendeskChatEligible && ! supportVariationDetermined && <LoadingButton /> }
 			{ isPresalesZendeskChatEligible ? (
 				<AsyncLoad
-					require="calypso/components/zendesk-chat-widget"
+					require="calypso/components/presales-zendesk-chat"
 					chatKey={ zendeskPresalesChatKey }
 				/>
 			) : (

--- a/client/my-sites/checkout/composite-checkout/components/checkout-help-link.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-help-link.tsx
@@ -1,19 +1,8 @@
 import config from '@automattic/calypso-config';
-import {
-	isWpComBusinessPlan,
-	isWpComEcommercePlan,
-	isWpComPersonalPlan,
-	isWpComPremiumPlan,
-	isPlan,
-} from '@automattic/calypso-products';
 import { Gridicon } from '@automattic/components';
 import { HelpCenter } from '@automattic/data-stores';
-import {
-	SUPPORT_HAPPYCHAT,
-	SUPPORT_FORUM,
-	shouldShowHelpCenterToUser,
-} from '@automattic/help-center';
-import { useShoppingCart } from '@automattic/shopping-cart';
+import { SUPPORT_FORUM, shouldShowHelpCenterToUser } from '@automattic/help-center';
+import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import { keyframes } from '@emotion/react';
 import styled from '@emotion/styled';
 import { useDispatch as useDataStoreDispatch } from '@wordpress/data';
@@ -21,18 +10,16 @@ import { useTranslate } from 'i18n-calypso';
 import { useSelector, useDispatch } from 'react-redux';
 import QuerySupportTypes from 'calypso/blocks/inline-help/inline-help-query-support-types';
 import HappychatButtonUnstyled from 'calypso/components/happychat/button';
-import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
+import ZendeskChat from 'calypso/components/zendesk-chat-widget';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import getSupportLevel from 'calypso/state/happychat/selectors/get-support-level';
-import isHappychatAvailable from 'calypso/state/happychat/selectors/is-happychat-available';
-import isPresalesChatAvailable from 'calypso/state/happychat/selectors/is-presales-chat-available';
+import isPresalesZendeskChatAvailable from 'calypso/state/happychat/selectors/is-presales-zendesk-chat-available';
 import { showInlineHelpPopover } from 'calypso/state/inline-help/actions';
 import getSupportVariation from 'calypso/state/selectors/get-inline-help-support-variation';
 import isSupportVariationDetermined from 'calypso/state/selectors/is-support-variation-determined';
 import { getSectionName } from 'calypso/state/ui/selectors';
 import type { Theme } from '@automattic/composite-checkout';
-import type { ResponseCartProduct } from '@automattic/shopping-cart';
 
 const HELP_CENTER_STORE = HelpCenter.register();
 
@@ -152,30 +139,24 @@ const LoadingButton = styled.p< StyledProps >`
 export default function CheckoutHelpLink() {
 	const reduxDispatch = useDispatch();
 	const translate = useTranslate();
-	const cartKey = useCartKey();
-	const { responseCart } = useShoppingCart( cartKey );
-	const plans = responseCart.products.filter( ( product ) => isPlan( product ) );
 	const { setShowHelpCenter } = useDataStoreDispatch( HELP_CENTER_STORE );
+	const isEnglishLocale = useIsEnglishLocale();
 
 	const {
-		happyChatAvailable,
-		presalesChatAvailable,
+		presalesZendeskChatAvailable,
 		section,
 		userId,
 		supportVariationDetermined,
 		supportVariation,
 	} = useSelector( ( state ) => {
 		return {
-			happyChatAvailable: isHappychatAvailable( state ),
-			presalesChatAvailable: isPresalesChatAvailable( state ),
+			presalesZendeskChatAvailable: isPresalesZendeskChatAvailable( state ),
 			section: getSectionName( state ),
 			userId: getCurrentUserId( state ),
 			supportVariationDetermined: isSupportVariationDetermined( state ),
 			supportVariation: getSupportVariation( state ),
 		};
 	} );
-	const presalesEligiblePlanLabel = getHighestWpComPlanLabel( plans );
-	const isPresalesChatEligible = presalesChatAvailable && presalesEligiblePlanLabel;
 
 	const userAllowedToHelpCenter = !! (
 		userId &&
@@ -193,22 +174,18 @@ export default function CheckoutHelpLink() {
 		);
 	};
 
-	// If chat is available and the cart has a pre-sales plan or is already eligible for chat.
-	const shouldRenderPaymentChatButton =
-		happyChatAvailable && ( isPresalesChatEligible || supportVariation === SUPPORT_HAPPYCHAT );
+	const zendeskPresalesChatKey: string | false = config( 'zendesk_presales_chat_key' );
+	const isPresalesZendeskChatEligible = presalesZendeskChatAvailable && isEnglishLocale;
 
 	const hasDirectSupport = supportVariation !== SUPPORT_FORUM;
 
-	// If chat isn't available, use the inline help button instead.
+	// If pre-sales chat isn't available, use the inline help button instead.
 	return (
 		<CheckoutHelpLinkWrapper>
 			<QuerySupportTypes />
-			{ ! shouldRenderPaymentChatButton && ! supportVariationDetermined && <LoadingButton /> }
-			{ shouldRenderPaymentChatButton ? (
-				<PaymentChatButton
-					plan={ presalesEligiblePlanLabel }
-					openHelpCenter={ userAllowedToHelpCenter }
-				/>
+			{ ! isPresalesZendeskChatEligible && ! supportVariationDetermined && <LoadingButton /> }
+			{ isPresalesZendeskChatEligible ? (
+				<ZendeskChat chatId={ zendeskPresalesChatKey } />
 			) : (
 				supportVariationDetermined && (
 					<CheckoutSummaryHelpButton onClick={ handleHelpButtonClicked }>
@@ -231,20 +208,4 @@ export default function CheckoutHelpLink() {
 			) }
 		</CheckoutHelpLinkWrapper>
 	);
-}
-
-function getHighestWpComPlanLabel( plans: ResponseCartProduct[] ) {
-	const planMatchersInOrder = [
-		{ label: 'WordPress.com eCommerce', matcher: isWpComEcommercePlan },
-		{ label: 'WordPress.com Business', matcher: isWpComBusinessPlan },
-		{ label: 'WordPress.com Premium', matcher: isWpComPremiumPlan },
-		{ label: 'WordPress.com Personal', matcher: isWpComPersonalPlan },
-	];
-	for ( const { label, matcher } of planMatchersInOrder ) {
-		for ( const plan of plans ) {
-			if ( matcher( plan.product_slug ) ) {
-				return label;
-			}
-		}
-	}
 }

--- a/client/state/happychat/selectors/is-presales-zendesk-chat-available.js
+++ b/client/state/happychat/selectors/is-presales-zendesk-chat-available.js
@@ -7,5 +7,5 @@ import 'calypso/state/happychat/init';
  * @returns {boolean}        true, when presales_zendesk is available
  */
 export default function isPresalesZendeskChatAvailable( state ) {
-	return state.happychat.user.availability?.presale_zendesk ?? false;
+	return state.happychat?.user?.availability?.presale_zendesk ?? false;
 }

--- a/client/state/happychat/selectors/is-presales-zendesk-chat-available.js
+++ b/client/state/happychat/selectors/is-presales-zendesk-chat-available.js
@@ -7,5 +7,5 @@ import 'calypso/state/happychat/init';
  * @returns {boolean}        true, when presales_zendesk is available
  */
 export default function isPresalesZendeskChatAvailable( state ) {
-	return state.happychat?.user?.availability?.presale_zendesk ?? false;
+	return state.happychat.user.availability?.presale_zendesk ?? false;
 }

--- a/client/state/happychat/selectors/is-presales-zendesk-chat-available.js
+++ b/client/state/happychat/selectors/is-presales-zendesk-chat-available.js
@@ -1,0 +1,11 @@
+import 'calypso/state/happychat/init';
+
+/**
+ * Returns if presales zendesk chat is available.
+ *
+ * @param   {object}  state  Global state tree
+ * @returns {boolean}        true, when presales_zendesk is available
+ */
+export default function isPresalesZendeskChatAvailable( state ) {
+	return state.happychat?.user?.availability?.presale_zendesk ?? false;
+}

--- a/client/state/happychat/selectors/test/is-presales-zendesk-chat-available.js
+++ b/client/state/happychat/selectors/test/is-presales-zendesk-chat-available.js
@@ -1,0 +1,28 @@
+import isPresalesZendeskChatAvailable from '../is-presales-zendesk-chat-available';
+
+describe( '#isPresalesZendeskChatAvailable()', () => {
+	test( 'should return false if presales zendesk chat is not available', () => {
+		const isPresaleZendeskAvailable = isPresalesZendeskChatAvailable( {
+			happychat: {
+				user: {
+					availability: {
+						presale_zendesk: false,
+					},
+				},
+			},
+		} );
+		expect( isPresaleZendeskAvailable ).toBe( false );
+	} );
+	test( 'should return true if presales zendesk chat is available', () => {
+		const isPresaleZendeskAvailable = isPresalesZendeskChatAvailable( {
+			happychat: {
+				user: {
+					availability: {
+						presale_zendesk: true,
+					},
+				},
+			},
+		} );
+		expect( isPresaleZendeskAvailable ).toBe( true );
+	} );
+} );

--- a/config/development.json
+++ b/config/development.json
@@ -24,6 +24,7 @@
 	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
 	"dsp_stripe_pub_key": "pk_live_51LYYzQF53KN4RFN0ePTwefdm7seki4pRuc4a19gPMGUba5mzuosz0IBR0cp4T57FiBgxK911ky0LNwlX2IHbm0SS00uPHEQNBO",
 	"dsp_widget_js_src": "https://widgets.wp.com/promote/widget.js",
+	"zendesk_presales_chat_key": "216bf91d-f10f-4f66-bf65-a0cba220cd38",
 	"features": {
 		"ad-tracking": false,
 		"calypso/help-center": true,

--- a/config/production.json
+++ b/config/production.json
@@ -14,6 +14,7 @@
 	"bilmur_url": "/wp-content/js/bilmur.min.js",
 	"dsp_stripe_pub_key": "pk_live_51LYYzQF53KN4RFN0ePTwefdm7seki4pRuc4a19gPMGUba5mzuosz0IBR0cp4T57FiBgxK911ky0LNwlX2IHbm0SS00uPHEQNBO",
 	"dsp_widget_js_src": "https://widgets.wp.com/promote/widget.js",
+	"zendesk_presales_chat_key": false,
 	"features": {
 		"ad-tracking": true,
 		"bilmur-script": true,

--- a/config/production.json
+++ b/config/production.json
@@ -14,7 +14,7 @@
 	"bilmur_url": "/wp-content/js/bilmur.min.js",
 	"dsp_stripe_pub_key": "pk_live_51LYYzQF53KN4RFN0ePTwefdm7seki4pRuc4a19gPMGUba5mzuosz0IBR0cp4T57FiBgxK911ky0LNwlX2IHbm0SS00uPHEQNBO",
 	"dsp_widget_js_src": "https://widgets.wp.com/promote/widget.js",
-	"zendesk_presales_chat_key": false,
+	"zendesk_presales_chat_key": "216bf91d-f10f-4f66-bf65-a0cba220cd38",
 	"features": {
 		"ad-tracking": true,
 		"bilmur-script": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -12,6 +12,7 @@
 	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
 	"dsp_stripe_pub_key": "pk_live_51LYYzQF53KN4RFN0ePTwefdm7seki4pRuc4a19gPMGUba5mzuosz0IBR0cp4T57FiBgxK911ky0LNwlX2IHbm0SS00uPHEQNBO",
 	"dsp_widget_js_src": "https://widgets.wp.com/promote/widget.js",
+	"zendesk_presales_chat_key": false,
 	"features": {
 		"ad-tracking": false,
 		"calypso/help-center": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -12,7 +12,7 @@
 	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
 	"dsp_stripe_pub_key": "pk_live_51LYYzQF53KN4RFN0ePTwefdm7seki4pRuc4a19gPMGUba5mzuosz0IBR0cp4T57FiBgxK911ky0LNwlX2IHbm0SS00uPHEQNBO",
 	"dsp_widget_js_src": "https://widgets.wp.com/promote/widget.js",
-	"zendesk_presales_chat_key": false,
+	"zendesk_presales_chat_key": "216bf91d-f10f-4f66-bf65-a0cba220cd38",
 	"features": {
 		"ad-tracking": false,
 		"calypso/help-center": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -12,6 +12,7 @@
 	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
 	"dsp_stripe_pub_key": "pk_live_51LYYzQF53KN4RFN0ePTwefdm7seki4pRuc4a19gPMGUba5mzuosz0IBR0cp4T57FiBgxK911ky0LNwlX2IHbm0SS00uPHEQNBO",
 	"dsp_widget_js_src": "https://widgets.wp.com/promote/widget.js",
+	"zendesk_presales_chat_key": false,
 	"features": {
 		"ad-tracking": false,
 		"calypso/help-center": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -12,7 +12,7 @@
 	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
 	"dsp_stripe_pub_key": "pk_live_51LYYzQF53KN4RFN0ePTwefdm7seki4pRuc4a19gPMGUba5mzuosz0IBR0cp4T57FiBgxK911ky0LNwlX2IHbm0SS00uPHEQNBO",
 	"dsp_widget_js_src": "https://widgets.wp.com/promote/widget.js",
-	"zendesk_presales_chat_key": false,
+	"zendesk_presales_chat_key": "216bf91d-f10f-4f66-bf65-a0cba220cd38",
 	"features": {
 		"ad-tracking": false,
 		"calypso/help-center": true,


### PR DESCRIPTION
#### Proposed Changes

* This enables a Zendesk pre-sales chat widget on checkout (availability of the chat is controlled by the wpcom endpoint)
* It replaces the HappyChat-based pre-sales chat. However, HappyChat will still be available to users who typically have access to it when the ZD isn't available, via the `CheckoutSummaryHelpButton` (as before).

Known issue: Once the ZD loaded widget is loaded, it will stay visible, even if we navigate away from the checkout section. That's currently acceptable.

#### Screenshots
**Zendesk Chat widget active:**
<img width="400" alt="Screenshot 2022-11-17 at 13 44 15" src="https://user-images.githubusercontent.com/844866/202473762-1651c357-a7ea-4409-8f68-b99f13441a60.png">

**Zendesk pre-sales chat not available, and user does **not** have chat support level:**
<img width="250" alt="Screenshot 2022-11-17 at 13 43 49" src="https://user-images.githubusercontent.com/844866/202473787-e15557f9-960b-41a2-bf6c-b67dbd33df06.png">

**Zendesk pre-sales chat not available, and user does have access to chat support level:**
<img width="250" alt="Screenshot 2022-11-17 at 13 43 21" src="https://user-images.githubusercontent.com/844866/202473798-cea8f7c8-c616-4463-b8a0-ebe360cd65e7.png">

#### Testing Instructions

Reproduce the states from the above screenshots in checkout:
 - ZD chat available (by overwriting `presalesZendeskChatAvailable` if it returns false)
 - ZD chat not available, while user does have access to chat support (i,e with an existing plan)
 - ZD chat not available, while user does not have access to chat support

#### Pre-merge Checklist

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?


This PR partially replaces #69706 - ZD chat in signup will be added separately. 
