### PR TITLE
Prevent edited plans to change with the flag #add-newsletter-payment-plan

### DIFF
--- a/client/my-sites/earn/memberships/products.jsx
+++ b/client/my-sites/earn/memberships/products.jsx
@@ -74,6 +74,11 @@ class MembershipsProductsSection extends Component {
 	closeDialog = () => this.setState( { showAddEditDialog: false, showDeleteDialog: false } );
 
 	render() {
+		// This will take the hash into account only when ading a new product
+		const subscribe_as_site_subscriber = this.state.product
+			? this.state.product?.subscribe_as_site_subscriber
+			: window.location.hash === '#add-newsletter-payment-plan';
+
 		return (
 			<div>
 				<QueryMembershipsSettings siteId={ this.props.siteId } />
@@ -127,9 +132,7 @@ class MembershipsProductsSection extends Component {
 						<RecurringPaymentsPlanAddEditModal
 							closeDialog={ this.closeDialog }
 							product={ Object.assign( this.state.product ?? {}, {
-								subscribe_as_site_subscriber:
-									this.state.product?.subscribe_as_site_subscriber ||
-									window.location.hash === '#add-newsletter-payment-plan',
+								subscribe_as_site_subscriber: subscribe_as_site_subscriber,
 							} ) }
 						/>
 					) }


### PR DESCRIPTION
Fixes #70357 

#### Proposed Changes

* Do not acknowledge ` #add-newsletter-payment-plan` flag when editing a plan

#### Testing Instructions

#### ON wordpress.com

 * Go to  https://www.wordpress.com/earn/payments-plans/{YOUR_TESTING_DOMAIN}
 * Edit the donation plan
 * Make sure it **does not have** "Email newly published posts to your customers." toggled
 * Create a new post 
* Add a subscribe button
* Click on add new plan (or go to the plans list and add `#add-newsletter-payment-plan` at the end of the URL
 * You should see the 'add a new plan' modal
 * Go to "email" tab and make sure "Email newly published posts to your customers." is toggled
 * Cancel
 * Edit the donation plan
 * Make sure it **DOES HAVE** "Email newly published posts to your customers." toggled

#### Calypso branch
 * Open the Calypso live link  
<img width="892" alt="Screenshot 2022-11-24 at 12 43 34" src="https://user-images.githubusercontent.com/790558/203776327-ec2cadf2-993a-4a27-bc51-c8ec2a69f641.png">
And add `earn/payments-plans/{YOUR_TESTING_DOMAIN}#add-newsletter-payment-plan` to the URL
(for example `https://container-trusting-nobel.calypso.live/earn/payments-plans/testjetpackpaidnewsletters.wordpress.com#add-newsletter-payment-plan`)

 * Sandbox the jetpack `paid-newsletter` branch, `public-api.wordpress.com` and `store.wordpress.com`
 * You should see the 'add a new plan' modal
 * Go to "email" tab and make sure "Email newly published posts to your customers." is toggled
 * Cancel
 * Edit the donation plan
 * Make sure it **DOES NOT HAVE** "Email newly published posts to your customers." toggled
