### PR TITLE
Share Site for Preview: Tweak the settings text

### DIFF
--- a/client/components/site-preview-link/index.tsx
+++ b/client/components/site-preview-link/index.tsx
@@ -105,12 +105,16 @@ export default function SitePreviewLink( {
 	return (
 		<div>
 			<ToggleControl
-				label={ translate( 'Create a preview link.' ) }
+				label={ translate( 'Enable site preview link.' ) }
 				checked={ checkedAndEnabled }
 				onChange={ onChange }
 				{ ...{ disabled: disabled || isBusy } } // disabled is not included on ToggleControl props type
 			/>
-			<HelpText>{ translate( 'Anyone with this link can view your site.' ) }</HelpText>
+			<HelpText>
+				{ translate(
+					'When enabled, anyone with the site preview link can view your Coming Soon site.'
+				) }
+			</HelpText>
 			{ ! forceOff &&
 				previewLinks?.map( ( { code, isCreating = false, isRemoving = false } ) => {
 					let linkValue = `${ siteUrl }?share=${ code }`;


### PR DESCRIPTION
## Proposed Changes

Couple of tweaks to the settings text.

### Before

<img width="771" alt="image" src="https://user-images.githubusercontent.com/36432/205656223-f8f808b8-ec8d-4e7f-8b68-fd61eb63e78c.png">

### After

<img width="777" alt="image" src="https://user-images.githubusercontent.com/36432/205656062-18738f29-ee9a-49bc-bfe3-1ac958b577bf.png">


## Testing Instructions

1. Create a new Business plan site.
2. Navigate to 'General Settings' and view the new settings text.