### PR TITLE
Theme Showcase: Fix Jetpack sites theme query

### DIFF
--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -441,7 +441,7 @@ class ThemeShowcase extends Component {
 			case this.tabFilters.ALL.key:
 				return this.allThemes( { themeProps } );
 			default:
-				return <ThemesSelection { ...themeProps } filter={ tabKey } />;
+				return this.allThemes( { themeProps: { ...themeProps, filter: tabKey } } );
 		}
 	};
 


### PR DESCRIPTION
#### Proposed Changes

This PR fixes an issue where Jetpack sites are not properly fetch themes from wpcom API, caused by not passing the correct component props (source=`wpcom`).  

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to a Jetpack site.
* Head to logged-in Theme Showcase `/themes/${site_slug}`.
  * If using calypso.live, the flag `themes/showcase-i4/search-and-filter` is required.
* Ensure that the subject filters are returning the same themes as the ones when using Simple site.
* Ensure that the subject filters in a Simple site is working as before.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
