### PR TITLE
Update Theme Search input when subject filter changed 

### DIFF
--- a/client/components/search-themes/index.tsx
+++ b/client/components/search-themes/index.tsx
@@ -1,7 +1,7 @@
 import { Gridicon } from '@automattic/components';
 import { __experimentalUseFocusOutside as useFocusOutside } from '@wordpress/compose';
 import { useTranslate } from 'i18n-calypso';
-import { useRef, useState } from 'react';
+import { useRef, useState, useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import KeyedSuggestions from 'calypso/components/keyed-suggestions';
 import Search, { SEARCH_MODE_ON_ENTER } from 'calypso/components/search';
@@ -29,6 +29,13 @@ const SearchThemes: React.FC< SearchThemesProps > = ( { query, onSearch, recordT
 	const [ editedSearchElement, setEditedSearchElement ] = useState( '' );
 	const [ isApplySearch, setIsApplySearch ] = useState( false );
 	const [ isSearchOpen, setIsSearchOpen ] = useState( false );
+
+	useEffect( () => {
+		// Prevent unnecessary render when there is unfinished filter subject:
+		if ( query.match( /(subject):(\s|$)/i ) ) {
+			setSearchInput( query );
+		}
+	}, [ query ] );
 
 	const findTextForSuggestions = ( inputValue: string ) => {
 		const val = inputValue;

--- a/client/components/search-themes/index.tsx
+++ b/client/components/search-themes/index.tsx
@@ -30,6 +30,8 @@ const SearchThemes: React.FC< SearchThemesProps > = ( { query, onSearch, recordT
 	const [ isApplySearch, setIsApplySearch ] = useState( false );
 	const [ isSearchOpen, setIsSearchOpen ] = useState( false );
 
+	// Sync the value of the search input with the subject filter,
+	// which is equivalent to adding `subject:<term>` to the search input
 	useEffect( () => {
 		// Prevent unnecessary render when there is unfinished filter subject:
 		if ( ! isSearchOpen ) {

--- a/client/components/search-themes/index.tsx
+++ b/client/components/search-themes/index.tsx
@@ -32,7 +32,7 @@ const SearchThemes: React.FC< SearchThemesProps > = ( { query, onSearch, recordT
 
 	useEffect( () => {
 		// Prevent unnecessary render when there is unfinished filter subject:
-		if ( query.match( /(subject):(\s|$)/i ) ) {
+		if ( ! isSearchOpen ) {
 			setSearchInput( query );
 		}
 	}, [ query ] );


### PR DESCRIPTION
## Proposed Changes

* When category filter is selected, the searchInput does not re-render accordingly, force the input to render by using `useEffect`

## Testing Instructions

* Head to the Themes Showcase /themes/${site_slug}
     * If using calypso.live, the flag themes/showcase-i4/search-and-filter is required.
* Confirm that the search input will update accordingly when category filter items are selected and vice versa
**BEFORE:**
![Screen Capture on 2022-11-23 at 11-23-40.gif](https://cdn-std.droplr.net/files/acc_1243635/pKdjlL)
**AFTER:**
<video src="https://user-images.githubusercontent.com/10071857/203878779-7b775e16-1680-4ead-b4eb-ce79a0caed12.mp4
">
## Reference
Related to #70162
This PR is derived from #70283