### PR TITLE
Stats: Leave the query date section for alignment of the period header

### DIFF
--- a/client/my-sites/stats/stats-date-picker/index.jsx
+++ b/client/my-sites/stats/stats-date-picker/index.jsx
@@ -90,25 +90,28 @@ class StatsDatePicker extends Component {
 	}
 
 	renderQueryDate() {
-		const { queryDate, moment, translate } = this.props;
-		if ( ! queryDate ) {
-			return null;
-		}
+		const { query, queryDate, moment, translate } = this.props;
 
-		const today = moment();
-		const date = moment( queryDate );
-		const isToday = today.isSame( date, 'day' );
+		let content;
+
+		if ( ! queryDate || ! isAutoRefreshAllowedForQuery( query ) ) {
+			content = null;
+		} else {
+			const today = moment();
+			const date = moment( queryDate );
+			const isToday = today.isSame( date, 'day' );
+
+			content = translate( '{{b}}Last update: %(time)s{{/b}} (Updates every 30 minutes)', {
+				args: { time: isToday ? date.format( 'LT' ) : date.fromNow() },
+				components: {
+					b: <span className="stats-date-picker__last-update" />,
+				},
+			} );
+		}
 
 		return (
 			<div className="stats-date-picker__refresh-status">
-				<span className="stats-date-picker__update-date">
-					{ translate( '{{b}}Last update: %(time)s{{/b}} (Updates every 30 minutes)', {
-						args: { time: isToday ? date.format( 'LT' ) : date.fromNow() },
-						components: {
-							b: <span className="stats-date-picker__last-update" />,
-						},
-					} ) }
-				</span>
+				<span className="stats-date-picker__update-date">{ content }</span>
 			</div>
 		);
 	}
@@ -167,7 +170,7 @@ class StatsDatePicker extends Component {
 				) : (
 					<div className="stats-section-title">
 						<h3>{ sectionTitle }</h3>
-						{ showQueryDate && isAutoRefreshAllowedForQuery( query ) && this.renderQueryDate() }
+						{ showQueryDate && this.renderQueryDate() }
 					</div>
 				) }
 			</div>


### PR DESCRIPTION
#### Proposed Changes

* Leave the query date section regardless of content to align the period header when navigating between dates.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up this change with the Calypso Live link.
* Navigate to page `/stats/day/${your-site}`.
* Ensure the date navigation does not move the alignment of the period header.

<img width="1280" alt="截圖 2022-11-21 下午4 13 16" src="https://user-images.githubusercontent.com/6869813/203000098-3ab9fa59-ca48-4d33-b2a0-0928e5c5cb6d.png">

https://user-images.githubusercontent.com/6869813/203000129-58ad64bc-b509-4b3e-9786-965bd3ce479c.mov

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/69960#pullrequestreview-1180003661
