### PR TITLE
Stats: Fix active routes checking with alternative paths

### DIFF
--- a/client/my-sites/stats/controller.jsx
+++ b/client/my-sites/stats/controller.jsx
@@ -188,8 +188,8 @@ export function overview( context, next ) {
 	const activeFilter = find( filters(), ( filter ) => {
 		return (
 			context.params.period === filter.period ||
-			context.path.indexOf( filter.path ) >= 0 ||
-			( filter.altPaths && context.path.indexOf( filter.altPaths ) >= 0 )
+			context.path === filter.path ||
+			( filter.altPaths && filter.altPaths.includes( context.path ) )
 		);
 	} );
 
@@ -220,8 +220,8 @@ export function site( context, next ) {
 
 	const activeFilter = find( filters, ( filter ) => {
 		return (
-			context.path.indexOf( filter.path ) >= 0 ||
-			( filter.altPaths && context.path.indexOf( filter.altPaths ) >= 0 )
+			context.path === filter.path ||
+			( filter.altPaths && filter.altPaths.includes( context.path ) )
 		);
 	} );
 
@@ -297,8 +297,8 @@ export function summary( context, next ) {
 
 	const activeFilter = find( filters, ( filter ) => {
 		return (
-			context.path.indexOf( filter.path ) >= 0 ||
-			( filter.altPaths && context.path.indexOf( filter.altPaths ) >= 0 )
+			context.path === filter.path ||
+			( filter.altPaths && filter.altPaths.includes( context.path ) )
 		);
 	} );
 

--- a/client/my-sites/stats/controller.jsx
+++ b/client/my-sites/stats/controller.jsx
@@ -188,7 +188,7 @@ export function overview( context, next ) {
 	const activeFilter = find( filters(), ( filter ) => {
 		return (
 			context.params.period === filter.period ||
-			context.path === filter.path ||
+			context.path.indexOf( filter.path ) >= 0 ||
 			( filter.altPaths && filter.altPaths.includes( context.path ) )
 		);
 	} );
@@ -220,7 +220,7 @@ export function site( context, next ) {
 
 	const activeFilter = find( filters, ( filter ) => {
 		return (
-			context.path === filter.path ||
+			context.path.indexOf( filter.path ) >= 0 ||
 			( filter.altPaths && filter.altPaths.includes( context.path ) )
 		);
 	} );
@@ -297,7 +297,7 @@ export function summary( context, next ) {
 
 	const activeFilter = find( filters, ( filter ) => {
 		return (
-			context.path === filter.path ||
+			context.path.indexOf( filter.path ) >= 0 ||
 			( filter.altPaths && filter.altPaths.includes( context.path ) )
 		);
 	} );


### PR DESCRIPTION
#### Proposed Changes

* Fix the active filter checking with `altPaths` as the [previous logic](https://github.com/Automattic/wp-calypso/blob/2436d081fb82fd0b18e25b0c5108033adc6e934d/client/my-sites/stats/controller.jsx#L192) inside the route controller.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up this change with the Calypso Live link.
* Navigate to the Stats overview page `/stats/week`.
* Ensure the table display the weekly data instead of the daily data.

| Before | After |
| --- | --- |
| <img width="1145" alt="截圖 2022-11-30 上午11 35 00" src="https://user-images.githubusercontent.com/6869813/204701988-7f210a9e-db76-489e-a6b7-d48a52302321.png"> | <img width="1151" alt="截圖 2022-11-30 上午11 34 41" src="https://user-images.githubusercontent.com/6869813/204702018-2308128c-ed73-43a0-89d6-8d42d7088da7.png"> |


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
