### PR TITLE
Limit Global Styles: Update the Premium Label in Style Selection

### DIFF
--- a/client/components/premium-badge/index.js
+++ b/client/components/premium-badge/index.js
@@ -8,7 +8,7 @@ import { hasTouch } from 'calypso/lib/touch-detect';
 
 import './style.scss';
 
-const PremiumBadge = ( { className, tooltipText } ) => {
+const PremiumBadge = ( { className, labelText = '', tooltipText } ) => {
 	const { __ } = useI18n();
 	const [ popoverAnchor, setPopoverAnchor ] = useState();
 	const [ isPopoverVisible, setIsPopoverVisible ] = useState( false );
@@ -52,7 +52,7 @@ const PremiumBadge = ( { className, tooltipText } ) => {
 			>
 				<Badge type="info">
 					<Icon icon={ starFilled } size={ 18 } />
-					<span>{ __( 'Premium' ) }</span>
+					<span>{ labelText || __( 'Premium' ) }</span>
 				</Badge>
 			</div>
 			<Popover

--- a/client/components/premium-badge/index.js
+++ b/client/components/premium-badge/index.js
@@ -60,6 +60,7 @@ const PremiumBadge = ( { className, labelText = '', tooltipText } ) => {
 				context={ popoverAnchor }
 				isVisible={ isPopoverVisible }
 				onClose={ () => setIsPopoverVisible( false ) }
+				focusOnShow={ false }
 			>
 				{ tooltipText }
 			</Popover>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -428,8 +428,9 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 		return (
 			<PremiumBadge
 				className="design-picker__premium-badge"
+				labelText={ translate( 'Upgrade' ) }
 				tooltipText={ translate(
-					'You can try this premium style out before upgrading your plan.'
+					'Unlock this style, and tons of other features, by upgrading to a Premium plan before launching your site.'
 				) }
 			/>
 		);


### PR DESCRIPTION
#### Proposed Changes

* Update the copy of the Global Styles premium label in Style Selection (see https://github.com/Automattic/dotcom-forge/issues/1225).
* Fix an issue where the popover stole the focus, getting the preview hover animation stuck on "mouseover".

| Before | After |
| - | - |
| ![image](https://user-images.githubusercontent.com/2070010/205678297-569af696-0a35-45c6-b8dd-01d8417fe01c.png) | <img alt="Screenshot 2022-12-05 at 15 38 04" src="https://user-images.githubusercontent.com/2070010/205678330-0499714c-a904-431a-870b-7e276f1a2db7.png"> |

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new free site and follow the steps until Style Selection.
* Apply the `wpcom-limit-global-styles` sticker to the newly created site and refresh the page.
* Choose a theme with style variations.
* ➡️ Check that the GS label and its tooltip show the updated copy.
* ➡️ Move the mouse around (enter, leave, on the preview, on the badge, on the tooltip) and ensure that the style preview animates correctly and as expected.
  * Note that clicking a preview (and thus selecting a style) will "stick" the preview to the style name until the focus is moved elsewhere (e.g. by clicking out). That's expected.


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #https://github.com/Automattic/dotcom-forge/issues/1229