### PR TITLE
Show nudge for Launchpad only if translation exists

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
@@ -169,7 +169,7 @@ const DomainsStep: Step = function DomainsStep( { navigation, flow } ) {
 
 	const getSubHeaderText = () => {
 		const decideLaterComponent = {
-			decide_later: (
+			span: (
 				// eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/interactive-supports-focus
 				<span
 					role="button"
@@ -183,21 +183,21 @@ const DomainsStep: Step = function DomainsStep( { navigation, flow } ) {
 			case 'newsletter':
 				return createInterpolateElement(
 					__(
-						'Help your Newsletter stand out with a custom domain. Not sure yet? <decide_later>Decide later</decide_later>.'
+						'Help your Newsletter stand out with a custom domain. Not sure yet? <span>Decide later</span>.'
 					),
 					decideLaterComponent
 				);
 			case 'link-in-bio':
 				return createInterpolateElement(
 					__(
-						'Set your Link in Bio apart with a custom domain. Not sure yet? <decide_later>Decide later</decide_later>.'
+						'Set your Link in Bio apart with a custom domain. Not sure yet? <span>Decide later</span>.'
 					),
 					decideLaterComponent
 				);
 			default:
 				return createInterpolateElement(
 					__(
-						'Help your site stand out with a custom domain. Not sure yet? <decide_later>Decide later</decide_later>.'
+						'Help your site stand out with a custom domain. Not sure yet? <span>Decide later</span>.'
 					),
 					decideLaterComponent
 				);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
@@ -169,7 +169,7 @@ const DomainsStep: Step = function DomainsStep( { navigation, flow } ) {
 
 	const getSubHeaderText = () => {
 		const decideLaterComponent = {
-			span: (
+			decide_later: (
 				// eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/interactive-supports-focus
 				<span
 					role="button"
@@ -183,21 +183,21 @@ const DomainsStep: Step = function DomainsStep( { navigation, flow } ) {
 			case 'newsletter':
 				return createInterpolateElement(
 					__(
-						'Help your Newsletter stand out with a custom domain. Not sure yet? <span>Decide later</span>.'
+						'Help your Newsletter stand out with a custom domain. Not sure yet? <decide_later>Decide later</decide_later>.'
 					),
 					decideLaterComponent
 				);
 			case 'link-in-bio':
 				return createInterpolateElement(
 					__(
-						'Set your Link in Bio apart with a custom domain. Not sure yet? <span>Decide later</span>.'
+						'Set your Link in Bio apart with a custom domain. Not sure yet? <decide_later>Decide later</decide_later>.'
 					),
 					decideLaterComponent
 				);
 			default:
 				return createInterpolateElement(
 					__(
-						'Help your site stand out with a custom domain. Not sure yet? <span>Decide later</span>.'
+						'Help your site stand out with a custom domain. Not sure yet? <decide_later>Decide later</decide_later>.'
 					),
 					decideLaterComponent
 				);

--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -125,10 +125,12 @@ export class SiteNotice extends Component {
 		const showJitms =
 			! this.props.isSiteWPForTeams && ( discountOrFreeToPaid || config.isEnabled( 'jitms' ) );
 
+		const isEnglish = config( 'english_locales' ).includes( i18n.getLocaleSlug() );
+		const hasNonenTranslation =
+			i18n.hasTranslation( 'Keep setting up your site' ) && i18n.hasTranslation( 'Next Steps' );
 		const showLaunchpadNotice =
-			site.options?.launchpad_screen === 'full' &&
-			i18n.hasTranslation( 'Keep setting up your site' ) &&
-			i18n.hasTranslation( 'Next Steps' );
+			site.options?.launchpad_screen === 'full' && ( isEnglish || hasNonenTranslation );
+
 		let SidebarNotice = null;
 
 		if ( showJitms ) {

--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -1,6 +1,6 @@
 import config from '@automattic/calypso-config';
 import { getUrlParts } from '@automattic/calypso-url';
-import { localize } from 'i18n-calypso';
+import { localize, hasTranslation } from 'i18n-calypso';
 import moment from 'moment';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
@@ -125,7 +125,10 @@ export class SiteNotice extends Component {
 		const showJitms =
 			! this.props.isSiteWPForTeams && ( discountOrFreeToPaid || config.isEnabled( 'jitms' ) );
 
-		const showLaunchpadNotice = site.options?.launchpad_screen === 'full';
+		const showLaunchpadNotice =
+			site.options?.launchpad_screen === 'full' &&
+			hasTranslation( 'Keep setting up your site' ) &&
+			hasTranslation( 'Next Steps' );
 		let SidebarNotice = null;
 
 		if ( showJitms ) {

--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -1,6 +1,6 @@
 import config from '@automattic/calypso-config';
 import { getUrlParts } from '@automattic/calypso-url';
-import { localize, hasTranslation } from 'i18n-calypso';
+import i18n, { localize } from 'i18n-calypso';
 import moment from 'moment';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
@@ -127,8 +127,8 @@ export class SiteNotice extends Component {
 
 		const showLaunchpadNotice =
 			site.options?.launchpad_screen === 'full' &&
-			hasTranslation( 'Keep setting up your site' ) &&
-			hasTranslation( 'Next Steps' );
+			i18n.hasTranslation( 'Keep setting up your site' ) &&
+			i18n.hasTranslation( 'Next Steps' );
 		let SidebarNotice = null;
 
 		if ( showJitms ) {


### PR DESCRIPTION
#### Proposed Changes

* Show the sidebar nudge to keep editing site only if translation exists.

**BEFORE**

<img width="653" alt="Screenshot 2022-11-25 at 9 29 44 AM" src="https://user-images.githubusercontent.com/1269602/203898752-cb15426f-fbd3-4fcd-bf62-ef49805a741a.png">

**AFTER** 

<img width="616" alt="Screenshot 2022-11-25 at 9 36 31 AM" src="https://user-images.githubusercontent.com/1269602/203899292-59351a9e-e740-4065-8cd2-32580d628d24.png">


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go through a tailored onboarding flow in a non-EN locale and visit Customer Home. Verify that the "Keep updating your site" nudge is not shown and instead the translated free domain nudge is shown, as seen in the screenshots above.

