### PR TITLE
Gifting toggle: Add support link for Learn More & update text

### DIFF
--- a/client/components/inline-support-link/context-links.js
+++ b/client/components/inline-support-link/context-links.js
@@ -67,6 +67,10 @@ const contextLinks = {
 		link: 'https://wordpress.com/support/getting-started-with-wordpress-com/#video-getting-started-with-word-press-com',
 		post_id: 158974,
 	},
+	'gift-a-subscription': {
+		link: 'https://wordpress.com/support/gift-a-wordpress-com-subscription',
+		post_id: 226176,
+	},
 	'google-analytics-measurement-id': {
 		link: 'https://wordpress.com/support/google-analytics/#get-your-measurement-id',
 		post_id: 98905,

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -654,7 +654,7 @@ export class SiteSettingsFormGeneral extends Component {
 							<ToggleControl
 								disabled={ isRequestingSettings || isSavingSettings }
 								className="site-settings__gifting-toggle"
-								label={ translate( 'Allow a site visitor to gift site plan costs.' ) }
+								label={ translate( 'Allow a site visitor to gift you with site plan costs' ) }
 								checked={ fields.wpcom_gifting_subscription }
 								onChange={ this.props.handleToggle( 'wpcom_gifting_subscription' ) }
 							/>
@@ -662,6 +662,9 @@ export class SiteSettingsFormGeneral extends Component {
 								{ translate(
 									"Allow a site visitor to cover the full cost of your site's WordPress.com plan."
 								) }
+								<InlineSupportLink supportContext="gift-a-subscription">
+									{ translate( 'Learn more.' ) }
+								</InlineSupportLink>
 							</FormSettingExplanation>
 						</CompactCard>
 					</div>

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -662,7 +662,7 @@ export class SiteSettingsFormGeneral extends Component {
 								{ translate(
 									"Allow a site visitor to cover the full cost of your site's WordPress.com plan."
 								) }
-								<InlineSupportLink supportContext="gift-a-subscription">
+								<InlineSupportLink supportContext="gift-a-subscription" showIcon="">
 									{ translate( 'Learn more.' ) }
 								</InlineSupportLink>
 							</FormSettingExplanation>

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -668,4 +668,7 @@ button.site-settings__general-settings-set-guessed-timezone.button.is-borderless
 	p {
 		font-style: italic;
 	}
+	.inline-support-link {
+		padding-left: 5px;
+	}
 }


### PR DESCRIPTION
#### Proposed Changes

Add a link to the support doc from the subscription gifting toggle copy in site settings.

#### Testing Instructions

- Go to Settings.
- Check the text and Learn more on the Gift Toggle.
- Clicking `Learn more` should open an overlay with the support page.

#### Screenshots
![image](https://user-images.githubusercontent.com/402286/203865886-2c49e6d0-6a4b-42eb-a012-0af7f706d0f7.png)
![image](https://user-images.githubusercontent.com/402286/203865894-37340b64-18dd-4c90-b00b-136f68e290c8.png)


#### Pre-merge Checklist

- [ ] ~~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~~
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~~
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] ~~For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~~

Fixes #70351
