### PR TITLE
Help Center: make external icons smaller

### DIFF
--- a/packages/help-center/src/components/help-center-search.scss
+++ b/packages/help-center/src/components/help-center-search.scss
@@ -285,7 +285,7 @@
 				}
 
 				> svg:last-child {
-					fill: unset;
+					fill: var(--studio-gray-20);
 					margin-left: auto;
 				}
 			}


### PR DESCRIPTION
## Proposed Changes

This changes the external icon color for the recommended resources to something a little softer. Rather than making it smaller which just looked weird.

<img width="409" alt="Markup 2022-11-18 at 12 47 52" src="https://user-images.githubusercontent.com/33258733/202702893-915b638c-1079-4d54-874a-e1d774881550.png">

## Testing Instructions

1. Pull branch
2. Start Calypso
3. Check Help Center and make sure the icons are grey
4. Look for regression in articles or when opening Help Center from another page like /me or /help/contact


Closes #68019