### PR TITLE
eCommerce Onboarding: Update image width to match the viewport with to avoid blurry images

### DIFF
--- a/packages/design-carousel/src/item.tsx
+++ b/packages/design-carousel/src/item.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 import './styles.scss';
 import { MShotsImage, MShotsOptions } from '@automattic/onboarding';
+import { useMediaQuery } from '@wordpress/compose';
 import cx from 'classnames';
 
 type Props = {
@@ -26,9 +27,15 @@ const getDesignPreviewUrl = ( design: any ): string => {
 export function Item( { style, design, className, type }: Props ) {
 	// Default to mobile options
 	let options: MShotsOptions = { w: 400, vpw: 400, vph: 872, format: 'png' };
+	const isLargerThan1440px = useMediaQuery( '(min-width: 1440px)' );
 
 	if ( type === 'desktop' ) {
-		options = { w: 1920, vpw: 1920, vph: 1280, format: 'png' };
+		options = {
+			w: isLargerThan1440px ? 1920 : 1280,
+			vpw: 1920,
+			vph: 1280,
+			format: 'png',
+		};
 	}
 
 	return (

--- a/packages/design-carousel/src/item.tsx
+++ b/packages/design-carousel/src/item.tsx
@@ -28,7 +28,7 @@ export function Item( { style, design, className, type }: Props ) {
 	let options: MShotsOptions = { w: 400, vpw: 400, vph: 872, format: 'png' };
 
 	if ( type === 'desktop' ) {
-		options = { w: 1280, vpw: 1920, vph: 1280, format: 'png' };
+		options = { w: 1920, vpw: 1920, vph: 1280, format: 'png' };
 	}
 
 	return (


### PR DESCRIPTION
#### Proposed Changes

* Upsize the screenshot with from 1280px to 1920px to avoid showing blurry screenshots on larger screens.
* Pro: The images look a lot better if viewed on a larger screen!
* Con: The images are able twice as large (1Mb vs. 500Kb) with this change. I'm not sure if that's a tradeoff we're willing to make.
* Another option here might be to reduce the overall size of the viewport.

**Before**

<img width="925" alt="Screen Shot 2022-12-05 at 1 55 28 PM" src="https://user-images.githubusercontent.com/2124984/205735214-7f724a85-608f-4ff4-8243-a82fe2ee9b0d.png">

**After**

<img width="1425" alt="Screen Shot 2022-12-05 at 2 02 59 PM" src="https://user-images.githubusercontent.com/2124984/205735176-110c64c5-cc33-4358-8ab0-eaa9bf2b16c8.png">


#### Testing Instructions

* Switch to this PR, navigate to `/setup/ecommerce/designCarousel` on a device with a large screen size
* Note the images should be pretty sharp

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #70764
