### PR TITLE
remove tailored onboarding config check and config vars

### DIFF
--- a/client/landing/stepper/index.tsx
+++ b/client/landing/stepper/index.tsx
@@ -71,9 +71,7 @@ interface configurableFlows {
 const availableFlows: Array< configurableFlows > = [
 	{ flowName: 'newsletter', pathToFlow: newsletter },
 	{ flowName: 'import-focused', pathToFlow: importFlow },
-	config.isEnabled( 'videopress/tailored-onboarding' )
-		? { flowName: 'videopress', pathToFlow: videopress }
-		: null,
+	{ flowName: 'videopress', pathToFlow: videopress },
 	{ flowName: 'link-in-bio', pathToFlow: linkInBio },
 	{ flowName: 'podcasts', pathToFlow: podcasts },
 	{ flowName: 'link-in-bio-post-setup', pathToFlow: linkInBioPostSetup },

--- a/config/development.json
+++ b/config/development.json
@@ -178,7 +178,6 @@
 		"upgrades/upcoming-renewals-notices": true,
 		"upgrades/wpcom-monthly-plans": true,
 		"upsell/concierge-session": true,
-		"videopress/tailored-onboarding": true,
 		"woop": false,
 		"wordpress-action-search": false,
 		"wpcom-user-bootstrap": false

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -124,7 +124,6 @@
 		"upgrades/upcoming-renewals-notices": true,
 		"upgrades/wpcom-monthly-plans": true,
 		"use-translation-chunks": true,
-		"videopress/tailored-onboarding": true,
 		"woop": false,
 		"wordpress-action-search": false,
 		"wpcom-user-bootstrap": true

--- a/config/production.json
+++ b/config/production.json
@@ -143,7 +143,6 @@
 		"upgrades/wpcom-monthly-plans": true,
 		"upsell/concierge-session": true,
 		"use-translation-chunks": true,
-		"videopress/tailored-onboarding": false,
 		"woop": false,
 		"wordpress-action-search": false,
 		"wpcom-user-bootstrap": true

--- a/config/stage.json
+++ b/config/stage.json
@@ -140,7 +140,6 @@
 		"upgrades/wpcom-monthly-plans": true,
 		"upsell/concierge-session": true,
 		"use-translation-chunks": true,
-		"videopress/tailored-onboarding": true,
 		"woop": false,
 		"wordpress-action-search": false,
 		"wpcom-user-bootstrap": true

--- a/config/test.json
+++ b/config/test.json
@@ -98,7 +98,6 @@
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,
 		"upgrades/wpcom-monthly-plans": true,
-		"videopress/tailored-onboarding": false,
 		"wordpress-action-search": false,
 		"wpcom-user-bootstrap": false
 	}

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -148,7 +148,6 @@
 		"upgrades/wpcom-monthly-plans": true,
 		"upsell/concierge-session": true,
 		"use-translation-chunks": true,
-		"videopress/tailored-onboarding": true,
 		"woop": false,
 		"wordpress-action-search": false,
 		"wpcom-user-bootstrap": true


### PR DESCRIPTION
#### Proposed Changes

* Make the videopress tailored onboarding flow available from production for all users

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Since its always testing locally, just test the flow and it should work as expected
* Use Calypso Live link `/setup/videopress`

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
