### PR TITLE
HC: fix promotional popover visibility when masterbar is hidden

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/help-center.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/help-center.js
@@ -65,7 +65,7 @@ function HelpCenterContent() {
 				aria-pressed={ show ? true : false }
 				aria-expanded={ show ? true : false }
 			/>
-			<PromotionalPopover contextRef={ helpIconRef } />
+			<PromotionalPopover iconElement={ helpIconRef } />
 		</>
 	);
 

--- a/client/layout/masterbar/masterbar-help-center.jsx
+++ b/client/layout/masterbar/masterbar-help-center.jsx
@@ -44,7 +44,7 @@ const MasterbarHelpCenter = ( { siteId, tooltip } ) => {
 				tooltip={ tooltip }
 				icon={ <HelpIcon ref={ helpIconRef } newItems={ newItems } /> }
 			/>
-			<PromotionalPopover contextRef={ helpIconRef.current } />
+			<PromotionalPopover iconElement={ helpIconRef.current } />
 		</>
 	);
 };

--- a/packages/help-center/src/components/promotional-popover.tsx
+++ b/packages/help-center/src/components/promotional-popover.tsx
@@ -6,10 +6,10 @@ import { useState } from 'react';
 import { HELP_CENTER_STORE } from '../stores';
 
 interface Props {
-	contextRef: React.RefObject< SVGSVGElement >;
+	iconElement: SVGSVGElement;
 }
 
-const PromotionalPopover = ( { contextRef }: Props ) => {
+const PromotionalPopover = ( { iconElement }: Props ) => {
 	const { hasSeenPromotion, doneLoading } = useSelect(
 		( select ) => ( {
 			hasSeenPromotion: select( HELP_CENTER_STORE ).getHasSeenPromotionalPopover(),
@@ -32,7 +32,14 @@ const PromotionalPopover = ( { contextRef }: Props ) => {
 		} );
 	};
 
-	if ( ! contextRef ) {
+	if ( ! iconElement ) {
+		return null;
+	}
+
+	const iconBox = iconElement.getBoundingClientRect();
+	const visibleElement = document.elementFromPoint( iconBox.left, iconBox.top );
+
+	if ( visibleElement !== iconElement ) {
 		return null;
 	}
 
@@ -41,7 +48,7 @@ const PromotionalPopover = ( { contextRef }: Props ) => {
 			<Popover
 				className="help-center__promotion-popover"
 				isVisible={ doneLoading && ! hasSeenPromotion && ! isDismissed }
-				context={ contextRef }
+				context={ iconElement }
 				onClose={ () => {
 					recordDismiss( 'clicking-outside' );
 					setHasSeenPromotionalPopover( true );


### PR DESCRIPTION
#### Proposed Changes

* There is a case where we didn't account for when releasing the help center promotional popover and this PR aims to fix it.
* When the masterbar is hidden we should avoid showing the promotional popover

#### Testing Instructions
- Checkout this branch or use PR link
- Clear your hc promotional popover preference
- Visit this url: http://calypso.localhost:3000/marketplace/thank-you/woocommerce-shipment-tracking?site=asdsadsadas.wpcomstaging.com
- The promotional popover should not show
- Do this same steps on production to see if you can reproduce:  https://wordpress.com/marketplace/thank-you/woocommerce-shipment-tracking?site=asdsadsadas.wpcomstaging.com
