### PR TITLE
Reading Settings: Create blank reading settings sections

### DIFF
--- a/client/my-sites/site-settings/settings-reading/main.tsx
+++ b/client/my-sites/site-settings/settings-reading/main.tsx
@@ -3,6 +3,9 @@ import { useTranslate } from 'i18n-calypso';
 import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
 import Main from 'calypso/components/main';
+import { NewsletterSettingsSection } from './newsletter-settings-section';
+import { RssFeedSettingsSection } from './rss-feed-settings-section';
+import { SiteSettingsSection } from './site-settings-section';
 
 const isEnabled = config.isEnabled( 'settings/modernize-reading-settings' );
 
@@ -17,6 +20,11 @@ const ReadingSettings = () => {
 		<Main className="site-settings">
 			<DocumentHead title={ translate( 'Reading Settings' ) } />
 			<FormattedHeader brandFont headerText={ translate( 'Reading Settings' ) } align="left" />
+			<form>
+				<SiteSettingsSection />
+				<RssFeedSettingsSection />
+				<NewsletterSettingsSection />
+			</form>
 		</Main>
 	);
 };

--- a/client/my-sites/site-settings/settings-reading/newsletter-settings-section.tsx
+++ b/client/my-sites/site-settings/settings-reading/newsletter-settings-section.tsx
@@ -1,0 +1,15 @@
+import { Card } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
+
+export const NewsletterSettingsSection = () => {
+	const translate = useTranslate();
+
+	return (
+		<>
+			{ /* @ts-expect-error SettingsSectionHeader is not typed and is causing errors */ }
+			<SettingsSectionHeader title={ translate( 'Newsletter settings' ) } showButton={ true } />
+			<Card>{ /* Newsletter settings will go here */ }</Card>
+		</>
+	);
+};

--- a/client/my-sites/site-settings/settings-reading/rss-feed-settings-section.tsx
+++ b/client/my-sites/site-settings/settings-reading/rss-feed-settings-section.tsx
@@ -1,0 +1,15 @@
+import { Card } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
+
+export const RssFeedSettingsSection = () => {
+	const translate = useTranslate();
+
+	return (
+		<>
+			{ /* @ts-expect-error SettingsSectionHeader is not typed and is causing errors */ }
+			<SettingsSectionHeader title={ translate( 'RSS feed settings' ) } showButton={ true } />
+			<Card>{ /* RSS feed settings will go here */ }</Card>
+		</>
+	);
+};

--- a/client/my-sites/site-settings/settings-reading/site-settings-section.tsx
+++ b/client/my-sites/site-settings/settings-reading/site-settings-section.tsx
@@ -1,0 +1,15 @@
+import { Card } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
+
+export const SiteSettingsSection = () => {
+	const translate = useTranslate();
+
+	return (
+		<>
+			{ /* @ts-expect-error SettingsSectionHeader is not typed and is causing errors */ }
+			<SettingsSectionHeader title={ translate( 'Site settings' ) } showButton={ true } />
+			<Card>{ /* Site settings will go here */ }</Card>
+		</>
+	);
+};


### PR DESCRIPTION
#### Proposed Changes

* create 3 blank reading settings sections with "Save settings" button each:
  * **Site settings**
  * **RSS feed settings**
  * **Newsletter settings**
* those sections will be populated in follow-up tasks

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run calypso locally
* Go to http://calypso.localhost:3000/settings/reading/<your-blog>
* Ensure sections are displayed as expected

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

![Screen Shot 2022-11-29 at 16 29 15](https://user-images.githubusercontent.com/2019970/204575933-1a08d997-d9a8-4a49-a68e-b644aeac0d2a.png)


Closes #70408
