### PR TITLE
Pattern Assembler - Keep the pattern selector open when adding/replacing a pattern

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -168,12 +168,8 @@ const PatternAssembler: Step = ( { navigation } ) => {
 				replaceSection( selectedPattern );
 			} else {
 				addSection( selectedPattern );
-				// Don't close the pattern selector when in multiple selection
-				return;
 			}
 		}
-
-		setShowPatternSelectorType( null );
 	};
 
 	const onBack = () => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-selector-loader.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-selector-loader.tsx
@@ -25,7 +25,7 @@ const PatternSelectorLoader = ( {
 				patterns={ headerPatterns }
 				onSelect={ onSelect }
 				onBack={ onBack }
-				title={ selectedPattern ? translate( 'Replace header' ) : translate( 'Add a header' ) }
+				title={ translate( 'Add a header' ) }
 				selectedPattern={ selectedPattern }
 			/>
 			<PatternSelector
@@ -33,7 +33,7 @@ const PatternSelectorLoader = ( {
 				patterns={ footerPatterns }
 				onSelect={ onSelect }
 				onBack={ onBack }
-				title={ selectedPattern ? translate( 'Replace footer' ) : translate( 'Add a footer' ) }
+				title={ translate( 'Add a footer' ) }
 				selectedPattern={ selectedPattern }
 			/>
 			<PatternSelector

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-selector-loader.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-selector-loader.tsx
@@ -43,7 +43,6 @@ const PatternSelectorLoader = ( {
 				onBack={ onBack }
 				title={ selectedPattern ? translate( 'Add a section' ) : translate( 'Add sections' ) }
 				selectedPattern={ selectedPattern }
-				multiple={ ! selectedPattern }
 			/>
 		</>
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-selector-loader.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-selector-loader.tsx
@@ -25,7 +25,7 @@ const PatternSelectorLoader = ( {
 				patterns={ headerPatterns }
 				onSelect={ onSelect }
 				onBack={ onBack }
-				title={ translate( 'Add a header' ) }
+				title={ selectedPattern ? translate( 'Replace header' ) : translate( 'Add a header' ) }
 				selectedPattern={ selectedPattern }
 			/>
 			<PatternSelector
@@ -33,7 +33,7 @@ const PatternSelectorLoader = ( {
 				patterns={ footerPatterns }
 				onSelect={ onSelect }
 				onBack={ onBack }
-				title={ translate( 'Add a footer' ) }
+				title={ selectedPattern ? translate( 'Replace footer' ) : translate( 'Add a footer' ) }
 				selectedPattern={ selectedPattern }
 			/>
 			<PatternSelector
@@ -41,7 +41,7 @@ const PatternSelectorLoader = ( {
 				patterns={ sectionPatterns }
 				onSelect={ onSelect }
 				onBack={ onBack }
-				title={ selectedPattern ? translate( 'Add a section' ) : translate( 'Add sections' ) }
+				title={ selectedPattern ? translate( 'Replace section' ) : translate( 'Add sections' ) }
 				selectedPattern={ selectedPattern }
 			/>
 		</>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-selector.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-selector.tsx
@@ -18,7 +18,6 @@ type PatternSelectorProps = {
 	title: string | null;
 	show: boolean;
 	selectedPattern: Pattern | null;
-	multiple?: boolean;
 };
 
 const PatternSelector = ( {
@@ -28,7 +27,6 @@ const PatternSelector = ( {
 	title,
 	show,
 	selectedPattern,
-	multiple,
 }: PatternSelectorProps ) => {
 	const locale = useLocale();
 	const patternSelectorRef = useRef< HTMLDivElement >( null );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-selector.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-selector.tsx
@@ -95,13 +95,11 @@ const PatternSelector = ( {
 					</Delayed>
 				</div>
 			</div>
-			{ multiple && (
-				<div className="pattern-selector__footer">
-					<Button className="pattern-assembler__button" onClick={ onBack } primary>
-						{ translate( 'Done' ) }
-					</Button>
-				</div>
-			) }
+			<div className="pattern-selector__footer">
+				<Button className="pattern-assembler__button" onClick={ onBack } primary>
+					{ translate( 'Done' ) }
+				</Button>
+			</div>
 		</div>
 	);
 };


### PR DESCRIPTION
This PR is a branch of [Pattern Assembler - Adding sections behaviour #70461](https://github.com/Automattic/wp-calypso/issues/70461)

#### Proposed Changes

* Keep the pattern selector always open

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to `/setup?siteSlug=[ YOUR SITE ]`
- Don't mark any goal or select any vertical
- Scroll to the bottom of the design picker and click on the Blank canvas CTA
- Check that the pattern selector remains open when you add or replace any patterns until you click on `Done` or the back button 


https://user-images.githubusercontent.com/1881481/205022026-b8b6a171-533b-4493-9c0e-5074705a4b65.mov



#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/1251 https://github.com/Automattic/wp-calypso/issues/70473
