### PR TITLE
Fix Jetpack Search pricing tier calculations

### DIFF
--- a/client/components/jetpack/upsell-product-card/index.tsx
+++ b/client/components/jetpack/upsell-product-card/index.tsx
@@ -127,7 +127,10 @@ const UpsellProductCard: React.FC< UpsellProductCardProps > = ( {
 						originalPrice={ originalPrice ?? 0 }
 						pricesAreFetching={ pricesAreFetching }
 						belowPriceText={ item.belowPriceText }
-						tooltipText={ priceTierList.length > 0 && productTooltip( item, priceTierList ) }
+						tooltipText={
+							priceTierList.length > 0 &&
+							productTooltip( item, priceTierList, currencyCode ?? 'USD' )
+						}
 						billingTerm={ billingTerm }
 						productName={ displayName }
 						hideSavingLabel={ false }

--- a/client/my-sites/checkout/composite-checkout/components/checkout-sidebar-plan-upsell/index.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-sidebar-plan-upsell/index.tsx
@@ -33,7 +33,11 @@ export function CheckoutSidebarPlanUpsell() {
 	const { responseCart, replaceProductInCart } = useShoppingCart( cartKey );
 	const siteId = useSelector( getSelectedSiteId );
 	const plan = responseCart.products.find( ( product ) => isPlan( product ) );
-	const variants = useGetProductVariants( siteId ?? undefined, plan?.product_slug ?? '' );
+	const variants = useGetProductVariants(
+		siteId ?? undefined,
+		plan?.product_slug ?? '',
+		plan?.current_quantity ?? null
+	);
 
 	if ( ! plan ) {
 		debug( 'no plan found in cart' );

--- a/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
@@ -193,23 +193,28 @@ function LineItemWrapper( {
 	const sitePlans = useSelector( ( state ) => getPlansBySiteId( state, siteId ) );
 	const activePlan = sitePlans?.data?.find( ( plan ) => plan.currentPlan );
 
-	const variants = useGetProductVariants( siteId, product.product_slug, ( variant ) => {
-		if ( ! canVariantBePurchased( variant, activePlan?.interval, activePlan?.productSlug ) ) {
-			return false;
-		}
+	const variants = useGetProductVariants(
+		siteId,
+		product.product_slug,
+		product.current_quantity,
+		( variant ) => {
+			if ( ! canVariantBePurchased( variant, activePlan?.interval, activePlan?.productSlug ) ) {
+				return false;
+			}
 
-		// Only show term variants which are equal to or longer than the variant that
-		// was in the cart when checkout finished loading (not necessarily the
-		// current variant). For WordPress.com only, not Jetpack. See
-		// https://github.com/Automattic/wp-calypso/issues/69633
-		if ( ! initialVariantTerm ) {
-			return true;
+			// Only show term variants which are equal to or longer than the variant that
+			// was in the cart when checkout finished loading (not necessarily the
+			// current variant). For WordPress.com only, not Jetpack. See
+			// https://github.com/Automattic/wp-calypso/issues/69633
+			if ( ! initialVariantTerm ) {
+				return true;
+			}
+			if ( isJetpack ) {
+				return true;
+			}
+			return variant.termIntervalInMonths >= initialVariantTerm;
 		}
-		if ( isJetpack ) {
-			return true;
-		}
-		return variant.termIntervalInMonths >= initialVariantTerm;
-	} );
+	);
 
 	const areThereVariants = variants.length > 1;
 

--- a/client/my-sites/checkout/composite-checkout/hooks/product-variants.tsx
+++ b/client/my-sites/checkout/composite-checkout/hooks/product-variants.tsx
@@ -92,6 +92,7 @@ const fallbackFilter = () => true;
 export function useGetProductVariants(
 	siteId: number | undefined,
 	productSlug: string,
+	currentQuantity: number | null,
 	filterCallback?: VariantFilterCallback
 ): WPCOMProductVariant[] {
 	const translate = useTranslate();
@@ -102,7 +103,7 @@ export function useGetProductVariants(
 	debug( 'variantProductSlugs', variantProductSlugs );
 
 	const variantsWithPrices: AvailableProductVariant[] = useSelector( ( state ) => {
-		return computeProductsWithPrices( state, siteId, variantProductSlugs );
+		return computeProductsWithPrices( state, siteId, variantProductSlugs, currentQuantity );
 	} );
 
 	const [ haveFetchedProducts, setHaveFetchedProducts ] = useState( false );

--- a/client/my-sites/plans/jetpack-plans/product-card/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-card/index.tsx
@@ -231,7 +231,9 @@ const ProductCard: React.FC< ProductCardProps > = ( {
 			isDeprecated={ isDeprecated }
 			isAligned={ isAligned }
 			displayFrom={ ! siteId && priceTierList.length > 0 }
-			tooltipText={ priceTierList.length > 0 && productTooltip( item, priceTierList ) }
+			tooltipText={
+				priceTierList.length > 0 && productTooltip( item, priceTierList, currencyCode ?? 'USD' )
+			}
 			aboveButtonText={ productAboveButtonText( item, siteProduct, isOwned, isItemPlanFeature ) }
 			isDisabled={ isDisabled }
 			disabledMessage={ disabledMessage }

--- a/client/my-sites/plans/jetpack-plans/product-card/product-above-button-text.ts
+++ b/client/my-sites/plans/jetpack-plans/product-card/product-above-button-text.ts
@@ -14,12 +14,16 @@ export default function productAboveButtonText(
 		siteProduct &&
 		( JETPACK_SEARCH_PRODUCTS as ReadonlyArray< string > ).includes( product.productSlug )
 	) {
-		return translate( '*estimated price based on %(records)s records', {
-			args: {
-				records: numberFormat( siteProduct.tierUsage, 0 ),
-			},
-			comment: 'records = number of records (posts, pages, etc) in a site',
-		} );
+		return translate(
+			'*estimated price based on %(records_and_or_requests)s records and/or monthly requests',
+			{
+				args: {
+					records_and_or_requests: numberFormat( siteProduct.tierUsage, 0 ),
+				},
+				comment:
+					'records_and_or_requests = number of records (posts, pages, etc) in a site or monthly search requests (whichever is greater)',
+			}
+		);
 	}
 	return null;
 }

--- a/client/my-sites/plans/jetpack-plans/product-card/product-tooltip.ts
+++ b/client/my-sites/plans/jetpack-plans/product-card/product-tooltip.ts
@@ -1,4 +1,10 @@
-import { JETPACK_SEARCH_PRODUCTS, getPriceTierForUnits } from '@automattic/calypso-products';
+import {
+	JETPACK_SEARCH_PRODUCTS,
+	PRODUCT_JETPACK_SEARCH_MONTHLY,
+	PRODUCT_WPCOM_SEARCH_MONTHLY,
+	getPriceTierForUnits,
+} from '@automattic/calypso-products';
+import formatCurrency from '@automattic/format-currency';
 import { translate, TranslateResult } from 'i18n-calypso';
 import { createElement } from 'react';
 import ExternalLink from 'calypso/components/external-link';
@@ -10,10 +16,12 @@ import type { PriceTierEntry } from '@automattic/calypso-products';
  *
  * @param product Product to check.
  * @param tiers Product price tiers.
+ * @param currencyCode Currency code for user.
  */
 export default function productTooltip(
 	product: SelectorProduct,
-	tiers: PriceTierEntry[]
+	tiers: PriceTierEntry[],
+	currencyCode: string
 ): null | TranslateResult {
 	if ( ! ( JETPACK_SEARCH_PRODUCTS as ReadonlyArray< string > ).includes( product.productSlug ) ) {
 		return null;
@@ -23,29 +31,39 @@ export default function productTooltip(
 		return null;
 	}
 
-	const priceTier100 = getPriceTierForUnits( tiers, 1 );
-	const priceTier1000 = getPriceTierForUnits( tiers, 101 );
+	const priceTier = getPriceTierForUnits( tiers, 1 );
 
-	if ( ! priceTier100 || ! priceTier1000 ) {
+	if (
+		! priceTier ||
+		! currencyCode ||
+		! priceTier.per_unit_fee ||
+		! priceTier.transform_quantity_divide_by
+	) {
 		return null;
+	}
+
+	let per_unit_monthly_fee = priceTier.per_unit_fee;
+	if (
+		product.productSlug !== PRODUCT_JETPACK_SEARCH_MONTHLY &&
+		product.productSlug !== PRODUCT_WPCOM_SEARCH_MONTHLY
+	) {
+		per_unit_monthly_fee = priceTier.per_unit_fee / 12;
 	}
 
 	return translate(
 		'{{p}}{{strong}}Pay only for what you need.{{/strong}}{{/p}}' +
-			'{{p}}Up to 100 records %(price100)s{{br/}}' +
-			'Up to 1,000 records %(price1000)s{{/p}}' +
+			'{{p}}%(price)s per every additional %(thousands_of_records)dk records and/or requests per month{{/p}}' +
 			'{{Info}}More info{{/Info}}',
 		{
 			args: {
-				price100: priceTier100.minimum_price_monthly_display,
-				price1000: priceTier1000.minimum_price_monthly_display,
+				price: formatCurrency( per_unit_monthly_fee, currencyCode, { isSmallestUnit: true } ),
+				thousands_of_records: priceTier.transform_quantity_divide_by / 1000,
 			},
 			comment:
-				'price100 = formatted price per 100 records, price1000 = formatted price per 1000 records. See https://jetpack.com/upgrade/search/.',
+				'price = formatted price per given number of records. thousands_of_records = number of records divided by 1000 (hence the k after it) See https://jetpack.com/upgrade/search/.',
 			components: {
 				strong: createElement( 'strong' ),
 				p: createElement( 'p' ),
-				br: createElement( 'br' ),
 				Info: createElement( ExternalLink, {
 					icon: true,
 					href: 'https://jetpack.com/upgrade/search/',

--- a/client/state/products-list/selectors/compute-products-with-prices.ts
+++ b/client/state/products-list/selectors/compute-products-with-prices.ts
@@ -20,7 +20,8 @@ interface NonNullablePlanAndProduct extends PlanAndProduct {
 export const computeProductsWithPrices = (
 	state: AppState,
 	siteId: number | undefined,
-	planSlugs: string[]
+	planSlugs: string[],
+	currentQuantity: number | null
 ): AvailableProductVariant[] => {
 	const products = getProductsList( state );
 
@@ -28,7 +29,12 @@ export const computeProductsWithPrices = (
 	const filteredPlanAndProducts = planAndProducts.filter( hasAvailablePlan );
 	const constructedVariants = filteredPlanAndProducts.map( ( availablePlanProduct ) => ( {
 		...availablePlanProduct,
-		...computeFullAndMonthlyPricesForPlan( state, siteId, availablePlanProduct.plan ),
+		...computeFullAndMonthlyPricesForPlan(
+			state,
+			siteId,
+			availablePlanProduct.plan,
+			currentQuantity
+		),
 	} ) );
 	const filteredConstructedVariants = constructedVariants.filter( hasAvailablePrice );
 

--- a/client/state/products-list/test/selectors.js
+++ b/client/state/products-list/test/selectors.js
@@ -187,24 +187,14 @@ describe( 'selectors', () => {
 		} );
 
 		test( 'Should return the correct tier 1 price for Jetpack Search product with < 100 posts', () => {
-			const state = {
-				posts: {
-					counts: {
-						counts: {
-							1: {
-								post: {
-									all: {
-										publish: 10, // only 10 posts
-									},
-								},
-							},
-						},
-					},
-				},
-			};
 			const SEARCH_PRICE_TIER_LIST = [
-				{ minimum_units: 0, maximum_units: 100, minimum_price: 5995 },
-				{ minimum_units: 101, maximum_units: 1000, minimum_price: 11900 },
+				{
+					minimum_units: 0,
+					maximum_units: null,
+					transform_quantity_divide_by: 10000,
+					transform_quantity_round: 'up',
+					per_unit_fee: 896,
+				},
 			];
 			const plan = { getStoreSlug: () => 'jetpack_search', getProductId: () => '2104' };
 			// JP Search is a "product" not a plan, so `getPlanDiscountedRawPrice()` & `getPlanRawPrice()` should return null.
@@ -214,32 +204,22 @@ describe( 'selectors', () => {
 			getIntroOfferPrice.mockImplementation( () => null );
 			getIntroOfferIsEligible.mockImplementation( () => false );
 			getProductPriceTierList.mockImplementation( () => SEARCH_PRICE_TIER_LIST );
-			expect( computeFullAndMonthlyPricesForPlan( state, 1, plan ) ).toEqual( {
+			expect( computeFullAndMonthlyPricesForPlan( {}, 1, plan, 10 ) ).toEqual( {
 				introductoryOfferPrice: null,
-				priceFull: 59.95,
-				priceFinal: 59.95,
+				priceFull: 8.96,
+				priceFinal: 8.96,
 			} );
 		} );
 
 		test( 'Should return the correct tier 2 price for Jetpack Search product with > 100 posts', () => {
-			const state = {
-				posts: {
-					counts: {
-						counts: {
-							1: {
-								post: {
-									all: {
-										publish: 101, // 101 posts
-									},
-								},
-							},
-						},
-					},
-				},
-			};
 			const SEARCH_PRICE_TIER_LIST = [
-				{ minimum_units: 0, maximum_units: 100, minimum_price: 5995 },
-				{ minimum_units: 101, maximum_units: 1000, minimum_price: 11900 },
+				{
+					minimum_units: 0,
+					maximum_units: null,
+					transform_quantity_divide_by: 10000,
+					transform_quantity_round: 'up',
+					per_unit_fee: 896,
+				},
 			];
 			const plan = { getStoreSlug: () => 'jetpack_search', getProductId: () => '2104' };
 			// JP Search is a "product" not a plan, so `getPlanDiscountedRawPrice()` & `getPlanRawPrice()` should return null.
@@ -249,10 +229,10 @@ describe( 'selectors', () => {
 			getIntroOfferPrice.mockImplementation( () => null );
 			getIntroOfferIsEligible.mockImplementation( () => false );
 			getProductPriceTierList.mockImplementation( () => SEARCH_PRICE_TIER_LIST );
-			expect( computeFullAndMonthlyPricesForPlan( state, 1, plan ) ).toEqual( {
+			expect( computeFullAndMonthlyPricesForPlan( {}, 1, plan, 10001 ) ).toEqual( {
 				introductoryOfferPrice: null,
-				priceFull: 119,
-				priceFinal: 119,
+				priceFull: 17.92,
+				priceFinal: 17.92,
 			} );
 		} );
 	} );

--- a/packages/calypso-products/src/get-price-tier-for-units.ts
+++ b/packages/calypso-products/src/get-price-tier-for-units.ts
@@ -7,6 +7,10 @@ export interface PriceTierEntry {
 	maximum_price: number;
 	maximum_price_display?: string | null | undefined;
 	maximum_price_monthly_display?: string | null | undefined;
+	transform_quantity_divide_by?: number | null | undefined;
+	transform_quantity_round?: string | null | undefined;
+	per_unit_fee?: number | null | undefined;
+	flat_fee?: number | null | undefined;
 }
 
 export function getPriceTierForUnits(

--- a/packages/calypso-products/src/get-price-tier-for-units.ts
+++ b/packages/calypso-products/src/get-price-tier-for-units.ts
@@ -7,9 +7,27 @@ export interface PriceTierEntry {
 	maximum_price: number;
 	maximum_price_display?: string | null | undefined;
 	maximum_price_monthly_display?: string | null | undefined;
+	/**
+	 * If set, is used to transform the usage/quantity of units used to derive the number of units
+	 * we want to bill the customer for, before multiplying by the per_unit_fee.
+	 *
+	 * To put simply, the purpose of this attribute is to bill the customer at a different granularity compared to their usage.
+	 */
 	transform_quantity_divide_by?: number | null | undefined;
+	/**
+	 * Used for rounding the number of units we want to bill the customer for (which is derived after dividing the
+	 * usage/quantity of units by the `transform_quantity_divide_by` number).
+	 *
+	 * Used only when `transform_quantity_divide_by` is set. Possible values are: `up`, `down`
+	 */
 	transform_quantity_round?: string | null | undefined;
+	/**
+	 * The amount in the currency's smallest unit that this tier costs per unit.
+	 */
 	per_unit_fee?: number | null | undefined;
+	/**
+	 * The amount in the currency's smallest unit that this tier costs as a flat fee (for the entire tier).
+	 */
 	flat_fee?: number | null | undefined;
 }
 

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -507,6 +507,8 @@ export interface ResponseCartProduct {
 
 	price_tier_minimum_units?: number | null;
 	price_tier_maximum_units?: number | null;
+	price_tier_transform_quantity_divide_by?: number | null;
+	price_tier_transform_quantity_round?: string | null;
 	is_domain_registration: boolean;
 	is_bundled: boolean;
 	is_sale_coupon_applied: boolean;

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -507,7 +507,21 @@ export interface ResponseCartProduct {
 
 	price_tier_minimum_units?: number | null;
 	price_tier_maximum_units?: number | null;
+
+	/**
+	 * If set, is used to transform the usage/quantity of units used to derive the number of units
+	 * we want to bill the customer for, before applying the per unit cost.
+	 *
+	 * To put simply, the purpose of this attribute is to bill the customer at a different granularity compared to their usage.
+	 */
 	price_tier_transform_quantity_divide_by?: number | null;
+
+	/**
+	 * Used for rounding the number of units we want to bill the customer for (which is derived after dividing the
+	 * usage/quantity of units by the `price_tier_transform_quantity_divide_by` number).
+	 *
+	 * Used only when `$this->price_tier_transform_quantity_divide_by` is set. Possible values are: `up`, `down`
+	 */
 	price_tier_transform_quantity_round?: string | null;
 	is_domain_registration: boolean;
 	is_bundled: boolean;

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -561,15 +561,21 @@ function JetpackSearchMeta( { product }: { product: ResponseCartProduct } ) {
 
 function ProductTier( { product }: { product: ResponseCartProduct } ) {
 	const translate = useTranslate();
-
-	if ( isJetpackSearch( product ) ) {
-		const productQuantity = product.current_quantity || 10_000;
-		const productQuantityDividedByThousand = productQuantity / 1000;
+	if ( isJetpackSearch( product ) && product.price_tier_transform_quantity_divide_by ) {
+		const currentQuantity = product.current_quantity || 1;
+		let units_used: number;
+		if ( product.price_tier_transform_quantity_round === 'down' ) {
+			units_used = Math.floor( currentQuantity / product.price_tier_transform_quantity_divide_by );
+		} else {
+			units_used = Math.ceil( currentQuantity / product.price_tier_transform_quantity_divide_by );
+		}
+		const purchaseQuantityDividedByThousand =
+			( units_used * product.price_tier_transform_quantity_divide_by ) / 1000;
 		return (
 			<LineItemMeta>
 				{ translate(
-					'Up to %(productQuantityDividedByThousand)sk records and/or requests per month',
-					{ args: { productQuantityDividedByThousand } }
+					'Up to %(purchaseQuantityDividedByThousand)sk records and/or requests per month',
+					{ args: { purchaseQuantityDividedByThousand } }
 				) }
 			</LineItemMeta>
 		);

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -562,23 +562,17 @@ function JetpackSearchMeta( { product }: { product: ResponseCartProduct } ) {
 function ProductTier( { product }: { product: ResponseCartProduct } ) {
 	const translate = useTranslate();
 
-	if ( isJetpackSearch( product ) && product.current_quantity ) {
-		const tierMaximum = product.price_tier_maximum_units;
-		const tierMinimum = product.price_tier_minimum_units;
-		if ( tierMaximum ) {
-			return (
-				<LineItemMeta>
-					{ translate( 'Up to %(tierMaximum)s records', { args: { tierMaximum } } ) }
-				</LineItemMeta>
-			);
-		}
-		if ( tierMinimum ) {
-			return (
-				<LineItemMeta>
-					{ translate( 'More than %(tierMinimum) records', { args: { tierMinimum } } ) }
-				</LineItemMeta>
-			);
-		}
+	if ( isJetpackSearch( product ) ) {
+		const productQuantity = product.current_quantity || 10_000;
+		const productQuantityDividedByThousand = productQuantity / 1000;
+		return (
+			<LineItemMeta>
+				{ translate(
+					'Up to %(productQuantityDividedByThousand)sk records and/or requests per month',
+					{ args: { productQuantityDividedByThousand } }
+				) }
+			</LineItemMeta>
+		);
 	}
 	return null;
 }


### PR DESCRIPTION
#### Proposed Changes

Jetpack Search used pricing tiers data for some features.
However, with new pricing released recently, many of those
features stopped working.
New pricing uses quantity-based pricing, which requires
different type of calculations and more fields returned from API.
This PR requires diff D92804-code, which adds those fields.

List of fixes:

#### 1. Tooltip on https://cloud.jetpack.com/jetpack-search

Before:
![image](https://user-images.githubusercontent.com/6437642/202613679-8129eb3d-1827-4c42-84b0-c1f10a500503.png)

After:

![image](https://user-images.githubusercontent.com/6437642/202613743-8d3e5538-694b-4f93-88c2-d09e0c93615b.png)

#### 2. Quantity of requests/records being purchased for Jetpack Search during checkout

Before:

![image](https://user-images.githubusercontent.com/6437642/202613903-463c630d-f376-435e-a3ae-f2796d5e75ee.png)

After:

![image](https://user-images.githubusercontent.com/6437642/202613950-04cc3a75-c6f8-4230-851a-532124a6cf02.png)

Related discussion on P2: p7pQDF-7v2-p2#comment-21900
Related thread on twitter: https://twitter.com/redcrew/status/1593306122429005824

#### 3. Restored dropdown for switch between monthly and yearly billing

Before:

![image](https://user-images.githubusercontent.com/6437642/202614405-afeecfda-473e-4d76-a940-fff93b957854.png)

After:

![image](https://user-images.githubusercontent.com/6437642/202614351-dc652db5-4cae-4c46-b3e2-bd09d0e28300.png)


#### Testing Instructions

* Apply patch D92804-code on your sandbox
* Sandbox public-api.wordpress.com
* Start jetpack cloud 
* Visit http://jetpack.cloud.localhost:3000/jetpack-search and verify that the price tooltip shows correct amounts.
* Start calypso
* Visit http://calypso.localhost:3000/checkout/your_blog_url_here/jetpack_search and verify that the subtext under item line mentions how many records and/or requests will be purchased, and that it is possible to change to monthly pricing.


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->