### PR TITLE
Add re-usable Zendesk Chat widget (component) & unit test

### DIFF
--- a/client/components/presales-zendesk-chat/index.tsx
+++ b/client/components/presales-zendesk-chat/index.tsx
@@ -1,0 +1,27 @@
+import { useEffect } from 'react';
+
+interface Props {
+	chatId: string | false;
+}
+
+const ZendeskChat = ( { chatId }: Props ) => {
+	useEffect( () => {
+		if ( ! chatId ) {
+			return;
+		}
+
+		const script = document.createElement( 'script' );
+		script.src = 'https://static.zdassets.com/ekr/snippet.js?key=' + encodeURIComponent( chatId );
+		script.type = 'text/javascript';
+		script.id = 'ze-snippet';
+
+		const container = document.getElementById( 'zendesk-chat-container' );
+		if ( container ) {
+			container.appendChild( script );
+		}
+	}, [ chatId ] );
+
+	return <div id="zendesk-chat-container" />;
+};
+
+export default ZendeskChat;

--- a/client/components/presales-zendesk-chat/test/index.js
+++ b/client/components/presales-zendesk-chat/test/index.js
@@ -1,0 +1,20 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render } from '@testing-library/react';
+import ZendeskChatWidget from '../index';
+
+describe( 'ZendeskChatWidget', () => {
+	test( 'should not include a script tag when no chat id is passed', () => {
+		const { container } = render( <ZendeskChatWidget /> );
+		expect( container.getElementsByTagName( 'script' ).length ).toBe( 0 );
+	} );
+
+	test( 'should contain the script tag and have the correct id', () => {
+		const { container } = render( <ZendeskChatWidget chatId="some-chat-id" /> );
+		const scriptTags = container.getElementsByTagName( 'script' );
+		expect( scriptTags.length ).toBe( 1 );
+		expect( scriptTags[ 0 ].id ).toBe( 'ze-snippet' );
+	} );
+} );


### PR DESCRIPTION
**Proposed Changes**

This PR simply extracts the <ZendeskChat /> re-usable component into it's own PR, for 1, to simplify PR logic, and for 2, We (Jetpack) needed access to this component immediately so that we can deploy our pre-sales chat widgets so they are ready to go by tomorrow morning (Wed, Nov 30th)
Also extracted/copied over the unit-test associated with the ZendeskChat component.

Asana task: 1202858161751496-as-1203406293146511/f

**Testing Instructions**

I think it should be enough to inspect the code, and run the unit-test at, yarn test-client client/components/presales-zendesk-chat-widget/test/index.js`

Pre-merge Checklist
[X ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
[ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
[X] Have you checked for TypeScript, React or other console errors?
[ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
[ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
 For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?