### PR TITLE
Show focus ring on theme card; make focus border 2px like elsewhere

### DIFF
--- a/client/components/theme/style.scss
+++ b/client/components/theme/style.scss
@@ -206,6 +206,10 @@ $soft-launch-badge-font-size: 0.725rem;
 		}
 	}
 
+	&:focus .theme__thumbnail-label {
+		box-shadow: 0 0 0 2px var(--color-primary-light);
+	}
+
 	.theme__thumbnail-label {
 		opacity: 0;
 		pointer-events: none;
@@ -240,7 +244,6 @@ $soft-launch-badge-font-size: 0.725rem;
 	padding-top: 75%; // 4:3 screenshot ratio
 	padding-bottom: $theme-info-height;
 	position: relative;
-	overflow: hidden;
 }
 
 .theme__update-alert {
@@ -366,7 +369,7 @@ $soft-launch-badge-font-size: 0.725rem;
 
 		.accessible-focus &:focus {
 			z-index: z-index("root", ".accessible-focus .theme__more-button button:focus");
-			outline: solid 3px var(--color-primary-light);
+			box-shadow: 0 0 0 2px var(--color-primary-light);
 		}
 	}
 

--- a/client/components/theme/style.scss
+++ b/client/components/theme/style.scss
@@ -206,7 +206,7 @@ $soft-launch-badge-font-size: 0.725rem;
 		}
 	}
 
-	&:focus .theme__thumbnail-label {
+	.accessible-focus &:focus .theme__thumbnail-label {
 		box-shadow: 0 0 0 2px var(--color-primary-light);
 	}
 
@@ -244,6 +244,7 @@ $soft-launch-badge-font-size: 0.725rem;
 	padding-top: 75%; // 4:3 screenshot ratio
 	padding-bottom: $theme-info-height;
 	position: relative;
+	overflow: hidden;
 }
 
 .theme__update-alert {
@@ -369,7 +370,7 @@ $soft-launch-badge-font-size: 0.725rem;
 
 		.accessible-focus &:focus {
 			z-index: z-index("root", ".accessible-focus .theme__more-button button:focus");
-			box-shadow: 0 0 0 2px var(--color-primary-light);
+			box-shadow: inset 0 0 0 2px var(--color-primary-light);
 		}
 	}
 


### PR DESCRIPTION
#### Proposed Changes

* When tabbing around the theme search results, we should show what is focused. 
* The overflow button focus ring should be the same width as other focus rings and be fully visible

I spotted this when testing [this](https://github.com/Automattic/wp-calypso/pull/pdtkmj-OF-p2#comment-1296).

Here's a video of how it looks in this PR:

https://user-images.githubusercontent.com/6851384/204387743-8a31d3a1-2b2f-498b-a50e-19544b8461c4.mp4



#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* You can try the existing code at https://horizon.wordpress.com/themes/:site. Try tabbing from the "Search themes..." box to any of the theme cards in the search results. Note how the "INFO" label is shown on focus, but there is no ring, and it's not obvious. Also, note how the overflow button focus ring is not a complete square and is 1px thicker than elsewhere. 
* Apply this patch to your local dev environment and then repeat the above test. Confirm it is like the video.  

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #