### PR TITLE
Sites as landing page: improve visual aspects in the interface settings

### DIFF
--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -10,7 +10,6 @@ import { connect } from 'react-redux';
 import CSSTransition from 'react-transition-group/CSSTransition';
 import TransitionGroup from 'react-transition-group/TransitionGroup';
 import ColorSchemePicker from 'calypso/blocks/color-scheme-picker';
-import Badge from 'calypso/components/badge';
 import QueryUserSettings from 'calypso/components/data/query-user-settings';
 import FormattedHeader from 'calypso/components/formatted-header';
 import FormButton from 'calypso/components/forms/form-button';
@@ -975,9 +974,6 @@ class Account extends Component {
 							<FormFieldset>
 								<FormLabel id="account__default_landing_page">
 									{ translate( 'Sites as landing page' ) }
-									<Badge className="account__beta-badge" type="info-blue">
-										{ translate( 'beta' ) }
-									</Badge>
 								</FormLabel>
 								<ToggleSitesAsLandingPage />
 							</FormFieldset>

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -973,7 +973,7 @@ class Account extends Component {
 						{ config.isEnabled( 'sites-as-landing-page' ) && (
 							<FormFieldset>
 								<FormLabel id="account__default_landing_page">
-									{ translate( 'Sites as landing page' ) }
+									{ translate( 'Admin home' ) }
 								</FormLabel>
 								<ToggleSitesAsLandingPage />
 							</FormFieldset>

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -956,6 +956,15 @@ class Account extends Component {
 
 						{ this.props.canDisplayCommunityTranslator && this.communityTranslator() }
 
+						{ config.isEnabled( 'sites-as-landing-page' ) && (
+							<FormFieldset className="account__settings-admin-home">
+								<FormLabel id="account__default_landing_page">
+									{ translate( 'Admin home' ) }
+								</FormLabel>
+								<ToggleSitesAsLandingPage />
+							</FormFieldset>
+						) }
+
 						{ config.isEnabled( 'me/account/color-scheme-picker' ) &&
 							supportsCssCustomProperties() && (
 								<FormFieldset>
@@ -969,15 +978,6 @@ class Account extends Component {
 									/>
 								</FormFieldset>
 							) }
-
-						{ config.isEnabled( 'sites-as-landing-page' ) && (
-							<FormFieldset>
-								<FormLabel id="account__default_landing_page">
-									{ translate( 'Admin home' ) }
-								</FormLabel>
-								<ToggleSitesAsLandingPage />
-							</FormFieldset>
-						) }
 					</form>
 				</Card>
 

--- a/client/me/account/style.scss
+++ b/client/me/account/style.scss
@@ -24,10 +24,6 @@
 	width: 100%;
 }
 
-.account__beta-badge {
-	margin-left: 8px;
-}
-
 .account__link-destination {
 	.components-base-control__field {
 		align-items: flex-start;

--- a/client/me/account/style.scss
+++ b/client/me/account/style.scss
@@ -24,6 +24,10 @@
 	width: 100%;
 }
 
+fieldset.account__settings-admin-home {
+	margin: 30px 0 20px 0;
+}
+
 .account__link-destination {
 	.components-base-control__field {
 		align-items: flex-start;

--- a/client/me/account/toggle-sites-as-landing-page.tsx
+++ b/client/me/account/toggle-sites-as-landing-page.tsx
@@ -1,5 +1,4 @@
 import { ToggleControl as OriginalToggleControl } from '@wordpress/components';
-import { createInterpolateElement } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
 import { useDispatch, useSelector } from 'react-redux';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -39,20 +38,13 @@ function ToggleSitesAsLandingPage() {
 		);
 	}
 
-	const label = createInterpolateElement(
-		translate( 'Make the <a>Sites page</a> my default landing page.' ),
-		{
-			a: <a href="/sites" target="_blank" rel="noopener noreferrer" />,
-		}
-	);
-
 	return (
 		<div>
 			<ToggleControl
 				checked={ !! useSitesAsLandingPage }
 				onChange={ handleToggle }
 				disabled={ isSaving }
-				label={ label }
+				label={ translate( 'Show me all my sites when logging in to WordPress.com' ) }
 			/>
 		</div>
 	);


### PR DESCRIPTION
#### Proposed Changes

This PR:
- removes the `BETA` badge;
- rewords the toggle description and its title;
- moves the setting up in the card so it's more visible.

I feel that the dashboard themes take a lot of precedence in attention, which might reduce the sites' toggle effectiveness. Let me know if this is OK to ship.

#### Testing Instructions

Enable the `sites-as-landing-page` feature flag and check that the badge is not there, the copy of the toggle explains itself better and it's better collocated, visually.

![image](https://user-images.githubusercontent.com/26530524/204905851-c76c7ad0-f478-4d27-8d86-49011736794a.png)
