### PR TITLE
Help Center: Not keeping HC minimized after reopening

### DIFF
--- a/packages/data-stores/src/help-center/actions.ts
+++ b/packages/data-stores/src/help-center/actions.ts
@@ -1,3 +1,4 @@
+import { GeneratorReturnType } from '../mapped-types';
 import { SiteDetails } from '../site';
 import { Location, HelpCenterSite } from './types';
 
@@ -42,7 +43,7 @@ export const setShowHelpCenter = function* ( show: boolean ) {
 	return {
 		type: 'HELP_CENTER_SET_SHOW',
 		show,
-	};
+	} as const;
 };
 
 export const setSubject = ( subject: string ) =>
@@ -92,17 +93,19 @@ export const resetStore = () =>
 		type: 'HELP_CENTER_RESET_STORE',
 	} as const );
 
-export type HelpCenterAction = ReturnType<
-	| typeof setSite
-	| typeof setSubject
-	| typeof setRouterState
-	| typeof resetRouterState
-	| typeof resetStore
-	| typeof setMessage
-	| typeof setUserDeclaredSite
-	| typeof setUserDeclaredSiteUrl
-	| typeof resetIframe
-	| typeof setIframe
-	| typeof setUnreadCount
-	| typeof setIsMinimized
->;
+export type HelpCenterAction =
+	| ReturnType<
+			| typeof setSite
+			| typeof setSubject
+			| typeof setRouterState
+			| typeof resetRouterState
+			| typeof resetStore
+			| typeof setMessage
+			| typeof setUserDeclaredSite
+			| typeof setUserDeclaredSiteUrl
+			| typeof resetIframe
+			| typeof setIframe
+			| typeof setUnreadCount
+			| typeof setIsMinimized
+	  >
+	| GeneratorReturnType< typeof setShowHelpCenter >;

--- a/packages/data-stores/src/help-center/actions.ts
+++ b/packages/data-stores/src/help-center/actions.ts
@@ -1,12 +1,6 @@
 import { SiteDetails } from '../site';
 import { Location, HelpCenterSite } from './types';
 
-export const setShowHelpCenter = ( show: boolean ) =>
-	( {
-		type: 'HELP_CENTER_SET_SHOW',
-		show,
-	} as const );
-
 export const setRouterState = ( history: Location[], index: number ) =>
 	( {
 		type: 'HELP_CENTER_SET_ROUTER_STATE',
@@ -38,6 +32,17 @@ export const setIsMinimized = ( minimized: boolean ) =>
 		type: 'HELP_CENTER_SET_MINIMIZED',
 		minimized,
 	} as const );
+
+export const setShowHelpCenter = function* ( show: boolean ) {
+	if ( ! show ) {
+		yield setIsMinimized( false );
+	}
+
+	return {
+		type: 'HELP_CENTER_SET_SHOW',
+		show,
+	};
+};
 
 export const setSubject = ( subject: string ) =>
 	( {

--- a/packages/data-stores/src/help-center/actions.ts
+++ b/packages/data-stores/src/help-center/actions.ts
@@ -35,6 +35,7 @@ export const setIsMinimized = ( minimized: boolean ) =>
 
 export const setShowHelpCenter = function* ( show: boolean ) {
 	if ( ! show ) {
+		// reset minimized state when the help center is closed
 		yield setIsMinimized( false );
 	}
 
@@ -92,7 +93,6 @@ export const resetStore = () =>
 	} as const );
 
 export type HelpCenterAction = ReturnType<
-	| typeof setShowHelpCenter
 	| typeof setSite
 	| typeof setSubject
 	| typeof setRouterState


### PR DESCRIPTION
#### Proposed Changes

After the user closes the HC when minimized, it looks strange to reopen it still minimized. With this PR we set `isMinimized` to false when the user closes the HC.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check Live Link
* Open HC -> Minimize HC -> Close HC -> Open HC
* HC should open maximized


Related to #70037
Fixes #70037