### PR TITLE
Sites as landing page: Update tracks events names for consistency with other events

### DIFF
--- a/client/sites-dashboard/components/sites-dashboard-opt-in-banner.tsx
+++ b/client/sites-dashboard/components/sites-dashboard-opt-in-banner.tsx
@@ -76,7 +76,7 @@ export const SitesDashboardOptInBanner = ( { sites }: SitesDashboardOptInBannerP
 			useSitesAsLandingPage: true,
 			updatedAt: new Date().valueOf(),
 		} );
-		dispatch( recordTracksEvent( 'calypso_sites_as_landing_page_accepted' ) );
+		dispatch( recordTracksEvent( 'calypso_sites_dashboard_landing_page_banner_accept_click' ) );
 	};
 
 	const handleDismiss = () => {
@@ -84,12 +84,12 @@ export const SitesDashboardOptInBanner = ( { sites }: SitesDashboardOptInBannerP
 			useSitesAsLandingPage: false,
 			updatedAt: new Date().valueOf(),
 		} );
-		dispatch( recordTracksEvent( 'calypso_sites_as_landing_page_rejected' ) );
+		dispatch( recordTracksEvent( 'calypso_sites_dashboard_landing_page_banner_reject_click' ) );
 	};
 
 	return (
 		<>
-			<TrackComponentView eventName="calypso_sites_as_landing_page_seen" />
+			<TrackComponentView eventName="calypso_sites_dashboard_landing_page_banner_inview" />
 			<SitesNotice
 				status="is-info"
 				text={ __( 'Do you want to make this page your default when visiting WordPress.com?' ) }


### PR DESCRIPTION
#### Proposed Changes

Update the tracks events for the sites landing page banner so there names are more consistent.

* `calypso_sites_as_landing_page_accepted` => `calypso_sites_dashboard_landing_page_banner_accept_click`
* `calypso_sites_as_landing_page_rejected` => `calypso_sites_dashboard_landing_page_banner_reject_click`
* `calypso_sites_as_landing_page_seen` => `calypso_sites_dashboard_landing_page_banner_inview`

Our other events start with `calypso_sites_dashboard_` which is nice for sorting in the event viewer. I know we don't call it a "dashboard" in anything public facing, but (1) historically this is what our events have used and (2) there are a lot of other events that start with `calypso_sites_` so it disambiguates.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Check that the `inview` and `click` events get sent at the correct time. You can clear the user preference in order to bring the banner up again.

![CleanShot 2022-11-29 at 18 01 09@2x](https://user-images.githubusercontent.com/1500769/204443110-4648596e-fafe-45e7-b997-25275b6e1034.png)




Related to #70450
