### PR TITLE
Add Zendesk pre-sales chat widget to Jetpack Cloud pricing page

### DIFF
--- a/client/components/zendesk-chat-widget/index.tsx
+++ b/client/components/zendesk-chat-widget/index.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 
 interface Props {
-	chatId: string | null;
+	chatId: string | false;
 }
 
 const ZendeskChat = ( { chatId }: Props ) => {

--- a/client/components/zendesk-chat-widget/index.tsx
+++ b/client/components/zendesk-chat-widget/index.tsx
@@ -1,0 +1,27 @@
+import { useEffect } from 'react';
+
+interface Props {
+	chatId: string | null;
+}
+
+const ZendeskChat = ( { chatId }: Props ) => {
+	useEffect( () => {
+		if ( ! chatId ) {
+			return;
+		}
+
+		const script = document.createElement( 'script' );
+		script.src = 'https://static.zdassets.com/ekr/snippet.js?key=' + chatId;
+		script.type = 'text/javascript';
+		script.id = 'ze-snippet';
+
+		const container = document.getElementById( 'zendesk-chat-container' );
+		if ( container ) {
+			container.appendChild( script );
+		}
+	}, [ chatId ] );
+
+	return <div id="zendesk-chat-container" />;
+};
+
+export default ZendeskChat;

--- a/client/components/zendesk-chat-widget/test/index.js
+++ b/client/components/zendesk-chat-widget/test/index.js
@@ -1,0 +1,20 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render } from '@testing-library/react';
+import ZendeskChatWidget from '../index';
+
+describe( 'ZendeskChatWidget', () => {
+	test( 'should not include a script tag when no chat id is passed', () => {
+		const { container } = render( <ZendeskChatWidget /> );
+		expect( container.getElementsByTagName( 'script' ).length ).toBe( 0 );
+	} );
+
+	test( 'should contain the script tag and have the correct id', () => {
+		const { container } = render( <ZendeskChatWidget chatId="some-chat-id" /> );
+		const scriptTags = container.getElementsByTagName( 'script' );
+		expect( scriptTags.length ).toBe( 1 );
+		expect( scriptTags[ 0 ].id ).toBe( 'ze-snippet' );
+	} );
+} );

--- a/client/my-sites/checkout/composite-checkout/components/checkout-help-link.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-help-link.tsx
@@ -1,19 +1,8 @@
 import config from '@automattic/calypso-config';
-import {
-	isWpComBusinessPlan,
-	isWpComEcommercePlan,
-	isWpComPersonalPlan,
-	isWpComPremiumPlan,
-	isPlan,
-} from '@automattic/calypso-products';
 import { Gridicon } from '@automattic/components';
 import { HelpCenter } from '@automattic/data-stores';
-import {
-	SUPPORT_HAPPYCHAT,
-	SUPPORT_FORUM,
-	shouldShowHelpCenterToUser,
-} from '@automattic/help-center';
-import { useShoppingCart } from '@automattic/shopping-cart';
+import { SUPPORT_FORUM, shouldShowHelpCenterToUser } from '@automattic/help-center';
+import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import { keyframes } from '@emotion/react';
 import styled from '@emotion/styled';
 import { useDispatch as useDataStoreDispatch } from '@wordpress/data';
@@ -21,18 +10,16 @@ import { useTranslate } from 'i18n-calypso';
 import { useSelector, useDispatch } from 'react-redux';
 import QuerySupportTypes from 'calypso/blocks/inline-help/inline-help-query-support-types';
 import HappychatButtonUnstyled from 'calypso/components/happychat/button';
-import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
+import ZendeskChat from 'calypso/components/zendesk-chat-widget';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import getSupportLevel from 'calypso/state/happychat/selectors/get-support-level';
-import isHappychatAvailable from 'calypso/state/happychat/selectors/is-happychat-available';
-import isPresalesChatAvailable from 'calypso/state/happychat/selectors/is-presales-chat-available';
+import isPresalesZendeskChatAvailable from 'calypso/state/happychat/selectors/is-presales-zendesk-chat-available';
 import { showInlineHelpPopover } from 'calypso/state/inline-help/actions';
 import getSupportVariation from 'calypso/state/selectors/get-inline-help-support-variation';
 import isSupportVariationDetermined from 'calypso/state/selectors/is-support-variation-determined';
 import { getSectionName } from 'calypso/state/ui/selectors';
 import type { Theme } from '@automattic/composite-checkout';
-import type { ResponseCartProduct } from '@automattic/shopping-cart';
 
 const HELP_CENTER_STORE = HelpCenter.register();
 
@@ -152,30 +139,24 @@ const LoadingButton = styled.p< StyledProps >`
 export default function CheckoutHelpLink() {
 	const reduxDispatch = useDispatch();
 	const translate = useTranslate();
-	const cartKey = useCartKey();
-	const { responseCart } = useShoppingCart( cartKey );
-	const plans = responseCart.products.filter( ( product ) => isPlan( product ) );
 	const { setShowHelpCenter } = useDataStoreDispatch( HELP_CENTER_STORE );
+	const isEnglishLocale = useIsEnglishLocale();
 
 	const {
-		happyChatAvailable,
-		presalesChatAvailable,
+		presalesZendeskChatAvailable,
 		section,
 		userId,
 		supportVariationDetermined,
 		supportVariation,
 	} = useSelector( ( state ) => {
 		return {
-			happyChatAvailable: isHappychatAvailable( state ),
-			presalesChatAvailable: isPresalesChatAvailable( state ),
+			presalesZendeskChatAvailable: isPresalesZendeskChatAvailable( state ),
 			section: getSectionName( state ),
 			userId: getCurrentUserId( state ),
 			supportVariationDetermined: isSupportVariationDetermined( state ),
 			supportVariation: getSupportVariation( state ),
 		};
 	} );
-	const presalesEligiblePlanLabel = getHighestWpComPlanLabel( plans );
-	const isPresalesChatEligible = presalesChatAvailable && presalesEligiblePlanLabel;
 
 	const userAllowedToHelpCenter = !! (
 		userId &&
@@ -193,22 +174,18 @@ export default function CheckoutHelpLink() {
 		);
 	};
 
-	// If chat is available and the cart has a pre-sales plan or is already eligible for chat.
-	const shouldRenderPaymentChatButton =
-		happyChatAvailable && ( isPresalesChatEligible || supportVariation === SUPPORT_HAPPYCHAT );
+	const zendeskPresalesChatKey: string | false = config( 'zendesk_presales_chat_key' );
+	const isPresalesZendeskChatEligible = presalesZendeskChatAvailable && isEnglishLocale;
 
 	const hasDirectSupport = supportVariation !== SUPPORT_FORUM;
 
-	// If chat isn't available, use the inline help button instead.
+	// If pre-sales chat isn't available, use the inline help button instead.
 	return (
 		<CheckoutHelpLinkWrapper>
 			<QuerySupportTypes />
-			{ ! shouldRenderPaymentChatButton && ! supportVariationDetermined && <LoadingButton /> }
-			{ shouldRenderPaymentChatButton ? (
-				<PaymentChatButton
-					plan={ presalesEligiblePlanLabel }
-					openHelpCenter={ userAllowedToHelpCenter }
-				/>
+			{ ! isPresalesZendeskChatEligible && ! supportVariationDetermined && <LoadingButton /> }
+			{ isPresalesZendeskChatEligible ? (
+				<ZendeskChat chatId={ zendeskPresalesChatKey } />
 			) : (
 				supportVariationDetermined && (
 					<CheckoutSummaryHelpButton onClick={ handleHelpButtonClicked }>
@@ -231,20 +208,4 @@ export default function CheckoutHelpLink() {
 			) }
 		</CheckoutHelpLinkWrapper>
 	);
-}
-
-function getHighestWpComPlanLabel( plans: ResponseCartProduct[] ) {
-	const planMatchersInOrder = [
-		{ label: 'WordPress.com eCommerce', matcher: isWpComEcommercePlan },
-		{ label: 'WordPress.com Business', matcher: isWpComBusinessPlan },
-		{ label: 'WordPress.com Premium', matcher: isWpComPremiumPlan },
-		{ label: 'WordPress.com Personal', matcher: isWpComPersonalPlan },
-	];
-	for ( const { label, matcher } of planMatchersInOrder ) {
-		for ( const plan of plans ) {
-			if ( matcher( plan.product_slug ) ) {
-				return label;
-			}
-		}
-	}
 }

--- a/client/my-sites/plans/jetpack-plans/product-store/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/index.tsx
@@ -17,6 +17,7 @@ import { NeedMoreInfo } from './need-more-info';
 import { PricingBanner } from './pricing-banner';
 import { Recommendations } from './recommendations';
 import { UserLicensesDialog } from './user-licenses-dialog';
+import { ZendeskPreSalesChat } from './zendesk-presales-chat';
 import type { ViewType, ProductStoreProps } from './types';
 
 import './wpcom-styles.scss';
@@ -129,6 +130,7 @@ const ProductStore: React.FC< ProductStoreProps > = ( {
 			{ showJetpackFree && <JetpackFree urlQueryArgs={ urlQueryArgs } siteId={ siteId } /> }
 
 			<Recommendations />
+			<ZendeskPreSalesChat />
 			<OpenSourceSection />
 
 			{ currentView === 'bundles' && <NeedMoreInfo /> }

--- a/client/my-sites/plans/jetpack-plans/product-store/zendesk-presales-chat/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/zendesk-presales-chat/index.tsx
@@ -1,0 +1,38 @@
+import config from '@automattic/calypso-config';
+import { getLocaleSlug } from 'i18n-calypso';
+import { useMemo } from 'react';
+import { useSelector } from 'react-redux';
+import ZendeskChat from 'calypso/components/zendesk-chat-widget';
+import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import type { ConfigData } from '@automattic/create-calypso-config';
+
+export const ZendeskPreSalesChat: React.VFC = () => {
+	const zendeskChatKey = config( 'zendesk_presales_chat_key' ) as keyof ConfigData;
+	const isLoggedIn = useSelector( isUserLoggedIn );
+
+	const shouldShowZendeskPresalesChat = useMemo( () => {
+		const isEnglishLocale = ( config( 'english_locales' ) as string[] ).includes(
+			getLocaleSlug() ?? ''
+		);
+		const currentTime = new Date();
+
+		/**
+		 * This is for testing.. Remove this before merging..
+		 * This forces the time to be within the time span thst the chat wiget will show.
+		 */
+		//currentTime.setUTCHours( 16 );
+
+		return (
+			! isLoggedIn &&
+			isEnglishLocale &&
+			isJetpackCloud() &&
+			currentTime.getUTCHours() >= 15 &&
+			currentTime.getUTCHours() < 21 &&
+			currentTime.getUTCDay() !== 0 &&
+			currentTime.getUTCDay() !== 6
+		);
+	}, [ isLoggedIn ] );
+
+	return shouldShowZendeskPresalesChat ? <ZendeskChat chatId={ zendeskChatKey } /> : null;
+};

--- a/client/my-sites/plans/jetpack-plans/product-store/zendesk-presales-chat/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/zendesk-presales-chat/index.tsx
@@ -17,12 +17,6 @@ export const ZendeskPreSalesChat: React.VFC = () => {
 		);
 		const currentTime = new Date();
 
-		/**
-		 * This is for testing.. Remove this before merging..
-		 * This forces the time to be within the time span thst the chat wiget will show.
-		 */
-		//currentTime.setUTCHours( 16 );
-
 		return (
 			! isLoggedIn &&
 			isEnglishLocale &&

--- a/client/my-sites/plans/jetpack-plans/product-store/zendesk-presales-chat/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/zendesk-presales-chat/index.tsx
@@ -8,14 +8,14 @@ import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import type { ConfigData } from '@automattic/create-calypso-config';
 
 const isWithinChatHours = ( currentTime: Date ) => {
-	const [ THREE_PM, NINE_PM ] = [ 15, 21 ];
+	const [ NINE_AM, SEVEN_PM ] = [ 9, 19 ];
 	const [ SUNDAY, SATURDAY ] = [ 0, 6 ];
 
 	const utcHour = currentTime.getUTCHours();
 	const utcWeekDay = currentTime.getUTCDay();
 
 	return (
-		utcHour >= THREE_PM && utcHour < NINE_PM && utcWeekDay !== SUNDAY && utcWeekDay !== SATURDAY
+		utcHour >= NINE_AM && utcHour < SEVEN_PM && utcWeekDay !== SUNDAY && utcWeekDay !== SATURDAY
 	);
 };
 

--- a/client/my-sites/plans/jetpack-plans/product-store/zendesk-presales-chat/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/zendesk-presales-chat/index.tsx
@@ -7,6 +7,18 @@ import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import type { ConfigData } from '@automattic/create-calypso-config';
 
+const isWithinChatHours = ( currentTime: Date ) => {
+	const [ THREE_PM, NINE_PM ] = [ 15, 21 ];
+	const [ SUNDAY, SATURDAY ] = [ 0, 6 ];
+
+	const utcHour = currentTime.getUTCHours();
+	const utcWeekDay = currentTime.getUTCDay();
+
+	return (
+		utcHour >= THREE_PM && utcHour < NINE_PM && utcWeekDay !== SUNDAY && utcWeekDay !== SATURDAY
+	);
+};
+
 export const ZendeskPreSalesChat: React.VFC = () => {
 	const zendeskChatKey = config( 'zendesk_presales_chat_key' ) as keyof ConfigData;
 	const isLoggedIn = useSelector( isUserLoggedIn );
@@ -17,15 +29,7 @@ export const ZendeskPreSalesChat: React.VFC = () => {
 		);
 		const currentTime = new Date();
 
-		return (
-			! isLoggedIn &&
-			isEnglishLocale &&
-			isJetpackCloud() &&
-			currentTime.getUTCHours() >= 15 &&
-			currentTime.getUTCHours() < 21 &&
-			currentTime.getUTCDay() !== 0 &&
-			currentTime.getUTCDay() !== 6
-		);
+		return ! isLoggedIn && isEnglishLocale && isJetpackCloud() && isWithinChatHours( currentTime );
 	}, [ isLoggedIn ] );
 
 	return shouldShowZendeskPresalesChat ? <ZendeskChat chatId={ zendeskChatKey } /> : null;

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -5,8 +5,8 @@ import {
 	isDomainMapping,
 } from '@automattic/calypso-products';
 import { isBlankCanvasDesign } from '@automattic/design-picker';
-import { isNewsletterOrLinkInBioFlow, LINK_IN_BIO_TLD_FLOW } from '@automattic/onboarding';
-import { isCurrentPlanFlow } from '@automattic/onboarding/src';
+import { isNewsletterOrLinkInBioFlow } from '@automattic/onboarding';
+import { isCurrentPlanFlow, LINK_IN_BIO_TLD_FLOW } from '@automattic/onboarding/src';
 import debugModule from 'debug';
 import { getLocaleSlug } from 'i18n-calypso';
 import {
@@ -788,7 +788,7 @@ class Signup extends Component {
 
 		return (
 			! this.props.isLoggedIn &&
-			isCurrentPlanFlow( this.props.flowName ) &&
+			( isCurrentPlanFlow( this.props.flowName ) || this.props.flowName === 'onboarding' ) &&
 			isEnglishLocale &&
 			currentTime.getUTCHours() >= 15 &&
 			currentTime.getUTCHours() < 21 &&

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -6,7 +6,9 @@ import {
 } from '@automattic/calypso-products';
 import { isBlankCanvasDesign } from '@automattic/design-picker';
 import { isNewsletterOrLinkInBioFlow, LINK_IN_BIO_TLD_FLOW } from '@automattic/onboarding';
+import { isCurrentPlanFlow } from '@automattic/onboarding/src';
 import debugModule from 'debug';
+import { getLocaleSlug } from 'i18n-calypso';
 import {
 	clone,
 	defer,
@@ -28,6 +30,7 @@ import { connect } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
 import QuerySiteDomains from 'calypso/components/data/query-site-domains';
 import LocaleSuggestions from 'calypso/components/locale-suggestions';
+import ZendeskChat from 'calypso/components/zendesk-chat-widget';
 import { addHotJarScript } from 'calypso/lib/analytics/hotjar';
 import {
 	recordSignupStart,
@@ -779,6 +782,21 @@ class Signup extends Component {
 		}
 	}
 
+	shouldShowZendeskPresalesChat() {
+		const isEnglishLocale = config( 'english_locales' ).includes( getLocaleSlug() ?? '' );
+		const currentTime = new Date();
+
+		return (
+			! this.props.isLoggedIn &&
+			isCurrentPlanFlow( this.props.flowName ) &&
+			isEnglishLocale &&
+			currentTime.getUTCHours() >= 15 &&
+			currentTime.getUTCHours() < 21 &&
+			currentTime.getUTCDay() !== 0 &&
+			currentTime.getUTCDay() !== 6
+		);
+	}
+
 	getPageTitle() {
 		if ( isNewsletterOrLinkInBioFlow( this.props.flowName ) ) {
 			return this.props.pageTitle;
@@ -801,6 +819,8 @@ class Signup extends Component {
 		}
 
 		const isReskinned = isReskinnedFlow( this.props.flowName );
+		const zendeskChatKey = config( 'zendesk_presales_chat_key' );
+		const shouldShowZendeskPresalesChat = this.shouldShowZendeskPresalesChat();
 
 		return (
 			<>
@@ -835,6 +855,7 @@ class Signup extends Component {
 						/>
 					) }
 				</div>
+				{ shouldShowZendeskPresalesChat && <ZendeskChat chatId={ zendeskChatKey } /> }
 			</>
 		);
 	}

--- a/client/state/happychat/selectors/is-presales-zendesk-chat-available.js
+++ b/client/state/happychat/selectors/is-presales-zendesk-chat-available.js
@@ -1,0 +1,11 @@
+import 'calypso/state/happychat/init';
+
+/**
+ * Returns if presales zendesk chat is available.
+ *
+ * @param   {object}  state  Global state tree
+ * @returns {boolean}        true, when presales_zendesk is available
+ */
+export default function isPresalesZendeskChatAvailable( state ) {
+	return state.happychat?.user?.availability?.presale_zendesk ?? false;
+}

--- a/client/state/happychat/selectors/test/is-presales-zendesk-chat-available.js
+++ b/client/state/happychat/selectors/test/is-presales-zendesk-chat-available.js
@@ -1,0 +1,28 @@
+import isPresalesZendeskChatAvailable from '../is-presales-zendesk-chat-available';
+
+describe( '#isPresalesZendeskChatAvailable()', () => {
+	test( 'should return false if presales zendesk chat is not available', () => {
+		const isPresaleZendeskAvailable = isPresalesZendeskChatAvailable( {
+			happychat: {
+				user: {
+					availability: {
+						presale_zendesk: false,
+					},
+				},
+			},
+		} );
+		expect( isPresaleZendeskAvailable ).toBe( false );
+	} );
+	test( 'should return true if presales zendesk chat is available', () => {
+		const isPresaleZendeskAvailable = isPresalesZendeskChatAvailable( {
+			happychat: {
+				user: {
+					availability: {
+						presale_zendesk: true,
+					},
+				},
+			},
+		} );
+		expect( isPresaleZendeskAvailable ).toBe( true );
+	} );
+} );

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -35,6 +35,7 @@
 	"livechat_support_locales": [ "en", "en-gb" ],
 	"dsp_stripe_pub_key": "pk_live_51LYYzQF53KN4RFN0ePTwefdm7seki4pRuc4a19gPMGUba5mzuosz0IBR0cp4T57FiBgxK911ky0LNwlX2IHbm0SS00uPHEQNBO",
 	"dsp_widget_js_src": "https://widgets.wp.com/promote/widget.js",
+	"zendesk_presales_chat_key": false,
 	"upwork_support_locales": [
 		"de",
 		"de-at",

--- a/config/development.json
+++ b/config/development.json
@@ -24,6 +24,7 @@
 	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
 	"dsp_stripe_pub_key": "pk_live_51LYYzQF53KN4RFN0ePTwefdm7seki4pRuc4a19gPMGUba5mzuosz0IBR0cp4T57FiBgxK911ky0LNwlX2IHbm0SS00uPHEQNBO",
 	"dsp_widget_js_src": "https://widgets.wp.com/promote/widget.js",
+	"zendesk_presales_chat_key": "216bf91d-f10f-4f66-bf65-a0cba220cd38",
 	"features": {
 		"ad-tracking": false,
 		"calypso/help-center": true,

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -26,6 +26,7 @@
 		}
 	],
 	"oauth_client_id": 68663,
+	"zendesk_presales_chat_key": "216bf91d-f10f-4f66-bf65-a0cba220cd38",
 	"features": {
 		"activity-log/v2": true,
 		"always_use_logout_url": true,

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -26,7 +26,7 @@
 		}
 	],
 	"oauth_client_id": 68663,
-	"zendesk_presales_chat_key": "216bf91d-f10f-4f66-bf65-a0cba220cd38",
+	"zendesk_presales_chat_key": "d729d42c-b547-4750-a6f6-8b30534a5f12",
 	"features": {
 		"activity-log/v2": true,
 		"always_use_logout_url": true,

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -24,6 +24,7 @@
 		}
 	],
 	"oauth_client_id": 69041,
+	"zendesk_presales_chat_key": false,
 	"features": {
 		"activity-log/v2": true,
 		"ad-tracking": true,

--- a/config/production.json
+++ b/config/production.json
@@ -14,6 +14,7 @@
 	"bilmur_url": "/wp-content/js/bilmur.min.js",
 	"dsp_stripe_pub_key": "pk_live_51LYYzQF53KN4RFN0ePTwefdm7seki4pRuc4a19gPMGUba5mzuosz0IBR0cp4T57FiBgxK911ky0LNwlX2IHbm0SS00uPHEQNBO",
 	"dsp_widget_js_src": "https://widgets.wp.com/promote/widget.js",
+	"zendesk_presales_chat_key": false,
 	"features": {
 		"ad-tracking": true,
 		"bilmur-script": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -12,6 +12,7 @@
 	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
 	"dsp_stripe_pub_key": "pk_live_51LYYzQF53KN4RFN0ePTwefdm7seki4pRuc4a19gPMGUba5mzuosz0IBR0cp4T57FiBgxK911ky0LNwlX2IHbm0SS00uPHEQNBO",
 	"dsp_widget_js_src": "https://widgets.wp.com/promote/widget.js",
+	"zendesk_presales_chat_key": false,
 	"features": {
 		"ad-tracking": false,
 		"calypso/help-center": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -12,6 +12,7 @@
 	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
 	"dsp_stripe_pub_key": "pk_live_51LYYzQF53KN4RFN0ePTwefdm7seki4pRuc4a19gPMGUba5mzuosz0IBR0cp4T57FiBgxK911ky0LNwlX2IHbm0SS00uPHEQNBO",
 	"dsp_widget_js_src": "https://widgets.wp.com/promote/widget.js",
+	"zendesk_presales_chat_key": false,
 	"features": {
 		"ad-tracking": false,
 		"calypso/help-center": true,

--- a/packages/onboarding/src/utils/flows.ts
+++ b/packages/onboarding/src/utils/flows.ts
@@ -6,6 +6,13 @@ export const LINK_IN_BIO_POST_SETUP_FLOW = 'link-in-bio-post-setup';
 export const VIDEOPRESS_FLOW = 'videopress';
 export const IMPORT_FOCUSED_FLOW = 'import-focused';
 export const ECOMMERCE_FLOW = 'ecommerce';
+export const BUSINESS_FLOW = 'business';
+export const PREMIUM_FLOW = 'premium';
+export const PERSONAL_FLOW = 'personal';
+export const ECOMMERCE_MONTHLY_FLOW = 'ecommerce-monthly';
+export const BUSINESS_MONTHLY_FLOW = 'business-monthly';
+export const PREMIUM_MONTHLY_FLOW = 'premium-monthly';
+export const PERSONAL_MONTHLY_FLOW = 'personal-monthly';
 
 export const isLinkInBioFlow = ( flowName: string | null ) => {
 	return Boolean(
@@ -33,5 +40,21 @@ export const isTailoredSignupFlow = ( flowName: string | null ) => {
 			( isNewsletterOrLinkInBioFlow( flowName ) ||
 				VIDEOPRESS_FLOW === flowName ||
 				ECOMMERCE_FLOW === flowName )
+	);
+};
+
+export const isCurrentPlanFlow = ( flowName: string | null ) => {
+	return Boolean(
+		flowName &&
+			[
+				ECOMMERCE_FLOW,
+				BUSINESS_FLOW,
+				PREMIUM_FLOW,
+				PERSONAL_FLOW,
+				ECOMMERCE_MONTHLY_FLOW,
+				BUSINESS_MONTHLY_FLOW,
+				PREMIUM_MONTHLY_FLOW,
+				PERSONAL_MONTHLY_FLOW,
+			].includes( flowName )
 	);
 };


### PR DESCRIPTION
#### Proposed Changes

This PR Adds the Zendesk pre-sales chat widget on the Jetpack Cloud Pricing page, as a requirement described in p8wKgj-3em-p2#comment-16943

Asana task: 1202858161751496-as-1203406293146511/f

Implementation Notes:

This PR utilizes the `<ZendeskChat />` component that has already been created in https://github.com/Automattic/wp-calypso/pull/70594

![Screenshot on 2022-11-28 at 11-50-02](https://user-images.githubusercontent.com/11078128/204347919-f7a87793-a59a-463c-b30d-445fb36fafe4.png)


#### Testing Instructions

It's assumed that you are proxied.

- Do any one of these
    - If your current time is some time between 9am UTC thru 7pm UTC (09:00 thru 19:00) UTC, then:
        - Click on Jetpack Cloud live link below and wait for the redirect to complete, then go to `/pricing`
        - Logged in:  Verify you do **Not** see the chat widget on the bottom right of the viewport.
        - Logged out:  Verify you **Do** see the chat widget on the bottom right of the viewport.
    - or boot up this PR 
        - Run `git fetch && git checkout  add/zenddesk-widget-to-cloud-pricing`
        - Run `yarn start-jetpack-cloud`
        - Goto [http://jetpack.cloud.localhost:3000/pricing](http://jetpack.cloud.localhost:3000/pricing)
        - If your current time is **Not** some time between 9 UTC thru 19 UTC, then:
            - Logged out: Verify you do **Not** see the chat widget on the bottom right of the viewport.
            - Go to file: `client/my-sites/plans/jetpack-plans/product-store/zendesk-presales-chat/index.tsx`, right after `line 18`, add: `currentTime.setUTCHours( '16' );`  - (This will force us within the chat operating hours.)
        - Logged in:  Verify you do **Not** see the chat widget on the bottom right of the viewport.
        - Logged out:  Verify you **Do** see the chat widget on the bottom right of the viewport.


<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [X] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - 0-as-1203406293146511