### PR TITLE
Move Jetpack GA to 'advertising' bucket

### DIFF
--- a/client/lib/analytics/tracker-buckets.ts
+++ b/client/lib/analytics/tracker-buckets.ts
@@ -2,7 +2,6 @@ import { getDoNotTrack } from '@automattic/calypso-analytics';
 import config from '@automattic/calypso-config';
 import { isPiiUrl, isUrlExcludedForPerformance } from 'calypso/lib/analytics/utils';
 import { isE2ETest } from 'calypso/lib/e2e';
-import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import getTrackingPrefs from './utils/get-tracking-prefs';
 
 const allAdTrackers = [
@@ -38,10 +37,9 @@ export enum Bucket {
 
 export const AdTrackersBuckets: { [ key in AdTracker ]: Bucket | null } = {
 	// Analytics trackers:
-	// 'ga' is categorized as analytics tracker in Jetpack Cloud, but not in Calypso
-	ga: isJetpackCloud() ? Bucket.ANALYTICS : Bucket.ADVERTISING,
 
 	// Advertising trackers:
+	ga: Bucket.ADVERTISING,
 	gaEnhancedEcommerce: Bucket.ADVERTISING,
 	fullstory: Bucket.ADVERTISING,
 	hotjar: Bucket.ADVERTISING,


### PR DESCRIPTION
#### Proposed Changes

* Move Jetpack GA to 'advertising' bucket

#### Testing Instructions
* Ensure ad-tracking is enabled on your development environment
* Launch Calypso / Jetpack Cloud
* If not based in CCPA/GDPR region, set a cookie e.g. `document.cookie = 'country_code=NL'` (or any other European country)
* Make sure you have you don't have "sensitive_pixel_option" (legacy) cookie in your session: `document.cookie='sensitive_pixel_option=; expires=Thu, 01 Jan 1970 00:00:01 GMT;'`
* Manually create a bucketing cookie (all buckets accepted): `document.cookie = 'sensitive_pixel_options=%7B%22version%22%3A20201224%2C%22ok%22%3Atrue%2C%22buckets%22%3A%7B%22essential%22%3Atrue%2C%22analytics%22%3Atrue%2C%22advertising%22%3Atrue%7D%7D';`
* Notice that GA is being loaded and works as usual i.e. if https://www.googletagmanager.com/gtag/js?id= scripts are included in page DOM)
* Manually change a bucketing cookie to exclude `advertising` bucket: `document.cookie = 'sensitive_pixel_options=%7B%22version%22%3A20201224%2C%22ok%22%3Atrue%2C%22buckets%22%3A%7B%22essential%22%3Atrue%2C%22analytics%22%3Atrue%2C%22advertising%22%3Afalse%7D%7D';`
* Notice that GA stopped being loaded to the session

Related to #66493
