### PR TITLE
Update/launchpad page copies

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -103,7 +103,7 @@ export function getEnhancedTasks(
 					break;
 				case 'link_in_bio_launched':
 					taskData = {
-						title: translate( 'Launch Link in bio' ),
+						title: translate( 'Launch your site' ),
 						completed: siteLaunchCompleted,
 						disabled: ! linkInBioLinksEditCompleted,
 						isLaunchTask: true,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/sidebar.tsx
@@ -221,7 +221,7 @@ describe( 'Sidebar', () => {
 				} );
 				renderSidebar( props, siteDetails );
 
-				const title = screen.getByRole( 'heading', { name: /ready to launch/i } );
+				const title = screen.getByRole( 'heading', { name: /link and launch/i } );
 				expect( title ).toBeVisible();
 			} );
 		} );
@@ -230,7 +230,7 @@ describe( 'Sidebar', () => {
 			it( 'shows a normal title', () => {
 				renderSidebar( props );
 
-				const title = screen.getByRole( 'heading', { name: /almost ready/i } );
+				const title = screen.getByRole( 'heading', { name: /link and launch/i } );
 				expect( title ).toBeVisible();
 			} );
 		} );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/translations.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/translations.ts
@@ -9,15 +9,13 @@ describe( 'Translations', () => {
 			it( 'provides flow specific text', () => {
 				const newsletterTranslations = getLaunchpadTranslations( 'newsletter' );
 				expect( newsletterTranslations.flowName ).toEqual( 'Newsletter' );
-				expect( newsletterTranslations.title ).toEqual( 'Your Newsletter is ready!' );
+				expect( newsletterTranslations.title ).toEqual( "You're all set to start publishing" );
 				expect( newsletterTranslations.launchTitle ).toBe( undefined );
 
 				const linkInBioTranslations = getLaunchpadTranslations( 'link-in-bio' );
 				expect( linkInBioTranslations.flowName ).toEqual( 'Link in Bio' );
-				expect( linkInBioTranslations.title ).toEqual( 'Your Link in Bio is almost ready!' );
-				expect( linkInBioTranslations.launchTitle ).toEqual(
-					'Your Link in Bio is ready to launch!'
-				);
+				expect( linkInBioTranslations.title ).toEqual( "You're ready to link and launch" );
+				expect( linkInBioTranslations.launchTitle ).toEqual( "You're ready to link and launch" );
 			} );
 		} );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/translations.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/translations.tsx
@@ -12,12 +12,18 @@ export function getLaunchpadTranslations( flow: string | null ): TranslatedLaunc
 	switch ( flow ) {
 		case NEWSLETTER_FLOW:
 			translatedStrings.flowName = translate( 'Newsletter' );
-			translatedStrings.title = translate( 'Your Newsletter is ready!' );
+			translatedStrings.title = translate( "You're all set to start publishing!" );
+			translatedStrings.subtitle = translate(
+				'Why not welcome your readers with your first post?'
+			);
 			break;
 		case LINK_IN_BIO_FLOW:
 			translatedStrings.flowName = translate( 'Link in Bio' );
 			translatedStrings.title = translate( 'Your Link in Bio is almost ready!' );
-			translatedStrings.launchTitle = translate( 'Your Link in Bio is ready to launch!' );
+			translatedStrings.launchTitle = translate( "You're ready to link and launch!" );
+			translatedStrings.subtitle = translate(
+				"All that's left is to add some links and launch your site."
+			);
 			break;
 		case VIDEOPRESS_FLOW:
 			translatedStrings.flowName = translate( 'Video' );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/translations.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/translations.tsx
@@ -12,15 +12,15 @@ export function getLaunchpadTranslations( flow: string | null ): TranslatedLaunc
 	switch ( flow ) {
 		case NEWSLETTER_FLOW:
 			translatedStrings.flowName = translate( 'Newsletter' );
-			translatedStrings.title = translate( "You're all set to start publishing!" );
+			translatedStrings.title = translate( "You're all set to start publishing" );
 			translatedStrings.subtitle = translate(
 				'Why not welcome your readers with your first post?'
 			);
 			break;
 		case LINK_IN_BIO_FLOW:
 			translatedStrings.flowName = translate( 'Link in Bio' );
-			translatedStrings.title = translate( 'Your Link in Bio is almost ready!' );
-			translatedStrings.launchTitle = translate( "You're ready to link and launch!" );
+			translatedStrings.title = translate( "You're ready to link and launch" );
+			translatedStrings.launchTitle = translate( "You're ready to link and launch" );
 			translatedStrings.subtitle = translate(
 				"All that's left is to add some links and launch your site."
 			);


### PR DESCRIPTION
#### Proposed Changes

* Updating Launchpad Link-in-bio and Newsletter titles, subtitles, and CTA to match updated design changes: 9wpoYJrMlYKAKUYvVBMN74-fi-1364%3A27047&t=l4zG6szT0A8I170D-0


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this branch (or use calypso.live generated link then navigate to `/setup/newsletter/launchpad?siteSlug={SITE_SLUG}` and `/setup/link-in-bio/launchpad?siteSlug={SITE_SLUG}`).
* Create a new Newsletter and Link-in-bio site (`/setup/link-in-bio` & `/setup/newsletter`) or use existing sites.
* Verify Link-in-bio site title, subtitle, CTA text match updated design changes. (Both states - before LIB is not ready to launch and when LIB is ready to launch).
* Verify Newsletter site title, subtitle, CTA text match updated design changes.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #70069