### PR TITLE
Limit Global Styles: Update the Copy of the Site Editor Modal

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/modal.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/modal.js
@@ -55,7 +55,7 @@ const GlobalStylesModal = () => {
 				</h1>
 				<p className="wpcom-global-styles-modal__description">
 					{ __(
-						"Change all of your site's fonts, colors and more. Available on any paid plan.",
+						"Change all of your site's fonts, colors and more. Available on the Premium plan.",
 						'full-site-editing'
 					) }
 				</p>


### PR DESCRIPTION
#### Proposed Changes

* Update the copy of the Site Editor modal to mention the correct plan.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Install this branch of the ETK plugin.
* Create a site with the `wpcom-limit-global-styles` sticker.
* Open the site editor.
* Open the Global Styles sidebar.
* ➡️ Ensure the modal mentions the "Premium plan" instead of "any paid plans".

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
