### PR TITLE
E2E: add comments to aid investigators to `Media: upload` spec.

### DIFF
--- a/test/e2e/specs/media/media__upload.ts
+++ b/test/e2e/specs/media/media__upload.ts
@@ -29,7 +29,9 @@ describe( DataHelper.createSuiteTitle( 'Media: Upload' ), () => {
 		};
 	} );
 
-	// Parametrized test.
+	// If any of the tests start failing unexpectedly and permanently, check the following:
+	// - ensure that plans, where appropriate, are enabled for the users;
+	// - ensure with MarTech that nothing with plans have changed;
 	describe.each`
 		siteType       | accountName
 		${ 'Simple' }  | ${ 'defaultUser' }


### PR DESCRIPTION
#### Proposed Changes

This PR is a chore but a useful one to help with situations such as p1668814107773069-slack-C03N25JPCE4.

Key changes :
- add comment directing investigators where to check in case of failure

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #