### PR TITLE
eCommerce Onboarding: Remove subheader from design carousel step

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-carousel/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-carousel/index.tsx
@@ -38,9 +38,6 @@ const DesignCarousel: Step = function DesignCarousel( { navigation } ) {
 				<FormattedHeader
 					id="seller-step-header"
 					headerText={ __( 'Choose a design to start' ) }
-					subHeaderText={ __(
-						"Don't worry, you can change or customize this at any time in the future."
-					) }
 					align="center"
 				/>
 			}


### PR DESCRIPTION
#### Proposed Changes

* Removes the subheading text from the design carousel step, fixing #70761
* I didn't see other flows using this step, so I've completely removed the text for now. We can add it back in the future as a condition if another flow needs it.

**Before**

<img width="1555" alt="Screen Shot 2022-12-05 at 1 27 34 PM" src="https://user-images.githubusercontent.com/2124984/205715714-e20c867e-6abd-4355-a18d-41a61309208c.png">

**After**

<img width="1554" alt="Screen Shot 2022-12-05 at 1 34 00 PM" src="https://user-images.githubusercontent.com/2124984/205715728-28418971-1470-4ede-827e-d80f3158d2c3.png">


#### Testing Instructions

* Switch to this PR, navigate to `/setup/ecommerce/designCarousel
* You should not see the subheading text

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #70761
