### PR TITLE
Stats: remove network requests for Odyssey

### DIFF
--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -190,7 +190,7 @@ class StatsSite extends Component {
 	}
 
 	renderStats() {
-		const { date, siteId, slug, isJetpack, isSitePrivate } = this.props;
+		const { date, siteId, slug, isJetpack, isSitePrivate, isOdysseyStats } = this.props;
 
 		const queryDate = date.format( 'YYYY-MM-DD' );
 		const { period, endOf } = this.props.period;
@@ -218,7 +218,7 @@ class StatsSite extends Component {
 
 		return (
 			<div className="stats">
-				{ ! config.isEnabled( 'is_running_in_jetpack_site' ) && (
+				{ ! isOdysseyStats && (
 					<div className="stats-banner-wrapper">
 						<JetpackBackupCredsBanner event="stats-backup-credentials" />
 					</div>
@@ -237,7 +237,7 @@ class StatsSite extends Component {
 									<InlineSupportLink
 										supportContext="stats"
 										showIcon={ false }
-										showSupportModal={ config.isEnabled( 'is_running_in_jetpack_site' ) }
+										showSupportModal={ ! isOdysseyStats }
 									/>
 								),
 							},
@@ -411,7 +411,7 @@ class StatsSite extends Component {
 					</div>
 				</div>
 				{ /** Promo Card is temprarily disabled to remove the query sent to `plugins`. */ }
-				{ ! config.isEnabled( 'is_running_in_jetpack_site' ) && (
+				{ ! isOdysseyStats && (
 					<div className="stats-content-promo">
 						<PromoCardBlock
 							productSlug="wordpress-seo-premium"
@@ -452,7 +452,7 @@ class StatsSite extends Component {
 	}
 
 	render() {
-		const { isJetpack, siteId, showEnableStatsModule } = this.props;
+		const { isJetpack, siteId, showEnableStatsModule, isOdysseyStats } = this.props;
 		const { period } = this.props.period;
 
 		// Track the last viewed tab.
@@ -464,13 +464,9 @@ class StatsSite extends Component {
 
 		return (
 			<Main className={ mainWrapperClass } fullWidthLayout>
-				{ ! config.isEnabled( 'is_running_in_jetpack_site' ) && <QueryKeyringConnections /> }
-				{ ! config.isEnabled( 'is_running_in_jetpack_site' ) && isJetpack && (
-					<QueryJetpackModules siteId={ siteId } />
-				) }
-				{ ! config.isEnabled( 'is_running_in_jetpack_site' ) && (
-					<QuerySiteKeyrings siteId={ siteId } />
-				) }
+				{ ! isOdysseyStats && <QueryKeyringConnections /> }
+				{ ! isOdysseyStats && isJetpack && <QueryJetpackModules siteId={ siteId } /> }
+				{ ! isOdysseyStats && <QuerySiteKeyrings siteId={ siteId } /> }
 				<DocumentHead title={ translate( 'Jetpack Stats' ) } />
 				<PageViewTracker
 					path={ `/stats/${ period }/:site` }
@@ -497,6 +493,7 @@ export default connect(
 		const isJetpack = isJetpackSite( state, siteId );
 		const showEnableStatsModule =
 			siteId && isJetpack && isJetpackModuleActive( state, siteId, 'stats' ) === false;
+		const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
 		return {
 			isJetpack,
 			isSitePrivate: isPrivateSite( state, siteId ),
@@ -504,6 +501,7 @@ export default connect(
 			slug: getSelectedSiteSlug( state ),
 			showEnableStatsModule,
 			path: getCurrentRouteParameterized( state, siteId ),
+			isOdysseyStats,
 		};
 	},
 	{ recordGoogleEvent, enableJetpackStatsModule, recordTracksEvent }

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -19,8 +19,6 @@ import Intervals from 'calypso/blocks/stats-navigation/intervals';
 import Banner from 'calypso/components/banner';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryJetpackModules from 'calypso/components/data/query-jetpack-modules';
-import QueryKeyringConnections from 'calypso/components/data/query-keyring-connections';
-import QuerySiteKeyrings from 'calypso/components/data/query-site-keyrings';
 import EmptyContent from 'calypso/components/empty-content';
 import FormattedHeader from 'calypso/components/formatted-header';
 import InlineSupportLink from 'calypso/components/inline-support-link';
@@ -464,9 +462,7 @@ class StatsSite extends Component {
 
 		return (
 			<Main className={ mainWrapperClass } fullWidthLayout>
-				{ ! isOdysseyStats && <QueryKeyringConnections /> }
 				{ ! isOdysseyStats && isJetpack && <QueryJetpackModules siteId={ siteId } /> }
-				{ ! isOdysseyStats && <QuerySiteKeyrings siteId={ siteId } /> }
 				<DocumentHead title={ translate( 'Jetpack Stats' ) } />
 				<PageViewTracker
 					path={ `/stats/${ period }/:site` }

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -408,7 +408,7 @@ class StatsSite extends Component {
 						}
 					</div>
 				</div>
-				{ /** Promo Card is temprarily disabled to remove the query sent to `plugins`. */ }
+				{ /** Promo Card is disabled for Odyssey because it doesn't make much sense in the context, which also removes an API call to `plugins`. */ }
 				{ ! isOdysseyStats && (
 					<div className="stats-content-promo">
 						<PromoCardBlock
@@ -462,6 +462,7 @@ class StatsSite extends Component {
 
 		return (
 			<Main className={ mainWrapperClass } fullWidthLayout>
+				{ /* Odyssey: if Stats module is not enabled, the page will not be rendered. */ }
 				{ ! isOdysseyStats && isJetpack && <QueryJetpackModules siteId={ siteId } /> }
 				<DocumentHead title={ translate( 'Jetpack Stats' ) } />
 				<PageViewTracker
@@ -487,9 +488,13 @@ export default connect(
 	( state ) => {
 		const siteId = getSelectedSiteId( state );
 		const isJetpack = isJetpackSite( state, siteId );
-		const showEnableStatsModule =
-			siteId && isJetpack && isJetpackModuleActive( state, siteId, 'stats' ) === false;
 		const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
+		// Odyssey: if Stats is not enabled, the page will not be rendered.
+		const showEnableStatsModule =
+			! isOdysseyStats &&
+			siteId &&
+			isJetpack &&
+			isJetpackModuleActive( state, siteId, 'stats' ) === false;
 		return {
 			isJetpack,
 			isSitePrivate: isPrivateSite( state, siteId ),

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -218,9 +218,11 @@ class StatsSite extends Component {
 
 		return (
 			<div className="stats">
-				<div className="stats-banner-wrapper">
-					<JetpackBackupCredsBanner event="stats-backup-credentials" />
-				</div>
+				{ ! config.isEnabled( 'is_running_in_jetpack_site' ) && (
+					<div className="stats-banner-wrapper">
+						<JetpackBackupCredsBanner event="stats-backup-credentials" />
+					</div>
+				) }
 
 				<FormattedHeader
 					brandFont
@@ -460,9 +462,13 @@ class StatsSite extends Component {
 
 		return (
 			<Main className={ mainWrapperClass } fullWidthLayout>
-				<QueryKeyringConnections />
-				{ isJetpack && <QueryJetpackModules siteId={ siteId } /> }
-				<QuerySiteKeyrings siteId={ siteId } />
+				{ ! config.isEnabled( 'is_running_in_jetpack_site' ) && <QueryKeyringConnections /> }
+				{ ! config.isEnabled( 'is_running_in_jetpack_site' ) && isJetpack && (
+					<QueryJetpackModules siteId={ siteId } />
+				) }
+				{ ! config.isEnabled( 'is_running_in_jetpack_site' ) && (
+					<QuerySiteKeyrings siteId={ siteId } />
+				) }
 				<DocumentHead title={ translate( 'Jetpack Stats' ) } />
 				<PageViewTracker
 					path={ `/stats/${ period }/:site` }

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -410,21 +410,23 @@ class StatsSite extends Component {
 						}
 					</div>
 				</div>
-
-				<div className="stats-content-promo">
-					<PromoCardBlock
-						productSlug="wordpress-seo-premium"
-						impressionEvent="calypso_stats_wordpress_seo_premium_banner_view"
-						clickEvent="calypso_stats_wordpress_seo_premium_banner_click"
-						headerText={ translate( 'Increase site visitors with Yoast SEO Premium' ) }
-						contentText={ translate(
-							'Purchase Yoast SEO Premium to ensure that more people find your incredible content.'
-						) }
-						ctaText={ translate( 'Learn more' ) }
-						image={ wordpressSeoIllustration }
-						href={ `/plugins/wordpress-seo-premium/${ slug }` }
-					/>
-				</div>
+				{ /** Promo Card is temprarily disabled to remove the query sent to `plugins`. */ }
+				{ ! config.isEnabled( 'is_running_in_jetpack_site' ) && (
+					<div className="stats-content-promo">
+						<PromoCardBlock
+							productSlug="wordpress-seo-premium"
+							impressionEvent="calypso_stats_wordpress_seo_premium_banner_view"
+							clickEvent="calypso_stats_wordpress_seo_premium_banner_click"
+							headerText={ translate( 'Increase site visitors with Yoast SEO Premium' ) }
+							contentText={ translate(
+								'Purchase Yoast SEO Premium to ensure that more people find your incredible content.'
+							) }
+							ctaText={ translate( 'Learn more' ) }
+							image={ wordpressSeoIllustration }
+							href={ `/plugins/wordpress-seo-premium/${ slug }` }
+						/>
+					</div>
+				) }
 				<JetpackColophon />
 			</div>
 		);

--- a/client/my-sites/stats/stats-insights/index.jsx
+++ b/client/my-sites/stats/stats-insights/index.jsx
@@ -26,7 +26,7 @@ import statsStrings from '../stats-strings';
 import StatsViews from '../stats-views';
 
 const StatsInsights = ( props ) => {
-	const { siteId, siteSlug, translate } = props;
+	const { siteId, siteSlug, translate, isOdysseyStats } = props;
 	const moduleStrings = statsStrings();
 
 	const isNewMainChart = config.isEnabled( 'stats/new-main-chart' );
@@ -74,10 +74,8 @@ const StatsInsights = ( props ) => {
 								moduleStrings={ moduleStrings.tags }
 								statType="statsTags"
 							/>
-							{ /** The feature relies on Jetpack Sharing module and is disabled for Odyssey for now. */ }
-							{ ! config.isEnabled( 'is_running_in_jetpack_site' ) && (
-								<StatShares siteId={ siteId } />
-							) }
+							{ /** The feature depends on Jetpack Sharing module and is disabled for Odyssey for now. */ }
+							{ ! isOdysseyStats && <StatShares siteId={ siteId } /> }
 						</div>
 						<div className="stats__module-column">
 							<Reach />
@@ -106,9 +104,11 @@ StatsInsights.propTypes = {
 
 const connectComponent = connect( ( state ) => {
 	const siteId = getSelectedSiteId( state );
+	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
 	return {
 		siteId,
 		siteSlug: getSelectedSiteSlug( state, siteId ),
+		isOdysseyStats,
 	};
 } );
 

--- a/client/my-sites/stats/stats-insights/index.jsx
+++ b/client/my-sites/stats/stats-insights/index.jsx
@@ -74,8 +74,10 @@ const StatsInsights = ( props ) => {
 								moduleStrings={ moduleStrings.tags }
 								statType="statsTags"
 							/>
-
-							<StatShares siteId={ siteId } />
+							{ /** The feature relies on Jetpack Sharing module and is disabled for Odyssey for now. */ }
+							{ ! config.isEnabled( 'is_running_in_jetpack_site' ) && (
+								<StatShares siteId={ siteId } />
+							) }
 						</div>
 						<div className="stats__module-column">
 							<Reach />

--- a/client/my-sites/stats/stats-insights/index.jsx
+++ b/client/my-sites/stats/stats-insights/index.jsx
@@ -74,7 +74,7 @@ const StatsInsights = ( props ) => {
 								moduleStrings={ moduleStrings.tags }
 								statType="statsTags"
 							/>
-							{ /** The feature depends on Jetpack Sharing module and is disabled for Odyssey for now. */ }
+							{ /** TODO: The feature depends on Jetpack Sharing module and is disabled for Odyssey for now. */ }
 							{ ! isOdysseyStats && <StatShares siteId={ siteId } /> }
 						</div>
 						<div className="stats__module-column">


### PR DESCRIPTION
#### Proposed Changes
Changes the following components for Odyssey Stats:
- Hides Yoast Promo Cards <- it queries `plugins` endpoints, and also it doesn't make much sense to promote Yoast SEO in Odyssey Stats
- Hides `JetpackBackupCredsBanner` - It queries `rewind` endpoint, and doesn't make sense in Odyssey Stats
- Removes query these settings: `QueryKeyringConnections`, `QuerySiteKeyrings` <- These two are used by Google My Business, but it already moved out to another module, so they become obsolete.
- `QueryJetpackModules` <- Disabled this for Odyssey, as the page is hiden, if Stats module is disabled.

#### Testing Instructions
* Open a site with Jetpack plugin
* Open `/wp-admin/admin.php?page=jetpack#/traffic?term=jetpack%20stats`
* Expand the Jetpack Stats section
* Open browser console and run `document.querySelector('#jp-settings-site-stats').querySelectorAll('.jp-form-fieldset')[1].setAttribute('style','color:red')`
* Turn on the new Stats experience (color red toggle)
* Open `/wp-admin/admin.php?page=stats`
* Ensure the page looks reasonable
* Inspect network requests
* Ensure only one 404 error for route `sites/$siteId/posts`

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
