### PR TITLE
chore: update Playwright to 1.28.

### DIFF
--- a/.teamcity/_self/projects/MarTech.kt
+++ b/.teamcity/_self/projects/MarTech.kt
@@ -43,7 +43,7 @@ object ToSAcceptanceTracking: BuildType ({
 		param("env.NODE_CONFIG_ENV", "test")
 		param("env.PLAYWRIGHT_BROWSERS_PATH", "0")
 		param("env.TEAMCITY_VERSION", "2021")
-		param("env.HEADLESS", "false")
+		param("env.HEADLESS", "true")
 		param("env.LOCALE", "en")
 	}
 

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -1035,7 +1035,7 @@ object KPIDashboardTests : BuildType({
 		param("env.NODE_CONFIG_ENV", "test")
 		param("env.PLAYWRIGHT_BROWSERS_PATH", "0")
 		param("env.TEAMCITY_VERSION", "2021")
-		param("env.HEADLESS", "false")
+		param("env.HEADLESS", "true")
 		param("env.LOCALE", "en")
 		param("env.DEBUG", "")
 		param("env.VIEWPORT_NAME", "desktop")

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -44,7 +44,7 @@
 		"enzyme": "^3.11.0",
 		"jest": "^27.3.1",
 		"lodash": "^4.17.21",
-		"playwright": "^1.26",
+		"playwright": "^1.28",
 		"postcss": "^8.4.5",
 		"react": "^17.0.2",
 		"react-dom": "^17.0.2",

--- a/packages/calypso-e2e/package.json
+++ b/packages/calypso-e2e/package.json
@@ -23,7 +23,7 @@
 		"jest-docblock": "^27",
 		"mailosaur": "^8.4.0",
 		"nock": "^12.0.3",
-		"playwright": "^1.26",
+		"playwright": "^1.28",
 		"totp-generator": "^0.0.12"
 	},
 	"devDependencies": {

--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -51,7 +51,7 @@
 		"lodash": "^4.17.20",
 		"mailosaur": "^8.4.0",
 		"node-fetch": "^2.6.1",
-		"playwright": "^1.26",
+		"playwright": "^1.28",
 		"postcss": "^8.3.11"
 	}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -249,7 +249,7 @@ __metadata:
     mailosaur: ^8.4.0
     nock: ^12.0.3
     node-fetch: ^2.6.7
-    playwright: ^1.26
+    playwright: ^1.28
     totp-generator: ^0.0.12
     typescript: ^4.7.4
   languageName: unknown
@@ -10319,7 +10319,7 @@ __metadata:
     keytar: ^7.7.0
     lodash: ^4.17.21
     make-dir: ^3.1.0
-    playwright: ^1.26
+    playwright: ^1.28
     postcss: ^8.4.5
     react: ^17.0.2
     react-dom: ^17.0.2
@@ -27381,23 +27381,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"playwright-core@npm:1.27.0":
-  version: 1.27.0
-  resolution: "playwright-core@npm:1.27.0"
+"playwright-core@npm:1.28.1":
+  version: 1.28.1
+  resolution: "playwright-core@npm:1.28.1"
   bin:
     playwright: cli.js
-  checksum: b0e3be60e733e82f6e1f65d1f14a59c98120fb9a82aec93db379f0074cf41dfc2a981a61da87a61f0893f68fdd9665154860add3d63b60889dbcc1a57895718c
+  checksum: ad6dcdd57b1be811443a352eab3ce7b6adb06204a784a76dfa5b41c15e84d96c0bfff931573da2d04f15f4a4f3dd26995afbe84c2cb377576de84168f51c3723
   languageName: node
   linkType: hard
 
-"playwright@npm:^1.26":
-  version: 1.27.0
-  resolution: "playwright@npm:1.27.0"
+"playwright@npm:^1.28":
+  version: 1.28.1
+  resolution: "playwright@npm:1.28.1"
   dependencies:
-    playwright-core: 1.27.0
+    playwright-core: 1.28.1
   bin:
     playwright: cli.js
-  checksum: 063e239793e9f8f35f170e9501861f94a5253d32bf34360fa67371a309bda66a66fab449e8ef76e250f84744a968f22866516d20c37829b19ef3ae02dff6f51b
+  checksum: 308a6053de7de012141bbdedeb3fb28dc6dcce0fa5bd4879da42a77d9b6f445495c6717783854ada8184585c9b0650e012a103e0fa70b3e164a3f358c638866f
   languageName: node
   linkType: hard
 
@@ -36380,7 +36380,7 @@ swiper@4.5.1:
     lodash: ^4.17.20
     mailosaur: ^8.4.0
     node-fetch: ^2.6.1
-    playwright: ^1.26
+    playwright: ^1.28
     postcss: ^8.3.11
     webpack: ^5.63.0
   languageName: unknown


### PR DESCRIPTION
#### Proposed Changes

This PR updates the version of Playwright to 1.28.

Key changes:
- set all E2E instances to use headless mode.
- update Playwright to 1.28.

#### Testing Instructions

Ensure the following build configurations are passing:
  - [x] Gutenberg E2E (desktop)
  - [x] Gutenberg E2E (mobile)
  - [x] Calypso E2E (desktop)
  - [x] Calypso E2E (mobile)
  - [x] Pre-Release E2E
  - [x] Code Style
  - [x] Unit Tests

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
