### PR TITLE
refundable bundle

### DIFF
--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -68,7 +68,6 @@ import {
 	isExpired,
 	isOneTimePurchase,
 	isPartnerPurchase,
-	isRefundable,
 	isRenewable,
 	isSubscription,
 	isCloseToExpiration,
@@ -495,7 +494,7 @@ class ManagePurchase extends Component {
 		} );
 	}
 
-	showPreCancellationModalDialog = ( cancelLink ) => {
+	showCancelSurvey = ( cancelLink ) => {
 		this.setState( {
 			showNonPrimaryDomainWarningDialog: false,
 			showRemoveSubscriptionWarningDialog: false,
@@ -540,23 +539,18 @@ class ManagePurchase extends Component {
 
 	renderRemoveSubscriptionWarningDialog( site, purchase ) {
 		if ( this.state.showRemoveSubscriptionWarningDialog ) {
-			const { hasCustomPrimaryDomain, primaryDomain } = this.props;
-			const customDomain = hasCustomPrimaryDomain && primaryDomain.name;
-			const primaryDomainName = customDomain ? primaryDomain.name : '';
-			const isPlanRefundable = isRefundable( purchase );
-			const actionFunction =
-				isPlanRefundable && customDomain
-					? this.goToCancelLink
-					: this.showPreCancellationModalDialog;
+			const { primaryDomain } = this.props;
+			const hasDomain = primaryDomain !== undefined && primaryDomain.name !== undefined;
+			const primaryDomainName = primaryDomain.name ? primaryDomain.name : '';
 
 			return (
 				<PreCancellationDialog
 					isDialogVisible={ this.state.showRemoveSubscriptionWarningDialog }
 					closeDialog={ this.closeDialog }
-					removePlan={ actionFunction }
+					removePlan={ this.showCancelSurvey }
 					site={ site }
 					purchase={ purchase }
-					hasDomain={ customDomain }
+					hasDomain={ hasDomain }
 					primaryDomain={ primaryDomainName }
 					wpcomURL={ site.wpcom_url }
 				/>

--- a/client/me/purchases/pre-cancellation-dialog/style.scss
+++ b/client/me/purchases/pre-cancellation-dialog/style.scss
@@ -204,4 +204,18 @@ $modal-breakpoint-mobile: 480px;
 			margin-bottom: 27px;
 		}
 	}
+
+	&.--with-refundable-bundle {
+		h2 {
+			margin-bottom: 20px;
+		}
+
+		.form-label {
+			margin-bottom: 20px;
+
+			&:last-child {
+				margin-bottom: 0;
+			}
+		}
+	}
 }


### PR DESCRIPTION
#### Proposed Changes

Add the edge case Subscription + Domain + Refund Window to the Pre Cancellation Modal component.

#### Screen
<img width="1075" alt="Screenshot 2022-12-01 at 02 44 13" src="https://user-images.githubusercontent.com/5706607/204945873-df2639a1-3e35-44b9-98ec-373760ad6b9b.png">
shot

#### Feature Flags:
URL query: ?flags=pre-cancellation-modal
Shell command: ENABLE_FEATURES=pre-cancellation-modal yarn start

#### Testing Instructions

1. Visit the page /me/purchases/ on Calypso
2. Select a Plan subscription + Domain in the refund window.
3. Verify the Edge Case show up.
4. Verify the Cancel Action reflects the choice made in the Pre Cancellation modal window

Related to #1222
