### PR TITLE
Woo Tailored Onboarding: Fix redirect after signup

### DIFF
--- a/client/landing/stepper/declarative-flow/tailored-ecommerce-flow.ts
+++ b/client/landing/stepper/declarative-flow/tailored-ecommerce-flow.ts
@@ -60,11 +60,16 @@ export const ecommerceFlow: Flow = {
 		const locale = useLocale();
 		const siteSlugParam = useSiteSlugParam();
 		const site = useSite();
+		const flags = new URLSearchParams( window.location.search ).get( 'flags' );
 
 		const getStartUrl = () => {
 			return locale && locale !== 'en'
-				? `/start/account/user/${ locale }?variationName=${ flowName }&redirect_to=/setup/storeProfiler?flow=${ flowName }`
-				: `/start/account/user?variationName=${ flowName }&redirect_to=/setup/storeProfiler?flow=${ flowName }`;
+				? `/start/account/user/${ locale }?variationName=${ flowName }&redirect_to=/setup/ecommerce/storeProfiler${
+						flags ? `?flags=${ flags }` : ''
+				  }`
+				: `/start/account/user?variationName=${ flowName }&redirect_to=/setup/ecommerce/storeProfiler${
+						flags ? `?flags=${ flags }` : ''
+				  }`;
 		};
 
 		function submit( providedDependencies: ProvidedDependencies = {} ) {

--- a/client/landing/stepper/declarative-flow/tailored-ecommerce-flow.ts
+++ b/client/landing/stepper/declarative-flow/tailored-ecommerce-flow.ts
@@ -63,13 +63,12 @@ export const ecommerceFlow: Flow = {
 		const flags = new URLSearchParams( window.location.search ).get( 'flags' );
 
 		const getStartUrl = () => {
-			return locale && locale !== 'en'
-				? `/start/account/user/${ locale }?variationName=${ flowName }&redirect_to=/setup/ecommerce/storeProfiler${
-						flags ? `?flags=${ flags }` : ''
-				  }`
-				: `/start/account/user?variationName=${ flowName }&redirect_to=/setup/ecommerce/storeProfiler${
-						flags ? `?flags=${ flags }` : ''
-				  }`;
+			const url =
+				locale && locale !== 'en'
+					? `/start/account/user/${ locale }?variationName=${ flowName }&redirect_to=/setup/ecommerce/storeProfiler`
+					: `/start/account/user?variationName=${ flowName }&redirect_to=/setup/ecommerce/storeProfiler`;
+
+			return url + ( flags && `?flags=${ flags }` );
 		};
 
 		function submit( providedDependencies: ProvidedDependencies = {} ) {


### PR DESCRIPTION
#### Proposed Changes

* Fix the redirect after the signup. The user was being redirected to `/setup/storeProfiler?flow=ecommerce` instead of `/setup/ecommerce/storeProfiler` after the checkout.
* I also added the flag on the redirect URL when the current URL contains it.

#### Testing Instructions

* Log out from your account
* Navigate to `setup/ecommerce?flags=signup/tailored-ecommerce`
* Click on "Create your store"
* Go through the signup process
* You should be redirected to `/setup/ecommerce/storeProfiler?flags=signup/tailored-ecommerce`

Closes #70545
