### PR TITLE
Theme Showcase: Add new background styles to the logged-out Theme Showcase

### DIFF
--- a/client/my-sites/themes/logged-out.jsx
+++ b/client/my-sites/themes/logged-out.jsx
@@ -1,4 +1,6 @@
+import { isEnabled } from '@automattic/calypso-config';
 import Main from 'calypso/components/main';
+import BodySectionCssClass from 'calypso/layout/body-section-css-class';
 import { connectOptions } from './theme-options';
 import ThemeShowcase from './theme-showcase';
 
@@ -6,6 +8,9 @@ const ConnectedThemeShowcase = connectOptions( ThemeShowcase );
 
 export default ( props ) => (
 	<Main fullWidthLayout className="themes">
+		{ isEnabled( 'themes/showcase-i4/search-and-filter' ) && (
+			<BodySectionCssClass bodyClass={ [ 'is-section-themes-i4' ] } />
+		) }
 		<ConnectedThemeShowcase
 			{ ...props }
 			origin="wpcom"

--- a/client/my-sites/themes/single-site-jetpack.jsx
+++ b/client/my-sites/themes/single-site-jetpack.jsx
@@ -1,13 +1,13 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { FEATURE_UPLOAD_THEMES, PLAN_BUSINESS } from '@automattic/calypso-products';
 import { pickBy } from 'lodash';
-import { useEffect } from 'react';
 import { connect } from 'react-redux';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
 import QueryActiveTheme from 'calypso/components/data/query-active-theme';
 import QueryCanonicalTheme from 'calypso/components/data/query-canonical-theme';
 import Main from 'calypso/components/main';
 import { useRequestSiteChecklistTaskUpdate } from 'calypso/data/site-checklist';
+import BodySectionCssClass from 'calypso/layout/body-section-css-class';
 import CurrentTheme from 'calypso/my-sites/themes/current-theme';
 import { CHECKLIST_KNOWN_TASKS } from 'calypso/state/data-layer/wpcom/checklist/index.js';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
@@ -72,17 +72,9 @@ const ConnectedSingleSiteJetpack = connectOptions( ( props ) => {
 
 	useRequestSiteChecklistTaskUpdate( siteId, CHECKLIST_KNOWN_TASKS.THEMES_BROWSED );
 
-	useEffect( () => {
-		if ( ! isNewSearchAndFilter ) {
-			return;
-		}
-
-		document.body.classList.add( 'is-section-themes-i4' );
-		return () => document.body.classList.remove( 'is-section-themes-i4' );
-	}, [] );
-
 	return (
 		<Main fullWidthLayout className="themes">
+			{ isNewSearchAndFilter && <BodySectionCssClass bodyClass={ [ 'is-section-themes-i4' ] } /> }
 			<ThemesHeader isReskinned={ isNewSearchAndFilter } />
 			{ ! isNewSearchAndFilter ? (
 				<CurrentTheme siteId={ siteId } />

--- a/client/my-sites/themes/single-site-wpcom.jsx
+++ b/client/my-sites/themes/single-site-wpcom.jsx
@@ -7,13 +7,13 @@ import {
 	PLAN_BUSINESS,
 	WPCOM_FEATURES_PREMIUM_THEMES,
 } from '@automattic/calypso-products';
-import { useEffect } from 'react';
 import { connect } from 'react-redux';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
 import QueryActiveTheme from 'calypso/components/data/query-active-theme';
 import QueryCanonicalTheme from 'calypso/components/data/query-canonical-theme';
 import Main from 'calypso/components/main';
 import { useRequestSiteChecklistTaskUpdate } from 'calypso/data/site-checklist';
+import BodySectionCssClass from 'calypso/layout/body-section-css-class';
 import CurrentTheme from 'calypso/my-sites/themes/current-theme';
 import { CHECKLIST_KNOWN_TASKS } from 'calypso/state/data-layer/wpcom/checklist/index.js';
 import isVipSite from 'calypso/state/selectors/is-vip-site';
@@ -78,17 +78,9 @@ const ConnectedSingleSiteWpcom = connectOptions( ( props ) => {
 
 	useRequestSiteChecklistTaskUpdate( siteId, CHECKLIST_KNOWN_TASKS.THEMES_BROWSED );
 
-	useEffect( () => {
-		if ( ! isNewSearchAndFilter ) {
-			return;
-		}
-
-		document.body.classList.add( 'is-section-themes-i4' );
-		return () => document.body.classList.remove( 'is-section-themes-i4' );
-	}, [] );
-
 	return (
 		<Main fullWidthLayout className="themes">
+			{ isNewSearchAndFilter && <BodySectionCssClass bodyClass={ [ 'is-section-themes-i4' ] } /> }
 			<ThemesHeader isReskinned={ isNewSearchAndFilter } />
 			{ ! isNewSearchAndFilter ? (
 				<CurrentTheme siteId={ siteId } />


### PR DESCRIPTION
#### Proposed Changes

This PR updates the logged-out Theme Showcase so that the CSS class name `is-section-themes-i4` is added to `<body />` when the flag `themes/showcase-i4/search-and-filter` is enabled. The main difference is with `is-section-themes-i4` the page background is whiter (#fdfdfd).

| Without `is-section-themes-i4` | With `is-section-themes-i4` |
| --- | --- |
| ![Screen Shot 2022-11-25 at 7 43 15 PM](https://user-images.githubusercontent.com/797888/203978752-36845d4d-afbd-4724-91ac-0ab758368f40.png) | ![Screen Shot 2022-11-25 at 7 42 52 PM](https://user-images.githubusercontent.com/797888/203978786-b0f9e12a-8d81-4d8c-97be-810819071d15.png)


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to logged-out Theme Showcase `/themes`.
  * If using calypso.live, the flag `themes/showcase-i4/search-and-filter` is required.
* Ensure that `<body />` has the class name `is-section-themes-i4` and the page background is #fdfdfd.
* Ensure that the logged-in Theme Showcase works as before.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

