### PR TITLE
Theme Showcase: Add Tracks event

### DIFF
--- a/client/components/keyed-suggestions/index.jsx
+++ b/client/components/keyed-suggestions/index.jsx
@@ -62,6 +62,7 @@ class KeyedSuggestions extends Component {
 		isShowTopLevelTermsOnMount: PropTypes.bool,
 		isDisableAutoSelectSuggestion: PropTypes.bool,
 		isDisableTextHighlight: PropTypes.bool,
+		recordTracksEvent: PropTypes.func,
 	};
 
 	static defaultProps = {
@@ -69,6 +70,7 @@ class KeyedSuggestions extends Component {
 		terms: {},
 		input: '',
 		exclusions: [],
+		recordTracksEvent: noop,
 	};
 
 	state = {
@@ -172,8 +174,19 @@ class KeyedSuggestions extends Component {
 	onMouseDown = ( event ) => {
 		event.stopPropagation();
 		event.preventDefault();
+
+		const { suggest, recordTracksEvent } = this.props;
 		const suggestion = event.currentTarget.textContent.split( ' ' )[ 0 ];
-		this.props.suggest( suggestion, this.state.isShowTopLevelTerms );
+		if ( this.state.isShowTopLevelTerms ) {
+			// Clean up suggestion that it's passed as, for example, "feature" instead of "feature:".
+			recordTracksEvent( 'search_dropdown_searchby_item_click', {
+				term: suggestion.split( ':' )[ 0 ],
+			} );
+		} else {
+			recordTracksEvent( 'search_dropdown_taxonomy_item_click', { term: suggestion } );
+		}
+
+		suggest( suggestion, this.state.isShowTopLevelTerms );
 	};
 
 	onMouseOver = ( event ) => {
@@ -445,14 +458,24 @@ class KeyedSuggestions extends Component {
 					</span>
 					{ Object.keys( this.props.terms[ key ] ).length > suggestions[ key ].length && (
 						<SuggestionsButtonAll
-							onClick={ this.onShowAllClick }
+							onClick={ ( category ) => {
+								this.onShowAllClick( category );
+								this.props.recordTracksEvent( 'search_dropdown_show_all_button_click', {
+									category: key,
+								} );
+							} }
 							category={ key }
 							label={ this.props.showAllLabelText || i18n.translate( 'Show all' ) }
 						/>
 					) }
 					{ key === this.state.showAll && (
 						<SuggestionsButtonAll
-							onClick={ this.onShowAllClick }
+							onClick={ ( category ) => {
+								this.onShowAllClick( category );
+								this.props.recordTracksEvent( 'search_dropdown_show_less_button_click', {
+									category: key,
+								} );
+							} }
 							category=""
 							label={ this.props.showLessLabelText || i18n.translate( 'Show less' ) }
 						/>

--- a/client/components/keyed-suggestions/index.jsx
+++ b/client/components/keyed-suggestions/index.jsx
@@ -179,11 +179,11 @@ class KeyedSuggestions extends Component {
 		const suggestion = event.currentTarget.textContent.split( ' ' )[ 0 ];
 		if ( this.state.isShowTopLevelTerms ) {
 			// Clean up suggestion that it's passed as, for example, "feature" instead of "feature:".
-			recordTracksEvent( 'search_dropdown_searchby_item_click', {
-				term: suggestion.split( ':' )[ 0 ],
+			recordTracksEvent( 'search_dropdown_taxonomy_click', {
+				taxonomy: suggestion.split( ':' )[ 0 ],
 			} );
 		} else {
-			recordTracksEvent( 'search_dropdown_taxonomy_item_click', { term: suggestion } );
+			recordTracksEvent( 'search_dropdown_taxonomy_term_click', { term: suggestion } );
 		}
 
 		suggest( suggestion, this.state.isShowTopLevelTerms );
@@ -460,7 +460,7 @@ class KeyedSuggestions extends Component {
 						<SuggestionsButtonAll
 							onClick={ ( category ) => {
 								this.onShowAllClick( category );
-								this.props.recordTracksEvent( 'search_dropdown_show_all_button_click', {
+								this.props.recordTracksEvent( 'search_dropdown_view_all_button_click', {
 									category: key,
 								} );
 							} }
@@ -472,7 +472,7 @@ class KeyedSuggestions extends Component {
 						<SuggestionsButtonAll
 							onClick={ ( category ) => {
 								this.onShowAllClick( category );
-								this.props.recordTracksEvent( 'search_dropdown_show_less_button_click', {
+								this.props.recordTracksEvent( 'search_dropdown_view_less_button_click', {
 									category: key,
 								} );
 							} }

--- a/client/components/search-themes/index.tsx
+++ b/client/components/search-themes/index.tsx
@@ -13,9 +13,10 @@ import './style.scss';
 interface SearchThemesProps {
 	query: string;
 	onSearch: ( query: string ) => void;
+	recordTracksEvent: ( eventName: string, eventProperties?: object ) => void;
 }
 
-const SearchThemes: React.FC< SearchThemesProps > = ( { query, onSearch } ) => {
+const SearchThemes: React.FC< SearchThemesProps > = ( { query, onSearch, recordTracksEvent } ) => {
 	const wrapperRef = useRef< HTMLDivElement | null >( null );
 	const searchRef = useRef< Search | null >( null );
 	const suggestionsRef = useRef< KeyedSuggestions | null >( null );
@@ -94,6 +95,11 @@ const SearchThemes: React.FC< SearchThemesProps > = ( { query, onSearch } ) => {
 		}
 	};
 
+	const onClearIconClick = () => {
+		clearSearch();
+		recordTracksEvent( 'search_clear_icon_click' );
+	};
+
 	return (
 		<div ref={ wrapperRef } { ...useFocusOutside( closeSearch ) }>
 			<div
@@ -133,6 +139,7 @@ const SearchThemes: React.FC< SearchThemesProps > = ( { query, onSearch } ) => {
 							isShowTopLevelTermsOnMount
 							isDisableAutoSelectSuggestion
 							isDisableTextHighlight
+							recordTracksEvent={ recordTracksEvent }
 						/>
 					) }
 					{ searchInput !== '' && (
@@ -143,7 +150,7 @@ const SearchThemes: React.FC< SearchThemesProps > = ( { query, onSearch } ) => {
 								tabIndex={ 0 }
 								aria-controls="search-component-search-themes"
 								aria-label={ translate( 'Clear Search' ) }
-								onClick={ clearSearch }
+								onClick={ onClearIconClick }
 							/>
 						</div>
 					) }

--- a/client/my-sites/themes/install-theme-button.jsx
+++ b/client/my-sites/themes/install-theme-button.jsx
@@ -83,8 +83,10 @@ const mapStateToProps = ( state ) => {
 };
 
 const mapDispatchToProps = ( dispatch ) => ( {
-	dispatchTracksEvent: ( { tracksEventProps } ) =>
-		dispatch( recordTracksEvent( 'calypso_click_theme_upload', tracksEventProps ) ),
+	dispatchTracksEvent: ( { tracksEventProps } ) => {
+		dispatch( recordTracksEvent( 'calypso_click_theme_upload', tracksEventProps ) );
+		dispatch( recordTracksEvent( 'calypso_themeshowcase_install_button_click', tracksEventProps ) );
+	},
 } );
 
 export default connect( mapStateToProps, mapDispatchToProps )( InstallThemeButton );

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -1,3 +1,4 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import config from '@automattic/calypso-config';
 import { FEATURE_INSTALL_THEMES } from '@automattic/calypso-products';
 import { localize } from 'i18n-calypso';
@@ -287,7 +288,9 @@ class ThemeShowcase extends Component {
 			this.setState( { tabFilter: this.tabFilters.ALL } );
 		}
 
+		recordTracksEvent( 'calypso_themeshowcase_filter_pricing_click', { tier } );
 		trackClick( 'search bar filter', tier );
+
 		const url = this.constructUrl( { tier } );
 		page( url );
 		this.scrollToSearchInput();
@@ -296,6 +299,8 @@ class ThemeShowcase extends Component {
 	onFilterClick = ( tabFilter ) => {
 		const scrollPos = window.pageYOffset;
 		const isNewSearchAndFilter = config.isEnabled( 'themes/showcase-i4/search-and-filter' );
+
+		recordTracksEvent( 'calypso_themeshowcase_filter_category_click', { category: tabFilter.key } );
 		trackClick( 'section nav filter', tabFilter );
 		this.setState( { tabFilter } );
 
@@ -354,6 +359,31 @@ class ThemeShowcase extends Component {
 			case this.tabFilters.TRENDING?.key:
 			case this.tabFilters.ALL.key:
 				return null;
+		}
+	};
+
+	recordSearchThemesTracksEvent = ( action, props ) => {
+		let eventName;
+		switch ( action ) {
+			case 'search_clear_icon_click':
+				eventName = 'calypso_themeshowcase_search_clear_icon_click';
+				break;
+			case 'search_dropdown_searchby_item_click':
+				eventName = 'calypso_themeshowcase_search_dropdown_searchby_item_click';
+				break;
+			case 'search_dropdown_taxonomy_item_click':
+				eventName = 'calypso_themeshowcase_search_dropdown_taxonomy_item_click';
+				break;
+			case 'search_dropdown_show_all_button_click':
+				eventName = 'calypso_themeshowcase_search_dropdown_show_all_button_click';
+				break;
+			case 'search_dropdown_show_less_button_click':
+				eventName = 'calypso_themeshowcase_search_dropdown_show_less_button_click';
+				break;
+		}
+
+		if ( eventName ) {
+			recordTracksEvent( eventName, props );
 		}
 	};
 
@@ -496,7 +526,11 @@ class ThemeShowcase extends Component {
 				<div className="themes__content" ref={ this.scrollRef }>
 					<QueryThemeFilters />
 					{ isNewSearchAndFilter ? (
-						<SearchThemes query={ filterString + search } onSearch={ this.doSearch } />
+						<SearchThemes
+							query={ filterString + search }
+							onSearch={ this.doSearch }
+							recordTracksEvent={ this.recordSearchThemesTracksEvent }
+						/>
 					) : (
 						<ThemesSearchCard
 							onSearch={ this.doSearch }

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -368,17 +368,17 @@ class ThemeShowcase extends Component {
 			case 'search_clear_icon_click':
 				eventName = 'calypso_themeshowcase_search_clear_icon_click';
 				break;
-			case 'search_dropdown_searchby_item_click':
-				eventName = 'calypso_themeshowcase_search_dropdown_searchby_item_click';
+			case 'search_dropdown_taxonomy_click':
+				eventName = 'calypso_themeshowcase_search_dropdown_taxonomy_click';
 				break;
-			case 'search_dropdown_taxonomy_item_click':
-				eventName = 'calypso_themeshowcase_search_dropdown_taxonomy_item_click';
+			case 'search_dropdown_taxonomy_term_click':
+				eventName = 'calypso_themeshowcase_search_dropdown_taxonomy_term_click';
 				break;
-			case 'search_dropdown_show_all_button_click':
-				eventName = 'calypso_themeshowcase_search_dropdown_show_all_button_click';
+			case 'search_dropdown_view_all_button_click':
+				eventName = 'calypso_themeshowcase_search_dropdown_view_all_button_click';
 				break;
-			case 'search_dropdown_show_less_button_click':
-				eventName = 'calypso_themeshowcase_search_dropdown_show_less_button_click';
+			case 'search_dropdown_view_less_button_click':
+				eventName = 'calypso_themeshowcase_search_dropdown_view_less_button_click';
 				break;
 		}
 


### PR DESCRIPTION
#### Proposed Changes

This PR adds Tracks events to the Theme Showcase.
![Screen Shot 2022-11-25 at 2 55 04 PM](https://user-images.githubusercontent.com/797888/203919547-86cdf3e5-626d-403b-9788-a0c49c6ba4de.png)


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the Theme Showcase `/themes/${site_slug}`.
  * If using calypso.live, the flag `themes/showcase-i4/search-and-filter` is required.
* Ensure that the Tracks events trigger as described above.
* Ensure that disabling the flag `themes/showcase-i4/search-and-filter` the old Theme Showcase works as before.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

