### PR TITLE
Sites as landing page: Display success notice after accepting `/sites` landing page opt-in

### DIFF
--- a/client/sites-dashboard/components/sites-dashboard-opt-in-banner.tsx
+++ b/client/sites-dashboard/components/sites-dashboard-opt-in-banner.tsx
@@ -72,8 +72,8 @@ export const SitesDashboardOptInBanner = ( { sites }: SitesDashboardOptInBannerP
 		return null;
 	}
 
-	const handleAccept = () => {
-		setLandingPagePreference( {
+	const handleAccept = async () => {
+		await setLandingPagePreference( {
 			useSitesAsLandingPage: true,
 			updatedAt: new Date().valueOf(),
 		} );

--- a/client/sites-dashboard/components/sites-dashboard-opt-in-banner.tsx
+++ b/client/sites-dashboard/components/sites-dashboard-opt-in-banner.tsx
@@ -79,7 +79,7 @@ export const SitesDashboardOptInBanner = ( { sites }: SitesDashboardOptInBannerP
 		} );
 		dispatch( recordTracksEvent( 'calypso_sites_dashboard_landing_page_banner_accept_click' ) );
 		dispatch(
-			successNotice( __( 'Default page updated' ), {
+			successNotice( __( 'Default page updated.' ), {
 				id: 'sites-dashboard-opt-in-accept',
 				duration: 10000,
 			} )

--- a/client/sites-dashboard/components/sites-dashboard-opt-in-banner.tsx
+++ b/client/sites-dashboard/components/sites-dashboard-opt-in-banner.tsx
@@ -8,6 +8,7 @@ import Notice from 'calypso/components/notice';
 import { SiteExcerptData } from 'calypso/data/sites/site-excerpt-types';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { successNotice } from 'calypso/state/notices/actions';
 import { useAsyncPreference } from 'calypso/state/preferences/use-async-preference';
 import {
 	SITES_AS_LANDING_PAGE_DEFAULT_VALUE,
@@ -77,6 +78,12 @@ export const SitesDashboardOptInBanner = ( { sites }: SitesDashboardOptInBannerP
 			updatedAt: new Date().valueOf(),
 		} );
 		dispatch( recordTracksEvent( 'calypso_sites_dashboard_landing_page_banner_accept_click' ) );
+		dispatch(
+			successNotice( __( 'Default page updated' ), {
+				id: 'sites-dashboard-opt-in-accept',
+				duration: 10000,
+			} )
+		);
 	};
 
 	const handleDismiss = () => {

--- a/client/state/preferences/use-async-preference.ts
+++ b/client/state/preferences/use-async-preference.ts
@@ -35,7 +35,7 @@ export const useAsyncPreference = < T extends AllowedPreferenceValues >( {
 	const setValue = useCallback(
 		( newValue: T ) => {
 			setLocalValue( newValue );
-			dispatch( savePreference( preferenceName, newValue ) );
+			return dispatch( savePreference( preferenceName, newValue ) );
 		},
 		[ dispatch, preferenceName ]
 	);


### PR DESCRIPTION
#### Proposed Changes

PR inspired by [this feedback](https://github.com/Automattic/wp-calypso/pull/70450#discussion_r1034085396). Not part of the original project brief so see what @zaguiini thinks before merging.

Shows a success `<GlobalNotice>` after accepting the SALP opt-in banner

https://user-images.githubusercontent.com/1500769/204707884-5fcbfbc6-b2bb-4b7d-a26f-cbb74ac16f91.mov

I did a little searching, and there doesn't seem to be any consistency around whether global notices should end with a full stop or exclamation point or end with the word "successful". I went with `"Default page updated"`.

I don't think we should show anything after rejecting the banner. IMO it doesn't make sense because, as far as the user is concerned, they haven't changed any preference. They're sticking with the status quo.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Delete the entire `sites-landing-page` preference object using the dev menu in the bottom right
* Go to `/sites`
* Accept banner. After saving is complete the global notice appears. The `calypso_sites_dashboard_landing_page_banner_accept_click` banner fires just like it used to.

