### PR TITLE
Pattern Assembler - Improve pattern names in the list of selected patterns

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -73,10 +73,11 @@ const PatternAssembler: Step = ( { navigation } ) => {
 			pattern_names: patterns.map( ( { name } ) => name ).join( ',' ),
 			pattern_count: patterns.length,
 		} );
-		patterns.forEach( ( { id, name } ) => {
+		patterns.forEach( ( { id, name, category } ) => {
 			recordTracksEvent( 'calypso_signup_pattern_assembler_pattern_final_select', {
 				pattern_id: id,
 				pattern_name: name,
+				pattern_category: category,
 			} );
 		} );
 	};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-layout.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-layout.tsx
@@ -58,8 +58,8 @@ const PatternLayout = ( {
 					{ selectedHeader ? (
 						<li className="pattern-layout__list-item pattern-layout__list-item--header">
 							<Icon className="pattern-layout__icon" icon={ header } size={ 24 } />
-							<span className="pattern-layout__list-item-text" title={ selectedHeader.name }>
-								{ selectedHeader.name }
+							<span className="pattern-layout__list-item-text" title={ selectedHeader.category }>
+								{ selectedHeader.category }
 							</span>
 							<PatternActionBar
 								patternType="header"
@@ -81,7 +81,7 @@ const PatternLayout = ( {
 					) }
 					<AsyncLoad require="./animate-list" featureName="domMax" placeholder={ <div /> }>
 						{ ( m: any ) =>
-							sections.map( ( { name, key }: Pattern, index ) => {
+							sections.map( ( { category, key }: Pattern, index ) => {
 								return (
 									<m.li
 										key={ key }
@@ -90,8 +90,8 @@ const PatternLayout = ( {
 										className="pattern-layout__list-item pattern-layout__list-item--section"
 									>
 										<Icon className="pattern-layout__icon" icon={ group } size={ 24 } />
-										<span className="pattern-layout__list-item-text" title={ name }>
-											{ name }
+										<span className="pattern-layout__list-item-text" title={ category }>
+											{ category }
 										</span>
 										<PatternActionBar
 											patternType="section"
@@ -119,8 +119,8 @@ const PatternLayout = ( {
 					{ selectedFooter ? (
 						<li className="pattern-layout__list-item pattern-layout__list-item--footer">
 							<Icon className="pattern-layout__icon" icon={ footer } size={ 24 } />
-							<span className="pattern-layout__list-item-text" title={ selectedFooter.name }>
-								{ selectedFooter.name }
+							<span className="pattern-layout__list-item-text" title={ selectedFooter.category }>
+								{ selectedFooter.category }
 							</span>
 							<PatternActionBar
 								patternType="footer"

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-selector-loader.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-selector-loader.tsx
@@ -1,6 +1,6 @@
 import { useTranslate } from 'i18n-calypso';
 import PatternSelector from './pattern-selector';
-import { headerPatterns, footerPatterns, sectionPatterns } from './patterns-data';
+import { useHeaderPatterns, useFooterPatterns, useSectionPatterns } from './patterns-data';
 import type { Pattern } from './types';
 
 type PatternSelectorLoaderProps = {
@@ -17,6 +17,9 @@ const PatternSelectorLoader = ( {
 	selectedPattern,
 }: PatternSelectorLoaderProps ) => {
 	const translate = useTranslate();
+	const headerPatterns = useHeaderPatterns();
+	const footerPatterns = useFooterPatterns();
+	const sectionPatterns = useSectionPatterns();
 
 	return (
 		<>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-selector.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-selector.tsx
@@ -43,29 +43,29 @@ const PatternSelector = ( {
 	}, [ show ] );
 
 	const renderPatterns = ( patternList: Pattern[] ) =>
-		patternList?.map( ( item: Pattern, index: number ) => (
+		patternList?.map( ( pattern: Pattern, index: number ) => (
 			<PatternPreviewAutoHeight
-				key={ `${ index }-${ item.id }` }
+				key={ `${ index }-${ pattern.id }` }
 				url={ getPatternPreviewUrl( {
-					id: item.id,
+					id: pattern.id,
 					language: locale,
 					siteTitle: site?.name,
 					stylesheet: selectedDesign?.recipe?.stylesheet,
 				} ) }
-				patternId={ item.id }
-				patternName={ item.name }
+				patternId={ pattern.id }
+				patternName={ pattern.category }
 			>
 				<div
-					aria-label={ item.name }
+					aria-label={ pattern.category }
 					tabIndex={ show ? 0 : -1 }
 					role="option"
-					title={ item.name }
-					aria-selected={ item.id === selectedPattern?.id }
+					title={ pattern.category }
+					aria-selected={ pattern.id === selectedPattern?.id }
 					className={ classnames( {
-						'pattern-selector__block-list--selected-pattern': item.id === selectedPattern?.id,
+						'pattern-selector__block-list--selected-pattern': pattern.id === selectedPattern?.id,
 					} ) }
-					onClick={ () => onSelect( item ) }
-					onKeyUp={ handleKeyboard( () => onSelect( item ) ) }
+					onClick={ () => onSelect( pattern ) }
+					onKeyUp={ handleKeyboard( () => onSelect( pattern ) ) }
 				/>
 			</PatternPreviewAutoHeight>
 		) );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/patterns-data.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/patterns-data.ts
@@ -1,240 +1,257 @@
-import { translate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import type { Pattern } from './types';
 
-const header = translate( 'Header' );
-const footer = translate( 'Footer' );
-const callToAction = translate( 'Call to action' );
-const images = translate( 'Images' );
-const list = translate( 'List' );
-const numbers = translate( 'Numbers' );
-const about = translate( 'About' );
-const testimonials = translate( 'Testimonials' );
-const links = translate( 'Links' );
+const useHeaderPatterns = () => {
+	const translate = useTranslate();
+	const header = translate( 'Header' );
 
-// All headers in dotcompatterns
-const headerPatterns: Pattern[] = [
-	{
-		id: 5579,
-		name: 'Centered header',
-		category: header,
-	},
-	/*
-	Discarded because there is a menu option named Blog
-	and for now the blogger flow is not supported
-	{
-		id: 5608,
-		name: 'Centered header with logo and navigation',
-		category: header,
-	},
-	*/
-	{
-		id: 5582,
-		name: 'Simple Header',
-		category: header,
-	},
-	{
-		id: 5588,
-		name: 'Header with site title and vertical navigation',
-		category: header,
-	},
-	{
-		id: 5590,
-		name: 'Simple header with image background',
-		category: header,
-	},
-	{
-		id: 5593,
-		name: 'Simple header with dark background',
-		category: header,
-	},
-	{
-		id: 5595,
-		name: 'Simple header with image',
-		category: header,
-	},
-	{
-		id: 5601,
-		name: 'Simple header with tagline',
-		category: header,
-	},
-	{
-		id: 5603,
-		name: 'Header with site title and menu button',
-		category: header,
-	},
-	{
-		id: 5605,
-		name: 'Header with site title and vertical navigation',
-		category: header,
-	},
-	{
-		id: 7914,
-		name: 'Header with button',
-		category: header,
-	},
-];
+	// All headers in dotcompatterns
+	const headerPatterns: Pattern[] = [
+		{
+			id: 5579,
+			name: 'Centered header',
+			category: header,
+		},
+		/*
+		Discarded because there is a menu option named Blog
+		and for now the blogger flow is not supported
+		{
+			id: 5608,
+			name: 'Centered header with logo and navigation',
+			category: header,
+		},
+		*/
+		{
+			id: 5582,
+			name: 'Simple Header',
+			category: header,
+		},
+		{
+			id: 5588,
+			name: 'Header with site title and vertical navigation',
+			category: header,
+		},
+		{
+			id: 5590,
+			name: 'Simple header with image background',
+			category: header,
+		},
+		{
+			id: 5593,
+			name: 'Simple header with dark background',
+			category: header,
+		},
+		{
+			id: 5595,
+			name: 'Simple header with image',
+			category: header,
+		},
+		{
+			id: 5601,
+			name: 'Simple header with tagline',
+			category: header,
+		},
+		{
+			id: 5603,
+			name: 'Header with site title and menu button',
+			category: header,
+		},
+		{
+			id: 5605,
+			name: 'Header with site title and vertical navigation',
+			category: header,
+		},
+		{
+			id: 7914,
+			name: 'Header with button',
+			category: header,
+		},
+	];
 
-// All footers in dotcompatterns
-// Missing footers in dotcomfsepatterns
-const footerPatterns: Pattern[] = [
-	{
-		id: 5316,
-		name: 'Footer with social icons, address, e-mail, and telephone number',
-		category: footer,
-	},
-	{
-		id: 5886,
-		name: 'Footer with large font size',
-		category: footer,
-	},
-	{
-		id: 5883,
-		name: 'Footer with credit line and navigation',
-		category: footer,
-	},
-	{
-		id: 5888,
-		name: 'Footer with navigation and credit line',
-		category: footer,
-	},
-	{
-		id: 5877,
-		name: 'Centered footer with social links',
-		category: footer,
-	},
-	{
-		id: 5873,
-		name: 'Simple centered footer',
-		category: footer,
-	},
-	{
-		id: 7917,
-		name: 'Footer with address, email address, and social links',
-		category: footer,
-	},
-	{
-		id: 7485,
-		name: 'Footer with newsletter subscription form',
-		category: footer,
-	},
-	{
-		id: 1622,
-		name: 'Footer with paragraph and links',
-		category: footer,
-	},
-	{
-		id: 5047,
-		name: 'Footer with navigation, contact details, social links, and subscription form',
-		category: footer,
-	},
-	{
-		id: 5880,
-		name: 'Footer with background color and three columns',
-		category: footer,
-	},
-];
+	return headerPatterns;
+};
 
-const sectionPatterns: Pattern[] = [
-	{
-		id: 7156,
-		name: 'Media and text with image on the right',
-		category: callToAction,
-	},
-	{
-		id: 7153,
-		name: 'Media and text with image on the left',
-		category: callToAction,
-	},
-	{
-		id: 7146,
-		name: 'Four column list',
-		category: callToAction,
-	},
-	{
-		id: 7132,
-		name: 'Cover image with left-aligned call to action',
-		category: callToAction,
-	},
-	{
-		id: 7159,
-		name: 'Cover image with centered text and a button',
-		category: callToAction,
-	},
-	{
-		id: 7149,
-		name: 'Two column image grid',
-		category: images,
-	},
-	{
-		id: 5691,
-		name: 'Three logos, heading, and paragraphs',
-		category: images,
-	},
-	{
-		id: 7143,
-		name: 'Full-width image',
-		category: images,
-	},
-	{
-		id: 737,
-		name: 'Logos',
-		category: images,
-	},
-	{
-		id: 1585,
-		name: 'Quote and logos',
-		category: images,
-	},
-	{
-		id: 7135,
-		name: 'Three columns with images and text',
-		category: list,
-	},
-	{
-		id: 789,
-		name: 'Numbered List',
-		category: list,
-	},
-	{
-		id: 6712,
-		name: 'List of events',
-		category: list,
-	},
-	{
-		id: 5666,
-		name: 'Large numbers, heading, and paragraphs',
-		category: numbers,
-	},
-	{
-		id: 462,
-		name: 'Numbers',
-		category: numbers,
-	},
-	{
-		id: 5663,
-		name: 'Large headline',
-		category: about,
-	},
-	{
-		id: 7140,
-		name: 'Left-aligned headline',
-		category: about,
-	},
-	{
-		id: 7138,
-		name: 'Centered headline and text',
-		category: about,
-	},
-	{
-		id: 7161,
-		name: 'Two testimonials side by side',
-		category: testimonials,
-	},
-	{
-		id: 1600,
-		name: 'Three column text and links',
-		category: links,
-	},
-];
+const useFooterPatterns = () => {
+	const translate = useTranslate();
+	const footer = translate( 'Footer' );
 
-export { headerPatterns, footerPatterns, sectionPatterns };
+	// All footers in dotcompatterns
+	// Missing footers in dotcomfsepatterns
+	const footerPatterns: Pattern[] = [
+		{
+			id: 5316,
+			name: 'Footer with social icons, address, e-mail, and telephone number',
+			category: footer,
+		},
+		{
+			id: 5886,
+			name: 'Footer with large font size',
+			category: footer,
+		},
+		{
+			id: 5883,
+			name: 'Footer with credit line and navigation',
+			category: footer,
+		},
+		{
+			id: 5888,
+			name: 'Footer with navigation and credit line',
+			category: footer,
+		},
+		{
+			id: 5877,
+			name: 'Centered footer with social links',
+			category: footer,
+		},
+		{
+			id: 5873,
+			name: 'Simple centered footer',
+			category: footer,
+		},
+		{
+			id: 7917,
+			name: 'Footer with address, email address, and social links',
+			category: footer,
+		},
+		{
+			id: 7485,
+			name: 'Footer with newsletter subscription form',
+			category: footer,
+		},
+		{
+			id: 1622,
+			name: 'Footer with paragraph and links',
+			category: footer,
+		},
+		{
+			id: 5047,
+			name: 'Footer with navigation, contact details, social links, and subscription form',
+			category: footer,
+		},
+		{
+			id: 5880,
+			name: 'Footer with background color and three columns',
+			category: footer,
+		},
+	];
+
+	return footerPatterns;
+};
+
+const useSectionPatterns = () => {
+	const translate = useTranslate();
+	const callToAction = translate( 'Call to action' );
+	const images = translate( 'Images' );
+	const list = translate( 'List' );
+	const numbers = translate( 'Numbers' );
+	const about = translate( 'About' );
+	const testimonials = translate( 'Testimonials' );
+	const links = translate( 'Links' );
+
+	const sectionPatterns: Pattern[] = [
+		{
+			id: 7156,
+			name: 'Media and text with image on the right',
+			category: callToAction,
+		},
+		{
+			id: 7153,
+			name: 'Media and text with image on the left',
+			category: callToAction,
+		},
+		{
+			id: 7146,
+			name: 'Four column list',
+			category: callToAction,
+		},
+		{
+			id: 7132,
+			name: 'Cover image with left-aligned call to action',
+			category: callToAction,
+		},
+		{
+			id: 7159,
+			name: 'Cover image with centered text and a button',
+			category: callToAction,
+		},
+		{
+			id: 7149,
+			name: 'Two column image grid',
+			category: images,
+		},
+		{
+			id: 5691,
+			name: 'Three logos, heading, and paragraphs',
+			category: images,
+		},
+		{
+			id: 7143,
+			name: 'Full-width image',
+			category: images,
+		},
+		{
+			id: 737,
+			name: 'Logos',
+			category: images,
+		},
+		{
+			id: 1585,
+			name: 'Quote and logos',
+			category: images,
+		},
+		{
+			id: 7135,
+			name: 'Three columns with images and text',
+			category: list,
+		},
+		{
+			id: 789,
+			name: 'Numbered List',
+			category: list,
+		},
+		{
+			id: 6712,
+			name: 'List of events',
+			category: list,
+		},
+		{
+			id: 5666,
+			name: 'Large numbers, heading, and paragraphs',
+			category: numbers,
+		},
+		{
+			id: 462,
+			name: 'Numbers',
+			category: numbers,
+		},
+		{
+			id: 5663,
+			name: 'Large headline',
+			category: about,
+		},
+		{
+			id: 7140,
+			name: 'Left-aligned headline',
+			category: about,
+		},
+		{
+			id: 7138,
+			name: 'Centered headline and text',
+			category: about,
+		},
+		{
+			id: 7161,
+			name: 'Two testimonials side by side',
+			category: testimonials,
+		},
+		{
+			id: 1600,
+			name: 'Three column text and links',
+			category: links,
+		},
+	];
+
+	return sectionPatterns;
+};
+
+export { useHeaderPatterns, useFooterPatterns, useSectionPatterns };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/patterns-data.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/patterns-data.ts
@@ -64,7 +64,7 @@ const headerPatterns: Pattern[] = [
 	},
 	{
 		id: 5605,
-		name: 'Simple header with image',
+		name: 'Header with site title and vertical navigation',
 		category: header,
 	},
 	{

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/patterns-data.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/patterns-data.ts
@@ -1,10 +1,22 @@
+import { translate } from 'i18n-calypso';
 import type { Pattern } from './types';
+
+const header = translate( 'Header' );
+const footer = translate( 'Footer' );
+const callToAction = translate( 'Call to action' );
+const images = translate( 'Images' );
+const list = translate( 'List' );
+const numbers = translate( 'Numbers' );
+const about = translate( 'About' );
+const testimonials = translate( 'Testimonials' );
+const links = translate( 'Links' );
 
 // All headers in dotcompatterns
 const headerPatterns: Pattern[] = [
 	{
 		id: 5579,
 		name: 'Centered header',
+		category: header,
 	},
 	/*
 	Discarded because there is a menu option named Blog
@@ -12,43 +24,53 @@ const headerPatterns: Pattern[] = [
 	{
 		id: 5608,
 		name: 'Centered header with logo and navigation',
+		category: header,
 	},
 	*/
 	{
 		id: 5582,
 		name: 'Simple Header',
+		category: header,
 	},
 	{
 		id: 5588,
 		name: 'Header with site title and vertical navigation',
+		category: header,
 	},
 	{
 		id: 5590,
 		name: 'Simple header with image background',
+		category: header,
 	},
 	{
 		id: 5593,
 		name: 'Simple header with dark background',
+		category: header,
 	},
 	{
 		id: 5595,
 		name: 'Simple header with image',
+		category: header,
 	},
 	{
 		id: 5601,
 		name: 'Simple header with tagline',
+		category: header,
 	},
 	{
 		id: 5603,
 		name: 'Header with site title and menu button',
+		category: header,
 	},
 	{
 		id: 5605,
 		name: 'Simple header with image',
+		category: header,
 	},
 	{
 		id: 7914,
 		name: 'Header with button',
+		category: header,
 	},
 ];
 
@@ -58,46 +80,57 @@ const footerPatterns: Pattern[] = [
 	{
 		id: 5316,
 		name: 'Footer with social icons, address, e-mail, and telephone number',
+		category: footer,
 	},
 	{
 		id: 5886,
 		name: 'Footer with large font size',
+		category: footer,
 	},
 	{
 		id: 5883,
 		name: 'Footer with credit line and navigation',
+		category: footer,
 	},
 	{
 		id: 5888,
 		name: 'Footer with navigation and credit line',
+		category: footer,
 	},
 	{
 		id: 5877,
 		name: 'Centered footer with social links',
+		category: footer,
 	},
 	{
 		id: 5873,
 		name: 'Simple centered footer',
+		category: footer,
 	},
 	{
 		id: 7917,
 		name: 'Footer with address, email address, and social links',
+		category: footer,
 	},
 	{
 		id: 7485,
 		name: 'Footer with newsletter subscription form',
+		category: footer,
 	},
 	{
 		id: 1622,
 		name: 'Footer with paragraph and links',
+		category: footer,
 	},
 	{
 		id: 5047,
 		name: 'Footer with navigation, contact details, social links, and subscription form',
+		category: footer,
 	},
 	{
 		id: 5880,
 		name: 'Footer with background color and three columns',
+		category: footer,
 	},
 ];
 
@@ -105,82 +138,102 @@ const sectionPatterns: Pattern[] = [
 	{
 		id: 7156,
 		name: 'Media and text with image on the right',
+		category: callToAction,
 	},
 	{
 		id: 7153,
 		name: 'Media and text with image on the left',
+		category: callToAction,
 	},
 	{
 		id: 7146,
 		name: 'Four column list',
+		category: callToAction,
 	},
 	{
 		id: 7132,
 		name: 'Cover image with left-aligned call to action',
+		category: callToAction,
 	},
 	{
 		id: 7159,
 		name: 'Cover image with centered text and a button',
+		category: callToAction,
 	},
 	{
 		id: 7149,
 		name: 'Two column image grid',
+		category: images,
 	},
 	{
 		id: 5691,
 		name: 'Three logos, heading, and paragraphs',
+		category: images,
 	},
 	{
 		id: 7143,
 		name: 'Full-width image',
+		category: images,
 	},
 	{
 		id: 737,
 		name: 'Logos',
+		category: images,
 	},
 	{
 		id: 1585,
 		name: 'Quote and logos',
+		category: images,
 	},
 	{
 		id: 7135,
 		name: 'Three columns with images and text',
+		category: list,
 	},
 	{
 		id: 789,
 		name: 'Numbered List',
+		category: list,
 	},
 	{
 		id: 6712,
 		name: 'List of events',
+		category: list,
 	},
 	{
 		id: 5666,
 		name: 'Large numbers, heading, and paragraphs',
+		category: numbers,
 	},
 	{
 		id: 462,
 		name: 'Numbers',
+		category: numbers,
 	},
 	{
 		id: 5663,
 		name: 'Large headline',
+		category: about,
 	},
 	{
 		id: 7140,
 		name: 'Left-aligned headline',
+		category: about,
 	},
 	{
 		id: 7138,
 		name: 'Centered headline and text',
+		category: about,
 	},
 	{
 		id: 7161,
 		name: 'Two testimonials side by side',
+		category: testimonials,
 	},
 	{
 		id: 1600,
 		name: 'Three column text and links',
+		category: links,
 	},
 ];
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/patterns-data.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/patterns-data.ts
@@ -23,7 +23,7 @@ const useHeaderPatterns = () => {
 		*/
 		{
 			id: 5582,
-			name: 'Simple Header',
+			name: 'Simple header',
 			category: header,
 		},
 		{
@@ -206,7 +206,7 @@ const useSectionPatterns = () => {
 		},
 		{
 			id: 789,
-			name: 'Numbered List',
+			name: 'Numbered list',
 			category: list,
 		},
 		{

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/types.ts
@@ -1,5 +1,6 @@
 export type Pattern = {
 	id: number;
 	name: string;
+	category: string;
 	key?: string;
 };


### PR DESCRIPTION
#### Proposed Changes

* Use pattern categories as pattern names in the list of selected patterns.
* Keep using the real pattern names in:
  * the JSON because they are still useful for maintaining the list.
  * the Track events because they are still useful for reading the stats.
* Add the new prop `pattern_category` in the Track event `calypso_signup_bcpa_pattern_final_select` to keep track of the most used categories in the final selection.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to `/setup?siteSlug=[ YOUR SITE ]`
- Don't mark any goal or select any vertical
- Scroll to the bottom of the design picker and click on the Blank canvas CTA
- Check that after choosing any header or footer, their names in the list are always "Header" or "Footer"
- Check that section patterns use their category name
- Check that the pattern selection works as expected

|Before|After|
|------|-----|
|<img width="322" alt="Screen Shot 2565-12-01 at 16 19 40" src="https://user-images.githubusercontent.com/1881481/205014446-02e12946-70ed-4dbe-a2c5-05adb2d207b6.png">|<img width="322" alt="Screen Shot 2565-12-01 at 16 04 58" src="https://user-images.githubusercontent.com/1881481/205013164-4ee0eb4c-b67c-4431-9cbf-0285cbdf37d2.png">|

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/1251
