### PR TITLE
Pricing page: Fix margin spacing of feature card in mobile view.

### DIFF
--- a/client/my-sites/plans/jetpack-plans/product-store/items-list/style-most-popular.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/items-list/style-most-popular.scss
@@ -23,6 +23,7 @@
 	display: grid;
 	grid-template-columns: 1fr;
 	grid-gap: 24px;
+	margin: 0;
 
 	@media only screen and (min-width: 821px) {
 		grid-template-columns: 1fr 1fr;


### PR DESCRIPTION
#### Proposed Changes

* Fix margin spacing of feature card in mobile view.

**Before**
<img width="398" alt="Screen Shot 2022-12-02 at 3 51 26 PM" src="https://user-images.githubusercontent.com/56598660/205243084-01c1e76e-ce9b-4da9-9238-fb62e017deff.png">

**After**
<img width="388" alt="Screen Shot 2022-12-02 at 3 51 56 PM" src="https://user-images.githubusercontent.com/56598660/205243144-f2144d65-d11f-45d6-aa9e-6de288f52bf0.png">

#### Testing Instructions

1. Run this branch by following the steps below (or you can use the Jetpack Cloud live link commented on this PR)
    * Run `git fetch && git checkout fix/pricing-page-feature-card-margin`
    * Run `yarn start-jetpack-cloud`

2. Set your screen to mobile view
3. Confirm that the feature cards margin is now correct.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

