### PR TITLE
Update createRequestAction to correctly handle an empty API response

### DIFF
--- a/client/state/data-layer/wpcom-http/test/index.js
+++ b/client/state/data-layer/wpcom-http/test/index.js
@@ -40,6 +40,20 @@ describe( '#queueRequest', () => {
 		} );
 	} );
 
+	test( 'should call `onSuccess` when a response returns with an empty string', () => {
+		return new Promise( ( done ) => {
+			const data = '';
+			nock( 'https://public-api.wordpress.com:443' ).get( '/rest/v1.1/me' ).reply( 200, data );
+
+			const dispatch = ( action ) => {
+				expect( action ).toEqual( extendAction( succeeder, successMeta( data ) ) );
+				done();
+			};
+
+			http( { dispatch }, getMe );
+		} );
+	} );
+
 	test( 'should call `onFailure` when a response returns with an error', () => {
 		return new Promise( ( done ) => {
 			const error = { error: 'bad' };


### PR DESCRIPTION
See conversation in p1669734008636179-slack-C7YPUHBB2

Discovered with https://github.com/Automattic/wp-calypso/pull/70480#issuecomment-1329980914

## Proposed Changes

*

## Testing Instructions

Tests should pass.