### PR TITLE
Pattern Assembler - Pattern selection UX

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -101,8 +101,7 @@ const PatternAssembler: Step = ( { navigation } ) => {
 		);
 	};
 
-	const addSection = ( pattern: Pattern ) => {
-		incrementIndexRef.current++;
+	const replaceSection = ( pattern: Pattern ) => {
 		if ( sectionPosition !== null ) {
 			setSections( [
 				...sections.slice( 0, sectionPosition ),
@@ -113,16 +112,19 @@ const PatternAssembler: Step = ( { navigation } ) => {
 				...sections.slice( sectionPosition + 1 ),
 			] );
 			setScrollToSelectorByPosition( sectionPosition );
-		} else {
-			setSections( [
-				...( sections as Pattern[] ),
-				{
-					...pattern,
-					key: `${ incrementIndexRef.current }-${ pattern.id }`,
-				},
-			] );
-			setScrollToSelectorByPosition( sections.length );
 		}
+	};
+
+	const addSection = ( pattern: Pattern ) => {
+		incrementIndexRef.current++;
+		setSections( [
+			...( sections as Pattern[] ),
+			{
+				...pattern,
+				key: `${ incrementIndexRef.current }-${ pattern.id }`,
+			},
+		] );
+		setScrollToSelectorByPosition( sections.length );
 	};
 
 	const deleteSection = ( position: number ) => {
@@ -149,25 +151,33 @@ const PatternAssembler: Step = ( { navigation } ) => {
 		] );
 	};
 
-	const onSelect = ( pattern: Pattern | null ) => {
-		if ( pattern ) {
-			if ( 'header' === showPatternSelectorType ) {
-				setHeader( pattern );
-			}
-			if ( 'footer' === showPatternSelectorType ) {
-				setFooter( pattern );
-			}
-			if ( 'section' === showPatternSelectorType ) {
-				addSection( pattern );
-			}
-
-			if ( showPatternSelectorType ) {
-				trackEventPatternSelect( {
-					patternType: showPatternSelectorType,
-					patternId: pattern.id,
-				} );
+	const onSelect = ( selectedPattern: Pattern ) => {
+		if ( 'header' === showPatternSelectorType ) {
+			setHeader( selectedPattern );
+		}
+		if ( 'footer' === showPatternSelectorType ) {
+			setFooter( selectedPattern );
+		}
+		if ( 'section' === showPatternSelectorType ) {
+			if ( sectionPosition !== null ) {
+				replaceSection( selectedPattern );
+			} else {
+				addSection( selectedPattern );
 			}
 		}
+
+		if ( showPatternSelectorType ) {
+			trackEventPatternSelect( {
+				patternType: showPatternSelectorType,
+				patternId: selectedPattern.id,
+			} );
+		}
+
+		if ( 'section' === showPatternSelectorType && sectionPosition === null ) {
+			// Don't close the pattern selector when in multiple selection
+			return;
+		}
+
 		setShowPatternSelectorType( null );
 	};
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -152,6 +152,13 @@ const PatternAssembler: Step = ( { navigation } ) => {
 	};
 
 	const onSelect = ( selectedPattern: Pattern ) => {
+		if ( showPatternSelectorType ) {
+			trackEventPatternSelect( {
+				patternType: showPatternSelectorType,
+				patternId: selectedPattern.id,
+			} );
+		}
+
 		if ( 'header' === showPatternSelectorType ) {
 			setHeader( selectedPattern );
 		}
@@ -163,19 +170,9 @@ const PatternAssembler: Step = ( { navigation } ) => {
 				replaceSection( selectedPattern );
 			} else {
 				addSection( selectedPattern );
+				// Don't close the pattern selector when in multiple selection
+				return;
 			}
-		}
-
-		if ( showPatternSelectorType ) {
-			trackEventPatternSelect( {
-				patternType: showPatternSelectorType,
-				patternId: selectedPattern.id,
-			} );
-		}
-
-		if ( 'section' === showPatternSelectorType && sectionPosition === null ) {
-			// Don't close the pattern selector when in multiple selection
-			return;
 		}
 
 		setShowPatternSelectorType( null );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -170,12 +170,8 @@ const PatternAssembler: Step = ( { navigation } ) => {
 				replaceSection( selectedPattern );
 			} else {
 				addSection( selectedPattern );
-				// Don't close the pattern selector when in multiple selection
-				return;
 			}
 		}
-
-		setShowPatternSelectorType( null );
 	};
 
 	const onBack = () => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-selector-loader.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-selector-loader.tsx
@@ -44,9 +44,8 @@ const PatternSelectorLoader = ( {
 				patterns={ sectionPatterns }
 				onSelect={ onSelect }
 				onBack={ onBack }
-				title={ selectedPattern ? translate( 'Add a section' ) : translate( 'Add sections' ) }
+				title={ selectedPattern ? translate( 'Replace section' ) : translate( 'Add sections' ) }
 				selectedPattern={ selectedPattern }
-				multiple={ ! selectedPattern }
 			/>
 		</>
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-selector-loader.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-selector-loader.tsx
@@ -4,10 +4,10 @@ import { useHeaderPatterns, useFooterPatterns, useSectionPatterns } from './patt
 import type { Pattern } from './types';
 
 type PatternSelectorLoaderProps = {
-	onSelect: ( selectedPattern: Pattern | null ) => void;
-	onBack: () => void;
 	showPatternSelectorType: string | null;
 	selectedPattern: Pattern | null;
+	onSelect: ( selectedPattern: Pattern ) => void;
+	onBack: () => void;
 };
 
 const PatternSelectorLoader = ( {
@@ -44,8 +44,9 @@ const PatternSelectorLoader = ( {
 				patterns={ sectionPatterns }
 				onSelect={ onSelect }
 				onBack={ onBack }
-				title={ translate( 'Add sections' ) }
+				title={ selectedPattern ? translate( 'Add a section' ) : translate( 'Add sections' ) }
 				selectedPattern={ selectedPattern }
+				multiple={ ! selectedPattern }
 			/>
 		</>
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-selector.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-selector.tsx
@@ -18,7 +18,6 @@ type PatternSelectorProps = {
 	title: string | null;
 	show: boolean;
 	selectedPattern: Pattern | null;
-	multiple?: boolean;
 };
 
 const PatternSelector = ( {
@@ -28,7 +27,6 @@ const PatternSelector = ( {
 	title,
 	show,
 	selectedPattern,
-	multiple,
 }: PatternSelectorProps ) => {
 	const locale = useLocale();
 	const patternSelectorRef = useRef< HTMLDivElement >( null );
@@ -95,13 +93,11 @@ const PatternSelector = ( {
 					</Delayed>
 				</div>
 			</div>
-			{ multiple && (
-				<div className="pattern-selector__footer">
-					<Button className="pattern-assembler__button" onClick={ onBack } primary>
-						{ translate( 'Done' ) }
-					</Button>
-				</div>
-			) }
+			<div className="pattern-selector__footer">
+				<Button className="pattern-assembler__button" onClick={ onBack } primary>
+					{ translate( 'Done' ) }
+				</Button>
+			</div>
 		</div>
 	);
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-selector.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-selector.tsx
@@ -8,16 +8,17 @@ import { useSite } from '../../../../hooks/use-site';
 import { ONBOARD_STORE } from '../../../../stores';
 import Delayed from './delayed-render-hook';
 import PatternPreviewAutoHeight from './pattern-preview-auto-height';
-import { getPatternPreviewUrl, handleKeyboard } from './utils';
+import { getPatternPreviewUrl } from './utils';
 import type { Pattern } from './types';
 
 type PatternSelectorProps = {
 	patterns: Pattern[];
-	onSelect: ( selectedPattern: Pattern | null ) => void;
+	onSelect: ( selectedPattern: Pattern ) => void;
 	onBack: () => void;
 	title: string | null;
 	show: boolean;
 	selectedPattern: Pattern | null;
+	multiple?: boolean;
 };
 
 const PatternSelector = ( {
@@ -27,6 +28,7 @@ const PatternSelector = ( {
 	title,
 	show,
 	selectedPattern,
+	multiple,
 }: PatternSelectorProps ) => {
 	const locale = useLocale();
 	const patternSelectorRef = useRef< HTMLDivElement >( null );
@@ -39,6 +41,9 @@ const PatternSelector = ( {
 		if ( show ) {
 			patternSelectorRef.current?.focus();
 			patternSelectorRef.current?.removeAttribute( 'tabindex' );
+		} else {
+			// Scroll to top when it hides
+			patternSelectorRef.current?.querySelector( '.pattern-selector__body' )?.scrollTo( 0, 0 );
 		}
 	}, [ show ] );
 
@@ -55,17 +60,13 @@ const PatternSelector = ( {
 				patternId={ pattern.id }
 				patternName={ pattern.category }
 			>
-				<div
-					aria-label={ pattern.category }
+				<Button
 					tabIndex={ show ? 0 : -1 }
-					role="option"
 					title={ pattern.category }
-					aria-selected={ pattern.id === selectedPattern?.id }
 					className={ classnames( {
 						'pattern-selector__block-list--selected-pattern': pattern.id === selectedPattern?.id,
 					} ) }
 					onClick={ () => onSelect( pattern ) }
-					onKeyUp={ handleKeyboard( () => onSelect( pattern ) ) }
 				/>
 			</PatternPreviewAutoHeight>
 		) );
@@ -93,6 +94,13 @@ const PatternSelector = ( {
 						<>{ renderPatterns( restPatterns ) }</>
 					</Delayed>
 				</div>
+			</div>
+			<div className="pattern-selector__footer">
+				{ multiple && (
+					<Button className="pattern-assembler__button" onClick={ onBack } primary>
+						{ translate( 'Done' ) }
+					</Button>
+				) }
 			</div>
 		</div>
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-selector.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-selector.tsx
@@ -95,13 +95,13 @@ const PatternSelector = ( {
 					</Delayed>
 				</div>
 			</div>
-			<div className="pattern-selector__footer">
-				{ multiple && (
+			{ multiple && (
+				<div className="pattern-selector__footer">
 					<Button className="pattern-assembler__button" onClick={ onBack } primary>
 						{ translate( 'Done' ) }
 					</Button>
-				) }
-			</div>
+				</div>
+			) }
 		</div>
 	);
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
@@ -149,6 +149,7 @@ $font-family: "SF Pro Text", $sans;
 					font-family: inherit;
 					color: var(--color-link);
 					transition: color 0.2s ease-in;
+					background-color: transparent;
 				}
 
 				&:hover,
@@ -275,6 +276,7 @@ $font-family: "SF Pro Text", $sans;
 
 		.pattern-selector__body {
 			margin-top: 32px;
+			margin-bottom: 32px;
 			padding: 2px;
 			overflow-y: scroll;
 			scrollbar-width: none;
@@ -295,15 +297,18 @@ $font-family: "SF Pro Text", $sans;
 				transform: scale(0.268);
 				transform-origin: top left;
 				position: absolute;
+				left: 0;
 				border-radius: 4px;
 				pointer-events: none;
 				overflow: hidden;
 			}
 
-			div {
+			button {
+				display: block;
 				border: 1px solid rgba(0, 0, 0, 5%);
 				border-radius: 4px;
 				min-height: 140px;
+				width: 100%;
 				transform: translateZ(0);
 				overflow: hidden;
 				user-select: none;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
@@ -281,6 +281,10 @@ $font-family: "SF Pro Text", $sans;
 			overflow-y: scroll;
 			scrollbar-width: none;
 
+			&:last-child {
+				margin-bottom: 0;
+			}
+
 			&::-webkit-scrollbar {
 				display: none;
 			}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/utils.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/utils.ts
@@ -25,15 +25,6 @@ export const getPatternPreviewUrl = ( {
 	} );
 };
 
-// Runs the callback if the keys Enter or Spacebar are in the keyboard event
-export const handleKeyboard =
-	( callback: () => void ) =>
-	( { key }: { key: string } ) => {
-		if ( key === 'Enter' || key === ' ' ) {
-			callback();
-		}
-	};
-
 export function createCustomHomeTemplateContent(
 	stylesheet: string,
 	hasHeader: boolean,


### PR DESCRIPTION
#### Proposed Changes
* Keep the pattern selector open when adding/replacing a pattern without going back to the list on each click
  * Allow adding multiple sections patterns
* Cleaned the code
* Fixed a CSS background issue
* Make sure the list of available patterns is scrolled to the top

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Click on the Calypso Live [(direct link)](https://calypso.live/?image=registry.a8c.com/calypso/app:build-51114) in the first comment 
* Update the URL to `/setup?siteSlug=[ YOUR SITE ]&flags=signup/design-picker-pattern-assembler`
* Don't mark any goal or vertical
* In the Design Picker, scroll down to find the Blank canvas CTA, click on `Start designing` to access the Pattern Assembler 
* Add and replace patterns to confirm that the pattern selector remains open until you click on `Done` or the back button 
* Confirm that you can add multiple section patterns without going back to the list on each click

https://user-images.githubusercontent.com/1881481/205022026-b8b6a171-533b-4493-9c0e-5074705a4b65.mov

## Screenshots 
Showing the flow to `Replace section`

<img width="332" alt="Screen Shot 2565-12-13 at 12 12 37" src="https://user-images.githubusercontent.com/1881481/207232578-6515c527-f239-4616-af06-9a587f23e154.png">

<img width="322" alt="Screen Shot 2565-12-13 at 12 13 00" src="https://user-images.githubusercontent.com/1881481/207232575-e90e11e6-e4ac-442b-9c98-a4678b037e65.png">

<img width="336" alt="Screen Shot 2565-12-13 at 12 14 04" src="https://user-images.githubusercontent.com/1881481/207232558-cf781076-b2ab-46ce-8cca-828783dc3e4e.png">



#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/70461 https://github.com/Automattic/wp-calypso/issues/70473
