### PR TITLE
Limit Global Styles: Improve wording of the upgrade notice in the Launchpad checklist

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -59,7 +59,7 @@ export function getEnhancedTasks(
 						title: translate( 'Choose a Plan' ),
 						subtitle: displayGlobalStylesWarning
 							? translate(
-									'Upgrade your plan to publish your color changes and unlock tons of other features'
+									'Upgrade to a Premium plan to publish your color changes and unlock tons of other features.'
 							  )
 							: '',
 						disabled: isVideoPressFlow( flow ),


### PR DESCRIPTION
#### Proposed Changes

Make the wording in the launchpad when a plan upgrade is necessary due to global styles better

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Use the live link or whatever
2. Go to /setup/newsletter
3. Go through the process choosing free domain, plan etc
4. After the 'Adding subscribers' screen you should see a preview of your site and some steps to the left. This should be the only screen affected by this PR
5. In another tab, apply the `wpcom-limit-global-styles` sticker to the site
6. Go back to the previous page and reload the site

The wording for the 'Choose a Plan' step should say "Upgrade to a Premium plan to publish your color changes and unlock tons of other features.", i.e. it should match the wording given in the text on https://github.com/Automattic/dotcom-forge/issues/1227 (not the wording in the screenshot)

Before | After
-------|------
![image](https://user-images.githubusercontent.com/93301/205700025-898065dc-c7a9-424e-95de-8e9f33305fef.png) | ![RHVxe6.png](https://user-images.githubusercontent.com/93301/205948810-84a94a86-6090-4763-ab86-e349a112a95e.png)

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/1227