### PR TITLE
Pricing page: Change JP Social line to bold text in bundle comparison table

### DIFF
--- a/client/my-sites/plans/jetpack-plans/product-store/features-list/features.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/features-list/features.tsx
@@ -102,7 +102,7 @@ export function useBundleFeaturesList( planSlug: string ) {
 			slug: 'growth',
 			title: translate( 'Growth' ),
 			features: [
-				translate( 'Social: Basic with unlimited shares' ),
+				<b>{ translate( 'Social: Basic with unlimited shares' ) }</b>,
 				<b>{ translate( 'CRM: Entrepreneur with 30 extensions' ) }</b>,
 			],
 		},


### PR DESCRIPTION
#### Proposed Changes

* Change JP Social line to bold text in Security/Complete bundle comparison table.

**old**
<img width="1222" alt="Screen Shot 2022-12-06 at 6 26 34 PM" src="https://user-images.githubusercontent.com/56598660/205886511-1b311f29-bad3-4a61-8982-310e40c2c797.png">

**new**
<img width="1233" alt="Screen Shot 2022-12-06 at 6 23 29 PM" src="https://user-images.githubusercontent.com/56598660/205886212-b968ef80-6fac-4957-b0a7-f241dcd757a5.png">


#### Testing Instructions

1. Run this branch by following the steps below (or you can use the Jetpack Cloud live link commented on this PR)
    * Run `git fetch && git checkout fix/pricing-page-bundle-comparison-text`
    * Run `yarn start-jetpack-cloud`

2. Confirm that the **JP Social line** is now in bold text in the Bundle comparison table.


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1202858161751496-as-1203459871003934

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203459871003934