### PR TITLE
Analytics: Prevent calling window.gtag if it does not exist

### DIFF
--- a/client/lib/analytics/ad-tracking/google-analytics-4.ts
+++ b/client/lib/analytics/ad-tracking/google-analytics-4.ts
@@ -17,22 +17,22 @@ export const ga4Properties: { [ env in Ga4PropertyGtag ]: string } = {
 };
 
 export function setup( params: Gtag.ConfigParams ) {
-	window.gtag( 'config', TRACKING_IDS.wpcomGoogleGA4Gtag, params );
+	window.gtag?.( 'config', TRACKING_IDS.wpcomGoogleGA4Gtag, params );
 
 	if ( isJetpackCloud() ) {
-		window.gtag( 'config', TRACKING_IDS.jetpackGoogleGA4Gtag, params );
+		window.gtag?.( 'config', TRACKING_IDS.jetpackGoogleGA4Gtag, params );
 	}
 }
 
 export function fireEcommercePurchase( purchase: GaPurchase, ga4PropertyGtag: Ga4PropertyGtag ) {
-	window.gtag( 'event', 'purchase', {
+	window.gtag?.( 'event', 'purchase', {
 		send_to: ga4Properties[ ga4PropertyGtag ],
 		...purchase,
 	} );
 }
 
 export function fireEcommerceAddToCart( item: GaItem, ga4PropertyGtag: Ga4PropertyGtag ) {
-	window.gtag( 'event', 'add_to_cart', {
+	window.gtag?.( 'event', 'add_to_cart', {
 		send_to: Ga4PropertyGtag[ ga4PropertyGtag ],
 		value: item.price,
 		currency: 'USD',
@@ -41,7 +41,7 @@ export function fireEcommerceAddToCart( item: GaItem, ga4PropertyGtag: Ga4Proper
 }
 
 export function firePageView( title: string, location: string, ga4PropertyGtag: Ga4PropertyGtag ) {
-	window.gtag( 'event', 'page_view', {
+	window.gtag?.( 'event', 'page_view', {
 		send_to: ga4Properties[ ga4PropertyGtag ],
 		page_title: title,
 		page_location: location,

--- a/client/lib/analytics/ad-tracking/google-analytics.js
+++ b/client/lib/analytics/ad-tracking/google-analytics.js
@@ -9,7 +9,7 @@ import './setup';
 export function setupGoogleAnalyticsGtag( params ) {
 	GA4.setup( params );
 
-	window.gtag( 'config', getGaGtag(), params );
+	window.gtag?.( 'config', getGaGtag(), params );
 }
 
 /**
@@ -55,7 +55,7 @@ export function fireGoogleAnalyticsPageView(
 		page_title: pageTitle,
 	};
 
-	window.gtag( 'config', getGaGtag( useJetpackGoogleAnalytics ), params );
+	window.gtag?.( 'config', getGaGtag( useJetpackGoogleAnalytics ), params );
 }
 
 /**
@@ -67,7 +67,7 @@ export function fireGoogleAnalyticsPageView(
  * @param {number} value Is a non-negative integer that will appear as the event value.
  */
 export function fireGoogleAnalyticsEvent( category, action, label, value ) {
-	window.gtag( 'event', action, {
+	window.gtag?.( 'event', action, {
 		event_category: category,
 		event_label: label,
 		value: value,


### PR DESCRIPTION
#### Proposed Changes

In the functions of `client/lib/analytics/ad-tracking/google-analytics.js` and `client/lib/analytics/ad-tracking/google-analytics-4.ts`, there are several instances of calling the global function `window.gtag()`. Both of those files try to ensure that this function exists by importing the `client/lib/analytics/ad-tracking/setup.js` file which has a side-effect of trying to initialize the `window.gtag` function, but there are many conditions where the function may not be initialized. 

This is causing fatal checkout errors (and probably errors elsewhere in calypso) like those reported in p1668791706938719-slack-C096PD42U

In this PR, we use optional chaining to only call `window.gtag()` in those files if it exists.

This appears to have been caused by https://github.com/Automattic/wp-calypso/pull/66493 based on timing although I'm not sure how.

#### Testing Instructions

None should be needed.