### PR TITLE
Add calypso_pages_addnewpage_click  to page_list

### DIFF
--- a/client/my-sites/pages/page-list.jsx
+++ b/client/my-sites/pages/page-list.jsx
@@ -13,6 +13,7 @@ import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import SectionHeader from 'calypso/components/section-header';
 import withBlockEditorSettings from 'calypso/data/block-editor/with-block-editor-settings';
 import withIsFSEActive from 'calypso/data/themes/with-is-fse-active';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import NoResults from 'calypso/my-sites/no-results';
 import { preloadEditor } from 'calypso/sections-preloaders';
 import {
@@ -74,6 +75,10 @@ class Pages extends Component {
 			this.setState( { pages: nextProps.pages, shadowItems: {} } );
 		}
 	}
+
+	trackNewpageClick = () => {
+		recordTracksEvent( 'calypso_pages_addnewpage_click', { blog_id: this.props.siteId } );
+	};
 
 	fetchPages = ( options ) => {
 		if ( this.props.loading || this.props.lastPage ) {
@@ -250,7 +255,13 @@ class Pages extends Component {
 
 		return (
 			<SectionHeader label={ translate( 'Pages' ) }>
-				<Button primary compact className="pages__add-page" href={ newPageLink }>
+				<Button
+					primary
+					compact
+					className="pages__add-page"
+					href={ newPageLink }
+					onClick={ this.trackNewpageClick }
+				>
 					{ translate( 'Add new page' ) }
 				</Button>
 			</SectionHeader>


### PR DESCRIPTION
## Proposed Changes

- Fire event `calypso_pages_addnewpage_click` when add new page button is clicked

## Testing Instructions
### Set up.

Open your dev tools, go to the Network tab, and clear all entries so you can monitor new network activity.
In the search/filter box on the network tab, type t.gif. This will filter network activity so you can see events.
When making some actions, click on the request and navigate to Payload tab to check all the event parameters

### Expected

- Head to the Page List /pages/${site_slug}
- Click on button `Add new page`
- Confirm the `calypso_pages_addnewpage_click` is fired

https://user-images.githubusercontent.com/10071857/204706911-f64ad80d-1243-4949-b0f1-52e5037b8042.mp4



## Reference
Related to #70487


