### PR TITLE
Stats: Restore followers count to the mobile tab menu

### DIFF
--- a/client/blocks/stats-navigation/style.scss
+++ b/client/blocks/stats-navigation/style.scss
@@ -1,3 +1,5 @@
+@import "@wordpress/base-styles/breakpoints";
+
 .stats-navigation {
 	box-shadow: inset 0 -1px 0 #0000000d;
 
@@ -18,7 +20,7 @@
 	.followers-count .button {
 		margin-left: 16px;
 
-		@include breakpoint-deprecated( "<480px" ) {
+		@media ( max-width: $break-mobile ) {
 			display: none;
 		}
 	}
@@ -34,6 +36,19 @@
 
 		@include breakpoint-deprecated( ">960px" ) {
 			display: flex;
+		}
+	}
+
+	.section-nav.is-open {
+		.followers-count .button {
+			@media ( max-width: $break-mobile ) {
+				display: inline-block;
+				padding: 8px;
+				color: var(--color-neutral-60);
+				font-size: $font-body-small;
+				font-weight: 600;
+				line-height: 24px;
+			}
 		}
 	}
 }

--- a/client/my-sites/stats/style.scss
+++ b/client/my-sites/stats/style.scss
@@ -229,12 +229,6 @@
 // Stats section scoped styles
 .is-section-stats {
 	background: var(--studio-white);
-
-	.followers-count .button {
-		@include breakpoint-deprecated( "<480px" ) {
-			display: none;
-		}
-	}
 }
 
 @import "calypso/my-sites/stats/grid-layout.scss";


### PR DESCRIPTION
#### Proposed Changes

* Show the follower count button inside the tab menu panel on the mobile viewport (width < 480px).

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up this change with the Calypso Live link.
* Navigate to the Stats page `Traffic`.
* Resize the viewport to the mobile (width < 480px).
* Open the mobile navigation panel.
* Ensure the `Followers` count button is displayed at the bottom of the panel.

| Before | After |
| --- | --- |
| <img width="449" alt="截圖 2022-11-26 上午2 14 13" src="https://user-images.githubusercontent.com/6869813/204038136-3a17433d-3d79-48fb-a264-29701cf3bccc.png"> | <img width="442" alt="截圖 2022-11-26 上午2 05 32" src="https://user-images.githubusercontent.com/6869813/204038154-0b31e141-d292-4bb6-8bc6-d1c94c0a65cc.png"> |

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #68974 
