### PR TITLE
Components: Refactor `VideosUI` tests to RTL

### DIFF
--- a/client/components/videos-ui/test/index.jsx
+++ b/client/components/videos-ui/test/index.jsx
@@ -1,8 +1,8 @@
 /**
  * @jest-environment jsdom
  */
-
-import { mount } from 'enzyme';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { Provider } from 'react-redux';
 import { createStore } from 'redux';
@@ -10,12 +10,20 @@ import ModalFooterBar from 'calypso/components/videos-ui/modal-footer-bar';
 import ModalHeaderBar from 'calypso/components/videos-ui/modal-header-bar';
 import { COURSE_SLUGS } from '../../../data/courses';
 import VideoUI from '../index';
-import VideoChapters from '../video-chapters';
 
 const useCourseData = () => {
 	return {
 		course: {
-			videos: [],
+			completions: {
+				testvideo: false,
+			},
+			videos: {
+				testvideo: {
+					title: 'Video',
+					duration_seconds: 60,
+					description: 'Test description',
+				},
+			},
 			cta: {
 				action: 'action',
 			},
@@ -55,7 +63,8 @@ describe( 'Video-UI', () => {
 		};
 	} );
 
-	test( 'Track event with intent prop', () => {
+	test( 'Track event with intent prop', async () => {
+		const user = userEvent.setup();
 		const useStateMock = ( useState ) => [ useState, jest.fn() ];
 		jest.spyOn( React, 'useState' ).mockImplementation( useStateMock );
 		const initialState = {
@@ -64,7 +73,7 @@ describe( 'Video-UI', () => {
 		};
 		const store = createStore( ( state ) => state, initialState );
 
-		const result = mount(
+		render(
 			<Provider store={ store }>
 				<VideoUI
 					store={ store }
@@ -75,7 +84,7 @@ describe( 'Video-UI', () => {
 			</Provider>
 		);
 
-		result.find( VideoChapters ).first().prop( 'onVideoPlayClick' )();
+		await user.click( screen.getByRole( 'button', { name: 'Play video' } ) );
 
 		expect( window._tkq.push ).toHaveBeenCalledWith( [
 			'recordEvent',
@@ -92,11 +101,13 @@ describe( 'Video-UI', () => {
 			{
 				course: COURSE_SLUGS.BLOGGING_QUICK_START,
 				intent: 'build',
+				video: 'testvideo',
 			},
 		] );
 	} );
 
-	test( 'Track event without intent prop', () => {
+	test( 'Track event without intent prop', async () => {
+		const user = userEvent.setup();
 		const useStateMock = ( useState ) => [ useState, jest.fn() ];
 		jest.spyOn( React, 'useState' ).mockImplementation( useStateMock );
 		const initialState = {
@@ -105,7 +116,7 @@ describe( 'Video-UI', () => {
 		};
 		const store = createStore( ( state ) => state, initialState );
 
-		const result = mount(
+		render(
 			<Provider store={ store }>
 				<VideoUI
 					store={ store }
@@ -115,7 +126,7 @@ describe( 'Video-UI', () => {
 			</Provider>
 		);
 
-		result.find( VideoChapters ).first().prop( 'onVideoPlayClick' )();
+		await user.click( screen.getByRole( 'button', { name: 'Play video' } ) );
 
 		expect( window._tkq.push ).toHaveBeenCalledWith( [
 			'recordEvent',
@@ -130,6 +141,7 @@ describe( 'Video-UI', () => {
 			'calypso_courses_play_click',
 			{
 				course: COURSE_SLUGS.BLOGGING_QUICK_START,
+				video: 'testvideo',
 			},
 		] );
 	} );


### PR DESCRIPTION
#### Proposed Changes

This PR refactors the `VideosUI` tests to use `@testing-library/react`.

#### Testing Instructions

Verify tests still pass: `yarn run test-client client/components/videos-ui/test/index.jsx`

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #63409
