### PR TITLE
Stats: make `is_running_in_jetpack_site` config a feature, not a config item

### DIFF
--- a/apps/stats/filter-json-config-loader.js
+++ b/apps/stats/filter-json-config-loader.js
@@ -4,7 +4,7 @@
  * @param {*} source Content of source file.
  * @returns filtered content of source file.
  */
-export default function loader( source ) {
+module.exports = function ( source ) {
 	const sourceObject = JSON.parse( source );
 	const targetObject = {};
 	const options = this.getOptions();
@@ -15,5 +15,5 @@ export default function loader( source ) {
 		}
 	}
 
-	return `export default ${ JSON.stringify( targetObject ) }`;
-}
+	return JSON.stringify( targetObject );
+};

--- a/apps/stats/src/app.jsx
+++ b/apps/stats/src/app.jsx
@@ -27,9 +27,13 @@ const setLocale = ( dispatch ) => {
 };
 
 async function AppBoot() {
-	// Use feature locks for Calypso production `config/production.json`.
+	// Note: configData hydrated in https://github.com/Automattic/jetpack/blob/d4d0f987cbf63a864b03b542b7813aabe87e0ed3/projects/packages/stats-admin/src/class-dashboard.php#L214
+	// Use feature locks for Calypso production `config/production.json`
 	window.configData = window.configData || {};
 	window.configData.features = productionConfig.features;
+	// Set is_running_in_jetpack_site to true if not specified (undefined or null).
+	window.configData.features.is_running_in_jetpack_site =
+		window.configData.features.is_running_in_jetpack_site ?? true;
 
 	const siteId = config( 'blog_id' );
 

--- a/apps/stats/src/app.jsx
+++ b/apps/stats/src/app.jsx
@@ -1,6 +1,7 @@
 /**
  * Global polyfills
  */
+import './load-config';
 import config from '@automattic/calypso-config';
 import '@automattic/calypso-polyfills';
 import { QueryClient } from 'react-query';
@@ -13,8 +14,6 @@ import { setStore } from 'calypso/state/redux-store';
 import sites from 'calypso/state/sites/reducer';
 import { setLocale as setLocaleAction } from 'calypso/state/ui/language/actions';
 import { combineReducers, addReducerEnhancer } from 'calypso/state/utils';
-// The JSON is filtered by `apps/stats/filter-json-config-loader.js`.
-import productionConfig from '../../../config/production.json';
 import { setupContextMiddleware } from './page-middleware/setup-context';
 import registerStatsPages from './routes';
 
@@ -27,14 +26,6 @@ const setLocale = ( dispatch ) => {
 };
 
 async function AppBoot() {
-	// Note: configData hydrated in https://github.com/Automattic/jetpack/blob/d4d0f987cbf63a864b03b542b7813aabe87e0ed3/projects/packages/stats-admin/src/class-dashboard.php#L214
-	// Use feature locks for Calypso production `config/production.json`
-	window.configData = window.configData || {};
-	window.configData.features = productionConfig.features;
-	// Set is_running_in_jetpack_site to true if not specified (undefined or null).
-	window.configData.features.is_running_in_jetpack_site =
-		window.configData.features.is_running_in_jetpack_site ?? true;
-
 	const siteId = config( 'blog_id' );
 
 	const rootReducer = combineReducers( {

--- a/apps/stats/src/load-config.js
+++ b/apps/stats/src/load-config.js
@@ -1,0 +1,9 @@
+// The JSON is filtered by `apps/stats/filter-json-config-loader.js`.
+import productionConfig from '../../../config/production.json';
+
+// Note: configData is hydrated in https://github.com/Automattic/jetpack/blob/d4d0f987cbf63a864b03b542b7813aabe87e0ed3/projects/packages/stats-admin/src/class-dashboard.php#L214
+window.configData.features = productionConfig.features;
+
+// Set is_running_in_jetpack_site to true if not specified (undefined or null).
+window.configData.features.is_running_in_jetpack_site =
+	window.configData.features.is_running_in_jetpack_site ?? true;

--- a/apps/stats/src/load-config.js
+++ b/apps/stats/src/load-config.js
@@ -1,9 +1,9 @@
 // The JSON is filtered by `apps/stats/filter-json-config-loader.js`.
 import productionConfig from '../../../config/production.json';
 
+// Set is_running_in_jetpack_site to true if not specified (undefined or null).
+productionConfig.features.is_running_in_jetpack_site =
+	window.configData.features.is_running_in_jetpack_site ?? true;
+
 // Note: configData is hydrated in https://github.com/Automattic/jetpack/blob/d4d0f987cbf63a864b03b542b7813aabe87e0ed3/projects/packages/stats-admin/src/class-dashboard.php#L214
 window.configData.features = productionConfig.features;
-
-// Set is_running_in_jetpack_site to true if not specified (undefined or null).
-window.configData.features.is_running_in_jetpack_site =
-	window.configData.features.is_running_in_jetpack_site ?? true;

--- a/apps/stats/webpack.config.js
+++ b/apps/stats/webpack.config.js
@@ -84,7 +84,7 @@ module.exports = {
 			} ),
 			FileConfig.loader(),
 			{
-				test: /^\.\.\/\.\.\/\.\.\/config\/production\.json$/,
+				test: /.*config\/production\.json$/,
 				use: { loader: './filter-json-config-loader', options: { keys: [ 'features' ] } },
 			},
 		],

--- a/client/lib/wp/browser.js
+++ b/client/lib/wp/browser.js
@@ -1,4 +1,4 @@
-import config, { isEnabled } from '@automattic/calypso-config';
+import config from '@automattic/calypso-config';
 import debugFactory from 'debug';
 import WPCOM from 'wpcom';
 import wpcomProxyRequest from 'wpcom-proxy-request';
@@ -12,9 +12,9 @@ const debug = debugFactory( 'calypso:wp' );
 
 let wpcom;
 
-if ( isEnabled( 'oauth' ) ) {
+if ( config.isEnabled( 'oauth' ) ) {
 	wpcom = new WPCOM( oauthToken.getToken(), wpcomXhrWrapper );
-} else if ( isEnabled( 'is_running_in_jetpack_site' ) || config( 'is_running_in_jetpack_site' ) ) {
+} else if ( config.isEnabled( 'is_running_in_jetpack_site' ) ) {
 	wpcom = new WPCOM( jetpack_site_xhr_wrapper );
 } else {
 	wpcom = new WPCOM( wpcomProxyRequest );

--- a/client/lib/wp/browser.js
+++ b/client/lib/wp/browser.js
@@ -1,4 +1,4 @@
-import config from '@automattic/calypso-config';
+import config, { isEnabled } from '@automattic/calypso-config';
 import debugFactory from 'debug';
 import WPCOM from 'wpcom';
 import wpcomProxyRequest from 'wpcom-proxy-request';
@@ -12,9 +12,9 @@ const debug = debugFactory( 'calypso:wp' );
 
 let wpcom;
 
-if ( config.isEnabled( 'oauth' ) ) {
+if ( isEnabled( 'oauth' ) ) {
 	wpcom = new WPCOM( oauthToken.getToken(), wpcomXhrWrapper );
-} else if ( config( 'is_running_in_jetpack_site' ) ) {
+} else if ( isEnabled( 'is_running_in_jetpack_site' ) || config( 'is_running_in_jetpack_site' ) ) {
 	wpcom = new WPCOM( jetpack_site_xhr_wrapper );
 } else {
 	wpcom = new WPCOM( wpcomProxyRequest );

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -232,10 +232,7 @@ class StatsSite extends Component {
 									<InlineSupportLink
 										supportContext="stats"
 										showIcon={ false }
-										showSupportModal={
-											config.isEnabled( 'is_running_in_jetpack_site' ) ||
-											config( 'is_running_in_jetpack_site' )
-										}
+										showSupportModal={ ! config.isEnabled( 'is_running_in_jetpack_site' ) }
 									/>
 								),
 							},

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -232,7 +232,10 @@ class StatsSite extends Component {
 									<InlineSupportLink
 										supportContext="stats"
 										showIcon={ false }
-										showSupportModal={ !! config( 'is_running_in_jetpack_site' ) }
+										showSupportModal={
+											config.isEnabled( 'is_running_in_jetpack_site' ) ||
+											config( 'is_running_in_jetpack_site' )
+										}
 									/>
 								),
 							},

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -232,7 +232,7 @@ class StatsSite extends Component {
 									<InlineSupportLink
 										supportContext="stats"
 										showIcon={ false }
-										showSupportModal={ ! config.isEnabled( 'is_running_in_jetpack_site' ) }
+										showSupportModal={ config.isEnabled( 'is_running_in_jetpack_site' ) }
 									/>
 								),
 							},

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -12,15 +12,12 @@
 	"discover_logged_out_redirect_url": false,
 	"happychat_pling_noise_path": "/calypso/audio/chat-pling.wav",
 	"facebook_api_key": false,
-	"features": {
-		"is_running_in_jetpack_site": false
-	},
+	"features": {},
 	"google_analytics_key": false,
 	"google_recaptcha_site_key": false,
 	"hotjar_enabled": false,
 	"hostname": false,
 	"i18n_default_locale_slug": "en",
-	"is_running_in_jetpack_site": false,
 	"lasagna_url": "wss://rt-api.wordpress.com/socket",
 	"login_url": false,
 	"logout_url": false,

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -12,7 +12,9 @@
 	"discover_logged_out_redirect_url": false,
 	"happychat_pling_noise_path": "/calypso/audio/chat-pling.wav",
 	"facebook_api_key": false,
-	"features": {},
+	"features": {
+		"is_running_in_jetpack_site": false
+	},
 	"google_analytics_key": false,
 	"google_recaptcha_site_key": false,
 	"hotjar_enabled": false,


### PR DESCRIPTION
#### Proposed Changes

Context: calling `config(some-non-existing-flag)` will throw a fatal error in development.

* This changes `is_running_in_jetpack_site` flag that was added in https://github.com/Automattic/wp-calypso/pull/69231 into a feature flag vs. a config item.
* The original PR makes the assumption that this flag will be available everywhere [`wp`](https://github.com/Automattic/wp-calypso/blob/trunk/client/lib/wp/README.md) is used. And that's a false assumption because this library is used in `apps/editing-toolkit` and `apps/happychat` but these don't have this flag, and they're broken now in development. 
* This PR is backwards compatible and will need a follow-up when the [Jetpack PR](https://github.com/Automattic/jetpack/pull/27471) is deployed. 
