### PR TITLE
Wrap FAQ heading on Plans step in translate call

### DIFF
--- a/client/my-sites/plans-features-main/plansStepFaq.jsx
+++ b/client/my-sites/plans-features-main/plansStepFaq.jsx
@@ -41,7 +41,7 @@ const PlanFAQ = ( { titanMonthlyRenewalCost } ) => {
 
 	return (
 		<div className="plan-faq">
-			<FAQHeader className="wp-brand-font">Frequently Asked Questions</FAQHeader>
+			<FAQHeader className="wp-brand-font">{ translate( 'Frequently Asked Questions' ) }</FAQHeader>
 			<FoldableFAQ
 				id="faq-1"
 				question={ translate( 'Is hosting included?' ) }


### PR DESCRIPTION
#### Proposed Changes

Wrap the "Frequently Asked Questions" H1 element on start/plans page in a `translate` call to show its translation for non-English locales

#### Testing Instructions

1. Change you user language to a popular non-English locale, like German, Swedish, Korean etc.
2. Checkout locally or navigate to calypso.live
3. Go to `start/plans` page, you'll probably have to go through domain selection step first.
4. Confirm that "Frequently Asked Questions" is translated.
5. Check again on wordpress.com to see the original issue.

Before:
<img width="1094" alt="Screenshot 2022-11-21 at 22 59 04" src="https://user-images.githubusercontent.com/7847633/203167496-bb8b440b-8125-4a0c-b0f9-65423183b1a9.png">

After:
<img width="1094" alt="Screenshot 2022-11-21 at 22 58 13" src="https://user-images.githubusercontent.com/7847633/203167510-51112433-690e-45d0-b519-5d15cc923222.png">



#### Pre-merge Checklist

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?

Fixes 528-gh-Automattic/i18n-issues
