### PR TITLE
Sensei Onboarding - Fix the Sensei Bundle price.

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-domain/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-domain/index.tsx
@@ -70,6 +70,7 @@ const SenseiDomain: Step = ( { navigation } ) => {
 						useProvidedProductsList
 						align="left"
 						isWideLayout={ true }
+						basePath=""
 					/>
 					<div className="domains__domain-side-content-container">
 						<div className="domains__domain-side-content domains__free-domain">

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-plan/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-plan/index.tsx
@@ -2,13 +2,13 @@
 import { useLocale } from '@automattic/i18n-utils';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useCallback, useState } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
+import classnames from 'classnames';
 import { Plans } from 'calypso/../packages/data-stores/src';
 import { SENSEI_FLOW, SenseiStepContainer } from 'calypso/../packages/onboarding/src';
 import { useSupportedPlans } from 'calypso/../packages/plans-grid/src/hooks';
 import PlanItem from 'calypso/../packages/plans-grid/src/plans-table/plan-item';
-import { useWPCOMPlugin } from 'calypso/data/marketplace/use-wpcom-plugins-query';
 import { useNewSiteVisibility } from 'calypso/landing/gutenboarding/hooks/use-selected-plan';
 import { PLANS_STORE } from 'calypso/landing/gutenboarding/stores/plans';
 import {
@@ -19,7 +19,6 @@ import {
 } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { domainRegistration } from 'calypso/lib/cart-values/cart-items';
-import { getProductSlugByPeriodVariation } from 'calypso/lib/plugins/utils';
 import { cartManagerClient } from 'calypso/my-sites/checkout/cart-manager-client';
 import { SenseiStepError } from '../sensei-setup/sensei-step-error';
 import { SenseiStepProgress, Progress } from '../sensei-setup/sensei-step-progress';
@@ -39,23 +38,22 @@ const cartProgressTitle: string = __( 'Preparing Your Bundle' );
 
 const SenseiPlan: Step = ( { flow, navigation: { goToStep } } ) => {
 	const [ billingPeriod, setBillingPeriod ] = useState< Plans.PlanBillingPeriod >( 'ANNUALLY' );
+	const billingPeriodIsAnnually = billingPeriod === 'ANNUALLY';
 	const [ status, setStatus ] = useState< Status >( Status.Initial );
 	const [ progress, setProgress ] = useState< Progress >( {
 		percentage: 0,
 		title: siteProgressTitle,
 	} );
 
-	const { __ } = useI18n();
+	const { hasTranslation } = useI18n();
 	const locale = useLocale();
 	const visibility = useNewSiteVisibility();
 	const currentUser = useSelect( ( select ) => select( USER_STORE ).getCurrentUser() );
-	const { supportedPlans, maxAnnualDiscount } = useSupportedPlans( locale, billingPeriod );
+	const { supportedPlans } = useSupportedPlans( locale, billingPeriod );
 	const { createSenseiSite, setSelectedSite } = useDispatch( ONBOARD_STORE );
 	const domain = useSelect( ( select ) => select( ONBOARD_STORE ).getSelectedDomain() );
-	const productList =
-		useSelect( ( select ) => select( PRODUCTS_LIST_STORE ).getProductsList(), [] ) || {};
-	const getPlanProduct = useSelect( ( select ) => select( PLANS_STORE ).getPlanProduct );
 	const { getNewSite } = useSelect( ( select ) => select( SITE_STORE ) );
+	const { getPlanProduct } = useSelect( ( select ) => select( PLANS_STORE ) );
 
 	const { saveSiteSettings, setIntentOnSite } = useDispatch( SITE_STORE );
 
@@ -67,10 +65,58 @@ const SenseiPlan: Step = ( { flow, navigation: { goToStep } } ) => {
 		setBillingPeriod( newBillingPeriod );
 	};
 
-	const { data: woothemesSenseiData } = useWPCOMPlugin( 'woothemes-sensei' );
-	const variation =
-		woothemesSenseiData?.variations?.[ billingPeriod === 'ANNUALLY' ? 'yearly' : 'monthly' ];
-	const woothemesSenseiProductSlug = getProductSlugByPeriodVariation( variation, productList );
+	const woothemesProduct = useSelect(
+		( select ) => {
+			const yearly = select( PRODUCTS_LIST_STORE ).getProductBySlug( 'woothemes_sensei_yearly' );
+			const monthly = select( PRODUCTS_LIST_STORE ).getProductBySlug( 'woothemes_sensei_monthly' );
+
+			if ( ! yearly || ! monthly ) {
+				return {
+					monthlyPrice: 0,
+					yearlyPrice: 0,
+					price: 0,
+					productSlug: '',
+				};
+			}
+
+			return {
+				monthlyPrice: monthly.cost,
+				yearlyPrice: yearly.cost,
+				price: billingPeriodIsAnnually ? Math.ceil( yearly.cost / 12 ) : monthly.cost,
+				productSlug: billingPeriodIsAnnually ? yearly.product_slug : monthly.product_slug,
+			};
+		},
+		[ billingPeriodIsAnnually ]
+	);
+
+	const planProduct = useSelect(
+		( select ) => {
+			const monthly = select( PLANS_STORE ).getPlanProduct(
+				planObject?.periodAgnosticSlug,
+				'MONTHLY'
+			);
+			const yearly = select( PLANS_STORE ).getPlanProduct(
+				planObject?.periodAgnosticSlug,
+				'ANNUALLY'
+			);
+			if ( ! yearly || ! monthly ) {
+				return {
+					monthlyPrice: 0,
+					yearlyPrice: 0,
+					price: 0,
+					productSlug: '',
+				};
+			}
+
+			return {
+				monthlyPrice: monthly.rawPrice,
+				yearlyPrice: yearly.rawPrice,
+				price: billingPeriodIsAnnually ? Math.ceil( yearly.rawPrice / 12 ) : monthly.rawPrice,
+				productSlug: '',
+			};
+		},
+		[ billingPeriodIsAnnually, planObject ]
+	);
 
 	const goToDomainStep = useCallback( () => {
 		if ( goToStep ) {
@@ -124,7 +170,7 @@ const SenseiPlan: Step = ( { flow, navigation: { goToStep } } ) => {
 					},
 				},
 				{
-					product_slug: woothemesSenseiProductSlug,
+					product_slug: woothemesProduct.productSlug,
 					extra: {
 						signup_flow: flow,
 					},
@@ -189,6 +235,30 @@ const SenseiPlan: Step = ( { flow, navigation: { goToStep } } ) => {
 		},
 	];
 
+	const isLoading = ! planProduct.monthlyPrice || ! woothemesProduct.monthlyPrice;
+	const price = planProduct.price + woothemesProduct.price;
+	const monthlyPrice = planProduct.monthlyPrice + woothemesProduct.monthlyPrice;
+	const annualPrice = planProduct.yearlyPrice + woothemesProduct.yearlyPrice;
+	const annualSavings = monthlyPrice * 12 - annualPrice;
+	const domainSavings = domain?.raw_price || 0;
+	const annualDiscount =
+		100 - Math.floor( ( annualPrice / ( monthlyPrice * 12 + domainSavings ) ) * 100 );
+
+	// translators: %s is the cost per year (e.g "billed as 96$ annually")
+	const newPlanItemPriceLabelAnnually = __(
+		'per month, billed as %s annually',
+		__i18n_text_domain__
+	);
+
+	const fallbackPlanItemPriceLabelAnnually = __( 'billed annually', __i18n_text_domain__ );
+
+	const planItemPriceLabelAnnually =
+		locale === 'en' || hasTranslation?.( 'per month, billed as %s annually' )
+			? sprintf( newPlanItemPriceLabelAnnually, `$${ annualPrice }` )
+			: fallbackPlanItemPriceLabelAnnually;
+
+	const planItemPriceLabelMonthly = __( 'per month, billed monthly', __i18n_text_domain__ );
+
 	return (
 		<SenseiStepContainer stepName="senseiPlan" recordTracksEvent={ recordTracksEvent }>
 			{ status === Status.Initial && (
@@ -202,9 +272,43 @@ const SenseiPlan: Step = ( { flow, navigation: { goToStep } } ) => {
 					<PlansIntervalToggle
 						intervalType={ billingPeriod }
 						onChange={ handlePlanBillingPeriodChange }
-						maxMonthlyDiscountPercentage={ maxAnnualDiscount }
+						maxMonthlyDiscountPercentage={ annualDiscount }
 					/>
 
+					<div
+						className={ classnames( 'plan-item plan-item--sensei', {
+							'plan-item--is-loading': isLoading,
+						} ) }
+					>
+						<div tabIndex={ 0 } role="button" className="plan-item__summary">
+							<div className="plan-item__price">
+								<div className="plan-item__price-amount">{ ! isLoading && `$${ price }` }</div>
+							</div>
+						</div>
+						<div className="plan-item__price-note">
+							{ ! isLoading && billingPeriod === 'ANNUALLY'
+								? planItemPriceLabelAnnually
+								: planItemPriceLabelMonthly }
+						</div>
+
+						{ /*
+							For the free plan, the following div is still rendered invisible
+							and ignored by screen readers (via aria-hidden) to ensure the same
+							vertical spacing as the rest of the plan cards
+						 */ }
+						<div
+							className={ classnames( 'plan-item__price-discount', {
+								'plan-item__price-discount--disabled': billingPeriod !== 'ANNUALLY',
+							} ) }
+						>
+							{ ! isLoading &&
+								sprintf(
+									// Translators: will be like "Save 30% by paying annually".  Make sure the % symbol is kept.
+									__( `You're saving %s by paying annually`, __i18n_text_domain__ ),
+									`$${ annualSavings }`
+								) }
+						</div>
+					</div>
 					<PlanItem
 						allPlansExpanded
 						slug="business"

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-plan/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-plan/styles.scss
@@ -1,3 +1,5 @@
+@import "@automattic/onboarding/styles/mixins";
+
 $sensei-color: #43af99;
 
 .sensei .progress-bar__progress {
@@ -6,6 +8,8 @@ $sensei-color: #43af99;
 
 .step-container.senseiPlan {
 	.plan-item {
+		margin-top: 0;
+
 		&__viewport {
 			border: none;
 		}
@@ -29,7 +33,48 @@ $sensei-color: #43af99;
 				border: 1px solid darken($sensei-color, 10%);
 			}
 		}
+
+		&__summary,
+		&__price-note,
+		&__price-discount {
+			display: none;
+		}
+
+		&--sensei {
+			display: flex;
+			flex-direction: column;
+			justify-content: flex-end;
+			align-items: center;
+			margin-top: 48px;
+
+			.plan-item {
+				&__summary,
+				&__price-note,
+				&__price-discount {
+					display: block;
+					text-transform: unset;
+				}
+			}
+		}
+
+		&--is-loading {
+			.plan-item {
+				&__summary {
+					@include onboarding-placeholder();
+					width: 30%;
+				}
+				&__price-note {
+					@include onboarding-placeholder();
+					width: 80%;
+				}
+				&__price-discount {
+					@include onboarding-placeholder();
+					width: 90%;
+				}
+			}
+		}
 	}
+
 
 	.plans-feature-list {
 		&__item {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-plan/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-plan/styles.scss
@@ -14,7 +14,9 @@ $sensei-color: #43af99;
 			border: none;
 		}
 
-		&__heading {
+		&__heading,
+		&__price {
+			display: flex;
 			justify-content: center;
 		}
 		&__price-amount,
@@ -22,6 +24,11 @@ $sensei-color: #43af99;
 		&__price-discount,
 		&__actions {
 			text-align: center;
+		}
+
+		&__price-amount {
+			margin-top: 20px;
+			color: $black;
 		}
 
 		&__select-button {
@@ -59,7 +66,7 @@ $sensei-color: #43af99;
 
 		&--is-loading {
 			.plan-item {
-				&__summary {
+				&__price-amount {
 					@include onboarding-placeholder();
 					width: 30%;
 				}
@@ -98,9 +105,6 @@ $sensei-color: #43af99;
 		}
 		&__item--requires-annual-disabled {
 			.plans-feature-list {
-				&__item-description {
-					color: #888;
-				}
 				&__item-annual-nudge {
 					display: block;
 				}


### PR DESCRIPTION
#### Proposed Changes

* Fixes the Sensei Bundle pricing on the Sensei Plans screen.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Start the Sensei Flow.
* Get to the Sensei Plans screen.
* Confirm that Sensei Bundle costs $54 for Monthly plan.
* Confirm that Sensei Bundle costs $449 for Yearly plan.

#### Before

<img width="1728" alt="Screen Shot 2022-12-05 at 18 31 02" src="https://user-images.githubusercontent.com/2578542/205664411-340cdd16-7e74-4492-9805-19a9bc5f11b6.png">
<img width="1728" alt="Screen Shot 2022-12-05 at 18 31 15" src="https://user-images.githubusercontent.com/2578542/205664433-bf23b4de-6ff2-421b-808a-30bee6a9aac1.png">


#### After

<img width="1728" alt="Screen Shot 2022-12-05 at 18 27 51" src="https://user-images.githubusercontent.com/2578542/205664499-30832521-e7a0-4ba5-8725-2264fc3d7370.png">
<img width="1727" alt="Screen Shot 2022-12-05 at 18 28 01" src="https://user-images.githubusercontent.com/2578542/205664519-6137ec58-666a-4dbe-aa88-dee203737fde.png">


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/sensei-pro/issues/1952
