### PR TITLE
Retire dotcomfsepatterns

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
@@ -46,11 +46,6 @@ class Block_Patterns_From_API {
 	public function __construct( Block_Patterns_Utils $utils = null ) {
 		$this->patterns_sources = array( 'block_patterns' );
 
-		// Switch the patterns source based on whether we're using a block-based theme.
-		if ( apply_filters( 'a8c_enable_fse_block_patterns_api', false ) ) {
-			$this->patterns_sources[] = 'fse_block_patterns';
-		}
-
 		$this->utils = empty( $utils ) ? new \A8C\FSE\Block_Patterns_Utils() : $utils;
 
 		// Add categories to this array using the core pattern name as the key for core patterns we wish to "recategorize".

--- a/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/test/class-block-patterns-from-api-test.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/test/class-block-patterns-from-api-test.php
@@ -102,24 +102,19 @@ class Block_Patterns_From_Api_Test extends TestCase {
 	}
 
 	/**
-	 *  Tests that we're making two requests and `a8c_enable_fse_block_patterns_api` is `true`
+	 *  Tests that we're making a request
 	 */
 	public function test_patterns_site_editor_source_site() {
-		add_filter( 'a8c_enable_fse_block_patterns_api', '__return_true' );
-
 		$utils_mock              = $this->createBlockPatternsUtilsMock( array( $this->pattern_mock_object ) );
 		$block_patterns_from_api = new Block_Patterns_From_API( $utils_mock );
 
-		$utils_mock->expects( $this->exactly( 2 ) )
+		$utils_mock->expects( $this->exactly( 1 ) )
 			->method( 'remote_get' )
 			->withConsecutive(
-				array( 'https://public-api.wordpress.com/rest/v1/ptk/patterns/fr?tags=pattern&pattern_meta=is_web&patterns_source=block_patterns' ),
-				array( 'https://public-api.wordpress.com/rest/v1/ptk/patterns/fr?tags=pattern&pattern_meta=is_web&patterns_source=fse_block_patterns' )
+				array( 'https://public-api.wordpress.com/rest/v1/ptk/patterns/fr?tags=pattern&pattern_meta=is_web&patterns_source=block_patterns' )
 			);
 
 		$this->assertEquals( array( 'a8c/' . $this->pattern_mock_object['name'] => true ), $block_patterns_from_api->register_patterns() );
-
-		remove_filter( 'a8c_enable_fse_block_patterns_api', '__return_true' );
 	}
 
 	/**


### PR DESCRIPTION
#### Proposed Changes

* Remove the filter that uses `a8c_enable_fse_block_patterns_api` to enable `dotcomfsepatterns`
* Update the test

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply the changes to your sandbox
* Add `define('WP_DISABLE_PATTERN_CACHE',  true);` in your `0-sandbox.php` to skip the cache
* From the [API Console](https://developer.wordpress.com/docs/api/console/) run `/sites/[YOUR SITE ID]/block-patterns/patterns` in `wp/v2`
* Confirm that the API return 244 patterns
<img width="954" alt="Screen Shot 2565-12-05 at 13 49 26" src="https://user-images.githubusercontent.com/1881481/205567734-e463998a-d2b2-4e17-891d-d9bfeacdcd55.png">


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/70746
