### PR TITLE
Show focus ring for segmented-control__item

### DIFF
--- a/client/components/segmented-control/style.scss
+++ b/client/components/segmented-control/style.scss
@@ -32,10 +32,6 @@
 	&.is-selected + .segmented-control__item .segmented-control__link {
 		border-left-color: var(--color-neutral-70);
 	}
-
-	.segmented-control__link:focus {
-		box-shadow: 0 0 0 2px var(--color-primary-light);
-	}
 }
 
 .segmented-control__link {
@@ -49,10 +45,15 @@
 	text-align: center;
 	transition: color 0.1s linear, background-color 0.1s linear;
 
-	&:focus {
+	.segmented-control__item:not(.is-selected) &:focus {
 		color: var(--color-neutral-70);
 		outline: none;
 		background-color: var(--color-neutral-0);
+	}
+
+	.accessible-focus &:focus {
+		box-shadow: 0 0 0 2px var(--color-primary-light);
+		outline: none;
 	}
 }
 

--- a/client/components/segmented-control/style.scss
+++ b/client/components/segmented-control/style.scss
@@ -32,6 +32,10 @@
 	&.is-selected + .segmented-control__item .segmented-control__link {
 		border-left-color: var(--color-neutral-70);
 	}
+
+	.segmented-control__link:focus {
+		box-shadow: 0 0 0 2px var(--color-primary-light);
+	}
 }
 
 .segmented-control__link {

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -113,11 +113,8 @@ body.is-section-themes-i4 {
 		padding: 4px;
 
 		.segmented-control__item {
-			margin-left: 2px;
-			margin-right: 2px;
-
 			&.is-selected {
-				.segmented-control__link:not(:focus) {
+				.segmented-control__link {
 					background-color: var(--color-surface);
 					box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
 					color: var(--color-neutral-100);
@@ -131,6 +128,10 @@ body.is-section-themes-i4 {
 				font-size: 0.875rem;
 				line-height: 20px;
 				padding: 0 16px;
+
+				.accessible-focus &:focus {
+					box-shadow: inset 0 0 0 2px var(--color-primary-light);
+				}
 			}
 		}
 	}

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -113,8 +113,11 @@ body.is-section-themes-i4 {
 		padding: 4px;
 
 		.segmented-control__item {
+			margin-left: 2px;
+			margin-right: 2px;
+
 			&.is-selected {
-				.segmented-control__link {
+				.segmented-control__link:not(:focus) {
 					background-color: var(--color-surface);
 					box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
 					color: var(--color-neutral-100);


### PR DESCRIPTION
#### Proposed Changes

* Show a focus ring when an item in the `segmented-control` is focused. 

I spotted this when testing [this](pdtkmj-OF-p2#comment-1296). 

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* You can try the existing code at https://horizon.wordpress.com/themes/:site. Try tabbing from the "Search themes..." box to the plan selector - the selected plan and available choices do not have a focus ring. 
* Apply this patch to your local dev environment and retry. It should now look like the video below. Note that the theme card also needs a focus ring in a couple of places - those will be done in a second PR. 



https://user-images.githubusercontent.com/6851384/204374998-490fb5e6-78ba-44c3-9358-651f1302ead0.mp4




#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #