### PR TITLE
Checkout: Eager load web payment methods

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/checkout-main.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-main.tsx
@@ -3,11 +3,7 @@ import { useStripe } from '@automattic/calypso-stripe';
 import colorStudio from '@automattic/color-studio';
 import { CheckoutProvider, checkoutTheme } from '@automattic/composite-checkout';
 import { useShoppingCart } from '@automattic/shopping-cart';
-import {
-	useStripePaymentRequest,
-	usePaymentRequestOptions,
-	isValueTruthy,
-} from '@automattic/wpcom-checkout';
+import { isValueTruthy } from '@automattic/wpcom-checkout';
 import { useSelect } from '@wordpress/data';
 import debugFactory from 'debug';
 import { useTranslate } from 'i18n-calypso';
@@ -333,25 +329,11 @@ export default function CheckoutMain( {
 		} );
 	} );
 
-	const paymentRequestOptions = usePaymentRequestOptions( stripeConfiguration, cartKey );
-	const { allowedPaymentTypes: allowedWebPayTypes, isLoading: isWebPayLoading } =
-		useStripePaymentRequest( {
-			paymentRequestOptions,
-			// No callback is needed here; this is being used only to determine what
-			// payment methods are available.
-			onSubmit: () => undefined,
-			stripe,
-		} );
-	const { applePay: isApplePayAvailable, googlePay: isGooglePayAvailable } = allowedWebPayTypes;
-
 	const paymentMethodObjects = useCreatePaymentMethods( {
 		isStripeLoading,
 		stripeLoadingError,
 		stripeConfiguration,
 		stripe,
-		isApplePayAvailable,
-		isGooglePayAvailable,
-		isWebPayLoading,
 		storedCards,
 		siteSlug: updatedSiteSlug,
 	} );
@@ -364,9 +346,7 @@ export default function CheckoutMain( {
 		responseCart.products.length < 1 ||
 		isInitialCartLoading ||
 		// Only wait for stored cards to load if we are using cards
-		( allowedPaymentMethods.includes( 'card' ) && isLoadingStoredCards ) ||
-		// Only wait for web pay to load if we are using web pay
-		( allowedPaymentMethods.includes( 'web-pay' ) && isWebPayLoading );
+		( allowedPaymentMethods.includes( 'card' ) && isLoadingStoredCards );
 
 	const contactDetails: ManagedContactDetails | undefined = useSelect( ( select ) =>
 		select( 'wpcom-checkout' )?.getContactInfo()
@@ -530,7 +510,6 @@ export default function CheckoutMain( {
 
 	useRecordCheckoutLoaded( {
 		isLoading,
-		isApplePayAvailable,
 		responseCart,
 		storedCards,
 		productAliasFromUrl,

--- a/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-methods/index.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-methods/index.ts
@@ -289,21 +289,16 @@ function useCreateApplePay( {
 	stripeLoadingError,
 	stripeConfiguration,
 	stripe,
-	isApplePayAvailable,
-	isWebPayLoading,
 	cartKey,
 }: {
 	isStripeLoading: boolean;
 	stripeLoadingError: StripeLoadingError;
 	stripeConfiguration: StripeConfiguration | null;
 	stripe: Stripe | null;
-	isApplePayAvailable: boolean;
-	isWebPayLoading: boolean;
 	cartKey: CartKey | undefined;
 } ): PaymentMethod | null {
 	const isStripeReady = ! isStripeLoading && ! stripeLoadingError && stripe && stripeConfiguration;
-
-	const shouldCreateApplePayMethod = isStripeReady && ! isWebPayLoading && isApplePayAvailable;
+	const shouldCreateApplePayMethod = isStripeReady;
 
 	const applePayMethod = useMemo( () => {
 		return shouldCreateApplePayMethod && stripe && stripeConfiguration && cartKey
@@ -319,25 +314,19 @@ function useCreateGooglePay( {
 	stripeLoadingError,
 	stripeConfiguration,
 	stripe,
-	isGooglePayAvailable,
-	isWebPayLoading,
 	cartKey,
 }: {
 	isStripeLoading: boolean;
 	stripeLoadingError: StripeLoadingError;
 	stripeConfiguration: StripeConfiguration | null;
 	stripe: Stripe | null;
-	isGooglePayAvailable: boolean;
-	isWebPayLoading: boolean;
 	cartKey: CartKey | undefined;
 } ): PaymentMethod | null {
 	const isStripeReady =
 		! isStripeLoading &&
 		! stripeLoadingError &&
-		! isWebPayLoading &&
 		stripe &&
 		stripeConfiguration &&
-		isGooglePayAvailable &&
 		isEnabled( 'checkout/google-pay' );
 
 	return useMemo( () => {
@@ -352,9 +341,6 @@ export default function useCreatePaymentMethods( {
 	stripeLoadingError,
 	stripeConfiguration,
 	stripe,
-	isApplePayAvailable,
-	isGooglePayAvailable,
-	isWebPayLoading,
 	storedCards,
 	siteSlug,
 }: {
@@ -362,9 +348,6 @@ export default function useCreatePaymentMethods( {
 	stripeLoadingError: StripeLoadingError;
 	stripeConfiguration: StripeConfiguration | null;
 	stripe: Stripe | null;
-	isApplePayAvailable: boolean;
-	isGooglePayAvailable: boolean;
-	isWebPayLoading: boolean;
 	storedCards: StoredCard[];
 	siteSlug: string | undefined;
 } ): PaymentMethod[] {
@@ -434,8 +417,6 @@ export default function useCreatePaymentMethods( {
 		stripeLoadingError,
 		stripeConfiguration,
 		stripe,
-		isApplePayAvailable,
-		isWebPayLoading,
 		cartKey,
 	} );
 
@@ -444,8 +425,6 @@ export default function useCreatePaymentMethods( {
 		stripeLoadingError,
 		stripeConfiguration,
 		stripe,
-		isGooglePayAvailable,
-		isWebPayLoading,
 		cartKey,
 	} );
 

--- a/client/my-sites/checkout/composite-checkout/hooks/use-record-checkout-loaded.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-record-checkout-loaded.ts
@@ -10,7 +10,6 @@ const debug = debugFactory( 'calypso:composite-checkout:use-record-checkout-load
 
 export default function useRecordCheckoutLoaded( {
 	isLoading,
-	isApplePayAvailable,
 	responseCart,
 	storedCards,
 	productAliasFromUrl,
@@ -18,7 +17,6 @@ export default function useRecordCheckoutLoaded( {
 	isGiftPurchase,
 }: {
 	isLoading: boolean;
-	isApplePayAvailable: boolean;
 	responseCart: ResponseCart;
 	storedCards: StoredCard[];
 	productAliasFromUrl: string | undefined | null;
@@ -34,7 +32,6 @@ export default function useRecordCheckoutLoaded( {
 				saved_cards: storedCards.length,
 				is_renewal: hasRenewalItem( responseCart ),
 				is_gift_purchase: isGiftPurchase,
-				apple_pay_available: isApplePayAvailable,
 				product_slug: productAliasFromUrl,
 				is_composite: true,
 				checkout_flow: checkoutFlow,

--- a/packages/wpcom-checkout/src/payment-methods/apple-pay.tsx
+++ b/packages/wpcom-checkout/src/payment-methods/apple-pay.tsx
@@ -1,12 +1,12 @@
-import { ProcessPayment } from '@automattic/composite-checkout';
+import { useTogglePaymentMethod } from '@automattic/composite-checkout';
 import { useI18n } from '@wordpress/react-i18n';
 import debugFactory from 'debug';
-import { Fragment, useCallback } from 'react';
+import { Fragment, useCallback, useEffect } from 'react';
 import { PaymentMethodLogos } from '../payment-method-logos';
 import PaymentRequestButton from '../payment-request-button';
 import { usePaymentRequestOptions, useStripePaymentRequest } from './web-pay-utils';
 import type { StripeConfiguration } from '@automattic/calypso-stripe';
-import type { PaymentMethod } from '@automattic/composite-checkout';
+import type { PaymentMethod, ProcessPayment } from '@automattic/composite-checkout';
 import type { CartKey } from '@automattic/shopping-cart';
 import type { Stripe } from '@stripe/stripe-js';
 
@@ -59,6 +59,7 @@ export function ApplePaySubmitButton( {
 	stripeConfiguration: StripeConfiguration;
 	cartKey: CartKey;
 } ) {
+	const togglePaymentMethod = useTogglePaymentMethod();
 	const paymentRequestOptions = usePaymentRequestOptions( stripeConfiguration, cartKey );
 	const onSubmit = useCallback(
 		( { name, paymentMethodToken } ) => {
@@ -84,10 +85,14 @@ export function ApplePaySubmitButton( {
 	} );
 	debug( 'apple-pay button isLoading', isLoading );
 
-	if ( ! isLoading && ! allowedPaymentTypes.applePay ) {
-		// This should never occur because we should not display this payment
-		// method as an option if it is not supported.
-		throw new Error( 'This payment type is not supported' );
+	useEffect( () => {
+		if ( ! isLoading ) {
+			togglePaymentMethod( 'apple-pay', allowedPaymentTypes.applePay );
+		}
+	}, [ isLoading, allowedPaymentTypes.applePay, togglePaymentMethod ] );
+
+	if ( ! allowedPaymentTypes.applePay ) {
+		return null;
 	}
 
 	return (

--- a/packages/wpcom-checkout/src/payment-methods/google-pay.tsx
+++ b/packages/wpcom-checkout/src/payment-methods/google-pay.tsx
@@ -1,12 +1,12 @@
-import { ProcessPayment } from '@automattic/composite-checkout';
+import { useTogglePaymentMethod } from '@automattic/composite-checkout';
 import debugFactory from 'debug';
-import { Fragment, useCallback } from 'react';
+import { Fragment, useCallback, useEffect } from 'react';
 import { GooglePayMark } from '../google-pay-mark';
 import { PaymentMethodLogos } from '../payment-method-logos';
 import PaymentRequestButton from '../payment-request-button';
 import { usePaymentRequestOptions, useStripePaymentRequest } from './web-pay-utils';
 import type { StripeConfiguration } from '@automattic/calypso-stripe';
-import type { PaymentMethod } from '@automattic/composite-checkout';
+import type { PaymentMethod, ProcessPayment } from '@automattic/composite-checkout';
 import type { CartKey } from '@automattic/shopping-cart';
 import type { Stripe } from '@stripe/stripe-js';
 
@@ -57,6 +57,7 @@ export function GooglePaySubmitButton( {
 	stripeConfiguration: StripeConfiguration;
 	cartKey: CartKey;
 } ) {
+	const togglePaymentMethod = useTogglePaymentMethod();
 	const paymentRequestOptions = usePaymentRequestOptions( stripeConfiguration, cartKey );
 	const onSubmit = useCallback(
 		( { name, paymentMethodToken } ) => {
@@ -81,10 +82,14 @@ export function GooglePaySubmitButton( {
 		stripe,
 	} );
 
-	if ( ! isLoading && ! allowedPaymentTypes.googlePay ) {
-		// This should never occur because we should not display this payment
-		// method as an option if it is not supported.
-		throw new Error( 'This payment type is not supported' );
+	useEffect( () => {
+		if ( ! isLoading ) {
+			togglePaymentMethod( 'google-pay', allowedPaymentTypes.googlePay );
+		}
+	}, [ isLoading, allowedPaymentTypes.googlePay, togglePaymentMethod ] );
+
+	if ( ! allowedPaymentTypes.googlePay ) {
+		return null;
 	}
 
 	return (


### PR DESCRIPTION
#### Problem

When checkout determines which payment methods to display, it creates a Stripe Payment Request so we can ask Stripe if Apple and/or Google Pay should be allowed. If it says they are, then we create the payment method UI objects for those payment methods and list them as available. When a user then selects a web payment method, that payment method UI will create another Stripe Payment request that allows it to show the special submit button for that payment type.

Sometimes, the first call says that a payment method is available, but then the second call says that it is not available once the user has clicked to select the payment method. This results in us failing to render the submit button and causing the user to see an error message, which is very poor UX. It's not clear why this could happen since the logic that determines what payment methods are available is obfuscated behind Stripe and Apple/Google's servers, but the frequency of this error has been increasing lately.

#### Proposed Changes

To solve this issue, I changed checkout to allow disabling payment methods from inside those payment methods with https://github.com/Automattic/wp-calypso/pull/71103. In this PR, we make use of that technique for Apple and Google Pay.

1. We modify `CheckoutMain` to _always_ create both Apple Pay and Google Pay payment methods without checking if they are available in any special way (except for the usual availability check made by the shopping cart).
2. Next, we update both the Apple Pay and Google Pay payment method submit buttons so that if their Stripe Payment Request says _not_ to allow that method, they mark the appropriate payment method as unavailable.

The result is that, as soon as checkout loads, it will attempt to render both the Apple and Google Pay buttons (although they will be invisible). The buttons will then decide themselves if their respective payment methods should be available.

Fixes https://github.com/Automattic/wp-calypso/issues/70019

![checkout-70614](https://user-images.githubusercontent.com/2036909/204950557-743dfd52-8bf2-478e-b612-7f9fbc8b064b.png)

#### Testing Instructions

- Add a product to your cart and visit checkout _in production calypso_ (NOT using this PR) using Google Chrome.
- Make sure you see Google Pay in checkout in production. If not, you may need to add a card to your Google wallet.
- Use the calypso.live link in this diff to load calypso; this is necessary so that you can view the app over https.
- Visit checkout again in the calypso.live version of calypso.
- Verify that you see Google Pay as a payment method.
- Verify that you _do not_ see Apple Pay as a payment method.
