### PR TITLE
Woo Tailored Onboarding: Fix redirect when the user is unauthenticated

### DIFF
--- a/client/landing/stepper/declarative-flow/tailored-ecommerce-flow.ts
+++ b/client/landing/stepper/declarative-flow/tailored-ecommerce-flow.ts
@@ -69,7 +69,7 @@ export const ecommerceFlow: Flow = {
 					? `/start/account/user/${ locale }?variationName=${ flowName }&redirect_to=/setup/ecommerce/storeProfiler`
 					: `/start/account/user?variationName=${ flowName }&redirect_to=/setup/ecommerce/storeProfiler`;
 
-			return url + ( flags && `?flags=${ flags }` );
+			return url + ( flags ? `?flags=${ flags }` : '' );
 		};
 
 		function submit( providedDependencies: ProvidedDependencies = {} ) {


### PR DESCRIPTION
#### Proposed Changes

* Fix the redirect for unauthenticated users. We were redirecting the users to the path that could contain `null`(/start/account/user?variationName=ecommerce&redirect_to=/setup/ecommerce/storeProfilernull) at the end. It wouldn't cause a massive outrage because the user would be redirected again to `/setup/ecommerce/intros`.

#### Testing Instructions

* Make sure you are not logged in
* Navigate to `/setup/ecommerce`
* Click on "Create your store"
* You should be redirected to `/start/account/user?variationName=ecommerce&redirect_to=/setup/ecommerce/storeProfiler` and not to `/start/account/user?variationName=ecommerce&redirect_to=/setup/ecommerce/storeProfilernull` (Notice the null at the end)
