### PR TITLE
Experiment with new masterbar icons and links

### DIFF
--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -243,7 +243,7 @@ class MasterbarLoggedIn extends Component {
 			>
 				<Icon className="gridicon" icon={ icon } />
 				{ hasMoreThanOneSite
-					? translate( 'My Sites', { comment: 'Toolbar, must be shorter than ~12 chars' } )
+					? translate( 'Sites', { comment: 'Toolbar, must be shorter than ~12 chars' } )
 					: translate( 'My Site', { comment: 'Toolbar, must be shorter than ~12 chars' } ) }
 			</Item>
 		);

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -2,6 +2,7 @@ import config from '@automattic/calypso-config';
 import { isEcommercePlan } from '@automattic/calypso-products/src';
 import { Button, Popover } from '@automattic/components';
 import { isWithinBreakpoint, subscribeIsWithinBreakpoint } from '@automattic/viewport';
+import { Icon, preformatted, layout, chevronLeft } from '@wordpress/icons';
 import { localize } from 'i18n-calypso';
 import page from 'page';
 import PropTypes from 'prop-types';
@@ -12,7 +13,6 @@ import AsyncLoad from 'calypso/components/async-load';
 import Gravatar from 'calypso/components/gravatar';
 import { getStatsPathForTab } from 'calypso/lib/route';
 import wpcom from 'calypso/lib/wp';
-import { domainManagementList } from 'calypso/my-sites/domains/paths';
 import { preload } from 'calypso/sections-helper';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import {
@@ -207,38 +207,41 @@ class MasterbarLoggedIn extends Component {
 		return 'my-sites';
 	};
 
-	// will render as back button on mobile and in editor
-	renderMySites() {
-		const {
-			domainOnlySite,
-			hasMoreThanOneSite,
-			siteSlug,
-			translate,
-			isCustomerHomeEnabled,
-			section,
-		} = this.props;
-		const { isMenuOpen, isResponsiveMenu } = this.state;
+	renderWordPressIcon() {
+		const { siteSlug, translate, isCustomerHomeEnabled } = this.props;
+		const { isMenuOpen } = this.state;
 
 		const homeUrl = isCustomerHomeEnabled
 			? `/home/${ siteSlug }`
 			: getStatsPathForTab( 'day', siteSlug );
 
-		let mySitesUrl = domainOnlySite ? domainManagementList( siteSlug ) : homeUrl;
-		if ( 'sites' === section && isResponsiveMenu ) {
-			mySitesUrl = '';
-		}
-		const icon =
-			this.state.isMobile && this.props.isInEditor ? 'chevron-left' : this.wordpressIcon();
 		return (
 			<Item
-				url={ mySitesUrl }
+				url={ homeUrl }
+				icon={ this.wordpressIcon() }
+				isActive={ this.isActive( 'sites' ) && ! isMenuOpen }
+				tooltip={ translate( 'View a list of your sites and access their dashboards' ) }
+			/>
+		);
+	}
+
+	// will render as back button on mobile and in editor
+	renderMySites() {
+		const { hasMoreThanOneSite, translate } = this.props;
+		const { isMenuOpen } = this.state;
+
+		//TODO make sure correct WordPress icon is used on Horizon sites
+		const icon = this.state.isMobile && this.props.isInEditor ? chevronLeft : layout;
+		return (
+			<Item
+				url="/sites"
 				tipTarget="my-sites"
-				icon={ icon }
 				onClick={ this.clickMySites }
 				isActive={ this.isActive( 'sites' ) && ! isMenuOpen }
 				tooltip={ translate( 'View a list of your sites and access their dashboards' ) }
 				preloadSection={ this.preloadMySites }
 			>
+				<Icon className="gridicon" icon={ icon } />
 				{ hasMoreThanOneSite
 					? translate( 'My Sites', { comment: 'Toolbar, must be shorter than ~12 chars' } )
 					: translate( 'My Site', { comment: 'Toolbar, must be shorter than ~12 chars' } ) }
@@ -285,12 +288,12 @@ class MasterbarLoggedIn extends Component {
 				tipTarget="reader"
 				className="masterbar__reader"
 				url="/read"
-				icon="reader"
 				onClick={ this.clickReader }
 				isActive={ this.isActive( 'reader' ) }
 				tooltip={ translate( 'Read the blogs and topics you follow' ) }
 				preloadSection={ this.preloadReader }
 			>
+				<Icon icon={ preformatted } className="gridicon" />
 				{ translate( 'Reader', { comment: 'Toolbar, must be shorter than ~12 chars' } ) }
 			</Item>
 		);
@@ -513,6 +516,7 @@ class MasterbarLoggedIn extends Component {
 					{ this.renderPopupSearch() }
 					<Masterbar>
 						<div className="masterbar__section masterbar__section--left">
+							{ this.renderWordPressIcon() }
 							{ this.renderMySites() }
 							{ this.renderLanguageSwitcher() }
 							{ this.renderSearch() }
@@ -532,6 +536,7 @@ class MasterbarLoggedIn extends Component {
 				{ this.renderPopupSearch() }
 				<Masterbar>
 					<div className="masterbar__section masterbar__section--left">
+						{ this.renderWordPressIcon() }
 						{ this.renderMySites() }
 						{ this.renderReader() }
 						{ this.renderLanguageSwitcher() }

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -237,7 +237,7 @@ class MasterbarLoggedIn extends Component {
 				url="/sites"
 				tipTarget="my-sites"
 				onClick={ this.clickMySites }
-				isActive={ this.isActive( 'sites' ) && ! isMenuOpen }
+				isActive={ this.isActive( 'sites-dashboard' ) && ! isMenuOpen }
 				tooltip={ translate( 'View a list of your sites and access their dashboards' ) }
 				preloadSection={ this.preloadMySites }
 			>

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -200,6 +200,9 @@ $masterbar-color-secondary: #101517;
 	.masterbar__item-content {
 		white-space: nowrap;
 		color: var(--color-masterbar-text);
+		display: inline-flex;
+		align-items: center;
+		gap: 4px;
 	}
 
 	.gridicon {


### PR DESCRIPTION
This PR shouldn't be merged. It is just an experiment with the new masterbar (pdKhl6-on-p2) styles, as per this Slack discussion (p1669730661773999-slack-C041RHH38NQ).

#### Proposed Changes

* Just an experiment for now. 

![image](https://user-images.githubusercontent.com/6851384/205358228-5ebbeefc-fe94-48eb-954c-2c2e8387327b.png)


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the Calypso Live link below and checkout the new masterbar navigation and icons
* WordPress logo -> `/home/:current-site`
* My Sites -> `/sites`
* Reader -> `/read`

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #