### PR TITLE
VideoPress Domain and Plan step: Translate title string

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-domain/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-domain/index.tsx
@@ -98,7 +98,7 @@ const ChooseADomain: Step = function ChooseADomain( { navigation, flow } ) {
 		return (
 			<FormattedHeader
 				id="choose-a-domain-header"
-				headerText="Choose a domain"
+				headerText={ __( 'Choose a domain' ) }
 				subHeaderText={
 					<>
 						{ __( 'Make your video site shine with a custom domain. Not sure yet?' ) }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-plan/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-plan/index.tsx
@@ -267,7 +267,7 @@ const ChooseAPlan: Step = function ChooseAPlan( { navigation, flow } ) {
 		return (
 			<FormattedHeader
 				id="choose-a-plan-header"
-				headerText="Choose a plan"
+				headerText={ __( 'Choose a plan' ) }
 				subHeaderText={ __( 'Unlock a powerful bundle of features for your video site.' ) }
 				align="center"
 			/>


### PR DESCRIPTION
#### Proposed Changes

* Add translate() call to the title string.

**BEFORE**
<img width="649" alt="Screenshot 2022-12-06 at 9 42 14 AM" src="https://user-images.githubusercontent.com/1269602/205811612-a62dc941-c806-40bb-b87b-d827f98749d3.png">
<img width="1074" alt="Screenshot 2022-12-06 at 9 42 09 AM" src="https://user-images.githubusercontent.com/1269602/205811622-35590ac7-883d-4380-913d-75cee5b59ccb.png">

**AFTER**
<img width="757" alt="Screenshot 2022-12-06 at 9 42 42 AM" src="https://user-images.githubusercontent.com/1269602/205811636-9e5e1152-8544-4172-aa17-47490d2b149b.png">
<img width="856" alt="Screenshot 2022-12-06 at 9 42 38 AM" src="https://user-images.githubusercontent.com/1269602/205811645-9be466a0-0c6e-4c8a-ad94-ae17a67f1f80.png">


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go through `/setup/videopress/?locale=ja` and verify that the domain and plan step title is translated as shown in the screenshots.

