### PR TITLE
Enable OpenGraph for coming soon page on Atomic

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/coming-soon.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/coming-soon.php
@@ -135,7 +135,6 @@ function render_fallback_coming_soon_page() {
 	remove_action( 'wp_footer', 'stats_footer', 101 );
 	add_filter( 'infinite_scroll_archive_supported', '__return_false', 99 ); // Disable infinite scroll feature.
 	add_filter( 'jetpack_disable_eu_cookie_law_widget', '__return_true', 1 );
-	add_filter( 'jetpack_enable_open_graph', '__return_false', 1 );
 	add_filter( 'wpcom_disable_logged_out_follow', '__return_true', 10, 1 ); // Disable follow actionbar.
 	add_filter( 'wpl_is_enabled_sitewide', '__return_false', 10, 1 ); // Disable likes.
 	add_filter( 'jetpack_implode_frontend_css', '__return_false', 99 ); // Jetpack "implodes" all registered CSS files into one file.


### PR DESCRIPTION
#### Proposed Changes

This PR changes the default share image for sites whose Privacy is set to Coming soon.

If no site icon is set, the share image will be this image:

![image](https://user-images.githubusercontent.com/528287/204283613-3de482f9-cb74-4904-9a02-4a698d01fee0.png)


#### Testing Instructions

Follow the ETK plugin testing instructions for Atomic: PCYsg-ly5-p2

(Grab the zip from TeamCity, by inspecting clicking Details next to the `Editing ToolKit (WPCom Plugins)` task and upload it to your Atomic website.)

After uploading the plugin you can:

- Set your site's Privacy to Coming soon (Settings > General)
- Remove site icon if any
- Open your site's homepage
- View source
- Ensure these two (separate) lines are there:

```<meta property="og:image" content="https://s1.wp.com/home.logged-out/images/wpcom-og-image.jpg" />```

```<meta name="twitter:image" content="https://s0.wp.com/i/webclip.png" />```

It's not possible to validate using the Facebook Sharing Debugger, since Facebook's DNS doesn't point to your sandbox.

`https://s0.wp.com/i/webclip.png`is the default site icon for WoA sites. We might want to look into this behavior in another PR.

#### Pre-merge Checklist

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [X] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?

Related to #62773