### PR TITLE
Update/users management

### DIFF
--- a/client/my-sites/people/controller.js
+++ b/client/my-sites/people/controller.js
@@ -130,7 +130,7 @@ function renderTeamMembers( context, next ) {
 	context.primary = (
 		<>
 			<TeamMembersTitle />
-			<TeamMembers />
+			<TeamMembers filter={ context.params.filter } search={ context.query.s } />
 		</>
 	);
 	next();
@@ -146,7 +146,7 @@ function renderSubscribers( context, next ) {
 	context.primary = (
 		<>
 			<SubscribersTitle />
-			<Subscribers />
+			<Subscribers filter={ context.params.filter } search={ context.query.s } />
 		</>
 	);
 	next();

--- a/client/my-sites/people/controller.js
+++ b/client/my-sites/people/controller.js
@@ -11,6 +11,7 @@ import PeopleList from './main';
 import PeopleAddSubscribers from './people-add-subscribers';
 import PeopleInviteDetails from './people-invite-details';
 import PeopleInvites from './people-invites';
+import Subscribers from './subscribers';
 
 export default {
 	redirectToTeam,
@@ -43,6 +44,10 @@ export default {
 
 	peopleInviteDetails( context, next ) {
 		renderPeopleInviteDetails( context, next );
+	},
+
+	subscribers( context, next ) {
+		renderSubscribers( context, next );
 	},
 
 	peopleAddSubscribers( context, next ) {
@@ -105,6 +110,22 @@ function renderPeopleInvites( context, next ) {
 		<>
 			<PeopleInvitesTitle />
 			<PeopleInvites />
+		</>
+	);
+	next();
+}
+
+function renderSubscribers( context, next ) {
+	const SubscribersTitle = () => {
+		const translate = useTranslate();
+
+		return <DocumentHead title={ translate( 'Subscribers', { textOnly: true } ) } />;
+	};
+
+	context.primary = (
+		<>
+			<SubscribersTitle />
+			<Subscribers />
 		</>
 	);
 	next();

--- a/client/my-sites/people/controller.js
+++ b/client/my-sites/people/controller.js
@@ -12,6 +12,7 @@ import PeopleAddSubscribers from './people-add-subscribers';
 import PeopleInviteDetails from './people-invite-details';
 import PeopleInvites from './people-invites';
 import Subscribers from './subscribers';
+import TeamMembers from './team-members';
 
 export default {
 	redirectToTeam,
@@ -44,6 +45,10 @@ export default {
 
 	peopleInviteDetails( context, next ) {
 		renderPeopleInviteDetails( context, next );
+	},
+
+	teamMembers( context, next ) {
+		renderTeamMembers( context, next );
 	},
 
 	subscribers( context, next ) {
@@ -110,6 +115,22 @@ function renderPeopleInvites( context, next ) {
 		<>
 			<PeopleInvitesTitle />
 			<PeopleInvites />
+		</>
+	);
+	next();
+}
+
+function renderTeamMembers( context, next ) {
+	const TeamMembersTitle = () => {
+		const translate = useTranslate();
+
+		return <DocumentHead title={ translate( 'Team Members', { textOnly: true } ) } />;
+	};
+
+	context.primary = (
+		<>
+			<TeamMembersTitle />
+			<TeamMembers />
 		</>
 	);
 	next();

--- a/client/my-sites/people/index.js
+++ b/client/my-sites/people/index.js
@@ -45,7 +45,7 @@ export default function () {
 	);
 
 	page(
-		'/people/team-members/:site_id',
+		'/people/:filter(team-members)/:site_id',
 		peopleController.enforceSiteEnding,
 		siteSelection,
 		navigation,
@@ -55,7 +55,7 @@ export default function () {
 	);
 
 	page(
-		'/people/subscribers/:site_id',
+		'/people/:filter(subscribers)/:site_id',
 		peopleController.enforceSiteEnding,
 		siteSelection,
 		navigation,

--- a/client/my-sites/people/index.js
+++ b/client/my-sites/people/index.js
@@ -45,6 +45,16 @@ export default function () {
 	);
 
 	page(
+		'/people/team-members/:site_id',
+		peopleController.enforceSiteEnding,
+		siteSelection,
+		navigation,
+		peopleController.teamMembers,
+		makeLayout,
+		clientRender
+	);
+
+	page(
 		'/people/subscribers/:site_id',
 		peopleController.enforceSiteEnding,
 		siteSelection,

--- a/client/my-sites/people/index.js
+++ b/client/my-sites/people/index.js
@@ -45,6 +45,16 @@ export default function () {
 	);
 
 	page(
+		'/people/subscribers/:site_id',
+		peopleController.enforceSiteEnding,
+		siteSelection,
+		navigation,
+		peopleController.subscribers,
+		makeLayout,
+		clientRender
+	);
+
+	page(
 		'/people/add-subscribers/:site_id',
 		peopleController.enforceSiteEnding,
 		siteSelection,

--- a/client/my-sites/people/people-section-nav-compact/index.tsx
+++ b/client/my-sites/people/people-section-nav-compact/index.tsx
@@ -1,0 +1,50 @@
+import { useTranslate } from 'i18n-calypso';
+import { useSelector } from 'react-redux';
+import NavItem from 'calypso/components/section-nav/item';
+import NavTabs from 'calypso/components/section-nav/tabs';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
+import PeopleSearch from '../people-section-nav/people-search';
+
+interface Props {
+	selectedFilter: string;
+	searchTerm?: string;
+}
+function PeopleSectionNavCompact( props: Props ) {
+	const _ = useTranslate();
+	const { selectedFilter, searchTerm } = props;
+	const site = useSelector( ( state ) => getSelectedSite( state ) );
+
+	const filters = [
+		{
+			title: _( 'Subscribers' ),
+			path: '/people/subscribers/' + site?.slug,
+			id: 'subscribers',
+		},
+		{
+			title: _( 'Team' ),
+			path: '/people/team-members/' + site?.slug,
+			id: 'team-members',
+		},
+	];
+
+	return (
+		<>
+			<NavTabs>
+				{ filters.map( function ( filterItem ) {
+					return (
+						<NavItem
+							key={ filterItem.id }
+							path={ filterItem.path }
+							selected={ filterItem.id === selectedFilter }
+						>
+							{ filterItem.title }
+						</NavItem>
+					);
+				} ) }
+			</NavTabs>
+			<PeopleSearch search={ searchTerm } />
+		</>
+	);
+}
+
+export default PeopleSectionNavCompact;

--- a/client/my-sites/people/subscribers/index.tsx
+++ b/client/my-sites/people/subscribers/index.tsx
@@ -1,0 +1,5 @@
+function Subscribers() {
+	return <>Users - people/subscribers route</>;
+}
+
+export default Subscribers;

--- a/client/my-sites/people/subscribers/index.tsx
+++ b/client/my-sites/people/subscribers/index.tsx
@@ -1,5 +1,34 @@
-function Subscribers() {
-	return <>Users - people/subscribers route</>;
+import { useTranslate } from 'i18n-calypso';
+import FormattedHeader from 'calypso/components/formatted-header';
+import Main from 'calypso/components/main';
+import SectionNav from 'calypso/components/section-nav';
+import PeopleSectionNavCompact from '../people-section-nav-compact';
+
+interface Props {
+	filter: string;
+	search?: string;
+}
+function Subscribers( props: Props ) {
+	const _ = useTranslate();
+	const { filter, search } = props;
+
+	return (
+		<Main>
+			<FormattedHeader
+				brandFont
+				className="people__page-heading"
+				headerText={ _( 'Users' ) }
+				subHeaderText={ _( 'People who have subscribed to your site and team members.' ) }
+				align="left"
+				hasScreenOptions
+			/>
+			<div>
+				<SectionNav>
+					<PeopleSectionNavCompact selectedFilter={ filter } searchTerm={ search } />
+				</SectionNav>
+			</div>
+		</Main>
+	);
 }
 
 export default Subscribers;

--- a/client/my-sites/people/team-members/index.tsx
+++ b/client/my-sites/people/team-members/index.tsx
@@ -1,5 +1,34 @@
-function TeamMembers() {
-	return <>Users - people/team-members route</>;
+import { useTranslate } from 'i18n-calypso';
+import FormattedHeader from 'calypso/components/formatted-header';
+import Main from 'calypso/components/main';
+import SectionNav from 'calypso/components/section-nav';
+import PeopleSectionNavCompact from '../people-section-nav-compact';
+
+interface Props {
+	filter: string;
+	search?: string;
+}
+function TeamMembers( props: Props ) {
+	const _ = useTranslate();
+	const { filter, search } = props;
+
+	return (
+		<Main>
+			<FormattedHeader
+				brandFont
+				className="people__page-heading"
+				headerText={ _( 'Users' ) }
+				subHeaderText={ _( 'People who have subscribed to your site and team members.' ) }
+				align="left"
+				hasScreenOptions
+			/>
+			<div>
+				<SectionNav>
+					<PeopleSectionNavCompact selectedFilter={ filter } searchTerm={ search } />
+				</SectionNav>
+			</div>
+		</Main>
+	);
 }
 
 export default TeamMembers;

--- a/client/my-sites/people/team-members/index.tsx
+++ b/client/my-sites/people/team-members/index.tsx
@@ -1,0 +1,5 @@
+function TeamMembers() {
+	return <>Users - people/team-members route</>;
+}
+
+export default TeamMembers;


### PR DESCRIPTION
#### Proposed Changes

The idea is to propose multiple small PRs for more straightforward reviews, so this is the first PR in a series of future PRs until we reach the goal/complete the project.

**User Management Revamp:**

* Introduced new routes
  * `/people/subscribers/{SITE_SLUG}`
  * `/people/team-members/{SITE_SLUG}`
* Created navigation tabs presenting new routes (Subscribers, Team)
* The search input will update the query param for now

#### Testing Instructions

* Go to `/people/subscribers/{SITE_SLUG}`
* Switch between tabs
* Check if the page title is changing while switching between tabs

#### Screenshot
<img width="750" alt="Screenshot 2022-12-07 at 23 41 12" src="https://user-images.githubusercontent.com/1241413/206312424-aa041719-c253-4ff7-9767-5479e6616cac.png">

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #70699
