### PR TITLE
Gifting: Remove all gift products from the cart whenever one is removed

### DIFF
--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -566,6 +566,11 @@ export interface ResponseCartProduct {
 	subscription_id?: string;
 	introductory_offer_terms?: IntroductoryOfferTerms;
 
+	/**
+	 * True if the cart item represents a purchase for a different user's site.
+	 */
+	is_gift_purchase?: boolean;
+
 	// Temporary optional properties for the monthly pricing test
 	related_monthly_plan_cost_display?: string;
 	related_monthly_plan_cost_integer?: number;

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -1023,10 +1023,8 @@ function WPLineItem( {
 									.map( ( cart_product ) => cart_product.uuid );
 							}
 
-							product_uuids_to_remove.forEach( function ( product_uuid ) {
-								removeProductFromCart( product_uuid ).catch( () => {
-									// Nothing needs to be done here. CartMessages will display the error to the user.
-								} );
+							Promise.all( product_uuids_to_remove.map( removeProductFromCart ) ).catch( () => {
+								// Nothing needs to be done here. CartMessages will display the error to the user.
 							} );
 							onRemoveProduct?.( label );
 						} }


### PR DESCRIPTION
#### Proposed Changes

Subscription gifts need to be all or nothing -- for example, if someone manages to gift a plan renewal but not the corresponding primary domain renewal that was automatically added to the shopping cart, then the site would likely break when the domain expires, so it would have wound up being a confusing and not very useful gift.

Currently, this is mostly enforced on the server, but the user experience is bad -- for example, trying to remove the gift domain renewal from the cart does nothing (pdtkmj-Ks-p2#comment-1269).

This pull request makes it so removing any gift product from the cart automatically removes all the others, and changes the confirmation message for removing a gift (which previously didn't quite make sense for someone gifting a subscription to someone else's site) to match.

Before (removing a plan or domain, and in some cases the removal wouldn't actually work after you press "Continue"):

![remove-plan-before](https://user-images.githubusercontent.com/235183/204555028-02dc627b-447d-43bd-80a1-a63c2edaa24d.png)
![remove-domain-before](https://user-images.githubusercontent.com/235183/204555026-a3df508e-40bd-4d64-af4c-b1b31be9b906.png)

After (removing either the plan or the domain):

![remove-gift-after](https://user-images.githubusercontent.com/235183/204555027-a9caaadd-10dd-4770-8678-e8ad760174f2.png)


#### Testing Instructions

The easiest way to test this is to have a site with a Personal plan and custom domain, where the custom domain is set to primary, and where subscription gifting is turned on via `/settings/general/`.

Log in as a different user, and visit a URL like `/checkout/personal-bundle/gift/[ID]`, where ID is the subscription ID (obtained from the server, or from the number in the URL when the original user clicks through to manage their subscription from the Purchases page).  This should put the plan and domain renewal in your shopping cart as a gift.

Test that if you go to remove either the plan or domain from the cart, the expected confirmation message is shown, and that going through with the removal causes both products to be removed from the cart and the cart to be emptied.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->