### PR TITLE
Stepper Framework: Quick fix on the navigation bar

### DIFF
--- a/client/signup/navigation-link/style.scss
+++ b/client/signup/navigation-link/style.scss
@@ -1,11 +1,13 @@
 .button.is-borderless.navigation-link {
-	padding: 0;
-	color: var(--color-text-inverted);
-	font-size: $font-body-small;
-	font-weight: 600;
+	body.is-section-signup & {
+		padding: 0;
+		color: var(--color-text-inverted);
+		font-size: $font-body-small;
+		font-weight: 600;
 
-	svg {
-		fill: var(--color-text-inverted);
+		svg {
+			fill: var(--color-text-inverted);
+		}
 	}
 }
 


### PR DESCRIPTION
#### Proposed Changes

https://github.com/Automattic/wp-calypso/pull/68722 moves the domains/plans step into the stepper framework, but it also introduces styles from there, e.g: [navigation-link](https://github.com/Automattic/wp-calypso/blob/a0dc006d7a6a8931a35a594186e7c907f7b13a2e/client/signup/navigation-link/style.scss#L1), and it leads the navigation bar on the stepper framework is invisible to the users.

This PR proposes a **quick fix** on the navigation bar on the stepper. The best way is to get rid of `StepWrapper` in domains/plans step so that the `signup/navigation-link` won’t be imported into the stepper framework. Also, we could also remove styles like `button.is-borderless` from https://github.com/Automattic/wp-calypso/pull/68722 at that time

There might be some side effects from that PR. If so, I'll plan to revert that PR but I hope this is the only issue we need to address

| Before | After |
| - | - |
| ![image](https://user-images.githubusercontent.com/13596067/203726234-a4d6cc30-0fdb-477f-aef1-31f7346a2e41.png) | ![image](https://user-images.githubusercontent.com/13596067/203726250-bfac9af2-5100-4c4c-bffc-1ce3294a11a8.png) |

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Site setup flow**

* Go to `/setup?siteSlug=<your_site>`
* After you go to the next step, ensure the navigation bar keeps visible

**Signup flow**

* Go to `/start`
* After you go to the next step, ensure the navigation bar keeps visible

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1669275947061349-slack-C02T4NVL4JJ