### PR TITLE
Jetpack pricing: make prices screen reader friendly

### DIFF
--- a/client/components/jetpack/card/jetpack-product-card/display-price/paid.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/display-price/paid.tsx
@@ -1,6 +1,7 @@
 import { TranslateResult } from 'i18n-calypso';
 import InfoPopover from 'calypso/components/info-popover';
 import PlanPrice from 'calypso/my-sites/plan-price';
+import PriceAriaLabel from './price-aria-label';
 import TimeFrame from './time-frame';
 import type { Duration } from 'calypso/my-sites/plans/jetpack-plans/types';
 import type { Moment } from 'moment';
@@ -19,68 +20,29 @@ type OwnProps = {
 	expiryDate?: Moment;
 };
 
-const Paid: React.FC< OwnProps > = ( {
-	discountedPrice,
-	discountedPriceDuration,
+const Placeholder: React.FC< OwnProps > = ( { billingTerm, expiryDate } ) => {
+	return (
+		<>
+			<PlanPrice
+				original
+				className="display-price__original-price"
+				rawPrice={ 0.01 }
+				currencyCode="$"
+			/>
+			{ /* Remove this secondary <PlanPrice/> placeholder if we're not showing discounted prices */ }
+			<PlanPrice discounted rawPrice={ 0.01 } currencyCode="$" />
+			<TimeFrame expiryDate={ expiryDate } billingTerm={ billingTerm } />
+		</>
+	);
+};
+
+const DiscountedPrice: React.FC< OwnProps & { finalPrice: number } > = ( {
 	discountedPriceFirst,
 	originalPrice,
-	pricesAreFetching,
-	billingTerm,
 	currencyCode,
-	displayFrom,
-	tooltipText,
-	expiryDate,
+	finalPrice,
 } ) => {
-	const finalPrice = discountedPrice ?? originalPrice;
-
-	// Placeholder (while prices are loading)
-	if ( ! currencyCode || ! originalPrice || pricesAreFetching ) {
-		return (
-			<>
-				<PlanPrice
-					original
-					className="display-price__original-price"
-					rawPrice={ 0.01 }
-					currencyCode="$"
-				/>
-				{ /* Remove this secondary <PlanPrice/> placeholder if we're not showing discounted prices */ }
-				<PlanPrice discounted rawPrice={ 0.01 } currencyCode="$" />
-				<TimeFrame expiryDate={ expiryDate } billingTerm={ billingTerm } />
-			</>
-		);
-	}
-
-	const renderDiscountedPrice = () => {
-		const theDiscountedPrice = (
-			<PlanPrice
-				discounted
-				rawPrice={ finalPrice as number }
-				currencyCode={ currencyCode }
-				omitHeading
-			/>
-		);
-		/*
-		 * Price should be displayed from left-to-right, even in right-to-left
-		 * languages. `PlanPrice` seems to keep the ltr direction no matter
-		 * what when seen in the dev docs page, but somehow it doesn't in
-		 * the pricing page.
-		 */
-		return (
-			<>
-				{ discountedPriceFirst && theDiscountedPrice }
-				<PlanPrice
-					original
-					className="display-price__original-price"
-					rawPrice={ originalPrice as number }
-					currencyCode={ currencyCode }
-					omitHeading
-				/>
-				{ ! discountedPriceFirst && theDiscountedPrice }
-			</>
-		);
-	};
-
-	const renderNonDiscountedPrice = () => (
+	const theDiscountedPrice = (
 		<PlanPrice
 			discounted
 			rawPrice={ finalPrice as number }
@@ -88,24 +50,87 @@ const Paid: React.FC< OwnProps > = ( {
 			omitHeading
 		/>
 	);
+	/*
+	 * Price should be displayed from left-to-right, even in right-to-left
+	 * languages. `PlanPrice` seems to keep the ltr direction no matter
+	 * what when seen in the dev docs page, but somehow it doesn't in
+	 * the pricing page.
+	 */
+	return (
+		<>
+			{ discountedPriceFirst && theDiscountedPrice }
+			<PlanPrice
+				original
+				className="display-price__original-price"
+				rawPrice={ originalPrice as number }
+				currencyCode={ currencyCode }
+				omitHeading
+			/>
+			{ ! discountedPriceFirst && theDiscountedPrice }
+		</>
+	);
+};
 
-	const renderPrice = () =>
-		finalPrice && finalPrice < originalPrice ? renderDiscountedPrice() : renderNonDiscountedPrice();
+const OriginalPrice: React.FC< OwnProps & { finalPrice: number } > = ( {
+	currencyCode,
+	finalPrice,
+} ) => {
+	return (
+		<PlanPrice
+			discounted
+			rawPrice={ finalPrice as number }
+			currencyCode={ currencyCode }
+			omitHeading
+		/>
+	);
+};
+
+const Paid: React.FC< OwnProps > = ( props ) => {
+	const {
+		discountedPrice,
+		discountedPriceDuration,
+		originalPrice,
+		pricesAreFetching,
+		billingTerm,
+		currencyCode,
+		displayFrom,
+		tooltipText,
+	} = props;
+	const finalPrice = ( discountedPrice ?? originalPrice ) as number;
+	const isDiscounted = !! ( finalPrice && originalPrice && finalPrice < originalPrice );
+
+	// Placeholder (while prices are loading)
+	if ( ! currencyCode || ! originalPrice || pricesAreFetching ) {
+		return <Placeholder { ...props } />;
+	}
 
 	return (
 		<>
-			{ displayFrom && <span className="display-price__from">from</span> }
-			{ renderPrice() }
+			<PriceAriaLabel
+				{ ...props }
+				currencyCode={ currencyCode }
+				finalPrice={ finalPrice }
+				isDiscounted={ isDiscounted }
+			/>
+			<span aria-hidden="true">
+				{ displayFrom && <span className="display-price__from">from</span> }
+				{ isDiscounted ? (
+					<DiscountedPrice { ...props } finalPrice={ finalPrice } />
+				) : (
+					<OriginalPrice { ...props } finalPrice={ finalPrice } />
+				) }
+			</span>
 			{ tooltipText && (
 				<InfoPopover position="top" className="display-price__price-tooltip">
 					{ tooltipText }
 				</InfoPopover>
 			) }
-			<TimeFrame
-				expiryDate={ expiryDate }
-				billingTerm={ billingTerm }
-				discountedPriceDuration={ discountedPriceDuration }
-			/>
+			<span aria-hidden="true">
+				<TimeFrame
+					billingTerm={ billingTerm }
+					discountedPriceDuration={ discountedPriceDuration }
+				/>
+			</span>
 		</>
 	);
 };

--- a/client/components/jetpack/card/jetpack-product-card/display-price/price-aria-label.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/display-price/price-aria-label.tsx
@@ -1,0 +1,47 @@
+import { formatCurrency } from '@automattic/format-currency';
+import { useTranslate } from 'i18n-calypso';
+import TimeFrame from './time-frame';
+import type { Duration } from 'calypso/my-sites/plans/jetpack-plans/types';
+
+interface Props {
+	currencyCode: string;
+	billingTerm: Duration;
+	isDiscounted: boolean;
+	finalPrice: number;
+	originalPrice?: number;
+	discountedPriceDuration?: number;
+}
+
+const formatOptions = { stripZeros: true };
+
+const DiscountedPriceLabel: React.FC< Props > = ( { originalPrice, finalPrice, currencyCode } ) => {
+	const translate = useTranslate();
+
+	return (
+		<>
+			{ translate( '%(finalPrice)s instead of %(originalPrice)s', {
+				args: {
+					finalPrice: formatCurrency( finalPrice, currencyCode, formatOptions ),
+					originalPrice: formatCurrency( originalPrice as number, currencyCode, formatOptions ),
+				},
+			} ) }
+		</>
+	);
+};
+
+export const PriceAriaLabel: React.FC< Props > = ( props ) => {
+	const { finalPrice, originalPrice, currencyCode, isDiscounted } = props;
+
+	return (
+		<span className="screen-reader-text">
+			{ isDiscounted && originalPrice ? (
+				<DiscountedPriceLabel { ...props } />
+			) : (
+				formatCurrency( finalPrice, currencyCode, formatOptions )
+			) }{ ' ' }
+			<TimeFrame { ...props } forScreenReader />
+		</span>
+	);
+};
+
+export default PriceAriaLabel;

--- a/client/components/jetpack/card/jetpack-product-card/display-price/time-frame.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/display-price/time-frame.tsx
@@ -24,7 +24,14 @@ interface PartialDiscountTimeFrameProps {
 	discountedPriceDuration: number;
 }
 
-const RegularTimeFrame: React.FC< RegularTimeFrameProps > = ( { billingTerm } ) => {
+interface A11yProps {
+	forScreenReader?: boolean;
+}
+
+const RegularTimeFrame: React.FC< RegularTimeFrameProps & A11yProps > = ( {
+	billingTerm,
+	forScreenReader,
+} ) => {
 	const translate = useTranslate();
 
 	const billingTermText = useMemo( () => {
@@ -45,6 +52,16 @@ const RegularTimeFrame: React.FC< RegularTimeFrameProps > = ( { billingTerm } ) 
 		};
 	}, [ billingTerm, translate ] );
 
+	if ( forScreenReader ) {
+		return (
+			<>
+				{ billingTerm === TERM_MONTHLY
+					? translate( 'per month, billed monthly' )
+					: translate( 'per month, billed yearly' ) }
+			</>
+		);
+	}
+
 	return (
 		<span className="display-price__billing-time-frame">
 			<span className="normal">{ billingTermText.normal }</span>
@@ -55,6 +72,7 @@ const RegularTimeFrame: React.FC< RegularTimeFrameProps > = ( { billingTerm } ) 
 
 const ExpiringDateTimeFrame: React.FC< ExpiringDateTimeFrameProps > = ( { productExpiryDate } ) => {
 	const translate = useTranslate();
+
 	return (
 		<time
 			className="display-price__expiration-date"
@@ -69,35 +87,48 @@ const ExpiringDateTimeFrame: React.FC< ExpiringDateTimeFrameProps > = ( { produc
 	);
 };
 
-const PartialDiscountTimeFrame: React.FC< PartialDiscountTimeFrameProps > = ( {
+const PartialDiscountTimeFrame: React.FC< PartialDiscountTimeFrameProps & A11yProps > = ( {
 	billingTerm,
 	discountedPriceDuration,
+	forScreenReader,
 } ) => {
 	const translate = useTranslate();
 
-	const BillingTermText = useMemo( () => {
-		if ( billingTerm === TERM_MONTHLY ) {
-			return discountedPriceDuration > 1
-				? translate( 'for the first %(months)d months, billed monthly', {
-						args: { months: discountedPriceDuration },
-				  } )
-				: translate( 'for the first month, billed monthly' );
-		}
+	const opts = {
+		count: discountedPriceDuration,
+		args: {
+			months: discountedPriceDuration,
+		},
+	};
 
-		return discountedPriceDuration > 1
-			? translate( 'for the first %(months)d months, billed yearly', {
-					args: { months: discountedPriceDuration },
-			  } )
-			: translate( 'for the first month, billed yearly' );
-	}, [ discountedPriceDuration, billingTerm, translate ] );
+	/* eslint-disable wpcalypso/i18n-mismatched-placeholders */
+	let text = translate(
+		'for the first month, billed yearly',
+		'for the first %(months)d months, billed yearly',
+		opts
+	);
 
-	return <span className="display-price__billing-time-frame">{ BillingTermText }</span>;
+	if ( billingTerm === TERM_MONTHLY ) {
+		text = translate(
+			'for the first month, billed monthly',
+			'for the first %(months)d months, billed monthly',
+			opts
+		);
+	}
+	/* eslint-enable wpcalypso/i18n-mismatched-placeholders */
+
+	if ( forScreenReader ) {
+		return <>{ text }</>;
+	}
+
+	return <span className="display-price__billing-time-frame">{ text }</span>;
 };
 
-const TimeFrame: React.FC< TimeFrameProps > = ( {
+const TimeFrame: React.FC< TimeFrameProps & A11yProps > = ( {
 	expiryDate,
 	billingTerm,
 	discountedPriceDuration,
+	forScreenReader,
 } ) => {
 	const moment = useLocalizedMoment();
 	const productExpiryDate =
@@ -112,11 +143,12 @@ const TimeFrame: React.FC< TimeFrameProps > = ( {
 			<PartialDiscountTimeFrame
 				billingTerm={ billingTerm }
 				discountedPriceDuration={ discountedPriceDuration }
+				forScreenReader={ forScreenReader }
 			/>
 		);
 	}
 
-	return <RegularTimeFrame billingTerm={ billingTerm } />;
+	return <RegularTimeFrame billingTerm={ billingTerm } forScreenReader={ forScreenReader } />;
 };
 
 export default TimeFrame;


### PR DESCRIPTION
### Changes proposed in this Pull Request

The price markup in the Jetpack pricing page can't be read by screen readers (see screencast below). This PR fixes it.

### Implementation notes

- Price markup is wrapped in a `span` with the `aria-hidden` property set to `true`, so that screen readers ignore it.
- The text meant to be read by screen readers is added at the same level but is wrapped in a `span` with the class `screen-reader-text`, so that it is not displayed in browsers.

### Testing instructions

- Spin up the pricing page, using a live link below, or by running this branch locally
- Make sure the page looks like production
- Using a screen reader, make sure prices are read properly. Alternatively, open the inspector and check you see the following markup:

<img width="309" alt="Screen Shot 2022-12-02 at 3 28 24 PM" src="https://user-images.githubusercontent.com/1620183/205380131-965942d3-f51b-42d9-9afc-44954f896dce.png">


### Screencasts

_Tested with VoiceOver on macOS._

Backup, Social, and CRM encompass the various cases found in the pricing page. Make sure to unmute videos.

#### Backup

_Before_

https://user-images.githubusercontent.com/1620183/205380228-7db615eb-476a-4d88-b64c-9dd5bd0847b2.mov

_After_

https://user-images.githubusercontent.com/1620183/205381061-d27993ce-0f41-465c-adb1-3dfc4b5b1633.mov



#### Social

_Before_

https://user-images.githubusercontent.com/1620183/205381084-c5121f6e-03e8-4904-8ed7-c374d46b2c17.mov



_After_


https://user-images.githubusercontent.com/1620183/205381110-48a9b0e7-ad00-4b61-9659-0c302f3948f6.mov



#### CRM

_Before_


https://user-images.githubusercontent.com/1620183/205381145-ca1eca55-5493-434c-b984-9a80a0163035.mov



_After_


https://user-images.githubusercontent.com/1620183/205381164-8e17d055-9e33-44cf-aebe-ed2e30fd7650.mov





