### PR TITLE
Virtual pages: update subtitle and tooltip copies

### DIFF
--- a/client/my-sites/pages/page-list.jsx
+++ b/client/my-sites/pages/page-list.jsx
@@ -282,7 +282,6 @@ class Pages extends Component {
 				type={ blockEditorSettings?.home_template?.postType }
 				/** We'd prefer to call it Homepage no matter which template is in use */
 				title={ translate( 'Homepage' ) }
-				description={ translate( 'The front page of your site' ) }
 				previewUrl={ site.URL }
 				isHomepage
 			/>

--- a/client/my-sites/pages/virtual-page/index.tsx
+++ b/client/my-sites/pages/virtual-page/index.tsx
@@ -23,12 +23,11 @@ interface Props {
 	id: string;
 	type: string;
 	title: string;
-	description?: string;
 	previewUrl?: string;
 	isHomepage?: boolean;
 }
 
-const VirtualPage = ( { site, id, type, title, description, previewUrl, isHomepage }: Props ) => {
+const VirtualPage = ( { site, id, type, title, previewUrl, isHomepage }: Props ) => {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 	const defaultEditorUrl = `/site-editor/${ site.slug }`;
@@ -83,9 +82,11 @@ const VirtualPage = ( { site, id, type, title, description, previewUrl, isHomepa
 					{ isHomepage && (
 						<InfoPopover position="right">
 							{ translate(
-								'The homepage of your site displays the %(title)s template. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+								'You can change the content of this page by editing the %(templateTitle)s template using the Site Editor. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
 								{
-									args: { title: decodeEntities( template.title.rendered || template.slug ) },
+									args: {
+										templateTitle: decodeEntities( template.title.rendered || template.slug ),
+									},
 									components: {
 										learnMoreLink: (
 											<ExternalLink
@@ -103,7 +104,11 @@ const VirtualPage = ( { site, id, type, title, description, previewUrl, isHomepa
 					) }
 				</a>
 				<div className="page-card-info">
-					{ description && <span className="page-card-info__description">{ description }</span> }
+					<span className="page-card-info__description">
+						{ translate( 'Showing the %(templateTitle)s template', {
+							args: { templateTitle: decodeEntities( template.title.rendered || template.slug ) },
+						} ) }
+					</span>
 				</div>
 			</div>
 			<EllipsisMenu position="bottom left" onToggle={ handleMenuToggle }>

--- a/client/my-sites/pages/virtual-page/index.tsx
+++ b/client/my-sites/pages/virtual-page/index.tsx
@@ -105,9 +105,10 @@ const VirtualPage = ( { site, id, type, title, previewUrl, isHomepage }: Props )
 				</a>
 				<div className="page-card-info">
 					<span className="page-card-info__description">
-						{ translate( 'Showing the %(templateTitle)s template', {
-							args: { templateTitle: decodeEntities( template.title.rendered || template.slug ) },
-						} ) }
+						{ isHomepage &&
+							translate( 'Showing the %(templateTitle)s template', {
+								args: { templateTitle: decodeEntities( template.title.rendered || template.slug ) },
+							} ) }
 					</span>
 				</div>
 			</div>


### PR DESCRIPTION
#### Proposed Changes

We want to emphasize the fact that the virtual homepage page is served by a template and is editable in the Site Editor.

| Before | After |
| ---- | ---- |
| <img width="400" alt="image" src="https://user-images.githubusercontent.com/1525580/204215753-8232bfda-8a07-4245-888e-c7d7ac5309c0.png"> | <img width="400" alt="image" src="https://user-images.githubusercontent.com/1525580/204244494-e0e24b57-da4f-40e2-839b-66eabc3dc1d2.png"> |
| <img width="400" alt="image" src="https://user-images.githubusercontent.com/1525580/204215688-85b94219-1d11-4a56-aab3-555d4277d9a3.png"> | <img width="400" alt="image" src="https://user-images.githubusercontent.com/1525580/204436191-1a99eda3-8e43-4815-9b09-47d08a4ca07a.png"> |

#### Testing Instructions

1. Check out this branch and run Calypso locally.
   - Or, if using the Calypso Live, append the `?flags=unified-pages/virtual-home-page` to the URL.
1. Set up a site satisfying the requirements in pdtkmj-MO-p2.
1.  Open `/pages/<site-slug>`
1. Verify that the copies are updated as per the above screenshots.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:

- #70466