### PR TITLE
E2E: properly break each scenario of `handleTestEvent` after handling.

### DIFF
--- a/packages/calypso-e2e/src/jest-playwright-config/environment.ts
+++ b/packages/calypso-e2e/src/jest-playwright-config/environment.ts
@@ -283,9 +283,6 @@ class JestEnvironmentPlaywright extends NodeEnvironment {
 	 * Handle events emitted by jest-circus.
 	 */
 	async handleTestEvent( event: Circus.Event, state: Circus.State ) {
-		if ( this.testFilename.includes( 'infrastructure__ssr' ) ) {
-			console.log( `Event: ${ event.name }` );
-		}
 		switch ( event.name ) {
 			case 'run_start':
 				this.allure?.startTestFile( this.testFilename );
@@ -329,6 +326,7 @@ class JestEnvironmentPlaywright extends NodeEnvironment {
 				if ( this.failure?.type === 'test' ) {
 					event.test.mode = 'skip';
 				}
+				break;
 			case 'test_fn_start':
 				// This event is fired after both the `beforeAll` and `beforeEach` hooks.
 				// Since this event fires after `beforeEach` hooks, it is the best way to detect
@@ -354,13 +352,18 @@ class JestEnvironmentPlaywright extends NodeEnvironment {
 				break;
 			}
 			case 'test_done': {
-				// This will capture events from hooks as well.
+				// Event is fired when the test step is complete, including all pre- and
+				// after-hooks. Therefore we tell Allure that the test step has completely
+				// finished.
 				this.allure?.endTestStep();
+				break;
 			}
 			case 'run_describe_finish': {
 				break;
 			}
 			case 'teardown': {
+				// Teardown is completed in its own function that runs after the spec is
+				// complete.
 				break;
 			}
 			case 'run_finish':


### PR DESCRIPTION
#### Proposed Changes

This PR adds a `break` statement to each event handler such that Jest correctly breaks once the correct event handler is used to process the events.

This change also should end up fixing the Allure report issues where Unknown is reported for passing test steps.

Key changes:
- add `break` statements to each event handler.
- remove debugging code accidentally merged into production

Context: p1669396354978079-slack-CQD1HH4MA and a ton of debugging over days.

#### Testing Instructions

Ensure the following build configurations are passing:
  - [ ] Gutenberg E2E (desktop)
  - [ ] Gutenberg E2E (mobile)
  - [ ] Calypso E2E (desktop)
  - [ ] Calypso E2E (mobile)
  - [ ] Pre-Release E2E

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #