### PR TITLE
E2E: update `CartCheckoutPage.getCheckoutTotalAmount` to use locator.

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/cart-checkout-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/cart-checkout-page.ts
@@ -183,14 +183,16 @@ export class CartCheckoutPage {
 	 * If optional parameter `rawString` is specified, the string as obtained is returned.
 	 *
 	 * @param param0 Object parameter.
-	 * @param {boolean} param0.rawString If true, the raw string is returned.
+	 * @param {boolean} param0.rawString If true, the string as displayed is returned.
 	 * @returns {Promise<number|string>} Total value of items in cart.
 	 */
 	async getCheckoutTotalAmount( { rawString = false }: { rawString?: boolean } = {} ): Promise<
 		number | string
 	> {
-		const elementHandle = await this.page.waitForSelector( selectors.totalAmount );
-		const stringAmount = await elementHandle.innerText();
+		const totalAmountLocator = this.page.locator( selectors.totalAmount );
+		await totalAmountLocator.waitFor( { timeout: 20 * 1000 } );
+
+		const stringAmount = await totalAmountLocator.innerText();
 		if ( rawString ) {
 			// Returns the raw string.
 			return stringAmount;


### PR DESCRIPTION
#### Proposed Changes

This PR updates the logic for the aforementioned method.

Key changes:
- add extended timeout when waiting for the checkout total element.
- use locators to locate the checkout total element with an extended timeout of 20s.

#### Testing Instructions

Ensure the following build configurations are passing:
  - [ ] Calypso E2E (desktop)
  - [ ] Pre-Release E2E

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
