### PR TITLE
Help Center: fix the broken tracks

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/CalypsoStateProvider.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/CalypsoStateProvider.js
@@ -37,9 +37,10 @@ const store = createStore(
 
 setStore( store );
 
+const section = window?.helpCenterAdminBar?.isLoaded ? 'wp-admin' : 'gutenberg-editor';
 const currentSite = window.helpCenterData.currentSite;
-currentSite && store.dispatch( setSelectedSiteId( currentSite.id ) );
-store.dispatch( setSection( { name: 'gutenberg-editor' } ) );
+currentSite && store.dispatch( setSelectedSiteId( currentSite.ID ) );
+store.dispatch( setSection( { name: section } ) );
 
 i18n.configure( { defaultLocaleSlug: window.helpCenterLocale } );
 
@@ -56,7 +57,7 @@ export default function CalypsoStateProvider( { children } ) {
 	return (
 		<Provider store={ store }>
 			<>
-				<QuerySites siteId={ currentSite.id } />
+				<QuerySites siteId={ currentSite.ID } />
 				{ children }
 			</>
 		</Provider>

--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/admin-bar.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/admin-bar.js
@@ -21,7 +21,7 @@ function AdminHelpCenterContent() {
 	}, [ show, button ] );
 
 	const handleToggleHelpCenter = () => {
-		recordTracksEvent( `calypso_inlinehelp_${ show ? 'show' : 'close' }`, {
+		recordTracksEvent( `calypso_inlinehelp_${ show ? 'close' : 'show' }`, {
 			forceSiteId: true,
 			location: 'help-center',
 			section: 'wp-admin',

--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/admin-bar.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/admin-bar.js
@@ -21,17 +21,12 @@ function AdminHelpCenterContent() {
 	}, [ show, button ] );
 
 	const handleToggleHelpCenter = () => {
-		if ( show ) {
-			recordTracksEvent( 'calypso_inlinehelp_close', {
-				location: 'help-center',
-				section: 'wp-admin',
-			} );
-		} else {
-			recordTracksEvent( 'calypso_inlinehelp_show', {
-				location: 'help-center',
-				section: 'wp-admin',
-			} );
-		}
+		recordTracksEvent( `calypso_inlinehelp_${ show ? 'show' : 'close' }`, {
+			forceSiteId: true,
+			location: 'help-center',
+			section: 'wp-admin',
+		} );
+
 		setShowHelpCenter( ! show );
 	};
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/help-center.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/help-center.js
@@ -34,6 +34,7 @@ function HelpCenterContent() {
 
 	const handleToggleHelpCenter = () => {
 		recordTracksEvent( `calypso_inlinehelp_${ show ? 'close' : 'show' }`, {
+			forceSiteId: true,
 			location: 'help-center',
 			section: sectionName,
 		} );

--- a/client/layout/masterbar/masterbar-help-center.jsx
+++ b/client/layout/masterbar/masterbar-help-center.jsx
@@ -27,6 +27,7 @@ const MasterbarHelpCenter = ( { siteId, tooltip } ) => {
 
 	const handleToggleHelpCenter = () => {
 		recordTracksEvent( `calypso_inlinehelp_${ helpCenterVisible ? 'close' : 'show' }`, {
+			forceSiteId: true,
 			location: 'help-center',
 			section: sectionName,
 		} );

--- a/client/lib/analytics/super-props.js
+++ b/client/lib/analytics/super-props.js
@@ -14,7 +14,8 @@ const getSuperProps = ( reduxStore ) => ( eventProperties ) => {
 		client: config( 'client_slug' ),
 	};
 
-	const omitSelectedSite = shouldReportOmitBlogId( eventProperties.path );
+	const omitSelectedSite =
+		! eventProperties.forceSiteId && shouldReportOmitBlogId( eventProperties.path );
 	const selectedSite = omitSelectedSite ? null : getSelectedSite( state );
 
 	if ( selectedSite ) {

--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -185,6 +185,7 @@ export const HelpCenterContactForm = () => {
 		const supportVariation = getSupportVariationFromMode( mode );
 		recordTracksEvent( 'calypso_inlinehelp_contact_view', {
 			support_variation: supportVariation,
+			forceSiteId: true,
 			location: 'help-center',
 			section: sectionName,
 		} );
@@ -264,6 +265,7 @@ export const HelpCenterContactForm = () => {
 				if ( supportSite ) {
 					recordTracksEvent( 'calypso_inlinehelp_contact_submit', {
 						support_variation: 'happychat',
+						forceSiteId: true,
 						location: 'help-center',
 						section: sectionName,
 					} );
@@ -271,6 +273,7 @@ export const HelpCenterContactForm = () => {
 					recordTracksEvent( 'calypso_help_live_chat_begin', {
 						site_plan_product_id: productId,
 						is_automated_transfer: supportSite.is_wpcom_atomic,
+						forceSiteId: true,
 						location: 'help-center',
 						section: sectionName,
 					} );
@@ -300,6 +303,7 @@ export const HelpCenterContactForm = () => {
 						.then( () => {
 							recordTracksEvent( 'calypso_inlinehelp_contact_submit', {
 								support_variation: 'kayako',
+								forceSiteId: true,
 								location: 'help-center',
 								section: sectionName,
 							} );
@@ -330,6 +334,7 @@ export const HelpCenterContactForm = () => {
 					.then( ( response ) => {
 						recordTracksEvent( 'calypso_inlinehelp_contact_submit', {
 							support_variation: 'forums',
+							forceSiteId: true,
 							location: 'help-center',
 							section: sectionName,
 						} );

--- a/packages/help-center/src/components/help-center-contact-page.tsx
+++ b/packages/help-center/src/components/help-center-contact-page.tsx
@@ -55,6 +55,7 @@ export const HelpCenterContactPage: React.FC = () => {
 			return;
 		}
 		recordTracksEvent( 'calypso_helpcenter_contact_options_impression', {
+			forceSiteId: true,
 			location: 'help-center',
 			chat_available: renderChat.state === 'AVAILABLE',
 			email_available: renderEmail.render,
@@ -203,6 +204,7 @@ export const HelpCenterContactButton: React.FC = () => {
 
 	const trackContactButtonClicked = () => {
 		recordTracksEvent( 'calypso_inlinehelp_morehelp_click', {
+			forceSiteId: true,
 			location: 'help-center',
 			section: sectionName,
 		} );

--- a/packages/help-center/src/components/help-center-content.tsx
+++ b/packages/help-center/src/components/help-center-content.tsx
@@ -8,7 +8,7 @@ import { useEffect, useRef } from '@wordpress/element';
 import classnames from 'classnames';
 import { useSelector } from 'react-redux';
 import { Route, useLocation } from 'react-router-dom';
-import { getSectionName, getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { getSectionName } from 'calypso/state/ui/selectors';
 /**
  * Internal Dependencies
  */
@@ -24,17 +24,16 @@ const HelpCenterContent: React.FC = () => {
 	const className = classnames( 'help-center__container-content' );
 	const containerRef = useRef< HTMLDivElement >( null );
 	const section = useSelector( getSectionName );
-	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
 
 	useEffect( () => {
 		recordTracksEvent( 'calypso_helpcenter_page_open', {
 			pathname: location.pathname,
 			search: location.search,
 			section,
-			blog_id: siteId,
+			forceSiteId: true,
 			location: 'help-center',
 		} );
-	}, [ location, section, siteId ] );
+	}, [ location, section ] );
 
 	// reset the scroll location on navigation
 	useEffect( () => {

--- a/packages/help-center/src/components/help-center-content.tsx
+++ b/packages/help-center/src/components/help-center-content.tsx
@@ -8,7 +8,7 @@ import { useEffect, useRef } from '@wordpress/element';
 import classnames from 'classnames';
 import { useSelector } from 'react-redux';
 import { Route, useLocation } from 'react-router-dom';
-import { getSectionName } from 'calypso/state/ui/selectors';
+import { getSectionName, getSelectedSiteId } from 'calypso/state/ui/selectors';
 /**
  * Internal Dependencies
  */
@@ -24,15 +24,17 @@ const HelpCenterContent: React.FC = () => {
 	const className = classnames( 'help-center__container-content' );
 	const containerRef = useRef< HTMLDivElement >( null );
 	const section = useSelector( getSectionName );
+	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
 
 	useEffect( () => {
 		recordTracksEvent( 'calypso_helpcenter_page_open', {
 			pathname: location.pathname,
 			search: location.search,
 			section,
+			blog_id: siteId,
 			location: 'help-center',
 		} );
-	}, [ location, section ] );
+	}, [ location, section, siteId ] );
 
 	// reset the scroll location on navigation
 	useEffect( () => {

--- a/packages/help-center/src/components/help-center-embed-result.tsx
+++ b/packages/help-center/src/components/help-center-embed-result.tsx
@@ -28,6 +28,7 @@ export const HelpCenterEmbedResult: React.FC = () => {
 	useEffect( () => {
 		const tracksData = {
 			search_query: query,
+			forceSiteId: true,
 			location: 'help-center',
 			section: sectionName,
 			result_url: link,

--- a/packages/help-center/src/components/help-center-more-resources.tsx
+++ b/packages/help-center/src/components/help-center-more-resources.tsx
@@ -52,6 +52,7 @@ export const HelpCenterMoreResources = () => {
 		recordTracksEvent( 'calypso_help_moreresources_click', {
 			is_business_or_ecommerce_plan_user: isBusinessOrEcomPlanUser,
 			resource: resource,
+			forceSiteId: true,
 			location: 'help-center',
 			section: sectionName,
 		} );
@@ -60,6 +61,7 @@ export const HelpCenterMoreResources = () => {
 	const trackWebinairsButtonClick = () => {
 		recordTracksEvent( 'calypso_help_courses_click', {
 			is_business_or_ecommerce_plan_user: isBusinessOrEcomPlanUser,
+			forceSiteId: true,
 			location: 'help-center',
 			section: sectionName,
 		} );

--- a/packages/help-center/src/components/help-center-sibyl-articles.tsx
+++ b/packages/help-center/src/components/help-center-sibyl-articles.tsx
@@ -34,6 +34,7 @@ function recordSibylArticleClick(
 ) {
 	return () =>
 		recordTracksEvent( 'calypso_helpcenter_page_open_sibyl_article', {
+			forceSiteId: true,
 			location: 'help-center',
 			article_link: article.link,
 			article_title: article.title,

--- a/packages/help-center/src/components/help-center.tsx
+++ b/packages/help-center/src/components/help-center.tsx
@@ -2,7 +2,6 @@
 /**
  * External Dependencies
  */
-import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { useSupportAvailability } from '@automattic/data-stores';
 import { useHappychatAvailable } from '@automattic/happychat-connection';
 import { useSelect, useDispatch } from '@wordpress/data';
@@ -67,12 +66,8 @@ const HelpCenter: React.FC< Container > = ( { handleClose, hidden } ) => {
 		portalParent.setAttribute( 'aria-labelledby', 'header-text' );
 
 		document.body.appendChild( portalParent );
-		const start = Date.now();
 
 		return () => {
-			recordTracksEvent( 'calypso_helpcenter_activity_time', {
-				elapsed: ( Date.now() - start ) / 1000,
-			} );
 			document.body.removeChild( portalParent );
 			closeChat();
 			handleClose();

--- a/packages/help-center/src/components/ticket-success-screen.tsx
+++ b/packages/help-center/src/components/ticket-success-screen.tsx
@@ -17,6 +17,7 @@ export const SuccessScreen: React.FC = () => {
 
 	const trackForumOpen = () =>
 		recordTracksEvent( 'calypso_inlinehelp_forums_open', {
+			forceSiteId: true,
 			location: 'help-center',
 			section: sectionName,
 		} );


### PR DESCRIPTION
## Proposed Changes

As outlined in this post - Help Center tracking events are missing the `blog_id`. This is due to a filter that omits the blog id if there is no site specific path shown.

1. Adds a new property to the event called `forceSiteId`. If this is passed then the site data is forced to return otherwise it will respect the output of `shouldReportOmitBlogId`.
2. Fixes a typo in the ETK plugin. The current site ID was supposed to be capitol but it was not.
3. Removes a tracks event that was broken and not helpful `calypso_helpcenter_activity_time`

## Testing Instructions

You will need to have the [Tracks Vigilante](https://github.com/Automattic/tracks-chrome-extension) installed and running to get live results.

1. Load Calypso live and open the Help Center from /home and a few other areas in calypso.
4. Check the Tracks events to make sure they have the correct Blog ID in the event.
5. Examine a few other NON Help Center events to make sure they have not regressed.
6. Go to the editor and make sure the track events show properly.
7. Pull branch and sync ETK to sandbox
8. Test in wp-admin of a sandboxed site and make sure the track event still has the blog_id.

Fixes #70578