### PR TITLE
My Home: Add site-editor-quick-start card

### DIFF
--- a/client/components/videos-ui/modal-footer-bar.jsx
+++ b/client/components/videos-ui/modal-footer-bar.jsx
@@ -16,13 +16,13 @@ const ModalFooterBar = ( { onBackClick = () => {}, course = {}, isCourseComplete
 		} );
 		onBackClick( event );
 	};
-	const onStartWritingClick = () => {
+	const onCourseCompletedCTAClick = () => {
 		recordTracksEvent( 'calypso_courses_cta_click', {
 			course: course?.slug,
 		} );
 	};
 
-	const getStartWritingUrl = () => {
+	const getCourseCompletedUrl = () => {
 		if ( ! course?.cta?.url || ! selectedSite?.domain ) {
 			return 'https://wordpress.com/post';
 		}
@@ -53,9 +53,9 @@ const ModalFooterBar = ( { onBackClick = () => {}, course = {}, isCourseComplete
 
 				{ isCourseComplete && (
 					<Button
-						onClick={ onStartWritingClick }
+						onClick={ onCourseCompletedCTAClick }
 						className="videos-ui__button"
-						href={ getStartWritingUrl() }
+						href={ getCourseCompletedUrl() }
 					>
 						{ course?.cta.action }
 					</Button>

--- a/client/components/videos-ui/video-chapters.jsx
+++ b/client/components/videos-ui/video-chapters.jsx
@@ -10,77 +10,80 @@ const VideoChapters = ( {
 	onVideoPlayClick,
 	isPreloadAnimationState,
 } ) => {
-	return Object.entries( course?.videos ).map( ( data, i ) => {
-		const isVideoCompleted = data[ 0 ] in course.completions && course.completions[ data[ 0 ] ];
-		const videoInfo = data[ 1 ];
+	return (
+		<>
+			{ Object.entries( course?.videos ).map( ( [ videoSlug, videoInfo ], i ) => {
+				const isVideoCompleted = videoSlug in course.completions && course.completions[ videoSlug ];
 
-		return (
-			<div
-				key={ i }
-				className={ classNames( 'videos-ui__chapter', {
-					selected: isChapterSelected( i ),
-					preload: isPreloadAnimationState,
-				} ) }
-			>
-				<button
-					type="button"
-					className="videos-ui__chapter-accordion-toggle"
-					onClick={ () => onChapterSelected( i ) }
-				>
-					<span className="videos-ui__video-title">
-						{ i + 1 }. { videoInfo.title }{ ' ' }
-					</span>
-					<span className="videos-ui__duration">
-						{ moment.unix( videoInfo.duration_seconds ).format( 'm:ss' ) }
-					</span>
-					{ isVideoCompleted && (
-						<span className="videos-ui__completed-checkmark">
-							<Gridicon icon="checkmark" size={ 12 } />
-						</span>
-					) }
-					{ isChapterSelected( i ) && ! isVideoCompleted && (
-						<span className="videos-ui__status-icon">
-							<Gridicon icon="chevron-up" size={ 18 } />
-						</span>
-					) }
-					{ ! isChapterSelected( i ) && ! isVideoCompleted && (
-						<span className="videos-ui__status-icon">
-							<Gridicon icon="chevron-down" size={ 18 } />
-						</span>
-					) }
-				</button>
-				<div className="videos-ui__active-video-content">
-					<div>
-						<p>{ videoInfo.description } </p>
-						<Button
-							className={ classNames( 'videos-ui__button', {
-								'videos-ui__video-completed': isVideoCompleted,
-							} ) }
-							onClick={ () => onVideoPlayClick( data[ 0 ], videoInfo ) }
+				return (
+					<div
+						key={ i }
+						className={ classNames( 'videos-ui__chapter', {
+							selected: isChapterSelected( i ),
+							preload: isPreloadAnimationState,
+						} ) }
+					>
+						<button
+							type="button"
+							className="videos-ui__chapter-accordion-toggle"
+							onClick={ () => onChapterSelected( i ) }
 						>
-							<svg
-								width="12"
-								height="14"
-								viewBox="0 0 12 14"
-								fill="none"
-								xmlns="http://www.w3.org/2000/svg"
-							>
-								<path
-									d="M1.9165 1.75L10.0832 7L1.9165 12.25V1.75Z"
-									fill="#101517"
-									stroke="#101517"
-									strokeWidth="2"
-									strokeLinecap="round"
-									strokeLinejoin="round"
-								/>
-							</svg>
-							<span>{ translate( 'Play video' ) }</span>
-						</Button>
+							<span className="videos-ui__video-title">
+								{ i + 1 }. { videoInfo.title }{ ' ' }
+							</span>
+							<span className="videos-ui__duration">
+								{ moment.unix( videoInfo.duration_seconds ).format( 'm:ss' ) }
+							</span>
+							{ isVideoCompleted && (
+								<span className="videos-ui__completed-checkmark">
+									<Gridicon icon="checkmark" size={ 12 } />
+								</span>
+							) }
+							{ isChapterSelected( i ) && ! isVideoCompleted && (
+								<span className="videos-ui__status-icon">
+									<Gridicon icon="chevron-up" size={ 18 } />
+								</span>
+							) }
+							{ ! isChapterSelected( i ) && ! isVideoCompleted && (
+								<span className="videos-ui__status-icon">
+									<Gridicon icon="chevron-down" size={ 18 } />
+								</span>
+							) }
+						</button>
+						<div className="videos-ui__active-video-content">
+							<div>
+								<p>{ videoInfo.description } </p>
+								<Button
+									className={ classNames( 'videos-ui__button', {
+										'videos-ui__video-completed': isVideoCompleted,
+									} ) }
+									onClick={ () => onVideoPlayClick( videoSlug, videoInfo ) }
+								>
+									<svg
+										width="12"
+										height="14"
+										viewBox="0 0 12 14"
+										fill="none"
+										xmlns="http://www.w3.org/2000/svg"
+									>
+										<path
+											d="M1.9165 1.75L10.0832 7L1.9165 12.25V1.75Z"
+											fill="#101517"
+											stroke="#101517"
+											strokeWidth="2"
+											strokeLinecap="round"
+											strokeLinejoin="round"
+										/>
+									</svg>
+									<span>{ translate( 'Play video' ) }</span>
+								</Button>
+							</div>
+						</div>
 					</div>
-				</div>
-			</div>
-		);
-	} );
+				);
+			} ) }
+		</>
+	);
 };
 
 export default VideoChapters;

--- a/client/components/videos-ui/video-player.jsx
+++ b/client/components/videos-ui/video-player.jsx
@@ -7,7 +7,7 @@ const VideoPlayer = ( {
 	course,
 	onVideoPlayStatusChanged,
 	onVideoCompleted,
-	intent = undefined,
+	intent,
 } ) => {
 	const [ shouldCheckForVideoComplete, setShouldCheckForVideoComplete ] = useState( true );
 

--- a/client/data/courses/constants.ts
+++ b/client/data/courses/constants.ts
@@ -1,5 +1,5 @@
-export const COURSE_SLUGS: Readonly< { PAYMENTS_FEATURES: string; BLOGGING_QUICK_START: string } > =
-	Object.freeze( {
-		BLOGGING_QUICK_START: 'blogging-quick-start',
-		PAYMENTS_FEATURES: 'payments-features',
-	} );
+export const COURSE_SLUGS = {
+	BLOGGING_QUICK_START: 'blogging-quick-start',
+	PAYMENTS_FEATURES: 'payments-features',
+	SITE_EDITOR_QUICK_START: 'site-editor-quick-start',
+} as const;

--- a/client/data/courses/index.ts
+++ b/client/data/courses/index.ts
@@ -1,4 +1,5 @@
 export { COURSE_SLUGS } from './constants';
+export type { Course, CourseSlug, CourseVideo, VideoSlug } from './types';
 export { default as useCourseData } from './use-course-data';
 export { default as useCourseDetails } from './use-course-details';
 export { default as useCourseQuery } from './use-course-query';

--- a/client/data/courses/types.ts
+++ b/client/data/courses/types.ts
@@ -1,4 +1,8 @@
-export type CourseSlug = 'blogging-quick-start';
+import { COURSE_SLUGS } from './constants';
+
+type ValueOf< T > = T[ keyof T ];
+
+export type CourseSlug = ValueOf< typeof COURSE_SLUGS >;
 
 export type VideoSlug = string;
 
@@ -19,6 +23,8 @@ export interface Course {
 		action: string;
 		url: string;
 	};
-	videos: CourseVideo[];
+	videos: {
+		[ key: string ]: CourseVideo;
+	};
 	completions: { [ key in VideoSlug ]: boolean | boolean[] };
 }

--- a/client/data/courses/use-course-details.ts
+++ b/client/data/courses/use-course-details.ts
@@ -6,8 +6,7 @@ import { useTranslate } from 'i18n-calypso';
  * Internal Dependencies
  */
 import { COURSE_SLUGS } from './constants';
-
-type CourseSlug = keyof typeof COURSE_SLUGS;
+import type { CourseSlug } from './types';
 
 interface CourseDetails {
 	headerTitle: string;
@@ -38,6 +37,17 @@ const useCourseDetails = ( courseSlug: CourseSlug ): CourseDetails | undefined =
 				translate( 'Accept donations or sell services' ),
 				translate( 'Setup paid, subscriber-only content' ),
 				translate( 'Run a fully featured ecommerce store' ),
+			],
+		};
+	} else if ( courseSlug === COURSE_SLUGS.SITE_EDITOR_QUICK_START ) {
+		return {
+			headerTitle: translate( 'Watch four videos.' ),
+			headerSubtitle: translate( 'Save yourself hours.' ),
+			headerSummary: [
+				translate( 'Learn the building blocks of site building' ),
+				translate( 'Understand how to add your style to your site' ),
+				translate( 'Upskill now to save hours later' ),
+				translate( 'Set yourself up for creative success' ),
 			],
 		};
 	}

--- a/client/data/courses/use-course-details.ts
+++ b/client/data/courses/use-course-details.ts
@@ -44,7 +44,7 @@ const useCourseDetails = ( courseSlug: CourseSlug ): CourseDetails | undefined =
 			headerTitle: translate( 'Watch four videos.' ),
 			headerSubtitle: translate( 'Save yourself hours.' ),
 			headerSummary: [
-				translate( 'Learn the building blocks of site building' ),
+				translate( 'Master the building blocks of a WordPress site' ),
 				translate( 'Understand how to add your style to your site' ),
 				translate( 'Upskill now to save hours later' ),
 				translate( 'Set yourself up for creative success' ),

--- a/client/lib/route-modal/use-route-modal.tsx
+++ b/client/lib/route-modal/use-route-modal.tsx
@@ -18,16 +18,19 @@ export interface RouteModalData {
 
 /**
  * React hook providing utils to control opening and closing modal via query string.
+ *
+ * @param queryKey The key from the query string to control the modal.
+ * @param targetValue If specified, the modal shows only when the value from the query string equals to it.
  */
-const useRouteModal = ( queryKey: string, defaultValue = '' ): RouteModalData => {
+const useRouteModal = ( queryKey: string, targetValue = '' ): RouteModalData => {
 	const currentQuery = useSelector( getCurrentQueryArguments );
 	const previousRoute = useSelector( getPreviousRoute );
 
 	const value = currentQuery?.[ queryKey ];
 
-	const isModalOpen = value != null;
+	const isModalOpen = value != null && ( ! targetValue || value === targetValue );
 
-	const openModal = ( currentValue: string = defaultValue ) => {
+	const openModal = ( currentValue: string = targetValue ) => {
 		const url = window.location.href.replace( window.location.origin, '' );
 		const queryParams = {
 			[ queryKey ]: currentValue,

--- a/client/my-sites/customer-home/cards/constants.js
+++ b/client/my-sites/customer-home/cards/constants.js
@@ -8,6 +8,7 @@ export const EDUCATION_PROMOTE_POST = 'home-education-promote-post';
 export const EDUCATION_FIND_SUCCESS = 'home-education-find-success';
 export const EDUCATION_RESPOND_TO_CUSTOMER_FEEDBACK = 'home-education-respond-to-customer-feedback';
 export const EDUCATION_BLOGGING_QUICK_START = 'home-education-blogging-quick-start';
+export const EDUCATION_SITE_EDITOR_QUICK_START = 'home-education-site-editor-quick-start';
 export const FEATURE_GO_MOBILE = 'home-feature-go-mobile';
 export const FEATURE_QUICK_START = 'home-feature-quick-start';
 export const FEATURE_STATS = 'home-feature-stats';

--- a/client/my-sites/customer-home/cards/education/site-editor-quick-start/index.jsx
+++ b/client/my-sites/customer-home/cards/education/site-editor-quick-start/index.jsx
@@ -1,0 +1,45 @@
+import { useTranslate } from 'i18n-calypso';
+import startLearningPrompt from 'calypso/assets/images/customer-home/illustration--secondary-start-learning.svg';
+import VideoModal from 'calypso/components/videos-ui/video-modal';
+import { COURSE_SLUGS } from 'calypso/data/courses';
+import { useRouteModal } from 'calypso/lib/route-modal';
+import { EDUCATION_SITE_EDITOR_QUICK_START } from 'calypso/my-sites/customer-home/cards/constants';
+import EducationalContent from '../educational-content';
+
+const SiteEditorQuickStart = () => {
+	const translate = useTranslate();
+	const { isModalOpen, openModal, closeModal } = useRouteModal(
+		'courseSlug',
+		COURSE_SLUGS.SITE_EDITOR_QUICK_START
+	);
+
+	return (
+		<EducationalContent
+			title={ translate( 'Design like an expert' ) }
+			description={ translate(
+				'Master the basics of Site Editing with four short videos. Learn how to edit colors, fonts, layouts, and bring your style to your site.'
+			) }
+			modalLinks={ [
+				{
+					ModalComponent: VideoModal,
+					modalComponentProps: {
+						isVisible: isModalOpen,
+						onClose: ( event ) => {
+							event.preventDefault();
+							closeModal();
+						},
+						courseSlug: COURSE_SLUGS.SITE_EDITOR_QUICK_START,
+					},
+					onClick: openModal,
+					text: translate( 'Start learning' ),
+				},
+			] }
+			illustration={ startLearningPrompt }
+			cardName={ EDUCATION_SITE_EDITOR_QUICK_START }
+			width="183"
+			height="120"
+		/>
+	);
+};
+
+export default SiteEditorQuickStart;

--- a/client/my-sites/customer-home/locations/secondary/learn-grow/index.jsx
+++ b/client/my-sites/customer-home/locations/secondary/learn-grow/index.jsx
@@ -13,6 +13,7 @@ import {
 	EDUCATION_RESPOND_TO_CUSTOMER_FEEDBACK,
 	EDUCATION_BLOGGING_QUICK_START,
 	EDUCATION_PROMOTE_POST,
+	EDUCATION_SITE_EDITOR_QUICK_START,
 } from 'calypso/my-sites/customer-home/cards/constants';
 import BloggingQuickStart from 'calypso/my-sites/customer-home/cards/education/blogging-quick-start';
 import EducationEarn from 'calypso/my-sites/customer-home/cards/education/earn';
@@ -21,6 +22,7 @@ import FreePhotoLibrary from 'calypso/my-sites/customer-home/cards/education/fre
 import PromotePost from 'calypso/my-sites/customer-home/cards/education/promote-post';
 // eslint-disable-next-line inclusive-language/use-inclusive-words
 import RespondToCustomerFeedback from 'calypso/my-sites/customer-home/cards/education/respond-to-customer-feedback';
+import SiteEditorQuickStart from 'calypso/my-sites/customer-home/cards/education/site-editor-quick-start';
 import EducationStore from 'calypso/my-sites/customer-home/cards/education/store';
 import WpCourses from 'calypso/my-sites/customer-home/cards/education/wpcourses';
 import { bumpStat, composeAnalytics, recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -35,6 +37,7 @@ const cardComponents = {
 	[ EDUCATION_FIND_SUCCESS ]: FindSuccess,
 	[ EDUCATION_RESPOND_TO_CUSTOMER_FEEDBACK ]: RespondToCustomerFeedback,
 	[ EDUCATION_BLOGGING_QUICK_START ]: BloggingQuickStart,
+	[ EDUCATION_SITE_EDITOR_QUICK_START ]: SiteEditorQuickStart,
 };
 
 const LearnGrow = () => {


### PR DESCRIPTION
#### Proposed Changes

* Add a new card, `site-editor-quick-start`
* Support new course slug, `site-editor-quick-start`
* Fix type errors in the `VideoUi` component
* Adjust the `isModalOpen` behavior inside `useRouteModal`. Now it's truthy only when the value is the same as `targetValue` if it's specified. This is the same as current usage cases so it won't have any breaking changes.

TODOs

- [x] Wait for the review of the copy, the title and description of each video, etc. See p1669020361538309-slack-C048CUFRGFQ

![image](https://user-images.githubusercontent.com/13596067/202998227-73b458ac-0a01-4ef1-abd0-2f490ac9f2d7.png)

![image](https://user-images.githubusercontent.com/13596067/203480470-2fdb6464-7299-4955-af7b-5ffeb3919a63.png)

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply D92978-code to your sandbox
* Go to `/home/<your_site>`
* In the learning grow sections
  * Verify the "Blog like an expert from day one" card shows first when the site intent is "write"
  * Verify the "Design like an expert" card shows regardless of the site intent but it would be the first one if the site intent is not "write"
* Click on the "Start learning" button inside the "Design like an expert" card, verify the site editor video screen shows
* When you finish all of the courses, verify the congrats bar shows at the bottom of the page
* Click on the "Start creating" button inside the congrats bar, verify you will land on the site editor

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/70189, https://github.com/Automattic/wp-calypso/issues/69175