### PR TITLE
E2E: minor improvements to Jest execution environment

### DIFF
--- a/packages/calypso-e2e/src/jest-playwright-config/environment.ts
+++ b/packages/calypso-e2e/src/jest-playwright-config/environment.ts
@@ -339,7 +339,7 @@ class JestEnvironmentPlaywright extends NodeEnvironment {
 						contextIndex++;
 					}
 					// Print paths to captured artifacts for faster triaging.
-					console.log( `Artifacts for ${ this.testFilename }: ${ this.testArtifactsPath }` );
+					console.error( `Artifacts for ${ this.testFilename }: ${ this.testArtifactsPath }` );
 				}
 
 				// Regardless of pass/fail status, close the browser instance.

--- a/packages/calypso-e2e/src/jest-playwright-config/environment.ts
+++ b/packages/calypso-e2e/src/jest-playwright-config/environment.ts
@@ -256,10 +256,18 @@ class JestEnvironmentPlaywright extends NodeEnvironment {
 				this.allure?.endHook( event.error ?? event.hook.asyncError );
 				this.failure = { type: 'hook', name: event.hook.type };
 				break;
+			case 'test_start':
+				// This includes not only the test steps but also the hooks.
+				// Precisely speaking, this event is fired after the `beforeAll` hooks
+				// but prior to the `beforeEach` hooks.
+				if ( this.failure?.type === 'test' ) {
+					event.test.mode = 'skip';
+				}
 			case 'test_fn_start': {
 				// Use `test_fn_start` event instead of `test_start` to filter
 				// out hooks.
 				// See https://github.com/facebook/jest/blob/main/packages/jest-types/src/Circus.ts#L132-L133
+				// As per upstream, this event is the most reliable detection of a test step.
 				this.allure?.startTestStep( event.test, state, this.testFilename );
 				// If a test has failed, skip rest of the steps.
 				if ( this.failure?.type === 'test' ) {


### PR DESCRIPTION
#### Proposed Changes

This PR is a collection of minor improvements to the Jest's execution environment.

Key changes:
- print just the top directory to the artifact folder if a test fails.
- manually print the error thrown by Jest `beforeAll` hook, which is suppressed by Jest.

#### Testing Instructions

1. pull the branch
2. intentionally introduce a failure in a `beforeAll` hook of a spec.
3. run the spec.


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
