### PR TITLE
VideoPress Tailored Onboarding: Fix dark progress bar on intro view (Try #2!)

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/intro/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/intro/styles.scss
@@ -100,10 +100,6 @@
 			background-color: #ffe61c;
 			color: #000;
 		}
-
-		.flow-progress {
-			background: #0003;
-		}
 	}
 
 	min-height: 100%;

--- a/client/landing/stepper/declarative-flow/internals/videopress.scss
+++ b/client/landing/stepper/declarative-flow/internals/videopress.scss
@@ -44,6 +44,10 @@ body.is-videopress-stepper {
 			}
 		}
 
+		&.intro .flow-progress {
+			background: #0003;
+		}
+
 		.signup-header {
 			padding: 24px;
 


### PR DESCRIPTION
Adds the dark progress bar styling on intro of VideoPress onboarding flow. A better solution instead of #70263 which needed to be reverted because it removed styling for the other onboarding flows like `link-in-bio`.

#### Proposed Changes

* Targets the progress bar when in the intro view with the `intro` class applied.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* View `setup/videopress`. You should see the dark progress bar at the top:

<img width="201" alt="Screenshot 2022-11-22 at 3 43 58 PM" src="https://user-images.githubusercontent.com/789137/203437134-6c199288-b337-431d-b108-04cd062d5ddb.png">

* View `setup/newsletter` and `setup/link-in-bio` and verify they still look as expected.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
