### PR TITLE
Partner Portal: empty state design for the assign licenses page

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/assign-license-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/assign-license-form/index.tsx
@@ -98,7 +98,10 @@ export default function AssignLicenseForm( {
 						count: licenseKeysArray.length,
 					} ) }
 				</Button>
-				<Button target="_blank" href="https://jetpack.com/jetpack-agency-beta-instructions/">
+				<Button
+					target="_blank"
+					href="https://jetpack.com/support/jetpack-agency-licensing-portal-instructions/add-sites-agency-portal-dashboard/"
+				>
 					{ translate( 'Learn how to add a site' ) }
 				</Button>
 			</div>

--- a/client/jetpack-cloud/sections/partner-portal/assign-license-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/assign-license-form/index.tsx
@@ -85,6 +85,26 @@ export default function AssignLicenseForm( {
 		page.redirect( addQueryArgs( { highlight: licenseKey }, '/partner-portal/licenses' ) );
 	};
 
+	if ( ! results.length ) {
+		return (
+			<div className="assign-license-form__empty-state">
+				<p>
+					{ translate(
+						'It looks like you don’t have any connected Jetpack sites you can apply this license to.'
+					) }
+				</p>
+				<Button primary onClick={ onAssignLater }>
+					{ translate( 'Assign license later', 'Assign licenses later', {
+						count: licenseKeysArray.length,
+					} ) }
+				</Button>
+				<Button target="_blank" href="https://jetpack.com/jetpack-agency-beta-instructions/">
+					{ translate( 'Learn how to add a site' ) }
+				</Button>
+			</div>
+		);
+	}
+
 	return (
 		<div className="assign-license-form">
 			<div className="assign-license-form__top">

--- a/client/jetpack-cloud/sections/partner-portal/assign-license-form/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/assign-license-form/style.scss
@@ -143,3 +143,32 @@ p.assign-license-form__description {
 		margin-bottom: 0;
 	}
 }
+
+.assign-license-form__empty-state {
+	p {
+		font-size: 1.5rem;
+		color: var(--color-text);
+		margin-block-start: 11px;
+		margin-block-end: 16px;
+		letter-spacing: 0.005em;
+		line-height: 32px;
+
+		@include break-medium {
+			max-width: 90%;
+		}
+
+		@include break-large {
+			margin-block-start: 6px;
+			max-width: 60%;
+		}
+	}
+
+	button {
+		margin-inline-end: 8px;
+		margin-block-end: 6px;
+
+		@include break-small {
+			margin-block-end: 0;
+		}
+	}
+}


### PR DESCRIPTION
#### Proposed Changes

This PR updates the empty state design for the assign licenses page.

#### Testing Instructions

**Prerequisites**

You should have no sites available. You can signup as a new user.

> **_NOTE:_** Make sure you add a payment method by visiting http://jetpack.cloud.localhost:3000/partner-portal/payment-methods.

1. Run `git checkout update/empty-site-state-for-assign-licenses-page` and `yarn start-jetpack-cloud`
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Click on `Licensing` on the top nav -> Click on `Licenses` on the left nav -> Go to the `Unassigned` tab -> Click on `Assign License` on any license item -> Verify that the new empty site design is shown as below and the buttons work as expected.

<table>
<tr>
<th>
Before
</th>
<th>
After
</th>
</tr>
<tr>
<td>
<img width="769" alt="Screenshot 2022-12-02 at 3 55 53 PM" src="https://user-images.githubusercontent.com/10586875/205272946-8f3cb275-7377-4d4d-8907-a3b318902cdd.png">
</td>
<td>
<img width="1920" alt="Screenshot 2022-12-02 at 4 03 53 PM" src="https://user-images.githubusercontent.com/10586875/205273402-b4cf20f9-5e44-4156-b97a-f60de3310c3a.png">
</td>
</tr>
</table>

4. Verify it looks well on mobile and tab view

Mobile view

<img width="509" alt="Screenshot 2022-12-02 at 2 01 25 PM" src="https://user-images.githubusercontent.com/10586875/205273663-c9a1e0ae-b4c8-4abc-b883-7a74f6d07d8b.png">

Tab view

<img width="539" alt="Screenshot 2022-12-02 at 2 02 56 PM" src="https://user-images.githubusercontent.com/10586875/205273693-d54db93a-0d9c-43c7-b9c7-f46104f5181c.png">

5. Verify the site selector as shown below when there are sites(You might have to refresh the page).

<img width="1920" alt="Screenshot 2022-12-02 at 4 08 03 PM" src="https://user-images.githubusercontent.com/10586875/205274268-a3904330-6ad9-41d2-9ab1-762cb5c6ba1a.png">

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1202619025189113-as-1201942917845813