### PR TITLE
Jetpack pricing: update open source copy

### DIFF
--- a/client/my-sites/plans/jetpack-plans/open-source/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/open-source/index.tsx
@@ -11,7 +11,18 @@ const OpenSourceSection: React.FC = () => {
 			<h3 className="jetpack-open-source__title">{ translate( 'Five for the Future' ) }</h3>
 			<p className="jetpack-open-source__desc">
 				{ translate(
-					'We invest profits from Jetpack back into the WordPress open source community through projects and event sponsorships.'
+					'Jetpack contributes {{link}}5% of its resources{{/link}} into WordPress development. That means each Jetpack purchase helps improve the sustainability of the WordPress community and the future of the open web.',
+					{
+						components: {
+							link: (
+								<a
+									href="https://wordpress.org/five-for-the-future/"
+									target="_blank"
+									rel="noopener noreferrer"
+								/>
+							),
+						},
+					}
 				) }
 			</p>
 		</div>

--- a/client/my-sites/plans/jetpack-plans/open-source/style.scss
+++ b/client/my-sites/plans/jetpack-plans/open-source/style.scss
@@ -34,4 +34,12 @@
 
 	font-size: 1rem;
 	text-align: center;
+
+	a {
+		text-decoration: underline;
+
+		&:hover {
+			text-decoration: none;
+		}
+	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR updates the copy of the open source section of the Jetpack pricing page.

### Testing instructions

- Spin up the pricing page, by using a live link below, or by running the branch locally
- Notice the copy matches the capture below

### Screenshots

<img width="793" alt="Screen Shot 2022-11-18 at 9 57 36 AM" src="https://user-images.githubusercontent.com/1620183/202733956-a5b2fd24-6866-4dda-9208-cd5df88ce4a9.png">
