### PR TITLE
Restore a missing sentence from the downgrade step

### DIFF
--- a/client/components/marketing-survey/cancel-purchase-form/step-components/upsell-step.tsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/upsell-step.tsx
@@ -243,19 +243,21 @@ export default function UpsellStep( { upsell, site, purchase, ...props }: StepPr
 					onDecline={ props.onDeclineUpsell }
 					image={ imgSwitchPlan }
 				>
-					{ translate(
-						'WordPress.com Personal still gives you access to customer support via email, removal of ads, and more — and for 50% of the cost of your current plan.'
-					) }{ ' ' }
-					{ refundAmount &&
-						translate(
-							'You can downgrade and get a partial refund of %(amount)s or ' +
-								'continue to the next step and cancel the plan.',
-							{
-								args: {
-									amount: formatCurrency( parseFloat( props.refundAmount ), currencyCode ),
-								},
-							}
-						) }
+					<>
+						{ translate(
+							'WordPress.com Personal still gives you access to customer support via email, removal of ads, and more — and for 50% of the cost of your current plan.'
+						) }{ ' ' }
+						{ refundAmount &&
+							translate(
+								'You can downgrade and get a partial refund of %(amount)s or ' +
+									'continue to the next step and cancel the plan.',
+								{
+									args: {
+										amount: formatCurrency( parseFloat( props.refundAmount ), currencyCode ),
+									},
+								}
+							) }
+					</>
 				</Upsell>
 			);
 		case 'free-month-offer':

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/upsell-step.tsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/upsell-step.tsx
@@ -116,6 +116,7 @@ export default function UpsellStep( { upsell, site, purchase, ...props }: StepPr
 	const couponCode = 'BIZC25';
 	const builtByURL =
 		'https://builtbywp.com/get-started/?utm_medium=automattic_referred&utm_source=WordPresscom&utm_campaign=cancel-flow';
+	const refundAmount = { props };
 
 	switch ( upsell ) {
 		case 'live-chat:plans':
@@ -244,7 +245,17 @@ export default function UpsellStep( { upsell, site, purchase, ...props }: StepPr
 				>
 					{ translate(
 						'WordPress.com Personal still gives you access to customer support via email, removal of ads, and more — and for 50% of the cost of your current plan.'
-					) }
+					) }{ ' ' }
+					{ refundAmount &&
+						translate(
+							'You can downgrade and get a partial refund of %(amount)s or ' +
+								'continue to the next step and cancel the plan.',
+							{
+								args: {
+									amount: formatCurrency( parseFloat( props.refundAmount ), currencyCode ),
+								},
+							}
+						) }
 				</Upsell>
 			);
 		case 'free-month-offer':

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/upsell-step.tsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/upsell-step.tsx
@@ -116,7 +116,7 @@ export default function UpsellStep( { upsell, site, purchase, ...props }: StepPr
 	const couponCode = 'BIZC25';
 	const builtByURL =
 		'https://builtbywp.com/get-started/?utm_medium=automattic_referred&utm_source=WordPresscom&utm_campaign=cancel-flow';
-	const refundAmount = { props };
+	const { refundAmount } = props;
 
 	switch ( upsell ) {
 		case 'live-chat:plans':
@@ -221,13 +221,13 @@ export default function UpsellStep( { upsell, site, purchase, ...props }: StepPr
 							translate(
 								'You will lose your free domain registration since that feature is only included in annual/biannual plans.'
 							) }
-						{ props.refundAmount && <br /> }
-						{ props.refundAmount &&
+						{ refundAmount && <br /> }
+						{ refundAmount &&
 							translate(
 								'You can downgrade immediately and get a partial refund of %(refundAmount)s.',
 								{
 									args: {
-										refundAmount: formatCurrency( parseFloat( props.refundAmount ), currencyCode ),
+										refundAmount: formatCurrency( parseFloat( refundAmount ), currencyCode ),
 									},
 								}
 							) }
@@ -253,7 +253,7 @@ export default function UpsellStep( { upsell, site, purchase, ...props }: StepPr
 									'continue to the next step and cancel the plan.',
 								{
 									args: {
-										amount: formatCurrency( parseFloat( props.refundAmount ), currencyCode ),
+										amount: formatCurrency( parseFloat( refundAmount ), currencyCode ),
 									},
 								}
 							) }


### PR DESCRIPTION
#### Proposed Changes

In the cancellation flow, for Premium plan users who select Too Expensive/Want cheaper plan, we used to show the partial refund amount.

There's also another sentence that was intended for a renewal period when the plan is not refundable but the code path is unreachable and it's not because of the recent changes, so adding it back is out of scope and will be addressed separately.

#### Testing Instructions

* Buy a Premium plan
* Cancel from /me/purchases
* In the survey, select price/too expensive
* You should see an offer to downgrade to Personal
* Refund the transaction from store admin or buy another Premium plan with credits
* Repeat steps, no downgrade offer visible

Note: I believe we are supposed to show these downgrade options to renewals but it's a separate bug that will be chased later.

<img width="815" alt="Screenshot 2022-12-06 at 14 58 16" src="https://user-images.githubusercontent.com/82778/205920947-93885c64-15c7-4b4d-bdcc-feb52a30c51a.png">


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
