### PR TITLE
Split pricing plans block by plan

### DIFF
--- a/apps/happy-blocks/index.php
+++ b/apps/happy-blocks/index.php
@@ -176,7 +176,21 @@ HTML;
  */
 function a8c_happyblocks_register() {
 	register_block_type(
-		'happy-blocks/pricing-plans',
+		'happy-blocks/pricing-plans-premium',
+		array(
+			'api_version'     => 2,
+			'render_callback' => 'a8c_happyblocks_render_pricing_plans_callback',
+		)
+	);
+	register_block_type(
+		'happy-blocks/pricing-plans-business',
+		array(
+			'api_version'     => 2,
+			'render_callback' => 'a8c_happyblocks_render_pricing_plans_callback',
+		)
+	);
+	register_block_type(
+		'happy-blocks/pricing-plans-ecommerce',
 		array(
 			'api_version'     => 2,
 			'render_callback' => 'a8c_happyblocks_render_pricing_plans_callback',

--- a/apps/happy-blocks/src/pricing-plans/edit.tsx
+++ b/apps/happy-blocks/src/pricing-plans/edit.tsx
@@ -1,4 +1,5 @@
 import './edit.scss';
+import { PLAN_BUSINESS, PLAN_ECOMMERCE, PLAN_PREMIUM } from '@automattic/calypso-products';
 import { useBlockProps } from '@wordpress/block-editor';
 import { BlockEditProps } from '@wordpress/blocks';
 import { useEffect } from '@wordpress/element';
@@ -10,7 +11,12 @@ import config from './config';
 import usePricingPlans from './hooks/pricing-plans';
 import { BlockAttributes } from './types';
 
-export const Edit: FunctionComponent< BlockEditProps< BlockAttributes > > = ( {
+interface EditProps {
+	defaultPlan: string;
+}
+
+const Edit: FunctionComponent< BlockEditProps< BlockAttributes > & EditProps > = ( {
+	defaultPlan,
 	attributes,
 	setAttributes,
 } ) => {
@@ -19,10 +25,10 @@ export const Edit: FunctionComponent< BlockEditProps< BlockAttributes > > = ( {
 	// See https://github.com/WordPress/gutenberg/issues/7342
 	useEffect( () => {
 		setAttributes( {
-			productSlug: attributes.productSlug ?? config.plans[ 0 ],
+			productSlug: attributes.productSlug ?? defaultPlan,
 			domain: attributes.domain ?? config.domain,
 		} );
-	}, [ attributes.domain, attributes.productSlug, setAttributes ] );
+	}, [ attributes.domain, attributes.productSlug, defaultPlan, setAttributes ] );
 
 	useEffect( () => {
 		const blogIdSelect: HTMLSelectElement | null =
@@ -59,4 +65,16 @@ export const Edit: FunctionComponent< BlockEditProps< BlockAttributes > > = ( {
 			<PricingPlans plans={ plans } attributes={ attributes } setAttributes={ setAttributes } />
 		</div>
 	);
+};
+
+export const EditPremium = ( props: BlockEditProps< BlockAttributes > ) => {
+	return <Edit { ...props } defaultPlan={ PLAN_PREMIUM } />;
+};
+
+export const EditBusiness = ( props: BlockEditProps< BlockAttributes > ) => {
+	return <Edit { ...props } defaultPlan={ PLAN_BUSINESS } />;
+};
+
+export const EditEcommerce = ( props: BlockEditProps< BlockAttributes > ) => {
+	return <Edit { ...props } defaultPlan={ PLAN_ECOMMERCE } />;
 };

--- a/apps/happy-blocks/src/pricing-plans/index.jsx
+++ b/apps/happy-blocks/src/pricing-plans/index.jsx
@@ -1,7 +1,7 @@
 import { registerBlockType } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
 import config from './config';
-import { Edit } from './edit';
+import { EditBusiness, EditEcommerce, EditPremium } from './edit';
 
 const blockAttributes = {
 	productSlug: {
@@ -12,21 +12,51 @@ const blockAttributes = {
 	},
 };
 
-function registerBlock() {
-	registerBlockType( 'happy-blocks/pricing-plans', {
+function registerBlocks() {
+	registerBlockType( 'happy-blocks/pricing-plans-premium', {
 		apiVersion: 2,
-		title: __( 'Upgrade', 'happy-blocks' ),
+		title: __( 'Upgrade Premium', 'happy-blocks' ),
 		icon: 'money-alt',
 		category: 'embed',
-		description: __( 'List of available pricing plans', 'happy-blocks' ),
+		description: __( 'Premium pricing plan upgrade', 'happy-blocks' ),
 		keywords: [
 			__( 'pricing', 'happy-blocks' ),
 			__( 'plans', 'happy-blocks' ),
 			__( 'upgrade', 'happy-blocks' ),
 		],
 		attributes: blockAttributes,
-		edit: Edit,
+		edit: EditPremium,
+	} );
+
+	registerBlockType( 'happy-blocks/pricing-plans-business', {
+		apiVersion: 2,
+		title: __( 'Upgrade Business', 'happy-blocks' ),
+		icon: 'money-alt',
+		category: 'embed',
+		description: __( 'Business pricing plan upgrade', 'happy-blocks' ),
+		keywords: [
+			__( 'pricing', 'happy-blocks' ),
+			__( 'plans', 'happy-blocks' ),
+			__( 'upgrade', 'happy-blocks' ),
+		],
+		attributes: blockAttributes,
+		edit: EditBusiness,
+	} );
+
+	registerBlockType( 'happy-blocks/pricing-plans-ecommerce', {
+		apiVersion: 2,
+		title: __( 'Upgrade eCommerce', 'happy-blocks' ),
+		icon: 'money-alt',
+		category: 'embed',
+		description: __( 'eCommerce pricing plan upgrade', 'happy-blocks' ),
+		keywords: [
+			__( 'pricing', 'happy-blocks' ),
+			__( 'plans', 'happy-blocks' ),
+			__( 'upgrade', 'happy-blocks' ),
+		],
+		attributes: blockAttributes,
+		edit: EditEcommerce,
 	} );
 }
 
-registerBlock();
+registerBlocks();


### PR DESCRIPTION
#### Proposed Changes

This pull request splits the Pricing Plans block into three separate blocks (backed by the same implementation) that allow for faster usage by having each one provide different default plan. Plans can still be customised from the block settings if desired.

<img width="735" alt="image" src="https://user-images.githubusercontent.com/112691742/204466115-2b053373-845d-4a0f-a43e-439ab0e1c693.png">



#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run `yarn dev --sync` in `apps/happy-blocks` to sync code to your sandbox
* Create a new topic, in the editor press `/` and search for "Upgrade" block.
* On your sandbox, edit `wp-content/themes/a8c/supportforums/editor/gutenberg-wpcom.php` and add to the function `supportforums_gutenberg_setup_frontend` before `return $settings;` line:
```
$settings['iso']['blocks']['allowBlocks'][] = 'happy-blocks/pricing-plans-premium';
$settings['iso']['blocks']['allowBlocks'][] = 'happy-blocks/pricing-plans-business';
$settings['iso']['blocks']['allowBlocks'][] = 'happy-blocks/pricing-plans-ecommerce';
```
* Ensure the three different plan options show up, and each one creates a block with the correct pricing plan pre-selected
* Publish the post and ensure the view of the block shows correctly.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
