### PR TITLE
Ecommerce Onboarding: Fixing stepper flow logic to make sure feature flag is honored

### DIFF
--- a/client/landing/stepper/index.tsx
+++ b/client/landing/stepper/index.tsx
@@ -95,17 +95,19 @@ const FlowSwitch: React.FC< { user: UserStore.CurrentUser | undefined } > = ( { 
 	const flowNameFromParam = useQuery().get( 'flow' );
 	const flowNameFromPathName = location.pathname.split( '/' )[ 1 ];
 	const recurType = useQuery().get( 'recur' );
-	let flow = siteSetupFlow;
 
 	// keep supporting the `flow` query param for backwards compatibility
 	if ( availableFlows.find( ( flow ) => flow.flowName === flowNameFromParam ) ) {
 		return <Redirect to={ `/${ flowNameFromParam }` } />;
 	}
 
+	let flow =
+		availableFlows.find( ( f ) => f.flowName === flowNameFromPathName )?.pathToFlow ||
+		siteSetupFlow;
 	if ( anchorFmPodcastId ) {
 		flow = anchorFmFlow;
-	} else if ( flowNameFromPathName === ecommerceFlow.name ) {
-		flow = ecommerceFlow;
+	}
+	if ( flow?.name === ecommerceFlow.name ) {
 		const isValidRecurType =
 			recurType && Object.values( ecommerceFlowRecurTypes ).includes( recurType );
 		if ( isValidRecurType ) {
@@ -113,12 +115,6 @@ const FlowSwitch: React.FC< { user: UserStore.CurrentUser | undefined } > = ( { 
 		} else {
 			setEcommerceFlowRecurType( ecommerceFlowRecurTypes.YEARLY );
 		}
-	} else {
-		availableFlows.forEach( ( currentFlow ) => {
-			if ( currentFlow.flowName === flowNameFromPathName ) {
-				flow = currentFlow.pathToFlow;
-			}
-		} );
 	}
 
 	user && receiveCurrentUser( user as UserStore.CurrentUser );


### PR DESCRIPTION
#### Proposed Changes

* This PR fixes a bug introduced in https://github.com/Automattic/wp-calypso/pull/69932; in adding custom query parameter logic for the eCommerce flow, I accidentally sidestepped the logic that was disabling the flow if the `signup/tailored-ecommerce` feature flag was not enabled. This PR refactors that logic so that the flow cannot be initialized without that flag. 

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this PR locally.
* Disable the `signup/tailored-ecommerce` feature flag and restart the app if necessary.
* Navigate to `/setup/ecommerce`
* Verify that you are redirected to WP.com home and not into the flow.
* Navigate to `/setup/link-in-bio`
* Verify that you are taken as expected to the `link-in-bio` flow.
* Enable the `signup/tailored-ecommerce` feature flag and restart the app.
* Navigate to `/setup/ecommerce`
* Verify that you are now taken into the `ecommerce` flow as expected.
* Navigate to `/setup/link-in-bio`
* Verify that you are still taken as expected to the `link-in-bio` flow.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #69386
