### PR TITLE
Fix: Logged-out navbar CTA parameter

### DIFF
--- a/client/layout/universal-navbar-header/index.jsx
+++ b/client/layout/universal-navbar-header/index.jsx
@@ -5,13 +5,12 @@ import { useSelector } from 'react-redux';
 import WordPressWordmark from 'calypso/components/wordpress-wordmark';
 import UniversalNavbarBtnMenuItem from 'calypso/layout/universal-navbar-header/btn-menu-item.jsx';
 import UniversalNavbarLiMenuItem from 'calypso/layout/universal-navbar-header/li-menu-item.jsx';
-import getCurrentRoute from 'calypso/state/selectors/get-current-route';
+import { getSectionName } from 'calypso/state/ui/selectors';
 
 const UniversalNavbarHeader = () => {
 	const translate = useTranslate();
 	const [ isMobileMenuOpen, setMobileMenuOpen ] = useState( false );
-	const currentRoute = useSelector( getCurrentRoute );
-	const ctaParam = currentRoute.replace( /^\//, '' ) + '-lp';
+	const sectionName = useSelector( getSectionName );
 
 	return (
 		<div>
@@ -204,7 +203,7 @@ const UniversalNavbarHeader = () => {
 										className="x-nav-item x-nav-item__wide"
 										titleValue={ translate( 'Get Started' ) }
 										elementContent={ translate( 'Get Started' ) }
-										urlValue={ '/start/business/?ref=' + ctaParam }
+										urlValue={ `/start/business/?ref=${ sectionName }-lp` }
 										type="nav"
 										typeClassName="x-nav-link x-nav-link__primary x-link cta-btn-nav"
 									/>

--- a/client/layout/universal-navbar-header/index.jsx
+++ b/client/layout/universal-navbar-header/index.jsx
@@ -1,13 +1,17 @@
 import './nav-style.scss';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
+import { useSelector } from 'react-redux';
 import WordPressWordmark from 'calypso/components/wordpress-wordmark';
 import UniversalNavbarBtnMenuItem from 'calypso/layout/universal-navbar-header/btn-menu-item.jsx';
 import UniversalNavbarLiMenuItem from 'calypso/layout/universal-navbar-header/li-menu-item.jsx';
+import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 
 const UniversalNavbarHeader = () => {
 	const translate = useTranslate();
 	const [ isMobileMenuOpen, setMobileMenuOpen ] = useState( false );
+	const currentRoute = useSelector( getCurrentRoute );
+	const ctaParam = currentRoute.replace( /^\//, '' ) + '-lp';
 
 	return (
 		<div>
@@ -200,7 +204,7 @@ const UniversalNavbarHeader = () => {
 										className="x-nav-item x-nav-item__wide"
 										titleValue={ translate( 'Get Started' ) }
 										elementContent={ translate( 'Get Started' ) }
-										urlValue="/start/business/?ref=plugins-lp"
+										urlValue={ '/start/business/?ref=' + ctaParam }
 										type="nav"
 										typeClassName="x-nav-link x-nav-link__primary x-link cta-btn-nav"
 									/>


### PR DESCRIPTION
#### Proposed Changes

This sets the current route as the URL parameter for the `Get Started` CTA button in the logged-out navbar

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Log out
* Go to `/themes` and `/plugins`
* The `Get Started` button should append the corresponding param (ie. `ref=themes-lp` and `ref=plugins-lp`)

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
