### PR TITLE
Stepper: More specific fix for navigation bar

### DIFF
--- a/client/signup/navigation-link/style.scss
+++ b/client/signup/navigation-link/style.scss
@@ -1,5 +1,5 @@
 .button.is-borderless.navigation-link {
-	body.is-section-signup & {
+	body:not(.is-section-stepper) & {
 		padding: 0;
 		color: var(--color-text-inverted);
 		font-size: $font-body-small;


### PR DESCRIPTION
#### Proposed Changes

This is just a more granular version of the working version provided by @arthur791004 https://github.com/Automattic/wp-calypso/pull/70362.

We exclude stepper from the changes to the navigation link provided by `StepWrapper`.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Site setup flow**

- Go to `/setup?siteSlug=<your_site>`
- After you go to the next step, ensure the navigation bar keeps visible

**Signup flow**

- Go to `/start`
- After you go to the next step, ensure the navigation bar keeps visible


Related to #70362
