### PR TITLE
Woo Tailored Onboarding: Fix the brief misalignment when loading the design carousel step

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-carousel/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-carousel/index.tsx
@@ -7,6 +7,7 @@ import FormattedHeader from 'calypso/components/formatted-header';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import type { Step } from '../../types';
+import './style.scss';
 
 const DesignCarousel: Step = function DesignCarousel( { navigation } ) {
 	const { goNext, goBack, submit } = navigation;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-carousel/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-carousel/style.scss
@@ -1,0 +1,5 @@
+.designCarousel.step-container .step-container__header .formatted-header {
+	.formatted-header__subtitle {
+		text-align: center;
+	}
+}


### PR DESCRIPTION
#### Proposed Changes

* The CSS class that centers the subheader is being loaded asynchronously, which causes the position to flick for a moment. I added a new style file for the designCarrousel step and placed the class that centers the subheader in it.

#### Testing Instructions

* Navigate to `/setup/ecommerce/designCarousel`
* Refresh the page using `command` + `R` or `control` + `R`
* The subheader should not be misaligned anymore

Closes #70547
