### PR TITLE
Themes: remove menu item from all sites views

### DIFF
--- a/client/my-sites/sidebar/static-data/all-sites-menu.js
+++ b/client/my-sites/sidebar/static-data/all-sites-menu.js
@@ -41,14 +41,6 @@ export default function allSitesMenu() {
 			url: '/pages',
 		},
 		{
-			icon: 'dashicons-admin-appearance',
-			slug: 'themes-php',
-			title: translate( 'Themes' ),
-			navigationLabel: translate( 'View themes for all sites' ),
-			type: 'menu-item',
-			url: '/themes',
-		},
-		{
 			icon: 'dashicons-admin-plugins',
 			slug: 'plugins',
 			title: translate( 'Plugins' ),


### PR DESCRIPTION
#### Proposed Changes

Fixes https://github.com/Automattic/wp-calypso/issues/70455

Themes don't support the multisite view, and navigating to `/themes` route will force you to pick a site. Considering that, we shouldn't show the "View themes for all sites," nor the Themes link in the multisite sidebar.

|Before|After|
|-|-|
|<img width="271" alt="Screenshot 2022-11-25 at 4 43 49 PM" src="https://user-images.githubusercontent.com/1182160/204018850-ea2c1975-fcd9-4ea8-a6c1-9221bfcec598.png">|<img width="271" alt="Screenshot 2022-11-25 at 4 44 12 PM" src="https://user-images.githubusercontent.com/1182160/204018876-d4592e97-bbc5-4198-8183-0b17994be1f6.png">|
<img width="271" alt="Screenshot 2022-11-25 at 4 47 25 PM" src="https://user-images.githubusercontent.com/1182160/204019369-6692d255-3f24-4e71-820f-51e7602b5fbd.png">|<img width="272" alt="Screenshot 2022-11-25 at 4 47 49 PM" src="https://user-images.githubusercontent.com/1182160/204019393-f5e04923-7497-4831-924a-4975bd3f7427.png">|


#### Testing Instructions

1. Navigate to `/stats/day`.
2. Verify that the `Themes` item is not present in the multisite sidebar.
3. Navigate to `/themes/{site_url}` by clicking on Appearance -> Themes.
4. Click on `Switch Site`
5. Verify that "View themes for all sites" is no longer present at the top of the site switcher.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
