### PR TITLE
Favicon component: Use the 'size' prop instead of hardcoding size to 18

### DIFF
--- a/client/reader/components/favicon/index.js
+++ b/client/reader/components/favicon/index.js
@@ -7,7 +7,7 @@ function Favicon( props ) {
 
 	// if loading error or missing icon show W Gridicon
 	if ( hasError || site.site_icon === null ) {
-		return <Gridicon icon="globe" size={ 18 } className={ props.className } />;
+		return <Gridicon icon="globe" size={ size } className={ props.className } />;
 	}
 
 	return (


### PR DESCRIPTION
## Description

Currently, if you try and set a custom size for the `Favicon` component, it won't work, as it's currently hardcoded to always be 18px.

In a future PR we're going to want to use Favicons which are 32px x 32px, like so:

```<Favicon site={ site } className="reader-sidebar-site_siteicon" size={ 32 } />```

I'm making this change to the Favicon component in a separate PR to keep things clean and easy to review.

## Related

#67164