### PR TITLE
HelpCenter: add fallback for primary site

### DIFF
--- a/packages/help-center/src/components/help-center.tsx
+++ b/packages/help-center/src/components/help-center.tsx
@@ -8,6 +8,7 @@ import { useHappychatAvailable } from '@automattic/happychat-connection';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { createPortal, useEffect, useRef } from '@wordpress/element';
 import { useSelector } from 'react-redux';
+import getPrimarySiteId from 'calypso/state/selectors/get-primary-site-id';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 /**
  * Internal Dependencies
@@ -46,11 +47,12 @@ const HelpCenter: React.FC< Container > = ( { handleClose, hidden } ) => {
 	}, [ data, setShowHelpCenter ] );
 
 	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
+	const primarySiteId = useSelector( ( state ) => getPrimarySiteId( state ) );
 
 	useSelect( ( select ) => select( USER_STORE ).getCurrentUser() );
 
 	const currentSite = window?.helpCenterData?.currentSite;
-	const site = useSelect( ( select ) => select( SITE_STORE ).getSite( siteId ) );
+	const site = useSelect( ( select ) => select( SITE_STORE ).getSite( siteId || primarySiteId ) );
 
 	setSite( currentSite ? currentSite : site );
 	useSupportAvailability( 'CHAT' );

--- a/packages/help-center/src/components/index.d.ts
+++ b/packages/help-center/src/components/index.d.ts
@@ -90,6 +90,11 @@ declare module 'calypso/state/sites/hooks' {
 	export const useSiteOption: ( state: unknown ) => string;
 }
 
+declare module 'calypso/state/selectors/get-primary-site-id' {
+	const getPrimarySiteId: ( state: unknown ) => number;
+	export default getPrimarySiteId;
+}
+
 declare module 'calypso/state/selectors/has-cancelable-user-purchases' {
 	const hasCancelableUserPurchases: ( state: unknown ) => boolean;
 	export default hasCancelableUserPurchases;


### PR DESCRIPTION
## Proposed Changes

There was an issue with Help Center that happened if a user logs in directly to a site agnostic page such as wordpress.com/me or wordpress.com/help

Since there is no defined site that the user is looking at Help Center is not aware of what site to use and therefore has no chosen site. This causes issue all over the place. Most notably when you try to submit a contact form. The site is blank and the form cannot be sent.

This grabs the primary site ID using `getPrimarySiteId` as a fallback.

## Testing Instructions

1. Pull branch and start calypso
2. BEFORE logging in go directly http://calypso.localhost:3000/me
3. Go to start a chat or email and make sure the primary site is set
4. Attempt the same thing else where to make sure there is no regression
5. Toggle through selected sites and make sure it still works