### PR TITLE
Update/videopress onboarding celebration modal

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/video-celebration-modal/index.jsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/video-celebration-modal/index.jsx
@@ -92,7 +92,7 @@ const VideoCelebrationModalInner = () => {
 		<NuxModal
 			isOpen={ isModalOpen }
 			className="wpcom-site-editor-video-celebration-modal"
-			title={ __( "You've added your first video!", 'full-site-editing' ) }
+			title={ __( 'You’ve added your first video!', 'full-site-editing' ) }
 			description={ __(
 				'Feel free to keep editing or continue and launch your site.',
 				'full-site-editing'

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/video-celebration-modal/index.jsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/video-celebration-modal/index.jsx
@@ -93,20 +93,20 @@ const VideoCelebrationModalInner = () => {
 			className="wpcom-site-editor-seller-celebration-modal"
 			title={ __( "You've added your first video!", 'full-site-editing' ) }
 			description={ __(
-				'Feel free to continue editing or go back to setup and launch your site.',
+				'Feel free to keep editing or continue and launch your site.',
 				'full-site-editing'
 			) }
 			imageSrc={ fireworksImage }
 			actionButtons={
 				<>
-					<Button onClick={ closeModal }>{ __( 'Continue editing', 'full-site-editing' ) }</Button>
+					<Button onClick={ closeModal }>{ __( 'Keep editing', 'full-site-editing' ) }</Button>
 					<Button
 						isPrimary
 						href={ `https://wordpress.com/setup/videopress/launchpad?siteSlug=${ window.location.hostname }` }
 						target="__blank"
 						rel="noopener noreferrer"
 					>
-						{ __( 'Back to setup', 'full-site-editing' ) }
+						{ __( 'Continue and launch', 'full-site-editing' ) }
 					</Button>
 				</>
 			}

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/video-celebration-modal/index.jsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/video-celebration-modal/index.jsx
@@ -7,6 +7,7 @@ import fireworksImage from 'calypso/assets/images/illustrations/fireworks.svg';
 import useSiteIntent from '../../../dotcom-fse/lib/site-intent/use-site-intent';
 import useHasSeenVideoCelbrationModal from '../../../dotcom-fse/lib/video-celebration-modal/use-has-seen-video-celebration-modal';
 import NuxModal from '../nux-modal';
+import './style.scss';
 
 // Shows a celebration modal after a video is first uploaded to a site and the editor is saved.
 const VideoCelebrationModalInner = () => {
@@ -90,7 +91,7 @@ const VideoCelebrationModalInner = () => {
 	return (
 		<NuxModal
 			isOpen={ isModalOpen }
-			className="wpcom-site-editor-seller-celebration-modal"
+			className="wpcom-site-editor-video-celebration-modal"
 			title={ __( "You've added your first video!", 'full-site-editing' ) }
 			description={ __(
 				'Feel free to keep editing or continue and launch your site.',

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/video-celebration-modal/style.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/video-celebration-modal/style.scss
@@ -1,0 +1,27 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
+.wpcom-site-editor-video-celebration-modal {
+	.components-modal__content {
+		@include break-small {
+			padding: 48px 90px;
+		}
+	}
+
+	.wpcom-block-editor-nux-modal__image-container {
+		img {
+			width: 158px;
+			height: 85px;
+		}
+	}
+
+	.wpcom-block-editor-nux-modal__buttons {
+		.components-button {
+			min-width: 113px;
+			&:not(.is-primary) {
+				border: 1px solid #c3c4c7;
+				border-radius: 4px;
+			}
+		}
+	}
+}

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/video-celebration-modal/style.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/video-celebration-modal/style.scss
@@ -24,4 +24,14 @@
 			}
 		}
 	}
+
+	.components-modal__header {
+		button {
+			svg {
+				path {
+					transform: scale(1);
+				}
+			}
+		}
+	}
 }

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-steps.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-steps.tsx
@@ -63,7 +63,7 @@ function getTourSteps(
 	isSiteEditor = false,
 	themeName: string | null = null
 ): WpcomStep[] {
-	const isVideoMaker = [ 'videomaker', 'videomaker white' ].includes( themeName ?? '' );
+	const isVideoMaker = 'videomaker' === ( themeName ?? '' );
 	return [
 		{
 			slug: 'welcome',


### PR DESCRIPTION
#### Proposed Changes

* copy and style changes for the Video celebration modal used by VideoPress onboarding

| before | after |
|--------|-------|
| <img width="670" alt="Screenshot 2022-11-21 at 2 59 36 PM" src="https://user-images.githubusercontent.com/4081020/203147436-5be3bae7-828f-42ad-81ac-efd8af505ccb.png"> | <img width="678" alt="Screenshot 2022-11-21 at 2 18 18 PM" src="https://user-images.githubusercontent.com/4081020/203147470-4c3df789-4709-485c-a9ed-bae29f3d94f7.png"> |



#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. run `install-plugin.sh editing-toolkit update/videopress-onboarding-celebration-modal` on your wpcom sandbox
2. go through the onboarding flow to the point where you upload your first video and save the page
   * **NOTE:** If you want to test with an existing site instead of setting up a new one, you can set `wp-content/plugins/editing-toolkit-plugin/prod/wpcom-block-editor-nux/class-wp-rest-wpcom-block-editor-video-celebration-modal-controller.php` on your sandbox to return `false` on line 86.
4. you should see the new celebration modal
5. Launch the Welcome Guide, and confirm that the video specific images are still displayed


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/greenhouse/issues/1392
