### PR TITLE
Limit Global Styles: Refactor the Color Dropdown in Newsletter Flow Implementation

### DIFF
--- a/client/components/select-dropdown/index.jsx
+++ b/client/components/select-dropdown/index.jsx
@@ -233,7 +233,7 @@ class SelectDropdown extends Component {
 				>
 					<div id={ 'select-dropdown-' + this.instanceId } className="select-dropdown__header">
 						<span className="select-dropdown__header-text" aria-label={ this.props.ariaLabel }>
-							{ selectedExtra && <>{ selectedExtra }</> }
+							{ selectedExtra }
 							{ selectedIcon }
 							{ selectedText }
 						</span>

--- a/client/components/select-dropdown/index.jsx
+++ b/client/components/select-dropdown/index.jsx
@@ -21,6 +21,7 @@ class SelectDropdown extends Component {
 		selectedText: TranslatableString,
 		selectedIcon: PropTypes.element,
 		selectedCount: PropTypes.number,
+		selectedExtra: PropTypes.element,
 		initialSelected: PropTypes.string,
 		className: PropTypes.string,
 		style: PropTypes.object,
@@ -35,6 +36,7 @@ class SelectDropdown extends Component {
 				label: PropTypes.oneOfType( [ TranslatableString, PropTypes.node ] ).isRequired,
 				path: PropTypes.string,
 				icon: PropTypes.element,
+				extra: PropTypes.element,
 			} )
 		),
 		isLoading: PropTypes.bool,
@@ -132,6 +134,17 @@ class SelectDropdown extends Component {
 		return get( find( options, { value: selected } ), 'icon' );
 	}
 
+	getSelectedExtra() {
+		const { options, selectedExtra } = this.props;
+		const { selected } = this.state;
+
+		if ( selectedExtra ) {
+			return selectedExtra;
+		}
+
+		return get( find( options, { value: selected } ), 'extra' );
+	}
+
 	dropdownOptions() {
 		let refIndex = 0;
 
@@ -181,6 +194,7 @@ class SelectDropdown extends Component {
 						onClick={ this.onSelectItem( item ) }
 						path={ item.path }
 						icon={ item.icon }
+						extra={ item.extra }
 					>
 						{ item.label }
 					</DropdownItem>
@@ -199,6 +213,7 @@ class SelectDropdown extends Component {
 
 		const selectedText = this.getSelectedText();
 		const selectedIcon = this.getSelectedIcon();
+		const selectedExtra = this.getSelectedExtra();
 
 		return (
 			<div id={ this.props.id } style={ this.props.style } className={ dropdownClassName }>
@@ -218,6 +233,7 @@ class SelectDropdown extends Component {
 				>
 					<div id={ 'select-dropdown-' + this.instanceId } className="select-dropdown__header">
 						<span className="select-dropdown__header-text" aria-label={ this.props.ariaLabel }>
+							{ selectedExtra && <>{ selectedExtra }</> }
 							{ selectedIcon }
 							{ selectedText }
 						</span>

--- a/client/components/select-dropdown/index.jsx
+++ b/client/components/select-dropdown/index.jsx
@@ -21,7 +21,7 @@ class SelectDropdown extends Component {
 		selectedText: TranslatableString,
 		selectedIcon: PropTypes.element,
 		selectedCount: PropTypes.number,
-		selectedExtra: PropTypes.element,
+		selectedSecondaryIcon: PropTypes.element,
 		initialSelected: PropTypes.string,
 		className: PropTypes.string,
 		style: PropTypes.object,
@@ -36,7 +36,7 @@ class SelectDropdown extends Component {
 				label: PropTypes.oneOfType( [ TranslatableString, PropTypes.node ] ).isRequired,
 				path: PropTypes.string,
 				icon: PropTypes.element,
-				extra: PropTypes.element,
+				secondaryIcon: PropTypes.element,
 			} )
 		),
 		isLoading: PropTypes.bool,
@@ -134,15 +134,15 @@ class SelectDropdown extends Component {
 		return get( find( options, { value: selected } ), 'icon' );
 	}
 
-	getSelectedExtra() {
-		const { options, selectedExtra } = this.props;
+	getSelectedSecondaryIcon() {
+		const { options, selectedSecondaryIcon } = this.props;
 		const { selected } = this.state;
 
-		if ( selectedExtra ) {
-			return selectedExtra;
+		if ( selectedSecondaryIcon ) {
+			return selectedSecondaryIcon;
 		}
 
-		return get( find( options, { value: selected } ), 'extra' );
+		return get( find( options, { value: selected } ), 'secondaryIcon' );
 	}
 
 	dropdownOptions() {
@@ -194,7 +194,7 @@ class SelectDropdown extends Component {
 						onClick={ this.onSelectItem( item ) }
 						path={ item.path }
 						icon={ item.icon }
-						extra={ item.extra }
+						secondaryIcon={ item.secondaryIcon }
 					>
 						{ item.label }
 					</DropdownItem>
@@ -213,7 +213,7 @@ class SelectDropdown extends Component {
 
 		const selectedText = this.getSelectedText();
 		const selectedIcon = this.getSelectedIcon();
-		const selectedExtra = this.getSelectedExtra();
+		const selectedSecondaryIcon = this.getSelectedSecondaryIcon();
 
 		return (
 			<div id={ this.props.id } style={ this.props.style } className={ dropdownClassName }>
@@ -233,7 +233,7 @@ class SelectDropdown extends Component {
 				>
 					<div id={ 'select-dropdown-' + this.instanceId } className="select-dropdown__header">
 						<span className="select-dropdown__header-text" aria-label={ this.props.ariaLabel }>
-							{ selectedExtra }
+							{ selectedSecondaryIcon }
 							{ selectedIcon }
 							{ selectedText }
 						</span>

--- a/client/components/select-dropdown/item.jsx
+++ b/client/components/select-dropdown/item.jsx
@@ -64,7 +64,7 @@ class SelectDropdownItem extends Component {
 							<Count count={ this.props.count } compact={ this.props.compactCount } />
 						</span>
 					) }
-					{ this.props.extra && <>{ this.props.extra }</> }
+					{ this.props.extra }
 				</a>
 			</li>
 		);

--- a/client/components/select-dropdown/item.jsx
+++ b/client/components/select-dropdown/item.jsx
@@ -59,12 +59,13 @@ class SelectDropdownItem extends Component {
 						{ this.props.icon }
 						{ this.props.children }
 					</span>
-					{ 'number' === typeof this.props.count && (
+					{ 'number' === typeof this.props.count ? (
 						<span data-text={ this.props.count } className="select-dropdown__item-count">
 							<Count count={ this.props.count } compact={ this.props.compactCount } />
 						</span>
+					) : (
+						<>{ this.props.extra }</>
 					) }
-					{ this.props.extra }
 				</a>
 			</li>
 		);

--- a/client/components/select-dropdown/item.jsx
+++ b/client/components/select-dropdown/item.jsx
@@ -15,7 +15,7 @@ class SelectDropdownItem extends Component {
 		disabled: PropTypes.bool,
 		icon: PropTypes.element,
 		ariaLabel: PropTypes.string,
-		extra: PropTypes.element,
+		secondaryIcon: PropTypes.element,
 	};
 
 	static defaultProps = {
@@ -64,7 +64,7 @@ class SelectDropdownItem extends Component {
 							<Count count={ this.props.count } compact={ this.props.compactCount } />
 						</span>
 					) : (
-						<>{ this.props.extra }</>
+						<>{ this.props.secondaryIcon }</>
 					) }
 				</a>
 			</li>

--- a/client/components/select-dropdown/item.jsx
+++ b/client/components/select-dropdown/item.jsx
@@ -15,6 +15,7 @@ class SelectDropdownItem extends Component {
 		disabled: PropTypes.bool,
 		icon: PropTypes.element,
 		ariaLabel: PropTypes.string,
+		extra: PropTypes.element,
 	};
 
 	static defaultProps = {
@@ -63,6 +64,7 @@ class SelectDropdownItem extends Component {
 							<Count count={ this.props.count } compact={ this.props.compactCount } />
 						</span>
 					) }
+					{ this.props.extra && <>{ this.props.extra }</> }
 				</a>
 			</li>
 		);

--- a/client/components/select-dropdown/style.scss
+++ b/client/components/select-dropdown/style.scss
@@ -143,6 +143,10 @@ $compact-header-height: 35;
 	text-overflow: ellipsis;
 	overflow: hidden;
 
+	.extra-gridicon {
+		fill: var(--color-neutral);
+	}
+
 	.has-count & {
 		padding-right: 40px;
 	}
@@ -242,6 +246,13 @@ $compact-header-height: 35;
 		&.is-selected:hover {
 			color: var(--color-text-inverted);
 		}
+	}
+
+	.extra-gridicon {
+		fill: var(--color-neutral);
+		position: absolute;
+		top: #{( $option-height - 18 ) * 0.5}px;
+		right: #{$side-margin - 8 }px;
 	}
 
 	.gridicon {

--- a/client/components/select-dropdown/style.scss
+++ b/client/components/select-dropdown/style.scss
@@ -143,10 +143,6 @@ $compact-header-height: 35;
 	text-overflow: ellipsis;
 	overflow: hidden;
 
-	.extra-gridicon {
-		fill: var(--color-neutral);
-	}
-
 	.has-count & {
 		padding-right: 40px;
 	}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/accent-color-control/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/accent-color-control/index.tsx
@@ -140,7 +140,7 @@ const AccentColorControl = ( { accentColor, setAccentColor }: AccentColorControl
 		const matchingOption = getMatchingOption();
 
 		if ( matchingOption?.isPremium || ( customColor && ! matchingOption ) ) {
-			return <Gridicon icon="lock" size={ 18 } color="gray" className="extra-gridicon" />;
+			return <Gridicon icon="lock" size={ 18 } className="extra-gridicon" />;
 		}
 		return null;
 	};
@@ -154,7 +154,7 @@ const AccentColorControl = ( { accentColor, setAccentColor }: AccentColorControl
 				selected={ option.value === accentColor.hex }
 				extra={
 					shouldLimitGlobalStyles && option.isPremium ? (
-						<Gridicon icon="lock" size={ 18 } color="gray" className="extra-gridicon" />
+						<Gridicon icon="lock" size={ 18 } className="extra-gridicon" />
 					) : null
 				}
 			>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/accent-color-control/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/accent-color-control/index.tsx
@@ -1,22 +1,38 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
-import { Popover } from '@automattic/components';
+import { Gridicon, Popover } from '@automattic/components';
 import { useLocale } from '@automattic/i18n-utils';
 import { hasMinContrast, hexToRgb, RGB } from '@automattic/onboarding';
 import { ColorPicker } from '@wordpress/components';
 import { Icon, color } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import classNames from 'classnames';
-import { Dispatch, SetStateAction, useCallback, useEffect, useState, useRef } from 'react';
+import {
+	Dispatch,
+	ReactElement,
+	SetStateAction,
+	useCallback,
+	useEffect,
+	useState,
+	useRef,
+} from 'react';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
 import SelectDropdown from 'calypso/components/select-dropdown';
 import { tip } from 'calypso/signup/icons';
+import { usePremiumGlobalStyles } from 'calypso/state/sites/hooks/use-premium-global-styles';
 import './style.scss';
 import ColorSwatch from './color-swatch';
 
 interface AccentColorControlProps {
 	accentColor: AccentColor;
 	setAccentColor: Dispatch< SetStateAction< AccentColor > >;
+}
+
+interface ColorOption {
+	label: string;
+	value: string;
+	icon: ReactElement;
+	isPremium: boolean;
 }
 
 export type AccentColor = {
@@ -32,40 +48,49 @@ enum COLORS {
 	VividPurple = '#9B51E0',
 }
 
-const COLOR_OPTIONS = [
-	{
-		label: 'Lettre',
-		value: COLORS.Lettre,
-		icon: <ColorSwatch color={ COLORS.Lettre } />,
-	},
-	{
-		label: 'Black',
-		value: COLORS.Black,
-		icon: <ColorSwatch color={ COLORS.Black } />,
-	},
-	{
-		label: 'Vivid red',
-		value: COLORS.VividRed,
-		icon: <ColorSwatch color={ COLORS.VividRed } />,
-	},
-	{
-		label: 'Vivid purple',
-		value: COLORS.VividPurple,
-		icon: <ColorSwatch color={ COLORS.VividPurple } />,
-	},
-	{
-		label: 'Custom',
-		value: 'custom',
-		icon: <Icon className="custom_color_icon" icon={ color } width={ 22 } height={ 22 } />,
-	},
-];
-
 const AccentColorControl = ( { accentColor, setAccentColor }: AccentColorControlProps ) => {
 	const { __, hasTranslation } = useI18n();
 	const locale = useLocale();
 	const [ customColor, setCustomColor ] = useState< AccentColor | null >( null );
 	const [ colorPickerOpen, setColorPickerOpen ] = useState< boolean >( false );
 	const accentColorRef = useRef< HTMLInputElement >( null );
+	const { shouldLimitGlobalStyles } = usePremiumGlobalStyles();
+
+	const getColorOptions = useCallback(
+		(): ColorOption[] => [
+			{
+				label: 'Lettre',
+				value: COLORS.Lettre,
+				icon: <ColorSwatch color={ COLORS.Lettre } />,
+				isPremium: false,
+			},
+			{
+				label: 'Black',
+				value: COLORS.Black,
+				icon: <ColorSwatch color={ COLORS.Black } />,
+				isPremium: shouldLimitGlobalStyles,
+			},
+			{
+				label: 'Vivid red',
+				value: COLORS.VividRed,
+				icon: <ColorSwatch color={ COLORS.VividRed } />,
+				isPremium: shouldLimitGlobalStyles,
+			},
+			{
+				label: 'Vivid purple',
+				value: COLORS.VividPurple,
+				icon: <ColorSwatch color={ COLORS.VividPurple } />,
+				isPremium: shouldLimitGlobalStyles,
+			},
+			{
+				label: 'Custom',
+				value: 'custom',
+				icon: <Icon className="custom_color_icon" icon={ color } width={ 22 } height={ 22 } />,
+				isPremium: shouldLimitGlobalStyles,
+			},
+		],
+		[ shouldLimitGlobalStyles ]
+	);
 
 	const handlePredefinedColorSelect = ( { value }: { value: string } ) => {
 		if ( value === 'custom' ) {
@@ -98,14 +123,64 @@ const AccentColorControl = ( { accentColor, setAccentColor }: AccentColorControl
 	};
 
 	const getMatchingOption = useCallback(
-		() => COLOR_OPTIONS.find( ( option ) => option.value === accentColor.hex ) || null,
-		[ accentColor.hex ]
+		() => getColorOptions().find( ( option ) => option.value === accentColor.hex ) || null,
+		[ accentColor.hex, getColorOptions ]
 	);
 
 	const getSelectedText = () => getMatchingOption()?.label || 'Custom';
 
 	const getSelectedIcon = () =>
 		customColor ? <ColorSwatch color={ customColor.hex } /> : getMatchingOption()?.icon;
+
+	const getSelectedExtra = () => {
+		if ( ! shouldLimitGlobalStyles ) {
+			return null;
+		}
+
+		const matchingOption = getMatchingOption();
+
+		if ( matchingOption?.isPremium || ( customColor && ! matchingOption ) ) {
+			return <Gridicon icon="lock" size={ 18 } color="gray" className="extra-gridicon" />;
+		}
+		return null;
+	};
+
+	const getDropdownOption = ( option: ColorOption ) => {
+		return (
+			<SelectDropdown.Item
+				key={ option.label }
+				icon={ option.icon }
+				onClick={ () => handlePredefinedColorSelect( { value: option.value } ) }
+				selected={ option.value === accentColor.hex }
+				extra={
+					shouldLimitGlobalStyles && option.isPremium ? (
+						<Gridicon icon="lock" size={ 18 } color="gray" className="extra-gridicon" />
+					) : null
+				}
+			>
+				{ option.label }
+			</SelectDropdown.Item>
+		);
+	};
+
+	const getDropdownOptions = () => {
+		if ( ! shouldLimitGlobalStyles ) {
+			return getColorOptions().map( ( option ) => getDropdownOption( option ) );
+		}
+
+		const freeColors = getColorOptions().filter( ( { isPremium } ) => ! isPremium );
+		const premiumColors = getColorOptions().filter( ( { isPremium } ) => isPremium );
+
+		const dropdownOptions = [
+			...freeColors.map( ( freeColor ) => getDropdownOption( freeColor ) ),
+			<SelectDropdown.Label key="dropdown-label">
+				{ __( 'Unlock more colors with a Premium plan' ) }
+			</SelectDropdown.Label>,
+			...premiumColors.map( ( premiumColor ) => getDropdownOption( premiumColor ) ),
+		];
+
+		return dropdownOptions;
+	};
 
 	useEffect( () => {
 		// In later stages of some flows, color for site is already set when this control loads.
@@ -158,17 +233,9 @@ const AccentColorControl = ( { accentColor, setAccentColor }: AccentColorControl
 					showSelectedOption={ !! customColor } // hide selected option with the exception of "Custom" option
 					selectedText={ getSelectedText() }
 					selectedIcon={ getSelectedIcon() }
+					selectedExtra={ getSelectedExtra() }
 				>
-					{ COLOR_OPTIONS.map( ( option ) => (
-						<SelectDropdown.Item
-							key={ option.label }
-							icon={ option.icon }
-							onClick={ () => handlePredefinedColorSelect( { value: option.value } ) }
-							selected={ option.value === accentColor.hex }
-						>
-							{ option.label }
-						</SelectDropdown.Item>
-					) ) }
+					{ getDropdownOptions() }
 				</SelectDropdown>
 			</FormFieldset>
 			<div

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/accent-color-control/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/accent-color-control/index.tsx
@@ -132,7 +132,7 @@ const AccentColorControl = ( { accentColor, setAccentColor }: AccentColorControl
 	const getSelectedIcon = () =>
 		customColor ? <ColorSwatch color={ customColor.hex } /> : getMatchingOption()?.icon;
 
-	const getSelectedExtra = () => {
+	const getSelectedSecondaryIcon = () => {
 		if ( ! shouldLimitGlobalStyles ) {
 			return null;
 		}
@@ -152,7 +152,7 @@ const AccentColorControl = ( { accentColor, setAccentColor }: AccentColorControl
 				icon={ option.icon }
 				onClick={ () => handlePredefinedColorSelect( { value: option.value } ) }
 				selected={ option.value === accentColor.hex }
-				extra={
+				secondaryIcon={
 					shouldLimitGlobalStyles && option.isPremium ? (
 						<Gridicon icon="lock" size={ 18 } className="extra-gridicon" />
 					) : null
@@ -233,7 +233,7 @@ const AccentColorControl = ( { accentColor, setAccentColor }: AccentColorControl
 					showSelectedOption={ !! customColor } // hide selected option with the exception of "Custom" option
 					selectedText={ getSelectedText() }
 					selectedIcon={ getSelectedIcon() }
-					selectedExtra={ getSelectedExtra() }
+					selectedSecondaryIcon={ getSelectedSecondaryIcon() }
 				>
 					{ getDropdownOptions() }
 				</SelectDropdown>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/accent-color-control/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/accent-color-control/style.scss
@@ -1,6 +1,24 @@
 @import "../../style";
 @import "@automattic/typography/styles/variables";
 
+$option-height: 40;
+$side-margin: 16;
+
+.select-dropdown__header-text {
+	.extra-gridicon {
+		fill: var(--color-neutral);
+	}
+}
+
+.select-dropdown__item {
+	.extra-gridicon {
+		fill: var(--color-neutral);
+		position: absolute;
+		top: #{( $option-height - 18 ) * 0.5}px;
+		right: #{$side-margin - 8 }px;
+	}
+}
+
 .accent-color-control__accent-color-input {
 	background-size: 25px, auto;
 	background-position: left 13px center, 95% !important;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/accent-color-control/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/accent-color-control/style.scss
@@ -15,7 +15,7 @@ $side-margin: 16;
 		fill: var(--color-neutral);
 		position: absolute;
 		top: #{( $option-height - 18 ) * 0.5}px;
-		right: #{$side-margin - 8 }px;
+		right: #{ $side-margin - 8 }px;
 	}
 }
 


### PR DESCRIPTION
We're refactoring how the the color accent dropdown in the newsletter flow is implemented according to https://github.com/Automattic/dotcom-forge/issues/1226 and described in paYJgx-2B7-p2.

@SaxonF We didn't have anything designed for when we select an item in the dropdown. I went ahead and added a lock to the selected item. Feel free to suggest any changes to how it looks.

![Captura de Pantalla 2022-11-18 a las 15 25 49](https://user-images.githubusercontent.com/1989914/202727093-b7b127f9-115e-46f9-b3ea-78e040a700cb.png)

Adding the lock next to the arrow of the dropdown didn't look really good.

#### Proposed Changes

* Updated the select dropdown component so that we can have extra information for each item in the dropdown.
* Added a group label to separate between paid and free accent colors when needed.

#### Testing Instructions

* Open the Calypso live link
* Navigate to `/setup/newsletter/newsletterSetup`
* The dropdown should show a group label and lock icons as described in the main task.
* When you select an item with a lock, it should be clear that it's a locked item when the dropdown is collapsed.
* Navigate to `/setup/newsletter/newsletterSetup?flags=-limit-global-styles`
* It should work as expected (no locks should be shown)

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
