### PR TITLE
Couple of Reader CSS fixes

### DIFF
--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -186,10 +186,6 @@
 
 		.reader-post-card__post {
 			margin-top: 0;
-
-			@include breakpoint-deprecated( "<960px" ) {
-				flex-direction: row;
-			}
 		}
 
 		.reader-post-card__post-details {

--- a/client/reader/conversations/stream.scss
+++ b/client/reader/conversations/stream.scss
@@ -60,6 +60,10 @@
 		margin-top: 16px;
 	}
 
+	@include breakpoint-deprecated( "<660px" ) {
+		margin: 0 16px 16px;
+	}
+
 	// Hides Follow button and tags in Conversations stream
 	.follow-button,
 	.reader-post-card__tags {


### PR DESCRIPTION
## Description

Navigate to the Conversations screen within the reader and shrink the width of your screen down and you'll see this:

<img width="941" alt="CleanShot 2022-11-21 at 10 56 17@2x" src="https://user-images.githubusercontent.com/5634774/203100574-575ef720-caa7-45d6-83c6-08c8f83e811d.png">

I expected to see this:

<img width="950" alt="CleanShot 2022-11-21 at 10 58 15@2x" src="https://user-images.githubusercontent.com/5634774/203100693-20a61ac2-b54d-44ed-aa11-f1bb705692e2.png">

I also noticed that there is zero padding around conversations when the browser is below 660px. This just looks terrible, so I added some padding.

### Before

<img width="502" alt="CleanShot 2022-11-22 at 09 25 16@2x" src="https://user-images.githubusercontent.com/5634774/203339267-2e2c0fcc-586b-4d57-9ced-7292fe648d9f.png">

### After

<img width="502" alt="CleanShot 2022-11-22 at 09 32 47@2x" src="https://user-images.githubusercontent.com/5634774/203340589-0240e956-e875-45c3-b392-b083958468b4.png">

## Related
#70243