### PR TITLE
Fix translation for domain step subheader

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
@@ -169,7 +169,7 @@ const DomainsStep: Step = function DomainsStep( { navigation, flow } ) {
 
 	const getSubHeaderText = () => {
 		const decideLaterComponent = {
-			decide_later: (
+			span: (
 				// eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/interactive-supports-focus
 				<span
 					role="button"
@@ -183,21 +183,21 @@ const DomainsStep: Step = function DomainsStep( { navigation, flow } ) {
 			case 'newsletter':
 				return createInterpolateElement(
 					__(
-						'Help your Newsletter stand out with a custom domain. Not sure yet? <decide_later>Decide later</decide_later>.'
+						'Help your Newsletter stand out with a custom domain. Not sure yet? <span>Decide later</span>.'
 					),
 					decideLaterComponent
 				);
 			case 'link-in-bio':
 				return createInterpolateElement(
 					__(
-						'Set your Link in Bio apart with a custom domain. Not sure yet? <decide_later>Decide later</decide_later>.'
+						'Set your Link in Bio apart with a custom domain. Not sure yet? <span>Decide later</span>.'
 					),
 					decideLaterComponent
 				);
 			default:
 				return createInterpolateElement(
 					__(
-						'Help your site stand out with a custom domain. Not sure yet? <decide_later>Decide later</decide_later>.'
+						'Help your site stand out with a custom domain. Not sure yet? <span>Decide later</span>.'
 					),
 					decideLaterComponent
 				);


### PR DESCRIPTION
The domain step subheader appears untranslated in non-EN, even though this string already has translations. 


<img width="831" alt="Screenshot 2022-11-25 at 7 36 04 AM" src="https://user-images.githubusercontent.com/1269602/203885861-1f92a24c-c281-474e-9797-0029f2cb9869.png">



The reason is that the string which has translation is:
```
Set your Link in Bio apart with a custom domain. Not sure yet? {{span}}Decide later{{/span}}.
```

whereas the string shown in the subheader is:

```
Set your Link in Bio apart with a custom domain. Not sure yet? <decide_later>Decide later</decide_later>.
```

The `decide_later` component name is long enough for it to not be detected as a fuzzy match, and it's instead been identified as a new string which needs translations. Check:

* https://translate.wordpress.com/projects/wpcom/fr/default?filters%5Bterm%5D=Set+your+Link+in+Bio+apart+with+a+custom+domain.+Not+sure+yet%3F
* https://translate.wordpress.com/projects/wpcom/fr/default?filters%5Bterm%5D=Help+your+Newsletter+stand+out+with+a+custom+domain.+Not+sure+yet%3F



This PR changes the component name so that the similarity score is higher and gets a fuzzy match.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Verify that the string is identified as fuzzy. 

