### PR TITLE
Ecommerce Onboarding - Design tweaks

### DIFF
--- a/client/components/formatted-header/style.scss
+++ b/client/components/formatted-header/style.scss
@@ -67,6 +67,7 @@
 	color: var(--color-neutral-50);
 	font-size: $font-body-small;
 	padding: 0 20px 24px;
+	text-align: center !important;
 
 	@include breakpoint-deprecated( ">480px" ) {
 		padding: 0;
@@ -75,6 +76,13 @@
 	.is-left-align &,
 	.is-right-align & {
 		padding: 0;
+	}
+	.is-left-align & {
+		text-align: start !important;
+	}
+
+	.is-right-align & {
+		text-align: end !important;
 	}
 
 	.tailored-flow-subtitle__cta-text {
@@ -87,7 +95,6 @@
 // Compact header on small screens
 .formatted-header.is-compact-on-mobile {
 	@include breakpoint-deprecated( "<660px" ) {
-		text-align: start;
 
 		.formatted-header__title {
 			/* stylelint-disable-next-line declaration-property-unit-allowed-list */

--- a/client/components/formatted-header/style.scss
+++ b/client/components/formatted-header/style.scss
@@ -67,7 +67,6 @@
 	color: var(--color-neutral-50);
 	font-size: $font-body-small;
 	padding: 0 20px 24px;
-	text-align: center !important;
 
 	@include breakpoint-deprecated( ">480px" ) {
 		padding: 0;
@@ -76,13 +75,6 @@
 	.is-left-align &,
 	.is-right-align & {
 		padding: 0;
-	}
-	.is-left-align & {
-		text-align: start !important;
-	}
-
-	.is-right-align & {
-		text-align: end !important;
 	}
 
 	.tailored-flow-subtitle__cta-text {
@@ -95,6 +87,7 @@
 // Compact header on small screens
 .formatted-header.is-compact-on-mobile {
 	@include breakpoint-deprecated( "<660px" ) {
+		text-align: start;
 
 		.formatted-header__title {
 			/* stylelint-disable-next-line declaration-property-unit-allowed-list */

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-carousel/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-carousel/index.tsx
@@ -68,6 +68,9 @@ const DesignCarousel: Step = function DesignCarousel( { navigation } ) {
 				<FormattedHeader
 					id="seller-step-header"
 					headerText={ __( 'Choose a design to start' ) }
+					subHeaderText={ __(
+						"Don't worry, you can change or customize this at any time in the future."
+					) }
 					align="center"
 				/>
 			}

--- a/packages/design-carousel/src/styles.scss
+++ b/packages/design-carousel/src/styles.scss
@@ -5,6 +5,21 @@
 $patterns: "17-2", "black", "ella-d", "link-cloud", "matt-smith", "ose-maiko", "purple", "yellow", "biba",
 	"chloe-currie", "emily", "luis-carvelleda", "mesh-gradient", "paul-nyberg", "tengfai";
 
+.designCarousel.step-container .step-container__header .formatted-header {
+	text-align: center;
+	.formatted-header__subtitle {
+		text-align: center;
+	}
+	&.is-left-align,
+	&.is-left-align .formatted-header__subtitle {
+		text-align: start;
+	}
+	&.is-right-align,
+	&.is-right-align .formatted-header__subtitle {
+		text-align: end;
+	}
+}
+
 .design-carousel__item {
 	flex: 1;
 

--- a/packages/design-carousel/src/styles.scss
+++ b/packages/design-carousel/src/styles.scss
@@ -33,7 +33,7 @@ $patterns: "17-2", "black", "ella-d", "link-cloud", "matt-smith", "ose-maiko", "
 	box-shadow: 2px 2px 10px 0 rgb(66 68 90 / 23%);
 	transition: transform 0.4s ease-in-out, opacity 0.3s ease-in-out;
 	border: 0.6vh solid #fff;
-	margin: 20px 0;
+	margin: 0 0 32px;
 	cursor: pointer;
 	padding: 0;
 	overflow: hidden;
@@ -161,7 +161,7 @@ $patterns: "17-2", "black", "ella-d", "link-cloud", "matt-smith", "ose-maiko", "
 
 .design-carousel__cta {
 	text-align: center;
-	margin: 10px 20px;
+	margin: 0 20px;
 
 	button {
 		display: inline-flex;

--- a/packages/onboarding/src/step-container/style.scss
+++ b/packages/onboarding/src/step-container/style.scss
@@ -71,7 +71,7 @@
 	 *	Header
 	 */
 	.step-container__header {
-		margin-bottom: 40px;
+		margin-bottom: 32px;
 		margin-top: 0;
 		display: block;
 		justify-content: space-between;


### PR DESCRIPTION
#### Proposed Changes

* This PR addresses two issues noted by @SaxonF in his comments on pdtkmj-LF-p2

```
Similar to what’s been proposed for Videopress, could we add a secondary paragraph to alleviate any “locked in” fears.
...
Spacing between the page header (title, sub header) , the carousel, and the continue button should be consistent (32px).
```

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this PR to local Calypso.
* Navigate to the design picker step of the ecommerce onboarding flow.
* Verify that the screen now has a subtitle and the header, carousel, and button are spaced appropriately.

<img width="1201" alt="image" src="https://user-images.githubusercontent.com/13437011/203414894-0e05d1bb-78ec-462c-ac5b-73cc5d18b63a.png">


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to pdtkmj-LF-p2#comment-1193