### PR TITLE
Pattern Assembler - Improve pattern names, ordering and missing patterns

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-layout.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-layout.tsx
@@ -40,6 +40,8 @@ const PatternLayout = ( {
 	onContinueClick,
 }: PatternLayoutProps ) => {
 	const translate = useTranslate();
+	const headerName = translate( 'Header' );
+	const footerName = translate( 'Footer' );
 
 	return (
 		<div className="pattern-layout">
@@ -56,8 +58,8 @@ const PatternLayout = ( {
 				<ul>
 					{ header ? (
 						<li className="pattern-layout__list-item pattern-layout__list-item--header">
-							<span className="pattern-layout__list-item-text" title={ header.name }>
-								{ header.name }
+							<span className="pattern-layout__list-item-text" title={ headerName }>
+								{ headerName }
 							</span>
 							<PatternActionBar
 								patternType="header"
@@ -112,8 +114,8 @@ const PatternLayout = ( {
 					</li>
 					{ footer ? (
 						<li className="pattern-layout__list-item pattern-layout__list-item--footer">
-							<span className="pattern-layout__list-item-text" title={ footer.name }>
-								{ footer.name }
+							<span className="pattern-layout__list-item-text" title={ footerName }>
+								{ footerName }
 							</span>
 							<PatternActionBar
 								patternType="footer"

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/patterns-data.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/patterns-data.ts
@@ -1,6 +1,35 @@
 import { translate } from 'i18n-calypso';
 import type { Pattern } from './types';
 
+// Category translations with an incremental number
+const categoryNumbers = ( ( count = 0 ) => {
+	return () => translate( 'Numbers %(count)d', { args: { count: ( count += 1 ) } } );
+} )();
+
+const categoryCallToAction = ( ( count = 0 ) => {
+	return () => translate( 'Call To Action %(count)d', { args: { count: ( count += 1 ) } } );
+} )();
+
+const categoryImages = ( ( count = 0 ) => {
+	return () => translate( 'Images %(count)d', { args: { count: ( count += 1 ) } } );
+} )();
+
+const categoryList = ( ( count = 0 ) => {
+	return () => translate( 'List %(count)d', { args: { count: ( count += 1 ) } } );
+} )();
+
+const categoryAbout = ( ( count = 0 ) => {
+	return () => translate( 'About %(count)d', { args: { count: ( count += 1 ) } } );
+} )();
+
+const categoryTestimonials = ( ( count = 0 ) => {
+	return () => translate( 'Testimonials %(count)d', { args: { count: ( count += 1 ) } } );
+} )();
+
+const categoryLinks = ( ( count = 0 ) => {
+	return () => translate( 'Links %(count)d', { args: { count: ( count += 1 ) } } );
+} )();
+
 // All headers in dotcompatterns
 const headerPatterns: Pattern[] = [
 	{
@@ -79,83 +108,83 @@ const footerPatterns: Pattern[] = [
 const sectionPatterns: Pattern[] = [
 	{
 		id: 7156,
-		name: translate( 'Call To Action 1' ),
+		name: categoryCallToAction(),
 	},
 	{
 		id: 7153,
-		name: translate( 'Call To Action 2' ),
+		name: categoryCallToAction(),
 	},
 	{
 		id: 7146,
-		name: translate( 'Call To Action 3' ),
+		name: categoryCallToAction(),
 	},
 	{
 		id: 7132,
-		name: translate( 'Call To Action 4' ),
+		name: categoryCallToAction(),
 	},
 	{
 		id: 7159,
-		name: translate( 'Call To Action 5' ),
+		name: categoryCallToAction(),
 	},
 	{
 		id: 7149,
-		name: translate( 'Images 1' ),
+		name: categoryImages(),
 	},
 	{
 		id: 5691,
-		name: translate( 'Images 2' ),
+		name: categoryImages(),
 	},
 	{
 		id: 7143,
-		name: translate( 'Images 3' ),
+		name: categoryImages(),
 	},
 	{
 		id: 737,
-		name: translate( 'Images 4' ),
+		name: categoryImages(),
 	},
 	{
 		id: 1585,
-		name: translate( 'Images 5' ),
+		name: categoryImages(),
 	},
 	{
 		id: 7135,
-		name: translate( 'List 1' ),
+		name: categoryList(),
 	},
 	{
 		id: 789,
-		name: translate( 'List 2' ),
+		name: categoryList(),
 	},
 	{
 		id: 6712,
-		name: translate( 'List 3' ),
+		name: categoryList(),
 	},
 	{
 		id: 5666,
-		name: translate( 'Numbers 1' ),
+		name: categoryNumbers(),
 	},
 	{
 		id: 462,
-		name: translate( 'Numbers 2' ),
+		name: categoryNumbers(),
 	},
 	{
 		id: 5663,
-		name: translate( 'About 1' ),
+		name: categoryAbout(),
 	},
 	{
 		id: 7140,
-		name: translate( 'About 2' ),
+		name: categoryAbout(),
 	},
 	{
 		id: 7138,
-		name: translate( 'About 3' ),
+		name: categoryAbout(),
 	},
 	{
 		id: 7161,
-		name: translate( 'Testimonials' ),
+		name: categoryTestimonials(),
 	},
 	{
 		id: 1600,
-		name: translate( 'Links' ),
+		name: categoryLinks(),
 	},
 ];
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/patterns-data.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/patterns-data.ts
@@ -6,8 +6,6 @@ const headerPatterns: Pattern[] = [
 		id: 5579,
 		name: 'Header 1',
 	},
-	// Previously removed because it has a menu item named Blog
-	// and it can be confused as we don't target bloggers in this flow
 	{
 		id: 5608,
 		name: 'Header 2',
@@ -161,14 +159,6 @@ const sectionPatterns: Pattern[] = [
 		name: 'Numbers 2',
 	},
 	{
-		id: 7161,
-		name: 'Testimonials',
-	},
-	{
-		id: 1600,
-		name: 'Links',
-	},
-	{
 		id: 5663,
 		name: 'About 1',
 	},
@@ -179,6 +169,14 @@ const sectionPatterns: Pattern[] = [
 	{
 		id: 7138,
 		name: 'About 3',
+	},
+	{
+		id: 7161,
+		name: 'Testimonials',
+	},
+	{
+		id: 1600,
+		name: 'Links',
 	},
 ];
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/patterns-data.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/patterns-data.ts
@@ -1,167 +1,184 @@
 import type { Pattern } from './types';
 
+// All headers in dotcompatterns
 const headerPatterns: Pattern[] = [
 	{
 		id: 5579,
-		name: 'Centered header',
+		name: 'Header 1',
+	},
+	// Previously removed because it has a menu item named Blog
+	// and it can be confused as we don't target bloggers in this flow
+	{
+		id: 5608,
+		name: 'Header 2',
 	},
 	{
 		id: 5582,
-		name: 'Simple header with large font size',
-	},
-	{
-		id: 5605,
-		name: 'Header with site title and vertical navigation',
-	},
-	{
-		id: 5603,
-		name: 'Header with site title and menu button',
-	},
-	{
-		id: 7914,
-		name: 'Header with button',
+		name: 'Header 3',
 	},
 	{
 		id: 5588,
-		name: 'Simple header',
-	},
-	{
-		id: 5601,
-		name: 'Simple header with tagline',
+		name: 'Header 4',
 	},
 	{
 		id: 5590,
-		name: 'Simple header with image background',
-	},
-	{
-		id: 5595,
-		name: 'Simple header with image',
+		name: 'Header 5',
 	},
 	{
 		id: 5593,
-		name: 'Simple header with dark background',
+		name: 'Header 6',
+	},
+	{
+		id: 5595,
+		name: 'Header 7',
+	},
+	{
+		id: 5601,
+		name: 'Header 8',
+	},
+	{
+		id: 5603,
+		name: 'Header 9',
+	},
+	{
+		id: 5605,
+		name: 'Header 11',
+	},
+	{
+		id: 7914,
+		name: 'Header 10',
 	},
 ];
 
+// All footers in dotcompatterns
+// Missing footers in dotcomfsepatterns
 const footerPatterns: Pattern[] = [
 	{
 		id: 5316,
-		name: 'Footer with social icons, address, e-mail, and telephone number',
+		name: 'Footer 1',
 	},
 	{
 		id: 5886,
-		name: 'Footer with large font size',
+		name: 'Footer 2',
 	},
 	{
 		id: 5883,
-		name: 'Footer with credit line and navigation',
+		name: 'Footer 3',
 	},
 	{
 		id: 5888,
-		name: 'Footer with navigation and credit line',
+		name: 'Footer 4',
 	},
 	{
 		id: 5877,
-		name: 'Centered footer with social links',
+		name: 'Footer 5',
 	},
 	{
 		id: 5873,
-		name: 'Simple centered footer',
+		name: 'Footer 6',
+	},
+	{
+		id: 7917,
+		name: 'Footer 7',
+	},
+	{
+		id: 7485,
+		name: 'Footer 8',
 	},
 	{
 		id: 1622,
-		name: 'Contact',
+		name: 'Footer 9',
 	},
 	{
 		id: 5047,
-		name: 'Footer with navigation, contact details, social links, and subscription form',
+		name: 'Footer 10',
 	},
 	{
 		id: 5880,
-		name: 'Footer with background color and three columns',
+		name: 'Footer 11',
 	},
 ];
 
 const sectionPatterns: Pattern[] = [
 	{
 		id: 7156,
-		name: 'Media and text with image on the right',
+		name: 'Call To Action 1',
 	},
 	{
 		id: 7153,
-		name: 'Media and text with image on the left',
+		name: 'Call To Action 2',
 	},
 	{
 		id: 7146,
-		name: 'Four column list',
-	},
-	{
-		id: 1600,
-		name: 'Three column text and links',
-	},
-	{
-		id: 7149,
-		name: 'Two column image grid',
-	},
-	{
-		id: 7135,
-		name: 'Three columns with images and text',
-	},
-	{
-		id: 5691,
-		name: 'Three logos, heading, and paragraphs',
-	},
-	{
-		id: 7143,
-		name: 'Full-width image',
-	},
-	{
-		id: 737,
-		name: 'Logos',
+		name: 'Call To Action 3',
 	},
 	{
 		id: 7132,
-		name: 'Cover image with left-aligned call to action',
+		name: 'Call To Action 4',
 	},
 	{
 		id: 7159,
-		name: 'Cover image with centered text and a button',
+		name: 'Call To Action 5',
+	},
+	{
+		id: 7149,
+		name: 'Images 1',
+	},
+	{
+		id: 5691,
+		name: 'Images 2',
+	},
+	{
+		id: 7143,
+		name: 'Images 3',
+	},
+	{
+		id: 737,
+		name: 'Images 4',
 	},
 	{
 		id: 1585,
-		name: 'Quote and logos',
+		name: 'Images 5',
+	},
+	{
+		id: 7135,
+		name: 'List 1',
 	},
 	{
 		id: 789,
-		name: 'Numbered list',
-	},
-	{
-		id: 5666,
-		name: 'Large numbers, heading, and paragraphs',
-	},
-	{
-		id: 462,
-		name: 'Numbers',
-	},
-	{
-		id: 5663,
-		name: 'Large headline',
-	},
-	{
-		id: 7140,
-		name: 'Left-aligned headline',
-	},
-	{
-		id: 7138,
-		name: 'Centered headline and text',
-	},
-	{
-		id: 7161,
-		name: 'Two testimonials side by side',
+		name: 'List 2',
 	},
 	{
 		id: 6712,
-		name: 'List of events',
+		name: 'List 3',
+	},
+	{
+		id: 5666,
+		name: 'Numbers 1',
+	},
+	{
+		id: 462,
+		name: 'Numbers 2',
+	},
+	{
+		id: 7161,
+		name: 'Testimonials',
+	},
+	{
+		id: 1600,
+		name: 'Links',
+	},
+	{
+		id: 5663,
+		name: 'About 1',
+	},
+	{
+		id: 7140,
+		name: 'About 2',
+	},
+	{
+		id: 7138,
+		name: 'About 3',
 	},
 ];
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/patterns-data.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/patterns-data.ts
@@ -1,50 +1,40 @@
+import { translate } from 'i18n-calypso';
 import type { Pattern } from './types';
 
 // All headers in dotcompatterns
 const headerPatterns: Pattern[] = [
 	{
 		id: 5579,
-		name: 'Header 1',
 	},
 	{
 		id: 5608,
-		name: 'Header 2',
 	},
 	{
 		id: 5582,
-		name: 'Header 3',
 	},
 	{
 		id: 5588,
-		name: 'Header 4',
 	},
 	{
 		id: 5590,
-		name: 'Header 5',
 	},
 	{
 		id: 5593,
-		name: 'Header 6',
 	},
 	{
 		id: 5595,
-		name: 'Header 7',
 	},
 	{
 		id: 5601,
-		name: 'Header 8',
 	},
 	{
 		id: 5603,
-		name: 'Header 9',
 	},
 	{
 		id: 5605,
-		name: 'Header 11',
 	},
 	{
 		id: 7914,
-		name: 'Header 10',
 	},
 ];
 
@@ -53,130 +43,119 @@ const headerPatterns: Pattern[] = [
 const footerPatterns: Pattern[] = [
 	{
 		id: 5316,
-		name: 'Footer 1',
 	},
 	{
 		id: 5886,
-		name: 'Footer 2',
 	},
 	{
 		id: 5883,
-		name: 'Footer 3',
 	},
 	{
 		id: 5888,
-		name: 'Footer 4',
 	},
 	{
 		id: 5877,
-		name: 'Footer 5',
 	},
 	{
 		id: 5873,
-		name: 'Footer 6',
 	},
 	{
 		id: 7917,
-		name: 'Footer 7',
 	},
 	{
 		id: 7485,
-		name: 'Footer 8',
 	},
 	{
 		id: 1622,
-		name: 'Footer 9',
 	},
 	{
 		id: 5047,
-		name: 'Footer 10',
 	},
 	{
 		id: 5880,
-		name: 'Footer 11',
 	},
 ];
 
 const sectionPatterns: Pattern[] = [
 	{
 		id: 7156,
-		name: 'Call To Action 1',
+		name: translate( 'Call To Action 1' ),
 	},
 	{
 		id: 7153,
-		name: 'Call To Action 2',
+		name: translate( 'Call To Action 2' ),
 	},
 	{
 		id: 7146,
-		name: 'Call To Action 3',
+		name: translate( 'Call To Action 3' ),
 	},
 	{
 		id: 7132,
-		name: 'Call To Action 4',
+		name: translate( 'Call To Action 4' ),
 	},
 	{
 		id: 7159,
-		name: 'Call To Action 5',
+		name: translate( 'Call To Action 5' ),
 	},
 	{
 		id: 7149,
-		name: 'Images 1',
+		name: translate( 'Images 1' ),
 	},
 	{
 		id: 5691,
-		name: 'Images 2',
+		name: translate( 'Images 2' ),
 	},
 	{
 		id: 7143,
-		name: 'Images 3',
+		name: translate( 'Images 3' ),
 	},
 	{
 		id: 737,
-		name: 'Images 4',
+		name: translate( 'Images 4' ),
 	},
 	{
 		id: 1585,
-		name: 'Images 5',
+		name: translate( 'Images 5' ),
 	},
 	{
 		id: 7135,
-		name: 'List 1',
+		name: translate( 'List 1' ),
 	},
 	{
 		id: 789,
-		name: 'List 2',
+		name: translate( 'List 2' ),
 	},
 	{
 		id: 6712,
-		name: 'List 3',
+		name: translate( 'List 3' ),
 	},
 	{
 		id: 5666,
-		name: 'Numbers 1',
+		name: translate( 'Numbers 1' ),
 	},
 	{
 		id: 462,
-		name: 'Numbers 2',
+		name: translate( 'Numbers 2' ),
 	},
 	{
 		id: 5663,
-		name: 'About 1',
+		name: translate( 'About 1' ),
 	},
 	{
 		id: 7140,
-		name: 'About 2',
+		name: translate( 'About 2' ),
 	},
 	{
 		id: 7138,
-		name: 'About 3',
+		name: translate( 'About 3' ),
 	},
 	{
 		id: 7161,
-		name: 'Testimonials',
+		name: translate( 'Testimonials' ),
 	},
 	{
 		id: 1600,
-		name: 'Links',
+		name: translate( 'Links' ),
 	},
 ];
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/types.ts
@@ -1,5 +1,5 @@
 export type Pattern = {
 	id: number;
-	name: string;
+	name?: string;
 	key?: string;
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/types.ts
@@ -1,5 +1,5 @@
 export type Pattern = {
 	id: number;
-	name?: string;
+	name?: any;
 	key?: string;
 };


### PR DESCRIPTION
#### Proposed Changes

* Rename patterns using the category and an incremental number
* Reorder the patterns as in the editor inserter
* Add missing header and footer patterns
* Add comments about the patterns selected
* Add translations for "Header", "Footer", and pattern categories with an incremental magic number

|Before|After|
|-------|-----|
|<img width="325" alt="Screen Shot 2565-11-23 at 14 07 37" src="https://user-images.githubusercontent.com/1881481/203500740-d28cc514-c038-414e-9cab-7a97963ea696.png">|<img width="324" alt="Screen Shot 2565-11-23 at 15 37 31" src="https://user-images.githubusercontent.com/1881481/203502431-cc2dfbb7-b04c-47aa-b2fe-3a3ad8d98ff0.png">|

@taipeicoder, you were right about the need for translations.

**Note:**

The incremental number in the section pattern names is translated following the recommendation in [i18n Calypso](https://github.com/Automattic/wp-calypso/blob/trunk/packages/i18n-calypso/README.md) and the FG page i18n Best Practices for Hardcoded numbers, dates, currencies, coupons etc.

I had fun using a closure to increment the counter dinamically. I'm hoping reviewers will have fun too! 

**Pending tasks related to patterns for follow-up issues:**
- Move the missing footer patterns from `dotcomfsepatterns` to `dotcompatterns` and then add them in the PA.
- Rename the `Blog` menu item to be `About` in footers

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup?siteSlug=[ YOUR SITE ]`
* Don't mark any goal or select any vertical
* Scroll to the bottom of the design picker and click on the Blank canvas CTA
* Check that after choosing any header or footer, their names in the list are always "Header" or "Footer"
* Check that section patterns use their category name and an incremental number when selected and on their tooltip
* Check that all the patterns have a preview and that the pattern selection works as expected
*
#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/1251
