### PR TITLE
Hide activate and customize options for WP.org themes on non-atomic sites

### DIFF
--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -29,7 +29,7 @@ import {
 	shouldShowTryAndCustomize,
 	isExternallyManagedTheme,
 	isSiteEligibleForManagedExternalThemes,
-	isWporgTheme,
+	isWpcomTheme,
 } from 'calypso/state/themes/selectors';
 
 const identity = ( theme ) => theme;
@@ -173,7 +173,7 @@ function getAllThemeOptions( { translate, isFSEActive } ) {
 			! isUserLoggedIn( state ) ||
 			isJetpackSiteMultiSite( state, siteId ) ||
 			isThemeActive( state, themeId, siteId ) ||
-			( isWporgTheme( state, themeId ) && ! isSiteWpcomAtomic( state, siteId ) ) ||
+			( ! isWpcomTheme( state, themeId ) && ! isSiteWpcomAtomic( state, siteId ) ) ||
 			( isThemePremium( state, themeId ) && ! isPremiumThemeAvailable( state, themeId, siteId ) ),
 	};
 

--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -29,6 +29,7 @@ import {
 	shouldShowTryAndCustomize,
 	isExternallyManagedTheme,
 	isSiteEligibleForManagedExternalThemes,
+	isWporgTheme,
 } from 'calypso/state/themes/selectors';
 
 const identity = ( theme ) => theme;
@@ -172,6 +173,7 @@ function getAllThemeOptions( { translate, isFSEActive } ) {
 			! isUserLoggedIn( state ) ||
 			isJetpackSiteMultiSite( state, siteId ) ||
 			isThemeActive( state, themeId, siteId ) ||
+			( isWporgTheme( state, themeId ) && ! isSiteWpcomAtomic( state, siteId ) ) ||
 			( isThemePremium( state, themeId ) && ! isPremiumThemeAvailable( state, themeId, siteId ) ),
 	};
 

--- a/client/state/themes/selectors/should-show-try-and-customize.js
+++ b/client/state/themes/selectors/should-show-try-and-customize.js
@@ -1,11 +1,13 @@
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
+import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
 import { isJetpackSite, isJetpackSiteMultiSite } from 'calypso/state/sites/selectors';
 import {
 	isPremiumThemeAvailable,
 	isThemeActive,
 	isThemeGutenbergFirst,
 	isThemePremium,
+	isWporgTheme,
 } from 'calypso/state/themes/selectors';
 
 import 'calypso/state/themes/init';
@@ -37,6 +39,13 @@ export function shouldShowTryAndCustomize( state, themeId, siteId ) {
 		) {
 			return false;
 		}
+	}
+
+	/**
+	 * If displaying a WP.org theme on a non-atomic site, bail
+	 */
+	if ( isWporgTheme( state, themeId ) && ! isSiteWpcomAtomic( state, siteId ) ) {
+		return false;
 	}
 
 	return (

--- a/client/state/themes/selectors/should-show-try-and-customize.js
+++ b/client/state/themes/selectors/should-show-try-and-customize.js
@@ -7,7 +7,7 @@ import {
 	isThemeActive,
 	isThemeGutenbergFirst,
 	isThemePremium,
-	isWporgTheme,
+	isWpcomTheme,
 } from 'calypso/state/themes/selectors';
 
 import 'calypso/state/themes/init';
@@ -44,7 +44,7 @@ export function shouldShowTryAndCustomize( state, themeId, siteId ) {
 	/**
 	 * If displaying a WP.org theme on a non-atomic site, bail
 	 */
-	if ( isWporgTheme( state, themeId ) && ! isSiteWpcomAtomic( state, siteId ) ) {
+	if ( ! isWpcomTheme( state, themeId ) && ! isSiteWpcomAtomic( state, siteId ) ) {
 		return false;
 	}
 


### PR DESCRIPTION
#### Proposed Changes

Hide activate and customize options for WP.org themes on non-atomic sites

#### Testing Instructions
**Atomic sites**
* Go to themes with an atomic site selected. Ex: `/themes/:site`
* Search for a WP.org theme. Ex: `astral`
* Click on the options of the given theme
* Verify the options `Activate` and `Try & Customize` MUST be present

**non-atomic sites**
* Go to themes with an atomic site selected. Ex: `/themes/:site`
* Search for a WP.org theme. Ex: `astral`
* Click on the options of the given theme
* Verify the options `Activate` and `Try & Customize` must NOT be present

| Atomic  | Non-atomic |
| ------------- | ------------- |
|<img width="1238" alt="Screen Shot 2022-11-18 at 16 53 08" src="https://user-images.githubusercontent.com/5039531/202805142-ec25957a-d25e-4f19-8455-c3cdf1d74fda.png">|<img width="1238" alt="Screen Shot 2022-11-18 at 16 51 56" src="https://user-images.githubusercontent.com/5039531/202805208-6de6d216-8385-4626-adb1-6bf648514532.png">|



#### Pre-merge Checklist
**Non-atomic sites**
<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
