### PR TITLE
E2E: Update to wait for load event in account authentication flow

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/login-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/login-page.ts
@@ -24,9 +24,13 @@ export class LoginPage {
 		const targetUrl = path ? `log-in/${ path }` : 'log-in';
 		// We are getting a pending status for https://wordpress.com/cspreport intermittently
 		// which causes the login to hang on networkidle when running the tests locally.
-		// This continues the route request.
+		// This fulfill's the route request with status 200.
 		// See https://github.com/Automattic/wp-calypso/issues/69294
-		await this.page.route( '**/cspreport', ( route ) => route.continue() );
+		await this.page.route( '**/cspreport', ( route ) => {
+			route.fulfill( {
+				status: 200,
+			} );
+		} );
 		return await this.page.goto( getCalypsoURL( targetUrl ) );
 	}
 

--- a/packages/calypso-e2e/src/lib/pages/login-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/login-page.ts
@@ -26,7 +26,7 @@ export class LoginPage {
 		// which causes the login to hang on networkidle when running the tests locally.
 		// This continues the route request.
 		// See https://github.com/Automattic/wp-calypso/issues/69294
-		await this.page.route( '**/csreport', ( route ) => route.continue() );
+		await this.page.route( '**/cspreport', ( route ) => route.continue() );
 		return await this.page.goto( getCalypsoURL( targetUrl ) );
 	}
 

--- a/packages/calypso-e2e/src/lib/pages/login-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/login-page.ts
@@ -22,7 +22,12 @@ export class LoginPage {
 	 */
 	async visit( { path }: { path: string } = { path: '' } ): Promise< Response | null > {
 		const targetUrl = path ? `log-in/${ path }` : 'log-in';
-		return await this.page.goto( getCalypsoURL( targetUrl ), { waitUntil: 'networkidle' } );
+		// We are getting a pending status for https://wordpress.com/cspreport intermittently
+		// which causes the login to hang on networkidle when running the tests locally.
+		// This continues the route request.
+		// See https://github.com/Automattic/wp-calypso/issues/69294
+		await this.page.route( '**/csreport', ( route ) => route.continue() );
+		return await this.page.goto( getCalypsoURL( targetUrl ) );
 	}
 
 	/**


### PR DESCRIPTION
#### Proposed Changes

Because of the intermittent issue #69294 in the account authentication flow where login hangs on `networkidle` for some users when running the tests locally, we could intercept the pending network call `/cspreport` to continue. 

Waiting for `networkidle` event when navigating to the login page is also removed. The default event `load` could be used instead especially since we are using direct navigation now. 

See more [here](https://github.com/Automattic/wp-calypso/issues/69294#issuecomment-1317561719).

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

The changes should not have any impact on the existing tests.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #69294 
