### PR TITLE
Notifications: Remove unused Google Fonts call

### DIFF
--- a/apps/notifications/src/index.ejs
+++ b/apps/notifications/src/index.ejs
@@ -10,7 +10,7 @@
 	<meta name="node-platform" content="<%= htmlWebpackPlugin.options.nodeVersion %>">
 	<meta name="node-version" content="<%= htmlWebpackPlugin.options.nodePlatform %>">
 	<meta name="git-describe" content="<%= htmlWebpackPlugin.options.gitDescribe %>">
-	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Noto+Serif:400,400i,700,700i&subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese&display=swap">
+	<link rel="stylesheet" href="https://fonts-api.wp.com/css?family=Noto+Serif:400,400i,700,700i&subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese&display=swap">
     <% htmlWebpackPlugin.files.css.forEach( function( style ) { if ( style.includes( 'rtl' ) && htmlWebpackPlugin.options.isRTL ) { %><link rel="stylesheet" href="<%= style %>"><% } else if ( ! ( style.includes( 'rtl' ) || htmlWebpackPlugin.options.isRTL ) ) { %><link rel="stylesheet" href="<%= style %>"><% } } ) %>
 </head>
 

--- a/apps/notifications/src/index.ejs
+++ b/apps/notifications/src/index.ejs
@@ -10,7 +10,6 @@
 	<meta name="node-platform" content="<%= htmlWebpackPlugin.options.nodeVersion %>">
 	<meta name="node-version" content="<%= htmlWebpackPlugin.options.nodePlatform %>">
 	<meta name="git-describe" content="<%= htmlWebpackPlugin.options.gitDescribe %>">
-	<link rel="stylesheet" href="https://fonts-api.wp.com/css?family=Noto+Serif:400,400i,700,700i&subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese&display=swap">
     <% htmlWebpackPlugin.files.css.forEach( function( style ) { if ( style.includes( 'rtl' ) && htmlWebpackPlugin.options.isRTL ) { %><link rel="stylesheet" href="<%= style %>"><% } else if ( ! ( style.includes( 'rtl' ) || htmlWebpackPlugin.options.isRTL ) ) { %><link rel="stylesheet" href="<%= style %>"><% } } ) %>
 </head>
 

--- a/apps/notifications/src/standalone/root.html
+++ b/apps/notifications/src/standalone/root.html
@@ -10,7 +10,6 @@
 	<meta name="node-platform" content="v10.8.0">
 	<meta name="node-version" content="darwin">
 	<meta name="git-describe" content="desktop/2.4.0-12531-gef8d1a2a9c-dirty">
-	<link rel="stylesheet" href="https://fonts-api.wp.com/css?family=Noto+Serif:400,400i,700,700i&subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese&display=swap">
 <link href="../../../../../../Downloads/ntfs/main.css?a0ff59cf6957666700e1" rel="stylesheet"></head>
 
 <body>

--- a/apps/notifications/src/standalone/root.html
+++ b/apps/notifications/src/standalone/root.html
@@ -10,7 +10,7 @@
 	<meta name="node-platform" content="v10.8.0">
 	<meta name="node-version" content="darwin">
 	<meta name="git-describe" content="desktop/2.4.0-12531-gef8d1a2a9c-dirty">
-	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Noto+Serif:400,400i,700,700i&subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese&display=swap">
+	<link rel="stylesheet" href="https://fonts-api.wp.com/css?family=Noto+Serif:400,400i,700,700i&subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese&display=swap">
 <link href="../../../../../../Downloads/ntfs/main.css?a0ff59cf6957666700e1" rel="stylesheet"></head>
 
 <body>


### PR DESCRIPTION
#### Proposed Changes

* Removes style tags that load google fonts. Usage was removed in https://github.com/Automattic/notifications-panel/pull/7

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* On your wpcom sandbox run `install-plugin.sh notifications update/notifications-fonts-urls`.
* Sandbox widgets.wp.com and a test site.
* Load the front end of the site and make sure there are no google font requests triggered from the notifications panel.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

See pMz3w-g6E-p2#comment-103418