### PR TITLE
VideoPress Tailored Onboarding: Fix progress bar style on intro view

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/intro/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/intro/styles.scss
@@ -1,7 +1,7 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@automattic/onboarding/styles/mixins";
 
-.intro {
+body.is-videopress-stepper .intro {
 	&.newsletter {
 		background-color: rgb(162 218 254);
 


### PR DESCRIPTION
Fixes issue where intro view styles weren't being applied.

**Before**
<img width="208" alt="Screenshot 2022-11-21 at 3 43 22 PM" src="https://user-images.githubusercontent.com/789137/203173907-af94e8d4-d965-464e-8941-ca6452371740.png">

**After**
<img width="191" alt="Screenshot 2022-11-21 at 3 49 53 PM" src="https://user-images.githubusercontent.com/789137/203173930-e493a1cc-5d40-427c-ad2f-b4565285a5e7.png">

#### Proposed Changes

* Target `body.is-videopress-stepper` to fix CSS selectors in the intro view.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* View `/setup/videopress`.
* The progress bar at the top should be dark and look nice.
* Proceed to the next step.
* The progress bar should be a lighter color (besides the yellow at the left)

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
