### PR TITLE
Hotfix: add missing isEnabled 

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/primary/issue-license/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/issue-license/index.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import CardHeading from 'calypso/components/card-heading';


### PR DESCRIPTION
Fixes the issue caused by - https://github.com/Automattic/wp-calypso/pull/70269

Please follow the testing instructions there.
