### PR TITLE
Do not overwrite `subscribe_as_site_subscriber` param when positive

### DIFF
--- a/client/my-sites/earn/memberships/products.jsx
+++ b/client/my-sites/earn/memberships/products.jsx
@@ -128,6 +128,7 @@ class MembershipsProductsSection extends Component {
 							closeDialog={ this.closeDialog }
 							product={ Object.assign( this.state.product ?? {}, {
 								subscribe_as_site_subscriber:
+									this.state.product?.subscribe_as_site_subscriber ||
 									window.location.hash === '#add-newsletter-payment-plan',
 							} ) }
 						/>


### PR DESCRIPTION
Fixes #70183

#### Proposed Changes

* Do not overwrite `subscribe_as_site_subscriber` param when positive

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**For existing plans with "Email newly published posts to your customers." toggle enabled**
1. Edit the plan
2.  "Email newly published posts to your customers." toggle should still be enabled

**For new newsletter plans**
1. Go to `http://calypso.localhost:3000/earn/payments-plans/${site_name}#add-newsletter-payment-plan`
2. Add new plan modal should pop up
3.  "Email newly published posts to your customers." toggle should still be enabled

Video showing the above:


https://user-images.githubusercontent.com/7076981/202798073-4f076fe0-c41a-4c1b-8c40-5a6395c7fb66.mov

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

