### PR TITLE
Add progress bar animations

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-launch/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-launch/index.tsx
@@ -1,7 +1,7 @@
 import { SenseiStepContainer } from '@automattic/onboarding';
 import { useDispatch } from '@wordpress/data';
-import { useCallback, useEffect } from '@wordpress/element';
-//import { useI18n } from '@wordpress/react-i18n';
+import { useCallback, useEffect, useState } from '@wordpress/element';
+import { useI18n } from '@wordpress/react-i18n';
 import { useSelector, useDispatch as useRootDispatch } from 'react-redux';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { useSiteSlugParam } from 'calypso/landing/stepper/hooks/use-site-slug-param';
@@ -9,7 +9,7 @@ import { SITE_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { fetchSitePlugins } from 'calypso/state/plugins/installed/actions';
 import { getPlugins } from 'calypso/state/plugins/installed/selectors';
-//import { SenseiStepProgress } from '../sensei-setup/sensei-step-progress';
+import { Progress, SenseiStepProgress } from '../sensei-setup/sensei-step-progress';
 
 interface InstalledPlugin {
 	id: string;
@@ -18,11 +18,12 @@ interface InstalledPlugin {
 }
 
 const SenseiLaunch = () => {
-	//const { __ } = useI18n();
+	const { __ } = useI18n();
 	const site = useSite();
 	const siteId = site?.ID;
 	const launchpadScreen = site?.options.launchpad_screen;
 	const siteSlug = useSiteSlugParam();
+	const [ retries, setRetries ] = useState< number >( 0 );
 
 	const selectSitePlugins = useCallback(
 		( state ) => {
@@ -34,33 +35,54 @@ const SenseiLaunch = () => {
 	const { saveSiteSettings } = useDispatch( SITE_STORE );
 	const plugins: InstalledPlugin[] = useSelector( selectSitePlugins );
 	const launchpadUrl = `/setup/sensei/launchpad?siteSlug=${ siteSlug }&siteId=${ siteId }`;
+	const expectedRetries = 10;
 
 	useEffect( () => {
 		const intervalId = setInterval( () => {
 			const woothemesSensei = plugins.find( ( plugin ) => plugin.slug === 'woothemes-sensei' );
 			if ( ! woothemesSensei?.active ) {
+				setRetries( retries + 1 );
 				dispatch( fetchSitePlugins( siteId ) );
 				return;
 			}
 
+			setRetries( -1 );
 			clearInterval( intervalId );
-			if ( launchpadScreen !== 'full' ) {
-				saveSiteSettings( siteId as number, { launchpad_screen: 'full' } ).finally( () => {
+
+			setTimeout( () => {
+				if ( launchpadScreen !== 'full' ) {
+					saveSiteSettings( siteId as number, { launchpad_screen: 'full' } ).finally( () => {
+						window.location.replace( launchpadUrl );
+					} );
+				} else {
 					window.location.replace( launchpadUrl );
-				} );
-			} else {
-				window.location.replace( launchpadUrl );
-			}
+				}
+			}, 800 );
 		}, 3000 );
 
 		return () => clearInterval( intervalId );
 	}, [ plugins, launchpadUrl, dispatch, siteId, saveSiteSettings, launchpadScreen ] );
 
+	const progress: Progress = {
+		percentage: ( retries * 100 ) / expectedRetries,
+		title: __( 'Installing Sensei' ),
+	};
+
+	if ( retries > expectedRetries / 2 || retries < 0 ) {
+		progress.title = __( 'Setting up your new Sensei Home' );
+	}
+
+	if ( retries > ( expectedRetries * 2 ) / 3 ) {
+		const slowPercentage = 66.6 + ( retries * 10 ) / expectedRetries;
+		progress.percentage = slowPercentage > 90 ? 90 : slowPercentage;
+	} else if ( retries < 0 ) {
+		progress.percentage = 100;
+	}
+
 	return (
-		<SenseiStepContainer
-			stepName="senseiSetup"
-			recordTracksEvent={ recordTracksEvent }
-		></SenseiStepContainer>
+		<SenseiStepContainer stepName="senseiSetup" recordTracksEvent={ recordTracksEvent }>
+			<SenseiStepProgress progress={ progress } />
+		</SenseiStepContainer>
 	);
 };
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-launch/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-launch/index.tsx
@@ -35,7 +35,7 @@ const SenseiLaunch = () => {
 	const { saveSiteSettings } = useDispatch( SITE_STORE );
 	const plugins: InstalledPlugin[] = useSelector( selectSitePlugins );
 	const launchpadUrl = `/setup/sensei/launchpad?siteSlug=${ siteSlug }&siteId=${ siteId }`;
-	const expectedRetries = 10;
+	const expectedRetries = 15;
 
 	useEffect( () => {
 		const intervalId = setInterval( () => {
@@ -72,8 +72,9 @@ const SenseiLaunch = () => {
 		progress.title = __( 'Setting up your new Sensei Home' );
 	}
 
+	// Slow down progress bar increase during the last steps.
 	if ( retries > ( expectedRetries * 2 ) / 3 ) {
-		const slowPercentage = 66.6 + ( retries * 10 ) / expectedRetries;
+		const slowPercentage = 66.6 + ( retries * 15 ) / expectedRetries;
 		progress.percentage = slowPercentage > 90 ? 90 : slowPercentage;
 	} else if ( retries < 0 ) {
 		progress.percentage = 100;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-launch/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-launch/index.tsx
@@ -1,7 +1,7 @@
 import { SenseiStepContainer } from '@automattic/onboarding';
 import { useDispatch } from '@wordpress/data';
 import { useCallback, useEffect } from '@wordpress/element';
-import { useI18n } from '@wordpress/react-i18n';
+//import { useI18n } from '@wordpress/react-i18n';
 import { useSelector, useDispatch as useRootDispatch } from 'react-redux';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { useSiteSlugParam } from 'calypso/landing/stepper/hooks/use-site-slug-param';
@@ -9,7 +9,7 @@ import { SITE_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { fetchSitePlugins } from 'calypso/state/plugins/installed/actions';
 import { getPlugins } from 'calypso/state/plugins/installed/selectors';
-import { SenseiStepProgress } from '../sensei-setup/sensei-step-progress';
+//import { SenseiStepProgress } from '../sensei-setup/sensei-step-progress';
 
 interface InstalledPlugin {
 	id: string;
@@ -18,7 +18,7 @@ interface InstalledPlugin {
 }
 
 const SenseiLaunch = () => {
-	const { __ } = useI18n();
+	//const { __ } = useI18n();
 	const site = useSite();
 	const siteId = site?.ID;
 	const launchpadScreen = site?.options.launchpad_screen;
@@ -57,9 +57,10 @@ const SenseiLaunch = () => {
 	}, [ plugins, launchpadUrl, dispatch, siteId, saveSiteSettings, launchpadScreen ] );
 
 	return (
-		<SenseiStepContainer stepName="senseiSetup" recordTracksEvent={ recordTracksEvent }>
-			<SenseiStepProgress>{ __( 'Installing Sensei' ) }</SenseiStepProgress>
-		</SenseiStepContainer>
+		<SenseiStepContainer
+			stepName="senseiSetup"
+			recordTracksEvent={ recordTracksEvent }
+		></SenseiStepContainer>
 	);
 };
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-launch/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-launch/index.tsx
@@ -36,11 +36,12 @@ const SenseiLaunch = () => {
 	const plugins: InstalledPlugin[] = useSelector( selectSitePlugins );
 	const launchpadUrl = `/setup/sensei/launchpad?siteSlug=${ siteSlug }&siteId=${ siteId }`;
 	const expectedRetries = 15;
+	const maxRetries = 40;
 
 	useEffect( () => {
 		const intervalId = setInterval( () => {
 			const woothemesSensei = plugins.find( ( plugin ) => plugin.slug === 'woothemes-sensei' );
-			if ( ! woothemesSensei?.active ) {
+			if ( ! woothemesSensei?.active && retries < maxRetries ) {
 				setRetries( retries + 1 );
 				dispatch( fetchSitePlugins( siteId ) );
 				return;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-setup/sensei-step-progress/components.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-setup/sensei-step-progress/components.ts
@@ -17,6 +17,7 @@ export const Container = styled.div`
 
 export const Content = styled.div`
 	max-width: 520px;
+	width: 100%;
 	margin: auto 24px;
 	padding: 32px 0 60px;
 	flex: 0 0 auto;
@@ -61,6 +62,7 @@ export const Progress = styled.div`
 	left: 0;
 	height: 4px;
 	background-color: #fff;
+	margin: 0 24px;
 `;
 
 export const ProgressValue = styled.div< { progress: number } >`

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-setup/sensei-step-progress/components.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-setup/sensei-step-progress/components.ts
@@ -71,6 +71,7 @@ export const ProgressValue = styled.div< { progress: number } >`
 	left: 0;
 	background-color: #217d7c;
 	width: ${ ( props ) => props.progress }%;
+	transition: width 800ms ease-out;
 `;
 
 export const TopRightImg = styled.img`

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-setup/sensei-step-progress/components.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-setup/sensei-step-progress/components.ts
@@ -1,4 +1,3 @@
-import { keyframes } from '@emotion/css';
 import styled from '@emotion/styled';
 
 export const Container = styled.div`
@@ -24,21 +23,6 @@ export const Content = styled.div`
 	position: relative;
 `;
 
-const ellipsisProgress = keyframes`
-    0% {
-        content: '';
-    }
-    33% {
-        content: '.';
-    }
-    66% {
-        content: '..';
-    }
-    100% {
-        content: '...';
-    }
-`;
-
 export const Text = styled.div`
 	font-family: 'Recoleta';
 	font-size: 32px;
@@ -46,13 +30,6 @@ export const Text = styled.div`
 	position: relative;
 	width: 100%;
 	text-align: center;
-	padding-right: 24px;
-	&::after {
-		display: inline-block;
-		position: absolute;
-		content: '';
-		animation: ${ ellipsisProgress } 2s ease infinite;
-	}
 `;
 
 export const Progress = styled.div`
@@ -62,7 +39,6 @@ export const Progress = styled.div`
 	left: 0;
 	height: 4px;
 	background-color: #fff;
-	margin: 0 24px;
 `;
 
 export const ProgressValue = styled.div< { progress: number } >`

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-setup/sensei-step-progress/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-setup/sensei-step-progress/index.tsx
@@ -11,18 +11,23 @@ import {
 	BottomLeftImg,
 } from './components';
 
-interface SenseiStepProgressProps {
-	children: string;
-}
+export type Progress = {
+	percentage: number;
+	title: string;
+};
 
-export const SenseiStepProgress: React.FC< SenseiStepProgressProps > = ( { children } ) => {
+type SenseiStepProgressProps = {
+	progress: Progress;
+};
+
+export const SenseiStepProgress: React.FC< SenseiStepProgressProps > = ( { progress } ) => {
 	return (
 		<Container>
 			<TopRightImg src={ topRightImgSrc } />
 			<Content>
-				<Text>{ children }</Text>
+				<Text>{ progress.title }</Text>
 				<Progress>
-					<ProgressValue progress={ 40 } />
+					<ProgressValue progress={ progress.percentage } />
 				</Progress>
 			</Content>
 			<BottomLeftImg src={ bottomLeftImgSrc } />

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-setup/sensei-step-progress/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-setup/sensei-step-progress/index.tsx
@@ -1,3 +1,4 @@
+import { Global } from '@emotion/react';
 import React from 'react';
 import bottomLeftImgSrc from 'calypso/assets/images/onboarding/sensei/progress-bg-bottom-left.png';
 import topRightImgSrc from 'calypso/assets/images/onboarding/sensei/progress-bg-top-right.png';
@@ -31,6 +32,7 @@ export const SenseiStepProgress: React.FC< SenseiStepProgressProps > = ( { progr
 				</Progress>
 			</Content>
 			<BottomLeftImg src={ bottomLeftImgSrc } />
+			<Global styles={ { '.sensei .flow-progress.progress-bar': { display: 'none' } } } />
 		</Container>
 	);
 };


### PR DESCRIPTION
#### Proposed Changes

* Adds animations to Sensei's progress screens
* For the screen before the checkout, we set the progress between some async calls
* For the screen before the launchpad I used the average number of retries that I observed while testing as an estimate of how many retries the process is going to take.

#### Testing Instructions
* Complete the flow and observe that the progress bar moves 

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
