### PR TITLE
Help Center: use new Happychat availability endpoint

### DIFF
--- a/packages/data-stores/src/index.ts
+++ b/packages/data-stores/src/index.ts
@@ -24,6 +24,7 @@ export { useSiteIntent } from './queries/use-site-intent';
 export { useSupportAvailability } from './support-queries/use-support-availability';
 export { useSubmitTicketMutation } from './support-queries/use-submit-support-ticket';
 export { useSubmitForumsMutation } from './support-queries/use-submit-forums-topic';
+export { useHasActiveSupport } from './support-queries/use-support-history';
 export * from './starter-designs-queries';
 export { useSibylQuery } from './support-queries/use-sibyl-query';
 export * from './site/types';

--- a/packages/data-stores/src/support-queries/types.ts
+++ b/packages/data-stores/src/support-queries/types.ts
@@ -26,3 +26,14 @@ export interface OtherSupportAvailability {
 	is_user_eligible_for_tickets: boolean;
 	is_user_eligible_for_chat: boolean;
 }
+
+export interface SupportSession {
+	id?: number;
+	status: string;
+	subject: string;
+	time: Date;
+	timestamp: number;
+	type: string;
+	url: string;
+	when: string;
+}

--- a/packages/data-stores/src/support-queries/use-support-availability.ts
+++ b/packages/data-stores/src/support-queries/use-support-availability.ts
@@ -1,4 +1,4 @@
-import apiFetch from '@wordpress/api-fetch';
+import apiFetch, { APIFetchOptions } from '@wordpress/api-fetch';
 import { useQuery } from 'react-query';
 import wpcomRequest, { canAccessWpcomApis } from 'wpcom-proxy-request';
 import { OtherSupportAvailability, HappyChatAvailability } from './types';
@@ -6,11 +6,6 @@ import { OtherSupportAvailability, HappyChatAvailability } from './types';
 type ResponseType< T extends 'CHAT' | 'OTHER' > = T extends 'CHAT'
 	? HappyChatAvailability
 	: OtherSupportAvailability;
-
-interface APIFetchOptions {
-	global: boolean;
-	path: string;
-}
 
 export function useSupportAvailability< SUPPORT_TYPE extends 'CHAT' | 'OTHER' >(
 	supportType: SUPPORT_TYPE,

--- a/packages/data-stores/src/support-queries/use-support-history.ts
+++ b/packages/data-stores/src/support-queries/use-support-history.ts
@@ -1,0 +1,52 @@
+import apiFetch, { APIFetchOptions } from '@wordpress/api-fetch';
+import { useQuery } from 'react-query';
+import wpcomRequest, { canAccessWpcomApis } from 'wpcom-proxy-request';
+import type { SupportTicket } from '@automattic/help-center';
+
+type SupportTicketResponse = {
+	data: SupportTicket[];
+};
+
+// export type Ticket = {
+// 	this_is_nice: string;
+// 	this_is_nice_too?: boolean;
+// };
+const ACTIVE_STATUSES = [ 'New', 'Open', 'Hold' ];
+
+export function useHasActiveSupport( type: 'CHAT' | 'OTHER' ) {
+	const { data: tickets, isLoading } = useActiveSupportHistory( type );
+
+	if ( isLoading || ! tickets ) {
+		return false;
+	}
+
+	return tickets.length > 0;
+}
+
+export function useActiveSupportHistory( type: 'CHAT' | 'OTHER' ) {
+	return useQuery< SupportTicket >(
+		'help-support-history',
+		async () =>
+			canAccessWpcomApis()
+				? await wpcomRequest( {
+						path: 'support-history/chat',
+						apiNamespace: 'wpcom/v2/',
+						apiVersion: '2',
+				  } )
+				: ( ( await apiFetch( {
+						path: `help-center/support-history/chat`,
+						global: true,
+				  } as APIFetchOptions ) ) as SupportTicketResponse ),
+		{
+			refetchOnMount: false,
+			refetchOnWindowFocus: false,
+			refetchOnReconnect: false,
+			select: ( response: SupportTicketResponse ) => {
+				return response.data.filter( ( item ) => ACTIVE_STATUSES.includes( item.status ) );
+			},
+			meta: {
+				persist: false,
+			},
+		}
+	);
+}

--- a/packages/happychat-connection/src/types.ts
+++ b/packages/happychat-connection/src/types.ts
@@ -60,8 +60,6 @@ export interface HappychatAuth {
 	user: {
 		jwt: string;
 	} & HappychatUser;
-	is_existing_session: boolean;
-	availability_url: string;
 	fullUser: User;
 }
 

--- a/packages/happychat-connection/src/types.ts
+++ b/packages/happychat-connection/src/types.ts
@@ -60,6 +60,8 @@ export interface HappychatAuth {
 	user: {
 		jwt: string;
 	} & HappychatUser;
+	is_existing_session: boolean;
+	availability_url: string;
 	fullUser: User;
 }
 

--- a/packages/happychat-connection/src/use-happychat-available.ts
+++ b/packages/happychat-connection/src/use-happychat-available.ts
@@ -3,7 +3,7 @@ import { useQuery } from 'react-query';
 
 interface HappychatAvailableResponse {
 	available: boolean;
-	env: boolean;
+	env: 'staging' | 'production';
 }
 
 export function useHappychatAvailable( enabled = true ) {

--- a/packages/happychat-connection/src/use-happychat-available.ts
+++ b/packages/happychat-connection/src/use-happychat-available.ts
@@ -8,7 +8,7 @@ interface HappychatAvailableResponse {
 
 export function useHappychatAvailable( enabled = true ) {
 	return useQuery< HappychatAvailableResponse >(
-		`happychat-available-${ Math.floor( Date.now() / 1000 ) }`,
+		'happychat-available',
 		() =>
 			apiFetch( {
 				mode: 'cors',
@@ -17,7 +17,7 @@ export function useHappychatAvailable( enabled = true ) {
 				url: 'https://public-api.wordpress.com/wpcom/v2/happychat/availability',
 			} ),
 		{
-			refetchOnWindowFocus: false,
+			refetchInterval: 1000 * 30, // 30 seconds
 			keepPreviousData: false,
 			enabled,
 		}

--- a/packages/happychat-connection/src/use-happychat-available.ts
+++ b/packages/happychat-connection/src/use-happychat-available.ts
@@ -3,7 +3,7 @@ import { useQuery } from 'react-query';
 
 interface HappychatAvailableResponse {
 	available: boolean;
-	proxied: boolean;
+	env: boolean;
 }
 
 export function useHappychatAvailable( enabled = true ) {
@@ -13,14 +13,8 @@ export function useHappychatAvailable( enabled = true ) {
 			apiFetch( {
 				mode: 'cors',
 				method: 'GET',
-				parse: false,
 				credentials: 'omit',
-				url: `https://public-api.wordpress.com/wpcom/v2/happychat/availability?cache_buster=${ Date.now() }`,
-			} ).then( ( response: any ) => {
-				return response.json().then( ( body: { available: boolean } ) => {
-					const proxied = response?.url === 'https://happychat-io-staging.go-vip.co/_availability';
-					return { available: body.available, proxied };
-				} );
+				url: 'https://public-api.wordpress.com/wpcom/v2/happychat/availability',
 			} ),
 		{
 			refetchOnWindowFocus: false,

--- a/packages/happychat-connection/src/use-happychat-available.ts
+++ b/packages/happychat-connection/src/use-happychat-available.ts
@@ -1,46 +1,33 @@
-import config, { isCalypsoLive } from '@automattic/calypso-config';
 import apiFetch from '@wordpress/api-fetch';
 import { useQuery } from 'react-query';
 
-type HCAvailability = { available?: boolean; status?: string; env?: 'staging' | 'production' };
-
-const key = Date.now();
-
-const isNonProdEnv =
-	[ 'stage', 'development', 'horizon' ].includes( config( 'env_id' ) ) || isCalypsoLive();
-
-function getHCAvailability() {
-	const url = isNonProdEnv
-		? 'https://happychat-io-staging.go-vip.co/_availability'
-		: 'https://happychat.io/_availability';
-	return new Promise< HCAvailability >( ( resolve ) => {
-		apiFetch( {
-			mode: 'cors',
-			method: 'GET',
-			credentials: 'omit',
-			url: `${ url }?${ Date.now() }`,
-		} ).then( ( response: any ) => {
-			resolve( {
-				env: isNonProdEnv ? 'staging' : 'production',
-				available: response?.available,
-			} );
-		} );
-	} );
+interface HappychatAvailableResponse {
+	available: boolean;
+	proxied: boolean;
 }
 
-/**
- * Sends a request to Happychat availability endpoint to check if chat is available.
- * By default, it caches the answer for 10 minutes or until page refresh.
- *
- * @param enabled on/off switch
- * @param staleTime time in ms to cache the result
- * @returns
- */
-export function useHappychatAvailable( enabled = true, staleTime = 10 * 60 * 1000 ) {
-	return useQuery( 'happychat-available' + key, () => getHCAvailability(), {
-		enabled,
-		staleTime,
-	} );
+export function useHappychatAvailable( enabled = true ) {
+	return useQuery< HappychatAvailableResponse >(
+		`happychat-available-${ Math.floor( Date.now() / 1000 ) }`,
+		() =>
+			apiFetch( {
+				mode: 'cors',
+				method: 'GET',
+				parse: false,
+				credentials: 'omit',
+				url: `https://public-api.wordpress.com/wpcom/v2/happychat/availability?cache_buster=${ Date.now() }`,
+			} ).then( ( response: any ) => {
+				return response.json().then( ( body: { available: boolean } ) => {
+					const proxied = response?.url === 'https://happychat-io-staging.go-vip.co/_availability';
+					return { available: body.available, proxied };
+				} );
+			} ),
+		{
+			refetchOnWindowFocus: false,
+			keepPreviousData: false,
+			enabled,
+		}
+	);
 }
 
 export default useHappychatAvailable;

--- a/packages/help-center/src/components/help-center-contact-page.tsx
+++ b/packages/help-center/src/components/help-center-contact-page.tsx
@@ -41,9 +41,9 @@ export const HelpCenterContactPage: React.FC = () => {
 
 	const renderEmail = useShouldRenderEmailOption();
 	const renderChat = useShouldRenderChatOption();
-	const { data: tickets, isLoading: isLoadingTickets } = useHasActiveSupport( 'TICKET' );
+	const { data: ticket, isLoading: isLoadingTicket } = useHasActiveSupport( 'TICKET' );
 	const { data: supportAvailability } = useSupportAvailability( 'CHAT' );
-	const isLoading = renderChat.isLoading || renderEmail.isLoading || isLoadingTickets;
+	const isLoading = renderChat.isLoading || renderEmail.isLoading || isLoadingTicket;
 
 	useEffect( () => {
 		if ( isLoading ) {
@@ -109,7 +109,7 @@ export const HelpCenterContactPage: React.FC = () => {
 			<BackButton />
 			<div className="help-center-contact-page__content">
 				<h3>{ __( 'Contact our WordPress.com experts', __i18n_text_domain__ ) }</h3>
-				{ tickets && <HelpCenterActiveTicketNotice tickets={ tickets as SupportSession } /> }
+				{ ticket && <HelpCenterActiveTicketNotice ticket={ ticket as SupportSession } /> }
 				<GMClosureNotice
 					displayAt="2022-10-29 00:00Z"
 					closesAt="2022-11-05 00:00Z"
@@ -147,7 +147,7 @@ export const HelpCenterContactPage: React.FC = () => {
 									</div>
 								</div>
 							</ConditionalLink>
-							{ renderChat.env && (
+							{ renderChat.env === 'staging' && (
 								<Notice
 									status="warning"
 									actions={ [ { label: 'HUD', url: 'https://hud-staging.happychat.io/' } ] }

--- a/packages/help-center/src/components/help-center-contact-page.tsx
+++ b/packages/help-center/src/components/help-center-contact-page.tsx
@@ -147,7 +147,7 @@ export const HelpCenterContactPage: React.FC = () => {
 									</div>
 								</div>
 							</ConditionalLink>
-							{ renderChat.proxied && (
+							{ renderChat.env && (
 								<Notice
 									status="warning"
 									actions={ [ { label: 'HUD', url: 'https://hud-staging.happychat.io/' } ] }

--- a/packages/help-center/src/components/help-center-contact-page.tsx
+++ b/packages/help-center/src/components/help-center-contact-page.tsx
@@ -20,7 +20,7 @@ import { getSectionName } from 'calypso/state/ui/selectors';
 /**
  * Internal Dependencies
  */
-import { BackButton } from '..';
+import { BackButton, SupportSession } from '..';
 import { useShouldRenderChatOption } from '../hooks/use-should-render-chat-option';
 import { useShouldRenderEmailOption } from '../hooks/use-should-render-email-option';
 import { useStillNeedHelpURL } from '../hooks/use-still-need-help-url';
@@ -109,7 +109,7 @@ export const HelpCenterContactPage: React.FC = () => {
 			<BackButton />
 			<div className="help-center-contact-page__content">
 				<h3>{ __( 'Contact our WordPress.com experts', __i18n_text_domain__ ) }</h3>
-				<HelpCenterActiveTicketNotice tickets={ tickets } />
+				{ tickets && <HelpCenterActiveTicketNotice tickets={ tickets as SupportSession } /> }
 				<GMClosureNotice
 					displayAt="2022-10-29 00:00Z"
 					closesAt="2022-11-05 00:00Z"
@@ -147,7 +147,7 @@ export const HelpCenterContactPage: React.FC = () => {
 									</div>
 								</div>
 							</ConditionalLink>
-							{ renderChat.env === 'staging' && (
+							{ renderChat.proxied && (
 								<Notice
 									status="warning"
 									actions={ [ { label: 'HUD', url: 'https://hud-staging.happychat.io/' } ] }

--- a/packages/help-center/src/components/help-center-contact-page.tsx
+++ b/packages/help-center/src/components/help-center-contact-page.tsx
@@ -5,7 +5,7 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import config from '@automattic/calypso-config';
 import { Spinner, GMClosureNotice } from '@automattic/components';
-import { useSupportAvailability } from '@automattic/data-stores';
+import { useSupportAvailability, useHasActiveSupport } from '@automattic/data-stores';
 import { isDefaultLocale, getLanguage, useLocale } from '@automattic/i18n-utils';
 import { Notice } from '@wordpress/components';
 import { useEffect, useMemo } from '@wordpress/element';
@@ -16,8 +16,6 @@ import classnames from 'classnames';
 import React from 'react';
 import { useSelector } from 'react-redux';
 import { Link, LinkProps } from 'react-router-dom';
-import { useActiveSupportTicketsQuery } from 'calypso/data/help/use-active-support-tickets-query';
-import { getCurrentUserEmail } from 'calypso/state/current-user/selectors';
 import { getSectionName } from 'calypso/state/ui/selectors';
 /**
  * Internal Dependencies
@@ -43,10 +41,7 @@ export const HelpCenterContactPage: React.FC = () => {
 
 	const renderEmail = useShouldRenderEmailOption();
 	const renderChat = useShouldRenderChatOption();
-	const email = useSelector( getCurrentUserEmail );
-	const { data: tickets, isLoading: isLoadingTickets } = useActiveSupportTicketsQuery( email, {
-		staleTime: 30 * 60 * 1000,
-	} );
+	const { data: tickets, isLoading: isLoadingTickets } = useHasActiveSupport( 'TICKET' );
 	const { data: supportAvailability } = useSupportAvailability( 'CHAT' );
 	const isLoading = renderChat.isLoading || renderEmail.isLoading || isLoadingTickets;
 

--- a/packages/help-center/src/components/help-center-container.tsx
+++ b/packages/help-center/src/components/help-center-container.tsx
@@ -73,7 +73,7 @@ const HelpCenterContainer: React.FC< Container > = ( { handleClose } ) => {
 	// https://github.com/react-grid-layout/react-draggable/blob/781ef77c86be9486400da9837f43b96186166e38/README.md
 	const nodeRef = useRef( null );
 
-	if ( ! show ) {
+	if ( ! show || hidden ) {
 		return null;
 	}
 

--- a/packages/help-center/src/components/help-center-container.tsx
+++ b/packages/help-center/src/components/help-center-container.tsx
@@ -1,8 +1,6 @@
 /**
  * External Dependencies
  */
-import { useSupportAvailability } from '@automattic/data-stores';
-import { useHappychatAvailable } from '@automattic/happychat-connection';
 import { useMobileBreakpoint } from '@automattic/viewport-react';
 import { Card } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
@@ -32,7 +30,7 @@ const OptionalDraggable: FC< OptionalDraggableProps > = ( { draggable, ...props 
 	return <Draggable { ...props } />;
 };
 
-const HelpCenterContainer: React.FC< Container > = ( { handleClose, hidden } ) => {
+const HelpCenterContainer: React.FC< Container > = ( { handleClose, hidden, showChat } ) => {
 	const { show, isMinimized } = useSelect( ( select ) => ( {
 		show: select( HELP_CENTER_STORE ).isHelpCenterShown(),
 		isMinimized: select( HELP_CENTER_STORE ).getIsMinimized(),
@@ -45,8 +43,7 @@ const HelpCenterContainer: React.FC< Container > = ( { handleClose, hidden } ) =
 	const classNames = classnames( 'help-center__container', isMobile ? 'is-mobile' : 'is-desktop', {
 		'is-minimized': isMinimized,
 	} );
-	const { data: supportAvailability } = useSupportAvailability( 'CHAT' );
-	const { data } = useHappychatAvailable( Boolean( supportAvailability?.is_user_eligible ) );
+
 	const { history, index } = useSelect( ( select ) =>
 		select( HELP_CENTER_STORE ).getRouterState()
 	);
@@ -79,7 +76,7 @@ const HelpCenterContainer: React.FC< Container > = ( { handleClose, hidden } ) =
 
 	return (
 		<MemoryRouter initialEntries={ history } initialIndex={ index }>
-			{ data?.status === 'assigned' && <Redirect to="/inline-chat?session=continued" /> }
+			{ showChat && <Redirect to="/inline-chat?session=continued" /> }
 			<HistoryRecorder />
 			<FeatureFlagProvider>
 				<OptionalDraggable

--- a/packages/help-center/src/components/help-center-container.tsx
+++ b/packages/help-center/src/components/help-center-container.tsx
@@ -1,6 +1,7 @@
 /**
  * External Dependencies
  */
+import { useHasActiveSupport } from '@automattic/data-stores';
 import { useMobileBreakpoint } from '@automattic/viewport-react';
 import { Card } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
@@ -30,11 +31,13 @@ const OptionalDraggable: FC< OptionalDraggableProps > = ( { draggable, ...props 
 	return <Draggable { ...props } />;
 };
 
-const HelpCenterContainer: React.FC< Container > = ( { handleClose, hidden, showChat } ) => {
+const HelpCenterContainer: React.FC< Container > = ( { handleClose } ) => {
 	const { show, isMinimized } = useSelect( ( select ) => ( {
 		show: select( HELP_CENTER_STORE ).isHelpCenterShown(),
 		isMinimized: select( HELP_CENTER_STORE ).getIsMinimized(),
 	} ) );
+
+	const { data: hasActiveChat } = useHasActiveSupport( 'CHAT', show );
 
 	const { setIsMinimized } = useDispatch( HELP_CENTER_STORE );
 
@@ -70,13 +73,13 @@ const HelpCenterContainer: React.FC< Container > = ( { handleClose, hidden, show
 	// https://github.com/react-grid-layout/react-draggable/blob/781ef77c86be9486400da9837f43b96186166e38/README.md
 	const nodeRef = useRef( null );
 
-	if ( ! show || hidden ) {
+	if ( ! show ) {
 		return null;
 	}
 
 	return (
 		<MemoryRouter initialEntries={ history } initialIndex={ index }>
-			{ showChat && <Redirect to="/inline-chat?session=continued" /> }
+			{ hasActiveChat && <Redirect to="/inline-chat?session=continued" /> }
 			<HistoryRecorder />
 			<FeatureFlagProvider>
 				<OptionalDraggable

--- a/packages/help-center/src/components/help-center-container.tsx
+++ b/packages/help-center/src/components/help-center-container.tsx
@@ -31,7 +31,7 @@ const OptionalDraggable: FC< OptionalDraggableProps > = ( { draggable, ...props 
 	return <Draggable { ...props } />;
 };
 
-const HelpCenterContainer: React.FC< Container > = ( { handleClose } ) => {
+const HelpCenterContainer: React.FC< Container > = ( { handleClose, hidden } ) => {
 	const { show, isMinimized } = useSelect( ( select ) => ( {
 		show: select( HELP_CENTER_STORE ).isHelpCenterShown(),
 		isMinimized: select( HELP_CENTER_STORE ).getIsMinimized(),

--- a/packages/help-center/src/components/help-center-notice.tsx
+++ b/packages/help-center/src/components/help-center-notice.tsx
@@ -3,7 +3,7 @@ import { ExternalLink } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { Icon, info } from '@wordpress/icons';
-import type { SupportTicket } from '../types';
+import type { SupportSession } from '../types';
 import type { AnalysisReport } from '@automattic/data-stores';
 import type { ReactNode } from 'react';
 
@@ -97,7 +97,7 @@ export function HelpCenterOwnershipNotice( { ownershipResult }: Props ) {
 export function HelpCenterActiveTicketNotice( {
 	tickets,
 }: {
-	tickets: SupportTicket[] | undefined;
+	tickets: SupportSession[] | undefined;
 } ) {
 	const locale = useLocale();
 

--- a/packages/help-center/src/components/help-center-notice.tsx
+++ b/packages/help-center/src/components/help-center-notice.tsx
@@ -94,14 +94,10 @@ export function HelpCenterOwnershipNotice( { ownershipResult }: Props ) {
 	return null;
 }
 
-export function HelpCenterActiveTicketNotice( {
-	tickets,
-}: {
-	tickets: SupportSession[] | undefined;
-} ) {
+export function HelpCenterActiveTicketNotice( { tickets }: { tickets: SupportSession } ) {
 	const locale = useLocale();
 
-	if ( ! tickets || ! tickets.length ) {
+	if ( ! tickets ) {
 		return null;
 	}
 
@@ -113,7 +109,7 @@ export function HelpCenterActiveTicketNotice( {
 						/* translators: %s humanized date ex: 2 hours ago */
 						__( 'You submitted a request %s.', __i18n_text_domain__ ),
 						getRelativeTimeString( {
-							timestamp: tickets[ 0 ].timestamp * 1000,
+							timestamp: tickets.timestamp * 1000,
 							locale,
 							style: 'long',
 						} )

--- a/packages/help-center/src/components/help-center-notice.tsx
+++ b/packages/help-center/src/components/help-center-notice.tsx
@@ -94,10 +94,10 @@ export function HelpCenterOwnershipNotice( { ownershipResult }: Props ) {
 	return null;
 }
 
-export function HelpCenterActiveTicketNotice( { tickets }: { tickets: SupportSession } ) {
+export function HelpCenterActiveTicketNotice( { ticket }: { ticket: SupportSession } ) {
 	const locale = useLocale();
 
-	if ( ! tickets ) {
+	if ( ! ticket ) {
 		return null;
 	}
 
@@ -109,7 +109,7 @@ export function HelpCenterActiveTicketNotice( { tickets }: { tickets: SupportSes
 						/* translators: %s humanized date ex: 2 hours ago */
 						__( 'You submitted a request %s.', __i18n_text_domain__ ),
 						getRelativeTimeString( {
-							timestamp: tickets.timestamp * 1000,
+							timestamp: ticket.timestamp * 1000,
 							locale,
 							style: 'long',
 						} )

--- a/packages/help-center/src/components/help-center.tsx
+++ b/packages/help-center/src/components/help-center.tsx
@@ -19,7 +19,7 @@ import HelpCenterContainer from './help-center-container';
 
 import '../styles.scss';
 
-const HelpCenter: React.FC< Container > = ( { handleClose } ) => {
+const HelpCenter: React.FC< Container > = ( { handleClose, hidden } ) => {
 	const portalParent = useRef( document.createElement( 'div' ) ).current;
 	const { setSite, setUnreadCount, setShowHelpCenter } = useDispatch( HELP_CENTER_STORE );
 	const { show, isMinimized } = useSelect( ( select ) => ( {
@@ -63,7 +63,10 @@ const HelpCenter: React.FC< Container > = ( { handleClose } ) => {
 		};
 	}, [ portalParent ] );
 
-	return createPortal( <HelpCenterContainer handleClose={ handleClose } />, portalParent );
+	return createPortal(
+		<HelpCenterContainer handleClose={ handleClose } hidden={ hidden } />,
+		portalParent
+	);
 };
 
 export default HelpCenter;

--- a/packages/help-center/src/hooks/use-should-render-chat-option.tsx
+++ b/packages/help-center/src/hooks/use-should-render-chat-option.tsx
@@ -6,7 +6,7 @@ type Result = {
 	state: 'AVAILABLE' | 'UNAVAILABLE' | 'CLOSED';
 	isLoading: boolean;
 	eligible: boolean;
-	proxied?: boolean;
+	env: boolean;
 };
 
 export function useShouldRenderChatOption(): Result {
@@ -21,7 +21,7 @@ export function useShouldRenderChatOption(): Result {
 			isLoading,
 			state: chatStatus?.is_chat_closed ? 'CLOSED' : 'UNAVAILABLE',
 			eligible: false,
-			proxied: chatAvailability?.proxied,
+			env: chatAvailability?.env,
 		};
 	} else if ( chatStatus?.is_chat_closed ) {
 		return {
@@ -29,7 +29,7 @@ export function useShouldRenderChatOption(): Result {
 			state: 'CLOSED',
 			isLoading,
 			eligible: true,
-			proxied: chatAvailability?.proxied,
+			env: chatAvailability?.env,
 		};
 	} else if ( chatAvailability?.available ) {
 		return {
@@ -37,7 +37,7 @@ export function useShouldRenderChatOption(): Result {
 			state: 'AVAILABLE',
 			isLoading,
 			eligible: true,
-			proxied: chatAvailability?.proxied,
+			env: chatAvailability?.env,
 		};
 	}
 	return {
@@ -45,6 +45,6 @@ export function useShouldRenderChatOption(): Result {
 		state: 'UNAVAILABLE',
 		isLoading,
 		eligible: true,
-		proxied: chatAvailability?.proxied,
+		env: chatAvailability?.env,
 	};
 }

--- a/packages/help-center/src/hooks/use-should-render-chat-option.tsx
+++ b/packages/help-center/src/hooks/use-should-render-chat-option.tsx
@@ -6,7 +6,7 @@ type Result = {
 	state: 'AVAILABLE' | 'UNAVAILABLE' | 'CLOSED';
 	isLoading: boolean;
 	eligible: boolean;
-	env: 'staging' | 'production';
+	env?: 'staging' | 'production';
 };
 
 export function useShouldRenderChatOption(): Result {

--- a/packages/help-center/src/hooks/use-should-render-chat-option.tsx
+++ b/packages/help-center/src/hooks/use-should-render-chat-option.tsx
@@ -6,16 +6,13 @@ type Result = {
 	state: 'AVAILABLE' | 'UNAVAILABLE' | 'CLOSED';
 	isLoading: boolean;
 	eligible: boolean;
-	env?: 'staging' | 'production';
+	proxied?: boolean;
 };
 
 export function useShouldRenderChatOption(): Result {
 	const { data: chatStatus } = useSupportAvailability( 'CHAT' );
-	// when the user is looking at the help page, we want to be extra sure they don't start a chat without available operators
-	// so in this case, let's make stale time 1 minute.
-	const { data, isLoading } = useHappychatAvailable(
-		Boolean( chatStatus?.is_user_eligible ),
-		60 * 1000
+	const { data: chatAvailability, isLoading } = useHappychatAvailable(
+		Boolean( chatStatus?.is_user_eligible )
 	);
 
 	if ( ! chatStatus?.is_user_eligible ) {
@@ -24,7 +21,7 @@ export function useShouldRenderChatOption(): Result {
 			isLoading,
 			state: chatStatus?.is_chat_closed ? 'CLOSED' : 'UNAVAILABLE',
 			eligible: false,
-			env: data?.env,
+			proxied: chatAvailability?.proxied,
 		};
 	} else if ( chatStatus?.is_chat_closed ) {
 		return {
@@ -32,15 +29,15 @@ export function useShouldRenderChatOption(): Result {
 			state: 'CLOSED',
 			isLoading,
 			eligible: true,
-			env: data?.env,
+			proxied: chatAvailability?.proxied,
 		};
-	} else if ( data?.available ) {
+	} else if ( chatAvailability?.available ) {
 		return {
 			render: true,
 			state: 'AVAILABLE',
 			isLoading,
 			eligible: true,
-			env: data.env,
+			proxied: chatAvailability?.proxied,
 		};
 	}
 	return {
@@ -48,6 +45,6 @@ export function useShouldRenderChatOption(): Result {
 		state: 'UNAVAILABLE',
 		isLoading,
 		eligible: true,
-		env: data?.env,
+		proxied: chatAvailability?.proxied,
 	};
 }

--- a/packages/help-center/src/hooks/use-should-render-chat-option.tsx
+++ b/packages/help-center/src/hooks/use-should-render-chat-option.tsx
@@ -6,7 +6,7 @@ type Result = {
 	state: 'AVAILABLE' | 'UNAVAILABLE' | 'CLOSED';
 	isLoading: boolean;
 	eligible: boolean;
-	env: boolean;
+	env: boolean | undefined;
 };
 
 export function useShouldRenderChatOption(): Result {

--- a/packages/help-center/src/hooks/use-should-render-chat-option.tsx
+++ b/packages/help-center/src/hooks/use-should-render-chat-option.tsx
@@ -6,7 +6,7 @@ type Result = {
 	state: 'AVAILABLE' | 'UNAVAILABLE' | 'CLOSED';
 	isLoading: boolean;
 	eligible: boolean;
-	env: boolean | undefined;
+	env: 'staging' | 'production';
 };
 
 export function useShouldRenderChatOption(): Result {

--- a/packages/help-center/src/index.ts
+++ b/packages/help-center/src/index.ts
@@ -10,3 +10,4 @@ export { default as Mail } from './icons/mail';
 export { default as NewReleases } from './icons/new-releases';
 export * from './support-variations';
 export { shouldShowHelpCenterToUser, shouldLoadInlineHelp } from './utils';
+export * from './types';

--- a/packages/help-center/src/types.ts
+++ b/packages/help-center/src/types.ts
@@ -6,6 +6,7 @@ export interface Container {
 	defaultFooterContent?: ReactElement;
 	isLoading?: boolean;
 	hidden?: boolean;
+	showChat?: boolean;
 }
 
 export interface Header {

--- a/packages/help-center/src/types.ts
+++ b/packages/help-center/src/types.ts
@@ -50,7 +50,7 @@ export interface SearchResult {
 	blog_id?: number;
 }
 
-export interface SupportTicket {
+export interface SupportSession {
 	id?: number;
 	status: string;
 	subject: string;


### PR DESCRIPTION
## Proposed Changes

We recently have added an endpoint to Happychat that queries to see if there is availability. This PR updates the `useHappychatAvailable` to query this endpoint rather than opening a socket connection.

In order to make this work we had to add another endpoint relay that checks if the request is coming from staging or production in order to check availability against the correct environment. Check that here - D94755-code

## Testing Instructions

1. This needs to be tested in: Simple, Atomic, Editor, and WP-ADMIN.
2. Open the developer console and examine the Network tab to view the API calls being made.
3. Open Help Center and start a chat.
4. You should be able to close the chat and open it back up.
5. Refresh the screen to make sure the session persists.
6. Try and poke holes in it as best you can.