### PR TITLE
Launchpad: Add notice to calypso sidebar

### DIFF
--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -52,6 +52,26 @@ export class SiteNotice extends Component {
 		);
 	}
 
+	getLaunchpadNotice() {
+		const { site } = this.props;
+
+		return (
+			<UpsellNudge
+				callToAction="Next Steps"
+				compact
+				forceHref={ true }
+				forceDisplay={ true }
+				dismissPreferenceName=""
+				dismissTemporary={ true }
+				href={ `/setup/${ site.options.site_intent }/launchpad?siteSlug=${ site.slug }` }
+				// TODO: Add relevant tracks events here
+				// onClick={ onClick }
+				// onDismissClick={ onDismiss }
+				title="🚀 Finish site setup"
+			/>
+		);
+	}
+
 	activeDiscountNotice() {
 		if ( ! this.props.activeDiscount ) {
 			return null;
@@ -101,21 +121,26 @@ export class SiteNotice extends Component {
 
 		const discountOrFreeToPaid = this.activeDiscountNotice();
 		const siteRedirectNotice = this.getSiteRedirectNotice( site );
+		const LaunchpadNotice = this.getLaunchpadNotice();
 
 		const showJitms =
-			! this.props.isSiteWPForTeams && ( discountOrFreeToPaid || config.isEnabled( 'jitms' ) );
+			! this.props.isSiteWPForTeams &&
+			( discountOrFreeToPaid || config.isEnabled( 'jitms' ) ) &&
+			site.options?.launchpad_screen !== 'full';
 
 		return (
 			<div className="current-site__notices">
 				<QueryActivePromotions />
 				{ siteRedirectNotice }
-				{ showJitms && (
+				{ showJitms ? (
 					<AsyncLoad
 						require="calypso/blocks/jitm"
 						placeholder={ null }
 						messagePath="calypso:sites:sidebar_notice"
 						template="sidebar-banner"
 					/>
+				) : (
+					LaunchpadNotice
 				) }
 				<QuerySitePlans siteId={ site.ID } />
 			</div>

--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -123,24 +123,31 @@ export class SiteNotice extends Component {
 		const LaunchpadNotice = this.getLaunchpadNotice();
 
 		const showJitms =
-			! this.props.isSiteWPForTeams &&
-			( discountOrFreeToPaid || config.isEnabled( 'jitms' ) ) &&
-			site.options?.launchpad_screen !== 'full';
+			! this.props.isSiteWPForTeams && ( discountOrFreeToPaid || config.isEnabled( 'jitms' ) );
 
-		return (
-			<div className="current-site__notices">
-				<QueryActivePromotions />
-				{ siteRedirectNotice }
-				{ showJitms ? (
+		const showLaunchpadNotice = site.options?.launchpad_screen === 'full';
+		let SidebarNotice = null;
+
+		if ( showJitms ) {
+			if ( showLaunchpadNotice ) {
+				SidebarNotice = LaunchpadNotice;
+			} else {
+				SidebarNotice = (
 					<AsyncLoad
 						require="calypso/blocks/jitm"
 						placeholder={ null }
 						messagePath="calypso:sites:sidebar_notice"
 						template="sidebar-banner"
 					/>
-				) : (
-					LaunchpadNotice
-				) }
+				);
+			}
+		}
+
+		return (
+			<div className="current-site__notices">
+				<QueryActivePromotions />
+				{ siteRedirectNotice }
+				{ SidebarNotice }
 				<QuerySitePlans siteId={ site.ID } />
 			</div>
 		);

--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -53,11 +53,11 @@ export class SiteNotice extends Component {
 	}
 
 	getLaunchpadNotice() {
-		const { site } = this.props;
+		const { site, translate } = this.props;
 
 		return (
 			<UpsellNudge
-				callToAction="Next Steps"
+				callToAction={ translate( 'Next Steps' ) }
 				className="current-site__launchpad-notice"
 				compact
 				dismissPreferenceName=""
@@ -65,11 +65,8 @@ export class SiteNotice extends Component {
 				forceHref={ true }
 				forceDisplay={ true }
 				href={ `/setup/${ site.options.site_intent }/launchpad?siteSlug=${ site.slug }` }
-				// TODO: Add relevant tracks events here
-				// onClick={ onClick }
-				// onDismissClick={ onDismiss }
 				primaryButton={ false }
-				title="Keep setting up your site"
+				title={ translate( 'Keep setting up your site' ) }
 			/>
 		);
 	}

--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -58,16 +58,18 @@ export class SiteNotice extends Component {
 		return (
 			<UpsellNudge
 				callToAction="Next Steps"
+				className="current-site__launchpad-notice"
 				compact
-				forceHref={ true }
-				forceDisplay={ true }
 				dismissPreferenceName=""
 				dismissTemporary={ true }
+				forceHref={ true }
+				forceDisplay={ true }
 				href={ `/setup/${ site.options.site_intent }/launchpad?siteSlug=${ site.slug }` }
 				// TODO: Add relevant tracks events here
 				// onClick={ onClick }
 				// onDismissClick={ onDismiss }
-				title="🚀 Finish site setup"
+				primaryButton={ false }
+				title="Keep setting up your site"
 			/>
 		);
 	}

--- a/client/my-sites/current-site/style.scss
+++ b/client/my-sites/current-site/style.scss
@@ -119,3 +119,9 @@
 .sidebar .current-site .all-sites {
 	border-bottom: 0;
 }
+
+.current-site__launchpad-notice {
+	button {
+		background-color: var(--studio-blue-50);
+	}
+}


### PR DESCRIPTION
### Proposed Changes

* Adds launchpad notice to Calypso sidebar
*  _Does not_ use the existing JITM engine

### Screenshots

![Screen Shot 2022-11-23 at 11 18 05 AM copy](https://user-images.githubusercontent.com/5414230/203629797-a29b0fa2-3b9e-4fd6-b6e9-22d095bafa8a.jpg)

### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a launchpad enabled site ( calypso.localhost:3000/setup/newsletter/intro or http://calypso.localhost:3000/setup/link-in-bio/intro ) or use an existing one
* **_Don't_** complete any launchpad tasks
* Click on the "Go to admin" button
* Verify that the notice loaded in the sidebar is the Launchpad Redirect Notice
* Return to the Launchpad
* Complete all tasks
* When redirected back to Calypso admin, verify that the notice is no longer related to Launchpad

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/69756 and p1669070392411239-slack-CHN6J22MP