### PR TITLE
Import subscribers: add missing track event record

### DIFF
--- a/packages/data-stores/src/subscriber/actions.ts
+++ b/packages/data-stores/src/subscriber/actions.ts
@@ -13,9 +13,11 @@ export function createActions() {
 	/**
 	 * ↓ Import subscribers by CSV
 	 */
-	const importCsvSubscribersStart = ( siteId: number ) => ( {
+	const importCsvSubscribersStart = ( siteId: number, file?: File, emails: string[] = [] ) => ( {
 		type: 'IMPORT_CSV_SUBSCRIBERS_START' as const,
 		siteId,
+		file,
+		emails,
 	} );
 
 	const importCsvSubscribersStartSuccess = ( siteId: number, jobId: number ) => ( {
@@ -36,7 +38,7 @@ export function createActions() {
 	} );
 
 	function* importCsvSubscribers( siteId: number, file?: File, emails: string[] = [] ) {
-		yield importCsvSubscribersStart( siteId );
+		yield importCsvSubscribersStart( siteId, file, emails );
 
 		try {
 			const data: ImportSubscribersResponse = yield wpcomRequest( {

--- a/packages/data-stores/src/subscriber/reducers.ts
+++ b/packages/data-stores/src/subscriber/reducers.ts
@@ -12,6 +12,8 @@ export const subscriber: Reducer< SubscriberState, Action > = ( state = {}, acti
 		return Object.assign( {}, state, {
 			import: {
 				inProgress: true,
+				file: action.file,
+				emails: action.emails,
 			},
 		} );
 	} else if ( action.type === 'IMPORT_CSV_SUBSCRIBERS_START_SUCCESS' ) {
@@ -35,13 +37,14 @@ export const subscriber: Reducer< SubscriberState, Action > = ( state = {}, acti
 			},
 		} );
 	} else if ( action.type === 'IMPORT_CSV_SUBSCRIBERS_UPDATE' ) {
-		if ( action.job )
+		if ( action.job ) {
 			return Object.assign( {}, state, {
 				import: {
 					inProgress: true,
 					job: action.job,
 				},
 			} );
+		}
 
 		return Object.assign( {}, state, {
 			import: {

--- a/packages/data-stores/src/subscriber/types.ts
+++ b/packages/data-stores/src/subscriber/types.ts
@@ -8,6 +8,8 @@ export interface SubscriberState {
 	};
 	import?: {
 		inProgress: boolean;
+		file?: File;
+		emails?: string[];
 		job?: ImportJob;
 		error?: ImportSubscribersError;
 	};

--- a/packages/subscriber/src/hooks/use-record-add-form-events.ts
+++ b/packages/subscriber/src/hooks/use-record-add-form-events.ts
@@ -29,6 +29,13 @@ export function useRecordAddFormEvents( recordTracksEvent?: RecordTrackEvents, f
 	}, [ addSelector?.inProgress ] );
 
 	useEffect( () => {
+		importSelector?.emails?.length &&
+			recordTracksEvent?.( `${ trackEventPrefix }_individual_subscribers`, {
+				flow_name: flowName,
+			} );
+	}, [ importSelector?.emails?.length ] );
+
+	useEffect( () => {
 		importSelector?.inProgress &&
 			recordTracksEvent?.( `${ trackEventPrefix }_csv_subscribers`, {
 				flow_name: flowName,


### PR DESCRIPTION
#### Proposed Changes

Import subscribers: add missing `calypso_subscriber_add_form_individual_subscribers`  track event record

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #69962
