### PR TITLE
Partner Portal: remove the feature flag code for the issue multiple licenses project

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { Button, Gridicon } from '@automattic/components';
 import { addQueryArgs } from '@wordpress/url';
 import classNames from 'classnames';
@@ -177,30 +176,21 @@ export default function SiteStatusContent( {
 			break;
 		}
 		case 'inactive': {
-			if ( ! isEnabled( 'jetpack/partner-portal-issue-multiple-licenses' ) ) {
-				content = (
+			content = ! isLicenseSelected ? (
+				<button onClick={ handleSelectLicenseAction }>
 					<span className="sites-overview__status-select-license">
 						<Gridicon icon="plus-small" size={ 16 } />
 						<span>{ translate( 'Add' ) }</span>
 					</span>
-				);
-			} else {
-				content = ! isLicenseSelected ? (
-					<button onClick={ handleSelectLicenseAction }>
-						<span className="sites-overview__status-select-license">
-							<Gridicon icon="plus-small" size={ 16 } />
-							<span>{ translate( 'Add' ) }</span>
-						</span>
-					</button>
-				) : (
-					<button onClick={ handleDeselectLicenseAction }>
-						<span className="sites-overview__status-unselect-license">
-							<Gridicon icon="checkmark" size={ 16 } />
-							<span>{ translate( 'Selected' ) }</span>
-						</span>
-					</button>
-				);
-			}
+				</button>
+			) : (
+				<button onClick={ handleDeselectLicenseAction }>
+					<span className="sites-overview__status-unselect-license">
+						<Gridicon icon="checkmark" size={ 16 } />
+						<span>{ translate( 'Selected' ) }</span>
+					</span>
+				</button>
+			);
 			break;
 		}
 	}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
@@ -1,4 +1,4 @@
-import config, { isEnabled } from '@automattic/calypso-config';
+import config from '@automattic/calypso-config';
 import { translate } from 'i18n-calypso';
 import { urlToSlug } from 'calypso/lib/url';
 import type {
@@ -213,8 +213,7 @@ const getLinks = (
 	type: AllowedTypes,
 	status: string,
 	siteUrl: string,
-	siteUrlWithScheme: string,
-	siteId: number
+	siteUrlWithScheme: string
 ): {
 	link: string;
 	isExternalLink: boolean;
@@ -226,21 +225,13 @@ const getLinks = (
 
 	switch ( type ) {
 		case 'backup': {
-			if ( status === 'inactive' ) {
-				if ( ! isEnabled( 'jetpack/partner-portal-issue-multiple-licenses' ) ) {
-					link = `/partner-portal/issue-license/?site_id=${ siteId }&product_slug=jetpack-backup-t2&source=dashboard`;
-				}
-			} else {
+			if ( status !== 'inactive' ) {
 				link = `/backup/${ siteUrlWithMultiSiteSupport }`;
 			}
 			break;
 		}
 		case 'scan': {
-			if ( status === 'inactive' ) {
-				if ( ! isEnabled( 'jetpack/partner-portal-issue-multiple-licenses' ) ) {
-					link = `/partner-portal/issue-license/?site_id=${ siteId }&product_slug=jetpack-scan&source=dashboard`;
-				}
-			} else {
+			if ( status !== 'inactive' ) {
 				link = `/scan/${ siteUrlWithMultiSiteSupport }`;
 			}
 			break;
@@ -286,7 +277,7 @@ export const getRowMetaData = (
 	const siteUrlWithScheme = rows.site?.value?.url_with_scheme;
 	const siteError = rows.site.error;
 	const siteId = rows.site?.value?.blog_id;
-	const { link, isExternalLink } = getLinks( type, row.status, siteUrl, siteUrlWithScheme, siteId );
+	const { link, isExternalLink } = getLinks( type, row.status, siteUrl, siteUrlWithScheme );
 	const tooltip = getTooltip( type, row.status );
 	const eventName = getRowEventName( type, row.status, isLargeScreen );
 	return {

--- a/client/jetpack-cloud/sections/partner-portal/license-product-card/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-product-card/index.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { Gridicon } from '@automattic/components';
 import formatCurrency from '@automattic/format-currency';
 import classNames from 'classnames';
@@ -37,11 +36,7 @@ export default function LicenseProductCard( props: Props ) {
 			return;
 		}
 
-		if ( isEnabled( 'jetpack/partner-portal-issue-multiple-licenses' ) ) {
-			onSelectProduct?.( product );
-		} else {
-			onSelectProduct?.( product.slug );
-		}
+		onSelectProduct?.( product );
 	}, [ onSelectProduct, product ] );
 
 	const onKeyDown = useCallback(

--- a/client/jetpack-cloud/sections/partner-portal/primary/issue-license/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/issue-license/index.tsx
@@ -1,11 +1,9 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import CardHeading from 'calypso/components/card-heading';
 import DocumentHead from 'calypso/components/data/document-head';
 import Main from 'calypso/components/main';
 import AssignLicenseStepProgress from 'calypso/jetpack-cloud/sections/partner-portal/assign-license-step-progress';
-import IssueLicenseForm from 'calypso/jetpack-cloud/sections/partner-portal/issue-license-form';
 import IssueMultipleLicensesForm from 'calypso/jetpack-cloud/sections/partner-portal/issue-multiple-licenses-form';
 import SidebarNavigation from 'calypso/jetpack-cloud/sections/partner-portal/sidebar-navigation';
 import { AssignLicenceProps } from '../../types';
@@ -31,14 +29,10 @@ export default function IssueLicense( { selectedSite, suggestedProduct }: Assign
 			<AssignLicenseStepProgress currentStep="issueLicense" selectedSite={ selectedSite } />
 			<CardHeading size={ 36 }>{ translate( 'Issue a new License' ) }</CardHeading>
 
-			{ isEnabled( 'jetpack/partner-portal-issue-multiple-licenses' ) ? (
-				<IssueMultipleLicensesForm
-					selectedSite={ selectedSite }
-					suggestedProduct={ suggestedProduct }
-				/>
-			) : (
-				<IssueLicenseForm selectedSite={ selectedSite } suggestedProduct={ suggestedProduct } />
-			) }
+			<IssueMultipleLicensesForm
+				selectedSite={ selectedSite }
+				suggestedProduct={ suggestedProduct }
+			/>
 		</Main>
 	);
 }

--- a/client/jetpack-cloud/sections/partner-portal/primary/licenses/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/licenses/index.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useDispatch, useSelector } from 'react-redux';
@@ -58,9 +57,7 @@ export default function Licenses( {
 			<DocumentHead title={ translate( 'Licenses' ) } />
 			<SidebarNavigation />
 			{ isAgencyUser && <SiteWelcomeBanner bannerKey="licenses-page" /> }
-			{ isEnabled( 'jetpack/partner-portal-issue-multiple-licenses' ) && (
-				<SiteAddLicenseNotification />
-			) }
+			<SiteAddLicenseNotification />
 			<div className="licenses__header">
 				<CardHeading size={ 36 }>{ translate( 'Licenses' ) }</CardHeading>
 

--- a/client/jetpack-cloud/sections/partner-portal/primary/payment-method-add/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/payment-method-add/index.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import {
 	ReloadSetupIntentId,
 	StripeHookProvider,
@@ -94,10 +93,6 @@ function PaymentMethodAdd( { selectedSite }: { selectedSite?: SiteDetails | null
 		[]
 	);
 
-	const isMultipleLicenseIssueEnabled = isEnabled(
-		'jetpack/partner-portal-issue-multiple-licenses'
-	);
-
 	const [ issueLicense, isLoading ] = useLicenseIssuing( product );
 	const [ issueMultipleLicense, isIssuingMultipleLicenses ] = useIssueMultipleLicenses(
 		products ? products.split( ',' ) : [],
@@ -161,7 +156,7 @@ function PaymentMethodAdd( { selectedSite }: { selectedSite?: SiteDetails | null
 	}, [ paymentMethodRequired, product ] );
 
 	useEffect( () => {
-		if ( isMultipleLicenseIssueEnabled && ! paymentMethodRequired && products ) {
+		if ( ! paymentMethodRequired && products ) {
 			issueMultipleLicense();
 		}
 	}, [ paymentMethodRequired ] );

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -40,7 +40,6 @@
 		"jetpack/activity-log-sharing": true,
 		"jetpack/agency-dashboard": true,
 		"jetpack/backup-messaging-i3": true,
-		"jetpack/partner-portal-issue-multiple-licenses": true,
 		"jetpack/partner-portal-payment": true,
 		"jetpack/plugin-management": true,
 		"jetpack/pricing-add-boost-social": true,

--- a/config/jetpack-cloud-horizon.json
+++ b/config/jetpack-cloud-horizon.json
@@ -34,7 +34,6 @@
 		"jetpack-cloud": true,
 		"jetpack/agency-dashboard": true,
 		"jetpack/backup-messaging-i3": true,
-		"jetpack/partner-portal-issue-multiple-licenses": true,
 		"jetpack/partner-portal-payment": true,
 		"jetpack/plugin-management": true,
 		"jetpack/pricing-add-boost-social": true,

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -37,7 +37,6 @@
 		"jetpack-cloud": true,
 		"jetpack/agency-dashboard": true,
 		"jetpack/backup-messaging-i3": true,
-		"jetpack/partner-portal-issue-multiple-licenses": true,
 		"jetpack/partner-portal-payment": true,
 		"jetpack/plugin-management": true,
 		"jetpack/pricing-add-boost-social": true,

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -37,7 +37,6 @@
 		"jetpack/activity-log-sharing": true,
 		"jetpack/agency-dashboard": true,
 		"jetpack/backup-messaging-i3": true,
-		"jetpack/partner-portal-issue-multiple-licenses": true,
 		"jetpack/partner-portal-payment": true,
 		"jetpack/plugin-management": true,
 		"jetpack/pricing-add-boost-social": true,


### PR DESCRIPTION
#### Proposed Changes

This PR removes the feature toggle switches from the production code

#### Testing Instructions

**Prerequisites**

Since some changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

> **_NOTE:_** Make sure you don't have any payment method added by visiting **[payment-methods](http://jetpack.cloud.localhost:3000/partner-portal/payment-methods)**.


**Instructions**

1. Run `git checkout remove/issue-multiple-licenses-feature-flag-code` and `yarn start-jetpack-cloud`
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Verify that clicking on `Add +` changes the button text to `Selected` and shows the button to **Issue x new License** when there is more than 1 inactive product for a site.
4. Verify that clicking on `Add +` redirects you to `issue-license` with the selected product when there is only 1 inactive product for a site.
5. Verify that clicking on Site or Backup when not inactive(the `+ Add button` is not shown) of any site takes you to the single site page.
6. Click on **Licensing** on the top nav and click the **Issue New License** button -> Select more than 1 product -> Add a payment method -> Verify the selected licenses are issued -> Assign the issued licenses to a site -> Verify that licenses are assigned to the selected site successfully, and notification is shown on the Licenses page

<img width="648" alt="Screenshot 2022-11-15 at 12 55 03 PM" src="https://user-images.githubusercontent.com/10586875/201888421-3bae8e3d-d975-4683-8302-6bafcaac4a9d.png">

<img width="1034" alt="Screenshot 2022-11-09 at 10 47 21 AM" src="https://user-images.githubusercontent.com/10586875/201256943-0e8526c7-76ca-4d42-b475-1bc9af646691.png">

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1203126240279377-as-1203415652420230