### PR TITLE
Limit Global Styles: Ensure Customizations are Previewed in Launchpad

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/launchpad-site-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/launchpad-site-preview.tsx
@@ -5,6 +5,7 @@ import { DEVICE_TYPE } from 'calypso/../packages/design-picker/src/constants';
 import { Device } from 'calypso/../packages/design-picker/src/types';
 import WebPreview from 'calypso/components/web-preview/component';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
+import { usePremiumGlobalStyles } from 'calypso/state/sites/hooks/use-premium-global-styles';
 import PreviewToolbar from '../design-setup/preview-toolbar';
 
 const LaunchpadSitePreview = ( {
@@ -16,6 +17,8 @@ const LaunchpadSitePreview = ( {
 } ) => {
 	const translate = useTranslate();
 	const color = useQuery().get( 'color' );
+	const { globalStylesInUse, shouldLimitGlobalStyles } = usePremiumGlobalStyles();
+
 	const previewUrl = siteSlug ? 'https://' + siteSlug : null;
 	const devicesToShow: Device[] = [ DEVICE_TYPE.COMPUTER, DEVICE_TYPE.PHONE ];
 	let defaultDevice = flow === NEWSLETTER_FLOW ? DEVICE_TYPE.COMPUTER : DEVICE_TYPE.PHONE;
@@ -40,6 +43,7 @@ const LaunchpadSitePreview = ( {
 			preview: true,
 			do_preview_no_interactions: ! isVideoPressFlow,
 			...( color && { preview_accent_color: color } ),
+			...( globalStylesInUse && shouldLimitGlobalStyles && { 'preview-global-styles': true } ),
 		} );
 	}
 


### PR DESCRIPTION
**DO NOT MERGE**

See https://github.com/Automattic/wp-calypso/pull/70834#pullrequestreview-1211409259.

#### Proposed Changes

* If the site has limited Global Styles and is using custom Global Styles, display those customizations in the Launchpad preview.

#### Technical Considerations

With Limited Global Styles, we are filtering out custom Global Styles from sites below the Premium plan.

This PR adds the `preview-global-styles` query param to the iframe URL to force the preview to display custom Global Styles regardless of the site plan.

The iframe URL also has a `preview_accent_color` query param (see D89679-code, cc @mattwiebe) that is used to force the preview to display a given primary color.

When used together **in the Newsletter flow**, the `preview-global-styles` param could be omitted. The flow only allows to customize the accent color, so forcing the color or the entire custom GS produces the same result.

On the other hand, if the preview were used in different flows that allowed for more GS customizations, then the `preview_accent_color` param would not be enough, while the `preview-global-styles` would ensure all the custom GS are previewed correctly.

Since `preview_accent_color` has a further use (forcing a specific color regardless of GS) and the two params shouldn't interfere with each others, I'm inclined in keeping them both.

But, I'm also unfamiliar with the Stepper flows, so I'd rather have a confirmation before committing. 🙂 

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open `/setup/newsletter/newsletterSetup` in a dev environment to get the correct feature flag (`limit-global-styles`).
* Pick a "premium" color.
* As soon as the site is created, add the `wpcom-limit-global-styles` sticker.
* Get to the Launchpad's last step.
* ➡️ Ensure the preview is using the "premium" color.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/1231