### PR TITLE
Theme Showcase: subject mismatch

### DIFF
--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -186,8 +186,9 @@ class ThemeShowcase extends Component {
 	};
 
 	getTabFilterFromUrl = ( filterString = '' ) => {
-		const matches = Object.values( this.tabSubjectTermTable ).filter(
-			( value ) => filterString.indexOf( value ) >= 0
+		const filterArray = filterString.split( '+' );
+		const matches = Object.values( this.tabSubjectTermTable ).filter( ( value ) =>
+			filterArray.includes( value )
 		);
 
 		let tabFilter = this.tabFilters.ALL;


### PR DESCRIPTION
#### Proposed Changes

* Split search string ( for `+` character ) into array to prevent subject mismatch

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the Themes Showcase /themes/${site_slug}
If using calypso.live, the flag themes/showcase-i4/search-and-filter is required.
* Confirm that subject filter only updated when subject is selected in search input (eg: `feature:blog-excerpts` should not update the subject filter item)

**BEFORE:**
![Screen%20Capture%20on%202022-12-06%20at%2011-08-07](https://user-images.githubusercontent.com/10071857/205811158-a2711912-7cc9-4d36-ad67-f9e8baf97eb0.gif)
**AFTER:**

https://user-images.githubusercontent.com/10071857/205811363-92773d53-dd35-4d7e-a29b-d356ff8d11de.mp4


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #70162
