### PR TITLE
Virtual pages: Enable feature flag in all envs

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -137,7 +137,7 @@
 		"themes/subscription-purchases": false,
 		"themes/theme-switch-persist-template": false,
 		"themes/third-party-premium": false,
-		"unified-pages/virtual-home-page": false,
+		"unified-pages/virtual-home-page": true,
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,
 		"upgrades/wpcom-monthly-plans": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -133,7 +133,7 @@
 		"themes/subscription-purchases": false,
 		"themes/theme-switch-persist-template": false,
 		"themes/third-party-premium": false,
-		"unified-pages/virtual-home-page": false,
+		"unified-pages/virtual-home-page": true,
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,
 		"upgrades/wpcom-monthly-plans": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -143,7 +143,7 @@
 		"themes/subscription-purchases": false,
 		"themes/theme-switch-persist-template": false,
 		"themes/third-party-premium": false,
-		"unified-pages/virtual-home-page": false,
+		"unified-pages/virtual-home-page": true,
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,
 		"upgrades/wpcom-monthly-plans": true,


### PR DESCRIPTION
#### Proposed Changes

This PR enables the `unified-pages/virtual-home-page` flag in all environments, previously reverted on #70680.


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
