### PR TITLE
Jetpack Agency Dashboard: redirect to /issue-license if there is only one inactive product

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content.tsx
@@ -1,8 +1,10 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { Button, Gridicon } from '@automattic/components';
+import { addQueryArgs } from '@wordpress/url';
 import classNames from 'classnames';
 import { translate } from 'i18n-calypso';
-import { useRef, useState } from 'react';
+import page from 'page';
+import { useRef, useState, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import Badge from 'calypso/components/badge';
 import Tooltip from 'calypso/components/tooltip';
@@ -10,7 +12,7 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { selectLicense, unselectLicense } from 'calypso/state/jetpack-agency-dashboard/actions';
 import { hasSelectedLicensesOfType } from 'calypso/state/jetpack-agency-dashboard/selectors';
 import SiteSetFavorite from './site-set-favorite';
-import { getRowMetaData } from './utils';
+import { getRowMetaData, getProductSlugFromProductType } from './utils';
 import type { AllowedTypes, SiteData } from './types';
 
 interface Props {
@@ -65,8 +67,21 @@ export default function SiteStatusContent( {
 		dispatch( recordTracksEvent( eventName ) );
 	};
 
+	const issueLicenseRedirectUrl = useMemo( () => {
+		return addQueryArgs( `/partner-portal/issue-license/`, {
+			site_id: siteId,
+			product_slug: getProductSlugFromProductType( type ),
+			source: 'dashboard',
+		} );
+	}, [ siteId, type ] );
+
 	const handleSelectLicenseAction = () => {
-		dispatch( selectLicense( siteId, type ) );
+		const inactiveProducts = Object.values( rows ).filter( ( row ) => row?.status === 'inactive' );
+		if ( inactiveProducts.length > 1 ) {
+			return dispatch( selectLicense( siteId, type ) );
+		}
+		// Redirect to issue-license if there is only one inactive product available for a site
+		return page( issueLicenseRedirectUrl );
 	};
 
 	const handleDeselectLicenseAction = () => {


### PR DESCRIPTION
#### Proposed Changes

This PR makes the changes to the agency dashboard by redirecting the user to /issue-license directly instead of showing the `Issue x License` button if there is only one inactive product.

#### Testing Instructions

1. Run `git checkout update/redirect-to-issue-license-if-one-inactive-product` and `yarn start-jetpack-cloud`
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Verify that clicking on `Add +` changes the button text to `Selected` and shows the button to **Issue x new License** when there is more than 1 inactive product for a site.

<img width="794" alt="Screenshot 2022-11-18 at 5 05 05 PM" src="https://user-images.githubusercontent.com/10586875/202696551-7fee79d6-4c22-43e5-b689-069c53900564.png">

4. Verify that clicking on `Add +` redirects you to `issue-license` with the selected product when there is only 1 inactive product for a site.

<img width="1070" alt="Screenshot 2022-11-18 at 5 06 39 PM" src="https://user-images.githubusercontent.com/10586875/202696691-126514c1-31c2-4629-8a51-4e75d8384cb9.png">

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1203126240279377-as-1203397767673961