### PR TITLE
Datacenter Picker: Use 'optimal' instead of 'best', remove margins

### DIFF
--- a/client/blocks/eligibility-warnings/data-center-picker.tsx
+++ b/client/blocks/eligibility-warnings/data-center-picker.tsx
@@ -123,7 +123,7 @@ const DataCenterPicker = ( {
 			{ ! isFormShowing && (
 				<div>
 					<span>
-						{ translate( 'Your site will be automatically placed in the best data center.' ) }
+						{ translate( 'Your site will be automatically placed in the optimal data center.' ) }
 					</span>
 					&nbsp;
 					<Button
@@ -172,7 +172,7 @@ const DataCenterPicker = ( {
 								checked={ value === '' }
 								onChange={ () => onChange( '' ) }
 							/>
-							<span>{ translate( 'Automatically place my site in the best data center' ) }</span>
+							<span>{ translate( 'Automatically place my site in the optimal data center' ) }</span>
 						</AutomaticFormLabel>
 						<FormRadiosBar
 							isThumbnail

--- a/client/blocks/eligibility-warnings/style.scss
+++ b/client/blocks/eligibility-warnings/style.scss
@@ -230,15 +230,6 @@
 	}
 }
 
-.eligibility-warnings__data-center-picker > div {
-	margin-left: 12px;
-	margin-right: 12px;
-	@media ( max-width: 480px ) {
-		margin-left: 6px;
-		margin-right: 6px;
-	}
-}
-
 .eligibility-warnings__warnings-card {
 	background: #f6f7f7;
 	margin: 0 24px;


### PR DESCRIPTION
Feedback from pdKhl6-15J-p2#comment-1453

Previously https://github.com/Automattic/dotcom-forge/issues/1237

## Proposed Changes

Uses 'optimal' instead of 'best', and removes unnecessary margins.

![image](https://user-images.githubusercontent.com/36432/204796205-4643921f-0aae-4d9c-a5f1-4ad82a19f882.png)

![image](https://user-images.githubusercontent.com/36432/204796235-eb2b91d1-9ba9-4352-b6c1-6da26ff90ea0.png)

![image](https://user-images.githubusercontent.com/36432/204796251-b5a34561-3f15-477e-849b-2ae47a74d9f3.png)

## Testing Instructions

1. Create a new WordPress.com site with a business plan.
2. Navigate to 'Hosting Configuration' and click 'Activate'.
3. Verify the `<EligibilityWarnings>` component displays with the Data Center Picker UI.
4. Verify the Data Center Picker UI is usable, accessible, and looks good in the browsers we support.
5. If you want to recreate the 'no eligibility warnings' state, map a domain to your site and then go back to 'Hosting Configuration' -> 'Activate'.