### PR TITLE
HelpCenterHeader: add onTouchStart listeners

### DIFF
--- a/packages/help-center/src/components/help-center-header.tsx
+++ b/packages/help-center/src/components/help-center-header.tsx
@@ -101,6 +101,7 @@ const HelpCenterHeader = ( { isMinimized = false, onMinimize, onMaximize, onDism
 							icon={ chevronUp }
 							tooltipPosition="top left"
 							onClick={ onMaximize }
+							onTouchStart={ onMaximize }
 						/>
 					) : (
 						<Button
@@ -109,6 +110,7 @@ const HelpCenterHeader = ( { isMinimized = false, onMinimize, onMaximize, onDism
 							icon={ lineSolid }
 							tooltipPosition="top left"
 							onClick={ onMinimize }
+							onTouchStart={ onMinimize }
 						/>
 					) }
 
@@ -118,6 +120,7 @@ const HelpCenterHeader = ( { isMinimized = false, onMinimize, onMaximize, onDism
 						tooltipPosition="top left"
 						icon={ closeSmall }
 						onClick={ onDismiss }
+						onTouchStart={ onDismiss }
 					/>
 				</div>
 			</Flex>


### PR DESCRIPTION
#### Proposed Changes

* When `Draggable` is enabled the `onClick` is not firing for touch events. In this case the drag start event fires. This is a known issue with the library and to mitigate this I added `onTouchStart` handlers.

#### Testing Instructions
**To reproduce this issue**
- Open the help center on production
- In chrome dev tools open the sensors and force the touch events like in the image below
<img width="490" alt="Screenshot 2022-12-01 at 19 03 39" src="https://user-images.githubusercontent.com/7000684/205127478-0a4089dd-b0ea-4bc6-8976-e46cfaf6faca.png">
- Click on the close or minimize button in the help center header
- You will noticed small movement and nothing happening on click
- If you inspect the element you will see that drag start classes are added to it on click

**Testing the branch**
- Follow the same steps from above using the container link
- Verify that the: minimize, maximize and close work as expected

Related to #70619
