### PR TITLE
Gifting: Update refund policies for gifting

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/refund-policies.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/refund-policies.tsx
@@ -22,6 +22,7 @@ export enum RefundPolicy {
 	GiftBiennialPurchase,
 	GiftMonthlyPurchase,
 	GiftYearlyPurchase,
+	GiftDomainPurchase,
 	GenericBiennial,
 	GenericMonthly,
 	GenericYearly,
@@ -40,6 +41,10 @@ export function getRefundPolicies( cart: ResponseCart ): RefundPolicy[] {
 
 	const refundPolicies: Array< RefundPolicy | undefined > = cart.products.map( ( product ) => {
 		if ( isGiftPurchase ) {
+			if ( isDomainRegistration( product ) ) {
+				return RefundPolicy.GiftDomainPurchase;
+			}
+
 			if ( isMonthlyProduct( product ) ) {
 				return RefundPolicy.GiftMonthlyPurchase;
 			}
@@ -62,9 +67,6 @@ export function getRefundPolicies( cart: ResponseCart ): RefundPolicy[] {
 		}
 
 		if ( isDomainRegistration( product ) ) {
-			if ( isGiftPurchase ) {
-				return;
-			}
 			if ( isRenewal( product ) ) {
 				return RefundPolicy.DomainNameRenewal;
 			}
@@ -219,6 +221,13 @@ function RefundPolicyItem( { refundPolicy }: { refundPolicy: RefundPolicy } ) {
 			);
 			break;
 
+		case RefundPolicy.GiftDomainPurchase:
+			text = translate(
+				'Please note: to receive a {{refundsSupportPage}}refund for a domain gift{{/refundsSupportPage}}, you must request the refund within 96 hours of the gift purchase',
+				{ components: { cancelDomainSupportPage, refundsSupportPage } }
+			);
+			break;
+
 		case RefundPolicy.GenericBiennial:
 		case RefundPolicy.PlanBiennialRenewal:
 			text = translate(
@@ -229,7 +238,7 @@ function RefundPolicyItem( { refundPolicy }: { refundPolicy: RefundPolicy } ) {
 
 		case RefundPolicy.GiftBiennialPurchase:
 			text = translate(
-				'You understand that {{refundsSupportPage}}refunds{{/refundsSupportPage}} are limited to 14 days after purchase for products with biennial subscriptions.',
+				'You understand that gift {{refundsSupportPage}}refunds{{/refundsSupportPage}} are limited to 14 days after purchase for products with biennial subscriptions.',
 				{ components: { refundsSupportPage } }
 			);
 			break;
@@ -244,7 +253,7 @@ function RefundPolicyItem( { refundPolicy }: { refundPolicy: RefundPolicy } ) {
 
 		case RefundPolicy.GiftMonthlyPurchase:
 			text = translate(
-				'You understand that {{refundsSupportPage}}refunds{{/refundsSupportPage}} are limited to 7 days after purchase or renewal for products with monthly subscriptions.',
+				'You understand that gift {{refundsSupportPage}}refunds{{/refundsSupportPage}} are limited to 7 days after purchase or renewal for products with monthly subscriptions.',
 				{ components: { refundsSupportPage } }
 			);
 			break;
@@ -259,7 +268,7 @@ function RefundPolicyItem( { refundPolicy }: { refundPolicy: RefundPolicy } ) {
 
 		case RefundPolicy.GiftYearlyPurchase:
 			text = translate(
-				'You understand that {{refundsSupportPage}}refunds{{/refundsSupportPage}} are limited to 14 days after purchase for products with yearly subscriptions.',
+				'You understand that gift {{refundsSupportPage}}refunds{{/refundsSupportPage}} are limited to 14 days after purchase for products with yearly subscriptions.',
 				{ components: { refundsSupportPage } }
 			);
 			break;

--- a/client/my-sites/checkout/composite-checkout/components/refund-policies.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/refund-policies.tsx
@@ -238,7 +238,7 @@ function RefundPolicyItem( { refundPolicy }: { refundPolicy: RefundPolicy } ) {
 
 		case RefundPolicy.GiftBiennialPurchase:
 			text = translate(
-				'You understand that gift {{refundsSupportPage}}refunds{{/refundsSupportPage}} are limited to 14 days after purchase for products with two year subscriptions.',
+				'You understand that gift {{refundsSupportPage}}refunds{{/refundsSupportPage}} are limited to 14 days after purchase for non-domain products with two year subscriptions.',
 				{ components: { refundsSupportPage } }
 			);
 			break;
@@ -253,7 +253,7 @@ function RefundPolicyItem( { refundPolicy }: { refundPolicy: RefundPolicy } ) {
 
 		case RefundPolicy.GiftMonthlyPurchase:
 			text = translate(
-				'You understand that gift {{refundsSupportPage}}refunds{{/refundsSupportPage}} are limited to 7 days after purchase for products with monthly subscriptions.',
+				'You understand that gift {{refundsSupportPage}}refunds{{/refundsSupportPage}} are limited to 7 days after purchase for non-domain products with monthly subscriptions.',
 				{ components: { refundsSupportPage } }
 			);
 			break;
@@ -268,7 +268,7 @@ function RefundPolicyItem( { refundPolicy }: { refundPolicy: RefundPolicy } ) {
 
 		case RefundPolicy.GiftYearlyPurchase:
 			text = translate(
-				'You understand that gift {{refundsSupportPage}}refunds{{/refundsSupportPage}} are limited to 14 days after purchase for products with yearly subscriptions.',
+				'You understand that gift {{refundsSupportPage}}refunds{{/refundsSupportPage}} are limited to 14 days after purchase for non-domain products with yearly subscriptions.',
 				{ components: { refundsSupportPage } }
 			);
 			break;

--- a/client/my-sites/checkout/composite-checkout/components/refund-policies.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/refund-policies.tsx
@@ -223,7 +223,7 @@ function RefundPolicyItem( { refundPolicy }: { refundPolicy: RefundPolicy } ) {
 
 		case RefundPolicy.GiftDomainPurchase:
 			text = translate(
-				'You understand that {{refundsSupportPage}}refunds{{/refundsSupportPage}} for a domain gift are limited to 96 hours after registration.',
+				'You understand that {{refundsSupportPage}}refunds{{/refundsSupportPage}} for a domain gift are limited to 96 hours after purchase.',
 				{ components: { refundsSupportPage } }
 			);
 			break;

--- a/client/my-sites/checkout/composite-checkout/components/refund-policies.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/refund-policies.tsx
@@ -39,6 +39,20 @@ export function getRefundPolicies( cart: ResponseCart ): RefundPolicy[] {
 	const isGiftPurchase = cart.is_gift_purchase;
 
 	const refundPolicies: Array< RefundPolicy | undefined > = cart.products.map( ( product ) => {
+		if ( isGiftPurchase ) {
+			if ( isMonthlyProduct( product ) ) {
+				return RefundPolicy.GiftMonthlyPurchase;
+			}
+
+			if ( isYearly( product ) ) {
+				return RefundPolicy.GiftYearlyPurchase;
+			}
+
+			if ( isBiennially( product ) ) {
+				return RefundPolicy.GiftBiennialPurchase;
+			}
+		}
+
 		if ( isGoogleWorkspaceExtraLicence( product ) ) {
 			return RefundPolicy.NonRefundable;
 		}

--- a/client/my-sites/checkout/composite-checkout/components/refund-policies.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/refund-policies.tsx
@@ -238,7 +238,7 @@ function RefundPolicyItem( { refundPolicy }: { refundPolicy: RefundPolicy } ) {
 
 		case RefundPolicy.GiftBiennialPurchase:
 			text = translate(
-				'You understand that gift {{refundsSupportPage}}refunds{{/refundsSupportPage}} are limited to 14 days after purchase for products with biennial subscriptions.',
+				'You understand that gift {{refundsSupportPage}}refunds{{/refundsSupportPage}} are limited to 14 days after purchase for products with two year subscriptions.',
 				{ components: { refundsSupportPage } }
 			);
 			break;

--- a/client/my-sites/checkout/composite-checkout/components/refund-policies.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/refund-policies.tsx
@@ -223,8 +223,8 @@ function RefundPolicyItem( { refundPolicy }: { refundPolicy: RefundPolicy } ) {
 
 		case RefundPolicy.GiftDomainPurchase:
 			text = translate(
-				'Please note: to receive a {{refundsSupportPage}}refund{{/refundsSupportPage}} for a domain gift, you must request the refund within 96 hours of the gift purchase',
-				{ components: { cancelDomainSupportPage, refundsSupportPage } }
+				'You understand that {{refundsSupportPage}}refunds{{/refundsSupportPage}} for a domain gift are limited to 96 hours after registration.',
+				{ components: { refundsSupportPage } }
 			);
 			break;
 

--- a/client/my-sites/checkout/composite-checkout/components/refund-policies.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/refund-policies.tsx
@@ -184,6 +184,10 @@ function RefundPolicyItem( { refundPolicy }: { refundPolicy: RefundPolicy } ) {
 	let text;
 
 	switch ( refundPolicy ) {
+		case RefundPolicy.GiftPurchase:
+			//Save this space if we need to add Gift Purchase return policy
+			break;
+
 		case RefundPolicy.DomainNameRegistration:
 			text = translate(
 				'You understand that {{refundsSupportPage}}domain name refunds{{/refundsSupportPage}} are limited to 96 hours after registration.',

--- a/client/my-sites/checkout/composite-checkout/components/refund-policies.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/refund-policies.tsx
@@ -229,7 +229,7 @@ function RefundPolicyItem( { refundPolicy }: { refundPolicy: RefundPolicy } ) {
 
 		case RefundPolicy.GiftBiennialPurchase:
 			text = translate(
-				'You understand that {{refundsSupportPage}}refunds{{/refundsSupportPage}} are limited to 14 days after purchase or renewal for non-domain products with monthly subscriptions.',
+				'You understand that {{refundsSupportPage}}refunds{{/refundsSupportPage}} are limited to 14 days after purchase for products with biennial subscriptions.',
 				{ components: { refundsSupportPage } }
 			);
 			break;
@@ -244,7 +244,7 @@ function RefundPolicyItem( { refundPolicy }: { refundPolicy: RefundPolicy } ) {
 
 		case RefundPolicy.GiftMonthlyPurchase:
 			text = translate(
-				'You understand that {{refundsSupportPage}}refunds{{/refundsSupportPage}} are limited to 7 days after purchase or renewal for non-domain products with monthly subscriptions.',
+				'You understand that {{refundsSupportPage}}refunds{{/refundsSupportPage}} are limited to 7 days after purchase or renewal for products with monthly subscriptions.',
 				{ components: { refundsSupportPage } }
 			);
 			break;
@@ -259,7 +259,7 @@ function RefundPolicyItem( { refundPolicy }: { refundPolicy: RefundPolicy } ) {
 
 		case RefundPolicy.GiftYearlyPurchase:
 			text = translate(
-				'You understand that {{refundsSupportPage}}refunds{{/refundsSupportPage}} are limited to 14 days after purchase or renewal for non-domain products with monthly subscriptions.',
+				'You understand that {{refundsSupportPage}}refunds{{/refundsSupportPage}} are limited to 14 days after purchase for products with yearly subscriptions.',
 				{ components: { refundsSupportPage } }
 			);
 			break;

--- a/client/my-sites/checkout/composite-checkout/components/refund-policies.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/refund-policies.tsx
@@ -33,6 +33,10 @@ export enum RefundPolicy {
 }
 
 export function getRefundPolicies( cart: ResponseCart ): RefundPolicy[] {
+	// const giftPolicies: boolean< ResponseCart.is_gift_purchase | undefined >;
+	// console.log( giftPolicies );
+	// dispatchEvent;
+
 	const refundPolicies: Array< RefundPolicy | undefined > = cart.products.map( ( product ) => {
 		if ( isGoogleWorkspaceExtraLicence( product ) ) {
 			return RefundPolicy.NonRefundable;

--- a/client/my-sites/checkout/composite-checkout/components/refund-policies.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/refund-policies.tsx
@@ -253,7 +253,7 @@ function RefundPolicyItem( { refundPolicy }: { refundPolicy: RefundPolicy } ) {
 
 		case RefundPolicy.GiftMonthlyPurchase:
 			text = translate(
-				'You understand that gift {{refundsSupportPage}}refunds{{/refundsSupportPage}} are limited to 7 days after purchase or renewal for products with monthly subscriptions.',
+				'You understand that gift {{refundsSupportPage}}refunds{{/refundsSupportPage}} are limited to 7 days after purchase for products with monthly subscriptions.',
 				{ components: { refundsSupportPage } }
 			);
 			break;

--- a/client/my-sites/checkout/composite-checkout/components/refund-policies.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/refund-policies.tsx
@@ -223,7 +223,7 @@ function RefundPolicyItem( { refundPolicy }: { refundPolicy: RefundPolicy } ) {
 
 		case RefundPolicy.GiftDomainPurchase:
 			text = translate(
-				'Please note: to receive a {{refundsSupportPage}}refund for a domain gift{{/refundsSupportPage}}, you must request the refund within 96 hours of the gift purchase',
+				'Please note: to receive a {{refundsSupportPage}}refund{{/refundsSupportPage}} for a domain gift, you must request the refund within 96 hours of the gift purchase',
 				{ components: { cancelDomainSupportPage, refundsSupportPage } }
 			);
 			break;

--- a/client/my-sites/checkout/composite-checkout/components/refund-policies.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/refund-policies.tsx
@@ -19,7 +19,9 @@ export enum RefundPolicy {
 	DomainNameRegistration = 1,
 	DomainNameRegistrationBundled,
 	DomainNameRenewal,
-	GiftPurchase,
+	GiftBiennialPurchase,
+	GiftMonthlyPurchase,
+	GiftYearlyPurchase,
 	GenericBiennial,
 	GenericMonthly,
 	GenericYearly,
@@ -37,10 +39,6 @@ export function getRefundPolicies( cart: ResponseCart ): RefundPolicy[] {
 	const isGiftPurchase = cart.is_gift_purchase;
 
 	const refundPolicies: Array< RefundPolicy | undefined > = cart.products.map( ( product ) => {
-		if ( isGiftPurchase ) {
-			return RefundPolicy.GiftPurchase;
-		}
-
 		if ( isGoogleWorkspaceExtraLicence( product ) ) {
 			return RefundPolicy.NonRefundable;
 		}
@@ -50,10 +48,12 @@ export function getRefundPolicies( cart: ResponseCart ): RefundPolicy[] {
 		}
 
 		if ( isDomainRegistration( product ) ) {
+			if ( isGiftPurchase ) {
+				return;
+			}
 			if ( isRenewal( product ) ) {
 				return RefundPolicy.DomainNameRenewal;
 			}
-
 			return RefundPolicy.DomainNameRegistration;
 		}
 
@@ -184,10 +184,6 @@ function RefundPolicyItem( { refundPolicy }: { refundPolicy: RefundPolicy } ) {
 	let text;
 
 	switch ( refundPolicy ) {
-		case RefundPolicy.GiftPurchase:
-			//Save this space if we need to add Gift Purchase return policy
-			break;
-
 		case RefundPolicy.DomainNameRegistration:
 			text = translate(
 				'You understand that {{refundsSupportPage}}domain name refunds{{/refundsSupportPage}} are limited to 96 hours after registration.',
@@ -217,8 +213,22 @@ function RefundPolicyItem( { refundPolicy }: { refundPolicy: RefundPolicy } ) {
 			);
 			break;
 
+		case RefundPolicy.GiftBiennialPurchase:
+			text = translate(
+				'You understand that {{refundsSupportPage}}refunds{{/refundsSupportPage}} are limited to 14 days after purchase or renewal for non-domain products with monthly subscriptions.',
+				{ components: { refundsSupportPage } }
+			);
+			break;
+
 		case RefundPolicy.GenericMonthly:
 		case RefundPolicy.PlanMonthlyRenewal:
+			text = translate(
+				'You understand that {{refundsSupportPage}}refunds{{/refundsSupportPage}} are limited to 7 days after purchase or renewal for non-domain products with monthly subscriptions.',
+				{ components: { refundsSupportPage } }
+			);
+			break;
+
+		case RefundPolicy.GiftMonthlyPurchase:
 			text = translate(
 				'You understand that {{refundsSupportPage}}refunds{{/refundsSupportPage}} are limited to 7 days after purchase or renewal for non-domain products with monthly subscriptions.',
 				{ components: { refundsSupportPage } }
@@ -229,6 +239,13 @@ function RefundPolicyItem( { refundPolicy }: { refundPolicy: RefundPolicy } ) {
 		case RefundPolicy.PlanYearlyRenewal:
 			text = translate(
 				'You understand that {{refundsSupportPage}}refunds{{/refundsSupportPage}} are limited to 14 days after purchase or renewal for non-domain products with yearly subscriptions.',
+				{ components: { refundsSupportPage } }
+			);
+			break;
+
+		case RefundPolicy.GiftYearlyPurchase:
+			text = translate(
+				'You understand that {{refundsSupportPage}}refunds{{/refundsSupportPage}} are limited to 14 days after purchase or renewal for non-domain products with monthly subscriptions.',
 				{ components: { refundsSupportPage } }
 			);
 			break;

--- a/client/my-sites/checkout/composite-checkout/components/refund-policies.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/refund-policies.tsx
@@ -19,6 +19,7 @@ export enum RefundPolicy {
 	DomainNameRegistration = 1,
 	DomainNameRegistrationBundled,
 	DomainNameRenewal,
+	GiftPurchase,
 	GenericBiennial,
 	GenericMonthly,
 	GenericYearly,
@@ -33,11 +34,13 @@ export enum RefundPolicy {
 }
 
 export function getRefundPolicies( cart: ResponseCart ): RefundPolicy[] {
-	// const giftPolicies: boolean< ResponseCart.is_gift_purchase | undefined >;
-	// console.log( giftPolicies );
-	// dispatchEvent;
+	const isGiftPurchase = cart.is_gift_purchase;
 
 	const refundPolicies: Array< RefundPolicy | undefined > = cart.products.map( ( product ) => {
+		if ( isGiftPurchase ) {
+			return RefundPolicy.GiftPurchase;
+		}
+
 		if ( isGoogleWorkspaceExtraLicence( product ) ) {
 			return RefundPolicy.NonRefundable;
 		}

--- a/client/my-sites/checkout/composite-checkout/components/test/refund-policies.ts
+++ b/client/my-sites/checkout/composite-checkout/components/test/refund-policies.ts
@@ -3,6 +3,7 @@ import {
 	PLAN_MONTHLY_PERIOD,
 	PLAN_PERSONAL,
 	PLAN_PREMIUM_2_YEARS,
+	PLAN_PREMIUM,
 	PLAN_PREMIUM_MONTHLY,
 	PRODUCT_JETPACK_SCAN_MONTHLY,
 	PRODUCT_WPCOM_CUSTOM_DESIGN,
@@ -37,6 +38,68 @@ function getPlanAndDomainBundle( planSlug: string ) {
 }
 
 describe( 'getRefundPolicies', () => {
+	test( 'domain gift', () => {
+		const cart = getEmptyResponseCart();
+		cart.products.push( {
+			...getEmptyResponseCartProduct(),
+			item_subtotal_integer: 10,
+			is_domain_registration: true,
+			meta: 'test.live',
+			product_slug: 'dotlive_domain',
+		} );
+
+		cart.is_gift_purchase = true;
+
+		const refundPolicies = getRefundPolicies( cart );
+
+		expect( refundPolicies ).toEqual( [ RefundPolicy.GiftDomainPurchase ] );
+	} );
+
+	test( 'biennial gift', () => {
+		const cart = getEmptyResponseCart();
+		cart.products.push( {
+			...getEmptyResponseCartProduct(),
+			item_subtotal_integer: 5,
+			product_slug: PLAN_PREMIUM_2_YEARS,
+		} );
+
+		cart.is_gift_purchase = true;
+
+		const refundPolicies = getRefundPolicies( cart );
+
+		expect( refundPolicies ).toEqual( [ RefundPolicy.GiftBiennialPurchase ] );
+	} );
+
+	test( 'annual gift', () => {
+		const cart = getEmptyResponseCart();
+		cart.products.push( {
+			...getEmptyResponseCartProduct(),
+			item_subtotal_integer: 5,
+			product_slug: PLAN_PREMIUM,
+		} );
+
+		cart.is_gift_purchase = true;
+
+		const refundPolicies = getRefundPolicies( cart );
+
+		expect( refundPolicies ).toEqual( [ RefundPolicy.GiftYearlyPurchase ] );
+	} );
+
+	test( 'monthly gift', () => {
+		const cart = getEmptyResponseCart();
+		cart.products.push( {
+			...getEmptyResponseCartProduct(),
+			item_subtotal_integer: 5,
+			product_slug: PLAN_PREMIUM_MONTHLY,
+		} );
+
+		cart.is_gift_purchase = true;
+
+		const refundPolicies = getRefundPolicies( cart );
+
+		expect( refundPolicies ).toEqual( [ RefundPolicy.GiftMonthlyPurchase ] );
+	} );
+
 	test( 'add-on product', () => {
 		const cart = getEmptyResponseCart();
 		cart.products.push( {

--- a/client/my-sites/checkout/composite-checkout/components/test/refund-policies.ts
+++ b/client/my-sites/checkout/composite-checkout/components/test/refund-policies.ts
@@ -61,6 +61,7 @@ describe( 'getRefundPolicies', () => {
 			...getEmptyResponseCartProduct(),
 			item_subtotal_integer: 5,
 			product_slug: PLAN_PREMIUM_2_YEARS,
+			bill_period: String( PLAN_BIENNIAL_PERIOD ),
 		} );
 
 		cart.is_gift_purchase = true;
@@ -91,6 +92,7 @@ describe( 'getRefundPolicies', () => {
 			...getEmptyResponseCartProduct(),
 			item_subtotal_integer: 5,
 			product_slug: PLAN_PREMIUM_MONTHLY,
+			bill_period: String( PLAN_MONTHLY_PERIOD ),
 		} );
 
 		cart.is_gift_purchase = true;


### PR DESCRIPTION
#### Proposed Changes

* Add new refund policy messages for gifting subscriptions
* See full discussion here: https://github.com/Automattic/payments-shilling/issues/1264

**Domain Gift**: 

`You understand that {{refundsSupportPage}}refunds{{/refundsSupportPage}} for a domain gift are limited to 96 hours after purchase.`

<img width="539" alt="GiftDomainPurchase-RefundPolicy-GH70557" src="https://user-images.githubusercontent.com/12505355/204877362-b27178c1-5e3b-4d17-9219-0343689149bd.png">

**Monthly Plan Gift**:

`You understand that gift {{refundsSupportPage}}refunds{{/refundsSupportPage}} are limited to 7 days after purchase for non-domain products with monthly subscriptions.`

<img width="523" alt="GiftMonthlyPurchase-RefundPolicy-GH70557" src="https://user-images.githubusercontent.com/12505355/204877433-092647cc-34fc-4d38-b5b7-e0224c6b4974.png">

**Annual Plan Gift**:

`You understand that gift {{refundsSupportPage}}refunds{{/refundsSupportPage}} are limited to 14 days after purchase for non-domain products with yearly subscriptions.` 

<img width="537" alt="GiftYearlyPurchase-RefundPolicy-GH70557" src="https://user-images.githubusercontent.com/12505355/204877499-a52ade3f-9ec2-4497-a9c0-3ab3643d832d.png">

Biennial Plan Gift: 

`You understand that gift {{refundsSupportPage}}refunds{{/refundsSupportPage}} are limited to 14 days after purchase for non-domain products with two year subscriptions.`

<img width="548" alt="GiftBiennialPurchase-RefundPolicy-GH70557" src="https://user-images.githubusercontent.com/12505355/204877568-1ed68295-6caa-4bf4-8318-6a9b31644362.png">



#### Testing Instructions

* Use the Calypso live links or pull this branch into your local development
* Follow the testing instructions outlined here: pdtkmj-Ks-p2
* When checking out using local Calypso or your live link, you should see the refund messages listed above.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [NA] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #1264
