### PR TITLE
Checkout: Add try/catch for recordPurchase in useCreatePaymentCompleteCallback

### DIFF
--- a/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-complete-callback.tsx
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-complete-callback.tsx
@@ -271,10 +271,22 @@ function recordPaymentCompleteAnalytics( {
 			device,
 		} )
 	);
-	recordPurchase( {
-		cart: responseCart,
-		orderId: transactionResult?.receipt_id,
-	} );
+
+	try {
+		recordPurchase( {
+			cart: responseCart,
+			orderId: transactionResult?.receipt_id,
+		} );
+	} catch ( err ) {
+		// eslint-disable-next-line no-console
+		console.error( err );
+		reduxDispatch(
+			recordCompositeCheckoutErrorDuringAnalytics( {
+				errorObject: err as Error,
+				failureDescription: 'useCreatePaymentCompleteCallback',
+			} )
+		);
+	}
 
 	return reduxDispatch(
 		recordTracksEvent( 'calypso_checkout_composite_payment_complete', {


### PR DESCRIPTION
#### Proposed Changes

There's a hook called `useCreatePaymentCompleteCallback` which is used by checkout for credit card purchases (not PayPal or other redirect payment methods) to perform some post-checkout actions. Some of those actions are analytics. In order for errors in the analytics to not break checkout, these calls are wrapped in try/catch with specialized logging. However, while this is true for `recordPaymentCompleteAnalytics()`, the call to `recordPurchase()` is not surrounded in those guards.

This PR adds a similar guard to that second call.

This is important especially since we've seen a lot of fatal errors after https://github.com/Automattic/wp-calypso/pull/66493 was merged (`window.gtag is not a function`). See Slack p1668788108708149-slack-C096PD42U for more info on the fatal errors.

#### Testing Instructions

None should be required. Just verify that the code change makes sense.