### PR TITLE
{WIP} Purchases: Add alternative parameters for AutoRenewToggle when site is null

### DIFF
--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -416,8 +416,8 @@ function PurchaseMetaExpiration( {
 		return (
 			<li className="manage-purchase__meta-expiration">
 				<em className="manage-purchase__detail-label">{ translate( 'Subscription Renewal' ) }</em>
-				{ ! hideAutoRenew && ! isJetpackPurchaseUsingPrimaryCancellationFlow && (
-					<div className="manage-purchase__auto-renew">
+				{ ! hideAutoRenew && (
+					/*! isJetpackPurchaseUsingPrimaryCancellationFlow && */ <div className="manage-purchase__auto-renew">
 						<span className="manage-purchase__detail manage-purchase__auto-renew-text">
 							{ subsRenewText }
 						</span>

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -344,6 +344,7 @@ function PurchaseMetaExpiration( {
 		// If a jetpack site has been disconnected, the "site" prop will be null here.
 		const shouldRenderToggle = site && isProductOwner;
 		const autoRenewToggle = shouldRenderToggle ? (
+			//console.log( site )
 			<AutoRenewToggle
 				planName={ site.plan.product_name_short }
 				siteDomain={ site.domain }
@@ -354,7 +355,16 @@ function PurchaseMetaExpiration( {
 				getChangePaymentMethodUrlFor={ getChangePaymentMethodUrlFor }
 			/>
 		) : (
-			<span />
+			//console.log( purchase )
+			<AutoRenewToggle
+				planName={ purchase.product_name }
+				siteDomain={ purchase.domain }
+				siteSlug={ purchase.domain }
+				purchase={ purchase }
+				toggleSource="manage-purchase"
+				showLink={ true }
+				getChangePaymentMethodUrlFor={ getChangePaymentMethodUrlFor }
+			/>
 		);
 		const subsRenewText = isAutorenewalEnabled
 			? translate( 'Auto-renew is {{autoRenewToggle}}ON{{/autoRenewToggle}}', {


### PR DESCRIPTION
#### Proposed Changes
* The validation for showing the auto-renew toggle requires a valid site be connected to the purchase in order to be shown.

* For certain Jetpack products, a site isn’t connected during the purchase process and so a user can’t turn auto-renew off until after they have connected a site to the product.

* By passing alternative parameters to the `AutoRenewToggle` component when `site` is null, we should be able to turn on the auto-renew toggle for every purchase, regardless of the site status. 

**Testing Instructions**

1. Apply this PR to your local development
2. Sandbox WordPress.com, Store Admin, and Calypso
3. Add a Stripe test card to your payment methods. Free credits have other auto-renewal blockers, so using this payment method could cause issues with testing.
4. Go to <https://cloud.jetpack.com/pricing>
5. Right-click/CMD-Click on the `Buy` button for any product (or at least anything except Jetpack Search, since that one requires you to choose a site for the purchase) and copy the link
6. Paste the link into your web browser and replace `https://wordpress.com` with `http://calypso.localhost:3000`
7. Complete checkout
3. Go to <http://calypso.localhost:3000/me/purchases> and click on your purchase

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
