### PR TITLE
Simplify the soft-launch theme badge

### DIFF
--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -365,9 +365,7 @@ export class Theme extends Component {
 			<>
 				{ this.props.softLaunched && (
 					<div className="theme__info-soft-launched">
-						<div className="theme__info-soft-launched-banner">
-							{ translate( 'Available to A8C-only' ) }
-						</div>
+						<div className="theme__info-soft-launched-banner">{ translate( 'A8C Only' ) }</div>
 					</div>
 				) }
 			</>

--- a/client/components/theme/style.scss
+++ b/client/components/theme/style.scss
@@ -1,4 +1,5 @@
 $theme-info-height: 54px;
+$soft-launch-badge-font-size: 0.725rem;
 
 .theme {
 	padding: 0;
@@ -406,16 +407,17 @@ $theme-info-height: 54px;
 
 .theme__info-soft-launched {
 	position: absolute;
-	top: 36px;
-	left: -12px;
+	top: 7px;
+	left: 7px;
 
 	.theme__info-soft-launched-banner {
 		background-color: var(--color-warning-20);
 		color: var(--color-warning-80);
-		font-size: rem(7px);
+		font-size: $soft-launch-badge-font-size;
 		font-weight: bold;
+		line-height: 1.2;
 		text-transform: uppercase;
-		transform: rotate(315deg);
-
+		padding: 3px 6px;
+		border-radius: 2px;
 	}
 }

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -211,9 +211,7 @@ class ThemeSheet extends Component {
 				<span className="theme__sheet-bar-title">
 					{ title }
 					{ softLaunched && (
-						<span className="theme__sheet-bar-soft-launched">
-							{ translate( 'Available to A8C-only' ) }
-						</span>
+						<span className="theme__sheet-bar-soft-launched">{ translate( 'A8C Only' ) }</span>
 					) }
 				</span>
 				<span className="theme__sheet-bar-tag">{ tag }</span>

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -38,11 +38,13 @@
 
 .theme__sheet-bar-soft-launched {
 	color: var(--color-warning-80);
-	font-size: 1.25rem;
+	font-size: 0.75rem;
 	font-weight: bold;
 	text-transform: uppercase;
 	background-color: var(--color-warning-20);
 	margin-left: 1rem;
+	padding: 2px 4px;
+	border-radius: 2px;
 }
 
 .theme__sheet-columns {


### PR DESCRIPTION
#### Proposed Changes

This simplifies the soft-launch badge by making the copy shorter and removing the rotation transform.

Original discussion: p1668529853731399/1668528209.225539-slack-C02M88KJ684

#### Testing Instructions
Prior to this change, viewing a soft-launched theme in the showcase or the theme page would show a badge like the following:

![image](https://user-images.githubusercontent.com/917632/202559255-9d23b9cd-24d4-4a7a-bcff-3189719e7cfe.png)
![image](https://user-images.githubusercontent.com/917632/202559285-6d4a5f99-cd32-4f2e-9b1d-a3385e9978e7.png)

After applying this patch, you should see the following badge instead

![image](https://user-images.githubusercontent.com/917632/202704078-c4df6392-1e05-4266-ac87-6a36644a1498.png)

![image](https://user-images.githubusercontent.com/917632/202559365-2ce26127-8814-4aeb-89d9-1726340a516a.png)


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [NA] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [NA ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [NA] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->