### PR TITLE
Import flow: bug fix and improvement

### DIFF
--- a/client/landing/stepper/declarative-flow/import-flow.ts
+++ b/client/landing/stepper/declarative-flow/import-flow.ts
@@ -7,6 +7,7 @@ import { ImporterMainPlatform } from 'calypso/blocks/import/types';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { useSiteSlugParam } from 'calypso/landing/stepper/hooks/use-site-slug-param';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
+import { useSiteSetupFlowProgress } from '../hooks/use-site-setup-flow-progress';
 import { StepPath } from './internals/steps-repository';
 import { Flow, ProvidedDependencies } from './internals/types';
 
@@ -33,11 +34,17 @@ export const importFlow: Flow = {
 	},
 
 	useStepNavigation( _currentStep, navigate ) {
+		const { setStepProgress } = useDispatch( ONBOARD_STORE );
 		const urlQueryParams = useQuery();
 		const siteSlugParam = useSiteSlugParam();
 		const isDesktop = useViewportMatch( 'large' );
 		const { setPendingAction } = useDispatch( ONBOARD_STORE );
 		const selectedDesign = useSelect( ( select ) => select( ONBOARD_STORE ).getSelectedDesign() );
+		const flowProgress = useSiteSetupFlowProgress( _currentStep, 'import', '' );
+
+		if ( flowProgress ) {
+			setStepProgress( flowProgress );
+		}
 
 		const exitFlow = ( to: string ) => {
 			setPendingAction( () => {

--- a/client/landing/stepper/declarative-flow/import-flow.ts
+++ b/client/landing/stepper/declarative-flow/import-flow.ts
@@ -39,12 +39,6 @@ export const importFlow: Flow = {
 		const { setPendingAction } = useDispatch( ONBOARD_STORE );
 		const selectedDesign = useSelect( ( select ) => select( ONBOARD_STORE ).getSelectedDesign() );
 
-		const appendFlowQueryParam = ( path: string ) => {
-			const joinChar = path.includes( '?' ) ? '&' : '?';
-
-			return `${ path }${ joinChar }flow=${ this.name }`;
-		};
-
 		const exitFlow = ( to: string ) => {
 			setPendingAction( () => {
 				return new Promise( () => {
@@ -73,14 +67,10 @@ export const importFlow: Flow = {
 						return exitFlow( providedDependencies?.url as string );
 					}
 
-					return navigate(
-						appendFlowQueryParam( providedDependencies?.url as string ) as StepPath
-					);
+					return navigate( providedDependencies?.url as StepPath );
 				}
 				case 'importReadyPreview': {
-					return navigate(
-						appendFlowQueryParam( providedDependencies?.url as string ) as StepPath
-					);
+					return navigate( providedDependencies?.url as StepPath );
 				}
 
 				case 'importerWix':
@@ -92,9 +82,7 @@ export const importFlow: Flow = {
 						return exitFlow( providedDependencies?.url as string );
 					}
 
-					return navigate(
-						appendFlowQueryParam( providedDependencies?.url as string ) as StepPath
-					);
+					return navigate( providedDependencies?.url as StepPath );
 				}
 
 				case 'designSetup': {
@@ -134,7 +122,7 @@ export const importFlow: Flow = {
 					if ( backToStep ) {
 						const path = `${ backToStep }?siteSlug=${ siteSlugParam }`;
 
-						return navigate( appendFlowQueryParam( path ) as StepPath );
+						return navigate( path as StepPath );
 					}
 
 					return navigate( 'import' );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/import/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/import/index.tsx
@@ -17,10 +17,10 @@ const isEnabledImportLight = isEnabled( 'onboarding/import-light-url-screen' );
 
 export const ImportWrapper: Step = function ( props ) {
 	const { __ } = useI18n();
-	const { navigation, children, stepName, flow: flowName } = props;
+	const { navigation, children, stepName } = props;
 	const currentRoute = useCurrentRoute();
 	const shouldHideSkipBtn = currentRoute !== BASE_ROUTE;
-	const shouldHideBackBtn = flowName === IMPORT_FOCUSED_FLOW && currentRoute === BASE_ROUTE;
+	const shouldHideBackBtn = currentRoute === `${ IMPORT_FOCUSED_FLOW }/${ BASE_ROUTE }`;
 
 	return (
 		<>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/importer/hooks/use-step-navigator.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/importer/hooks/use-step-navigator.ts
@@ -69,7 +69,7 @@ export function useStepNavigator(
 			run: true,
 		};
 
-		return addQueryArgs( queryParams, `/${ BASE_STEPPER_ROUTE }/importerWordpress` );
+		return addQueryArgs( queryParams, `/${ BASE_STEPPER_ROUTE }/${ flow }/importerWordpress` );
 	}
 
 	function getCheckoutUrl() {

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -161,7 +161,7 @@ export function generateFlows( {
 			name: 'import',
 			steps: [ 'user', 'domains', 'plans-import' ],
 			destination: ( dependencies ) =>
-				`/setup/import?flow=import-focused&siteSlug=${ dependencies.siteSlug }`,
+				`/setup/import-focused/import?siteSlug=${ dependencies.siteSlug }`,
 			description: 'Beginning of the flow to import content',
 			lastModified: '2022-10-03',
 			showRecaptcha: true,


### PR DESCRIPTION
#### Proposed Changes

* Removed the `Back` button from the initial screen of the `import-focused` stepper flow
* Added header progress bar on the `import-focused` stepper flow
* Got rid of the logic of adding flow query param since now the flow name is a part of the route

#### Testing Instructions

* Go to `/setup/import-focused?siteSlug={SITE_SLUG}`
* Check if there is a header progress bar
* Check if there is no Back button from the initial import screen

#### Screenshot
<img width="1325" alt="Screenshot 2022-11-18 at 16 57 43" src="https://user-images.githubusercontent.com/1241413/202826073-6b237761-c0f4-4845-9556-286015231a12.png">

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #70100
