### PR TITLE
Share Site for Preview: Improve notice message text

### DIFF
--- a/client/components/site-preview-link/index.tsx
+++ b/client/components/site-preview-link/index.tsx
@@ -64,11 +64,11 @@ export default function SitePreviewLink( {
 	const { createLink, isLoading: isCreating } = useCreateSitePreviewLink( {
 		siteId,
 		onSuccess: () => {
-			showSuccessNotice( translate( 'Preview link created.' ) );
+			showSuccessNotice( translate( 'Preview link enabled.' ) );
 			recordTracksEvent( 'calypso_site_preview_link_created', { source } );
 		},
 		onError: () => {
-			showErrorNotice( translate( 'Unable to create preview link.' ) );
+			showErrorNotice( translate( 'Unable to enable preview link.' ) );
 			recordTracksEvent( 'calypso_site_preview_link_created_error', { source } );
 		},
 	} );
@@ -76,11 +76,11 @@ export default function SitePreviewLink( {
 	const { deleteLink, isLoading: isDeleting } = useDeleteSitePreviewLink( {
 		siteId,
 		onSuccess: () => {
-			showSuccessNotice( translate( 'Preview link removed.' ) );
+			showSuccessNotice( translate( 'Preview link disabled.' ) );
 			recordTracksEvent( 'calypso_site_preview_link_deleted', { source } );
 		},
 		onError: () => {
-			showErrorNotice( translate( 'Unable to remove preview link.' ) );
+			showErrorNotice( translate( 'Unable to disable preview link.' ) );
 			recordTracksEvent( 'calypso_site_preview_link_deleted_error', { source } );
 		},
 	} );
@@ -117,7 +117,7 @@ export default function SitePreviewLink( {
 					if ( isCreating ) {
 						linkValue = translate( 'Loading…' );
 					} else if ( isRemoving ) {
-						linkValue = translate( 'Removing…' );
+						linkValue = translate( 'Disabling…' );
 					}
 					return (
 						<ClipboardButtonInput

--- a/client/components/site-preview-link/index.tsx
+++ b/client/components/site-preview-link/index.tsx
@@ -64,11 +64,11 @@ export default function SitePreviewLink( {
 	const { createLink, isLoading: isCreating } = useCreateSitePreviewLink( {
 		siteId,
 		onSuccess: () => {
-			showSuccessNotice( translate( 'Preview link created successfully!' ) );
+			showSuccessNotice( translate( 'Preview link created.' ) );
 			recordTracksEvent( 'calypso_site_preview_link_created', { source } );
 		},
 		onError: () => {
-			showErrorNotice( translate( 'Error creating the preview link.' ) );
+			showErrorNotice( translate( 'Unable to create preview link.' ) );
 			recordTracksEvent( 'calypso_site_preview_link_created_error', { source } );
 		},
 	} );
@@ -76,11 +76,11 @@ export default function SitePreviewLink( {
 	const { deleteLink, isLoading: isDeleting } = useDeleteSitePreviewLink( {
 		siteId,
 		onSuccess: () => {
-			showSuccessNotice( translate( 'Preview link removed successfully!' ) );
+			showSuccessNotice( translate( 'Preview link removed.' ) );
 			recordTracksEvent( 'calypso_site_preview_link_deleted', { source } );
 		},
 		onError: () => {
-			showErrorNotice( translate( 'Error removing the preview link.' ) );
+			showErrorNotice( translate( 'Unable to remove preview link.' ) );
 			recordTracksEvent( 'calypso_site_preview_link_deleted_error', { source } );
 		},
 	} );


### PR DESCRIPTION
## Proposed Changes

Improves the notice message text to make it more consistent with other messages:

![CleanShot 2022-12-05 at 06 39 28@2x](https://user-images.githubusercontent.com/36432/205664192-06c136e9-22bb-4427-b6e0-d955e86aac63.png)

![CleanShot 2022-12-05 at 06 39 20@2x](https://user-images.githubusercontent.com/36432/205664199-72e557b5-6f73-40af-9568-6bce46e3e571.png)


## Testing Instructions

1. Create a new Business site.
2. Navigate to 'General Settings'.
3. Click 'Create a preview link' toggle and see success notice displayed as 'Preview link created.'
4. Click 'Create a preview link' toggle and see success notice displayed as 'Preview link removed.'