### PR TITLE
VideoPress Onboarding: More style changes

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-domain/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-domain/index.tsx
@@ -100,7 +100,7 @@ const ChooseADomain: Step = function ChooseADomain( { navigation, flow } ) {
 				headerText="Choose a domain"
 				subHeaderText={
 					<>
-						{ __( 'Make your video site shine with a custom domain. Not sure yet ?' ) }
+						{ __( 'Make your video site shine with a custom domain. Not sure yet?' ) }
 						<button
 							className="button navigation-link step-container__navigation-link has-underline is-borderless"
 							onClick={ onSkip }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-domain/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-domain/style.scss
@@ -206,6 +206,12 @@ $videopress-background: #010101;
 				color: #000;
 			}
 		}
+
+		.domain-registration-suggestion__match-reasons {
+			svg.gridicon {
+				fill: var(--color-text-subtle);
+			}
+		}
 	}
 
 	.register-domain-step__next-page {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-plan/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-plan/index.tsx
@@ -184,9 +184,10 @@ const ChooseAPlan: Step = function ChooseAPlan( { navigation, flow } ) {
 		const getVideoPressFeaturesList = ( plan: Plans.Plan ) => {
 			/* translators: A label displaying the amount of storage space available in the plan, eg: "13GB" or "200GB" */
 			const storageString = plan.storage ? sprintf( __( '%s storage space' ), plan.storage ) : null;
+			const uploadVideosString = __( 'Upload videos' );
 
-			const filterStorageString = ( feature: PlanSimplifiedFeature ) =>
-				storageString !== feature.name;
+			const filterDuplicateFeatures = ( feature: PlanSimplifiedFeature ) =>
+				! [ storageString, uploadVideosString ].includes( feature.name );
 
 			return [
 				null !== storageString && {
@@ -199,7 +200,7 @@ const ChooseAPlan: Step = function ChooseAPlan( { navigation, flow } ) {
 				{ name: __( 'Background videos' ), requiresAnnuallyBilledPlan: false },
 				{ name: __( 'Private videos' ), requiresAnnuallyBilledPlan: false },
 				{ name: __( 'Adaptive video streaming' ), requiresAnnuallyBilledPlan: false },
-				...( plan.features.filter( filterStorageString ) ?? [] ),
+				...( plan.features.filter( filterDuplicateFeatures ) ?? [] ),
 			].filter( isValueTruthy );
 		};
 

--- a/client/landing/stepper/declarative-flow/internals/videopress.scss
+++ b/client/landing/stepper/declarative-flow/internals/videopress.scss
@@ -171,6 +171,12 @@ body.is-videopress-stepper {
 			gap: 10px;
 		}
 
+		.launchpad__task:nth-last-child(2) {
+			.launchpad__checklist-item {
+				border-bottom: none;
+			}
+		}
+
 		.launchpad__checklist-item {
 			color: $videopress-theme-base-text-color;
 			border-bottom: 1px solid rgba(255, 255, 255, 0.2);
@@ -179,10 +185,6 @@ body.is-videopress-stepper {
 				color: $videopress-theme-yellow;
 				fill: $videopress-theme-yellow;
 				border-color: #474747;
-			}
-
-			&:last-of-type {
-				border-bottom: none;
 			}
 		}
 

--- a/client/landing/stepper/declarative-flow/internals/videopress.scss
+++ b/client/landing/stepper/declarative-flow/internals/videopress.scss
@@ -220,6 +220,11 @@ body.is-videopress-stepper {
 			}
 		}
 
+		.launchpad__task.pending .launchpad__checklist-item-chevron {
+			color: #fff;
+			fill: #fff;
+		}
+
 		.launchpad__task.completed:hover,
 		.launchpad__task.pending:hover .launchpad__checklist-item-text,
 		.launchpad__task.completed > a:focus .launchpad__checklist-item-text,

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -489,7 +489,7 @@ export class UserStep extends Component {
 				flowName={ this.props.flowName }
 				stepName={ this.props.stepName }
 				positionInFlow={ this.props.positionInFlow }
-				headerText={ this.props.translate( "Let's get you signed up" ) }
+				headerText={ this.props.translate( 'Let’s get you signed up' ) }
 				subHeaderText={ this.getSubHeaderText() }
 				stepIndicator={ this.props.translate( 'Step %(currentStep)s of %(totalSteps)s', {
 					args: {

--- a/client/signup/videopress-step-wrapper/style.scss
+++ b/client/signup/videopress-step-wrapper/style.scss
@@ -319,10 +319,10 @@
 	@extend %videopress-form-button;
 	background: var(--videopress-color-background-button);
 	color: #070707;
-	border-radius: 0;
+	border-radius: 2px;
 
 	&:hover {
-		color: #070707;
+		color: #070707 !important;
 	}
 }
 


### PR DESCRIPTION
#### Proposed Changes

* various style changes for the VideoPress tailored onboarding flow:
1. On user account creation
    - round the corners of the yellow button and remove the white text on hover.
    - Add the cute curly apostrophe to "Let's get started"
2. Domain checkout
    - Make the domain checkmark icon white
    - There's a space in the text "Not sure yet ?"
3. Plans
    - removed redundant `Upload videos` feature (its implied)
4. Launchpad
    - show the white arrow caret next to "Upload your first video"
    - Show divider between the launchpad items

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go through the full onboarding flow including new account creation at `/setup/videopress`
* look for the items mentioned above in the Proposed Changes

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/greenhouse/issues/1402
