### PR TITLE
Launchpad: Address a11y issues from aXe report

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/step-content.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/step-content.tsx
@@ -60,7 +60,7 @@ const StepContent = ( { siteSlug, submit, goNext, goToStep, flow }: StepContentP
 	}, [ email, isEmailVerified ] );
 
 	return (
-		<div className="launchpad__container">
+		<main className="launchpad__container">
 			{ showEmailValidationBanner && (
 				<EmailValidationBanner
 					email={ email }
@@ -78,7 +78,7 @@ const StepContent = ( { siteSlug, submit, goNext, goToStep, flow }: StepContentP
 				/>
 				<LaunchpadSitePreview flow={ flow } siteSlug={ iFrameURL } />
 			</div>
-		</div>
+		</main>
 	);
 };
 

--- a/client/signup/signup-header/index.tsx
+++ b/client/signup/signup-header/index.tsx
@@ -43,7 +43,7 @@ const SignupHeader = ( {
 	);
 
 	return (
-		<div className="signup-header">
+		<div className="signup-header" role="banner" aria-label="banner">
 			{ flowProgress && ! shouldShowLoadingScreen && (
 				<ProgressBar
 					className={ variationName ? variationName : progressBar.flowName }
@@ -52,7 +52,7 @@ const SignupHeader = ( {
 				/>
 			) }
 			<WordPressLogo size={ 120 } className={ logoClasses } />
-			{ showPageTitle && <h1>{ variablePageTitle } </h1> }
+			{ showPageTitle && <h1>{ variablePageTitle }</h1> }
 			{ /* This should show a sign in link instead of
 			   the progressIndicator on the account step. */ }
 			<div className="signup-header__right">{ ! shouldShowLoadingScreen && rightComponent }</div>

--- a/packages/components/src/progress-bar/index.tsx
+++ b/packages/components/src/progress-bar/index.tsx
@@ -65,6 +65,7 @@ export default class ProgressBar extends React.PureComponent< Props, State > {
 				aria-valuemax={ total }
 				aria-valuemin={ 0 }
 				aria-valuenow={ value }
+				aria-label="progress bar"
 				className="progress-bar__progress"
 				role="progressbar"
 				style={ styles }


### PR DESCRIPTION
#### Proposed Changes
This PR fixes some of the a11y issues on the Launchpad page found by the aXe report.

#### Testing Instructions
1. Install the [axe DevTools Chrome Extension](https://chrome.google.com/webstore/detail/axe-devtools-web-accessib/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US&utm_term=axe%20chrome%20extension&utm_campaign=Search%20-%20axe%20DevTools%20-%20Checker&utm_source=adwords&utm_medium=ppc&hsa_src=g&hsa_ad=626089536231&hsa_tgt=kwd-1186988429008&hsa_mt=p&hsa_ver=3&hsa_acc=7854167720&hsa_kw=axe%20chrome%20extension&hsa_grp=142979637051&hsa_cam=17378411167&hsa_net=adwords&gclid=Cj0KCQiA1NebBhDDARIsAANiDD1KGFmeObe-Fk_129u36Uen8lPXADKbWrD_xcu31W-8X_gOdjofhXIaAlC6EALw_wcB)
2. Go to Launchpad on WordPress.com (either newsletter or link-in-bio, it doesn't make a difference for the aXe report)
`https://wordpress.com/setup/newsletter/launchpad?siteSlug=YOUR_SITE_SLUG`
3. Open the aXe DevTools inside Chrome DevTools and run a full-page scan.
4. Checkout this branch and go to Launchpad locally
`http://calypso.localhost:3000/setup/newsletter/launchpad?siteSlug=YOUR_SITE_SLUG`
5. Compare the two aXe reports, the local one should return fewer issues

![bmL8m9.png](https://user-images.githubusercontent.com/20927667/202592553-defc0d36-7c7e-4636-b979-7455eada20bd.png)

![Eg86di.png](https://user-images.githubusercontent.com/20927667/203196424-96936b83-e72b-4f18-b8fe-bd4cc9f4e511.png)

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #69690