### PR TITLE
Sites as landing page: use house as icon in banner instead of heart

### DIFF
--- a/client/sites-dashboard/components/sites-dashboard-opt-in-banner.tsx
+++ b/client/sites-dashboard/components/sites-dashboard-opt-in-banner.tsx
@@ -100,7 +100,7 @@ export const SitesDashboardOptInBanner = ( { sites }: SitesDashboardOptInBannerP
 			<SitesNotice
 				status="is-info"
 				text={ __( 'Do you want to make this page your default when visiting WordPress.com?' ) }
-				icon="heart"
+				icon="house"
 				showDismiss={ false }
 			>
 				<NoticeActions>


### PR DESCRIPTION
#### Proposed Changes

@SaxonF proposed using an icon that represents the intent of the banner better. We're now using the `house` icon:

![image](https://user-images.githubusercontent.com/26530524/204897570-883343ee-a6cf-4cb6-973b-363d305a3fff.png)


#### Testing Instructions

- run this branch;
- make sure the banner shows up (as in https://github.com/Automattic/wp-calypso/pull/70450);
- verify that the banner icon is a house.