### PR TITLE
Share Site for Preview: Ensure share link has a trailing slash

### DIFF
--- a/client/components/site-preview-link/index.tsx
+++ b/client/components/site-preview-link/index.tsx
@@ -5,6 +5,7 @@ import { ToggleControl } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import { useDispatch } from 'react-redux';
+import { trailingslashit } from 'calypso/lib/route';
 import { successNotice, errorNotice } from 'calypso/state/notices/actions';
 import ClipboardButtonInput from '../clipboard-button-input';
 import { useCreateSitePreviewLink } from './use-create-site-preview-link';
@@ -113,7 +114,7 @@ export default function SitePreviewLink( {
 			<HelpText>{ translate( 'Anyone with this link can view your site.' ) }</HelpText>
 			{ ! forceOff &&
 				previewLinks?.map( ( { code, isCreating = false, isRemoving = false } ) => {
-					let linkValue = `${ siteUrl }?share=${ code }`;
+					let linkValue = `${ trailingslashit( siteUrl ) }?share=${ code }`;
 					if ( isCreating ) {
 						linkValue = translate( 'Loading…' );
 					} else if ( isRemoving ) {


### PR DESCRIPTION
## Proposed Changes

Ensures the share link has a trailing slash to avoid unnecessary redirect:

<img width="761" alt="image" src="https://user-images.githubusercontent.com/36432/205658953-3f0077e9-9214-43af-8939-19f7caca0e63.png">


## Testing Instructions

1. Create a new Business plan site.
2. Navigate to 'General Settings' and view the new preview link.