### PR TITLE
Add Personal pricing plan to the new Upsell block

### DIFF
--- a/apps/happy-blocks/index.php
+++ b/apps/happy-blocks/index.php
@@ -176,6 +176,13 @@ HTML;
  */
 function a8c_happyblocks_register() {
 	register_block_type(
+		'happy-blocks/pricing-plans-personal',
+		array(
+			'api_version'     => 2,
+			'render_callback' => 'a8c_happyblocks_render_pricing_plans_callback',
+		)
+	);
+	register_block_type(
 		'happy-blocks/pricing-plans-premium',
 		array(
 			'api_version'     => 2,

--- a/apps/happy-blocks/src/pricing-plans/config.ts
+++ b/apps/happy-blocks/src/pricing-plans/config.ts
@@ -5,6 +5,8 @@ import {
 	PLAN_BUSINESS,
 	PLAN_ECOMMERCE_MONTHLY,
 	PLAN_ECOMMERCE,
+	PLAN_PERSONAL,
+	PLAN_PERSONAL_MONTHLY,
 } from '@automattic/calypso-products';
 
 /**
@@ -12,6 +14,8 @@ import {
  */
 const config = {
 	plans: [
+		PLAN_PERSONAL,
+		PLAN_PERSONAL_MONTHLY,
 		PLAN_PREMIUM_MONTHLY,
 		PLAN_PREMIUM,
 		PLAN_BUSINESS_MONTHLY,

--- a/apps/happy-blocks/src/pricing-plans/edit.tsx
+++ b/apps/happy-blocks/src/pricing-plans/edit.tsx
@@ -1,5 +1,10 @@
 import './edit.scss';
-import { PLAN_BUSINESS, PLAN_ECOMMERCE, PLAN_PREMIUM } from '@automattic/calypso-products';
+import {
+	PLAN_BUSINESS,
+	PLAN_ECOMMERCE,
+	PLAN_PERSONAL,
+	PLAN_PREMIUM,
+} from '@automattic/calypso-products';
 import { useBlockProps } from '@wordpress/block-editor';
 import { BlockEditProps } from '@wordpress/blocks';
 import { useEffect } from '@wordpress/element';
@@ -65,6 +70,10 @@ const Edit: FunctionComponent< BlockEditProps< BlockAttributes > & EditProps > =
 			<PricingPlans plans={ plans } attributes={ attributes } setAttributes={ setAttributes } />
 		</div>
 	);
+};
+
+export const EditPersonal = ( props: BlockEditProps< BlockAttributes > ) => {
+	return <Edit { ...props } defaultPlan={ PLAN_PERSONAL } />;
 };
 
 export const EditPremium = ( props: BlockEditProps< BlockAttributes > ) => {

--- a/apps/happy-blocks/src/pricing-plans/index.jsx
+++ b/apps/happy-blocks/src/pricing-plans/index.jsx
@@ -1,7 +1,7 @@
 import { registerBlockType } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
 import config from './config';
-import { EditBusiness, EditEcommerce, EditPremium } from './edit';
+import { EditBusiness, EditEcommerce, EditPersonal, EditPremium } from './edit';
 
 const blockAttributes = {
 	productSlug: {
@@ -13,6 +13,21 @@ const blockAttributes = {
 };
 
 function registerBlocks() {
+	registerBlockType( 'happy-blocks/pricing-plans-personal', {
+		apiVersion: 2,
+		title: __( 'Upgrade Personal', 'happy-blocks' ),
+		icon: 'money-alt',
+		category: 'embed',
+		description: __( 'Personal pricing plan upgrade', 'happy-blocks' ),
+		keywords: [
+			__( 'pricing', 'happy-blocks' ),
+			__( 'plans', 'happy-blocks' ),
+			__( 'upgrade', 'happy-blocks' ),
+		],
+		attributes: blockAttributes,
+		edit: EditPersonal,
+	} );
+
 	registerBlockType( 'happy-blocks/pricing-plans-premium', {
 		apiVersion: 2,
 		title: __( 'Upgrade Premium', 'happy-blocks' ),


### PR DESCRIPTION
#### Proposed Changes

This Pull Request adds the Personal pricing plan option to the new Pricing Plans Upsell block

<img width="649" alt="image" src="https://user-images.githubusercontent.com/112691742/204776693-2e7aab3f-d3f2-4619-bcd4-7a6ac8a09460.png">


<img width="670" alt="image" src="https://user-images.githubusercontent.com/112691742/204776650-e27126e7-fd23-4c67-bc69-c4615394ee5f.png">


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run `yarn dev --sync` in `apps/happy-blocks` to sync code to your sandbox
* On your sandbox, edit `wp-content/themes/a8c/supportforums/editor/gutenberg-wpcom.php` and add to the function `supportforums_gutenberg_setup_frontend` before `return $settings;` line:
```
$settings['iso']['blocks']['allowBlocks'][] = 'happy-blocks/pricing-plans-personal';
```
* Create a new topic, in the editor press `/` and search for "Upgrade Personal" block and insert it.
* Submit the post, ensure the block loads in the Post view and shows the correct plan and the pre-selected billing option.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
