### PR TITLE
Add variation IDs to paid product results

### DIFF
--- a/client/data/marketplace/constants.ts
+++ b/client/data/marketplace/constants.ts
@@ -44,4 +44,8 @@ export const RETURNABLE_FIELDS = [
 
 	// Images
 	'plugin.icons',
+
+	// Marketplace product fields
+	'plugin.store_product_monthly_id',
+	'plugin.store_product_yearly_id',
 ] as const;

--- a/client/data/marketplace/types.ts
+++ b/client/data/marketplace/types.ts
@@ -53,6 +53,8 @@ export type ESIndexResult = {
 	'plugin.support_threads'?: number;
 	'plugin.support_threads_resolved'?: number;
 	plugin: {
+		store_product_monthly_id?: number;
+		store_product_yearly_id?: number;
 		author: string;
 		title: string;
 		excerpt: string;

--- a/client/data/marketplace/use-es-query.ts
+++ b/client/data/marketplace/use-es-query.ts
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import languages, { LanguageSlug } from '@automattic/languages';
 import {
 	UseQueryResult,
@@ -129,7 +130,7 @@ export const getESPluginsInfiniteQueryParams = (
 		search( {
 			query: searchTerm,
 			author,
-			groupId: 'wporg',
+			groupId: config.isEnabled( 'marketplace-jetpack-plugin-search' ) ? 'marketplace' : 'wporg',
 			category: options.category,
 			pageHandle: pageParam + '',
 			pageSize,

--- a/client/data/marketplace/use-es-query.ts
+++ b/client/data/marketplace/use-es-query.ts
@@ -94,6 +94,10 @@ const mapIndexResultsToPluginData = ( results: ESHits ): Plugin[] => {
 			last_updated: hit.modified,
 			short_description: hit.plugin.excerpt, // TODO: add localization
 			icon: createIconUrl( hit.slug, hit.plugin.icons ),
+			variations: {
+				monthly: { product_id: hit.plugin.store_product_monthly_id },
+				yearly: { product_id: hit.plugin.store_product_yearly_id },
+			},
 			railcar,
 		};
 

--- a/client/my-sites/plugins/plugin-details-header/index.jsx
+++ b/client/my-sites/plugins/plugin-details-header/index.jsx
@@ -1,11 +1,9 @@
-import config from '@automattic/calypso-config';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import Badge from 'calypso/components/badge';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { formatNumberMetric } from 'calypso/lib/format-number-compact';
 import { preventWidows } from 'calypso/lib/formatting';
-import { getPluginAuthorKeyword } from 'calypso/lib/plugins/utils';
 import PluginRatings from 'calypso/my-sites/plugins/plugin-ratings/';
 import { useLocalizedPlugins } from 'calypso/my-sites/plugins/utils';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
@@ -132,11 +130,7 @@ function PluginDetailsHeaderPlaceholder() {
 }
 
 function getPluginAuthor( plugin ) {
-	if ( config.isEnabled( 'marketplace-jetpack-plugin-search' ) ) {
-		return plugin.author_name;
-	}
-
-	return getPluginAuthorKeyword( plugin );
+	return plugin.author_name;
 }
 
 export default PluginDetailsHeader;

--- a/client/my-sites/plugins/use-plugins/index.ts
+++ b/client/my-sites/plugins/use-plugins/index.ts
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import { Plugin } from 'calypso/data/marketplace/types';
@@ -133,7 +134,9 @@ const usePlugins = ( {
 			results = featuredPlugins?.length ?? 0;
 			break;
 		default:
-			plugins = [ ...dotComPlugins, ...ESPlugins ];
+			plugins = config.isEnabled( 'marketplace-jetpack-plugin-search' )
+				? [ ...dotComPlugins, ...ESPlugins ]
+				: ESPlugins;
 			isFetching = isFetchingDotCom || isFetchingES;
 			results = ( ESPagination?.results ?? 0 ) + dotComPlugins.length;
 			break;

--- a/client/my-sites/plugins/use-plugins/index.ts
+++ b/client/my-sites/plugins/use-plugins/index.ts
@@ -135,10 +135,15 @@ const usePlugins = ( {
 			break;
 		default:
 			plugins = config.isEnabled( 'marketplace-jetpack-plugin-search' )
-				? [ ...dotComPlugins, ...ESPlugins ]
-				: ESPlugins;
-			isFetching = isFetchingDotCom || isFetchingES;
-			results = ( ESPagination?.results ?? 0 ) + dotComPlugins.length;
+				? ESPlugins
+				: [ ...dotComPlugins, ...ESPlugins ];
+			isFetching = config.isEnabled( 'marketplace-jetpack-plugin-search' )
+				? isFetchingES
+				: isFetchingDotCom || isFetchingES;
+			results = config.isEnabled( 'marketplace-jetpack-plugin-search' )
+				? ESPagination?.results ?? 0
+				: ( ESPagination?.results ?? 0 ) + dotComPlugins.length;
+
 			break;
 	}
 

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -66,7 +66,7 @@
 		"livechat_solution": true,
 		"mailchimp": false,
 		"marketplace-domain-bundle": false,
-		"marketplace-jetpack-plugin-search": true,
+		"marketplace-jetpack-plugin-search": false,
 		"marketplace-personal-premium": false,
 		"marketplace-test": false,
 		"me/account/color-scheme-picker": true,

--- a/config/production.json
+++ b/config/production.json
@@ -73,7 +73,7 @@
 		"login/react-lost-password-screen": true,
 		"mailchimp": true,
 		"marketplace-domain-bundle": false,
-		"marketplace-jetpack-plugin-search": true,
+		"marketplace-jetpack-plugin-search": false,
 		"marketplace-personal-premium": false,
 		"marketplace-test": false,
 		"me/account-close": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -70,7 +70,7 @@
 		"login/react-lost-password-screen": true,
 		"mailchimp": true,
 		"marketplace-domain-bundle": true,
-		"marketplace-jetpack-plugin-search": true,
+		"marketplace-jetpack-plugin-search": false,
 		"marketplace-personal-premium": false,
 		"marketplace-test": true,
 		"me/account-close": true,

--- a/config/test.json
+++ b/config/test.json
@@ -60,7 +60,7 @@
 		"legal-updates-banner": true,
 		"limit-global-styles": true,
 		"mailchimp": true,
-		"marketplace-jetpack-plugin-search": true,
+		"marketplace-jetpack-plugin-search": false,
 		"marketplace-personal-premium": false,
 		"me/account-close": true,
 		"me/vat-details": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -79,7 +79,7 @@
 		"logmein": true,
 		"mailchimp": true,
 		"marketplace-domain-bundle": true,
-		"marketplace-jetpack-plugin-search": true,
+		"marketplace-jetpack-plugin-search": false,
 		"marketplace-personal-premium": false,
 		"marketplace-test": true,
 		"me/account-close": true,


### PR DESCRIPTION
#### Proposed Changes

* Query for the `store_product_yearly_id` and `store_product_monthly_id` fields
* Map these fields to the plugin type
* Add a feature flag for mixing the search results

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Visit `/plugins?flags=marketplace-jetpack-plugin-search`
- Search for a paid plugin, eg. `woocommerce-bookings`
- Scroll down
- Verify that the search results have prices listed:  
  <img width="1060" alt="CleanShot 2022-11-28 at 17 11 55@2x" src="https://user-images.githubusercontent.com/11555574/204326531-b93a5aa9-00fb-43e8-b5ca-a2f0f3835ca8.png">

> **Note** not all products have their variation IDs assigned yet in WC.com, so not all results will show prices

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #70479