### PR TITLE
Analytics: Add optional chaining for all remaining unguarded window.gtag calls

### DIFF
--- a/client/lib/analytics/ad-tracking/ad-track-registration.js
+++ b/client/lib/analytics/ad-tracking/ad-track-registration.js
@@ -23,7 +23,7 @@ export async function adTrackRegistration() {
 			},
 		];
 		debug( 'adTrackRegistration: [Google Ads Gtag]', params );
-		window.gtag( ...params );
+		window.gtag?.( ...params );
 	}
 
 	// Facebook

--- a/client/lib/analytics/ad-tracking/ad-track-signup-complete.js
+++ b/client/lib/analytics/ad-tracking/ad-track-signup-complete.js
@@ -70,7 +70,7 @@ export async function adTrackSignupComplete( { isNewUserSite } ) {
 			},
 		];
 		debug( 'recordSignup: [Google Ads Gtag]', params );
-		window.gtag( ...params );
+		window.gtag?.( ...params );
 	}
 
 	// Bing

--- a/client/lib/analytics/ad-tracking/ad-track-signup-start.js
+++ b/client/lib/analytics/ad-tracking/ad-track-signup-start.js
@@ -40,6 +40,6 @@ export async function adTrackSignupStart( flow ) {
 			},
 		];
 		debug( 'adTrackSignupStart: [Google Ads Gtag]', params );
-		window.gtag( ...params );
+		window.gtag?.( ...params );
 	}
 }

--- a/client/lib/analytics/ad-tracking/record-add-to-cart.js
+++ b/client/lib/analytics/ad-tracking/record-add-to-cart.js
@@ -32,7 +32,7 @@ export async function recordAddToCart( cartItem ) {
 			},
 		];
 		debug( 'recordAddToCart: [Google Ads Gtag] WPCom', params );
-		window.gtag( ...params );
+		window.gtag?.( ...params );
 	}
 
 	// Facebook

--- a/client/lib/analytics/ad-tracking/record-order.js
+++ b/client/lib/analytics/ad-tracking/record-order.js
@@ -396,7 +396,7 @@ function recordOrderInGoogleAds( cart, orderId, wpcomJetpackCartInfo ) {
 			},
 		];
 		debug( 'recordOrderInGoogleAds: Record WPCom Purchase', params );
-		window.gtag( ...params );
+		window.gtag?.( ...params );
 	}
 
 	if ( mayWeTrackByTracker( 'googleAds' ) && wpcomJetpackCartInfo.containsJetpackProducts ) {
@@ -411,7 +411,7 @@ function recordOrderInGoogleAds( cart, orderId, wpcomJetpackCartInfo ) {
 			},
 		];
 		debug( 'recordOrderInGoogleAds: Record Jetpack Purchase', params );
-		window.gtag( ...params );
+		window.gtag?.( ...params );
 	}
 }
 
@@ -468,7 +468,7 @@ function recordOrderInGAEnhancedEcommerce( cart, orderId, wpcomJetpackCartInfo )
 		},
 	];
 
-	window.gtag( ...params );
+	window.gtag?.( ...params );
 
 	debug( 'recordOrderInGAEnhancedEcommerce: Record WPCom Purchase', params );
 }
@@ -513,7 +513,7 @@ function recordOrderInJetpackGA( cart, orderId, wpcomJetpackCartInfo ) {
 			},
 		];
 		debug( 'recordOrderInJetpackGA: Record Jetpack Purchase', jetpackParams );
-		window.gtag( ...jetpackParams );
+		window.gtag?.( ...jetpackParams );
 	}
 }
 

--- a/client/lib/analytics/ad-tracking/retarget.js
+++ b/client/lib/analytics/ad-tracking/retarget.js
@@ -61,7 +61,7 @@ export async function retarget( urlPath ) {
 	if ( mayWeTrackByTracker( 'googleAds' ) ) {
 		const params = [ 'config', TRACKING_IDS.wpcomGoogleAdsGtag, { page_path: urlPath } ];
 		debug( 'retarget: [Google Ads] WPCom', params );
-		window.gtag( ...params );
+		window.gtag?.( ...params );
 	}
 
 	// Floodlight


### PR DESCRIPTION
#### Proposed Changes

As a follow-up to https://github.com/Automattic/wp-calypso/pull/70185, this PR adds optional chaining to _all_ instances of `window.gtag()` that do not already have an obvious guard in place (an example of a safe call is [setupWpcomGoogleAdsGtag](https://github.com/Automattic/wp-calypso/blob/829b830509666897621416dc7a4772f7180fbe0d/client/lib/analytics/ad-tracking/setup.js#L202-L204) since `setupGtag()` adds the function explicitly). The previous PR only added it to the calls that appeared to be causing fatal checkout errors, but I imagine that these other calls may also benefit from the extra protection.

I didn't trace all the analytics logic so it's possible that some of these calls are already guaranteed to be safe, but since IMO analytics should never be allowed to crash our application, I opted for a blanket approach. If you can find evidence that these changes are not required during review, please leave a comment!

#### Testing Instructions

None should be needed.