### PR TITLE
[E2E][GB 14.6.x] Test fixes for Gutenberg

### DIFF
--- a/packages/calypso-e2e/src/lib/components/comments-component.ts
+++ b/packages/calypso-e2e/src/lib/components/comments-component.ts
@@ -50,7 +50,8 @@ export class CommentsComponent {
 		}
 
 		await commentField.type( comment );
-		await Promise.all( [ this.page.waitForNavigation(), submitButton.click() ] );
+
+		await submitButton.click();
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
@@ -12,7 +12,7 @@ const selectors = {
 	blockInserterButton: `${ panel } button[class*="inserter-toggle"]`,
 
 	// Draft
-	saveDraftButton: `${ panel } button[aria-label="Save draft"]`,
+	saveDraftButton: `${ panel } button[aria-label="Save draft"], button[aria-label="Saved"]`,
 	switchToDraftButton: `${ panel } button.editor-post-switch-to-draft`,
 
 	// Preview
@@ -145,6 +145,7 @@ export class EditorToolbarComponent {
 		const savedButtonLocator = this.editor.locator( `${ selectors.saveDraftButton }.is-saved` );
 
 		await saveButtonLocator.click();
+
 		await savedButtonLocator.waitFor();
 	}
 

--- a/packages/calypso-e2e/src/lib/pages/published/published-post-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/published/published-post-page.ts
@@ -66,6 +66,7 @@ export class PublishedPostPage {
 	 * @returns {Promise<void>} No return value.
 	 */
 	async likePost(): Promise< void > {
+		await this.page.evaluate( () => window.scrollTo( 0, document.body.scrollHeight ) );
 		const frame = await this.getLikeFrame();
 		await frame.click( selectors.likeButton );
 		await frame.waitForSelector( selectors.likedText, { state: 'visible' } );


### PR DESCRIPTION
#### Proposed Changes


Misc test fixes, preparing for the upcoming 14.6.x release on WPCOM.


#### Testing Instructions

AT and simple _edge_ tests should pass.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/70299
