### PR TITLE
Pattern Assembler - Pattern improvements

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/patterns-data.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/patterns-data.ts
@@ -6,10 +6,14 @@ const headerPatterns: Pattern[] = [
 		id: 5579,
 		name: 'Centered header',
 	},
+	/*
+	Discarded because there is a menu option named Blog
+	and for now the blogger flow is not supported
 	{
 		id: 5608,
 		name: 'Centered Header with Logo and Navigation',
 	},
+	*/
 	{
 		id: 5582,
 		name: 'Simple Header',

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/patterns-data.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/patterns-data.ts
@@ -11,7 +11,7 @@ const headerPatterns: Pattern[] = [
 	and for now the blogger flow is not supported
 	{
 		id: 5608,
-		name: 'Centered Header with Logo and Navigation',
+		name: 'Centered header with logo and navigation',
 	},
 	*/
 	{
@@ -81,19 +81,19 @@ const footerPatterns: Pattern[] = [
 	},
 	{
 		id: 7917,
-		name: 'Footer with Address, Email Address, and Social Links',
+		name: 'Footer with address, email address, and social links',
 	},
 	{
 		id: 7485,
-		name: 'Footer with Newsletter Subscription Form',
+		name: 'Footer with newsletter subscription form',
 	},
 	{
 		id: 1622,
-		name: 'Footer with Paragraph and Links',
+		name: 'Footer with paragraph and links',
 	},
 	{
 		id: 5047,
-		name: 'Footer with Navigation, Contact Details, Social Links, and Subscription Form',
+		name: 'Footer with navigation, contact details, social links, and subscription form',
 	},
 	{
 		id: 5880,
@@ -128,7 +128,7 @@ const sectionPatterns: Pattern[] = [
 	},
 	{
 		id: 5691,
-		name: 'Three Logos, Heading, and Paragraphs',
+		name: 'Three logos, heading, and paragraphs',
 	},
 	{
 		id: 7143,
@@ -156,7 +156,7 @@ const sectionPatterns: Pattern[] = [
 	},
 	{
 		id: 5666,
-		name: 'Large Numbers, heading, and paragraphs',
+		name: 'Large numbers, heading, and paragraphs',
 	},
 	{
 		id: 462,
@@ -164,7 +164,7 @@ const sectionPatterns: Pattern[] = [
 	},
 	{
 		id: 5663,
-		name: 'Large Headline',
+		name: 'Large headline',
 	},
 	{
 		id: 7140,
@@ -180,7 +180,7 @@ const sectionPatterns: Pattern[] = [
 	},
 	{
 		id: 1600,
-		name: 'Three Column Text and Links',
+		name: 'Three column text and links',
 	},
 ];
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/patterns-data.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/patterns-data.ts
@@ -1,48 +1,55 @@
 import type { Pattern } from './types';
 
+// All headers in dotcompatterns
 const headerPatterns: Pattern[] = [
 	{
 		id: 5579,
 		name: 'Centered header',
 	},
 	{
+		id: 5608,
+		name: 'Centered Header with Logo and Navigation',
+	},
+	{
 		id: 5582,
-		name: 'Simple header with large font size',
-	},
-	{
-		id: 5605,
-		name: 'Header with site title and vertical navigation',
-	},
-	{
-		id: 5603,
-		name: 'Header with site title and menu button',
-	},
-	{
-		id: 7914,
-		name: 'Header with button',
+		name: 'Simple Header',
 	},
 	{
 		id: 5588,
-		name: 'Simple header',
-	},
-	{
-		id: 5601,
-		name: 'Simple header with tagline',
+		name: 'Header with site title and vertical navigation',
 	},
 	{
 		id: 5590,
 		name: 'Simple header with image background',
 	},
 	{
+		id: 5593,
+		name: 'Simple header with dark background',
+	},
+	{
 		id: 5595,
 		name: 'Simple header with image',
 	},
 	{
-		id: 5593,
-		name: 'Simple header with dark background',
+		id: 5601,
+		name: 'Simple header with tagline',
+	},
+	{
+		id: 5603,
+		name: 'Header with site title and menu button',
+	},
+	{
+		id: 5605,
+		name: 'Simple header with image',
+	},
+	{
+		id: 7914,
+		name: 'Header with button',
 	},
 ];
 
+// All footers in dotcompatterns
+// Missing footers in dotcomfsepatterns
 const footerPatterns: Pattern[] = [
 	{
 		id: 5316,
@@ -69,12 +76,20 @@ const footerPatterns: Pattern[] = [
 		name: 'Simple centered footer',
 	},
 	{
+		id: 7917,
+		name: 'Footer with Address, Email Address, and Social Links',
+	},
+	{
+		id: 7485,
+		name: 'Footer with Newsletter Subscription Form',
+	},
+	{
 		id: 1622,
-		name: 'Contact',
+		name: 'Footer with Paragraph and Links',
 	},
 	{
 		id: 5047,
-		name: 'Footer with navigation, contact details, social links, and subscription form',
+		name: 'Footer with Navigation, Contact Details, Social Links, and Subscription Form',
 	},
 	{
 		id: 5880,
@@ -96,20 +111,20 @@ const sectionPatterns: Pattern[] = [
 		name: 'Four column list',
 	},
 	{
-		id: 1600,
-		name: 'Three column text and links',
+		id: 7132,
+		name: 'Cover image with left-aligned call to action',
+	},
+	{
+		id: 7159,
+		name: 'Cover image with centered text and a button',
 	},
 	{
 		id: 7149,
 		name: 'Two column image grid',
 	},
 	{
-		id: 7135,
-		name: 'Three columns with images and text',
-	},
-	{
 		id: 5691,
-		name: 'Three logos, heading, and paragraphs',
+		name: 'Three Logos, Heading, and Paragraphs',
 	},
 	{
 		id: 7143,
@@ -120,24 +135,24 @@ const sectionPatterns: Pattern[] = [
 		name: 'Logos',
 	},
 	{
-		id: 7132,
-		name: 'Cover image with left-aligned call to action',
-	},
-	{
-		id: 7159,
-		name: 'Cover image with centered text and a button',
-	},
-	{
 		id: 1585,
 		name: 'Quote and logos',
 	},
 	{
+		id: 7135,
+		name: 'Three columns with images and text',
+	},
+	{
 		id: 789,
-		name: 'Numbered list',
+		name: 'Numbered List',
+	},
+	{
+		id: 6712,
+		name: 'List of events',
 	},
 	{
 		id: 5666,
-		name: 'Large numbers, heading, and paragraphs',
+		name: 'Large Numbers, heading, and paragraphs',
 	},
 	{
 		id: 462,
@@ -145,7 +160,7 @@ const sectionPatterns: Pattern[] = [
 	},
 	{
 		id: 5663,
-		name: 'Large headline',
+		name: 'Large Headline',
 	},
 	{
 		id: 7140,
@@ -160,8 +175,8 @@ const sectionPatterns: Pattern[] = [
 		name: 'Two testimonials side by side',
 	},
 	{
-		id: 6712,
-		name: 'List of events',
+		id: 1600,
+		name: 'Three Column Text and Links',
 	},
 ];
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/types.ts
@@ -1,5 +1,5 @@
 export type Pattern = {
 	id: number;
-	name: string;
+	name: any;
 	key?: string;
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/types.ts
@@ -1,5 +1,5 @@
 export type Pattern = {
 	id: number;
-	name: any;
+	name: string;
 	key?: string;
 };


### PR DESCRIPTION
#### Proposed Changes

* Reorder patterns to match the editor list
* Add missing patterns (7917 and 7485)
* Discard a [header](https://dotcompatterns.wordpress.com/2022/08/29/centered-header-with-logo-and-navigation/) pattern for now because it may be confusing as the PA is not supported in the blogger flow. Why not better rename that menu option? We can follow up with that 

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup?siteSlug=[ YOUR SITE ]`
* Don't mark any goal or select any vertical
* Scroll to the bottom of the design picker and click on the Blank canvas CTA
* Check that all the patterns have a preview and that the pattern selection works as expected

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/1251
