### PR TITLE
HC: add admin-bar popover

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/admin-bar.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/admin-bar.js
@@ -1,5 +1,5 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import HelpCenter from '@automattic/help-center';
+import HelpCenter, { PromotionalPopover } from '@automattic/help-center';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
 import * as ReactDOM from 'react-dom';
@@ -37,7 +37,12 @@ function AdminHelpCenterContent() {
 
 	button.onclick = handleToggleHelpCenter;
 
-	return <HelpCenter handleClose={ () => setShowHelpCenter( false ) } />;
+	return (
+		<>
+			<HelpCenter handleClose={ () => setShowHelpCenter( false ) } />
+			<PromotionalPopover contextRef={ button } />
+		</>
+	);
 }
 
 if ( window?.helpCenterAdminBar?.isLoaded ) {


### PR DESCRIPTION
#### Proposed Changes

* We needed to to update out wp-admin bar to add the popover as well

#### Testing Instructions
- connect to your sandbox
- run yarn dev --sync in you etk
- clear the promotional preference
- go to the https://your-simple-site.wordpress.com/wp-admin/edit.php
- check if the popover is shown and can be dismissed
- check if the popover doesn't show on reload
