### PR TITLE
Show help centre notice only if translation exists

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
@@ -169,7 +169,7 @@ const DomainsStep: Step = function DomainsStep( { navigation, flow } ) {
 
 	const getSubHeaderText = () => {
 		const decideLaterComponent = {
-			decide_later: (
+			span: (
 				// eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/interactive-supports-focus
 				<span
 					role="button"
@@ -183,21 +183,21 @@ const DomainsStep: Step = function DomainsStep( { navigation, flow } ) {
 			case 'newsletter':
 				return createInterpolateElement(
 					__(
-						'Help your Newsletter stand out with a custom domain. Not sure yet? <decide_later>Decide later</decide_later>.'
+						'Help your Newsletter stand out with a custom domain. Not sure yet? <span>Decide later</span>.'
 					),
 					decideLaterComponent
 				);
 			case 'link-in-bio':
 				return createInterpolateElement(
 					__(
-						'Set your Link in Bio apart with a custom domain. Not sure yet? <decide_later>Decide later</decide_later>.'
+						'Set your Link in Bio apart with a custom domain. Not sure yet? <span>Decide later</span>.'
 					),
 					decideLaterComponent
 				);
 			default:
 				return createInterpolateElement(
 					__(
-						'Help your site stand out with a custom domain. Not sure yet? <decide_later>Decide later</decide_later>.'
+						'Help your site stand out with a custom domain. Not sure yet? <span>Decide later</span>.'
 					),
 					decideLaterComponent
 				);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
@@ -169,7 +169,7 @@ const DomainsStep: Step = function DomainsStep( { navigation, flow } ) {
 
 	const getSubHeaderText = () => {
 		const decideLaterComponent = {
-			span: (
+			decide_later: (
 				// eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/interactive-supports-focus
 				<span
 					role="button"
@@ -183,21 +183,21 @@ const DomainsStep: Step = function DomainsStep( { navigation, flow } ) {
 			case 'newsletter':
 				return createInterpolateElement(
 					__(
-						'Help your Newsletter stand out with a custom domain. Not sure yet? <span>Decide later</span>.'
+						'Help your Newsletter stand out with a custom domain. Not sure yet? <decide_later>Decide later</decide_later>.'
 					),
 					decideLaterComponent
 				);
 			case 'link-in-bio':
 				return createInterpolateElement(
 					__(
-						'Set your Link in Bio apart with a custom domain. Not sure yet? <span>Decide later</span>.'
+						'Set your Link in Bio apart with a custom domain. Not sure yet? <decide_later>Decide later</decide_later>.'
 					),
 					decideLaterComponent
 				);
 			default:
 				return createInterpolateElement(
 					__(
-						'Help your site stand out with a custom domain. Not sure yet? <span>Decide later</span>.'
+						'Help your site stand out with a custom domain. Not sure yet? <decide_later>Decide later</decide_later>.'
 					),
 					decideLaterComponent
 				);

--- a/packages/help-center/src/components/promotional-popover.tsx
+++ b/packages/help-center/src/components/promotional-popover.tsx
@@ -1,5 +1,4 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import config from '@automattic/calypso-config';
 import { Button, Popover } from '@automattic/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
@@ -27,7 +26,7 @@ const PromotionalPopover = ( { iconElement }: Props ) => {
 	const { setHasSeenPromotionalPopover } = useDispatch( HELP_CENTER_STORE );
 	const [ isDismissed, setIsDismissed ] = useState( false );
 	const { __, hasTranslation } = useI18n();
-	const translate = useTranslate();
+	const { localeSlug } = useTranslate();
 
 	const recordDismiss = ( location: 'clicking-button' | 'clicking-outside' ) => {
 		recordTracksEvent( 'calypso_helpcenter_promotion_popover_dismissed', {
@@ -46,7 +45,7 @@ const PromotionalPopover = ( { iconElement }: Props ) => {
 		return null;
 	}
 
-	const isEnglish = config( 'english_locales' ).includes( translate.localeSlug );
+	const isEnglish = [ 'en', 'en-gb' ].includes( localeSlug || '' );
 	const isTranslationComplete =
 		isEnglish ||
 		( hasTranslation( '✨ Our new Help Center', __i18n_text_domain__ ) &&

--- a/packages/help-center/src/components/promotional-popover.tsx
+++ b/packages/help-center/src/components/promotional-popover.tsx
@@ -24,7 +24,7 @@ const PromotionalPopover = ( { iconElement }: Props ) => {
 
 	const { setHasSeenPromotionalPopover } = useDispatch( HELP_CENTER_STORE );
 	const [ isDismissed, setIsDismissed ] = useState( false );
-	const { __ } = useI18n();
+	const { __, hasTranslation } = useI18n();
 
 	const recordDismiss = ( location: 'clicking-button' | 'clicking-outside' ) => {
 		recordTracksEvent( 'calypso_helpcenter_promotion_popover_dismissed', {
@@ -40,6 +40,18 @@ const PromotionalPopover = ( { iconElement }: Props ) => {
 	const visibleElement = document.elementFromPoint( iconBox.left, iconBox.top );
 
 	if ( visibleElement !== iconElement ) {
+		return null;
+	}
+
+	const isTranslationComplete =
+		hasTranslation( '✨ Our new Help Center', __i18n_text_domain__ ) &&
+		hasTranslation(
+			'We moved our help resources! You can always find it in the top bar.',
+			__i18n_text_domain__
+		) &&
+		hasTranslation( 'Got it', __i18n_text_domain__ );
+
+	if ( ! isTranslationComplete ) {
 		return null;
 	}
 

--- a/packages/help-center/src/components/promotional-popover.tsx
+++ b/packages/help-center/src/components/promotional-popover.tsx
@@ -1,7 +1,9 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
+import config from '@automattic/calypso-config';
 import { Button, Popover } from '@automattic/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
+import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import { HELP_CENTER_STORE } from '../stores';
 
@@ -25,6 +27,7 @@ const PromotionalPopover = ( { iconElement }: Props ) => {
 	const { setHasSeenPromotionalPopover } = useDispatch( HELP_CENTER_STORE );
 	const [ isDismissed, setIsDismissed ] = useState( false );
 	const { __, hasTranslation } = useI18n();
+	const translate = useTranslate();
 
 	const recordDismiss = ( location: 'clicking-button' | 'clicking-outside' ) => {
 		recordTracksEvent( 'calypso_helpcenter_promotion_popover_dismissed', {
@@ -43,13 +46,15 @@ const PromotionalPopover = ( { iconElement }: Props ) => {
 		return null;
 	}
 
+	const isEnglish = config( 'english_locales' ).includes( translate.localeSlug );
 	const isTranslationComplete =
-		hasTranslation( '✨ Our new Help Center', __i18n_text_domain__ ) &&
-		hasTranslation(
-			'We moved our help resources! You can always find it in the top bar.',
-			__i18n_text_domain__
-		) &&
-		hasTranslation( 'Got it', __i18n_text_domain__ );
+		isEnglish ||
+		( hasTranslation( '✨ Our new Help Center', __i18n_text_domain__ ) &&
+			hasTranslation(
+				'We moved our help resources! You can always find it in the top bar.',
+				__i18n_text_domain__
+			) &&
+			hasTranslation( 'Got it', __i18n_text_domain__ ) );
 
 	if ( ! isTranslationComplete ) {
 		return null;


### PR DESCRIPTION
#### Proposed Changes

* Show help centre notice only if translation exists


<img width="1689" alt="Screenshot 2022-11-25 at 9 49 28 AM" src="https://user-images.githubusercontent.com/1269602/203900486-06884514-cc89-4a29-aac9-2d4f9d500fc3.png">

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Verify the following scenarios for the help centre notice:
*  It is translated and visible in `pt-br` since translation [exists](https://translate.wordpress.com/projects/wpcom/-all-translated/854076/).
* It is not visible in `ja` since translation is not available.
* It is visible in `en`.

