### PR TITLE
Agency Dashboard: Add tracks event when user had an existing standalone product license before purchased a bundle

### DIFF
--- a/client/state/partner-portal/licenses/selectors.ts
+++ b/client/state/partner-portal/licenses/selectors.ts
@@ -30,7 +30,13 @@ export function hasFetchedLicenseCounts( state: PartnerPortalStore ): boolean {
 	return state.partnerPortal.licenses.hasFetchedLicenseCounts;
 }
 
-// Returns the product IDs of the assigned plan(bundle) & all the products to a particular site in an array.
+/**
+ * Returns the product IDs of the assigned plan (bundle) & all the products to a particular site in an array.
+ *
+ * @param state
+ * @param siteId
+ * @returns {Array} An array of products and plan IDs.
+ */
 export function getAssignedPlanAndProductIDsForSite(
 	state: AppState,
 	siteId: number
@@ -47,4 +53,17 @@ export function getAssignedPlanAndProductIDsForSite(
 		planAndProductIDs.push( parseInt( product.product_id ) )
 	);
 	return planAndProductIDs;
+}
+
+/**
+ * Returns if the site has purchased standalone product licenses (not bundles) for the given site ID.
+ *
+ * @param state
+ * @param siteId
+ * @returns {boolean} True if the site has standalone products only.
+ */
+export function hasPurchasedProductsOnly( state: AppState, siteId: number ): Array< number > {
+	const currentSite = state?.sites?.items?.[ siteId ];
+
+	return currentSite?.products?.length && currentSite?.plan?.is_free;
 }


### PR DESCRIPTION
#### Proposed Changes

This PR adds a track event when the user already has a standalone product (e.g., Backup, Scan, etc.), but purchases a bundle license.

Discussion: p1668676233123129-slack-C039K7CD119

#### Testing Instructions
- Create a new JN site
- Checkout this branch locally
- Run `yarn start-jetpack-cloud`
- Visit http://jetpack.cloud.localhost:3000/dashboard
- Click the `Add` button on backup and issue the license
- Visit the dashboard again
- Click the `Add` button on the scan, **but choose a bundle on the license selection page**
- Using the Network tab (Dev Tools) or the [Tracks Vigilante Chrome Extension](p7H4VZ-3cB-p2), verify that the `calypso_partner_portal_issue_bundle_license_with_existing_standalone_products` event is tracked

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1203126240279377-as-1203136066214515