### PR TITLE
Import focused flow improvements

### DIFF
--- a/client/landing/stepper/declarative-flow/import-flow.ts
+++ b/client/landing/stepper/declarative-flow/import-flow.ts
@@ -150,6 +150,8 @@ export const importFlow: Flow = {
 
 		const goNext = () => {
 			switch ( _currentStep ) {
+				case 'import':
+					return exitFlow( `/home/${ siteSlugParam }` );
 				default:
 					return navigate( 'import' );
 			}

--- a/client/landing/stepper/declarative-flow/import-flow.ts
+++ b/client/landing/stepper/declarative-flow/import-flow.ts
@@ -156,7 +156,12 @@ export const importFlow: Flow = {
 		};
 
 		const goToStep = ( step: StepPath | `${ StepPath }?${ string }` ) => {
-			navigate( step );
+			switch ( step ) {
+				case 'goals':
+					return exitFlow( `/setup/site-setup/goals?siteSlug=${ siteSlugParam }` );
+				default:
+					return navigate( step );
+			}
 		};
 
 		return { goNext, goBack, goToStep, submit };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/import/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/import/index.tsx
@@ -17,10 +17,21 @@ const isEnabledImportLight = isEnabled( 'onboarding/import-light-url-screen' );
 
 export const ImportWrapper: Step = function ( props ) {
 	const { __ } = useI18n();
-	const { navigation, children, stepName } = props;
+	const { navigation, children, stepName, flow } = props;
 	const currentRoute = useCurrentRoute();
-	const shouldHideSkipBtn = currentRoute !== BASE_ROUTE;
 	const shouldHideBackBtn = currentRoute === `${ IMPORT_FOCUSED_FLOW }/${ BASE_ROUTE }`;
+	const skipLabelText =
+		flow === IMPORT_FOCUSED_FLOW ? __( 'Skip to dashboard' ) : __( "I don't have a site address" );
+
+	const shouldHideSkipBtn = () => {
+		switch ( flow ) {
+			case IMPORT_FOCUSED_FLOW:
+				return currentRoute !== `${ flow }/${ BASE_ROUTE }`;
+
+			default:
+				return currentRoute !== `${ flow }/${ BASE_ROUTE }` || isEnabledImportLight;
+		}
+	};
 
 	return (
 		<>
@@ -30,12 +41,12 @@ export const ImportWrapper: Step = function ( props ) {
 				stepName={ stepName || 'import-step' }
 				flowName="importer"
 				className="import__onboarding-page"
-				hideSkip={ isEnabledImportLight || shouldHideSkipBtn }
+				hideSkip={ shouldHideSkipBtn() }
 				hideBack={ shouldHideBackBtn }
 				hideFormattedHeader={ true }
 				goBack={ navigation.goBack }
 				goNext={ navigation.goNext }
-				skipLabelText={ __( "I don't have a site address" ) }
+				skipLabelText={ skipLabelText }
 				isFullLayout={ true }
 				stepContent={ children as ReactElement }
 				recordTracksEvent={ recordTracksEvent }


### PR DESCRIPTION
#### Proposed Changes

- Show navigation "Skip to dashboard" button for import-focused flow
- Fix redirection to the goals step of the site setup flow
    - Before this commit, the Start building button redirects to the base step of the current flow instead of the goals step of the site setup flow.

#### Testing Instructions

**Skip to dashboard button**
* Go to `/setup/import-focused/import?siteSlug={SITE_SLUG}
* Check if there is the `Skip to dashboard` nav button

**Start building button**
* Go to `/setup/import-focused/import?siteSlug={SITE_SLUG}
* Enter any existing `wordpress.com` website
* Click on the `Start building` button
* Check if the `Start building` button redirects to the goals page

#### Screenshots
<img width="919" alt="Screenshot 2022-11-29 at 15 08 42" src="https://user-images.githubusercontent.com/1241413/204551500-07e2d41a-9f38-48ad-b894-89c1794c5a52.png">

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #69965
Closes #70484
