### PR TITLE
Stats: Update background for insights page

### DIFF
--- a/client/my-sites/stats/all-time-highlights-section/style.scss
+++ b/client/my-sites/stats/all-time-highlights-section/style.scss
@@ -6,6 +6,9 @@ $mobile-layout-breakpoint: $break-small;
 
 .stats__all-time-highlights-section {
 	.highlight-cards {
+		background-color: inherit;
+		box-shadow: none;
+
 		@media ( max-width: $mobile-layout-breakpoint ) {
 			display: none;
 		}

--- a/client/my-sites/stats/annual-highlights-section/index.tsx
+++ b/client/my-sites/stats/annual-highlights-section/index.tsx
@@ -4,7 +4,6 @@ import { useSelector } from 'react-redux';
 import QuerySiteStats from 'calypso/components/data/query-site-stats';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
 import { getSiteStatsNormalizedData } from 'calypso/state/stats/lists/selectors';
-import './style.scss';
 
 type Insights = {
 	day?: string;
@@ -60,7 +59,7 @@ export default function AnnualHighlightsSection( { siteId }: { siteId: number } 
 	const viewMoreHref = siteSlug ? `/stats/annualstats/${ siteSlug }` : null;
 
 	return (
-		<div className="stats__annual-highlights-section">
+		<>
 			{ siteId && (
 				<>
 					<QuerySiteStats siteId={ siteId } statType="statsInsights" />
@@ -68,6 +67,6 @@ export default function AnnualHighlightsSection( { siteId }: { siteId: number } 
 				</>
 			) }
 			<AnnualHighlightCards counts={ counts } titleHref={ viewMoreHref } year={ year } />
-		</div>
+		</>
 	);
 }

--- a/client/my-sites/stats/annual-highlights-section/style.scss
+++ b/client/my-sites/stats/annual-highlights-section/style.scss
@@ -1,3 +1,0 @@
-.stats__annual-highlights-section {
-	margin: 32px 0;
-}

--- a/client/my-sites/stats/modernized-chart-tabs-styles.scss
+++ b/client/my-sites/stats/modernized-chart-tabs-styles.scss
@@ -138,7 +138,7 @@ $yearBarChartBorderRadius: 4px;
 		border: 0;
 
 		&.is-enabled {
-			background-color: var(--color-surface);
+			background-color: inherit;
 		}
 
 		.stats-tab {

--- a/client/my-sites/stats/modernized-chart-tabs-styles.scss
+++ b/client/my-sites/stats/modernized-chart-tabs-styles.scss
@@ -9,8 +9,6 @@ $yearBarChartBorderRadius: 4px;
 
 // For feature `stats/new-main-chart`
 .stats--new-main-chart {
-	background-color: #fdfdfd;
-
 	// Common Legend options
 	.chart__legend {
 		margin-bottom: 16px;
@@ -77,7 +75,7 @@ $yearBarChartBorderRadius: 4px;
 	// Main Chart
 	.chart {
 		padding-left: 20px;
-		background-color: #fdfdfd;
+		background-color: inherit;
 
 		.chart__bar {
 			// Cancel the chart bar styles

--- a/client/my-sites/stats/modernized-page-header-styles.scss
+++ b/client/my-sites/stats/modernized-page-header-styles.scss
@@ -9,7 +9,7 @@
 			padding-bottom: 16px;
 
 			@media ( max-width: $break-medium ) {
-				margin: 24px 16px 12px;
+				margin: 0 16px;
 			}
 
 			.formatted-header__title {

--- a/client/my-sites/stats/modernized-page-header-styles.scss
+++ b/client/my-sites/stats/modernized-page-header-styles.scss
@@ -2,16 +2,11 @@
 
 // For page header styles behind feature `stats/new-main-chart`
 .stats--new-wrapper {
-	// Page layout
-	&.main {
-		// padding-top: 82px;
-	}
-
-	// FormattedHeader styles
 	.formatted-header {
 		&.is-left-align,
 		&.is-right-align {
-			margin: 0 0 16px 0;
+			margin: 0;
+			padding-bottom: 16px;
 
 			@media ( max-width: $break-medium ) {
 				margin: 24px 16px 12px;

--- a/client/my-sites/stats/stats-insights/index.jsx
+++ b/client/my-sites/stats/stats-insights/index.jsx
@@ -44,21 +44,21 @@ const StatsInsights = ( props ) => {
 	// TODO: should be refactored into separate components
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	return (
-		<Main className={ isNewMainChart ? 'stats--new-wrapper' : undefined } wideLayout>
+		<Main className={ isNewMainChart ? 'stats--new-wrapper' : undefined } fullWidthLayout>
 			<DocumentHead title={ translate( 'Jetpack Stats' ) } />
 			<PageViewTracker path="/stats/insights/:site" title="Stats > Insights" />
-			<FormattedHeader
-				brandFont
-				className="stats__section-header"
-				headerText={ translate( 'Jetpack Stats' ) }
-				subHeaderText={ translate( "View your site's performance and learn from trends." ) }
-				align="left"
-			/>
-			<StatsNavigation selectedItem="insights" siteId={ siteId } slug={ siteSlug } />
-			<div>
+			<div className="stats">
+				<FormattedHeader
+					brandFont
+					className="stats__section-header"
+					headerText={ translate( 'Jetpack Stats' ) }
+					subHeaderText={ translate( "View your site's performance and learn from trends." ) }
+					align="left"
+				/>
+				<StatsNavigation selectedItem="insights" siteId={ siteId } slug={ siteSlug } />
+				{ showNewAnnualHighlights && <AnnualHighlightsSection siteId={ siteId } /> }
+				{ showAllTimeHighlights && <AllTimelHighlightsSection siteId={ siteId } /> }
 				<div className="stats__module--insights-unified">
-					{ showNewAnnualHighlights && <AnnualHighlightsSection siteId={ siteId } /> }
-					{ showAllTimeHighlights && <AllTimelHighlightsSection siteId={ siteId } /> }
 					<PostingActivity />
 					<SectionHeader label={ translate( 'All-time views' ) } />
 					<StatsViews />

--- a/client/my-sites/stats/stats-insights/index.jsx
+++ b/client/my-sites/stats/stats-insights/index.jsx
@@ -100,8 +100,8 @@ const StatsInsights = ( props ) => {
 						</div>
 					</div>
 				</div>
+				<JetpackColophon />
 			</div>
-			<JetpackColophon />
 		</Main>
 	);
 	/* eslint-enable wpcalypso/jsx-classname-namespace */

--- a/client/my-sites/stats/stats-module/style.scss
+++ b/client/my-sites/stats/stats-module/style.scss
@@ -711,6 +711,7 @@ ul.module-header-actions {
 .stats-content-promo {
 	.promo-card-block {
 		border-radius: 5px; /* stylelint-disable-line scales/radii */
+		margin: 0;
 	}
 }
 

--- a/client/my-sites/stats/stats-period-header/style.scss
+++ b/client/my-sites/stats/stats-period-header/style.scss
@@ -5,7 +5,7 @@
 	flex-wrap: wrap;
 	align-items: center;
 	justify-content: center;
-	margin-bottom: 16px;
+	margin: 16px 0;
 
 	.period {
 		font-family: Recoleta, sans-serif;

--- a/client/my-sites/stats/stats-views/index.jsx
+++ b/client/my-sites/stats/stats-views/index.jsx
@@ -41,7 +41,7 @@ class StatsViews extends Component {
 		];
 
 		return (
-			<div>
+			<>
 				{ siteId && <QuerySiteStats statType={ statType } siteId={ siteId } query={ query } /> }
 				<Card className={ classNames( 'stats-views', { 'is-loading': ! viewData } ) }>
 					<StatsModulePlaceholder isLoading={ ! viewData } />
@@ -74,7 +74,7 @@ class StatsViews extends Component {
 						</span>
 					</div>
 				</Card>
-			</div>
+			</>
 		);
 	}
 }

--- a/client/my-sites/stats/style.scss
+++ b/client/my-sites/stats/style.scss
@@ -3,6 +3,9 @@
 @import "calypso/my-sites/stats/modernized-page-header-styles.scss";
 @import "@automattic/components/src/highlight-cards/variables.scss";
 
+$stats-background-color: #fdfdfd;
+$stats-sections-max-width: 1224px;
+
 // Module container
 @include breakpoint-deprecated( ">960px" ) {
 	.stats__module-column {
@@ -31,35 +34,31 @@
 	}
 }
 
-.stats .jetpack-colophon {
-	background-color: #fdfdfd;
-}
-
-.stats .stats-content-promo {
-	background-color: #fdfdfd;
-
-	.promo-card-block {
-		margin: 0;
-	}
-}
-
-.stats > * {
-	@media ( min-width: 660px ) {
-		padding: 0 32px;
-	}
-
-	// 272 is the --sidebar-width-max value that can't be used in media queries.
-	// 1224 is the max-width for the stats content
-	@media ( min-width: calc(272px + 1224px) ) {
-		padding: 0 max(calc(50% - 612px), 32px);
-	}
+.stats__section-header,
+.stats-navigation {
+	background-color: var(--studio-white);
 }
 
 .stats {
+	background-color: $stats-background-color;
+
+	// Ensures vertical padding for certain sections.
 	> .highlight-cards,
 	> .stats__all-time-highlights-section {
 		padding-top: $vertical-margin;
 		padding-bottom: $vertical-margin;
+	}
+
+	// Ensures horizontal padding for all sections.
+	> * {
+		@media ( min-width: 660px ) {
+			padding: 0 32px;
+		}
+
+		// 272 is --sidebar-width-max value. Note that CSS variables can't be used in media queries.
+		@media ( min-width: calc(272px + #{$stats-sections-max-width}) ) {
+			padding: 0 max(calc(50% - #{$stats-sections-max-width / 2}), 32px);
+		}
 	}
 }
 

--- a/client/my-sites/stats/style.scss
+++ b/client/my-sites/stats/style.scss
@@ -50,15 +50,18 @@ $stats-sections-max-width: 1224px;
 	}
 
 	// Ensures horizontal padding for all sections.
-	> * {
-		@media ( min-width: 660px ) {
-			padding: 0 32px;
-		}
-
-		// 272 is --sidebar-width-max value. Note that CSS variables can't be used in media queries.
-		@media ( min-width: calc(272px + #{$stats-sections-max-width}) ) {
+	@media ( min-width: 660px ) {
+		> * {
 			padding: 0 max(calc(50% - #{$stats-sections-max-width / 2}), 32px);
 		}
+
+		> .card.banner.jetpack-backup-creds-banner {
+			margin: 0 max(calc(50% - #{$stats-sections-max-width / 2}), 32px);
+		}
+	}
+
+	> .card.banner.jetpack-backup-creds-banner {
+		margin-bottom: 1em;
 	}
 }
 

--- a/client/my-sites/stats/style.scss
+++ b/client/my-sites/stats/style.scss
@@ -1,6 +1,7 @@
 @import "calypso/my-sites/stats/modernized-tooltip-styles.scss";
 @import "calypso/my-sites/stats/modernized-chart-tabs-styles.scss";
 @import "calypso/my-sites/stats/modernized-page-header-styles.scss";
+@import "@automattic/components/src/highlight-cards/variables.scss";
 
 // Module container
 @include breakpoint-deprecated( ">960px" ) {
@@ -51,6 +52,14 @@
 	// 1224 is the max-width for the stats content
 	@media ( min-width: calc(272px + 1224px) ) {
 		padding: 0 calc(50% - 612px);
+	}
+}
+
+.stats {
+	> .highlight-cards,
+	> .stats__all-time-highlights-section {
+		padding-top: $vertical-margin;
+		padding-bottom: $vertical-margin;
 	}
 }
 

--- a/client/my-sites/stats/style.scss
+++ b/client/my-sites/stats/style.scss
@@ -51,7 +51,7 @@
 	// 272 is the --sidebar-width-max value that can't be used in media queries.
 	// 1224 is the max-width for the stats content
 	@media ( min-width: calc(272px + 1224px) ) {
-		padding: 0 calc(50% - 612px);
+		padding: 0 max(calc(50% - 612px), 32px);
 	}
 }
 

--- a/client/my-sites/stats/wordads/index.jsx
+++ b/client/my-sites/stats/wordads/index.jsx
@@ -173,123 +173,126 @@ class WordAds extends Component {
 
 		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		return (
-			<Main className={ mainWrapperClass } wideLayout>
+			<Main className={ mainWrapperClass } fullWidthLayout>
 				<DocumentHead title={ translate( 'WordAds Stats' ) } />
 				<PageViewTracker
 					path={ `/stats/ads/${ period }/:site` }
 					title={ `WordAds > ${ titlecase( period ) }` }
 				/>
-				<FormattedHeader
-					brandFont
-					className="wordads__section-header"
-					headerText={ translate( 'Jetpack Stats' ) }
-					subHeaderText={ translate( 'See how ads are performing on your site.' ) }
-					align="left"
-				/>
 
-				{ ! canAccessAds && (
-					<EmptyContent
-						illustration="/calypso/images/illustrations/illustration-404.svg"
-						title={
-							! canUpgradeToUseWordAds
-								? translate( 'You are not authorized to view this page' )
-								: translate( 'WordAds is not enabled on your site' )
-						}
-						action={ canUpgradeToUseWordAds ? translate( 'Explore WordAds' ) : false }
-						actionURL={ '/earn/ads-settings/' + slug }
+				<div className="stats">
+					<FormattedHeader
+						brandFont
+						className="wordads__section-header"
+						headerText={ translate( 'Jetpack Stats' ) }
+						subHeaderText={ translate( 'See how ads are performing on your site.' ) }
+						align="left"
 					/>
-				) }
 
-				{ canAccessAds && (
-					<Fragment>
-						<StatsNavigation
-							selectedItem="wordads"
-							interval={ period }
-							siteId={ siteId }
-							slug={ slug }
+					{ ! canAccessAds && (
+						<EmptyContent
+							illustration="/calypso/images/illustrations/illustration-404.svg"
+							title={
+								! canUpgradeToUseWordAds
+									? translate( 'You are not authorized to view this page' )
+									: translate( 'WordAds is not enabled on your site' )
+							}
+							action={ canUpgradeToUseWordAds ? translate( 'Explore WordAds' ) : false }
+							actionURL={ '/earn/ads-settings/' + slug }
 						/>
+					) }
 
-						<div id="my-stats-content" className={ statsWrapperClass }>
-							{ isNewMainChart ? (
-								<>
-									<StatsPeriodHeader>
-										<StatsPeriodNavigation
-											date={ queryDate }
-											hidePreviousArrow={ this.isPrevArrowHidden( period, queryDate ) }
-											hideNextArrow={ yesterday === queryDate }
-											period={ period }
-											url={ `/stats/ads/${ period }/${ slug }` }
-										>
-											<DatePicker
-												period={ period }
+					{ canAccessAds && (
+						<Fragment>
+							<StatsNavigation
+								selectedItem="wordads"
+								interval={ period }
+								siteId={ siteId }
+								slug={ slug }
+							/>
+
+							<div id="my-stats-content" className={ statsWrapperClass }>
+								{ isNewMainChart ? (
+									<>
+										<StatsPeriodHeader>
+											<StatsPeriodNavigation
 												date={ queryDate }
-												query={ query }
-												statsType="statsAds"
-												showQueryDate
+												hidePreviousArrow={ this.isPrevArrowHidden( period, queryDate ) }
+												hideNextArrow={ yesterday === queryDate }
+												period={ period }
+												url={ `/stats/ads/${ period }/${ slug }` }
+											>
+												<DatePicker
+													period={ period }
+													date={ queryDate }
+													query={ query }
+													statsType="statsAds"
+													showQueryDate
+												/>
+											</StatsPeriodNavigation>
+											<Intervals
+												selected={ period }
+												pathTemplate={ pathTemplate }
+												compact={ false }
 											/>
-										</StatsPeriodNavigation>
-										<Intervals
-											selected={ period }
-											pathTemplate={ pathTemplate }
-											compact={ false }
+										</StatsPeriodHeader>
+
+										<WordAdsChartTabs
+											activeTab={ getActiveTab( this.props.chartTab ) }
+											activeLegend={ this.state.activeLegend }
+											availableLegend={ this.getAvailableLegend() }
+											onChangeLegend={ this.onChangeLegend }
+											barClick={ this.barClick }
+											switchTab={ this.switchChart }
+											charts={ CHARTS }
+											queryDate={ queryDate }
+											period={ this.props.period }
+											chartTab={ this.props.chartTab }
 										/>
-									</StatsPeriodHeader>
-
-									<WordAdsChartTabs
-										activeTab={ getActiveTab( this.props.chartTab ) }
-										activeLegend={ this.state.activeLegend }
-										availableLegend={ this.getAvailableLegend() }
-										onChangeLegend={ this.onChangeLegend }
-										barClick={ this.barClick }
-										switchTab={ this.switchChart }
-										charts={ CHARTS }
-										queryDate={ queryDate }
-										period={ this.props.period }
-										chartTab={ this.props.chartTab }
-									/>
-								</>
-							) : (
-								<>
-									<WordAdsChartTabs
-										activeTab={ getActiveTab( this.props.chartTab ) }
-										activeLegend={ this.state.activeLegend }
-										availableLegend={ this.getAvailableLegend() }
-										onChangeLegend={ this.onChangeLegend }
-										barClick={ this.barClick }
-										switchTab={ this.switchChart }
-										charts={ CHARTS }
-										queryDate={ queryDate }
-										period={ this.props.period }
-										chartTab={ this.props.chartTab }
-									/>
-									<StickyPanel className="stats__sticky-navigation">
-										<StatsPeriodNavigation
-											date={ queryDate }
-											hidePreviousArrow={ this.isPrevArrowHidden( period, queryDate ) }
-											hideNextArrow={ yesterday === queryDate }
-											period={ period }
-											url={ `/stats/ads/${ period }/${ slug }` }
-										>
-											<DatePicker
-												period={ period }
+									</>
+								) : (
+									<>
+										<WordAdsChartTabs
+											activeTab={ getActiveTab( this.props.chartTab ) }
+											activeLegend={ this.state.activeLegend }
+											availableLegend={ this.getAvailableLegend() }
+											onChangeLegend={ this.onChangeLegend }
+											barClick={ this.barClick }
+											switchTab={ this.switchChart }
+											charts={ CHARTS }
+											queryDate={ queryDate }
+											period={ this.props.period }
+											chartTab={ this.props.chartTab }
+										/>
+										<StickyPanel className="stats__sticky-navigation">
+											<StatsPeriodNavigation
 												date={ queryDate }
-												query={ query }
-												statsType="statsAds"
-												showQueryDate
-											/>
-										</StatsPeriodNavigation>
-									</StickyPanel>
-								</>
-							) }
+												hidePreviousArrow={ this.isPrevArrowHidden( period, queryDate ) }
+												hideNextArrow={ yesterday === queryDate }
+												period={ period }
+												url={ `/stats/ads/${ period }/${ slug }` }
+											>
+												<DatePicker
+													period={ period }
+													date={ queryDate }
+													query={ query }
+													statsType="statsAds"
+													showQueryDate
+												/>
+											</StatsPeriodNavigation>
+										</StickyPanel>
+									</>
+								) }
 
-							<div className="stats__module-list stats__module-headerless--unified">
-								<WordAdsEarnings site={ site } />
+								<div className="stats__module-list stats__module-headerless--unified">
+									<WordAdsEarnings site={ site } />
+								</div>
 							</div>
-						</div>
 
-						<JetpackColophon />
-					</Fragment>
-				) }
+							<JetpackColophon />
+						</Fragment>
+					) }
+				</div>
 			</Main>
 		);
 		/* eslint-enable wpcalypso/jsx-classname-namespace */

--- a/packages/components/src/highlight-cards/style.scss
+++ b/packages/components/src/highlight-cards/style.scss
@@ -2,13 +2,7 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@automattic/typography/styles/variables";
 @import "../styles/typography";
-
-$font-recoleta: Recoleta, $sans;
-$vertical-margin: 32px;
-// From client/assets/stylesheets/shared/mixins/_breakpoints.scss.
-// Technically deprecated, but majority of Calypso still uses this.
-$custom-mobile-breakpoint: 660px;
-
+@import "./variables.scss";
 
 .stats > .highlight-cards {
 	padding-top: $vertical-margin;

--- a/packages/components/src/highlight-cards/style.scss
+++ b/packages/components/src/highlight-cards/style.scss
@@ -4,11 +4,6 @@
 @import "../styles/typography";
 @import "./variables.scss";
 
-.stats > .highlight-cards {
-	padding-top: $vertical-margin;
-	padding-bottom: $vertical-margin;
-}
-
 .highlight-cards {
 	color: var(--studio-gray-100);
 	font-size: $font-body-small;

--- a/packages/components/src/highlight-cards/variables.scss
+++ b/packages/components/src/highlight-cards/variables.scss
@@ -1,0 +1,5 @@
+$font-recoleta: Recoleta, $sans;
+$vertical-margin: 32px;
+// From client/assets/stylesheets/shared/mixins/_breakpoints.scss.
+// Technically deprecated, but majority of Calypso still uses this.
+$custom-mobile-breakpoint: 660px;


### PR DESCRIPTION
#### Proposed Changes

<img width="1517" alt="image" src="https://user-images.githubusercontent.com/4044428/202600262-c796a235-872b-4c6d-b750-eca55970e4b3.png">

- Updates the background for the insights page of the Stats section.
- (Fixes [visual](https://user-images.githubusercontent.com/4044428/202600484-9a04a6a2-6b13-4e55-8425-a7755ef9b0c1.png) [regressions](https://user-images.githubusercontent.com/4044428/202600406-a9d2ba93-eff5-408d-9d4f-29e1e5f2f083.png) introduced in #70093.)

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open this PR in a live branch.
* Navigate to the Insights page of the Stats section.
* Ensure that the new styling has been applied.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #69953.