### PR TITLE
E2E: selectively apply extended timeout in specific cases.

### DIFF
--- a/packages/calypso-e2e/src/element-helper.ts
+++ b/packages/calypso-e2e/src/element-helper.ts
@@ -76,7 +76,7 @@ export async function clickNavTab(
 
 	// Mobile view - navtabs become a dropdown and thus it must be opened first.
 	if ( envVariables.VIEWPORT_NAME === 'mobile' ) {
-		await page.waitForLoadState( 'networkidle' );
+		await page.waitForLoadState( 'networkidle', { timeout: 25 * 1000 } );
 
 		// Open the Navtabs which now act as a pseudo-dropdown menu.
 		const navTabsButtonLocator = page.locator( selectors.navTabMobileToggleButton );
@@ -88,7 +88,7 @@ export async function clickNavTab(
 
 	// Click on the intended item and wait for navigation to finish.
 	const navTabItem = page.locator( selectors.navTabItem( { name: name, selected: false } ) );
-	await Promise.all( [ page.waitForNavigation( { timeout: 10 * 1000 } ), navTabItem.click() ] );
+	await Promise.all( [ page.waitForNavigation(), navTabItem.click() ] );
 
 	// Final verification.
 	const newSelectedTabLocator = page.locator(

--- a/packages/calypso-e2e/src/lib/components/block-widget-editor-component.ts
+++ b/packages/calypso-e2e/src/lib/components/block-widget-editor-component.ts
@@ -49,7 +49,7 @@ export class BlockWidgetEditorComponent {
 				if ( ( await locator.count() ) === 0 ) {
 					return;
 				}
-				await locator.click( { timeout: 10 * 1000 } );
+				await locator.click();
 			} catch {
 				//noop
 			}

--- a/packages/calypso-e2e/src/lib/components/editor-gutenberg-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-gutenberg-component.ts
@@ -58,7 +58,7 @@ export class EditorGutenbergComponent {
 	async enterTitle( title: string ): Promise< void > {
 		const sanitizedTitle = title.trim();
 		const locator = this.editor.locator( selectors.title );
-		await locator.fill( sanitizedTitle );
+		await locator.fill( sanitizedTitle, { timeout: 20 * 1000 } );
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/components/navbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/navbar-component.ts
@@ -60,8 +60,8 @@ export class NavbarComponent {
 		useKeyboard = false,
 	}: { useKeyboard?: boolean } = {} ): Promise< void > {
 		await Promise.all( [
-			this.page.waitForLoadState( 'networkidle' ),
-			this.page.waitForResponse( /async-load-calypso-blocks-jitm.*/, { timeout: 15 * 1000 } ),
+			this.page.waitForLoadState( 'networkidle', { timeout: 20 * 1000 } ),
+			this.page.waitForResponse( /async-load-calypso-blocks-jitm.*/, { timeout: 20 * 1000 } ),
 		] );
 
 		if ( useKeyboard ) {

--- a/packages/calypso-e2e/src/lib/components/sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/sidebar-component.ts
@@ -35,9 +35,12 @@ export class SidebarComponent {
 	 * Waits for the WordPress.com Calypso sidebar to be ready on the page.
 	 */
 	async waitForSidebarInitialization(): Promise< void > {
-		await this.page.waitForLoadState( 'load' );
 		const sidebarLocator = this.page.locator( selectors.sidebar );
-		await sidebarLocator.waitFor();
+
+		await Promise.all( [
+			this.page.waitForLoadState( 'load', { timeout: 20 * 1000 } ),
+			sidebarLocator.waitFor( { timeout: 20 * 1000 } ),
+		] );
 
 		// If the sidebar is collapsed (via the Collapse Menu toggle),
 		// re-expand the sidebar.

--- a/packages/calypso-e2e/src/lib/flows/start-site-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/start-site-flow.ts
@@ -97,7 +97,7 @@ export class StartSiteFlow {
 	 * @param {string} vertical Name of the vertical to select
 	 */
 	async enterVertical( vertical: string ): Promise< void > {
-		await this.page.waitForLoadState( 'networkidle' );
+		await this.page.waitForLoadState( 'networkidle', { timeout: 20 * 1000 } );
 
 		const input = this.page.locator( selectors.verticalInput );
 		await input.fill( vertical );

--- a/packages/calypso-e2e/src/lib/pages/cart-checkout-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/cart-checkout-page.ts
@@ -89,7 +89,10 @@ export class CartCheckoutPage {
 	 * @param {string} blogName Blogname for which checkout is to be loaded.
 	 */
 	async visit( blogName: string ): Promise< void > {
-		await this.page.goto( getCalypsoURL( `checkout/${ blogName }` ), { waitUntil: 'networkidle' } );
+		await this.page.goto( getCalypsoURL( `checkout/${ blogName }` ), {
+			waitUntil: 'networkidle',
+			timeout: 20 * 1000,
+		} );
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/pages/editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/editor-page.ts
@@ -108,7 +108,7 @@ export class EditorPage {
 	 * Example "new page": {@link https://wordpress.com/page}
 	 */
 	async visit( type: 'post' | 'page' = 'post' ): Promise< Response | null > {
-		const request = await this.page.goto( getCalypsoURL( type ) );
+		const request = await this.page.goto( getCalypsoURL( type ), { timeout: 20 * 1000 } );
 		await this.waitUntilLoaded();
 
 		return request;

--- a/packages/calypso-e2e/src/lib/pages/editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/editor-page.ts
@@ -108,7 +108,7 @@ export class EditorPage {
 	 * Example "new page": {@link https://wordpress.com/page}
 	 */
 	async visit( type: 'post' | 'page' = 'post' ): Promise< Response | null > {
-		const request = await this.page.goto( getCalypsoURL( type ), { timeout: 20 * 1000 } );
+		const request = await this.page.goto( getCalypsoURL( type ), { timeout: 30 * 1000 } );
 		await this.waitUntilLoaded();
 
 		return request;

--- a/packages/calypso-e2e/src/lib/pages/general-settings-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/general-settings-page.ts
@@ -41,6 +41,7 @@ export class GeneralSettingsPage {
 	async visit( siteSlug: string ): Promise< void > {
 		await this.page.goto( getCalypsoURL( `settings/general/${ siteSlug }` ), {
 			waitUntil: 'networkidle',
+			timeout: 20 * 1000,
 		} );
 	}
 

--- a/packages/calypso-e2e/src/lib/pages/login-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/login-page.ts
@@ -41,7 +41,10 @@ export class LoginPage {
 		await this.fillUsername( username );
 		await this.clickSubmit();
 		await this.fillPassword( password );
-		await Promise.all( [ this.page.waitForNavigation(), this.clickSubmit() ] );
+		await Promise.all( [
+			this.page.waitForNavigation( { timeout: 20 * 1000 } ),
+			this.clickSubmit(),
+		] );
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/pages/marketing-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/marketing-page.ts
@@ -32,7 +32,7 @@ export class MarketingPage {
 	 */
 	async clickTab( name: string ): Promise< void > {
 		await clickNavTab( this.page, name );
-		await this.page.waitForLoadState( 'networkidle' );
+		await this.page.waitForLoadState( 'networkidle', { timeout: 20 * 1000 } );
 	}
 
 	/* SEO Preview Methods */

--- a/packages/calypso-e2e/src/lib/pages/people-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/people-page.ts
@@ -82,7 +82,7 @@ export class PeoplePage {
 	 * Delete the user from site.
 	 */
 	async deleteUser(): Promise< void > {
-		await this.page.waitForLoadState( 'networkidle' );
+		await this.page.waitForLoadState( 'networkidle', { timeout: 20 * 1000 } );
 
 		const elementHandle = await this.page.waitForSelector(
 			selectors.deletedUserContentAction( 'delete' )

--- a/packages/calypso-e2e/src/lib/pages/plans-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plans-page.ts
@@ -140,7 +140,7 @@ export class PlansPage {
 		// See https://github.com/Automattic/wp-calypso/issues/64389
 		// and https://github.com/Automattic/wp-calypso/pull/64421#discussion_r892589761.
 		await Promise.all( [
-			this.page.waitForLoadState( 'networkidle' ),
+			this.page.waitForLoadState( 'networkidle', { timeout: 20 * 1000 } ),
 			this.page.waitForResponse( /.*active-promotions.*/ ),
 		] );
 		await clickNavTab( this.page, targetTab, { force: true } );

--- a/packages/calypso-e2e/src/lib/pages/plugins-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plugins-page.ts
@@ -288,7 +288,7 @@ export class PluginsPage {
 	 * @returns {Promise<boolean>} True if plugin is active on any site. False otherwise.
 	 */
 	async pluginIsInstalled(): Promise< boolean > {
-		await this.page.waitForLoadState( 'networkidle' );
+		await this.page.waitForLoadState( 'networkidle', { timeout: 20 * 1000 } );
 		const locator = this.page.locator( selectors.pluginToggle( 'Active' ) );
 		if ( ( await locator.count() ) > 0 ) {
 			return true;

--- a/packages/calypso-e2e/src/lib/pages/plugins-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plugins-page.ts
@@ -81,7 +81,7 @@ export class PluginsPage {
 			waitUntil: 'networkidle',
 			// Manual override of the timeout - `networkidle` can take longer
 			// to fire, especially for Simple sites.
-			timeout: 15 * 1000,
+			timeout: 20 * 1000,
 		} );
 	}
 

--- a/packages/calypso-e2e/src/lib/pages/posts-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/posts-page.ts
@@ -56,7 +56,7 @@ export class PostsPage {
 	async clickTab( name: PostsPageTabs ): Promise< void > {
 		// Without waiting for the `networkidle` event to fire, the clicks on the
 		// mobile navbar dropdowns are swallowed up.
-		await this.page.waitForLoadState( 'networkidle' );
+		await this.page.waitForLoadState( 'networkidle', { timeout: 20 * 1000 } );
 
 		await clickNavTab( this.page, name );
 		await this.waitUntilLoaded();

--- a/test/e2e/specs/fse/fse__temp-smoke-test.ts
+++ b/test/e2e/specs/fse/fse__temp-smoke-test.ts
@@ -51,7 +51,7 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 		// Because this is a temporary smoke test, adding the needed FSE selectors here instead of
 		// spinning up a POM class that we will later needed to redo.
 		// This should ensure the editor hasn't done a WSoD.
-		await page.waitForLoadState( 'networkidle' );
+		await page.waitForLoadState( 'networkidle', { timeout: 30 * 1000 } );
 
 		fullSiteEditorPage = new FullSiteEditorPage( page, { target: features.siteType } );
 		await fullSiteEditorPage.waitUntilLoaded();

--- a/test/e2e/specs/i18n/i18n__editor.ts
+++ b/test/e2e/specs/i18n/i18n__editor.ts
@@ -296,19 +296,14 @@ describe( 'I18N: Editor', function () {
 		describe( 'Editing Toolkit Plugin', function () {
 			it( 'Translations for Welcome Guide', async function () {
 				const frame = await editorPage.getEditorHandle();
-				const timeout = 10 * 1000;
 				// We know these are all defined because of the filtering above. Non-null asserting is safe here.
 				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 				const etkTranslations = translations[ locale ]!.etkPlugin!;
 
 				await editorPage.openEditorOptionsMenu();
-				await frame.locator( etkTranslations.welcomeGuide.openGuideSelector ).click( { timeout } );
-				await frame.waitForSelector( etkTranslations.welcomeGuide.welcomeTitleSelector, {
-					timeout,
-				} );
-				await frame
-					.locator( etkTranslations.welcomeGuide.closeButtonSelector )
-					.click( { timeout } );
+				await frame.locator( etkTranslations.welcomeGuide.openGuideSelector ).click();
+				await frame.waitForSelector( etkTranslations.welcomeGuide.welcomeTitleSelector );
+				await frame.locator( etkTranslations.welcomeGuide.closeButtonSelector ).click();
 			} );
 		} );
 
@@ -321,8 +316,6 @@ describe( 'I18N: Editor', function () {
 				let frame: Page | Frame;
 				let editorPage: EditorPage;
 
-				const blockTimeout = 10 * 1000;
-
 				it( 'Insert test block', async function () {
 					editorPage = new EditorPage( page, { target: features.siteType } );
 					await editorPage.addBlockFromSidebar( block.blockName, block.blockEditorSelector );
@@ -333,9 +326,7 @@ describe( 'I18N: Editor', function () {
 					// Ensure block contents are translated as expected.
 					await Promise.all(
 						block.blockEditorContent.map( ( content ) =>
-							frame.waitForSelector( `${ block.blockEditorSelector } ${ content }`, {
-								timeout: blockTimeout,
-							} )
+							frame.waitForSelector( `${ block.blockEditorSelector } ${ content }` )
 						)
 					);
 				} );
@@ -346,8 +337,7 @@ describe( 'I18N: Editor', function () {
 
 					// Ensure the block is highlighted.
 					await frame.waitForSelector(
-						`:is( ${ block.blockEditorSelector }.is-selected, ${ block.blockEditorSelector }.has-child-selected)`,
-						{ timeout: blockTimeout }
+						`:is( ${ block.blockEditorSelector }.is-selected, ${ block.blockEditorSelector }.has-child-selected)`
 					);
 
 					// If on block insertion, one of the sub-blocks are selected, click on
@@ -359,8 +349,7 @@ describe( 'I18N: Editor', function () {
 
 					// Ensure the Settings with the block selected shows the expected title.
 					await frame.waitForSelector(
-						`.block-editor-block-card__title:has-text("${ block.blockPanelTitle }")`,
-						{ timeout: blockTimeout }
+						`.block-editor-block-card__title:has-text("${ block.blockPanelTitle }")`
 					);
 				} );
 			}

--- a/test/e2e/specs/infrastructure/infrastructure__ssr-enabled.ts
+++ b/test/e2e/specs/infrastructure/infrastructure__ssr-enabled.ts
@@ -22,6 +22,6 @@ describe( DataHelper.createSuiteTitle( 'Server-side Rendering' ), function () {
 		${ DataHelper.getCalypsoURL( 'theme/twentytwenty' ) }
 	`( 'Check endpoint: $endpoint', async function ( { endpoint } ) {
 		await page.goto( endpoint );
-		await page.waitForSelector( '#wpcom[data-calypso-ssr="true"]' );
+		await page.locator( '#wpcom[data-calypso-ssr="true"]' ).waitFor( { timeout: 15 * 1000 } );
 	} );
 } );

--- a/test/e2e/specs/martech/tos-screenshots__checkout.ts
+++ b/test/e2e/specs/martech/tos-screenshots__checkout.ts
@@ -16,6 +16,7 @@ import { Page, Browser } from 'playwright';
 import uploadScreenshotsToBlog from '../../lib/martech-tos-helper';
 
 declare const browser: Browser;
+const EXTENDED_TIMEOUT = 20 * 1000;
 
 describe( DataHelper.createSuiteTitle( 'ToS acceptance tracking screenshots' ), function () {
 	let page: Page;
@@ -32,7 +33,7 @@ describe( DataHelper.createSuiteTitle( 'ToS acceptance tracking screenshots' ), 
 		restAPIClient = new RestAPIClient( SecretsManager.secrets.testAccounts.martechTosUser );
 
 		await restAPIClient.setMySettings( { language: 'en' } );
-		await page.reload( { waitUntil: 'networkidle' } );
+		await page.reload( { waitUntil: 'networkidle', timeout: EXTENDED_TIMEOUT } );
 	} );
 
 	it( 'Navigate to Upgrades > Plans', async function () {
@@ -56,7 +57,7 @@ describe( DataHelper.createSuiteTitle( 'ToS acceptance tracking screenshots' ), 
 				cartCheckoutPage = new CartCheckoutPage( page );
 
 				await restAPIClient.setMySettings( { language: locale } );
-				await page.reload( { waitUntil: 'networkidle' } );
+				await page.reload( { waitUntil: 'networkidle', timeout: EXTENDED_TIMEOUT } );
 			} );
 
 			it( `Screenshot checkout page for ${ locale }`, async function () {


### PR DESCRIPTION
#### Proposed Changes

This PR deals with the minor fallout of https://github.com/Automattic/wp-calypso/pull/70392.

Key changes:
- extend timeouts from the default 10s at key areas that require longer timeouts.
- remove manual override of timeouts (`10 * 1000`) because the 10s timeout is now default.

#### Testing Instructions

Ensure the following build configurations are passing:
  - [x] Calypso E2E (desktop)
  - [x] Calypso E2E (mobile)

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Caused by https://github.com/Automattic/wp-calypso/pull/70392.
Supersedes https://github.com/Automattic/wp-calypso/pull/70561.
