### PR TITLE
HelpCenter: add hasTranslation checks for contact page

### DIFF
--- a/packages/help-center/src/components/help-center-contact-page.tsx
+++ b/packages/help-center/src/components/help-center-contact-page.tsx
@@ -80,9 +80,9 @@ export const HelpCenterContactPage: React.FC = () => {
 
 		if ( isLanguageSupported ) {
 			const language = getLanguage( locale )?.name;
-			return language && hasTranslation( `Email (${ language })` )
+			return language && hasTranslation( 'Email (%s)' )
 				? sprintf(
-						/* translators: %s is the language name */
+						// translators: %s is the language name
 						__( 'Email (%s)', __i18n_text_domain__ ),
 						language
 				  )
@@ -94,7 +94,7 @@ export const HelpCenterContactPage: React.FC = () => {
 		}
 
 		return __( 'Email', __i18n_text_domain__ );
-	}, [ __, locale, hasTranslation ] );
+	}, [ __, locale ] );
 
 	if ( isLoading ) {
 		return (

--- a/packages/help-center/src/components/help-center-contact-page.tsx
+++ b/packages/help-center/src/components/help-center-contact-page.tsx
@@ -9,7 +9,7 @@ import { useSupportAvailability } from '@automattic/data-stores';
 import { isDefaultLocale, getLanguage, useLocale } from '@automattic/i18n-utils';
 import { Notice } from '@wordpress/components';
 import { useEffect, useMemo } from '@wordpress/element';
-import { sprintf } from '@wordpress/i18n';
+import { hasTranslation, sprintf } from '@wordpress/i18n';
 import { comment, Icon } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
@@ -62,7 +62,7 @@ export const HelpCenterContactPage: React.FC = () => {
 	}, [ isLoading, renderChat.state, renderEmail.render ] );
 
 	const liveChatHeaderText = useMemo( () => {
-		if ( isDefaultLocale( locale ) ) {
+		if ( isDefaultLocale( locale ) || ! hasTranslation( 'Live chat (English)' ) ) {
 			return __( 'Live chat', __i18n_text_domain__ );
 		}
 
@@ -80,7 +80,7 @@ export const HelpCenterContactPage: React.FC = () => {
 
 		if ( isLanguageSupported ) {
 			const language = getLanguage( locale )?.name;
-			return language
+			return language && hasTranslation( `Email (${ language })` )
 				? sprintf(
 						/* translators: %s is the language name */
 						__( 'Email (%s)', __i18n_text_domain__ ),
@@ -89,8 +89,12 @@ export const HelpCenterContactPage: React.FC = () => {
 				: __( 'Email', __i18n_text_domain__ );
 		}
 
-		return __( 'Email (English)', __i18n_text_domain__ );
-	}, [ __, locale ] );
+		if ( hasTranslation( 'Email (English)' ) ) {
+			return __( 'Email (English)', __i18n_text_domain__ );
+		}
+
+		return __( 'Email', __i18n_text_domain__ );
+	}, [ __, locale, hasTranslation ] );
 
 	if ( isLoading ) {
 		return (


### PR DESCRIPTION
#### Proposed Changes
| Before  | After |
| ------------- | ------------- |
|  <img width="414" alt="Screenshot 2022-11-28 at 22 07 39" src="https://user-images.githubusercontent.com/7000684/204381257-0d9daa15-ebe7-4c1b-aa90-34ce6c38a33d.png"> |  <img width="416" alt="Screenshot 2022-11-28 at 22 06 57" src="https://user-images.githubusercontent.com/7000684/204381311-6d9d3b34-1e78-447e-acb6-2791323bc52a.png"> |

* Even though for the original PR the translations were reported as done [here](https://github.com/Automattic/wp-calypso/pull/70140#issuecomment-1326821071) we seem to be missing translations in the ETK. For example [here](https://translate.wordpress.org/projects/wp-plugins/full-site-editing/stable/fr/default/?filters%5Bstatus%5D=untranslated)
* This PR adds `hasTranslation` checks to mitigate this issue.

#### Testing Instructions
- Checkout this branch
- Sync the ETK with your sandbox
- Test on sandboxed simple site in the editor
- Make sure that you have French locale set
- Check the Email and Live chat strings in the help center contact page
Related to #70115
