### PR TITLE
Refactor Pricing Plan block to use variants

### DIFF
--- a/apps/happy-blocks/index.php
+++ b/apps/happy-blocks/index.php
@@ -164,32 +164,12 @@ HTML;
  */
 function a8c_happyblocks_register() {
 	register_block_type(
-		'happy-blocks/pricing-plans-personal',
+		'happy-blocks/pricing-plans',
 		array(
 			'api_version'     => 2,
 			'render_callback' => 'a8c_happyblocks_render_pricing_plans_callback',
 		)
 	);
-	register_block_type(
-		'happy-blocks/pricing-plans-premium',
-		array(
-			'api_version'     => 2,
-			'render_callback' => 'a8c_happyblocks_render_pricing_plans_callback',
-		)
-	);
-	register_block_type(
-		'happy-blocks/pricing-plans-business',
-		array(
-			'api_version'     => 2,
-			'render_callback' => 'a8c_happyblocks_render_pricing_plans_callback',
-		)
-	);
-	register_block_type(
-		'happy-blocks/pricing-plans-ecommerce',
-		array(
-			'api_version'     => 2,
-			'render_callback' => 'a8c_happyblocks_render_pricing_plans_callback',
-		)
-	);
+
 }
 add_action( 'init', 'a8c_happyblocks_register' );

--- a/apps/happy-blocks/src/pricing-plans/edit.tsx
+++ b/apps/happy-blocks/src/pricing-plans/edit.tsx
@@ -1,10 +1,4 @@
 import './edit.scss';
-import {
-	PLAN_BUSINESS,
-	PLAN_ECOMMERCE,
-	PLAN_PERSONAL,
-	PLAN_PREMIUM,
-} from '@automattic/calypso-products';
 import { useBlockProps } from '@wordpress/block-editor';
 import { BlockEditProps } from '@wordpress/blocks';
 import { useEffect } from '@wordpress/element';
@@ -16,12 +10,7 @@ import config from './config';
 import usePricingPlans from './hooks/pricing-plans';
 import { BlockAttributes } from './types';
 
-interface EditProps {
-	defaultPlan: string;
-}
-
-const Edit: FunctionComponent< BlockEditProps< BlockAttributes > & EditProps > = ( {
-	defaultPlan,
+export const Edit: FunctionComponent< BlockEditProps< BlockAttributes > > = ( {
 	attributes,
 	setAttributes,
 } ) => {
@@ -30,10 +19,10 @@ const Edit: FunctionComponent< BlockEditProps< BlockAttributes > & EditProps > =
 	// See https://github.com/WordPress/gutenberg/issues/7342
 	useEffect( () => {
 		setAttributes( {
-			productSlug: attributes.productSlug ?? defaultPlan,
+			productSlug: attributes.productSlug ?? attributes.defaultProductSlug,
 			domain: attributes.domain ?? config.domain,
 		} );
-	}, [ attributes.domain, attributes.productSlug, defaultPlan, setAttributes ] );
+	}, [ attributes.defaultProductSlug, attributes.domain, attributes.productSlug, setAttributes ] );
 
 	useEffect( () => {
 		const blogIdSelect: HTMLSelectElement | null =
@@ -70,20 +59,4 @@ const Edit: FunctionComponent< BlockEditProps< BlockAttributes > & EditProps > =
 			<PricingPlans plans={ plans } attributes={ attributes } setAttributes={ setAttributes } />
 		</div>
 	);
-};
-
-export const EditPersonal = ( props: BlockEditProps< BlockAttributes > ) => {
-	return <Edit { ...props } defaultPlan={ PLAN_PERSONAL } />;
-};
-
-export const EditPremium = ( props: BlockEditProps< BlockAttributes > ) => {
-	return <Edit { ...props } defaultPlan={ PLAN_PREMIUM } />;
-};
-
-export const EditBusiness = ( props: BlockEditProps< BlockAttributes > ) => {
-	return <Edit { ...props } defaultPlan={ PLAN_BUSINESS } />;
-};
-
-export const EditEcommerce = ( props: BlockEditProps< BlockAttributes > ) => {
-	return <Edit { ...props } defaultPlan={ PLAN_ECOMMERCE } />;
 };

--- a/apps/happy-blocks/src/pricing-plans/index.jsx
+++ b/apps/happy-blocks/src/pricing-plans/index.jsx
@@ -1,9 +1,18 @@
+import {
+	PLAN_BUSINESS,
+	PLAN_ECOMMERCE,
+	PLAN_PERSONAL,
+	PLAN_PREMIUM,
+} from '@automattic/calypso-products';
 import { registerBlockType } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
 import config from './config';
-import { EditBusiness, EditEcommerce, EditPersonal, EditPremium } from './edit';
+import { Edit } from './edit';
 
 const blockAttributes = {
+	defaultProductSlug: {
+		enum: config.plans,
+	},
 	productSlug: {
 		enum: config.plans,
 	},
@@ -13,64 +22,54 @@ const blockAttributes = {
 };
 
 function registerBlocks() {
-	registerBlockType( 'happy-blocks/pricing-plans-personal', {
+	registerBlockType( 'happy-blocks/pricing-plans', {
 		apiVersion: 2,
-		title: __( 'Upgrade Personal', 'happy-blocks' ),
+		title: __( 'Upgrade Pricing Plan', 'happy-blocks' ),
 		icon: 'money-alt',
 		category: 'embed',
-		description: __( 'Personal pricing plan upgrade', 'happy-blocks' ),
+		description: __( 'Pricing Plan upgrade block', 'happy-blocks' ),
 		keywords: [
 			__( 'pricing', 'happy-blocks' ),
 			__( 'plans', 'happy-blocks' ),
 			__( 'upgrade', 'happy-blocks' ),
 		],
 		attributes: blockAttributes,
-		edit: EditPersonal,
-	} );
-
-	registerBlockType( 'happy-blocks/pricing-plans-premium', {
-		apiVersion: 2,
-		title: __( 'Upgrade Premium', 'happy-blocks' ),
-		icon: 'money-alt',
-		category: 'embed',
-		description: __( 'Premium pricing plan upgrade', 'happy-blocks' ),
-		keywords: [
-			__( 'pricing', 'happy-blocks' ),
-			__( 'plans', 'happy-blocks' ),
-			__( 'upgrade', 'happy-blocks' ),
+		edit: Edit,
+		variations: [
+			{
+				isDefault: true,
+				name: 'personal',
+				title: __( 'Upgrade Personal', 'happy-blocks' ),
+				description: __( 'Upgrade to Personal pricing plan', 'happy-blocks' ),
+				attributes: {
+					defaultProductSlug: PLAN_PERSONAL,
+				},
+			},
+			{
+				name: 'premium',
+				title: __( 'Upgrade Premium', 'happy-blocks' ),
+				description: __( 'Upgrade to Premium pricing plan', 'happy-blocks' ),
+				attributes: {
+					defaultProductSlug: PLAN_PREMIUM,
+				},
+			},
+			{
+				name: 'business',
+				title: __( 'Upgrade Business', 'happy-blocks' ),
+				description: __( 'Upgrade to Business pricing plan', 'happy-blocks' ),
+				attributes: {
+					defaultProductSlug: PLAN_BUSINESS,
+				},
+			},
+			{
+				name: 'ecommerce',
+				title: __( 'Upgrade eCommerce', 'happy-blocks' ),
+				description: __( 'Upgrade to eCommerce pricing plan', 'happy-blocks' ),
+				attributes: {
+					defaultProductSlug: PLAN_ECOMMERCE,
+				},
+			},
 		],
-		attributes: blockAttributes,
-		edit: EditPremium,
-	} );
-
-	registerBlockType( 'happy-blocks/pricing-plans-business', {
-		apiVersion: 2,
-		title: __( 'Upgrade Business', 'happy-blocks' ),
-		icon: 'money-alt',
-		category: 'embed',
-		description: __( 'Business pricing plan upgrade', 'happy-blocks' ),
-		keywords: [
-			__( 'pricing', 'happy-blocks' ),
-			__( 'plans', 'happy-blocks' ),
-			__( 'upgrade', 'happy-blocks' ),
-		],
-		attributes: blockAttributes,
-		edit: EditBusiness,
-	} );
-
-	registerBlockType( 'happy-blocks/pricing-plans-ecommerce', {
-		apiVersion: 2,
-		title: __( 'Upgrade eCommerce', 'happy-blocks' ),
-		icon: 'money-alt',
-		category: 'embed',
-		description: __( 'eCommerce pricing plan upgrade', 'happy-blocks' ),
-		keywords: [
-			__( 'pricing', 'happy-blocks' ),
-			__( 'plans', 'happy-blocks' ),
-			__( 'upgrade', 'happy-blocks' ),
-		],
-		attributes: blockAttributes,
-		edit: EditEcommerce,
 	} );
 }
 

--- a/apps/happy-blocks/src/pricing-plans/types.d.ts
+++ b/apps/happy-blocks/src/pricing-plans/types.d.ts
@@ -1,4 +1,5 @@
 export interface BlockAttributes {
+	defaultProductSlug: string;
 	productSlug: string;
 	domain: string;
 }


### PR DESCRIPTION
#### Proposed Changes

This Pull Request refactors the previously multiple times registered Pricing Plan block to use the [variations API](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-variations/)  which greatly simplifies the code and prevents some issues we have found regarding inconsistent titles and description in the editor settings UI after plans configurations are changed.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->




* Run `yarn dev --sync` in `apps/happy-blocks` to sync code to your sandbox
* On your sandbox, edit `wp-content/themes/a8c/supportforums/editor/gutenberg-wpcom.php` and add to the function `supportforums_gutenberg_setup_frontend` before `return $settings;` line:
```
$settings['iso']['blocks']['allowBlocks'][] = 'happy-blocks/pricing-plans';
```
* On that same file, remove all other Pricing Plans registrations (lines starting with `$settings['iso']['blocks']['allowBlocks'][] = 'happy-blocks/*...` leaving just the new one.
* Create a new topic, in the editor press `/` and search for "Upgrade" block.
* Focus the block, and in the block settings pane (gear icon) pre-select one of the available plans. Ensure the block updates to the selected plan in the editor, then pre-select a billing option (yearly/monthly) for the user.
* Submit the post, ensure the block loads in the Post view and shows the correct plan and the pre-selected billing option.
* Repeat the previous steps for the four pricing plans to check all of them render correctly in the view.



#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
