### PR TITLE
Payments: Migrate PurchaseMetaprice to typescript

### DIFF
--- a/client/me/purchases/manage-purchase/purchase-meta-introductory-offer-detail.tsx
+++ b/client/me/purchases/manage-purchase/purchase-meta-introductory-offer-detail.tsx
@@ -1,0 +1,59 @@
+import { getIntroductoryOfferIntervalDisplay } from '@automattic/wpcom-checkout';
+import { useTranslate } from 'i18n-calypso';
+import {
+	isWithinIntroductoryOfferPeriod,
+	isIntroductoryOfferFreeTrial,
+} from 'calypso/lib/purchases';
+
+function PurchaseMetaIntroductoryOfferDetail( { purchase } ) {
+	const translate = useTranslate();
+
+	if ( ! isWithinIntroductoryOfferPeriod( purchase ) ) {
+		return null;
+	}
+
+	const text = getIntroductoryOfferIntervalDisplay(
+		translate,
+		purchase.introductoryOffer.intervalUnit,
+		purchase.introductoryOffer.intervalCount,
+		isIntroductoryOfferFreeTrial( purchase ),
+		'manage-purchases',
+		purchase.introductoryOffer.remainingRenewalsUsingOffer
+	);
+
+	let regularPriceText = null;
+	if ( purchase.introductoryOffer.isNextRenewalUsingOffer ) {
+		regularPriceText = translate(
+			'After the offer ends, the subscription price will be %(regularPrice)s',
+			{
+				args: {
+					regularPrice: purchase.regularPriceText,
+				},
+			}
+		);
+	} else if ( purchase.introductoryOffer.isNextRenewalProrated ) {
+		regularPriceText = translate(
+			'After the first renewal, the subscription price will be %(regularPrice)s',
+			{
+				args: {
+					regularPrice: purchase.regularPriceText,
+				},
+			}
+		);
+	}
+
+	return (
+		<>
+			<br />
+			<small> { text } </small>
+			{ regularPriceText && (
+				<>
+					{ ' ' }
+					<br /> <small> { regularPriceText } </small>{ ' ' }
+				</>
+			) }
+		</>
+	);
+}
+
+export default PurchaseMetaIntroductoryOfferDetail;

--- a/client/me/purchases/manage-purchase/purchase-meta-introductory-offer-detail.tsx
+++ b/client/me/purchases/manage-purchase/purchase-meta-introductory-offer-detail.tsx
@@ -4,56 +4,58 @@ import {
 	isWithinIntroductoryOfferPeriod,
 	isIntroductoryOfferFreeTrial,
 } from 'calypso/lib/purchases';
+import { Purchase } from 'calypso/lib/purchases/types';
 
-function PurchaseMetaIntroductoryOfferDetail( { purchase } ) {
+function PurchaseMetaIntroductoryOfferDetail( { purchase }: { purchase: Purchase } ) {
 	const translate = useTranslate();
 
 	if ( ! isWithinIntroductoryOfferPeriod( purchase ) ) {
 		return null;
 	}
-
-	const text = getIntroductoryOfferIntervalDisplay(
-		translate,
-		purchase.introductoryOffer.intervalUnit,
-		purchase.introductoryOffer.intervalCount,
-		isIntroductoryOfferFreeTrial( purchase ),
-		'manage-purchases',
-		purchase.introductoryOffer.remainingRenewalsUsingOffer
-	);
-
-	let regularPriceText = null;
-	if ( purchase.introductoryOffer.isNextRenewalUsingOffer ) {
-		regularPriceText = translate(
-			'After the offer ends, the subscription price will be %(regularPrice)s',
-			{
-				args: {
-					regularPrice: purchase.regularPriceText,
-				},
-			}
+	if ( purchase?.introductoryOffer && purchase.introductoryOffer !== null ) {
+		const text = getIntroductoryOfferIntervalDisplay(
+			translate,
+			purchase.introductoryOffer.intervalUnit,
+			purchase.introductoryOffer.intervalCount,
+			isIntroductoryOfferFreeTrial( purchase ),
+			'manage-purchases',
+			purchase.introductoryOffer.remainingRenewalsUsingOffer
 		);
-	} else if ( purchase.introductoryOffer.isNextRenewalProrated ) {
-		regularPriceText = translate(
-			'After the first renewal, the subscription price will be %(regularPrice)s',
-			{
-				args: {
-					regularPrice: purchase.regularPriceText,
-				},
-			}
+
+		let regularPriceText = null;
+		if ( purchase.introductoryOffer.isNextRenewalUsingOffer ) {
+			regularPriceText = translate(
+				'After the offer ends, the subscription price will be %(regularPrice)s',
+				{
+					args: {
+						regularPrice: purchase.regularPriceText,
+					},
+				}
+			);
+		} else if ( purchase.introductoryOffer.isNextRenewalProrated ) {
+			regularPriceText = translate(
+				'After the first renewal, the subscription price will be %(regularPrice)s',
+				{
+					args: {
+						regularPrice: purchase.regularPriceText,
+					},
+				}
+			);
+		}
+
+		return (
+			<>
+				<br />
+				<small> { text } </small>
+				{ regularPriceText && (
+					<>
+						{ ' ' }
+						<br /> <small> { regularPriceText } </small>{ ' ' }
+					</>
+				) }
+			</>
 		);
 	}
-
-	return (
-		<>
-			<br />
-			<small> { text } </small>
-			{ regularPriceText && (
-				<>
-					{ ' ' }
-					<br /> <small> { regularPriceText } </small>{ ' ' }
-				</>
-			) }
-		</>
-	);
 }
 
 export default PurchaseMetaIntroductoryOfferDetail;

--- a/client/me/purchases/manage-purchase/purchase-meta-price.tsx
+++ b/client/me/purchases/manage-purchase/purchase-meta-price.tsx
@@ -1,0 +1,125 @@
+import {
+	getPlan,
+	getProductFromSlug,
+	isDIFMProduct,
+	isDomainTransfer,
+	isEmailMonthly,
+	TERM_BIENNIALLY,
+	TERM_MONTHLY,
+} from '@automattic/calypso-products';
+import { useTranslate } from 'i18n-calypso';
+import {
+	isIncludedWithPlan,
+	isOneTimePurchase,
+	getDIFMTieredPurchaseDetails,
+} from 'calypso/lib/purchases';
+
+function PurchaseMetaPrice( { purchase } ) {
+	const translate = useTranslate();
+	const { productSlug, productDisplayPrice } = purchase;
+	const plan = getPlan( productSlug ) || getProductFromSlug( productSlug );
+
+	if ( isOneTimePurchase( purchase ) || isDomainTransfer( purchase ) ) {
+		if ( isDIFMProduct( purchase ) ) {
+			const difmTieredPurchaseDetails = getDIFMTieredPurchaseDetails( purchase );
+			if ( difmTieredPurchaseDetails && difmTieredPurchaseDetails.extraPageCount > 0 ) {
+				const {
+					extraPageCount,
+					formattedCostOfExtraPages: costOfExtraPages,
+					formattedOneTimeFee: oneTimeFee,
+				} = difmTieredPurchaseDetails;
+				return (
+					<div>
+						<div>
+							{ translate( 'Service: %(oneTimeFee)s (one-time)', {
+								args: {
+									oneTimeFee,
+								},
+							} ) }
+						</div>
+						<div>
+							{ translate(
+								'%(extraPageCount)d extra page: %(costOfExtraPages)s (one-time)',
+								'%(extraPageCount)d extra pages: %(costOfExtraPages)s (one-time)',
+								{
+									count: extraPageCount,
+									args: {
+										extraPageCount,
+										costOfExtraPages,
+									},
+								}
+							) }
+						</div>
+					</div>
+				);
+			}
+		}
+
+		// translators: displayPrice is the price of the purchase with localized currency (i.e. "C$10")
+		return translate( '{{displayPrice/}} {{period}}(one-time){{/period}}', {
+			components: {
+				displayPrice: (
+					<span
+						// eslint-disable-next-line react/no-danger
+						dangerouslySetInnerHTML={ { __html: productDisplayPrice } }
+					/>
+				),
+				period: <span className="manage-purchase__time-period" />,
+			},
+		} );
+	}
+
+	if ( isIncludedWithPlan( purchase ) ) {
+		return translate( 'Free with Plan' );
+	}
+
+	const getPeriod = () => {
+		if ( isEmailMonthly( purchase ) ) {
+			return translate( 'month' );
+		}
+
+		if ( plan && plan.term ) {
+			switch ( plan.term ) {
+				case TERM_BIENNIALLY:
+					return translate( 'two years' );
+				case TERM_MONTHLY:
+					return translate( 'month' );
+			}
+		}
+
+		if ( purchase.billPeriodLabel ) {
+			switch ( purchase.billPeriodLabel ) {
+				case 'per year':
+					return translate( 'year' );
+				case 'per month':
+					return translate( 'month' );
+				case 'per week':
+					return translate( 'week' );
+				case 'per day':
+					return translate( 'day' );
+			}
+		}
+
+		throw new Error( `Failed to get a billing term for ${ productSlug }` );
+	};
+
+	const getPriceLabel = ( period ) => {
+		//translators: displayPrice is the price of the purchase with localized currency (i.e. "C$10"), %(period)s is how long the plan is active (i.e. "year")
+		return translate( '{{displayPrice/}} {{period}}/ %(period)s{{/period}}', {
+			args: { period },
+			components: {
+				displayPrice: (
+					<span
+						// eslint-disable-next-line react/no-danger
+						dangerouslySetInnerHTML={ { __html: productDisplayPrice } }
+					/>
+				),
+				period: <span className="manage-purchase__time-period" />,
+			},
+		} );
+	};
+
+	return getPriceLabel( getPeriod() );
+}
+
+export default PurchaseMetaPrice;

--- a/client/me/purchases/manage-purchase/purchase-meta-price.tsx
+++ b/client/me/purchases/manage-purchase/purchase-meta-price.tsx
@@ -13,8 +13,9 @@ import {
 	isOneTimePurchase,
 	getDIFMTieredPurchaseDetails,
 } from 'calypso/lib/purchases';
+import { Purchase } from 'calypso/lib/purchases/types';
 
-function PurchaseMetaPrice( { purchase } ) {
+function PurchaseMetaPrice( { purchase }: { purchase: Purchase } ) {
 	const translate = useTranslate();
 	const { productSlug, productDisplayPrice } = purchase;
 	const plan = getPlan( productSlug ) || getProductFromSlug( productSlug );
@@ -22,7 +23,10 @@ function PurchaseMetaPrice( { purchase } ) {
 	if ( isOneTimePurchase( purchase ) || isDomainTransfer( purchase ) ) {
 		if ( isDIFMProduct( purchase ) ) {
 			const difmTieredPurchaseDetails = getDIFMTieredPurchaseDetails( purchase );
-			if ( difmTieredPurchaseDetails && difmTieredPurchaseDetails.extraPageCount > 0 ) {
+			if (
+				difmTieredPurchaseDetails?.extraPageCount &&
+				difmTieredPurchaseDetails.extraPageCount > 0
+			) {
 				const {
 					extraPageCount,
 					formattedCostOfExtraPages: costOfExtraPages,
@@ -78,7 +82,7 @@ function PurchaseMetaPrice( { purchase } ) {
 			return translate( 'month' );
 		}
 
-		if ( plan && plan.term ) {
+		if ( typeof plan === 'object' && plan.term ) {
 			switch ( plan.term ) {
 				case TERM_BIENNIALLY:
 					return translate( 'two years' );
@@ -103,7 +107,7 @@ function PurchaseMetaPrice( { purchase } ) {
 		throw new Error( `Failed to get a billing term for ${ productSlug }` );
 	};
 
-	const getPriceLabel = ( period ) => {
+	const getPriceLabel = ( period: string ) => {
 		//translators: displayPrice is the price of the purchase with localized currency (i.e. "C$10"), %(period)s is how long the plan is active (i.e. "year")
 		return translate( '{{displayPrice/}} {{period}}/ %(period)s{{/period}}', {
 			args: { period },

--- a/client/me/purchases/manage-purchase/purchase-meta-price.tsx
+++ b/client/me/purchases/manage-purchase/purchase-meta-price.tsx
@@ -13,7 +13,7 @@ import {
 	isOneTimePurchase,
 	getDIFMTieredPurchaseDetails,
 } from 'calypso/lib/purchases';
-import { Purchase } from 'calypso/lib/purchases/types';
+import type { Purchase } from 'calypso/lib/purchases/types';
 
 function PurchaseMetaPrice( { purchase }: { purchase: Purchase } ) {
 	const translate = useTranslate();

--- a/client/me/purchases/manage-purchase/purchase-meta-price.tsx
+++ b/client/me/purchases/manage-purchase/purchase-meta-price.tsx
@@ -104,7 +104,7 @@ function PurchaseMetaPrice( { purchase }: { purchase: Purchase } ) {
 			}
 		}
 
-		throw new Error( `Failed to get a billing term for ${ productSlug }` );
+		return translate( 'year' );
 	};
 
 	const getPriceLabel = ( period: string ) => {

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -8,7 +8,6 @@ import {
 } from '@automattic/calypso-products';
 import { Card } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
-import { getIntroductoryOfferIntervalDisplay } from '@automattic/wpcom-checkout';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { times } from 'lodash';
@@ -34,8 +33,6 @@ import {
 	isSubscription,
 	isCloseToExpiration,
 	isRenewable,
-	isWithinIntroductoryOfferPeriod,
-	isIntroductoryOfferFreeTrial,
 } from 'calypso/lib/purchases';
 import { CALYPSO_CONTACT, JETPACK_SUPPORT } from 'calypso/lib/url/support';
 import { getCurrentUser, getCurrentUserId } from 'calypso/state/current-user/selectors';
@@ -46,6 +43,7 @@ import { managePurchase } from '../paths';
 import { canEditPaymentDetails, isJetpackTemporarySitePurchase } from '../utils';
 import AutoRenewToggle from './auto-renew-toggle';
 import PaymentInfoBlock from './payment-info-block';
+import PurchaseMetaIntroductoryOfferDetail from './purchase-meta-introductory-offer-detail';
 import PurchaseMetaPrice from './purchase-meta-price';
 
 export default function PurchaseMeta( {
@@ -215,57 +213,6 @@ function PurchaseMetaOwner( { owner } ) {
 				<UserItem user={ { ...owner, name: owner.display_name } } />
 			</span>
 		</li>
-	);
-}
-
-function PurchaseMetaIntroductoryOfferDetail( { purchase } ) {
-	const translate = useTranslate();
-
-	if ( ! isWithinIntroductoryOfferPeriod( purchase ) ) {
-		return null;
-	}
-
-	const text = getIntroductoryOfferIntervalDisplay(
-		translate,
-		purchase.introductoryOffer.intervalUnit,
-		purchase.introductoryOffer.intervalCount,
-		isIntroductoryOfferFreeTrial( purchase ),
-		'manage-purchases',
-		purchase.introductoryOffer.remainingRenewalsUsingOffer
-	);
-
-	let regularPriceText = null;
-	if ( purchase.introductoryOffer.isNextRenewalUsingOffer ) {
-		regularPriceText = translate(
-			'After the offer ends, the subscription price will be %(regularPrice)s',
-			{
-				args: {
-					regularPrice: purchase.regularPriceText,
-				},
-			}
-		);
-	} else if ( purchase.introductoryOffer.isNextRenewalProrated ) {
-		regularPriceText = translate(
-			'After the first renewal, the subscription price will be %(regularPrice)s',
-			{
-				args: {
-					regularPrice: purchase.regularPriceText,
-				},
-			}
-		);
-	}
-
-	return (
-		<>
-			<br />
-			<small> { text } </small>
-			{ regularPriceText && (
-				<>
-					{ ' ' }
-					<br /> <small> { regularPriceText } </small>{ ' ' }
-				</>
-			) }
-		</>
 	);
 }
 

--- a/client/me/purchases/manage-purchase/test/purchase-meta-introductory-offer-detail.js
+++ b/client/me/purchases/manage-purchase/test/purchase-meta-introductory-offer-detail.js
@@ -1,0 +1,71 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/* eslint-disable jest/no-conditional-expect */
+/* eslint-disable jest/valid-title */
+
+import { render, screen } from '@testing-library/react';
+import { Provider as ReduxProvider } from 'react-redux';
+import { createReduxStore } from 'calypso/state';
+import PurchaseMeta from '../purchase-meta';
+
+describe( 'PurchaseMetaIntroductoryOfferDetail', () => {
+	it( 'does render "First 3 months free"', () => {
+		const store = createReduxStore(
+			{
+				purchases: {
+					data: [
+						{
+							ID: 1,
+							bill_period_label: 'per year',
+							bill_period_days: 365,
+							amount: 26.37,
+							currency_code: 'USD',
+							currency_symbol: '$',
+							expiry_date: '2023-03-02T00:00:00+00:00',
+							expiry_status: 'expiring',
+							introductory_offer: {
+								cost_per_interval: 0,
+								end_date: '2023-03-02T00:00:00+00:00',
+								interval_count: 3,
+								interval_unit: 'month',
+								is_next_renewal_prorated: true,
+								is_next_renewal_using_offer: false,
+								is_within_period: true,
+								remaining_renewals_using_offer: 0,
+								should_prorate_when_offer_ends: true,
+								transition_after_renewal_count: 0,
+							},
+							regular_price_text: '$35',
+						},
+					],
+				},
+				sites: {
+					requestingAll: false,
+				},
+				currentUser: {
+					id: 1,
+					user: {
+						primary_blog: 'example',
+					},
+				},
+			},
+			( state ) => state
+		);
+		render(
+			<ReduxProvider store={ store }>
+				<PurchaseMeta
+					hasLoadedPurchasesFromServer={ true }
+					purchaseId={ 1 }
+					siteSlug="test"
+					isDataLoading={ false }
+				/>
+			</ReduxProvider>
+		);
+		expect( screen.getByText( /First 3 months free\b/ ) ).toBeInTheDocument();
+		expect(
+			screen.getByText( /After the first renewal, the subscription price will be \$35\b/ )
+		).toBeInTheDocument();
+	} );
+} );

--- a/client/me/purchases/manage-purchase/test/purchase-meta-introductory-offer-detail.js
+++ b/client/me/purchases/manage-purchase/test/purchase-meta-introductory-offer-detail.js
@@ -2,9 +2,6 @@
  * @jest-environment jsdom
  */
 
-/* eslint-disable jest/no-conditional-expect */
-/* eslint-disable jest/valid-title */
-
 import { render, screen } from '@testing-library/react';
 import { Provider as ReduxProvider } from 'react-redux';
 import { createReduxStore } from 'calypso/state';


### PR DESCRIPTION
#### Proposed Changes

* Migrate purchaseMetaprice Component to typescript. This is related to refactor work already done at:
https://github.com/Automattic/wp-calypso/pull/69904

#### Testing Instructions

* As it is a TypeScript migration, it should not change anything so ensure that the usual functionality described below on the purchases page just works as expected.
* Goto this page `/purchases/subscriptions/:site/:purchaseID` , if the purchase is billed `per year`/`per month`/`per week`/`per day` then it should under the price column as `$price/period` where period is one of `year/month/week/day`  ![ALoapO.png](https://user-images.githubusercontent.com/552016/203852979-805d6eda-670c-4b6c-bd8a-76046f8bea77.png)
* If the purchase is a domain that came free with the plan then you should see `Free with plan` under the price column ![X3xZPs.png](https://user-images.githubusercontent.com/552016/203853193-e7de615f-ab1c-459e-8233-1aa32712d4b9.png)
* For DIFM products, purchase a DIFM product [from here](https://wordpress.com/do-it-for-me/), now on the purchases page, we should see the one-time fee mentioned followed by the `(one-time)` keyword ![7XRI2m.png](https://user-images.githubusercontent.com/552016/203854100-7b4e8c3a-ae62-475c-b6ee-af54a78f0089.png)

* All tests should pass as expected.

Fixes Automattic/payments-shilling#1304
