### PR TITLE
Unified design picker: Add prop category category to events

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -200,6 +200,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 		return {
 			flow,
 			intent,
+			category: categorization.selection,
 			slug: design.slug + variationSlugSuffix,
 			theme: design.recipe?.stylesheet,
 			theme_style: design.recipe?.stylesheet + variationSlugSuffix,


### PR DESCRIPTION
#### Proposed Changes

This PR adds the property `category` to events in the unified design picker, in order to identify which category filter was selected when the event is triggered. The original purpose of adding this prop was to identify whether a generated design was selected from the "Show All" tab or the vertical tab, but I thought the prop would be a good addition for other events as well.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the unified design picker `setup/site-setup/designSetup?siteSlug=${site_slug}`
* Ensure that events such as previewing a design (`calypso_signup_design_preview_select`), and selecting a design (`calypso_signup_select_design`) now have the prop `category`, matching the selected category filter.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
