### PR TITLE
Do not show the step progress for the dotlink variation of Link in Bio flow.

### DIFF
--- a/client/landing/stepper/declarative-flow/link-in-bio.ts
+++ b/client/landing/stepper/declarative-flow/link-in-bio.ts
@@ -28,13 +28,19 @@ export const linkInBio: Flow = {
 		const flowName = this.name;
 		const { setStepProgress } = useDispatch( ONBOARD_STORE );
 		const flowProgress = useFlowProgress( { stepName: _currentStep, flowName } );
-		setStepProgress( flowProgress );
 		const siteSlug = useSiteSlug();
 		const userIsLoggedIn = useSelect( ( select ) => select( USER_STORE ).isCurrentUserLoggedIn() );
 		const locale = useLocale();
 		const queryParams = useQuery();
-
 		const tld = queryParams.get( 'tld' );
+
+		// At the moment, the TLD variation relies on going back and forth from the classic signup framework
+		// and the Stepper framework. Since it begins from the former, the Stepper framework doesn't have a chance
+		// to inject the step progress there, which can be quite confusing. Thus, we've decided to just not show it at all.
+		// Once the whole flow is moved into Stepper, this can also be removed. See Automattic/martech#1256
+		if ( ! tld ) {
+			setStepProgress( flowProgress );
+		}
 
 		// trigger guides on step movement, we don't care about failures or response
 		wpcom.req.post(


### PR DESCRIPTION
#### Proposed Changes

This PR resolves Automattic/martech#1256. The issue originally states that we should show the blue progress bar for the TLD variation as well. i.e. this one:
<img width="995" alt="image" src="https://user-images.githubusercontent.com/1842898/203250305-ea8faaa8-f441-44b8-8299-518acbd3a075.png">

However, since `/start/link-in-bio-tld?tld=link` starts from the signup framework, the Stepper framework doesn't have a chance to inject the bar there. We decide to just hide it throughout the flow so it's less confusing.  

#### Testing Instructions

Caution: As described in https://github.com/Automattic/wp-calypso/pull/69797, it's recommended to disable the developer sympathy mode if testing on a local instance.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Checking the regular Link in Bio flow, `/setup/link-in-bio`, make sure that the blue progress bar at the top is there after the user step.
2. Checking the dotlink variation of Link in Bio flow, `/start/link-in-bio-tld?tld=link`, the blue progress bar should be completely gone.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
