### PR TITLE
HelpCenter: show new help center to 50% of the users

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -391,7 +391,7 @@ function load_help_center() {
 		return false;
 	}
 
-	$current_segment = 30; // segment of existing users that will get the help center in %.
+	$current_segment = 50; // segment of existing users that will get the help center in %.
 	$user_segment    = get_current_user_id() % 100;
 
 	if ( $is_proxied || $user_segment < $current_segment ) {

--- a/packages/help-center/src/utils.ts
+++ b/packages/help-center/src/utils.ts
@@ -9,7 +9,7 @@ export function shouldShowHelpCenterToUser( userId: number ) {
 	const isNonProdEnv =
 		[ 'stage', 'development', 'horizon' ].includes( config( 'env_id' ) ) || isCalypsoLive();
 
-	const currentSegment = 30; //percentage of users that will see the Help Center, not the FAB
+	const currentSegment = 50; //percentage of users that will see the Help Center, not the FAB
 	const userSegment = userId % 100;
 	return isNonProdEnv || userSegment < currentSegment;
 }


### PR DESCRIPTION
#### Proposed Changes

* This PR bumps the user segment for showing the new help center.
* With this PR the help center will be shown to 50% of the users.

#### Testing Instructions
- Do a quick sanity check of the help center
- Test while not proxied, you can use `testing10percentid` user to try it.