### PR TITLE
Partner Portal: filter already assigned products and plan to a site when issuing licenses

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/issue-multiple-licenses-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-multiple-licenses-form/index.tsx
@@ -2,7 +2,7 @@ import { Button } from '@automattic/components';
 import { getQueryArg } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useState, useEffect } from 'react';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { useIssueMultipleLicenses } from 'calypso/jetpack-cloud/sections/partner-portal/hooks';
 import LicenseBundleCard from 'calypso/jetpack-cloud/sections/partner-portal/license-bundle-card';
 import LicenseProductCard from 'calypso/jetpack-cloud/sections/partner-portal/license-product-card';
@@ -12,6 +12,7 @@ import {
 } from 'calypso/jetpack-cloud/sections/partner-portal/utils';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import useProductsQuery from 'calypso/state/partner-portal/licenses/hooks/use-products-query';
+import { getAssignedPlanAndProductIDsForSite } from 'calypso/state/partner-portal/licenses/selectors';
 import { AssignLicenceProps } from '../types';
 
 import './style.scss';
@@ -22,9 +23,21 @@ export default function IssueMultipleLicensesForm( {
 }: AssignLicenceProps ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
-	const { data: allProducts, isLoading: isLoadingProducts } = useProductsQuery( {
+	const { data, isLoading: isLoadingProducts } = useProductsQuery( {
 		select: selectAlphaticallySortedProductOptions,
 	} );
+
+	let allProducts = data;
+	const addedPlanAndProducts = useSelector( ( state ) =>
+		selectedSite ? getAssignedPlanAndProductIDsForSite( state, selectedSite.ID ) : null
+	);
+
+	// Filter products & plan that are already assigned to a site
+	if ( selectedSite && addedPlanAndProducts && allProducts ) {
+		allProducts = allProducts.filter(
+			( product ) => ! addedPlanAndProducts.includes( product.product_id )
+		);
+	}
 
 	const bundles =
 		allProducts?.filter( ( { family_slug } ) => family_slug === 'jetpack-packs' ) || [];

--- a/client/state/partner-portal/licenses/selectors.ts
+++ b/client/state/partner-portal/licenses/selectors.ts
@@ -35,7 +35,7 @@ export function getAssignedPlanAndProductIDsForSite(
 	state: AppState,
 	siteId: number
 ): Array< number > {
-	let planAndProductIDs: number[] = [];
+	const planAndProductIDs: number[] = [];
 	const currentSite = state?.sites?.items?.[ siteId ];
 	// Get the assigned plan(bundle) to a site.
 	const plan = currentSite?.plan.product_id;
@@ -43,12 +43,8 @@ export function getAssignedPlanAndProductIDsForSite(
 		planAndProductIDs.push( plan );
 	}
 	// Get all assigned products to a site.
-	const products = currentSite?.products.map( ( product: { product_id: string } ) =>
-		// parseInt since the product IDs are strings of numbers.
-		parseInt( product.product_id )
+	currentSite?.products.forEach( ( product: { product_id: string } ) =>
+		planAndProductIDs.push( parseInt( product.product_id ) )
 	);
-	if ( products?.length ) {
-		planAndProductIDs = [ ...planAndProductIDs, ...products ];
-	}
 	return planAndProductIDs;
 }

--- a/client/state/partner-portal/licenses/selectors.ts
+++ b/client/state/partner-portal/licenses/selectors.ts
@@ -6,6 +6,7 @@ import {
 } from 'calypso/state/partner-portal/types';
 // Required for modular state.
 import 'calypso/state/partner-portal/init';
+import type { AppState } from 'calypso/types';
 
 export function hasFetchedLicenses( state: PartnerPortalStore ): boolean {
 	return state.partnerPortal.licenses.hasFetched;
@@ -27,4 +28,27 @@ export function getLicenseCounts( state: PartnerPortalStore ): LicenseCounts {
 
 export function hasFetchedLicenseCounts( state: PartnerPortalStore ): boolean {
 	return state.partnerPortal.licenses.hasFetchedLicenseCounts;
+}
+
+// Returns the product IDs of the assigned plan(bundle) & all the products to a particular site in an array.
+export function getAssignedPlanAndProductIDsForSite(
+	state: AppState,
+	siteId: number
+): Array< number > {
+	let planAndProductIDs: number[] = [];
+	const currentSite = state?.sites?.items?.[ siteId ];
+	// Get the assigned plan(bundle) to a site.
+	const plan = currentSite?.plan.product_id;
+	if ( plan ) {
+		planAndProductIDs.push( plan );
+	}
+	// Get all assigned products to a site.
+	const products = currentSite?.products.map( ( product: { product_id: string } ) =>
+		// parseInt since the product IDs are strings of numbers.
+		parseInt( product.product_id )
+	);
+	if ( products?.length ) {
+		planAndProductIDs = [ ...planAndProductIDs, ...products ];
+	}
+	return planAndProductIDs;
 }


### PR DESCRIPTION
#### Proposed Changes

This PR makes the changes to filter out the products and plan(bundle) already assigned to a particular site.

#### Testing Instructions

1. Run `git checkout update/filter-already-assigned-products-to-site` and `yarn start-jetpack-cloud`
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Click on `Add +` on any site  -> Click on **Issue x new License**.
4. Verify that products and the plan(bundle, if any) assigned before are not available for selection. 
5. If you don't see any `Add +` button, you can click on `Issue new license` button from the more options(`…` menu)

<img width="1139" alt="Screenshot 2022-11-18 at 2 21 48 PM" src="https://user-images.githubusercontent.com/10586875/202661337-9ad7fec2-327c-4ab5-977a-f6990fc440a2.png">

6. Create a new JN Site, repeat step 3 and verify all the licenses are available for selection. Please note that you will have to refresh the page before repeating step 3.

<img width="1095" alt="Screenshot 2022-11-18 at 2 22 39 PM" src="https://user-images.githubusercontent.com/10586875/202661389-171b53cd-008c-4818-95c1-bedb7581f0fb.png">

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1203126240279377-as-1203341767675741