### PR TITLE
Fix handling empty API responses

### DIFF
--- a/client/state/data-layer/wpcom-http/test/utils.js
+++ b/client/state/data-layer/wpcom-http/test/utils.js
@@ -32,6 +32,7 @@ describe( 'WPCOM HTTP Data Layer', () => {
 			expect( getData( withData( null ) ) ).toBe( null );
 			expect( getData( withData( 0 ) ) ).toBe( 0 );
 			expect( getData( withData( false ) ) ).toBe( false );
+			expect( getData( withData( [] ) ) ).toEqual( [] );
 		} );
 	} );
 
@@ -155,17 +156,29 @@ describe( 'WPCOM HTTP Data Layer', () => {
 		} );
 
 		const data = { count: 5 };
+		const dataEmptyString = '';
+		const dataEmptyArray = [];
 		const error = { message: 'oh no!' };
 		const progress = { loaded: 45, total: 80 };
 
 		const fetchHttpAction = { type: 'REFILL' };
 		const successHttpAction = { type: 'REFILL', meta: { dataLayer: { data } } };
+		const successEmptyStringHttpAction = {
+			type: 'REFILL',
+			meta: { dataLayer: { data: dataEmptyString } },
+		};
+		const successEmptyArrayHttpAction = {
+			type: 'REFILL',
+			meta: { dataLayer: { data: dataEmptyArray } },
+		};
 		const failureHttpAction = { type: 'REFILL', meta: { dataLayer: { error } } };
 		const progressHttpAction = { type: 'REFILL', meta: { dataLayer: { progress } } };
 		const bothHttpAction = { type: 'REFILL', meta: { dataLayer: { data, error } } };
 
 		const fetchAction = { type: 'REQUEST' };
 		const successAction = { type: 'SUCCESS', data };
+		const successEmptyStringAction = { type: 'SUCCESS', data: dataEmptyString };
+		const successEmptyArrayAction = { type: 'SUCCESS', data: dataEmptyArray };
 		const failureAction = { type: 'FAILURE', error };
 		const progressAction = { type: 'PROGRESS', progress };
 
@@ -185,6 +198,16 @@ describe( 'WPCOM HTTP Data Layer', () => {
 		test( 'should call onSuccess if meta includes response data', () => {
 			dispatcher( store, successHttpAction );
 			expect( dispatch ).toHaveBeenCalledWith( successAction );
+		} );
+
+		test( 'should call onSuccess if meta includes empty string response data', () => {
+			dispatcher( store, successEmptyStringHttpAction );
+			expect( dispatch ).toHaveBeenCalledWith( successEmptyStringAction );
+		} );
+
+		test( 'should call onSuccess if meta includes empty array response data', () => {
+			dispatcher( store, successEmptyArrayHttpAction );
+			expect( dispatch ).toHaveBeenCalledWith( successEmptyArrayAction );
 		} );
 
 		test( 'should call onError if meta includes error data', () => {

--- a/client/state/data-layer/wpcom-http/test/utils.js
+++ b/client/state/data-layer/wpcom-http/test/utils.js
@@ -20,6 +20,7 @@ describe( 'WPCOM HTTP Data Layer', () => {
 			const data = { utterance: 'Bork bork' };
 
 			expect( getData( withData( data ) ) ).toEqual( data );
+			expect( getData( withData( [] ) ) ).toEqual( [] );
 		} );
 
 		test( 'should return undefined if no response data available', () => {
@@ -32,7 +33,6 @@ describe( 'WPCOM HTTP Data Layer', () => {
 			expect( getData( withData( null ) ) ).toBe( null );
 			expect( getData( withData( 0 ) ) ).toBe( 0 );
 			expect( getData( withData( false ) ) ).toBe( false );
-			expect( getData( withData( [] ) ) ).toEqual( [] );
 		} );
 	} );
 

--- a/client/state/data-layer/wpcom-http/utils.js
+++ b/client/state/data-layer/wpcom-http/utils.js
@@ -211,12 +211,12 @@ function createRequestAction( options, action ) {
 	} = options;
 
 	const error = getError( action );
-	if ( error ) {
+	if ( undefined !== error ) {
 		return onError( action, error );
 	}
 
 	const data = getData( action );
-	if ( data ) {
+	if ( undefined !== data ) {
 		try {
 			return onSuccess( action, fromApi( data ) );
 		} catch ( err ) {
@@ -225,12 +225,12 @@ function createRequestAction( options, action ) {
 	}
 
 	const progress = getProgress( action );
-	if ( progress ) {
+	if ( undefined !== progress ) {
 		return onProgress( action, progress );
 	}
 
 	const record = getStreamRecord( action );
-	if ( record ) {
+	if ( undefined !== record ) {
 		return onStreamRecord( action, record );
 	}
 


### PR DESCRIPTION
#### Proposed Changes

In this PR, I propose to add support for empty API responses in the Data Later. The fix was originally introduced in https://github.com/Automattic/wp-calypso/pull/18543 but was missed during further rebase/merges.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Run tests:

```
yarn run test-client client/state/data-layer/wpcom-http/test/utils.js
```

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~~
- [ ] ~~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~~
- [ ] ~~For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~~
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/70790