### PR TITLE
Fix username check with wrong types

### DIFF
--- a/apps/happy-blocks/index.php
+++ b/apps/happy-blocks/index.php
@@ -114,7 +114,7 @@ function a8c_happyblocks_pricing_plans_get_domain() {
 	}
 
 	$topic_id  = bbp_get_topic_id();
-	$author_id = get_post_field( 'post_author', $topic_id );
+	$author_id = intval( get_post_field( 'post_author', $topic_id ) );
 
 	/*
 	If the current user is the author of the topic, return the topic's domain selected


### PR DESCRIPTION
#### Proposed Changes

This Pull Request fixes the userId comparison where a string was being compared to a number.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


* Run `yarn dev --sync` in `apps/happy-blocks` to sync code to your sandbox
* Create a new topic, pick any domain from the 'Site  I need help with' dropdown.
* In the Gutenberg editor press `/` and search for "Upgrade" block, insert any of them.
* Ensure the block contains the "for [domain from the dropdown]" below the plan name
* Publish the topic
* Once you are redirected to the non-edit view of the topic, ensure the "for [domain I need help with]" domain is shown.
* Access that same view with another user, ensure the "for [domain I need help with]" is not shown now.


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
