### PR TITLE
Prepare gifting release for 10% sites

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -632,9 +632,15 @@ export class SiteSettingsFormGeneral extends Component {
 			isSavingSettings,
 			handleSubmitForm,
 			hasSubscriptionGifting,
+			siteId,
 		} = this.props;
 
 		if ( ! isEnabled( 'subscription-gifting' ) ) {
+			return;
+		}
+
+		// TODO: remove when we're fully released
+		if ( siteId % 10 !== 0 ) {
 			return;
 		}
 

--- a/config/production.json
+++ b/config/production.json
@@ -132,6 +132,7 @@
 		"stepper-woocommerce-poc": true,
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,
+		"subscription-gifting": true,
 		"themes/atomic-homepage-replace": true,
 		"themes/plugin-bundling": true,
 		"themes/premium": true,


### PR DESCRIPTION
PLEASE DO NOT MERGE UNTIL WEDNESDAY, 30 AND @allilevine's  APPROVAL

#### Proposed Changes

* Add feature flag `subscription-gifting` to production config
* Add condition for showing gifting settings to only `blog_id % 10 === 0`, context [here](https://github.com/Automattic/dotcom-forge/issues/1282)

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/settings/general/:site`
* Check if gifting settings are guarded by the `blog_id % 10 === 0` criteria

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] ~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCY~sg-g6b-p2)?
- [ ] ~Have you checked for TypeScript, React or other console errors?~
- [ ] ~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~
- [ ] ~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~
- [ ] ~For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/1282