### PR TITLE
  Enable Zendesk pre-sales chat in Signup

### DIFF
--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -6,7 +6,9 @@ import {
 } from '@automattic/calypso-products';
 import { isBlankCanvasDesign } from '@automattic/design-picker';
 import { isNewsletterOrLinkInBioFlow, LINK_IN_BIO_TLD_FLOW } from '@automattic/onboarding';
+import { isCurrentPlanFlow } from '@automattic/onboarding/src';
 import debugModule from 'debug';
+import { getLocaleSlug } from 'i18n-calypso';
 import {
 	clone,
 	defer,
@@ -27,6 +29,7 @@ import { connect } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
 import QuerySiteDomains from 'calypso/components/data/query-site-domains';
 import LocaleSuggestions from 'calypso/components/locale-suggestions';
+import ZendeskChat from 'calypso/components/zendesk-chat-widget';
 import { addHotJarScript } from 'calypso/lib/analytics/hotjar';
 import {
 	recordSignupStart,
@@ -846,6 +849,21 @@ class Signup extends Component {
 		}
 	}
 
+	shouldShowZendeskPresalesChat() {
+		const isEnglishLocale = config( 'english_locales' ).includes( getLocaleSlug() ?? '' );
+		const currentTime = new Date();
+
+		return (
+			! this.props.isLoggedIn &&
+			isCurrentPlanFlow( this.props.flowName ) &&
+			isEnglishLocale &&
+			currentTime.getUTCHours() >= 15 &&
+			currentTime.getUTCHours() < 21 &&
+			currentTime.getUTCDay() !== 0 &&
+			currentTime.getUTCDay() !== 6
+		);
+	}
+
 	getPageTitle() {
 		if ( isNewsletterOrLinkInBioFlow( this.props.flowName ) ) {
 			return this.props.pageTitle;
@@ -868,6 +886,8 @@ class Signup extends Component {
 		}
 
 		const isReskinned = isReskinnedFlow( this.props.flowName );
+		const zendeskChatKey = config( 'zendesk_presales_chat_key' );
+		const shouldShowZendeskPresalesChat = this.shouldShowZendeskPresalesChat();
 
 		return (
 			<>
@@ -902,6 +922,7 @@ class Signup extends Component {
 						/>
 					) }
 				</div>
+				{ shouldShowZendeskPresalesChat && <ZendeskChat chatId={ zendeskChatKey } /> }
 			</>
 		);
 	}

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -5,8 +5,8 @@ import {
 	isDomainMapping,
 } from '@automattic/calypso-products';
 import { isBlankCanvasDesign } from '@automattic/design-picker';
-import { isNewsletterOrLinkInBioFlow, LINK_IN_BIO_TLD_FLOW } from '@automattic/onboarding';
-import { isCurrentPlanFlow } from '@automattic/onboarding/src';
+import { isNewsletterOrLinkInBioFlow } from '@automattic/onboarding';
+import { isCurrentPlanFlow, LINK_IN_BIO_TLD_FLOW } from '@automattic/onboarding/src';
 import debugModule from 'debug';
 import { getLocaleSlug } from 'i18n-calypso';
 import {
@@ -855,7 +855,7 @@ class Signup extends Component {
 
 		return (
 			! this.props.isLoggedIn &&
-			isCurrentPlanFlow( this.props.flowName ) &&
+			( isCurrentPlanFlow( this.props.flowName ) || this.props.flowName === 'onboarding' ) &&
 			isEnglishLocale &&
 			currentTime.getUTCHours() >= 15 &&
 			currentTime.getUTCHours() < 21 &&

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -86,6 +86,7 @@ import {
 	setSignupCompleteSlug,
 	getSignupCompleteSlug,
 	setSignupCompleteFlowName,
+	retrieveRecognizedLogins,
 } from './storageUtils';
 import {
 	canResumeFlow,
@@ -858,6 +859,7 @@ class Signup extends Component {
 
 		return (
 			! this.props.isLoggedIn &&
+			! retrieveRecognizedLogins() &&
 			( isCurrentPlanFlow( this.props.flowName ) || this.props.flowName === 'onboarding' ) &&
 			isEnglishLocale &&
 			currentTime.getUTCHours() >= 15 &&

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -5,8 +5,11 @@ import {
 	isDomainMapping,
 } from '@automattic/calypso-products';
 import { isBlankCanvasDesign } from '@automattic/design-picker';
-import { isNewsletterOrLinkInBioFlow } from '@automattic/onboarding';
-import { isCurrentPlanFlow, LINK_IN_BIO_TLD_FLOW } from '@automattic/onboarding/src';
+import {
+	isNewsletterOrLinkInBioFlow,
+	LINK_IN_BIO_TLD_FLOW,
+	isCurrentPlanFlow,
+} from '@automattic/onboarding';
 import debugModule from 'debug';
 import { getLocaleSlug } from 'i18n-calypso';
 import {

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -857,10 +857,19 @@ class Signup extends Component {
 		const isEnglishLocale = config( 'english_locales' ).includes( getLocaleSlug() ?? '' );
 		const currentTime = new Date();
 
+		const eligibleFlows = [
+			'do-it-for-me',
+			'domain',
+			'onboarding',
+			'onboarding-with-email',
+			'with-theme',
+		];
+
 		return (
 			! this.props.isLoggedIn &&
 			! retrieveRecognizedLogins() &&
-			( isCurrentPlanFlow( this.props.flowName ) || this.props.flowName === 'onboarding' ) &&
+			( eligibleFlows.includes( this.props.flowName ) ||
+				isCurrentPlanFlow( this.props.flowName ) ) &&
 			isEnglishLocale &&
 			currentTime.getUTCHours() >= 15 &&
 			currentTime.getUTCHours() < 21 &&

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -29,10 +29,10 @@ import page from 'page';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
+import AsyncLoad from 'calypso/components/async-load';
 import DocumentHead from 'calypso/components/data/document-head';
 import QuerySiteDomains from 'calypso/components/data/query-site-domains';
 import LocaleSuggestions from 'calypso/components/locale-suggestions';
-import ZendeskChat from 'calypso/components/zendesk-chat-widget';
 import { addHotJarScript } from 'calypso/lib/analytics/hotjar';
 import {
 	recordSignupStart,
@@ -925,7 +925,12 @@ class Signup extends Component {
 						/>
 					) }
 				</div>
-				{ shouldShowZendeskPresalesChat && <ZendeskChat chatId={ zendeskChatKey } /> }
+				{ shouldShowZendeskPresalesChat && (
+					<AsyncLoad
+						require="calypso/components/presales-zendesk-chat"
+						chatKey={ zendeskChatKey }
+					/>
+				) }
 			</>
 		);
 	}

--- a/client/signup/storageUtils.js
+++ b/client/signup/storageUtils.js
@@ -12,6 +12,11 @@ export const retrieveSignupDestination = () => {
 	return cookies.wpcom_signup_complete_destination;
 };
 
+export const retrieveRecognizedLogins = () => {
+	const cookies = cookie.parse( document.cookie );
+	return cookies.recognized_logins ?? null;
+};
+
 export const clearSignupDestinationCookie = () => {
 	// Set expiration to a random time in the past so that the cookie gets removed.
 	const expirationDate = new Date( new Date().getTime() - 1000 );

--- a/packages/onboarding/src/utils/flows.ts
+++ b/packages/onboarding/src/utils/flows.ts
@@ -15,7 +15,6 @@ export const BUSINESS_MONTHLY_FLOW = 'business-monthly';
 export const PREMIUM_MONTHLY_FLOW = 'premium-monthly';
 export const PERSONAL_MONTHLY_FLOW = 'personal-monthly';
 
-
 export const isLinkInBioFlow = ( flowName: string | null ) => {
 	return Boolean(
 		flowName &&

--- a/packages/onboarding/src/utils/flows.ts
+++ b/packages/onboarding/src/utils/flows.ts
@@ -7,6 +7,14 @@ export const VIDEOPRESS_FLOW = 'videopress';
 export const IMPORT_FOCUSED_FLOW = 'import-focused';
 export const ECOMMERCE_FLOW = 'ecommerce';
 export const FREE_FLOW = 'free';
+export const BUSINESS_FLOW = 'business';
+export const PREMIUM_FLOW = 'premium';
+export const PERSONAL_FLOW = 'personal';
+export const ECOMMERCE_MONTHLY_FLOW = 'ecommerce-monthly';
+export const BUSINESS_MONTHLY_FLOW = 'business-monthly';
+export const PREMIUM_MONTHLY_FLOW = 'premium-monthly';
+export const PERSONAL_MONTHLY_FLOW = 'personal-monthly';
+
 
 export const isLinkInBioFlow = ( flowName: string | null ) => {
 	return Boolean(
@@ -45,4 +53,20 @@ export const isTailoredSignupFlow = ( flowName: string | null ) => {
 export const ecommerceFlowRecurTypes = {
 	YEARLY: 'yearly',
 	MONTHLY: 'monthly',
+};
+
+export const isCurrentPlanFlow = ( flowName: string | null ) => {
+	return Boolean(
+		flowName &&
+			[
+				ECOMMERCE_FLOW,
+				BUSINESS_FLOW,
+				PREMIUM_FLOW,
+				PERSONAL_FLOW,
+				ECOMMERCE_MONTHLY_FLOW,
+				BUSINESS_MONTHLY_FLOW,
+				PREMIUM_MONTHLY_FLOW,
+				PERSONAL_MONTHLY_FLOW,
+			].includes( flowName )
+	);
 };


### PR DESCRIPTION
#### Proposed Changes

* As a follow-up to #70118 this enables the ZD pre-sales chat in signup, under specific conditions
* This includes a new helper function `isCurrentPlanFlow` added to the `onboarding` package.

#### Testing Instructions

Visit a few signup URLs, and check that the zendesk widget is visible/not visible (modify `currentTime` in `Signup.shouldShowZendeskPresalesChat` to make sure it is within operating time, for example by adding `currentTime.setUTCHours( '16' );` ):

* logged-in  `/start` - **not visible**
* logged-out `/start` - **visible**
* logged-out `/start/crowdsignal/oauth2-name?oauth2_client_id=978` - **not visible**
* logged-out `/start/premium` - **visible**

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?


This replaces the signup part of #69706, and is based on #70118
