### PR TITLE
Add https:// prefix to the Domain flow input

### DIFF
--- a/client/components/domains/use-my-domain/domain-input.jsx
+++ b/client/components/domains/use-my-domain/domain-input.jsx
@@ -69,6 +69,12 @@ function UseMyDomainInput( {
 	const domainInputNote = hasDomainInputNoteLabel
 		? __( 'This won’t affect your existing site.' )
 		: '';
+
+	const hasDomainPlaceholderLabel =
+		[ 'en', 'en-gb' ].includes( locale ) || hasTranslation( 'yoursiteaddress.com' );
+	const domainPlaceholderLabel = hasDomainPlaceholderLabel
+		? __( 'yoursiteaddress.com' )
+		: __( 'mydomain.com' );
 	return (
 		<Card className={ baseClassName }>
 			{ ! isSignupStep && (
@@ -80,7 +86,7 @@ function UseMyDomainInput( {
 				<label>{ domainInputLabel }</label>
 				<FormFieldset className={ baseClassName + '__domain-input-fieldset' }>
 					<FormTextInput
-						placeholder={ __( 'mydomain.com' ) }
+						placeholder={ domainPlaceholderLabel }
 						value={ domainName }
 						onChange={ onChange }
 						onKeyDown={ keyDown }

--- a/client/components/domains/use-my-domain/domain-input.jsx
+++ b/client/components/domains/use-my-domain/domain-input.jsx
@@ -1,5 +1,5 @@
 import { Card, Button, FormInputValidation, Gridicon } from '@automattic/components';
-import { useLocale } from '@automattic/i18n-utils';
+import { englishLocales, useLocale } from '@automattic/i18n-utils';
 import { __, hasTranslation } from '@wordpress/i18n';
 import { Icon } from '@wordpress/icons';
 import PropTypes from 'prop-types';
@@ -47,25 +47,12 @@ function UseMyDomainInput( {
 		}
 	};
 
-	const hasDomainInputLabel =
-		[ 'en', 'en-gb' ].includes( locale ) ||
-		hasTranslation( 'Enter the domain you would like to use:' );
-	const domainInputLabel = hasDomainInputLabel
-		? __( 'Enter the domain you would like to use:' )
-		: __( 'Enter your domain here' );
-
-	const hasDomainInputNoteLabel =
-		[ 'en', 'en-gb' ].includes( locale ) ||
-		hasTranslation( 'Enter the domain you would like to use:' );
-	const domainInputNote = hasDomainInputNoteLabel
-		? __( 'This won’t affect your existing site.' )
-		: '';
-
 	const hasDomainPlaceholderLabel =
-		[ 'en', 'en-gb' ].includes( locale ) || hasTranslation( 'yoursiteaddress.com' );
+		englishLocales.includes( locale ) || hasTranslation( 'yoursiteaddress.com' );
 	const domainPlaceholderLabel = hasDomainPlaceholderLabel
 		? __( 'yoursiteaddress.com' )
 		: __( 'mydomain.com' );
+
 	return (
 		<Card className={ baseClassName }>
 			{ ! isSignupStep && (
@@ -74,7 +61,7 @@ function UseMyDomainInput( {
 				</div>
 			) }
 			<div className={ baseClassName + '__domain-input' }>
-				<label>{ domainInputLabel }</label>
+				<label>{ __( 'Enter the domain you would like to use:' ) }</label>
 				<FormFieldset className={ baseClassName + '__domain-input-fieldset' }>
 					<FormTextInput
 						placeholder={ domainPlaceholderLabel }
@@ -101,16 +88,16 @@ function UseMyDomainInput( {
 					) }
 					{ validationError && <FormInputValidation isError text={ validationError } icon="" /> }
 				</FormFieldset>
-				{ domainInputNote && (
-					<p className={ baseClassName + '__domain-input-note' }>
-						<Icon
-							className={ baseClassName + '__domain-input-note-icon' }
-							icon={ bulb }
-							size={ 14 }
-						/>
-						{ domainInputNote }
-					</p>
-				) }
+
+				<p className={ baseClassName + '__domain-input-note' }>
+					<Icon
+						className={ baseClassName + '__domain-input-note-icon' }
+						icon={ bulb }
+						size={ 14 }
+					/>
+					{ __( 'This won’t affect your existing site.' ) }
+				</p>
+
 				<FormButton
 					className={ baseClassName + '__domain-input-button' }
 					primary

--- a/client/components/domains/use-my-domain/domain-input.jsx
+++ b/client/components/domains/use-my-domain/domain-input.jsx
@@ -83,6 +83,8 @@ function UseMyDomainInput( {
 						onKeyDown={ keyDown }
 						isError={ !! validationError }
 						ref={ domainNameInput }
+						autocapitalize="none"
+						autocorrect="off"
 					/>
 					{ domainName && (
 						<Button

--- a/client/components/domains/use-my-domain/domain-input.jsx
+++ b/client/components/domains/use-my-domain/domain-input.jsx
@@ -48,9 +48,9 @@ function UseMyDomainInput( {
 	};
 
 	const hasDomainPlaceholderLabel =
-		englishLocales.includes( locale ) || hasTranslation( 'yoursiteaddress.com' );
+		englishLocales.includes( locale ) || hasTranslation( 'yourgroovydomain.com' );
 	const domainPlaceholderLabel = hasDomainPlaceholderLabel
-		? __( 'yoursiteaddress.com' )
+		? __( 'yourgroovydomain.com' )
 		: __( 'mydomain.com' );
 
 	return (

--- a/client/components/domains/use-my-domain/domain-input.jsx
+++ b/client/components/domains/use-my-domain/domain-input.jsx
@@ -54,15 +54,6 @@ function UseMyDomainInput( {
 		? __( 'Enter the domain you would like to use:' )
 		: __( 'Enter your domain here' );
 
-	const hasDomainNoteLabel =
-		[ 'en', 'en-gb' ].includes( locale ) ||
-		hasTranslation(
-			'Please enter your site address without “www” or “https://” e.g. mydomain.com'
-		);
-	const domainNote = hasDomainNoteLabel
-		? __( 'Please enter your site address without “www” or “https://” e.g. mydomain.com' )
-		: '';
-
 	const hasDomainInputNoteLabel =
 		[ 'en', 'en-gb' ].includes( locale ) ||
 		hasTranslation( 'Enter the domain you would like to use:' );
@@ -105,9 +96,6 @@ function UseMyDomainInput( {
 								size={ 12 }
 							/>
 						</Button>
-					) }
-					{ domainNote && (
-						<p className={ baseClassName + '__domain-input-note' }>{ domainNote }</p>
 					) }
 					{ validationError && <FormInputValidation isError text={ validationError } icon="" /> }
 				</FormFieldset>

--- a/client/components/domains/use-my-domain/style.scss
+++ b/client/components/domains/use-my-domain/style.scss
@@ -45,7 +45,7 @@
 		max-width: 370px;
 
 		.form-text-input {
-			padding: 9px 14px;
+			padding: 9px 14px 9px 68px;
 			margin-bottom: 9px;
 
 			&::placeholder {
@@ -82,6 +82,14 @@
 				fill: #000;
 			}
 		}
+	}
+
+	& &__domain-input-fieldset::before {
+		content: "https://";
+		color: #000;
+		position: absolute;
+		left: 16px;
+		top: 10px;
 	}
 }
 

--- a/client/components/domains/use-my-domain/style.scss
+++ b/client/components/domains/use-my-domain/style.scss
@@ -80,14 +80,14 @@
 			margin-right: 4px !important;
 
 			path {
-				fill: $black;
+				fill: var(--color-text);
 			}
 		}
 	}
 
 	& &__domain-input-fieldset::before {
 		content: "https://";
-		color: $black;
+		color: var(--color-text);
 		position: absolute;
 		left: 16px;
 		top: 10px;

--- a/client/components/domains/use-my-domain/style.scss
+++ b/client/components/domains/use-my-domain/style.scss
@@ -1,6 +1,7 @@
 @import "@automattic/typography/styles/variables";
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/colors";
 
 .use-my-domain {
 	display: flex;
@@ -79,14 +80,14 @@
 			margin-right: 4px !important;
 
 			path {
-				fill: #000;
+				fill: $black;
 			}
 		}
 	}
 
 	& &__domain-input-fieldset::before {
 		content: "https://";
-		color: #000;
+		color: $black;
 		position: absolute;
 		left: 16px;
 		top: 10px;


### PR DESCRIPTION
#### Proposed Changes

This adds a fixed `https://` prefix to the domain input (as per [comment](https://github.com/Automattic/wp-calypso/issues/69787#issuecomment-1318892953)).


https://user-images.githubusercontent.com/2749938/204770375-9dba581e-1b4d-41cc-865b-0cd657ea6147.mp4



#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use an English locale
* Go to `/start/domains/use-your-domain`
* You should see the prefix `https://` on the input:
<img width="420" alt="Screen Shot on 2022-11-30 at 12-19-36" src="https://user-images.githubusercontent.com/2749938/204770551-4f737fbf-d57a-47ff-a850-0492b8283878.png">


* Use a non-English locale
* Refresh
* The placeholder should fallback to a translated version of `mydomain.com`
<img width="420" alt="Screen Shot on 2022-11-18 at 15-20-12" src="https://user-images.githubusercontent.com/2749938/202714626-e92640a2-ad6f-4267-87dc-2d5c4d3bc568.png">


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #69787
