### PR TITLE
Reader masterbar icon improvements

### DIFF
--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -278,7 +278,7 @@ class MasterbarLoggedIn extends Component {
 		);
 	}
 
-	renderReader() {
+	renderReader( showLabel = true ) {
 		const { translate } = this.props;
 		return (
 			<Item
@@ -291,7 +291,8 @@ class MasterbarLoggedIn extends Component {
 				tooltip={ translate( 'Read the blogs and topics you follow' ) }
 				preloadSection={ this.preloadReader }
 			>
-				{ translate( 'Reader', { comment: 'Toolbar, must be shorter than ~12 chars' } ) }
+				{ showLabel &&
+					translate( 'Reader', { comment: 'Toolbar, must be shorter than ~12 chars' } ) }
 			</Item>
 		);
 	}
@@ -424,7 +425,6 @@ class MasterbarLoggedIn extends Component {
 				/>
 				<MasterBarMobileMenu onClose={ this.handleToggleMenu } open={ this.state.isMenuOpen }>
 					{ this.renderPublish() }
-					{ this.renderReader() }
 					{ this.renderMe() }
 				</MasterBarMobileMenu>
 				{ menuBtnRef && (
@@ -514,6 +514,7 @@ class MasterbarLoggedIn extends Component {
 					<Masterbar>
 						<div className="masterbar__section masterbar__section--left">
 							{ this.renderMySites() }
+							{ this.renderReader( false ) }
 							{ this.renderLanguageSwitcher() }
 							{ this.renderSearch() }
 						</div>

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -151,6 +151,14 @@ $masterbar-color-secondary: #101517;
 		}
 	}
 
+	&--left {
+		@include breakpoint-deprecated( "<660px" ) {
+			a .masterbar__item-content {
+				display: none;
+			}
+		}
+	}
+
 	&--right {
 		flex: 1;
 		justify-content: flex-end;


### PR DESCRIPTION
## Description

On a mobile device, the current top-level reader nav icon feels pretty complicated and broken. This PR aims to fix that.

## Updates

On a mobile device, here's how we currently handle the top-level reader icon:

![before](https://user-images.githubusercontent.com/5634774/205118386-8eaf6eba-4b4f-45bc-aa43-34bbcec6d410.gif)

We are layering two nav menus on top of each other. The first nav menu then blocks the second nav menu.

To fix this I've simply moved the reader icon back to the masterbar, being smart to hide the label once we get to a resolution which won't support it:

![after](https://user-images.githubusercontent.com/5634774/205118871-bf912b1c-6016-4a3e-8c44-d307499ef751.gif)

In a desktop browser, we'll also see an update to remove labels when we are running out of room as a result of this PR:

![CleanShot 2022-12-01 at 12 23 04](https://user-images.githubusercontent.com/5634774/205119349-ba13e6c9-caca-4a2c-a63c-3a5db6bfe3df.png)

## Related

#67164
