### PR TITLE
Woo tailored flow: Added feature flag to redirect URL

### DIFF
--- a/client/landing/stepper/declarative-flow/tailored-ecommerce-flow.ts
+++ b/client/landing/stepper/declarative-flow/tailored-ecommerce-flow.ts
@@ -103,14 +103,13 @@ export const ecommerceFlow: Flow = {
 
 						// The site is coming from the checkout already Atomic (and with the new URL)
 						// There's probably a better way of handling this change
-						const returnUrl = encodeURIComponent(
-							`/setup/${ flowName }/checkPlan?theme=${
-								selectedDesign?.slug
-							}&flags=signup/tailored-ecommerce&siteSlug=${ siteSlug.replace(
-								'.wordpress.com',
-								'.wpcomstaging.com'
-							) }`
-						);
+						const urlParams = new URLSearchParams( {
+							theme: selectedDesign?.slug || '',
+							siteSlug: siteSlug.replace( '.wordpress.com', '.wpcomstaging.com' ),
+							flags: 'signup/tailored-ecommerce',
+						} );
+
+						const returnUrl = encodeURIComponent( `/setup/${ flowName }/checkPlan?${ urlParams }` );
 
 						return window.location.assign(
 							`/checkout/${ encodeURIComponent(

--- a/client/landing/stepper/declarative-flow/tailored-ecommerce-flow.ts
+++ b/client/landing/stepper/declarative-flow/tailored-ecommerce-flow.ts
@@ -96,7 +96,7 @@ export const ecommerceFlow: Flow = {
 					}
 
 					if ( providedDependencies?.siteSlug ) {
-						const destination = `/setup/${ flowName }/checkPlan?siteSlug=${ siteSlug }`;
+						const destination = `/setup/${ flowName }/checkPlan?siteSlug=${ siteSlug }&flags=signup/tailored-ecommerce`;
 						persistSignupDestination( destination );
 						setSignupCompleteSlug( siteSlug );
 						setSignupCompleteFlowName( flowName );
@@ -106,7 +106,10 @@ export const ecommerceFlow: Flow = {
 						const returnUrl = encodeURIComponent(
 							`/setup/${ flowName }/checkPlan?theme=${
 								selectedDesign?.slug
-							}&siteSlug=${ siteSlug.replace( '.wordpress.com', '.wpcomstaging.com' ) }`
+							}&flags=signup/tailored-ecommerce&siteSlug=${ siteSlug.replace(
+								'.wordpress.com',
+								'.wpcomstaging.com'
+							) }`
 						);
 
 						return window.location.assign(


### PR DESCRIPTION
#### Proposed Changes

The eCommerce tailored flow is behind a feature flag. The flag can be enabled by a query parameter, but we were losing this configuration when the user was being redirected from checkout.

This PR adds the `flags` parameter to the redirect URL so it stays enabled.

#### Testing Instructions

* Access `/setup/ecommerce?flags=signup/tailored-ecommerce`
![Kzuj86.png](https://user-images.githubusercontent.com/3801502/199599954-b3782d86-09e7-476d-8438-1deeb554b45a.png)
* Click create your store and you'll be redirected to `storeProfiler`
![hi6n1t.png](https://user-images.githubusercontent.com/3801502/199600105-22c535f9-40d2-4722-9125-1ab581bbdcf9.png)
* Click Continue and you'll be redirected to `designCarousel` step
![zjAGwD.png](https://user-images.githubusercontent.com/3801502/199600270-b58849e5-e9de-4f1f-91f0-9c1800953a02.png)
* Choose a theme and click Continue.


* Pick a domain
![jBqZvh.png](https://user-images.githubusercontent.com/3801502/199599045-9f548ac2-fc6c-47de-8114-d08ac694504e.png)

* You'll go to checkout, buy the eCommerce plan
![fRQXUo.png](https://user-images.githubusercontent.com/3801502/199599545-785e4cc9-e768-4655-9a16-20770a943b46.png)
* After checkout, the site is gonna be set up 
![image](https://user-images.githubusercontent.com/3801502/201522232-03d3fdc0-2403-40fa-8f2e-1b0c93f8a8e0.png)

* You should be redirected to `/wp-admin/admin.php?page=wc-admin`. 
**The Site should have the plan/domain/theme you chose in the flow.**