### PR TITLE
Fix some sign-up flows which put user step last

### DIFF
--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -189,6 +189,7 @@ class Signup extends Component {
 		this.removeFulfilledSteps( this.props );
 
 		this.updateShouldShowLoadingScreen();
+		this.completeFlowAfterLoggingIn();
 
 		if ( canResumeFlow( this.props.flowName, this.props.progress, this.props.isLoggedIn ) ) {
 			// Resume from the current window location
@@ -315,18 +316,22 @@ class Signup extends Component {
 		setTimeout( () => window.scrollTo( 0, 0 ), 0 );
 	}
 
-	completeP2FlowAfterLoggingIn() {
-		if ( ! this.props.flowName !== 'p2v1' || ! this.props.progress ) {
+	completeFlowAfterLoggingIn() {
+		const flowName = this.props.flowName;
+		// p2v1 also has a user step at the end but the flow is otherwise broken.
+		// reader also has a user step at the end, but this change doesn't fix that flow.
+		const eligbleFlows = [ 'domain', 'add-domain', 'with-theme' ];
+		if ( ! eligbleFlows.includes( flowName ) || ! this.props.progress ) {
 			return;
 		}
+		const stepName = this.props.stepName;
 
-		const p2SiteStep = this.props.progress[ 'p2-site' ];
-
-		if ( p2SiteStep && p2SiteStep.status === 'pending' && this.props.isLoggedIn ) {
-			// By removing and adding the p2-site step, we trigger the `SignupFlowController` store listener
+		const step = this.props.progress[ stepName ];
+		if ( step && step.status === 'pending' && this.props.isLoggedIn ) {
+			// By removing and adding the step, we trigger the `SignupFlowController` store listener
 			// to process the signup flow.
-			this.props.removeStep( p2SiteStep );
-			this.props.addStep( p2SiteStep );
+			this.props.removeStep( step );
+			this.props.addStep( step );
 		}
 	}
 

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -320,7 +320,7 @@ class Signup extends Component {
 		const flowName = this.props.flowName;
 		// p2v1 also has a user step at the end but the flow is otherwise broken.
 		// reader also has a user step at the end, but this change doesn't fix that flow.
-		const eligbleFlows = [ 'domain', 'add-domain', 'with-theme' ];
+		const eligbleFlows = [ 'domain', 'add-domain' ];
 		if ( ! eligbleFlows.includes( flowName ) || ! this.props.progress ) {
 			return;
 		}


### PR DESCRIPTION
#### Proposed Changes
The domain and add-domain sign-up flows put the user step (login/signup) last. If a user already had an account they were prompted to login, once logged in, they were sent back into the sign-up flow which gots comprehensively stuck.

This change has fixed the problem by resurrecting some code implemented in #44172 which removed and readded the in-progress step so it would reprocess with the signup flow.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

 1. Go to /start/domain/domain-only?new=test&search=yes while logged out, this simulates searching for 'test' on wordpress.com/domains while logged out
 2. Choose a domain
 3. Choose a plan
 4. Enter the email address of an existing account on the registration page
 5. Follow link to login on the validation message
 6. Login (with 2fa if necessary)
 7. After login you should get redirected back into the flow
 8. After a loading/progress screen it should redirect you into /home with your new site and domain.


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #70091
