### PR TITLE
Stats: Fix broken routing

### DIFF
--- a/client/my-sites/stats/controller.jsx
+++ b/client/my-sites/stats/controller.jsx
@@ -189,7 +189,7 @@ export function overview( context, next ) {
 		return (
 			context.params.period === filter.period ||
 			context.path.indexOf( filter.path ) >= 0 ||
-			( filter.altPaths && filter.altPaths.includes( context.path ) )
+			( filter.altPaths && context.path.indexOf( filter.altPaths ) >= 0 )
 		);
 	} );
 
@@ -221,7 +221,7 @@ export function site( context, next ) {
 	const activeFilter = find( filters, ( filter ) => {
 		return (
 			context.path.indexOf( filter.path ) >= 0 ||
-			( filter.altPaths && filter.altPaths.includes( context.path ) )
+			( filter.altPaths && context.path.indexOf( filter.altPaths ) >= 0 )
 		);
 	} );
 
@@ -298,7 +298,7 @@ export function summary( context, next ) {
 	const activeFilter = find( filters, ( filter ) => {
 		return (
 			context.path.indexOf( filter.path ) >= 0 ||
-			( filter.altPaths && filter.altPaths.includes( context.path ) )
+			( filter.altPaths && context.path.indexOf( filter.altPaths ) >= 0 )
 		);
 	} );
 


### PR DESCRIPTION
Fixes #70600.

#### Proposed Changes

* Reverts commit c3af4e390e540719fccb47834c069035543ab7e8.
* Restores functionality for routes handled by the StatsSummary component.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up the live branch for this PR.
* Navigate to the Stats page.
* Click on any of the clickable module headers, like "Posts & Pages" or "Referrers".
* Ensure that the Stats Summary page renders as expected. Before this fix, a blank white page would be rendered.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
