### PR TITLE
Jetpack Cloud: empty sites design for sites landing page

### DIFF
--- a/client/my-sites/sites/index.jsx
+++ b/client/my-sites/sites/index.jsx
@@ -154,7 +154,8 @@ class Sites extends Component {
 			this.props;
 		const filteredSites = sites.filter( this.filterSites );
 
-		const showEmptyContent = hasFetchedSites && ! filteredSites.length;
+		// Show empty content only on Jetpack Cloud
+		const showEmptyContent = isJetpackCloud() && hasFetchedSites && ! filteredSites.length;
 
 		return (
 			<>

--- a/client/my-sites/sites/index.jsx
+++ b/client/my-sites/sites/index.jsx
@@ -172,7 +172,7 @@ class Sites extends Component {
 							<Button
 								primary
 								target="_blank"
-								href="https://jetpack.com/jetpack-agency-beta-instructions/"
+								href="https://jetpack.com/support/jetpack-agency-licensing-portal-instructions/add-sites-agency-portal-dashboard/"
 							>
 								{ translate( 'Learn how to add a site' ) }
 							</Button>

--- a/client/my-sites/sites/style.scss
+++ b/client/my-sites/sites/style.scss
@@ -1,3 +1,6 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
 .main.sites {
 	max-width: 320px;
 }
@@ -38,5 +41,43 @@
 	.sites.main {
 		padding-left: 0;
 		padding-right: 0;
+	}
+}
+
+.main.sites__main-empty {
+	padding: 2em !important;
+	max-width: 320px;
+
+	@include break-mobile {
+		max-width: 420px;
+	}
+
+	@include break-small {
+		max-width: 520px;
+	}
+
+	@include break-large {
+		padding: 0 !important;
+	}
+}
+
+.sites__empty-state {
+	p {
+		font-size: 1.5rem;
+		color: var(--color-text);
+		margin-block-start: 11px;
+		margin-block-end: 16px;
+		letter-spacing: 0.005em;
+		line-height: 32px;
+
+		@include break-large {
+			margin-block-start: 6px;
+		}
+	}
+	h1 {
+		font-weight: 400;
+		margin-block-end: 5px;
+		margin-block-start: 5px;
+		font-size: 2.25rem;
 	}
 }


### PR DESCRIPTION
#### Proposed Changes

This PR updates the empty state design for the site selection page(/landing, /plugins, /scan, /backup etc)

#### Testing Instructions

**Prerequisites**

You should have no sites available. You can signup as a new user.

1. Run `git checkout update/landing-page-empty-state-design` and `yarn start-jetpack-cloud`
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Click on `Manage Sites` on the top nav ->  Verify that the new empty site design is shown as below and the button works as expected.

<table>
<tr>
<th>
Before
</th>
<th>
After
</th>
</tr>
<tr>
<td>
<img width="1919" alt="Screenshot 2022-12-02 at 5 45 14 PM" src="https://user-images.githubusercontent.com/10586875/205295224-5a809829-fc51-4acf-afbc-12fd1b48c383.png">
</td>
<td>
<img width="1920" alt="Screenshot 2022-12-02 at 5 44 29 PM" src="https://user-images.githubusercontent.com/10586875/205295273-2b4f54f5-6600-4ee4-a9c7-51d19493698d.png">
</td>
</tr>
</table>

4. Verify it looks well on mobile and tab view

Mobile view

<img width="413" alt="Screenshot 2022-12-02 at 5 44 11 PM" src="https://user-images.githubusercontent.com/10586875/205295348-9bb27932-6b56-40c8-a2c1-9712b83d8eee.png">

Tab view

<img width="817" alt="Screenshot 2022-12-02 at 5 44 18 PM" src="https://user-images.githubusercontent.com/10586875/205295357-56b8b6a1-6050-4d24-9250-b085ef69f472.png">

5. Verify the site selector as shown below when there are sites(You might have to refresh the page).

<img width="1917" alt="Screenshot 2022-12-02 at 6 13 35 PM" src="https://user-images.githubusercontent.com/10586875/205295644-1d2c8ee6-f8d9-45cf-95ab-7b742b93d8f2.png">

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1202619025189113-as-1201942917845821