### PR TITLE
Login: link to site with URL instead of site name

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -424,7 +424,7 @@ class Login extends Component {
 			);
 		} else if ( fromSite ) {
 			// if redirected from Calypso URL with a site slug, offer a link to that site's frontend
-			postHeader = <VisitSite siteSlug={ fromSite } />;
+			postHeader = <VisitSite linkWithSiteName={ false } siteSlug={ fromSite } />;
 		} else if ( isP2Login ) {
 			headerText = translate( 'Log in' );
 			postHeader = (

--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -424,7 +424,7 @@ class Login extends Component {
 			);
 		} else if ( fromSite ) {
 			// if redirected from Calypso URL with a site slug, offer a link to that site's frontend
-			postHeader = <VisitSite linkWithSiteName={ false } siteSlug={ fromSite } />;
+			postHeader = <VisitSite siteSlug={ fromSite } />;
 		} else if ( isP2Login ) {
 			headerText = translate( 'Log in' );
 			postHeader = (

--- a/client/blocks/visit-site/index.jsx
+++ b/client/blocks/visit-site/index.jsx
@@ -14,7 +14,7 @@ function useSite( siteSlug ) {
 	return site;
 }
 
-export default function VisitSite( { linkWithSiteName = true, siteSlug } ) {
+export default function VisitSite( { siteSlug } ) {
 	const translate = useTranslate();
 	const site = useSite( siteSlug );
 
@@ -22,7 +22,7 @@ export default function VisitSite( { linkWithSiteName = true, siteSlug } ) {
 		return null;
 	}
 
-	const siteLink = <a href={ site.URL }>{ linkWithSiteName ? site.name.trim() : siteSlug }</a>;
+	const siteLink = <a href={ site.URL }>{ siteSlug }</a>;
 
 	return (
 		<div className="visit-site">

--- a/client/blocks/visit-site/index.jsx
+++ b/client/blocks/visit-site/index.jsx
@@ -22,7 +22,7 @@ export default function VisitSite( { siteSlug } ) {
 		return null;
 	}
 
-	const siteLink = <a href={ site.URL }>{ siteSlug }</a>;
+	const siteLink = <a href={ site.URL }>{ siteSlug.replace( '::', '/' ) }</a>;
 
 	return (
 		<div className="visit-site">

--- a/client/blocks/visit-site/index.jsx
+++ b/client/blocks/visit-site/index.jsx
@@ -14,7 +14,7 @@ function useSite( siteSlug ) {
 	return site;
 }
 
-export default function VisitSite( { siteSlug } ) {
+export default function VisitSite( { linkWithSiteName = true, siteSlug } ) {
 	const translate = useTranslate();
 	const site = useSite( siteSlug );
 
@@ -22,7 +22,7 @@ export default function VisitSite( { siteSlug } ) {
 		return null;
 	}
 
-	const siteLink = <a href={ site.URL }>{ site.name.trim() }</a>;
+	const siteLink = <a href={ site.URL }>{ linkWithSiteName ? site.name.trim() : siteSlug }</a>;
 
 	return (
 		<div className="visit-site">


### PR DESCRIPTION
#### Proposed Changes

Links to site suggested to visit instead of login with site URL instead of site name.

**Before**
<img width="1098" alt="Screenshot 2022-11-21 at 12 00 40" src="https://user-images.githubusercontent.com/87168/203021791-0e962a35-6f64-4484-8c4c-165a1a3981b7.png">

<img width="779" alt="Screenshot 2022-11-21 at 12 21 12" src="https://user-images.githubusercontent.com/87168/203026114-e59e7d31-337e-44f2-a6fc-dc853121823e.png">


**After**
<img width="1089" alt="Screenshot 2022-11-21 at 12 00 21" src="https://user-images.githubusercontent.com/87168/203021813-eb4c16c1-b557-44ac-9210-09597c6be381.png">

<img width="758" alt="Screenshot 2022-11-21 at 12 20 10" src="https://user-images.githubusercontent.com/87168/203026143-ddb69e1d-25d6-4cf0-ba03-ad2e900bd7bb.png">


#### Testing Instructions

- Logout
- Visit https://wordpress.com/log-in?site=test394247501.wordpress.com&redirect_to=%2Fhome%2Ftest394247501.wordpress.com
- Now login, and visit something that triggers the site list. Append `?site=` to URL. E.g.: http://calypso.localhost:3000/media?site=test394247501.wordpress.com
- As was before already, bogus site slugs don't show up at all if the site doesn't exist, e.g. http://calypso.localhost:3000/log-in/?site=something-doesn%27t%20exist.wordpress.com
- Sites in sub-directories are taken into account by replacing `::` with `/` in site slug.


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
