### PR TITLE
Datacenter Picker: Fix typo in description for primary datacenter

### DIFF
--- a/client/blocks/eligibility-warnings/data-center-picker.tsx
+++ b/client/blocks/eligibility-warnings/data-center-picker.tsx
@@ -148,7 +148,7 @@ const DataCenterPicker = ( {
 					</FormHeadingContainer>
 					<FormDescription>
 						{ translate(
-							'Choose a primary data center for your site. For redundancy, your site will replicate in real-time to a second data center in different region. {{supportLink}}Learn more{{/supportLink}}.',
+							'Choose a primary data center for your site. For redundancy, your site will replicate in real-time to a second data center in a different region. {{supportLink}}Learn more{{/supportLink}}.',
 							{
 								components: {
 									supportLink: (

--- a/client/my-sites/hosting/web-server-settings-card/index.js
+++ b/client/my-sites/hosting/web-server-settings-card/index.js
@@ -67,7 +67,7 @@ const WebServerSettingsCard = ( {
 				<FormSettingExplanation>
 					{ translate(
 						'The primary data center is where your site is physically located. ' +
-							'For redundancy, your site also replicates in real-time to a second data center in different region.'
+							'For redundancy, your site also replicates in real-time to a second data center in a different region.'
 					) }
 				</FormSettingExplanation>
 			</FormFieldset>


### PR DESCRIPTION
#### Proposed Changes

* Add missing `a` article before `different region` in primary datacenter description string.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Review updated string.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1669886343461349-slack-CEM18K8LT
