### PR TITLE
Pattern Assembler: Adjust the copy and position of Blank Canvas card

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -97,10 +97,10 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 
 		const blankCanvasDesignOffset = allDesigns.static.designs.findIndex( isBlankCanvasDesign );
 		if ( blankCanvasDesignOffset !== -1 ) {
-			// Extract the blank canvas design first and then insert it into 4th position for the build intent
+			// Extract the blank canvas design first and then insert it into the last one for the build intent
 			const blankCanvasDesign = allDesigns.static.designs.splice( blankCanvasDesignOffset, 1 );
 			if ( isEnabled( 'signup/design-picker-pattern-assembler' ) && intent === SiteIntent.Build ) {
-				allDesigns.static.designs.splice( 3, 0, ...blankCanvasDesign );
+				allDesigns.static.designs.push( ...blankCanvasDesign );
 			}
 		}
 

--- a/packages/design-picker/src/components/pattern-assembler-cta/index.tsx
+++ b/packages/design-picker/src/components/pattern-assembler-cta/index.tsx
@@ -24,7 +24,7 @@ const PatternAssemblerCta = ( { onButtonClick }: PatternAssemblerCtaProps ) => {
 							"Can't find something you like? Jump right into the editor to design your homepage from scratch."
 					  )
 					: translate(
-							"Can't find something you like? Start with a blank canvas and design your own homepage using our library of patterns"
+							"Can't find something you like? Start with a blank canvas and design your own homepage using our library of patterns."
 					  ) }
 			</p>
 			<Button className="pattern-assembler-cta__button" onClick={ onButtonClick } primary>

--- a/packages/design-picker/src/components/pattern-assembler-cta/index.tsx
+++ b/packages/design-picker/src/components/pattern-assembler-cta/index.tsx
@@ -17,18 +17,18 @@ const PatternAssemblerCta = ( { onButtonClick }: PatternAssemblerCtaProps ) => {
 			<div className="pattern-assembler-cta__image-wrapper">
 				<img className="pattern-assembler-cta__image" src={ blankCanvasImage } alt="Blank Canvas" />
 			</div>
-			<h3 className="pattern-assembler-cta__title">{ translate( 'Start with a blank canvas' ) }</h3>
+			<h3 className="pattern-assembler-cta__title">{ translate( 'Design your own' ) }</h3>
 			<p className="pattern-assembler-cta__subtitle">
 				{ ! isDesktop
 					? translate(
 							"Can't find something you like? Jump right into the editor to design your homepage from scratch."
 					  )
 					: translate(
-							"Can't find something you like? Create something of your own by mixing and matching patterns."
+							"Can't find something you like? Start with a blank canvas and design your own homepage using our library of patterns"
 					  ) }
 			</p>
 			<Button className="pattern-assembler-cta__button" onClick={ onButtonClick } primary>
-				{ ! isDesktop ? translate( 'Open the editor' ) : translate( 'Get started' ) }
+				{ ! isDesktop ? translate( 'Open the editor' ) : translate( 'Start designing' ) }
 			</Button>
 		</div>
 	);


### PR DESCRIPTION
#### Proposed Changes

* Adjust the copy of the Blank Canvas card
* Adjust the position of the Blank Canvas card

| Before | After |
| - | - |
| ![image](https://user-images.githubusercontent.com/13596067/203008975-b87a5729-b7f0-4a9d-a7a0-85c23be42d07.png) | ![image](https://user-images.githubusercontent.com/13596067/203008810-62d930bf-f282-497a-9092-72246d695fac.png) |

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup?siteSlug=<your_site>`
* Click "Continue" button until you land on the design picker
* Verify the position of the Blank Canvas card is at the end of list
* Verify the copy aligns https://github.com/Automattic/dotcom-forge/issues/1251 

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/1251
