### PR TITLE
Subdomain suggestions for link in bio flows

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -111,7 +111,6 @@ class RegisterDomainStep extends Component {
 		isSignupStep: PropTypes.bool,
 		includeWordPressDotCom: PropTypes.bool,
 		includeDotBlogSubdomain: PropTypes.bool,
-		includeDotLink: PropTypes.bool,
 		showExampleSuggestions: PropTypes.bool,
 		onSave: PropTypes.func,
 		onAddMapping: PropTypes.func,
@@ -128,8 +127,8 @@ class RegisterDomainStep extends Component {
 		showAlreadyOwnADomain: PropTypes.bool,
 		domainAndPlanUpsellFlow: PropTypes.bool,
 		useProvidedProductsList: PropTypes.bool,
-		managedSubdomains: PropTypes.string,
-		managedSubdomainQuantity: PropTypes.number,
+		otherManagedSubdomains: PropTypes.array,
+		otherManagedSubdomainsCountOverride: PropTypes.number,
 		handleClickUseYourDomain: PropTypes.func,
 	};
 
@@ -194,7 +193,7 @@ class RegisterDomainStep extends Component {
 		return (
 			this.props.includeWordPressDotCom ||
 			this.props.includeDotBlogSubdomain ||
-			this.props.includeDotLink
+			this.props.otherManagedSubdomains.length > 0
 		);
 	}
 
@@ -326,11 +325,24 @@ class RegisterDomainStep extends Component {
 		}
 	}
 
+	getOtherManagedSubdomainsQuantity() {
+		let otherManagedSubdomainsCount = 0;
+		// In order to generate "other" (Not blog or wpcom) subdomains an Array of those subdomains need to be provided
+		if ( Array.isArray( this.props.otherManagedSubdomains ) ) {
+			// If an override is not provided we generate 1 suggestion per 1 other subdomain
+			otherManagedSubdomainsCount = this.props.otherManagedSubdomains.length;
+			if ( typeof this.props.otherManagedSubdomainsCountOverride === 'number' ) {
+				otherManagedSubdomainsCount = this.props.otherManagedSubdomainsCountOverride;
+			}
+		}
+		return otherManagedSubdomainsCount;
+	}
+
 	getFreeSubdomainSuggestionsQuantity() {
 		return (
 			this.props.includeWordPressDotCom +
 			this.props.includeDotBlogSubdomain +
-			this.props.includeDotLink
+			this.getOtherManagedSubdomainsQuantity()
 		);
 	}
 
@@ -1075,14 +1087,14 @@ class RegisterDomainStep extends Component {
 	getSubdomainSuggestions = ( domain, timestamp ) => {
 		const subdomainQuery = {
 			query: domain,
-			quantity: this.props.managedSubdomainQuantity ?? this.getFreeSubdomainSuggestionsQuantity(),
+			quantity: this.getFreeSubdomainSuggestionsQuantity(),
 			include_wordpressdotcom: this.props.includeWordPressDotCom,
 			include_dotblogsubdomain: this.props.includeDotBlogSubdomain,
 			only_wordpressdotcom: this.props.includeDotBlogSubdomain,
 			tld_weight_overrides: null,
 			vendor: 'dot',
-			managed_subdomains: this.props.managedSubdomains,
-			managed_subdomain_quantity: this.props.managedSubdomainQuantity ?? 1,
+			managed_subdomains: this.props.otherManagedSubdomains.join(),
+			managed_subdomain_quantity: this.getOtherManagedSubdomainsQuantity(),
 			...this.getActiveFiltersForAPI(),
 		};
 

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -128,6 +128,11 @@ class RegisterDomainStep extends Component {
 		domainAndPlanUpsellFlow: PropTypes.bool,
 		useProvidedProductsList: PropTypes.bool,
 		otherManagedSubdomains: PropTypes.array,
+
+		/**
+		 * If an override is not provided we generate 1 suggestion per 1 other subdomain
+		 * Multiple subdomains of .wordpress.com have not been tested
+		 */
 		otherManagedSubdomainsCountOverride: PropTypes.number,
 		handleClickUseYourDomain: PropTypes.func,
 	};
@@ -147,6 +152,7 @@ class RegisterDomainStep extends Component {
 		onSkip: noop,
 		showSkipButton: false,
 		useProvidedProductsList: false,
+		otherManagedSubdomains: null,
 	};
 
 	constructor( props ) {
@@ -193,7 +199,7 @@ class RegisterDomainStep extends Component {
 		return (
 			this.props.includeWordPressDotCom ||
 			this.props.includeDotBlogSubdomain ||
-			this.props.otherManagedSubdomains.length > 0
+			this.props.otherManagedSubdomains?.length > 0
 		);
 	}
 
@@ -1093,7 +1099,7 @@ class RegisterDomainStep extends Component {
 			only_wordpressdotcom: this.props.includeDotBlogSubdomain,
 			tld_weight_overrides: null,
 			vendor: 'dot',
-			managed_subdomains: this.props.otherManagedSubdomains.join(),
+			managed_subdomains: this.props.otherManagedSubdomains?.join(),
 			managed_subdomain_quantity: this.getOtherManagedSubdomainsQuantity(),
 			...this.getActiveFiltersForAPI(),
 		};

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -129,7 +129,7 @@ export function generateFlows( {
 		},
 		{
 			name: LINK_IN_BIO_FLOW,
-			steps: [ 'domains', 'plans-link-in-bio' ],
+			steps: [ 'domains-link-in-bio', 'plans-link-in-bio' ],
 			destination: ( dependencies ) =>
 				`/setup/link-in-bio/launchpad?siteSlug=${ encodeURIComponent( dependencies.siteSlug ) }`,
 			description: 'Beginning of the flow to create a link in bio',
@@ -142,7 +142,7 @@ export function generateFlows( {
 		},
 		{
 			name: LINK_IN_BIO_TLD_FLOW,
-			steps: [ 'domains', 'user', 'plans-link-in-bio' ],
+			steps: [ 'domains-link-in-bio-tld', 'user', 'plans-link-in-bio' ],
 			middleDestination: {
 				user: ( dependencies ) => `/setup/link-in-bio/patterns?tld=${ dependencies.tld }`,
 			},

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -14,6 +14,8 @@ const stepNameToModuleName = {
 	domains: 'domains',
 	'domain-only': 'domains',
 	'domains-launch': 'domains',
+	'domains-link-in-bio': 'domains',
+	'domains-link-in-bio-tld': 'domains',
 	'domains-store': 'domains',
 	'domains-theme-preselected': 'domains',
 	'mailbox-domain': 'domains',

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -119,7 +119,9 @@ export function generateSteps( {
 			props: {
 				isDomainOnly: false,
 				includeWordPressDotCom: true,
-				includeDotLink: true,
+				// the .link tld comes with the w.link subdomain from our partnership.
+				// see pau2Xa-4tC-p2#comment-12869 for more details
+				otherManagedSubdomains: [ 'link' ],
 			},
 			delayApiRequestUntilComplete: true,
 		},
@@ -140,8 +142,10 @@ export function generateSteps( {
 			props: {
 				isDomainOnly: false,
 				includeWordPressDotCom: false,
-				includeDotLink: true,
-				managedSubdomainQuantity: 2,
+				// the .link tld comes with the w.link subdomain from our partnership.
+				// see pau2Xa-4tC-p2#comment-12869 for more details
+				otherManagedSubdomains: [ 'link' ],
+				otherManagedSubdomainsCountOverride: 2,
 			},
 			delayApiRequestUntilComplete: true,
 		},

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -104,6 +104,48 @@ export function generateSteps( {
 			dependencies: [ 'siteSlug' ],
 		},
 
+		'domains-link-in-bio': {
+			stepName: 'domains-link-in-bio',
+			apiRequestFunction: createSiteWithCart,
+			providesDependencies: [
+				'siteId',
+				'siteSlug',
+				'domainItem',
+				'themeItem',
+				'shouldHideFreePlan',
+				'isManageSiteFlow',
+			],
+			optionalDependencies: [ 'shouldHideFreePlan', 'isManageSiteFlow' ],
+			props: {
+				isDomainOnly: false,
+				includeWordPressDotCom: true,
+				includeDotLink: true,
+			},
+			delayApiRequestUntilComplete: true,
+		},
+
+		'domains-link-in-bio-tld': {
+			stepName: 'domains-link-in-bio-tld',
+			apiRequestFunction: createSiteWithCart,
+			dependencies: [ 'tld' ],
+			providesDependencies: [
+				'siteId',
+				'siteSlug',
+				'domainItem',
+				'themeItem',
+				'shouldHideFreePlan',
+				'isManageSiteFlow',
+			],
+			optionalDependencies: [ 'shouldHideFreePlan', 'isManageSiteFlow' ],
+			props: {
+				isDomainOnly: false,
+				includeWordPressDotCom: false,
+				includeDotLink: true,
+				managedSubdomainQuantity: 2,
+			},
+			delayApiRequestUntilComplete: true,
+		},
+
 		'plans-site-selected': {
 			stepName: 'plans-site-selected',
 			apiRequestFunction: addPlanToCart,

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -525,11 +525,11 @@ class DomainsStep extends Component {
 		}
 
 		const includeWordPressDotCom = this.props.includeWordPressDotCom ?? ! this.props.isDomainOnly;
-		const promoTlds = this.props?.queryObject?.tld?.split( ',' ) ?? [];
 
 		// the .link tld comes with the w.link subdomain from our partnership.
 		// see pau2Xa-4tC-p2#comment-12869 for more details
-		const managedSubdomains = promoTlds.includes( 'link' ) ? 'link' : null;
+		const managedSubdomains = this.props.signupDependencies.tld ?? null;
+		const promoTlds = this.props.signupDependencies.tld?.split( ',' ) ?? [];
 
 		return (
 			<CalypsoShoppingCartProvider>
@@ -543,6 +543,7 @@ class DomainsStep extends Component {
 					promoTlds={ promoTlds }
 					mapDomainUrl={ this.getUseYourDomainUrl() }
 					managedSubdomains={ managedSubdomains }
+					managedSubdomainQuantity={ this.props.managedSubdomainQuantity }
 					transferDomainUrl={ this.getUseYourDomainUrl() }
 					useYourDomainUrl={ this.getUseYourDomainUrl() }
 					onAddMapping={ this.handleAddMapping.bind( this, 'domainForm' ) }
@@ -552,6 +553,7 @@ class DomainsStep extends Component {
 					analyticsSection={ this.getAnalyticsSection() }
 					domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
 					includeWordPressDotCom={ includeWordPressDotCom }
+					includeDotLink={ !! this.props.signupDependencies.tld }
 					includeDotBlogSubdomain={ this.shouldIncludeDotBlogSubdomain() }
 					isSignupStep
 					isPlanSelectionAvailableInFlow={ this.props.isPlanSelectionAvailableLaterInFlow }

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -525,11 +525,7 @@ class DomainsStep extends Component {
 		}
 
 		const includeWordPressDotCom = this.props.includeWordPressDotCom ?? ! this.props.isDomainOnly;
-
-		// the .link tld comes with the w.link subdomain from our partnership.
-		// see pau2Xa-4tC-p2#comment-12869 for more details
-		const managedSubdomains = this.props.signupDependencies.tld ?? null;
-		const promoTlds = this.props.signupDependencies.tld?.split( ',' ) ?? [];
+		const promoTlds = this.props?.queryObject?.tld?.split( ',' ) ?? [];
 
 		return (
 			<CalypsoShoppingCartProvider>
@@ -542,8 +538,8 @@ class DomainsStep extends Component {
 					basePath={ this.props.path }
 					promoTlds={ promoTlds }
 					mapDomainUrl={ this.getUseYourDomainUrl() }
-					managedSubdomains={ managedSubdomains }
-					managedSubdomainQuantity={ this.props.managedSubdomainQuantity }
+					otherManagedSubdomains={ this.props.otherManagedSubdomains }
+					otherManagedSubdomainsCountOverride={ this.props.otherManagedSubdomainsCountOverride }
 					transferDomainUrl={ this.getUseYourDomainUrl() }
 					useYourDomainUrl={ this.getUseYourDomainUrl() }
 					onAddMapping={ this.handleAddMapping.bind( this, 'domainForm' ) }
@@ -553,7 +549,6 @@ class DomainsStep extends Component {
 					analyticsSection={ this.getAnalyticsSection() }
 					domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
 					includeWordPressDotCom={ includeWordPressDotCom }
-					includeDotLink={ !! this.props.signupDependencies.tld }
 					includeDotBlogSubdomain={ this.shouldIncludeDotBlogSubdomain() }
 					isSignupStep
 					isPlanSelectionAvailableInFlow={ this.props.isPlanSelectionAvailableLaterInFlow }


### PR DESCRIPTION
### Proposed Changes

Alter domain suggestions as discussed.

#### CASE1 - For the link-in-bio flow (the regular LNB onboarding flow):
- 1 free w.link subdomain suggestion
- 1 free wordpress.com subdomain suggestion
- The rest are suggested domains for purchase with a mixture of TLDs from the link-in-bio vendor set up by @delputnam  (.link, .ld, .bio, .m, etc)
<img width="1408" alt="image" src="https://user-images.githubusercontent.com/3422709/204080920-7c7eef2d-b38e-4456-ab33-78539198097c.png">


#### CASE2 - For the link-in-bio-tld flow (the one we get to via the landing page):
- 2 free w.link subdomain suggestions
- the rest are suggested .link domains for purchase
<img width="1412" alt="image" src="https://user-images.githubusercontent.com/3422709/204080976-ac7bd7d7-9504-462c-8e1e-bfdf197bc0f0.png">
- Make sure any other uses of the domains step are uneffected
### Not in this PR
- The stepper framework domains step does not have these variations currently implemented. (setup/link-in-bio/domains)


#### Testing Instructions
- Go to `/start/link-in-bio` and make sure CASE1 above is achieved
- Go to `/start/link-in-bio-tld?tld=link` and make sure CASE2 above is achieved
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes Automattic/martech#1257