### PR TITLE
Stats: Label blank authors in normalized data.

### DIFF
--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -657,6 +657,10 @@ export const normalizers = {
 				className: 'module-content-list-item-large',
 			};
 
+			if ( record.label.length === 0 ) {
+				record.label = translate( 'Untracked Author' );
+			}
+
 			if ( item.posts && item.posts.length > 0 ) {
 				record.children = item.posts.map( ( child ) => {
 					return {

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -649,17 +649,13 @@ export const normalizers = {
 
 		return authorsData.map( ( item ) => {
 			const record = {
-				label: item.name,
+				label: item.name || translate( 'Untracked Authors' ),
 				iconClassName: 'avatar-user',
 				icon: parseAvatar( item.avatar ),
 				children: null,
 				value: item.views,
 				className: 'module-content-list-item-large',
 			};
-
-			if ( record.label.length === 0 ) {
-				record.label = translate( 'Untracked Author' );
-			}
 
 			if ( item.posts && item.posts.length > 0 ) {
 				record.children = item.posts.map( ( child ) => {


### PR DESCRIPTION
#### Proposed Changes

Assigns a label to the catch-all author when a given site has untracked authors. This happens for any author who doesn't have an active Jetpack connection. The end result is we'll display "Untracked Author" instead of having the confusing blank avatar without a label.

**Before:**
![AuthorsBefore](https://user-images.githubusercontent.com/40267301/205857610-9b0475f4-f520-4c4f-b16a-da7890f4feb6.png)

**After:**
![AuthorsAfter](https://user-images.githubusercontent.com/40267301/205857640-fca0c8ac-2a84-4b6e-96b4-9aba9650f736.png)

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit the live branch.
* Visit a site with multiple authors.
* View Jetpack Stats → Traffic → Authors.
* Confirm the "Untracked Authors" label is shown instead of an unnamed avatar.
* Click on the Authors header.
* Confirm the entry is properly labeled there too.

For a12s you can reproduce and test these changes following the steps outlined here: pejTkB-4F#comment-89

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #69299.
