### PR TITLE
Virtual pages: Track click events

### DIFF
--- a/client/my-sites/pages/virtual-page/index.tsx
+++ b/client/my-sites/pages/virtual-page/index.tsx
@@ -4,16 +4,16 @@ import { localizeUrl } from '@automattic/i18n-utils';
 import { ExternalLink } from '@wordpress/components';
 import { decodeEntities } from '@wordpress/html-entities';
 import { useTranslate } from 'i18n-calypso';
-import { useDispatch } from 'react-redux';
+import { connect } from 'react-redux';
 import EllipsisMenu from 'calypso/components/ellipsis-menu';
 import InfoPopover from 'calypso/components/info-popover';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import PopoverMenuItemClipboard from 'calypso/components/popover-menu/item-clipboard';
 import { addQueryArgs } from 'calypso/lib/route';
+import { recordGoogleEvent, recordTracksEvent } from 'calypso/state/analytics/actions';
 import { infoNotice } from 'calypso/state/notices/actions';
 import { setLayoutFocus } from 'calypso/state/ui/layout-focus/actions';
 import { setPreviewUrl } from 'calypso/state/ui/preview/actions';
-import { recordEvent } from '../helpers';
 import Placeholder from '../placeholder';
 import type { SiteDetails } from '@automattic/data-stores';
 import './style.scss';
@@ -26,10 +26,24 @@ interface Props {
 	description?: string;
 	previewUrl?: string;
 	isHomepage?: boolean;
+
+	recordGoogleEvent: any;
+	recordTracksEvent: any;
+	setPreviewUrl: any;
+	setLayoutFocus: any;
+	infoNotice: any;
 }
 
-const VirtualPage = ( { site, id, type, title, description, previewUrl, isHomepage }: Props ) => {
-	const dispatch = useDispatch();
+const VirtualPage = ( {
+	site,
+	id,
+	type,
+	title,
+	description,
+	previewUrl,
+	isHomepage,
+	...props
+}: Props ) => {
 	const translate = useTranslate();
 	const defaultEditorUrl = `/site-editor/${ site.slug }`;
 	const editorUrl = ! isHomepage
@@ -38,29 +52,54 @@ const VirtualPage = ( { site, id, type, title, description, previewUrl, isHomepa
 
 	const { data: template } = useTemplate( site.ID, id );
 
-	const handleMenuToggle = ( isVisible: boolean ) => {
+	const recordGoogleEvent = ( action: string ) => {
+		props.recordGoogleEvent( 'Pages', action );
+	};
+
+	const toggleEllipsisMenu = ( isVisible: boolean ) => {
 		if ( isVisible ) {
-			dispatch( recordEvent( 'Clicked More Options Menu' ) );
+			props.recordTracksEvent( 'calypso_pages_ellipsismenu_open_click', {
+				page_type: 'virtual',
+				blog_id: site.ID,
+			} );
+			props.recordGoogleEvent( 'Pages', 'Clicked More Options Menu' );
 		}
 	};
 
-	const recordEditPage = () => dispatch( recordEvent( 'Clicked Edit Page' ) );
+	const recordEllipsisMenuItemClickEvent = ( item: string ) => {
+		props.recordTracksEvent( 'calypso_pages_ellipsismenu_item_click', {
+			page_type: 'virtual',
+			blog_id: site.ID,
+			item,
+		} );
+	};
 
-	const recordViewPage = () => dispatch( recordEvent( 'Clicked View Page' ) );
+	const clickPageTitle = () => {
+		props.recordTracksEvent( 'calypso_pages_page_title_click', {
+			page_type: 'virtual',
+			blog_id: site.ID,
+		} );
+	};
+
+	const editPage = () => {
+		recordEllipsisMenuItemClickEvent( 'editpage' );
+		recordGoogleEvent( 'Clicked Edit Page' );
+	};
 
 	const viewPage = () => {
-		recordViewPage();
-		dispatch( setPreviewUrl( previewUrl ) );
-		dispatch( setLayoutFocus( 'preview' ) );
+		recordEllipsisMenuItemClickEvent( 'viewpage' );
+		recordGoogleEvent( 'Clicked View Page' );
+
+		props.setPreviewUrl( previewUrl );
+		props.setLayoutFocus( 'preview' );
 	};
 
 	const copyPageLink = () => {
-		dispatch(
-			infoNotice( translate( 'Link copied to clipboard.' ), {
-				duration: 3000,
-			} )
-		);
-		dispatch( recordEvent( 'Clicked Copy Page Link' ) );
+		props.infoNotice( translate( 'Link copied to clipboard.' ), {
+			duration: 3000,
+		} );
+		recordEllipsisMenuItemClickEvent( 'copylink' );
+		props.recordGoogleEvent( 'Pages', 'Clicked Copy Page Link' );
 	};
 
 	if ( ! template ) {
@@ -78,6 +117,7 @@ const VirtualPage = ( { site, id, type, title, description, previewUrl, isHomepa
 						textOnly: true,
 						args: { title },
 					} ) }
+					onClick={ clickPageTitle }
 				>
 					<span>{ title }</span>
 					{ isHomepage && (
@@ -106,8 +146,8 @@ const VirtualPage = ( { site, id, type, title, description, previewUrl, isHomepa
 					{ description && <span className="page-card-info__description">{ description }</span> }
 				</div>
 			</div>
-			<EllipsisMenu position="bottom left" onToggle={ handleMenuToggle }>
-				<PopoverMenuItem onClick={ recordEditPage } href={ editorUrl }>
+			<EllipsisMenu position="bottom left" onToggle={ toggleEllipsisMenu }>
+				<PopoverMenuItem onClick={ editPage } href={ editorUrl }>
 					<Gridicon icon="pencil" size={ 18 } />
 					{ translate( 'Edit' ) }
 				</PopoverMenuItem>
@@ -128,4 +168,12 @@ const VirtualPage = ( { site, id, type, title, description, previewUrl, isHomepa
 	);
 };
 
-export default VirtualPage;
+const mapDispatchToProps = {
+	recordGoogleEvent,
+	recordTracksEvent,
+	setPreviewUrl,
+	setLayoutFocus,
+	infoNotice,
+};
+
+export default connect( null, mapDispatchToProps )( VirtualPage );


### PR DESCRIPTION
#### Proposed Changes

This PR implements the following Tracks event:

| Trigger | Event | Props |
|-|-|-|
| User clicks virtual homepage card<br><img width="265" alt="image" src="https://user-images.githubusercontent.com/1525580/205231681-d55f47b5-5fe8-450b-b7a2-c6929a1c250b.png"> | `calypso_pages_page_title_click` | `page_type: virtual`
| User clicks to open the ellipsis menu<br><img width="209" alt="image" src="https://user-images.githubusercontent.com/1525580/205232035-87f5d92e-d26a-4792-98a7-ff031d3b129c.png"> | `calypso_pages_ellipsismenu_open_click`<br><br>Existing GA event:<br><img width="475" alt="image" src="https://user-images.githubusercontent.com/1525580/205234156-538b30fb-3c2e-4a81-b3ea-174598b4a584.png"> | `page_type: virtual`
| User clicks the Edit menu item<br><img width="206" alt="image" src="https://user-images.githubusercontent.com/1525580/205232282-e6230fff-d886-4885-aa7b-3f92d34c9f05.png"> | `calypso_pages_ellipsismenu_item_click`<br><br>Existing GA event:<br><img width="397" alt="image" src="https://user-images.githubusercontent.com/1525580/205233767-1ec8fae2-ca90-47fd-8748-829121511022.png"> | `page_type: virtual`<br>`item: editpage`
| User clicks the View page menu item<br><img width="184" alt="image" src="https://user-images.githubusercontent.com/1525580/205232677-76d9f4ea-b02b-454f-8f1f-10261d520bd8.png"> | `calypso_pages_ellipsismenu_item_click`<br><br>Existing GA event:<br><img width="425" alt="image" src="https://user-images.githubusercontent.com/1525580/205234306-abb34474-dfd9-46ed-9159-6d2cdc6e4ef5.png"> | `page_type: virtual`<br>`item: viewpage` | 
| User clicks the Copy link menu item<br><img width="190" alt="image" src="https://user-images.githubusercontent.com/1525580/205232983-13f793cd-4ec1-44e2-97f6-15a33c5357c1.png"> | `calypso_pages_ellipsismenu_item_click`<br><br>Existing GA event:<br><img width="457" alt="image" src="https://user-images.githubusercontent.com/1525580/205234422-d1fb4101-2ee0-49c0-b6f8-778ea680662b.png"> | `page_type: virtual`<br>`item: copylink`




#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. In browser console, run: `localStorage.setItem( 'debug', 'calypso:analytics*' );`
2. Refresh your browser
3. Test the events above, by watching for `calypso:analytics` (for Tracks) and `calypso:analytics:ga` (for GA)

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #70487
