### PR TITLE
Take two: Implement white login for all /log-in routes

### DIFF
--- a/client/blocks/login/error-notice.jsx
+++ b/client/blocks/login/error-notice.jsx
@@ -23,7 +23,6 @@ class ErrorNotice extends Component {
 		requestAccountError: PropTypes.object,
 		requestError: PropTypes.object,
 		twoFactorAuthRequestError: PropTypes.object,
-		isGutenboarding: PropTypes.bool.isRequired,
 		locale: PropTypes.string,
 	};
 
@@ -62,17 +61,10 @@ class ErrorNotice extends Component {
 	}
 
 	getSignupUrl() {
-		const { currentQuery, currentRoute, oauth2Client, locale, isGutenboarding } = this.props;
+		const { currentQuery, currentRoute, oauth2Client, locale } = this.props;
 		const { pathname } = getUrlParts( window.location.href );
 
-		return getSignupUrl(
-			currentQuery,
-			currentRoute,
-			oauth2Client,
-			locale,
-			pathname,
-			isGutenboarding
-		);
+		return getSignupUrl( currentQuery, currentRoute, oauth2Client, locale, pathname );
 	}
 
 	render() {

--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -50,7 +50,7 @@ class Login extends Component {
 		disableAutoFocus: PropTypes.bool,
 		isLinking: PropTypes.bool,
 		isJetpack: PropTypes.bool.isRequired,
-		isGutenboarding: PropTypes.bool.isRequired,
+		isWhiteLogin: PropTypes.bool.isRequired,
 		isJetpackWooCommerceFlow: PropTypes.bool.isRequired,
 		isManualRenewalImmediateLoginAttempt: PropTypes.bool,
 		linkingSocialService: PropTypes.string,
@@ -83,7 +83,7 @@ class Login extends Component {
 
 	static defaultProps = {
 		isJetpack: false,
-		isGutenboarding: false,
+		isWhiteLogin: false,
 		isJetpackWooCommerceFlow: false,
 	};
 
@@ -163,7 +163,6 @@ class Login extends Component {
 			page(
 				login( {
 					isJetpack: this.props.isJetpack,
-					isGutenboarding: this.props.isGutenboarding,
 					// If no notification is sent, the user is using the authenticator for 2FA by default
 					twoFactorAuthType: authType,
 					locale: this.props.locale,
@@ -220,16 +219,8 @@ class Login extends Component {
 	};
 
 	getSignupUrl = () => {
-		const {
-			currentRoute,
-			oauth2Client,
-			currentQuery,
-			pathname,
-			locale,
-			isGutenboarding,
-			signupUrl,
-			isWoo,
-		} = this.props;
+		const { currentRoute, oauth2Client, currentQuery, pathname, locale, signupUrl, isWoo } =
+			this.props;
 
 		if ( signupUrl ) {
 			return signupUrl;
@@ -240,20 +231,13 @@ class Login extends Component {
 			return 'https://woocommerce.com/start/';
 		}
 
-		return getSignupUrl(
-			currentQuery,
-			currentRoute,
-			oauth2Client,
-			locale,
-			pathname,
-			isGutenboarding
-		);
+		return getSignupUrl( currentQuery, currentRoute, oauth2Client, locale, pathname );
 	};
 
 	renderHeader() {
 		const {
 			isJetpack,
-			isGutenboarding,
+			isWhiteLogin,
 			isJetpackWooCommerceFlow,
 			isP2Login,
 			wccomFrom,
@@ -450,7 +434,7 @@ class Login extends Component {
 			);
 		}
 
-		if ( isGutenboarding ) {
+		if ( isWhiteLogin ) {
 			preHeader = (
 				<div className="login__form-gutenboarding-wordpress-logo">
 					<svg
@@ -495,7 +479,6 @@ class Login extends Component {
 		const {
 			domain,
 			isJetpack,
-			isGutenboarding,
 			isP2Login,
 			privateSite,
 			twoFactorAuthType,
@@ -553,7 +536,6 @@ class Login extends Component {
 						require="calypso/blocks/login/two-factor-authentication/two-factor-content"
 						isBrowserSupported={ this.state.isBrowserSupported }
 						isJetpack={ isJetpack }
-						isGutenboarding={ isGutenboarding }
 						isWoo={ isWoo }
 						isPartnerSignup={ isPartnerSignup }
 						twoFactorAuthType={ twoFactorAuthType }
@@ -608,7 +590,6 @@ class Login extends Component {
 							socialService={ socialService }
 							socialServiceResponse={ socialServiceResponse }
 							domain={ domain }
-							isGutenboarding={ isGutenboarding }
 							isP2Login={ isP2Login }
 							locale={ locale }
 							userEmail={ userEmail }
@@ -632,7 +613,6 @@ class Login extends Component {
 				socialService={ socialService }
 				socialServiceResponse={ socialServiceResponse }
 				domain={ domain }
-				isGutenboarding={ isGutenboarding }
 				isP2Login={ isP2Login }
 				locale={ locale }
 				userEmail={ userEmail }
@@ -647,7 +627,7 @@ class Login extends Component {
 	}
 
 	render() {
-		const { isJetpack, oauth2Client, locale, isGutenboarding } = this.props;
+		const { isJetpack, oauth2Client, locale } = this.props;
 		return (
 			<div
 				className={ classNames( 'login', {
@@ -657,7 +637,7 @@ class Login extends Component {
 			>
 				{ this.renderHeader() }
 
-				<ErrorNotice locale={ locale } isGutenboarding={ isGutenboarding } />
+				<ErrorNotice locale={ locale } />
 
 				{ this.renderNotice() }
 

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -76,7 +76,6 @@ export class LoginForm extends Component {
 		socialServiceResponse: PropTypes.object,
 		translate: PropTypes.func.isRequired,
 		userEmail: PropTypes.string,
-		isGutenboarding: PropTypes.bool,
 		isPartnerSignup: PropTypes.bool,
 		locale: PropTypes.string,
 		showSocialLoginFormOnly: PropTypes.bool,
@@ -544,7 +543,6 @@ export class LoginForm extends Component {
 			requestError,
 			socialAccountIsLinking: linkingSocialUser,
 			isJetpackWooCommerceFlow,
-			isGutenboarding,
 			isP2Login,
 			isJetpackWooDnaFlow,
 			wccomFrom,
@@ -561,7 +559,7 @@ export class LoginForm extends Component {
 
 		const signupUrl = this.props.signupUrl
 			? window.location.origin + pathWithLeadingSlash( this.props.signupUrl )
-			: getSignupUrl( currentQuery, currentRoute, oauth2Client, locale, pathname, isGutenboarding );
+			: getSignupUrl( currentQuery, currentRoute, oauth2Client, locale, pathname );
 
 		const socialToS = this.props.translate(
 			// To make any changes to this copy please speak to the legal team

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -186,7 +186,12 @@
 	}
 
 	.visit-site {
-		margin: -12px 0 24px;
+		margin: 12px 0 24px;
+		text-align: left;
+
+		@include break-mobile {
+			text-align: center;
+		}
 	}
 }
 

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -167,10 +167,14 @@ export default withCurrentRoute(
 		const isJetpackLogin = currentRoute.startsWith( '/log-in/jetpack' );
 		const isPartnerSignup = isPartnerSignupQuery( currentQuery );
 		const isPartnerSignupStart = currentRoute.startsWith( '/start/wpcc' );
-		const isWhiteLogin =
-			currentRoute.startsWith( '/log-in/new' ) || ( isPartnerSignup && ! isPartnerSignupStart );
 		const isJetpackWooDnaFlow = wooDnaConfig( getInitialQueryArguments( state ) ).isWooDnaFlow();
 		const isP2Login = 'login' === sectionName && 'p2' === currentQuery?.from;
+		const isReskinLoginRoute =
+			currentRoute.startsWith( '/log-in' ) &&
+			! isJetpackLogin &&
+			! isP2Login &&
+			Boolean( currentQuery?.client_id ) === false;
+		const isWhiteLogin = isReskinLoginRoute || ( isPartnerSignup && ! isPartnerSignupStart );
 		const noMasterbarForRoute =
 			isJetpackLogin || ( isWhiteLogin && ! isPartnerSignup ) || isJetpackWooDnaFlow || isP2Login;
 		const isPopup = '1' === currentQuery?.is_popup;

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -143,7 +143,8 @@
 		line-height: 20px;
 	}
 
-	.button.is-primary {
+	.button.is-primary,
+	.login .button.is-primary {
 		background: $woo-purple-60;
 		border: none;
 		color: #fff;

--- a/client/lib/login/index.js
+++ b/client/lib/login/index.js
@@ -43,14 +43,7 @@ export function pathWithLeadingSlash( path ) {
 	return path ? `/${ path.replace( /^\/+/, '' ) }` : '';
 }
 
-export function getSignupUrl(
-	currentQuery,
-	currentRoute,
-	oauth2Client,
-	locale,
-	pathname,
-	isGutenboarding
-) {
+export function getSignupUrl( currentQuery, currentRoute, oauth2Client, locale, pathname ) {
 	let signupUrl = config( 'signup_url' );
 
 	const redirectTo = get( currentQuery, 'redirect_to', '' );
@@ -108,17 +101,6 @@ export function getSignupUrl(
 			oauth2Params.set( 'wccom-from', wccomFrom );
 		}
 		signupUrl = `${ signupUrl }/wpcc?${ oauth2Params.toString() }`;
-	}
-
-	if ( isGutenboarding ) {
-		const langFragment = locale && locale !== 'en' ? `/${ locale }` : '';
-		const defaultSignupUrl = `/new/plans${ langFragment }?signup`;
-		signupUrl = get( currentQuery, 'signup_url', defaultSignupUrl );
-
-		// Sanitize the url if it doesn't start with /new
-		if ( ! startsWith( signupUrl, '/new' ) ) {
-			signupUrl = defaultSignupUrl;
-		}
 	}
 
 	if ( oauth2Client && isJetpackCloudOAuth2Client( oauth2Client ) ) {

--- a/client/lib/paths/login/index.js
+++ b/client/lib/paths/login/index.js
@@ -4,8 +4,6 @@ import { addQueryArgs } from 'calypso/lib/url';
 /**
  * @param {{
 	isJetpack?: boolean;
-	isGutenboarding?: boolean;
-	isWhiteLogin?: boolean;
 	locale?: string;
 	redirectTo?: string;
 	twoFactorAuthType?: string;
@@ -24,8 +22,6 @@ import { addQueryArgs } from 'calypso/lib/url';
  */
 export function login( {
 	isJetpack = undefined,
-	isGutenboarding = undefined,
-	isWhiteLogin = undefined,
 	locale = undefined,
 	redirectTo = undefined,
 	twoFactorAuthType = undefined,
@@ -50,16 +46,12 @@ export function login( {
 		url += '/' + socialService + '/callback';
 	} else if ( twoFactorAuthType && isJetpack ) {
 		url += '/jetpack/' + twoFactorAuthType;
-	} else if ( twoFactorAuthType && ( isGutenboarding || isWhiteLogin ) ) {
-		url += '/new/' + twoFactorAuthType;
 	} else if ( twoFactorAuthType ) {
 		url += '/' + twoFactorAuthType;
 	} else if ( socialConnect ) {
 		url += '/social-connect';
 	} else if ( isJetpack ) {
 		url += '/jetpack';
-	} else if ( isGutenboarding || isWhiteLogin ) {
-		url += '/new';
 	} else if ( useMagicLink ) {
 		url += '/link';
 	} else if ( useQRCode ) {

--- a/client/lib/paths/login/test/index.js
+++ b/client/lib/paths/login/test/index.js
@@ -38,11 +38,6 @@ describe( 'login', () => {
 		expect( url ).toBe( '/log-in/jetpack?from=potato' );
 	} );
 
-	test( 'should return the login url for Gutenboarding specific login', () => {
-		const url = login( { isGutenboarding: true } );
-		expect( url ).toBe( '/log-in/new' );
-	} );
-
 	test( 'should return the login url with WooCommerce.com handler', () => {
 		const url = login( { oauth2ClientId: 12345, wccomFrom: 'testing' } );
 		expect( url ).toBe( '/log-in?client_id=12345&wccom-from=testing' );

--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -12,7 +12,7 @@ import WPLogin from './wp-login';
 
 const enhanceContextWithLogin = ( context ) => {
 	const {
-		params: { flow, isJetpack, isGutenboarding, socialService, twoFactorAuthType, action },
+		params: { flow, isJetpack, socialService, twoFactorAuthType, action },
 		path,
 		query,
 		isServerSide,
@@ -45,13 +45,20 @@ const enhanceContextWithLogin = ( context ) => {
 	const socialServiceResponse = client_id
 		? { client_id, user_email, user_name, id_token, state }
 		: null;
+	const isJetpackLogin = isJetpack === 'jetpack';
+	const isP2Login = query && query.from === 'p2';
+	const isWhiteLogin =
+		! isJetpackLogin &&
+		! isP2Login &&
+		Boolean( query?.client_id ) === false &&
+		Boolean( query?.oauth2_client_id ) === false;
 
 	context.primary = (
 		<WPLogin
 			action={ action }
-			isJetpack={ isJetpack === 'jetpack' }
-			isGutenboarding={ isGutenboarding === 'new' }
-			isP2Login={ query && query.from === 'p2' }
+			isJetpack={ isJetpackLogin }
+			isWhiteLogin={ isWhiteLogin }
+			isP2Login={ isP2Login }
 			path={ path }
 			twoFactorAuthType={ twoFactorAuthType }
 			socialService={ socialService }

--- a/client/login/magic-login/index.jsx
+++ b/client/login/magic-login/index.jsx
@@ -1,6 +1,5 @@
 import config from '@automattic/calypso-config';
 import { Gridicon } from '@automattic/components';
-import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import page from 'page';
 import PropTypes from 'prop-types';
@@ -56,7 +55,6 @@ class MagicLogin extends Component {
 
 		const loginParameters = {
 			isJetpack: this.props.isJetpackLogin,
-			isGutenboarding: this.props.isGutenboardingLogin,
 			locale: this.props.locale,
 			emailAddress: this.props.query?.email_address,
 			signupUrl: this.props.query?.signup_url,
@@ -66,10 +64,9 @@ class MagicLogin extends Component {
 	};
 
 	renderLinks() {
-		const { isJetpackLogin, isGutenboardingLogin, locale, showCheckYourEmail, translate } =
-			this.props;
+		const { isJetpackLogin, locale, showCheckYourEmail, translate } = this.props;
 
-		if ( showCheckYourEmail ) {
+		if ( showCheckYourEmail || this.props.query?.client_id ) {
 			return null;
 		}
 
@@ -79,7 +76,6 @@ class MagicLogin extends Component {
 		// paste somewhere else, their email address isn't included in it.
 		const loginParameters = {
 			isJetpack: isJetpackLogin,
-			isGutenboarding: isGutenboardingLogin,
 			locale: locale,
 			signupUrl: this.props.query?.signup_url,
 		};
@@ -133,13 +129,9 @@ class MagicLogin extends Component {
 		};
 
 		return (
-			<Main
-				className={ classNames( 'magic-login', 'magic-login__request-link', {
-					'is-white-login': this.props.isGutenboardingLogin,
-				} ) }
-			>
+			<Main className="magic-login magic-login__request-link is-white-login">
 				{ this.props.isJetpackLogin && <JetpackHeader /> }
-				{ this.props.isGutenboardingLogin && this.renderGutenboardingLogo() }
+				{ this.renderGutenboardingLogo() }
 
 				{ this.renderLocaleSuggestions() }
 
@@ -158,7 +150,6 @@ const mapState = ( state ) => ( {
 	query: getCurrentQueryArguments( state ),
 	showCheckYourEmail: getMagicLoginCurrentView( state ) === CHECK_YOUR_EMAIL_PAGE,
 	isJetpackLogin: getCurrentRoute( state ) === '/log-in/jetpack/link',
-	isGutenboardingLogin: getCurrentRoute( state )?.startsWith( '/log-in/new/link' ),
 } );
 
 const mapDispatch = {

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -37,7 +37,7 @@ export class Login extends Component {
 		isLoggedIn: PropTypes.bool.isRequired,
 		isLoginView: PropTypes.bool,
 		isJetpack: PropTypes.bool.isRequired,
-		isGutenboarding: PropTypes.bool.isRequired,
+		isWhiteLogin: PropTypes.bool.isRequired,
 		isPartnerSignup: PropTypes.bool.isRequired,
 		locale: PropTypes.string.isRequired,
 		oauth2Client: PropTypes.object,
@@ -52,7 +52,7 @@ export class Login extends Component {
 		action: PropTypes.string,
 	};
 
-	static defaultProps = { isJetpack: false, isGutenboarding: false, isLoginView: true };
+	static defaultProps = { isJetpack: false, isWhiteLogin: false, isLoginView: true };
 
 	state = {
 		usernameOrEmail: '',
@@ -141,10 +141,10 @@ export class Login extends Component {
 	}
 
 	renderFooter() {
-		const { isJetpack, isGutenboarding, isP2Login, translate } = this.props;
+		const { isJetpack, isWhiteLogin, isP2Login, translate } = this.props;
 		const isOauthLogin = !! this.props.oauth2Client;
 
-		if ( isJetpack || isGutenboarding || isP2Login ) {
+		if ( isJetpack || isWhiteLogin || isP2Login ) {
 			return null;
 		}
 
@@ -221,7 +221,7 @@ export class Login extends Component {
 			domain,
 			isLoggedIn,
 			isJetpack,
-			isGutenboarding,
+			isWhiteLogin,
 			isP2Login,
 			oauth2Client,
 			privateSite,
@@ -257,10 +257,11 @@ export class Login extends Component {
 						locale={ locale }
 						privateSite={ privateSite }
 						twoFactorAuthType={ twoFactorAuthType }
-						isGutenboarding={ isGutenboarding }
+						isWhiteLogin={ isWhiteLogin }
 						isP2Login={ isP2Login }
 						signupUrl={ signupUrl }
 						usernameOrEmail={ this.state.usernameOrEmail }
+						oauth2ClientId={ this.props.oauth2Client?.id }
 					/>
 				) }
 				{ isLoginView && <TranslatorInvite path={ path } /> }
@@ -275,7 +276,7 @@ export class Login extends Component {
 				privateSite={ privateSite }
 				clientId={ clientId }
 				isJetpack={ isJetpack }
-				isGutenboarding={ isGutenboarding }
+				isWhiteLogin={ isWhiteLogin }
 				isP2Login={ isP2Login }
 				oauth2Client={ oauth2Client }
 				socialService={ socialService }

--- a/client/login/wp-login/login-links.jsx
+++ b/client/login/wp-login/login-links.jsx
@@ -104,12 +104,11 @@ export class LoginLinks extends Component {
 			locale: this.props.locale,
 			twoFactorAuthType: 'link',
 			signupUrl: this.props.query?.signup_url,
+			oauth2ClientId: this.props.oauth2ClientId,
 		};
 
 		if ( this.props.currentRoute === '/log-in/jetpack' ) {
 			loginParameters.twoFactorAuthType = 'jetpack/link';
-		} else if ( this.props.isGutenboarding ) {
-			loginParameters.twoFactorAuthType = 'new/link';
 		}
 
 		return login( loginParameters );
@@ -127,7 +126,7 @@ export class LoginLinks extends Component {
 		if (
 			isCrowdsignalOAuth2Client( this.props.oauth2Client ) ||
 			isJetpackCloudOAuth2Client( this.props.oauth2Client ) ||
-			this.props.isGutenboarding ||
+			this.props.isWhiteLogin ||
 			this.props.isP2Login ||
 			this.props.isPartnerSignup
 		) {
@@ -315,7 +314,6 @@ export class LoginLinks extends Component {
 		// Taken from client/layout/masterbar/logged-out.jsx
 		const {
 			currentRoute,
-			isGutenboarding,
 			isP2Login,
 			locale,
 			oauth2Client,
@@ -328,7 +326,7 @@ export class LoginLinks extends Component {
 		// use '?signup_url' if explicitly passed as URL query param
 		const signupUrl = this.props.signupUrl
 			? window.location.origin + pathWithLeadingSlash( this.props.signupUrl )
-			: getSignupUrl( query, currentRoute, oauth2Client, locale, pathname, isGutenboarding );
+			: getSignupUrl( query, currentRoute, oauth2Client, locale, pathname );
 
 		if ( isJetpackCloudOAuth2Client( oauth2Client ) && '/log-in/authenticator' !== currentRoute ) {
 			return null;

--- a/test/e2e/specs/onboarding/ftme__sell.ts
+++ b/test/e2e/specs/onboarding/ftme__sell.ts
@@ -53,7 +53,7 @@ describe( DataHelper.createSuiteTitle( 'FTME: Sell' ), function () {
 		it( 'Navigate to Signup page', async function () {
 			const loginPage = new LoginPage( page );
 			await loginPage.visit();
-			await loginPage.clickSignUp();
+			await loginPage.clickCreateNewAccount();
 		} );
 
 		it( 'Sign up as new user', async function () {

--- a/test/e2e/specs/plans/plans__signup-free.ts
+++ b/test/e2e/specs/plans/plans__signup-free.ts
@@ -38,7 +38,7 @@ describe(
 			it( 'Navigate to Signup page', async function () {
 				const loginPage = new LoginPage( page );
 				await loginPage.visit();
-				await loginPage.clickSignUp();
+				await loginPage.clickCreateNewAccount();
 			} );
 
 			it( 'Sign up as new user', async function () {


### PR DESCRIPTION
Re-implements Automattic/wp-calypso#69598 and fixes the pre-release test that failed during deployment.