### PR TITLE
Woo Tailored Onboarding: Enable the signup/tailored-ecommerce feature flag in all environments

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -100,7 +100,7 @@
 		"signup/inline-help": false,
 		"signup/professional-email-step": false,
 		"signup/social": true,
-		"signup/tailored-ecommerce": false,
+		"signup/tailored-ecommerce": true,
 		"signup/woo-verify-email": false,
 		"site-indicator": true,
 		"sites-as-landing-page": true,

--- a/config/production.json
+++ b/config/production.json
@@ -117,7 +117,7 @@
 		"signup/inline-help": false,
 		"signup/professional-email-step": false,
 		"signup/social": true,
-		"signup/tailored-ecommerce": false,
+		"signup/tailored-ecommerce": true,
 		"signup/woo-verify-email": false,
 		"site-indicator": true,
 		"sites-as-landing-page": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -115,7 +115,7 @@
 		"signup/inline-help": false,
 		"signup/professional-email-step": false,
 		"signup/social": true,
-		"signup/tailored-ecommerce": false,
+		"signup/tailored-ecommerce": true,
 		"signup/woo-verify-email": false,
 		"site-indicator": true,
 		"sites-as-landing-page": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -124,7 +124,7 @@
 		"signup/inline-help": false,
 		"signup/professional-email-step": false,
 		"signup/social": true,
-		"signup/tailored-ecommerce": false,
+		"signup/tailored-ecommerce": true,
 		"signup/woo-verify-email": false,
 		"site-indicator": true,
 		"sites-as-landing-page": true,


### PR DESCRIPTION
#### Proposed Changes

This enables the `signup/tailored-ecommerce` flag in all environments (the last step to fully launch the Woo tailored onboardng flow).

