### PR TITLE
Sites as landing page: redirect to `/sites`

### DIFF
--- a/client/root.js
+++ b/client/root.js
@@ -1,7 +1,7 @@
 import config from '@automattic/calypso-config';
 import page from 'page';
 import { isUserLoggedIn, getCurrentUser } from 'calypso/state/current-user/selectors';
-import { fetchPreferences } from 'calypso/state/preferences/actions';
+import { fetchPreferences, savePreference } from 'calypso/state/preferences/actions';
 import { getPreference, hasReceivedRemotePreferences } from 'calypso/state/preferences/selectors';
 import getPrimarySiteId from 'calypso/state/selectors/get-primary-site-id';
 import { requestSite } from 'calypso/state/sites/actions';
@@ -29,6 +29,19 @@ function handleLoggedOut() {
 }
 
 async function handleLoggedIn( context ) {
+	// Testing code. Remove before merging.
+	// Usage:
+	//    Go to `/?sites-landing-page=true` or `/?sites-landing-page=false` to set the preference.
+	if ( new URLSearchParams( context.querystring ).has( 'sites-landing-page' ) ) {
+		context.store.dispatch(
+			savePreference( 'sites-landing-page', {
+				useSitesAsLandingPage:
+					new URLSearchParams( context.querystring ).get( 'sites-landing-page' ) === 'true',
+				updatedAt: Date.now(),
+			} )
+		);
+	}
+
 	let redirectPath = await getLoggedInLandingPage( context.store );
 
 	if ( context.querystring ) {

--- a/client/root.js
+++ b/client/root.js
@@ -48,18 +48,18 @@ async function handleLoggedIn( context ) {
 	await context.store.dispatch( waitForSite( primarySiteId ) );
 
 	const state = context.store.getState();
-	const siteSlug = getSiteSlug( state, primarySiteId );
+	const primarySiteSlug = getSiteSlug( state, primarySiteId );
 	const isCustomerHomeEnabled = canCurrentUserUseCustomerHome( state, primarySiteId );
 
 	let redirectPath;
 
-	if ( ! siteSlug ) {
+	if ( ! primarySiteSlug ) {
 		// there is no primary site or the site info couldn't be fetched. Redirect to Reader.
 		redirectPath = '/read';
 	} else if ( isCustomerHomeEnabled ) {
-		redirectPath = `/home/${ siteSlug }`;
+		redirectPath = `/home/${ primarySiteSlug }`;
 	} else {
-		redirectPath = `/stats/${ siteSlug }`;
+		redirectPath = `/stats/${ primarySiteSlug }`;
 	}
 
 	if ( context.querystring ) {

--- a/client/root.js
+++ b/client/root.js
@@ -1,7 +1,7 @@
 import config from '@automattic/calypso-config';
 import globalPageInstance from 'page';
 import { isUserLoggedIn, getCurrentUser } from 'calypso/state/current-user/selectors';
-import { fetchPreferences, savePreference } from 'calypso/state/preferences/actions';
+import { fetchPreferences } from 'calypso/state/preferences/actions';
 import { getPreference, hasReceivedRemotePreferences } from 'calypso/state/preferences/selectors';
 import getPrimarySiteId from 'calypso/state/selectors/get-primary-site-id';
 import { requestSite } from 'calypso/state/sites/actions';
@@ -33,19 +33,6 @@ function handleLoggedOut( page ) {
 }
 
 async function handleLoggedIn( page, context ) {
-	// Testing code. Remove before merging.
-	// Usage:
-	//    Go to `/?sites-landing-page=true` or `/?sites-landing-page=false` to set the preference.
-	if ( new URLSearchParams( context.querystring ).has( 'sites-landing-page' ) ) {
-		context.store.dispatch(
-			savePreference( 'sites-landing-page', {
-				useSitesAsLandingPage:
-					new URLSearchParams( context.querystring ).get( 'sites-landing-page' ) === 'true',
-				updatedAt: Date.now(),
-			} )
-		);
-	}
-
 	let redirectPath = await getLoggedInLandingPage( context.store );
 
 	if ( context.querystring ) {

--- a/client/test/root-section.ts
+++ b/client/test/root-section.ts
@@ -1,0 +1,166 @@
+/**
+ * @jest-environment jsdom
+ */
+import { isEnabled } from '@automattic/calypso-config';
+import { waitFor } from '@testing-library/dom';
+import pageLibrary from 'page';
+import initRootSection from '../root';
+
+function initRouter( { state }: { state: any } ) {
+	const dispatch = jest.fn();
+	const getState = jest.fn( () => state );
+
+	const page = pageLibrary.create();
+	page( '*', ( context, next ) => {
+		context.store = { dispatch, getState };
+		next();
+	} );
+	initRootSection( null, page );
+	page.start();
+
+	return { dispatch, getState, page };
+}
+
+describe( 'Logged Out Landing Page', () => {
+	test( 'logged out goes to devdocs', async () => {
+		// This is the behaviour only in non-production environments
+		expect( isEnabled( 'devdocs/redirect-loggedout-homepage' ) ).toBeTruthy();
+
+		const state = { currentUser: { id: null } };
+		const { page } = initRouter( { state } );
+
+		page( '/' );
+
+		await waitFor( () => expect( page.current ).toBe( '/devdocs/start' ) );
+	} );
+} );
+
+describe( 'Logged In Landing Page', () => {
+	test( 'user with no sites goes to reader', async () => {
+		const state = { currentUser: { id: 1 }, sites: { items: {} } };
+		const { page } = initRouter( { state } );
+
+		page( '/' );
+
+		await waitFor( () => expect( page.current ).toBe( '/read' ) );
+	} );
+
+	test( 'user with a primary site but no permissions goes to stats', async () => {
+		const state = {
+			currentUser: { id: 1, capabilities: { 1: {} }, user: { primary_blog: 1 } },
+			sites: {
+				items: {
+					1: {
+						ID: 1,
+						URL: 'https://test.wordpress.com',
+					},
+				},
+			},
+		};
+		const { page } = initRouter( { state } );
+
+		page( '/' );
+
+		await waitFor( () => expect( page.current ).toBe( '/stats/test.wordpress.com' ) );
+	} );
+
+	test( 'user with a primary site and edit permissions goes to My Home', async () => {
+		const state = {
+			currentUser: { id: 1, capabilities: { 1: { edit_posts: true } }, user: { primary_blog: 1 } },
+			sites: {
+				items: {
+					1: {
+						ID: 1,
+						URL: 'https://test.wordpress.com',
+					},
+				},
+			},
+		};
+		const { page } = initRouter( { state } );
+
+		page( '/' );
+
+		await waitFor( () => expect( page.current ).toBe( '/home/test.wordpress.com' ) );
+	} );
+
+	test( 'user with a Jetpack site set as their primary site goes to stats', async () => {
+		const state = {
+			currentUser: { id: 1, capabilities: { 1: { edit_posts: true } }, user: { primary_blog: 1 } },
+			sites: {
+				items: {
+					1: {
+						ID: 1,
+						URL: 'https://test.jurassic.ninja',
+						jetpack: true,
+					},
+				},
+			},
+		};
+		const { page } = initRouter( { state } );
+
+		page( '/' );
+
+		await waitFor( () => expect( page.current ).toBe( '/stats/test.jurassic.ninja' ) );
+	} );
+
+	test( 'user who opts in goes to sites page', async () => {
+		const state = {
+			currentUser: {
+				id: 1,
+				capabilities: { 1: { edit_posts: true } },
+				user: { primary_blog: 1, site_count: 2 },
+			},
+			preferences: {
+				localValues: {
+					'sites-landing-page': { useSitesAsLandingPage: true, updatedAt: 1111 },
+				},
+			},
+			sites: {
+				items: {
+					1: {
+						ID: 1,
+						URL: 'https://test.wordpress.com',
+					},
+					2: {
+						ID: 2,
+						URL: 'https://test.jurassic.ninja',
+						jetpack: true,
+					},
+				},
+			},
+		};
+		const { page } = initRouter( { state } );
+
+		page( '/' );
+
+		await waitFor( () => expect( page.current ).toBe( '/sites' ) );
+	} );
+
+	test( 'user who opts in but only has 1 site does not go to sites page', async () => {
+		const state = {
+			currentUser: {
+				id: 1,
+				capabilities: { 1: { edit_posts: true } },
+				user: { primary_blog: 1, site_count: 1 },
+			},
+			preferences: {
+				localValues: {
+					'sites-landing-page': { useSitesAsLandingPage: true, updatedAt: 1111 },
+				},
+			},
+			sites: {
+				items: {
+					1: {
+						ID: 1,
+						URL: 'https://test.wordpress.com',
+					},
+				},
+			},
+		};
+		const { page } = initRouter( { state } );
+
+		page( '/' );
+
+		await waitFor( () => expect( page.current ).toBe( '/home/test.wordpress.com' ) );
+	} );
+} );


### PR DESCRIPTION
Uses a user preference (and the `sites-as-landing-page` feature flag) to determine whether the Sites page should be used as the landing page. See #70295.

https://user-images.githubusercontent.com/1500769/203693063-3f90b791-1e42-4b00-bd0a-800caac56e58.mp4

#### Proposed Changes

* If the feature flag is set, the preference is `true`, and the user has multiple sites, then navigating to `/` will redirect to `/sites`
* Uses a new `sites-landing-page` preference, which is an object that contains a `useSitesAsLandingPage` field
* Refactors the landing page selection code into it's own function. This allows us to use early exit, which is much easier to ensure we only load the things into the redux that we absolutely have to. If the refactor makes the diff hard to read try taking a look at the individual commits.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

There's no UI to set the preference yet, so use `/?sites-landing-page=true` or `/?sites-landing-page=false` to set the preference. This test harness will be removed before merging.

- Test that `/` works
- Test that Jetpack Cloud is unchanged
- Try logging out and logging in
- Test a user has 0 or 1 sites but still has the preference set.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] ~Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?~ This change isn't related to a specific site
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~
- [ ] ~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~
- [ ] ~For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #70295
