### PR TITLE
Newsletter: Fix color control on Post-Setup screen

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/accent-color-control/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/accent-color-control/index.tsx
@@ -149,6 +149,7 @@ const AccentColorControl = ( { accentColor, setAccentColor }: AccentColorControl
 						: __( 'Accent color' ) }
 				</FormLabel>
 				<SelectDropdown
+					// @ts-expect-error SelectDropdown is defined in .jsx file and has no type definitions generated
 					ref={ accentColorRef }
 					className="accent-color-control__accent-color-input"
 					id="accentColor"

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/accent-color-control/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/accent-color-control/index.tsx
@@ -168,7 +168,7 @@ const AccentColorControl = ( { accentColor, setAccentColor }: AccentColorControl
 							{ option.label }
 						</SelectDropdown.Item>
 					) ) }
-				</SelectDropdown>{ ' ' }
+				</SelectDropdown>
 			</FormFieldset>
 			<div
 				className={ classNames( 'accent-color-control__contrast-warning', {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/accent-color-control/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/accent-color-control/index.tsx
@@ -98,7 +98,7 @@ const AccentColorControl = ( { accentColor, setAccentColor }: AccentColorControl
 	};
 
 	const getMatchingOption = useCallback(
-		() => COLOR_OPTIONS.filter( ( option ) => option.value === accentColor.hex )[ 0 ] || null,
+		() => COLOR_OPTIONS.find( ( option ) => option.value === accentColor.hex ) || null,
 		[ accentColor.hex ]
 	);
 


### PR DESCRIPTION
### Proposed Changes

The setup screen for the newsletter flow includes a color control for site accent color. This was [updated recently](https://github.com/Automattic/wp-calypso/commit/8abf3ac442e86a6980a75a214bc82ec2cfd0a1ee#diff-7ef7e4486dfb2e270808a116bbcce9231c12e1976dbe82231c43c14c479e5086) to use a Select Dropdown rather than a color picker. 

While changes work on the the initial setup screen, they are not working correctly on the post-setup screen, which uses the same components and allows user to edit previously set values. Specifically, the color is not being initially set correctly on the control. We are actually still fetching the correct color, but that comes from an API request after the Select Dropdown component is rendered. Even though we pass the updated color as a prop, the component does not update after initial load. 

This PR adjust how we're using the Select Dropdown component from uncontrolled to controlled. See the [component's readme](https://github.com/Automattic/wp-calypso/tree/trunk/client/components/select-dropdown) for context. This requires passing children to SelectDropdown rather than an options array as a prop, and it requires we do some state management rather than delegate state management to SelectDropdown. 

### Testing Instructions

1. Check out this branch and run `yarn` and `yarn start` if needed. 

2. Go to https://wordpress.com/hp-2022-tailored-flows/ and start a newsletter site. 

3. Before you get to first setup screen (with site title/tagline/color), update your url to http://calypso.localhost:3000/ to ensure you're running this local branch. 

4. TEST: When you arrive on newsletter setup screen, please confirm the color control is rending properly. Try changing the color and confirm it updates as expected. Save and proceed. This behavior should not have changed, we're just testing to confirm no regressive breakages with the color control. 

5. TEST: When you get to launchpad screen, confirm the color you selected is shown in the web preview. Again this behavior should not have changed, we're just testing to confirm no regressive breakages with the color control. 

6. Click the Personalize Newsletter link and go to the newsletter post-setup page. 

7. TEST: Confirm on post-setup screen that color control still renders correctly, and confirm the color shows the color you selected in step 4. This behavior is what has changed. Before this PR, the color for this control was not updating to your previously selected color. 

8. TEST: Choose a new color, save, and continue. Confirm that your new color now shows on the launchpad preview. 

9. TEST: Repeat steps 6-8 once more just to confirm the color control always shows what you've selected, and that your changes are saved. 