### PR TITLE
Show the manage plugin menu for installed plugins without a subscription

### DIFF
--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -275,6 +275,11 @@ const PluginDetailsCTA = ( { plugin, isPlaceholder } ) => {
 		<Fragment>
 			<QuerySitePurchases siteId={ selectedSite?.ID } />
 			<div className="plugin-details-cta__container">
+				{ isPluginInstalledOnsite && sitePlugin && (
+					<div className="plugin-details-cta__manage-plugin-menu-new-purchase">
+						<ManagePluginMenu plugin={ plugin } />
+					</div>
+				) }
 				{ ! plugin.isSaasProduct && (
 					<div className="plugin-details-cta__price">
 						<PluginPrice plugin={ plugin } billingPeriod={ billingPeriod }>
@@ -381,7 +386,7 @@ function PrimaryButton( {
 				is_saas_product: plugin?.isSaasProduct,
 			} )
 		);
-	}, [ dispatch ] );
+	}, [ dispatch, plugin, isLoggedIn ] );
 
 	if ( ! isLoggedIn ) {
 		return (

--- a/client/my-sites/plugins/plugin-details-CTA/style.scss
+++ b/client/my-sites/plugins/plugin-details-CTA/style.scss
@@ -122,6 +122,12 @@
 	margin-top: -12px;
 }
 
+.plugin-details-cta__manage-plugin-menu-new-purchase {
+	position: absolute;
+	right: 40px;
+	top: 40px;
+}
+
 .plugin-details-cta__installed-text {
 	color: var(--studio-gray-100);
 	font-size: $font-body;

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -128,6 +128,7 @@ $calypso-header-height: 31px;
 	}
 
 	.plugin-details__actions {
+		position: relative;
 		grid-area: actions;
 		background-color: var(--studio-gray-0);
 		padding: 40px;


### PR DESCRIPTION
#### Proposed Changes

Show the manage plugin option for plugins without a subscription, before this change, there was no option to manage the already installed plugin.

<img width="444" alt="Screen Shot 2022-11-24 at 18 46 27" src="https://user-images.githubusercontent.com/5039531/203871645-f53c2f68-2c1f-427e-aaa6-615aa5985da8.png">

#### Testing Instructions
* Upload a paid plugins
* Go to the plugin details page of the installed plugins. Ex: `/plugins/{plugin_slug}/{site}`
* Check if the those items are visible
  * The menu with the remove option
  * The price
  * The CTA to purchase 
