### PR TITLE
Make the title string translatable in the tailored flows

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
@@ -169,7 +169,7 @@ const DomainsStep: Step = function DomainsStep( { navigation, flow } ) {
 
 	const getSubHeaderText = () => {
 		const decideLaterComponent = {
-			decide_later: (
+			span: (
 				// eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/interactive-supports-focus
 				<span
 					role="button"
@@ -183,21 +183,21 @@ const DomainsStep: Step = function DomainsStep( { navigation, flow } ) {
 			case 'newsletter':
 				return createInterpolateElement(
 					__(
-						'Help your Newsletter stand out with a custom domain. Not sure yet? <decide_later>Decide later</decide_later>.'
+						'Help your Newsletter stand out with a custom domain. Not sure yet? <span>Decide later</span>.'
 					),
 					decideLaterComponent
 				);
 			case 'link-in-bio':
 				return createInterpolateElement(
 					__(
-						'Set your Link in Bio apart with a custom domain. Not sure yet? <decide_later>Decide later</decide_later>.'
+						'Set your Link in Bio apart with a custom domain. Not sure yet? <span>Decide later</span>.'
 					),
 					decideLaterComponent
 				);
 			default:
 				return createInterpolateElement(
 					__(
-						'Help your site stand out with a custom domain. Not sure yet? <decide_later>Decide later</decide_later>.'
+						'Help your site stand out with a custom domain. Not sure yet? <span>Decide later</span>.'
 					),
 					decideLaterComponent
 				);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
@@ -169,7 +169,7 @@ const DomainsStep: Step = function DomainsStep( { navigation, flow } ) {
 
 	const getSubHeaderText = () => {
 		const decideLaterComponent = {
-			span: (
+			decide_later: (
 				// eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/interactive-supports-focus
 				<span
 					role="button"
@@ -183,21 +183,21 @@ const DomainsStep: Step = function DomainsStep( { navigation, flow } ) {
 			case 'newsletter':
 				return createInterpolateElement(
 					__(
-						'Help your Newsletter stand out with a custom domain. Not sure yet? <span>Decide later</span>.'
+						'Help your Newsletter stand out with a custom domain. Not sure yet? <decide_later>Decide later</decide_later>.'
 					),
 					decideLaterComponent
 				);
 			case 'link-in-bio':
 				return createInterpolateElement(
 					__(
-						'Set your Link in Bio apart with a custom domain. Not sure yet? <span>Decide later</span>.'
+						'Set your Link in Bio apart with a custom domain. Not sure yet? <decide_later>Decide later</decide_later>.'
 					),
 					decideLaterComponent
 				);
 			default:
 				return createInterpolateElement(
 					__(
-						'Help your site stand out with a custom domain. Not sure yet? <span>Decide later</span>.'
+						'Help your site stand out with a custom domain. Not sure yet? <decide_later>Decide later</decide_later>.'
 					),
 					decideLaterComponent
 				);

--- a/client/landing/stepper/declarative-flow/link-in-bio-post-setup.ts
+++ b/client/landing/stepper/declarative-flow/link-in-bio-post-setup.ts
@@ -1,4 +1,5 @@
 import { LINK_IN_BIO_POST_SETUP_FLOW } from '@automattic/onboarding';
+import { translate } from 'i18n-calypso';
 import { useSiteSlug } from '../hooks/use-site-slug';
 import { recordSubmitStep } from './internals/analytics/record-submit-step';
 import { ProvidedDependencies } from './internals/types';
@@ -7,7 +8,9 @@ import type { Flow } from './internals/types';
 
 export const linkInBioPostSetup: Flow = {
 	name: LINK_IN_BIO_POST_SETUP_FLOW,
-	title: 'Link in Bio',
+	get title() {
+		return translate( 'Link in Bio' );
+	},
 	useSteps() {
 		return [ 'linkInBioPostSetup' ] as StepPath[];
 	},

--- a/client/landing/stepper/declarative-flow/link-in-bio.ts
+++ b/client/landing/stepper/declarative-flow/link-in-bio.ts
@@ -1,6 +1,7 @@
 import { useLocale } from '@automattic/i18n-utils';
 import { useFlowProgress, LINK_IN_BIO_FLOW } from '@automattic/onboarding';
 import { useSelect, useDispatch } from '@wordpress/data';
+import { translate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import { recordFullStoryEvent } from 'calypso/lib/analytics/fullstory';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -20,7 +21,9 @@ import type { Flow, ProvidedDependencies } from './internals/types';
 
 export const linkInBio: Flow = {
 	name: LINK_IN_BIO_FLOW,
-	title: 'Link in Bio',
+	get title() {
+		return translate( 'Link in Bio' );
+	},
 	useSteps() {
 		useEffect( () => {
 			recordTracksEvent( 'calypso_signup_start', { flow: this.name } );

--- a/client/landing/stepper/declarative-flow/newsletter-post-setup.ts
+++ b/client/landing/stepper/declarative-flow/newsletter-post-setup.ts
@@ -1,4 +1,5 @@
 import { NEWSLETTER_POST_SETUP_FLOW } from '@automattic/onboarding';
+import { translate } from 'i18n-calypso';
 import { useSiteSlug } from '../hooks/use-site-slug';
 import { recordSubmitStep } from './internals/analytics/record-submit-step';
 import { ProvidedDependencies } from './internals/types';
@@ -7,7 +8,9 @@ import type { Flow } from './internals/types';
 
 export const newsletterPostSetup: Flow = {
 	name: NEWSLETTER_POST_SETUP_FLOW,
-	title: 'Newsletter',
+	get title() {
+		return translate( 'Newsletter' );
+	},
 	useSteps() {
 		return [ 'newsletterPostSetup' ] as StepPath[];
 	},

--- a/client/landing/stepper/declarative-flow/newsletter.ts
+++ b/client/landing/stepper/declarative-flow/newsletter.ts
@@ -1,6 +1,7 @@
 import { useLocale } from '@automattic/i18n-utils';
 import { useFlowProgress, NEWSLETTER_FLOW } from '@automattic/onboarding';
 import { useSelect, useDispatch } from '@wordpress/data';
+import { translate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import { recordFullStoryEvent } from 'calypso/lib/analytics/fullstory';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -14,7 +15,9 @@ import type { Flow } from './internals/types';
 
 export const newsletter: Flow = {
 	name: NEWSLETTER_FLOW,
-	title: 'Newsletter',
+	get title() {
+		return translate( 'Newsletter' );
+	},
 	useSteps() {
 		useEffect( () => {
 			recordTracksEvent( 'calypso_signup_start', { flow: this.name } );

--- a/client/landing/stepper/declarative-flow/videopress.ts
+++ b/client/landing/stepper/declarative-flow/videopress.ts
@@ -1,5 +1,6 @@
 import { useFlowProgress, VIDEOPRESS_FLOW } from '@automattic/onboarding';
 import { useSelect, useDispatch } from '@wordpress/data';
+import { translate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useSiteSlug } from '../hooks/use-site-slug';
@@ -10,7 +11,9 @@ import './internals/videopress.scss';
 
 export const videopress: Flow = {
 	name: VIDEOPRESS_FLOW,
-	title: 'Video',
+	get title() {
+		return translate( 'Video' );
+	},
 	useSteps() {
 		useEffect( () => {
 			recordTracksEvent( 'calypso_signup_start', { flow: this.name } );


### PR DESCRIPTION
### Proposed Changes

Make the title a translatable string.

### BEFORE

<img width="341" alt="Screenshot 2022-11-25 at 8 36 01 AM" src="https://user-images.githubusercontent.com/1269602/203893319-17047b0c-1c8a-4b8c-87d5-101642d1c9b1.png">

<img width="1322" alt="Screenshot 2022-11-25 at 8 38 44 AM" src="https://user-images.githubusercontent.com/1269602/203893419-6aee2eae-670c-48f5-a68f-54cfd4393602.png">

### AFTER

<img width="384" alt="Screenshot 2022-11-25 at 8 36 13 AM" src="https://user-images.githubusercontent.com/1269602/203893522-7b306759-5aa4-4e99-95f6-4051af511c11.png">

<img width="1025" alt="Screenshot 2022-11-25 at 8 38 56 AM" src="https://user-images.githubusercontent.com/1269602/203893530-c74b8583-9bd1-4459-b0f7-c1da13bf1aa7.png">

#### Testing Instructions



* Verify that the document title and page title are translated as shown in the screenshots above, for the newsletter and LiB flows.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
