### PR TITLE
Jetpack Pro Dashboard: make "Issue x license" button sticky when scrolled below the viewport

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
@@ -15,6 +15,7 @@ import NavItem from 'calypso/components/section-nav/item';
 import NavTabs from 'calypso/components/section-nav/tabs';
 import SidebarNavigation from 'calypso/components/sidebar-navigation';
 import useFetchDashboardSites from 'calypso/data/agency-dashboard/use-fetch-dashboard-sites';
+import useDetectWindowBoundary from 'calypso/lib/detect-window-boundary';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { resetSite } from 'calypso/state/jetpack-agency-dashboard/actions';
 import {
@@ -31,6 +32,8 @@ import SiteWelcomeBanner from './site-welcome-banner';
 import { getProductSlugFromProductType } from './utils';
 
 import './style.scss';
+
+const CALYPSO_MASTERBAR_HEIGHT = 47;
 
 export default function SitesOverview() {
 	const translate = useTranslate();
@@ -147,6 +150,10 @@ export default function SitesOverview() {
 		} );
 	}, [ selectedLicensesSiteId, selectedLicenses ] );
 
+	const [ divRef, hasCrossed ] = useDetectWindowBoundary( CALYPSO_MASTERBAR_HEIGHT );
+
+	const outerDivProps = divRef ? { ref: divRef as React.RefObject< HTMLDivElement > } : {};
+
 	const renderIssueLicenseButton = () => {
 		return (
 			<div className="sites-overview__licenses-buttons">
@@ -173,7 +180,7 @@ export default function SitesOverview() {
 						)
 					}
 				>
-					{ translate( 'Issue %(numLicenses)d new license', 'Issue %(numLicenses)d new licenses', {
+					{ translate( 'Issue %(numLicenses)d license', 'Issue %(numLicenses)d licenses', {
 						context: 'button label',
 						count: selectedLicensesCount,
 						args: {
@@ -185,6 +192,9 @@ export default function SitesOverview() {
 		);
 	};
 
+	const showIssueLicenseButtonsLargeScreen =
+		isWithinBreakpoint( '>960px' ) && selectedLicensesCount > 0;
+
 	return (
 		<div className="sites-overview">
 			<DocumentHead title={ pageTitle } />
@@ -194,20 +204,25 @@ export default function SitesOverview() {
 					<div className="sites-overview__content-wrapper">
 						<SiteWelcomeBanner isDashboardView />
 						{ data?.sites && <SiteAddLicenseNotification /> }
-						<div className="sites-overview__page-title-container">
-							<div className="sites-overview__page-heading">
-								{ isEnabled( 'jetpack/partner-portal-downtime-monitoring-updates' ) ? (
-									<h2 className="sites-overview__page-title">{ downTimeMonitoringUpdates }</h2>
-								) : (
-									<h2 className="sites-overview__page-title">{ pageTitle }</h2>
-								) }
-								<div className="sites-overview__page-subtitle">
-									{ translate( 'Manage all your Jetpack sites from one location' ) }
+						<div className="sites-overview__viewport" { ...outerDivProps }>
+							<div
+								className={ classNames( 'sites-overview__page-title-container', {
+									'is-sticky': showIssueLicenseButtonsLargeScreen && hasCrossed,
+								} ) }
+							>
+								<div className="sites-overview__page-heading">
+									{ isEnabled( 'jetpack/partner-portal-downtime-monitoring-updates' ) ? (
+										<h2 className="sites-overview__page-title">{ downTimeMonitoringUpdates }</h2>
+									) : (
+										<h2 className="sites-overview__page-title">{ pageTitle }</h2>
+									) }
+									<div className="sites-overview__page-subtitle">
+										{ translate( 'Manage all your Jetpack sites from one location' ) }
+									</div>
 								</div>
+
+								{ showIssueLicenseButtonsLargeScreen && renderIssueLicenseButton() }
 							</div>
-							{ isWithinBreakpoint( '>960px' ) &&
-								selectedLicensesCount > 0 &&
-								renderIssueLicenseButton() }
 						</div>
 						<SectionNav
 							applyUpdatedStyles

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
@@ -46,9 +46,29 @@
 }
 .sites-overview__page-title-container {
 	display: none;
+
 	@include breakpoint-deprecated( ">660px" ) {
 		display: flex;
 		align-items: center;
+	}
+
+	&.is-sticky {
+		position: fixed;
+		width: calc(100% - var(--sidebar-width-max));
+		left: var(--sidebar-width-max);
+		top: var(--masterbar-height);
+		background-color: rgba(246, 247, 247, 0.95);
+		box-shadow: 0 4px 4px 0 rgb(0 0 0 / 8%);
+		z-index: 1001;
+		height: 74px;
+
+		.sites-overview__page-heading {
+			display: none;
+		}
+
+		.sites-overview__licenses-buttons {
+			margin-right: 48px;
+		}
 	}
 }
 .sites-overview__page-title {
@@ -60,6 +80,9 @@
 	color: var(--studio-gray-60);
 	margin-bottom: 8px;
 }
+.sites-overview__viewport {
+	margin-left: auto;
+}
 .sites-overview__licenses-buttons {
 	margin-left: auto;
 
@@ -70,7 +93,6 @@
 
 	.sites-overview__licenses-buttons-cancel {
 		text-decoration: underline;
-		padding: 2;
 		margin-inline-end: 32px;
 		text-underline-offset: 3px;
 	}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
@@ -58,7 +58,7 @@
 		left: var(--sidebar-width-max);
 		top: var(--masterbar-height);
 		background-color: rgba(246, 247, 247, 0.95);
-		box-shadow: 0 4px 4px 0 rgb(0 0 0 / 8%);
+		box-shadow: 2px 2px 2px 0 rgb(0 0 0 / 8%);
 		z-index: 1001;
 		height: 74px;
 

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/test/sites-overview.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/test/sites-overview.tsx
@@ -11,6 +11,16 @@ import thunk from 'redux-thunk';
 import SitesOverviewContext from '../context';
 import SitesOverview from '../index';
 
+window.IntersectionObserver = jest.fn( () => ( {
+	observe: jest.fn(),
+	disconnect: jest.fn(),
+	root: null,
+	rootMargin: '',
+	thresholds: [],
+	takeRecords: jest.fn(),
+	unobserve: jest.fn(),
+} ) );
+
 describe( '<SitesOverview>', () => {
 	const initialState = {
 		sites: {},


### PR DESCRIPTION
#### Proposed Changes

This PR makes the `Issue x licenses` button sticky when it is scrolled below the viewport. It also updates the text label from `Issue x new licenses` to `Issue x licenses` 

#### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout update/make-issue-license-button-sticky-when-scrolled` and `yarn start-jetpack-cloud`
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Click on `Add +`  where there is more than 1 inactive product for a site -> Scroll to the bottom and verify that the buttons `Cancel` and `Issue x licenses` becomes sticky when scrolling the section below the viewport and fade away when scrolled to the top.

Before scroll

<img width="1040" alt="Screenshot 2022-11-24 at 11 24 24 AM" src="https://user-images.githubusercontent.com/10586875/203705241-42bb15d6-faa2-46f3-b1b1-68cfe03678c1.png">

<img width="1047" alt="Screenshot 2022-11-24 at 11 55 52 AM" src="https://user-images.githubusercontent.com/10586875/203709668-babb36c4-4080-48ed-8c07-9d6f30c96cb1.png">

After scroll

<img width="1079" alt="Screenshot 2022-11-24 at 11 24 39 AM" src="https://user-images.githubusercontent.com/10586875/203705259-0feb77a9-e4e4-4185-961a-d4fa7f65ee33.png">

Recording

https://user-images.githubusercontent.com/10586875/203706749-7dba0db3-5051-4d5a-8d9d-b4484c00b00a.mov


> **_NOTE:_** You should have either 20 sites and reduce the screen size using the dev tool to see this in action. 

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1203126240279377-as-1203311546423732