### PR TITLE
Update colors to be consistent with designs

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-domain/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-domain/style.scss
@@ -230,10 +230,10 @@ $sensei-color: #43af99;
 			border: none;
 			border-radius: 4px;
 			background-color: $sensei-color;
-			color: #000;
+			color: #fff;
 
 			&:hover {
-				background: lighten($sensei-color, 10%);
+				background: darken($sensei-color, 10%);
 			}
 		}
 	}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-plan/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-plan/styles.scss
@@ -1,5 +1,7 @@
+$sensei-color: #43af99;
+
 .sensei .progress-bar__progress {
-	background-color: #43af99;
+	background-color: $sensei-color;
 }
 
 .step-container.senseiPlan {
@@ -20,11 +22,11 @@
 
 		&__select-button {
 			width: 100%;
-			background-color: #43af99;
-			border: 1px solid darken(#43af99, 10%);
+			background-color: $sensei-color;
+			border: 1px solid darken($sensei-color, 10%);
 			&:hover:not(:disabled) {
-				background-color: darken(#43af99, 10%);
-				border: 1px solid darken(#43af99, 10%);
+				background-color: darken($sensei-color, 10%);
+				border: 1px solid darken($sensei-color, 10%);
 			}
 		}
 	}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-plan/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-plan/styles.scss
@@ -1,3 +1,7 @@
+.sensei .progress-bar__progress {
+	background-color: #43af99;
+}
+
 .step-container.senseiPlan {
 	.plan-item {
 		&__viewport {
@@ -16,6 +20,12 @@
 
 		&__select-button {
 			width: 100%;
+			background-color: #43af99;
+			border: 1px solid darken(#43af99, 10%);
+			&:hover:not(:disabled) {
+				background-color: darken(#43af99, 10%);
+				border: 1px solid darken(#43af99, 10%);
+			}
 		}
 	}
 


### PR DESCRIPTION
#### Proposed Changes

* This standardizes the colors to match the Sensei green better

Changes:
- The bundle screen now has green bar at the top and a green button:
<img width="1220" alt="Screenshot 2022-11-25 at 4 26 17 PM" src="https://user-images.githubusercontent.com/3220162/204065585-a641d778-1f29-4091-80bc-108d46e44623.png">

- The domain screen has white text for the featured domain suggestions:
<img width="429" alt="Screenshot 2022-11-25 at 4 26 20 PM" src="https://user-images.githubusercontent.com/3220162/204065587-d72f5f2d-1368-4873-8930-f98dc7af5e97.png">

