### PR TITLE
Remove sites-as-landing-page feature flag

### DIFF
--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -1,6 +1,6 @@
 import config from '@automattic/calypso-config';
-import { Card, Button } from '@automattic/components';
-import { getLanguage, isLocaleVariant, canBeTranslated } from '@automattic/i18n-utils';
+import { Button, Card } from '@automattic/components';
+import { canBeTranslated, getLanguage, isLocaleVariant } from '@automattic/i18n-utils';
 import languages from '@automattic/languages';
 import debugFactory from 'debug';
 import { localize } from 'i18n-calypso';
@@ -40,14 +40,14 @@ import { clearStore } from 'calypso/lib/user/store';
 import wpcom from 'calypso/lib/wp';
 import AccountEmailField from 'calypso/me/account/account-email-field';
 import ReauthRequired from 'calypso/me/reauth-required';
-import { recordGoogleEvent, recordTracksEvent, bumpStat } from 'calypso/state/analytics/actions';
+import { bumpStat, recordGoogleEvent, recordTracksEvent } from 'calypso/state/analytics/actions';
 import {
 	getCurrentUserDate,
 	getCurrentUserDisplayName,
 	getCurrentUserName,
 	getCurrentUserVisibleSiteCount,
 } from 'calypso/state/current-user/selectors';
-import { successNotice, errorNotice, removeNotice } from 'calypso/state/notices/actions';
+import { errorNotice, removeNotice, successNotice } from 'calypso/state/notices/actions';
 import canDisplayCommunityTranslator from 'calypso/state/selectors/can-display-community-translator';
 import getUnsavedUserSettings from 'calypso/state/selectors/get-unsaved-user-settings';
 import getUserSettings from 'calypso/state/selectors/get-user-settings';
@@ -61,13 +61,12 @@ import { isFetchingUserSettings } from 'calypso/state/user-settings/selectors';
 import { saveUnsavedUserSettings } from 'calypso/state/user-settings/thunks';
 import AccountSettingsCloseLink from './close-link';
 import ToggleSitesAsLandingPage from './toggle-sites-as-landing-page';
+import './style.scss';
 
 export const noticeId = 'me-settings-notice';
 const noticeOptions = {
 	id: noticeId,
 };
-
-import './style.scss';
 
 /**
  * Debug instance
@@ -956,14 +955,12 @@ class Account extends Component {
 
 						{ this.props.canDisplayCommunityTranslator && this.communityTranslator() }
 
-						{ config.isEnabled( 'sites-as-landing-page' ) && (
-							<FormFieldset className="account__settings-admin-home">
-								<FormLabel id="account__default_landing_page">
-									{ translate( 'Admin home' ) }
-								</FormLabel>
-								<ToggleSitesAsLandingPage />
-							</FormFieldset>
-						) }
+						<FormFieldset className="account__settings-admin-home">
+							<FormLabel id="account__default_landing_page">
+								{ translate( 'Admin home' ) }
+							</FormLabel>
+							<ToggleSitesAsLandingPage />
+						</FormFieldset>
 
 						{ config.isEnabled( 'me/account/color-scheme-picker' ) &&
 							supportsCssCustomProperties() && (

--- a/client/root.js
+++ b/client/root.js
@@ -73,15 +73,13 @@ const waitForPrefs = () => async ( dispatch, getState ) => {
 };
 
 async function getLoggedInLandingPage( { dispatch, getState } ) {
-	if ( config.isEnabled( 'sites-as-landing-page' ) ) {
-		await dispatch( waitForPrefs() );
-		const useSitesAsLandingPage = hasSitesAsLandingPage( getState() );
+	await dispatch( waitForPrefs() );
+	const useSitesAsLandingPage = hasSitesAsLandingPage( getState() );
 
-		const siteCount = getCurrentUser( getState() )?.site_count;
+	const siteCount = getCurrentUser( getState() )?.site_count;
 
-		if ( useSitesAsLandingPage && siteCount > 1 ) {
-			return '/sites';
-		}
+	if ( useSitesAsLandingPage && siteCount > 1 ) {
+		return '/sites';
 	}
 
 	// determine the primary site ID (it's a property of "current user" object) and then

--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -1,5 +1,4 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import config from '@automattic/calypso-config';
 import { Button, Gridicon, useScrollToTop, JetpackLogo } from '@automattic/components';
 import { createSitesListComponent } from '@automattic/sites';
 import { css } from '@emotion/css';
@@ -206,9 +205,7 @@ export function SitesDashboard( {
 				</HeaderControls>
 			</PageHeader>
 			<PageBodyWrapper>
-				{ config.isEnabled( 'sites-as-landing-page' ) && (
-					<SitesDashboardOptInBanner sites={ allSites } />
-				) }
+				<SitesDashboardOptInBanner sites={ allSites } />
 				<SitesDashboardSitesList
 					sites={ allSites }
 					filtering={ { search } }

--- a/config/development.json
+++ b/config/development.json
@@ -158,7 +158,6 @@
 		"signup/tailored-ecommerce": true,
 		"signup/woo-verify-email": false,
 		"site-indicator": true,
-		"sites-as-landing-page": true,
 		"ssr/prefetch-timebox": false,
 		"stats/new-main-chart": true,
 		"stats/new-stats-module-component": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -103,7 +103,6 @@
 		"signup/tailored-ecommerce": true,
 		"signup/woo-verify-email": false,
 		"site-indicator": true,
-		"sites-as-landing-page": true,
 		"ssr/prefetch-timebox": true,
 		"stats/new-main-chart": true,
 		"stats/new-stats-module-component": true,

--- a/config/production.json
+++ b/config/production.json
@@ -120,7 +120,6 @@
 		"signup/tailored-ecommerce": true,
 		"signup/woo-verify-email": false,
 		"site-indicator": true,
-		"sites-as-landing-page": false,
 		"ssr/log-prefetch-errors": true,
 		"ssr/prefetch-timebox": true,
 		"ssr/sample-log-cache-misses": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -118,7 +118,6 @@
 		"signup/tailored-ecommerce": true,
 		"signup/woo-verify-email": false,
 		"site-indicator": true,
-		"sites-as-landing-page": true,
 		"ssr/prefetch-timebox": true,
 		"stats/new-main-chart": true,
 		"stats/new-stats-module-component": true,

--- a/config/test.json
+++ b/config/test.json
@@ -87,7 +87,6 @@
 		"signup/inline-help": false,
 		"signup/social": true,
 		"site-indicator": true,
-		"sites-as-landing-page": true,
 		"ssr/prefetch-timebox": true,
 		"stats/new-main-chart": true,
 		"stats/new-stats-module-component": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -128,7 +128,6 @@
 		"signup/tailored-ecommerce": true,
 		"signup/woo-verify-email": false,
 		"site-indicator": true,
-		"sites-as-landing-page": true,
 		"ssr/prefetch-timebox": true,
 		"stats/new-main-chart": true,
 		"stats/new-stats-module-component": true,


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/70297

#### Proposed Changes

* Remove the `sites-as-landing-page` feature flag

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Make sure all traces of `sites-as-landing-page` have been removed
* Follow the test plan for [Sites: Introduce landing page opt-in banner](https://github.com/Automattic/wp-calypso/pull/70450) and make sure the Banner is still shown and that the setting still works

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
