### PR TITLE
Jetpack pricing page: standardize headings

### DIFF
--- a/client/components/jetpack/card/jetpack-product-card/display-price/paid.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/display-price/paid.tsx
@@ -52,7 +52,12 @@ const Paid: React.FC< OwnProps > = ( {
 
 	const renderDiscountedPrice = () => {
 		const theDiscountedPrice = (
-			<PlanPrice discounted rawPrice={ finalPrice as number } currencyCode={ currencyCode } />
+			<PlanPrice
+				discounted
+				rawPrice={ finalPrice as number }
+				currencyCode={ currencyCode }
+				omitHeading
+			/>
 		);
 		/*
 		 * Price should be displayed from left-to-right, even in right-to-left
@@ -68,6 +73,7 @@ const Paid: React.FC< OwnProps > = ( {
 					className="display-price__original-price"
 					rawPrice={ originalPrice as number }
 					currencyCode={ currencyCode }
+					omitHeading
 				/>
 				{ ! discountedPriceFirst && theDiscountedPrice }
 			</>
@@ -75,7 +81,12 @@ const Paid: React.FC< OwnProps > = ( {
 	};
 
 	const renderNonDiscountedPrice = () => (
-		<PlanPrice discounted rawPrice={ finalPrice as number } currencyCode={ currencyCode } />
+		<PlanPrice
+			discounted
+			rawPrice={ finalPrice as number }
+			currencyCode={ currencyCode }
+			omitHeading
+		/>
 	);
 
 	const renderPrice = () =>

--- a/client/jetpack-cloud/sections/pricing/style.scss
+++ b/client/jetpack-cloud/sections/pricing/style.scss
@@ -12,9 +12,6 @@
 
 	font-family: Inter, $sans;
 
-	h2 {
-		line-height: inherit;
-	}
 	#header {
 		display: none;
 	}

--- a/client/my-sites/plan-price/index.jsx
+++ b/client/my-sites/plan-price/index.jsx
@@ -2,7 +2,7 @@ import { getCurrencyObject } from '@automattic/format-currency';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
-import { Component } from 'react';
+import { Component, createElement } from 'react';
 import Badge from 'calypso/components/badge';
 
 import './style.scss';
@@ -21,12 +21,15 @@ export class PlanPrice extends Component {
 			isOnSale,
 			taxText,
 			translate,
+			omitHeading,
 		} = this.props;
 
 		const classes = classNames( 'plan-price', className, {
 			'is-original': original,
 			'is-discounted': discounted,
 		} );
+
+		const tagName = omitHeading ? 'span' : 'h4';
 
 		// productDisplayPrice is returned from Store Price and provides a geo-IDed currency format
 		const shouldUseDisplayPrice = () => {
@@ -42,14 +45,14 @@ export class PlanPrice extends Component {
 		};
 
 		if ( shouldUseDisplayPrice() ) {
-			return (
-				<h4 className={ classes }>
-					<span
-						className="plan-price__integer"
-						// eslint-disable-next-line react/no-danger
-						dangerouslySetInnerHTML={ { __html: productDisplayPrice } }
-					/>
-				</h4>
+			return createElement(
+				tagName,
+				{ className: classes },
+				<span
+					className="plan-price__integer"
+					// eslint-disable-next-line react/no-danger
+					dangerouslySetInnerHTML={ { __html: productDisplayPrice } }
+				/>
 			);
 		}
 
@@ -115,8 +118,10 @@ export class PlanPrice extends Component {
 		const smallerPriceHtml = renderPriceHtml( priceRange[ 0 ] );
 		const higherPriceHtml = priceRange[ 1 ] && renderPriceHtml( priceRange[ 1 ] );
 
-		return (
-			<span className={ classes }>
+		return createElement(
+			tagName,
+			{ className: classes },
+			<>
 				<sup className="plan-price__currency-symbol">{ priceRange[ 0 ].price.symbol }</sup>
 				{ ! higherPriceHtml && renderPriceHtml( priceRange[ 0 ] ) }
 				{ higherPriceHtml &&
@@ -139,7 +144,7 @@ export class PlanPrice extends Component {
 					</span>
 				) }
 				{ isOnSale && <Badge>{ saleBadgeText }</Badge> }
-			</span>
+			</>
 		);
 	}
 }
@@ -158,6 +163,7 @@ PlanPrice.propTypes = {
 	displayPerMonthNotation: PropTypes.bool,
 	currencyFormatOptions: PropTypes.object,
 	productDisplayPrice: PropTypes.string,
+	omitHeading: PropTypes.bool,
 };
 
 PlanPrice.defaultProps = {

--- a/client/my-sites/plan-price/index.jsx
+++ b/client/my-sites/plan-price/index.jsx
@@ -116,7 +116,7 @@ export class PlanPrice extends Component {
 		const higherPriceHtml = priceRange[ 1 ] && renderPriceHtml( priceRange[ 1 ] );
 
 		return (
-			<h4 className={ classes }>
+			<span className={ classes }>
 				<sup className="plan-price__currency-symbol">{ priceRange[ 0 ].price.symbol }</sup>
 				{ ! higherPriceHtml && renderPriceHtml( priceRange[ 0 ] ) }
 				{ higherPriceHtml &&
@@ -139,7 +139,7 @@ export class PlanPrice extends Component {
 					</span>
 				) }
 				{ isOnSale && <Badge>{ saleBadgeText }</Badge> }
-			</h4>
+			</span>
 		);
 	}
 }

--- a/client/my-sites/plans/jetpack-plans/faq/style.scss
+++ b/client/my-sites/plans/jetpack-plans/faq/style.scss
@@ -12,6 +12,7 @@
 
 	font-size: 1.5rem;
 	font-weight: 700;
+	line-height: 1.5;
 	letter-spacing: -1px;
 	text-align: center;
 

--- a/client/my-sites/plans/jetpack-plans/open-source/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/open-source/index.tsx
@@ -8,7 +8,7 @@ const OpenSourceSection: React.FC = () => {
 	return (
 		<div className="jetpack-open-source">
 			<img className="jetpack-open-source__icon" width="54" height="48" src={ icon } alt="" />
-			<h3 className="jetpack-open-source__title">{ translate( 'Five for the Future' ) }</h3>
+			<h2 className="jetpack-open-source__title">{ translate( 'Five for the Future' ) }</h2>
 			<p className="jetpack-open-source__desc">
 				{ translate(
 					'Jetpack contributes {{link}}5% of its resources{{/link}} into WordPress development. That means each Jetpack purchase helps improve the sustainability of the WordPress community and the future of the open web.',

--- a/client/my-sites/plans/jetpack-plans/open-source/style.scss
+++ b/client/my-sites/plans/jetpack-plans/open-source/style.scss
@@ -22,8 +22,9 @@
 .jetpack-open-source__title {
 	margin-bottom: 1rem;
 
-	font-size: 1.5rem !important;
-	font-weight: 700 !important;
+	font-size: 1.5rem;
+	font-weight: 700;
+	line-height: 1;
 }
 
 .jetpack-open-source__desc {

--- a/client/my-sites/plans/jetpack-plans/product-store/featured-item-card/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/featured-item-card/index.tsx
@@ -21,7 +21,7 @@ export const FeaturedItemCard: React.FC< FeaturedItemCardProps > = ( {
 
 			<div className="featured-item-card--body">
 				<div>
-					<h2 className="featured-item-card--title">{ title }</h2>
+					<h3 className="featured-item-card--title">{ title }</h3>
 					<div className="featured-item-card--price">{ price }</div>
 					<div className="featured-item-card--desc">{ description }</div>
 				</div>

--- a/client/my-sites/plans/jetpack-plans/product-store/featured-item-card/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/featured-item-card/style.scss
@@ -54,6 +54,7 @@
 .featured-item-card--title {
 	font-size: $font-title-medium;
 	font-weight: 700;
+	line-height: 1;
 
 	@include break-medium {
 		font-size: $font-title-large;

--- a/client/my-sites/plans/jetpack-plans/product-store/items-list/all-items.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/items-list/all-items.tsx
@@ -35,7 +35,7 @@ export const AllItems: React.FC< AllItemsProps > = ( {
 
 	return (
 		<div className={ wrapperClassName }>
-			<h3 className="jetpack-product-store__all-items--header">{ heading }</h3>
+			<h2 className="jetpack-product-store__all-items--header">{ heading }</h2>
 
 			<ul className="jetpack-product-store__all-items--grid">
 				{ items.map( ( item ) => {

--- a/client/my-sites/plans/jetpack-plans/product-store/items-list/most-popular.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/items-list/most-popular.tsx
@@ -36,7 +36,7 @@ export const MostPopular: React.FC< MostPopularProps > = ( {
 
 	return (
 		<div className={ wrapperClassName }>
-			<h3 className="jetpack-product-store__most-popular--heading">{ heading }</h3>
+			<h2 className="jetpack-product-store__most-popular--heading">{ heading }</h2>
 			<ul className="jetpack-product-store__most-popular--items">
 				{ items.map( ( item ) => {
 					const isOwned = getIsOwned( item );

--- a/client/my-sites/plans/jetpack-plans/product-store/items-list/style-most-popular.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/items-list/style-most-popular.scss
@@ -9,7 +9,7 @@
 	margin-bottom: rem(24px);
 	font-size: $font-title-small;
 	font-weight: 700;
-	line-height: rem(29px);
+	line-height: 1.2;
 
 	@include break-medium {
 		margin-bottom: rem(32px);

--- a/client/my-sites/plans/jetpack-plans/product-store/items-list/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/items-list/style.scss
@@ -38,11 +38,6 @@
 	}
 }
 
-
-.jetpack-product-store__all-items h3 {
-	margin-bottom: 2.5em;
-}
-
 .jetpack-product-store__all-items--header {
 	margin-top: rem(32px);
 	margin-bottom: rem(24px);
@@ -51,7 +46,7 @@
 
 	@include break-medium {
 		margin-top: rem(72px);
-		margin-bottom: rem(48px);
+		margin-bottom: rem(60px);
 		font-size: $font-title-medium;
 		line-height: rem(29px);
 		font-weight: 600;

--- a/client/my-sites/plans/jetpack-plans/product-store/jetpack-free/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/jetpack-free/index.tsx
@@ -12,9 +12,9 @@ export const JetpackFree: React.FC< JetpackFreeProps > = ( { urlQueryArgs, siteI
 
 	return (
 		<div className="jetpack-product-store__jetpack-free">
-			<h3 className="jetpack-product-store__jetpack-free--headline">
+			<h2 className="jetpack-product-store__jetpack-free--headline">
 				{ translate( 'Still not sure?' ) }
-			</h3>
+			</h2>
 			<p className="jetpack-product-store__jetpack-free--info">
 				{ translate( 'Start with the free version and try out our premium products later.' ) }
 			</p>

--- a/client/my-sites/plans/jetpack-plans/product-store/jetpack-free/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/jetpack-free/style.scss
@@ -7,6 +7,7 @@
 
 .jetpack-product-store__jetpack-free--headline {
 	font-size: $font-title-large;
+	line-height: 1;
 	margin-bottom: 1em;
 }
 

--- a/client/my-sites/plans/jetpack-plans/product-store/need-more-info/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/need-more-info/index.tsx
@@ -12,9 +12,9 @@ export const NeedMoreInfo: React.FC = () => {
 
 	return (
 		<div className="jetpack-product-store__need-more-info">
-			<h3 className="jetpack-product-store__need-more-info-headline">
+			<h2 className="jetpack-product-store__need-more-info-headline">
 				{ translate( 'Need more info?' ) }
-			</h3>
+			</h2>
 			<div className="jetpack-product-store__need-more-info-buttons">
 				<MoreInfoBox
 					buttonLabel={ translate( 'Compare all product bundles' ) }

--- a/client/my-sites/plans/jetpack-plans/product-store/recommendations/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/recommendations/index.tsx
@@ -30,9 +30,9 @@ export const Recommendations: React.FC = () => {
 
 	return (
 		<div className="jetpack-product-store__recommendations">
-			<p className="jetpack-product-store__recommendations--title">
+			<h2 className="jetpack-product-store__recommendations--title">
 				{ translate( 'Recommended by the biggest names in WordPress' ) }
-			</p>
+			</h2>
 			<ul className="jetpack-product-store__recommendations--logos">
 				{ details.map( ( { logo, alt } ) => (
 					<li key={ alt }>

--- a/client/my-sites/plans/jetpack-plans/product-store/recommendations/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/recommendations/style.scss
@@ -3,6 +3,11 @@
 }
 
 .jetpack-product-store__recommendations--title {
+	margin-bottom: 1.5em;
+
+	font-size: 1.25rem;
+	font-weight: 400;
+	line-height: 1.2;
 	text-align: center;
 }
 

--- a/client/my-sites/plans/jetpack-plans/product-store/simple-item-card/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/simple-item-card/style.scss
@@ -47,6 +47,7 @@
 
 .simple-item-card__title {
 	font-size: $font-title-medium;
+	font-weight: 600;
 	line-height: rem(29px);
 	margin-bottom: 0 !important;
 	color: var(--studio-gray-100);

--- a/client/my-sites/plans/jetpack-plans/product-store/wpcom-styles.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/wpcom-styles.scss
@@ -21,28 +21,6 @@ $wpcom-menu-collapse: 783px;
 		border-width: 0;
 	}
 
-	// h2 {
-	// 	font-size: $font-title-small;
-	// 	font-weight: 600;
-	// 	line-height: 32px;
-
-	// 	@include break-small {
-	// 		font-size: $font-headline-small;
-	// 		line-height: 40px;
-	// 	}
-	// }
-
-	// h3 {
-	// 	font-size: $font-body;
-	// 	font-weight: 600;
-	// 	line-height: 23px;
-
-	// 	@include break-small {
-	// 		font-size: $font-title-small;
-	// 		line-height: 23px;
-	// 	}
-	// }
-
 	// Start after the collapsible admin menu shows up
 	@media (min-width: $wpcom-menu-collapse) {
 		@media (max-width: $break-wide) {

--- a/client/my-sites/plans/jetpack-plans/product-store/wpcom-styles.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/wpcom-styles.scss
@@ -21,27 +21,27 @@ $wpcom-menu-collapse: 783px;
 		border-width: 0;
 	}
 
-	h2 {
-		font-size: $font-title-small;
-		font-weight: 600;
-		line-height: 32px;
+	// h2 {
+	// 	font-size: $font-title-small;
+	// 	font-weight: 600;
+	// 	line-height: 32px;
 
-		@include break-small {
-			font-size: $font-headline-small;
-			line-height: 40px;
-		}
-	}
+	// 	@include break-small {
+	// 		font-size: $font-headline-small;
+	// 		line-height: 40px;
+	// 	}
+	// }
 
-	h3 {
-		font-size: $font-body;
-		font-weight: 600;
-		line-height: 23px;
+	// h3 {
+	// 	font-size: $font-body;
+	// 	font-weight: 600;
+	// 	line-height: 23px;
 
-		@include break-small {
-			font-size: $font-title-small;
-			line-height: 23px;
-		}
-	}
+	// 	@include break-small {
+	// 		font-size: $font-title-small;
+	// 		line-height: 23px;
+	// 	}
+	// }
 
 	// Start after the collapsible admin menu shows up
 	@media (min-width: $wpcom-menu-collapse) {


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR reorganizes heading levels in the Jetpack pricing page so that the page conforms to the [1.3.1 Info and Relationships](https://www.w3.org/TR/WCAG21/#info-and-relationships) accessibility guideline.

### Implementation notes

This PR removes the global `h2` and `h3` styles of the pricing page. Given the differences in style between the page headings, they introduced too much complexity.

It also removes units from headings line heights, which ensures a consistent rendering across browsers.

### Testing instructions

- Spin up the pricing page in Cloud, using the live link below, or by running the branch locally
- Check that the page looks like production (headings line heights may differ slightly)
- Optionally, open [the VoiceOver rotor ](https://support.apple.com/en-ca/guide/voiceover/mchlp2719/mac) or any other screen reader equivalent: you should see the document outline shown in the capture below
- Visit the pricing page in Calypso blue
- Check that headings look like the ones in the Cloud pricing page

### Screenshots

_Before: the programmatically determined outline of the document makes little sense_
<img width="500" alt="Screen Shot 2022-11-29 at 10 32 00 AM" src="https://user-images.githubusercontent.com/1620183/204574195-0fcef45d-7134-470a-82ad-6944c75ee41f.png">


_After: the programmatically determined document outline now matches the visual representation of the page_
<img width="500" alt="Screen Shot 2022-11-29 at 10 31 37 AM" src="https://user-images.githubusercontent.com/1620183/204574168-c9bd445f-d55b-4a57-a625-23180d91684e.png">
