### PR TITLE
VideoPress Onboarding: Tweaks to launchpad styles

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -54,6 +54,7 @@ export function getEnhancedTasks(
 				case 'plan_selected':
 					taskData = {
 						title: translate( 'Choose a Plan' ),
+						disabled: true,
 						actionDispatch: () => {
 							recordTaskClickTracksEvent( flow, task.completed, task.id );
 							window.location.assign( `/plans/${ siteSlug }` );
@@ -136,6 +137,7 @@ export function getEnhancedTasks(
 				case 'videopress_setup':
 					taskData = {
 						completed: true,
+						disabled: true,
 						title: translate( 'Set up your video site' ),
 					};
 					break;
@@ -144,6 +146,7 @@ export function getEnhancedTasks(
 						title: translate( 'Upload your first video' ),
 						actionUrl: launchpadUploadVideoLink,
 						completed: videoPressUploadCompleted,
+						disabled: videoPressUploadCompleted,
 						actionDispatch: () => {
 							recordTaskClickTracksEvent( flow, task.completed, task.id );
 							window.location.replace( launchpadUploadVideoLink );

--- a/client/landing/stepper/declarative-flow/internals/videopress.scss
+++ b/client/landing/stepper/declarative-flow/internals/videopress.scss
@@ -153,6 +153,10 @@ body.is-videopress-stepper {
 			display: none;
 		}
 
+		.launchpad__sidebar-description {
+			color: $videopress-theme-header-subtitle-text-color;
+		}
+
 		.step-container {
 			background-color: $videopress-theme-background-color;
 			color: $videopress-theme-grey;
@@ -173,6 +177,10 @@ body.is-videopress-stepper {
 			border: none;
 			color: $videopress-theme-base-text-color;
 			gap: 10px;
+
+			.gridicons-clipboard {
+				fill: $videopress-theme-base-text-color;
+			}
 		}
 
 		.launchpad__task:nth-last-child(2) {
@@ -189,6 +197,22 @@ body.is-videopress-stepper {
 				color: $videopress-theme-yellow;
 				fill: $videopress-theme-yellow;
 				border-color: #474747;
+			}
+
+			&[disabled] {
+				.launchpad__checklist-item-text {
+					color: $videopress-theme-header-subtitle-text-color;
+				}
+
+				.launchpad__checklist-item-checkmark {
+					fill: $videopress-theme-header-subtitle-text-color;
+				}
+			}
+
+			.badge {
+				background-color: transparent;
+				color: $videopress-theme-base-text-color;
+				border: 1px solid #fff8;
 			}
 		}
 
@@ -231,35 +255,16 @@ body.is-videopress-stepper {
 			fill: #fff;
 		}
 
-		.launchpad__task.completed:hover,
 		.launchpad__task.pending:hover .launchpad__checklist-item-text,
-		.launchpad__task.completed > a:focus .launchpad__checklist-item-text,
 		.launchpad__task.pending > a:focus .launchpad__checklist-item-text,
-		.launchpad__task.completed:hover .launchpad__checklist-item-chevron,
-		.launchpad__task.completed:hover .launchpad__checklist-item-checkmark,
 		.launchpad__task.pending:hover .launchpad__checklist-item-chevron,
 		.launchpad__task.pending:hover .launchpad__checklist-item-checkmark,
-		.launchpad__task.completed > a:focus .launchpad__checklist-item-chevron,
-		.launchpad__task.completed > a:focus .launchpad__checklist-item-checkmark,
 		.launchpad__task.pending > a:focus .launchpad__checklist-item-chevron,
 		.launchpad__task.pending > a:focus .launchpad__checklist-item-checkmark,
 		.button.launchpad__checklist-item:hover:not([disabled]),
-		.button.launchpad__checklist-item:focus:not([disabled]),
-		.launchpad__task.completed:hover .launchpad__checklist-item-text {
+		.button.launchpad__checklist-item:focus:not([disabled]) {
 			color: $videopress-theme-yellow;
 			fill: $videopress-theme-yellow;
-		}
-
-		.launchpad__task.completed:hover .badge,
-		.launchpad__task.pending:hover .badge,
-		.launchpad__task.completed > a:focus .badge,
-		.launchpad__task.pending > a:focus .badge {
-			color: #000;
-			background-color: $videopress-theme-yellow;
-		}
-
-		.launchpad__task:hover .badge {
-			background-color: $videopress-theme-yellow;
 		}
 
 	}


### PR DESCRIPTION
#### Proposed Changes

Fixes some style bugs reported by @evilluendas:

* Don't apply any hover styles to the completed/disabled tasks
* Changed style of plan badge to not be yellow
* Fixed text color.
* `Copy` icon is now white.

<img width="368" alt="Screenshot 2022-12-02 at 1 27 48 PM" src="https://user-images.githubusercontent.com/789137/205380784-4a5c5c06-50bd-4e3b-b431-07016a37968e.png">

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Start at `/setup/videopress` and proceed to the launchpad.
* Hovering over tasks should not apply any hover styles.
* Plan badge should be white instead of yellow.
* Hover over the domain name, the copy icon should be white.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
