### PR TITLE
Update DP theme's copy

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/upgrade-modal.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/upgrade-modal.tsx
@@ -3,7 +3,7 @@ import { Button, Gridicon, Dialog, ScreenReaderText } from '@automattic/componen
 import { ExternalLink } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import classNames from 'classnames';
-import { useTranslate } from 'i18n-calypso';
+import i18n, { useTranslate } from 'i18n-calypso';
 import wooCommerceImage from 'calypso/assets/images/onboarding/woo-commerce.svg';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import { useThemeDetails } from 'calypso/landing/stepper/hooks/use-theme-details';
@@ -28,6 +28,7 @@ interface UpgradeModalContent {
 
 const UpgradeModal = ( { slug, isOpen, closeModal, checkout }: UpgradeModalProps ) => {
 	const translate = useTranslate();
+	const currentLocale = i18n.getLocaleSlug();
 	const theme = useThemeDetails( slug );
 	const features = theme.data && theme.data.taxonomies.theme_feature;
 	const featuresHeading = translate( 'Theme features' ) as string;
@@ -51,21 +52,30 @@ const UpgradeModal = ( { slug, isOpen, closeModal, checkout }: UpgradeModalProps
 
 	const getStandardPurchaseModalData = (): UpgradeModalContent => {
 		const premiumPlanPrice = premiumPlanProduct?.combined_cost_display;
+
 		return {
 			header: (
 				<h1 className="upgrade-modal__heading">{ translate( 'Unlock this premium theme' ) }</h1>
 			),
 			text: (
 				<p>
-					{ translate(
-						"Get access to our Premium themes, and a ton of other features, with a subscription to the Premium plan. It's {{strong}}%s{{/strong}} a year, risk-free with a 14-day money-back guarantee.",
-						{
-							components: {
-								strong: <strong />,
-							},
-							args: premiumPlanPrice,
-						}
-					) }
+					{ currentLocale === 'en' ||
+					currentLocale?.startsWith( 'en-' ) ||
+					i18n.hasTranslation(
+						"Get access to our Premium themes, and a ton of other features, with a subscription to the Premium plan. It's {{strong}}%s{{/strong}} a year, risk-free with a 14-day money-back guarantee."
+					)
+						? translate(
+								"Get access to our Premium themes, and a ton of other features, with a subscription to the Premium plan. It's {{strong}}%s{{/strong}} a year, risk-free with a 14-day money-back guarantee.",
+								{
+									components: {
+										strong: <strong />,
+									},
+									args: premiumPlanPrice,
+								}
+						  )
+						: translate(
+								'You can purchase a subscription to use this theme or join the Premium plan to get it for free.'
+						  ) }
 				</p>
 			),
 			price: null,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/upgrade-modal.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/upgrade-modal.tsx
@@ -51,6 +51,7 @@ const UpgradeModal = ( { slug, isOpen, closeModal, checkout }: UpgradeModalProps
 	const isThirdParty = isEnabled( 'themes/subscription-purchases' ) || false;
 
 	const getStandardPurchaseModalData = (): UpgradeModalContent => {
+		const premiumPlanName = premiumPlanProduct?.product_name;
 		const premiumPlanPrice = premiumPlanProduct?.combined_cost_display;
 
 		return {
@@ -74,7 +75,13 @@ const UpgradeModal = ( { slug, isOpen, closeModal, checkout }: UpgradeModalProps
 								}
 						  )
 						: translate(
-								'You can purchase a subscription to use this theme or join the Premium plan to get it for free.'
+								"This theme requires %(premiumPlanName)s to unlock. It's %(premiumPlanPrice)s a year, risk-free with a 14-day money-back guarantee.",
+								{
+									args: {
+										premiumPlanName,
+										premiumPlanPrice,
+									},
+								}
 						  ) }
 				</p>
 			),

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/upgrade-modal.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/upgrade-modal.tsx
@@ -58,37 +58,26 @@ const UpgradeModal = ( { slug, isOpen, closeModal, checkout }: UpgradeModalProps
 			text: (
 				<p>
 					{ translate(
-						'You can purchase a subscription to use this theme or join the Premium plan to get it for free.'
+						"Get access to our Premium themes, and a ton of other features, with a subscription to the Premium plan. It's {{strong}}%s{{/strong}} a year, risk-free with a 14-day money-back guarantee.",
+						{
+							components: {
+								strong: <strong />,
+							},
+							args: premiumPlanPrice,
+						}
 					) }
 				</p>
 			),
-			price: (
-				<div className="upgrade-modal__theme-price">
-					{ translate( '{{span}}%(premiumPlanPrice)s{{/span}} per year', {
-						components: {
-							span: <span />,
-						},
-						args: {
-							premiumPlanPrice,
-						},
-					} ) }
-				</div>
-			),
+			price: null,
 			action: (
-				<>
-					<div className="upgrade-modal__actions">
-						<Button className="upgrade-modal__upgrade" primary onClick={ () => checkout() }>
-							{ translate( 'Buy and activate theme' ) }
-						</Button>
-					</div>
-					<p className="upgrade-modal__plan-nudge">
-						{ translate( 'or get it for free when on the {{button}}Premium plan{{/button}}', {
-							components: {
-								button: <Button onClick={ () => checkout() } plain />,
-							},
-						} ) }
-					</p>
-				</>
+				<div className="upgrade-modal__actions bundle">
+					<Button className="upgrade-modal__cancel" onClick={ () => closeModal() }>
+						{ translate( 'Cancel' ) }
+					</Button>
+					<Button className="upgrade-modal__upgrade-plan" primary onClick={ () => checkout() }>
+						{ translate( 'Upgrade to activate' ) }
+					</Button>
+				</div>
 			),
 		};
 	};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/upgrade-modal.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/upgrade-modal.tsx
@@ -51,8 +51,8 @@ const UpgradeModal = ( { slug, isOpen, closeModal, checkout }: UpgradeModalProps
 	const isThirdParty = isEnabled( 'themes/subscription-purchases' ) || false;
 
 	const getStandardPurchaseModalData = (): UpgradeModalContent => {
-		const premiumPlanName = premiumPlanProduct?.product_name;
-		const premiumPlanPrice = premiumPlanProduct?.combined_cost_display;
+		const planName = premiumPlanProduct?.product_name;
+		const planPrice = premiumPlanProduct?.combined_cost_display;
 
 		return {
 			header: (
@@ -71,15 +71,15 @@ const UpgradeModal = ( { slug, isOpen, closeModal, checkout }: UpgradeModalProps
 									components: {
 										strong: <strong />,
 									},
-									args: premiumPlanPrice,
+									args: planPrice,
 								}
 						  )
 						: translate(
-								"This theme requires %(premiumPlanName)s to unlock. It's %(premiumPlanPrice)s a year, risk-free with a 14-day money-back guarantee.",
+								"This theme requires %(planName)s to unlock. It's %(planPrice)s a year, risk-free with a 14-day money-back guarantee.",
 								{
 									args: {
-										premiumPlanName,
-										premiumPlanPrice,
+										planName,
+										planPrice,
 									},
 								}
 						  ) }

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -5,7 +5,6 @@ import { isEnabled } from '@automattic/calypso-config';
 import { FEATURE_WOOP } from '@automattic/calypso-products';
 import { MShotsImage } from '@automattic/onboarding';
 import { useViewportMatch } from '@wordpress/compose';
-import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
@@ -177,13 +176,7 @@ const DesignButton: React.FC< DesignButtonProps > = ( {
 				? __( 'Included in your plan' )
 				: __( 'Available with WordPress.com Business' );
 		} else if ( isPremium && shouldUpgrade ) {
-			text = sprintf(
-				/* translators: %(price)s - the price of the theme */
-				__( '%(price)s per year or included in WordPress.com Premium' ),
-				{
-					price: design.price,
-				}
-			);
+			text = __( 'Included in WordPress.com Premium' );
 		} else if ( isPremium && ! shouldUpgrade && hasPurchasedTheme ) {
 			text = __( 'Purchased on an annual subscription' );
 		} else if ( isPremium && ! shouldUpgrade && ! hasPurchasedTheme ) {


### PR DESCRIPTION
## Proposed Changes

*   Update Premium theme card and upgrade modal on Onboarding flow 
![image](https://user-images.githubusercontent.com/10071857/203979533-ab73e114-7c26-42b5-98ed-b88c934dad0a.png)


## Testing Instructions

* Access /designSetup step from Goals screen `setup/goals?siteSlug=${site_slug}&flags=-themes/subscription-purchases`
* Confirm that Premium theme cards's price has been removed
* Click on Premium theme to open theme preview screen -> Unlock theme
* Confirm the upgrade modal is updated with new content, make sure the buttons on modal are working correctly

https://user-images.githubusercontent.com/10071857/203905280-f2bfad3b-beab-4c56-84c8-55bf4a0d6a3d.mp4

 
## Reference

Related to #70388
Slack convo p1669312403810119-slack-C048CUFRGFQ