### PR TITLE
Happy blocks: Ensure pricing plans url is used in upsell block

### DIFF
--- a/apps/happy-blocks/src/pricing-plans/components/pricing-plan-detail.tsx
+++ b/apps/happy-blocks/src/pricing-plans/components/pricing-plan-detail.tsx
@@ -11,7 +11,7 @@ import BillingOptions from './billing-options';
  * These URLs are broken down into parts due to 119-gh-Automattic/lighthouse-forums
  */
 const CHECKOUT_URL = 'https' + '://' + 'wordpress.com/checkout';
-const PRICING_URL = 'https' + '://' + 'wordpress.com/pricing';
+const PLANS_URL = 'https' + '://' + 'wordpress.com/plans';
 
 interface Props {
 	plan: BlockPlan;
@@ -34,7 +34,7 @@ const PricingPlanDetail: FunctionComponent< BlockSaveProps< BlockAttributes > & 
 
 	const CtaLink = attributes.domain
 		? `${ CHECKOUT_URL }/${ attributes.domain }/${ plan.pathSlug }`
-		: PRICING_URL;
+		: PLANS_URL;
 
 	return (
 		<section className="hb-pricing-plans-embed__detail">


### PR DESCRIPTION
#### Proposed Changes

This pull request changes the Upgrade Pricing Plan (Upsell) block's CTA button for the case where there's no domain available so that the user is sent to `/plans` instead of `/pricing`. This way already logged in users will be presented with a list of their domains to upgrade instead of being presented with the new site creation flow.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run `yarn dev --sync` in `apps/happy-blocks` to sync code to your sandbox
* In the Gutenberg editor press `/` and search for "Upgrade" block, insert any of them.
* Publish the topic
* Click on the "Upgrade to [plan]" button and ensure you're redirected to `/plans` (note: you must un-sandbox before clicking the CTA, otherwise it won't work).


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
