### PR TITLE
Pattern Assembler - Use an empty home template when there is no pattern selection

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -271,7 +271,12 @@ const PatternAssembler: Step = ( { navigation } ) => {
 												stylesheet,
 												'home',
 												translate( 'Home' ),
-												createCustomHomeTemplateContent( stylesheet, !! header, !! footer )
+												createCustomHomeTemplateContent(
+													stylesheet,
+													!! header,
+													!! footer,
+													!! sections.length
+												)
 											)
 										)
 										.then( () => runThemeSetupOnSite( siteSlugOrId, design ) )

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/utils.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/utils.ts
@@ -37,7 +37,8 @@ export const handleKeyboard =
 export function createCustomHomeTemplateContent(
 	stylesheet: string,
 	hasHeader: boolean,
-	hasFooter: boolean
+	hasFooter: boolean,
+	hasSections: boolean
 ) {
 	const content: string[] = [];
 	if ( hasHeader ) {
@@ -46,7 +47,7 @@ export function createCustomHomeTemplateContent(
 		);
 	}
 
-	if ( hasHeader || hasFooter ) {
+	if ( hasHeader || hasFooter || hasSections ) {
 		content.push( `
 	<!-- wp:group {"tagName":"main"} -->
 		<main class="wp-block-group">

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/utils.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/utils.ts
@@ -46,14 +46,13 @@ export function createCustomHomeTemplateContent(
 		);
 	}
 
-	content.push( `
-<!-- wp:group {"tagName":"main"} -->
-	<main class="wp-block-group">
-	<!-- wp:paragraph -->
-	<p></p>
-	<!-- /wp:paragraph -->
-	</main>
-<!-- /wp:group -->` );
+	if ( hasHeader || hasFooter ) {
+		content.push( `
+	<!-- wp:group {"tagName":"main"} -->
+		<main class="wp-block-group">
+		</main>
+	<!-- /wp:group -->` );
+	}
 
 	if ( hasFooter ) {
 		content.push(


### PR DESCRIPTION
#### Proposed Changes

* Only add the main block group when there are patterns selected

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Access `/setup?siteSlug=[ YOUR SITE ]`
- No select any goal or vertical
- Scroll down and click on the BC CTA
- Don't add a header or footer and click on `Continue`
- Check that the editor is empty, including the List view

**Editor canvas**
|Before|After|
|-------|-----|
|<img width="1012" alt="Screen Shot 2565-12-02 at 11 46 31" src="https://user-images.githubusercontent.com/1881481/205216872-1302ce62-d898-4ac9-8332-0cda8323f9d9.png">|<img width="937" alt="Screen Shot 2565-12-02 at 11 24 02" src="https://user-images.githubusercontent.com/1881481/205215222-cc9b18fc-efc7-4193-8dda-8e73d86073ac.png">|

**List view**
|Before|After|
|-------|-----|
|<img width="349" alt="Screen Shot 2565-12-02 at 11 46 43" src="https://user-images.githubusercontent.com/1881481/205216863-92416894-8adf-446d-b309-d7dedc7c5dbe.png">|<img width="351" alt="Screen Shot 2565-12-02 at 11 24 14" src="https://user-images.githubusercontent.com/1881481/205215213-0bd5691a-055c-4faa-a19c-1bb65e4f0b72.png">|



#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #70683
