### PR TITLE
Sites: Introduce landing page opt-in banner

### DIFF
--- a/client/root.js
+++ b/client/root.js
@@ -2,10 +2,11 @@ import config from '@automattic/calypso-config';
 import globalPageInstance from 'page';
 import { isUserLoggedIn, getCurrentUser } from 'calypso/state/current-user/selectors';
 import { fetchPreferences } from 'calypso/state/preferences/actions';
-import { getPreference, hasReceivedRemotePreferences } from 'calypso/state/preferences/selectors';
+import { hasReceivedRemotePreferences } from 'calypso/state/preferences/selectors';
 import getPrimarySiteId from 'calypso/state/selectors/get-primary-site-id';
 import { requestSite } from 'calypso/state/sites/actions';
 import { canCurrentUserUseCustomerHome, getSite, getSiteSlug } from 'calypso/state/sites/selectors';
+import { hasSitesAsLandingPage } from 'calypso/state/sites/selectors/has-sites-as-landing-page';
 
 /**
  * @param clientRouter Unused. We can't use the isomorphic router because we want to do redirects.
@@ -74,10 +75,7 @@ const waitForPrefs = () => async ( dispatch, getState ) => {
 async function getLoggedInLandingPage( { dispatch, getState } ) {
 	if ( config.isEnabled( 'sites-as-landing-page' ) ) {
 		await dispatch( waitForPrefs() );
-		const useSitesAsLandingPage = getPreference(
-			getState(),
-			'sites-landing-page'
-		)?.useSitesAsLandingPage;
+		const useSitesAsLandingPage = hasSitesAsLandingPage( getState() );
 
 		const siteCount = getCurrentUser( getState() )?.site_count;
 

--- a/client/sites-dashboard/components/sites-dashboard-opt-in-banner.tsx
+++ b/client/sites-dashboard/components/sites-dashboard-opt-in-banner.tsx
@@ -1,0 +1,63 @@
+import styled from '@emotion/styled';
+import { useI18n } from '@wordpress/react-i18n';
+import Banner from 'calypso/components/banner';
+import { SiteExcerptData } from 'calypso/data/sites/site-excerpt-types';
+
+interface SitesDashboardOptInBannerProps {
+	sites: SiteExcerptData[];
+	className: string;
+}
+
+const SitesBanner = styled( Banner )( {
+	width: 'auto',
+	margin: '0 0 32px 0',
+
+	'.banner__close-icon': {
+		position: 'static',
+		top: 'unset',
+		left: 'unset',
+		marginLeft: '24px',
+		order: 3,
+		width: '18px',
+	},
+
+	'.banner__title': {
+		fontWeight: 'normal',
+	},
+
+	'.banner__action': {
+		marginTop: 0,
+		marginLeft: '32px',
+		display: 'flex',
+	},
+} );
+
+export const SitesDashboardOptInBanner = ( {
+	sites,
+	className,
+}: SitesDashboardOptInBannerProps ) => {
+	const { __ } = useI18n();
+
+	if ( sites.length < 2 ) {
+		return null;
+	}
+
+	return (
+		<div className={ className }>
+			<SitesBanner
+				callToAction={ __( 'Yes, make it my landing page' ) }
+				primaryButton={ false }
+				dismissWithoutSavingPreference
+				disableHref
+				event="calypso_sites_as_landing_page"
+				showIcon={ false }
+				onClick={ () => {} }
+				onDismiss={ () => {} }
+				title={ __( 'Do you want to make this page the default when you visit WordPress.com?' ) }
+				tracksImpressionName="calypso_sites_as_landing_page_seen"
+				tracksClickName="calypso_sites_as_landing_page_accepted"
+				tracksDismissName="calypso_sites_as_landing_page_rejected"
+			/>
+		</div>
+	);
+};

--- a/client/sites-dashboard/components/sites-dashboard-opt-in-banner.tsx
+++ b/client/sites-dashboard/components/sites-dashboard-opt-in-banner.tsx
@@ -18,13 +18,13 @@ interface SitesDashboardOptInBannerProps {
 
 const SitesNotice = styled( Notice )( {
 	marginBlockStart: '32px',
-	backgroundColor: 'var(--color-neutral-0)',
-	color: 'var(--color-text)',
+	backgroundColor: 'var(--color-neutral-0) !important',
+	color: 'var(--color-text) !important',
 
 	'.notice__icon-wrapper': {
 		paddingInlineStart: '8px',
 		background: 'transparent !important',
-		color: 'var(--color-accent)',
+		color: 'var(--color-accent) !important',
 	},
 
 	'.notice__content': {

--- a/client/sites-dashboard/components/sites-dashboard-opt-in-banner.tsx
+++ b/client/sites-dashboard/components/sites-dashboard-opt-in-banner.tsx
@@ -1,8 +1,11 @@
 import { Button } from '@automattic/components';
 import styled from '@emotion/styled';
 import { useI18n } from '@wordpress/react-i18n';
+import { useDispatch } from 'react-redux';
 import Notice from 'calypso/components/notice';
 import { SiteExcerptData } from 'calypso/data/sites/site-excerpt-types';
+import TrackComponentView from 'calypso/lib/analytics/track-component-view';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
 interface SitesDashboardOptInBannerProps {
 	sites: SiteExcerptData[];
@@ -34,24 +37,40 @@ const NoticeActions = styled.div( {
 	padding: '16px',
 } );
 
+const EVENT_PREFIX = 'calypso_sites_as_landing_page';
+
 export const SitesDashboardOptInBanner = ( { sites }: SitesDashboardOptInBannerProps ) => {
 	const { __ } = useI18n();
+	const dispatch = useDispatch();
 
 	if ( sites.length < 2 ) {
 		return null;
 	}
 
+	const handleAccept = () => {
+		dispatch( recordTracksEvent( `${ EVENT_PREFIX }_accepted` ) );
+	};
+
+	const handleDismiss = () => {
+		dispatch( recordTracksEvent( `${ EVENT_PREFIX }_rejected` ) );
+	};
+
 	return (
-		<SitesNotice
-			status="is-info"
-			text={ __( 'Do you want to make this page your default when visiting WordPress.com?' ) }
-			icon="heart"
-			showDismiss={ false }
-		>
-			<NoticeActions>
-				<Button borderless>{ __( 'No, thanks' ) }</Button>
-				<Button>{ __( 'Yes, make it my home' ) }</Button>
-			</NoticeActions>
-		</SitesNotice>
+		<>
+			<TrackComponentView eventName={ `${ EVENT_PREFIX }_seen` } />
+			<SitesNotice
+				status="is-info"
+				text={ __( 'Do you want to make this page your default when visiting WordPress.com?' ) }
+				icon="heart"
+				showDismiss={ false }
+			>
+				<NoticeActions>
+					<Button borderless onClick={ handleDismiss }>
+						{ __( 'No, thanks' ) }
+					</Button>
+					<Button onClick={ handleAccept }>{ __( 'Yes, make it my home' ) }</Button>
+				</NoticeActions>
+			</SitesNotice>
+		</>
 	);
 };

--- a/client/sites-dashboard/components/sites-dashboard-opt-in-banner.tsx
+++ b/client/sites-dashboard/components/sites-dashboard-opt-in-banner.tsx
@@ -1,11 +1,13 @@
 import { Button } from '@automattic/components';
 import styled from '@emotion/styled';
 import { useI18n } from '@wordpress/react-i18n';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import Notice from 'calypso/components/notice';
 import { SiteExcerptData } from 'calypso/data/sites/site-excerpt-types';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { hasReceivedRemotePreferences } from 'calypso/state/preferences/selectors';
+import { hasSitesAsLandingPage } from 'calypso/state/sites/selectors/has-sites-as-landing-page';
 
 interface SitesDashboardOptInBannerProps {
 	sites: SiteExcerptData[];
@@ -42,8 +44,10 @@ const EVENT_PREFIX = 'calypso_sites_as_landing_page';
 export const SitesDashboardOptInBanner = ( { sites }: SitesDashboardOptInBannerProps ) => {
 	const { __ } = useI18n();
 	const dispatch = useDispatch();
+	const hasReceivedPreferences = useSelector( hasReceivedRemotePreferences );
+	const hasOptedInToSitesAsLandingPage = useSelector( hasSitesAsLandingPage );
 
-	if ( sites.length < 2 ) {
+	if ( sites.length < 2 || ! hasReceivedPreferences || hasOptedInToSitesAsLandingPage ) {
 		return null;
 	}
 

--- a/client/sites-dashboard/components/sites-dashboard-opt-in-banner.tsx
+++ b/client/sites-dashboard/components/sites-dashboard-opt-in-banner.tsx
@@ -44,8 +44,6 @@ const NoticeActions = styled.div( {
 	flexShrink: 0,
 } );
 
-const EVENT_PREFIX = 'calypso_sites_as_landing_page';
-
 const ONE_DAY_IN_MILLISECONDS = 86400 * 1000;
 
 const hasDismissedTheBannerRecently = ( {
@@ -79,7 +77,7 @@ export const SitesDashboardOptInBanner = ( { sites }: SitesDashboardOptInBannerP
 			useSitesAsLandingPage: true,
 			updatedAt: new Date().valueOf(),
 		} );
-		dispatch( recordTracksEvent( `${ EVENT_PREFIX }_accepted` ) );
+		dispatch( recordTracksEvent( 'calypso_sites_as_landing_page_accepted' ) );
 	};
 
 	const handleDismiss = () => {
@@ -87,12 +85,12 @@ export const SitesDashboardOptInBanner = ( { sites }: SitesDashboardOptInBannerP
 			useSitesAsLandingPage: false,
 			updatedAt: new Date().valueOf(),
 		} );
-		dispatch( recordTracksEvent( `${ EVENT_PREFIX }_rejected` ) );
+		dispatch( recordTracksEvent( 'calypso_sites_as_landing_page_rejected' ) );
 	};
 
 	return (
 		<>
-			<TrackComponentView eventName={ `${ EVENT_PREFIX }_seen` } />
+			<TrackComponentView eventName="calypso_sites_as_landing_page_seen" />
 			<SitesNotice
 				status="is-info"
 				text={ __( 'Do you want to make this page your default when visiting WordPress.com?' ) }

--- a/client/sites-dashboard/components/sites-dashboard-opt-in-banner.tsx
+++ b/client/sites-dashboard/components/sites-dashboard-opt-in-banner.tsx
@@ -2,6 +2,7 @@ import { Button } from '@automattic/components';
 import { useBreakpoint } from '@automattic/viewport-react';
 import styled from '@emotion/styled';
 import { useI18n } from '@wordpress/react-i18n';
+import moment from 'moment';
 import { useDispatch } from 'react-redux';
 import Notice from 'calypso/components/notice';
 import { SiteExcerptData } from 'calypso/data/sites/site-excerpt-types';
@@ -44,14 +45,12 @@ const NoticeActions = styled.div( {
 	flexShrink: 0,
 } );
 
-const ONE_DAY_IN_MILLISECONDS = 86400 * 1000;
-
 const hasDismissedTheBannerRecently = ( {
 	updatedAt,
 }: typeof SITES_AS_LANDING_PAGE_DEFAULT_VALUE ) => {
-	const fourteenDaysAgo = new Date().valueOf() - ONE_DAY_IN_MILLISECONDS * 14;
+	const fourteenDaysAgo = moment().subtract( 14, 'days' ).startOf( 'day' );
 
-	return updatedAt > fourteenDaysAgo;
+	return moment( updatedAt ).isAfter( fourteenDaysAgo );
 };
 
 export const SitesDashboardOptInBanner = ( { sites }: SitesDashboardOptInBannerProps ) => {

--- a/client/sites-dashboard/components/sites-dashboard-opt-in-banner.tsx
+++ b/client/sites-dashboard/components/sites-dashboard-opt-in-banner.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@automattic/components';
+import { useBreakpoint } from '@automattic/viewport-react';
 import styled from '@emotion/styled';
 import { useI18n } from '@wordpress/react-i18n';
 import { useDispatch } from 'react-redux';
@@ -40,6 +41,7 @@ const NoticeActions = styled.div( {
 	gap: '16px',
 	alignItems: 'center',
 	padding: '16px',
+	flexShrink: 0,
 } );
 
 const EVENT_PREFIX = 'calypso_sites_as_landing_page';
@@ -55,6 +57,7 @@ const hasDismissedTheBannerRecently = ( {
 };
 
 export const SitesDashboardOptInBanner = ( { sites }: SitesDashboardOptInBannerProps ) => {
+	const isSmallScreen = useBreakpoint( '<660px' );
 	const { __ } = useI18n();
 	const dispatch = useDispatch();
 	const [ landingPagePreference, setLandingPagePreference ] = useAsyncPreference( {
@@ -63,6 +66,7 @@ export const SitesDashboardOptInBanner = ( { sites }: SitesDashboardOptInBannerP
 	} );
 
 	if (
+		isSmallScreen ||
 		sites.length < 2 ||
 		landingPagePreference === 'none' ||
 		landingPagePreference.useSitesAsLandingPage ||

--- a/client/sites-dashboard/components/sites-dashboard-opt-in-banner.tsx
+++ b/client/sites-dashboard/components/sites-dashboard-opt-in-banner.tsx
@@ -66,7 +66,6 @@ export const SitesDashboardOptInBanner = ( { sites }: SitesDashboardOptInBannerP
 	} );
 
 	if (
-		isSmallScreen ||
 		sites.length < 2 ||
 		landingPagePreference === 'none' ||
 		landingPagePreference.useSitesAsLandingPage ||
@@ -102,9 +101,11 @@ export const SitesDashboardOptInBanner = ( { sites }: SitesDashboardOptInBannerP
 			>
 				<NoticeActions>
 					<Button borderless onClick={ handleDismiss }>
-						{ __( 'No, thanks' ) }
+						{ isSmallScreen ? __( 'No' ) : __( 'No, thanks' ) }
 					</Button>
-					<Button onClick={ handleAccept }>{ __( 'Yes, make it my home' ) }</Button>
+					<Button onClick={ handleAccept }>
+						{ isSmallScreen ? __( 'Yes' ) : __( 'Yes, make it my home' ) }
+					</Button>
 				</NoticeActions>
 			</SitesNotice>
 		</>

--- a/client/sites-dashboard/components/sites-dashboard-opt-in-banner.tsx
+++ b/client/sites-dashboard/components/sites-dashboard-opt-in-banner.tsx
@@ -1,41 +1,40 @@
+import { Button } from '@automattic/components';
 import styled from '@emotion/styled';
 import { useI18n } from '@wordpress/react-i18n';
-import Banner from 'calypso/components/banner';
+import Notice from 'calypso/components/notice';
 import { SiteExcerptData } from 'calypso/data/sites/site-excerpt-types';
 
 interface SitesDashboardOptInBannerProps {
 	sites: SiteExcerptData[];
-	className: string;
 }
 
-const SitesBanner = styled( Banner )( {
-	width: 'auto',
-	margin: '0 0 32px 0',
+const SitesNotice = styled( Notice )( {
+	marginBlockStart: '32px',
+	backgroundColor: 'var(--color-neutral-0)',
+	color: 'var(--color-text)',
 
-	'.banner__close-icon': {
-		position: 'static',
-		top: 'unset',
-		left: 'unset',
-		marginLeft: '24px',
-		order: 3,
-		width: '18px',
+	'.notice__icon-wrapper': {
+		paddingInlineStart: '8px',
+		background: 'transparent !important',
+		color: 'var(--color-accent)',
 	},
 
-	'.banner__title': {
-		fontWeight: 'normal',
-	},
-
-	'.banner__action': {
-		marginTop: 0,
-		marginLeft: '32px',
+	'.notice__content': {
+		paddingBlock: '16px',
+		paddingInline: '8px',
 		display: 'flex',
+		alignItems: 'center',
 	},
 } );
 
-export const SitesDashboardOptInBanner = ( {
-	sites,
-	className,
-}: SitesDashboardOptInBannerProps ) => {
+const NoticeActions = styled.div( {
+	display: 'flex',
+	gap: '16px',
+	alignItems: 'center',
+	padding: '16px',
+} );
+
+export const SitesDashboardOptInBanner = ( { sites }: SitesDashboardOptInBannerProps ) => {
 	const { __ } = useI18n();
 
 	if ( sites.length < 2 ) {
@@ -43,21 +42,16 @@ export const SitesDashboardOptInBanner = ( {
 	}
 
 	return (
-		<div className={ className }>
-			<SitesBanner
-				callToAction={ __( 'Yes, make it my landing page' ) }
-				primaryButton={ false }
-				dismissWithoutSavingPreference
-				disableHref
-				event="calypso_sites_as_landing_page"
-				showIcon={ false }
-				onClick={ () => {} }
-				onDismiss={ () => {} }
-				title={ __( 'Do you want to make this page the default when you visit WordPress.com?' ) }
-				tracksImpressionName="calypso_sites_as_landing_page_seen"
-				tracksClickName="calypso_sites_as_landing_page_accepted"
-				tracksDismissName="calypso_sites_as_landing_page_rejected"
-			/>
-		</div>
+		<SitesNotice
+			status="is-info"
+			text={ __( 'Do you want to make this page your default when visiting WordPress.com?' ) }
+			icon="heart"
+			showDismiss={ false }
+		>
+			<NoticeActions>
+				<Button borderless>{ __( 'No, thanks' ) }</Button>
+				<Button>{ __( 'Yes, make it my home' ) }</Button>
+			</NoticeActions>
+		</SitesNotice>
 	);
 };

--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -1,4 +1,5 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
+import config from '@automattic/calypso-config';
 import { Button, Gridicon, useScrollToTop, JetpackLogo } from '@automattic/components';
 import { createSitesListComponent } from '@automattic/sites';
 import { css } from '@emotion/css';
@@ -205,7 +206,9 @@ export function SitesDashboard( {
 				</HeaderControls>
 			</PageHeader>
 			<PageBodyWrapper>
-				<SitesDashboardOptInBanner sites={ allSites } />
+				{ config.isEnabled( 'sites-as-landing-page' ) && (
+					<SitesDashboardOptInBanner sites={ allSites } />
+				) }
 				<SitesDashboardSitesList
 					sites={ allSites }
 					filtering={ { search } }

--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -20,6 +20,7 @@ import {
 	SitesContentControls,
 	handleQueryParamChange,
 } from './sites-content-controls';
+import { SitesDashboardOptInBanner } from './sites-dashboard-opt-in-banner';
 import { useSitesDisplayMode } from './sites-display-mode-switcher';
 import { SitesGrid } from './sites-grid';
 import { SitesTable } from './sites-table';
@@ -67,7 +68,7 @@ const PageBodyWrapper = styled.div( {
 	marginInline: 'auto',
 } );
 
-const HeaderControls = styled.div( {
+const headerControls = css( {
 	maxWidth: MAX_PAGE_WIDTH,
 	marginBlock: 0,
 	marginInline: 'auto',
@@ -162,7 +163,8 @@ export function SitesDashboard( {
 		<main>
 			<DocumentHead title={ __( 'Sites' ) } />
 			<PageHeader>
-				<HeaderControls>
+				<SitesDashboardOptInBanner sites={ allSites } className={ headerControls } />
+				<div className={ headerControls }>
 					<DashboardHeading>{ __( 'Sites' ) }</DashboardHeading>
 					<SplitButton
 						primary
@@ -201,7 +203,7 @@ export function SitesDashboard( {
 							<span>{ __( 'Import an existing site' ) }</span>
 						</PopoverMenuItem>
 					</SplitButton>
-				</HeaderControls>
+				</div>
 			</PageHeader>
 			<PageBodyWrapper>
 				<SitesDashboardSitesList

--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -68,7 +68,7 @@ const PageBodyWrapper = styled.div( {
 	marginInline: 'auto',
 } );
 
-const headerControls = css( {
+const HeaderControls = styled.div( {
 	maxWidth: MAX_PAGE_WIDTH,
 	marginBlock: 0,
 	marginInline: 'auto',
@@ -163,8 +163,7 @@ export function SitesDashboard( {
 		<main>
 			<DocumentHead title={ __( 'Sites' ) } />
 			<PageHeader>
-				<SitesDashboardOptInBanner sites={ allSites } className={ headerControls } />
-				<div className={ headerControls }>
+				<HeaderControls>
 					<DashboardHeading>{ __( 'Sites' ) }</DashboardHeading>
 					<SplitButton
 						primary
@@ -203,9 +202,10 @@ export function SitesDashboard( {
 							<span>{ __( 'Import an existing site' ) }</span>
 						</PopoverMenuItem>
 					</SplitButton>
-				</div>
+				</HeaderControls>
 			</PageHeader>
 			<PageBodyWrapper>
+				<SitesDashboardOptInBanner sites={ allSites } />
 				<SitesDashboardSitesList
 					sites={ allSites }
 					filtering={ { search } }

--- a/client/state/preferences/use-async-preference.ts
+++ b/client/state/preferences/use-async-preference.ts
@@ -8,7 +8,9 @@ interface UseAsyncPreferenceOptions< T > {
 	preferenceName: string;
 }
 
-export const useAsyncPreference = < T extends string >( {
+type AllowedPreferenceValues = Parameters< typeof savePreference >[ 1 ];
+
+export const useAsyncPreference = < T extends AllowedPreferenceValues >( {
 	defaultValue,
 	preferenceName,
 }: UseAsyncPreferenceOptions< T > ) => {

--- a/client/state/sites/selectors/has-sites-as-landing-page.ts
+++ b/client/state/sites/selectors/has-sites-as-landing-page.ts
@@ -2,8 +2,16 @@ import { createSelector } from '@automattic/state-utils';
 import { getPreference } from 'calypso/state/preferences/selectors';
 import type { AppState } from 'calypso/types';
 
+export const SITES_AS_LANDING_PAGE_PREFERENCE = 'sites-landing-page';
+
+export const SITES_AS_LANDING_PAGE_DEFAULT_VALUE = {
+	useSitesAsLandingPage: false,
+	updatedAt: 0,
+};
+
 export const hasSitesAsLandingPage = createSelector( ( state: AppState ): boolean => {
-	const { useSitesAsLandingPage = false } = getPreference( state, 'sites-landing-page' ) ?? {};
+	const { useSitesAsLandingPage } =
+		getPreference( state, SITES_AS_LANDING_PAGE_PREFERENCE ) ?? SITES_AS_LANDING_PAGE_DEFAULT_VALUE;
 
 	return useSitesAsLandingPage;
 } );

--- a/client/state/sites/selectors/has-sites-as-landing-page.ts
+++ b/client/state/sites/selectors/has-sites-as-landing-page.ts
@@ -1,0 +1,9 @@
+import { createSelector } from '@automattic/state-utils';
+import { getPreference } from 'calypso/state/preferences/selectors';
+import type { AppState } from 'calypso/types';
+
+export const hasSitesAsLandingPage = createSelector( ( state: AppState ): boolean => {
+	const { useSitesAsLandingPage = false } = getPreference( state, 'sites-landing-page' ) ?? {};
+
+	return useSitesAsLandingPage;
+} );

--- a/client/state/sites/selectors/has-sites-as-landing-page.ts
+++ b/client/state/sites/selectors/has-sites-as-landing-page.ts
@@ -1,4 +1,3 @@
-import { createSelector } from '@automattic/state-utils';
 import { getPreference } from 'calypso/state/preferences/selectors';
 import type { AppState } from 'calypso/types';
 
@@ -9,9 +8,9 @@ export const SITES_AS_LANDING_PAGE_DEFAULT_VALUE = {
 	updatedAt: 0,
 };
 
-export const hasSitesAsLandingPage = createSelector( ( state: AppState ): boolean => {
+export const hasSitesAsLandingPage = ( state: AppState ): boolean => {
 	const { useSitesAsLandingPage } =
 		getPreference( state, SITES_AS_LANDING_PAGE_PREFERENCE ) ?? SITES_AS_LANDING_PAGE_DEFAULT_VALUE;
 
 	return useSitesAsLandingPage;
-} );
+};


### PR DESCRIPTION
#### Proposed Changes

Closes https://github.com/Automattic/wp-calypso/issues/70294. Introduces a banner allowing the user to set `/sites` as their landing page.

| Small screens | Large screens |
| -------------- | -------------- |
| ![image](https://user-images.githubusercontent.com/26530524/204351671-072e7459-15e7-436e-84af-50b4766ea6f4.png) | ![image](https://user-images.githubusercontent.com/26530524/204053064-a61140b3-1385-4608-bd1a-1e4578c3ba22.png) |

#### Pre-Testing Instructions

If the preference is already saved, you won't see the banner unless you want to wait for 14 days 😅

You can reset it by dispatching

```json
{
  "type": "PREFERENCES_RECEIVE",
  "values": {
    "sites-landing-page": null
  }
}
```

in the Redux DevTools to forget the preference.

Finally, make sure you have more than one site and that the feature flag (`sites-as-landing-page`) is enabled.

#### Testing instructions

Once you see the banner, check that the `calypso_sites_as_landing_page_seen` Tracks event was dispatched.

Try rejecting the banner and checking that it's gone even after refreshing the page, along with a dispatched event called `calypso_sites_as_landing_page_rejected`. You can reset the preference to verify that the banner will show up again.

If you click the `Yes, make it my home` button, the banner will be gone, the `calypso_sites_as_landing_page_accepted` event will be dispatched, and the preference will be saved positively. You can see that browsing `/` will send you to `/sites`.