### PR TITLE
Site Editor: handle dashboard navigation

### DIFF
--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -1065,6 +1065,25 @@ function handleInlineHelpButton( calypsoPort ) {
 }
 
 /**
+ * Handles the back to Dashboard link after the removal of the previously-used Portal in Gutenberg 14.5
+ *
+ * @param {MessagePort} calypsoPort Port used for communication with parent frame.
+ */
+function handleSiteEditorBackButton( calypsoPort ) {
+	// have to do this event delegation style because the Editor isn't fully initialized yet.
+	document.getElementById( 'wpwrap' ).addEventListener( 'click', ( event ) => {
+		const clickedElement = event.target;
+		if ( clickedElement.classList.contains( 'edit-site-navigation-panel__back-to-dashboard' ) ) {
+			event.preventDefault();
+			calypsoPort.postMessage( {
+				action: 'openLinkInParentFrame',
+				payload: { postUrl: clickedElement.href },
+			} );
+		}
+	} );
+}
+
+/**
  * If WelcomeTour is set to show, check if the App Banner is visible.
  * If App Banner is visible, we set the Welcome Tour to not show.
  * When the App Banner gets dismissed, we set the Welcome Tour to show.
@@ -1199,6 +1218,8 @@ function initPort( message ) {
 		handleInlineHelpButton( calypsoPort );
 
 		handleAppBannerShowing( calypsoPort );
+
+		handleSiteEditorBackButton( calypsoPort );
 	}
 
 	window.removeEventListener( 'message', initPort, false );


### PR DESCRIPTION
Gutenberg 14.5 has removed the slotfill we formerly used for the dashboard link override, instead introducing a `__experimentalDashboardLink` setting.

So we’re just hacking in an event listener.

#### Proposed Changes

* event listener for dashboard link in Site Editor

#### Testing Instructions

1. Sandbox `widgets.wp.com`
2. Use D93195-code on your sandbox (code from this PR)
3. Enter the Site Editor via Calypso
4. Open the side nav and click `< Dashboard`
5. You should be taken to `wordpress.com/home/YOUR_SITE_SLUG` rather than navigating inside the iframe

*

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
