### PR TITLE
Style selection: Fix issue where Twenty Twenty-Three has fully white global style indicators 

### DIFF
--- a/packages/design-picker/src/components/style-variation-badges/badge.tsx
+++ b/packages/design-picker/src/components/style-variation-badges/badge.tsx
@@ -51,8 +51,8 @@ const Badge: React.FC< BadgeProps > = ( { variation, onClick } ) => {
 				style={ {
 					background: `linear-gradient(
 							to right,
-							${ styles.color.background } 0 50%,
-							${ styles.color.foreground || styles.color.primary } 50% 100%)`,
+							${ styles.background } 0 50%,
+							${ styles.text } 50% 100%)`,
 				} }
 			/>
 		</div>

--- a/packages/design-picker/src/components/style-variation-badges/badge.tsx
+++ b/packages/design-picker/src/components/style-variation-badges/badge.tsx
@@ -1,7 +1,7 @@
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import { useMemo } from 'react';
-import { getPreviewStylesFromVariation } from './utils';
+import { getStylesColorFromVariation } from './utils';
 import type { StyleVariation } from '../../types';
 import './style.scss';
 
@@ -14,12 +14,12 @@ interface BadgeProps {
 
 const Badge: React.FC< BadgeProps > = ( { variation, onClick } ) => {
 	const { __ } = useI18n();
-	const styles = useMemo(
-		() => variation && getPreviewStylesFromVariation( variation ),
+	const color = useMemo(
+		() => variation && getStylesColorFromVariation( variation ),
 		[ variation ]
 	);
 
-	if ( ! styles ) {
+	if ( ! color ) {
 		return null;
 	}
 
@@ -51,8 +51,8 @@ const Badge: React.FC< BadgeProps > = ( { variation, onClick } ) => {
 				style={ {
 					background: `linear-gradient(
 							to right,
-							${ styles.background } 0 50%,
-							${ styles.text } 50% 100%)`,
+							${ color.background } 0 50%,
+							${ color.text } 50% 100%)`,
 				} }
 			/>
 		</div>

--- a/packages/design-picker/src/components/style-variation-badges/utils.ts
+++ b/packages/design-picker/src/components/style-variation-badges/utils.ts
@@ -17,7 +17,7 @@ function getValueFromVariationSettingColorPalette(
 }
 
 function getColorBackground( color: StyleVariationPreviewColorPalette ) {
-	return color.base || color.background;
+	return color.base || color.background || '#ffffff';
 }
 
 function getColorText( color: StyleVariationPreviewColorPalette ) {

--- a/packages/design-picker/src/components/style-variation-badges/utils.ts
+++ b/packages/design-picker/src/components/style-variation-badges/utils.ts
@@ -2,8 +2,8 @@ import { hexToRgb, hasMinContrast } from '@automattic/onboarding';
 import type {
 	StyleVariation,
 	StyleVariationSettingsColorPalette,
-	StyleVariationPreview,
 	StyleVariationPreviewColorPalette,
+	StyleVariationStylesColor,
 } from '../../types';
 
 const COLOR_PALETTE_SUPPORTS = [ 'background', 'base', 'contrast', 'foreground', 'primary' ];
@@ -31,7 +31,9 @@ function getColorText( color: StyleVariationPreviewColorPalette ) {
 	return foreground || primary;
 }
 
-export function getPreviewStylesFromVariation( variation: StyleVariation ): StyleVariationPreview {
+export function getStylesColorFromVariation(
+	variation: StyleVariation
+): StyleVariationStylesColor {
 	let color: StyleVariationPreviewColorPalette = {};
 	for ( const key of COLOR_PALETTE_SUPPORTS ) {
 		const value = getValueFromVariationSettingColorPalette( variation, key );

--- a/packages/design-picker/src/components/style-variation-badges/utils.ts
+++ b/packages/design-picker/src/components/style-variation-badges/utils.ts
@@ -1,3 +1,4 @@
+import { hexToRgb, hasMinContrast } from '@automattic/onboarding';
 import type {
 	StyleVariation,
 	StyleVariationSettingsColorPalette,
@@ -5,7 +6,7 @@ import type {
 	StyleVariationPreviewColorPalette,
 } from '../../types';
 
-const COLOR_PALETTE_SUPPORTS = [ 'background', 'foreground', 'primary' ];
+const COLOR_PALETTE_SUPPORTS = [ 'background', 'base', 'contrast', 'foreground', 'primary' ];
 
 function getValueFromVariationSettingColorPalette(
 	variation: StyleVariation,
@@ -15,6 +16,21 @@ function getValueFromVariationSettingColorPalette(
 	return palette.find( ( item: StyleVariationSettingsColorPalette ) => item.slug === name )?.color;
 }
 
+function getColorBackground( color: StyleVariationPreviewColorPalette ) {
+	return color.base || color.background;
+}
+
+function getColorText( color: StyleVariationPreviewColorPalette ) {
+	const { contrast, foreground, primary } = color;
+	if ( contrast ) {
+		const backgroundRgb = hexToRgb( getColorBackground( color ) );
+		const contrastRgb = hexToRgb( contrast );
+		return hasMinContrast( contrastRgb, backgroundRgb, 0.2 ) ? contrast : foreground || primary;
+	}
+
+	return foreground || primary;
+}
+
 export function getPreviewStylesFromVariation( variation: StyleVariation ): StyleVariationPreview {
 	let color: StyleVariationPreviewColorPalette = {};
 	for ( const key of COLOR_PALETTE_SUPPORTS ) {
@@ -22,5 +38,8 @@ export function getPreviewStylesFromVariation( variation: StyleVariation ): Styl
 		color = { ...color, ...( value && { [ key ]: value } ) };
 	}
 
-	return { color };
+	return {
+		background: getColorBackground( color ),
+		text: getColorText( color ),
+	};
 }

--- a/packages/design-picker/src/types.ts
+++ b/packages/design-picker/src/types.ts
@@ -42,6 +42,8 @@ export interface StyleVariationPreview {
 }
 
 export interface StyleVariationPreviewColorPalette {
+	base?: string;
+	contrast?: string;
 	background?: string;
 	foreground?: string;
 	primary?: string;


### PR DESCRIPTION
#### Proposed Changes

This PR updates the color extraction function for the global style indicators to support new properties `base` and `contrast`.  Using these two new values, we can infer colors to generate style indicators.

| Before | After |
| --- | --- |
| ![Screen Shot 2022-12-01 at 11 58 50 AM](https://user-images.githubusercontent.com/797888/204962604-3b2ec66a-4b80-4bd8-b786-0164b87dc0fd.png) | ![Screen Shot 2022-12-01 at 11 59 56 AM](https://user-images.githubusercontent.com/797888/204962728-d41b52df-7318-4f3c-8cb2-934794c0320c.png)

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the design picker `/setup/site-setup/designSetup?siteSlug=${site_slug}`.
* Find the Twenty Twenty-Three theme.
* Ensure that the global style indicator show background and text colors. 

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #70587
