### PR TITLE
Help Center: fix scrolling and minimizing on mobile

### DIFF
--- a/packages/help-center/src/styles.scss
+++ b/packages/help-center/src/styles.scss
@@ -112,6 +112,7 @@ $head-foot-height: 50px;
 			left: 0;
 			right: 0;
 			max-height: calc(100% - 45px);
+			height: 100%;
 
 			.help-center__container-content {
 				flex: auto;


### PR DESCRIPTION
#### Testing Instructions

* Before reviewing, I recommend going to wordpress.com and viewing the Help Center on mobile view.
* Try to screw down and you won't be able to.
* Start a chat against staging.
* The Help Center will disappear.
* Repeat the same under the live link below. It should work as you'd expect. 