### PR TITLE
E2E: Switch to premium plan in failing test

### DIFF
--- a/test/e2e/specs/onboarding/ftme__sell.ts
+++ b/test/e2e/specs/onboarding/ftme__sell.ts
@@ -26,9 +26,9 @@ import { apiCloseAccount } from '../shared';
 declare const browser: Browser;
 
 describe( DataHelper.createSuiteTitle( 'FTME: Sell' ), function () {
-	const planName = 'Personal';
+	const planName = 'Premium';
 	const testUser = DataHelper.getNewTestUser( {
-		usernamePrefix: 'ftmepersonal',
+		usernamePrefix: 'ftmepremium',
 	} );
 	const blogTagLine = DataHelper.getRandomPhrase();
 


### PR DESCRIPTION
#### Proposed Changes

Context: p1669289799322919-slack-C02DQP0FP

Due to a temporary issue in the backend testing environment, this E2E test fails when adding the Personal plan to the cart. This PR changes the e2e test to switch the to the Premium plan.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Once the E2E environment is set up:
* `cd test/e2e`
* `yarn jest specs/onboarding/ftme__sell.ts`
* Confirm that the e2e test completes successfully.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->