### PR TITLE
Enable tailored eCommerce flow in production

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -100,7 +100,7 @@
 		"signup/inline-help": false,
 		"signup/professional-email-step": false,
 		"signup/social": true,
-		"signup/tailored-ecommerce": false,
+		"signup/tailored-ecommerce": true,
 		"signup/woo-verify-email": false,
 		"site-indicator": true,
 		"sites-as-landing-page": true,

--- a/config/production.json
+++ b/config/production.json
@@ -117,7 +117,7 @@
 		"signup/inline-help": false,
 		"signup/professional-email-step": false,
 		"signup/social": true,
-		"signup/tailored-ecommerce": false,
+		"signup/tailored-ecommerce": true,
 		"signup/woo-verify-email": false,
 		"site-indicator": true,
 		"sites-as-landing-page": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -115,7 +115,7 @@
 		"signup/inline-help": false,
 		"signup/professional-email-step": false,
 		"signup/social": true,
-		"signup/tailored-ecommerce": false,
+		"signup/tailored-ecommerce": true,
 		"signup/woo-verify-email": false,
 		"site-indicator": true,
 		"sites-as-landing-page": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -124,7 +124,7 @@
 		"signup/inline-help": false,
 		"signup/professional-email-step": false,
 		"signup/social": true,
-		"signup/tailored-ecommerce": false,
+		"signup/tailored-ecommerce": true,
 		"signup/woo-verify-email": false,
 		"site-indicator": true,
 		"sites-as-landing-page": true,


### PR DESCRIPTION
#### Proposed Changes

* This PR enables the `signup/tailored-ecommerce` feature flag in the following enviroments:
  - `horizon`
  - `wpcalypso`
  - `stage`
  - `production`
* For now, it does _not_ enable the flag in the `test` environment -- we should follow up separately with KitKat to work out what we ought to do around e2e tests.

#### Testing Instructions

Given that we're enabling the feature flag in `wpcalypso`, we can test this using the Calypso Live environment.
* Open the live branch for this PR in a browser tab
* In that browser tab, navigate to `/setup/ecommerce`
* Verify that you're dropped into `/setup/ecommerce/intro`
* In the same tab, navifate to `/setup/ecommerce?recur=monthly`
* Verify that you're dropped into `/setup/ecommerce/intro`

#### Pre-merge Checklist

- [N/A] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [N/A] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [N/A] Have you checked for TypeScript, React or other console errors?
- [N/A] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [N/A] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [N/A] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?