### PR TITLE
Add ellipsis menu tracks events for 'real' page

### DIFF
--- a/client/my-sites/pages/page/index.js
+++ b/client/my-sites/pages/page/index.js
@@ -366,7 +366,7 @@ class Page extends Component {
 			<PostActionsEllipsisMenuQRCode
 				globalId={ this.props.page.global_ID }
 				key="qrcode"
-				handleClick={ this.exportPageQr }
+				handleClick={ this.viewPageQr }
 			/>
 		);
 	}
@@ -784,7 +784,7 @@ class Page extends Component {
 		saveAs( blob, fileName );
 	};
 
-	exportPageQr = () => {
+	viewPageQr = () => {
 		this.recordEllipsisMenuItemClickEvent( 'qrcode' );
 	};
 

--- a/client/my-sites/pages/page/index.js
+++ b/client/my-sites/pages/page/index.js
@@ -87,6 +87,14 @@ class Page extends Component {
 		showPublishedStatus: false,
 	};
 
+	recordEllipsisMenuItemClickEvent = ( item ) => {
+		this.props.recordTracksEvent( 'calypso_pages_ellipsismenu_item_click', {
+			page_type: 'real',
+			blog_id: this.props.site.ID,
+			item,
+		} );
+	};
+
 	// Construct a link to the Site the page belongs too
 	getSiteDomain() {
 		return ( this.props.site && this.props.site.domain ) || '...';
@@ -210,7 +218,7 @@ class Page extends Component {
 
 		if ( this.props.wpAdminGutenberg ) {
 			return (
-				<PopoverMenuItem onClick={ this.props.recordEditPage } href={ this.props.editorUrl }>
+				<PopoverMenuItem onClick={ this.editPage } href={ this.props.editorUrl }>
 					<Gridicon icon="pencil" size={ 18 } />
 					{ this.props.translate( 'Edit' ) }
 				</PopoverMenuItem>
@@ -402,8 +410,12 @@ class Page extends Component {
 	}
 
 	editPage = () => {
-		this.props.recordEditPage();
-		pageRouter( this.props.editorUrl );
+		this.recordEllipsisMenuItemClickEvent( 'edit' );
+		this.props.recordEvent( 'Clicked Edit Page' );
+
+		if ( this.props.wpAdminGutenberg ) {
+			pageRouter( this.props.editorUrl );
+		}
 	};
 
 	getPageStatusInfo() {
@@ -744,7 +756,7 @@ class Page extends Component {
 			blog_id: this.props.siteId,
 			can_edit: canEdit,
 		} );
-		this.props.recordPageTitle();
+		this.props.recordEvent( 'Clicked Page Title' );
 	};
 
 	copyPage = () => {
@@ -776,8 +788,12 @@ class Page extends Component {
 
 	handleMenuToggle = ( isVisible ) => {
 		if ( isVisible ) {
+			this.props.recordTracksEvent( 'calypso_pages_ellipsismenu_open_click', {
+				page_type: 'real',
+				blog_id: this.props.siteId,
+			} );
 			// record a GA event when the menu is opened
-			this.props.recordMoreOptions();
+			this.props.recordEvent( 'Clicked More Options Menu' );
 			preloadEditor();
 		}
 	};

--- a/client/my-sites/pages/page/index.js
+++ b/client/my-sites/pages/page/index.js
@@ -75,11 +75,6 @@ class Page extends Component {
 		setLayoutFocus: PropTypes.func.isRequired,
 		recordEvent: PropTypes.func.isRequired,
 		recordTracksEvent: PropTypes.func.isRequired,
-		recordMoreOptions: PropTypes.func.isRequired,
-		recordPageTitle: PropTypes.func.isRequired,
-		recordEditPage: PropTypes.func.isRequired,
-		recordViewPage: PropTypes.func.isRequired,
-		recordStatsPage: PropTypes.func.isRequired,
 	};
 
 	static defaultProps = {
@@ -853,11 +848,6 @@ const mapDispatch = {
 	setLayoutFocus,
 	recordTracksEvent,
 	recordEvent,
-	recordMoreOptions: () => recordEvent( 'Clicked More Options Menu' ),
-	recordPageTitle: () => recordEvent( 'Clicked Page Title' ),
-	recordEditPage: () => recordEvent( 'Clicked Edit Page' ),
-	recordViewPage: () => recordEvent( 'Clicked View Page' ),
-	recordStatsPage: () => recordEvent( 'Clicked Stats Page' ),
 	updateSiteFrontPage,
 };
 

--- a/client/my-sites/pages/page/index.js
+++ b/client/my-sites/pages/page/index.js
@@ -104,7 +104,8 @@ class Page extends Component {
 		const { isPreviewable, page, previewURL } = this.props;
 
 		if ( page.status && page.status === 'publish' ) {
-			this.props.recordViewPage();
+			this.recordEllipsisMenuItemClickEvent( 'viewpage' );
+			this.props.recordEvent( 'Clicked View Page' );
 		}
 
 		if ( ! isPreviewable && typeof window === 'object' ) {
@@ -366,7 +367,13 @@ class Page extends Component {
 		if ( ! config.isEnabled( 'post-list/qr-code-link' ) ) {
 			return null;
 		}
-		return <PostActionsEllipsisMenuQRCode globalId={ this.props.page.global_ID } key="qrcode" />;
+		return (
+			<PostActionsEllipsisMenuQRCode
+				globalId={ this.props.page.global_ID }
+				key="qrcode"
+				handleClick={ this.exportPageQr }
+			/>
+		);
 	}
 
 	getCopyLinkItem() {
@@ -391,8 +398,9 @@ class Page extends Component {
 		);
 	}
 
-	statsPage = () => {
-		this.props.recordStatsPage();
+	viewStats = () => {
+		this.recordEllipsisMenuItemClickEvent( 'viewstats' );
+		this.props.recordEvent( 'Clicked Stats Page' );
 		pageRouter( statsLinkForPage( this.props.page, this.props.site ) );
 	};
 
@@ -402,7 +410,7 @@ class Page extends Component {
 		}
 
 		return (
-			<PopoverMenuItem onClick={ this.statsPage }>
+			<PopoverMenuItem onClick={ this.viewStats }>
 				<Gridicon icon="stats" size={ 18 } />
 				{ this.props.translate( 'Stats' ) }
 			</PopoverMenuItem>
@@ -410,10 +418,10 @@ class Page extends Component {
 	}
 
 	editPage = () => {
-		this.recordEllipsisMenuItemClickEvent( 'edit' );
+		this.recordEllipsisMenuItemClickEvent( 'editpage' );
 		this.props.recordEvent( 'Clicked Edit Page' );
 
-		if ( this.props.wpAdminGutenberg ) {
+		if ( ! this.props.wpAdminGutenberg ) {
 			pageRouter( this.props.editorUrl );
 		}
 	};
@@ -760,10 +768,12 @@ class Page extends Component {
 	};
 
 	copyPage = () => {
+		this.recordEllipsisMenuItemClickEvent( 'copypage' );
 		this.props.recordEvent( 'Clicked Copy Page' );
 	};
 
 	exportPage = () => {
+		this.recordEllipsisMenuItemClickEvent( 'exportpage' );
 		this.props.recordEvent( 'Clicked Export Page' );
 		const { page } = this.props;
 
@@ -779,11 +789,17 @@ class Page extends Component {
 		saveAs( blob, fileName );
 	};
 
+	exportPageQr = () => {
+		this.recordEllipsisMenuItemClickEvent( 'qrcode' );
+	};
+
 	copyPageLink = () => {
+		this.recordEllipsisMenuItemClickEvent( 'copylink' );
+		this.props.recordEvent( 'Clicked Copy Page Link' );
+
 		this.props.infoNotice( this.props.translate( 'Link copied to clipboard.' ), {
 			duration: 3000,
 		} );
-		this.props.recordEvent( 'Clicked Copy Page Link' );
 	};
 
 	handleMenuToggle = ( isVisible ) => {

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/qrcode.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/qrcode.jsx
@@ -17,7 +17,7 @@ const qrIcon = (
 	/>
 );
 
-function PostActionsEllipsisMenuQRCode( { globalId } ) {
+function PostActionsEllipsisMenuQRCode( { globalId, handleClick } ) {
 	const [ showQRCode, setShowQRCode ] = useState( false );
 
 	const translate = useTranslate();
@@ -25,6 +25,7 @@ function PostActionsEllipsisMenuQRCode( { globalId } ) {
 	const post = useSelector( ( state ) => getPost( state, globalId ) );
 
 	const generateQRCode = () => {
+		handleClick();
 		setShowQRCode( true );
 	};
 


### PR DESCRIPTION
#### Proposed Changes

PR implements the following Tracks event:

| Trigger | Event | Props |
|-|-|-|
| User clicks page title<br><img width="265" alt="image" src="https://user-images.githubusercontent.com/10071857/205556002-90667436-c8b6-41dd-ae2c-8128c5723a40.png"> | `calypso_pages_page_title_click` | `page_type: real`
| User clicks to open the ellipsis menu<br><img width="209" alt="image" src="https://user-images.githubusercontent.com/10071857/205556475-b3bce21a-a870-4dcd-94d4-d7077625ca48.gif"> | `calypso_pages_ellipsismenu_open_click`<br><br>Existing GA event:<br><img width="475" alt="image" src="https://user-images.githubusercontent.com/10071857/205556664-36468318-8aa1-4668-be73-a2b8ce6f0a19.png"> | `page_type: real`
| User clicks the Edit menu item<br><img width="206" alt="image" src="https://user-images.githubusercontent.com/10071857/205557984-4ed653bc-8bd1-4436-aa36-5e21339b816b.png"> | `calypso_pages_ellipsismenu_item_click`<br><br>Existing GA event:<br><img width="397" alt="image" src="https://user-images.githubusercontent.com/1525580/205233767-1ec8fae2-ca90-47fd-8748-829121511022.png"> | `page_type: real`<br>`item: editpage`
| User clicks the View page menu item<br><img width="184" alt="image" src="https://user-images.githubusercontent.com/10071857/205559298-d1fc7830-970f-4d92-bccd-45d22ada5aa9.png"> | `calypso_pages_ellipsismenu_item_click`<br><br>Existing GA event:<br><img width="425" alt="image" src="https://user-images.githubusercontent.com/10071857/205559449-b3ccd89e-296c-4b55-93d5-e7857c2f78ee.png"> | `page_type: real`<br>`item: viewpage` | 
| User clicks the Stats menu item<br><img width="184" alt="image" src="https://user-images.githubusercontent.com/10071857/205559584-ca6f9505-cd7b-4e9d-95e2-7e5176ed4adc.png"> | `calypso_pages_ellipsismenu_item_click`<br><br>Existing GA event:<br><img width="425" alt="image" src="https://user-images.githubusercontent.com/10071857/205559690-9f22ae9b-d7c9-419e-b8b8-cc6f377f89a6.png"> | `page_type: real`<br>`item: viewstats` | 
| User clicks the Copy menu item<br><img width="184" alt="image" src="https://user-images.githubusercontent.com/10071857/205559888-ca4adae4-84e1-4b8d-95f1-b75a4d2984de.png"> | `calypso_pages_ellipsismenu_item_click`<br><br>Existing GA event:<br><img width="425" alt="image" src="https://user-images.githubusercontent.com/10071857/205560140-5838acb7-0b2e-479b-9f3d-bdcc1d9fdbed.png"> | `page_type: real`<br>`item: copypage` | 
| User clicks the Copy link menu item<br><img width="190" alt="image" src="https://user-images.githubusercontent.com/10071857/205560313-23244910-8ce4-462c-9e8c-3b83ec44ba36.png"> | `calypso_pages_ellipsismenu_item_click`<br><br>Existing GA event:<br><img width="457" alt="image" src="https://user-images.githubusercontent.com/10071857/205560423-ce40ecad-2dd4-4fee-bbe3-512071f228a3.png"> | `page_type: real`<br>`item: copylink`
| User clicks the Export link menu item<br><img width="190" alt="image" src="https://user-images.githubusercontent.com/10071857/205561155-428034a7-1d57-4e39-af66-3d1a04eecea0.png"> | `calypso_pages_ellipsismenu_item_click`<br><br>Existing GA event:<br><img width="457" alt="image" src="https://user-images.githubusercontent.com/10071857/205561105-4f5f2dea-b476-4784-808d-6be2cf746dd7.png"> | `page_type: real`<br>`item: exportpage`
| User clicks the QR code link menu item<br><img width="190" alt="image" src="https://user-images.githubusercontent.com/10071857/205561039-7adf215a-927c-4d7b-a050-63f3f47f743b.png"> | `calypso_pages_ellipsismenu_item_click`<br><br>Existing GA event:NA | `page_type: real`<br>`item: qrcode`

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. In browser console, run: `localStorage.setItem( 'debug', 'calypso:analytics*' );`
2. Refresh your browser
3. Test the events above, by watching for `calypso:analytics` (for Tracks) and `calypso:analytics:ga` (for GA)

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #70487