### PR TITLE
Don't show addons in Jetpack pricing page 

### DIFF
--- a/client/my-sites/plans/jetpack-plans/product-grid/utils.ts
+++ b/client/my-sites/plans/jetpack-plans/product-grid/utils.ts
@@ -65,9 +65,8 @@ export const getPlansToDisplay = ( {
 	return plansToDisplay;
 };
 
-const removeAddons = (
-	product: SelectorProduct | null // eslint-disable-next-line @typescript-eslint/no-explicit-any
-) => ! JETPACK_BACKUP_ADDON_PRODUCTS.includes( product?.productSlug as any );
+const removeAddons = ( product: SelectorProduct ) =>
+	! ( JETPACK_BACKUP_ADDON_PRODUCTS as ReadonlyArray< string > ).includes( product?.productSlug );
 
 export const getProductsToDisplay = ( {
 	duration,
@@ -76,9 +75,9 @@ export const getProductsToDisplay = ( {
 	includedInPlanProducts,
 }: {
 	duration: Duration;
-	availableProducts: ( SelectorProduct | null )[];
-	purchasedProducts: ( SelectorProduct | null )[];
-	includedInPlanProducts: ( SelectorProduct | null )[];
+	availableProducts: SelectorProduct[];
+	purchasedProducts: SelectorProduct[];
+	includedInPlanProducts: SelectorProduct[];
 } ): SelectorProduct[] => {
 	const purchasedProductsWithoutAddOn = purchasedProducts.filter( removeAddons );
 


### PR DESCRIPTION
#### Proposed Changes

* Currently, if the user purchases add-ons and goes to the pricing page, it is shown in **All Products** section. This PR  hides those add-ons for now. In the next iteration of add-on integration, we will decide how to handle this case. 

#### Testing Instructions

* Create a JN site with Jetpack Backup 10GB product (or) Jetpack Security 10GB
* click on Jetpack Cloud live link below
    * Goto /backup
* or boot up this PR
   * Run git fetch && git checkout fix/pricing-page-hide-addons
   * Run yarn start-jetpack-cloud
   * Goto http://jetpack.cloud.localhost:3000/backup
* Simulate the Storage and purchase Add on by following the testing instructions in #69377
* Once Add-on is purchased, navigate to the pricing page ( /pricing/:site-id ) and make sure add-ons are't show in all products section

#### Screenshot

##### Before
<img width="1309" alt="Screenshot 2022-11-17 at 9 58 08 PM" src="https://user-images.githubusercontent.com/2027003/202519817-24dccb33-fd95-4eb2-932c-9cd85e7b1768.png">

##### After
<img width="1280" alt="Screenshot 2022-11-17 at 11 12 02 PM" src="https://user-images.githubusercontent.com/2027003/202519837-cf9530ee-3e19-4f66-a068-f0d2076f4f58.png">


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
