### PR TITLE
Help Center: full release 75%

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -391,7 +391,7 @@ function load_help_center() {
 		return false;
 	}
 
-	$current_segment = 100; // segment of existing users that will get the help center in %.
+	$current_segment = 75; // segment of existing users that will get the help center in %.
 	$user_segment    = get_current_user_id() % 100;
 
 	if ( $is_proxied || $user_segment < $current_segment ) {

--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -391,7 +391,7 @@ function load_help_center() {
 		return false;
 	}
 
-	$current_segment = 50; // segment of existing users that will get the help center in %.
+	$current_segment = 100; // segment of existing users that will get the help center in %.
 	$user_segment    = get_current_user_id() % 100;
 
 	if ( $is_proxied || $user_segment < $current_segment ) {

--- a/packages/help-center/src/utils.ts
+++ b/packages/help-center/src/utils.ts
@@ -9,7 +9,7 @@ export function shouldShowHelpCenterToUser( userId: number ) {
 	const isNonProdEnv =
 		[ 'stage', 'development', 'horizon' ].includes( config( 'env_id' ) ) || isCalypsoLive();
 
-	const currentSegment = 50; //percentage of users that will see the Help Center, not the FAB
+	const currentSegment = 100; //percentage of users that will see the Help Center, not the FAB
 	const userSegment = userId % 100;
 	return isNonProdEnv || userSegment < currentSegment;
 }

--- a/packages/help-center/src/utils.ts
+++ b/packages/help-center/src/utils.ts
@@ -9,7 +9,7 @@ export function shouldShowHelpCenterToUser( userId: number ) {
 	const isNonProdEnv =
 		[ 'stage', 'development', 'horizon' ].includes( config( 'env_id' ) ) || isCalypsoLive();
 
-	const currentSegment = 100; //percentage of users that will see the Help Center, not the FAB
+	const currentSegment = 75; //percentage of users that will see the Help Center, not the FAB
 	const userSegment = userId % 100;
 	return isNonProdEnv || userSegment < currentSegment;
 }


### PR DESCRIPTION
## Proposed Changes

This is the big release. We are updating Help Center to go from 50 ⇢ 75%. (we decided to bump to 75 first then 100 next week) read here ⇢ p1670242984432289-slack-C02T4NVL4JJ

We are opting to leave the `shouldShowHelpCenterToUser` hook for now and just increment the user segment. From here we can choose to clean up all the areas we are using it one at a time. Smaller PR's are better 😄 

## Testing Instructions

Test Calypso using un-proxied user to make sure that the Help Center is loading
Check in Atomic as well