### PR TITLE
Style @automatttic/privacy-toolset FormToggle with wp-components styling

### DIFF
--- a/packages/privacy-toolset/.storybook/preview.js
+++ b/packages/privacy-toolset/.storybook/preview.js
@@ -1,0 +1,1 @@
+import '@wordpress/components/build-style/style.css';

--- a/packages/privacy-toolset/CHANGELOG.md
+++ b/packages/privacy-toolset/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## next
 
+## 1.0.1
+
+- Document `wp-components` stylesheet as a project dependency
+- Remove custom styling of `<FormToggle/>`
+
 ## 1.0.0
 
 - Init the repo

--- a/packages/privacy-toolset/README.md
+++ b/packages/privacy-toolset/README.md
@@ -4,11 +4,17 @@ A library of tools created as React components designed to unify privacy mechani
 
 ## Installation
 
-Install the toolset.
-
+1. Install the toolset.
 ```bash
 yarn add @automattic/privacy-toolset
 ```
+
+2. Add `wp-components` stylesheet
+Many components include CSS to add style, you will need to add in order to appear correctly. Within WordPress, add the `wp-components` stylesheet as a dependency of your plugin's stylesheet. See [wp_enqueue_style documentation](https://developer.wordpress.org/reference/functions/wp_enqueue_style/#parameters) for how to specify dependencies.
+
+In non-WordPress projects, link to the `build-style/style.css` file directly, it is located at `node_modules/@wordpress/components/build-style/style.css`.
+
+Source: [@wordpress/components](https://www.npmjs.com/package/@wordpress/components)
 
 ## Usage
 
@@ -23,7 +29,7 @@ const Component = () => (
 );
 ```
 
-> Disclaimer: see the detailed `content` parameter structure, see `src/cookie-banner/cookie-banner.stories.tsx`.
+> Disclaimer: for the detailed `content` parameter structure, see `src/cookie-banner/cookie-banner.stories.tsx`.
 
 ## Development Workflow
 

--- a/packages/privacy-toolset/README.md
+++ b/packages/privacy-toolset/README.md
@@ -5,11 +5,13 @@ A library of tools created as React components designed to unify privacy mechani
 ## Installation
 
 1. Install the toolset.
+
 ```bash
 yarn add @automattic/privacy-toolset
 ```
 
 2. Add `wp-components` stylesheet
+
 Many components include CSS to add style, you will need to add in order to appear correctly. Within WordPress, add the `wp-components` stylesheet as a dependency of your plugin's stylesheet. See [wp_enqueue_style documentation](https://developer.wordpress.org/reference/functions/wp_enqueue_style/#parameters) for how to specify dependencies.
 
 In non-WordPress projects, link to the `build-style/style.css` file directly, it is located at `node_modules/@wordpress/components/build-style/style.css`.

--- a/packages/privacy-toolset/package.json
+++ b/packages/privacy-toolset/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/privacy-toolset",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"description": "Privacy tools and components for Automattic solutions",
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"license": "GPL-2.0-or-later",

--- a/packages/privacy-toolset/src/cookie-banner/styles.scss
+++ b/packages/privacy-toolset/src/cookie-banner/styles.scss
@@ -3,6 +3,9 @@
 // Granular consent banner (v2).
 $granular-banner-max-width: 900px;
 
+// Padding
+$horizontal-padding: 20px;
+
 // Colors.
 $cookie-banner-bg-color: #fff;
 $cookie-banner-text-color: #000;
@@ -47,7 +50,7 @@ $cookie-banner-font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Robo
 	margin: 0;
 	max-height: 90vh;
 	z-index: 50001;
-	padding: 20px;
+	padding: 20px 0;
 	background-color: $cookie-banner-bg-color;
 	box-shadow: 0 8px 16px rgba(0, 0, 0, 0.2), 0 1px 3px rgba(0, 0, 0, 0.15), 0 1px 0 rgba(0, 0, 0, 0.05);
 	border-radius: 3 * 2px;
@@ -87,12 +90,12 @@ $cookie-banner-font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Robo
 		color: $cookie-banner-text-muted-color;
 		font-size: $cookie-banner-font-size;
 		line-height: $cookie-banner-line-height;
-
 	}
 
 	.cookie-banner__simple-options {
 		display: flex;
 		justify-content: space-between;
+		padding: 0 $horizontal-padding;
 		gap: 25px;
 
 		.cookie-banner__button-container {
@@ -107,6 +110,7 @@ $cookie-banner-font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Robo
 		flex-direction: column;
 		overflow-y: scroll;
 		scroll-padding-bottom: 25px;
+		padding: 0 $horizontal-padding;
 
 		.cookie-banner__options-lead-text {
 			margin-bottom: 12px;
@@ -136,62 +140,8 @@ $cookie-banner-font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Robo
 			}
 		}
 	}
-	.cookie-banner__options-selection input[type="checkbox"] {
-		appearance: none;
-		position: relative;
-		border: 0;
-		outline: 0;
+	.cookie-banner__options-selection input[type="checkbox"]:not(:disabled) {
 		cursor: pointer;
-		box-sizing: unset;
-		transition: ease 0.3s;
-		-webkit-transition: ease 0.3s;
-		-moz-transition: ease 0.3s;
-		-o-transition: ease 0.3s;
-		height: 24px;
-
-		// Track.
-		&::after {
-			$track-size: 18px;
-
-			content: "";
-			width: 2 * $track-size;
-			height: $track-size;
-			display: block;
-			background: transparent;
-			border-radius: $track-size;
-			border: 1px solid #000;
-			clear: both;
-		}
-
-		// Handle.
-		&::before {
-			$handle-size: 12px;
-
-			content: "";
-			width: $handle-size;
-			height: $handle-size;
-			display: block;
-			position: absolute;
-			left: 4px;
-			top: 4px;
-			border-radius: math.div($handle-size, 2);
-			background-color: #000;
-		}
-
-		&:checked::before {
-			left: 22px;
-			background-color: #fff;
-		}
-		&:checked::after {
-			background: $cookie-banner-checkbox-color;
-			border-color: $cookie-banner-checkbox-color;
-		}
-		&:disabled {
-			&::after {
-				background-color: #aaa;
-				border-color: #aaa;
-			}
-		}
 	}
 	.cookie-banner__ok-button,
 	.cookie-banner__accept-all-button,


### PR DESCRIPTION

#### Proposed Changes

* Improve styles to support wp-components styling
* Add wp-components stylesheet to storybook preview

#### Testing Instructions

* Checkout the changes
* Run `yarn workspace @automattic/privacy-toolset run storybook`
* Storybook should automatically open in your browser
* Go to the path `?path=/story/cookie-banner--default` (should be open by default)
* Click "Customize" - you should see an expanded version of the Cookie Banner as below

<img width="973" alt="CleanShot 2022-12-02 at 08 40 34@2x" src="https://user-images.githubusercontent.com/8419292/205317877-22e20d7b-1ed5-491f-9b1c-54282bd81561.png">

* Uncheck the "Analytics" bucket
* Click "Accept Selection" - it should result in the action `accept: {essential: true, analytics: false, advertising: true}`

Related to #70601
