### PR TITLE
E2E: reduce default timeout value to 10000ms

### DIFF
--- a/packages/calypso-e2e/src/env-variables.ts
+++ b/packages/calypso-e2e/src/env-variables.ts
@@ -11,6 +11,7 @@ const defaultEnvVariables: SupportedEnvVariables = {
 	TEST_LOCALES: [ ...MAG16_LOCALES ],
 	HEADLESS: false,
 	SLOW_MO: 0,
+	TIMEOUT: 10000,
 	GUTENBERG_EDGE: false,
 	COBLOCKS_EDGE: false,
 	AUTHENTICATE_ACCOUNTS: [ 'simpleSitePersonalPlanUser', 'eCommerceUser', 'defaultUser' ],
@@ -23,6 +24,16 @@ const defaultEnvVariables: SupportedEnvVariables = {
 	ALLURE_RESULTS_PATH: '',
 };
 
+/**
+ * Captures and performs type check on all known environment variables.
+ *
+ * When a new environment variable is to be added, make sure to add the variable to
+ * both the definition above and the `SupportedEnvVariables` interface.
+ *
+ * @param {string} name Name of the environment variable.
+ * @param {string} value Value of the environment variable.
+ * @returns {EnvVariableValue} Cast and type-checked environment variable value.
+ */
 const castKnownEnvVariable = ( name: string, value: string ): EnvVariableValue => {
 	let output: EnvVariableValue = value;
 

--- a/packages/calypso-e2e/src/jest-playwright-config/environment.ts
+++ b/packages/calypso-e2e/src/jest-playwright-config/environment.ts
@@ -208,6 +208,10 @@ class JestEnvironmentPlaywright extends NodeEnvironment {
 							recordVideo: { dir: os.tmpdir() },
 						} );
 
+						// Set the default timeout for all Playwright methods.
+						// Default value is 15000ms, defined in env-variables.ts.
+						page.setDefaultTimeout( env.TIMEOUT );
+
 						const context = page.context();
 
 						await context.tracing.start( {

--- a/packages/calypso-e2e/src/lib/pages/plugins-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plugins-page.ts
@@ -77,7 +77,10 @@ export class PluginsPage {
 	 * @param {string} site Optional site URL.
 	 */
 	async visit( site = '' ): Promise< void > {
-		await this.page.goto( getCalypsoURL( `plugins/${ site }` ), { waitUntil: 'networkidle' } );
+		await this.page.goto( getCalypsoURL( `plugins/${ site }` ), {
+			waitUntil: 'networkidle',
+			timeout: 15 * 1000,
+		} );
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/pages/plugins-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plugins-page.ts
@@ -79,6 +79,8 @@ export class PluginsPage {
 	async visit( site = '' ): Promise< void > {
 		await this.page.goto( getCalypsoURL( `plugins/${ site }` ), {
 			waitUntil: 'networkidle',
+			// Manual override of the timeout - `networkidle` can take longer
+			// to fire, especially for Simple sites.
 			timeout: 15 * 1000,
 		} );
 	}

--- a/packages/calypso-e2e/src/types/env-variables.types.ts
+++ b/packages/calypso-e2e/src/types/env-variables.types.ts
@@ -18,6 +18,7 @@ export interface SupportedEnvVariables extends EnvVariables {
 	ARTIFACTS_PATH: string;
 	HEADLESS: boolean;
 	SLOW_MO: number;
+	TIMEOUT: number;
 	TEST_ON_ATOMIC: boolean;
 	TEST_ON_JETPACK: boolean;
 	CALYPSO_BASE_URL: string;

--- a/test/e2e/specs/onboarding/setup__build.ts
+++ b/test/e2e/specs/onboarding/setup__build.ts
@@ -59,8 +59,8 @@ describe(
 			} );
 
 			it( 'Land in Home dashboard', async function () {
-				// This process takes a long time.
 				await page.waitForURL( DataHelper.getCalypsoURL( `/home/${ siteSlug }` ), {
+					// This process takes a long time, uncertain why.
 					timeout: 30 * 1000,
 				} );
 			} );

--- a/test/e2e/specs/onboarding/setup__build.ts
+++ b/test/e2e/specs/onboarding/setup__build.ts
@@ -59,7 +59,10 @@ describe(
 			} );
 
 			it( 'Land in Home dashboard', async function () {
-				await page.waitForURL( DataHelper.getCalypsoURL( `/home/${ siteSlug }` ) );
+				// This process takes a long time.
+				await page.waitForURL( DataHelper.getCalypsoURL( `/home/${ siteSlug }` ), {
+					timeout: 30 * 1000,
+				} );
 			} );
 		} );
 	}


### PR DESCRIPTION
#### Proposed Changes

This PR reduces the default timeout value for the Playwright side of the E2E framework to 10000ms.

The default timeout of the Jest Side remains at the default value.

Context: p1669068425400639-slack-C1A1EKDGQ

#### Testing Instructions

1. pull this branch.
2. open a test file and insert a failing wait statement (eg. `waitForURL('ljwer')`.
3. execute the test with `yarn jest ...`

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #