### PR TITLE
Theme Showcase: Enable flag themes/showcase-i4/search-and-filter for all environments

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -133,7 +133,7 @@
 		"themes/atomic-homepage-replace": true,
 		"themes/plugin-bundling": true,
 		"themes/premium": true,
-		"themes/showcase-i4/search-and-filter": false,
+		"themes/showcase-i4/search-and-filter": true,
 		"themes/subscription-purchases": false,
 		"themes/theme-switch-persist-template": false,
 		"themes/third-party-premium": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -129,7 +129,7 @@
 		"themes/atomic-homepage-replace": true,
 		"themes/plugin-bundling": true,
 		"themes/premium": true,
-		"themes/showcase-i4/search-and-filter": false,
+		"themes/showcase-i4/search-and-filter": true,
 		"themes/subscription-purchases": false,
 		"themes/theme-switch-persist-template": false,
 		"themes/third-party-premium": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -139,7 +139,7 @@
 		"themes/atomic-homepage-replace": true,
 		"themes/plugin-bundling": true,
 		"themes/premium": true,
-		"themes/showcase-i4/search-and-filter": false,
+		"themes/showcase-i4/search-and-filter": true,
 		"themes/subscription-purchases": false,
 		"themes/theme-switch-persist-template": false,
 		"themes/third-party-premium": false,

--- a/packages/calypso-e2e/src/lib/pages/themes-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/themes-page.ts
@@ -15,7 +15,7 @@ const selectors = {
 	// Search
 	showAllThemesButton: 'text=Show all themes',
 	searchToolbar: '.themes-magic-search',
-	searchInput: `[placeholder="Search by style or feature: portfolio, store, multiple menus, or…"]`,
+	searchInput: '.themes__content input.search__input',
 
 	// Theme card
 	popoverButton: '.theme__more-button',


### PR DESCRIPTION
#### Proposed Changes

This PR enables the flag `themes/showcase-i4/search-and-filter` for all environments.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Ensure that all environment configs that contains the flag `themes/showcase-i4/search-and-filter` is set to true.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

