### PR TITLE
Payment Management: Add existing-card-ebanx payment processor to PaymentMethodSelector

### DIFF
--- a/client/me/purchases/manage-purchase/payment-method-selector/index.tsx
+++ b/client/me/purchases/manage-purchase/payment-method-selector/index.tsx
@@ -165,6 +165,8 @@ export default function PaymentMethodSelector( {
 				paypal: ( data: unknown ) => assignPayPalProcessor( purchase, reduxDispatch, data ),
 				'existing-card': ( data: unknown ) =>
 					assignExistingCardProcessor( purchase, reduxDispatch, data ),
+				'existing-card-ebanx': ( data: unknown ) =>
+					assignExistingCardProcessor( purchase, reduxDispatch, data ),
 				card: ( data: unknown ) =>
 					assignNewCardProcessor(
 						{


### PR DESCRIPTION
#### Proposed Changes

Some saved credit cards are created using Ebanx rather than Stripe. These payment methods end up with the key `existing-card-ebanx` on the frontend. This key is used by `CheckoutProvider` to determine which Payment Processor Function to use when the payment form is submitted.

In checkout, [there is a Payment Processor Function set up to handle this key](https://github.com/Automattic/wp-calypso/blob/8b455ceaf7b462e1a0e2a25216361f45abe97cbf/client/my-sites/checkout/composite-checkout/components/checkout-main.tsx#L483-L484), but that's not the only place that saved credit cards are displayed. The "add new payment method" form (and the "change payment method form") use a component called `PaymentMethodSelector`, which [does not have](https://github.com/Automattic/wp-calypso/blob/8b455ceaf7b462e1a0e2a25216361f45abe97cbf/client/me/purchases/manage-purchase/payment-method-selector/index.tsx#L164-L182) a Payment Processor Function for `existing-card-ebanx`.

This PR adds a payment processor function for that key into `PaymentMethodSelector` (it should work the same as the Stripe one so this just duplicates the Stripe method as we do in checkout).

Fixes https://github.com/Automattic/wp-calypso/issues/70264

#### Testing Instructions

First you'll need a saved Ebanx credit card. Skip these steps if you already have one. We currently only support doing this in checkout, so you'll need to make a new purchase and enter the Ebanx card details. 

- To see Ebanx as a payment method option in checkout, first you'll need to have BRL as your currency, and then you'll need to select "Brazil" as the country inside checkout (and a Brazillian postal code like `61919-230`).
- Verify that the "Credit and debit card" form asks for all the Ebanx fields in addition to the credit card fields (Taxpayer Identification Number, Phone, etc.) If it does not, you may not have selected "Brazil" as the country.
- Use an [ebanx test card](https://developer.ebanx.com/docs/resources/testCreditCards/) and [test customer info](https://developer.ebanx.com/docs/resources/testCustomerData/) to fill out the credit card form. "CEP" means "Postal code" and "CPF" means "Taxpayer Identification Number".
- Complete the purchase with the Ebanx card which will save the card for later.

Once you have an Ebanx credit card saved, here's how to test this PR:

- Visit the payment method management page (starting at https://wordpress.com/me/purchases) for an active subscription and click "Change payment method".
- If the selected payment method is _already_ an Ebanx card, change it to something else first and submit the form so we can be sure that the assignment will work.
- Select the saved Ebanx card in the form and submit it.
- Verify that the saved Ebanx card is assigned to the payment method and that no errors appear in the browser's JS console.