### PR TITLE
Plugin Details: Add "Premium versions available" USP

### DIFF
--- a/client/my-sites/plugins/plugin-details-sidebar-usp/index.jsx
+++ b/client/my-sites/plugins/plugin-details-sidebar-usp/index.jsx
@@ -53,7 +53,7 @@ const Title = styled.div`
 	${ ( props ) => ! props.showAsAccordion && 'margin-bottom: 8px;' };
 `;
 const Description = styled.div`
-	color: var( --studio-gray-60 );
+	color: var( --studio-gray-80 );
 	margin-bottom: 12px;
 	font-size: 14px;
 `;

--- a/client/my-sites/plugins/plugin-details-sidebar/index.jsx
+++ b/client/my-sites/plugins/plugin-details-sidebar/index.jsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import {
 	isFreePlanProduct,
 	FEATURE_INSTALL_PLUGINS,
@@ -61,8 +62,29 @@ const PluginDetailsSidebar = ( {
 			label: translate( 'View documentation' ),
 		} );
 
+	/**
+	 * TODO: Update the isPremiumVersionAvailable check and the premiumVersionLink property
+	 * to read from plugins data
+	 */
+	const isPremiumVersionAvailable = config.isEnabled( 'plugins/premium-version-available' );
+	const premiumVersionLink = 'https://WP.com';
+
 	return (
 		<div className="plugin-details-sidebar__plugin-details-content">
+			{ isPremiumVersionAvailable && (
+				<PluginDetailsSidebarUSP
+					id="demo"
+					title={ translate( 'Premium version available' ) }
+					description={ translate(
+						'This plugin has a premium version that might suit your needs better.'
+					) }
+					links={ [
+						{ href: premiumVersionLink, label: translate( 'Check out the premium version' ) },
+					] }
+					first
+				/>
+			) }
+
 			{ isWooCommercePluginRequired && (
 				<PluginDetailsSidebarUSP
 					id="woo"
@@ -75,7 +97,7 @@ const PluginDetailsSidebar = ( {
 							},
 						}
 					) }
-					first
+					first={ ! isPremiumVersionAvailable }
 				/>
 			) }
 


### PR DESCRIPTION
#### Proposed Changes

* Add a USP section for plugins with a premium version available
* Update the USP description color to gray-80

PS: This is a WIP and it's behind a feature flag, while the information about a premium version available is not retrieved by the backend.

#### Testing Instructions
* Go to a plugin details page. Ex: `/plugins/woocommerce/{site}`
* Check if the sidebar warns about a premium version available 
* Enable the feature flag `plugins/premium-version-available`. You can enable it by adding `?flags=+plugins/premium-version-available` to the end of the URL
* Check if the USP is displayed as below

| Before  | After |
| ------------- | ------------- |
|<img width="386" alt="Screen Shot 2022-11-22 at 19 48 27" src="https://user-images.githubusercontent.com/5039531/203443788-00fe5c49-7cf1-4f18-a9c5-0f8b0ff8d0b3.png">|<img width="386" alt="Screen Shot 2022-11-22 at 19 48 53" src="https://user-images.githubusercontent.com/5039531/203443842-8f514443-4bc5-4bf8-aa08-f54f9206e882.png">|



---

Related to #60769 
