### PR TITLE
Domains: Fix incorrect "tabindex" property in DomainsTableHeader

### DIFF
--- a/client/my-sites/domains/domain-management/list/domains-table-header.jsx
+++ b/client/my-sites/domains/domain-management/list/domains-table-header.jsx
@@ -130,7 +130,7 @@ class DomainsTableHeader extends PureComponent {
 								'is-sortable': column?.isSortable,
 							} ) }
 							data-column={ column.name }
-							tabindex={ column?.isSortable ? 0 : -1 }
+							tabIndex={ column?.isSortable ? 0 : -1 }
 						>
 							{ column.label }{ ' ' }
 							{ column.bubble > 0 && (


### PR DESCRIPTION
#### Proposed Changes

This PR fixes an incorrect `tabindex` property with a lowercase `i` in the `DomainsTableHeader` component.

#### Testing Instructions

- Build this branch locally (the live Calypso link hides javascript warnings)
- Open your browser's developer console
- Go to the domains list page
- Ensure there's no "Warning: Invalid DOM property tabindex. Did you mean tabIndex?" warning shown in the console

#### Pre-merge Checklist

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #69489
