### PR TITLE
Remove row gap value

### DIFF
--- a/client/components/search-themes/style.scss
+++ b/client/components/search-themes/style.scss
@@ -122,10 +122,6 @@ $search-border-radius: 4px;
 			justify-content: flex-start;
 			padding: 9px 14px;
 
-			&:first-of-type {
-				margin-top: 2px;
-			}
-
 			&.is-selected {
 				background-color: var(--color-neutral-0);
 				color: inherit;

--- a/client/components/search-themes/style.scss
+++ b/client/components/search-themes/style.scss
@@ -81,7 +81,6 @@ $search-border-radius: 4px;
 			background-color: var(--color-surface);
 			display: flex;
 			flex-direction: column;
-			gap: 2px;
 		}
 
 		.keyed-suggestions__category {
@@ -121,7 +120,11 @@ $search-border-radius: 4px;
 			font-size: 0;
 			gap: 16px;
 			justify-content: flex-start;
-			padding: 8px 14px;
+			padding: 9px 14px;
+
+			&:first-of-type {
+				margin-top: 2px;
+			}
 
 			&.is-selected {
 				background-color: var(--color-neutral-0);


### PR DESCRIPTION
## Proposed Changes

* Fix the dead area in suggestion list items by removing the row gap

## Testing Instructions

* Head to the Themes Showcase /themes/${site_slug}
     * If using calypso.live, the flag themes/showcase-i4/search-and-filter is required.
* Click on the searchbox to open the top term selection panel
* Confirm that clicking on space of the items won't let to close the panel unexpectedly ( on the [origin issue](https://github.com/Automattic/wp-calypso/issues/70162#issuecomment-1326232364), the cursor will turn from pointer to arrow when hovering on the space between items )

**BEFORE:** https://github.com/Automattic/wp-calypso/issues/70162#issuecomment-1326232364

**AFTER:**
https://user-images.githubusercontent.com/10071857/203923224-96f5b0db-4823-484a-be3c-54e96080f4b6.mp4


cc: @SaxonF , please let me know your thoughts on this solution when I removed row gap and replace with +1px to padding
![ezgif com-gif-maker](https://user-images.githubusercontent.com/10071857/203922693-b6713c8d-6f44-4d9e-b175-e43c73868905.gif)

## Reference
Related to #70162
