### PR TITLE
Revert "Prevent edited plans to change with the flag #add-newsletter-payment-plan"

### DIFF
--- a/client/my-sites/earn/memberships/products.jsx
+++ b/client/my-sites/earn/memberships/products.jsx
@@ -74,11 +74,6 @@ class MembershipsProductsSection extends Component {
 	closeDialog = () => this.setState( { showAddEditDialog: false, showDeleteDialog: false } );
 
 	render() {
-		// This will take the hash into account only when ading a new product
-		const subscribe_as_site_subscriber = this.state.product
-			? this.state.product?.subscribe_as_site_subscriber
-			: window.location.hash === '#add-newsletter-payment-plan';
-
 		return (
 			<div>
 				<QueryMembershipsSettings siteId={ this.props.siteId } />
@@ -132,7 +127,9 @@ class MembershipsProductsSection extends Component {
 						<RecurringPaymentsPlanAddEditModal
 							closeDialog={ this.closeDialog }
 							product={ Object.assign( this.state.product ?? {}, {
-								subscribe_as_site_subscriber: subscribe_as_site_subscriber,
+								subscribe_as_site_subscriber:
+									this.state.product?.subscribe_as_site_subscriber ||
+									window.location.hash === '#add-newsletter-payment-plan',
 							} ) }
 						/>
 					) }


### PR DESCRIPTION
It should not have been merged to `trunk`

Reverts Automattic/wp-calypso#70368