### PR TITLE
Gifting: Update gift label on checkout

### DIFF
--- a/packages/wpcom-checkout/package.json
+++ b/packages/wpcom-checkout/package.json
@@ -41,6 +41,7 @@
 		"@automattic/shopping-cart": "workspace:^",
 		"@emotion/styled": "^11.3.0",
 		"@stripe/stripe-js": "^1.17.1",
+		"@wordpress/compose": "^5.7.0",
 		"@wordpress/data": "^6.9.0",
 		"@wordpress/i18n": "^4.9.0",
 		"@wordpress/react-i18n": "^3.7.0",

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -25,6 +25,7 @@ import {
 } from '@automattic/composite-checkout';
 import formatCurrency from '@automattic/format-currency';
 import styled from '@emotion/styled';
+import { useViewportMatch } from '@wordpress/compose';
 import { useTranslate } from 'i18n-calypso';
 import { useState, PropsWithChildren } from 'react';
 import { getLabel, getSublabel } from './checkout-labels';
@@ -103,7 +104,9 @@ export const CouponLineItem = styled( WPCouponLineItem )< {
 `;
 
 const GiftBadgeWrapper = styled.span`
-	width: 100%;
+	@media ( max-width: 660px ) {
+		width: 100%;
+	}
 `;
 
 const GiftBadge = styled.span`
@@ -871,6 +874,7 @@ function WPLineItem( {
 } > ) {
 	const id = product.uuid;
 	const translate = useTranslate();
+	const isMobile = useViewportMatch( 'small', '<' );
 	const hasBundledDomainsInCart = responseCart.products.some(
 		( product ) =>
 			( product.is_domain_registration || product.product_slug === 'domain_transfer' ) &&
@@ -916,6 +920,12 @@ function WPLineItem( {
 		products: [ product ],
 	} );
 
+	const giftBadgeElement = (
+		<GiftBadgeWrapper>
+			<GiftBadge>{ translate( 'Gift' ) }</GiftBadge>
+		</GiftBadgeWrapper>
+	);
+
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	return (
 		<div
@@ -923,13 +933,10 @@ function WPLineItem( {
 			data-e2e-product-slug={ productSlug }
 			data-product-type={ isPlan( product ) ? 'plan' : product.product_slug }
 		>
-			{ responseCart.is_gift_purchase && (
-				<GiftBadgeWrapper>
-					<GiftBadge>{ translate( 'Gift' ) }</GiftBadge>
-				</GiftBadgeWrapper>
-			) }
+			{ isMobile && responseCart.is_gift_purchase && giftBadgeElement }
 			<LineItemTitle id={ itemSpanId } isSummary={ isSummary }>
 				{ label }
+				{ ! isMobile && responseCart.is_gift_purchase && giftBadgeElement }
 			</LineItemTitle>
 			<span aria-labelledby={ itemSpanId } className="checkout-line-item__price">
 				<LineItemPrice

--- a/yarn.lock
+++ b/yarn.lock
@@ -1701,6 +1701,7 @@ __metadata:
     "@stripe/stripe-js": ^1.17.1
     "@testing-library/jest-dom": ^5.16.2
     "@testing-library/react": ^12.1.3
+    "@wordpress/compose": ^5.7.0
     "@wordpress/data": ^6.9.0
     "@wordpress/i18n": ^4.9.0
     "@wordpress/react-i18n": ^3.7.0


### PR DESCRIPTION
#### Proposed Changes

Show Gift label inline with the product on checkout for desktop and keep it before the product for mobile.

#### Screenshot
| Desktop | Mobile |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/402286/203439065-debb1dc7-303a-454e-994b-4eebc0c99721.png) | ![image](https://user-images.githubusercontent.com/402286/203439080-d7530a62-0471-4b61-9dbd-8ed08219e2a5.png) |

#### Testing Instructions

1. In a site with Gifting enabled (and showing the banner)
2. Using other site, go to this site and click on the banner.
3. Verify that the Gift badge appears as in the screenshot.

#### Pre-merge Checklist

- [ ] ~~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~~
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~~
- [ ] ~~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~~
- [ ] ~~For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~~

Fixed https://github.com/Automattic/dotcom-forge/issues/1230