### PR TITLE
Launchpad: Use host from adminUrl for preview

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/step-content.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/step-content.tsx
@@ -1,9 +1,11 @@
+import { useSelect } from '@wordpress/data';
 import { useState, useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import { NEWSLETTER_FLOW } from 'calypso/../packages/onboarding/src';
 import { useGetDomainsQuery } from 'calypso/data/domains/use-get-domains-query';
 import { NavigationControls } from 'calypso/landing/stepper/declarative-flow/internals/types';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
+import { SITE_STORE } from 'calypso/landing/stepper/stores';
 import { ResponseDomain } from 'calypso/lib/domains/types';
 import {
 	getCurrentUserEmail,
@@ -28,7 +30,9 @@ function sortByRegistrationDate( domainObjectA: ResponseDomain, domainObjectB: R
 
 const StepContent = ( { siteSlug, submit, goNext, goToStep, flow }: StepContentProps ) => {
 	const site = useSite();
-
+	const adminUrl = useSelect(
+		( select ) => site && select( SITE_STORE ).getSiteOption( site.ID, 'admin_url' )
+	);
 	const { data: allDomains = [] } = useGetDomainsQuery( site?.ID ?? null, {
 		retry: false,
 	} );
@@ -45,7 +49,8 @@ const StepContent = ( { siteSlug, submit, goNext, goToStep, flow }: StepContentP
 
 	const sidebarDomain = nonWpcomDomains?.length ? nonWpcomDomains[ 0 ] : wpcomDomains[ 0 ];
 
-	const iFrameURL = wpcomDomains.length ? wpcomDomains[ 0 ]?.domain : nonWpcomDomains[ 0 ]?.domain;
+	// The adminUrl points to the .wordpress.com domain for this site, so we'll use this for the preview.
+	const iFrameURL = adminUrl ? new URL( adminUrl as string ).host : null;
 
 	const isEmailVerified = useSelector( isCurrentUserEmailVerified );
 	const email = useSelector( getCurrentUserEmail );


### PR DESCRIPTION
#### Proposed Changes

The preview window in Launchpad can't preview a site on `.w.link` domain, while it works as expected for sites on `.wordpress.com` domains when third-party cookies are blocked.

In this PR, we change the iframe URL for the preview component to the host from the `admin_url`. The `admin_url` points to `<slug>.wordpress.com/wp-admin`, and we use the host (`<slug>.wordpress.com`) part of this URL.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/link-in-bio-tld?tld=link` and proceed through the flow steps.
* On the domain screen, select a `.w.link` domain.
* Once you reach the launchpad, confirm that you can see the preview in the right side of your screen.
* Open the network inspector and reload the page. Search for requests with `iframe` in the URL.
* Confirm that the host for this request is a `.wordpress.com` subdomain instead of a `.w.link` subdomain.

#### Testing for regressions
* Go through the newsletter and link-in-bio flows and confirm that the launchpad correctly shows the preview.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes Automattic/martech#1275
