### PR TITLE
Marketplace: Refactor `SignupSuccess` tests to RTL

### DIFF
--- a/client/my-sites/marketplace/pages/submission-success/test/__snapshots__/index.js.snap
+++ b/client/my-sites/marketplace/pages/submission-success/test/__snapshots__/index.js.snap
@@ -1,31 +1,164 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Marketplace SignupSuccess should render the page as expected 1`] = `
-<ContextProvider
-  value={
-    Object {
-      "store": Object {
-        "@@observable": [Function],
-        "addReducer": [Function],
-        "dispatch": [Function],
-        "getCurrentReducer": [Function],
-        "getState": [Function],
-        "replaceReducer": [Function],
-        "subscribe": [Function],
-      },
-      "subscription": Object {
-        "addNestedSub": [Function],
-        "getListeners": [Function],
-        "handleChangeWrapper": [Function],
-        "isSubscribed": [Function],
-        "notifyNestedSubs": [Function],
-        "onStateChange": [Function],
-        "trySubscribe": [Function],
-        "tryUnsubscribe": [Function],
-      },
-    }
-  }
->
-  <SignupSuccess />
-</ContextProvider>
+<div>
+  <header
+    class="masterbar css-10e139q-MasterbarStyledBlock etx5n0d1"
+    id="header"
+  >
+    <svg
+      class="css-1tj4oyq-WordPressLogoStyled etx5n0d0"
+      height="72"
+      viewBox="0 0 72 72"
+      width="72"
+    >
+      <path
+        d="M36,0C16.1,0,0,16.1,0,36c0,19.9,16.1,36,36,36c19.9,0,36-16.2,36-36C72,16.1,55.8,0,36,0z M3.6,36 c0-4.7,1-9.1,2.8-13.2l15.4,42.3C11.1,59.9,3.6,48.8,3.6,36z M36,68.4c-3.2,0-6.2-0.5-9.1-1.3l9.7-28.2l9.9,27.3 c0.1,0.2,0.1,0.3,0.2,0.4C43.4,67.7,39.8,68.4,36,68.4z M40.5,20.8c1.9-0.1,3.7-0.3,3.7-0.3c1.7-0.2,1.5-2.8-0.2-2.7 c0,0-5.2,0.4-8.6,0.4c-3.2,0-8.5-0.4-8.5-0.4c-1.7-0.1-2,2.6-0.2,2.7c0,0,1.7,0.2,3.4,0.3l5,13.8L28,55.9L16.2,20.8 c2-0.1,3.7-0.3,3.7-0.3c1.7-0.2,1.5-2.8-0.2-2.7c0,0-5.2,0.4-8.6,0.4c-0.6,0-1.3,0-2.1,0C14.7,9.4,24.7,3.6,36,3.6 c8.4,0,16.1,3.2,21.9,8.5c-0.1,0-0.3,0-0.4,0c-3.2,0-5.4,2.8-5.4,5.7c0,2.7,1.5,4.9,3.2,7.6c1.2,2.2,2.7,4.9,2.7,8.9 c0,2.8-0.8,6.3-2.5,10.5l-3.2,10.8L40.5,20.8z M52.3,64l9.9-28.6c1.8-4.6,2.5-8.3,2.5-11.6c0-1.2-0.1-2.3-0.2-3.3 c2.5,4.6,4,9.9,4,15.5C68.4,47.9,61.9,58.4,52.3,64z"
+      />
+    </svg>
+  </header>
+  <div
+    class="signup-success"
+  >
+    <div
+      class="signup-success__header"
+    >
+      <img
+        alt=""
+        src="submission-success.png"
+      />
+      <h1
+        class="signup-success__header-title wp-brand-font"
+      >
+        We’ll be in touch
+      </h1>
+      <p>
+        Thank you for applying to join the WordPress.com marketplace. We’ll be in touch with you very soon to discuss next steps.
+      </p>
+    </div>
+    <div
+      class="signup-success__body"
+    >
+      <div
+        class="signup-success__row"
+      >
+        <img
+          alt=""
+          class="signup-success__row-icon"
+          src="check-circle-gray.svg"
+        />
+        <div
+          class="signup-success__row-wrapper"
+        >
+          <div
+            class="signup-success__row-content"
+          >
+            <h2>
+              Learn More
+            </h2>
+            <p>
+              Read more about selling on the WordPress.com marketplace.
+            </p>
+          </div>
+          <a
+            class="components-button is-secondary"
+            href="https://developer.wordpress.com/wordpress-com-marketplace/"
+          >
+            Continue
+          </a>
+        </div>
+      </div>
+      <hr />
+      <div
+        class="signup-success__row"
+      >
+        <img
+          alt=""
+          class="signup-success__row-icon"
+          src="shopping-cart.svg"
+        />
+        <div
+          class="signup-success__row-wrapper"
+        >
+          <div
+            class="signup-success__row-content"
+          >
+            <h2>
+              View the marketplace
+            </h2>
+            <p>
+              Sign in to see what the marketplace has to offer.
+            </p>
+          </div>
+          <a
+            class="components-button is-secondary"
+            href="/plugins"
+          >
+            Continue
+          </a>
+        </div>
+      </div>
+      <hr />
+      <div
+        class="signup-success__row"
+      >
+        <img
+          alt=""
+          class="signup-success__row-icon"
+          src="settings.svg"
+        />
+        <div
+          class="signup-success__row-wrapper"
+        >
+          <div
+            class="signup-success__row-content"
+          >
+            <h2>
+              Developer Page
+            </h2>
+            <p>
+              Learn more about building a WordPress.com integration.
+            </p>
+          </div>
+          <a
+            class="components-button is-secondary"
+            href="https://developer.wordpress.com"
+          >
+            Continue
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="signup-success__footer"
+  >
+    <p>
+      Contact our teams directly:
+    </p>
+    <p
+      class="signup-success__footer-contact"
+    >
+      <a
+        href="https://wpvip.com/?ref=partners-lp"
+      >
+        WordPress.com VIP
+      </a>
+      ,
+       
+      <a
+        href="https://jetpack.com/for/hosts/?ref=partners-lp"
+      >
+        Jetpack
+      </a>
+      , or
+       
+      <a
+        href="https://woocommerce.com/?ref=partners-lp"
+      >
+        WooCommerce
+      </a>
+    </p>
+  </div>
+</div>
 `;

--- a/client/my-sites/marketplace/pages/submission-success/test/index.js
+++ b/client/my-sites/marketplace/pages/submission-success/test/index.js
@@ -2,20 +2,20 @@
  * @jest-environment jsdom
  */
 
-import { shallow } from 'enzyme';
+import { render } from '@testing-library/react';
 import { Provider as ReduxProvider } from 'react-redux';
 import { createReduxStore } from 'calypso/state';
 import SignupSuccess from '../signup-success';
 
 describe( 'Marketplace SignupSuccess', () => {
 	const store = createReduxStore();
-	const wrapper = shallow(
+	const { container } = render(
 		<ReduxProvider store={ store }>
 			<SignupSuccess />
 		</ReduxProvider>
 	);
 
 	test( 'should render the page as expected', () => {
-		expect( wrapper ).toMatchSnapshot();
+		expect( container ).toMatchSnapshot();
 	} );
 } );


### PR DESCRIPTION
#### Proposed Changes

This PR refactors the `SignupSuccess` tests to use `@testing-library/react`.

#### Testing Instructions

Verify tests still pass: `yarn run test-client client/my-sites/marketplace/pages/submission-success/test/index.js`

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #63409
