### PR TITLE
Remove duplicate search feature

### DIFF
--- a/client/components/search-themes/index.tsx
+++ b/client/components/search-themes/index.tsx
@@ -89,7 +89,8 @@ const SearchThemes: React.FC< SearchThemesProps > = ( { query, onSearch, recordT
 			// Only allow one `subject:` filter
 			updatedInput = updatedInput.replace( /(subject):([\w-]*[\s|$])(?=.*\1)/gi, '' );
 
-			updateInput( insertSuggestion( suggestion, searchInput, cursorPosition ) );
+			// Strip filters and excess whitespace
+			updateInput( updatedInput.replace( /\s+/g, ' ' ).trim() );
 			closeSearch();
 		}
 	};

--- a/client/components/search-themes/index.tsx
+++ b/client/components/search-themes/index.tsx
@@ -46,11 +46,10 @@ const SearchThemes: React.FC< SearchThemesProps > = ( { query, onSearch, recordT
 
 	const updateInput = ( updatedInput: string ) => {
 		// Clean up duplicate criteria
-		const searchInput = updatedInput.replace(
-			/(\b(feature|column|subject):.*[^ ]\b)(?=.*\1)/gi,
-			''
-		);
-		setSearchInput( searchInput );
+		updatedInput = updatedInput.replace( /(\b(feature|column|subject):.*[^ ]\b)(?=.*\1)/gi, '' );
+		// Only allow one `subject:` filter
+		updatedInput = updatedInput.replace( /(subject):([\w-]*)(?=.*\1)/gi, '' );
+		setSearchInput( updatedInput );
 		setIsApplySearch( true );
 		searchRef.current?.clear();
 	};

--- a/client/components/search-themes/index.tsx
+++ b/client/components/search-themes/index.tsx
@@ -48,7 +48,7 @@ const SearchThemes: React.FC< SearchThemesProps > = ( { query, onSearch, recordT
 		// Clean up duplicate criteria
 		updatedInput = updatedInput.replace( /(\b(feature|column|subject):.*[^ ]\b)(?=.*\1)/gi, '' );
 		// Only allow one `subject:` filter
-		updatedInput = updatedInput.replace( /(subject):([\w-]*)(?=.*\1)/gi, '' );
+		updatedInput = updatedInput.replace( /(subject):([\w-]*[\s|$])(?=.*\1)/gi, '' );
 		setSearchInput( updatedInput );
 		setIsApplySearch( true );
 		searchRef.current?.clear();

--- a/client/components/search-themes/index.tsx
+++ b/client/components/search-themes/index.tsx
@@ -45,10 +45,6 @@ const SearchThemes: React.FC< SearchThemesProps > = ( { query, onSearch, recordT
 	};
 
 	const updateInput = ( updatedInput: string ) => {
-		// Clean up duplicate criteria
-		updatedInput = updatedInput.replace( /(\b(feature|column|subject):.*[^ ]\b)(?=.*\1)/gi, '' );
-		// Only allow one `subject:` filter
-		updatedInput = updatedInput.replace( /(subject):([\w-]*[\s|$])(?=.*\1)/gi, '' );
 		setSearchInput( updatedInput );
 		setIsApplySearch( true );
 		searchRef.current?.clear();
@@ -87,6 +83,12 @@ const SearchThemes: React.FC< SearchThemesProps > = ( { query, onSearch, recordT
 			updateInput( updatedInput + suggestion );
 			focusOnInput();
 		} else {
+			updatedInput = insertSuggestion( suggestion, searchInput, cursorPosition );
+			// Clean up duplicate criteria
+			updatedInput = updatedInput.replace( /(\b(feature|column|subject):.*[^ ]\b)(?=.*\1)/gi, '' );
+			// Only allow one `subject:` filter
+			updatedInput = updatedInput.replace( /(subject):([\w-]*[\s|$])(?=.*\1)/gi, '' );
+
 			updateInput( insertSuggestion( suggestion, searchInput, cursorPosition ) );
 			closeSearch();
 		}

--- a/client/components/search-themes/index.tsx
+++ b/client/components/search-themes/index.tsx
@@ -45,7 +45,12 @@ const SearchThemes: React.FC< SearchThemesProps > = ( { query, onSearch, recordT
 	};
 
 	const updateInput = ( updatedInput: string ) => {
-		setSearchInput( updatedInput );
+		// Clean up duplicate criteria
+		const searchInput = updatedInput.replace(
+			/(\b(feature|column|subject):.*[^ ]\b)(?=.*\1)/gi,
+			''
+		);
+		setSearchInput( searchInput );
 		setIsApplySearch( true );
 		searchRef.current?.clear();
 	};


### PR DESCRIPTION
## Proposed Changes

This PR update the search input in the ThemeSearch component to 

1.  Remove search duplication such as `column:left-sidebar column:left-sidebar feature:accessibility-ready feature:accessibility-ready` , [screenshot here](https://github.com/Automattic/wp-calypso/pull/70283#issuecomment-1324450451)
2.  Only allow 01 subject filter in the searchbox (because the Subject filter is single-select)

![Screen Capture on 2022-11-23 at 16-12-38.gif](https://cdn-std.droplr.net/files/acc_1243635/DFyr4O)

## Testing Instructions

*   Head to the Themes Showcase `/themes/${site_slug}`
    *   If using calypso.live, the flag `themes/showcase-i4/search-and-filter` is required.
*   Click on the searchbox and add search criteria to filter themese
*   Confirm that there is no duplication on `feature:` and `column:` filter
*   Confirm that the new selected `subject:` filter will replace the previous one  
**BEFORE:**
![image](https://user-images.githubusercontent.com/10071857/203464729-289622ed-66c6-4c95-a783-59a01520e7bb.gif)
**AFTER:**     
![Screen Capture on 2022-11-23 at 16-17-06](https://user-images.githubusercontent.com/10071857/203499447-718c6de9-a5a3-490c-ba77-46ff6233dac7.gif)



## Reference

Related to #70162