### PR TITLE
Style selection in design picker: Background color of sidebar

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -11,7 +11,8 @@
  * General onboarding styling
  */
 body {
-	background-color: #fdfdfd;
+	--color-body-background: #fdfdfd;
+	background-color: var(--color-body-background);
 }
 
 body,

--- a/packages/design-preview/src/components/style.scss
+++ b/packages/design-preview/src/components/style.scss
@@ -24,6 +24,7 @@ $break-design-preview: 1024px;
 
 .design-preview__sidebar {
 	align-items: center;
+	background: #fdfdfd;
 	border-bottom: 1px solid rgb(0 0 0 / 5%);
 	box-shadow: -4px 0 8px rgb(0 0 0 / 7%);
 	box-sizing: border-box;

--- a/packages/design-preview/src/components/style.scss
+++ b/packages/design-preview/src/components/style.scss
@@ -24,7 +24,7 @@ $break-design-preview: 1024px;
 
 .design-preview__sidebar {
 	align-items: center;
-	background: #fdfdfd;
+	background-color: var(--color-body-background);
 	border-bottom: 1px solid rgb(0 0 0 / 5%);
 	box-shadow: -4px 0 8px rgb(0 0 0 / 7%);
 	box-sizing: border-box;


### PR DESCRIPTION
#### Proposed Changes

* Add the same background color as the body using a CSS variable to hide the logo behind the sidebar on mobile

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the unified design picker `/setup/designSetup?siteSlug=${site_slug}`
* Click on a theme with style variations to open the preview
* Resize the window until the sidebar appears at the top of the page
* Check that the sidebar has the same background color as the body and the logo is not visible

|Before|After|
|------|-----|
|<img width="920" alt="Screen Shot 2565-11-22 at 15 58 46" src="https://user-images.githubusercontent.com/1881481/203271258-1bef2958-5d48-4c04-88c9-1a85270c1b67.png">|<img width="922" alt="Screen Shot 2565-11-22 at 15 58 31" src="https://user-images.githubusercontent.com/1881481/203271277-e777efef-72b7-4320-a3eb-73dfab1dfc6d.png">|


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/70026
