### PR TITLE
HelpCenter: improve chat and email button text

### DIFF
--- a/packages/help-center/src/components/help-center-contact-page.tsx
+++ b/packages/help-center/src/components/help-center-contact-page.tsx
@@ -5,8 +5,14 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Spinner, GMClosureNotice } from '@automattic/components';
 import { useSupportAvailability } from '@automattic/data-stores';
+import {
+	isDefaultLocale,
+	getLanguage,
+	useLocale,
+	emailSupportLocales,
+} from '@automattic/i18n-utils';
 import { Notice } from '@wordpress/components';
-import { useEffect } from '@wordpress/element';
+import { useEffect, useMemo } from '@wordpress/element';
 import { comment, Icon } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
@@ -36,6 +42,7 @@ const ConditionalLink: React.FC< { active: boolean } & LinkProps > = ( { active,
 
 export const HelpCenterContactPage: React.FC = () => {
 	const { __ } = useI18n();
+	const locale = useLocale();
 
 	const renderEmail = useShouldRenderEmailOption();
 	const renderChat = useShouldRenderChatOption();
@@ -56,6 +63,26 @@ export const HelpCenterContactPage: React.FC = () => {
 			email_available: renderEmail.render,
 		} );
 	}, [ isLoading, renderChat.state, renderEmail.render ] );
+
+	const liveChatHeaderText = useMemo( () => {
+		if ( isDefaultLocale( locale ) ) {
+			return __( 'Live chat', __i18n_text_domain__ );
+		}
+
+		return __( 'Live chat (English)', __i18n_text_domain__ );
+	}, [ __, locale ] );
+
+	const emailHeaderText = useMemo( () => {
+		if ( isDefaultLocale( locale ) ) {
+			return __( 'Email', __i18n_text_domain__ );
+		}
+
+		if ( emailSupportLocales.includes( locale ) ) {
+			return `${ __( 'Email', __i18n_text_domain__ ) } (${ getLanguage( locale )?.name })`;
+		}
+
+		return __( 'Email (English)', __i18n_text_domain__ );
+	}, [ __, locale ] );
 
 	if ( isLoading ) {
 		return (
@@ -103,7 +130,7 @@ export const HelpCenterContactPage: React.FC = () => {
 										<Icon icon={ comment } />
 									</div>
 									<div>
-										<h2>{ __( 'Live chat', __i18n_text_domain__ ) }</h2>
+										<h2>{ liveChatHeaderText }</h2>
 										<p>
 											{ renderChat.state !== 'AVAILABLE'
 												? __( 'Chat is unavailable right now', __i18n_text_domain__ )
@@ -143,7 +170,7 @@ export const HelpCenterContactPage: React.FC = () => {
 									<Icon icon={ <Mail /> } />
 								</div>
 								<div>
-									<h2>{ __( 'Email', __i18n_text_domain__ ) }</h2>
+									<h2>{ emailHeaderText }</h2>
 									<p>{ __( 'An expert will get back to you soon', __i18n_text_domain__ ) }</p>
 								</div>
 							</div>

--- a/packages/help-center/src/components/help-center-contact-page.tsx
+++ b/packages/help-center/src/components/help-center-contact-page.tsx
@@ -79,7 +79,7 @@ export const HelpCenterContactPage: React.FC = () => {
 		);
 
 		if ( isLanguageSupported ) {
-			const language = getLanguage( locale );
+			const language = getLanguage( locale )?.name;
 			return language
 				? sprintf(
 						/* translators: %s is the language name */

--- a/packages/help-center/src/components/help-center-contact-page.tsx
+++ b/packages/help-center/src/components/help-center-contact-page.tsx
@@ -9,6 +9,7 @@ import { useSupportAvailability } from '@automattic/data-stores';
 import { isDefaultLocale, getLanguage, useLocale } from '@automattic/i18n-utils';
 import { Notice } from '@wordpress/components';
 import { useEffect, useMemo } from '@wordpress/element';
+import { sprintf } from '@wordpress/i18n';
 import { comment, Icon } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
@@ -80,7 +81,11 @@ export const HelpCenterContactPage: React.FC = () => {
 		if ( isLanguageSupported ) {
 			const language = getLanguage( locale );
 			return language
-				? `${ __( 'Email', __i18n_text_domain__ ) } (${ language.name })`
+				? sprintf(
+						/* translators: %s is the language name */
+						__( 'Email (%s)' ),
+						language
+				  )
 				: __( 'Email', __i18n_text_domain__ );
 		}
 

--- a/packages/help-center/src/components/help-center-contact-page.tsx
+++ b/packages/help-center/src/components/help-center-contact-page.tsx
@@ -3,14 +3,10 @@
  * External Dependencies
  */
 import { recordTracksEvent } from '@automattic/calypso-analytics';
+import config from '@automattic/calypso-config';
 import { Spinner, GMClosureNotice } from '@automattic/components';
 import { useSupportAvailability } from '@automattic/data-stores';
-import {
-	isDefaultLocale,
-	getLanguage,
-	useLocale,
-	emailSupportLocales,
-} from '@automattic/i18n-utils';
+import { isDefaultLocale, getLanguage, useLocale } from '@automattic/i18n-utils';
 import { Notice } from '@wordpress/components';
 import { useEffect, useMemo } from '@wordpress/element';
 import { comment, Icon } from '@wordpress/icons';
@@ -77,8 +73,15 @@ export const HelpCenterContactPage: React.FC = () => {
 			return __( 'Email', __i18n_text_domain__ );
 		}
 
-		if ( emailSupportLocales.includes( locale ) ) {
-			return `${ __( 'Email', __i18n_text_domain__ ) } (${ getLanguage( locale )?.name })`;
+		const isLanguageSupported = ( config( 'upwork_support_locales' ) as Array< string > ).includes(
+			locale
+		);
+
+		if ( isLanguageSupported ) {
+			const language = getLanguage( locale );
+			return language
+				? `${ __( 'Email', __i18n_text_domain__ ) } (${ language.name })`
+				: __( 'Email', __i18n_text_domain__ );
 		}
 
 		return __( 'Email (English)', __i18n_text_domain__ );

--- a/packages/i18n-utils/src/locales.ts
+++ b/packages/i18n-utils/src/locales.ts
@@ -26,6 +26,7 @@ export const englishLocales: Locale[] = [ 'en', 'en-gb' ];
 
 // replaces config( 'livechat_support_locales' )
 export const livechatSupportLocales: Locale[] = [ 'en' ];
+export const emailSupportLocales: Locale[] = [ 'fr', 'de', 'it', 'ja', 'pt-br', 'es', 'sv' ];
 
 // replaces config( 'support_site_locales' )
 export const supportSiteLocales: Locale[] = [

--- a/packages/i18n-utils/src/locales.ts
+++ b/packages/i18n-utils/src/locales.ts
@@ -26,7 +26,6 @@ export const englishLocales: Locale[] = [ 'en', 'en-gb' ];
 
 // replaces config( 'livechat_support_locales' )
 export const livechatSupportLocales: Locale[] = [ 'en' ];
-export const emailSupportLocales: Locale[] = [ 'fr', 'de', 'it', 'ja', 'pt-br', 'es', 'sv' ];
 
 // replaces config( 'support_site_locales' )
 export const supportSiteLocales: Locale[] = [


### PR DESCRIPTION
#### Proposed Changes

<img width="408" alt="Screenshot 2022-11-17 at 16 54 29" src="https://user-images.githubusercontent.com/7000684/202509556-4927ba2e-e46f-4d9c-80ba-7baba0fdcc59.png">

* Our chat and email button texts should reflect the language for each of the support channels
* **Live Chat**. We offer support in english only. So for english locale the text should remain the same but for other locales it should be the string `Live Chat (English)` translated according to the locale.
* **Email**. The text for english locale remains the same. For the languages that we offer email support which are Dutch, French, German, Italian, Japanese, Portuguese, Spanish and Swedish the string is the translation of `Email (Language)`. For example for spanish the final string should be `Correo electrónico (Español)`. For all the other locales the translation string is `Email (English)`.

#### Testing Instructions
- Checkout this branch and run `yarn start` or use the PR link
- Go to your account page and change the locale http://calypso.localhost:3000/me/account
- Test the help center contact page with the locales: english,  spanish or any other locale supported for email support, and any other locale which is not supported.

Related to #70115
