### PR TITLE
My Home Checklist Hotfix: more specific selector

### DIFF
--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/style.scss
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/style.scss
@@ -3,21 +3,24 @@
 @import "../../../grid-mixins.scss";
 
 .site-setup-list {
-	padding: 0;
-	box-shadow: none;
-	border-bottom: 1px solid var(--color-border-subtle);
+	&.card {
+		padding: 0;
+		box-shadow: none;
+		border-bottom: 1px solid var(--color-border-subtle);
 
-	@include display-grid;
-	@include grid-template-columns( 12, 24px, 1fr );
+		@include display-grid;
+		@include grid-template-columns( 12, 24px, 1fr );
 
-	@include breakpoint-deprecated( ">660px" ) {
-		border-bottom: none;
-		border-radius: 3px; /* stylelint-disable-line scales/radii */
+		@include breakpoint-deprecated( ">660px" ) {
+			border-bottom: none;
+			border-radius: 3px; /* stylelint-disable-line scales/radii */
+		}
+
+		@include breakpoint-deprecated( "<960px" ) {
+			display: block;
+		}
 	}
 
-	@include breakpoint-deprecated( "<960px" ) {
-		display: block;
-	}
 
 	.site-setup-list__nav-item-email {
 		display: none;


### PR DESCRIPTION
### Proposed Changes

* hotfix my home checklist layout 

### Screenshots

#### Before

<img width="1558" alt="Screen Shot 2022-12-05 at 3 35 14 PM" src="https://user-images.githubusercontent.com/5414230/205760887-b57e3064-c369-4335-a072-4e6b209311a6.png">

#### After

<img width="1496" alt="Screen Shot 2022-12-05 at 2 57 03 PM" src="https://user-images.githubusercontent.com/5414230/205760951-288186ff-b0df-4745-856f-4c1da790b2ef.png">

### Testing Instructions

Visit My Home: Checklist is laid out properly

*

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

- Context p1670276175778169-slack-C03N25JPCE4
- Fixes an issue introduced by a recent PR that updates cookie banner styles https://github.com/Automattic/wp-calypso/pull/70601