### PR TITLE
Third-Party Themes: Moving the getProductsByBillingSlug selector

### DIFF
--- a/client/state/products-list/selectors/get-products-by-billing-slug.ts
+++ b/client/state/products-list/selectors/get-products-by-billing-slug.ts
@@ -1,0 +1,28 @@
+import 'calypso/state/products-list/init';
+import { getProductsList, ProductListItem } from './get-products-list';
+import type { AppState } from 'calypso/types';
+
+/**
+ * Returns an array of products that matches the specified billing product slug.
+ *
+ * @param state the state object
+ * @param billingProductSlug the product slug to match
+ * @returns ProductsListItem[]|undefined an array of products that matches the specified billing product slug or undefined if the products list is not loaded yet
+ */
+export const getProductsByBillingSlug = (
+	state: AppState,
+	billingProductSlug: string
+): ProductListItem[] | undefined => {
+	if ( ! billingProductSlug ) {
+		return undefined;
+	}
+
+	const products = getProductsList( state );
+
+	if ( Object.keys( products ).length === 0 ) {
+		return undefined;
+	}
+	return Object.values( products ).filter(
+		( product ) => product.billing_product_slug === billingProductSlug
+	);
+};

--- a/client/state/products-list/selectors/get-products-list.ts
+++ b/client/state/products-list/selectors/get-products-list.ts
@@ -38,6 +38,7 @@ export interface ProductListItem {
 	sale_cost?: number;
 	is_privacy_protection_product_purchase_allowed?: boolean;
 	product_term?: string;
+	billing_product_slug?: string;
 }
 
 export function getProductsList( state: AppState ): Record< string, ProductListItem > {

--- a/client/state/products-list/selectors/index.js
+++ b/client/state/products-list/selectors/index.js
@@ -10,6 +10,7 @@ export { getProductDescription } from './get-product-description';
 export { getProductDisplayCost } from './get-product-display-cost';
 export { getProductPriceTierList } from './get-product-price-tiers';
 export { getProductTerm } from './get-product-term';
+export { getProductsByBillingSlug } from './get-products-by-billing-slug';
 export { getProductsList } from './get-products-list';
 export { getProductsListType } from './get-products-list-type';
 export { isProductsListFetching } from './is-products-list-fetching';

--- a/client/state/products-list/test/selectors.js
+++ b/client/state/products-list/test/selectors.js
@@ -14,6 +14,7 @@ import {
 	getProductPriceTierList,
 	isProductsListFetching,
 	planSlugToPlanProduct,
+	getProductsByBillingSlug,
 } from '../selectors';
 
 jest.mock( 'calypso/state/selectors/get-intro-offer-price', () => jest.fn() );
@@ -521,6 +522,67 @@ describe( 'selectors', () => {
 		test( 'should return true when productsList.isFetching is true', () => {
 			const state = { productsList: { isFetching: true } };
 			expect( isProductsListFetching( state ) ).toBe( true );
+		} );
+	} );
+
+	describe( '#getProductsByBillingSlug()', () => {
+		const billingSlug = 'wp-mp-theme-tsubaki-test';
+
+		const tsubaki = {
+			product_id: 3001,
+			product_name: 'Tsubaki Third-Party Test',
+			product_slug: 'wp_mp_theme_tsubaki_test_yearly',
+			description: '',
+			product_type: 'marketplace_theme',
+			available: true,
+			billing_product_slug: 'wp-mp-theme-tsubaki-test',
+			is_domain_registration: false,
+			cost_display: 'US$100.00',
+			combined_cost_display: 'US$100.00',
+			cost: 100,
+			cost_smallest_unit: 10000,
+			currency_code: 'USD',
+			price_tier_list: [],
+			price_tier_usage_quantity: null,
+			product_term: 'year',
+			price_tiers: [],
+			price_tier_slug: '',
+		};
+
+		const items = {
+			wp_mp_theme_tsubaki_test_yearly: tsubaki,
+		};
+
+		test( 'Should return undefined if the items are empty', () => {
+			const state = {
+				productsList: {
+					items: {},
+				},
+			};
+
+			expect( getProductsByBillingSlug( state, billingSlug ) ).toBeUndefined();
+		} );
+
+		test( 'Should return undefined if the billing slug is not defined', () => {
+			const state = {
+				productsList: {
+					items,
+				},
+			};
+
+			expect( getProductsByBillingSlug( state ) ).toBeUndefined();
+		} );
+
+		test( 'Should return the list of products containing tsubaki', () => {
+			const state = {
+				productsList: {
+					items,
+				},
+			};
+
+			const productsBySlug = getProductsByBillingSlug( state, billingSlug );
+
+			expect( productsBySlug[ 0 ] ).toBe( tsubaki );
 		} );
 	} );
 } );

--- a/packages/data-stores/src/products-list/selectors.ts
+++ b/packages/data-stores/src/products-list/selectors.ts
@@ -1,6 +1,5 @@
 import { select } from '@wordpress/data';
 import { STORE_KEY } from './constants';
-import { ProductsListItem } from './types';
 import type { State } from './reducer';
 
 export const getState = ( state: State ) => state;
@@ -20,29 +19,4 @@ export const getProductBySlug = ( _state: State, slug: string ) => {
 	}
 
 	return products?.[ slug ];
-};
-
-/**
- * Returns an array of products that matches the specified billing product slug.
- *
- * @param _state the state object
- * @param billingProductSlug the product slug to match
- * @returns ProductsListItem[]|undefined an array of products that matches the specified billing product slug or undefined if the products list is not loaded yet
- */
-export const getProductsByBillingSlug = (
-	_state: State,
-	billingProductSlug: string
-): ProductsListItem[] | undefined => {
-	if ( ! billingProductSlug ) {
-		return undefined;
-	}
-
-	const products = select( STORE_KEY ).getProductsList();
-
-	if ( ! products ) {
-		return undefined;
-	}
-	return Object.values( products ).filter(
-		( product ) => product.billing_product_slug === billingProductSlug
-	);
 };

--- a/packages/data-stores/src/products-list/test/selectors.ts
+++ b/packages/data-stores/src/products-list/test/selectors.ts
@@ -45,26 +45,6 @@ describe( 'selectors', () => {
 				price_tiers: [],
 				price_tier_slug: '',
 			},
-			wp_mp_theme_tsubaki_test_yearly: {
-				product_id: 3001,
-				product_name: 'Tsubaki Third-Party Test',
-				product_slug: 'wp_mp_theme_tsubaki_test_yearly',
-				description: '',
-				product_type: 'marketplace_theme',
-				available: true,
-				billing_product_slug: 'wp-mp-theme-tsubaki-test',
-				is_domain_registration: false,
-				cost_display: 'US$100.00',
-				combined_cost_display: 'US$100.00',
-				cost: 100,
-				cost_smallest_unit: 10000,
-				currency_code: 'USD',
-				price_tier_list: [],
-				price_tier_usage_quantity: null,
-				product_term: 'year',
-				price_tiers: [],
-				price_tier_slug: '',
-			},
 		};
 
 		( wpcomRequest as jest.Mock ).mockResolvedValue( apiResponse );
@@ -85,8 +65,5 @@ describe( 'selectors', () => {
 
 		expect( select( store ).getProductsList() ).toEqual( apiResponse );
 		expect( select( store ).getProductBySlug( 'free_plan' ) ).toEqual( apiResponse[ 'free_plan' ] );
-		expect( select( store ).getProductsByBillingSlug( 'wp-mp-theme-tsubaki-test' ) ).toEqual( [
-			apiResponse[ 'wp_mp_theme_tsubaki_test_yearly' ],
-		] );
 	} );
 } );

--- a/packages/data-stores/src/products-list/types.ts
+++ b/packages/data-stores/src/products-list/types.ts
@@ -7,7 +7,6 @@ export interface Dispatch {
 
 export interface ProductsListItem {
 	available: boolean;
-	billing_product_slug: string;
 	combined_cost_display: string;
 	cost: number;
 	currency_code: string;


### PR DESCRIPTION
#### Proposed Changes

* Moves the `getProductsByBillingSlug` selector to the client state. 
* I moved it away from the data-stores package because it was not working on our use case. It was also causing the calypso build to break.
* This selector will be used to get the marketplace themes' billing cycle available.

#### Testing Instructions

* Run the new automated tests for the `product-list`
```bash
node 'node_modules/.bin/jest' 'client/state/products-list/test/selectors.js' -c 'test/client/jest.config.js' -t 'selectors #getProductsByBillingSlug\(\)'
```
* Make sure the data-stores tests that I changed are passing(see #70072):
```bash
node 'node_modules/.bin/jest' './packages/data-stores/src/products-list/test/selectors.ts' -c './packages/data-stores/jest.config.js' -t 'selectors'
```

Related to #69616
