### PR TITLE
Tailored Ecommerce: Fix design carousel on portrait tablet view

### DIFF
--- a/packages/design-carousel/src/styles.scss
+++ b/packages/design-carousel/src/styles.scss
@@ -23,19 +23,19 @@ $patterns: "17-2", "black", "ella-d", "link-cloud", "matt-smith", "ose-maiko", "
 .design-carousel__item {
 	flex: 1;
 
-	@include break-small {
+	@include break-large {
 		aspect-ratio: 1.5;
 	}
 
 	&.design-carousel__item-mobile {
-		@include break-small {
-			display: none !important;
+		@include break-large {
+			display: none;
 		}
 	}
 	&.design-carousel__item-desktop {
-		display: none !important;
-		@include break-small {
-			display: flex !important;
+		display: none;
+		@include break-large {
+			display: flex;
 		}
 
 		@include break-medium {

--- a/packages/design-carousel/src/styles.scss
+++ b/packages/design-carousel/src/styles.scss
@@ -37,6 +37,11 @@ $patterns: "17-2", "black", "ella-d", "link-cloud", "matt-smith", "ose-maiko", "
 		@include break-small {
 			display: flex !important;
 		}
+
+		@include break-medium {
+			width: 75%;
+			margin: 0 auto;
+		}
 	}
 
 	// iPhone aspect ratio
@@ -71,6 +76,10 @@ $patterns: "17-2", "black", "ella-d", "link-cloud", "matt-smith", "ose-maiko", "
 		display: block;
 		height: 100%;
 		width: 100%;
+
+		@include break-medium {
+			height: auto;
+		}
 	}
 
 	.mshots-image-visible {

--- a/packages/design-carousel/src/styles.scss
+++ b/packages/design-carousel/src/styles.scss
@@ -23,24 +23,19 @@ $patterns: "17-2", "black", "ella-d", "link-cloud", "matt-smith", "ose-maiko", "
 .design-carousel__item {
 	flex: 1;
 
-	@include break-large {
+	@include break-medium {
 		aspect-ratio: 1.5;
 	}
 
 	&.design-carousel__item-mobile {
-		@include break-large {
+		@include break-medium {
 			display: none;
 		}
 	}
 	&.design-carousel__item-desktop {
 		display: none;
-		@include break-large {
-			display: flex;
-		}
-
 		@include break-medium {
-			width: 75%;
-			margin: 0 auto;
+			display: flex;
 		}
 	}
 
@@ -59,12 +54,9 @@ $patterns: "17-2", "black", "ella-d", "link-cloud", "matt-smith", "ose-maiko", "
 	overflow: hidden;
 	height: calc(65vh - 50px);
 	outline: none;
+	max-width: 100%;
 
-	@media (max-height: 375px) {
-		aspect-ratio: 0.5;
-	}
-
-	// needed for iOS Safari. iOS has
+	// needed for iOS Safari.
 	@supports (min-height: 65svh) {
 		height: calc(65svh - 50px);
 	}
@@ -74,12 +66,8 @@ $patterns: "17-2", "black", "ella-d", "link-cloud", "matt-smith", "ose-maiko", "
 
 	.mshots-image__container {
 		display: block;
-		height: 100%;
+		height: auto;
 		width: 100%;
-
-		@include break-medium {
-			height: auto;
-		}
 	}
 
 	.mshots-image-visible {
@@ -93,6 +81,8 @@ $patterns: "17-2", "black", "ella-d", "link-cloud", "matt-smith", "ose-maiko", "
 
 	.design-carousel__slide {
 		width: auto;
+		max-width: 100%;
+		height: auto;
 	}
 
 	.swiper-slide-active .design-carousel__item {

--- a/packages/design-carousel/src/styles.scss
+++ b/packages/design-carousel/src/styles.scss
@@ -36,6 +36,7 @@ $patterns: "17-2", "black", "ella-d", "link-cloud", "matt-smith", "ose-maiko", "
 		display: none;
 		@include break-medium {
 			display: flex;
+			box-sizing: border-box;
 		}
 	}
 


### PR DESCRIPTION
#### Proposed Changes

* Ensure theme images do not get cut off at narrower desktop screen widths.
* Remove `!important`s, they didn't seem to have an effect.
* Also fixes a bug where viewing the carousel on a phone-sized screen in landscape orientation stretched the images:

<img width="699" alt="Screen Shot 2022-12-14 at 1 47 06 PM" src="https://user-images.githubusercontent.com/2124984/207685502-3931e48a-0870-4520-a826-d29e8dcdf246.png">


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Prior to applying this patch, go to `/setup/ecommerce/designCarousel`. Switch to Responsive mode in the inspector and as you narrow the screen, you should see the theme image gets cut off, primarily on the right side.

https://user-images.githubusercontent.com/2124984/207683946-af47b659-5750-48fd-bfcb-622bb47aefb2.mov


After applying the patch and visiting the same url, the image should adjust to the max-width of the screen until it switches to mobile orientation/mode:

https://user-images.githubusercontent.com/2124984/207684729-9125f48e-38eb-4df7-aa05-6f04ff424459.mov

Please test in all the devices/screen configurations!

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [NA] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [NA] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [NA] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [NA] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [NA] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #70644
