### PR TITLE
App Banner: Redirect Android users who don't have the app installed to specific sections, after install/login

### DIFF
--- a/client/blocks/app-banner/index.jsx
+++ b/client/blocks/app-banner/index.jsx
@@ -134,15 +134,15 @@ export class AppBanner extends Component {
 			//TODO: update when section deep links are available.
 			switch ( currentSection ) {
 				case GUTENBERG:
-					return `intent://post/#Intent;scheme=${ scheme };package=${ packageName };end`;
+					return `intent://details?id=${ packageName }&url=${ scheme }://post&referrer=calypso#Intent;scheme=market;action=android.intent.action.VIEW;package=com.android.vending;end`;
 				case HOME:
-					return `intent://home/#Intent;scheme=${ scheme };package=${ packageName };end`;
+					return `intent://details?id=${ packageName }&url=${ scheme }://home&referrer=calypso#Intent;scheme=market;action=android.intent.action.VIEW;package=com.android.vending;end`;
 				case NOTES:
-					return `intent://notifications/#Intent;scheme=${ scheme };package=${ packageName };end`;
+					return `intent://details?id=${ packageName }&url=${ scheme }://notifications&referrer=calypso#Intent;scheme=market;action=android.intent.action.VIEW;package=com.android.vending;end`;
 				case READER:
-					return `intent://read/#Intent;scheme=${ scheme };package=${ packageName };end`;
+					return `intent://details?id=${ packageName }&url=${ scheme }://reader&referrer=calypso#Intent;scheme=market;action=android.intent.action.VIEW;package=com.android.vending;end`;
 				case STATS:
-					return `intent://stats/#Intent;scheme=${ scheme };package=${ packageName };end`;
+					return `intent://details?id=${ packageName }&url=${ scheme }://stats&referrer=calypso#Intent;scheme=market;action=android.intent.action.VIEW;package=com.android.vending;end`;
 			}
 		}
 

--- a/client/blocks/app-banner/index.jsx
+++ b/client/blocks/app-banner/index.jsx
@@ -140,7 +140,7 @@ export class AppBanner extends Component {
 				case NOTES:
 					return `intent://details?id=${ packageName }&url=${ scheme }://notifications&referrer=calypso#Intent;scheme=market;action=android.intent.action.VIEW;package=com.android.vending;end`;
 				case READER:
-					return `intent://details?id=${ packageName }&url=${ scheme }://reader&referrer=calypso#Intent;scheme=market;action=android.intent.action.VIEW;package=com.android.vending;end`;
+					return `intent://details?id=${ packageName }&url=${ scheme }://read&referrer=calypso#Intent;scheme=market;action=android.intent.action.VIEW;package=com.android.vending;end`;
 				case STATS:
 					return `intent://details?id=${ packageName }&url=${ scheme }://stats&referrer=calypso#Intent;scheme=market;action=android.intent.action.VIEW;package=com.android.vending;end`;
 			}


### PR DESCRIPTION
#### Proposed Changes

With this PR, the intent URIs associated with [Calypso's mobile app banners](https://github.com/Automattic/wp-calypso/tree/trunk/client/blocks/app-banner) have been updated to allow for deep linking. Following this update, users who tap on the banners' buttons will be redirected to the specified section of the app, even if they have to first install and log into the app. (Previously, they'd only be redirected if the app was already installed.)  

Note, for simplicity, this PR updates the URIs for both the WordPress and the Jetpack app. The mentions of the WordPress app will eventually be removed sometime in the coming months.

#### Testing Instructions

HTML to test the updated links for both the Jetpack and WordPress app can be found below.

<details>
 <summary>HTML for Jetpack app links ⤵️</summary>

```
<a href="intent://details/?id=com.jetpack.android&url=jetpack://post&referrer=calypso#Intent;scheme=market;action=android.intent.action.VIEW;package=com.android.vending;end">Jetpack app link to editor</a>

<a href="intent://details/?id=com.jetpack.android&url=jetpack://home&referrer=calypso#Intent;scheme=market;action=android.intent.action.VIEW;package=com.android.vending;end">Jetpack app link to home page</a>

<a href="intent://details/?id=com.jetpack.android&url=jetpack://notifications&referrer=calypso#Intent;scheme=market;action=android.intent.action.VIEW;package=com.android.vending;end">Jetpack app link to notifications panel</a>

<a href="intent://details/?id=com.jetpack.android&url=jetpack://read&referrer=calypso#Intent;scheme=market;action=android.intent.action.VIEW;package=com.android.vending;end">Jetpack app link to the Reader</a>

<a href="intent://details/?id=com.jetpack.android&url=jetpack://stats&referrer=calypso#Intent;scheme=market;action=android.intent.action.VIEW;package=com.android.vending;end">Jetpack app link to stats</a>
```

</details>

<details>
 <summary>HTML for WordPress app links ⤵️</summary>

```
<a href="intent://details/?id=org.wordpress.android&url=wordpress://post&referrer=calypso#Intent;scheme=market;action=android.intent.action.VIEW;package=com.android.vending;end">WordPress app link to editor</a>

<a href="intent://details/?id=org.wordpress.android&url=wordpress://home&referrer=calypso#Intent;scheme=market;action=android.intent.action.VIEW;package=com.android.vending;end">WordPress app link to home page</a>

<a href="intent://details/?id=org.wordpress.android&url=wordpress://notifications&referrer=calypso#Intent;scheme=market;action=android.intent.action.VIEW;package=com.android.vending;end">WordPress app link to notifications panel</a>

<a href="intent://details/?id=org.wordpress.android&url=wordpress://read&referrer=calypso#Intent;scheme=market;action=android.intent.action.VIEW;package=com.android.vending;end">WordPress app link to the Reader</a>

<a href="intent://details/?id=org.wordpress.android&url=wordpress://stats&referrer=calypso#Intent;scheme=market;action=android.intent.action.VIEW;package=com.android.vending;end">WordPress app link to stats</a>
```
</details>

To test, the HTML can be copied/pasted to the code/HTML editor a self-hosted WordPress site and then visited in a browser on an Android device. The updated links should:

* Redirect to the Google Play store if the app is not installed on the Android device.
* When installing the app from Google Play Store, after login in, the deep link should then redirect to the feature specified.
* If the app is installed, it should open and redirect to the feature specified in the deep link.

In addition, it'd be useful to verify that the link appears as expected within the banner's HTML with this branch checked out. The banner can be viewed via the mobile web (which can also be [emulated using browser tools](https://developer.chrome.com/docs/devtools/device-mode/#viewport)) when navigating directly to the Reader, Stats, Notifications, or the editor.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
