### PR TITLE
Fix flaky navbar interaction on Notification: Actions test

### DIFF
--- a/packages/calypso-e2e/src/element-helper.ts
+++ b/packages/calypso-e2e/src/element-helper.ts
@@ -243,3 +243,19 @@ export async function waitForWPWidgetsIfNecessary( page: Page ): Promise< void >
 		} );
 	} );
 }
+
+/**
+ * Reusable method used to wait for the `/home` endpoint to finish
+ * load as much as possible. This method should be Atomic/Simple agnostic.
+ *
+ * @param {Page} page Page object.
+ */
+export async function waitForHomeLoadEnd( page: Page ): Promise< void > {
+	await Promise.all( [
+		// This call appears to fire close to the end.
+		// While it is not the last request to load, it should be a
+		// reasonable stand-in.
+		page.waitForResponse( /async-load-calypso-blocks-jitm.*/ ),
+		page.waitForLoadState( 'networkidle' ),
+	] );
+}

--- a/packages/calypso-e2e/src/element-helper.ts
+++ b/packages/calypso-e2e/src/element-helper.ts
@@ -250,7 +250,7 @@ export async function waitForWPWidgetsIfNecessary( page: Page ): Promise< void >
  *
  * @param {Page} page Page object.
  */
-export async function waitForHomeLoadEnd( page: Page ): Promise< void > {
+export async function waitForHomeLoad( page: Page ): Promise< void > {
 	await Promise.all( [
 		// This call appears to fire close to the end.
 		// While it is not the last request to load, it should be a

--- a/packages/calypso-e2e/src/element-helper.ts
+++ b/packages/calypso-e2e/src/element-helper.ts
@@ -243,19 +243,3 @@ export async function waitForWPWidgetsIfNecessary( page: Page ): Promise< void >
 		} );
 	} );
 }
-
-/**
- * Reusable method used to wait for the `/home` endpoint to finish
- * load as much as possible. This method should be Atomic/Simple agnostic.
- *
- * @param {Page} page Page object.
- */
-export async function waitForHomeLoad( page: Page ): Promise< void > {
-	await Promise.all( [
-		// This call appears to fire close to the end.
-		// While it is not the last request to load, it should be a
-		// reasonable stand-in.
-		page.waitForResponse( /async-load-calypso-blocks-jitm.*/ ),
-		page.waitForLoadState( 'networkidle' ),
-	] );
-}

--- a/packages/calypso-e2e/src/lib/components/navbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/navbar-component.ts
@@ -1,4 +1,5 @@
 import { Page } from 'playwright';
+import { envVariables } from '../..';
 
 const selectors = {
 	// Buttons on navbar
@@ -60,7 +61,15 @@ export class NavbarComponent {
 	async openNotificationsPanel( {
 		useKeyboard = false,
 	}: { useKeyboard?: boolean } = {} ): Promise< void > {
-		await this.page.waitForLoadState( 'networkidle' );
+		const promises: [ Promise< unknown > ] = [ this.page.waitForLoadState( 'networkidle' ) ];
+
+		if ( envVariables.VIEWPORT_NAME === 'desktop' ) {
+			promises.push(
+				this.page.waitForResponse( /async-load-calypso-blocks-jitm.*/, { timeout: 15 * 1000 } )
+			);
+		}
+
+		await Promise.all( promises );
 
 		if ( useKeyboard ) {
 			return await this.page.keyboard.type( 'n' );

--- a/packages/calypso-e2e/src/lib/components/navbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/navbar-component.ts
@@ -7,7 +7,6 @@ const selectors = {
 	writeButton: '.masterbar__item-new',
 	notificationsButton: 'a[href="/notifications"]',
 	meButton: 'a[data-tip-target="me"]',
-	helpButton: '[title="Help"]',
 };
 /**
  * Component representing the navbar/masterbar at top of WPCOM.

--- a/packages/calypso-e2e/src/lib/components/navbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/navbar-component.ts
@@ -6,6 +6,7 @@ const selectors = {
 	writeButton: '.masterbar__item-new',
 	notificationsButton: 'a[href="/notifications"]',
 	meButton: 'a[data-tip-target="me"]',
+	helpButton: '[title="Help"]',
 };
 /**
  * Component representing the navbar/masterbar at top of WPCOM.
@@ -29,6 +30,11 @@ export class NavbarComponent {
 	 */
 	private async pageSettled(): Promise< void > {
 		await this.page.waitForLoadState( 'load' );
+
+		// Wait for the last navbar component to load.
+		await this.page.waitForSelector( selectors.helpButton, {
+			state: 'visible',
+		} );
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/components/navbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/navbar-component.ts
@@ -1,4 +1,5 @@
 import { Page } from 'playwright';
+import { waitForHomeLoad } from '../../element-helper';
 
 const selectors = {
 	// Buttons on navbar
@@ -24,26 +25,12 @@ export class NavbarComponent {
 	}
 
 	/**
-	 * Wait for load state of the page.
-	 *
-	 * @returns {Promise<void>} No return value.
-	 */
-	private async pageSettled(): Promise< void > {
-		await this.page.waitForLoadState( 'load' );
-
-		// Wait for the last navbar component to load.
-		await this.page.waitForSelector( selectors.helpButton, {
-			state: 'visible',
-		} );
-	}
-
-	/**
 	 * Locates and clicks on the new post button on the nav bar.
 	 *
 	 * @returns {Promise<void>} No return value.
 	 */
 	async clickNewPost(): Promise< void > {
-		await this.pageSettled();
+		await waitForHomeLoad( this.page );
 		await this.page.click( selectors.writeButton );
 	}
 
@@ -53,7 +40,7 @@ export class NavbarComponent {
 	 * @returns {Promise<void>} No return value.
 	 */
 	async clickMySites(): Promise< void > {
-		await this.pageSettled();
+		await waitForHomeLoad( this.page );
 		await this.page.click( selectors.mySiteButton );
 	}
 
@@ -61,7 +48,7 @@ export class NavbarComponent {
 	 * Click on `Me` on top right of the Home dashboard.
 	 */
 	async clickMe(): Promise< void > {
-		await this.pageSettled();
+		await waitForHomeLoad( this.page );
 		await Promise.all( [ this.page.waitForNavigation(), this.page.click( selectors.meButton ) ] );
 	}
 
@@ -77,20 +64,14 @@ export class NavbarComponent {
 	async openNotificationsPanel( {
 		useKeyboard = false,
 	}: { useKeyboard?: boolean } = {} ): Promise< void > {
-		await this.pageSettled();
-
-		const notificationsButton = await this.page.waitForSelector( selectors.notificationsButton, {
-			state: 'visible',
-		} );
-		await Promise.all( [
-			this.page.waitForLoadState( 'networkidle' ),
-			notificationsButton.waitForElementState( 'stable' ),
-		] );
+		await waitForHomeLoad( this.page );
 
 		if ( useKeyboard ) {
 			return await this.page.keyboard.type( 'n' );
 		}
 
-		return await this.page.click( selectors.notificationsButton );
+		const notificationsButtonLocator = this.page.locator( selectors.notificationsButton );
+
+		return await notificationsButtonLocator.click();
 	}
 }

--- a/packages/calypso-e2e/src/lib/components/navbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/navbar-component.ts
@@ -1,5 +1,4 @@
 import { Page } from 'playwright';
-import { waitForHomeLoad } from '../../element-helper';
 
 const selectors = {
 	// Buttons on navbar
@@ -30,7 +29,6 @@ export class NavbarComponent {
 	 * @returns {Promise<void>} No return value.
 	 */
 	async clickNewPost(): Promise< void > {
-		await waitForHomeLoad( this.page );
 		await this.page.click( selectors.writeButton );
 	}
 
@@ -40,7 +38,6 @@ export class NavbarComponent {
 	 * @returns {Promise<void>} No return value.
 	 */
 	async clickMySites(): Promise< void > {
-		await waitForHomeLoad( this.page );
 		await this.page.click( selectors.mySiteButton );
 	}
 
@@ -48,7 +45,6 @@ export class NavbarComponent {
 	 * Click on `Me` on top right of the Home dashboard.
 	 */
 	async clickMe(): Promise< void > {
-		await waitForHomeLoad( this.page );
 		await Promise.all( [ this.page.waitForNavigation(), this.page.click( selectors.meButton ) ] );
 	}
 
@@ -64,7 +60,7 @@ export class NavbarComponent {
 	async openNotificationsPanel( {
 		useKeyboard = false,
 	}: { useKeyboard?: boolean } = {} ): Promise< void > {
-		await waitForHomeLoad( this.page );
+		await this.page.waitForLoadState( 'networkidle' );
 
 		if ( useKeyboard ) {
 			return await this.page.keyboard.type( 'n' );

--- a/packages/calypso-e2e/src/lib/components/navbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/navbar-component.ts
@@ -1,5 +1,4 @@
 import { Page } from 'playwright';
-import { envVariables } from '../..';
 
 const selectors = {
 	// Buttons on navbar
@@ -60,15 +59,10 @@ export class NavbarComponent {
 	async openNotificationsPanel( {
 		useKeyboard = false,
 	}: { useKeyboard?: boolean } = {} ): Promise< void > {
-		const promises: [ Promise< unknown > ] = [ this.page.waitForLoadState( 'networkidle' ) ];
-
-		if ( envVariables.VIEWPORT_NAME === 'desktop' ) {
-			promises.push(
-				this.page.waitForResponse( /async-load-calypso-blocks-jitm.*/, { timeout: 15 * 1000 } )
-			);
-		}
-
-		await Promise.all( promises );
+		await Promise.all( [
+			this.page.waitForLoadState( 'networkidle' ),
+			this.page.waitForResponse( /async-load-calypso-blocks-jitm.*/, { timeout: 15 * 1000 } ),
+		] );
 
 		if ( useKeyboard ) {
 			return await this.page.keyboard.type( 'n' );


### PR DESCRIPTION
### Context
An attempt to fix the `Notification: Actions` e2e test, which has been [intermittently failing lately](https://github.com/Automattic/wp-calypso/issues/69857). This is part of a previous effort to [improve and un-quarantine the test](https://github.com/Automattic/wp-calypso/pull/69446). After a chat session with Edwin, we identified the problem area (navbar loading) and a few potential solutions:

- Update pageSettled() in navbar-component.ts to use methods more in-line with Playwright's current suggestions.
- Wait for some other object on the navbarComponent to load first (less ideal).
- Add a general wait to the test (least ideal).