### PR TITLE
Revive: Fixes the broken back navigation of the dotlink variation of Link in Bio flow.

### DIFF
--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -585,7 +585,7 @@ class Signup extends Component {
 			'siteId',
 			'siteSlug',
 			'flags', // for the feature flags
-			...flow.providesDependenciesInQuery,
+			...( flow?.providesDependenciesInQuery ?? [] ),
 		];
 
 		const result = {};

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -18,7 +18,6 @@ import {
 	kebabCase,
 	map,
 	omit,
-	pick,
 	startsWith,
 } from 'lodash';
 import page from 'page';
@@ -162,18 +161,12 @@ class Signup extends Component {
 
 	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
 	UNSAFE_componentWillMount() {
-		const flow = flows.getFlow( this.props.flowName, this.props.isLoggedIn );
-		const queryObject = this.props.initialContext?.query ?? {};
-
-		let providedDependencies;
-
-		if ( flow.providesDependenciesInQuery ) {
-			providedDependencies = pick( queryObject, flow.providesDependenciesInQuery );
-		}
+		let providedDependencies = this.getCurrentFlowSupportedQueryParams();
 
 		// Prevent duplicate sites, check pau2Xa-1Io-p2#comment-6759.
 		if ( this.props.isManageSiteFlow ) {
 			providedDependencies = {
+				...providedDependencies,
 				siteSlug: getSignupCompleteSlug(),
 				isManageSiteFlow: this.props.isManageSiteFlow,
 			};
@@ -191,8 +184,12 @@ class Signup extends Component {
 		this.updateShouldShowLoadingScreen();
 		this.completeFlowAfterLoggingIn();
 
-		if ( canResumeFlow( this.props.flowName, this.props.progress, this.props.isLoggedIn ) ) {
-			// Resume from the current window location
+		// Resume from the current window location if there is stored, completed step progress.
+		// However, if the step is removed, e.g. the user step is removed after logging-in, it can't be resumed.
+		if (
+			canResumeFlow( this.props.flowName, this.props.progress, this.props.isLoggedIn ) &&
+			! this.isCurrentStepRemovedFromFlow()
+		) {
 			return;
 		}
 
@@ -203,7 +200,9 @@ class Signup extends Component {
 				.steps[ 0 ];
 			this.setState( { resumingStep: destinationStep } );
 			const locale = ! this.props.isLoggedIn ? this.props.locale : '';
-			return page.redirect( getStepUrl( this.props.flowName, destinationStep, undefined, locale ) );
+			return page.redirect(
+				getStepUrl( this.props.flowName, destinationStep, undefined, locale, providedDependencies )
+			);
 		}
 	}
 
@@ -579,6 +578,27 @@ class Signup extends Component {
 		return window.location.origin + path;
 	};
 
+	getCurrentFlowSupportedQueryParams = () => {
+		const queryObject = this.props.initialContext?.query ?? {};
+		const flow = flows.getFlow( this.props.flowName, this.props.isLoggedIn );
+		const supportedParams = [
+			'siteId',
+			'siteSlug',
+			'flags', // for the feature flags
+			...flow.providesDependenciesInQuery,
+		];
+
+		const result = {};
+		for ( const param of supportedParams ) {
+			const value = queryObject[ param ];
+			if ( value != null ) {
+				result[ param ] = value;
+			}
+		}
+
+		return result;
+	};
+
 	// `flowName` is an optional parameter used to redirect to another flow, i.e., from `main`
 	// to `ecommerce`. If not specified, the current flow (`this.props.flowName`) continues.
 	goToStep = ( stepName, stepSectionName, flowName = this.props.flowName ) => {
@@ -587,8 +607,15 @@ class Signup extends Component {
 		// to invalid step.
 		if ( stepName && ! this.isEveryStepSubmitted() ) {
 			const locale = ! this.props.isLoggedIn ? this.props.locale : '';
-			const { siteId, siteSlug } = this.props.initialContext?.query ?? {};
-			page( getStepUrl( flowName, stepName, stepSectionName, locale, { siteId, siteSlug } ) );
+			page(
+				getStepUrl(
+					flowName,
+					stepName,
+					stepSectionName,
+					locale,
+					this.getCurrentFlowSupportedQueryParams()
+				)
+			);
 		} else if ( this.isEveryStepSubmitted() ) {
 			this.goToFirstInvalidStep();
 		}
@@ -628,7 +655,6 @@ class Signup extends Component {
 			progress,
 			this.props.isLoggedIn
 		);
-		const { siteId, siteSlug } = this.props.initialContext?.query ?? {};
 
 		if ( firstInvalidStep ) {
 			recordSignupInvalidStep( this.props.flowName, this.props.stepName );
@@ -642,10 +668,13 @@ class Signup extends Component {
 			const locale = ! this.props.isLoggedIn ? this.props.locale : '';
 			debug( `Navigating to the first invalid step: ${ firstInvalidStep.stepName }` );
 			page(
-				getStepUrl( this.props.flowName, firstInvalidStep.stepName, '', locale, {
-					siteId,
-					siteSlug,
-				} )
+				getStepUrl(
+					this.props.flowName,
+					firstInvalidStep.stepName,
+					'',
+					locale,
+					this.getCurrentFlowSupportedQueryParams()
+				)
 			);
 		}
 	};
@@ -715,8 +744,6 @@ class Signup extends Component {
 				isDomainTransfer( domainItem ) ||
 				isDomainMapping( domainItem ) );
 
-		const { siteId, siteSlug } = this.props.initialContext?.query ?? {};
-
 		// Hide the free option in the signup flow
 		const selectedHideFreePlan = get( this.props, 'signupDependencies.shouldHideFreePlan', false );
 		const hideFreePlan = planWithDomain || this.props.isDomainOnlySite || selectedHideFreePlan;
@@ -757,7 +784,7 @@ class Signup extends Component {
 							positionInFlow={ this.getPositionInFlow() }
 							hideFreePlan={ hideFreePlan }
 							isReskinned={ isReskinned }
-							queryParams={ { siteId, siteSlug } }
+							queryParams={ this.getCurrentFlowSupportedQueryParams() }
 							{ ...propsForCurrentStep }
 						/>
 					) }
@@ -766,11 +793,15 @@ class Signup extends Component {
 		);
 	}
 
-	shouldWaitToRender() {
-		const isStepRemovedFromFlow = ! includes(
+	isCurrentStepRemovedFromFlow() {
+		return ! includes(
 			flows.getFlow( this.props.flowName, this.props.isLoggedIn ).steps,
 			this.props.stepName
 		);
+	}
+
+	shouldWaitToRender() {
+		const isStepRemovedFromFlow = this.isCurrentStepRemovedFromFlow();
 		const isDomainsForSiteEmpty =
 			this.props.isLoggedIn &&
 			this.props.signupDependencies.siteSlug &&


### PR DESCRIPTION
## Summary
Reverts Automattic/wp-calypso#70570 that reverted https://github.com/Automattic/wp-calypso/pull/70371 since it broke the /start flow. This PR revives it, together with a fix for the previously-broken cases.

I've also ensured the pre-release tests are test by following PCYsg-JGn-p2:
<img width="1088" alt="image" src="https://user-images.githubusercontent.com/1842898/204958315-43b09b20-ed50-406e-9681-6f322fd231f0.png">


## Test instructions

* The test plan in #70371 should still hold
* Go through a few `/start/*` flows and make sure the work as expected.
 