### PR TITLE
Reading Settings: Add new reading settings page route

### DIFF
--- a/client/my-sites/site-settings/settings-reading/controller.ts
+++ b/client/my-sites/site-settings/settings-reading/controller.ts
@@ -1,0 +1,8 @@
+import { Callback } from 'page';
+import { createElement } from 'react';
+import ReadingSettings from './main';
+
+export const createReadingSettings: Callback = ( context, next ) => {
+	context.primary = createElement( ReadingSettings );
+	next();
+};

--- a/client/my-sites/site-settings/settings-reading/index.ts
+++ b/client/my-sites/site-settings/settings-reading/index.ts
@@ -1,0 +1,17 @@
+import page from 'page';
+import { makeLayout, render as clientRender } from 'calypso/controller';
+import { navigation, siteSelection } from 'calypso/my-sites/controller';
+import { siteSettings } from 'calypso/my-sites/site-settings/settings-controller';
+import { createReadingSettings } from './controller';
+
+export default function () {
+	page(
+		'/settings/reading/:site_id',
+		siteSelection,
+		navigation,
+		siteSettings,
+		createReadingSettings,
+		makeLayout,
+		clientRender
+	);
+}

--- a/client/my-sites/site-settings/settings-reading/main.tsx
+++ b/client/my-sites/site-settings/settings-reading/main.tsx
@@ -1,0 +1,24 @@
+import config from '@automattic/calypso-config';
+import { useTranslate } from 'i18n-calypso';
+import DocumentHead from 'calypso/components/data/document-head';
+import FormattedHeader from 'calypso/components/formatted-header';
+import Main from 'calypso/components/main';
+
+const isEnabled = config.isEnabled( 'settings/modernize-reading-settings' );
+
+const ReadingSettings = () => {
+	const translate = useTranslate();
+
+	if ( ! isEnabled ) {
+		return null;
+	}
+
+	return (
+		<Main className="site-settings">
+			<DocumentHead title={ translate( 'Reading Settings' ) } />
+			<FormattedHeader brandFont headerText={ translate( 'Reading Settings' ) } align="left" />
+		</Main>
+	);
+};
+
+export default ReadingSettings;

--- a/client/sections.js
+++ b/client/sections.js
@@ -144,6 +144,12 @@ const sections = [
 		group: 'sites',
 	},
 	{
+		name: 'settings-reading',
+		paths: [ '/settings/reading' ],
+		module: 'calypso/my-sites/site-settings/settings-reading',
+		group: 'sites',
+	},
+	{
 		name: 'settings-discussion',
 		paths: [ '/settings/discussion' ],
 		module: 'calypso/my-sites/site-settings/settings-discussion',


### PR DESCRIPTION
#### Proposed Changes

* create `/settings/writing/<your-blog>` route for development of the new reading settings page
* display an empty page with document title and page title as "Reading Settings"

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run calypso locally go to https://wordpress.com/settings/reading/<your-blog>
* Page with Reading Settings title should be displayed

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

![Screen Shot 2022-11-29 at 11 51 14](https://user-images.githubusercontent.com/2019970/204510306-107c384a-1894-49b9-8176-3e3e1919d645.png)


Closes #70404 
