### PR TITLE
Update sale banner copy

### DIFF
--- a/client/jetpack-cloud/sections/pricing/sale-banner/index.tsx
+++ b/client/jetpack-cloud/sections/pricing/sale-banner/index.tsx
@@ -62,7 +62,7 @@ const SaleBanner: React.FC< Props > = ( { coupon } ) => {
 						<div>
 							<b>{ saleTitle }</b>
 							&nbsp;
-							{ translate( 'Take %(discount)d%% off all annual Jetpack bundles and products.', {
+							{ translate( 'Take %(discount)d%% off all new annual Jetpack purchases.', {
 								args: { discount: coupon.final_discount },
 							} ) }
 						</div>


### PR DESCRIPTION
#### Proposed Changes

Update sale banner copy to communicate that the sale is only for new purchases

#### Testing Instructions

1. Start your local environment via `yarn start-jetpack-cloud`
2. Go to http://jetpack.cloud.localhost:3000/pricing
3. Confirm sale banner copy is updated correctly
![image](https://user-images.githubusercontent.com/65001528/204372510-bf561351-8ec0-4e25-b1c6-203d894cbce5.png)

Context: p1669665511987229-slack-C02L8G7V18X


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?