### PR TITLE
Remove loading screen for videopress-account signup step

### DIFF
--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -372,8 +372,11 @@ class Signup extends Component {
 	}
 
 	updateShouldShowLoadingScreen = ( progress = this.props.progress ) => {
-		if ( isWooOAuth2Client( this.props.oauth2Client ) ) {
-			// We don't want to show the loading screen for the Woo signup flow.
+		if (
+			isWooOAuth2Client( this.props.oauth2Client ) ||
+			'videopress-account' === this.props.flowName
+		) {
+			// We don't want to show the loading screen for the Woo signup and videopress-account flow.
 			return;
 		}
 


### PR DESCRIPTION
Fix Automattic/greenhouse#1368
Fix Automattic/greenhouse#1391

#### Proposed Changes

This PR removes the loading screen after a user account creation in the videopress-account flow.

#### Testing Instructions

* Apply this PR
* In an incognito window, go to `http://calypso.localhost:3000/setup/intro?flow=videopress`
* Go to the user account creation step
* Create a new user account
* ✅ You shouldn't see a loading screen or a message saying "Your site will be ready shortly" after creating an account
