### PR TITLE
Allow launchpad checklist to display warning icons

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/checklist-item.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/checklist-item.tsx
@@ -6,7 +6,7 @@ import { Task } from './types';
 
 const ChecklistItem = ( { task, isPrimaryAction }: { task: Task; isPrimaryAction?: boolean } ) => {
 	const isRtl = useRtl();
-	const { id, completed, disabled, title, actionDispatch } = task;
+	const { id, completed, disabled, title, actionDispatch, warning } = task;
 
 	// Display chevron if task is incomplete. Don't display chevron and badge at the same time.
 	const shouldDisplayChevron = ! completed && ! disabled && ! task.badgeText;
@@ -43,6 +43,17 @@ const ChecklistItem = ( { task, isPrimaryAction }: { task: Task; isPrimaryAction
 								aria-label={ translate( 'Task complete' ) }
 								className="launchpad__checklist-item-checkmark"
 								icon="checkmark"
+								size={ 18 }
+							/>
+						</div>
+					) }
+					{ ! completed && warning && (
+						// show exclamation mark for tasks with warnings
+						<div className="launchpad__checklist-item-warning-container">
+							<Gridicon
+								aria-label={ translate( 'Task has a warning' ) }
+								className="launchpad__checklist-item-warning"
+								icon="notice-outline"
 								size={ 18 }
 							/>
 						</div>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
@@ -344,7 +344,7 @@
 	}
 }
 .launchpad__checklist-item-warning {
-	fill: var(--color-error);
+	fill: var(--color-warning);
 }
 
 // general styles

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
@@ -332,14 +332,19 @@
 	pointer-events: none;
 }
 
-.launchpad__checklist-item-checkmark-container {
+.launchpad__checklist-item-checkmark-container,
+.launchpad__checklist-item-warning-container {
 	margin-right: 8px;
 	width: 20px;
 
-	.launchpad__checklist-item-checkmark {
+	.launchpad__checklist-item-checkmark,
+	.launchpad__checklist-item-warning {
 		top: 2px;
 		vertical-align: text-bottom;
 	}
+}
+.launchpad__checklist-item-warning {
+	fill: var(--color-error);
 }
 
 // general styles

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/types.ts
@@ -7,6 +7,7 @@ export interface Task {
 	badgeText?: string;
 	actionDispatch?: () => void;
 	isLaunchTask?: boolean;
+	warning?: boolean;
 }
 
 export interface LaunchpadFlowTaskList {


### PR DESCRIPTION
Some steps might need to show a warning to get attention.

#### Proposed Changes

* Allow launchpad checklist to show a warning for certain steps
* 
#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this branch
* `yarn run start`
* Go to http://calypso.localhost:3000/setup/newsletter
* Run through the process until you see the launchpad
* Make the `plan_selected` step in `client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/tasks.tsx` have `completed: false, warning: true`
* Refresh the page
* Notice that an exclamation mark is displayed next to the Choose a Plan step


Before | After
-------|------
![image](https://user-images.githubusercontent.com/93301/205130360-e11a0ea5-02fe-4ac1-995d-b6b3d76c1a9c.png) | ![image](https://user-images.githubusercontent.com/93301/205131177-4feac90f-5551-40fe-82d7-655589b85354.png)




#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/1227
