### PR TITLE
Stepper: Add Free Flow Scaffolding

### DIFF
--- a/client/landing/stepper/declarative-flow/free.ts
+++ b/client/landing/stepper/declarative-flow/free.ts
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { useLocale } from '@automattic/i18n-utils';
 import { useFlowProgress, FREE_FLOW } from '@automattic/onboarding';
 import { useSelect, useDispatch } from '@wordpress/data';
@@ -22,11 +23,13 @@ export const free: Flow = {
 	title: 'Free',
 	useSteps() {
 		useEffect( () => {
+			if ( ! isEnabled( 'signup/free-flow' ) ) {
+				return window.location.assign( '/start/free' );
+			}
 			recordTracksEvent( 'calypso_signup_start', { flow: this.name } );
 			recordFullStoryEvent( 'calypso_signup_start_free', { flow: this.name } );
 		}, [] );
 
-		// return [ 'intro', 'freeSetup', 'launchpad' ] as StepPath[];
 		return [
 			'intro',
 			'linkInBioSetup',

--- a/client/landing/stepper/declarative-flow/free.ts
+++ b/client/landing/stepper/declarative-flow/free.ts
@@ -1,0 +1,140 @@
+import { useLocale } from '@automattic/i18n-utils';
+import { useFlowProgress, FREE_FLOW } from '@automattic/onboarding';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { useEffect } from 'react';
+import { recordFullStoryEvent } from 'calypso/lib/analytics/fullstory';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import wpcom from 'calypso/lib/wp';
+import {
+	clearSignupDestinationCookie,
+	setSignupCompleteSlug,
+	persistSignupDestination,
+	setSignupCompleteFlowName,
+} from 'calypso/signup/storageUtils';
+import { useSiteSlug } from '../hooks/use-site-slug';
+import { USER_STORE, ONBOARD_STORE } from '../stores';
+import { recordSubmitStep } from './internals/analytics/record-submit-step';
+import type { StepPath } from './internals/steps-repository';
+import type { Flow, ProvidedDependencies } from './internals/types';
+
+export const free: Flow = {
+	name: FREE_FLOW,
+	title: 'Free',
+	useSteps() {
+		useEffect( () => {
+			recordTracksEvent( 'calypso_signup_start', { flow: this.name } );
+			recordFullStoryEvent( 'calypso_signup_start_free', { flow: this.name } );
+		}, [] );
+
+		// return [ 'intro', 'freeSetup', 'launchpad' ] as StepPath[];
+		return [
+			'intro',
+			'linkInBioSetup',
+			'domains',
+			'plans',
+			'patterns',
+			'siteCreationStep',
+			'processing',
+			'launchpad',
+		] as StepPath[];
+	},
+
+	useStepNavigation( _currentStep, navigate ) {
+		const flowName = this.name;
+		const { setStepProgress } = useDispatch( ONBOARD_STORE );
+		const flowProgress = useFlowProgress( { stepName: _currentStep, flowName } );
+		setStepProgress( flowProgress );
+		const siteSlug = useSiteSlug();
+		const userIsLoggedIn = useSelect( ( select ) => select( USER_STORE ).isCurrentUserLoggedIn() );
+		const locale = useLocale();
+
+		// trigger guides on step movement, we don't care about failures or response
+		wpcom.req.post(
+			'guides/trigger',
+			{
+				apiNamespace: 'wpcom/v2/',
+			},
+			{
+				flow: flowName,
+				step: _currentStep,
+			}
+		);
+
+		const submit = ( providedDependencies: ProvidedDependencies = {} ) => {
+			const logInUrl =
+				locale && locale !== 'en'
+					? `/start/account/user/${ locale }?variationName=${ flowName }&pageTitle=Link%20in%20Bio&redirect_to=/setup/${ flowName }/patterns`
+					: `/start/account/user?variationName=${ flowName }&pageTitle=Link%20in%20Bio&redirect_to=/setup/${ flowName }/patterns`;
+
+			recordSubmitStep( providedDependencies, '', flowName, _currentStep );
+
+			switch ( _currentStep ) {
+				case 'intro':
+					clearSignupDestinationCookie();
+
+					if ( userIsLoggedIn ) {
+						return navigate( 'patterns' );
+					}
+					return window.location.assign( logInUrl );
+
+				case 'patterns':
+					return navigate( 'linkInBioSetup' );
+
+				case 'linkInBioSetup':
+					return navigate( 'domains' );
+
+				case 'domains':
+					return navigate( 'plans' );
+
+				case 'plans':
+					return navigate( 'siteCreationStep' );
+
+				case 'siteCreationStep':
+					return navigate( 'processing' );
+
+				case 'processing':
+					if ( providedDependencies?.goToCheckout ) {
+						const destination = `/setup/${ flowName }/launchpad?siteSlug=${ providedDependencies.siteSlug }`;
+						persistSignupDestination( destination );
+						setSignupCompleteSlug( providedDependencies?.siteSlug );
+						setSignupCompleteFlowName( flowName );
+						const returnUrl = encodeURIComponent(
+							`/setup/${ flowName }/launchpad?siteSlug=${ providedDependencies?.siteSlug }`
+						);
+
+						return window.location.assign(
+							`/checkout/${ encodeURIComponent(
+								( providedDependencies?.siteSlug as string ) ?? ''
+							) }?redirect_to=${ returnUrl }&signup=1`
+						);
+					}
+					return navigate( `launchpad?siteSlug=${ providedDependencies?.siteSlug }` );
+
+				case 'launchpad': {
+					return navigate( 'processing' );
+				}
+			}
+			return providedDependencies;
+		};
+
+		const goBack = () => {
+			return;
+		};
+
+		const goNext = () => {
+			switch ( _currentStep ) {
+				case 'launchpad':
+					return window.location.assign( `/view/${ siteSlug }` );
+
+				default:
+					return navigate( 'intro' );
+			}
+		};
+
+		const goToStep = ( step: StepPath | `${ StepPath }?${ string }` ) => {
+			navigate( step );
+		};
+
+		return { goNext, goBack, goToStep, submit };
+	},
+};

--- a/client/landing/stepper/declarative-flow/free.ts
+++ b/client/landing/stepper/declarative-flow/free.ts
@@ -32,7 +32,7 @@ export const free: Flow = {
 
 		return [
 			'intro',
-			'linkInBioSetup',
+			'freeSetup',
 			'domains',
 			'plans',
 			'patterns',
@@ -81,9 +81,9 @@ export const free: Flow = {
 					return window.location.assign( logInUrl );
 
 				case 'patterns':
-					return navigate( 'linkInBioSetup' );
+					return navigate( 'freeSetup' );
 
-				case 'linkInBioSetup':
+				case 'freeSetup':
 					return navigate( 'domains' );
 
 				case 'domains':

--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -67,7 +67,8 @@ button {
 .anchor-fm,
 .subscribers,
 .ecommerce,
-.intro {
+.intro,
+.free-setup {
 	padding: 60px 0 0;
 	box-sizing: border-box;
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/free-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/free-setup/index.tsx
@@ -1,0 +1,111 @@
+import { StepContainer, base64ImageToBlob } from '@automattic/onboarding';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { createInterpolateElement } from '@wordpress/element';
+import { useI18n } from '@wordpress/react-i18n';
+import React, { FormEvent, useEffect } from 'react';
+import FormattedHeader from 'calypso/components/formatted-header';
+import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { useSite } from '../../../../hooks/use-site';
+import SetupForm from '../components/setup-form';
+import type { Step } from '../../types';
+
+import './styles.scss';
+
+const FreeSetup: Step = function FreeSetup( { navigation } ) {
+	const { submit } = navigation;
+	const { __ } = useI18n();
+	const site = useSite();
+
+	const formText = {
+		titlePlaceholder: __( 'My Website' ),
+		titleMissing: __( `Oops. Looks like your website doesn't have a name yet.` ),
+		taglinePlaceholder: __( 'Add a short description here' ),
+		iconPlaceholder: __( 'Upload a profile image' ),
+	};
+
+	const [ invalidSiteTitle, setInvalidSiteTitle ] = React.useState( false );
+	const [ selectedFile, setSelectedFile ] = React.useState< File | undefined >();
+	const [ base64Image, setBase64Image ] = React.useState< string | null >();
+	const [ siteTitle, setComponentSiteTitle ] = React.useState( '' );
+	const [ tagline, setTagline ] = React.useState( '' );
+	const { setSiteTitle, setSiteDescription, setSiteLogo } = useDispatch( ONBOARD_STORE );
+	const state = useSelect( ( select ) => select( ONBOARD_STORE ) ).getState();
+
+	useEffect( () => {
+		const { siteTitle, siteDescription, siteLogo } = state;
+		setTagline( siteDescription );
+		setComponentSiteTitle( siteTitle );
+
+		if ( siteLogo ) {
+			const file = new File( [ base64ImageToBlob( siteLogo ) ], 'site-logo.png' );
+			setSelectedFile( file );
+		}
+	}, [ state ] );
+
+	useEffect( () => {
+		if ( ! site ) {
+			return;
+		}
+
+		setComponentSiteTitle( site.name || '' );
+		setTagline( site.description );
+	}, [ site ] );
+
+	const handleSubmit = async ( event: FormEvent ) => {
+		event.preventDefault();
+		setInvalidSiteTitle( ! siteTitle.trim().length );
+
+		setSiteDescription( tagline );
+		setSiteTitle( siteTitle );
+
+		if ( selectedFile && base64Image ) {
+			try {
+				setSiteLogo( base64Image );
+			} catch ( _error ) {
+				// communicate the error to the user
+			}
+		}
+
+		if ( siteTitle.trim().length ) {
+			submit?.( { siteTitle, tagline } );
+		}
+	};
+
+	return (
+		<StepContainer
+			stepName="free-setup"
+			isWideLayout={ true }
+			hideBack={ true }
+			flowName="free"
+			formattedHeader={
+				<FormattedHeader
+					id="free-setup-header"
+					headerText={ createInterpolateElement( __( 'Personalize your<br />Website' ), {
+						br: <br />,
+					} ) }
+					align="center"
+				/>
+			}
+			stepContent={
+				<SetupForm
+					site={ site }
+					siteTitle={ siteTitle }
+					setComponentSiteTitle={ setComponentSiteTitle }
+					invalidSiteTitle={ invalidSiteTitle }
+					setInvalidSiteTitle={ setInvalidSiteTitle }
+					tagline={ tagline }
+					setTagline={ setTagline }
+					selectedFile={ selectedFile }
+					setSelectedFile={ setSelectedFile }
+					setBase64Image={ setBase64Image }
+					handleSubmit={ handleSubmit }
+					translatedText={ formText }
+				/>
+			}
+			recordTracksEvent={ recordTracksEvent }
+		/>
+	);
+};
+
+export default FreeSetup;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/free-setup/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/free-setup/styles.scss
@@ -10,7 +10,7 @@ $font-family: "SF Pro Text", $sans;
 		min-height: unset;
 	}
 
-	.free-setup .step-container__header {
+	.step-container__header {
 		margin-bottom: 32px;
 	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/free-setup/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/free-setup/styles.scss
@@ -1,0 +1,16 @@
+@import "../style";
+
+$font-family: "SF Pro Text", $sans;
+
+.free-setup {
+	.step-container__content {
+		display: flex;
+		justify-content: center;
+		margin-bottom: 30px;
+		min-height: unset;
+	}
+
+	.free-setup .step-container__header {
+		margin-bottom: 32px;
+	}
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/index.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/index.ts
@@ -52,6 +52,7 @@ export { default as designCarousel } from './design-carousel';
 export { default as domains } from './domains';
 export { default as setThemeStep } from './set-theme-step';
 export { default as waitForAtomic } from './wait-for-atomic';
+export { default as freeSetup } from './free-setup';
 
 export type StepPath =
 	| 'courses'
@@ -107,4 +108,5 @@ export type StepPath =
 	| 'storeProfiler'
 	| 'chooseAPlan'
 	| 'videomakerSetup'
-	| 'domains';
+	| 'domains'
+	| 'freeSetup';

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/intro/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/intro/index.tsx
@@ -3,6 +3,7 @@ import {
 	NEWSLETTER_FLOW,
 	ECOMMERCE_FLOW,
 	VIDEOPRESS_FLOW,
+	FREE_FLOW,
 } from '@automattic/onboarding';
 import { createInterpolateElement, useMemo } from '@wordpress/element';
 import { useI18n } from '@wordpress/react-i18n';
@@ -53,6 +54,16 @@ const useIntroContent = ( flowName: string | null ): IntroContent => {
 			return {
 				title: createInterpolateElement(
 					__( 'A home for all your videos.<br />Play. Roll. Share.' ),
+					{ br: <br /> }
+				),
+				buttonText: __( 'Get started' ),
+			};
+		}
+
+		if ( flowName === FREE_FLOW ) {
+			return {
+				title: createInterpolateElement(
+					__( 'You’re 1 minute away from<br />a beautiful, free website.<br />Ready? ' ),
 					{ br: <br /> }
 				),
 				buttonText: __( 'Get started' ),

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/intro/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/intro/styles.scss
@@ -2,6 +2,7 @@
 @import "@automattic/onboarding/styles/mixins";
 
 .intro {
+	&.free,
 	&.newsletter {
 		background-color: rgb(162 218 254);
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
@@ -135,7 +135,8 @@
 // Launchpad - Sidebar heading text
 
 .newsletter,
-.link-in-bio:not(.domains) {
+.link-in-bio:not(.domains),
+.free {
 	.step-container {
 		.step-container__content h1,
 		.step-container__content h1.launchpad__sidebar-h1 {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -43,6 +43,11 @@ export function getEnhancedTasks(
 		tasks.map( ( task ) => {
 			let taskData = {};
 			switch ( task.id ) {
+				case 'setup_free':
+					taskData = {
+						title: translate( 'Personalize your site' ),
+					};
+					break;
 				case 'setup_newsletter':
 					taskData = {
 						title: translate( 'Personalize Newsletter' ),
@@ -52,6 +57,11 @@ export function getEnhancedTasks(
 								`/setup/newsletter-post-setup/newsletterPostSetup?siteSlug=${ siteSlug }`
 							);
 						},
+					};
+					break;
+				case 'design_edited':
+					taskData = {
+						title: translate( 'Edit site design' ),
 					};
 					break;
 				case 'plan_selected':
@@ -133,6 +143,31 @@ export function getEnhancedTasks(
 
 								setPendingAction( async () => {
 									setProgressTitle( __( 'Launching Link in bio' ) );
+									await launchSite( site.ID );
+
+									// Waits for half a second so that the loading screen doesn't flash away too quickly
+									await new Promise( ( res ) => setTimeout( res, 500 ) );
+									recordTaskClickTracksEvent( flow, siteLaunchCompleted, task.id );
+									window.location.assign( `/home/${ siteSlug }` );
+								} );
+
+								submit?.();
+							}
+						},
+					};
+					break;
+				case 'site_launched':
+					taskData = {
+						title: translate( 'Launch your site' ),
+						completed: siteLaunchCompleted,
+						isLaunchTask: true,
+						actionDispatch: () => {
+							if ( site?.ID ) {
+								const { setPendingAction, setProgressTitle } = dispatch( ONBOARD_STORE );
+								const { launchSite } = dispatch( SITE_STORE );
+
+								setPendingAction( async () => {
+									setProgressTitle( __( 'Launching Website' ) );
 									await launchSite( site.ID );
 
 									// Waits for half a second so that the loading screen doesn't flash away too quickly

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/tasks.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/tasks.tsx
@@ -67,6 +67,24 @@ export const tasks: Task[] = [
 		taskType: 'blog',
 		disabled: true,
 	},
+	{
+		id: 'setup_free',
+		completed: true,
+		disabled: false,
+		taskType: 'blog',
+	},
+	{
+		id: 'design_edited',
+		completed: false,
+		disabled: false,
+		taskType: 'blog',
+	},
+	{
+		id: 'site_launched',
+		completed: false,
+		disabled: false,
+		taskType: 'blog',
+	},
 ];
 
 export const launchpadFlowTasks: LaunchpadFlowTaskList = {
@@ -77,6 +95,13 @@ export const launchpadFlowTasks: LaunchpadFlowTaskList = {
 		'plan_selected',
 		'links_added',
 		'link_in_bio_launched',
+	],
+	free: [
+		'setup_free',
+		'design_selected',
+		'first_post_published',
+		'design_edited',
+		'site_launched',
 	],
 	videopress: [ 'videopress_setup', 'plan_selected', 'videopress_upload', 'videopress_launched' ],
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/translations.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/translations.ts
@@ -16,6 +16,11 @@ describe( 'Translations', () => {
 				expect( linkInBioTranslations.flowName ).toEqual( 'Link in Bio' );
 				expect( linkInBioTranslations.title ).toEqual( "You're ready to link and launch" );
 				expect( linkInBioTranslations.launchTitle ).toEqual( "You're ready to link and launch" );
+
+				const freeFlowTranslations = getLaunchpadTranslations( 'free' );
+				expect( freeFlowTranslations.flowName ).toEqual( 'Free Website' );
+				expect( freeFlowTranslations.title ).toEqual( 'Your website is almost ready!' );
+				expect( freeFlowTranslations.launchTitle ).toEqual( 'Your website is almost ready!' );
 			} );
 		} );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/translations.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/translations.tsx
@@ -1,4 +1,9 @@
-import { LINK_IN_BIO_FLOW, NEWSLETTER_FLOW, VIDEOPRESS_FLOW } from '@automattic/onboarding';
+import {
+	LINK_IN_BIO_FLOW,
+	NEWSLETTER_FLOW,
+	VIDEOPRESS_FLOW,
+	FREE_FLOW,
+} from '@automattic/onboarding';
 import { translate } from 'i18n-calypso';
 import { TranslatedLaunchpadStrings } from './types';
 
@@ -24,6 +29,12 @@ export function getLaunchpadTranslations( flow: string | null ): TranslatedLaunc
 			translatedStrings.subtitle = translate(
 				"All that's left is to add some links and launch your site."
 			);
+			break;
+		case FREE_FLOW:
+			translatedStrings.flowName = translate( 'Free Website' );
+			translatedStrings.title = translate( 'Your website is almost ready!' );
+			translatedStrings.launchTitle = translate( 'Your website is almost ready!' );
+			translatedStrings.subtitle = translate( 'Keep the momentum going with these final steps.' );
 			break;
 		case VIDEOPRESS_FLOW:
 			translatedStrings.flowName = translate( 'Video' );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
@@ -2,6 +2,7 @@ import {
 	StepContainer,
 	isNewsletterOrLinkInBioFlow,
 	LINK_IN_BIO_FLOW,
+	FREE_FLOW,
 } from '@automattic/onboarding';
 import { useSelect } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
@@ -117,7 +118,7 @@ const ProcessingStep: Step = function ( props ) {
 	const isJetpackPowered = isNewsletterOrLinkInBioFlow( flowName );
 
 	// Currently we have the Domains and Plans only for link in bio
-	if ( flowName === LINK_IN_BIO_FLOW ) {
+	if ( flowName === LINK_IN_BIO_FLOW || FREE_FLOW ) {
 		return <TailoredFlowPreCheckoutScreen flowName={ flowName } />;
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
@@ -2,7 +2,7 @@ import {
 	StepContainer,
 	isNewsletterOrLinkInBioFlow,
 	LINK_IN_BIO_FLOW,
-	FREE_FLOW,
+	isFreeFlow,
 } from '@automattic/onboarding';
 import { useSelect } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
@@ -118,7 +118,7 @@ const ProcessingStep: Step = function ( props ) {
 	const isJetpackPowered = isNewsletterOrLinkInBioFlow( flowName );
 
 	// Currently we have the Domains and Plans only for link in bio
-	if ( flowName === LINK_IN_BIO_FLOW || FREE_FLOW ) {
+	if ( flowName === LINK_IN_BIO_FLOW || isFreeFlow( flowName ) ) {
 		return <TailoredFlowPreCheckoutScreen flowName={ flowName } />;
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/tailored-flow-precheckout-screen/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/tailored-flow-precheckout-screen/style.scss
@@ -8,7 +8,8 @@
 		}
 	}
 	.newsletter,
-	.link-in-bio {
+	.link-in-bio,
+	.free {
 		.signup-header {
 			.signup-header__right {
 				visibility: hidden;
@@ -66,7 +67,8 @@
 		}
 	}
 
-	.newsletter {
+	.newsletter,
+	.free {
 		.processing-step__container {
 			background-color: #a2dafe;
 			background-image:

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/styles.scss
@@ -2,7 +2,8 @@
 
 $font-family: "SF Pro Text", $sans;
 
-.link-in-bio-setup {
+.link-in-bio-setup,
+.free-setup {
 	.step-container__content {
 		display: flex;
 		justify-content: center;

--- a/client/landing/stepper/index.tsx
+++ b/client/landing/stepper/index.tsx
@@ -30,6 +30,7 @@ import { requestSites } from 'calypso/state/sites/actions';
 import { WindowLocaleEffectManager } from '../gutenboarding/components/window-locale-effect-manager';
 import { setupWpDataDebug } from '../gutenboarding/devtools';
 import { anchorFmFlow } from './declarative-flow/anchor-fm-flow';
+import { free } from './declarative-flow/free';
 import { importFlow } from './declarative-flow/import-flow';
 import { FlowRenderer } from './declarative-flow/internals';
 import { linkInBio } from './declarative-flow/link-in-bio';
@@ -76,6 +77,7 @@ const availableFlows: Array< configurableFlows > = [
 	{ flowName: 'podcasts', pathToFlow: podcasts },
 	{ flowName: 'link-in-bio-post-setup', pathToFlow: linkInBioPostSetup },
 	{ flowName: 'newsletter-post-setup', pathToFlow: newsletterPostSetup },
+	{ flowName: 'free', pathToFlow: free },
 	config.isEnabled( 'themes/plugin-bundling' )
 		? { flowName: 'plugin-bundle', pathToFlow: pluginBundleFlow }
 		: null,

--- a/client/signup/signup-header/index.tsx
+++ b/client/signup/signup-header/index.tsx
@@ -1,5 +1,5 @@
 import { ProgressBar } from '@automattic/components';
-import { useFlowProgress } from '@automattic/onboarding';
+import { useFlowProgress, FREE_FLOW } from '@automattic/onboarding';
 import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import WordPressLogo from 'calypso/components/wordpress-logo';
@@ -42,10 +42,11 @@ const SignupHeader = ( {
 	const flowProgress = useFlowProgress(
 		variationName ? { flowName: variationName, stepName: progressBar.stepName } : progressBar
 	);
+	const showProgressBar = progressBar.flowName !== FREE_FLOW;
 
 	return (
 		<div className="signup-header" role="banner" aria-label="banner">
-			{ flowProgress && ! shouldShowLoadingScreen && (
+			{ flowProgress && ! shouldShowLoadingScreen && showProgressBar && (
 				<ProgressBar
 					className={ variationName ? variationName : progressBar.flowName }
 					value={ flowProgress.progress }

--- a/config/development.json
+++ b/config/development.json
@@ -153,6 +153,7 @@
 		"sign-in-with-apple": true,
 		"sign-in-with-apple/redirect": true,
 		"signup/design-picker-pattern-assembler": true,
+		"signup/free-flow": true,
 		"signup/inline-help": false,
 		"signup/professional-email-step": false,
 		"signup/social": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -98,6 +98,7 @@
 		"settings/security/monitor": true,
 		"sign-in-with-apple": false,
 		"signup/design-picker-pattern-assembler": true,
+		"signup/free-flow": true,
 		"signup/inline-help": false,
 		"signup/professional-email-step": false,
 		"signup/social": true,

--- a/config/production.json
+++ b/config/production.json
@@ -115,6 +115,7 @@
 		"sign-in-with-apple": true,
 		"sign-in-with-apple/redirect": true,
 		"signup/design-picker-pattern-assembler": false,
+		"signup/free-flow": false,
 		"signup/inline-help": false,
 		"signup/professional-email-step": false,
 		"signup/social": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -113,6 +113,7 @@
 		"sign-in-with-apple": true,
 		"sign-in-with-apple/redirect": true,
 		"signup/design-picker-pattern-assembler": false,
+		"signup/free-flow": false,
 		"signup/inline-help": false,
 		"signup/professional-email-step": false,
 		"signup/social": true,

--- a/packages/onboarding/src/flow-progress/use-flow-progress.ts
+++ b/packages/onboarding/src/flow-progress/use-flow-progress.ts
@@ -23,6 +23,13 @@ const flows: Record< string, { [ step: string ]: number } > = {
 		plans: 4,
 		launchpad: 5,
 	},
+	free: {
+		intro: 0,
+		user: 0,
+		patterns: 1,
+		freeSetup: 2,
+		launchpad: 3,
+	},
 	videopress: {
 		intro: 0,
 		user: 1,

--- a/packages/onboarding/src/setup-tailored-site-after-creation.ts
+++ b/packages/onboarding/src/setup-tailored-site-after-creation.ts
@@ -2,7 +2,13 @@ import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Onboard } from '@automattic/data-stores';
 import { select } from '@wordpress/data';
 import wpcomRequest from 'wpcom-proxy-request';
-import { isLinkInBioFlow, isNewsletterOrLinkInBioFlow, LINK_IN_BIO_FLOW } from './utils';
+import {
+	isLinkInBioFlow,
+	isNewsletterOrLinkInBioFlow,
+	LINK_IN_BIO_FLOW,
+	FREE_FLOW,
+	isFreeFlow,
+} from './utils';
 
 const ONBOARD_STORE = Onboard.register();
 
@@ -52,10 +58,10 @@ export function setupSiteAfterCreation( { siteId, flowName }: SetupOnboardingSit
 			blogdescription: siteDescription,
 		};
 
-		if ( isNewsletterOrLinkInBioFlow( flowName ) ) {
+		if ( isNewsletterOrLinkInBioFlow( flowName ) || isFreeFlow( flowName ) ) {
 			// link-in-bio and link-in-bio-tld are considered the same intent.
-			if ( isLinkInBioFlow( flowName ) ) {
-				settings.site_intent = LINK_IN_BIO_FLOW;
+			if ( isLinkInBioFlow( flowName ) || isFreeFlow( flowName ) ) {
+				settings.site_intent = isLinkInBioFlow( flowName ) ? LINK_IN_BIO_FLOW : FREE_FLOW;
 				if ( selectedPatternContent ) {
 					const pattern = {
 						content: selectedPatternContent,

--- a/packages/onboarding/src/utils/flows.ts
+++ b/packages/onboarding/src/utils/flows.ts
@@ -6,6 +6,7 @@ export const LINK_IN_BIO_POST_SETUP_FLOW = 'link-in-bio-post-setup';
 export const VIDEOPRESS_FLOW = 'videopress';
 export const IMPORT_FOCUSED_FLOW = 'import-focused';
 export const ECOMMERCE_FLOW = 'ecommerce';
+export const FREE_FLOW = 'free';
 
 export const isLinkInBioFlow = ( flowName: string | null ) => {
 	return Boolean(
@@ -32,6 +33,7 @@ export const isTailoredSignupFlow = ( flowName: string | null ) => {
 		flowName &&
 			( isNewsletterOrLinkInBioFlow( flowName ) ||
 				VIDEOPRESS_FLOW === flowName ||
-				ECOMMERCE_FLOW === flowName )
+				ECOMMERCE_FLOW === flowName ||
+				FREE_FLOW === flowName )
 	);
 };

--- a/packages/onboarding/src/utils/flows.ts
+++ b/packages/onboarding/src/utils/flows.ts
@@ -15,6 +15,10 @@ export const isLinkInBioFlow = ( flowName: string | null ) => {
 	);
 };
 
+export const isFreeFlow = ( flowName: string | null ) => {
+	return Boolean( flowName && FREE_FLOW === flowName );
+};
+
 export const isNewsletterOrLinkInBioFlow = ( flowName: string | null ) => {
 	return Boolean(
 		flowName &&


### PR DESCRIPTION
### Proposed Changes

We are adding a simplified Free Flow for users to create a free site. It is based on stepper and mimics our recent tailored flows like newsletter and link in bio. The eventual goal is something close to proposed designs in this P2 about the Free Flow: p9Jlb4-5ST-p2. 

For this PR, the goal is NOT a ready-to-launch flow, but simply to get scaffolding in place so that we can define, work, and coordinate on discrete tasks. I created a [Tracking Task](https://github.com/Automattic/wp-calypso/issues/70491) with known follow ups. 

Specific changes: 
- Add a new "Free" flow
- Update the tailored flow "Intro" to allow starting a Free site
- Add a new "Free Setup" screen
- Add basic checklist items and translations to render Launchpad for Free Flow
- Updates to packages to set Launchpad screen settings for new Free sites

### Testing Instructions

**Question: This PR creates a new flow that is not ready for production. Should it be put behind a feature flag?**

Because this task is designed to setup scaffolding to clear the way for other tasks, not everything is working correctly. Just for clarity, I've noted many known issues below. All of these are addressed in the [Free Flow Tracking Task](https://github.com/Automattic/wp-calypso/issues/70491).

Because this flow is not fully working, the **real feedback needed is on whether what's included here provides a reasonable basis for others to work from, or whether there are other things that be included in this initial scaffolding.**

1) Check out this branch and run yarn and yarn start if needed. 

2) Go to this URL to start the process for setting up a site: 
http://calypso.localhost:3000/setup/free/intro

3) Go through the steps all the way to Launchpad.
   - You should get through all steps correctly. 
   - Known Issue: The Setup screen does not yet have a field for generating a domain name.
   - Known Issue: The Choose a Design screen is re-using the screen for Link in Bio. We will ultimately replace this with a new screen and different selection of themes.
   - Known Issue: You will see Domains and Plans screens. We will ultimately remove those.
  
4) On Launchpad, screen appearance and tasks should roughly match the launchpad screen shot in the P2 about the Free Flow: p9Jlb4-5ST-p2.
   - Known Issue: The link to Personalize Your Website is not active. That screen still needs to be created. 
   - Known Issue: You can click Write Your First Post. It will take you to the post editor. But if you go to My Home, which normally redirects to Launchpad, it will redirect to the "Goals" onboarding screen. You'll need to use the back button or manually enter the Launchpad url to return. Also, the Write Your First Post task will not be completed. 
   - Known Issue: The link to Edit Design does not currently go anywhere.
   - Known Issue: The Launch Your Site link will work, but you will end up redirected again to the "Goals" onboarding screen.
   
5) **UPDATE**: Adding extra testing step. Please consider testing newsletter and link in bio flows to ensure no regressive breakages. By definition, this PR has to touch files / methods / components used by those flows. 