### PR TITLE
Design Picker: Show blank canvas CTA for every category

### DIFF
--- a/packages/design-picker/src/components/pattern-assembler-cta/style.scss
+++ b/packages/design-picker/src/components/pattern-assembler-cta/style.scss
@@ -11,6 +11,8 @@
 	line-height: 24px;
 	background-color: #f6f7f7;
 	color: #50575e;
+	// Put it at the end of the list, especially for the generated design category
+	order: 1;
 
 	@include break-small {
 		padding: 32px;

--- a/packages/design-picker/src/utils/index.ts
+++ b/packages/design-picker/src/utils/index.ts
@@ -3,6 +3,7 @@ export * from './available-designs';
 export * from './designs';
 export * from './fonts';
 import { SHOW_ALL_SLUG } from '../constants';
+import { isBlankCanvasDesign } from './available-designs';
 import type { Category, Design } from '../types';
 
 export function gatherCategories( designs: Design[] ): Category[] {
@@ -30,8 +31,10 @@ export function filterDesignsByCategory(
 	}
 
 	return designs.filter(
-		( { categories, showFirst } ) =>
-			showFirst || categories.find( ( { slug } ) => slug === categorySlug )
+		( design ) =>
+			design.showFirst ||
+			isBlankCanvasDesign( design ) ||
+			design.categories.find( ( { slug } ) => slug === categorySlug )
 	);
 }
 


### PR DESCRIPTION
#### Proposed Changes

* Referring to pekYwv-4x-p2, we want to blank canvas CTA at the bottom of every category. So, this PR makes a change to keep the blank canvas design regardless of the selected category

https://user-images.githubusercontent.com/13596067/205604899-461eb16b-f98c-4da5-abf8-e2c858a868a3.mov

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup?siteSlug=<your_site>`
* Click "Continue" until you land on the Design Picker
* Go through every category, and you have to see the blank canvas CTA

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to pekYwv-4x-p2