### PR TITLE
Virtual page: Update tooltip

### DIFF
--- a/client/my-sites/pages/page-list.jsx
+++ b/client/my-sites/pages/page-list.jsx
@@ -293,7 +293,6 @@ class Pages extends Component {
 				type={ blockEditorSettings?.home_template?.postType }
 				/** We'd prefer to call it Homepage no matter which template is in use */
 				title={ translate( 'Homepage' ) }
-				description={ translate( 'The front page of your site' ) }
 				previewUrl={ site.URL }
 				isHomepage
 			/>

--- a/client/my-sites/pages/virtual-page/index.tsx
+++ b/client/my-sites/pages/virtual-page/index.tsx
@@ -142,9 +142,12 @@ const VirtualPage = ( {
 					{ isHomepage && template && (
 						<InfoPopover position="right">
 							{ translate(
-								'The homepage of your site displays the %(title)s template. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+								'%(subject)s can change the content of this page by editing the %(templateTitle)s template using the Site Editor. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
 								{
-									args: { title: decodeEntities( template.title.rendered || template.slug ) },
+									args: {
+										subject: isAdmin ? 'You' : 'Administrators',
+										templateTitle: decodeEntities( template.title.rendered || template.slug ),
+									},
 									components: {
 										learnMoreLink: (
 											<ExternalLink

--- a/client/my-sites/pages/virtual-page/index.tsx
+++ b/client/my-sites/pages/virtual-page/index.tsx
@@ -147,7 +147,7 @@ const VirtualPage = ( {
 					<span>{ title }</span>
 					{ isHomepage && (
 						<InfoPopover position="right">
-							{ ! isAdmin && template
+							{ isAdmin && template
 								? translate(
 										'You can change the content of this page by editing the %(templateTitle)s template using the Site Editor. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
 										{

--- a/client/my-sites/pages/virtual-page/index.tsx
+++ b/client/my-sites/pages/virtual-page/index.tsx
@@ -27,7 +27,6 @@ interface Props {
 	id: string;
 	type: string;
 	title: string;
-	description?: string;
 	previewUrl?: string;
 	isHomepage?: boolean;
 
@@ -44,7 +43,6 @@ const VirtualPage = ( {
 	id,
 	type,
 	title,
-	description,
 	previewUrl,
 	isHomepage,
 	isAdmin,
@@ -164,9 +162,15 @@ const VirtualPage = ( {
 						</InfoPopover>
 					) }
 				</a>
-				<div className="page-card-info">
-					{ description && <span className="page-card-info__description">{ description }</span> }
-				</div>
+				{ isHomepage && template && (
+					<div className="page-card-info">
+						<span className="page-card-info__description">
+							{ translate( 'Your homepage uses the %(templateTitle)s template', {
+								args: { templateTitle: decodeEntities( template.title.rendered || template.slug ) },
+							} ) }
+						</span>
+					</div>
+				) }
 			</div>
 			<EllipsisMenu position="bottom left" onToggle={ toggleEllipsisMenu }>
 				{ isAdmin && (

--- a/client/my-sites/pages/virtual-page/index.tsx
+++ b/client/my-sites/pages/virtual-page/index.tsx
@@ -122,15 +122,13 @@ const VirtualPage = ( {
 		return <Placeholder.Page key={ id } multisite={ ! site } />;
 	}
 
-	const popoverTranslationComps = {
-		learnMoreLink: (
-			<ExternalLink
-				href={ localizeUrl( 'https://wordpress.com/support/templates/#template-hierarchy' ) }
-				target="_blank"
-				rel="noopener noreferrer"
-			/>
-		),
-	};
+	const popoverLearnMoreLink = (
+		<ExternalLink
+			href={ localizeUrl( 'https://wordpress.com/support/templates/#template-hierarchy' ) }
+			target="_blank"
+			rel="noopener noreferrer"
+		/>
+	);
 
 	return (
 		<CompactCard key={ id } className="page is-virtual">
@@ -149,11 +147,13 @@ const VirtualPage = ( {
 					<span>{ title }</span>
 					{ isHomepage && (
 						<InfoPopover position="right">
-							{ isAdmin && template
+							{ ! isAdmin && template
 								? translate(
 										'You can change the content of this page by editing the %(templateTitle)s template using the Site Editor. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
 										{
-											components: popoverTranslationComps,
+											components: {
+												learnMoreLink: popoverLearnMoreLink,
+											},
 											args: {
 												templateTitle: decodeEntities( template.title.rendered || template.slug ),
 											},
@@ -162,7 +162,9 @@ const VirtualPage = ( {
 								: translate(
 										'Administrators can change the content of this page using the Site Editor. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
 										{
-											components: popoverTranslationComps,
+											components: {
+												learnMoreLink: popoverLearnMoreLink,
+											},
 										}
 								  ) }
 						</InfoPopover>

--- a/client/my-sites/pages/virtual-page/index.tsx
+++ b/client/my-sites/pages/virtual-page/index.tsx
@@ -122,6 +122,16 @@ const VirtualPage = ( {
 		return <Placeholder.Page key={ id } multisite={ ! site } />;
 	}
 
+	const popoverTranslationComps = {
+		learnMoreLink: (
+			<ExternalLink
+				href={ localizeUrl( 'https://wordpress.com/support/templates/#template-hierarchy' ) }
+				target="_blank"
+				rel="noopener noreferrer"
+			/>
+		),
+	};
+
 	return (
 		<CompactCard key={ id } className="page is-virtual">
 			{ isHomepage && <Gridicon icon="house" size={ 16 } className="page__icon" /> }
@@ -143,17 +153,7 @@ const VirtualPage = ( {
 								? translate(
 										'You can change the content of this page by editing the %(templateTitle)s template using the Site Editor. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
 										{
-											components: {
-												learnMoreLink: (
-													<ExternalLink
-														href={ localizeUrl(
-															'https://wordpress.com/support/templates/#template-hierarchy'
-														) }
-														target="_blank"
-														rel="noopener noreferrer"
-													/>
-												),
-											},
+											components: popoverTranslationComps,
 											args: {
 												templateTitle: decodeEntities( template.title.rendered || template.slug ),
 											},
@@ -162,17 +162,7 @@ const VirtualPage = ( {
 								: translate(
 										'Administrators can change the content of this page using the Site Editor. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
 										{
-											components: {
-												learnMoreLink: (
-													<ExternalLink
-														href={ localizeUrl(
-															'https://wordpress.com/support/templates/#template-hierarchy'
-														) }
-														target="_blank"
-														rel="noopener noreferrer"
-													/>
-												),
-											},
+											components: popoverTranslationComps,
 										}
 								  ) }
 						</InfoPopover>

--- a/client/my-sites/pages/virtual-page/index.tsx
+++ b/client/my-sites/pages/virtual-page/index.tsx
@@ -122,7 +122,7 @@ const VirtualPage = ( {
 		return <Placeholder.Page key={ id } multisite={ ! site } />;
 	}
 
-	const popoverLearnMoreLink = (
+	const homepageLearnMoreLink = (
 		<ExternalLink
 			href={ localizeUrl( 'https://wordpress.com/support/templates/#template-hierarchy' ) }
 			target="_blank"
@@ -152,7 +152,7 @@ const VirtualPage = ( {
 										'You can change the content of this page by editing the %(templateTitle)s template using the Site Editor. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
 										{
 											components: {
-												learnMoreLink: popoverLearnMoreLink,
+												learnMoreLink: homepageLearnMoreLink,
 											},
 											args: {
 												templateTitle: decodeEntities( template.title.rendered || template.slug ),
@@ -163,7 +163,7 @@ const VirtualPage = ( {
 										'Administrators can change the content of this page using the Site Editor. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
 										{
 											components: {
-												learnMoreLink: popoverLearnMoreLink,
+												learnMoreLink: homepageLearnMoreLink,
 											},
 										}
 								  ) }

--- a/client/my-sites/pages/virtual-page/index.tsx
+++ b/client/my-sites/pages/virtual-page/index.tsx
@@ -137,28 +137,44 @@ const VirtualPage = ( {
 					onClick={ clickPageTitle }
 				>
 					<span>{ title }</span>
-					{ isHomepage && template && (
+					{ isHomepage && (
 						<InfoPopover position="right">
-							{ translate(
-								'%(subject)s can change the content of this page by editing the %(templateTitle)s template using the Site Editor. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
-								{
-									args: {
-										subject: isAdmin ? 'You' : 'Administrators',
-										templateTitle: decodeEntities( template.title.rendered || template.slug ),
-									},
-									components: {
-										learnMoreLink: (
-											<ExternalLink
-												href={ localizeUrl(
-													'https://wordpress.com/support/templates/#template-hierarchy'
-												) }
-												target="_blank"
-												rel="noopener noreferrer"
-											/>
-										),
-									},
-								}
-							) }
+							{ isAdmin && template
+								? translate(
+										'You can change the content of this page by editing the %(templateTitle)s template using the Site Editor. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+										{
+											components: {
+												learnMoreLink: (
+													<ExternalLink
+														href={ localizeUrl(
+															'https://wordpress.com/support/templates/#template-hierarchy'
+														) }
+														target="_blank"
+														rel="noopener noreferrer"
+													/>
+												),
+											},
+											args: {
+												templateTitle: decodeEntities( template.title.rendered || template.slug ),
+											},
+										}
+								  )
+								: translate(
+										'Administrators can change the content of this page using the Site Editor. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+										{
+											components: {
+												learnMoreLink: (
+													<ExternalLink
+														href={ localizeUrl(
+															'https://wordpress.com/support/templates/#template-hierarchy'
+														) }
+														target="_blank"
+														rel="noopener noreferrer"
+													/>
+												),
+											},
+										}
+								  ) }
 						</InfoPopover>
 					) }
 				</a>


### PR DESCRIPTION
#### Proposed Changes
* Update tooltip message for virtual homepage

| Administrators | Non-administrators|
|-|-|
|  <img width="400" alt="image" src="https://user-images.githubusercontent.com/1525580/205430629-9a9a9cb2-2b3d-47ce-b16d-e261422967c7.png"> | <img width="400" alt="image" src="https://user-images.githubusercontent.com/10071857/205875100-b978812e-63ab-4744-a05b-a813e1ef9eba.png"> |

* Update description for virtual homepage
<img width="479" alt="BD0pp2" src="https://user-images.githubusercontent.com/10071857/205876570-27fa5e80-7a62-448c-b8a2-a8a474de912f.png">

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit Calypso page editor pages/${ siteSlug }with a non-admin account ( editor for example )
* Confirm the tooltip message above for editor & admin users

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #70727