### PR TITLE
Show standard focus ring for the Banner when it is a link

### DIFF
--- a/client/components/banner/style.scss
+++ b/client/components/banner/style.scss
@@ -48,6 +48,12 @@
 		}
 	}
 
+	&:focus {
+		&.is-card-link {
+			box-shadow: 0 0 0 2px var(--color-primary-light);
+		}
+	}
+
 	@include breakpoint-deprecated( ">480px" ) {
 		align-items: center;
 

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -76,6 +76,15 @@ body.is-section-themes-i4 {
 			line-height: 22px;
 			padding: 8px 14px;
 			white-space: nowrap;
+
+			&:hover {
+				background-color: var(--studio-blue-60);
+			}
+
+			.accessible-focus &:focus {
+				box-shadow: 0 0 0 2px var(--color-primary-light);
+				outline: 0;
+			}
 		}
 	}
 }


### PR DESCRIPTION
#### Proposed Changes

* When the Banner is a link, show the focus ring we use elsewhere instead of a dotted border which is hard to spot

I spotted this when testing [this](https://github.com/Automattic/wp-calypso/pull/pdtkmj-OF-p2#comment-1296).

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Before 

![image](https://user-images.githubusercontent.com/6851384/204378724-6b00d688-8d1f-4d26-b37d-e172020875bd.png)


After

![image](https://user-images.githubusercontent.com/6851384/204378698-e99af04a-bc08-422f-9a63-eaab7bcfe22d.png)

* You can try the existing code at https://horizon.wordpress.com/themes/:site. Make sure you select a site with the Free plan so you'll see the Banner. Confirm when focused that you see the before image above. 
* Apply this patch to your local dev environment and retry. Confirm you see the after image above. 
* This is a library component so you can try it at other locations - try it at, `/settings/performance/:site`, for example, which has several of these Banners. 

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
