### PR TITLE
Checkout: Hide contact validation errors during auto-completion, with fixes

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
@@ -272,6 +272,7 @@ export default function WPCheckout( {
 	}
 
 	const isDIFMInCart = hasDIFMProduct( responseCart );
+	const contactDetailsType = getContactDetailsType( responseCart );
 
 	return (
 		<CheckoutStepGroup
@@ -330,12 +331,14 @@ export default function WPCheckout( {
 				}
 				formStatus={ formStatus }
 			/>
-			<CheckoutContactStep
-				countriesList={ countriesList }
-				isLoggedOutCart={ isLoggedOutCart }
-				showErrorMessageBriefly={ showErrorMessageBriefly }
-				validatingButtonText={ validatingButtonText }
-			/>
+			{ contactDetailsType !== 'none' && (
+				<CheckoutContactStep
+					countriesList={ countriesList }
+					isLoggedOutCart={ isLoggedOutCart }
+					showErrorMessageBriefly={ showErrorMessageBriefly }
+					validatingButtonText={ validatingButtonText }
+				/>
+			) }
 			<PaymentMethodStep
 				activeStepFooter={ <PaymentMethodStepContent /> }
 				editButtonText={ String( translate( 'Edit' ) ) }
@@ -401,10 +404,6 @@ function CheckoutContactStep( {
 
 	const [ shouldShowContactDetailsValidationErrors, setShouldShowContactDetailsValidationErrors ] =
 		useState( false );
-
-	if ( contactDetailsType === 'none' ) {
-		return null;
-	}
 
 	return (
 		<CheckoutStep

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
@@ -65,7 +65,11 @@ import WPContactFormSummary from './wp-contact-form-summary';
 import type { OnChangeItemVariant } from './item-variation-picker';
 import type { CheckoutPageErrorCallback } from '@automattic/composite-checkout';
 import type { RemoveProductFromCart, MinimalRequestCartProduct } from '@automattic/shopping-cart';
-import type { CountryListItem, ManagedContactDetails } from '@automattic/wpcom-checkout';
+import type {
+	ContactDetailsType,
+	CountryListItem,
+	ManagedContactDetails,
+} from '@automattic/wpcom-checkout';
 
 const debug = debugFactory( 'calypso:composite-checkout:wp-checkout' );
 
@@ -337,6 +341,7 @@ export default function WPCheckout( {
 					isLoggedOutCart={ isLoggedOutCart }
 					showErrorMessageBriefly={ showErrorMessageBriefly }
 					validatingButtonText={ validatingButtonText }
+					contactDetailsType={ contactDetailsType }
 				/>
 			) }
 			<PaymentMethodStep
@@ -372,20 +377,20 @@ function CheckoutContactStep( {
 	isLoggedOutCart,
 	showErrorMessageBriefly,
 	validatingButtonText,
+	contactDetailsType,
 }: {
 	countriesList: CountryListItem[];
 	isLoggedOutCart: boolean;
 	showErrorMessageBriefly: ( error: string ) => void;
 	validatingButtonText: string;
+	contactDetailsType: Exclude< ContactDetailsType, 'none' >;
 } ) {
 	const translate = useTranslate();
 	const cartKey = useCartKey();
 	const { responseCart, updateLocation } = useShoppingCart( cartKey );
 	const reduxDispatch = useReduxDispatch();
-	const contactDetailsType = getContactDetailsType( responseCart );
 	const { isComplete: isAutoValidationComplete } = useCachedDomainContactDetails( {
 		overrideCountryList: countriesList,
-		shouldWait: contactDetailsType === 'none',
 	} );
 
 	const areThereDomainProductsInCart =

--- a/client/my-sites/checkout/composite-checkout/components/wp-contact-form.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-contact-form.tsx
@@ -1,7 +1,6 @@
 import { FormStatus, useFormStatus, useIsStepActive } from '@automattic/composite-checkout';
 import styled from '@emotion/styled';
 import { useSelect } from '@wordpress/data';
-import useCachedDomainContactDetails from '../hooks/use-cached-domain-contact-details';
 import ContactDetailsContainer from './contact-details-container';
 import type {
 	CountryListItem,
@@ -42,8 +41,6 @@ export default function WPContactForm( {
 	const { formStatus } = useFormStatus();
 	const isStepActive = useIsStepActive();
 	const isDisabled = ! isStepActive || formStatus !== FormStatus.READY;
-
-	useCachedDomainContactDetails( countriesList );
 
 	return (
 		<BillingFormFields>

--- a/client/my-sites/checkout/composite-checkout/hooks/use-cached-domain-contact-details.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-cached-domain-contact-details.ts
@@ -2,7 +2,7 @@ import { useSetStepComplete } from '@automattic/composite-checkout';
 import { getCountryPostalCodeSupport } from '@automattic/wpcom-checkout';
 import { useDispatch } from '@wordpress/data';
 import debugFactory from 'debug';
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useSelector, useDispatch as useReduxDispatch } from 'react-redux';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { requestContactDetailsCache } from 'calypso/state/domains/management/actions';
@@ -15,17 +15,24 @@ import type {
 
 const debug = debugFactory( 'calypso:composite-checkout:use-cached-domain-contact-details' );
 
-function useCachedContactDetails(): PossiblyCompleteDomainContactDetails | null {
+function useCachedContactDetails( {
+	shouldWait,
+}: {
+	shouldWait?: boolean;
+} ): PossiblyCompleteDomainContactDetails | null {
 	const reduxDispatch = useReduxDispatch();
 	const haveRequestedCachedDetails = useRef< 'not-started' | 'pending' | 'done' >( 'not-started' );
 	const cachedContactDetails = useSelector( getContactDetailsCache );
 	useEffect( () => {
+		if ( shouldWait ) {
+			return;
+		}
 		if ( haveRequestedCachedDetails.current === 'not-started' ) {
 			debug( 'requesting cached domain contact details' );
 			reduxDispatch( requestContactDetailsCache() );
 			haveRequestedCachedDetails.current = 'pending';
 		}
-	}, [ reduxDispatch ] );
+	}, [ reduxDispatch, shouldWait ] );
 	if ( haveRequestedCachedDetails.current === 'pending' && cachedContactDetails ) {
 		debug( 'cached domain contact details retrieved', cachedContactDetails );
 		haveRequestedCachedDetails.current = 'done';
@@ -33,14 +40,22 @@ function useCachedContactDetails(): PossiblyCompleteDomainContactDetails | null 
 	return cachedContactDetails;
 }
 
+/**
+ * Automatically attempt to populate the checkout contact form and complete the
+ * contact step (running validation as normal).
+ *
+ * Must be run inside a CheckoutStepGroup in order to have the ability to
+ * complete steps.
+ */
 function useCachedContactDetailsForCheckoutForm(
 	cachedContactDetails: PossiblyCompleteDomainContactDetails | null,
 	overrideCountryList?: CountryListItem[]
-): void {
+): { isComplete: boolean } {
 	const countriesList = useCountryList( overrideCountryList );
 	const reduxDispatch = useReduxDispatch();
 	const setStepCompleteStatus = useSetStepComplete();
 	const didFillForm = useRef( false );
+	const [ isComplete, setComplete ] = useState( false );
 
 	const arePostalCodesSupported =
 		countriesList.length && cachedContactDetails?.countryCode
@@ -92,6 +107,7 @@ function useCachedContactDetailsForCheckoutForm(
 				if ( didSkip ) {
 					reduxDispatch( recordTracksEvent( 'calypso_checkout_skip_to_last_step' ) );
 				}
+				setComplete( true );
 			} );
 	}, [
 		reduxDispatch,
@@ -101,15 +117,21 @@ function useCachedContactDetailsForCheckoutForm(
 		loadDomainContactDetailsFromCache,
 		countriesList,
 	] );
+
+	return { isComplete };
 }
 
 /**
  * Load cached contact details from the server and use them to populate the
  * checkout contact form and the shopping cart tax location.
  */
-export default function useCachedDomainContactDetails(
-	overrideCountryList?: CountryListItem[]
-): void {
-	const cachedContactDetails = useCachedContactDetails();
-	useCachedContactDetailsForCheckoutForm( cachedContactDetails, overrideCountryList );
+export default function useCachedDomainContactDetails( {
+	overrideCountryList,
+	shouldWait,
+}: {
+	overrideCountryList?: CountryListItem[];
+	shouldWait?: boolean;
+} ) {
+	const cachedContactDetails = useCachedContactDetails( { shouldWait } );
+	return useCachedContactDetailsForCheckoutForm( cachedContactDetails, overrideCountryList );
 }

--- a/client/my-sites/checkout/composite-checkout/hooks/use-cached-domain-contact-details.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-cached-domain-contact-details.ts
@@ -37,7 +37,7 @@ function useCachedContactDetails( {
 		debug( 'cached domain contact details retrieved', cachedContactDetails );
 		haveRequestedCachedDetails.current = 'done';
 	}
-	return cachedContactDetails;
+	return shouldWait ? null : cachedContactDetails;
 }
 
 /**

--- a/client/my-sites/checkout/composite-checkout/test/checkout-contact-step.js
+++ b/client/my-sites/checkout/composite-checkout/test/checkout-contact-step.js
@@ -388,14 +388,7 @@ describe( 'Checkout contact step', () => {
 				validContactDetails.postal_code
 			);
 
-			// Do not await this click because we need to capture the 'Please wait'
-			// text that may only be visible very briefly. findByText('Please wait')
-			// will wait for it to appear.
-			user.click( await screen.findByText( 'Continue' ) );
-
-			// Wait for the validation to complete.
-			await screen.findAllByText( 'Please wait…' );
-			await waitForElementToBeRemoved( () => screen.queryAllByText( 'Please wait…' ) );
+			await user.click( screen.getByText( 'Continue' ) );
 
 			if ( complete === 'does' ) {
 				expect( await screen.findByTestId( 'payment-method-step--visible' ) ).toBeInTheDocument();

--- a/client/my-sites/checkout/composite-checkout/test/checkout-contact-step.js
+++ b/client/my-sites/checkout/composite-checkout/test/checkout-contact-step.js
@@ -119,6 +119,14 @@ describe( 'Checkout contact step', () => {
 		} );
 	} );
 
+	it( 'renders the step after the contact step as active if the purchase is free', async () => {
+		const cartChanges = { total_cost_integer: 0, total_cost_display: '0' };
+		render( <MyCheckout cartChanges={ cartChanges } />, container );
+		await waitFor( () => {
+			expect( screen.getByText( 'Free Purchase' ) ).toBeVisible();
+		} );
+	} );
+
 	it( 'renders the contact step when the purchase is not free', async () => {
 		render( <MyCheckout />, container );
 		await waitFor( () => {

--- a/client/my-sites/checkout/composite-checkout/test/checkout-contact-step.js
+++ b/client/my-sites/checkout/composite-checkout/test/checkout-contact-step.js
@@ -390,9 +390,14 @@ describe( 'Checkout contact step', () => {
 				screen.getByLabelText( /(Postal|ZIP) code/i ),
 				validContactDetails.postal_code
 			);
-			await user.click( await screen.findByText( 'Continue' ) );
 
-			// Wait for the validation to complete
+			// Do not await this click because we need to capture the 'Please wait'
+			// text that may only be visible very briefly. findByText('Please wait')
+			// will wait for it to appear.
+			user.click( await screen.findByText( 'Continue' ) );
+
+			// Wait for the validation to complete.
+			await screen.findAllByText( 'Please wait…' );
 			await waitForElementToBeRemoved( () => screen.queryAllByText( 'Please wait…' ) );
 
 			if ( complete === 'does' ) {

--- a/client/my-sites/checkout/composite-checkout/test/checkout-contact-step.js
+++ b/client/my-sites/checkout/composite-checkout/test/checkout-contact-step.js
@@ -255,7 +255,10 @@ describe( 'Checkout contact step', () => {
 		// Wait for the cart to load
 		await screen.findByText( 'Country' );
 
-		// Wait for the validation to complete, then check we've advanced to the next payment step
+		// Wait for the validation to complete.
+		await screen.findAllByText( 'Please wait…' );
+		await waitForElementToBeRemoved( () => screen.queryAllByText( 'Please wait…' ) );
+
 		expect( await screen.findByTestId( 'payment-method-step--visible' ) ).toBeInTheDocument();
 	} );
 

--- a/client/my-sites/checkout/composite-checkout/test/checkout-contact-step.js
+++ b/client/my-sites/checkout/composite-checkout/test/checkout-contact-step.js
@@ -255,11 +255,7 @@ describe( 'Checkout contact step', () => {
 		expect( screen.queryByTestId( 'payment-method-step--visible' ) ).not.toBeInTheDocument();
 	} );
 
-	/**
-	 * TODO: Restore these tests, which were failing for some reason on #64718
-	 */
-	/* eslint-disable jest/no-disabled-tests */
-	it.skip( 'autocompletes the contact step when there are valid cached details', async () => {
+	it( 'autocompletes the contact step when there are valid cached details', async () => {
 		mockCachedContactDetailsEndpoint( {
 			country_code: 'US',
 			postal_code: '10001',
@@ -269,12 +265,12 @@ describe( 'Checkout contact step', () => {
 		render( <MyCheckout cartChanges={ cartChanges } />, container );
 		// Wait for the cart to load
 		await screen.findByText( 'Country' );
-		// Wait for the validation to complete
-		await waitForElementToBeRemoved( () => screen.queryAllByText( 'Please wait…' ) );
-		expect( screen.queryByTestId( 'payment-method-step--visible' ) ).toBeInTheDocument();
+
+		// Wait for the validation to complete, then check we've advanced to the next payment step
+		expect( await screen.findByTestId( 'payment-method-step--visible' ) ).toBeInTheDocument();
 	} );
 
-	it.skip( 'does not autocomplete the contact step when there are invalid cached details', async () => {
+	it( 'does not autocomplete the contact step when there are invalid cached details', async () => {
 		mockCachedContactDetailsEndpoint( {
 			country_code: 'US',
 			postal_code: 'ABCD',
@@ -284,8 +280,6 @@ describe( 'Checkout contact step', () => {
 		render( <MyCheckout cartChanges={ cartChanges } />, container );
 		// Wait for the cart to load
 		await screen.findByText( 'Country' );
-		// Wait for the validation to complete
-		await waitForElementToBeRemoved( () => screen.queryAllByText( 'Please wait…' ) );
 		await expect( screen.findByTestId( 'payment-method-step--visible' ) ).toNeverAppear();
 	} );
 

--- a/client/my-sites/checkout/composite-checkout/test/checkout-contact-step.js
+++ b/client/my-sites/checkout/composite-checkout/test/checkout-contact-step.js
@@ -321,6 +321,10 @@ describe( 'Checkout contact step', () => {
 				};
 			} )();
 
+			mockCachedContactDetailsEndpoint( {
+				country_code: '',
+				postal_code: '',
+			} );
 			mockContactDetailsValidationEndpoint(
 				name === 'plan' ? 'tax' : name,
 				{

--- a/client/my-sites/checkout/composite-checkout/test/checkout-contact-step.js
+++ b/client/my-sites/checkout/composite-checkout/test/checkout-contact-step.js
@@ -3,7 +3,7 @@
  */
 import { StripeHookProvider } from '@automattic/calypso-stripe';
 import { ShoppingCartProvider, createShoppingCartManagerClient } from '@automattic/shopping-cart';
-import { render, screen, within, waitFor, waitForElementToBeRemoved } from '@testing-library/react';
+import { render, screen, within, waitForElementToBeRemoved } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import nock from 'nock';
 import { Provider as ReduxProvider } from 'react-redux';
@@ -103,70 +103,56 @@ describe( 'Checkout contact step', () => {
 	it( 'does not render the contact step when the purchase is free', async () => {
 		const cartChanges = { total_cost_integer: 0, total_cost_display: '0' };
 		render( <MyCheckout cartChanges={ cartChanges } /> );
-		await waitFor( () => {
-			expect(
-				screen.queryByText( /Enter your (billing|contact) information/ )
-			).not.toBeInTheDocument();
-		} );
+		await expect( screen.findByText( /Enter your (billing|contact) information/ ) ).toNeverAppear();
 	} );
 
 	it( 'renders the step after the contact step as active if the purchase is free', async () => {
 		const cartChanges = { total_cost_integer: 0, total_cost_display: '0' };
 		render( <MyCheckout cartChanges={ cartChanges } /> );
-		await waitFor( () => {
-			expect( screen.getByText( 'Free Purchase' ) ).toBeVisible();
-		} );
+		expect( await screen.findByText( 'Free Purchase' ) ).toBeVisible();
 	} );
 
 	it( 'renders the contact step when the purchase is not free', async () => {
 		render( <MyCheckout /> );
-		await waitFor( () => {
-			expect( screen.getByText( /Enter your (billing|contact) information/ ) ).toBeInTheDocument();
-		} );
+		expect(
+			await screen.findByText( /Enter your (billing|contact) information/ )
+		).toBeInTheDocument();
 	} );
 
 	it( 'renders the tax fields only when no domain is in the cart', async () => {
 		const cartChanges = { products: [ planWithoutDomain ] };
 		render( <MyCheckout cartChanges={ cartChanges } /> );
-		await waitFor( () => {
-			expect( screen.getByText( 'Country' ) ).toBeInTheDocument();
-			expect( screen.queryByText( 'Phone' ) ).not.toBeInTheDocument();
-			expect( screen.queryByText( 'Email' ) ).not.toBeInTheDocument();
-		} );
+		expect( await screen.findByText( 'Country' ) ).toBeInTheDocument();
+		expect( screen.queryByText( 'Phone' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Email' ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'renders the domain fields when a domain is in the cart', async () => {
 		const cartChanges = { products: [ planWithBundledDomain, domainProduct ] };
 		render( <MyCheckout cartChanges={ cartChanges } /> );
-		await waitFor( () => {
-			expect( screen.getByText( 'Country' ) ).toBeInTheDocument();
-			expect( screen.getByText( 'Phone' ) ).toBeInTheDocument();
-			expect( screen.getByText( 'Email' ) ).toBeInTheDocument();
-		} );
+		expect( await screen.findByText( 'Country' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Phone' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Email' ) ).toBeInTheDocument();
 	} );
 
 	it( 'renders the domain fields when a domain transfer is in the cart', async () => {
 		const cartChanges = { products: [ planWithBundledDomain, domainTransferProduct ] };
 		render( <MyCheckout cartChanges={ cartChanges } /> );
-		await waitFor( () => {
-			expect( screen.getByText( 'Country' ) ).toBeInTheDocument();
-			expect( screen.getByText( 'Phone' ) ).toBeInTheDocument();
-			expect( screen.getByText( 'Email' ) ).toBeInTheDocument();
-		} );
+		expect( await screen.findByText( 'Country' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Phone' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Email' ) ).toBeInTheDocument();
 	} );
 
 	it( 'does not render country-specific domain fields when no country has been chosen and a domain is in the cart', async () => {
 		const cartChanges = { products: [ planWithBundledDomain, domainProduct ] };
 		render( <MyCheckout cartChanges={ cartChanges } /> );
-		await waitFor( () => {
-			expect( screen.getByText( 'Country' ) ).toBeInTheDocument();
-			expect( screen.getByText( 'Phone' ) ).toBeInTheDocument();
-			expect( screen.getByText( 'Email' ) ).toBeInTheDocument();
-			expect( screen.queryByText( 'Address' ) ).not.toBeInTheDocument();
-			expect( screen.queryByText( 'City' ) ).not.toBeInTheDocument();
-			expect( screen.queryByText( 'State' ) ).not.toBeInTheDocument();
-			expect( screen.queryByText( 'ZIP code' ) ).not.toBeInTheDocument();
-		} );
+		expect( await screen.findByText( 'Country' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Phone' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Email' ) ).toBeInTheDocument();
+		expect( screen.queryByText( 'Address' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'City' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'State' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'ZIP code' ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'renders country-specific domain fields when a country has been chosen and a domain is in the cart', async () => {
@@ -174,15 +160,13 @@ describe( 'Checkout contact step', () => {
 		const cartChanges = { products: [ planWithBundledDomain, domainProduct ] };
 		render( <MyCheckout cartChanges={ cartChanges } /> );
 		await user.selectOptions( await screen.findByLabelText( 'Country' ), 'US' );
-		await waitFor( () => {
-			expect( screen.getByText( 'Country' ) ).toBeInTheDocument();
-			expect( screen.getByText( 'Phone' ) ).toBeInTheDocument();
-			expect( screen.getByText( 'Email' ) ).toBeInTheDocument();
-			expect( screen.getByText( 'Address' ) ).toBeInTheDocument();
-			expect( screen.getByText( 'City' ) ).toBeInTheDocument();
-			expect( screen.getByText( 'State' ) ).toBeInTheDocument();
-			expect( screen.getByText( 'ZIP code' ) ).toBeInTheDocument();
-		} );
+		expect( await screen.findByText( 'Country' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Phone' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Email' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Address' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'City' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'State' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'ZIP code' ) ).toBeInTheDocument();
 	} );
 
 	it( 'renders domain fields with postal code when a country with postal code support has been chosen and a plan is in the cart', async () => {
@@ -190,10 +174,8 @@ describe( 'Checkout contact step', () => {
 		const cartChanges = { products: [ planWithoutDomain ] };
 		render( <MyCheckout cartChanges={ cartChanges } /> );
 		await user.selectOptions( await screen.findByLabelText( 'Country' ), 'US' );
-		await waitFor( () => {
-			expect( screen.getByText( 'Country' ) ).toBeInTheDocument();
-			expect( screen.getByText( 'Postal code' ) ).toBeInTheDocument();
-		} );
+		expect( await screen.findByText( 'Country' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Postal code' ) ).toBeInTheDocument();
 	} );
 
 	it( 'renders domain fields except postal code when a country without postal code support has been chosen and a plan is in the cart', async () => {
@@ -201,10 +183,8 @@ describe( 'Checkout contact step', () => {
 		const cartChanges = { products: [ planWithoutDomain ] };
 		render( <MyCheckout cartChanges={ cartChanges } /> );
 		await user.selectOptions( await screen.findByLabelText( 'Country' ), 'CW' );
-		await waitFor( () => {
-			expect( screen.getByText( 'Country' ) ).toBeInTheDocument();
-			expect( screen.queryByText( 'Postal code' ) ).not.toBeInTheDocument();
-		} );
+		expect( await screen.findByText( 'Country' ) ).toBeInTheDocument();
+		expect( screen.queryByText( 'Postal code' ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'renders domain fields with postal code when a country with postal code support has been chosen and a domain is in the cart', async () => {
@@ -212,12 +192,10 @@ describe( 'Checkout contact step', () => {
 		const cartChanges = { products: [ planWithBundledDomain, domainProduct ] };
 		render( <MyCheckout cartChanges={ cartChanges } /> );
 		await user.selectOptions( await screen.findByLabelText( 'Country' ), 'US' );
-		await waitFor( () => {
-			expect( screen.getByText( 'Country' ) ).toBeInTheDocument();
-			expect( screen.getByText( 'Phone' ) ).toBeInTheDocument();
-			expect( screen.getByText( 'Email' ) ).toBeInTheDocument();
-			expect( screen.getByText( 'ZIP code' ) ).toBeInTheDocument();
-		} );
+		expect( await screen.findByText( 'Country' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Phone' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Email' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'ZIP code' ) ).toBeInTheDocument();
 	} );
 
 	it( 'renders domain fields except postal code when a country without postal code support has been chosen and a domain is in the cart', async () => {
@@ -225,14 +203,12 @@ describe( 'Checkout contact step', () => {
 		const cartChanges = { products: [ planWithBundledDomain, domainProduct ] };
 		render( <MyCheckout cartChanges={ cartChanges } /> );
 		await user.selectOptions( await screen.findByLabelText( 'Country' ), 'CW' );
-		await waitFor( () => {
-			expect( screen.getByText( 'Country' ) ).toBeInTheDocument();
-			expect( screen.getByText( 'Phone' ) ).toBeInTheDocument();
-			expect( screen.getByText( 'Email' ) ).toBeInTheDocument();
-			expect( screen.queryByText( 'Postal Code' ) ).not.toBeInTheDocument();
-			expect( screen.queryByText( 'Postal code' ) ).not.toBeInTheDocument();
-			expect( screen.queryByText( 'ZIP code' ) ).not.toBeInTheDocument();
-		} );
+		expect( await screen.findByText( 'Country' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Phone' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Email' ) ).toBeInTheDocument();
+		expect( screen.queryByText( 'Postal Code' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Postal code' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'ZIP code' ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'does not complete the contact step when the contact step button has not been clicked and there are no cached details', async () => {
@@ -448,10 +424,8 @@ describe( 'Checkout contact step', () => {
 
 	it( 'renders the checkout summary', async () => {
 		render( <MyCheckout /> );
-		await waitFor( () => {
-			expect( screen.getByText( 'Purchase Details' ) ).toBeInTheDocument();
-			expect( navigate ).not.toHaveBeenCalled();
-		} );
+		expect( await screen.findByText( 'Purchase Details' ) ).toBeInTheDocument();
+		expect( navigate ).not.toHaveBeenCalled();
 	} );
 
 	it( 'removes a product from the cart after clicking to remove', async () => {
@@ -467,8 +441,6 @@ describe( 'Checkout contact step', () => {
 		const confirmModal = await screen.findByRole( 'dialog' );
 		const confirmButton = await within( confirmModal ).findByText( 'Continue' );
 		await user.click( confirmButton );
-		await waitFor( () => {
-			expect( screen.queryByLabelText( 'WordPress.com Personal' ) ).not.toBeInTheDocument();
-		} );
+		await expect( screen.findByLabelText( 'WordPress.com Personal' ) ).toNeverAppear();
 	} );
 } );

--- a/client/my-sites/checkout/composite-checkout/test/checkout-contact-step.js
+++ b/client/my-sites/checkout/composite-checkout/test/checkout-contact-step.js
@@ -46,7 +46,6 @@ jest.mock( 'calypso/state/products-list/selectors/is-marketplace-product' );
 jest.mock( 'calypso/lib/navigate' );
 
 describe( 'Checkout contact step', () => {
-	let container;
 	let MyCheckout;
 
 	beforeEach( () => {
@@ -58,9 +57,6 @@ describe( 'Checkout contact step', () => {
 		getDomainsBySiteId.mockImplementation( () => [] );
 		isMarketplaceProduct.mockImplementation( () => false );
 		isJetpackSite.mockImplementation( () => false );
-
-		container = document.createElement( 'div' );
-		document.body.appendChild( container );
 
 		const initialCart = getBasicCart();
 
@@ -104,14 +100,9 @@ describe( 'Checkout contact step', () => {
 		};
 	} );
 
-	afterEach( () => {
-		document.body.removeChild( container );
-		container = null;
-	} );
-
 	it( 'does not render the contact step when the purchase is free', async () => {
 		const cartChanges = { total_cost_integer: 0, total_cost_display: '0' };
-		render( <MyCheckout cartChanges={ cartChanges } />, container );
+		render( <MyCheckout cartChanges={ cartChanges } /> );
 		await waitFor( () => {
 			expect(
 				screen.queryByText( /Enter your (billing|contact) information/ )
@@ -121,14 +112,14 @@ describe( 'Checkout contact step', () => {
 
 	it( 'renders the step after the contact step as active if the purchase is free', async () => {
 		const cartChanges = { total_cost_integer: 0, total_cost_display: '0' };
-		render( <MyCheckout cartChanges={ cartChanges } />, container );
+		render( <MyCheckout cartChanges={ cartChanges } /> );
 		await waitFor( () => {
 			expect( screen.getByText( 'Free Purchase' ) ).toBeVisible();
 		} );
 	} );
 
 	it( 'renders the contact step when the purchase is not free', async () => {
-		render( <MyCheckout />, container );
+		render( <MyCheckout /> );
 		await waitFor( () => {
 			expect( screen.getByText( /Enter your (billing|contact) information/ ) ).toBeInTheDocument();
 		} );
@@ -136,7 +127,7 @@ describe( 'Checkout contact step', () => {
 
 	it( 'renders the tax fields only when no domain is in the cart', async () => {
 		const cartChanges = { products: [ planWithoutDomain ] };
-		render( <MyCheckout cartChanges={ cartChanges } />, container );
+		render( <MyCheckout cartChanges={ cartChanges } /> );
 		await waitFor( () => {
 			expect( screen.getByText( 'Country' ) ).toBeInTheDocument();
 			expect( screen.queryByText( 'Phone' ) ).not.toBeInTheDocument();
@@ -146,7 +137,7 @@ describe( 'Checkout contact step', () => {
 
 	it( 'renders the domain fields when a domain is in the cart', async () => {
 		const cartChanges = { products: [ planWithBundledDomain, domainProduct ] };
-		render( <MyCheckout cartChanges={ cartChanges } />, container );
+		render( <MyCheckout cartChanges={ cartChanges } /> );
 		await waitFor( () => {
 			expect( screen.getByText( 'Country' ) ).toBeInTheDocument();
 			expect( screen.getByText( 'Phone' ) ).toBeInTheDocument();
@@ -156,7 +147,7 @@ describe( 'Checkout contact step', () => {
 
 	it( 'renders the domain fields when a domain transfer is in the cart', async () => {
 		const cartChanges = { products: [ planWithBundledDomain, domainTransferProduct ] };
-		render( <MyCheckout cartChanges={ cartChanges } />, container );
+		render( <MyCheckout cartChanges={ cartChanges } /> );
 		await waitFor( () => {
 			expect( screen.getByText( 'Country' ) ).toBeInTheDocument();
 			expect( screen.getByText( 'Phone' ) ).toBeInTheDocument();
@@ -166,7 +157,7 @@ describe( 'Checkout contact step', () => {
 
 	it( 'does not render country-specific domain fields when no country has been chosen and a domain is in the cart', async () => {
 		const cartChanges = { products: [ planWithBundledDomain, domainProduct ] };
-		render( <MyCheckout cartChanges={ cartChanges } />, container );
+		render( <MyCheckout cartChanges={ cartChanges } /> );
 		await waitFor( () => {
 			expect( screen.getByText( 'Country' ) ).toBeInTheDocument();
 			expect( screen.getByText( 'Phone' ) ).toBeInTheDocument();
@@ -181,7 +172,7 @@ describe( 'Checkout contact step', () => {
 	it( 'renders country-specific domain fields when a country has been chosen and a domain is in the cart', async () => {
 		const user = userEvent.setup();
 		const cartChanges = { products: [ planWithBundledDomain, domainProduct ] };
-		render( <MyCheckout cartChanges={ cartChanges } />, container );
+		render( <MyCheckout cartChanges={ cartChanges } /> );
 		await user.selectOptions( await screen.findByLabelText( 'Country' ), 'US' );
 		await waitFor( () => {
 			expect( screen.getByText( 'Country' ) ).toBeInTheDocument();
@@ -197,7 +188,7 @@ describe( 'Checkout contact step', () => {
 	it( 'renders domain fields with postal code when a country with postal code support has been chosen and a plan is in the cart', async () => {
 		const user = userEvent.setup();
 		const cartChanges = { products: [ planWithoutDomain ] };
-		render( <MyCheckout cartChanges={ cartChanges } />, container );
+		render( <MyCheckout cartChanges={ cartChanges } /> );
 		await user.selectOptions( await screen.findByLabelText( 'Country' ), 'US' );
 		await waitFor( () => {
 			expect( screen.getByText( 'Country' ) ).toBeInTheDocument();
@@ -208,7 +199,7 @@ describe( 'Checkout contact step', () => {
 	it( 'renders domain fields except postal code when a country without postal code support has been chosen and a plan is in the cart', async () => {
 		const user = userEvent.setup();
 		const cartChanges = { products: [ planWithoutDomain ] };
-		render( <MyCheckout cartChanges={ cartChanges } />, container );
+		render( <MyCheckout cartChanges={ cartChanges } /> );
 		await user.selectOptions( await screen.findByLabelText( 'Country' ), 'CW' );
 		await waitFor( () => {
 			expect( screen.getByText( 'Country' ) ).toBeInTheDocument();
@@ -219,7 +210,7 @@ describe( 'Checkout contact step', () => {
 	it( 'renders domain fields with postal code when a country with postal code support has been chosen and a domain is in the cart', async () => {
 		const user = userEvent.setup();
 		const cartChanges = { products: [ planWithBundledDomain, domainProduct ] };
-		render( <MyCheckout cartChanges={ cartChanges } />, container );
+		render( <MyCheckout cartChanges={ cartChanges } /> );
 		await user.selectOptions( await screen.findByLabelText( 'Country' ), 'US' );
 		await waitFor( () => {
 			expect( screen.getByText( 'Country' ) ).toBeInTheDocument();
@@ -232,7 +223,7 @@ describe( 'Checkout contact step', () => {
 	it( 'renders domain fields except postal code when a country without postal code support has been chosen and a domain is in the cart', async () => {
 		const user = userEvent.setup();
 		const cartChanges = { products: [ planWithBundledDomain, domainProduct ] };
-		render( <MyCheckout cartChanges={ cartChanges } />, container );
+		render( <MyCheckout cartChanges={ cartChanges } /> );
 		await user.selectOptions( await screen.findByLabelText( 'Country' ), 'CW' );
 		await waitFor( () => {
 			expect( screen.getByText( 'Country' ) ).toBeInTheDocument();
@@ -246,7 +237,7 @@ describe( 'Checkout contact step', () => {
 
 	it( 'does not complete the contact step when the contact step button has not been clicked and there are no cached details', async () => {
 		const cartChanges = { products: [ planWithoutDomain ] };
-		render( <MyCheckout cartChanges={ cartChanges } />, container );
+		render( <MyCheckout cartChanges={ cartChanges } /> );
 		// Wait for the cart to load
 		await screen.findByText( 'Country' );
 		expect( screen.queryByTestId( 'payment-method-step--visible' ) ).not.toBeInTheDocument();
@@ -259,7 +250,7 @@ describe( 'Checkout contact step', () => {
 		} );
 		mockContactDetailsValidationEndpoint( 'tax', { success: true } );
 		const cartChanges = { products: [ planWithoutDomain ] };
-		render( <MyCheckout cartChanges={ cartChanges } />, container );
+		render( <MyCheckout cartChanges={ cartChanges } /> );
 		// Wait for the cart to load
 		await screen.findByText( 'Country' );
 
@@ -277,7 +268,7 @@ describe( 'Checkout contact step', () => {
 		} );
 		mockContactDetailsValidationEndpoint( 'tax', { success: false, messages: [ 'Invalid' ] } );
 		const cartChanges = { products: [ planWithoutDomain ] };
-		render( <MyCheckout cartChanges={ cartChanges } />, container );
+		render( <MyCheckout cartChanges={ cartChanges } /> );
 		// Wait for the cart to load
 		await screen.findByText( 'Country' );
 		await expect( screen.findByTestId( 'payment-method-step--visible' ) ).toNeverAppear();
@@ -293,7 +284,7 @@ describe( 'Checkout contact step', () => {
 			messages: { postal_code: [ 'Postal code error message' ] },
 		} );
 		const cartChanges = { products: [ planWithoutDomain ] };
-		render( <MyCheckout cartChanges={ cartChanges } />, container );
+		render( <MyCheckout cartChanges={ cartChanges } /> );
 		// Wait for the cart to load
 		await screen.findByText( 'Country' );
 		await expect( screen.findByText( 'Postal code error message' ) ).toNeverAppear();
@@ -402,8 +393,7 @@ describe( 'Checkout contact step', () => {
 				<MyCheckout
 					cartChanges={ { products: [ product ] } }
 					additionalProps={ { isLoggedOutCart: logged === 'out' } }
-				/>,
-				container
+				/>
 			);
 
 			// Wait for the cart to load
@@ -457,7 +447,7 @@ describe( 'Checkout contact step', () => {
 	);
 
 	it( 'renders the checkout summary', async () => {
-		render( <MyCheckout />, container );
+		render( <MyCheckout /> );
 		await waitFor( () => {
 			expect( screen.getByText( 'Purchase Details' ) ).toBeInTheDocument();
 			expect( navigate ).not.toHaveBeenCalled();
@@ -467,7 +457,7 @@ describe( 'Checkout contact step', () => {
 	it( 'removes a product from the cart after clicking to remove', async () => {
 		const user = userEvent.setup();
 		const cartChanges = { products: [ planWithoutDomain, domainProduct ] };
-		render( <MyCheckout cartChanges={ cartChanges } />, container );
+		render( <MyCheckout cartChanges={ cartChanges } /> );
 		const activeSection = await screen.findByTestId( 'review-order-step--visible' );
 		const removeProductButton = await within( activeSection ).findByLabelText(
 			'Remove WordPress.com Personal from cart'

--- a/client/my-sites/checkout/composite-checkout/test/checkout-contact-step.js
+++ b/client/my-sites/checkout/composite-checkout/test/checkout-contact-step.js
@@ -272,6 +272,22 @@ describe( 'Checkout contact step', () => {
 		await expect( screen.findByTestId( 'payment-method-step--visible' ) ).toNeverAppear();
 	} );
 
+	it( 'does not show errors when autocompleting the contact step when there are invalid cached details', async () => {
+		mockCachedContactDetailsEndpoint( {
+			country_code: 'US',
+			postal_code: 'ABCD',
+		} );
+		mockContactDetailsValidationEndpoint( 'tax', {
+			success: false,
+			messages: { postal_code: [ 'Postal code error message' ] },
+		} );
+		const cartChanges = { products: [ planWithoutDomain ] };
+		render( <MyCheckout cartChanges={ cartChanges } />, container );
+		// Wait for the cart to load
+		await screen.findByText( 'Country' );
+		await expect( screen.findByText( 'Postal code error message' ) ).toNeverAppear();
+	} );
+
 	it.each( [
 		{ complete: 'does', valid: 'valid', name: 'plan', email: 'fails', logged: 'in' },
 		{ complete: 'does not', valid: 'invalid', name: 'plan', email: 'fails', logged: 'in' },

--- a/client/my-sites/checkout/composite-checkout/test/use-cached-domain-contact-details.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/use-cached-domain-contact-details.tsx
@@ -63,7 +63,7 @@ function MyTestContent( { countries }: { countries: CountryListItem[] } ) {
 	const { responseCart, reloadFromServer, updateLocation } = useShoppingCart(
 		initialCart.cart_key
 	);
-	useCachedDomainContactDetails( countries );
+	useCachedDomainContactDetails( { overrideCountryList: countries } );
 	const contactInfo: ManagedContactDetails = useSelect( ( select ) =>
 		select( 'wpcom-checkout' ).getContactInfo()
 	);

--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -153,7 +153,9 @@ Renders a list of the line items and their `displayValue` properties followed by
 
 ### CheckoutStep
 
-A checkout step. This should be a direct child of [CheckoutSteps](#CheckoutSteps) and is itself a wrapper for [CheckoutStepBody](#CheckoutStepBody). If you want to make something that looks like a step but is not connected to other steps, use a [CheckoutStepBody](#CheckoutStepBody) instead.
+A checkout step. This should be a **direct** child of [CheckoutSteps](#CheckoutSteps) and is itself a wrapper for [CheckoutStepBody](#CheckoutStepBody). If you want to make something that looks like a step but is not connected to other steps, use a [CheckoutStepBody](#CheckoutStepBody) instead.
+
+If you want to create a wrapper around a step, you must set the `isCheckoutStep` property of your wrapper component to identify it as a checkout step; otherwise it will be rendered without any step context and things will probably not work. Example: `function MyWrapper() { return <CheckoutStep /> }; MyWrapper.isCheckoutStep = true;`
 
 This component's props are:
 

--- a/packages/composite-checkout/src/components/checkout-steps.tsx
+++ b/packages/composite-checkout/src/components/checkout-steps.tsx
@@ -772,7 +772,7 @@ export function useSetStepComplete(): ( stepId: string ) => Promise< boolean > {
 	return useJITCallback( async ( stepId: string ) => {
 		const stepNumber = getStepNumberFromId( stepId );
 		if ( ! stepNumber ) {
-			throw new Error( `Cannot find step with id ${ stepId }` );
+			throw new Error( `Cannot find step with id '${ stepId }' when trying to set step complete.` );
 		}
 		// To try to complete a step, we must try to complete all previous steps
 		// first, ignoring steps that are already complete.


### PR DESCRIPTION
#### Proposed Changes

This is the second attempt at https://github.com/Automattic/wp-calypso/pull/69943 which was reverted in https://github.com/Automattic/wp-calypso/pull/70721 because there was a bug with free purchases. In the previous PR, we moved the checkout contact details step into a wrapper component due to certain rendering needs (see below). There is one case where no contact details step is rendered at all: when the purchase is free ($0 total, not full credits). Before https://github.com/Automattic/wp-calypso/pull/69943, we did not render the step at all in this case, but after that PR, we _did_ render it, except that the wrapper returned null. The result was that, if the purchase was free, checkout would think that the contact details step was present and _active_ even though it was null, effectively blocking checkout.

This PR makes one important alteration: it only renders the new wrapper itself if checkout is not free. In addition, this PR adds a test to prove that the bug has been fixed.

#### Original Changes

When checkout loads, it fetches saved contact details from an API endpoint, pre-fills the contact form with those details, and attempts to auto-complete the contact details step. Since https://github.com/Automattic/wp-calypso/pull/64344, this process uses the same logic as if a user filled out the form and clicked "Continue" manually. However, there is a downside: the contact details will be validated by another API endpoint, and if they are invalid the user will see an error reported as soon as checkout loads. Since the user didn't actually take any action at this point, this UX can be confusing.

In this PR, we refactor the placement of the auto-completion code so that its validation call will not report any errors on failure.

Fixes https://github.com/Automattic/wp-calypso/issues/69211

Before this change, you might see a validation error like this when checkout first loads:

<img width="977" alt="validation-error" src="https://user-images.githubusercontent.com/2036909/201235660-6c218f93-0ae4-418d-bb69-29e953fe404f.png">


#### Testing Instructions

> **Note**
> Reviewing the code of this PR is probably easiest by reviewing each commit separately. The changes move large blocks of code around and can be hard to understand when viewed all at once.

There are unit tests for this behavior but you can test it manually as follows:

First test that successful validation still works:

- Make sure you have valid cached _domain_ contact details for a user (using a domain product will cause more fields to be visible). You can do this by visiting checkout when a domain product is in your cart, filling out the contact information step and pressing "Continue". Assuming they are valid, they will be saved for future visits to checkout.
- Add a _domain_ product to your cart and visit checkout (or reload if you are already there).
- Verify that you see the contact information step load before it is auto-completed.
- Verify that the active step is now the payment method step.

Next test that manual validation displays error messages:

- Add a _domain_ product to your cart and visit checkout.
- Click to edit the contact information step if it is not already active.
- Enter invalid contact information (eg: by clearing the "Last name" field).
- Press "Continue".
- Verify that you see a validation error.
- Verify that the active step is still the contact information step.

Finally, test that auto-completion does not display error messages:

- Apply D92139-code and sandbox the API. This will break the domain contact details validation endpoint.
- Add a _domain_ product to your cart and visit checkout.
- Verify that you see the contact information step load before it is auto-completed.
- Verify that you _do not see_ a validation error.
- Verify that the active step is still the contact information step.
