### PR TITLE
Third-Party Themes: Updating banner and CTA texts

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -753,6 +753,9 @@ class ThemeSheet extends Component {
 			canUserUploadThemes,
 			isWPForTeamsSite,
 			isLoggedIn,
+			isExternallyManagedTheme,
+			isPurchased,
+			isSiteEligibleForManagedExternalThemes,
 		} = this.props;
 
 		const analyticsPath = `/theme/${ id }${ section ? '/' + section : '' }${
@@ -987,8 +990,6 @@ export default connect(
 		const isJetpack = isJetpackSite( state, siteId );
 		const isStandaloneJetpack = isJetpack && ! isAtomic;
 
-		const isExternallyManagedTheme = getIsExternallyManagedTheme( state, theme?.id );
-
 		return {
 			...theme,
 			id,
@@ -1019,7 +1020,7 @@ export default connect(
 			demoUrl: getThemeDemoUrl( state, id, siteId ),
 			isWPForTeamsSite: isSiteWPForTeams( state, siteId ),
 			softLaunched: theme?.soft_launched,
-			isExternallyManagedTheme,
+			isExternallyManagedTheme: getIsExternallyManagedTheme( state, theme?.id ),
 			isSiteEligibleForManagedExternalThemes: getIsSiteEligibleForManagedExternalThemes(
 				state,
 				siteId

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -701,7 +701,7 @@ class ThemeSheet extends Component {
 			return translate( 'Access this WooCommerce theme with a Business plan!' );
 		} else if ( isExternallyManagedTheme ) {
 			if ( ! isPurchased && ! isSiteEligibleForManagedExternalThemes ) {
-				return translate( 'Upgrade to a Business Plan and subscribe to this theme!' );
+				return translate( 'Upgrade to a Business plan and subscribe to this theme!' );
 			}
 			return translate( 'Subscribe to this premium theme!' );
 		}

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -576,8 +576,8 @@ class ThemeSheet extends Component {
 			} else if (
 				isPremium &&
 				! isPurchased &&
-				( isBundledSoftwareSet ||
-					( isExternallyManagedTheme && ! isSiteEligibleForManagedExternalThemes ) )
+				isBundledSoftwareSet &&
+				! isExternallyManagedTheme
 			) {
 				// upgrade plan
 				return translate( 'Upgrade to activate', {

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -703,7 +703,7 @@ class ThemeSheet extends Component {
 			if ( ! isPurchased && ! isSiteEligibleForManagedExternalThemes ) {
 				return translate( 'Upgrade to a Business Plan and subscribe to this theme!' );
 			}
-			return translate( 'Subscribe to this Premium Theme!' );
+			return translate( 'Subscribe to this premium theme!' );
 		}
 		return translate( 'Access this theme for FREE with a Premium or Business plan!' );
 	};
@@ -724,10 +724,10 @@ class ThemeSheet extends Component {
 		} else if ( isExternallyManagedTheme ) {
 			if ( ! isPurchased && ! isSiteEligibleForManagedExternalThemes ) {
 				return translate(
-					'Unlock this theme by upgrading to a Business plan and subscribing to this Premium Theme.'
+					'Unlock this theme by upgrading to a Business plan and subscribing to this premium theme.'
 				);
 			}
-			return translate( 'Subscribe to this Premium Theme and unlock all its features.' );
+			return translate( 'Subscribe to this premium theme and unlock all its features.' );
 		}
 		return translate(
 			'Instantly unlock all premium themes, more storage space, advanced customization, video support, and more when you upgrade.'

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -89,7 +89,7 @@
 	position: absolute;
 	top: 5px;
 	right: 50%;
-	margin-right: 20px;
+	margin-right: 20px !important;
 
 	.theme__sheet-badge-beta {
 		background-color: var(--color-surface);


### PR DESCRIPTION
#### Proposed Changes

* Add new texts to the banner and the CTA for the Third-Party(marketplace) themes use cases
* The behavior for free, premium, and bundled themes should not be changed.

#### Testing Instructions

**Free theme**

* Navigate to `/theme/masu/{free-site}` and to `/theme/masu` on an incognito tab.
* Make sure the CTA says: `Activate this design (FREE)` and `Pick this design (FREE)` respectively
<img width="758" alt="Screen Shot 2022-11-21 at 06 48 43" src="https://user-images.githubusercontent.com/1234758/203019088-464d527a-caad-4f6d-b879-044a259d5b99.png">
<img width="757" alt="Screen Shot 2022-11-21 at 06 49 28" src="https://user-images.githubusercontent.com/1234758/203019541-54a1241f-5b1e-4d47-97bb-4c6db411d82c.png">

**Bundled theme unauthenticated**

* Navigate to `/theme/thriving-artist` on an incognito tab
* The CTA should say: `Pick this theme`
* The banner should be displayed
<img width="756" alt="Screen Shot 2022-11-21 at 06 53 35" src="https://user-images.githubusercontent.com/1234758/203020168-488b78c7-ed3f-4694-beac-20d103cbebab.png">


**Bundled theme on a Free site / Bundled theme on a premium site**

* Navigate to `/theme/thriving-artist/{free-site}`
* The CTA should be `Upgrade to activate`, and the banner should be displayed
<img width="754" alt="Screen Shot 2022-11-21 at 06 48 07" src="https://user-images.githubusercontent.com/1234758/203018958-e77ee9fc-1564-4fb2-b8b9-c362503bdfa6.png">

**Bundled theme on a business site**

* Navigate to `/theme/thriving-artist/{business-site}`
* The CTA should be `Activate this theme`, and the banner should not be displayed
<img width="753" alt="Screen Shot 2022-11-21 at 06 58 07" src="https://user-images.githubusercontent.com/1234758/203021175-839ddb8f-9613-4a14-91f1-a67250cb8afc.png">

----
To test the Third-Party theme, add the following code to your 0-sandbox and make sure the `public-api` is sandboxed.
```php
function test_theme_type( $theme ) {
        if ( $theme['id'] === 'tsubaki' ) {
                $theme['theme_type'] = 'managed-external';
        }

        return $theme;
}

add_filter( 'wpcom_theme_api_meta', 'test_theme_type', 1000 );
```

**Third-Party themes unauthenticated**

* Navigate to `/theme/tsubaki`
* You should see the CTA and the banner in the image below

<img width="756" alt="Screen Shot 2022-11-21 at 08 57 15" src="https://user-images.githubusercontent.com/1234758/203046941-b13f4c23-25b3-47a6-b127-f24aaddd9f20.png">

**Third-party themes on a free or premium site**

* Navigate to `/theme/tsubaki/{free-site}`
* The CTA should invite the user to `Upgrade to subscribe`
* The banner should be displayed

<img width="759" alt="Screen Shot 2022-11-21 at 09 00 46" src="https://user-images.githubusercontent.com/1234758/203047988-3ef0fa76-485a-4d83-b31d-f0167de65bb2.png">

**Third-Party theme on a business site**

* Navigate to `/themes/tsubaki/{business-site}`
* The CTA should invite the user to `Subscribe to active`
* The banner should be displayed

<img width="757" alt="Screen Shot 2022-11-21 at 09 10 26" src="https://user-images.githubusercontent.com/1234758/203050568-885e17ae-764c-487b-a89b-84cf99efd7d7.png">



Related to #69616