### PR TITLE
Checkout: Use rearranged radio button variant picker

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/checkout-main.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-main.tsx
@@ -101,6 +101,7 @@ export default function CheckoutMain( {
 	jetpackPurchaseToken,
 	isUserComingFromLoginForm,
 	customizedPreviousPath,
+	forceRadioButtons,
 }: {
 	siteSlug: string | undefined;
 	siteId: number | undefined;
@@ -128,6 +129,9 @@ export default function CheckoutMain( {
 	jetpackPurchaseToken?: string;
 	isUserComingFromLoginForm?: boolean;
 	customizedPreviousPath?: string;
+	// TODO: This is just for unit tests. Remove forceRadioButtons everywhere
+	// when calypso_checkout_variant_picker_radio_2212 ExPlat test completes.
+	forceRadioButtons?: boolean;
 } ) {
 	const translate = useTranslate();
 	const isJetpackNotAtomic =
@@ -717,6 +721,7 @@ export default function CheckoutMain( {
 				initiallySelectedPaymentMethodId={ paymentMethods?.length ? paymentMethods[ 0 ].id : null }
 			>
 				<WPCheckout
+					forceRadioButtons={ forceRadioButtons }
 					customizedPreviousPath={ customizedPreviousPath }
 					isRemovingProductFromCart={ isRemovingProductFromCart }
 					areThereErrors={ areThereErrors }

--- a/client/my-sites/checkout/composite-checkout/components/checkout-sidebar-plan-upsell/index.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-sidebar-plan-upsell/index.tsx
@@ -17,7 +17,7 @@ import { useGetProductVariants } from '../../hooks/product-variants';
 import {
 	getItemVariantCompareToPrice,
 	getItemVariantDiscountPercentage,
-} from '../item-variation-picker/variant-price';
+} from '../item-variation-picker/util';
 
 import './style.scss';
 

--- a/client/my-sites/checkout/composite-checkout/components/item-variation-picker/index.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/item-variation-picker/index.tsx
@@ -1,8 +1,14 @@
 import { FunctionComponent } from 'react';
 import { ItemVariationDropDown } from './item-variation-dropdown';
+import { ItemVariationRadioButtons } from './item-variation-radio-buttons';
 import type { ItemVariationPickerProps } from './types';
 
-export const ItemVariationPicker: FunctionComponent< ItemVariationPickerProps > = ( props ) => {
+export const ItemVariationPicker: FunctionComponent<
+	ItemVariationPickerProps & { type: 'dropdown' | 'radio' }
+> = ( props ) => {
+	if ( props.type === 'radio' ) {
+		return <ItemVariationRadioButtons { ...props } />;
+	}
 	return <ItemVariationDropDown { ...props } />;
 };
 

--- a/client/my-sites/checkout/composite-checkout/components/item-variation-picker/item-variation-dropdown.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/item-variation-picker/item-variation-dropdown.tsx
@@ -3,7 +3,7 @@ import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import { FunctionComponent, useCallback, useEffect, useState } from 'react';
-import { ItemVariantPrice } from './variant-price';
+import { ItemVariantDropDownPrice } from './variant-dropdown-price';
 import type { ItemVariationPickerProps, WPCOMProductVariant } from './types';
 import type { ResponseCartProduct } from '@automattic/shopping-cart';
 
@@ -197,7 +197,7 @@ export const ItemVariationDropDown: FunctionComponent< ItemVariationPickerProps 
 				role="button"
 			>
 				{ selectedVariantIndex !== null ? (
-					<ItemVariantPrice variant={ variants[ selectedVariantIndex ] } />
+					<ItemVariantDropDownPrice variant={ variants[ selectedVariantIndex ] } />
 				) : (
 					<span>{ translate( 'Pick a product term' ) }</span>
 				) }
@@ -266,7 +266,7 @@ function ItemVariantOption( {
 			onClick={ onSelect }
 			selected={ isSelected }
 		>
-			<ItemVariantPrice variant={ variant } compareTo={ compareTo } />
+			<ItemVariantDropDownPrice variant={ variant } compareTo={ compareTo } />
 		</Option>
 	);
 }

--- a/client/my-sites/checkout/composite-checkout/components/item-variation-picker/item-variation-radio-buttons.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/item-variation-picker/item-variation-radio-buttons.tsx
@@ -1,10 +1,10 @@
 import { RadioButton } from '@automattic/composite-checkout';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
-import { FunctionComponent } from 'react';
 import { ItemVariantRadioPrice } from './variant-radio-price';
 import type { ItemVariationPickerProps, WPCOMProductVariant, OnChangeItemVariant } from './types';
 import type { ResponseCartProduct } from '@automattic/shopping-cart';
+import type { FunctionComponent } from 'react';
 
 const TermOptions = styled.ul`
 	flex-basis: 100%;
@@ -23,6 +23,7 @@ const TermOptionsItem = styled.li`
 `;
 
 interface ProductVariantProps {
+	radioButtonGroup: string;
 	productVariant: WPCOMProductVariant;
 	selectedItem: ResponseCartProduct;
 	onChangeItemVariant: OnChangeItemVariant;
@@ -31,13 +32,13 @@ interface ProductVariantProps {
 }
 
 const ProductVariant: FunctionComponent< ProductVariantProps > = ( {
+	radioButtonGroup,
 	productVariant,
 	selectedItem,
 	onChangeItemVariant,
 	isDisabled,
 	compareTo,
 } ) => {
-	const translate = useTranslate();
 	const { variantLabel, productSlug, productId } = productVariant;
 	const selectedProductSlug = selectedItem.product_slug;
 	const isChecked = productSlug === selectedProductSlug;
@@ -45,7 +46,7 @@ const ProductVariant: FunctionComponent< ProductVariantProps > = ( {
 	return (
 		<TermOptionsItem>
 			<RadioButton
-				name={ productSlug + variantLabel }
+				name={ radioButtonGroup }
 				id={ productSlug + variantLabel }
 				value={ productSlug }
 				checked={ isChecked }
@@ -53,9 +54,8 @@ const ProductVariant: FunctionComponent< ProductVariantProps > = ( {
 				onChange={ () => {
 					! isDisabled && onChangeItemVariant( selectedItem.uuid, productSlug, productId );
 				} }
-				ariaLabel={ translate( 'Select a different term length' ) as string }
+				ariaLabel={ variantLabel }
 				label={ <ItemVariantRadioPrice variant={ productVariant } compareTo={ compareTo } /> }
-				children={ [] }
 			/>
 		</TermOptionsItem>
 	);
@@ -67,6 +67,7 @@ export const ItemVariationRadioButtons: FunctionComponent< ItemVariationPickerPr
 	isDisabled,
 	variants,
 } ) => {
+	const translate = useTranslate();
 	if ( variants.length < 2 ) {
 		return null;
 	}
@@ -74,9 +75,14 @@ export const ItemVariationRadioButtons: FunctionComponent< ItemVariationPickerPr
 	const compareTo = variants[ 0 ];
 
 	return (
-		<TermOptions className="item-variation-picker">
+		<TermOptions
+			role="radiogroup"
+			aria-label={ translate( 'Pick a product term' ) }
+			className="item-variation-picker"
+		>
 			{ variants.map( ( productVariant: WPCOMProductVariant ) => (
 				<ProductVariant
+					radioButtonGroup={ `item-variation-picker ${ selectedItem.product_name } ${ selectedItem.uuid }` }
 					key={ productVariant.productSlug + productVariant.variantLabel }
 					selectedItem={ selectedItem }
 					onChangeItemVariant={ onChangeItemVariant }

--- a/client/my-sites/checkout/composite-checkout/components/item-variation-picker/item-variation-radio-buttons.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/item-variation-picker/item-variation-radio-buttons.tsx
@@ -49,6 +49,7 @@ const ProductVariant: FunctionComponent< ProductVariantProps > = ( {
 				name={ radioButtonGroup }
 				id={ productSlug + variantLabel }
 				value={ productSlug }
+				data-product-slug={ productSlug }
 				checked={ isChecked }
 				disabled={ isDisabled }
 				onChange={ () => {

--- a/client/my-sites/checkout/composite-checkout/components/item-variation-picker/item-variation-radio-buttons.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/item-variation-picker/item-variation-radio-buttons.tsx
@@ -1,0 +1,90 @@
+import { RadioButton } from '@automattic/composite-checkout';
+import styled from '@emotion/styled';
+import { useTranslate } from 'i18n-calypso';
+import { FunctionComponent } from 'react';
+import { ItemVariantPrice } from './variant-price';
+import type { ItemVariationPickerProps, WPCOMProductVariant, OnChangeItemVariant } from './types';
+import type { ResponseCartProduct } from '@automattic/shopping-cart';
+
+const TermOptions = styled.ul`
+	flex-basis: 100%;
+	margin: 20px 0 0;
+	padding: 0;
+`;
+
+const TermOptionsItem = styled.li`
+	margin: 8px 0 0;
+	padding: 0;
+	list-style: none;
+
+	:first-of-type {
+		margin-top: 0;
+	}
+`;
+
+interface ProductVariantProps {
+	productVariant: WPCOMProductVariant;
+	selectedItem: ResponseCartProduct;
+	onChangeItemVariant: OnChangeItemVariant;
+	isDisabled: boolean;
+	compareTo?: WPCOMProductVariant;
+}
+
+const ProductVariant: FunctionComponent< ProductVariantProps > = ( {
+	productVariant,
+	selectedItem,
+	onChangeItemVariant,
+	isDisabled,
+	compareTo,
+} ) => {
+	const translate = useTranslate();
+	const { variantLabel, productSlug, productId } = productVariant;
+	const selectedProductSlug = selectedItem.product_slug;
+	const isChecked = productSlug === selectedProductSlug;
+
+	return (
+		<TermOptionsItem>
+			<RadioButton
+				name={ productSlug + variantLabel }
+				id={ productSlug + variantLabel }
+				value={ productSlug }
+				checked={ isChecked }
+				disabled={ isDisabled }
+				onChange={ () => {
+					! isDisabled && onChangeItemVariant( selectedItem.uuid, productSlug, productId );
+				} }
+				ariaLabel={ translate( 'Select a different term length' ) as string }
+				label={ <ItemVariantPrice variant={ productVariant } compareTo={ compareTo } /> }
+				children={ [] }
+			/>
+		</TermOptionsItem>
+	);
+};
+
+export const ItemVariationRadioButtons: FunctionComponent< ItemVariationPickerProps > = ( {
+	selectedItem,
+	onChangeItemVariant,
+	isDisabled,
+	variants,
+} ) => {
+	if ( variants.length < 2 ) {
+		return null;
+	}
+
+	const compareTo = variants[ 0 ];
+
+	return (
+		<TermOptions className="item-variation-picker">
+			{ variants.map( ( productVariant: WPCOMProductVariant ) => (
+				<ProductVariant
+					key={ productVariant.productSlug + productVariant.variantLabel }
+					selectedItem={ selectedItem }
+					onChangeItemVariant={ onChangeItemVariant }
+					isDisabled={ isDisabled }
+					productVariant={ productVariant }
+					compareTo={ compareTo }
+				/>
+			) ) }
+		</TermOptions>
+	);
+};

--- a/client/my-sites/checkout/composite-checkout/components/item-variation-picker/item-variation-radio-buttons.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/item-variation-picker/item-variation-radio-buttons.tsx
@@ -2,7 +2,7 @@ import { RadioButton } from '@automattic/composite-checkout';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import { FunctionComponent } from 'react';
-import { ItemVariantPrice } from './variant-price';
+import { ItemVariantRadioPrice } from './variant-radio-price';
 import type { ItemVariationPickerProps, WPCOMProductVariant, OnChangeItemVariant } from './types';
 import type { ResponseCartProduct } from '@automattic/shopping-cart';
 
@@ -54,7 +54,7 @@ const ProductVariant: FunctionComponent< ProductVariantProps > = ( {
 					! isDisabled && onChangeItemVariant( selectedItem.uuid, productSlug, productId );
 				} }
 				ariaLabel={ translate( 'Select a different term length' ) as string }
-				label={ <ItemVariantPrice variant={ productVariant } compareTo={ compareTo } /> }
+				label={ <ItemVariantRadioPrice variant={ productVariant } compareTo={ compareTo } /> }
 				children={ [] }
 			/>
 		</TermOptionsItem>

--- a/client/my-sites/checkout/composite-checkout/components/item-variation-picker/item-variation-radio-buttons.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/item-variation-picker/item-variation-radio-buttons.tsx
@@ -55,7 +55,6 @@ const ProductVariant: FunctionComponent< ProductVariantProps > = ( {
 				onChange={ () => {
 					! isDisabled && onChangeItemVariant( selectedItem.uuid, productSlug, productId );
 				} }
-				ariaLabel={ variantLabel }
 				label={ <ItemVariantRadioPrice variant={ productVariant } compareTo={ compareTo } /> }
 			/>
 		</TermOptionsItem>

--- a/client/my-sites/checkout/composite-checkout/components/item-variation-picker/item-variation-radio-buttons.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/item-variation-picker/item-variation-radio-buttons.tsx
@@ -46,6 +46,7 @@ const ProductVariant: FunctionComponent< ProductVariantProps > = ( {
 	return (
 		<TermOptionsItem>
 			<RadioButton
+				isFixedHeight
 				name={ radioButtonGroup }
 				id={ productSlug + variantLabel }
 				value={ productSlug }

--- a/client/my-sites/checkout/composite-checkout/components/item-variation-picker/types.ts
+++ b/client/my-sites/checkout/composite-checkout/components/item-variation-picker/types.ts
@@ -5,6 +5,7 @@ export type WPCOMProductSlug = string;
 export type WPCOMProductVariant = {
 	price: number;
 	pricePerMonth: number;
+	pricePerYear: number;
 	termIntervalInMonths: number;
 	termIntervalInDays: number;
 	currency: string;

--- a/client/my-sites/checkout/composite-checkout/components/item-variation-picker/util.ts
+++ b/client/my-sites/checkout/composite-checkout/components/item-variation-picker/util.ts
@@ -1,0 +1,30 @@
+import type { WPCOMProductVariant } from './types';
+
+export function getItemVariantCompareToPrice(
+	variant: WPCOMProductVariant,
+	compareTo?: WPCOMProductVariant
+): number | undefined {
+	// This is the price that the compareTo variant would be if it was using the
+	// billing term of the variant. For example, if the price of the compareTo
+	// variant was 120 per year, and the variant we are displaying here is 5 per
+	// month, then `compareToPriceForVariantTerm` would be (120 / 12) * 1,
+	// or 10 (per month). In this case, selecting the variant would save the user
+	// 50% (5 / 10).
+	const compareToPriceForVariantTerm = compareTo
+		? compareTo.pricePerMonth * variant.termIntervalInMonths
+		: undefined;
+	return compareToPriceForVariantTerm;
+}
+
+export function getItemVariantDiscountPercentage(
+	variant: WPCOMProductVariant,
+	compareTo?: WPCOMProductVariant
+): number {
+	const compareToPriceForVariantTerm = getItemVariantCompareToPrice( variant, compareTo );
+	// Extremely low "discounts" are possible if the price of the longer term has been rounded
+	// if they cannot be rounded to at least a percentage point we should not show them.
+	const discountPercentage = compareToPriceForVariantTerm
+		? Math.floor( 100 - ( variant.price / compareToPriceForVariantTerm ) * 100 )
+		: 0;
+	return discountPercentage;
+}

--- a/client/my-sites/checkout/composite-checkout/components/item-variation-picker/variant-dropdown-price.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/item-variation-picker/variant-dropdown-price.tsx
@@ -1,0 +1,118 @@
+import formatCurrency from '@automattic/format-currency';
+import { useMobileBreakpoint } from '@automattic/viewport-react';
+import { styled } from '@automattic/wpcom-checkout';
+import { useTranslate } from 'i18n-calypso';
+import { FunctionComponent } from 'react';
+import { getItemVariantDiscountPercentage, getItemVariantCompareToPrice } from './util';
+import type { WPCOMProductVariant } from './types';
+
+const Discount = styled.span`
+	color: ${ ( props ) => props.theme.colors.discount };
+	margin-right: 8px;
+
+	.rtl & {
+		margin-right: 0;
+		margin-left: 8px;
+	}
+
+	.item-variant-option--selected & {
+		color: #b8e6bf;
+	}
+
+	@media ( max-width: 660px ) {
+		width: 100%;
+	}
+`;
+
+const DoNotPayThis = styled.del`
+	text-decoration: line-through;
+	margin-right: 8px;
+	color: #646970;
+
+	.rtl & {
+		margin-right: 0;
+		margin-left: 8px;
+	}
+
+	.item-variant-option--selected & {
+		color: #fff;
+	}
+`;
+
+const Price = styled.span`
+	color: #646970;
+
+	.item-variant-option--selected & {
+		color: #fff;
+	}
+`;
+
+const Variant = styled.div`
+	align-items: center;
+	display: flex;
+	font-size: 14px;
+	font-weight: 400;
+	justify-content: space-between;
+	line-height: 20px;
+	width: 100%;
+
+	.item-variant-option--selected & {
+		color: #fff;
+	}
+`;
+
+const Label = styled.span`
+	display: flex;
+	// MOBILE_BREAKPOINT is <480px, used in useMobileBreakpoint
+	@media ( max-width: 480px ) {
+		flex-direction: column;
+	}
+`;
+
+const DiscountPercentage: FunctionComponent< { percent: number } > = ( { percent } ) => {
+	const translate = useTranslate();
+	return (
+		<Discount>
+			{ translate( 'Save %(percent)s%%', {
+				args: {
+					percent,
+				},
+			} ) }
+		</Discount>
+	);
+};
+
+export const ItemVariantDropDownPrice: FunctionComponent< {
+	variant: WPCOMProductVariant;
+	compareTo?: WPCOMProductVariant;
+} > = ( { variant, compareTo } ) => {
+	const isMobile = useMobileBreakpoint();
+	const compareToPriceForVariantTerm = getItemVariantCompareToPrice( variant, compareTo );
+	const discountPercentage = getItemVariantDiscountPercentage( variant, compareTo );
+	const formattedCurrentPrice = formatCurrency( variant.price, variant.currency, {
+		stripZeros: true,
+	} );
+	const formattedCompareToPriceForVariantTerm = compareToPriceForVariantTerm
+		? formatCurrency( compareToPriceForVariantTerm, variant.currency, { stripZeros: true } )
+		: undefined;
+
+	return (
+		<Variant>
+			<Label>
+				{ variant.variantLabel }
+				{ discountPercentage > 0 && isMobile && (
+					<DiscountPercentage percent={ discountPercentage } />
+				) }
+			</Label>
+			<span>
+				{ discountPercentage > 0 && ! isMobile && (
+					<DiscountPercentage percent={ discountPercentage } />
+				) }
+				{ discountPercentage > 0 && (
+					<DoNotPayThis>{ formattedCompareToPriceForVariantTerm }</DoNotPayThis>
+				) }
+				<Price>{ formattedCurrentPrice }</Price>
+			</span>
+		</Variant>
+	);
+};

--- a/client/my-sites/checkout/composite-checkout/components/item-variation-picker/variant-price.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/item-variation-picker/variant-price.tsx
@@ -23,10 +23,6 @@ const Discount = styled.span`
 
 const Price = styled.span`
 	color: #646970;
-
-	.item-variant-option--selected & {
-		color: #fff;
-	}
 `;
 
 const Variant = styled.div`
@@ -37,10 +33,6 @@ const Variant = styled.div`
 	justify-content: space-between;
 	line-height: 20px;
 	width: 100%;
-
-	.item-variant-option--selected & {
-		color: #fff;
-	}
 `;
 
 const Label = styled.span`

--- a/client/my-sites/checkout/composite-checkout/components/item-variation-picker/variant-price.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/item-variation-picker/variant-price.tsx
@@ -5,16 +5,15 @@ import { FunctionComponent } from 'react';
 import type { WPCOMProductVariant } from './types';
 
 const Discount = styled.span`
-	color: ${ ( props ) => props.theme.colors.discount };
+	color: #234929;
 	display: block;
+	background-color: #b8e6bf;
+	padding: 0 1em;
+	border-radius: 4px;
 
 	.rtl & {
 		margin-right: 0;
 		margin-left: 8px;
-	}
-
-	.item-variant-option--selected & {
-		color: #b8e6bf;
 	}
 
 	@media ( max-width: 660px ) {

--- a/client/my-sites/checkout/composite-checkout/components/item-variation-picker/variant-price.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/item-variation-picker/variant-price.tsx
@@ -15,10 +15,6 @@ const Discount = styled.span`
 		margin-right: 0;
 		margin-left: 8px;
 	}
-
-	@media ( max-width: 660px ) {
-		width: 100%;
-	}
 `;
 
 const Price = styled.span`

--- a/client/my-sites/checkout/composite-checkout/components/item-variation-picker/variant-price.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/item-variation-picker/variant-price.tsx
@@ -82,7 +82,7 @@ const PriceArea = styled.span`
 	text-align: right;
 `;
 
-const PricePerTermText = styled.div`
+const SubText = styled.div`
 	font-size: small;
 	color: #777;
 `;
@@ -101,9 +101,9 @@ export const ItemVariantPrice: FunctionComponent< {
 	const pricePerYearFormatted = formatCurrency( pricePerYear, variant.currency, {
 		stripZeros: true,
 	} );
-	const perYearText = translate( '%(pricePerYear)s / year x 2', {
+	const subText = translate( 'Billed as one payment of %(totalPrice)s', {
 		args: {
-			pricePerYear: pricePerYearFormatted,
+			totalPrice: formattedCurrentPrice,
 		},
 	} );
 
@@ -111,12 +111,16 @@ export const ItemVariantPrice: FunctionComponent< {
 		<Variant>
 			<Label>
 				{ variant.variantLabel }
-				{ variant.termIntervalInMonths === 24 && (
-					<PricePerTermText>{ perYearText }</PricePerTermText>
-				) }
+				{ variant.termIntervalInMonths === 24 && <SubText>{ subText }</SubText> }
 			</Label>
 			<PriceArea>
-				<Price>{ formattedCurrentPrice }</Price>
+				<Price>
+					{ translate( '%(pricePerYear)s / year', {
+						args: {
+							pricePerYear: pricePerYearFormatted,
+						},
+					} ) }
+				</Price>
 				{ discountPercentage > 0 && <DiscountPercentage percent={ discountPercentage } /> }
 			</PriceArea>
 		</Variant>

--- a/client/my-sites/checkout/composite-checkout/components/item-variation-picker/variant-price.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/item-variation-picker/variant-price.tsx
@@ -97,8 +97,10 @@ export const ItemVariantPrice: FunctionComponent< {
 		stripZeros: true,
 	} );
 
-	const pricePerYear = variant.pricePerYear;
-	const pricePerYearFormatted = formatCurrency( pricePerYear, variant.currency, {
+	const pricePerYearFormatted = formatCurrency( variant.pricePerYear, variant.currency, {
+		stripZeros: true,
+	} );
+	const pricePerMonthFormatted = formatCurrency( variant.pricePerMonth, variant.currency, {
 		stripZeros: true,
 	} );
 	const subText = translate( 'Billed as one payment of %(totalPrice)s', {
@@ -107,6 +109,23 @@ export const ItemVariantPrice: FunctionComponent< {
 		},
 	} );
 
+	const shouldShowMonthlyPrice =
+		compareTo?.termIntervalInMonths === 1 || variant.termIntervalInMonths === 1;
+	const priceDisplay = ( () => {
+		if ( shouldShowMonthlyPrice ) {
+			return translate( '%(pricePerMonth)s / month', {
+				args: {
+					pricePerMonth: pricePerMonthFormatted,
+				},
+			} );
+		}
+		return translate( '%(pricePerYear)s / year', {
+			args: {
+				pricePerYear: pricePerYearFormatted,
+			},
+		} );
+	} )();
+
 	return (
 		<Variant>
 			<Label>
@@ -114,13 +133,7 @@ export const ItemVariantPrice: FunctionComponent< {
 				{ variant.termIntervalInMonths === 24 && <SubText>{ subText }</SubText> }
 			</Label>
 			<PriceArea>
-				<Price>
-					{ translate( '%(pricePerYear)s / year', {
-						args: {
-							pricePerYear: pricePerYearFormatted,
-						},
-					} ) }
-				</Price>
+				<Price>{ priceDisplay }</Price>
 				{ discountPercentage > 0 && <DiscountPercentage percent={ discountPercentage } /> }
 			</PriceArea>
 		</Variant>

--- a/client/my-sites/checkout/composite-checkout/components/item-variation-picker/variant-price.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/item-variation-picker/variant-price.tsx
@@ -62,10 +62,7 @@ const Variant = styled.div`
 
 const Label = styled.span`
 	display: flex;
-	// MOBILE_BREAKPOINT is <480px, used in useMobileBreakpoint
-	@media ( max-width: 480px ) {
-		flex-direction: column;
-	}
+	flex-direction: column;
 `;
 
 const DiscountPercentage: FunctionComponent< { percent: number } > = ( { percent } ) => {

--- a/client/my-sites/checkout/composite-checkout/components/item-variation-picker/variant-price.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/item-variation-picker/variant-price.tsx
@@ -22,7 +22,7 @@ const Discount = styled.span`
 `;
 
 const Price = styled.span`
-	color: #646970;
+	color: #000;
 `;
 
 const Variant = styled.div`

--- a/client/my-sites/checkout/composite-checkout/components/item-variation-picker/variant-radio-price.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/item-variation-picker/variant-radio-price.tsx
@@ -35,12 +35,14 @@ const Variant = styled.div`
 const VariantTermLabel = styled.span`
 	display: flex;
 	flex-direction: column;
+	gap: 2px;
 `;
 
 const PriceArea = styled.span`
 	text-align: right;
 	display: flex;
 	flex-direction: column;
+	gap: 2px;
 `;
 
 const DiscountPercentage: FunctionComponent< { percent: number } > = ( { percent } ) => {

--- a/client/my-sites/checkout/composite-checkout/components/item-variation-picker/variant-radio-price.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/item-variation-picker/variant-radio-price.tsx
@@ -2,6 +2,7 @@ import formatCurrency from '@automattic/format-currency';
 import { styled } from '@automattic/wpcom-checkout';
 import { useTranslate } from 'i18n-calypso';
 import { FunctionComponent } from 'react';
+import { getItemVariantDiscountPercentage } from './util';
 import type { WPCOMProductVariant } from './types';
 
 const Discount = styled.span`
@@ -49,35 +50,6 @@ const DiscountPercentage: FunctionComponent< { percent: number } > = ( { percent
 	);
 };
 
-export function getItemVariantCompareToPrice(
-	variant: WPCOMProductVariant,
-	compareTo?: WPCOMProductVariant
-): number | undefined {
-	// This is the price that the compareTo variant would be if it was using the
-	// billing term of the variant. For example, if the price of the compareTo
-	// variant was 120 per year, and the variant we are displaying here is 5 per
-	// month, then `compareToPriceForVariantTerm` would be (120 / 12) * 1,
-	// or 10 (per month). In this case, selecting the variant would save the user
-	// 50% (5 / 10).
-	const compareToPriceForVariantTerm = compareTo
-		? compareTo.pricePerMonth * variant.termIntervalInMonths
-		: undefined;
-	return compareToPriceForVariantTerm;
-}
-
-export function getItemVariantDiscountPercentage(
-	variant: WPCOMProductVariant,
-	compareTo?: WPCOMProductVariant
-): number {
-	const compareToPriceForVariantTerm = getItemVariantCompareToPrice( variant, compareTo );
-	// Extremely low "discounts" are possible if the price of the longer term has been rounded
-	// if they cannot be rounded to at least a percentage point we should not show them.
-	const discountPercentage = compareToPriceForVariantTerm
-		? Math.floor( 100 - ( variant.price / compareToPriceForVariantTerm ) * 100 )
-		: 0;
-	return discountPercentage;
-}
-
 const PriceArea = styled.span`
 	text-align: right;
 `;
@@ -87,7 +59,7 @@ const SubText = styled.div`
 	color: #777;
 `;
 
-export const ItemVariantPrice: FunctionComponent< {
+export const ItemVariantRadioPrice: FunctionComponent< {
 	variant: WPCOMProductVariant;
 	compareTo?: WPCOMProductVariant;
 } > = ( { variant, compareTo } ) => {

--- a/client/my-sites/checkout/composite-checkout/components/item-variation-picker/variant-radio-price.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/item-variation-picker/variant-radio-price.tsx
@@ -32,7 +32,13 @@ const Variant = styled.div`
 	width: 100%;
 `;
 
-const Label = styled.span`
+const VariantTermLabel = styled.span`
+	display: flex;
+	flex-direction: column;
+`;
+
+const PriceArea = styled.span`
+	text-align: right;
 	display: flex;
 	flex-direction: column;
 `;
@@ -50,11 +56,7 @@ const DiscountPercentage: FunctionComponent< { percent: number } > = ( { percent
 	);
 };
 
-const PriceArea = styled.span`
-	text-align: right;
-`;
-
-const SubText = styled.div`
+const VariantBillingTotal = styled.div`
 	font-size: small;
 	color: #777;
 `;
@@ -75,11 +77,6 @@ export const ItemVariantRadioPrice: FunctionComponent< {
 	const pricePerMonthFormatted = formatCurrency( variant.pricePerMonth, variant.currency, {
 		stripZeros: true,
 	} );
-	const subText = translate( 'Billed as one payment of %(totalPrice)s', {
-		args: {
-			totalPrice: formattedCurrentPrice,
-		},
-	} );
 
 	const shouldShowMonthlyPrice =
 		compareTo?.termIntervalInMonths === 1 || variant.termIntervalInMonths === 1;
@@ -98,12 +95,19 @@ export const ItemVariantRadioPrice: FunctionComponent< {
 		} );
 	} )();
 
+	const shouldShowBillingTotal = variant.termIntervalInMonths !== compareTo?.termIntervalInMonths;
+	const billingTotal = translate( 'Billed as one payment of %(totalPrice)s', {
+		args: {
+			totalPrice: formattedCurrentPrice,
+		},
+	} );
+
 	return (
 		<Variant>
-			<Label>
+			<VariantTermLabel>
 				{ variant.variantLabel }
-				{ variant.termIntervalInMonths === 24 && <SubText>{ subText }</SubText> }
-			</Label>
+				{ shouldShowBillingTotal && <VariantBillingTotal>{ billingTotal }</VariantBillingTotal> }
+			</VariantTermLabel>
 			<PriceArea>
 				<Price>{ priceDisplay }</Price>
 				{ discountPercentage > 0 && <DiscountPercentage percent={ discountPercentage } /> }

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-review.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-review.tsx
@@ -74,6 +74,7 @@ export default function WPCheckoutOrderReview( {
 	siteId,
 	isSummary,
 	createUserAndSiteBeforeTransaction,
+	forceRadioButtons,
 }: {
 	className?: string;
 	removeProductFromCart?: RemoveProductFromCart;
@@ -83,6 +84,9 @@ export default function WPCheckoutOrderReview( {
 	siteId?: number | undefined;
 	isSummary?: boolean;
 	createUserAndSiteBeforeTransaction?: boolean;
+	// TODO: This is just for unit tests. Remove forceRadioButtons everywhere
+	// when calypso_checkout_variant_picker_radio_2212 ExPlat test completes.
+	forceRadioButtons?: boolean;
 } ) {
 	const translate = useTranslate();
 	const [ isCouponFieldVisible, setCouponFieldVisible ] = useState( false );
@@ -163,6 +167,7 @@ export default function WPCheckoutOrderReview( {
 
 			<WPOrderReviewSection>
 				<WPOrderReviewLineItems
+					forceRadioButtons={ forceRadioButtons }
 					siteId={ siteId }
 					removeProductFromCart={ removeProductFromCart }
 					removeCoupon={ removeCouponAndClearField }

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
@@ -143,6 +143,7 @@ export default function WPCheckout( {
 	areThereErrors,
 	isInitialCartLoading,
 	customizedPreviousPath,
+	forceRadioButtons,
 }: {
 	addItemToCart: ( item: MinimalRequestCartProduct ) => void;
 	changePlanLength: OnChangeItemVariant;
@@ -159,6 +160,9 @@ export default function WPCheckout( {
 	areThereErrors: boolean;
 	isInitialCartLoading: boolean;
 	customizedPreviousPath?: string;
+	// TODO: This is just for unit tests. Remove forceRadioButtons everywhere
+	// when calypso_checkout_variant_picker_radio_2212 ExPlat test completes.
+	forceRadioButtons?: boolean;
 } ) {
 	const cartKey = useCartKey();
 	const {
@@ -340,6 +344,7 @@ export default function WPCheckout( {
 				titleContent={ <OrderReviewTitle /> }
 				completeStepContent={
 					<WPCheckoutOrderReview
+						forceRadioButtons={ forceRadioButtons }
 						removeProductFromCart={ removeProductFromCart }
 						couponFieldStateProps={ couponFieldStateProps }
 						onChangePlanLength={ changePlanLength }

--- a/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
@@ -70,6 +70,7 @@ export function WPOrderReviewLineItems( {
 	onRemoveProduct,
 	onRemoveProductClick,
 	onRemoveProductCancel,
+	forceRadioButtons,
 }: {
 	className?: string;
 	siteId?: number | undefined;
@@ -83,6 +84,9 @@ export function WPOrderReviewLineItems( {
 	onRemoveProduct?: ( label: string ) => void;
 	onRemoveProductClick?: ( label: string ) => void;
 	onRemoveProductCancel?: ( label: string ) => void;
+	// TODO: This is just for unit tests. Remove forceRadioButtons everywhere
+	// when calypso_checkout_variant_picker_radio_2212 ExPlat test completes.
+	forceRadioButtons?: boolean;
 } ) {
 	const creditsLineItem = getCreditsLineItemFromCart( responseCart );
 	const couponLineItem = getCouponLineItemFromCart( responseCart );
@@ -99,6 +103,7 @@ export function WPOrderReviewLineItems( {
 		<WPOrderReviewList className={ joinClasses( [ className, 'order-review-line-items' ] ) }>
 			{ responseCart.products.map( ( product ) => (
 				<LineItemWrapper
+					forceRadioButtons={ forceRadioButtons }
 					key={ product.product_slug }
 					product={ product }
 					siteId={ siteId }
@@ -161,6 +166,7 @@ function LineItemWrapper( {
 	hasPartnerCoupon,
 	isDisabled,
 	initialVariantTerm,
+	forceRadioButtons,
 }: {
 	product: ResponseCartProduct;
 	siteId?: number | undefined;
@@ -176,6 +182,9 @@ function LineItemWrapper( {
 	hasPartnerCoupon: boolean;
 	isDisabled: boolean;
 	initialVariantTerm: number | null | undefined;
+	// TODO: This is just for unit tests. Remove forceRadioButtons everywhere
+	// when calypso_checkout_variant_picker_radio_2212 ExPlat test completes.
+	forceRadioButtons?: boolean;
 } ) {
 	const isRenewal = isWpComProductRenewal( product );
 	const isWooMobile = isWcMobileApp();
@@ -224,7 +233,8 @@ function LineItemWrapper( {
 			isEligible: areThereVariants && shouldShowVariantSelector && ! isJetpack,
 		}
 	);
-	const shouldUseRadioButtons = isJetpack || experimentAssignment?.variationName === 'treatment';
+	const shouldUseRadioButtons =
+		forceRadioButtons || ( ! isJetpack && experimentAssignment?.variationName === 'treatment' );
 
 	return (
 		<WPOrderReviewListItem key={ product.uuid }>
@@ -240,15 +250,17 @@ function LineItemWrapper( {
 				onRemoveProductClick={ onRemoveProductClick }
 				onRemoveProductCancel={ onRemoveProductCancel }
 			>
-				{ ! isLoadingExperimentAssignment && areThereVariants && shouldShowVariantSelector && (
-					<ItemVariationPicker
-						selectedItem={ product }
-						onChangeItemVariant={ onChangePlanLength }
-						isDisabled={ isDisabled }
-						variants={ variants }
-						type={ shouldUseRadioButtons ? 'radio' : 'dropdown' }
-					/>
-				) }
+				{ ( ! isLoadingExperimentAssignment || forceRadioButtons ) &&
+					areThereVariants &&
+					shouldShowVariantSelector && (
+						<ItemVariationPicker
+							selectedItem={ product }
+							onChangeItemVariant={ onChangePlanLength }
+							isDisabled={ isDisabled }
+							variants={ variants }
+							type={ shouldUseRadioButtons ? 'radio' : 'dropdown' }
+						/>
+					) }
 			</LineItem>
 		</WPOrderReviewListItem>
 	);

--- a/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
@@ -238,6 +238,7 @@ function LineItemWrapper( {
 						onChangeItemVariant={ onChangePlanLength }
 						isDisabled={ isDisabled }
 						variants={ variants }
+						type={ isJetpack ? 'dropdown' : 'radio' }
 					/>
 				) }
 			</LineItem>

--- a/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
@@ -15,6 +15,7 @@ import styled from '@emotion/styled';
 import { useState } from 'react';
 import { useSelector } from 'react-redux';
 import { hasDIFMProduct } from 'calypso/lib/cart-values/cart-items';
+import { useExperiment } from 'calypso/lib/explat';
 import { isWcMobileApp } from 'calypso/lib/mobile-app';
 import {
 	canVariantBePurchased,
@@ -217,6 +218,13 @@ function LineItemWrapper( {
 	);
 
 	const areThereVariants = variants.length > 1;
+	const [ isLoadingExperimentAssignment, experimentAssignment ] = useExperiment(
+		'calypso_checkout_variant_picker_radio_2212',
+		{
+			isEligible: areThereVariants && shouldShowVariantSelector && ! isJetpack,
+		}
+	);
+	const shouldUseRadioButtons = isJetpack || experimentAssignment?.variationName === 'treatment';
 
 	return (
 		<WPOrderReviewListItem key={ product.uuid }>
@@ -232,13 +240,13 @@ function LineItemWrapper( {
 				onRemoveProductClick={ onRemoveProductClick }
 				onRemoveProductCancel={ onRemoveProductCancel }
 			>
-				{ areThereVariants && shouldShowVariantSelector && (
+				{ ! isLoadingExperimentAssignment && areThereVariants && shouldShowVariantSelector && (
 					<ItemVariationPicker
 						selectedItem={ product }
 						onChangeItemVariant={ onChangePlanLength }
 						isDisabled={ isDisabled }
 						variants={ variants }
-						type={ isJetpack ? 'dropdown' : 'radio' }
+						type={ shouldUseRadioButtons ? 'radio' : 'dropdown' }
 					/>
 				) }
 			</LineItem>

--- a/client/my-sites/checkout/composite-checkout/hooks/product-variants.tsx
+++ b/client/my-sites/checkout/composite-checkout/hooks/product-variants.tsx
@@ -3,6 +3,7 @@ import {
 	findPlansKeys,
 	findProductKeys,
 	getBillingMonthsForTerm,
+	getBillingYearsForTerm,
 	getPlan,
 	getProductFromSlug,
 	getTermDuration,
@@ -126,7 +127,9 @@ export function useGetProductVariants(
 					: variant.priceFinal || variant.priceFull;
 
 			const termIntervalInMonths = getBillingMonthsForTerm( variant.plan.term );
+			const termIntervalInYears = getBillingYearsForTerm( variant.plan.term );
 			const pricePerMonth = price / termIntervalInMonths;
+			const pricePerYear = price / termIntervalInYears;
 
 			return {
 				variantLabel: getTermText( variant.plan.term, translate ),
@@ -136,6 +139,7 @@ export function useGetProductVariants(
 				termIntervalInMonths: getBillingMonthsForTerm( variant.plan.term ),
 				termIntervalInDays: getTermDuration( variant.plan.term ) ?? 0,
 				pricePerMonth,
+				pricePerYear,
 				currency: variant.product.currency_code,
 			};
 		},

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout-variant-picker.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout-variant-picker.tsx
@@ -249,19 +249,18 @@ describe( 'CheckoutMain with a variant picker', () => {
 			getPlansBySiteId.mockImplementation( () => ( {
 				data: getActivePersonalPlanDataForType( activePlan ),
 			} ) );
-			const user = userEvent.setup();
 			const cartChanges = { products: [ getBusinessPlanForInterval( cartPlan ) ] };
 			render( <MyCheckout cartChanges={ cartChanges } /> );
 
-			const openVariantPicker = await screen.findByLabelText( 'Pick a product term' );
-			await user.click( openVariantPicker );
+			const variantPicker = await screen.findByLabelText( 'Pick a product term' );
 
-			const currentVariantItem = await screen.findByRole( 'option', {
+			const currentVariantItem = await screen.findByRole( 'radio', {
 				name: getVariantItemTextForInterval( cartPlan ),
 			} );
-			const variantItem = await screen.findByRole( 'option', {
+			const variantItem = await screen.findByRole( 'radio', {
 				name: getVariantItemTextForInterval( expectedVariant ),
 			} );
+			const variantItemLabel = variantPicker.querySelector( `label[for='${ variantItem.id }']` );
 
 			const currentVariantSlug = currentVariantItem.dataset.productSlug;
 			const variantSlug = variantItem.dataset.productSlug;
@@ -281,7 +280,7 @@ describe( 'CheckoutMain with a variant picker', () => {
 
 			const discountPercentage = Math.floor( 100 - ( finalPrice / priceBeforeDiscount ) * 100 );
 			expect(
-				within( variantItem ).getByText( `Save ${ discountPercentage }%` )
+				within( variantItemLabel as HTMLElement ).getByText( `Save ${ discountPercentage }%` )
 			).toBeInTheDocument();
 		}
 	);

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout-variant-picker.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout-variant-picker.tsx
@@ -146,18 +146,16 @@ describe( 'CheckoutMain with a variant picker', () => {
 			getPlansBySiteId.mockImplementation( () => ( {
 				data: getActivePersonalPlanDataForType( activePlan ),
 			} ) );
-			const user = userEvent.setup();
 			const cartChanges = { products: [ getBusinessPlanForInterval( cartPlan ) ] };
 			render( <MyCheckout cartChanges={ cartChanges } /> );
 
-			const openVariantPicker = await screen.findByLabelText( 'Pick a product term' );
-			await user.click( openVariantPicker );
+			await screen.findByLabelText( 'Pick a product term' );
 
 			expect(
-				await screen.findByRole( 'option', {
+				await screen.findByRole( 'radio', {
 					name: getVariantItemTextForInterval( expectedVariant ),
 				} )
-			).toBeVisible();
+			).toBeInTheDocument();
 		}
 	);
 
@@ -177,8 +175,7 @@ describe( 'CheckoutMain with a variant picker', () => {
 			render( <MyCheckout cartChanges={ cartChanges } /> );
 
 			// Open the variant picker
-			let openVariantPicker = await screen.findByLabelText( 'Pick a product term' );
-			await user.click( openVariantPicker );
+			await screen.findByLabelText( 'Pick a product term' );
 
 			// Select the new variant
 			const variantOption = await screen.findByLabelText(
@@ -189,15 +186,11 @@ describe( 'CheckoutMain with a variant picker', () => {
 			// Wait for the cart to refresh with the new variant
 			await screen.findByText( getPlanSubtitleTextForInterval( cartPlan ) );
 
-			// Open the variant picker again so we can look for the result
-			openVariantPicker = await screen.findByLabelText( 'Pick a product term' );
-			await user.click( openVariantPicker );
-
 			expect(
-				await screen.findByRole( 'option', {
+				await screen.findByRole( 'radio', {
 					name: getVariantItemTextForInterval( expectedVariant ),
 				} )
-			).toBeVisible();
+			).toBeInTheDocument();
 		}
 	);
 
@@ -210,16 +203,14 @@ describe( 'CheckoutMain with a variant picker', () => {
 			getPlansBySiteId.mockImplementation( () => ( {
 				data: getActivePersonalPlanDataForType( activePlan ),
 			} ) );
-			const user = userEvent.setup();
 			const cartChanges = { products: [ getBusinessPlanForInterval( cartPlan ) ] };
 			nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
 			render( <MyCheckout cartChanges={ cartChanges } /> );
 
-			const openVariantPicker = await screen.findByLabelText( 'Pick a product term' );
-			await user.click( openVariantPicker );
+			await screen.findByLabelText( 'Pick a product term' );
 
 			await expect(
-				screen.findByRole( 'option', {
+				screen.findByRole( 'radio', {
 					name: getVariantItemTextForInterval( expectedVariant ),
 				} )
 			).toNeverAppear();

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout-variant-picker.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout-variant-picker.tsx
@@ -120,6 +120,7 @@ describe( 'CheckoutMain with a variant picker', () => {
 					>
 						<StripeHookProvider fetchStripeConfiguration={ fetchStripeConfiguration }>
 							<CheckoutMain
+								forceRadioButtons={ true }
 								siteId={ siteId }
 								siteSlug="foo.com"
 								getStoredCards={ async () => [] }

--- a/client/my-sites/checkout/composite-checkout/test/util/index.ts
+++ b/client/my-sites/checkout/composite-checkout/test/util/index.ts
@@ -687,11 +687,11 @@ export function getBusinessPlanForInterval( type: string ) {
 export function getVariantItemTextForInterval( type: string ) {
 	switch ( type ) {
 		case 'monthly':
-			return 'One month';
+			return /One month/;
 		case 'yearly':
-			return 'One year';
+			return /One year/;
 		case 'two-year':
-			return 'Two years';
+			return /Two years/;
 		default:
 			throw new Error( `Unknown plan type '${ type }'` );
 	}

--- a/packages/calypso-products/src/main.ts
+++ b/packages/calypso-products/src/main.ts
@@ -485,6 +485,17 @@ export function getBillingMonthsForTerm( term: string ): number {
 	throw new Error( `Unknown term: ${ term }` );
 }
 
+export function getBillingYearsForTerm( term: string ): number {
+	if ( term === TERM_MONTHLY ) {
+		return 0;
+	} else if ( term === TERM_ANNUALLY ) {
+		return 1;
+	} else if ( term === TERM_BIENNIALLY ) {
+		return 2;
+	}
+	throw new Error( `Unknown term: ${ term }` );
+}
+
 export function plansLink(
 	urlString: string,
 	siteSlug: string | undefined | null,

--- a/packages/composite-checkout/src/components/radio-button.tsx
+++ b/packages/composite-checkout/src/components/radio-button.tsx
@@ -95,6 +95,7 @@ const Radio = styled.input`
 interface LabelProps {
 	disabled?: boolean;
 	checked?: boolean;
+	isFixedHeight?: boolean;
 }
 
 const Label = styled.label< LabelProps & React.LabelHTMLAttributes< HTMLLabelElement > >`
@@ -106,9 +107,9 @@ const Label = styled.label< LabelProps & React.LabelHTMLAttributes< HTMLLabelEle
 	display: flex;
 	flex-wrap: wrap;
 	justify-content: space-between;
-	align-items: center;
+	align-items: ${ ( props ) => ( props.isFixedHeight ? 'center' : 'flex-start' ) };
 	font-size: 14px;
-	height: 72px;
+	height: ${ ( props ) => ( props.isFixedHeight ? '72px' : 'auto' ) };
 
 	.rtl & {
 		padding: 16px 40px 16px 14px;
@@ -125,7 +126,7 @@ const Label = styled.label< LabelProps & React.LabelHTMLAttributes< HTMLLabelEle
 		content: '';
 		border: 1px solid ${ ( props ) => props.theme.colors.borderColor };
 		border-radius: 100%;
-		top: 28px;
+		top: ${ ( props ) => ( props.isFixedHeight ? '28px' : '19px' ) };
 		left: 16px;
 		position: absolute;
 		background: ${ ( props ) => props.theme.colors.surface };
@@ -144,7 +145,7 @@ const Label = styled.label< LabelProps & React.LabelHTMLAttributes< HTMLLabelEle
 		height: 8px;
 		content: '';
 		border-radius: 100%;
-		top: 32px;
+		top: ${ ( props ) => ( props.isFixedHeight ? '32px' : '23px' ) };
 		left: 20px;
 		position: absolute;
 		background: ${ getRadioColor };
@@ -175,6 +176,7 @@ export default function RadioButton( {
 	label,
 	disabled,
 	id,
+	isFixedHeight,
 	ariaLabel,
 	...otherProps
 }: RadioButtonProps ) {
@@ -200,7 +202,12 @@ export default function RadioButton( {
 				aria-label={ ariaLabel }
 				{ ...otherProps }
 			/>
-			<Label checked={ checked } htmlFor={ id } disabled={ disabled }>
+			<Label
+				checked={ checked }
+				htmlFor={ id }
+				disabled={ disabled }
+				isFixedHeight={ isFixedHeight }
+			>
 				{ label }
 			</Label>
 			{ children && <RadioButtonChildren checked={ checked }>{ children }</RadioButtonChildren> }
@@ -217,6 +224,7 @@ interface RadioButtonProps {
 	value: string;
 	onChange?: () => void;
 	ariaLabel?: string;
+	isFixedHeight?: boolean;
 	children?: React.ReactNode;
 }
 

--- a/packages/composite-checkout/src/components/radio-button.tsx
+++ b/packages/composite-checkout/src/components/radio-button.tsx
@@ -216,7 +216,7 @@ interface RadioButtonProps {
 	checked?: boolean;
 	value: string;
 	onChange?: () => void;
-	ariaLabel: string;
+	ariaLabel?: string;
 	children?: React.ReactNode;
 }
 
@@ -228,7 +228,7 @@ RadioButton.propTypes = {
 	checked: PropTypes.bool,
 	value: PropTypes.string.isRequired,
 	onChange: PropTypes.func,
-	ariaLabel: PropTypes.string.isRequired,
+	ariaLabel: PropTypes.string,
 };
 
 function handleWrapperDisabled( { disabled }: { disabled?: boolean } ) {

--- a/packages/composite-checkout/src/components/radio-button.tsx
+++ b/packages/composite-checkout/src/components/radio-button.tsx
@@ -106,8 +106,9 @@ const Label = styled.label< LabelProps & React.LabelHTMLAttributes< HTMLLabelEle
 	display: flex;
 	flex-wrap: wrap;
 	justify-content: space-between;
-	align-items: flex-start;
+	align-items: center;
 	font-size: 14px;
+	height: 72px;
 
 	.rtl & {
 		padding: 16px 40px 16px 14px;
@@ -124,7 +125,7 @@ const Label = styled.label< LabelProps & React.LabelHTMLAttributes< HTMLLabelEle
 		content: '';
 		border: 1px solid ${ ( props ) => props.theme.colors.borderColor };
 		border-radius: 100%;
-		top: 19px;
+		top: 28px;
 		left: 16px;
 		position: absolute;
 		background: ${ ( props ) => props.theme.colors.surface };
@@ -143,7 +144,7 @@ const Label = styled.label< LabelProps & React.LabelHTMLAttributes< HTMLLabelEle
 		height: 8px;
 		content: '';
 		border-radius: 100%;
-		top: 23px;
+		top: 32px;
 		left: 20px;
 		position: absolute;
 		background: ${ getRadioColor };

--- a/packages/composite-checkout/src/components/radio-button.tsx
+++ b/packages/composite-checkout/src/components/radio-button.tsx
@@ -176,6 +176,7 @@ export default function RadioButton( {
 	disabled,
 	id,
 	ariaLabel,
+	...otherProps
 }: RadioButtonProps ) {
 	const [ isFocused, changeFocus ] = useState( false );
 
@@ -197,6 +198,7 @@ export default function RadioButton( {
 				} }
 				readOnly={ ! onChange }
 				aria-label={ ariaLabel }
+				{ ...otherProps }
 			/>
 			<Label checked={ checked } htmlFor={ id } disabled={ disabled }>
 				{ label }


### PR DESCRIPTION
#### Proposed Changes

This PR replaces the billing term variant picker in checkout for WordPress.com with a set of radio buttons instead of a dropdown menu. **Checkout for Jetpack sites will remain unchanged** and continue to use the dropdown menu. The radio buttons implement the variant picker design laid out in https://github.com/Automattic/wp-calypso/issues/65968#issuecomment-1324384020. This follows a series of adjustments made to the variant picker to improve its usefulness (see pbOQVh-24K-p2).

This new UI is only made available for people in the Explat AB test experiment group `calypso_checkout_variant_picker_radio_2212`. A p2 post for this experiment is here: pbxNRc-2ce-p2

#### Screenshots

Before this change:

<img width="567" alt="Screen Shot 2022-11-22 at 8 10 22 PM" src="https://user-images.githubusercontent.com/2036909/203451532-a6cea1a0-5dc0-4889-9fc1-a2db1c3a380f.png">

<img width="570" alt="Screen Shot 2022-11-22 at 8 10 31 PM" src="https://user-images.githubusercontent.com/2036909/203451538-63bdb0ff-d4e2-42c1-bc99-f18da8aca7f6.png">

After this change, a monthly plan in the cart:

<img width="569" alt="Screen Shot 2022-11-22 at 8 05 05 PM" src="https://user-images.githubusercontent.com/2036909/203451147-7c311190-d47c-48fd-872f-02918a5c62c9.png">

After this change, an annual plan in the cart:

<img width="567" alt="Screenshot 2022-12-01 at 8 29 49 PM" src="https://user-images.githubusercontent.com/2036909/205194279-557b5f0e-55d7-4c74-8acc-7bc8f60c86ea.png">

After this change, an annual plan and a first-year discount in the cart:

<img width="568" alt="Screen Shot 2022-11-22 at 8 06 14 PM" src="https://user-images.githubusercontent.com/2036909/203451157-e94a77a8-2906-4438-8431-f4dc37adae76.png">

#### Testing Instructions

There are unit tests which cover the new UI, but you can test it manually by assigning yourself to the `treatment` experiment group in Abacus: 20943-explat-experiment

Add various products to your cart and visit checkout to see how they look. Specifically, WordPress.com plans will trigger the radio button variant picker. Jetpack plans will trigger the dropdown variant picker, but that should be unchanged.

Click to select different plans in the radio button variant picker and verify that they change as expected.