### PR TITLE
Theme Showcase: Upsell nudge CSS

### DIFF
--- a/client/my-sites/themes/single-site-jetpack.jsx
+++ b/client/my-sites/themes/single-site-jetpack.jsx
@@ -65,7 +65,7 @@ const ConnectedSingleSiteJetpack = connectOptions( ( props ) => {
 			title={ translate(
 				'Unlock ALL premium themes and upload your own themes with our Business and eCommerce plans!'
 			) }
-			forceHref={ true }
+			callToAction={ translate( 'Upgrade now' ) }
 			showIcon={ true }
 		/>
 	);

--- a/client/my-sites/themes/single-site-wpcom.jsx
+++ b/client/my-sites/themes/single-site-wpcom.jsx
@@ -42,7 +42,7 @@ const ConnectedSingleSiteWpcom = connectOptions( ( props ) => {
 						feature={ WPCOM_FEATURES_PREMIUM_THEMES }
 						plan={ PLAN_PREMIUM }
 						title={ translate( 'Unlock ALL premium themes with our Premium and Business plans!' ) }
-						forceHref={ true }
+						callToAction={ translate( 'Upgrade now' ) }
 						showIcon={ true }
 					/>
 				);
@@ -56,7 +56,7 @@ const ConnectedSingleSiteWpcom = connectOptions( ( props ) => {
 						feature={ FEATURE_UPLOAD_THEMES }
 						plan={ PLAN_BUSINESS }
 						title={ translate( 'Upload your own themes with our Business and eCommerce plans!' ) }
-						forceHref={ true }
+						callToAction={ translate( 'Upgrade now' ) }
 						showIcon={ true }
 					/>
 				);
@@ -69,7 +69,7 @@ const ConnectedSingleSiteWpcom = connectOptions( ( props ) => {
 					feature={ FEATURE_UPLOAD_THEMES }
 					plan={ PLAN_BUSINESS }
 					title={ translate( 'Upload your own themes with our Business and eCommerce plans!' ) }
-					forceHref={ true }
+					callToAction={ translate( 'Upgrade now' ) }
 					showIcon={ true }
 				/>
 			);

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -72,10 +72,10 @@ body.is-section-themes-i4 {
 		.banner__action .button {
 			background-color: var(--studio-blue-50);
 			border: none;
-			border-radius: 4px;
 			font-size: $font-body-small;
-			padding: 10px 14px;
-			line-height: 20px;
+			font-weight: 400;
+			line-height: 22px;
+			padding: 8px 14px;
 			white-space: nowrap;
 		}
 	}

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -20,7 +20,7 @@ body.is-section-themes-i4 {
 		margin-top: 32px;
 	}
 
-	.upsell-nudge {
+	.themes__content .upsell-nudge {
 		background-color: #f0f7fc;
 		border: none;
 		box-shadow: none;

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -2,10 +2,82 @@
 @import "@wordpress/base-styles/mixins";
 
 body.is-section-themes-i4 {
-	--color-surface-backdrop: #fdfdfd;
+	&.theme-default.color-scheme {
+		--color-surface-backdrop: #fdfdfd;
+	}
 
-	&.theme-default .focus-content .layout__content {
+	.layout:not(.has-no-sidebar) .layout__content {
 		padding-top: var(--masterbar-height);
+	}
+
+	.theme__filters {
+		@include break-small {
+			padding: 24px 0;
+		}
+	}
+
+	.themes__selection .themes-list {
+		margin-top: 32px;
+	}
+
+	.upsell-nudge {
+		background-color: #f0f7fc;
+		border: none;
+		box-shadow: none;
+		margin-top: 32px;
+		margin-bottom: 0;
+		padding: 24px 30px;
+		border-radius: 4px;
+
+		&.is-dismissible {
+			.dismissible-card__close-button {
+				height: 16px;
+				width: 16px;
+
+				svg {
+					height: 16px;
+					width: 16px;
+				}
+			}
+		}
+
+		.banner__content {
+			gap: 16px;
+
+			@include breakpoint-deprecated( ">660px" ) {
+				gap: 32px;
+			}
+		}
+
+		.banner__title,
+		.banner__description {
+			color: var(--color-neutral-80);
+			font-size: $font-body-small;
+			line-height: 20px;
+		}
+
+		.banner__title {
+			font-weight: 500;
+		}
+
+		.banner__icon {
+			background-color: var(--studio-blue-50);
+			display: none;
+		}
+
+		.banner__icon-circle {
+			background-color: var(--studio-blue-50);
+		}
+
+		.banner__action .button {
+			background-color: var(--studio-blue-50);
+			border: none;
+			border-radius: 4px;
+			font-size: $font-body-small;
+			padding: 10px 14px;
+			line-height: 20px;
+			white-space: nowrap;
+		}
 	}
 }
 

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -11,9 +11,8 @@ body.is-section-themes-i4 {
 	}
 
 	.theme__filters {
-		@include break-small {
-			padding: 24px 0;
-		}
+		margin-top: 24px;
+		padding: 0;
 	}
 
 	.themes__selection .themes-list {


### PR DESCRIPTION
#### Proposed Changes

This PR updates the upsell banner as per the design spec to be similar to the one in the /plugins page.
![Screen Shot 2022-11-28 at 2 51 34 PM](https://user-images.githubusercontent.com/797888/204212503-b3b43b98-4abc-47cb-b49d-556fcb0a0042.png)

See comparison below:
| Before | After |
| --- | --- |
| ![Screen Shot 2022-11-28 at 2 52 15 PM](https://user-images.githubusercontent.com/797888/204212622-268a9ec9-95f6-4884-9c38-7bae10a1af5b.png) | ![Screen Shot 2022-11-28 at 2 52 35 PM](https://user-images.githubusercontent.com/797888/204212684-85fe2f1b-b8c4-45f2-9604-4d036368d7e8.png)

In addition, this PR also improves the CSS rule specificity when the class name `is-section-themes-i4` is applies to `<body/>`.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the Theme Showcase `/themes/${site_slug}`.
  * If using calypso.live, the flag `themes/showcase-i4/search-and-filter` is required.
* Ensure that the PR updates the page UI according to the description above.
* Ensure that mobile/table resolution works well with the new UI.
* Ensure that the existing UI works as before.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->