### PR TITLE
[FiX][E2E][Gutenberg] replace regex that strips numerals from the tab name to also get of the comma separator

### DIFF
--- a/packages/calypso-e2e/src/element-helper.ts
+++ b/packages/calypso-e2e/src/element-helper.ts
@@ -65,7 +65,7 @@ export async function clickNavTab(
 	// different implementation in PostsPage.
 	const selectedTabLocator = page.locator( selectors.navTabItem( { selected: true } ) );
 	const selectedTabName = await selectedTabLocator.innerText();
-	if ( selectedTabName.replace( /[0-9]/g, '' ) === name ) {
+	if ( selectedTabName.replace( /[0-9]|,/g, '' ) === name ) {
 		return;
 	}
 
@@ -97,7 +97,7 @@ export async function clickNavTab(
 	const newSelectedTabName = await newSelectedTabLocator.innerText();
 
 	// Strip numerals from the extracted tab name, similar to above.
-	if ( newSelectedTabName.replace( /[0-9]/g, '' ) !== name ) {
+	if ( newSelectedTabName.replace( /[0-9]|,/g, '' ) !== name ) {
 		throw new Error(
 			`Failed to confirm NavTab is active: expected ${ name }, got ${ newSelectedTabName }`
 		);


### PR DESCRIPTION

#### Proposed Changes

What the title says :) -- for some reason - maybe a recent change in the Calypso web app that included a comma separator for the numerals? (i.e `7,384`, notice the comma) -- the tests that used this helper function started to fail. Happens that it failed in https://github.com/Automattic/wp-calypso/blob/trunk/packages/calypso-e2e/src/element-helper.ts#L100 because the selected name of the tab would be "<TabName>," which wouldn't match the `name` because the name doesn't include the comma. The solution is to make the regex also replace the comma if present in the string.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Tests should pass.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
