### PR TITLE
Theme Showcase: Show active theme as the first theme in the grid

### DIFF
--- a/client/my-sites/themes/single-site-jetpack.jsx
+++ b/client/my-sites/themes/single-site-jetpack.jsx
@@ -4,6 +4,8 @@ import { pickBy } from 'lodash';
 import { useEffect } from 'react';
 import { connect } from 'react-redux';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
+import QueryActiveTheme from 'calypso/components/data/query-active-theme';
+import QueryCanonicalTheme from 'calypso/components/data/query-canonical-theme';
 import Main from 'calypso/components/main';
 import { useRequestSiteChecklistTaskUpdate } from 'calypso/data/site-checklist';
 import CurrentTheme from 'calypso/my-sites/themes/current-theme';
@@ -11,6 +13,7 @@ import { CHECKLIST_KNOWN_TASKS } from 'calypso/state/data-layer/wpcom/checklist/
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import { getCurrentPlan, isRequestingSitePlans } from 'calypso/state/sites/plans/selectors';
 import { isJetpackSiteMultiSite } from 'calypso/state/sites/selectors';
+import { getActiveTheme } from 'calypso/state/themes/selectors';
 import { addTracking } from './helpers';
 import { connectOptions } from './theme-options';
 import ThemeShowcase from './theme-showcase';
@@ -34,6 +37,7 @@ const ConnectedThemesSelection = connectOptions( ( props ) => {
 const ConnectedSingleSiteJetpack = connectOptions( ( props ) => {
 	const {
 		currentPlan,
+		currentThemeId,
 		emptyContent,
 		filter,
 		getScreenshotOption,
@@ -80,7 +84,15 @@ const ConnectedSingleSiteJetpack = connectOptions( ( props ) => {
 	return (
 		<Main fullWidthLayout className="themes">
 			<ThemesHeader isReskinned={ isNewSearchAndFilter } />
-			<CurrentTheme siteId={ siteId } />
+			{ ! isNewSearchAndFilter ? (
+				<CurrentTheme siteId={ siteId } />
+			) : (
+				<>
+					<QueryActiveTheme siteId={ siteId } />
+					{ currentThemeId && <QueryCanonicalTheme themeId={ currentThemeId } siteId={ siteId } /> }
+				</>
+			) }
+
 			<ThemeShowcase
 				{ ...props }
 				upsellUrl={ upsellUrl }
@@ -129,10 +141,12 @@ const ConnectedSingleSiteJetpack = connectOptions( ( props ) => {
 
 export default connect( ( state, { siteId, tier } ) => {
 	const currentPlan = getCurrentPlan( state, siteId );
+	const currentThemeId = getActiveTheme( state, siteId );
 	const isMultisite = isJetpackSiteMultiSite( state, siteId );
 	const showWpcomThemesList = ! isMultisite;
 	return {
 		currentPlan,
+		currentThemeId,
 		tier,
 		showWpcomThemesList,
 		emptyContent: null,

--- a/client/my-sites/themes/single-site-wpcom.jsx
+++ b/client/my-sites/themes/single-site-wpcom.jsx
@@ -10,6 +10,8 @@ import {
 import { useEffect } from 'react';
 import { connect } from 'react-redux';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
+import QueryActiveTheme from 'calypso/components/data/query-active-theme';
+import QueryCanonicalTheme from 'calypso/components/data/query-canonical-theme';
 import Main from 'calypso/components/main';
 import { useRequestSiteChecklistTaskUpdate } from 'calypso/data/site-checklist';
 import CurrentTheme from 'calypso/my-sites/themes/current-theme';
@@ -17,12 +19,14 @@ import { CHECKLIST_KNOWN_TASKS } from 'calypso/state/data-layer/wpcom/checklist/
 import isVipSite from 'calypso/state/selectors/is-vip-site';
 import { getCurrentPlan, isRequestingSitePlans } from 'calypso/state/sites/plans/selectors';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
+import { getActiveTheme } from 'calypso/state/themes/selectors';
 import { connectOptions } from './theme-options';
 import ThemeShowcase from './theme-showcase';
 import ThemesHeader from './themes-header';
 
 const ConnectedSingleSiteWpcom = connectOptions( ( props ) => {
-	const { currentPlan, isVip, requestingSitePlans, siteId, siteSlug, translate } = props;
+	const { currentPlan, currentThemeId, isVip, requestingSitePlans, siteId, siteSlug, translate } =
+		props;
 
 	const isNewSearchAndFilter = isEnabled( 'themes/showcase-i4/search-and-filter' );
 	const displayUpsellBanner = ! requestingSitePlans && currentPlan && ! isVip;
@@ -86,7 +90,15 @@ const ConnectedSingleSiteWpcom = connectOptions( ( props ) => {
 	return (
 		<Main fullWidthLayout className="themes">
 			<ThemesHeader isReskinned={ isNewSearchAndFilter } />
-			<CurrentTheme siteId={ siteId } />
+			{ ! isNewSearchAndFilter ? (
+				<CurrentTheme siteId={ siteId } />
+			) : (
+				<>
+					<QueryActiveTheme siteId={ siteId } />
+					{ currentThemeId && <QueryCanonicalTheme themeId={ currentThemeId } siteId={ siteId } /> }
+				</>
+			) }
+
 			<ThemeShowcase
 				{ ...props }
 				upsellUrl={ upsellUrl }
@@ -102,4 +114,5 @@ export default connect( ( state, { siteId } ) => ( {
 	siteSlug: getSiteSlug( state, siteId ),
 	requestingSitePlans: isRequestingSitePlans( state, siteId ),
 	currentPlan: getCurrentPlan( state, siteId ),
+	currentThemeId: getActiveTheme( state, siteId ),
 } ) )( ConnectedSingleSiteWpcom );

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -506,50 +506,45 @@ class ThemeShowcase extends Component {
 							select={ this.onTierSelect }
 						/>
 					) }
-					{ isLoggedIn &&
-						( isNewSearchAndFilter ? (
-							<div className="theme__filters">
-								<ThemesToolbarGroup
-									items={ Object.values( this.tabFilters ) }
-									selectedKey={ this.state.tabFilter.key }
-									onSelect={ ( key ) =>
-										this.onFilterClick(
-											Object.values( this.tabFilters ).find(
-												( tabFilter ) => tabFilter.key === key
-											)
-										)
-									}
+					{ isNewSearchAndFilter && (
+						<div className="theme__filters">
+							<ThemesToolbarGroup
+								items={ Object.values( this.tabFilters ) }
+								selectedKey={ this.state.tabFilter.key }
+								onSelect={ ( key ) =>
+									this.onFilterClick(
+										Object.values( this.tabFilters ).find( ( tabFilter ) => tabFilter.key === key )
+									)
+								}
+							/>
+							{ premiumThemesEnabled && ! isMultisite && (
+								<SimplifiedSegmentedControl
+									key={ tier }
+									initialSelected={ tier || 'all' }
+									options={ this.tabTiers }
+									onSelect={ this.onTierSelect }
 								/>
-								{ premiumThemesEnabled && ! isMultisite && (
-									<SimplifiedSegmentedControl
-										key={ tier }
-										initialSelected={ tier || 'all' }
-										options={ this.tabTiers }
-										onSelect={ this.onTierSelect }
-									/>
-								) }
-							</div>
-						) : (
-							<SectionNav
-								className="themes__section-nav"
-								selectedText={ this.state.tabFilter.text }
-							>
-								<NavTabs>
-									{ Object.values( this.tabFilters )
-										.sort( ( a, b ) => a.order - b.order )
-										.map( ( tabFilter ) => (
-											<NavItem
-												key={ tabFilter.key }
-												onClick={ () => this.onFilterClick( tabFilter ) }
-												selected={ tabFilter.key === this.state.tabFilter.key }
-												count={ this.notificationCount( tabFilter.key ) }
-											>
-												{ tabFilter.text }
-											</NavItem>
-										) ) }
-								</NavTabs>
-							</SectionNav>
-						) ) }
+							) }
+						</div>
+					) }
+					{ isLoggedIn && ! isNewSearchAndFilter && (
+						<SectionNav className="themes__section-nav" selectedText={ this.state.tabFilter.text }>
+							<NavTabs>
+								{ Object.values( this.tabFilters )
+									.sort( ( a, b ) => a.order - b.order )
+									.map( ( tabFilter ) => (
+										<NavItem
+											key={ tabFilter.key }
+											onClick={ () => this.onFilterClick( tabFilter ) }
+											selected={ tabFilter.key === this.state.tabFilter.key }
+											count={ this.notificationCount( tabFilter.key ) }
+										>
+											{ tabFilter.text }
+										</NavItem>
+									) ) }
+							</NavTabs>
+						</SectionNav>
+					) }
 					{ this.renderBanner() }
 					{ this.renderThemes( themeProps ) }
 					{ siteId && <QuerySitePlans siteId={ siteId } /> }

--- a/client/state/themes/selectors/get-themes-for-query-ignoring-page.js
+++ b/client/state/themes/selectors/get-themes-for-query-ignoring-page.js
@@ -44,7 +44,7 @@ export const getThemesForQueryIgnoringPage = createSelector(
 				const currentTheme = getCanonicalTheme( state, selectedSiteId, currentThemeId );
 
 				if ( currentTheme ) {
-					themesForQueryIgnoringPage.filter = themesForQueryIgnoringPage.filter(
+					themesForQueryIgnoringPage = themesForQueryIgnoringPage.filter(
 						( theme ) => theme.id !== currentTheme.id
 					);
 					themesForQueryIgnoringPage.unshift( currentTheme );

--- a/client/state/themes/selectors/get-themes-for-query-ignoring-page.js
+++ b/client/state/themes/selectors/get-themes-for-query-ignoring-page.js
@@ -1,11 +1,7 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { createSelector } from '@automattic/state-utils';
 import { flatMap } from 'lodash';
-import {
-	getActiveTheme,
-	getCanonicalTheme,
-	isRequestingActiveTheme,
-} from 'calypso/state/themes/selectors';
+import { getActiveTheme, getCanonicalTheme } from 'calypso/state/themes/selectors';
 import { getSerializedThemesQueryWithoutPage } from 'calypso/state/themes/utils';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
@@ -43,10 +39,7 @@ export const getThemesForQueryIgnoringPage = createSelector(
 			);
 
 			// Set active theme to be the first theme in the array.
-			if (
-				isEnabled( 'themes/showcase-i4/search-and-filter' ) &&
-				! isRequestingActiveTheme( state, selectedSiteId )
-			) {
+			if ( isEnabled( 'themes/showcase-i4/search-and-filter' ) && selectedSiteId ) {
 				const currentThemeId = getActiveTheme( state, selectedSiteId );
 				const currentTheme = getCanonicalTheme( state, selectedSiteId, currentThemeId );
 

--- a/client/state/themes/selectors/get-themes-for-query-ignoring-page.js
+++ b/client/state/themes/selectors/get-themes-for-query-ignoring-page.js
@@ -1,7 +1,11 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { createSelector } from '@automattic/state-utils';
 import { flatMap } from 'lodash';
-import { getActiveTheme, getCanonicalTheme } from 'calypso/state/themes/selectors';
+import {
+	getActiveTheme,
+	getCanonicalTheme,
+	isRequestingActiveTheme,
+} from 'calypso/state/themes/selectors';
 import { getSerializedThemesQueryWithoutPage } from 'calypso/state/themes/utils';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
@@ -30,6 +34,7 @@ export const getThemesForQueryIgnoringPage = createSelector(
 
 		// If query is default, filter out recommended themes.
 		if ( ! ( query.search || query.filter || query.tier ) ) {
+			const selectedSiteId = state.ui ? getSelectedSiteId( state ) : null;
 			const recommendedThemes = state.themes.recommendedThemes.themes;
 			const themeIds = flatMap( recommendedThemes, ( theme ) => theme.id );
 
@@ -38,8 +43,10 @@ export const getThemesForQueryIgnoringPage = createSelector(
 			);
 
 			// Set active theme to be the first theme in the array.
-			if ( isEnabled( 'themes/showcase-i4/search-and-filter' ) ) {
-				const selectedSiteId = state.ui ? getSelectedSiteId( state ) : null;
+			if (
+				isEnabled( 'themes/showcase-i4/search-and-filter' ) &&
+				! isRequestingActiveTheme( state, selectedSiteId )
+			) {
 				const currentThemeId = getActiveTheme( state, selectedSiteId );
 				const currentTheme = getCanonicalTheme( state, selectedSiteId, currentThemeId );
 


### PR DESCRIPTION
#### Proposed Changes

This PR removes the current theme card from the Theme Showcase. Instead, we show the active theme as the first theme in the grid, but only when there are no queries set. This means, no search queries, no category filter selected, and no pricing filter selected. See p1669167875807189-slack-C048CUFRGFQ for more context.

| Before | After |
| --- | --- |
| ![Screen Shot 2022-11-23 at 6 47 43 PM](https://user-images.githubusercontent.com/797888/203527933-c8462701-9040-4e6d-8dc3-24a8d484113b.png) | ![Screen Shot 2022-11-23 at 6 48 15 PM](https://user-images.githubusercontent.com/797888/203528047-f450d3b0-7a5f-48f2-aaf9-fc3c745fcf69.png)

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the Theme Showcase `/themes/${site_slug}`.
  * If using calypso.live, the flag `themes/showcase-i4/search-and-filter` is required.
* Ensure that the current theme card is no longer present.
* Ensure that the active theme is shown first in the theme grid when no queries are set. 
* Ensure that no themes are missing because of the reordering.
* Ensure that the logged-out Theme Showcase works as before.
* Ensure that the existing Theme Showcase works as before.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->