### PR TITLE
Checkout: Extract CheckoutStepGroup state into store object

### DIFF
--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -153,7 +153,7 @@ Renders a list of the line items and their `displayValue` properties followed by
 
 ### CheckoutStep
 
-A checkout step. This should be a **direct** child of [CheckoutSteps](#CheckoutSteps) and is itself a wrapper for [CheckoutStepBody](#CheckoutStepBody). If you want to make something that looks like a step but is not connected to other steps, use a [CheckoutStepBody](#CheckoutStepBody) instead.
+A checkout step. This should be a direct child of [CheckoutSteps](#CheckoutSteps) and is itself a wrapper for [CheckoutStepBody](#CheckoutStepBody). If you want to make something that looks like a step but is not connected to other steps, use a [CheckoutStepBody](#CheckoutStepBody) instead.
 
 This component's props are:
 

--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -153,7 +153,9 @@ Renders a list of the line items and their `displayValue` properties followed by
 
 ### CheckoutStep
 
-A checkout step. This should be a direct child of [CheckoutSteps](#CheckoutSteps) and is itself a wrapper for [CheckoutStepBody](#CheckoutStepBody). If you want to make something that looks like a step but is not connected to other steps, use a [CheckoutStepBody](#CheckoutStepBody) instead.
+A checkout step. This should be a **direct** child of [CheckoutSteps](#CheckoutSteps) and is itself a wrapper for [CheckoutStepBody](#CheckoutStepBody). If you want to make something that looks like a step but is not connected to other steps, use a [CheckoutStepBody](#CheckoutStepBody) instead.
+
+If you want to create a wrapper around a step, you must set the `isCheckoutStep` property of your wrapper component to identify it as a checkout step; otherwise it will be rendered without any step context and things will probably not work. Example: `function MyWrapper() { return <CheckoutStep /> }; MyWrapper.isCheckoutStep = true;`
 
 This component's props are:
 

--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -87,12 +87,6 @@ A generic button component that is used internally for almost all buttons (like 
 - `fullWidth?: bool`. The button width defaults to 'auto', but if this is set it will be '100%'.
 - `isBusy?: bool`. If true, the button will be displayed as a loading spinner.
 
-### Checkout
-
-The main wrapper component for Checkout. It has the following props.
-
-- `className?: string`. The className for the component.
-
 ### CheckoutFormSubmit
 
 An element that will display a [CheckoutSubmitButton](#CheckoutSubmitButton) when placed inside a [CheckoutStepGroup](#CheckoutStepGroup).
@@ -153,7 +147,7 @@ Renders a list of the line items and their `displayValue` properties followed by
 
 ### CheckoutStep
 
-A checkout step. This should be a direct child of [CheckoutSteps](#CheckoutSteps) and is itself a wrapper for [CheckoutStepBody](#CheckoutStepBody). If you want to make something that looks like a step but is not connected to other steps, use a [CheckoutStepBody](#CheckoutStepBody) instead.
+A checkout step. This should be a direct child of [CheckoutStepGroup](#CheckoutStepGroup) and is itself a wrapper for [CheckoutStepBody](#CheckoutStepBody). If you want to make something that looks like a step but is not connected to other steps, use a [CheckoutStepBody](#CheckoutStepBody) instead.
 
 This component's props are:
 
@@ -170,13 +164,9 @@ This component's props are:
 - `validatingButtonText?: string`. Used in place of "Please wait…" on the next step button when `isCompleteCallback` returns an unresolved Promise.
 - `validatingButtonAriaLabel:? string`. Used for the `aria-label` attribute on the next step button when `isCompleteCallback` returns an unresolved Promise.
 
-### CheckoutStepArea
-
-Creates the Checkout form and provides a wrapper for [CheckoutStep](#CheckoutStep) and [CheckoutStepBody](#CheckoutStepBody) objects. Should be a direct child of [Checkout](#Checkout).
-
 ### CheckoutStepAreaWrapper
 
-A styled div, controlled by the [theme](#checkoutTheme), that's used as the inner wrapper for the [CheckoutStepArea](#CheckoutStepArea) component. You shouldn't need to use this manually.
+A styled div, controlled by the [theme](#checkoutTheme), that's used as an inner wrapper for the [CheckoutStepGroup](#CheckoutStepGroup) component. You shouldn't need to use this manually.
 
 ### CheckoutStepBody
 
@@ -216,12 +206,6 @@ Available props:
 - `stepAreaHeader?: ReactNode`. A slot for additional components that can be injected at the top of the step group.
 - `store?: CheckoutStepGroupStore`. A way to inject a data store for the step group created by [createCheckoutStepGroupStore](#createCheckoutStepGroupStore). If not provided, a store will be created automatically.
 
-### CheckoutSteps
-
-A wrapper for [CheckoutStep](#CheckoutStep) objects that will connect the steps and provide a way to switch between them. Should be a direct child of [Checkout](#Checkout). It has the following props.
-
-- `areStepsActive?: boolean`. Whether or not the set of steps is active and able to be edited. Defaults to `true`.
-
 ### CheckoutSubmitButton
 
 The submit button for the form. This actually renders the submit button for the currently active payment method, but it provides the `onClick` handler to attach it to the payment processor function, a `disabled` prop when the form should be disabled, and a React Error boundary. Normally this is already rendered by [CheckoutFormSubmit](#CheckoutFormSubmit), but if you want to use it directly, you can.
@@ -235,7 +219,7 @@ The props you can provide to this component are as follows.
 
 ### CheckoutSummaryArea
 
-Renders its `children` prop and acts as a wrapper to flow outside of the [`CheckoutSteps`](#CheckoutSteps) wrapper (floated on desktop, collapsed on mobile). It has the following props.
+Renders its `children` prop and acts as a wrapper to flow outside of the [`CheckoutStepGroup`](#CheckoutStepGroup) wrapper (floated on desktop, collapsed on mobile). It has the following props.
 
 - `className?: string`. The className for the component.
 
@@ -255,7 +239,7 @@ An enum that holds the values of the [form status](#useFormStatus).
 
 ### MainContentWrapper
 
-A styled div, controlled by the [theme](#checkoutTheme), that's used as the inner wrapper for the [Checkout](#Checkout) component. You shouldn't need to use this manually.
+A styled div, controlled by the [theme](#checkoutTheme), that's used as an inner wrapper for the [CheckoutStepGroup](#CheckoutStepGroup) component. You shouldn't need to use this manually.
 
 ### OrderReviewLineItems
 

--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -210,6 +210,12 @@ This component's props are:
 
 A container for [CheckoutStep](#CheckoutStep) elements.
 
+Available props:
+
+- `areStepsActive?: boolean`. A boolean you can set to explicitly disable all the steps in the group.
+- `stepAreaHeader?: ReactNode`. A slot for additional components that can be injected at the top of the step group.
+- `store?: CheckoutStepGroupStore`. A way to inject a data store for the step group created by [createCheckoutStepGroupStore](#createCheckoutStepGroupStore). If not provided, a store will be created automatically.
+
 ### CheckoutSteps
 
 A wrapper for [CheckoutStep](#CheckoutStep) objects that will connect the steps and provide a way to switch between them. Should be a direct child of [Checkout](#Checkout). It has the following props.
@@ -324,6 +330,10 @@ An enum that holds the values of the [transaction status](#useTransactionStatus)
 ### checkoutTheme
 
 An [@emotion/styled](https://emotion.sh/docs/styled) theme object that can be merged with custom theme variables and passed to [CheckoutProvider](#checkout-provider) in order to customize the default Checkout design.
+
+## createCheckoutStepGroupStore
+
+A function to create a `CheckoutStepGroupStore` which can be passed to [CheckoutStepGroup](#CheckoutStepGroup) if you need additional control over the steps.
 
 ### getDefaultOrderReviewStep
 

--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -155,8 +155,6 @@ Renders a list of the line items and their `displayValue` properties followed by
 
 A checkout step. This should be a **direct** child of [CheckoutSteps](#CheckoutSteps) and is itself a wrapper for [CheckoutStepBody](#CheckoutStepBody). If you want to make something that looks like a step but is not connected to other steps, use a [CheckoutStepBody](#CheckoutStepBody) instead.
 
-If you want to create a wrapper around a step, you must set the `isCheckoutStep` property of your wrapper component to identify it as a checkout step; otherwise it will be rendered without any step context and things will probably not work. Example: `function MyWrapper() { return <CheckoutStep /> }; MyWrapper.isCheckoutStep = true;`
-
 This component's props are:
 
 - `stepId: string`. A unique ID for the step.

--- a/packages/composite-checkout/src/components/checkout-steps.tsx
+++ b/packages/composite-checkout/src/components/checkout-steps.tsx
@@ -113,6 +113,9 @@ function createCheckoutStepGroupActions(
 		if ( stepNumber > state.totalSteps ) {
 			stepNumber = state.totalSteps;
 		}
+		if ( stepNumber === state.activeStepNumber ) {
+			return;
+		}
 		state.activeStepNumber = stepNumber;
 		onStateChange();
 	};
@@ -120,6 +123,9 @@ function createCheckoutStepGroupActions(
 	const setTotalSteps = ( stepCount: number ) => {
 		if ( stepCount < 0 ) {
 			throw new Error( `Cannot set total steps to '${ stepCount }' because it is too low` );
+		}
+		if ( stepCount === state.totalSteps ) {
+			return;
 		}
 		state.totalSteps = stepCount;
 		onStateChange();
@@ -283,9 +289,7 @@ export const CheckoutStepGroupInner = ( {
 	const { activeStepNumber, stepCompleteStatus } = state;
 	const { setTotalSteps } = actions;
 
-	useEffect( () => {
-		setTotalSteps( totalSteps );
-	}, [ totalSteps, setTotalSteps ] );
+	setTotalSteps( totalSteps );
 
 	debug(
 		'active step',
@@ -578,9 +582,7 @@ export function CheckoutStepArea( {
 } > ) {
 	const { state } = useContext( CheckoutStepGroupContext );
 	const { activeStepNumber, totalSteps } = state;
-	const actualActiveStepNumber =
-		activeStepNumber > totalSteps && totalSteps > 0 ? totalSteps : activeStepNumber;
-	const isThereAnotherNumberedStep = actualActiveStepNumber < totalSteps;
+	const isThereAnotherNumberedStep = activeStepNumber < totalSteps;
 
 	const classNames = joinClasses( [
 		'checkout__step-wrapper',
@@ -604,9 +606,7 @@ export function CheckoutFormSubmit( {
 } ) {
 	const { state } = useContext( CheckoutStepGroupContext );
 	const { activeStepNumber, totalSteps } = state;
-	const actualActiveStepNumber =
-		activeStepNumber > totalSteps && totalSteps > 0 ? totalSteps : activeStepNumber;
-	const isThereAnotherNumberedStep = actualActiveStepNumber < totalSteps;
+	const isThereAnotherNumberedStep = activeStepNumber < totalSteps;
 	const { onPageLoadError } = useContext( CheckoutContext );
 	const onSubmitButtonLoadError = useCallback(
 		( error ) => onPageLoadError?.( 'submit_button_load', error ),

--- a/packages/composite-checkout/src/components/checkout-steps.tsx
+++ b/packages/composite-checkout/src/components/checkout-steps.tsx
@@ -772,7 +772,7 @@ export function useSetStepComplete(): ( stepId: string ) => Promise< boolean > {
 	return useJITCallback( async ( stepId: string ) => {
 		const stepNumber = getStepNumberFromId( stepId );
 		if ( ! stepNumber ) {
-			throw new Error( `Cannot find step with id ${ stepId }` );
+			throw new Error( `Cannot find step with id '${ stepId }' when trying to set step complete.` );
 		}
 		// To try to complete a step, we must try to complete all previous steps
 		// first, ignoring steps that are already complete.

--- a/packages/composite-checkout/src/lib/subscription-manager.ts
+++ b/packages/composite-checkout/src/lib/subscription-manager.ts
@@ -1,0 +1,21 @@
+export type SubscriptionManagerCallback = () => void;
+export type SubscriptionManagerUnsubscribe = () => void;
+
+export class SubscriptionManager {
+	subscribers: SubscriptionManagerCallback[];
+
+	constructor() {
+		this.subscribers = [];
+	}
+
+	subscribe = ( callback: SubscriptionManagerCallback ): SubscriptionManagerUnsubscribe => {
+		this.subscribers.push( callback );
+		return () => {
+			this.subscribers = this.subscribers.filter( ( client ) => client !== callback );
+		};
+	};
+
+	notifySubscribers = () => {
+		this.subscribers.forEach( ( callback ) => callback() );
+	};
+}

--- a/packages/composite-checkout/src/public-api.ts
+++ b/packages/composite-checkout/src/public-api.ts
@@ -8,14 +8,11 @@ import CheckoutOrderSummaryStep, {
 import CheckoutPaymentMethods from './components/checkout-payment-methods';
 import { CheckoutProvider } from './components/checkout-provider';
 import {
-	Checkout,
 	CheckoutFormSubmit,
 	CheckoutStep,
-	CheckoutStepArea,
 	CheckoutStepAreaWrapper,
 	CheckoutStepBody,
 	CheckoutStepGroup,
-	CheckoutSteps,
 	CheckoutSummaryArea,
 	CheckoutSummaryCard,
 	MainContentWrapper,
@@ -62,7 +59,6 @@ export type { Theme } from './lib/theme';
 // Re-export the public API
 export {
 	Button,
-	Checkout,
 	CheckoutCheckIcon,
 	CheckoutErrorBoundary,
 	CheckoutFormSubmit,
@@ -73,11 +69,9 @@ export {
 	CheckoutPaymentMethods,
 	CheckoutProvider,
 	CheckoutStep,
-	CheckoutStepArea,
 	CheckoutStepAreaWrapper,
 	CheckoutStepBody,
 	CheckoutStepGroup,
-	CheckoutSteps,
 	CheckoutSubmitButton,
 	CheckoutSummaryArea,
 	CheckoutSummaryCard,

--- a/packages/composite-checkout/src/public-api.ts
+++ b/packages/composite-checkout/src/public-api.ts
@@ -21,6 +21,7 @@ import {
 	useIsStepActive,
 	useIsStepComplete,
 	useSetStepComplete,
+	createCheckoutStepGroupStore,
 } from './components/checkout-steps';
 import CheckoutSubmitButton from './components/checkout-submit-button';
 import {
@@ -85,6 +86,7 @@ export {
 	RadioButton,
 	SubmitButtonWrapper,
 	checkoutTheme,
+	createCheckoutStepGroupStore,
 	getDefaultOrderReviewStep,
 	getDefaultOrderSummary,
 	getDefaultOrderSummaryStep,

--- a/packages/composite-checkout/src/types.ts
+++ b/packages/composite-checkout/src/types.ts
@@ -1,4 +1,5 @@
 import '@emotion/react';
+import type { SubscriptionManager } from './lib/subscription-manager';
 import type { Theme as ThemeType } from './lib/theme';
 import type { ReactElement } from 'react';
 
@@ -285,12 +286,24 @@ export type SetStepComplete = ( stepId: string ) => Promise< boolean >;
 
 export type CheckoutStepCompleteStatus = Record< string, boolean >;
 
+export interface CheckoutStepGroupStore {
+	state: CheckoutStepGroupState;
+	actions: CheckoutStepGroupActions;
+	subscription: SubscriptionManager;
+}
+
 export interface CheckoutStepGroupState {
 	activeStepNumber: number;
-	stepCompleteStatus: CheckoutStepCompleteStatus;
 	totalSteps: number;
+	stepCompleteStatus: CheckoutStepCompleteStatus;
+	stepIdMap: StepIdMap;
+	stepCompleteCallbackMap: StepCompleteCallbackMap;
+}
+
+export interface CheckoutStepGroupActions {
 	setActiveStepNumber: ( stepNumber: number ) => void;
 	setStepCompleteStatus: ( newStatus: CheckoutStepCompleteStatus ) => void;
+	setStepComplete: SetStepComplete;
 	getStepNumberFromId: ( stepId: string ) => number | undefined;
 	setStepCompleteCallback: (
 		stepNumber: number,

--- a/packages/composite-checkout/src/types.ts
+++ b/packages/composite-checkout/src/types.ts
@@ -1,6 +1,6 @@
 import '@emotion/react';
-import { ReactElement } from 'react';
-import { Theme as ThemeType } from './lib/theme';
+import type { Theme as ThemeType } from './lib/theme';
+import type { Dispatch, SetStateAction, ReactElement } from 'react';
 
 declare module '@emotion/react' {
 	// eslint-disable-next-line @typescript-eslint/no-empty-interface
@@ -275,4 +275,26 @@ export interface LineItemsState {
 export interface LineItemsProviderProps {
 	items: LineItem[];
 	total: LineItem;
+}
+
+export type SetStepComplete = ( stepId: string ) => Promise< boolean >;
+
+export interface CheckoutStepCompleteStatus {
+	[ key: string ]: boolean;
+}
+
+export interface CheckoutStepGroupState {
+	activeStepNumber: number;
+	stepCompleteStatus: CheckoutStepCompleteStatus;
+	totalSteps: number;
+	setActiveStepNumber: ( stepNumber: number ) => void;
+	setStepCompleteStatus: Dispatch< SetStateAction< CheckoutStepCompleteStatus > >;
+	getStepNumberFromId: ( stepId: string ) => number | undefined;
+	setStepCompleteCallback: (
+		stepNumber: number,
+		stepId: string,
+		callback: StepCompleteCallback
+	) => void;
+	getStepCompleteCallback: ( stepNumber: number ) => StepCompleteCallback;
+	setTotalSteps: ( totalSteps: number ) => void;
 }

--- a/packages/composite-checkout/src/types.ts
+++ b/packages/composite-checkout/src/types.ts
@@ -1,6 +1,6 @@
 import '@emotion/react';
 import type { Theme as ThemeType } from './lib/theme';
-import type { Dispatch, SetStateAction, ReactElement } from 'react';
+import type { ReactElement } from 'react';
 
 declare module '@emotion/react' {
 	// eslint-disable-next-line @typescript-eslint/no-empty-interface
@@ -277,18 +277,20 @@ export interface LineItemsProviderProps {
 	total: LineItem;
 }
 
+export type StepIdMap = Record< string, number >;
+
+export type StepCompleteCallbackMap = Record< string, StepCompleteCallback >;
+
 export type SetStepComplete = ( stepId: string ) => Promise< boolean >;
 
-export interface CheckoutStepCompleteStatus {
-	[ key: string ]: boolean;
-}
+export type CheckoutStepCompleteStatus = Record< string, boolean >;
 
 export interface CheckoutStepGroupState {
 	activeStepNumber: number;
 	stepCompleteStatus: CheckoutStepCompleteStatus;
 	totalSteps: number;
 	setActiveStepNumber: ( stepNumber: number ) => void;
-	setStepCompleteStatus: Dispatch< SetStateAction< CheckoutStepCompleteStatus > >;
+	setStepCompleteStatus: ( newStatus: CheckoutStepCompleteStatus ) => void;
 	getStepNumberFromId: ( stepId: string ) => number | undefined;
 	setStepCompleteCallback: (
 		stepNumber: number,


### PR DESCRIPTION
#### Proposed Changes

The `CheckoutStepGroup` component in the `@automattic/composite-checkout` package keeps internal state which it uses to manage the `CheckoutStep` components inside it. The state includes data like the currently active step, the total number of steps, and the step ids. It also includes a set of action functions which can modify that state. All of this is managed by a series of `useState` and `useRef` calls inside `CheckoutStepGroup`. The data and actions are exposed to child components using a series of custom hooks.

This all works for most cases, but it is not very flexible. There are times when it might be useful to directly manipulate the step state without having to reach for a custom hook. For example, in https://github.com/Automattic/wp-calypso/pull/70737 we need to modify the active step from the _parent_ of the `CheckoutStepGroup`, which cannot use the hooks since it is outside the component.

In this PR, we refactor `CheckoutStepGroup` to move the state and actions into a custom object called a `CheckoutStepGroupStore`. This object is automatically created by each `CheckoutStepGroup` but can also be manually injected as a prop, if more control is needed. The store can be used to get the current state or change it without any dependency on React, allowing it to be used anywhere in a render tree.

Extracted from https://github.com/Automattic/wp-calypso/pull/70737

#### Testing Instructions

Automated tests are already built into both calypso and this package.

You can manually test this by visiting checkout and clicking through the steps to verify that they appear and change as expected.