### PR TITLE
Theme Showcase: Fix issue where filter value is overridden.

### DIFF
--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -438,10 +438,8 @@ class ThemeShowcase extends Component {
 				return <ThemesSelection { ...themeProps } />;
 			case this.tabFilters.TRENDING?.key:
 				return <TrendingThemes { ...themeProps } />;
-			case this.tabFilters.ALL.key:
-				return this.allThemes( { themeProps } );
 			default:
-				return this.allThemes( { themeProps: { ...themeProps, filter: tabKey } } );
+				return this.allThemes( { themeProps } );
 		}
 	};
 


### PR DESCRIPTION
#### Proposed Changes

This PR fixes an issue where selecting one of the subject filters (e.g.: Blog, Podcast, Store, etc.) will override the filter query value, causing the result set to be incorrect. 

| Before | After |
| --- | --- |
| ![Screen Shot 2022-12-01 at 5 57 33 PM](https://user-images.githubusercontent.com/797888/205023835-ef246305-7b79-4707-bf4d-5489927d6530.png) | ![Screen Shot 2022-12-01 at 5 59 01 PM](https://user-images.githubusercontent.com/797888/205023869-30ad3487-3c49-4566-9a69-918488001d25.png)

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the logged-in Theme Showcase `/themes/${site_slug}`.
  * If using calypso.live, the flag `themes/showcase-i4/search-and-filter` is required.
* Open dev tools, ensure that the search API request is being sent as shown in the screenshot above.
* Ensure that the current Theme Showcase is working as before.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

