### PR TITLE
Stats: add Calypso Stats to TeamCity build config

### DIFF
--- a/.teamcity/_self/projects/WPComPlugins.kt
+++ b/.teamcity/_self/projects/WPComPlugins.kt
@@ -155,7 +155,7 @@ private object Notifications : WPComPluginBuild(
 private object CalypsoStats : WPComPluginBuild(
 	buildId = "WPComPlugins_CalypsoStats",
 	buildName = "CalypsoStats",
-	pluginSlug = "CalypsoStats",
+	pluginSlug = "calypso-stats",
 	archiveDir = "./dist/",
 	docsLink = "PCYsg-elI-p2",
 	// This param is executed in bash right before the build script compares

--- a/.teamcity/_self/projects/WPComPlugins.kt
+++ b/.teamcity/_self/projects/WPComPlugins.kt
@@ -158,21 +158,6 @@ private object CalypsoStats : WPComPluginBuild(
 	pluginSlug = "calypso-stats",
 	archiveDir = "./dist/",
 	docsLink = "PCYsg-elI-p2",
-	// This param is executed in bash right before the build script compares
-	// the build with the previous release version. The purpose of this code
-	// is to remove sources of randomness so that the diff operation only
-	// compares legitimate changes.
-	normalizeFiles = """
-		# Replace the old cache buster with the new one in the previous release html files.
-		if [ -f './release-archive/build_meta.json' ] ; then
-			old_cache_buster=`jq -r '.cache_buster' ./release-archive/build_meta.json`
-		else
-			old_cache_buster=`cat ./release-archive/cache-buster.txt`
-		fi
-
-		new_cache_buster=`jq -r '.cache_buster' ./dist/build_meta.json`
-		sed -i "s~${'$'}old_cache_buster~${'$'}new_cache_buster~g" release-archive/index.html release-archive/rtl.html
-	""".trimIndent(),
 )
 
 private object O2Blocks : WPComPluginBuild(

--- a/.teamcity/_self/projects/WPComPlugins.kt
+++ b/.teamcity/_self/projects/WPComPlugins.kt
@@ -29,6 +29,7 @@ object WPComPlugins : Project({
 	buildType(EditingToolkit)
 	buildType(WpcomBlockEditor)
 	buildType(Notifications)
+	buildType(CalypsoStats)
 	buildType(O2Blocks)
 	buildType(HappyBlocks)
 	buildType(Happychat)
@@ -46,6 +47,7 @@ object WPComPlugins : Project({
 				withStatus = successful()
 				withTags = anyOf(
 					"notifications-release-build",
+					"calypso-stats-release-build",
 					"etk-release-build",
 					"wpcom-block-editor-release-build",
 					"o2-blocks-release-build",
@@ -138,6 +140,29 @@ private object Notifications : WPComPluginBuild(
 		# instances of the hash in the *old* files with the newest version.
 		sed -i "s~${'$'}old_hash~${'$'}new_hash~g" release-archive/index.html release-archive/rtl.html
 
+		# Replace the old cache buster with the new one in the previous release html files.
+		if [ -f './release-archive/build_meta.json' ] ; then
+			old_cache_buster=`jq -r '.cache_buster' ./release-archive/build_meta.json`
+		else
+			old_cache_buster=`cat ./release-archive/cache-buster.txt`
+		fi
+
+		new_cache_buster=`jq -r '.cache_buster' ./dist/build_meta.json`
+		sed -i "s~${'$'}old_cache_buster~${'$'}new_cache_buster~g" release-archive/index.html release-archive/rtl.html
+	""".trimIndent(),
+)
+
+private object CalypsoStats : WPComPluginBuild(
+	buildId = "WPComPlugins_CalypsoStats",
+	buildName = "CalypsoStats",
+	pluginSlug = "CalypsoStats",
+	archiveDir = "./dist/",
+	docsLink = "PCYsg-elI-p2",
+	// This param is executed in bash right before the build script compares
+	// the build with the previous release version. The purpose of this code
+	// is to remove sources of randomness so that the diff operation only
+	// compares legitimate changes.
+	normalizeFiles = """
 		# Replace the old cache buster with the new one in the previous release html files.
 		if [ -f './release-archive/build_meta.json' ] ; then
 			old_cache_buster=`jq -r '.cache_buster' ./release-archive/build_meta.json`


### PR DESCRIPTION
#### Proposed Changes
Basically mimics the config for Notifications, only removed the hash check for the html file, because Calypso Stats desn't have one.

#### Testing Instructions
It has to be merged to be tested - `p58i-dox#comment-56262-p2`, so please check whether there are obvious mistakes.


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
