### PR TITLE
Reorder theme signup flow steps

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -84,10 +84,10 @@ export function generateFlows( {
 		},
 		{
 			name: 'with-theme',
-			steps: [ 'domains-theme-preselected', 'plans', 'user' ],
+			steps: [ 'user', 'domains-theme-preselected', 'plans' ],
 			destination: getChecklistThemeDestination,
 			description: 'Preselect a theme to activate/buy from an external source',
-			lastModified: '2020-08-11',
+			lastModified: '2022-11-28',
 			showRecaptcha: true,
 		},
 		{


### PR DESCRIPTION
#### Proposed Changes

Move the user step to the beginning of the theme signup flow rather than the end.

This not only avoids a bug (see #70177) which stops people logging into existing accounts from completing the flow but also experiments in other flows indicate that having the user stage last performs worse.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Go to /start/with-theme?ref=calypshowcase&theme=masu while logged out, this simulates choosing a theme from wordpress.com/themes while logged out
2. Enter the email address of an existing account on the registration page
3. Follow link to login on the validation message
4. Login (with 2fa if necessary)
5. After login you should get redirected back into the flow
6. Choose a domain
7. Choose a plan
8. Watch the loading screen
9. Get redirected to the home screen for the new site.

The flow should also get tested with creating a new account - follow the same steps as above but create a new account at step 2.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
