### PR TITLE
Remove Jetpack pre-sales chat time restrictions. Run chat widget 24/5.

### DIFF
--- a/client/my-sites/plans/jetpack-plans/product-store/zendesk-presales-chat-widget/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/zendesk-presales-chat-widget/index.tsx
@@ -7,16 +7,11 @@ import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import type { ConfigData } from '@automattic/create-calypso-config';
 
-const isWithinChatHours = ( currentTime: Date ) => {
-	const [ NINE_AM, SEVEN_PM ] = [ 9, 19 ];
+const isWithinAvailableChatDays = ( currentTime: Date ) => {
 	const [ SUNDAY, SATURDAY ] = [ 0, 6 ];
-
-	const utcHour = currentTime.getUTCHours();
 	const utcWeekDay = currentTime.getUTCDay();
 
-	return (
-		utcHour >= NINE_AM && utcHour < SEVEN_PM && utcWeekDay !== SUNDAY && utcWeekDay !== SATURDAY
-	);
+	return utcWeekDay !== SUNDAY && utcWeekDay !== SATURDAY;
 };
 
 export const ZendeskPreSalesChat: React.VFC = () => {
@@ -29,7 +24,12 @@ export const ZendeskPreSalesChat: React.VFC = () => {
 		);
 		const currentTime = new Date();
 
-		return ! isLoggedIn && isEnglishLocale && isJetpackCloud() && isWithinChatHours( currentTime );
+		return (
+			! isLoggedIn &&
+			isEnglishLocale &&
+			isJetpackCloud() &&
+			isWithinAvailableChatDays( currentTime )
+		);
 	}, [ isLoggedIn ] );
 
 	return shouldShowZendeskPresalesChat ? <ZendeskChat chatId={ zendeskChatKey } /> : null;


### PR DESCRIPTION
#### Proposed Changes

We are changing the chat widget to always show available 24/5 (no weekends).
Changes as per Slack discussion: p1669902732922609/1669845364.924939-slack-C04BZQFCWE9

#### Testing Instructions

- Do any one of these
    - Click on Jetpack Cloud live link below and wait for the redirect to complete, then go to `/pricing`
        - If your current time is in between the hours of 9:00am - 7:00pm (UTC), Verify you see the chat widget on the bottom right of the viewport. If your current time is not within those hours, you should still see the chat widget (as before this PR, you couldn't)
        - Change your computers time so that it is not anywhere in between the hours of 9:00am - 7:00pm (UTC) - You can modify your computers time by going to System Preferences --> Date & Time, etc....
        - Once your computers time is outside the 9:00am - 7:00pm (UTC) timeframe, reload the page and verify the chat interface **is still visible** on the page. (it should be now showing 24 hours a day)
    - or boot up this PR 
        - Run `git fetch && git checkout  update/remove-presalse-chat-time-restrictions`
        - Run `yarn start-jetpack-cloud`
        - Goto [http://jetpack.cloud.localhost:3000/pricing](http://jetpack.cloud.localhost:3000/pricing)
        - If your current time is in between the hours of 9:00am - 7:00pm (UTC), Verify you see the chat widget on the bottom right of the viewport. If your current time is not within those hours, you should still see the chat widget (as before this PR, you couldn't)
        - Change your computers time so that it is not anywhere in between the hours of 9:00am - 7:00pm (UTC) - You can modify your computers time by going to System Preferences --> Date & Time, etc....
        - Once your computers time is outside the 9:00am - 7:00pm (UTC) timeframe, reload the page and verify the chat interface **is still visible** on the page. (it should be now showing 24 hours a day)

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->