### PR TITLE
Woo Tailored Onboarding:  Add the storeAddress step in the Woo flow

### DIFF
--- a/client/landing/stepper/declarative-flow/tailored-ecommerce-flow.ts
+++ b/client/landing/stepper/declarative-flow/tailored-ecommerce-flow.ts
@@ -34,6 +34,7 @@ export const ecommerceFlow: Flow = {
 		return [
 			'intro',
 			'storeProfiler',
+			'storeAddress',
 			'domains',
 			'designCarousel',
 			'siteCreationStep',
@@ -131,6 +132,9 @@ export const ecommerceFlow: Flow = {
 					return window.location.assign( logInUrl );
 
 				case 'storeProfiler':
+					return navigate( 'storeAddress' );
+
+				case 'storeAddress':
 					return navigate( 'designCarousel' );
 
 				case 'designCarousel':
@@ -161,6 +165,8 @@ export const ecommerceFlow: Flow = {
 		const goBack = () => {
 			switch ( _currentStepName ) {
 				case 'designCarousel':
+					return navigate( 'storeAddress' );
+				case 'storeAddress':
 					return navigate( 'storeProfiler' );
 				default:
 					return navigate( 'intro' );
@@ -172,6 +178,8 @@ export const ecommerceFlow: Flow = {
 				case 'intro':
 					return navigate( 'storeProfiler' );
 				case 'storeProfiler':
+					return navigate( 'storeAddress' );
+				case 'storeAddress':
 					return navigate( 'designCarousel' );
 				case 'designCarousel':
 					return navigate( 'designCarousel' );

--- a/client/landing/stepper/declarative-flow/tailored-ecommerce-flow.ts
+++ b/client/landing/stepper/declarative-flow/tailored-ecommerce-flow.ts
@@ -93,7 +93,7 @@ export const ecommerceFlow: Flow = {
 				case 'processing':
 					// Coming from setThemeStep
 					if ( providedDependencies?.selectedDesign ) {
-						return window.location.assign( `${ site?.URL }/wp-admin/admin.php?page=wc-admin` );
+						return navigate( 'storeAddress' );
 					}
 
 					if ( providedDependencies?.finishedWaitingForAtomic ) {
@@ -132,10 +132,10 @@ export const ecommerceFlow: Flow = {
 					return window.location.assign( logInUrl );
 
 				case 'storeProfiler':
-					return navigate( 'storeAddress' );
+					return navigate( 'designCarousel' );
 
 				case 'storeAddress':
-					return navigate( 'designCarousel' );
+					return window.location.assign( `${ site?.URL }/wp-admin/admin.php?page=wc-admin` );
 
 				case 'designCarousel':
 					return navigate( 'domains' );


### PR DESCRIPTION
#### Proposed Changes

* Add the `storeAddress` step so we can capture the user's address and city. This will make the site starts with the "Store Details" task completed

#### Testing Instructions

* Navigate to `/setup/ecommerce?flags=signup/tailored-ecommerce`
* Go through the steps, including the storeAddress store.
* When you land on wc-admin you should the "Store details" task marked as complete. 

Closes #70471
