### PR TITLE
Only show upgrade to yearly prompt for plans

### DIFF
--- a/client/my-sites/plans/jetpack-plans/product-store/hooks/use-store-item-info.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/hooks/use-store-item-info.tsx
@@ -20,7 +20,7 @@ import {
 	getSiteProducts,
 	isJetpackSiteMultiSite,
 } from 'calypso/state/sites/selectors';
-import { EXTERNAL_PRODUCTS_LIST } from '../../constants';
+import { EXTERNAL_PRODUCTS_LIST, ITEM_TYPE_PLAN } from '../../constants';
 import productButtonLabel from '../../product-card/product-button-label';
 import { SelectorProduct } from '../../types';
 import { UseStoreItemInfoProps } from '../types';
@@ -74,9 +74,14 @@ export const useStoreItemInfo = ( {
 		[ sitePlan, siteProducts ]
 	);
 
+	//Standalone products are currently not upgradable to yearly
+	//Once the feature is enabled, remove the last condition to enable the upgrade button
 	const getIsUpgradeableToYearly = useCallback(
 		( item: SelectorProduct ) =>
-			getIsOwned( item ) && selectedTerm === TERM_ANNUALLY && item.term === TERM_MONTHLY,
+			getIsOwned( item ) &&
+			selectedTerm === TERM_ANNUALLY &&
+			item.term === TERM_MONTHLY &&
+			item.type === ITEM_TYPE_PLAN,
 		[ getIsOwned, selectedTerm ]
 	);
 


### PR DESCRIPTION
#### Proposed Changes

* Standalone products such as Akismet, backups and so on do not have an upgrade path in the backend to go from yearly to monthly
* The result is the user sees the upgrade to yearly button, clicks it and checks out resulting in them now having the annual subscription IN ADDITION to the existing monthly plan, which is a poor experience.
* The payments team will eventually enable the upgrade path, but for now this PR provides a workaround by suppressing the button except for plans.
* Plan upgrade to annual is also broken and that will be addressed in another patch, this just fixes the buttons on standalone products.
* Related issue https://github.com/Automattic/payments-shilling/issues/1255

#### Testing Instructions
* To see the issue, add a monthly standalone product, like Akismet to your test site
* Visit jetpack.com/pricing and click on the products tab.  Your monthly product should show an upgrade to yearly button
* If you click it it adds the yearly subscription to the cart, and purchasing results in both products being active
* Use the Jetpack Cloud live link (below) or build this PR locally
* Go to /pricing/:site to see the pricing page for your test site
* Click on the Products tab and find your monthly product
* The button should now say manage subscription and it leads to your site's purchases page


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
