### PR TITLE
Stats: Fix bug in title logic for MobilePromoCard.

### DIFF
--- a/packages/components/src/mobile-promo-card/index.tsx
+++ b/packages/components/src/mobile-promo-card/index.tsx
@@ -22,15 +22,15 @@ export default function MobilePromoCard( { className, isWoo }: MobilePromoCardPr
 
 	// Determines message text based on mobile, tablet, or Desktop.
 	const getMessage = () => {
-		if ( isApple ) {
-			return translate(
-				'Check your stats on-the-go and get real-time notifications with the Jetpack mobile app.'
-			);
-		}
-		if ( isGoogle ) {
-			return translate(
-				'Check your stats on-the-go and get real-time notifications with the Woo mobile app.'
-			);
+		// The mobile use case. If Apple or Google mobile device, Jetpack or Woo.
+		if ( isApple || isGoogle ) {
+			return isWoo
+				? translate(
+						'Check your stats on-the-go and get real-time notifications with the Woo mobile app.'
+				  )
+				: translate(
+						'Check your stats on-the-go and get real-time notifications with the Jetpack mobile app.'
+				  );
 		}
 		// Using useTranslate() with interpolation to set up the linked message.
 		// https://wpcalypso.wordpress.com/devdocs/packages/i18n-calypso/README.md


### PR DESCRIPTION
#### Proposed Changes

Fixes a bug in the title logic on mobile devices.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this branch.
* Run `yarn workspace @automattic/components run storybook`.
* Visit the Mobile Promo Card entry.
* Use the Chrome dev tools and change to the "iPhone 12 Pro" setting. Refresh the view and confirm the title shows correctly for both Jetpack and Woo cards.
* Change to the "Pixel 5" setting and check the title for both Jetpack and Woo cards.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
