### PR TITLE
Virtual pages: Add stats and qrcode menu item to virtual homepage

### DIFF
--- a/client/components/popover-menu/item-qr-code.jsx
+++ b/client/components/popover-menu/item-qr-code.jsx
@@ -1,0 +1,56 @@
+import { Dialog } from '@automattic/components';
+import { Icon } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import QRCode from 'qrcode.react';
+import { useCallback, useState, useEffect } from 'react';
+import PopoverMenuItem from './item';
+
+const icon = (
+	<Icon
+		icon={
+			<svg className="gridicon needs-offset-y" viewBox="0 0 24 24" width="18" height="18">
+				<path d="M1,1h1v1h-1z M2,1h1v1h-1z M3,1h1v1h-1z M4,1h1v1h-1z M5,1h1v1h-1z M6,1h1v1h-1z M7,1h1v1h-1z M9,1h1v1h-1z M11,1h1v1h-1z M12,1h1v1h-1z M13,1h1v1h-1z M15,1h1v1h-1z M16,1h1v1h-1z M17,1h1v1h-1z M18,1h1v1h-1z M19,1h1v1h-1z M20,1h1v1h-1z M21,1h1v1h-1z M1,2h1v1h-1z M7,2h1v1h-1z M12,2h1v1h-1z M13,2h1v1h-1z M15,2h1v1h-1z M21,2h1v1h-1z M1,3h1v1h-1z M3,3h1v1h-1z M4,3h1v1h-1z M5,3h1v1h-1z M7,3h1v1h-1z M9,3h1v1h-1z M10,3h1v1h-1z M11,3h1v1h-1z M15,3h1v1h-1z M17,3h1v1h-1z M18,3h1v1h-1z M19,3h1v1h-1z M21,3h1v1h-1z M1,4h1v1h-1z M3,4h1v1h-1z M4,4h1v1h-1z M5,4h1v1h-1z M7,4h1v1h-1z M9,4h1v1h-1z M12,4h1v1h-1z M15,4h1v1h-1z M17,4h1v1h-1z M18,4h1v1h-1z M19,4h1v1h-1z M21,4h1v1h-1z M1,5h1v1h-1z M3,5h1v1h-1z M4,5h1v1h-1z M5,5h1v1h-1z M7,5h1v1h-1z M10,5h1v1h-1z M11,5h1v1h-1z M13,5h1v1h-1z M15,5h1v1h-1z M17,5h1v1h-1z M18,5h1v1h-1z M19,5h1v1h-1z M21,5h1v1h-1z M1,6h1v1h-1z M7,6h1v1h-1z M9,6h1v1h-1z M11,6h1v1h-1z M12,6h1v1h-1z M15,6h1v1h-1z M21,6h1v1h-1z M1,7h1v1h-1z M2,7h1v1h-1z M3,7h1v1h-1z M4,7h1v1h-1z M5,7h1v1h-1z M6,7h1v1h-1z M7,7h1v1h-1z M9,7h1v1h-1z M11,7h1v1h-1z M13,7h1v1h-1z M15,7h1v1h-1z M16,7h1v1h-1z M17,7h1v1h-1z M18,7h1v1h-1z M19,7h1v1h-1z M20,7h1v1h-1z M21,7h1v1h-1z M9,8h1v1h-1z M10,8h1v1h-1z M11,8h1v1h-1z M12,8h1v1h-1z M13,8h1v1h-1z M2,9h1v1h-1z M4,9h1v1h-1z M6,9h1v1h-1z M7,9h1v1h-1z M8,9h1v1h-1z M9,9h1v1h-1z M12,9h1v1h-1z M13,9h1v1h-1z M14,9h1v1h-1z M15,9h1v1h-1z M16,9h1v1h-1z M18,9h1v1h-1z M19,9h1v1h-1z M21,9h1v1h-1z M3,10h1v1h-1z M4,10h1v1h-1z M6,10h1v1h-1z M8,10h1v1h-1z M9,10h1v1h-1z M10,10h1v1h-1z M11,10h1v1h-1z M13,10h1v1h-1z M14,10h1v1h-1z M17,10h1v1h-1z M19,10h1v1h-1z M20,10h1v1h-1z M21,10h1v1h-1z M4,11h1v1h-1z M5,11h1v1h-1z M6,11h1v1h-1z M7,11h1v1h-1z M8,11h1v1h-1z M9,11h1v1h-1z M11,11h1v1h-1z M13,11h1v1h-1z M16,11h1v1h-1z M18,11h1v1h-1z M21,11h1v1h-1z M2,12h1v1h-1z M10,12h1v1h-1z M13,12h1v1h-1z M15,12h1v1h-1z M18,12h1v1h-1z M2,13h1v1h-1z M3,13h1v1h-1z M4,13h1v1h-1z M7,13h1v1h-1z M9,13h1v1h-1z M13,13h1v1h-1z M14,13h1v1h-1z M16,13h1v1h-1z M17,13h1v1h-1z M18,13h1v1h-1z M20,13h1v1h-1z M21,13h1v1h-1z M9,14h1v1h-1z M11,14h1v1h-1z M16,14h1v1h-1z M18,14h1v1h-1z M20,14h1v1h-1z M1,15h1v1h-1z M2,15h1v1h-1z M3,15h1v1h-1z M4,15h1v1h-1z M5,15h1v1h-1z M6,15h1v1h-1z M7,15h1v1h-1z M9,15h1v1h-1z M10,15h1v1h-1z M11,15h1v1h-1z M14,15h1v1h-1z M15,15h1v1h-1z M16,15h1v1h-1z M17,15h1v1h-1z M18,15h1v1h-1z M20,15h1v1h-1z M1,16h1v1h-1z M7,16h1v1h-1z M9,16h1v1h-1z M13,16h1v1h-1z M14,16h1v1h-1z M16,16h1v1h-1z M17,16h1v1h-1z M1,17h1v1h-1z M3,17h1v1h-1z M4,17h1v1h-1z M5,17h1v1h-1z M7,17h1v1h-1z M10,17h1v1h-1z M12,17h1v1h-1z M13,17h1v1h-1z M14,17h1v1h-1z M15,17h1v1h-1z M20,17h1v1h-1z M1,18h1v1h-1z M3,18h1v1h-1z M4,18h1v1h-1z M5,18h1v1h-1z M7,18h1v1h-1z M9,18h1v1h-1z M11,18h1v1h-1z M12,18h1v1h-1z M17,18h1v1h-1z M18,18h1v1h-1z M20,18h1v1h-1z M21,18h1v1h-1z M1,19h1v1h-1z M3,19h1v1h-1z M4,19h1v1h-1z M5,19h1v1h-1z M7,19h1v1h-1z M11,19h1v1h-1z M13,19h1v1h-1z M16,19h1v1h-1z M17,19h1v1h-1z M19,19h1v1h-1z M21,19h1v1h-1z M1,20h1v1h-1z M7,20h1v1h-1z M9,20h1v1h-1z M11,20h1v1h-1z M14,20h1v1h-1z M15,20h1v1h-1z M16,20h1v1h-1z M17,20h1v1h-1z M1,21h1v1h-1z M2,21h1v1h-1z M3,21h1v1h-1z M4,21h1v1h-1z M5,21h1v1h-1z M6,21h1v1h-1z M7,21h1v1h-1z M10,21h1v1h-1z M11,21h1v1h-1z M12,21h1v1h-1z M13,21h1v1h-1z M17,21h1v1h-1z M19,21h1v1h-1z M20,21h1v1h-1z" />
+			</svg>
+		}
+	/>
+);
+
+function QRCodeDialog( { url, showQRCode } ) {
+	const translate = useTranslate();
+
+	const buttons = [ { action: 'cancel', label: translate( 'Close' ) } ];
+
+	const [ showQRCodeDialog, setShowQRCodeDialog ] = useState( false );
+
+	useEffect( () => {
+		setShowQRCodeDialog( showQRCode );
+	}, [ showQRCode ] );
+
+	const onCloseDialog = useCallback( () => {
+		setShowQRCodeDialog( false );
+	}, [] );
+
+	return (
+		<Dialog isVisible={ showQRCodeDialog } buttons={ buttons } onClose={ onCloseDialog }>
+			<QRCode value={ url } size={ 200 } renderAs="canvas" level="H" />
+		</Dialog>
+	);
+}
+
+export default function PopoverMenuItemQrCode( { url, handleClick, children } ) {
+	const [ showQRCode, setShowQRCode ] = useState( false );
+
+	const generateQRCode = () => {
+		handleClick();
+		setShowQRCode( true );
+	};
+
+	return (
+		<>
+			<PopoverMenuItem onClick={ generateQRCode } icon={ icon }>
+				{ children }
+			</PopoverMenuItem>
+			<QRCodeDialog url={ url } showQRCode={ showQRCode } />
+		</>
+	);
+}

--- a/client/my-sites/pages/page/index.js
+++ b/client/my-sites/pages/page/index.js
@@ -366,7 +366,7 @@ class Page extends Component {
 			<PostActionsEllipsisMenuQRCode
 				globalId={ this.props.page.global_ID }
 				key="qrcode"
-				handleClick={ this.viewPageQr }
+				onClick={ this.viewPageQrCode }
 			/>
 		);
 	}
@@ -784,7 +784,7 @@ class Page extends Component {
 		saveAs( blob, fileName );
 	};
 
-	viewPageQr = () => {
+	viewPageQrCode = () => {
 		this.recordEllipsisMenuItemClickEvent( 'qrcode' );
 	};
 

--- a/client/my-sites/pages/virtual-page/index.tsx
+++ b/client/my-sites/pages/virtual-page/index.tsx
@@ -1,14 +1,17 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { CompactCard, Gridicon } from '@automattic/components';
 import { useTemplate } from '@automattic/data-stores';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { ExternalLink } from '@wordpress/components';
 import { decodeEntities } from '@wordpress/html-entities';
 import { useTranslate } from 'i18n-calypso';
+import pageRouter from 'page';
 import { connect } from 'react-redux';
 import EllipsisMenu from 'calypso/components/ellipsis-menu';
 import InfoPopover from 'calypso/components/info-popover';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import PopoverMenuItemClipboard from 'calypso/components/popover-menu/item-clipboard';
+import PopoverMenuItemQrCode from 'calypso/components/popover-menu/item-qr-code';
 import { addQueryArgs } from 'calypso/lib/route';
 import { recordGoogleEvent, recordTracksEvent } from 'calypso/state/analytics/actions';
 import { infoNotice } from 'calypso/state/notices/actions';
@@ -97,6 +100,18 @@ const VirtualPage = ( {
 		props.setLayoutFocus( 'preview' );
 	};
 
+	const viewStats = () => {
+		recordEllipsisMenuItemClickEvent( 'viewstats' );
+
+		if ( isHomepage ) {
+			pageRouter( `/stats/post/0/${ site.slug }` );
+		}
+	};
+
+	const viewPageQrCode = () => {
+		recordEllipsisMenuItemClickEvent( 'qrcode' );
+	};
+
 	const copyPageLink = () => {
 		props.infoNotice( translate( 'Link copied to clipboard.' ), {
 			duration: 3000,
@@ -168,6 +183,17 @@ const VirtualPage = ( {
 					<PopoverMenuItemClipboard text={ previewUrl } onCopy={ copyPageLink } icon="link">
 						{ translate( 'Copy link' ) }
 					</PopoverMenuItemClipboard>
+				) }
+				{ previewUrl && (
+					<PopoverMenuItem onClick={ viewStats }>
+						<Gridicon icon="stats" size={ 18 } />
+						{ translate( 'Stats' ) }
+					</PopoverMenuItem>
+				) }
+				{ previewUrl && isEnabled( 'post-list/qr-code-link' ) && (
+					<PopoverMenuItemQrCode url={ previewUrl } handleClick={ viewPageQrCode }>
+						{ translate( 'QR Code' ) }
+					</PopoverMenuItemQrCode>
 				) }
 			</EllipsisMenu>
 		</CompactCard>

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/qrcode.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/qrcode.jsx
@@ -1,35 +1,15 @@
-import { Icon } from '@wordpress/components';
-import { useState } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
-import PopoverMenuItem from 'calypso/components/popover-menu/item';
+import PopoverMenuItemQrCode from 'calypso/components/popover-menu/item-qr-code';
 import { getPost } from 'calypso/state/posts/selectors';
-import PostActionsQRCode from '../../post-actions-qr-code';
 
 const noop = () => {};
 
-const qrIcon = (
-	<Icon
-		icon={
-			<svg className="gridicon needs-offset-y" viewBox="0 0 24 24" width="18" height="18">
-				<path d="M1,1h1v1h-1z M2,1h1v1h-1z M3,1h1v1h-1z M4,1h1v1h-1z M5,1h1v1h-1z M6,1h1v1h-1z M7,1h1v1h-1z M9,1h1v1h-1z M11,1h1v1h-1z M12,1h1v1h-1z M13,1h1v1h-1z M15,1h1v1h-1z M16,1h1v1h-1z M17,1h1v1h-1z M18,1h1v1h-1z M19,1h1v1h-1z M20,1h1v1h-1z M21,1h1v1h-1z M1,2h1v1h-1z M7,2h1v1h-1z M12,2h1v1h-1z M13,2h1v1h-1z M15,2h1v1h-1z M21,2h1v1h-1z M1,3h1v1h-1z M3,3h1v1h-1z M4,3h1v1h-1z M5,3h1v1h-1z M7,3h1v1h-1z M9,3h1v1h-1z M10,3h1v1h-1z M11,3h1v1h-1z M15,3h1v1h-1z M17,3h1v1h-1z M18,3h1v1h-1z M19,3h1v1h-1z M21,3h1v1h-1z M1,4h1v1h-1z M3,4h1v1h-1z M4,4h1v1h-1z M5,4h1v1h-1z M7,4h1v1h-1z M9,4h1v1h-1z M12,4h1v1h-1z M15,4h1v1h-1z M17,4h1v1h-1z M18,4h1v1h-1z M19,4h1v1h-1z M21,4h1v1h-1z M1,5h1v1h-1z M3,5h1v1h-1z M4,5h1v1h-1z M5,5h1v1h-1z M7,5h1v1h-1z M10,5h1v1h-1z M11,5h1v1h-1z M13,5h1v1h-1z M15,5h1v1h-1z M17,5h1v1h-1z M18,5h1v1h-1z M19,5h1v1h-1z M21,5h1v1h-1z M1,6h1v1h-1z M7,6h1v1h-1z M9,6h1v1h-1z M11,6h1v1h-1z M12,6h1v1h-1z M15,6h1v1h-1z M21,6h1v1h-1z M1,7h1v1h-1z M2,7h1v1h-1z M3,7h1v1h-1z M4,7h1v1h-1z M5,7h1v1h-1z M6,7h1v1h-1z M7,7h1v1h-1z M9,7h1v1h-1z M11,7h1v1h-1z M13,7h1v1h-1z M15,7h1v1h-1z M16,7h1v1h-1z M17,7h1v1h-1z M18,7h1v1h-1z M19,7h1v1h-1z M20,7h1v1h-1z M21,7h1v1h-1z M9,8h1v1h-1z M10,8h1v1h-1z M11,8h1v1h-1z M12,8h1v1h-1z M13,8h1v1h-1z M2,9h1v1h-1z M4,9h1v1h-1z M6,9h1v1h-1z M7,9h1v1h-1z M8,9h1v1h-1z M9,9h1v1h-1z M12,9h1v1h-1z M13,9h1v1h-1z M14,9h1v1h-1z M15,9h1v1h-1z M16,9h1v1h-1z M18,9h1v1h-1z M19,9h1v1h-1z M21,9h1v1h-1z M3,10h1v1h-1z M4,10h1v1h-1z M6,10h1v1h-1z M8,10h1v1h-1z M9,10h1v1h-1z M10,10h1v1h-1z M11,10h1v1h-1z M13,10h1v1h-1z M14,10h1v1h-1z M17,10h1v1h-1z M19,10h1v1h-1z M20,10h1v1h-1z M21,10h1v1h-1z M4,11h1v1h-1z M5,11h1v1h-1z M6,11h1v1h-1z M7,11h1v1h-1z M8,11h1v1h-1z M9,11h1v1h-1z M11,11h1v1h-1z M13,11h1v1h-1z M16,11h1v1h-1z M18,11h1v1h-1z M21,11h1v1h-1z M2,12h1v1h-1z M10,12h1v1h-1z M13,12h1v1h-1z M15,12h1v1h-1z M18,12h1v1h-1z M2,13h1v1h-1z M3,13h1v1h-1z M4,13h1v1h-1z M7,13h1v1h-1z M9,13h1v1h-1z M13,13h1v1h-1z M14,13h1v1h-1z M16,13h1v1h-1z M17,13h1v1h-1z M18,13h1v1h-1z M20,13h1v1h-1z M21,13h1v1h-1z M9,14h1v1h-1z M11,14h1v1h-1z M16,14h1v1h-1z M18,14h1v1h-1z M20,14h1v1h-1z M1,15h1v1h-1z M2,15h1v1h-1z M3,15h1v1h-1z M4,15h1v1h-1z M5,15h1v1h-1z M6,15h1v1h-1z M7,15h1v1h-1z M9,15h1v1h-1z M10,15h1v1h-1z M11,15h1v1h-1z M14,15h1v1h-1z M15,15h1v1h-1z M16,15h1v1h-1z M17,15h1v1h-1z M18,15h1v1h-1z M20,15h1v1h-1z M1,16h1v1h-1z M7,16h1v1h-1z M9,16h1v1h-1z M13,16h1v1h-1z M14,16h1v1h-1z M16,16h1v1h-1z M17,16h1v1h-1z M1,17h1v1h-1z M3,17h1v1h-1z M4,17h1v1h-1z M5,17h1v1h-1z M7,17h1v1h-1z M10,17h1v1h-1z M12,17h1v1h-1z M13,17h1v1h-1z M14,17h1v1h-1z M15,17h1v1h-1z M20,17h1v1h-1z M1,18h1v1h-1z M3,18h1v1h-1z M4,18h1v1h-1z M5,18h1v1h-1z M7,18h1v1h-1z M9,18h1v1h-1z M11,18h1v1h-1z M12,18h1v1h-1z M17,18h1v1h-1z M18,18h1v1h-1z M20,18h1v1h-1z M21,18h1v1h-1z M1,19h1v1h-1z M3,19h1v1h-1z M4,19h1v1h-1z M5,19h1v1h-1z M7,19h1v1h-1z M11,19h1v1h-1z M13,19h1v1h-1z M16,19h1v1h-1z M17,19h1v1h-1z M19,19h1v1h-1z M21,19h1v1h-1z M1,20h1v1h-1z M7,20h1v1h-1z M9,20h1v1h-1z M11,20h1v1h-1z M14,20h1v1h-1z M15,20h1v1h-1z M16,20h1v1h-1z M17,20h1v1h-1z M1,21h1v1h-1z M2,21h1v1h-1z M3,21h1v1h-1z M4,21h1v1h-1z M5,21h1v1h-1z M6,21h1v1h-1z M7,21h1v1h-1z M10,21h1v1h-1z M11,21h1v1h-1z M12,21h1v1h-1z M13,21h1v1h-1z M17,21h1v1h-1z M19,21h1v1h-1z M20,21h1v1h-1z" />
-			</svg>
-		}
-	/>
-);
-
 function PostActionsEllipsisMenuQRCode( { globalId, handleClick = noop } ) {
-	const [ showQRCode, setShowQRCode ] = useState( false );
-
 	const translate = useTranslate();
 
 	const post = useSelector( ( state ) => getPost( state, globalId ) );
-
-	const generateQRCode = () => {
-		handleClick();
-		setShowQRCode( true );
-	};
 
 	if ( ! post || ! post.URL || ! post.status ) {
 		return null;
@@ -41,12 +21,9 @@ function PostActionsEllipsisMenuQRCode( { globalId, handleClick = noop } ) {
 	}
 
 	return (
-		<>
-			<PopoverMenuItem onClick={ generateQRCode } icon={ qrIcon }>
-				{ translate( 'QR Code' ) }
-			</PopoverMenuItem>
-			<PostActionsQRCode siteUrl={ post.URL } showQRCode={ showQRCode } />
-		</>
+		<PopoverMenuItemQrCode url={ post.URL } handleClick={ handleClick }>
+			{ translate( 'QR Code' ) }
+		</PopoverMenuItemQrCode>
 	);
 }
 


### PR DESCRIPTION
#### Proposed Changes

This PR implements the stats and qrcode menu item to virtual homepage, with the corresponding Tracks events. See below:

|Trigger|Event|On click|
|-|-|-|
|User clicks Stats menu item<br><img width="192" alt="image" src="https://user-images.githubusercontent.com/1525580/205890652-44c30eb3-5159-4f24-9b51-efecd7dbb877.png">|`calypso_pages_ellipsismenu_item_click`<br>`page_type: virtual`<br>`item: viewstats`|Redirected to `/stats/post/0/{siteSlug}`|
|User clicks QR Code menu item<br><img width="182" alt="image" src="https://user-images.githubusercontent.com/1525580/205891610-5303a2ea-4a37-4a11-a083-4f8eb2d6a277.png">|`calypso_pages_ellipsismenu_item_click`<br>`page_type: virtual`<br>`item: qrcode`|Shows QR Code to the site's homepage url|

#### Testing Instructions

1. In browser console, run: `localStorage.setItem( 'debug', 'calypso:analytics*' );`
2. Refresh your browser
3. Test the events above, by watching for `calypso:analytics`, and make sure that the effect after click is correct.
4. As I introduced a bit of refactor, please make sure that the Stats and QR Code for regular page AND posts are still working :)

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #70569
