### PR TITLE
Update presales Zendesk chat time to 22 (10pm).

### DIFF
--- a/client/my-sites/plans/jetpack-plans/product-store/zendesk-presales-chat-widget/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/zendesk-presales-chat-widget/index.tsx
@@ -1,0 +1,34 @@
+import config from '@automattic/calypso-config';
+import { getLocaleSlug } from 'i18n-calypso';
+import { useMemo } from 'react';
+import { useSelector } from 'react-redux';
+import ZendeskChat from 'calypso/components/presales-zendesk-chat';
+import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import type { ConfigData } from '@automattic/create-calypso-config';
+
+const isWithinChatHours = ( currentTime: Date ) => {
+	const [ NINE_AM, TEN_PM ] = [ 9, 22 ];
+	const [ SUNDAY, SATURDAY ] = [ 0, 6 ];
+
+	const utcHour = currentTime.getUTCHours();
+	const utcWeekDay = currentTime.getUTCDay();
+
+	return utcHour >= NINE_AM && utcHour < TEN_PM && utcWeekDay !== SUNDAY && utcWeekDay !== SATURDAY;
+};
+
+export const ZendeskPreSalesChat: React.FC = () => {
+	const zendeskChatKey = config( 'zendesk_presales_chat_key' ) as keyof ConfigData;
+	const isLoggedIn = useSelector( isUserLoggedIn );
+
+	const shouldShowZendeskPresalesChat = useMemo( () => {
+		const isEnglishLocale = ( config( 'english_locales' ) as string[] ).includes(
+			getLocaleSlug() ?? ''
+		);
+		const currentTime = new Date();
+
+		return ! isLoggedIn && isEnglishLocale && isJetpackCloud() && isWithinChatHours( currentTime );
+	}, [ isLoggedIn ] );
+
+	return shouldShowZendeskPresalesChat ? <ZendeskChat chatId={ zendeskChatKey } /> : null;
+};


### PR DESCRIPTION
#### Proposed Changes

Update the time when the Chat interface is shown. Previously it was showing until 7:00pm. Now it will show until 10:00pm UTC.

#### Testing Instructions

I think just simply inspecting the code is enough.. It's such a small chsnge.

*

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
