### PR TITLE
Pattern Assembler - Update copy of preview placeholder

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-assembler-preview.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-assembler-preview.scss
@@ -88,7 +88,7 @@
 }
 
 .pattern-assembler-preview__icon {
-	margin-bottom: 40px;
+	margin-bottom: 28px;
 	fill: #c9c9c9;
 }
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-assembler-preview.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-assembler-preview.scss
@@ -81,6 +81,8 @@
 
 	span {
 		font-size: $font-title-small;
+		padding: 0 30px;
+		text-align: center;
 	}
 }
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-assembler-preview.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-assembler-preview.scss
@@ -77,10 +77,11 @@
 		color: var(--studio-gray-100);
 		margin-bottom: 5px;
 		font-size: $font-title-small;
+		font-weight: 500;
 	}
 
 	span {
-		font-size: $font-title-small;
+		font-size: $font-body;
 		padding: 0 30px;
 		text-align: center;
 	}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-assembler-preview.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-assembler-preview.scss
@@ -53,6 +53,7 @@
 
 .pattern-assembler-preview__placeholder {
 	display: flex;
+	flex-direction: column;
 	align-items: center;
 	justify-content: center;
 	position: absolute;
@@ -71,6 +72,21 @@
 	background-color: #f8f8f8;
 	opacity: 1;
 	z-index: -1;
+
+	h2 {
+		color: var(--studio-gray-100);
+		margin-bottom: 5px;
+		font-size: $font-title-small;
+	}
+
+	span {
+		font-size: $font-title-small;
+	}
+}
+
+.pattern-assembler-preview__icon {
+	margin-bottom: 40px;
+	fill: #c9c9c9;
 }
 
 .pattern-assembler-preview__spinner {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-assembler-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-assembler-preview.tsx
@@ -2,6 +2,7 @@ import { getDesignPreviewUrl } from '@automattic/design-picker';
 import { useLocale } from '@automattic/i18n-utils';
 import { Spinner } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
+import { Icon, layout } from '@wordpress/icons';
 import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
@@ -65,7 +66,15 @@ const PatternAssemblerPreview = ( { header, sections = [], footer, scrollToSelec
 						) }
 					>
 						{ ! hasSelectedPatterns && (
-							<span>{ translate( 'Your page is blank. Start adding content on the left.' ) }</span>
+							<>
+								<Icon className="pattern-assembler-preview__icon" icon={ layout } size={ 100 } />
+								<h2>{ translate( 'Welcome to your blank canvas' ) }</h2>
+								<span>
+									{ translate(
+										"It's time to get creative. Add your first pattern to get started."
+									) }
+								</span>
+							</>
 						) }
 					</div>,
 					webPreviewFrameContainer

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-assembler-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-assembler-preview.tsx
@@ -67,7 +67,7 @@ const PatternAssemblerPreview = ( { header, sections = [], footer, scrollToSelec
 					>
 						{ ! hasSelectedPatterns && (
 							<>
-								<Icon className="pattern-assembler-preview__icon" icon={ layout } size={ 100 } />
+								<Icon className="pattern-assembler-preview__icon" icon={ layout } size={ 72 } />
 								<h2>{ translate( 'Welcome to your blank canvas' ) }</h2>
 								<span>
 									{ translate(


### PR DESCRIPTION
#### Proposed Changes

* Update design for preview placeholder
* Add paddings for mobile preview

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to`/setup/site-setup?siteSlug=<your_site>`
* Continue until you land on the Design Picker
* Click the "start designing" button at the end of the Design Picker
* Verify whether the new styles of the preview placeholder look good for all viewports

|Before|After|
|------|-----|
|<img width="640" alt="Screen Shot 2565-12-02 at 16 38 08" src="https://user-images.githubusercontent.com/1881481/205262725-b453e0d8-2a48-494e-b8cd-1cb116affae5.png">|<img width="562" alt="Screen Shot 2565-12-06 at 10 16 15" src="https://user-images.githubusercontent.com/1881481/205806254-e52f5096-64cc-4477-b050-3514a27a46f0.png">|


**On the mobile viewport**
<img width="535" alt="Screen Shot 2565-12-06 at 10 30 41" src="https://user-images.githubusercontent.com/1881481/205806308-8857efd0-5740-4073-bd06-b094d5e22af0.png">




#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/70692
