### PR TITLE
Feature flag for template persisting on theme switch

### DIFF
--- a/client/state/themes/actions/activate-theme.js
+++ b/client/state/themes/actions/activate-theme.js
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { translate } from 'i18n-calypso';
 import { CALYPSO_CONTACT } from 'calypso/lib/url/support';
 import wpcom from 'calypso/lib/wp';
@@ -35,6 +36,7 @@ export function activateTheme(
 			.post( `/sites/${ siteId }/themes/mine`, {
 				theme: themeId,
 				...( dontChangeHomepage && { dont_change_homepage: true } ),
+				...( isEnabled( 'themes/template-persistent' ) && { persistTemplate: true } ),
 			} )
 			.then( ( theme ) => {
 				// Fall back to ID for Jetpack sites which don't return a stylesheet attr.

--- a/client/state/themes/actions/activate-theme.js
+++ b/client/state/themes/actions/activate-theme.js
@@ -36,7 +36,7 @@ export function activateTheme(
 			.post( `/sites/${ siteId }/themes/mine`, {
 				theme: themeId,
 				...( dontChangeHomepage && { dont_change_homepage: true } ),
-				...( isEnabled( 'themes/template-persistent' ) && { persist_template: true } ),
+				...( isEnabled( 'themes/theme-switch-persist-template' ) && { persist_template: true } ),
 			} )
 			.then( ( theme ) => {
 				// Fall back to ID for Jetpack sites which don't return a stylesheet attr.

--- a/client/state/themes/actions/activate-theme.js
+++ b/client/state/themes/actions/activate-theme.js
@@ -36,7 +36,7 @@ export function activateTheme(
 			.post( `/sites/${ siteId }/themes/mine`, {
 				theme: themeId,
 				...( dontChangeHomepage && { dont_change_homepage: true } ),
-				...( isEnabled( 'themes/template-persistent' ) && { persistTemplate: true } ),
+				...( isEnabled( 'themes/template-persistent' ) && { persist_template: true } ),
 			} )
 			.then( ( theme ) => {
 				// Fall back to ID for Jetpack sites which don't return a stylesheet attr.

--- a/client/state/themes/actions/activate-theme.js
+++ b/client/state/themes/actions/activate-theme.js
@@ -36,7 +36,9 @@ export function activateTheme(
 			.post( `/sites/${ siteId }/themes/mine`, {
 				theme: themeId,
 				...( dontChangeHomepage && { dont_change_homepage: true } ),
-				...( isEnabled( 'themes/theme-switch-persist-template' ) && { persist_template: true } ),
+				...( isEnabled( 'themes/theme-switch-persist-template' ) && {
+					persist_homepage_template: true,
+				} ),
 			} )
 			.then( ( theme ) => {
 				// Fall back to ID for Jetpack sites which don't return a stylesheet attr.

--- a/config/development.json
+++ b/config/development.json
@@ -171,6 +171,7 @@
 		"themes/premium": true,
 		"themes/showcase-i4/search-and-filter": true,
 		"themes/subscription-purchases": true,
+		"themes/template-persistent": true,
 		"themes/third-party-premium": true,
 		"titan/iframe-control-panel": false,
 		"unified-pages/virtual-home-page": true,

--- a/config/development.json
+++ b/config/development.json
@@ -171,7 +171,7 @@
 		"themes/premium": true,
 		"themes/showcase-i4/search-and-filter": true,
 		"themes/subscription-purchases": true,
-		"themes/template-persistent": true,
+		"themes/theme-switch-persist-template": true,
 		"themes/third-party-premium": true,
 		"titan/iframe-control-panel": false,
 		"unified-pages/virtual-home-page": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -117,6 +117,7 @@
 		"themes/premium": true,
 		"themes/showcase-i4/search-and-filter": false,
 		"themes/subscription-purchases": false,
+		"themes/template-persistent": true,
 		"themes/third-party-premium": false,
 		"unified-pages/virtual-home-page": true,
 		"upgrades/redirect-payments": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -117,7 +117,7 @@
 		"themes/premium": true,
 		"themes/showcase-i4/search-and-filter": false,
 		"themes/subscription-purchases": false,
-		"themes/template-persistent": true,
+		"themes/theme-switch-persist-template": true,
 		"themes/third-party-premium": false,
 		"unified-pages/virtual-home-page": true,
 		"upgrades/redirect-payments": true,

--- a/config/production.json
+++ b/config/production.json
@@ -136,7 +136,7 @@
 		"themes/premium": true,
 		"themes/showcase-i4/search-and-filter": false,
 		"themes/subscription-purchases": false,
-		"themes/template-persistent": false,
+		"themes/theme-switch-persist-template": false,
 		"themes/third-party-premium": false,
 		"unified-pages/virtual-home-page": false,
 		"upgrades/redirect-payments": true,

--- a/config/production.json
+++ b/config/production.json
@@ -136,6 +136,7 @@
 		"themes/premium": true,
 		"themes/showcase-i4/search-and-filter": false,
 		"themes/subscription-purchases": false,
+		"themes/template-persistent": false,
 		"themes/third-party-premium": false,
 		"unified-pages/virtual-home-page": false,
 		"upgrades/redirect-payments": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -133,6 +133,7 @@
 		"themes/premium": true,
 		"themes/showcase-i4/search-and-filter": false,
 		"themes/subscription-purchases": false,
+		"themes/template-persistent": false,
 		"themes/third-party-premium": false,
 		"unified-pages/virtual-home-page": false,
 		"upgrades/redirect-payments": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -133,7 +133,7 @@
 		"themes/premium": true,
 		"themes/showcase-i4/search-and-filter": false,
 		"themes/subscription-purchases": false,
-		"themes/template-persistent": false,
+		"themes/theme-switch-persist-template": false,
 		"themes/third-party-premium": false,
 		"unified-pages/virtual-home-page": false,
 		"upgrades/redirect-payments": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -141,6 +141,7 @@
 		"themes/premium": true,
 		"themes/showcase-i4/search-and-filter": false,
 		"themes/subscription-purchases": false,
+		"themes/template-persistent": false,
 		"themes/third-party-premium": false,
 		"unified-pages/virtual-home-page": false,
 		"upgrades/redirect-payments": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -141,7 +141,7 @@
 		"themes/premium": true,
 		"themes/showcase-i4/search-and-filter": false,
 		"themes/subscription-purchases": false,
-		"themes/template-persistent": false,
+		"themes/theme-switch-persist-template": false,
 		"themes/third-party-premium": false,
 		"unified-pages/virtual-home-page": false,
 		"upgrades/redirect-payments": true,


### PR DESCRIPTION
## Proposed Changes

* Use feature flag `themes/theme-switch-persist-template` to turn on/off template persistent feature on theme switching

## Testing Instructions

* Visit `http://calypso.localhost:3000/theme/{ theme }/{ siteId }?flags=-themes/theme-switch-persist-template` 
* Confirm that the home template is not persisted upon theme switching

## Reference
Related to #70179
This PR has an attached diff D92974-code