### PR TITLE
Config: Avoid throwing when accessing undefined key

### DIFF
--- a/packages/create-calypso-config/src/index.ts
+++ b/packages/create-calypso-config/src/index.ts
@@ -10,20 +10,10 @@ export type ConfigData = Record< string, any > & {
  * data then this will report the failure with either an
  * error or a console warning.
  *
- * When in the 'development' NODE_ENV it will raise an error
- * to crash execution early. However, because many modules
- * call this function in the module-global scope a failure
- * here can not only crash that module but also entire
- * application flows as well as trigger unexpected and
- * unwanted behaviors. Therefore if the NODE_ENV is not
- * 'development' we will return `undefined` and log a message
- * to the console instead of halting the execution thread.
- *
  * The config files are loaded in sequence: _shared.json, {env}.json, {env}.local.json
  *
  * @see server/config/parser.js
  * @param data Configurat data.
- * @throws {ReferenceError} when key not defined in the config (NODE_ENV=development only)
  * @returns A function that gets the value of property named by the key
  */
 const config =
@@ -33,16 +23,9 @@ const config =
 			return data[ key ] as T;
 		}
 
-		if ( 'development' === process.env.NODE_ENV ) {
-			throw new ReferenceError(
-				`Could not find config value for key '${ key }'\n` +
-					"Please make sure that if you need it then it has a default value assigned in 'config/_shared.json'"
-			);
-		}
-
-		// display console error only in a browser
+		// Display console error in a browser during development
 		// (not in tests, for example)
-		if ( 'undefined' !== typeof window ) {
+		if ( 'development' === process.env.NODE_ENV && 'undefined' !== typeof window ) {
 			// eslint-disable-next-line no-console
 			console.error(
 				'%cCore Error: ' +

--- a/packages/create-calypso-config/src/test/index.js
+++ b/packages/create-calypso-config/src/test/index.js
@@ -45,10 +45,9 @@ describe( 'index', () => {
 
 			afterEach( () => ( process.env.NODE_ENV = NODE_ENV ) );
 
-			test( "should throw an error when given key doesn't exist (NODE_ENV == development)", () => {
+			test( "should not throw an error even when a given key doesn't exist", () => {
 				process.env.NODE_ENV = 'development';
-
-				expect( () => config( fakeKey ) ).toThrowError( ReferenceError );
+				expect( () => config( fakeKey ) ).not.toThrow( Error );
 			} );
 
 			test( "should not throw an error when given key doesn't exist (NODE_ENV != development)", () => {

--- a/packages/create-calypso-config/src/test/index.js
+++ b/packages/create-calypso-config/src/test/index.js
@@ -60,6 +60,21 @@ describe( 'index', () => {
 					expect( () => config( fakeKey ) ).not.toThrow( Error );
 				} );
 			} );
+
+			test( "should only log to the console in development when a given key doesn't exist", () => {
+				const spy = jest.spyOn( console, 'error' );
+				config( fakeKey );
+				expect( spy ).not.toHaveBeenCalled();
+
+				// Force a browser-like, development environment.
+				global.window = true;
+				process.env.NODE_ENV = 'development';
+				config( fakeKey );
+				expect( spy ).toHaveBeenCalled();
+
+				delete global.window;
+				jest.restoreAllMocks();
+			} );
 		} );
 	} );
 


### PR DESCRIPTION
An alternative approach to #70122.

#### Proposed Changes

- Removes throwing an error when accessing an undefined key on a configuration object.
- Only log errors to the console when running in development.

```js
// Below no longer throws an error in development.
// Below will only log "Could not find config value for key" to the console in development.
config( 'undefined-value' );
```

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this branch to your local checkout.
* Go to `config/_shared.json` and delete random, nonessential keys for a local Calypso instance, like `is_running_in_jetpack_site`.
* Navigate to Calypso Stats and ensure that the interface works as expected, despite the header link relying on the now non-existent `is_running_in_jetpack_site` config value.
<img width="538" alt="image" src="https://user-images.githubusercontent.com/4044428/202793405-e25202e8-e063-4189-9562-bbf7da1a560f.png">

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
