### PR TITLE
Plugins: point multisite sidebar links to the all sites view

### DIFF
--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -311,13 +311,27 @@ export class SiteSelector extends Component {
 		return sites;
 	}
 
+	mapAllSitesPath = ( path ) => {
+		if ( path.includes( '/posts/my' ) ) {
+			return path.replace( '/posts/my', '/posts' );
+		}
+
+		// We used to show multisite plugins management on /plugins route, but that has changed
+		// and now we show the plugins marketplace on it, which is a single site view.
+		if ( path.match( /^\/plugins\/?/ ) ) {
+			return '/plugins/manage';
+		}
+
+		return path;
+	};
+
 	renderAllSites() {
 		if ( ! this.props.showAllSites || this.state.searchTerm || ! this.props.allSitesPath ) {
 			return null;
 		}
 
 		const multiSiteContext = allSitesMenu().find(
-			( menu ) => menu.url === this.props.allSitesPath.replace( '/posts/my', '/posts' )
+			( menuItem ) => menuItem.url === this.mapAllSitesPath( this.props.allSitesPath )
 		);
 
 		// Let's not display the all sites button if there is no multi-site context.
@@ -492,6 +506,12 @@ const navigateToSite =
 				// There is currently no "all sites" version of the insights page
 				if ( path.match( /^\/stats\/insights\/?/ ) ) {
 					return '/stats/day';
+				}
+
+				// Route /plugins no longer handles the "all sites" view, and is being used by Marketplace plugins.
+				// Until that's resolved let's override it to show the multisite management view for plugins.
+				if ( path.match( /^\/plugins\/?/ ) ) {
+					return '/plugins/manage';
 				}
 
 				// Jetpack Cloud: default to /backups/ when in the details of a particular backup

--- a/client/my-sites/sidebar/static-data/all-sites-menu.js
+++ b/client/my-sites/sidebar/static-data/all-sites-menu.js
@@ -54,7 +54,7 @@ export default function allSitesMenu() {
 			title: translate( 'Plugins' ),
 			navigationLabel: translate( 'View plugins for all sites' ),
 			type: 'menu-item',
-			url: '/plugins',
+			url: '/plugins/manage',
 		},
 	];
 }


### PR DESCRIPTION
#### Proposed Changes

Fixes https://github.com/Automattic/wp-calypso/issues/70453

Plugins marketplace work overrode the `/plugins` route, which was initially used for the all-sites view. We can repoint the existing sidebar links to the /plugins/manage route, which still serves the correct all-sites plugins management view.

#### Testing Instructions

1. Navigate to the Plugins page for your test simple site (`http://calypso.localhost:3000/plugins/{site_url}`).
2. Click on `Switch Site`.
3. Click on `View plugins for all sites`.
4. Verify that you are taken to the `/plugins/manage` page, which shows installed plugins for all sites.
5. Click on `/Stats` in the multisite sidebar.
6. Click on the `Plugins` in the multisite sidebar.
7. Verify that it also links to the `/plugins/manage` page.
8. Confirm that the `Posts` multisite link behavior didn't change.

|Before|After|
|-|-|
|<img width="1726" alt="Screenshot 2022-11-26 at 3 10 11 AM" src="https://user-images.githubusercontent.com/1182160/204068337-7079aa89-6fbf-43f7-bab0-3e2afcf2a8db.png">|<img width="1727" alt="Screenshot 2022-11-26 at 3 09 44 AM" src="https://user-images.githubusercontent.com/1182160/204068343-4e66d5f6-3ab6-4f5c-8e12-f22fae053598.png">|


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
