### PR TITLE
Add GET and COOKIE data sanitization

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/coming-soon.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/coming-soon.php
@@ -45,9 +45,9 @@ function should_show_coming_soon_page() {
  */
 function get_share_code() {
 	if ( isset( $_GET['share'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		return $_GET['share']; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		return sanitize_key( wp_unslash( $_GET['share'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 	} elseif ( isset( $_COOKIE['wp_share_code'] ) ) {
-		return $_COOKIE['wp_share_code'];
+		return sanitize_key( wp_unslash( $_COOKIE['wp_share_code'] ) );
 	}
 	return '';
 }


### PR DESCRIPTION
#### Proposed Changes

In this PR I propose to add GET and COOKIE data sanitization for recently added preview links feature.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
 
##### Simple site

1. Prepare a Coming Soon site and sandbox it
2. Apply D93335-code to sandbox and use the REST API endpoint to set a preview link for a Simple site, note the output
3. Get ETK from this PR deployed on the WPCOM sandbox, e.g.:

```
cd wp-calypso/
cd apps/editing-toolkit
yarn dev --sync
```

or:

```
install-plugin.sh editing-toolkit update/share-site-for-preview-sanitization
```

4. Try accessing the site in an incognito session, and confirm it serves the Coming Soon page
5. Access the site using the URL with appended code, e.g.:
https://SITE_SLUG.wordpress.com/?share=SHARE_CODE
6. Confirm that Coming Soon is not displayed anymore
7. Navigate through pages and confirm that they can be accessed
8. Remove `share_code` cookie to see Coming Soon again

##### Atomic site

1. Prepare an Atomic dev site
2. Apply D93335-code to sandbox and use the REST API endpoint to set a preview link for an Atomic site, note the output
3. Get ETK from this PR deployed on the Atomic site, e.g.:

- Pack `editing-toolkit-plugin/` directory
- Disable and remove managed ETK plugin
- Upload the new one to the Atomic dev site and activate it
- disable auto-udpates for the plugin

4. Try accessing the site in an incognito session, and confirm it serves the Coming Soon page
5. Access the site using the URL with appended code, e.g.:
https://SITE_SLUG.wpcomstaging.com/?share=SHARE_CODE
6. Confirm that Coming Soon is not displayed anymore
7. Navigate through pages and confirm that they can be accessed
8. Remove `share_code` cookie to see Coming Soon again

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1190-gh-Automattic/dotcom-forge and follow up for https://github.com/Automattic/wp-calypso/pull/70114