### PR TITLE
Jetpack pricing: use lists

### DIFF
--- a/client/my-sites/plans/jetpack-plans/faq/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/faq/index.tsx
@@ -79,145 +79,169 @@ const JetpackFAQ: FC = () => {
 		<>
 			<section className="jetpack-faq">
 				<h2 className="jetpack-faq__heading">{ translate( 'Frequently Asked Questions' ) }</h2>
-				<FoldableFAQ
-					id="getting-started"
-					question={ translate( 'How do I start using Jetpack on my website?' ) }
-					onToggle={ onFaqToggle }
-					className="jetpack-faq__section"
-				>
-					{ translate(
-						'Learn everything you need to know about getting started with Jetpack {{gettingStartedLink}}here{{/gettingStartedLink}}.',
-						{
-							components: { gettingStartedLink: jetpackGettingStartedLink() },
-						}
-					) }
-				</FoldableFAQ>
-				<FoldableFAQ
-					id="backup-storage-limits"
-					question={ translate( 'How do backup storage limits work?' ) }
-					onToggle={ onFaqToggle }
-					className="jetpack-faq__section"
-				>
-					{ translate(
-						"If your site's backup storage limit is reached, your older backups will be deleted. Depending on the size of your site and your site's backup storage limit, your site's backup retention period may be reduced down to 7 days of your most recent backups. You will still be able to restore existing backups, but new site updates will not be backed up until you free up storage or upgrade your storage limit."
-					) }
-				</FoldableFAQ>
-				<FoldableFAQ
-					id="priority-support"
-					question={ translate( 'Is priority support included in all plans?' ) }
-					onToggle={ onFaqToggle }
-					className="jetpack-faq__section"
-				>
-					{ translate(
-						'Yes, our expert Happiness Engineers provide priority support to all customers with paid plans and services! Have a question or a problem? Just {{helpLink}}contact support{{/helpLink}} and we’ll get back to you in no time.',
-						{
-							components: { helpLink: getHelpLink( 'more_questions' ) },
-						}
-					) }
-				</FoldableFAQ>
-				<FoldableFAQ
-					id="cancellation-policy"
-					question={ translate( 'What is your cancellation policy?' ) }
-					onToggle={ onFaqToggle }
-					className="jetpack-faq__section"
-				>
-					{ translate(
-						'If you are dissatisfied for any reason, we offer full refunds within %(annualDays)d days for yearly plans, and within %(monthlyDays)d days for monthly plans. If you have a question about our paid plans, {{helpLink}}please let us know{{/helpLink}}!',
-						{
-							args: { annualDays: 14, monthlyDays: 7 },
-							components: { helpLink: getHelpLink( 'cancellation' ) },
-						}
-					) }
-				</FoldableFAQ>
-				<FoldableFAQ
-					id="volume-discount"
-					question={ translate( 'Do you have any discounts for multiple sites?' ) }
-					onToggle={ onFaqToggle }
-					className="jetpack-faq__section"
-				>
-					{ translate(
-						'Anyone with at least five websites can join our licensing platform and enjoy a 25% discount across all Jetpack products! You can learn more about our {{agenciesLink}}licensing platform and agency program here{{/agenciesLink}}.',
-						{
-							components: { agenciesLink: getAgenciesLink() },
-						}
-					) }
-				</FoldableFAQ>
-				<FoldableFAQ
-					id="multiyear-plans"
-					question={ translate( 'Do you have discounts for multi-year plans?' ) }
-					onToggle={ onFaqToggle }
-					className="jetpack-faq__section"
-				>
-					{ translate(
-						"We currently do not offer multi-year subscriptions or discounts for Jetpack products. However if you're an Enterprise, {{helpLink}}contact us{{/helpLink}}.",
-						{
-							components: { helpLink: getHelpLink( 'multiyear-questions' ) },
-						}
-					) }
-				</FoldableFAQ>
-				<FoldableFAQ
-					id="wpcom-account"
-					question={ translate( 'Why do I need a WordPress.com account?' ) }
-					onToggle={ onFaqToggle }
-					className="jetpack-faq__section"
-				>
-					{ translate(
-						'Many of Jetpack’s core features make use of the WordPress.com cloud. In order to make sure everything' +
-							' works correctly, Jetpack requires you to connect a free WordPress.com account. If you don’t already' +
-							' have an account you can easily create one during the connection process.'
-					) }
-				</FoldableFAQ>
-				<FoldableFAQ
-					id="hosting-requirements"
-					question={ translate( 'What are the hosting requirements?' ) }
-					onToggle={ onFaqToggle }
-					className="jetpack-faq__section"
-				>
-					{ translate(
-						'You should be running the latest version of WordPress and a publicly-accessible site with XML-RPC enabled.'
-					) }
-				</FoldableFAQ>
-				<FoldableFAQ
-					id="multisite-network"
-					question={ translate( 'Does this work with a multisite network?' ) }
-					onToggle={ onFaqToggle }
-					className="jetpack-faq__section"
-				>
-					{ translate(
-						'Jetpack’s free features are compatible with WordPress Multisite networks. Paid features' +
-							' also work with Multisite networks, but each site requires its own subscription. Jetpack VaultPress Backup' +
-							' and Jetpack Scan are not currently compatible with Multisite networks.'
-					) }
-				</FoldableFAQ>
-				<FoldableFAQ
-					id="gdpr"
-					question={ translate( 'Does Jetpack comply with the GDPR?', {
-						comment:
-							'GDPR refers to the General Data Protection Regulation in effect in the European Union',
-					} ) }
-					onToggle={ onFaqToggle }
-					className="jetpack-faq__section"
-				>
-					{ translate(
-						'Jetpack understands the General Data Protection Regulation. {{link}}Read more about how Jetpack is committed to operating in accordance with the GDPR.{{/link}}',
-						{
-							components: { link: jetpackGDPRLink() },
-						}
-					) }
-				</FoldableFAQ>
-				<FoldableFAQ
-					id="more-questions"
-					question={ translate( 'Have more questions?' ) }
-					onToggle={ onFaqToggle }
-					className="jetpack-faq__section"
-				>
-					{ translate(
-						'No problem! Feel free to {{helpLink}}get in touch{{/helpLink}} with our Happiness Engineers.',
-						{
-							components: { helpLink: getHelpLink( 'more_questions' ) },
-						}
-					) }
-				</FoldableFAQ>
+				<ul className="jetpack-faq__list">
+					<li>
+						<FoldableFAQ
+							id="getting-started"
+							question={ translate( 'How do I start using Jetpack on my website?' ) }
+							onToggle={ onFaqToggle }
+							className="jetpack-faq__section"
+						>
+							{ translate(
+								'Learn everything you need to know about getting started with Jetpack {{gettingStartedLink}}here{{/gettingStartedLink}}.',
+								{
+									components: { gettingStartedLink: jetpackGettingStartedLink() },
+								}
+							) }
+						</FoldableFAQ>
+					</li>
+					<li>
+						<FoldableFAQ
+							id="backup-storage-limits"
+							question={ translate( 'How do backup storage limits work?' ) }
+							onToggle={ onFaqToggle }
+							className="jetpack-faq__section"
+						>
+							{ translate(
+								"If your site's backup storage limit is reached, your older backups will be deleted. Depending on the size of your site and your site's backup storage limit, your site's backup retention period may be reduced down to 7 days of your most recent backups. You will still be able to restore existing backups, but new site updates will not be backed up until you free up storage or upgrade your storage limit."
+							) }
+						</FoldableFAQ>
+					</li>
+					<li>
+						<FoldableFAQ
+							id="priority-support"
+							question={ translate( 'Is priority support included in all plans?' ) }
+							onToggle={ onFaqToggle }
+							className="jetpack-faq__section"
+						>
+							{ translate(
+								'Yes, our expert Happiness Engineers provide priority support to all customers with paid plans and services! Have a question or a problem? Just {{helpLink}}contact support{{/helpLink}} and we’ll get back to you in no time.',
+								{
+									components: { helpLink: getHelpLink( 'more_questions' ) },
+								}
+							) }
+						</FoldableFAQ>
+					</li>
+					<li>
+						<FoldableFAQ
+							id="cancellation-policy"
+							question={ translate( 'What is your cancellation policy?' ) }
+							onToggle={ onFaqToggle }
+							className="jetpack-faq__section"
+						>
+							{ translate(
+								'If you are dissatisfied for any reason, we offer full refunds within %(annualDays)d days for yearly plans, and within %(monthlyDays)d days for monthly plans. If you have a question about our paid plans, {{helpLink}}please let us know{{/helpLink}}!',
+								{
+									args: { annualDays: 14, monthlyDays: 7 },
+									components: { helpLink: getHelpLink( 'cancellation' ) },
+								}
+							) }
+						</FoldableFAQ>
+					</li>
+					<li>
+						<FoldableFAQ
+							id="volume-discount"
+							question={ translate( 'Do you have any discounts for multiple sites?' ) }
+							onToggle={ onFaqToggle }
+							className="jetpack-faq__section"
+						>
+							{ translate(
+								'Anyone with at least five websites can join our licensing platform and enjoy a 25% discount across all Jetpack products! You can learn more about our {{agenciesLink}}licensing platform and agency program here{{/agenciesLink}}.',
+								{
+									components: { agenciesLink: getAgenciesLink() },
+								}
+							) }
+						</FoldableFAQ>
+					</li>
+					<li>
+						<FoldableFAQ
+							id="multiyear-plans"
+							question={ translate( 'Do you have discounts for multi-year plans?' ) }
+							onToggle={ onFaqToggle }
+							className="jetpack-faq__section"
+						>
+							{ translate(
+								"We currently do not offer multi-year subscriptions or discounts for Jetpack products. However if you're an Enterprise, {{helpLink}}contact us{{/helpLink}}.",
+								{
+									components: { helpLink: getHelpLink( 'multiyear-questions' ) },
+								}
+							) }
+						</FoldableFAQ>
+					</li>
+					<li>
+						<FoldableFAQ
+							id="wpcom-account"
+							question={ translate( 'Why do I need a WordPress.com account?' ) }
+							onToggle={ onFaqToggle }
+							className="jetpack-faq__section"
+						>
+							{ translate(
+								'Many of Jetpack’s core features make use of the WordPress.com cloud. In order to make sure everything' +
+									' works correctly, Jetpack requires you to connect a free WordPress.com account. If you don’t already' +
+									' have an account you can easily create one during the connection process.'
+							) }
+						</FoldableFAQ>
+					</li>
+					<li>
+						<FoldableFAQ
+							id="hosting-requirements"
+							question={ translate( 'What are the hosting requirements?' ) }
+							onToggle={ onFaqToggle }
+							className="jetpack-faq__section"
+						>
+							{ translate(
+								'You should be running the latest version of WordPress and a publicly-accessible site with XML-RPC enabled.'
+							) }
+						</FoldableFAQ>
+					</li>
+					<li>
+						<FoldableFAQ
+							id="multisite-network"
+							question={ translate( 'Does this work with a multisite network?' ) }
+							onToggle={ onFaqToggle }
+							className="jetpack-faq__section"
+						>
+							{ translate(
+								'Jetpack’s free features are compatible with WordPress Multisite networks. Paid features' +
+									' also work with Multisite networks, but each site requires its own subscription. Jetpack VaultPress Backup' +
+									' and Jetpack Scan are not currently compatible with Multisite networks.'
+							) }
+						</FoldableFAQ>
+					</li>
+					<li>
+						<FoldableFAQ
+							id="gdpr"
+							question={ translate( 'Does Jetpack comply with the GDPR?', {
+								comment:
+									'GDPR refers to the General Data Protection Regulation in effect in the European Union',
+							} ) }
+							onToggle={ onFaqToggle }
+							className="jetpack-faq__section"
+						>
+							{ translate(
+								'Jetpack understands the General Data Protection Regulation. {{link}}Read more about how Jetpack is committed to operating in accordance with the GDPR.{{/link}}',
+								{
+									components: { link: jetpackGDPRLink() },
+								}
+							) }
+						</FoldableFAQ>
+					</li>
+					<li>
+						<FoldableFAQ
+							id="more-questions"
+							question={ translate( 'Have more questions?' ) }
+							onToggle={ onFaqToggle }
+							className="jetpack-faq__section"
+						>
+							{ translate(
+								'No problem! Feel free to {{helpLink}}get in touch{{/helpLink}} with our Happiness Engineers.',
+								{
+									components: { helpLink: getHelpLink( 'more_questions' ) },
+								}
+							) }
+						</FoldableFAQ>
+					</li>
+				</ul>
 			</section>
 		</>
 		/* eslint-enable wpcalypso/jsx-classname-namespace */

--- a/client/my-sites/plans/jetpack-plans/faq/style.scss
+++ b/client/my-sites/plans/jetpack-plans/faq/style.scss
@@ -20,6 +20,12 @@
 	}
 }
 
+.jetpack-faq__list {
+	margin: 0;
+
+	list-style-type: none;
+}
+
 // Make sure FAQ's are visible below the sticky header when linked to
 .jetpack-faq__section {
 	button {

--- a/client/my-sites/plans/jetpack-plans/product-lightbox/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-lightbox/index.tsx
@@ -29,14 +29,14 @@ type Props = ProductStoreBaseProps & {
 };
 
 const TagItems: React.FC< { tags: JetpackTag[] } > = ( { tags } ) => (
-	<>
+	<ul className="product-lightbox__detail-tags-list">
 		{ tags.map( ( tag ) => (
-			<div className="product-lightbox__detail-tags-tag" key={ tag.tag }>
+			<li className="product-lightbox__detail-tags-tag" key={ tag.tag }>
 				<span aria-hidden="true">{ Tags[ tag.tag ] }</span>
 				<p>{ tag.label }</p>
-			</div>
+			</li>
 		) ) }
-	</>
+	</ul>
 );
 
 const ProductLightbox: React.FC< Props > = ( {

--- a/client/my-sites/plans/jetpack-plans/product-lightbox/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-lightbox/style.scss
@@ -112,6 +112,12 @@
 	font-size: 1rem;
 }
 
+.product-lightbox__detail-tags-list {
+	display: inline;
+
+	margin: 0;
+}
+
 .product-lightbox__detail-tags {
 	margin-bottom: 16px;
 

--- a/client/my-sites/plans/jetpack-plans/product-store/features-list/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/features-list/index.tsx
@@ -19,9 +19,9 @@ export const FeaturesList: React.FC< FeaturesListProps > = ( { item } ) => {
 	}
 
 	const output = (
-		<div className="features-list">
+		<ul className="features-list">
 			{ featuresList.map( ( { features, icon, included, slug, title } ) => (
-				<div key={ slug } className="features-list__group">
+				<li key={ slug } className="features-list__group">
 					<div className="features-list__group--title">
 						<img className="features-list__group--icon" alt="" src={ icon } />
 						{ title }
@@ -37,9 +37,9 @@ export const FeaturesList: React.FC< FeaturesListProps > = ( { item } ) => {
 							</li>
 						) ) }
 					</ul>
-				</div>
+				</li>
 			) ) }
-		</div>
+		</ul>
 	);
 
 	if ( isMobile ) {

--- a/client/my-sites/plans/jetpack-plans/product-store/features-list/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/features-list/style.scss
@@ -2,9 +2,12 @@
 @import "@wordpress/base-styles/mixins";
 
 .features-list {
+	margin: 0;
 	padding: 1.5rem;
+
 	border-end-start-radius: 8px; /* stylelint-disable-line scales/radii */
 	border-end-end-radius: 8px; /* stylelint-disable-line scales/radii */
+	list-style-type: none;
 
 	@include break-mobile {
 		padding-bottom: 2.5rem;

--- a/client/my-sites/plans/jetpack-plans/product-store/items-list/all-items.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/items-list/all-items.tsx
@@ -37,7 +37,7 @@ export const AllItems: React.FC< AllItemsProps > = ( {
 		<div className={ wrapperClassName }>
 			<h3 className="jetpack-product-store__all-items--header">{ heading }</h3>
 
-			<div className="jetpack-product-store__all-items--grid">
+			<ul className="jetpack-product-store__all-items--grid">
 				{ items.map( ( item ) => {
 					const isOwned = getIsOwned( item );
 					const isSuperseded = getIsSuperseded( item );
@@ -81,22 +81,23 @@ export const AllItems: React.FC< AllItemsProps > = ( {
 					const ctaAsPrimary = ! ( isOwned || getIsPlanFeature( item ) || isSuperseded );
 
 					return (
-						<SimpleItemCard
-							ctaAsPrimary={ ctaAsPrimary }
-							ctaHref={ getCheckoutURL( item ) }
-							ctaLabel={ ctaLabel }
-							description={ description }
-							icon={ <img alt="" src={ getProductIcon( { productSlug: item.productSlug } ) } /> }
-							isCtaDisabled={ isCtaDisabled }
-							isCtaExternal={ isExternal }
-							key={ item.productSlug }
-							onClickCta={ getOnClickPurchase( item ) }
-							price={ price }
-							title={ item.displayName }
-						/>
+						<li key={ item.productSlug }>
+							<SimpleItemCard
+								ctaAsPrimary={ ctaAsPrimary }
+								ctaHref={ getCheckoutURL( item ) }
+								ctaLabel={ ctaLabel }
+								description={ description }
+								icon={ <img alt="" src={ getProductIcon( { productSlug: item.productSlug } ) } /> }
+								isCtaDisabled={ isCtaDisabled }
+								isCtaExternal={ isExternal }
+								onClickCta={ getOnClickPurchase( item ) }
+								price={ price }
+								title={ item.displayName }
+							/>
+						</li>
 					);
 				} ) }
-			</div>
+			</ul>
 		</div>
 	);
 };

--- a/client/my-sites/plans/jetpack-plans/product-store/items-list/most-popular.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/items-list/most-popular.tsx
@@ -37,7 +37,7 @@ export const MostPopular: React.FC< MostPopularProps > = ( {
 	return (
 		<div className={ wrapperClassName }>
 			<h3 className="jetpack-product-store__most-popular--heading">{ heading }</h3>
-			<div className="jetpack-product-store__most-popular--items">
+			<ul className="jetpack-product-store__most-popular--items">
 				{ items.map( ( item ) => {
 					const isOwned = getIsOwned( item );
 					const isSuperseded = getIsSuperseded( item );
@@ -83,7 +83,7 @@ export const MostPopular: React.FC< MostPopularProps > = ( {
 					const ctaAsPrimary = ! ( isOwned || getIsPlanFeature( item ) || isSuperseded );
 
 					return (
-						<div key={ item.productSlug } className="jetpack-product-store__most-popular--item">
+						<li key={ item.productSlug } className="jetpack-product-store__most-popular--item">
 							<FeaturedItemCard
 								ctaAsPrimary={ ctaAsPrimary }
 								ctaHref={ getCheckoutURL( item ) }
@@ -97,10 +97,10 @@ export const MostPopular: React.FC< MostPopularProps > = ( {
 								title={ item.displayName }
 							/>
 							<FeaturesList item={ item } />
-						</div>
+						</li>
 					);
 				} ) }
-			</div>
+			</ul>
 		</div>
 	);
 };

--- a/client/my-sites/plans/jetpack-plans/product-store/items-list/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/items-list/style.scss
@@ -6,6 +6,10 @@
 	column-gap: 80px;
 	row-gap: 32px;
 
+	margin: 0;
+
+	list-style-type: none;
+
 	@include break-medium {
 		grid-template-columns: repeat(2, 1fr);
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR updates the Jetpack pricing page so that lists use adequate markup. This is required in order for the page to conform to the [1.3.1 Info and Relationships](https://www.w3.org/TR/WCAG21/#info-and-relationships) accessibility guideline.

### Testing instructions

- Spin up the pricing page, using a live link below, or by running the branch locally
- Check that the page looks like production
- Optionally, check that VoiceOver or any other screen reader reads lists, as shown in the screencast below

### Screencast

https://user-images.githubusercontent.com/1620183/204599047-aa8a1271-d489-4693-a59a-bfc4f5fcca78.mov
