### PR TITLE
Fix short timeout info for duration

### DIFF
--- a/client/server/middleware/logger.js
+++ b/client/server/middleware/logger.js
@@ -43,7 +43,7 @@ const logRequest = ( req, res, options ) => {
 
 	// Requests which take longer than one second aren't performing well. We log
 	// extra performance data in this case to troubleshoot the cause.
-	if ( duration > 2 ) {
+	if ( duration > 1000 ) {
 		req.logger.info(
 			// TODO: does warn not exist here for tests?
 			{


### PR DESCRIPTION
In #69538, I accidentally some testing code in -- logging "long request durations" for everything over 2ms. This changes that back to 1s.

The impact is just that we're logging 2x as many documents to our logstash index. 