### PR TITLE
Stats: Recover the chart with data for no resizing on the first load

### DIFF
--- a/client/components/chart/index.jsx
+++ b/client/components/chart/index.jsx
@@ -109,10 +109,6 @@ function Chart( {
 
 	// Memoize data calculations to avoid performing them too often.
 	const { chartData, isEmptyChart, yMax } = useMemo( () => {
-		if ( ! hasResized ) {
-			return {};
-		}
-
 		const nextData = data.length <= maxBars ? data : data.slice( 0 - maxBars );
 		const nextVals = data.map( ( { value } ) => value );
 
@@ -123,10 +119,11 @@ function Chart( {
 		};
 	}, [ data, maxBars, hasResized ] );
 
+	// Recover the chart with data even if no sizing is updated on the first loading.
 	// If we don't have any sizing info yet, render an empty chart with the ref.
-	if ( ! hasResized ) {
-		return <div ref={ resizeRef } className="chart" />;
-	}
+	// if ( ! hasResized ) {
+	// 	return <div ref={ resizeRef } className="chart" />;
+	// }
 
 	// Otherwise, render full chart.
 	const { isTooltipVisible, tooltipContext, tooltipPosition, tooltipData } = tooltip;


### PR DESCRIPTION
#### Proposed Changes

* Recover the chart without checking the `hasResized` flag.

> The original intention is that window needs to trigger resize after the chart's initial data has been drawn to update the viewport width to accommodate more bar charts. This PR aims to recover the missing chart on the first loading rather than fix the resizing bug.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up this change with the Calypso Live link.
* Navigate to page `/stats/day/${your-site}`.
* Ensure the chart always appears on every reload, even though sometimes the width of the bar charts becomes wider.

https://user-images.githubusercontent.com/6869813/203344865-00be4fe0-b156-4a4b-9185-0d936efbf911.mov

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #70256
