### PR TITLE
E2E: fix artifact rule for Pre-Release Tests in TeamCity.

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -784,7 +784,7 @@ object PreReleaseE2ETests : BuildType({
 		screenshots => screenshots
 		trace => trace
 		allure-results => allure-results.tgz
-	"""
+	""".trimIndent()
 
 	vcs {
 		root(Settings.WpCalypso)


### PR DESCRIPTION
#### Proposed Changes

This PR corrects the `artifactRules` in TeamCity to correctly capture artifacts.

Key changes:
- trim the indent when defining the rules.

Context:
p1669290699657499-slack-C1A1EKDGQ

#### Testing Instructions

Make sure there are artifacts in the build.

**Previous**:
![image](https://user-images.githubusercontent.com/6549265/203841861-42ee512c-17ae-4bbf-8881-48d218d4c015.png)

**Corrected**:
![image](https://user-images.githubusercontent.com/6549265/203841896-e47a8f6f-a44e-44d7-9ecd-dae97df98d00.png)


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #