### PR TITLE
Fixes the broken back navigation of the dotlink variation of Link in Bio flow.

### DIFF
--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -174,6 +174,7 @@ class Signup extends Component {
 		// Prevent duplicate sites, check pau2Xa-1Io-p2#comment-6759.
 		if ( this.props.isManageSiteFlow ) {
 			providedDependencies = {
+				...providedDependencies,
 				siteSlug: getSignupCompleteSlug(),
 				isManageSiteFlow: this.props.isManageSiteFlow,
 			};

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -213,7 +213,7 @@ class Signup extends Component {
 					destinationStep,
 					undefined,
 					locale,
-					this.getFilteredQueryArgs()
+					this.getCurrentFlowSupportedQueryParams()
 				)
 			);
 		}
@@ -584,7 +584,7 @@ class Signup extends Component {
 		return window.location.origin + path;
 	};
 
-	getFilteredQueryArgs = () => {
+	getCurrentFlowSupportedQueryParams = () => {
 		const queryObject = this.props.initialContext?.query ?? {};
 		const flow = flows.getFlow( this.props.flowName, this.props.isLoggedIn );
 		const { siteId, siteSlug } = queryObject;
@@ -605,7 +605,13 @@ class Signup extends Component {
 		if ( stepName && ! this.isEveryStepSubmitted() ) {
 			const locale = ! this.props.isLoggedIn ? this.props.locale : '';
 			page(
-				getStepUrl( flowName, stepName, stepSectionName, locale, this.getFilteredQueryArgs() )
+				getStepUrl(
+					flowName,
+					stepName,
+					stepSectionName,
+					locale,
+					this.getCurrentFlowSupportedQueryParams()
+				)
 			);
 		} else if ( this.isEveryStepSubmitted() ) {
 			this.goToFirstInvalidStep();
@@ -664,7 +670,7 @@ class Signup extends Component {
 					firstInvalidStep.stepName,
 					'',
 					locale,
-					this.getFilteredQueryArgs()
+					this.getCurrentFlowSupportedQueryParams()
 				)
 			);
 		}
@@ -775,7 +781,7 @@ class Signup extends Component {
 							positionInFlow={ this.getPositionInFlow() }
 							hideFreePlan={ hideFreePlan }
 							isReskinned={ isReskinned }
-							queryParams={ this.getFilteredQueryArgs() }
+							queryParams={ this.getCurrentFlowSupportedQueryParams() }
 							{ ...propsForCurrentStep }
 						/>
 					) }

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -191,8 +191,12 @@ class Signup extends Component {
 
 		this.updateShouldShowLoadingScreen();
 
-		if ( canResumeFlow( this.props.flowName, this.props.progress, this.props.isLoggedIn ) ) {
-			// Resume from the current window location
+		// Resume from the current window location if there is stored, completed step progress.
+		// However, if the step is removed, e.g. the user step is removed after logging-in, it can't be resumed.
+		if (
+			canResumeFlow( this.props.flowName, this.props.progress, this.props.isLoggedIn ) &&
+			! this.isCurrentStepRemovedFromFlow()
+		) {
 			return;
 		}
 
@@ -780,11 +784,15 @@ class Signup extends Component {
 		);
 	}
 
-	shouldWaitToRender() {
-		const isStepRemovedFromFlow = ! includes(
+	isCurrentStepRemovedFromFlow() {
+		return ! includes(
 			flows.getFlow( this.props.flowName, this.props.isLoggedIn ).steps,
 			this.props.stepName
 		);
+	}
+
+	shouldWaitToRender() {
+		const isStepRemovedFromFlow = this.isCurrentStepRemovedFromFlow();
 		const isDomainsForSiteEmpty =
 			this.props.isLoggedIn &&
 			this.props.signupDependencies.siteSlug &&


### PR DESCRIPTION
#### Proposed Changes

Since the dotlink variation of Link in Bio flow is a mix of the signup framework and the Stepper framework, it happens to touch various back navigation issues of the signup framework that has never been exposed by the other flows before. In this PR, there are three issues addressed:

1. If it's the site managing flow(i.e. the signup flow running by a logged-in user. Navigating back after the user step can easily trigger this.), the `providedDependencies` object is currently completely overwritten. Thus, any dependency provided in the query object will be lost. This PR makes sure the latter are kept even in the site managing flow.
2. Currently the query objects are filtered down to only the site slug and the site id after going to the next step. For the flows that provides dependencies in the query strings, that means they will be lost after completing any step. This PR implements a utility function that takes all the dependencies in query into consideration.
3. The current `canResumeFlow()` logic doesn't consider the case that the current step can be removed. For example, the user step will be removed once its completed, since the user is considered logged-in after that. The current logic will falsely consider it's resumable and stuck forever since it will want to resume from a step that's no longer exist. This PR adds a check and bails the resume process if the current step has been removed.

#### Testing Instructions

_Caution: If you test on a local instance, it's adviced to turn off the developer sympathy mode by `ENABLE_FEATURES=no-force-sympathy`_ 

In general, go through `/start/link-in-bio-tld?tld=link` and navigate back from any step shouldn't result in any blank screen or a broken site. We can view this flow as consisting of 4 joints: `[domain step, user step] on the signup framework` -> `[patterns, link in bio info] on the Stepper framework` -> `[plans step] on the signup framework` -> `checkout, as its own` -> `[launchpad] on the Stepeer framework`. Having those joints checked at least would be the best:

1. Go through the domains step and the user step and then navigate back from the patterns step. You should arrive at the domains step since the user step will have been removed.
4. Navigating back from the plans step, you should arrive the link in bio info step.
5. Picking a paid plan on the plan step which then leads you to the checkout page, navigate back and you will arrive at the domains step. That's expected since the whole flow is considered completed, so the framework will take you to the beginning.
6. The same applies to picking the free plan and then to navigate back from the Launchpad. The framework considers the signup flow is completed so it will direct you to the beginning, i.e. the domains step.

Note that either you completing the checkout or dismissing it, navigating back from the Launchpad you will first see the plans admin page and then you will need to navigate back one more time to see the checkout page again. That's another issue due to how the routing of the checkout page work, and it's out of the scope of this PR.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Automattic/martech#1261.
