### PR TITLE
Help Center: add new config key

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/config.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/config.js
@@ -18,6 +18,7 @@ window.configData = {
 	signup_url: '/',
 	discover_blog_id: 53424024,
 	discover_feed_id: 41325786,
+	is_running_in_jetpack_site: false,
 };
 window.process = {
 	env: {


### PR DESCRIPTION
## Proposed Changes

This fixes the annoying error

```
Uncaught ReferenceError: Could not find config value for key 'is_running_in_jetpack_site'
```

This will be unnecessary once this is merged #70122 

## Testing Instructions
Pull Branch
Sync ETK and sandbox a test site
Open help center from wp-admin of the test site