### PR TITLE
Log a track event when clicking on WP.org theme card

### DIFF
--- a/client/components/themes-list/index.jsx
+++ b/client/components/themes-list/index.jsx
@@ -162,7 +162,11 @@ function Empty( props ) {
 	return shouldUpgradeToInstallThemes ? (
 		<div className="themes-list__empty-container">
 			{ matchingThemes.length ? (
-				<WPOrgMatchingThemes matchingThemes={ matchingThemes } { ...props } />
+				<WPOrgMatchingThemes
+					matchingThemes={ matchingThemes }
+					selectedSite={ selectedSite }
+					{ ...props }
+				/>
 			) : (
 				<div className="themes-list__not-found-text">
 					{ translate( 'No themes match your search' ) }
@@ -191,15 +195,31 @@ function Empty( props ) {
 function WPOrgMatchingThemes( props ) {
 	const { matchingThemes } = props;
 
+	const onWPOrgCardClick = useCallback(
+		( theme ) => {
+			props.recordTracksEvent( 'calypso_themeshowcase_search_empty_wp_org_card_click', {
+				site_plan: props.selectedSite?.plan?.product_slug,
+				theme_id: theme?.id,
+			} );
+		},
+		[ props.recordTracksEvent, props.selectedSite ]
+	);
+
 	return (
-		<>
-			<div className="themes-list">
-				{ matchingThemes.map( ( theme, index ) => (
-					<ThemeBlock key={ 'theme-block' + index } theme={ theme } index={ index } { ...props } />
-				) ) }
-				<TrailingItems />
-			</div>
-		</>
+		<div className="themes-list">
+			{ matchingThemes.map( ( theme, index ) => (
+				<div
+					onClick={ () => onWPOrgCardClick( theme ) }
+					key={ 'theme-block' + index }
+					role="button"
+					tabIndex={ 0 }
+					onKeyUp={ () => onWPOrgCardClick( theme ) }
+				>
+					<ThemeBlock theme={ theme } index={ index } { ...props } />
+				</div>
+			) ) }
+			<TrailingItems />
+		</div>
 	);
 }
 


### PR DESCRIPTION
#### Proposed Changes

Log a track event when clicking on WP.org theme card

#### Testing Instructions
* On the browser console terminal enter `localStorage.setItem( 'debug', 'calypso:analytics*' )`
* Go to a themes page with a free site selected. Ex: `/themes/:free_site`
* Search for a theme that only exists in WP.org. Ex: `astral`
* Click on the card
* Check if the event `calypso_themeshowcase_search_empty_wp_org_card_click` was logged on the terminal console

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->



#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
