### PR TITLE
Add/sort by last update

### DIFF
--- a/client/blocks/reader-subscription-list-item/index.jsx
+++ b/client/blocks/reader-subscription-list-item/index.jsx
@@ -128,7 +128,7 @@ function ReaderSubscriptionListItem( {
 									{ formatUrlForDisplay( siteUrl ) }
 								</ExternalLink>
 							</li>
-							{ showLastUpdatedDate && feed && feed.last_update && (
+							{ showLastUpdatedDate && feed && feed.last_update && ! isNaN( feed.last_update ) && (
 								<li>
 									<span className="reader-subscription-list-item__timestamp">
 										{ translate( 'updated %s', {
@@ -137,9 +137,12 @@ function ReaderSubscriptionListItem( {
 									</span>
 								</li>
 							) }
-							{ feed && feed.date_subscribed && (
+							{ feed && feed.date_subscribed && ! isNaN( feed.date_subscribed ) && (
 								<li>
-									<span className="reader-subscription-list-item__date-subscribed">
+									<span
+										className="reader-subscription-list-item__date-subscribed"
+										title={ moment( feed.date_subscribed ).format( 'll' ) }
+									>
 										{ translate( 'followed %s', {
 											args: moment( feed.date_subscribed ).format( 'MMM YYYY' ),
 										} ) }
@@ -172,10 +175,21 @@ export default compose(
 
 		if ( feed ) {
 			const follow = getReaderFollowForFeed( state, parseInt( ownProps.feedId ) );
-			// Add site icon to feed object so have icon for external feeds
-			feed.site_icon = follow?.site_icon;
-			// Add date_subscribed timestamp to feed object
-			feed.date_subscribed = follow?.date_subscribed;
+
+			if ( follow ) {
+				// Add site icon to feed object so have icon for external feeds when not set
+				if ( feed.site_icon === undefined ) {
+					feed.site_icon = follow.site_icon;
+				}
+				// Add date_subscribed timestamp to feed object when not set
+				if ( feed.date_subscribed === undefined || isNaN( feed.date_subscribed ) ) {
+					feed.date_subscribed = follow.date_subscribed;
+				}
+				// Add last_update timestamp to feed object when not set
+				if ( feed.last_update === undefined || isNaN( feed.last_update ) ) {
+					feed.last_update = follow.last_updated;
+				}
+			}
 		}
 
 		return {

--- a/client/blocks/reader-subscription-list-item/index.jsx
+++ b/client/blocks/reader-subscription-list-item/index.jsx
@@ -133,6 +133,7 @@ function ReaderSubscriptionListItem( {
 									<span className="reader-subscription-list-item__timestamp">
 										{ translate( 'updated %s', {
 											args: moment( feed.last_update ).fromNow(),
+											context: 'date feed was last updated',
 										} ) }
 									</span>
 								</li>
@@ -145,6 +146,7 @@ function ReaderSubscriptionListItem( {
 									>
 										{ translate( 'followed %s', {
 											args: moment( feed.date_subscribed ).format( 'MMM YYYY' ),
+											context: 'date feed was followed',
 										} ) }
 									</span>
 								</li>

--- a/client/reader/following-manage/index.jsx
+++ b/client/reader/following-manage/index.jsx
@@ -52,7 +52,7 @@ class FollowingManage extends Component {
 	static propTypes = {
 		sitesQuery: PropTypes.string,
 		subsQuery: PropTypes.string,
-		subsSortOrder: PropTypes.oneOf( [ 'date-followed', 'alpha' ] ),
+		subsSortOrder: PropTypes.oneOf( [ 'date-followed', 'alpha', 'date-updated' ] ),
 		translate: PropTypes.func,
 		showMoreResults: PropTypes.bool,
 	};

--- a/client/reader/following-manage/sort-controls.jsx
+++ b/client/reader/following-manage/sort-controls.jsx
@@ -8,7 +8,7 @@ const noop = () => {};
 class FollowingManageSortControls extends Component {
 	static propTypes = {
 		onSortChange: PropTypes.func,
-		sortOrder: PropTypes.oneOf( [ 'date-followed', 'alpha' ] ),
+		sortOrder: PropTypes.oneOf( [ 'date-followed', 'alpha', 'date-updated' ] ),
 	};
 
 	static defaultProps = {
@@ -30,6 +30,7 @@ class FollowingManageSortControls extends Component {
 				value={ sortOrder }
 			>
 				<option value="date-followed">{ this.props.translate( 'Sort by date followed' ) }</option>
+				<option value="date-updated">{ this.props.translate( 'Sort by date updated' ) }</option>
 				<option value="alpha">{ this.props.translate( 'Sort by site name' ) }</option>
 			</FormSelect>
 		);

--- a/client/reader/following-manage/subscriptions.jsx
+++ b/client/reader/following-manage/subscriptions.jsx
@@ -27,7 +27,7 @@ class FollowingManageSubscriptions extends Component {
 		follows: PropTypes.array.isRequired,
 		doSearch: PropTypes.func.isRequired,
 		query: PropTypes.string,
-		sortOrder: PropTypes.oneOf( [ 'date-followed', 'alpha' ] ),
+		sortOrder: PropTypes.oneOf( [ 'date-followed', 'alpha', 'date-updated' ] ),
 		windowScrollerRef: PropTypes.func,
 	};
 
@@ -39,6 +39,22 @@ class FollowingManageSubscriptions extends Component {
 				const displayUrl = formatUrlForDisplay( follow.URL );
 				return getFeedTitle( site, feed, displayUrl ).toLowerCase().trimStart();
 			} );
+		}
+
+		if ( sortOrder === 'date-updated' ) {
+			return sortBy( follows, ( follow ) => {
+				let last_update = 0;
+				if ( follow.date_subscribed && ! isNaN( follow.date_subscribed ) ) {
+					last_update = follow.date_subscribed;
+				}
+				if ( follow.last_updated && ! isNaN( follow.last_updated ) ) {
+					last_update = follow.last_updated;
+				}
+				if ( follow.feed && follow.feed.last_update && ! isNaN( follow.feed.last_update ) ) {
+					last_update = follow.feed.last_update;
+				}
+				return last_update;
+			} ).reverse();
 		}
 
 		return sortBy( follows, [ 'date_subscribed' ] ).reverse();


### PR DESCRIPTION
This PR adds a new sort by option on the Reader manage feeds page;

The new options is `Sort by date updated`

<img width="756" alt="Screenshot 2022-11-18 at 14 17 03" src="https://user-images.githubusercontent.com/5560595/202725287-3ad4e3d8-cce9-4f11-8192-f34bd053fd06.png">

This PR also adds a tooltip to the date subscribed

<img width="775" alt="Screenshot 2022-11-18 at 14 07 43" src="https://user-images.githubusercontent.com/5560595/202725539-d8b7e970-f9ef-4bff-bdbf-4cfe9f559e9d.png">

Lastly, the PR includes some translation context to help with translating the `updated` and `followed` strings on this page.

