### PR TITLE
Datacenter Picker: Minor UI tweaks and soft-launch

### DIFF
--- a/client/blocks/eligibility-warnings/data-center-picker.tsx
+++ b/client/blocks/eligibility-warnings/data-center-picker.tsx
@@ -22,17 +22,9 @@ type Props = ExternalProps & LocalizeProps;
 
 const DataCenterOptions = [
 	{
-		value: 'ams',
-		name: 'geo_affinity',
-		label: translate( 'Amsterdam' ),
-		thumbnail: {
-			imageUrl: amsImg,
-		},
-	},
-	{
 		value: 'bur',
 		name: 'geo_affinity',
-		label: translate( 'California' ),
+		label: translate( 'US West' ),
 		thumbnail: {
 			imageUrl: burImg,
 		},
@@ -40,7 +32,7 @@ const DataCenterOptions = [
 	{
 		value: 'dfw',
 		name: 'geo_affinity',
-		label: translate( 'Texas' ),
+		label: translate( 'US Central' ),
 		thumbnail: {
 			imageUrl: dfwImg,
 		},
@@ -48,9 +40,17 @@ const DataCenterOptions = [
 	{
 		value: 'dca',
 		name: 'geo_affinity',
-		label: translate( 'Washington, D.C.' ),
+		label: translate( 'US East' ),
 		thumbnail: {
 			imageUrl: dcaImg,
+		},
+	},
+	{
+		value: 'ams',
+		name: 'geo_affinity',
+		label: translate( 'EU West' ),
+		thumbnail: {
+			imageUrl: amsImg,
 		},
 	},
 ];

--- a/client/blocks/eligibility-warnings/data-center-picker.tsx
+++ b/client/blocks/eligibility-warnings/data-center-picker.tsx
@@ -151,7 +151,15 @@ const DataCenterPicker = ( {
 							'Choose a primary data center for your site. For redundancy, your site will replicate in real-time to a second data center in different region. {{supportLink}}Learn more{{/supportLink}}.',
 							{
 								components: {
-									supportLink: <ExternalLink icon target="_blank" href={ localizeUrl( '#' ) } />,
+									supportLink: (
+										<ExternalLink
+											icon
+											target="_blank"
+											href={ localizeUrl(
+												'https://wordpress.com/support/choose-your-sites-primary-data-center/'
+											) }
+										/>
+									),
 								},
 							}
 						) }

--- a/client/blocks/eligibility-warnings/index.tsx
+++ b/client/blocks/eligibility-warnings/index.tsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import {
 	FEATURE_UPLOAD_PLUGINS,
 	FEATURE_PERFORMANCE,
@@ -206,7 +205,7 @@ export const EligibilityWarnings = ( {
 				</CompactCard>
 			) }
 
-			{ showDataCenterPicker && config.isEnabled( 'hosting/datacenter-picker' ) && (
+			{ showDataCenterPicker && (
 				<CompactCard className="eligibility-warnings__data-center-picker">
 					<TrackComponentView eventName="calypso_automated_transfer_datacenter_picker_display" />
 					<DataCenterPicker

--- a/client/my-sites/hosting/web-server-settings-card/index.js
+++ b/client/my-sites/hosting/web-server-settings-card/index.js
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { Button, Card, Spinner } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import { useState } from 'react';
@@ -262,9 +261,7 @@ const WebServerSettingsCard = ( {
 
 	return (
 		<Card className="web-server-settings-card">
-			{ config.isEnabled( 'hosting/datacenter-picker' ) && (
-				<QuerySiteGeoAffinity siteId={ siteId } />
-			) }
+			<QuerySiteGeoAffinity siteId={ siteId } />
 			<QuerySitePhpVersion siteId={ siteId } />
 			<QuerySiteStaticFile404 siteId={ siteId } />
 			<MaterialIcon icon="build" size={ 32 } />
@@ -274,7 +271,7 @@ const WebServerSettingsCard = ( {
 					'For sites with specialized needs, fine-tune how the web server runs your website.'
 				) }
 			</p>
-			{ config.isEnabled( 'hosting/datacenter-picker' ) && getGeoAffinityContent() }
+			{ getGeoAffinityContent() }
 			{ getPhpVersionContent() }
 			{ getStaticFile404Content() }
 			{ ( isGettingGeoAffinity || isGettingPhpVersion || isGettingStaticFile404 ) && <Spinner /> }

--- a/client/my-sites/hosting/web-server-settings-card/index.js
+++ b/client/my-sites/hosting/web-server-settings-card/index.js
@@ -11,6 +11,7 @@ import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormSelect from 'calypso/components/forms/form-select';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
+import FormTextInput from 'calypso/components/forms/form-text-input';
 import MaterialIcon from 'calypso/components/material-icon';
 import { updateAtomicPhpVersion, updateAtomicStaticFile404 } from 'calypso/state/hosting/actions';
 import { getAtomicHostingGeoAffinity } from 'calypso/state/selectors/get-atomic-hosting-geo-affinity';
@@ -40,52 +41,30 @@ const WebServerSettingsCard = ( {
 	const [ selectedPhpVersion, setSelectedPhpVersion ] = useState( '' );
 	const [ selectedStaticFile404, setSelectedStaticFile404 ] = useState( '' );
 
-	const getDataCenterOptions = () => {
-		return [
-			{
-				value: 'auto',
-				label: translate( 'Automatic' ),
-			},
-			{
-				value: 'ams',
-				label: translate( 'Amsterdam' ),
-			},
-			{
-				value: 'bur',
-				label: translate( 'California' ),
-			},
-			{
-				value: 'dfw',
-				label: translate( 'Texas' ),
-			},
-			{
-				value: 'dca',
-				label: translate( 'Washington, D.C.' ),
-			},
-		];
-	};
-
 	const getGeoAffinityContent = () => {
-		if ( isGettingGeoAffinity ) {
+		if ( isGettingGeoAffinity || 'auto' === geoAffinity ) {
 			return;
 		}
+
+		const dataCenterOptions = {
+			bur: translate( 'US West (Burbank, California)' ),
+			dfw: translate( 'US Central (Dallas-Fort Worth, Texas)' ),
+			dca: translate( 'US East (Washington, D.C.)' ),
+			ams: translate( 'EU West (Amsterdam, Netherlands)' ),
+		};
+		const displayValue =
+			dataCenterOptions[ geoAffinity ] !== undefined
+				? dataCenterOptions[ geoAffinity ]
+				: geoAffinity;
 
 		return (
 			<FormFieldset>
 				<FormLabel>{ translate( 'Primary Data Center' ) }</FormLabel>
-				<FormSelect className="web-server-settings-card__data-center-select" value={ geoAffinity }>
-					{ getDataCenterOptions().map( ( option ) => {
-						return (
-							<option
-								disabled={ option.value !== geoAffinity }
-								value={ option.value }
-								key={ option.label }
-							>
-								{ option.label }
-							</option>
-						);
-					} ) }
-				</FormSelect>
+				<FormTextInput
+					className="web-server-settings-card__data-center-input"
+					value={ displayValue }
+					disabled
+				/>
 				<FormSettingExplanation>
 					{ translate(
 						'The primary data center is where your site is physically located. ' +


### PR DESCRIPTION
See https://github.com/Automattic/dotcom-forge/issues/1239

## Proposed Changes

1. Uses `US West`, etc. as the labels, per feedback pdKhl6-15J-p2#comment-1472
2. Only shows the primary data center in 'Web Server Settings' when it was chosen, and displays as a text input pdKhl6-15J-p2#comment-1479
3. Removes the feature flag for a soft launch.

<img width="808" alt="image" src="https://user-images.githubusercontent.com/36432/205067805-d062422c-1bd9-4696-978f-66a64febd201.png">

<img width="789" alt="image" src="https://user-images.githubusercontent.com/36432/205067757-3993f363-0ba1-496c-8fd7-69d03fa62299.png">

## Testing Instructions

1. Create a new WordPress.com site with a business plan.
2. Navigate to 'Hosting Configuration' and click 'Activate'.
3. Verify the `<EligibilityWarnings>` component displays with the Data Center Picker UI.
4. Verify the Data Center Picker UI is usable, accessible, and looks good in the browsers we support.
5. Click 'Continue' and wait for the site to go Atomic.
6. Look at the 'Web Server Settings' UI and verify it appears as expected.