### PR TITLE
Launchpad: Remove incorrect notice CTA styling

### DIFF
--- a/client/my-sites/current-site/style.scss
+++ b/client/my-sites/current-site/style.scss
@@ -120,3 +120,8 @@
 	border-bottom: 0;
 }
 
+.current-site__launchpad-notice {
+	button {
+		background-color: var(--color-primary);
+	}
+}

--- a/client/my-sites/current-site/style.scss
+++ b/client/my-sites/current-site/style.scss
@@ -120,8 +120,3 @@
 	border-bottom: 0;
 }
 
-.current-site__launchpad-notice {
-	button {
-		background-color: var(--studio-blue-50);
-	}
-}


### PR DESCRIPTION
#### Proposed Changes

* Removes mistakenly overridden button styling and instead utilizes the dashboard color scheme

#### Screenshots

![Screen Shot 2022-11-30 at 5 27 59 PM copy](https://user-images.githubusercontent.com/5414230/204943941-87e21871-e252-4e0d-b535-977880c9f3c2.jpg)

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


* Create a launchpad enabled site ( calypso.localhost:3000/setup/newsletter/intro or http://calypso.localhost:3000/setup/link-in-bio/intro ) or use an existing one
* **_Don't_** complete any launchpad tasks
* Click on the "Go to admin" button
* Verify that the notice loaded in the sidebar is the Launchpad Redirect Notice
* Verify that the CTA button matches the dashboard color scheme (  https://wordpress.com/me/account )

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
