### PR TITLE
Framework: Remove `enzyme` from Calypso client

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -126,7 +126,6 @@
 		"duplicate-package-checker-webpack-plugin": "^3.0.0",
 		"email-validator": "^2.0.4",
 		"emoji-text": "^0.2.6",
-		"enzyme": "^3.11.0",
 		"express": "^4.17.1",
 		"express-async-handler": "^1.1.4",
 		"express-useragent": "^1.0.15",

--- a/docs/testing/component-tests.md
+++ b/docs/testing/component-tests.md
@@ -21,14 +21,14 @@ This obviously varies between components, but a few easy things to start out wit
 Like its child components?
 
 ```javascript
-import AnExpectedChildComponent from 'an-expected-child-component';
-import { shallow } from 'enzyme';
+import Dialog from '@automattic/components';
+import { render, screen } from '@testing-library/react';
 import MyComponent from 'my-component';
 
-test( 'should have AnExpectedChildComponent as a child of MyComponent', () => {
-	const wrapper = shallow( <MyComponent /> );
-	expect( wrapper ).toMatchSnapshot();
-	expect( wrapper.find( AnExpectedChildComponent ) ).toHaveLength( 1 );
+test( 'should have Dialog as a child of MyComponent', () => {
+	const { container } = render( <MyComponent /> );
+	expect( container ).toMatchSnapshot();
+	expect( screen.getByRole( 'dialog' ) ).toBeVisible();
 } );
 ```
 
@@ -61,12 +61,15 @@ When a user for example clicks an element does the component react like it shoul
 Example test from `calypso/client/components/token-field`:
 
 ```javascript
-test( 'should remove tokens when X icon clicked', () => {
-	const wrapper = mount( <TokenFieldWrapper /> );
-	const tokenFieldNode = wrapper.find( '.token-field' );
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
-	tokenFieldNode.find( '.token-field__remove-token' ).first().simulate( 'click' );
-	expect( wrapper.state( 'tokens' ) ).toEqual( [ 'bar' ] );
+test( 'should remove tokens when X icon clicked', async () => {
+	const user = userEvent.setup();
+	render( <TokenFieldWrapper /> );
+	await user.click( screen.getAllByRole( 'button', { name: 'Remove' } )[ 0 ] );
+	const tokenField = screen.getByRole( 'textbox', { name: 'Your Field' } );
+	expect( tokenField ).toHaveValue( 'bar' );
 } );
 ```
 
@@ -107,7 +110,7 @@ class ThemesList extends React.Component {
 So we test it like this:
 
 ```javascript
-import { shallow } from 'enzyme';
+import { render, screen } from '@testing-library/react';
 import EmptyContent from 'calypso/components/empty-content';
 import Theme from 'calypso/components/theme';
 import { ThemesList } from '../';
@@ -121,20 +124,20 @@ const defaultProps = deepFreeze( {
 } );
 
 test( 'should render a div with a className of "themes-list"', () => {
-	const wrapper = shallow( <ThemesList { ...defaultProps } /> );
-	expect( wrapper ).toMatchSnapshot();
-	expect( wrapper.hasClass( 'themes-list' ) ).toBe( true );
-	expect( wrapper.find( Theme ) ).toHaveLength( defaultProps.themes.length );
+	const { container } = render( <ThemesList { ...defaultProps } /> );
+	expect( container ).toMatchSnapshot();
+	expect( container.firstChild ).toHaveClass( 'themes-list' );
+	expect( container.querySelectorAll( '.theme' ) ).toHaveLength( defaultProps.themes.length );
 } );
 
 test( 'should render a <Theme /> child for each provided theme', () => {
-	const wrapper = shallow( <ThemesList { ...defaultProps } /> );
-	expect( wrapper.find( Theme ) ).toHaveLength( defaultProps.themes.length );
+	const { container } = render( <ThemesList { ...defaultProps } /> );
+	expect( container.querySelectorAll( '.theme' ) ).toHaveLength( defaultProps.themes.length );
 } );
 
 test( 'should display the EmptyContent component when no themes are provided', () => {
-	const wrapper = shallow( <ThemesList { ...defaultProps } themes={ [] } /> );
-	expect( wrapper.type() ).toBe( EmptyContent );
+	const { container } = render( <ThemesList { ...defaultProps } themes={ [] } /> );
+	expect( container ).toBeEmptyDOMElement();
 } );
 ```
 

--- a/docs/testing/component-tests.md
+++ b/docs/testing/component-tests.md
@@ -21,7 +21,6 @@ This obviously varies between components, but a few easy things to start out wit
 Like its child components?
 
 ```javascript
-import Dialog from '@automattic/components';
 import { render, screen } from '@testing-library/react';
 import MyComponent from 'my-component';
 

--- a/docs/testing/snapshot-testing.md
+++ b/docs/testing/snapshot-testing.md
@@ -69,7 +69,7 @@ over the course of a series of commits, the snapshot diffs record the evolution 
 structure. Pretty cool 😎
 
 ```js
-import { render screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import LocaleSuggestions from '../locale-suggestions';
 import MyComponent from '../my-component';
 

--- a/docs/testing/snapshot-testing.md
+++ b/docs/testing/snapshot-testing.md
@@ -69,20 +69,20 @@ over the course of a series of commits, the snapshot diffs record the evolution 
 structure. Pretty cool 😎
 
 ```js
-import { shallow } from 'enzyme';
+import { render screen } from '@testing-library/react';
 import LocaleSuggestions from '../locale-suggestions';
 import MyComponent from '../my-component';
 
 describe( 'MyComponent', () => {
 	test( 'should render', () => {
-		const wrapper = shallow( <MyComponent /> );
-		expect( wrapper ).toMatchSnapshot();
+		const { container } = render( <MyComponent /> );
+		expect( container ).toMatchSnapshot();
 	} );
 
 	test( 'should render with locale suggestions if locale is provided', () => {
-		const wrapper = shallow( <MyComponent locale="es" /> );
-		expect( wrapper ).toMatchSnapshot();
-		expect( wrapper.find( LocaleSuggestions ) ).toHaveLength( 1 );
+		const { container } = render( <MyComponent locale="es" /> );
+		expect( container ).toMatchSnapshot();
+		expect( screen.getByText( 'Also available in' ) ).toBeVisible();
 	} );
 } );
 ```
@@ -140,24 +140,15 @@ conjunction with other tests that do describe our expectations, like in the exam
 
 ```
 test( 'should render with locale suggestions if locale is provided', () => {
-  const wrapper = shallow( <MyComponent locale="es" /> );
+  const { container } = render( <MyComponent locale="es" /> );
 
   // Snapshot will catch unintended changes
-  expect( wrapper ).toMatchSnapshot();
+  expect( container ).toMatchSnapshot();
 
   // This is what we actually expect to find in our test
-  expect( wrapper.find( LocaleSuggestions ) ).toHaveLength( 1 );
+  expect( screen.getByText( 'Also available in' ) ).toBeVisible();
 } );
 ```
-
-[`shallow`](http://airbnb.io/enzyme/docs/api/shallow.html) rendering is your friend:
-
-> Shallow rendering is useful to constrain yourself to testing a component as a unit, and to ensure
-> that your tests aren't indirectly asserting on behavior of child components.
-
-It's tempting to snapshot full renders, but that makes for huge snapshots. Additionally, you're no
-longer testing your component, but all of the components in the entire tree. With `shallow`, we
-snapshot just the components that are directly rendered by our component.
 
 [snapshot testing]: https://facebook.github.io/jest/docs/en/snapshot-testing.html
 [update snapshots]: https://facebook.github.io/jest/docs/en/snapshot-testing.html#updating-snapshots

--- a/docs/testing/unit-tests.md
+++ b/docs/testing/unit-tests.md
@@ -44,7 +44,7 @@ See [testing-overview.md](testing-overview.md) on how to run Calypso tests.
 
 ## Writing tests
 
-We use [Jest](https://facebook.github.io/jest) testing framework for unit tests, and [Enzyme](https://github.com/airbnb/enzyme) for testing React components. You can find more information on testing components at [component tests](component-tests.md).
+We use [Jest](https://facebook.github.io/jest) testing framework for unit tests, and [Testing Library](https://testing-library.com/) for testing React components. You can find more information on testing components at [component tests](component-tests.md).
 
 Though you'll still see Chai assertions and Sinon spies/mocks throughout the code base, for all new tests we use the Jest API for [globals](https://facebook.github.io/jest/docs/en/api.html) (`describe`, `test`, `beforeEach` and so on) [assertions](http://facebook.github.io/jest/docs/en/expect.html), [mocks](http://facebook.github.io/jest/docs/en/mock-functions.html), [spies](http://facebook.github.io/jest/docs/en/jest-object.html#jestspyonobject-methodname) and [mock functions](https://facebook.github.io/jest/docs/en/mock-function-api.html).
 
@@ -259,6 +259,6 @@ jest.mock( 'lib/wp', () => ( {
 ## Further reading
 
 - [React testing with Jest](https://facebook.github.io/jest/docs/en/tutorial-react.html)
-- [Enyzme API](https://github.com/airbnb/enzyme/tree/HEAD/docs/api)
+- [Testing Library documentation](https://testing-library.com/docs/)
 - [Test Contra-variance](http://blog.cleancoder.com/uncle-bob/2017/10/03/TestContravariance.html)
 - [The Failures of "Into to TDD"](http://blog.testdouble.com/posts/2014-01-25-the-failures-of-intro-to-tdd.html)

--- a/test/client/setup-test-framework.js
+++ b/test/client/setup-test-framework.js
@@ -18,31 +18,6 @@ afterAll( () => {
 	nock.cleanAll();
 } );
 
-// It "mocks" enzyme, so that we can delay loading of
-// the utility functions until enzyme is imported in tests.
-// Props to @gdborton for sharing this technique in his article:
-// https://medium.com/airbnb-engineering/unlocking-test-performance-migrating-from-mocha-to-jest-2796c508ec50.
-let mockEnzymeSetup = false;
-
-jest.mock( 'enzyme', () => {
-	const actualEnzyme = jest.requireActual( 'enzyme' );
-	if ( ! mockEnzymeSetup ) {
-		mockEnzymeSetup = true;
-
-		// configure custom Enzyme matchers for Jest
-		jest.requireActual( 'jest-enzyme' );
-
-		// configure enzyme 3 for React, from docs: http://airbnb.io/enzyme/docs/installation/index.html
-		const Adapter = jest.requireActual( '@wojtekmaj/enzyme-adapter-react-17' );
-		actualEnzyme.configure( { adapter: new Adapter() } );
-
-		// configure snapshot serializer for enzyme
-		const { createSerializer } = jest.requireActual( 'enzyme-to-json' );
-		expect.addSnapshotSerializer( createSerializer( { mode: 'deep' } ) );
-	}
-	return actualEnzyme;
-} );
-
 // This is used by @wordpress/components in https://github.com/WordPress/gutenberg/blob/trunk/packages/components/src/ui/utils/space.ts#L33
 // JSDOM or CSSDOM don't provide an implementation for it, so for now we have to mock it.
 global.CSS = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -12844,7 +12844,6 @@ __metadata:
     duplicate-package-checker-webpack-plugin: ^3.0.0
     email-validator: ^2.0.4
     emoji-text: ^0.2.6
-    enzyme: ^3.11.0
     express: ^4.17.1
     express-async-handler: ^1.1.4
     express-useragent: ^1.0.15


### PR DESCRIPTION
#### Proposed Changes

This PR removes `enzyme` from the Calypso client and Calypso's documentation, since it's now only used in a few apps and packages.

#### Testing Instructions

Verify all checks are green.

Related: #63409

cc @flootr
