### PR TITLE
Stats: Fix horizontal padding and show mobile styles earlier to chart tabs

### DIFF
--- a/client/my-sites/stats/modernized-chart-tabs-styles.scss
+++ b/client/my-sites/stats/modernized-chart-tabs-styles.scss
@@ -35,7 +35,7 @@ $custom-stats-tab-mobile-break: $break-small;
 			text-transform: none;
 			letter-spacing: inherit;
 
-			@media ( max-width: $custom-stats-tab-mobile-break ) {
+			@media ( max-width: $break-mobile ) {
 				display: none;
 			}
 		}

--- a/client/my-sites/stats/modernized-chart-tabs-styles.scss
+++ b/client/my-sites/stats/modernized-chart-tabs-styles.scss
@@ -178,6 +178,11 @@ $custom-stats-tab-mobile-break: $break-small;
 			@media ( max-width: $custom-stats-tab-mobile-break ) {
 				width: 100%;
 				float: none;
+				border-bottom: 1px solid var(--color-neutral-5);
+
+				&:first-child {
+					border-top: 1px solid var(--color-neutral-5);
+				}
 
 				&:not(:first-child) {
 					margin: 0;

--- a/client/my-sites/stats/modernized-chart-tabs-styles.scss
+++ b/client/my-sites/stats/modernized-chart-tabs-styles.scss
@@ -234,6 +234,7 @@ $custom-stats-tab-mobile-break: $break-small;
 					@media ( max-width: $custom-stats-tab-mobile-break ) {
 						margin-left: auto;
 						padding: 0 20px 0 10px;
+						font-size: $font-body-small;
 
 						// For mobile stats-tabs in Store page
 						&:not(.store-stats-orders-chart__value):not(:last-child) {

--- a/client/my-sites/stats/modernized-chart-tabs-styles.scss
+++ b/client/my-sites/stats/modernized-chart-tabs-styles.scss
@@ -1,8 +1,10 @@
+@use "sass:math";
 @import "@wordpress/base-styles/breakpoints";
 @import "@automattic/components/src/highlight-cards/variables.scss";
 
 $barChartBorderRadius: 2px;
 $yearBarChartBorderRadius: 4px;
+$custom-stats-tab-mobile-break: $break-small;
 
 .stats > .stats--new-main-chart {
 	padding-top: $vertical-margin;
@@ -25,7 +27,7 @@ $yearBarChartBorderRadius: 4px;
 	.chart__legend {
 		margin-bottom: 16px;
 
-		@media ( max-width: $break-medium ) {
+		@media ( max-width: $custom-mobile-breakpoint ) {
 			padding: 0 16px;
 		}
 
@@ -33,7 +35,7 @@ $yearBarChartBorderRadius: 4px;
 			text-transform: none;
 			letter-spacing: inherit;
 
-			@media ( max-width: $break-mobile ) {
+			@media ( max-width: $custom-stats-tab-mobile-break ) {
 				display: none;
 			}
 		}
@@ -142,28 +144,50 @@ $yearBarChartBorderRadius: 4px;
 	// Chart Tabs
 	.stats-tabs {
 		width: 100%;
-		display: flex;
-		flex-wrap: wrap;
-		align-items: center;
 		padding: 24px 0 16px;
 		border: 0;
+		box-sizing: border-box;
+
+		display: flex;
+		align-items: center;
+
+		@media (max-width: $custom-mobile-breakpoint) {
+			padding: 24px math.div($vertical-margin, 2) 16px;
+		}
+
+		@media (max-width: $custom-stats-tab-mobile-break) {
+			display: block;
+			padding: 24px 0 16px;
+		}
 
 		&.is-enabled {
 			background-color: inherit;
 		}
 
+		// Adjust new stats-tabs styling beyond the mobile layout
 		.stats-tab {
-			width: 100%;
+			flex: 1;
+			width: auto;
+			border: 0;
+
+			&:not(:first-child) {
+				margin-left: 16px;
+			}
 
 			// Keep the original mobile stats-tabs styles
-			// Adjust new stats-tabs styling beyond the mobile layout
-			@media ( min-width: $break-mobile ) {
-				flex: 1;
-				width: auto;
-				border: 0;
+			@media ( max-width: $custom-stats-tab-mobile-break ) {
+				width: 100%;
+				float: none;
 
 				&:not(:first-child) {
-					margin-left: 16px;
+					margin: 0;
+				}
+			}
+
+			.gridicon {
+				@media ( max-width: $custom-stats-tab-mobile-break ) {
+					float: left;
+					margin: 3px 8px 0 20px;
 				}
 			}
 
@@ -174,9 +198,9 @@ $yearBarChartBorderRadius: 4px;
 				border-radius: 4px;
 				overflow: hidden;
 				color: var(--studio-black);
-				padding: 10px 0;
+				padding: 10px 6px;
 
-				@media ( max-width: $break-mobile ) {
+				@media ( max-width: $custom-stats-tab-mobile-break ) {
 					display: flex;
 					align-items: center;
 					justify-content: space-between;
@@ -207,8 +231,9 @@ $yearBarChartBorderRadius: 4px;
 					line-height: 30px;
 					margin-left: 0;
 
-					@media ( max-width: $break-mobile ) {
+					@media ( max-width: $custom-stats-tab-mobile-break ) {
 						margin-left: auto;
+						padding: 0 20px 0 10px;
 
 						// For mobile stats-tabs in Store page
 						&:not(.store-stats-orders-chart__value):not(:last-child) {
@@ -221,7 +246,7 @@ $yearBarChartBorderRadius: 4px;
 					justify-content: center;
 
 					// For mobile stats-tabs in Store page
-					@media ( max-width: $break-mobile ) {
+					@media ( max-width: $custom-stats-tab-mobile-break ) {
 						display: none;
 					}
 				}
@@ -253,7 +278,7 @@ $yearBarChartBorderRadius: 4px;
 					background-color: var(--color-surface);
 
 					// Keep the original mobile stats-tabs border styles
-					@media ( max-width: $break-mobile ) {
+					@media ( max-width: $custom-stats-tab-mobile-break ) {
 						border-color: transparent;
 					}
 

--- a/client/my-sites/stats/modernized-layout-styles.scss
+++ b/client/my-sites/stats/modernized-layout-styles.scss
@@ -5,7 +5,6 @@ $stats-background-color: #fdfdfd;
 $stats-sections-max-width: 1224px;
 $stats-layout-contnet-padding-top: 79px;
 $sidebar-appearance-break-point: 783px;
-$legacy-break-small: 660px;
 
 // Elements above main layout content per pages
 .stats__section-header,
@@ -27,7 +26,7 @@ $legacy-break-small: 660px;
 	}
 
 	// Ensures horizontal padding for all sections.
-	@media ( min-width: $legacy-break-small ) {
+	@media ( min-width: $custom-mobile-breakpoint ) {
 		> * {
 			padding: 0 max(calc(50% - #{math.div($stats-sections-max-width, 2)}), 32px);
 		}

--- a/client/my-sites/store/components/delta/style.scss
+++ b/client/my-sites/store/components/delta/style.scss
@@ -57,10 +57,10 @@
 	}
 
 	.delta__labels {
-		align-items: left;
 		display: flex;
 		flex-direction: row;
 		flex-wrap: wrap;
+		justify-content: flex-start;
 
 		.delta__suffix,
 		.delta__value {


### PR DESCRIPTION
#### Proposed Changes

* Add horizontal padding to chart tabs when `width <= 660px`.
* Introduce `$break-small` (600px) breakpoint to show the mobile .stats-tabs earlier than `480px`.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up this change with the Calypso Live link.
* Navigate to the Stats `Traffic`, `Store`, and `Ads` pages.
* Ensure the chart tabs apply horizontal padding when the viewport `width <= 660px`.

| Before | After |
| --- | --- |
| <img width="708" alt="before" src="https://user-images.githubusercontent.com/6869813/204600889-b5e733e1-5ab2-4028-91f2-03dd17967bfd.png"> | <img width="708" alt="padding_after" src="https://user-images.githubusercontent.com/6869813/204600943-9e9e6a37-4818-4ace-a002-3ea936782c98.png"> |


* Ensure the mobile chart tabs show when the viewport `width <= 600px` earlier than before.


| Before | After |
| --- | --- |
| <img width="651" alt="截圖 2022-11-30 上午1 36 12" src="https://user-images.githubusercontent.com/6869813/204601752-683b00d8-5a3b-46da-825c-0084f3412b46.png"> | <img width="666" alt="mobile_after" src="https://user-images.githubusercontent.com/6869813/204601039-8bbef672-db35-48c9-a9c2-3bc29240f449.png"> |

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #70258 
