### PR TITLE
Update Assign License disable status

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/assign-license-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/assign-license-form/index.tsx
@@ -43,7 +43,7 @@ export default function AssignLicenseForm( {
 	search: string;
 } ) {
 	const translate = useTranslate();
-	const [ selectedSite, setSelectedSite ] = useState( { ID: 1, domain: '' } );
+	const [ selectedSite, setSelectedSite ] = useState( { ID: null, domain: null } );
 	const licenseKey = getQueryArg( window.location.href, 'key' ) as string;
 	const products = getQueryArg( window.location.href, 'products' ) as string;
 	const licenseKeysArray = products !== undefined ? products.split( ',' ) : [ licenseKey ];
@@ -109,7 +109,7 @@ export default function AssignLicenseForm( {
 					<Button
 						primary
 						className="assign-license-form__assign-now"
-						disabled={ ! selectedSite }
+						disabled={ ! selectedSite?.ID }
 						busy={ isLoading }
 						onClick={ assignLicenses }
 					>

--- a/client/jetpack-cloud/sections/partner-portal/assign-license-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/assign-license-form/index.tsx
@@ -43,7 +43,7 @@ export default function AssignLicenseForm( {
 	search: string;
 } ) {
 	const translate = useTranslate();
-	const [ selectedSite, setSelectedSite ] = useState( { ID: null, domain: null } );
+	const [ selectedSite, setSelectedSite ] = useState( { ID: 0, domain: '' } );
 	const licenseKey = getQueryArg( window.location.href, 'key' ) as string;
 	const products = getQueryArg( window.location.href, 'products' ) as string;
 	const licenseKeysArray = products !== undefined ? products.split( ',' ) : [ licenseKey ];
@@ -109,7 +109,7 @@ export default function AssignLicenseForm( {
 					<Button
 						primary
 						className="assign-license-form__assign-now"
-						disabled={ ! selectedSite?.ID }
+						disabled={ selectedSite?.ID === 0 }
 						busy={ isLoading }
 						onClick={ assignLicenses }
 					>


### PR DESCRIPTION
Fix the disable function on the Assign License button to disable the button when there is no selected site ID property

#### Proposed Changes

* This PR fixes an issue with the assign license button on the license assignment page not being disabled where there is no site selected on initial page load

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this PR
* Run yarn-start-jetpack-cloud
* Visit the license page at http://jetpack.cloud.localhost:3000/partner-portal/licenses
* Attempt to assign an individual license by clicking on the assign license option on any existing license
* Ensure that on the license assignment page the button labeled "Assign License" is now disabled until a valid site is selected

<img width="1047" alt="Screenshot 2022-11-21 at 5 20 08 PM" src="https://user-images.githubusercontent.com/1273880/203184422-74d90de5-3cb4-4f18-817f-862568a3108a.png">


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
