### PR TITLE
Theme Showcase: Increase theme card size

### DIFF
--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -16,7 +16,20 @@ body.is-section-themes-i4 {
 	}
 
 	.themes__selection .themes-list {
-		margin-top: 32px;
+		margin: 32px -16px 0;
+
+		.theme,
+		.themes-list__spacer {
+			width: 320px;
+		}
+
+		.theme {
+			margin: 0 16px 32px;
+		}
+
+		.themes-list__spacer {
+			margin: 0 16px;
+		}
 	}
 
 	.themes__content .upsell-nudge {


### PR DESCRIPTION
#### Proposed Changes

This PR increases the theme card size from `230px` to `320px` while also increasing the gap between them from `20px` to `36px`. Read pekYwv-8T-p2#comment-123 for more context behind increasing the theme card size. See comparison below:

| Before | After |
| --- | --- |
| ![Screen Shot 2022-12-06 at 5 42 32 PM](https://user-images.githubusercontent.com/797888/205875944-4b589143-9be0-4057-a8fd-a03f3dfac2a1.png) | ![Screen Shot 2022-12-06 at 5 44 16 PM](https://user-images.githubusercontent.com/797888/205876304-5fab28d1-9487-4186-af65-ae0ae43b2832.png)


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the Theme Showcase `/themes/${site_slug}`.
* Ensure that the theme card size is increased as described above.
* Ensure that the logged-out Theme Showcase also has increased theme card size. 

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->