### PR TITLE
Pattern Assembler: Adjust styles of the blank canvas card

### DIFF
--- a/packages/design-picker/src/components/pattern-assembler-cta/style.scss
+++ b/packages/design-picker/src/components/pattern-assembler-cta/style.scss
@@ -25,6 +25,10 @@
 		margin-bottom: 8px;
 	}
 
+	.pattern-assembler-cta__subtitle {
+		max-width: 600px;
+	}
+
 	.pattern-assembler-cta__button {
 		margin-top: 32px;
 		padding: 10px 0;

--- a/packages/design-picker/src/components/pattern-assembler-cta/style.scss
+++ b/packages/design-picker/src/components/pattern-assembler-cta/style.scss
@@ -8,6 +8,7 @@
 	text-align: center;
 	align-items: center;
 	padding: 16px;
+	line-height: 24px;
 	background-color: #f6f7f7;
 	color: #50575e;
 
@@ -23,6 +24,9 @@
 	.pattern-assembler-cta__title {
 		margin-top: 32px;
 		margin-bottom: 8px;
+		font-weight: 500;
+		font-size: 1.25rem;
+		color: var(--studio-gray-100);
 	}
 
 	.pattern-assembler-cta__subtitle {

--- a/packages/design-picker/src/components/style.scss
+++ b/packages/design-picker/src/components/style.scss
@@ -458,7 +458,7 @@
 		}
 	}
 
-	h3 {
+	.unified-design-picker__title {
 		font-size: $font-title-small;
 		font-weight: 600;
 		margin-top: 40px;

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -504,7 +504,10 @@ const UnifiedDesignPicker: React.FC< UnifiedDesignPickerProps > = ( {
 					} ) }
 				>
 					<div>
-						<h3> { translate( 'Custom designs for your site' ) } </h3>
+						<h3 className="unified-design-picker__title">
+							{ ' ' }
+							{ translate( 'Custom designs for your site' ) }{ ' ' }
+						</h3>
 						<p className="unified-design-picker__subtitle">
 							{ translate( 'Based on your input, these designs have been tailored for you.' ) }
 						</p>

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -505,8 +505,7 @@ const UnifiedDesignPicker: React.FC< UnifiedDesignPickerProps > = ( {
 				>
 					<div>
 						<h3 className="unified-design-picker__title">
-							{ ' ' }
-							{ translate( 'Custom designs for your site' ) }{ ' ' }
+							{ translate( 'Custom designs for your site' ) }
 						</h3>
 						<p className="unified-design-picker__subtitle">
 							{ translate( 'Based on your input, these designs have been tailored for you.' ) }


### PR DESCRIPTION
#### Proposed Changes

* Set the max-width on the description so that it could break into 2 lines
* Adjust styles to align with 7l53h5fxAUNjVRBQ82YFwn-fi-1407%3A56649&t=szU0LgIfnh63KDmY-0

| Before | After |
| - | - |
| ![image](https://user-images.githubusercontent.com/13596067/203494801-d561c60f-af79-44eb-9aab-751a026fac8f.png) | ![image](https://user-images.githubusercontent.com/13596067/203494833-e93df897-badf-4b14-af41-c81230bde5ec.png) |

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup/site-setup?siteSlug=<your_site>`
* Continue until you land on the Design Picker
* Scroll to the button to see the blank canvas card
  * Verify the description breaks into 2 lines
  * Verify the styles of the title align with figma

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/1251