### PR TITLE
Docs: Add `loadScript` error prevention ideas

### DIFF
--- a/packages/load-script/README.md
+++ b/packages/load-script/README.md
@@ -2,6 +2,8 @@
 
 This utility function allows us to use a standardized method of loading remote scripts and injecting them into the `<head>` of our document to bring external functionality into the app.
 
+WARNING: external scripts might break the entire application in unpredictable ways. Please, make sure to read the **Error handling** section below and take the appropriate actions while developing and after deploying code that loads an external script.
+
 ## Usage
 
 ```js
@@ -54,3 +56,13 @@ await loadScript( REMOTE_SCRIPT_URL, undefined, { id: 'my-script-tag-id' } );
 ## Error handling
 
 If using the callback, it should expect a single argument, which will be `null` on success or an object on failure. This error object contains the `src` property, which will contain the src url of the script that failed to load. If using the Promise form, the error object will be passed to the nearest `catch` handler as a rejection.
+
+Important: we've historically had cases when external scripts broke the entire application. To prevent this from happening, there are a few things we could do:
+
+### Implementing an error boundary
+
+Wrapping the external script loading into an error boundary could help catch some of the errors. See [#62483](https://github.com/Automattic/wp-calypso/pull/62483) for prior art and ideally, use that technique when implementing the loading of the external script.
+
+### Keep an eye on the logs
+
+Since many error types wouldn't be caught by the error boundary, we should keep an eye on the logs for at least a few days after deploying a change related to loading an external script, especially when it's about a new script that we previously didn't load. See p58i-ch2-p2 for more details.


### PR DESCRIPTION
#### Proposed Changes

Inspired by a recent comment from @nb, this PR adds some additional docs to `loadScript` to suggest using an error boundary and keeping an extra eye on the logs when deploying a change to code that loads an existing external script, or a new one.

#### Testing Instructions

Not needed, this is a documentation change.

Related to https://github.com/Automattic/wp-calypso/pull/70213#discussion_r1033093875.
