### PR TITLE
Implement minor tweaks, fixes and improvements for the new Pricing Plans block

### DIFF
--- a/apps/happy-blocks/index.php
+++ b/apps/happy-blocks/index.php
@@ -97,17 +97,25 @@ add_action( 'enqueue_block_editor_assets', 'a8c_happyblocks_assets' );
 add_action( 'wp_enqueue_scripts', 'a8c_happyblocks_view_assets' );
 
 /**
+ * Get the topic's selected help site's domain.
+ *
+ * @return string
+ */
+function a8c_happyblocks_get_topic_domain() {
+	$topic_id = bbp_get_topic_id();
+	return get_post_meta( $topic_id, 'which_blog_domain', true );
+}
+
+/**
  * Get the pricing plans configuration
  *
  * @return array
  */
 function a8c_happyblocks_get_config() {
-	$topic_id             = bbp_get_topic_id();
-	$selected_blog_domain = get_post_meta( $topic_id, 'which_blog_domain', true );
 
 	return array(
 		'locale' => get_user_locale(),
-		'domain' => $selected_blog_domain,
+		'domain' => a8c_happyblocks_get_topic_domain(),
 	);
 }
 
@@ -118,7 +126,8 @@ function a8c_happyblocks_get_config() {
  * @return string
  */
 function a8c_happyblocks_render_pricing_plans_callback( $attributes ) {
-	$json_attributes = htmlspecialchars( wp_json_encode( $attributes ), ENT_QUOTES, 'UTF-8' );
+	$attributes['domain'] = a8c_happyblocks_get_topic_domain();
+	$json_attributes      = htmlspecialchars( wp_json_encode( $attributes ), ENT_QUOTES, 'UTF-8' );
 
 	return <<<HTML
 		<div data-attributes="${json_attributes}" class="a8c-happy-tools-pricing-plans-block-placeholder" />

--- a/apps/happy-blocks/index.php
+++ b/apps/happy-blocks/index.php
@@ -102,10 +102,12 @@ add_action( 'wp_enqueue_scripts', 'a8c_happyblocks_view_assets' );
  * @return array
  */
 function a8c_happyblocks_get_config() {
-	$domain = wp_parse_url( home_url() )['host'];
+	$topic_id             = bbp_get_topic_id();
+	$selected_blog_domain = get_post_meta( $topic_id, 'which_blog_domain', true );
+
 	return array(
-		'domain' => $domain,
 		'locale' => get_user_locale(),
+		'domain' => $selected_blog_domain,
 	);
 }
 

--- a/apps/happy-blocks/index.php
+++ b/apps/happy-blocks/index.php
@@ -56,8 +56,8 @@ function a8c_happyblocks_assets() {
 	wp_enqueue_script(
 		'a8c-happyblocks-edit-js',
 		plugins_url( 'dist/editor.min.js', __FILE__ ),
-		array( 'a8c-happyblocks-pricing-plans' ),
-		$assets['version'],
+		array_merge( array( 'a8c-happyblocks-pricing-plans' ), $assets['dependencies'] ),
+		assets['version'],
 		true
 	);
 
@@ -88,7 +88,7 @@ function a8c_happyblocks_view_assets() {
 	wp_enqueue_script(
 		'a8c-happyblock-view-js',
 		plugins_url( $script_file, __FILE__ ),
-		array( 'wp-element' ),
+		$assets['dependencies'],
 		$assets['version'],
 		true
 	);

--- a/apps/happy-blocks/index.php
+++ b/apps/happy-blocks/index.php
@@ -57,7 +57,7 @@ function a8c_happyblocks_assets() {
 		'a8c-happyblocks-edit-js',
 		plugins_url( 'dist/editor.min.js', __FILE__ ),
 		array_merge( array( 'a8c-happyblocks-pricing-plans' ), $assets['dependencies'] ),
-		assets['version'],
+		$assets['version'],
 		true
 	);
 

--- a/apps/happy-blocks/src/pricing-plans/components/billing-info.tsx
+++ b/apps/happy-blocks/src/pricing-plans/components/billing-info.tsx
@@ -1,3 +1,5 @@
+import { isWpComMonthlyPlan } from '@automattic/calypso-products';
+import { __ } from '@wordpress/i18n';
 import { FunctionComponent } from 'react';
 import { BlockPlan } from '../hooks/pricing-plans';
 
@@ -10,7 +12,10 @@ const BillingInfo: FunctionComponent< Props > = ( { plan } ) => {
 		<div className="hb-pricing-plans-embed__billing-info">
 			<span className="hb-pricing-plans-embed__billing-info-value">{ plan.price }</span>
 			<span className="hb-pricing-plans-embed__billing-info-description">
-				/{ plan.getBillingTimeFrame() }
+				/
+				{ isWpComMonthlyPlan( plan.productSlug )
+					? __( 'month', 'happy-blocks' )
+					: __( 'month, billed annually', 'happy-blocks' ) }
 			</span>
 		</div>
 	);

--- a/apps/happy-blocks/src/pricing-plans/components/billing-options.tsx
+++ b/apps/happy-blocks/src/pricing-plans/components/billing-options.tsx
@@ -1,6 +1,7 @@
 import { TERM_ANNUALLY, TERM_MONTHLY } from '@automattic/calypso-products';
-import { sprintf, __ } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { FunctionComponent } from 'react';
+import usePlanVariants from '../hooks/plan-variants';
 import { BlockPlan } from '../hooks/pricing-plans';
 
 const Promo: FunctionComponent = ( { children } ) => (
@@ -13,48 +14,13 @@ interface Props {
 	onChange: ( value?: string ) => void;
 }
 
-const getAnnualDiscount = ( annualPlan?: BlockPlan, monthlyPlan?: BlockPlan ) => {
-	if ( ! annualPlan || ! monthlyPlan ) {
-		return null;
-	}
-
-	const annualPricePerMonth = annualPlan.rawPrice / 12;
-
-	const discountRate = Math.round(
-		( 100 * ( monthlyPlan.rawPrice - annualPricePerMonth ) ) / monthlyPlan.rawPrice
-	);
-
-	return sprintf(
-		// translators: %s is the discount rate
-		__( 'Save %s', 'happy-blocks' ),
-		`${ discountRate }%`
-	);
-};
-
 const BillingOptions: FunctionComponent< Props > = ( { plans, value, onChange } ) => {
-	const selectedPlan = plans?.find( ( plan ) => plan.productSlug === value );
-
-	if ( ! plans || ! selectedPlan ) {
-		return null;
-	}
-
-	const monthlyPlan =
-		selectedPlan.term === TERM_MONTHLY
-			? selectedPlan
-			: plans.find( ( plan ) => plan.term === TERM_MONTHLY && plan.type === selectedPlan.type );
-
-	const annualPlan =
-		selectedPlan.term === TERM_ANNUALLY
-			? selectedPlan
-			: plans.find( ( plan ) => plan.term === TERM_ANNUALLY && plan.type === selectedPlan.type );
-
-	const annualDiscount = getAnnualDiscount( annualPlan, monthlyPlan );
-
-	const planChoices = [ monthlyPlan, annualPlan ].filter( Boolean );
+	const selectedPlan = plans?.find( ( plan ) => plan.productSlug === value ) ?? plans[ 0 ];
+	const { monthlyPlan, annualPlan, annualDiscount } = usePlanVariants( plans, selectedPlan );
 
 	return (
 		<fieldset className="hb-pricing-plans-embed__billing-options">
-			{ planChoices.map( ( plan ) => (
+			{ [ monthlyPlan, annualPlan ].map( ( plan ) => (
 				<div key={ plan?.productSlug }>
 					<label className="hb-pricing-plans-embed__billing-option-label">
 						<input

--- a/apps/happy-blocks/src/pricing-plans/components/billing-options.tsx
+++ b/apps/happy-blocks/src/pricing-plans/components/billing-options.tsx
@@ -1,4 +1,5 @@
-import { isWpComMonthlyPlan } from '@automattic/calypso-products';
+import { isWpComAnnualPlan, isWpComMonthlyPlan } from '@automattic/calypso-products';
+import { useInstanceId } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import { FunctionComponent } from 'react';
 import usePlanVariants from '../hooks/plan-variants';
@@ -17,6 +18,8 @@ interface Props {
 const BillingOptions: FunctionComponent< Props > = ( { plans, value, onChange } ) => {
 	const selectedPlan = plans?.find( ( plan ) => plan.productSlug === value ) ?? plans[ 0 ];
 	const { monthlyPlan, annualPlan, annualDiscount } = usePlanVariants( plans, selectedPlan );
+	const instanceId = useInstanceId( BillingOptions );
+	const id = `hb-plans-radio-control-${ instanceId }`;
 
 	if ( ! monthlyPlan || ! annualPlan ) {
 		return null;
@@ -29,8 +32,8 @@ const BillingOptions: FunctionComponent< Props > = ( { plans, value, onChange } 
 					<label className="hb-pricing-plans-embed__billing-option-label">
 						<input
 							className="hb-pricing-plans-embed__billing-option-input"
+							id={ id }
 							type="radio"
-							name="price"
 							value={ plan?.productSlug }
 							checked={ plan?.productSlug === value }
 							onChange={ () => onChange( plan?.productSlug ) }
@@ -38,7 +41,7 @@ const BillingOptions: FunctionComponent< Props > = ( { plans, value, onChange } 
 						{ isWpComMonthlyPlan( plan.productSlug )
 							? __( 'Monthly', 'happy-blocks' )
 							: __( 'Annually', 'happy-blocks' ) }
-						{ annualDiscount && isWpComMonthlyPlan( plan.productSlug ) && (
+						{ annualDiscount && isWpComAnnualPlan( plan.productSlug ) && (
 							<Promo>({ annualDiscount })</Promo>
 						) }
 					</label>

--- a/apps/happy-blocks/src/pricing-plans/components/billing-options.tsx
+++ b/apps/happy-blocks/src/pricing-plans/components/billing-options.tsx
@@ -1,4 +1,4 @@
-import { TERM_ANNUALLY, TERM_MONTHLY } from '@automattic/calypso-products';
+import { isWpComMonthlyPlan } from '@automattic/calypso-products';
 import { __ } from '@wordpress/i18n';
 import { FunctionComponent } from 'react';
 import usePlanVariants from '../hooks/plan-variants';
@@ -18,6 +18,10 @@ const BillingOptions: FunctionComponent< Props > = ( { plans, value, onChange } 
 	const selectedPlan = plans?.find( ( plan ) => plan.productSlug === value ) ?? plans[ 0 ];
 	const { monthlyPlan, annualPlan, annualDiscount } = usePlanVariants( plans, selectedPlan );
 
+	if ( ! monthlyPlan || ! annualPlan ) {
+		return null;
+	}
+
 	return (
 		<fieldset className="hb-pricing-plans-embed__billing-options">
 			{ [ monthlyPlan, annualPlan ].map( ( plan ) => (
@@ -31,10 +35,10 @@ const BillingOptions: FunctionComponent< Props > = ( { plans, value, onChange } 
 							checked={ plan?.productSlug === value }
 							onChange={ () => onChange( plan?.productSlug ) }
 						/>
-						{ plan?.term === TERM_MONTHLY
+						{ isWpComMonthlyPlan( plan.productSlug )
 							? __( 'Monthly', 'happy-blocks' )
 							: __( 'Annually', 'happy-blocks' ) }
-						{ annualDiscount && plan?.term === TERM_ANNUALLY && (
+						{ annualDiscount && isWpComMonthlyPlan( plan.productSlug ) && (
 							<Promo>({ annualDiscount })</Promo>
 						) }
 					</label>

--- a/apps/happy-blocks/src/pricing-plans/components/block-settings.tsx
+++ b/apps/happy-blocks/src/pricing-plans/components/block-settings.tsx
@@ -33,10 +33,13 @@ const BlockSettings: FunctionComponent<
 
 	return (
 		<InspectorControls>
-			<PanelBody title={ __( 'Basic', 'happy-blocks' ) } initialOpen={ true }>
+			<PanelBody
+				className="hb-pricing-plans-embed__settings"
+				title={ __( 'Basic', 'happy-blocks' ) }
+				initialOpen={ true }
+			>
 				<PanelRow>
 					<SelectControl
-						className="hb-pricing-plans-embed__settings-plan"
 						label={ __( 'Plan', 'happy-blocks' ) }
 						value={ currentPlan?.type }
 						options={ planTypeOptions }

--- a/apps/happy-blocks/src/pricing-plans/components/block-settings.tsx
+++ b/apps/happy-blocks/src/pricing-plans/components/block-settings.tsx
@@ -1,6 +1,7 @@
+import { TERM_ANNUALLY, TERM_MONTHLY } from '@automattic/calypso-products';
 import { InspectorControls } from '@wordpress/block-editor';
 import { BlockEditProps } from '@wordpress/blocks';
-import { SelectControl, PanelRow, PanelBody } from '@wordpress/components';
+import { SelectControl, PanelRow, PanelBody, RadioControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { FunctionComponent } from 'react';
 import usePlanOptions from '../hooks/plan-options';
@@ -14,7 +15,21 @@ interface Props {
 const BlockSettings: FunctionComponent<
 	Pick< BlockEditProps< BlockAttributes >, 'attributes' | 'setAttributes' > & Props
 > = ( { attributes, setAttributes, plans } ) => {
-	const options = usePlanOptions( plans );
+	const planTypeOptions = usePlanOptions( plans );
+	const currentPlan = plans?.find( ( plan ) => plan.productSlug === attributes.productSlug );
+
+	const setPlan = ( type: string, term: string ) => {
+		const plan = plans?.find( ( plan ) => plan.type === type && plan.term === term );
+		setAttributes( { productSlug: plan?.productSlug } );
+	};
+
+	const onPlanTypeChange = ( newPlanType: string ) => {
+		setPlan( newPlanType, currentPlan?.term ?? plans[ 0 ].term );
+	};
+
+	const onPlanTermChange = ( newPlanTerm: string ) => {
+		setPlan( currentPlan?.type ?? plans[ 0 ].type, newPlanTerm );
+	};
 
 	return (
 		<InspectorControls>
@@ -23,9 +38,20 @@ const BlockSettings: FunctionComponent<
 					<SelectControl
 						className="hb-pricing-plans-embed__settings-plan"
 						label={ __( 'Plan', 'happy-blocks' ) }
-						value={ attributes.productSlug }
-						options={ options }
-						onChange={ ( productSlug ) => setAttributes( { productSlug } ) }
+						value={ currentPlan?.type }
+						options={ planTypeOptions }
+						onChange={ onPlanTypeChange }
+					/>
+				</PanelRow>
+				<PanelRow>
+					<RadioControl
+						label={ __( 'Price', 'happy-blocks' ) }
+						selected={ currentPlan?.term }
+						options={ [
+							{ label: __( 'Monthly', 'happy-blocks' ), value: TERM_MONTHLY },
+							{ label: __( 'Annually', 'happy-blocks' ), value: TERM_ANNUALLY },
+						] }
+						onChange={ onPlanTermChange }
 					/>
 				</PanelRow>
 			</PanelBody>

--- a/apps/happy-blocks/src/pricing-plans/components/pricing-plan-detail.tsx
+++ b/apps/happy-blocks/src/pricing-plans/components/pricing-plan-detail.tsx
@@ -24,7 +24,11 @@ const PricingPlanDetail: FunctionComponent< BlockSaveProps< BlockAttributes > & 
 				<BillingInfo plan={ plan } />
 				<BillingOptions plans={ plans } value={ attributes.productSlug } onChange={ setPlan } />
 			</div>
-			<BillingButton href={ plan.upgradeLink }>{ plan.upgradeLabel }</BillingButton>
+			<BillingButton
+				href={ `https://wordpress.com/checkout/${ attributes.domain }/${ plan.pathSlug }` }
+			>
+				{ plan.upgradeLabel }
+			</BillingButton>
 		</section>
 	);
 };

--- a/apps/happy-blocks/src/pricing-plans/components/pricing-plans-header.tsx
+++ b/apps/happy-blocks/src/pricing-plans/components/pricing-plans-header.tsx
@@ -22,7 +22,13 @@ const PricingPlansHeader: FunctionComponent< Props > = ( { plan } ) => {
 				<p>{ plan.getDescription() }</p>
 				<p>
 					{ createInterpolateElement( __( '<a>Learn more</a>', 'happy-blocks' ), {
-						a: <a target="_blank" href="https://wordpress.com/pricing" rel="noreferrer" />,
+						a: (
+							<a
+								target="_blank"
+								href={ `https://wordpress.com/plans/${ config.domain }` }
+								rel="noreferrer"
+							/>
+						),
 					} ) }
 				</p>
 			</div>

--- a/apps/happy-blocks/src/pricing-plans/components/pricing-plans-header.tsx
+++ b/apps/happy-blocks/src/pricing-plans/components/pricing-plans-header.tsx
@@ -1,21 +1,22 @@
 import { createInterpolateElement } from '@wordpress/element';
 import { sprintf, __ } from '@wordpress/i18n';
 import { FunctionComponent } from 'react';
-import config from '../config';
 import { BlockPlan } from '../hooks/pricing-plans';
+import { BlockAttributes } from '../types';
 
 interface Props {
 	plan: BlockPlan;
+	attributes: BlockAttributes;
 }
 
-const PricingPlansHeader: FunctionComponent< Props > = ( { plan } ) => {
+const PricingPlansHeader: FunctionComponent< Props > = ( { plan, attributes } ) => {
 	return (
 		<section className="hb-pricing-plans-embed__header">
 			<div className="hb-pricing-plans-embed__header-label">{ plan.getTitle() }</div>
 			<div className="hb-pricing-plans-embed__header-domain">
 				{
 					// translators: %s is the domain name of the plan
-					sprintf( __( 'for %s', 'happy-blocks' ), config.domain )
+					sprintf( __( 'for %s', 'happy-blocks' ), attributes.domain )
 				}
 			</div>
 			<div className="hb-pricing-plans-embed__header-description">
@@ -25,7 +26,7 @@ const PricingPlansHeader: FunctionComponent< Props > = ( { plan } ) => {
 						a: (
 							<a
 								target="_blank"
-								href={ `https://wordpress.com/plans/${ config.domain }` }
+								href={ `https://wordpress.com/plans/${ attributes.domain }` }
 								rel="noreferrer"
 							/>
 						),

--- a/apps/happy-blocks/src/pricing-plans/components/pricing-plans.tsx
+++ b/apps/happy-blocks/src/pricing-plans/components/pricing-plans.tsx
@@ -21,7 +21,7 @@ const PricingPlans: FunctionComponent<
 
 	return (
 		<div className="hb-pricing-plans-embed">
-			<PricingPlansHeader plan={ currentPlan } />
+			<PricingPlansHeader attributes={ attributes } plan={ currentPlan } />
 			<PricingPlanDetail
 				plan={ currentPlan }
 				plans={ plans }

--- a/apps/happy-blocks/src/pricing-plans/edit.scss
+++ b/apps/happy-blocks/src/pricing-plans/edit.scss
@@ -86,6 +86,15 @@ $brand-text: "SF Pro Text", $sans;
 			letter-spacing: -0.24px;
 			color: $studio-gray-80;
 
+			p:first-of-type {
+				overflow: hidden;
+				text-overflow: ellipsis;
+				display: -webkit-box;
+				line-clamp: 2;
+				-webkit-line-clamp: 2;
+				-webkit-box-orient: vertical;
+			}
+
 			p {
 				margin: 0 !important;
 			}

--- a/apps/happy-blocks/src/pricing-plans/edit.scss
+++ b/apps/happy-blocks/src/pricing-plans/edit.scss
@@ -43,7 +43,7 @@ $brand-text: "SF Pro Text", $sans;
 
 	&__skeleton {
 		color: $studio-gray-0;
-		background-color: $studio-gray-0;
+		background-color: $studio-gray-5;
 		width: 100%;
 		margin: 24px 0;
 		min-height: 215px;

--- a/apps/happy-blocks/src/pricing-plans/edit.scss
+++ b/apps/happy-blocks/src/pricing-plans/edit.scss
@@ -34,11 +34,29 @@ $brand-text: "SF Pro Text", $sans;
 	background-color: $studio-white;
 
 
-	&__settings-plan select {
-		min-height: 30px !important;
-		height: 30px !important;
-		padding: 0 26px 0 8px !important;
-		margin: 0 !important;
+	&__settings {
+		select {
+			min-height: 30px !important;
+			height: 30px !important;
+			padding: 0 26px 0 8px !important;
+			margin: 0 !important;
+		}
+
+		.components-panel__row {
+			display: block;
+		}
+
+		.components-radio-control__option {
+			display: flex;
+			gap: 10px;
+		}
+
+		.components-flex.components-h-stack.components-v-stack {
+			margin-top: 8px;
+			flex-direction: row;
+			gap: 20px;
+			justify-content: flex-start;
+		}
 	}
 
 	&__skeleton {

--- a/apps/happy-blocks/src/pricing-plans/edit.tsx
+++ b/apps/happy-blocks/src/pricing-plans/edit.tsx
@@ -15,14 +15,37 @@ export const Edit: FunctionComponent< BlockEditProps< BlockAttributes > > = ( {
 	setAttributes,
 } ) => {
 	const { data: plans, isLoading } = usePricingPlans();
-
 	// Set default values for attributes which are required when rendering the block
 	// See https://github.com/WordPress/gutenberg/issues/7342
 	useEffect( () => {
 		setAttributes( {
 			productSlug: attributes.productSlug ?? config.plans[ 0 ],
+			domain: attributes.domain ?? '',
 		} );
-	}, [ attributes.productSlug, setAttributes ] );
+	}, [ attributes.domain, attributes.productSlug, setAttributes ] );
+
+	useEffect( () => {
+		const blogIdSelect: HTMLSelectElement | null =
+			document.querySelector( 'select[name="blog_id"]' );
+
+		if ( ! blogIdSelect ) {
+			return;
+		}
+
+		const updateBlogId = () => {
+			const url = blogIdSelect.options[ blogIdSelect.selectedIndex ].text;
+			const domain = url.replace( /^https?:\/\//, '' );
+
+			setAttributes( { domain } );
+		};
+
+		updateBlogId();
+		blogIdSelect.addEventListener( 'change', updateBlogId );
+
+		return () => {
+			blogIdSelect.removeEventListener( 'change', updateBlogId );
+		};
+	}, [ setAttributes ] );
 
 	const blockProps = useBlockProps();
 

--- a/apps/happy-blocks/src/pricing-plans/edit.tsx
+++ b/apps/happy-blocks/src/pricing-plans/edit.tsx
@@ -20,7 +20,7 @@ export const Edit: FunctionComponent< BlockEditProps< BlockAttributes > > = ( {
 	useEffect( () => {
 		setAttributes( {
 			productSlug: attributes.productSlug ?? config.plans[ 0 ],
-			domain: attributes.domain ?? '',
+			domain: attributes.domain ?? config.domain,
 		} );
 	}, [ attributes.domain, attributes.productSlug, setAttributes ] );
 

--- a/apps/happy-blocks/src/pricing-plans/edit.tsx
+++ b/apps/happy-blocks/src/pricing-plans/edit.tsx
@@ -26,7 +26,7 @@ export const Edit: FunctionComponent< BlockEditProps< BlockAttributes > > = ( {
 
 	const blockProps = useBlockProps();
 
-	if ( isLoading || ! plans ) {
+	if ( isLoading || ! plans?.length ) {
 		return <Skeleton />;
 	}
 

--- a/apps/happy-blocks/src/pricing-plans/hooks/plan-options.ts
+++ b/apps/happy-blocks/src/pricing-plans/hooks/plan-options.ts
@@ -1,23 +1,16 @@
-import { TERM_ANNUALLY } from '@automattic/calypso-products';
-import { __ } from '@wordpress/i18n';
 import { BlockPlan } from './pricing-plans';
-
-const getPlanLabel = ( plan: BlockPlan ): string => {
-	const title = plan.getTitle().toString();
-
-	const period =
-		plan.term === TERM_ANNUALLY ? __( 'annually', 'happy-tools' ) : __( 'monthly', 'happy-tools' );
-
-	return `${ title } (${ period })`;
-};
 
 const usePlanOptions = ( plans: BlockPlan[] ) => {
 	const options = plans.map( ( plan ) => ( {
-		label: getPlanLabel( plan ),
-		value: plan.productSlug,
+		label: plan.getTitle().toString(),
+		value: plan.type,
 	} ) );
 
-	return options;
+	const uniqueOptions = [
+		...new Map( options.map( ( option ) => [ option.value, option ] ) ).values(),
+	];
+
+	return uniqueOptions;
 };
 
 export default usePlanOptions;

--- a/apps/happy-blocks/src/pricing-plans/hooks/plan-variants.ts
+++ b/apps/happy-blocks/src/pricing-plans/hooks/plan-variants.ts
@@ -1,0 +1,41 @@
+import { isWpComAnnualPlan, isWpComMonthlyPlan } from '@automattic/calypso-products';
+import { sprintf, __ } from '@wordpress/i18n';
+import { BlockPlan } from './pricing-plans';
+
+const getAnnualDiscount = ( annualPlan?: BlockPlan, monthlyPlan?: BlockPlan ) => {
+	if ( ! annualPlan || ! monthlyPlan ) {
+		return null;
+	}
+
+	const annualPricePerMonth = annualPlan.rawPrice / 12;
+
+	const discountRate = Math.round(
+		( 100 * ( monthlyPlan.rawPrice - annualPricePerMonth ) ) / monthlyPlan.rawPrice
+	);
+
+	return sprintf(
+		// translators: %s is the discount rate
+		__( 'Save %s', 'happy-blocks' ),
+		`${ discountRate }%`
+	);
+};
+
+const usePlanVariants = ( plans: BlockPlan[], selectedPlan: BlockPlan ) => {
+	const monthlyPlan = isWpComMonthlyPlan( selectedPlan.productSlug )
+		? selectedPlan
+		: plans.find(
+				( plan ) => isWpComMonthlyPlan( plan.productSlug ) && plan.type === selectedPlan.type
+		  );
+
+	const annualPlan = isWpComAnnualPlan( selectedPlan.productSlug )
+		? selectedPlan
+		: plans.find(
+				( plan ) => isWpComAnnualPlan( plan.productSlug ) && plan.type === selectedPlan.type
+		  );
+
+	const annualDiscount = getAnnualDiscount( annualPlan, monthlyPlan );
+
+	return { monthlyPlan, annualPlan, annualDiscount };
+};
+
+export default usePlanVariants;

--- a/apps/happy-blocks/src/pricing-plans/hooks/pricing-plans.ts
+++ b/apps/happy-blocks/src/pricing-plans/hooks/pricing-plans.ts
@@ -7,9 +7,9 @@ import { ApiPricingPlan } from '../types.js';
 
 export interface BlockPlan extends Plan {
 	productSlug: string;
+	pathSlug: string;
 	rawPrice: number;
 	price: string;
-	upgradeLink: string;
 	upgradeLabel: string;
 }
 
@@ -21,6 +21,7 @@ const parsePlans = ( data: ApiPricingPlan[] ): BlockPlan[] => {
 			return {
 				...plan,
 				productSlug: apiPlan.product_slug,
+				pathSlug: apiPlan.path_slug,
 				rawPrice: apiPlan.raw_price,
 				price:
 					formatCurrency(
@@ -28,7 +29,6 @@ const parsePlans = ( data: ApiPricingPlan[] ): BlockPlan[] => {
 						apiPlan.currency_code,
 						{ stripZeros: true }
 					) ?? '',
-				upgradeLink: `https://wordpress.com/checkout/${ config.domain }/${ apiPlan.path_slug }`,
 				upgradeLabel: sprintf(
 					// translators: %s is the plan name
 					__( 'Upgrade to %s', 'happy-tools' ),

--- a/apps/happy-blocks/src/pricing-plans/hooks/pricing-plans.ts
+++ b/apps/happy-blocks/src/pricing-plans/hooks/pricing-plans.ts
@@ -5,6 +5,12 @@ import { sprintf, __ } from '@wordpress/i18n';
 import config from '../config';
 import { ApiPricingPlan } from '../types.js';
 
+/**
+ * This URL is broken down into parts due to 119-gh-Automattic/lighthouse-forums
+ */
+const PLANS_API_URL =
+	'https' + '://' + 'public-api.wordpress.com/rest/v1.5/plans?locale=' + config.locale;
+
 export interface BlockPlan extends Plan {
 	productSlug: string;
 	pathSlug: string;
@@ -52,9 +58,7 @@ const usePricingPlans = () => {
 			setIsLoading( true );
 			setError( null );
 			try {
-				const response = await fetch(
-					`https://public-api.wordpress.com/rest/v1.5/plans?locale=${ config.locale }`
-				);
+				const response = await fetch( PLANS_API_URL );
 				const data = await response.json();
 				setPlans( parsePlans( data ) );
 			} catch ( e: unknown ) {

--- a/apps/happy-blocks/src/pricing-plans/index.jsx
+++ b/apps/happy-blocks/src/pricing-plans/index.jsx
@@ -14,7 +14,7 @@ function registerBlock() {
 		apiVersion: 2,
 		title: __( 'Upgrade', 'happy-blocks' ),
 		icon: 'money-alt',
-		category: 'a8c',
+		category: 'embed',
 		description: __( 'List of available pricing plans', 'happy-blocks' ),
 		keywords: [
 			__( 'pricing', 'happy-blocks' ),

--- a/apps/happy-blocks/src/pricing-plans/index.jsx
+++ b/apps/happy-blocks/src/pricing-plans/index.jsx
@@ -7,6 +7,9 @@ const blockAttributes = {
 	productSlug: {
 		enum: config.plans,
 	},
+	domain: {
+		type: 'string',
+	},
 };
 
 function registerBlock() {

--- a/apps/happy-blocks/src/pricing-plans/types.d.ts
+++ b/apps/happy-blocks/src/pricing-plans/types.d.ts
@@ -1,5 +1,6 @@
 export interface BlockAttributes {
 	productSlug: string;
+	domain: string;
 }
 
 /**

--- a/apps/happy-blocks/src/pricing-plans/view.tsx
+++ b/apps/happy-blocks/src/pricing-plans/view.tsx
@@ -15,7 +15,7 @@ const ViewPricingPlans: FunctionComponent< BlockEditProps< BlockAttributes > > =
 		setDummyAttributes( ( values ) => ( { ...values, ...newValues } ) );
 	};
 
-	if ( isLoading || ! plans ) {
+	if ( isLoading || ! plans?.length ) {
 		return <Skeleton />;
 	}
 


### PR DESCRIPTION
#### Proposed Changes

* This Pull Request addresses the issues discussed in 116-gh-Automattic/lighthouse-forums for the new Pricing Plans block.

And additionally:
- Adds the `wp_enqueue_script` dependencies which were missing
- Changes the block category to ' embed' 
- A fix for 119-gh-Automattic/lighthouse-forums


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


* Run `yarn dev --sync` in `apps/happy-blocks` to sync code to your sandbox
* Create a new topic, in the editor press `/` and search for "Upgrade" block.
* Verify the issues discussed in 116-gh-Automattic/lighthouse-forums have been resolved.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
