### PR TITLE
Help Center: fix search tracks

### DIFF
--- a/client/blocks/inline-help/inline-help-search-card.tsx
+++ b/client/blocks/inline-help/inline-help-search-card.tsx
@@ -51,15 +51,15 @@ const InlineHelpSearchCard = ( {
 		if ( location === 'help-center' ) {
 			if ( inputQuery?.length > 2 ) {
 				recordTracksEvent( 'calypso_inlinehelp_search', {
-					search_query: searchQuery,
+					search_query: query,
 					location: location,
 					section: sectionName,
 				} );
 			}
 		} else if ( inputQuery?.length ) {
-			debug( 'search query received: ', searchQuery );
+			debug( 'search query received: ', query );
 			recordTracksEvent( 'calypso_inlinehelp_search', {
-				search_query: searchQuery,
+				search_query: query,
 				location: location,
 				section: sectionName,
 			} );


### PR DESCRIPTION
## Proposed Changes

Recently discovered that the search results were not being registered properly in our Tracks events. This updates the event to use the actual `query` from the card rather that the user input.

| Before | After |
| - | - |
| ![Screen Capture on 2022-12-02 at 16-30-54](https://user-images.githubusercontent.com/33258733/205339085-50ec412b-7669-40dc-a191-6baae5774850.gif) | ![Screen Capture on 2022-12-02 at 17-16-26](https://user-images.githubusercontent.com/33258733/205339203-2cd32d62-8f68-479a-8d46-6138fff0b749.gif) |

## Testing Instructions

Open up the calypso live and run some test searches
Use the Tracks Vigilante to verify the search is being tracked