### PR TITLE
Re-adding subscribers role for atomic sites

### DIFF
--- a/client/data/site-roles/use-site-roles-query.js
+++ b/client/data/site-roles/use-site-roles-query.js
@@ -4,7 +4,11 @@ import wp from 'calypso/lib/wp';
 function useSiteRolesQuery( siteId, queryOptions = {} ) {
 	return useQuery( [ 'site-roles', siteId ], () => wp.req.get( `/sites/${ siteId }/roles` ), {
 		...queryOptions,
-		select: ( { roles } ) => roles,
+		select: ( { roles } ) => {
+			return roles.map( ( role ) =>
+				role.name === 'subscriber' ? { ...role, display_name: 'Viewer' } : role
+			);
+		},
 		enabled: !! siteId,
 	} );
 }

--- a/client/my-sites/invites/invite-form-header/index.jsx
+++ b/client/my-sites/invites/invite-form-header/index.jsx
@@ -217,7 +217,7 @@ class InviteFormHeader extends Component {
 				break;
 			case 'subscriber':
 				explanation = this.props.translate(
-					'As a subscriber, you will be able to manage your profile on %(siteName)s.',
+					'As a viewer, you will be able to manage your profile on %(siteName)s.',
 					{
 						args: {
 							siteName: this.getSiteName(),

--- a/client/my-sites/people/invite-people/index.jsx
+++ b/client/my-sites/people/invite-people/index.jsx
@@ -415,7 +415,7 @@ class InvitePeople extends Component {
 		} = this.props;
 
 		let includeFollower = isPrivate && ! isAtomic;
-		const includeSubscriber = ! includeSubscriberImporter;
+		const includeSubscriber = isAtomic;
 
 		if ( ! includeSubscriberImporter ) {
 			// Atomic private sites don't support Viewers/Followers.

--- a/client/my-sites/people/people-profile/index.jsx
+++ b/client/my-sites/people/people-profile/index.jsx
@@ -75,7 +75,7 @@ const PeopleProfile = ( { siteId, type, user, invite } ) => {
 				} );
 				break;
 			case 'subscriber':
-				text = translate( 'Subscriber', {
+				text = translate( 'Viewer', {
 					context: 'Noun: A user role displayed in a badge',
 				} );
 				break;


### PR DESCRIPTION
#### Proposed Changes

We've removed the `Subscriber` role in the people invite page on Atomic sites due to the introduction of subscriber importer. But the behavior of a `Subscriber` role on an Atomic site also includes creating a local user on the target site previously. This PR brings this functionality back to the Atomic site and should work the same as before. (Site owner can invite a subscriber on the Atomic sites and it will create a local user after an invitee has accepted the invitation).

In this PR, we've also rename the role `Subscriber` to `Viewer`.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Prepare a **Atomic** testing site and navigate to `http://calypso.localhost:3000/people/new/${SITE_SLUG}`.
2. See if you see a `Viewer` role inside the Role list.
![Screen Shot 2022-12-01 at 2 13 05 PM](https://user-images.githubusercontent.com/4074459/204981436-4134f96f-7a94-4da8-839a-6aa9532e728d.png)
3. Invite a user with your testing email address, can be an email address with or without a wpcom account.
4. Checking the inbox and see if you get an invitation email, click "Accept invitation" and follow the instruction.
5. You'll also see terms that gets updated to "As a viewer, you will...".
<img width="445" alt="Screen Shot 2022-12-01 at 2 22 46 PM" src="https://user-images.githubusercontent.com/4074459/204983058-e671c317-33f3-4e85-844c-ed67a909bb7a.png">

6. After you accept the invitation, go back to your Atomic testing site and go to the team page `http://calypso.localhost:3000/people/team/${SITE_SLUG}` and see if the invitee has shown up as a team user and the badge should be labeled as "Viewer" instead of "Subscriber".
![Screen Shot 2022-12-01 at 3 17 15 PM](https://user-images.githubusercontent.com/4074459/204990574-87acaaec-1a8f-420c-b838-c713ecd362bd.png)

7. Navigate to Settings > General > Privacy and make your testing site `Private`.
8. Try to use the account you invited earlier to login to your site and see if it still gets access to your private site.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #70216 
