### PR TITLE
Limit Global Styles: Refactor the custom launch bar controls

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
@@ -205,16 +205,16 @@ function wpcom_global_styles_in_use() {
 }
 
 /**
- * Adds the global style notice banner to the custom launch bar controls.
+ * Adds the global style notice banner to the launch bar controls.
  *
- * @param array $custom_controls List of custom controls.
+ * @param array $bar_controls List of launch bar controls.
  *
- * return array The collection of launch bar custom controls to render.
+ * return array The collection of launch bar controls to render.
  */
-function wpcom_display_global_styles_banner( $custom_controls ) {
+function wpcom_display_global_styles_launch_bar( $bar_controls ) {
 	// Do not show the banner if the user can use global styles.
 	if ( ! wpcom_should_limit_global_styles() || ! wpcom_global_styles_in_use() ) {
-		return;
+		return $bar_controls;
 	}
 
 	if ( method_exists( '\WPCOM_Masterbar', 'get_calypso_site_slug' ) ) {
@@ -226,21 +226,56 @@ function wpcom_display_global_styles_banner( $custom_controls ) {
 
 	$upgrade_url = 'https://wordpress.com/plans/' . $site_slug;
 
-	$custom_controls[] = array(
-		'desktop_message'    => __( 'Styles hidden', 'full-site-editing' ),
-		'mobile_message'     => __( 'Styles', 'full-site-editing' ),
-		'track_button_name'  => 'wpcom_global_styles_gating_notice',
-		'tooltip'            => __( 'You need to be on a paid plan for your style changes to be made public.', 'full-site-editing' ),
-		'tooltip_link_title' => __( 'Upgrade your plan', 'full-site-editing' ),
-		'tooltip_link_url'   => $upgrade_url,
-		'icon_path'          => 'M13 9h-2V7h2v2zm0 2h-2v6h2v-6zm-1-7c-4.411 0-8 3.589-8 8s3.589 8 8 8 8-3.589 8-8-3.589-8-8-8m0-2c5.523 0 10 4.477 10 10s-4.477 10-10 10S2 17.523 2 12 6.477 2 12 2z',
-		'icon_color'         => 'orange',
-		'extra_tooltip'      => 'toggle_global_styles',
-	);
+	if ( wpcom_is_previewing_global_styles() ) {
+		$preview_text     = __( 'Hide premium styles', 'full-site-editing' );
+		$preview_location = remove_query_arg( 'preview-global-styles' );
+	} else {
+		$preview_text     = __( 'Preview styles before upgrading', 'full-site-editing' );
+		$preview_location = add_query_arg( 'preview-global-styles', '' );
+	}
 
-	return $custom_controls;
+	ob_start(); ?>
+		<div class="launch-custom-button">
+			<div class="launch-custom-tooltip hidden-tooltip">
+				<div>
+					<?php echo esc_html__( 'Publish your style changes and unlock tons of other features by upgrading to a Premium plan.', 'full-site-editing' ); ?>
+				</div>
+				<button
+					class="launch-tooltip-button"
+					data-launchbar-tooltip-url="<?php echo esc_url( $upgrade_url ); ?>"
+					data-launchbar-tooltip-button-track="wpcom_global_styles_gating_notice"
+				>
+					<?php echo esc_html__( 'Upgrade your plan', 'full-site-editing' ); ?>
+				</button>
+				<a class="launch-custom-link" href="<?php echo esc_url( $preview_location ); ?>">
+					<?php echo esc_html( $preview_text ); ?>
+				</a>
+			</div>
+			<a data-launchbar-track="wpcom_global_styles_gating_notice">
+				<svg width="25" height="25" viewBox="0 0 30 23" xmlns="http://www.w3.org/2000/svg">
+					<path d="M12 4c-4.4 0-8 3.6-8 8v.1c0 4.1 3.2 7.5 7.2 7.9h.8c4.4 0 8-3.6 8-8s-3.6-8-8-8zm0 15V5c3.9 0 7 3.1 7 7s-3.1 7-7 7z" style="fill: orange" />
+				</svg>
+				<span class="is-mobile">
+					<?php echo esc_html__( 'Styles', 'full-site-editing' ); ?>
+				</span>
+				<span class="is-desktop">
+					<?php echo esc_html__( 'Publish styles', 'full-site-editing' ); ?>
+				</span>
+			</a>
+		</div>
+	<?php
+	$global_styles_bar_control = ob_get_clean();
+
+	$launch_site_control_key = array_search( 'launch-site', array_keys( $bar_controls ), true );
+
+	if ( $launch_site_control_key ) {
+		array_splice( $bar_controls, $launch_site_control_key, 0, $global_styles_bar_control );
+	} else {
+		$bar_controls[] = $global_styles_bar_control;
+	}
+	return $bar_controls;
 }
-add_filter( 'wpcom_custom_launch_bar_controls', 'wpcom_display_global_styles_banner' );
+add_filter( 'wpcom_launch_bar_controls', 'wpcom_display_global_styles_launch_bar' );
 
 /**
  * Include the Rest API that returns the global style information for a give WordPress site.
@@ -266,23 +301,3 @@ function wpcom_is_previewing_global_styles( ?int $user_id = null ) {
 	// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 	return isset( $_GET['preview-global-styles'] ) && user_can( $user_id, 'administrator' );
 }
-
-/**
- * Renders the link for previewing global styles in the launch banner.
- *
- * @return void
- */
-function wpcom_display_global_styles_banner_extra_tooltip() {
-	if ( wpcom_is_previewing_global_styles() ) {
-		$text     = __( 'Hide premium styles', 'full-site-editing' );
-		$location = remove_query_arg( 'preview-global-styles' );
-	} else {
-		$text     = __( 'Preview styles before upgrading', 'full-site-editing' );
-		$location = add_query_arg( 'preview-global-styles', '' );
-	}
-
-	?>
-	<a class="launch-custom-link" href="<?php echo esc_url( $location ); ?>"><?php echo esc_html( $text ); ?></a>
-	<?php
-}
-add_action( 'launch_bar_extra_tooltip_toggle_global_styles', 'wpcom_display_global_styles_banner_extra_tooltip' );

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
@@ -224,7 +224,7 @@ function wpcom_display_global_styles_launch_bar( $bar_controls ) {
 		$site_slug = wp_parse_url( $home_url, PHP_URL_HOST );
 	}
 
-	$upgrade_url = 'https://wordpress.com/plans/' . $site_slug;
+	$upgrade_url = 'https://wordpress.com/plans/' . $site_slug . '?plan=value_bundle';
 
 	if ( wpcom_is_previewing_global_styles() ) {
 		$preview_text     = __( 'Hide premium styles', 'full-site-editing' );

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
@@ -40,11 +40,11 @@ function wpcom_should_limit_global_styles( $blog_id = 0 ) {
 }
 
 /**
- * Enqueues the WP.com Global Styles scripts and styles.
+ * Enqueues the WP.com Global Styles scripts and styles for the block editor.
  *
  * @return void
  */
-function wpcom_global_styles_enqueue_scripts_and_styles() {
+function wpcom_global_styles_enqueue_block_editor_assets() {
 	$screen = get_current_screen();
 	if ( ! $screen || 'site-editor' !== $screen->id ) {
 		return;
@@ -104,7 +104,40 @@ function wpcom_global_styles_enqueue_scripts_and_styles() {
 		filemtime( plugin_dir_path( __FILE__ ) . 'dist/wpcom-global-styles.css' )
 	);
 }
-add_action( 'enqueue_block_editor_assets', 'wpcom_global_styles_enqueue_scripts_and_styles' );
+add_action( 'enqueue_block_editor_assets', 'wpcom_global_styles_enqueue_block_editor_assets' );
+
+/**
+ * Enqueues the WP.com Global Styles scripts and styles for the front end.
+ *
+ * @return void
+ */
+function wpcom_global_styles_enqueue_assets() {
+	if ( ! wpcom_should_limit_global_styles() ) {
+		return;
+	}
+
+	$asset_file   = plugin_dir_path( __FILE__ ) . 'dist/wpcom-global-styles-view.asset.php';
+	$asset        = file_exists( $asset_file )
+		? require $asset_file
+		: null;
+	$dependencies = $asset['dependencies'] ?? array();
+	$version      = $asset['version'] ?? filemtime( plugin_dir_path( __FILE__ ) . 'dist/wpcom-global-styles-view.min.js' );
+
+	wp_enqueue_script(
+		'wpcom-global-styles',
+		plugins_url( 'dist/wpcom-global-styles-view.min.js', __FILE__ ),
+		$dependencies,
+		$version,
+		true
+	);
+	wp_enqueue_style(
+		'wpcom-global-styles',
+		plugins_url( 'dist/wpcom-global-styles-view.css', __FILE__ ),
+		array(),
+		filemtime( plugin_dir_path( __FILE__ ) . 'dist/wpcom-global-styles-view.css' )
+	);
+}
+add_action( 'wp_enqueue_scripts', 'wpcom_global_styles_enqueue_assets' );
 
 /**
  * Removes the user styles from a site with limited global styles.
@@ -235,23 +268,22 @@ function wpcom_display_global_styles_launch_bar( $bar_controls ) {
 	}
 
 	ob_start(); ?>
-		<div class="launch-custom-button">
-			<div class="launch-custom-tooltip hidden-tooltip">
+		<div class="launch-bar-global-styles-button">
+			<div class="launch-bar-global-styles-popover hidden">
 				<div>
 					<?php echo esc_html__( 'Publish your style changes and unlock tons of other features by upgrading to a Premium plan.', 'full-site-editing' ); ?>
 				</div>
-				<button
-					class="launch-tooltip-button"
-					data-launchbar-tooltip-url="<?php echo esc_url( $upgrade_url ); ?>"
-					data-launchbar-tooltip-button-track="wpcom_global_styles_gating_notice"
+				<a
+					class="launch-bar-global-styles-upgrade-button"
+					href="<?php echo esc_url( $upgrade_url ); ?>"
 				>
 					<?php echo esc_html__( 'Upgrade your plan', 'full-site-editing' ); ?>
-				</button>
-				<a class="launch-custom-link" href="<?php echo esc_url( $preview_location ); ?>">
+				</a>
+				<a class="launch-bar-global-styles-preview-link" href="<?php echo esc_url( $preview_location ); ?>">
 					<?php echo esc_html( $preview_text ); ?>
 				</a>
 			</div>
-			<a data-launchbar-track="wpcom_global_styles_gating_notice">
+			<a class="launch-bar-global-styles-toggle" href="#">
 				<svg width="25" height="25" viewBox="0 0 30 23" xmlns="http://www.w3.org/2000/svg">
 					<path d="M12 4c-4.4 0-8 3.6-8 8v.1c0 4.1 3.2 7.5 7.2 7.9h.8c4.4 0 8-3.6 8-8s-3.6-8-8-8zm0 15V5c3.9 0 7 3.1 7 7s-3.1 7-7 7z" style="fill: orange" />
 				</svg>

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/wpcom-global-styles-view.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/wpcom-global-styles-view.js
@@ -1,0 +1,31 @@
+/* global launchBarUserData */
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import './wpcom-global-styles-view.scss';
+
+( function () {
+	const popoverToggle = document.querySelector( '.launch-bar-global-styles-toggle' );
+	const popover = document.querySelector( '.launch-bar-global-styles-popover' );
+	const upgradeButton = document.querySelector( '.launch-bar-global-styles-upgrade-button' );
+
+	popoverToggle?.addEventListener( 'click', ( event ) => {
+		event.preventDefault();
+
+		recordTracksEvent( 'wpcom_launchbar_button_click', {
+			button: 'wpcom_global_styles_gating_notice',
+			blog_id: launchBarUserData?.blogId,
+		} );
+
+		popover?.classList.toggle( 'hidden' );
+	} );
+
+	upgradeButton?.addEventListener( 'click', ( event ) => {
+		event.preventDefault();
+
+		recordTracksEvent( 'wpcom_launchbar_button_click', {
+			button: 'wpcom_global_styles_gating_notice_upgrade',
+			blog_id: launchBarUserData?.blogId,
+		} );
+
+		window.location = upgradeButton.href;
+	} );
+} )();

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/wpcom-global-styles-view.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/wpcom-global-styles-view.js
@@ -2,30 +2,34 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import './wpcom-global-styles-view.scss';
 
+function recordEvent( button ) {
+	recordTracksEvent( 'wpcom_launchbar_button_click', {
+		button,
+		blog_id: launchBarUserData?.blogId,
+	} );
+}
+
 ( function () {
 	const popoverToggle = document.querySelector( '.launch-bar-global-styles-toggle' );
 	const popover = document.querySelector( '.launch-bar-global-styles-popover' );
 	const upgradeButton = document.querySelector( '.launch-bar-global-styles-upgrade-button' );
+	const previewButton = document.querySelector( '.launch-bar-global-styles-preview-link' );
 
 	popoverToggle?.addEventListener( 'click', ( event ) => {
 		event.preventDefault();
-
-		recordTracksEvent( 'wpcom_launchbar_button_click', {
-			button: 'wpcom_global_styles_gating_notice',
-			blog_id: launchBarUserData?.blogId,
-		} );
-
+		recordEvent( 'wpcom_global_styles_gating_notice' );
 		popover?.classList.toggle( 'hidden' );
 	} );
 
 	upgradeButton?.addEventListener( 'click', ( event ) => {
 		event.preventDefault();
-
-		recordTracksEvent( 'wpcom_launchbar_button_click', {
-			button: 'wpcom_global_styles_gating_notice_upgrade',
-			blog_id: launchBarUserData?.blogId,
-		} );
-
+		recordEvent( 'wpcom_global_styles_gating_notice_upgrade' );
 		window.location = upgradeButton.href;
+	} );
+
+	previewButton?.addEventListener( 'click', ( event ) => {
+		event.preventDefault();
+		recordEvent( 'wpcom_global_styles_gating_notice_preview' );
+		window.location = previewButton.href;
 	} );
 } )();

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/wpcom-global-styles-view.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/wpcom-global-styles-view.scss
@@ -1,0 +1,56 @@
+/* stylelint-disable declaration-property-unit-allowed-list */
+
+.launch-bar-global-styles-popover {
+	position: absolute;
+	width: 260px;
+	top: 48px;
+	font-size: 14px;
+	background-color: #fff;
+	padding: 16px;
+	margin-left: -70px;
+	line-height: 20px;
+	color: #24282d;
+	box-shadow: 0 3px 10px rgb(0 0 0 / 20%);
+	font-weight: 400;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+
+	@media screen and ( max-width: 960px ) {
+		margin-left: -100px;
+	}
+	@media screen and ( max-width: 550px ) {
+		width: 70%;
+		margin-left: 10%;
+		left: 0;
+	}
+
+	.launch-bar-global-styles-upgrade-button {
+		font-size: 14px;
+		margin-top: 16px;
+		background: #007cba;
+		min-height: 36px;
+		box-sizing: border-box;
+		border-radius: 2px;
+		width: 100%;
+		justify-content: center;
+
+		&:hover {
+			background: #006ba1;
+		}
+	}
+
+	.launch-bar-global-styles-preview-link {
+		margin: 20px 0 0;
+		padding: 0;
+		min-height: auto;
+		color: #0675c4;
+		font-weight: 500;
+		font-size: 12px;
+
+		&:hover {
+			background: #fff;
+			color: #044b7a;
+		}
+	}
+}

--- a/apps/editing-toolkit/package.json
+++ b/apps/editing-toolkit/package.json
@@ -33,7 +33,7 @@
 		"build:wpcom-block-editor-nav-sidebar": "calypso-build --env source='wpcom-block-editor-nav-sidebar'",
 		"build:wpcom-block-editor-nux": "calypso-build --env source='wpcom-block-editor-nux'",
 		"build:wpcom-documentation-links": "calypso-build --env source='wpcom-documentation-links'",
-		"build:wpcom-global-styles": "calypso-build --env source='wpcom-global-styles'",
+		"build:wpcom-global-styles": "calypso-build --env source='wpcom-global-styles','wpcom-global-styles/wpcom-global-styles-view'",
 		"clean": "rm -rf dist editing-toolkit-plugin/*/dist || true",
 		"dev": "yarn run calypso-apps-builder --localPath editing-toolkit-plugin --remotePath /home/wpcom/public_html/wp-content/plugins/editing-toolkit-plugin/dev",
 		"lint:php": "../../vendor/bin/phpcs --standard=../phpcs.xml ./ ",

--- a/packages/calypso-analytics/src/tracks.ts
+++ b/packages/calypso-analytics/src/tracks.ts
@@ -32,6 +32,8 @@ const EVENT_NAME_EXCEPTIONS = [
 	// Checkout
 	'calypso_checkout_switch_to_p_24',
 	'calypso_checkout_composite_p24_submit_clicked',
+	// Launch Bar
+	'wpcom_launchbar_button_click',
 ];
 let _superProps: any; // Added to all Tracks events.
 let _loadTracksResult = Promise.resolve(); // default value for non-BOM environments.


### PR DESCRIPTION
#### Proposed Changes

⚠️ Requires D94049-code.

* Refactor the implementation of Limit Global Styles custom launch bar controls to use the new filter implementation.
* Move all the GS-specific code away from the launch bar and into ETK.
  * This required a little change on the package's build system (to build front end assets separately) and adding the launch bar Tracks event as an exception (because of naming conventions).
* Also update the control's copy and visuals to match the latest design draft (see https://github.com/Automattic/dotcom-forge/issues/1222) and move it to before the "Launch"/"Visibility" button.

| Before | After |
| - | - |
| ![image](https://user-images.githubusercontent.com/2070010/205147812-9e03d5d1-8925-480c-98f0-6d7077c9af9b.png) | <img alt="Screenshot 2022-12-01 at 19 55 57" src="https://user-images.githubusercontent.com/2070010/205147852-0f72efc9-62bc-40cc-a278-034c5f7f62e1.png"> |

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply D94049-code to your sandbox.
* Sync these changes to your sandbox via `install-plugin.sh editing-toolkit update/global-styles-frontend-notice`.
* Create a site with limited Global Styles by applying the `wpcom-limit-global-styles` sticker.
* Test these combinations of the launch bar:

| Global Styles | Site Privacy | Expected Output |
| - | - | - |
| Non-gated | Coming Soon, Unlaunched | The GS control never appears in the launch bar. |
| Non-gated | Public, Private | The launch bar does not appear. |
| Gated, non-custom | Coming Soon, Unlaunched | The GS control does not appear in the launch bar. |
| Gated, non-custom | Public, Private | The launch bar does not appear. |
| Gated, custom | Coming Soon, Unlaunched | The GS control appears before the Launch/Visibility control. |
| Gated, custom | Public, Private | The GS control is the only control. |

* Test the GS control:
  * Does the popover look good at all screen sizes?
  * Does toggling the popover record a `wpcom_global_styles_gating_notice` event?
  * Does clicking on the Upgrade button record a `wpcom_global_styles_gating_upgrade` event before navigating to the Plans page?
  * Does clicking on the "Preview" button reload the page appending `?preview-global-styles`?

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/1222