### PR TITLE
Pattern Assembler: Remove header and footer placeholder

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/utils.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/utils.ts
@@ -44,8 +44,6 @@ export function createCustomHomeTemplateContent(
 		content.push(
 			`<!-- wp:template-part {"slug":"header","tagName":"header","theme":"${ stylesheet }"} /-->`
 		);
-	} else {
-		content.push( `<!-- wp:template-part {"area":"header"} /-->` );
 	}
 
 	content.push( `
@@ -61,8 +59,6 @@ export function createCustomHomeTemplateContent(
 		content.push(
 			`<!-- wp:template-part {"slug":"footer","tagName":"footer","theme":"${ stylesheet }","className":"site-footer-container"} /-->`
 		);
-	} else {
-		content.push( `<!-- wp:template-part {"area":"footer"} /-->` );
 	}
 
 	return content.join( '\n' );


### PR DESCRIPTION
#### Proposed Changes

* This PR is focusing on removing the placeholder of the header and footer when the user finished the PA step. Now we will insert the header and footer only when the user selected them.
* We are making this change because of feedback in the PA Walkthrough pekYwv-2A-p2

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup?siteSlug=<your_site>`
* Click the "Continue" button until you land on the Design Picker
* Click the "Start designing" button of Blank Canvas CTA at the end of page to enter the Pattern Assembler
* Don't select any patterns in the Pattern Assember step
* When you land on the site editor, verify the placeholder of the header and footer won't show.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/1251, https://github.com/Automattic/wp-calypso/pull/69779