### PR TITLE
Add support for a monthly-to-yearly domain nudge

### DIFF
--- a/client/my-sites/domains/domain-search/index.jsx
+++ b/client/my-sites/domains/domain-search/index.jsx
@@ -24,7 +24,6 @@ import {
 } from 'calypso/lib/cart-values/cart-items';
 import { getSuggestionsVendor } from 'calypso/lib/domains/suggestions';
 import withCartKey from 'calypso/my-sites/checkout/with-cart-key';
-// Monthly plans don't have free domains
 import NewDomainsRedirectionNoticeUpsell from 'calypso/my-sites/domains/domain-management/components/domain/new-domains-redirection-notice-upsell';
 import {
 	domainAddEmailUpsell,

--- a/client/my-sites/domains/domain-search/index.jsx
+++ b/client/my-sites/domains/domain-search/index.jsx
@@ -24,6 +24,7 @@ import {
 } from 'calypso/lib/cart-values/cart-items';
 import { getSuggestionsVendor } from 'calypso/lib/domains/suggestions';
 import withCartKey from 'calypso/my-sites/checkout/with-cart-key';
+// Monthly plans don't have free domains
 import NewDomainsRedirectionNoticeUpsell from 'calypso/my-sites/domains/domain-management/components/domain/new-domains-redirection-notice-upsell';
 import {
 	domainAddEmailUpsell,
@@ -38,6 +39,7 @@ import {
 } from 'calypso/state/domains/actions';
 import { getProductsList } from 'calypso/state/products-list/selectors';
 import canUserPurchaseGSuite from 'calypso/state/selectors/can-user-purchase-gsuite';
+import isSiteOnMonthlyPlan from 'calypso/state/selectors/is-site-on-monthly-plan';
 import isSiteUpgradeable from 'calypso/state/selectors/is-site-upgradeable';
 import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 import {
@@ -150,7 +152,11 @@ class DomainSearch extends Component {
 				// Nothing needs to be done here. CartMessages will display the error to the user.
 				return;
 			}
-			page( `/plans/${ this.props.selectedSiteSlug }?domainAndPlanPackage=true` );
+			// Monthly plans don't have free domains
+			const intervalTypePath = this.props.isSiteOnMonthlyPlan ? 'yearly/' : '';
+			page(
+				`/plans/${ intervalTypePath }${ this.props.selectedSiteSlug }?domainAndPlanPackage=true`
+			);
 			return;
 		}
 
@@ -300,6 +306,7 @@ export default connect(
 			selectedSiteSlug: getSelectedSiteSlug( state ),
 			domainsWithPlansOnly: currentUserHasFlag( state, DOMAINS_WITH_PLANS_ONLY ),
 			isSiteUpgradeable: isSiteUpgradeable( state, siteId ),
+			isSiteOnMonthlyPlan: isSiteOnMonthlyPlan( state, siteId ),
 			productsList: getProductsList( state ),
 			userCanPurchaseGSuite: canUserPurchaseGSuite( state ),
 		};

--- a/client/state/selectors/is-site-on-monthly-plan.js
+++ b/client/state/selectors/is-site-on-monthly-plan.js
@@ -1,0 +1,22 @@
+import { isMonthly } from '@automattic/calypso-products';
+import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
+
+/**
+ * Returns true if site is on a monthly plan, false if the site is not
+ * or if the site or plan is unknown.
+ *
+ * @param {object} state Global state tree
+ * @param {number} siteId Site ID
+ * @returns {boolean} Whether site is on a monthly plan
+ */
+const isSiteOnMonthlyPlan = ( state, siteId ) => {
+	const currentPlan = getCurrentPlan( state, siteId );
+
+	if ( ! currentPlan ) {
+		return false;
+	}
+
+	return isMonthly( currentPlan.productSlug );
+};
+
+export default isSiteOnMonthlyPlan;


### PR DESCRIPTION
A monthly plan, getting a JITM nudge to upgrade to annual to get a free domain, would need to have the plan step show yearly plans. Monthly plans don't have a free domain credit.

This change will ask monthly plans to switch to an annual plan to get a free domain, if the user clicks on a link like this:

/domains/add/YOUR-TEST-SITE.wordpress.com?domainAndPlanPackage=true

Sites on a 2-year plan or on Free should be unaffected by the change

#### Proposed Changes

<img width="316" alt="Screenshot 2022-11-18 at 12 11 36" src="https://user-images.githubusercontent.com/82778/202677552-b1e6b6f3-3fe2-4eea-9a7a-a827b86b6a72.png">


#### Testing Instructions

* Apply D92820-code and sandbox the API, enable the store sandbox
* Get a monthly plan
* Go to /home
* Click the Free domain with an annual plan sidebar nudge and complete the checkout
* You should get a domain with an annual plan
* Make sure the same nudge works fine with a Free plan
* Make sure the nudge doesn't appear if you're on an annual or 2-year plan

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
