### PR TITLE
Start: Restore 'Back to My Home' back button behavior

### DIFF
--- a/client/components/site-selector/add-site.tsx
+++ b/client/components/site-selector/add-site.tsx
@@ -1,15 +1,17 @@
 import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { FunctionComponent, useCallback } from 'react';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { onboardingUrl } from 'calypso/lib/paths';
 import { addQueryArgs } from 'calypso/lib/url';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 
 const SiteSelectorAddSite: FunctionComponent = () => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
+	const sourceSiteSlug = useSelector( getSelectedSiteSlug );
 
 	const recordAddNewSite = useCallback( () => {
 		const event = isJetpackCloud()
@@ -26,6 +28,7 @@ const SiteSelectorAddSite: FunctionComponent = () => {
 				{
 					ref: 'calypso-selector',
 					source: 'my-home',
+					sourceSiteSlug,
 				},
 				onboardingUrl()
 			) }

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -801,6 +801,7 @@ class DomainsStep extends Component {
 		const { isAllDomains, translate, isReskinned, userSiteCount } = this.props;
 		const siteUrl = this.props.selectedSite?.URL;
 		const siteSlug = this.props.queryObject?.siteSlug;
+		const sourceSiteSlug = this.props.queryObject?.sourceSiteSlug;
 		const source = this.props.queryObject?.source;
 		let backUrl;
 		let backLabelText;
@@ -824,8 +825,8 @@ class DomainsStep extends Component {
 				backUrl = siteUrl;
 				backLabelText = translate( 'Back to My Site' );
 				isExternalBackUrl = true;
-			} else if ( 'my-home' === source && siteSlug ) {
-				backUrl = `/home/${ siteSlug }`;
+			} else if ( 'my-home' === source && sourceSiteSlug ) {
+				backUrl = `/home/${ sourceSiteSlug }`;
 				backLabelText = translate( 'Back to My Home' );
 			} else if ( 'general-settings' === source && siteSlug ) {
 				backUrl = `/settings/general/${ siteSlug }`;


### PR DESCRIPTION
See some discussion in pdKhl6-1ly-p2

## Proposed Changes

Adds a `sourceSiteSlug` query parameter to restore 'Back to My Home' back button behavior when a user clicks 'Add new site' from the Site Switcher.

The behavior was removed in https://github.com/Automattic/wp-calypso/pull/70760 because our original `siteSlug` query parameter started causing unexpected buggy behavior. The logic was originally added with https://github.com/Automattic/wp-calypso/pull/64292

<img width="619" alt="image" src="https://user-images.githubusercontent.com/36432/205947767-9e66c0b6-39d9-4f0a-8981-525374b9ff76.png">

<img width="500" alt="image" src="https://user-images.githubusercontent.com/36432/205948869-81db26b8-bc4b-402b-b692-fff4ef038e84.png">

## Testing Instructions

1. Navigate to My Home for one of your sites.
2. Click on 'Switch sites' to open the Site Switcher.
3. Click on 'Add new site' at the bottom of the Site Switcher.
4. On `/start`, verify the in-page back button says 'Back to My Home'
5. Click on the 'Back to My Home' button and verify you're returned to the original site.
6. Grep the codebase to verify there are no other entry points with `source=my-home`.

Note: some lovely caching wonkiness can occur if you repeat the steps for a second site (without refreshing the page): https://github.com/Automattic/wp-calypso/pull/68727#issuecomment-1271241893 We can pretend that doesn't exist.
