### PR TITLE
Fix DP misalign on mobile

### DIFF
--- a/packages/design-picker/src/components/pattern-assembler-cta/style.scss
+++ b/packages/design-picker/src/components/pattern-assembler-cta/style.scss
@@ -7,16 +7,17 @@
 	justify-content: center;
 	text-align: center;
 	align-items: center;
-	padding: 64px;
+	padding: 16px;
 	background-color: #f6f7f7;
 	color: #50575e;
 
-	@include break-medium {
-		grid-column: 1 / span 3;
+	@include break-small {
+		padding: 32px;
 	}
 
-	@media ( max-width: $break-mobile ) {
-		padding: 32px;
+	@include break-medium {
+		grid-column: 1 / span 3;
+		padding: 64px;
 	}
 
 	.pattern-assembler-cta__title {

--- a/packages/design-picker/src/components/pattern-assembler-cta/style.scss
+++ b/packages/design-picker/src/components/pattern-assembler-cta/style.scss
@@ -15,6 +15,10 @@
 		grid-column: 1 / span 3;
 	}
 
+	@media ( max-width: $break-mobile ) {
+		padding: 32px;
+	}
+
 	.pattern-assembler-cta__title {
 		margin-top: 32px;
 		margin-bottom: 8px;


### PR DESCRIPTION
## Proposed Changes

* Fix DP misalign on mobile by reduce the padding of the Pattern Assembler CTA

## Testing Instructions

* View the screen on mobile breakpoint
* From goals screen http://calypso.localhost:3000/setup/site-setup/goals?siteSlug={ siteId }
* Select Build flow `Promote myself or business`
* Make sure the Design Picker is center aligned

![image](https://user-images.githubusercontent.com/10071857/202965814-ca19455c-c5cc-4baf-9ec7-8bf2ee0b0174.png)


## Reference
Related to #70184
