### PR TITLE
Add pricing plans CTA click metrics

### DIFF
--- a/apps/happy-blocks/package.json
+++ b/apps/happy-blocks/package.json
@@ -19,6 +19,7 @@
 		"start": "wp-scripts start"
 	},
 	"dependencies": {
+		"@automattic/calypso-analytics": "workspace:^",
 		"@automattic/calypso-build": "workspace:^",
 		"@automattic/calypso-config": "workspace:^",
 		"@automattic/calypso-products": "workspace:^",

--- a/apps/happy-blocks/src/pricing-plans/components/billing-button.tsx
+++ b/apps/happy-blocks/src/pricing-plans/components/billing-button.tsx
@@ -3,11 +3,18 @@ import { FunctionComponent } from 'react';
 
 interface Props {
 	href: string;
+	onClick?: () => void;
 }
 
-const BillingButton: FunctionComponent< Props > = ( { href, children } ) => {
+const BillingButton: FunctionComponent< Props > = ( { href, children, onClick = () => null } ) => {
 	return (
-		<Button className="hb-pricing-plans-embed__detail-cta" href={ href } target="_blank" isPrimary>
+		<Button
+			onClick={ onClick }
+			className="hb-pricing-plans-embed__detail-cta"
+			href={ href }
+			target="_blank"
+			isPrimary
+		>
 			{ children }
 		</Button>
 	);

--- a/apps/happy-blocks/src/pricing-plans/components/pricing-plan-detail.tsx
+++ b/apps/happy-blocks/src/pricing-plans/components/pricing-plan-detail.tsx
@@ -1,3 +1,4 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { BlockSaveProps } from '@wordpress/blocks';
 import { FunctionComponent } from 'react';
 import { BlockPlan } from '../hooks/pricing-plans';
@@ -18,6 +19,13 @@ const PricingPlanDetail: FunctionComponent< BlockSaveProps< BlockAttributes > & 
 	attributes,
 	setPlan,
 } ) => {
+	const onCtaClick = () => {
+		recordTracksEvent( 'calypso_happyblocks_upgrade_plan_click', {
+			plan: plan.productSlug,
+			domain: attributes.domain,
+		} );
+	};
+
 	return (
 		<section className="hb-pricing-plans-embed__detail">
 			<div>
@@ -25,6 +33,7 @@ const PricingPlanDetail: FunctionComponent< BlockSaveProps< BlockAttributes > & 
 				<BillingOptions plans={ plans } value={ attributes.productSlug } onChange={ setPlan } />
 			</div>
 			<BillingButton
+				onClick={ onCtaClick }
 				href={ `https://wordpress.com/checkout/${ attributes.domain }/${ plan.pathSlug }` }
 			>
 				{ plan.upgradeLabel }

--- a/yarn.lock
+++ b/yarn.lock
@@ -19494,6 +19494,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "happy-blocks@workspace:apps/happy-blocks"
   dependencies:
+    "@automattic/calypso-analytics": "workspace:^"
     "@automattic/calypso-apps-builder": "workspace:^"
     "@automattic/calypso-build": "workspace:^"
     "@automattic/calypso-config": "workspace:^"


### PR DESCRIPTION
#### Proposed Changes

Add metrics for clicks on "Upgrade to [plan]" CTA button clicks.

#### Testing Instructions

1. In the forums Gutenberg editor, create a new post and include the Pricing Plans block (by entering `/upgrade`)
2. Click on the button "Upgrade to [someplan]"
3. Verify in the network inspector a request similar to `https://pixel.wp.com/t.gif?plan=ecommerce-bundle&domain=example.wordpress.com&_en=calypso_happyblocks_upgrade_plan_click...` has been sent. 

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
