### PR TITLE
Woo Tailored Onboarding: Added ecommerce flow with domains step

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/analytics/record-submit-step.ts
+++ b/client/landing/stepper/declarative-flow/internals/analytics/record-submit-step.ts
@@ -25,6 +25,10 @@ export function recordSubmitStep(
 				propValue = ( propValue as { slug: string } ).slug;
 			}
 
+			if ( propName === 'current_plan' ) {
+				propValue = ( propValue as { product_slug: string } ).product_slug;
+			}
+
 			return {
 				...props,
 				[ propName ]: propValue,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/check-plan/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/check-plan/index.tsx
@@ -1,0 +1,22 @@
+/* eslint-disable no-console */
+import { useEffect } from 'react';
+import { useSite } from 'calypso/landing/stepper/hooks/use-site';
+import type { Step } from '../../types';
+
+const CheckPlan: Step = function CheckPlan( { navigation } ) {
+	const { submit } = navigation;
+	const site = useSite();
+
+	useEffect( () => {
+		if ( ! site ) {
+			return;
+		}
+		submit?.( { currentPlan: site.plan } );
+
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ site ] );
+
+	return null;
+};
+
+export default CheckPlan;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-carousel/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-carousel/index.tsx
@@ -1,52 +1,22 @@
+import { Design } from '@automattic/design-picker';
 import { StepContainer } from '@automattic/onboarding';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useDispatch } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
 import AsyncLoad from 'calypso/components/async-load';
 import FormattedHeader from 'calypso/components/formatted-header';
-import { useSite } from 'calypso/landing/stepper/hooks/use-site';
-import { useSiteIdParam } from 'calypso/landing/stepper/hooks/use-site-id-param';
-import { useSiteSlugParam } from 'calypso/landing/stepper/hooks/use-site-slug-param';
-import { ONBOARD_STORE, SITE_STORE } from 'calypso/landing/stepper/stores';
+import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import { reduxDispatch } from 'calypso/lib/redux-bridge';
-import { requestActiveTheme } from 'calypso/state/themes/actions';
 import type { Step } from '../../types';
-import type { Design } from '@automattic/design-picker/src/types';
 
 const DesignCarousel: Step = function DesignCarousel( { navigation } ) {
 	const { goNext, goBack, submit } = navigation;
 	const { __ } = useI18n();
 
-	const selectedDesign = useSelect( ( select ) => select( ONBOARD_STORE ).getSelectedDesign() );
 	const { setSelectedDesign } = useDispatch( ONBOARD_STORE );
-	const { setThemeOnSite, installTheme } = useDispatch( SITE_STORE );
-	const { setPendingAction } = useDispatch( ONBOARD_STORE );
 
-	const site = useSite();
-	const siteSlug = useSiteSlugParam();
-	const siteId = useSiteIdParam();
-	const siteSlugOrId = siteId || siteSlug;
-	const isJetpackSite = useSelect( ( select ) => select( SITE_STORE ).isJetpackSite( site?.ID ) );
-
-	function pickDesign( _selectedDesign: Design | undefined = selectedDesign ) {
+	function pickDesign( _selectedDesign: Design ) {
 		setSelectedDesign( _selectedDesign );
-		if ( siteSlugOrId && _selectedDesign ) {
-			setPendingAction( async () => {
-				if ( isJetpackSite ) {
-					try {
-						await installTheme( siteSlugOrId, _selectedDesign.slug );
-					} catch ( e ) {
-						// TODO: Handle better theme already installed
-					}
-				}
-
-				await setThemeOnSite( siteSlugOrId, _selectedDesign.slug ).then( () =>
-					reduxDispatch( requestActiveTheme( site?.ID || -1 ) )
-				);
-				return { selectedDesign: _selectedDesign, siteSlug };
-			} );
-			submit?.();
-		}
+		submit?.();
 	}
 
 	return (

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/index.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/index.ts
@@ -21,6 +21,7 @@ export { default as importerMedium } from './importer-medium';
 export { default as importerSquarespace } from './importer-squarespace';
 export { default as importerWordpress } from './importer-wordpress';
 export { default as businessInfo } from './business-info';
+export { default as checkPlan } from './check-plan';
 export { default as storeAddress } from './store-address';
 export { default as vertical } from './site-vertical';
 export { default as wooTransfer } from './woo-transfer';
@@ -48,6 +49,8 @@ export { default as getCurrentThemeSoftwareSets } from './get-current-theme-soft
 export { default as storeProfiler } from './store-profiler';
 export { default as designCarousel } from './design-carousel';
 export { default as domains } from './domains';
+export { default as setThemeStep } from './set-theme-step';
+export { default as waitForAtomic } from './wait-for-atomic';
 
 export type StepPath =
 	| 'courses'
@@ -79,6 +82,8 @@ export type StepPath =
 	| 'vertical'
 	| 'wooTransfer'
 	| 'wooInstallPlugins'
+	| 'waitForAtomic'
+	| 'checkPlan'
 	| 'error'
 	| 'wooConfirm'
 	| 'wooVerifyEmail'
@@ -96,6 +101,7 @@ export type StepPath =
 	| 'subscribers'
 	| 'getCurrentThemeSoftwareSets'
 	| 'designCarousel'
+	| 'setThemeStep'
 	| 'storeProfiler'
 	| 'chooseAPlan'
 	| 'videomakerSetup'

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/set-theme-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/set-theme-step/index.tsx
@@ -1,0 +1,46 @@
+import { useDispatch, useSelect } from '@wordpress/data';
+import { useEffect } from 'react';
+import { useSite } from 'calypso/landing/stepper/hooks/use-site';
+import { useSiteSlugParam } from 'calypso/landing/stepper/hooks/use-site-slug-param';
+import { useThemeParam } from 'calypso/landing/stepper/hooks/use-theme-param';
+import { ONBOARD_STORE, SITE_STORE } from 'calypso/landing/stepper/stores';
+import { reduxDispatch } from 'calypso/lib/redux-bridge';
+import { requestActiveTheme } from 'calypso/state/themes/actions';
+import type { Step } from '../../types';
+
+const SetThemeStep: Step = function SetThemeStep( { navigation } ) {
+	const { submit } = navigation;
+
+	const { setPendingAction } = useDispatch( ONBOARD_STORE );
+	const { setThemeOnSite, installTheme } = useDispatch( SITE_STORE );
+
+	const siteId = useSite()?.ID;
+	const siteSlug = useSiteSlugParam() || '';
+	const selectedDesign = useSelect( ( select ) => select( ONBOARD_STORE ).getSelectedDesign() );
+	const themeParam = useThemeParam();
+
+	useEffect( () => {
+		const themeSlug = themeParam || selectedDesign?.slug;
+
+		if ( ! ( siteSlug && themeSlug ) ) {
+			return;
+		}
+
+		setPendingAction( async () => {
+			try {
+				await installTheme( siteSlug, themeSlug );
+			} catch ( e ) {
+				// TODO: Handle better theme already installed
+			}
+			await setThemeOnSite( siteSlug, themeSlug ).then( () =>
+				reduxDispatch( requestActiveTheme( siteId || -1 ) )
+			);
+			return { selectedDesign: { slug: themeSlug } };
+		} );
+		submit?.();
+	}, [ siteSlug, selectedDesign ] );
+
+	return null;
+};
+
+export default SetThemeStep;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/wait-for-atomic/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/wait-for-atomic/index.tsx
@@ -1,0 +1,144 @@
+/* eslint-disable no-console */
+import config from '@automattic/calypso-config';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { useEffect } from 'react';
+import { useSite } from 'calypso/landing/stepper/hooks/use-site';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { logToLogstash } from 'calypso/lib/logstash';
+import { ONBOARD_STORE, SITE_STORE } from '../../../../stores';
+import type { Step } from '../../types';
+
+export interface FailureInfo {
+	type: string;
+	code: number | string;
+	error: string;
+}
+
+export const transferStates = {
+	PENDING: 'pending',
+	ACTIVE: 'active',
+	PROVISIONED: 'provisioned',
+	COMPLETED: 'completed',
+	ERROR: 'error',
+	REVERTED: 'reverted',
+	RELOCATING_REVERT: 'relocating_revert',
+	RELOCATING_SWITCHEROO: 'relocating_switcheroo',
+	REVERTING: 'reverting',
+	RENAMING: 'renaming',
+	EXPORTING: 'exporting',
+	IMPORTING: 'importing',
+	CLEANUP: 'cleanup',
+} as const;
+
+const wait = ( ms: number ) => new Promise( ( res ) => setTimeout( res, ms ) );
+
+const WaitForAtomic: Step = function WaitForAtomic( { navigation } ) {
+	const { submit } = navigation;
+	const { setPendingAction, setProgress } = useDispatch( ONBOARD_STORE );
+	const { requestLatestAtomicTransfer } = useDispatch( SITE_STORE );
+	const site = useSite();
+
+	const siteId = site?.ID;
+
+	const { getSiteLatestAtomicTransfer, getSiteLatestAtomicTransferError } = useSelect( ( select ) =>
+		select( SITE_STORE )
+	);
+	const { getIntent } = useSelect( ( select ) => select( ONBOARD_STORE ) );
+
+	const handleTransferFailure = ( failureInfo: FailureInfo ) => {
+		recordTracksEvent( 'calypso_woocommerce_dashboard_snag_error', {
+			action: failureInfo.type,
+			site: site?.URL,
+			code: failureInfo.code,
+			error: failureInfo.error,
+			intent: getIntent(),
+		} );
+
+		logToLogstash( {
+			feature: 'calypso_client',
+			message: failureInfo.error,
+			severity: config( 'env_id' ) === 'production' ? 'error' : 'debug',
+			blog_id: siteId,
+			properties: {
+				env: config( 'env_id' ),
+				type: 'calypso_woocommerce_dashboard_snag_error',
+				action: failureInfo.type,
+				site: site?.URL,
+				code: failureInfo.code,
+			},
+		} );
+	};
+
+	useEffect( () => {
+		if ( ! siteId ) {
+			return;
+		}
+
+		setPendingAction( async () => {
+			setProgress( 0 );
+
+			const startTime = new Date().getTime();
+			const totalTimeout = 1000 * 300;
+			const maxFinishTime = startTime + totalTimeout;
+
+			// Poll for transfer status
+			let stopPollingTransfer = false;
+
+			while ( ! stopPollingTransfer ) {
+				await wait( 3000 );
+				await requestLatestAtomicTransfer( siteId );
+				const transfer = getSiteLatestAtomicTransfer( siteId );
+				const transferError = getSiteLatestAtomicTransferError( siteId );
+				const transferStatus = transfer?.status;
+				const isTransferringStatusFailed = transferError && transferError?.status >= 500;
+
+				switch ( transferStatus ) {
+					case transferStates.PENDING:
+						setProgress( 0.2 );
+						break;
+					case transferStates.ACTIVE:
+						setProgress( 0.4 );
+						break;
+					case transferStates.PROVISIONED:
+						setProgress( 0.5 );
+						break;
+					case transferStates.COMPLETED:
+						setProgress( 0.7 );
+						break;
+				}
+
+				if ( isTransferringStatusFailed || transferStatus === transferStates.ERROR ) {
+					handleTransferFailure( {
+						type: 'transfer',
+						error: transferError?.message || '',
+						code: transferError?.code || '',
+					} );
+					throw new Error( 'transfer error' );
+				}
+
+				if ( maxFinishTime < new Date().getTime() ) {
+					handleTransferFailure( {
+						type: 'transfer_timeout',
+						error: 'transfer took too long',
+						code: 'transfer_timeout',
+					} );
+					throw new Error( 'transfer timeout' );
+				}
+
+				stopPollingTransfer = transferStatus === transferStates.COMPLETED;
+			}
+
+			setProgress( 1 );
+
+			return { finishedWaitingForAtomic: true };
+		} );
+
+		submit?.();
+
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ siteId ] );
+
+	return null;
+};
+
+export default WaitForAtomic;

--- a/client/landing/stepper/declarative-flow/tailored-ecommerce-flow.ts
+++ b/client/landing/stepper/declarative-flow/tailored-ecommerce-flow.ts
@@ -1,13 +1,22 @@
+import { PLAN_ECOMMERCE, PLAN_ECOMMERCE_MONTHLY } from '@automattic/calypso-products';
 import { useLocale } from '@automattic/i18n-utils';
 import { useFlowProgress, ECOMMERCE_FLOW } from '@automattic/onboarding';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useEffect } from 'react';
 import { recordFullStoryEvent } from 'calypso/lib/analytics/fullstory';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import {
+	setSignupCompleteSlug,
+	persistSignupDestination,
+	setSignupCompleteFlowName,
+} from 'calypso/signup/storageUtils';
+import { useSite } from '../hooks/use-site';
+import { useSiteSlugParam } from '../hooks/use-site-slug-param';
 import { USER_STORE, ONBOARD_STORE } from '../stores';
 import { recordSubmitStep } from './internals/analytics/record-submit-step';
 import type { StepPath } from './internals/steps-repository';
 import type { Flow, ProvidedDependencies } from './internals/types';
+import type { SiteDetailsPlan } from '@automattic/data-stores';
 
 export const ecommerceFlowRecurTypes = {
 	YEARLY: 'yearly',
@@ -22,16 +31,35 @@ export const ecommerceFlow: Flow = {
 			recordFullStoryEvent( 'calypso_signup_start_ecommerce', { flow: this.name } );
 		}, [] );
 
-		return [ 'intro', 'storeProfiler', 'designCarousel', 'processing' ] as StepPath[];
+		return [
+			'intro',
+			'storeProfiler',
+			'domains',
+			'designCarousel',
+			'siteCreationStep',
+			'processing',
+			'waitForAtomic',
+			'setThemeStep',
+			'checkPlan',
+		] as StepPath[];
 	},
 
 	useStepNavigation( _currentStepName, navigate ) {
 		const flowName = this.name;
-		const { setStepProgress } = useDispatch( ONBOARD_STORE );
+		const { setStepProgress, setPlanCartItem, resetOnboardStore } = useDispatch( ONBOARD_STORE );
 		const flowProgress = useFlowProgress( { stepName: _currentStepName, flowName } );
 		setStepProgress( flowProgress );
 		const userIsLoggedIn = useSelect( ( select ) => select( USER_STORE ).isCurrentUserLoggedIn() );
+		const { selectedDesign, recurType } = useSelect( ( select ) => ( {
+			selectedDesign: select( ONBOARD_STORE ).getSelectedDesign(),
+			recurType: select( ONBOARD_STORE ).getEcommerceFlowRecurType(),
+		} ) );
+		const selectedPlan =
+			recurType === ecommerceFlowRecurTypes.YEARLY ? PLAN_ECOMMERCE : PLAN_ECOMMERCE_MONTHLY;
+
 		const locale = useLocale();
+		const siteSlugParam = useSiteSlugParam();
+		const site = useSite();
 
 		const getStartUrl = () => {
 			return locale && locale !== 'en'
@@ -42,8 +70,54 @@ export const ecommerceFlow: Flow = {
 		function submit( providedDependencies: ProvidedDependencies = {} ) {
 			recordSubmitStep( providedDependencies, '', flowName, _currentStepName );
 			const logInUrl = getStartUrl();
+			const siteSlug = ( providedDependencies?.siteSlug as string ) || siteSlugParam || '';
 
 			switch ( _currentStepName ) {
+				case 'domains':
+					recordTracksEvent( 'calypso_signup_plan_select', {
+						product_slug: selectedPlan,
+						from_section: 'default',
+					} );
+
+					setPlanCartItem( { product_slug: selectedPlan } );
+					return navigate( 'siteCreationStep' );
+
+				case 'siteCreationStep':
+					return navigate( 'processing' );
+
+				case 'processing':
+					// Coming from setThemeStep
+					if ( providedDependencies?.selectedDesign ) {
+						resetOnboardStore();
+						return window.location.assign( `${ site?.URL }/wp-admin/admin.php?page=wc-admin` );
+					}
+
+					if ( providedDependencies?.finishedWaitingForAtomic ) {
+						return navigate( 'setThemeStep' );
+					}
+
+					if ( providedDependencies?.siteSlug ) {
+						const destination = `/setup/${ flowName }/checkPlan?siteSlug=${ siteSlug }`;
+						persistSignupDestination( destination );
+						setSignupCompleteSlug( siteSlug );
+						setSignupCompleteFlowName( flowName );
+
+						// The site is coming from the checkout already Atomic (and with the new URL)
+						// There's probably a better way of handling this change
+						const returnUrl = encodeURIComponent(
+							`/setup/${ flowName }/checkPlan?theme=${
+								selectedDesign?.slug
+							}&siteSlug=${ siteSlug.replace( '.wordpress.com', '.wpcomstaging.com' ) }`
+						);
+
+						return window.location.assign(
+							`/checkout/${ encodeURIComponent(
+								( siteSlug as string ) ?? ''
+							) }?redirect_to=${ returnUrl }&signup=1`
+						);
+					}
+					return navigate( `checkPlan?siteSlug=${ siteSlug }` );
+
 				case 'intro':
 					if ( userIsLoggedIn ) {
 						return navigate( 'storeProfiler' );
@@ -52,10 +126,28 @@ export const ecommerceFlow: Flow = {
 
 				case 'storeProfiler':
 					return navigate( 'designCarousel' );
+
 				case 'designCarousel':
+					return navigate( 'domains' );
+
+				case 'setThemeStep':
 					return navigate( 'processing' );
-				case 'processing':
-					return navigate( 'intro' );
+
+				case 'waitForAtomic':
+					return navigate( 'processing' );
+
+				case 'checkPlan':
+					// eCommerce Plan
+					if (
+						[ PLAN_ECOMMERCE, PLAN_ECOMMERCE_MONTHLY ].includes(
+							( providedDependencies?.currentPlan as SiteDetailsPlan )?.product_slug
+						)
+					) {
+						return navigate( 'waitForAtomic' );
+					}
+
+					// Not eCommerce Plan
+					return window.location.assign( `/setup/site-setup/goals?siteSlug=${ siteSlug }` );
 			}
 			return providedDependencies;
 		}
@@ -67,7 +159,6 @@ export const ecommerceFlow: Flow = {
 				default:
 					return navigate( 'intro' );
 			}
-			return;
 		};
 
 		const goNext = () => {

--- a/client/landing/stepper/hooks/use-theme-param.ts
+++ b/client/landing/stepper/hooks/use-theme-param.ts
@@ -1,0 +1,5 @@
+import { useQuery } from './use-query';
+
+export function useThemeParam(): string | null {
+	return useQuery().get( 'theme' );
+}

--- a/packages/data-stores/src/site/actions.ts
+++ b/packages/data-stores/src/site/actions.ts
@@ -285,7 +285,7 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		yield saveSiteSettings( siteId, { blogdescription } );
 	}
 
-	function* installTheme( siteSlugOrId: string, themeSlug: string ) {
+	function* installTheme( siteSlugOrId: string | string, themeSlug: string ) {
 		yield wpcomRequest( {
 			path: `/sites/${ siteSlugOrId }/themes/${ themeSlug }/install`,
 			apiVersion: '1.1',

--- a/packages/onboarding/src/setup-tailored-site-after-creation.ts
+++ b/packages/onboarding/src/setup-tailored-site-after-creation.ts
@@ -36,7 +36,7 @@ interface SetupOnboardingSiteOptions {
 }
 
 export function setupSiteAfterCreation( { siteId, flowName }: SetupOnboardingSiteOptions ) {
-	const { resetOnboardStore } = dispatch( ONBOARD_STORE );
+	// const { resetOnboardStore } = dispatch( ONBOARD_STORE );
 	const { saveSiteSettings, setIntentOnSite, setStaticHomepageOnSite } = dispatch( SITE_STORE );
 	const selectedPatternContent = select( ONBOARD_STORE ).getPatternContent();
 	const siteTitle = select( ONBOARD_STORE ).getSelectedSiteTitle();
@@ -109,7 +109,12 @@ export function setupSiteAfterCreation( { siteId, flowName }: SetupOnboardingSit
 				has_site_title: !! siteTitle,
 				has_tagline: !! siteDescription,
 			} );
-			resetOnboardStore();
+			/**
+			 * We need to wait the site being created, then go to checkout and wait for the user
+			 * to buy the plan before we can set a premium theme to the site. If we reset the store
+			 * here we loose this information.
+			 **/
+			// resetOnboardStore();
 		} );
 	}
 }


### PR DESCRIPTION
#### Proposed Changes

* This PR build on top of https://github.com/Automattic/wp-calypso/pull/70289 to use Domains step on the new tailored eCommerce flow.


#### Testing Instructions
* Make sure the flag `signup/tailored-ecommerce` is enabled in your environment
* Access `/setup/ecommerce` and you'll be redirected to `/setup/ecommerce/intro`
![Kzuj86.png](https://user-images.githubusercontent.com/3801502/199599954-b3782d86-09e7-476d-8438-1deeb554b45a.png)
* Click create your store and you'll be redirected to `storeProfiler`
![hi6n1t.png](https://user-images.githubusercontent.com/3801502/199600105-22c535f9-40d2-4722-9125-1ab581bbdcf9.png)
* Click Continue and you'll be redirected to `designCarousel` step
![zjAGwD.png](https://user-images.githubusercontent.com/3801502/199600270-b58849e5-e9de-4f1f-91f0-9c1800953a02.png)
* Choose a theme and click Continue.


* Pick a domain
![jBqZvh.png](https://user-images.githubusercontent.com/3801502/199599045-9f548ac2-fc6c-47de-8114-d08ac694504e.png)

* You'll go to checkout
![fRQXUo.png](https://user-images.githubusercontent.com/3801502/199599545-785e4cc9-e768-4655-9a16-20770a943b46.png)
* After checkout, the site is gonna be set up 
![image](https://user-images.githubusercontent.com/3801502/201522232-03d3fdc0-2403-40fa-8f2e-1b0c93f8a8e0.png)

* You should be redirected to `/home/<new-site-slug>`. 
**The Site should have the plan/domain/theme you chose in the flow.**