### PR TITLE
New Welcome Tour Slide for Site Editor

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-launch.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-launch.tsx
@@ -60,7 +60,13 @@ function WelcomeTour() {
 	const currentTheme = useSelect( ( select ) => select( 'core' ).getCurrentTheme() );
 	const themeName = currentTheme?.name?.raw?.toLowerCase() ?? null;
 
-	const tourSteps = getTourSteps( localeSlug, isWelcomeTourNext(), isSiteEditor, themeName );
+	const tourSteps = getTourSteps(
+		localeSlug,
+		isWelcomeTourNext(),
+		isSiteEditor,
+		themeName,
+		intent
+	);
 
 	// Only keep Payment block step if user comes from seller simple flow
 	if ( ! ( 'sell' === intent && sitePlan && 'ecommerce-bundle' !== sitePlan.product_slug ) ) {

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-launch.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-launch.tsx
@@ -60,13 +60,7 @@ function WelcomeTour() {
 	const currentTheme = useSelect( ( select ) => select( 'core' ).getCurrentTheme() );
 	const themeName = currentTheme?.name?.raw?.toLowerCase() ?? null;
 
-	const tourSteps = getTourSteps(
-		localeSlug,
-		isWelcomeTourNext(),
-		isSiteEditor,
-		themeName,
-		intent
-	);
+	const tourSteps = getTourSteps( localeSlug, isWelcomeTourNext(), isSiteEditor, themeName );
 
 	// Only keep Payment block step if user comes from seller simple flow
 	if ( ! ( 'sell' === intent && sitePlan && 'ecommerce-bundle' !== sitePlan.product_slug ) ) {

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-steps.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-steps.tsx
@@ -3,6 +3,7 @@ import { isMobile } from '@automattic/viewport';
 import { ExternalLink } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { getQueryArg } from '@wordpress/url';
 import type { WpcomStep } from '@automattic/tour-kit';
 
 interface TourAsset {
@@ -61,23 +62,23 @@ function getTourSteps(
 	localeSlug: string,
 	referencePositioning = false,
 	isSiteEditor = false,
-	themeName: string | null = null,
-	intent = ''
+	themeName: string | null = null
 ): WpcomStep[] {
+	const completedFlow = getQueryArg( window.location.href, 'completedFlow' );
 	const isVideoMaker = 'videomaker' === ( themeName ?? '' );
-	const isPatternAssembler = 'build' === intent;
+	const isPatternAssemblerFlow = 'pattern_assembler' === completedFlow;
 	const siteEditorCourseUrl = `https://wordpress.com/home/${ window.location.hostname }?courseSlug=site-editor-quick-start`;
 
 	return [
 		{
 			slug: 'welcome',
 			meta: {
-				heading: isPatternAssembler
+				heading: isPatternAssemblerFlow
 					? __( 'Nice job! Your new page is set up.', 'full-site-editing' )
 					: __( 'Welcome to WordPress!', 'full-site-editing' ),
 				descriptions: {
 					desktop: ( () => {
-						if ( isPatternAssembler ) {
+						if ( isPatternAssemblerFlow ) {
 							return createInterpolateElement(
 								__(
 									'This is the Site Editor, it’s where you can change everything about your site, including adding content to your homepage. <link_to_site_editor_course>Watch these short videos</link_to_site_editor_course> or take a tour to get started.',
@@ -102,8 +103,8 @@ function getTourSteps(
 					mobile: null,
 				},
 				imgSrc: getTourAssets( isVideoMaker ? 'videomakerWelcome' : 'welcome' ),
-				imgHref: siteEditorCourseUrl,
-				imgPlayable: true,
+				imgHref: isPatternAssemblerFlow ? siteEditorCourseUrl : undefined,
+				imgPlayable: isPatternAssemblerFlow,
 			},
 			options: {
 				classNames: {

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-steps.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-steps.tsx
@@ -87,7 +87,7 @@ function getTourSteps(
 						if ( isPatternAssemblerFlow ) {
 							return createInterpolateElement(
 								__(
-									'This is the Site Editor, it’s where you can change everything about your site, including adding content to your homepage. <link_to_site_editor_course>Watch these short videos</link_to_site_editor_course> or take a tour to get started.',
+									'This is the Site Editor, it’s where you can change everything about your site, including adding content to your homepage. <link_to_site_editor_course>Watch these short videos</link_to_site_editor_course> and take this tour to get started.',
 									'full-site-editing'
 								),
 								{

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-steps.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-steps.tsx
@@ -87,7 +87,7 @@ function getTourSteps(
 						if ( isPatternAssemblerFlow ) {
 							return createInterpolateElement(
 								__(
-									'This is the Site Editor, it’s where you can change everything about your site, including adding content to your homepage. <link_to_site_editor_course>Watch these short videos</link_to_site_editor_course> and take this tour to get started.',
+									'This is the Site Editor, where you can change everything about your site, including adding content to your homepage. <link_to_site_editor_course>Watch these short videos</link_to_site_editor_course> and take this tour to get started.',
 									'full-site-editing'
 								),
 								{

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-steps.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-steps.tsx
@@ -1,3 +1,4 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { isMobile } from '@automattic/viewport';
 import { ExternalLink } from '@wordpress/components';
@@ -68,6 +69,11 @@ function getTourSteps(
 	const isVideoMaker = 'videomaker' === ( themeName ?? '' );
 	const isPatternAssemblerFlow = 'pattern_assembler' === completedFlow;
 	const siteEditorCourseUrl = `https://wordpress.com/home/${ window.location.hostname }?courseSlug=site-editor-quick-start`;
+	const onSiteEditorCourseLinkClick = () => {
+		recordTracksEvent( 'calypso_editor_wpcom_tour_site_editor_course_link_click', {
+			is_pattern_assembler: isPatternAssemblerFlow,
+		} );
+	};
 
 	return [
 		{
@@ -85,7 +91,12 @@ function getTourSteps(
 									'full-site-editing'
 								),
 								{
-									link_to_site_editor_course: <ExternalLink href={ siteEditorCourseUrl } />,
+									link_to_site_editor_course: (
+										<ExternalLink
+											href={ siteEditorCourseUrl }
+											onClick={ onSiteEditorCourseLinkClick }
+										/>
+									),
 								}
 							);
 						}
@@ -103,13 +114,18 @@ function getTourSteps(
 					mobile: null,
 				},
 				imgSrc: getTourAssets( isVideoMaker ? 'videomakerWelcome' : 'welcome' ),
-				imgHref: isPatternAssemblerFlow ? siteEditorCourseUrl : undefined,
-				imgPlayable: isPatternAssemblerFlow,
+				imgLink: isPatternAssemblerFlow
+					? {
+							href: siteEditorCourseUrl,
+							playable: true,
+							onClick: onSiteEditorCourseLinkClick,
+					  }
+					: undefined,
 			},
 			options: {
 				classNames: {
 					desktop: 'wpcom-editor-welcome-tour__step',
-					mobile: [ 'is-with-extra-padding', 'wpcom-editor-welcome-tour__step' ],
+					mobile: [ 'is-with-extra-padding', 'calypso_editor_wpcom_draft_post_modal_show' ],
 				},
 			},
 		},

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-steps.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-steps.tsx
@@ -61,27 +61,49 @@ function getTourSteps(
 	localeSlug: string,
 	referencePositioning = false,
 	isSiteEditor = false,
-	themeName: string | null = null
+	themeName: string | null = null,
+	intent = ''
 ): WpcomStep[] {
 	const isVideoMaker = 'videomaker' === ( themeName ?? '' );
+	const isPatternAssembler = 'build' === intent;
+	const siteEditorCourseUrl = `https://wordpress.com/home/${ window.location.hostname }?courseSlug=site-editor-quick-start`;
+
 	return [
 		{
 			slug: 'welcome',
 			meta: {
-				heading: __( 'Welcome to WordPress!', 'full-site-editing' ),
+				heading: isPatternAssembler
+					? __( 'Nice job! Your new page is set up.', 'full-site-editing' )
+					: __( 'Welcome to WordPress!', 'full-site-editing' ),
 				descriptions: {
-					desktop: isSiteEditor
-						? __(
-								'Take this short, interactive tour to learn the fundamentals of the WordPress Site Editor.',
-								'full-site-editing'
-						  )
-						: __(
-								'Take this short, interactive tour to learn the fundamentals of the WordPress editor.',
-								'full-site-editing'
-						  ),
+					desktop: ( () => {
+						if ( isPatternAssembler ) {
+							return createInterpolateElement(
+								__(
+									'This is the Site Editor, it’s where you can change everything about your site, including adding content to your homepage. <link_to_site_editor_course>Watch these short videos</link_to_site_editor_course> or take a tour to get started.',
+									'full-site-editing'
+								),
+								{
+									link_to_site_editor_course: <ExternalLink href={ siteEditorCourseUrl } />,
+								}
+							);
+						}
+
+						return isSiteEditor
+							? __(
+									'Take this short, interactive tour to learn the fundamentals of the WordPress Site Editor.',
+									'full-site-editing'
+							  )
+							: __(
+									'Take this short, interactive tour to learn the fundamentals of the WordPress editor.',
+									'full-site-editing'
+							  );
+					} )(),
 					mobile: null,
 				},
 				imgSrc: getTourAssets( isVideoMaker ? 'videomakerWelcome' : 'welcome' ),
+				imgHref: siteEditorCourseUrl,
+				imgPlayable: true,
 			},
 			options: {
 				classNames: {

--- a/apps/editing-toolkit/jest.config.js
+++ b/apps/editing-toolkit/jest.config.js
@@ -12,6 +12,7 @@
  */
 
 const path = require( 'path' );
+const base = require( '@automattic/calypso-jest' );
 // @wordpress/scripts manually adds additional Jest config ontop of
 // @wordpress/jest-preset-default so we pull in this file to extend it
 const defaults = require( '@wordpress/scripts/config/jest-unit.config.js' );
@@ -21,6 +22,7 @@ const defaults = require( '@wordpress/scripts/config/jest-unit.config.js' );
 const pluginRoot = path.resolve( './' );
 
 const config = {
+	...base,
 	...defaults,
 	rootDir: path.normalize( '../../' ), // To detect wp-calypso root node_modules
 	testMatch: [ `${ pluginRoot }/**/?(*.)test.[jt]s?(x)` ],

--- a/apps/editing-toolkit/package.json
+++ b/apps/editing-toolkit/package.json
@@ -126,6 +126,7 @@
 	"devDependencies": {
 		"@automattic/calypso-apps-builder": "workspace:^",
 		"@automattic/calypso-eslint-overrides": "workspace:^",
+		"@automattic/calypso-jest": "workspace:^",
 		"@testing-library/jest-dom": "^5.16.2",
 		"@testing-library/react": "^12.1.3",
 		"@types/node": "^15.0.2",

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -79,6 +79,7 @@ interface Props {
 	stripeConnectSuccess: 'gutenberg' | null;
 	showDraftPostModal: boolean;
 	blockEditorSettings: BlockEditorSettings;
+	completedFlow?: string;
 }
 
 interface CheckoutModalOptions extends RequestCart {
@@ -777,6 +778,7 @@ const mapStateToProps = (
 		showDraftPostModal,
 		pressThisData,
 		blockEditorSettings,
+		completedFlow,
 	}: Props
 ) => {
 	const siteId = getSelectedSiteId( state );
@@ -803,6 +805,7 @@ const mapStateToProps = (
 		showDraftPostModal,
 		...pressThisData,
 		answer_prompt: getQueryArg( window.location.href, 'answer_prompt' ),
+		completedFlow,
 	} );
 
 	// needed for loading the editor in SU sessions

--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -212,12 +212,9 @@ function getAnchorFmData( query ) {
 	return { anchor_podcast, anchor_episode, spotify_url };
 }
 
-function showDraftPostModal() {
-	const value = window.sessionStorage.getItem( 'wpcom_signup_complete_show_draft_post_modal' );
-	if ( value ) {
-		window.sessionStorage.removeItem( 'wpcom_signup_complete_show_draft_post_modal' );
-	}
-
+function getSessionStorageOneTimeValue( key ) {
+	const value = window.sessionStorage.getItem( key );
+	window.sessionStorage.removeItem( key );
 	return value;
 }
 
@@ -252,7 +249,9 @@ export const post = ( context, next ) => {
 			parentPostId={ parentPostId }
 			creatingNewHomepage={ postType === 'page' && context.query.hasOwnProperty( 'new-homepage' ) }
 			stripeConnectSuccess={ context.query.stripe_connect_success ?? null }
-			showDraftPostModal={ showDraftPostModal() }
+			showDraftPostModal={ getSessionStorageOneTimeValue(
+				'wpcom_signup_complete_show_draft_post_modal'
+			) }
 		/>
 	);
 
@@ -269,6 +268,7 @@ export const siteEditor = ( context, next ) => {
 			// It will force the component to remount completely when the Id changes.
 			key={ siteId }
 			editorType="site"
+			completedFlow={ getSessionStorageOneTimeValue( 'wpcom_signup_completed_flow' ) }
 		/>
 	);
 

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -226,6 +226,7 @@ const siteSetupFlow: Flow = {
 
 					// End of Pattern Assembler flow
 					if ( selectedDesign?.design_type === 'assembler' ) {
+						window.sessionStorage.setItem( 'wpcom_signup_completed_flow', 'pattern_assembler' );
 						return exitFlow( `/site-editor/${ siteSlug }` );
 					}
 

--- a/packages/tour-kit/src/types.ts
+++ b/packages/tour-kit/src/types.ts
@@ -135,6 +135,8 @@ export interface WpcomStep extends Step {
 				type: string;
 			};
 		};
+		imgHref?: string;
+		imgPlayable?: boolean;
 	};
 }
 

--- a/packages/tour-kit/src/types.ts
+++ b/packages/tour-kit/src/types.ts
@@ -135,8 +135,11 @@ export interface WpcomStep extends Step {
 				type: string;
 			};
 		};
-		imgHref?: string;
-		imgPlayable?: boolean;
+		imgLink?: {
+			href: string;
+			playable?: boolean;
+			onClick?: () => void;
+		};
 	};
 }
 

--- a/packages/tour-kit/src/variants/wpcom/components/wpcom-tour-kit-step-card-navigation.tsx
+++ b/packages/tour-kit/src/variants/wpcom/components/wpcom-tour-kit-step-card-navigation.tsx
@@ -36,7 +36,7 @@ const WpcomTourKitStepCardNavigation: React.FunctionComponent< Props > = ( {
 							onClick={ onNextStep }
 							ref={ setInitialFocusedElement }
 						>
-							{ __( 'Take tour', __i18n_text_domain__ ) }
+							{ __( 'Take the tour', __i18n_text_domain__ ) }
 						</Button>
 					</div>
 				) : (

--- a/packages/tour-kit/src/variants/wpcom/components/wpcom-tour-kit-step-card-navigation.tsx
+++ b/packages/tour-kit/src/variants/wpcom/components/wpcom-tour-kit-step-card-navigation.tsx
@@ -36,7 +36,7 @@ const WpcomTourKitStepCardNavigation: React.FunctionComponent< Props > = ( {
 							onClick={ onNextStep }
 							ref={ setInitialFocusedElement }
 						>
-							{ __( 'Try it out!', __i18n_text_domain__ ) }
+							{ __( 'Take tour', __i18n_text_domain__ ) }
 						</Button>
 					</div>
 				) : (

--- a/packages/tour-kit/src/variants/wpcom/components/wpcom-tour-kit-step-card.tsx
+++ b/packages/tour-kit/src/variants/wpcom/components/wpcom-tour-kit-step-card.tsx
@@ -20,7 +20,7 @@ const WpcomTourKitStepCard: React.FunctionComponent< WpcomTourStepRendererProps 
 } ) => {
 	const { __ } = useI18n();
 	const lastStepIndex = steps.length - 1;
-	const { descriptions, heading, imgSrc, imgHref, imgPlayable } = steps[ currentStepIndex ].meta;
+	const { descriptions, heading, imgSrc, imgLink } = steps[ currentStepIndex ].meta;
 	const isLastStep = currentStepIndex === lastStepIndex;
 
 	const description = descriptions[ isMobile() ? 'mobile' : 'desktop' ] ?? descriptions.desktop;
@@ -43,14 +43,15 @@ const WpcomTourKitStepCard: React.FunctionComponent< WpcomTourStepRendererProps 
 						) }
 						<img alt={ __( 'Tour Media', __i18n_text_domain__ ) } src={ imgSrc.desktop?.src } />
 					</picture>
-					{ imgHref && (
+					{ imgLink && (
 						<a
 							className={ classnames( 'wpcom-tour-ket-step-card__medida-link', {
-								'wpcom-tour-ket-step-card__medida-link--playable': imgPlayable,
+								'wpcom-tour-ket-step-card__medida-link--playable': imgLink.playable,
 							} ) }
-							href={ imgHref }
+							href={ imgLink.href }
 							target="_blank"
 							rel="noreferrer noopener"
+							onClick={ imgLink.onClick }
 						>
 							<Icon
 								icon={

--- a/packages/tour-kit/src/variants/wpcom/components/wpcom-tour-kit-step-card.tsx
+++ b/packages/tour-kit/src/variants/wpcom/components/wpcom-tour-kit-step-card.tsx
@@ -45,8 +45,8 @@ const WpcomTourKitStepCard: React.FunctionComponent< WpcomTourStepRendererProps 
 					</picture>
 					{ imgLink && (
 						<a
-							className={ classnames( 'wpcom-tour-ket-step-card__medida-link', {
-								'wpcom-tour-ket-step-card__medida-link--playable': imgLink.playable,
+							className={ classnames( 'wpcom-tour-kit-step-card__media-link', {
+								'wpcom-tour-kit-step-card__media-link--playable': imgLink.playable,
 							} ) }
 							href={ imgLink.href }
 							target="_blank"

--- a/packages/tour-kit/src/variants/wpcom/components/wpcom-tour-kit-step-card.tsx
+++ b/packages/tour-kit/src/variants/wpcom/components/wpcom-tour-kit-step-card.tsx
@@ -1,6 +1,8 @@
 import { getMediaQueryList, isMobile, MOBILE_BREAKPOINT } from '@automattic/viewport';
 import { Button, Card, CardBody, CardFooter, CardMedia } from '@wordpress/components';
+import { Icon } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
+import classnames from 'classnames';
 import WpcomTourKitRating from './wpcom-tour-kit-rating';
 import WpcomTourKitStepCardNavigation from './wpcom-tour-kit-step-card-navigation';
 import WpcomTourKitStepCardOverlayControls from './wpcom-tour-kit-step-card-overlay-controls';
@@ -18,7 +20,7 @@ const WpcomTourKitStepCard: React.FunctionComponent< WpcomTourStepRendererProps 
 } ) => {
 	const { __ } = useI18n();
 	const lastStepIndex = steps.length - 1;
-	const { descriptions, heading, imgSrc } = steps[ currentStepIndex ].meta;
+	const { descriptions, heading, imgSrc, imgHref, imgPlayable } = steps[ currentStepIndex ].meta;
 	const isLastStep = currentStepIndex === lastStepIndex;
 
 	const description = descriptions[ isMobile() ? 'mobile' : 'desktop' ] ?? descriptions.desktop;
@@ -41,6 +43,34 @@ const WpcomTourKitStepCard: React.FunctionComponent< WpcomTourStepRendererProps 
 						) }
 						<img alt={ __( 'Tour Media', __i18n_text_domain__ ) } src={ imgSrc.desktop?.src } />
 					</picture>
+					{ imgHref && (
+						<a
+							className={ classnames( 'wpcom-tour-ket-step-card__medida-link', {
+								'wpcom-tour-ket-step-card__medida-link--playable': imgPlayable,
+							} ) }
+							href={ imgHref }
+							target="_blank"
+							rel="noreferrer noopener"
+						>
+							<Icon
+								icon={
+									<svg
+										width="27"
+										height="32"
+										viewBox="0 0 27 32"
+										fill="none"
+										xmlns="http://www.w3.org/2000/svg"
+									>
+										<path
+											d="M27 16L-1.4682e-06 31.5885L-1.05412e-07 0.411542L27 16Z"
+											fill="white"
+										/>
+									</svg>
+								}
+								size={ 27 }
+							/>
+						</a>
+					) }
 				</CardMedia>
 			) }
 			<CardBody>

--- a/packages/tour-kit/src/variants/wpcom/styles.scss
+++ b/packages/tour-kit/src/variants/wpcom/styles.scss
@@ -191,10 +191,42 @@ $wpcom-tour-kit-step-card-overlay-controls-button-bg-color: #32373c; // former $
 	min-width: 85px;
 }
 
+.wpcom-tour-kit-step-card__media {
+	position: relative;
+}
+
 // TODO: Remove once @wordpress/components/src/card/styles/card-styles.js is updated
 .wpcom-tour-kit-step-card__media img {
 	display: block;
 	height: auto;
 	max-width: 100%;
 	width: 100%;
+}
+
+.wpcom-tour-ket-step-card__medida-link {
+	position: absolute;
+	left: 0;
+	right: 0;
+	top: 0;
+	bottom: 0;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+
+	svg {
+		display: none;
+		transition: transform 0.15s ease-in-out;
+
+		&:hover {
+			transform: scale(1.05);
+		}
+	}
+
+	&--playable {
+		background-color: rgba(0, 0, 0, 0.5);
+
+		svg {
+			display: block;
+		}
+	}
 }

--- a/packages/tour-kit/src/variants/wpcom/styles.scss
+++ b/packages/tour-kit/src/variants/wpcom/styles.scss
@@ -203,7 +203,7 @@ $wpcom-tour-kit-step-card-overlay-controls-button-bg-color: #32373c; // former $
 	width: 100%;
 }
 
-.wpcom-tour-ket-step-card__medida-link {
+.wpcom-tour-kit-step-card__media-link {
 	position: absolute;
 	left: 0;
 	right: 0;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1745,6 +1745,7 @@ __metadata:
     "@automattic/calypso-apps-builder": "workspace:^"
     "@automattic/calypso-build": "workspace:^"
     "@automattic/calypso-eslint-overrides": "workspace:^"
+    "@automattic/calypso-jest": "workspace:^"
     "@automattic/calypso-polyfills": "workspace:^"
     "@automattic/components": "workspace:^"
     "@automattic/composite-checkout": "workspace:^"


### PR DESCRIPTION
#### Proposed Changes

* Introduce `completedFlow` to the site editor and it will be used only once when you finish the flow and land on the site editor
* Replace the first slide of the welcome tour with the new one if the completed flow is pattern assembler
* When you click on the image or link on the new slide, you will see the site editor course on a new tab
* Add a new event to track the link is clicked
* Update the copy of the first slide from "Try it out" to "Take tour"

**TODOs**

- [x] register event: calypso_editor_wpcom_tour_site_editor_course_link_click

**Screenshot**

![image](https://user-images.githubusercontent.com/13596067/205040626-bfb4f7ae-3dd8-48c7-b9a6-cef63dbd0c7c.png)

**Event**

![image](https://user-images.githubusercontent.com/13596067/205260101-3d73e19e-93da-4914-a21a-75af2a0546fe.png)


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open another terminal and run `cd apps/editing-toolkit && yarn dev --sync` to sync the ETK plugin to your sandbox. Or you can run `install-plugin.sh editing-toolkit feat/pa-welcome-tour` on your sandbox.
* Sandbox **_your site_**
* Go to `/setup?siteSlug=<your_site>&flags=signup/design-picker-pattern-assembler` 
* Continue until you land on the Design Picker step
* Scroll to bottom and click the Blank Canvas CTA
* Select any patterns and continue
* When you land on the site editor, verify the first slide is the new one
* Click on the image or link, and the browser will open a new tab and the site editor course will show
* Check your network status and verify `calypso_editor_wpcom_tour_site_editor_course_link_click` event is sent
* Refresh the site editor, and verify the first slide is the same as before

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/70386
