### PR TITLE
Pricing page: Update 'Great for' section styling in lightbox to match new design.

### DIFF
--- a/client/my-sites/plans/jetpack-plans/product-lightbox/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-lightbox/style.scss
@@ -106,7 +106,7 @@
 }
 
 .product-lightbox__detail-desc {
-	margin-bottom: 0.5rem;
+	margin-bottom: 16px;
 	line-height: 1.5;
 	color: #2c3338;
 	font-size: 1rem;

--- a/client/my-sites/plans/jetpack-plans/product-lightbox/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-lightbox/style.scss
@@ -1,3 +1,6 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
 .product-lightbox__modal {
 	padding: 0;
 	border-radius: 8px; /* stylelint-disable-line scales/radii */
@@ -214,6 +217,11 @@
 	width: 40%;
 	background-color: #f6f7f7;
 	border-radius: 0 8px 8px 0; /* stylelint-disable-line scales/radii */
+	box-shadow: 0 4px 8px rgb(0 0 0 / 30%);
+
+	@include break-medium {
+		box-shadow: none;
+	}
 }
 
 .product-lightbox__variants-options {

--- a/client/my-sites/plans/jetpack-plans/product-lightbox/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-lightbox/style.scss
@@ -72,7 +72,7 @@
 	height: 100%;
 	width: 60%;
 	overflow-y: auto;
-	background-color: #f6f7f7;
+	background-color: var(--studio-white);
 	border-radius: 8px 0 0 8px; /* stylelint-disable-line scales/radii */
 
 	hr {
@@ -119,11 +119,14 @@
 }
 
 .product-lightbox__detail-tags {
+	background-color: #f6f7f7;
 	margin-bottom: 16px;
+	padding: 5.5px 8px;
+	border-radius: 4px;
 
 	&-label {
 		font-weight: 600;
-		font-size: $font-body-small;
+		font-size: $font-body-extra-small;
 		margin-right: 6px;
 		color: #000;
 	}
@@ -143,7 +146,7 @@
 
 		p {
 			color: #3c434a;
-			font-size: $font-body-small;
+			font-size: $font-body-extra-small;
 			margin: 0;
 			position: relative;
 			top: 2px;

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -223,7 +223,6 @@ import {
 	JETPACK_TAG_FOR_WOOCOMMERCE_STORES,
 	JETPACK_TAG_FOR_NEWS_ORGANISATIONS,
 	JETPACK_TAG_FOR_MEMBERSHIP_SITES,
-	JETPACK_TAG_FOR_ONLINE_FORUMS,
 	FEATURE_ADVANCED_DESIGN_CUSTOMIZATION_AND_CSS,
 	FEATURE_CANCELLATION_ACCEPT_PAYMENTS,
 	FEATURE_CANCELLATION_AD_FREE_SITE,
@@ -283,7 +282,6 @@ const getJetpackCommonPlanDetails = () => ( {
 		{ tag: JETPACK_TAG_FOR_WOOCOMMERCE_STORES, label: translate( 'WooCommerce stores' ) },
 		{ tag: JETPACK_TAG_FOR_NEWS_ORGANISATIONS, label: translate( 'News organizations' ) },
 		{ tag: JETPACK_TAG_FOR_MEMBERSHIP_SITES, label: translate( 'Membership sites' ) },
-		{ tag: JETPACK_TAG_FOR_ONLINE_FORUMS, label: translate( 'Online forums' ) },
 	],
 } );
 const getDotcomPlanDetails = () => ( {


### PR DESCRIPTION
#### Proposed Changes
As part of the new improvements in the pricing page's lightbox, this PR updates the `Great for` styling to match the new design.

**Old**
<img width="1104" alt="Screen Shot 2022-11-30 at 6 43 17 PM" src="https://user-images.githubusercontent.com/56598660/204775596-4e9f0f5e-c39a-4a00-b59a-7e85648da64e.png">

**New**
<img width="1112" alt="Screen Shot 2022-11-30 at 6 41 29 PM" src="https://user-images.githubusercontent.com/56598660/204775449-4a36f92a-ff17-4873-bc1d-1cc74dc8d7b7.png">

#### Testing Instructions

1. Now run this branch by following the steps below (or you can use the Jetpack Cloud live link commented on this PR)
    * Run `git fetch && git checkout update/pricing-page-lightbox-great-for-section`
    * Run `yarn start-jetpack-cloud`

2. Goto http://jetpack.cloud.localhost:3000/pricing or use the Jetpack Cloud live link and append `/pricing`
3. Press any 'More about ***' link to display a product lightbox.
4. Confirm that the `Great for` section now has the new design.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1202858161751496-as-1203463248826776


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - 0-as-1203463248826776