### PR TITLE
Site Selector: Remove `siteSlug` from 'Add new site' button link to prevent unexpected behavior

### DIFF
--- a/client/components/site-selector/add-site.tsx
+++ b/client/components/site-selector/add-site.tsx
@@ -28,7 +28,7 @@ const SiteSelectorAddSite: FunctionComponent = () => {
 				{
 					ref: 'calypso-selector',
 					source: 'my-home',
-					sourceSiteSlug: siteSlug,
+					siteSlug,
 				},
 				onboardingUrl()
 			) }

--- a/client/components/site-selector/add-site.tsx
+++ b/client/components/site-selector/add-site.tsx
@@ -28,7 +28,7 @@ const SiteSelectorAddSite: FunctionComponent = () => {
 				{
 					ref: 'calypso-selector',
 					source: 'my-home',
-					siteSlug,
+					sourceSiteSlug: siteSlug,
 				},
 				onboardingUrl()
 			) }

--- a/client/components/site-selector/add-site.tsx
+++ b/client/components/site-selector/add-site.tsx
@@ -1,18 +1,16 @@
 import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { FunctionComponent, useCallback } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch } from 'react-redux';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { onboardingUrl } from 'calypso/lib/paths';
 import { addQueryArgs } from 'calypso/lib/url';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 
 const SiteSelectorAddSite: FunctionComponent = () => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
-	const siteSlug = useSelector( getSelectedSiteSlug );
 	const recordAddNewSite = useCallback( () => {
 		const event = isJetpackCloud()
 			? 'calypso_add_new_jetpack_click'
@@ -28,7 +26,6 @@ const SiteSelectorAddSite: FunctionComponent = () => {
 				{
 					ref: 'calypso-selector',
 					source: 'my-home',
-					siteSlug,
 				},
 				onboardingUrl()
 			) }

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -800,7 +800,7 @@ class DomainsStep extends Component {
 
 		const { isAllDomains, translate, isReskinned, userSiteCount } = this.props;
 		const siteUrl = this.props.selectedSite?.URL;
-		const siteSlug = this.props.queryObject?.siteSlug;
+		const sourceSiteSlug = this.props.queryObject?.sourceSiteSlug;
 		const source = this.props.queryObject?.source;
 		let backUrl;
 		let backLabelText;
@@ -824,11 +824,11 @@ class DomainsStep extends Component {
 				backUrl = siteUrl;
 				backLabelText = translate( 'Back to My Site' );
 				isExternalBackUrl = true;
-			} else if ( 'my-home' === source && siteSlug ) {
-				backUrl = `/home/${ siteSlug }`;
+			} else if ( 'my-home' === source && sourceSiteSlug ) {
+				backUrl = `/home/${ sourceSiteSlug }`;
 				backLabelText = translate( 'Back to My Home' );
-			} else if ( 'general-settings' === source && siteSlug ) {
-				backUrl = `/settings/general/${ siteSlug }`;
+			} else if ( 'general-settings' === source && sourceSiteSlug ) {
+				backUrl = `/settings/general/${ sourceSiteSlug }`;
 				backLabelText = translate( 'Back to General Settings' );
 			} else if ( 'sites-dashboard' === source ) {
 				backUrl = '/sites';

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -800,7 +800,7 @@ class DomainsStep extends Component {
 
 		const { isAllDomains, translate, isReskinned, userSiteCount } = this.props;
 		const siteUrl = this.props.selectedSite?.URL;
-		const sourceSiteSlug = this.props.queryObject?.sourceSiteSlug;
+		const siteSlug = this.props.queryObject?.siteSlug;
 		const source = this.props.queryObject?.source;
 		let backUrl;
 		let backLabelText;
@@ -824,11 +824,11 @@ class DomainsStep extends Component {
 				backUrl = siteUrl;
 				backLabelText = translate( 'Back to My Site' );
 				isExternalBackUrl = true;
-			} else if ( 'my-home' === source && sourceSiteSlug ) {
-				backUrl = `/home/${ sourceSiteSlug }`;
+			} else if ( 'my-home' === source && siteSlug ) {
+				backUrl = `/home/${ siteSlug }`;
 				backLabelText = translate( 'Back to My Home' );
-			} else if ( 'general-settings' === source && sourceSiteSlug ) {
-				backUrl = `/settings/general/${ sourceSiteSlug }`;
+			} else if ( 'general-settings' === source && siteSlug ) {
+				backUrl = `/settings/general/${ siteSlug }`;
 				backLabelText = translate( 'Back to General Settings' );
 			} else if ( 'sites-dashboard' === source ) {
 				backUrl = '/sites';


### PR DESCRIPTION
## Proposed Changes

Switches from `siteSlug` to `sourceSiteSlug` to prevent a state collision where the Plans picker wouldn't load. Introduced in https://github.com/Automattic/wp-calypso/pull/70571

See p1670240472927109-slack-C029GN3KD

<img width="419" alt="Screenshot 2022-12-05 at 14 26 54" src="https://user-images.githubusercontent.com/87168/205637600-7e788f73-29aa-45d1-8969-5edde2ce6f1d.png">


## Testing Instructions

1. Make sure I didn't miss any other variables that need to be renamed.
2. From My Home Sidebar, click 'Switch site' and then 'Add new site'.
3. Verify the back button appears as 'Back to Sites'.
4. Enter a domain and pick the free `.wordpress.com` option.
5. Verify the plan picker loads.
6. Navigate to `/sites` in a new window and click 'Add new site'.
7. Verify the back button appears as 'Back to Sites'.
8. Enter a domain and pick the free `.wordpress.com` option.
4. Verify the plan picker loads.

Note: some lovely caching wonkiness can occur without refreshing the page: https://github.com/Automattic/wp-calypso/pull/68727#issuecomment-1271241893 We can ignore that.