### PR TITLE
VideoPress Onboarding: Mobile Choose A Plan popup fixes

### DIFF
--- a/packages/plans-grid/src/plans-interval-toggle/index.tsx
+++ b/packages/plans-grid/src/plans-interval-toggle/index.tsx
@@ -3,13 +3,21 @@ import { Popover } from '@wordpress/components';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import classNames from 'classnames';
+import { useState } from 'react';
 import * as React from 'react';
 import SegmentedControl from '../segmented-control';
 import type { Plans } from '@automattic/data-stores';
 
 import './style.scss';
 
-export const PopupMessages: React.FunctionComponent = ( { children } ) => {
+interface PopupMessagesProps {
+	anchorRect?: DOMRect;
+}
+
+export const PopupMessages: React.FunctionComponent< PopupMessagesProps > = ( {
+	anchorRect,
+	children,
+} ) => {
 	const variants: Record< string, React.ComponentProps< typeof Popover >[ 'position' ] > = {
 		desktop: 'middle right',
 		mobile: 'bottom center',
@@ -26,6 +34,7 @@ export const PopupMessages: React.FunctionComponent = ( { children } ) => {
 					) }
 					position={ variants[ variant ] }
 					noArrow={ false }
+					anchorRect={ anchorRect }
 				>
 					{ children }
 				</Popover>
@@ -50,6 +59,7 @@ const PlansIntervalToggle: React.FunctionComponent< PlansIntervalToggleProps > =
 } ) => {
 	const { __, _x, hasTranslation } = useI18n();
 	const locale = useLocale();
+	const [ spanRef, setSpanRef ] = useState< HTMLSpanElement >();
 
 	const fallbackMonthlyLabel = __( 'Pay monthly', __i18n_text_domain__ );
 	// Translators: intended as "pay monthly", as opposed to "pay annually"
@@ -89,7 +99,10 @@ const PlansIntervalToggle: React.FunctionComponent< PlansIntervalToggleProps > =
 					selected={ intervalType === 'ANNUALLY' }
 					onClick={ () => onChange( 'ANNUALLY' ) }
 				>
-					<span className="plans-interval-toggle__label">
+					<span
+						className="plans-interval-toggle__label"
+						ref={ ( ref ) => ref && setSpanRef( ref ) }
+					>
 						{ annuallyLabel } { children }
 					</span>
 
@@ -98,7 +111,7 @@ const PlansIntervalToggle: React.FunctionComponent< PlansIntervalToggleProps > =
 					 * not being undefined and not being 0
 					 */ }
 					{ intervalType === 'MONTHLY' && maxMonthlyDiscountPercentage && (
-						<PopupMessages>
+						<PopupMessages anchorRect={ spanRef?.getBoundingClientRect() }>
 							{ sprintf(
 								// translators: will be like "Save up to 30% by paying annually...". Please keep "%%" for the percent sign
 								__(

--- a/packages/plans-grid/src/plans-interval-toggle/style.scss
+++ b/packages/plans-grid/src/plans-interval-toggle/style.scss
@@ -90,6 +90,8 @@
 	}
 
 	// `data-y-axis` needed to override original popover styles
+	// `data-y-axis` appears to no longer be rendered, so defining both here incase it changes again
+	&--desktop,
 	&--desktop[data-y-axis="middle"] {
 		display: none;
 


### PR DESCRIPTION
#### Proposed Changes

**On Choose a Plan page:**
    - remove double popover on mobile when `Monthly` is selected
    - correctly position the popover

| Before | After |
|-----|------|
| <img width="411" alt="Screenshot 2022-11-23 at 4 27 58 PM" src="https://user-images.githubusercontent.com/4081020/203649040-fc75c682-5dd3-449b-9c3b-4ebe46108774.png"> | <img width="400" alt="Screenshot 2022-11-23 at 4 26 21 PM" src="https://user-images.githubusercontent.com/4081020/203648853-94ab7f63-f547-4d5a-afb0-01a7543c045b.png"> |

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit `/setup/videopress` using mobile debug tools in your browser to get into a mobile + touch layout
* Go through the flow to the `Choose A Plan` screen
* select `Monthly` interval
* You should only see 1 popover, and it should be properly centered under the `Annual` option
* Test that not having the new `anchorRect` param doesn't break the build
   1. comment out or delete `anchorRect={ anchorRect }` on line 37 of `packages/plans-grid/src/plans-interval-toggle
/index.tsx` 
   2. rebuild
   3. visit Choose A Plan again, you should see the popover off to the side like in the "Before" image, but no functionality should be broken and no double popovers should be shown

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
