### PR TITLE
Stats: fix header styling for wp-admin

### DIFF
--- a/apps/stats/src/page-middleware/layout.jsx
+++ b/apps/stats/src/page-middleware/layout.jsx
@@ -28,7 +28,13 @@ export const ProviderWrappedLayout = ( {
 				<QueryClientProvider client={ queryClient }>
 					<ReduxProvider store={ store }>
 						<MomentProvider>
-							<Layout primary={ primary } secondary={ secondary } redirectUri={ redirectUri } />
+							<Layout
+								primary={ primary }
+								secondary={ secondary }
+								redirectUri={ redirectUri }
+								sectionName="stats"
+								groupName="sites"
+							/>
 						</MomentProvider>
 					</ReduxProvider>
 					<CalypsoReactQueryDevtools />

--- a/client/my-sites/stats/modernized-layout-styles.scss
+++ b/client/my-sites/stats/modernized-layout-styles.scss
@@ -60,7 +60,8 @@ $legacy-break-small: 660px;
 .wp-admin {
 	& .layout__content,
 	&.theme-default .focus-content .layout__content {
-		padding: 0;
+		padding-top: 0;
+		padding-left: 1px;
 	}
 	// Fixed header doesn't work well for WP-Admin, as the master isn't fixed.
 	& .is-section-stats .has-fixed-nav .fixed-navigation-header__header {

--- a/client/my-sites/stats/modernized-layout-styles.scss
+++ b/client/my-sites/stats/modernized-layout-styles.scss
@@ -63,7 +63,7 @@ $legacy-break-small: 660px;
 		padding-top: 0;
 		padding-left: 1px;
 	}
-	// Fixed header doesn't work well for WP-Admin, as the master isn't fixed.
+	// Fixed header doesn't work well for WP-Admin, as the masterbar isn't fixed.
 	& .is-section-stats .has-fixed-nav .fixed-navigation-header__header {
 		position: relative;
 		top: initial;

--- a/client/my-sites/stats/modernized-layout-styles.scss
+++ b/client/my-sites/stats/modernized-layout-styles.scss
@@ -56,3 +56,22 @@ $legacy-break-small: 660px;
 		}
 	}
 }
+
+.wp-admin {
+	& .layout__content,
+	&.theme-default .focus-content .layout__content {
+		padding: 0;
+	}
+	// Fixed header doesn't work well for WP-Admin, as the master isn't fixed.
+	& .is-section-stats .has-fixed-nav .fixed-navigation-header__header {
+		position: relative;
+		top: initial;
+		left: initial;
+	}
+	& .is-section-stats .has-fixed-nav {
+		padding-top: 0;
+	}
+	#wpcontent {
+		padding-left: 1px;
+	}
+}

--- a/client/my-sites/stats/modernized-layout-styles.scss
+++ b/client/my-sites/stats/modernized-layout-styles.scss
@@ -57,6 +57,7 @@ $legacy-break-small: 660px;
 	}
 }
 
+// Overrides paddings for WP Admin pages.
 .wp-admin {
 	& .layout__content,
 	&.theme-default .focus-content .layout__content {


### PR DESCRIPTION
#### Proposed Changes

Fixed header styling for WP Admin.

#### Testing Instructions

* Ensure Calypso Stats still looks okay
* Open Odyssey Stats `/wp-admin/admin.php?page=stats#!/stats/post/post_id/blog_slug`
* Ensure header for individual stats for posts looks reasonable

|Before   | After   |
|--------|--------|
|![image](https://user-images.githubusercontent.com/1425433/204406515-39c491e1-37ae-416a-b919-ed0b5adbbbb2.png) | ![image](https://user-images.githubusercontent.com/1425433/204406665-2b335880-d3c5-498f-91eb-94cdaff227b5.png)|

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

