### PR TITLE
Add sites-as-landing-page feature flag

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -155,6 +155,7 @@
 		"signup/tailored-ecommerce": true,
 		"signup/woo-verify-email": false,
 		"site-indicator": true,
+		"sites-as-landing-page": true,
 		"ssr/prefetch-timebox": false,
 		"stats/new-all-time-highlights": true,
 		"stats/new-annual-highlights": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -102,6 +102,7 @@
 		"signup/tailored-ecommerce": false,
 		"signup/woo-verify-email": false,
 		"site-indicator": true,
+		"sites-as-landing-page": true,
 		"ssr/prefetch-timebox": true,
 		"stats/new-all-time-highlights": true,
 		"stats/new-annual-highlights": true,

--- a/config/production.json
+++ b/config/production.json
@@ -119,6 +119,7 @@
 		"signup/tailored-ecommerce": false,
 		"signup/woo-verify-email": false,
 		"site-indicator": true,
+		"sites-as-landing-page": false,
 		"ssr/log-prefetch-errors": true,
 		"ssr/prefetch-timebox": true,
 		"ssr/sample-log-cache-misses": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -117,6 +117,7 @@
 		"signup/tailored-ecommerce": false,
 		"signup/woo-verify-email": false,
 		"site-indicator": true,
+		"sites-as-landing-page": true,
 		"ssr/prefetch-timebox": true,
 		"stats/new-all-time-highlights": true,
 		"stats/new-annual-highlights": true,

--- a/config/test.json
+++ b/config/test.json
@@ -87,6 +87,7 @@
 		"signup/inline-help": false,
 		"signup/social": true,
 		"site-indicator": true,
+		"sites-as-landing-page": true,
 		"ssr/prefetch-timebox": true,
 		"stats/new-all-time-highlights": true,
 		"stats/new-annual-highlights": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -125,6 +125,7 @@
 		"signup/tailored-ecommerce": false,
 		"signup/woo-verify-email": false,
 		"site-indicator": true,
+		"sites-as-landing-page": true,
 		"ssr/prefetch-timebox": true,
 		"stats/new-all-time-highlights": true,
 		"stats/new-annual-highlights": true,


### PR DESCRIPTION
#### Proposed Changes

* Adds a new (unused) `sites-as-landing-page` feature flag

The intention of this flag is so we can work on making `/sites` the landing page over multiple PRs without changing the UI.

Getting the change in early so other PRs can start depending on the flag.

The flag isn't set in any Jetpack Cloud context. That's because we shouldn't ever be changing the landing page behaviour of Jetpack Cloud.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Check the value of the feature flag by pasting this into the console:

```js
window.configData.features['sites-as-landing-page']
```

It should be `true` in development, `true` on staging and horizon after you've begun the deploy process, and `false` in prod once the deployment is complete.

Otherwise it'll be `undefined`. Which is fine because any code that uses this flag will usually treat anything falsy as `false`.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] ~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~
- [ ] ~Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?~ This change isn't site related
- [ ] ~Have you checked for TypeScript, React or other console errors?~
- [ ] ~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~
- [ ] ~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~
- [ ] ~For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #70293
