### PR TITLE
Pricing Plans Block: Redirect non-OP to pricing page

### DIFF
--- a/apps/happy-blocks/index.php
+++ b/apps/happy-blocks/index.php
@@ -127,19 +127,7 @@ function a8c_happyblocks_pricing_plans_get_domain() {
 		}
 	}
 
-	/*
-	If the user is logged in but not the author of the topic,
-	return the domain of the user's primary blog.
-	*/
-	$user = wp_get_current_user();
-
-	if ( isset( $user->primary_blog ) ) {
-		$primary = get_blog_details( $user->primary_blog );
-		if ( $primary ) {
-			return $primary->domain;
-		}
-	}
-
+	// If the current user is not the author of the topic, then don't return any domain.
 	return false;
 }
 


### PR DESCRIPTION
#### Proposed Changes

After a conversation with @david-gonzalez-a8c we've concluded that, for this first iteration, this block is going to work better if for every user visualising the block, if they're not the original posters of the topic then they will be redirect to the Pricing page, where they can select both the preferred plan and the domain they want to use it for.

In a future iteration, we will redirect any logged in user to the checkout too, but we will first have to make sure a previous step for selecting the domain for the plan is in place.


#### Testing Instructions

* Run `yarn dev --sync` in `apps/happy-blocks` to sync code to your sandbox
* Create a new topic, in the editor press `/` and search for "Upgrade" block. Pick any of the available blocks (eCommerce, Business, etc)
* Publish the post and wait for the topic "view" to load.
* Disconnect from the Sandbox, click the "Upgrade to [plan]" button and ensure you're shown the checkout page with the correct plan pre-added to the cart and the domain matches the one you entered in "Site you need help with" when creating the Post
* Access the topic logged in as another user, click the "Upgrade to [Plan]" button and ensure you are redirected to `https://wordpress.com/pricing`.




<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
