### PR TITLE
Stepper eCommerce flow: Fix design carousel CTA

### DIFF
--- a/packages/design-carousel/src/index.tsx
+++ b/packages/design-carousel/src/index.tsx
@@ -1,4 +1,3 @@
-import { Gridicon } from '@automattic/components';
 import { useStarterDesignsQuery } from '@automattic/data-stores';
 import { useLocale } from '@automattic/i18n-utils';
 import { Button } from '@wordpress/components';
@@ -95,7 +94,6 @@ export default function DesignCarousel( { onPick }: Props ) {
 					} }
 				>
 					<span>{ __( 'Continue' ) }</span>
-					<Gridicon icon="heart" size={ 18 } />
 				</Button>
 			</div>
 		</div>

--- a/packages/design-carousel/src/styles.scss
+++ b/packages/design-carousel/src/styles.scss
@@ -155,22 +155,8 @@ $patterns: "17-2", "black", "ella-d", "link-cloud", "matt-smith", "ose-maiko", "
 		width: 28vh;
 	}
 
-	svg {
-		display: none;
-	}
-
 	use {
 		fill: #fff;
-	}
-
-	&:not(:disabled):hover {
-		svg {
-			display: inline;
-		}
-
-		span {
-			display: none;
-		}
 	}
 }
 


### PR DESCRIPTION
This PR changes the hover state of the Design Carousel component, used in the eCommerce flow (`/setup/ecommerce`).

From (icon):
![image](https://user-images.githubusercontent.com/3801502/205719568-8ce046e8-ade6-4186-9e7f-f2e0454e1441.png)

To (text):
![image](https://user-images.githubusercontent.com/3801502/205719920-d9ddfee9-3b96-4598-b642-af4d71c86ba4.png)

Closes https://github.com/Automattic/wp-calypso/issues/70763