### PR TITLE
Writing prompts: add a toggle for enabling and disabling in the editor

### DIFF
--- a/client/my-sites/site-settings/composing/blogging-prompts.jsx
+++ b/client/my-sites/site-settings/composing/blogging-prompts.jsx
@@ -1,0 +1,49 @@
+import { Card } from '@automattic/components';
+import { ToggleControl } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import SupportInfo from 'calypso/components/support-info';
+
+const BloggingPrompts = ( {
+	fields,
+	handleToggle,
+	isRequestingSettings,
+	isSavingSettings,
+	isAtomic,
+	siteIsJetpack,
+} ) => {
+	const translate = useTranslate();
+
+	return (
+		<Card className="composing__card site-settings__card">
+			<SupportInfo
+				text={ translate( 'Displays a writing prompt when starting a new post.' ) }
+				link="https://wordpress.com/support/writing-prompts"
+				privacyLink={ siteIsJetpack && ! isAtomic }
+			/>
+			<ToggleControl
+				checked={ !! fields.jetpack_blogging_prompts_enabled }
+				disabled={ isRequestingSettings || isSavingSettings }
+				onChange={ handleToggle( 'jetpack_blogging_prompts_enabled' ) }
+				label={ translate( 'Show writing prompts' ) }
+			/>
+		</Card>
+	);
+};
+
+BloggingPrompts.defaultProps = {
+	isSavingSettings: false,
+	isRequestingSettings: true,
+	fields: {},
+};
+
+BloggingPrompts.propTypes = {
+	handleToggle: PropTypes.func.isRequired,
+	isSavingSettings: PropTypes.bool,
+	isRequestingSettings: PropTypes.bool,
+	fields: PropTypes.object,
+	isAtomic: PropTypes.bool,
+	siteIsJetpack: PropTypes.bool,
+};
+
+export default BloggingPrompts;

--- a/client/my-sites/site-settings/composing/index.jsx
+++ b/client/my-sites/site-settings/composing/index.jsx
@@ -2,6 +2,7 @@ import { CompactCard } from '@automattic/components';
 import PropTypes from 'prop-types';
 import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
 import DateTimeFormat from '../date-time-format';
+import BloggingPrompts from './blogging-prompts';
 import DefaultPostFormat from './default-post-format';
 import Latex from './latex';
 import Markdown from './markdown';
@@ -49,6 +50,20 @@ const Composing = ( {
 			siteIsJetpack={ siteIsJetpack }
 			handleToggle={ handleToggle }
 		/>
+
+		{
+			// Blogging prompts is a Jetpack editor extension that's enabled for Simple and Atomic sites only.
+			( ! siteIsJetpack || isAtomic ) && (
+				<BloggingPrompts
+					fields={ fields }
+					isRequestingSettings={ isRequestingSettings }
+					isSavingSettings={ isSavingSettings }
+					isAtomic={ isAtomic }
+					siteIsJetpack={ siteIsJetpack }
+					handleToggle={ handleToggle }
+				/>
+			)
+		}
 
 		{ siteIsJetpack && (
 			<>

--- a/client/my-sites/site-settings/composing/index.jsx
+++ b/client/my-sites/site-settings/composing/index.jsx
@@ -52,7 +52,7 @@ const Composing = ( {
 		/>
 
 		{
-			// Blogging prompts is a Jetpack editor extension that's enabled for Simple and Atomic sites only.
+			// Blogging prompts is a Jetpack editor extension that's enabled for Simple and Atomic sites only
 			( ! siteIsJetpack || isAtomic ) && (
 				<BloggingPrompts
 					fields={ fields }

--- a/client/my-sites/site-settings/form-writing.jsx
+++ b/client/my-sites/site-settings/form-writing.jsx
@@ -215,6 +215,7 @@ const getFormSettings = ( settings ) => {
 		'podcasting_category_id',
 		'wpcom_publish_posts_with_markdown',
 		'featured_image_email_enabled',
+		'jetpack_blogging_prompts_enabled',
 	] );
 
 	// handling `gmt_offset` and `timezone_string` values


### PR DESCRIPTION
#### Proposed Changes

Adds a toggle to Settings > Writing that allows enabling or disabling showing the writing prompts in the editor.

<img width="825" alt="image" src="https://user-images.githubusercontent.com/1699996/205524339-a0ad293f-34e7-48e0-82f0-676d37114323.png">

Note that the documentation link included in this PR is currently a draft, so the link is not yet available.

#### Testing Instructions

Test in combination with https://github.com/Automattic/jetpack/pull/27746

##### Simple sites

- Set up a site to show writing prompts by setting the front page to show posts or setting a dedicated page for posts in Settings > Reading
- Sandbox public-api.wordpress.com and the site domain
- Apply the Jetpack change to your sandbox with `bin/jetpack-downloader test jetpack add/blogging-prompts-toggle`
- Loading this branch, visit `/settings/writing/{site}`
- The "Show writing prompts" toggle should be set to on by default
- Check that a writing prompt shows as a placeholder when you start a new post
- Uncheck the toggle
- See that a writing prompt does not show when starting a new post

##### Jetpack sites

- On an Atomic site, install the Jetpack Beta plugin and select the `add/blogging-prompts-toggle` feature branch
- Repeat the steps above to make sure the toggle works as expected


