### PR TITLE
Fix GDPR banner styling issue

### DIFF
--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -310,6 +310,15 @@
 		padding-left: 0;
 		padding-right: 0;
 		background-color: initial;
+		&.gdpr-banner {
+			background-color: var(--color-neutral-70);
+			padding-left: 24px;
+			padding-right: 24px;
+			.gdpr-banner__buttons button {
+				border: none;
+				background-color: #fff;
+			}
+		}
 	}
 
 	.magic-login {


### PR DESCRIPTION
#### Proposed Changes

This PR fixes the styling issue with GDPR banner on the new Woo login page

#### Testing Instructions

1. Open `config/development.json` and change `gdpr-banner` to true.
2. Run `yarn start` as usual.
3. Clear cookies.
4. Visit http://calypso.localhost:3000/start/wpcc/oauth2-user?ref=oauth2&oauth2_redirect=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%2F%3Fresponse_type%3Dcode%26client_id%3D50916%26state%3D1c95307c7b05686e63d0ea211438e82c11815a6dc8be0a0f7eeab75e68db46f5%26redirect_uri%3Dhttps%253A%252F%252Fwoocommerce.com%252Fwc-api%252Fwpcom-signin%253Fnext%253Dmy-dashboard%26blog_id%3D0%26wpcom_connect%3D1%26authorize%3D1%26wccom-from%26calypso_env%3Dproduction%26jetpack-code%26jetpack-user-id%3D0%26action%3Doauth2-login&oauth2_client_id=50916
5. Confirm GDPR banner shows up as expected 

#### Screenshot
![Screen Shot 2022-11-22 at 2 29 20 PM](https://user-images.githubusercontent.com/4723145/203436574-b6c6dc0e-8f36-482e-af18-8dfeb85cead6.jpg)



#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/70306
