### PR TITLE
Always refresh the product prices in all signup flows

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-domain/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-domain/index.tsx
@@ -2,6 +2,7 @@
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
 import { StepContainer } from 'calypso/../packages/onboarding/src';
+import QueryProductsList from 'calypso/components/data/query-products-list';
 import RegisterDomainStep from 'calypso/components/domains/register-domain-step';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { ONBOARD_STORE, PRODUCTS_LIST_STORE } from 'calypso/landing/stepper/stores';
@@ -117,18 +118,21 @@ const ChooseADomain: Step = function ChooseADomain( { navigation, flow } ) {
 	const stepContent = isVideoPressFlow ? getVideoPressFlowStepContent() : getDefaultStepContent();
 
 	return (
-		<StepContainer
-			stepName="chooseADomain"
-			shouldHideNavButtons={ isVideoPressFlow }
-			goBack={ goBack }
-			goNext={ goNext }
-			isHorizontalLayout={ false }
-			isWideLayout={ true }
-			isLargeSkipLayout={ false }
-			stepContent={ stepContent }
-			recordTracksEvent={ recordTracksEvent }
-			formattedHeader={ getFormattedHeader() }
-		/>
+		<>
+			<QueryProductsList />
+			<StepContainer
+				stepName="chooseADomain"
+				shouldHideNavButtons={ isVideoPressFlow }
+				goBack={ goBack }
+				goNext={ goNext }
+				isHorizontalLayout={ false }
+				isWideLayout={ true }
+				isLargeSkipLayout={ false }
+				stepContent={ stepContent }
+				recordTracksEvent={ recordTracksEvent }
+				formattedHeader={ getFormattedHeader() }
+			/>
+		</>
 	);
 };
 

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -864,7 +864,7 @@ class DomainsStep extends Component {
 				shouldHideNavButtons={ this.isTailoredFlow() }
 				stepContent={
 					<div>
-						{ ! this.props.productsLoaded && <QueryProductsList /> }
+						<QueryProductsList />
 						{ this.renderContent() }
 					</div>
 				}


### PR DESCRIPTION
Recently we've launched some promo prices for certain TLDs and we noticed that the prices are not always rendered. it turned out that we're not refetching the products list from the API if it already exists in local storage so if you're an existing customer you might not see any promo prices.

#### Proposed Changes

* Add the QueryProductsList component to always be rendered so we would always refresh the product prices in all signup flows


#### Testing Instructions

* You need to run Calypso with `ENABLE_FEATURES=no-force-sympathy yarn start`
* Make sure that the product list is cached in the store by visiting /start/
* Change the backend code like this - 2e562-pb
* Then when you visit any /start or /setup flow you should always get the new .blog price

#### Pre-merge Checklist

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
