### PR TITLE
Stepper: New api for site setup

### DIFF
--- a/packages/onboarding/src/setup-tailored-site-after-creation.ts
+++ b/packages/onboarding/src/setup-tailored-site-after-creation.ts
@@ -47,15 +47,10 @@ export function setupSiteAfterCreation( { siteId, flowName }: SetupOnboardingSit
 			blogdescription: string;
 			launchpad_screen?: string;
 			intent?: string;
-			site_icon?: File;
 		} = {
 			blogname: siteTitle,
 			blogdescription: siteDescription,
 		};
-
-		if ( siteLogo ) {
-			settings.site_icon = new File( [ base64ImageToBlob( siteLogo ) ], 'site-logo.png' );
-		}
 
 		if ( isNewsletterOrLinkInBioFlow( flowName ) ) {
 			// link-in-bio and link-in-bio-tld are considered the same intent.
@@ -72,6 +67,13 @@ export function setupSiteAfterCreation( { siteId, flowName }: SetupOnboardingSit
 		}
 
 		formData.push( [ 'settings', JSON.stringify( settings ) ] );
+
+		if ( siteLogo ) {
+			formData.push( [
+				'site_icon',
+				new File( [ base64ImageToBlob( siteLogo ) ], 'site-logo.png' ),
+			] );
+		}
 
 		return wpcomRequest< { updated: object } >( {
 			// since this is a new site, its safe to assume that homepage ID is 2

--- a/packages/onboarding/src/setup-tailored-site-after-creation.ts
+++ b/packages/onboarding/src/setup-tailored-site-after-creation.ts
@@ -47,10 +47,15 @@ export function setupSiteAfterCreation( { siteId, flowName }: SetupOnboardingSit
 			blogdescription: string;
 			launchpad_screen?: string;
 			intent?: string;
+			site_icon?: File;
 		} = {
 			blogname: siteTitle,
 			blogdescription: siteDescription,
 		};
+
+		if ( siteLogo ) {
+			settings.site_icon = new File( [ base64ImageToBlob( siteLogo ) ], 'site-logo.png' );
+		}
 
 		if ( isNewsletterOrLinkInBioFlow( flowName ) ) {
 			// link-in-bio and link-in-bio-tld are considered the same intent.
@@ -68,13 +73,6 @@ export function setupSiteAfterCreation( { siteId, flowName }: SetupOnboardingSit
 
 		formData.push( [ 'settings', JSON.stringify( settings ) ] );
 
-		if ( siteLogo ) {
-			formData.push( [
-				'site_icon',
-				new File( [ base64ImageToBlob( siteLogo ) ], 'site-logo.png' ),
-			] );
-		}
-
 		return wpcomRequest< { updated: object } >( {
 			// since this is a new site, its safe to assume that homepage ID is 2
 			path: `/sites/${ siteId }/sites-setup`,
@@ -82,7 +80,6 @@ export function setupSiteAfterCreation( { siteId, flowName }: SetupOnboardingSit
 			apiNamespace: 'wpcom/v2',
 			apiVersion: '2',
 			formData,
-			body: { content: selectedPatternContent, template: 'blank' },
 		} ).then( () => {
 			recordTracksEvent( 'calypso_signup_site_options_submit', {
 				has_site_title: !! siteTitle,
@@ -92,7 +89,7 @@ export function setupSiteAfterCreation( { siteId, flowName }: SetupOnboardingSit
 			 * We need to wait the site being created, then go to checkout and wait for the user
 			 * to buy the plan before we can set a premium theme to the site. If we reset the store
 			 * here we loose this information.
-			 **/
+			 */
 			// resetOnboardStore();
 		} );
 	}

--- a/packages/onboarding/src/setup-tailored-site-after-creation.ts
+++ b/packages/onboarding/src/setup-tailored-site-after-creation.ts
@@ -80,7 +80,7 @@ export function setupSiteAfterCreation( { siteId, flowName }: SetupOnboardingSit
 		}
 
 		return wpcomRequest< { updated: object } >( {
-			path: `/sites/${ siteId }/sites-setup`,
+			path: `/sites/${ siteId }/onboarding-site-customization`,
 			method: 'POST',
 			apiNamespace: 'wpcom/v2',
 			apiVersion: '2',

--- a/packages/onboarding/src/setup-tailored-site-after-creation.ts
+++ b/packages/onboarding/src/setup-tailored-site-after-creation.ts
@@ -52,19 +52,17 @@ export function setupSiteAfterCreation( { siteId, flowName }: SetupOnboardingSit
 			blogdescription: siteDescription,
 		};
 
-		const pattern: {
-			content: string | undefined;
-			template?: string | undefined;
-		} = {
-			content: selectedPatternContent,
-		};
-
 		if ( isNewsletterOrLinkInBioFlow( flowName ) ) {
 			// link-in-bio and link-in-bio-tld are considered the same intent.
 			if ( isLinkInBioFlow( flowName ) ) {
 				settings.intent = LINK_IN_BIO_FLOW;
 				if ( selectedPatternContent ) {
-					pattern.content = selectedPatternContent;
+					const pattern: {
+						content: string | undefined;
+						template?: string | undefined;
+					} = {
+						content: selectedPatternContent,
+					};
 					pattern.template = 'blank';
 					formData.push( [ 'pattern', JSON.stringify( pattern ) ] );
 				}

--- a/packages/onboarding/src/setup-tailored-site-after-creation.ts
+++ b/packages/onboarding/src/setup-tailored-site-after-creation.ts
@@ -52,12 +52,21 @@ export function setupSiteAfterCreation( { siteId, flowName }: SetupOnboardingSit
 			blogdescription: siteDescription,
 		};
 
+		const pattern: {
+			content: string | undefined;
+			template?: string | undefined;
+		} = {
+			content: selectedPatternContent,
+		};
+
 		if ( isNewsletterOrLinkInBioFlow( flowName ) ) {
 			// link-in-bio and link-in-bio-tld are considered the same intent.
 			if ( isLinkInBioFlow( flowName ) ) {
 				settings.intent = LINK_IN_BIO_FLOW;
 				if ( selectedPatternContent ) {
-					formData.push( [ 'pattern', selectedPatternContent ] );
+					pattern.content = selectedPatternContent;
+					pattern.template = 'blank';
+					formData.push( [ 'pattern', JSON.stringify( pattern ) ] );
 				}
 			} else {
 				settings.intent = flowName;

--- a/packages/onboarding/src/setup-tailored-site-after-creation.ts
+++ b/packages/onboarding/src/setup-tailored-site-after-creation.ts
@@ -57,13 +57,10 @@ export function setupSiteAfterCreation( { siteId, flowName }: SetupOnboardingSit
 			if ( isLinkInBioFlow( flowName ) ) {
 				settings.site_intent = LINK_IN_BIO_FLOW;
 				if ( selectedPatternContent ) {
-					const pattern: {
-						content: string | undefined;
-						template?: string | undefined;
-					} = {
+					const pattern = {
 						content: selectedPatternContent,
+						template: 'blank',
 					};
-					pattern.template = 'blank';
 					formData.push( [ 'pattern', JSON.stringify( pattern ) ] );
 				}
 			} else {
@@ -83,7 +80,6 @@ export function setupSiteAfterCreation( { siteId, flowName }: SetupOnboardingSit
 		}
 
 		return wpcomRequest< { updated: object } >( {
-			// since this is a new site, its safe to assume that homepage ID is 2
 			path: `/sites/${ siteId }/sites-setup`,
 			method: 'POST',
 			apiNamespace: 'wpcom/v2',

--- a/packages/onboarding/src/setup-tailored-site-after-creation.ts
+++ b/packages/onboarding/src/setup-tailored-site-after-creation.ts
@@ -1,12 +1,10 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { Site, Onboard } from '@automattic/data-stores';
-import { select, dispatch } from '@wordpress/data';
+import { Onboard } from '@automattic/data-stores';
+import { select } from '@wordpress/data';
 import wpcomRequest from 'wpcom-proxy-request';
-import { uploadAndSetSiteLogo } from './upload-and-set-site-logo';
 import { isLinkInBioFlow, isNewsletterOrLinkInBioFlow, LINK_IN_BIO_FLOW } from './utils';
 
 const ONBOARD_STORE = Onboard.register();
-const SITE_STORE = Site.register( { client_id: '', client_secret: '' } );
 
 export const base64ImageToBlob = ( base64String: string ) => {
 	// extract content type and base64 payload from original string
@@ -37,74 +35,55 @@ interface SetupOnboardingSiteOptions {
 
 export function setupSiteAfterCreation( { siteId, flowName }: SetupOnboardingSiteOptions ) {
 	// const { resetOnboardStore } = dispatch( ONBOARD_STORE );
-	const { saveSiteSettings, setIntentOnSite, setStaticHomepageOnSite } = dispatch( SITE_STORE );
 	const selectedPatternContent = select( ONBOARD_STORE ).getPatternContent();
 	const siteTitle = select( ONBOARD_STORE ).getSelectedSiteTitle();
 	const siteDescription = select( ONBOARD_STORE ).getSelectedSiteDescription();
 	const siteLogo = select( ONBOARD_STORE ).getSelectedSiteLogo();
 
-	const postSiteSettings = ( siteId: number ) => {
-		const siteSettings = {
+	if ( siteId && flowName ) {
+		const formData: ( string | File )[][] = [];
+		const settings: {
+			blogname: string;
+			blogdescription: string;
+			launchpad_screen?: string;
+			intent?: string;
+		} = {
 			blogname: siteTitle,
 			blogdescription: siteDescription,
 		};
 
-		return saveSiteSettings( siteId, siteSettings );
-	};
-
-	const postSiteLogo = () => {
-		if ( ! siteLogo || ! siteId ) {
-			return Promise.resolve();
-		}
-		return uploadAndSetSiteLogo(
-			siteId,
-			new File( [ base64ImageToBlob( siteLogo ) ], 'site-logo.png' )
-		);
-	};
-
-	const setIntent = ( siteId: number, flow: string ) => {
-		if ( isNewsletterOrLinkInBioFlow( flow ) ) {
+		if ( isNewsletterOrLinkInBioFlow( flowName ) ) {
 			// link-in-bio and link-in-bio-tld are considered the same intent.
-			if ( isLinkInBioFlow( flow ) ) {
-				return setIntentOnSite( siteId.toString(), LINK_IN_BIO_FLOW );
+			if ( isLinkInBioFlow( flowName ) ) {
+				settings.intent = LINK_IN_BIO_FLOW;
+				if ( selectedPatternContent ) {
+					formData.push( [ 'pattern', selectedPatternContent ] );
+				}
+			} else {
+				settings.intent = flowName;
 			}
-			return setIntentOnSite( siteId.toString(), flow );
+
+			settings.launchpad_screen = 'full';
 		}
-		return Promise.resolve();
-	};
 
-	const setLaunchpadScreen = ( siteId: number, flow: string ) => {
-		if ( isNewsletterOrLinkInBioFlow( flow ) ) {
-			return saveSiteSettings( siteId, {
-				launchpad_screen: 'full',
-			} );
+		formData.push( [ 'settings', JSON.stringify( settings ) ] );
+
+		if ( siteLogo ) {
+			formData.push( [
+				'site_icon',
+				new File( [ base64ImageToBlob( siteLogo ) ], 'site-logo.png' ),
+			] );
 		}
-		return Promise.resolve();
-	};
 
-	const setPattern = async ( siteId: number, flow: string ) => {
-		if ( isLinkInBioFlow( flow ) ) {
-			await wpcomRequest( {
-				// since this is a new site, its safe to assume that homepage ID is 2
-				path: `/sites/${ siteId }/pages/2`,
-				method: 'POST',
-				apiNamespace: 'wp/v2',
-				body: { content: selectedPatternContent, template: 'blank' },
-			} );
-
-			return setStaticHomepageOnSite( siteId, 2 );
-		}
-		return Promise.resolve();
-	};
-
-	if ( siteId && flowName ) {
-		return Promise.all( [
-			postSiteSettings( siteId ),
-			postSiteLogo(),
-			setPattern( siteId, flowName ),
-			setIntent( siteId, flowName ),
-			setLaunchpadScreen( siteId, flowName ),
-		] ).then( () => {
+		return wpcomRequest< { updated: object } >( {
+			// since this is a new site, its safe to assume that homepage ID is 2
+			path: `/sites/${ siteId }/sites-setup`,
+			method: 'POST',
+			apiNamespace: 'wpcom/v2',
+			apiVersion: '2',
+			formData,
+			body: { content: selectedPatternContent, template: 'blank' },
+		} ).then( () => {
 			recordTracksEvent( 'calypso_signup_site_options_submit', {
 				has_site_title: !! siteTitle,
 				has_tagline: !! siteDescription,

--- a/packages/onboarding/src/setup-tailored-site-after-creation.ts
+++ b/packages/onboarding/src/setup-tailored-site-after-creation.ts
@@ -80,7 +80,7 @@ export function setupSiteAfterCreation( { siteId, flowName }: SetupOnboardingSit
 		}
 
 		return wpcomRequest< { updated: object } >( {
-			path: `/sites/${ siteId }/onboarding-site-customization`,
+			path: `/sites/${ siteId }/onboarding-customization`,
 			method: 'POST',
 			apiNamespace: 'wpcom/v2',
 			apiVersion: '2',

--- a/packages/onboarding/src/setup-tailored-site-after-creation.ts
+++ b/packages/onboarding/src/setup-tailored-site-after-creation.ts
@@ -46,7 +46,7 @@ export function setupSiteAfterCreation( { siteId, flowName }: SetupOnboardingSit
 			blogname: string;
 			blogdescription: string;
 			launchpad_screen?: string;
-			intent?: string;
+			site_intent?: string;
 		} = {
 			blogname: siteTitle,
 			blogdescription: siteDescription,
@@ -55,7 +55,7 @@ export function setupSiteAfterCreation( { siteId, flowName }: SetupOnboardingSit
 		if ( isNewsletterOrLinkInBioFlow( flowName ) ) {
 			// link-in-bio and link-in-bio-tld are considered the same intent.
 			if ( isLinkInBioFlow( flowName ) ) {
-				settings.intent = LINK_IN_BIO_FLOW;
+				settings.site_intent = LINK_IN_BIO_FLOW;
 				if ( selectedPatternContent ) {
 					const pattern: {
 						content: string | undefined;
@@ -67,7 +67,7 @@ export function setupSiteAfterCreation( { siteId, flowName }: SetupOnboardingSit
 					formData.push( [ 'pattern', JSON.stringify( pattern ) ] );
 				}
 			} else {
-				settings.intent = flowName;
+				settings.site_intent = flowName;
 			}
 
 			settings.launchpad_screen = 'full';


### PR DESCRIPTION
#### Proposed Changes

In `setupSiteAfterCreation` we call a big number of APIs to setup the site after its creation, during the tailored flows.
We created a new endpoint (D93265) to rule them all and unify the calls for site setup. 

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go though Link in bio or Newsletter flows
* Check that changes are there
