### PR TITLE
Help Center: dont dispatch undefined actions in Happychat Connection

### DIFF
--- a/apps/happychat/src/index.ejs
+++ b/apps/happychat/src/index.ejs
@@ -31,6 +31,7 @@
 				sections: {},
 				enable_all_sections: false,
 				livechat_support_locales: [ 'en' ],
+				is_running_in_jetpack_site: false,
 				upwork_support_locales: [ 'de' ],
 				happychat_pling_noise_path: '/calypso-happychat/chat-pling.wav',
 				jetpack_support_blog: 'jetpackme.wordpress.com',

--- a/packages/happychat-connection/src/connection.ts
+++ b/packages/happychat-connection/src/connection.ts
@@ -21,7 +21,6 @@ const buildConnection: ( socket: string | Socket ) => Socket = ( socket ) =>
 
 //The second one is an identity function, used in 'use-happychat-available' hook
 export type Dispatch = ( ( arg: unknown ) => void ) | ( < T >( value: T ) => T );
-
 export class Connection {
 	receiveAccept?: ( accept: boolean ) => void;
 	receiveConnect?: () => void;
@@ -50,16 +49,23 @@ export class Connection {
 	/**
 	 * Init the SocketIO connection: check user authorization and bind socket events
 	 *
-	 * @param dispatch Redux dispatch function
+	 * @param originalDispatch Redux dispatch function
 	 * @param auth Authentication promise, will return the user info upon fulfillment
 	 * @returns Fulfilled (returns the opened socket)
 	 *                   	 or rejected (returns an error message)
 	 */
-	init( dispatch: Dispatch, auth: Promise< HappychatAuth > ) {
+	init( originalDispatch: Dispatch, auth: Promise< HappychatAuth > ) {
 		if ( this.openSocket ) {
 			debug( 'socket is already connected' );
 			return this.openSocket;
 		}
+
+		const dispatch = ( action: unknown ) => {
+			if ( action ) {
+				return originalDispatch( action );
+			}
+		};
+
 		this.dispatch = dispatch;
 
 		this.openSocket = new Promise( ( resolve, reject ) => {


### PR DESCRIPTION
#### Proposed Changes

* In some cases, we don't provide `receiveHappychatEnv` callback to `Connection`, Which makes this [line](https://github.com/Automattic/wp-calypso/blob/fix/dont-dispatch-undefined-actions/packages/happychat-connection/src/connection.ts#L77) dispatch `undefined`. This makes redux throw an error and breaks the app.
* This PR fixes that. 

#### Testing Instructions

1. cd into apps/happychat
2. run yarn dev --sync.
3. go to https://hud-staging.happychat.io/ and log in.
4. while proxied go to https://widgets.wp.com/calypso-happychat/.
5. all should work.
