### PR TITLE
Tailored flow intro screen: Translate the document title and header

### DIFF
--- a/client/signup/signup-header/index.tsx
+++ b/client/signup/signup-header/index.tsx
@@ -1,6 +1,7 @@
 import { ProgressBar } from '@automattic/components';
 import { useFlowProgress } from '@automattic/onboarding';
 import classnames from 'classnames';
+import { useTranslate } from 'i18n-calypso';
 import WordPressLogo from 'calypso/components/wordpress-logo';
 import './style.scss';
 
@@ -17,12 +18,6 @@ interface Props {
 	pageTitle?: string;
 }
 
-const VARIATION_TITLES: Record< string, string > = {
-	newsletter: 'Newsletter',
-	'link-in-bio': 'Link in Bio',
-	videopress: 'Video',
-};
-
 const SignupHeader = ( {
 	shouldShowLoadingScreen,
 	isReskinned,
@@ -33,6 +28,12 @@ const SignupHeader = ( {
 	const logoClasses = classnames( 'wordpress-logo', {
 		'is-large': shouldShowLoadingScreen && ! isReskinned,
 	} );
+	const translate = useTranslate();
+	const VARIATION_TITLES: Record< string, string > = {
+		newsletter: translate( 'Newsletter' ),
+		'link-in-bio': translate( 'Link in Bio' ),
+		videopress: translate( 'Video' ),
+	};
 	const params = new URLSearchParams( window.location.search );
 	const variationName = params.get( 'variationName' );
 	const variationTitle = variationName && VARIATION_TITLES[ variationName ];

--- a/packages/onboarding/src/step-container/index.tsx
+++ b/packages/onboarding/src/step-container/index.tsx
@@ -192,7 +192,7 @@ const StepContainer: React.FC< Props > = ( {
 					{ headerButton && <div className="step-container__header-button">{ headerButton }</div> }
 					{ showHeaderJetpackPowered && (
 						<div className="step-container__header-jetpack-powered">
-							<JetpackLogo monochrome size={ 18 } /> <span>Jetpack powered</span>
+							<JetpackLogo monochrome size={ 18 } /> <span>{ translate( 'Jetpack powered' ) }</span>
 						</div>
 					) }
 				</div>
@@ -208,12 +208,12 @@ const StepContainer: React.FC< Props > = ( {
 			) }
 			{ showJetpackPowered && (
 				<div className="step-container__jetpack-powered">
-					<JetpackLogo monochrome size={ 18 } /> <span>Jetpack powered</span>
+					<JetpackLogo monochrome size={ 18 } /> <span>{ translate( 'Jetpack powered' ) }</span>
 				</div>
 			) }
 			{ showVideoPressPowered && (
 				<div className="step-container__videopress-powered">
-					<VideoPressLogo size={ 24 } /> <span>Powered by VideoPress</span>
+					<VideoPressLogo size={ 24 } /> <span>{ translate( 'Powered by VideoPress' ) }</span>
 				</div>
 			) }
 		</div>


### PR DESCRIPTION
#### Proposed Changes

* Add `translate()` to the document title, signup header and "Powered by" text in the tailored flows.

**BEFORE**
<img width="1456" alt="Screenshot 2022-12-06 at 10 10 07 AM" src="https://user-images.githubusercontent.com/1269602/205817112-50ccf507-d3b4-4b6b-801f-79325bf41cf1.png">

<img width="1439" alt="Screenshot 2022-12-06 at 9 52 41 AM" src="https://user-images.githubusercontent.com/1269602/205817123-01a771e7-25bd-450f-b741-d60449f7bdba.png">

**AFTER**

<img width="1389" alt="Screenshot 2022-12-06 at 9 52 21 AM" src="https://user-images.githubusercontent.com/1269602/205817161-e702a9fc-4b69-4690-8bdd-b53628531294.png">


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup/newsletter/intro?locale=ja`, `/setup/videopress/intro?locale=ja`, and `/setup/link-in-bio/intro?locale=ja` and  verify that the document title and signup header are translated. The "Powered by ..." content will be in english for now till the translations complete. It should be fine to merge since the string is any way shown in English. 
