### PR TITLE
eCommerce Onboarding: Add theme information to Tracks props at design selection

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-carousel/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-carousel/index.tsx
@@ -12,12 +12,11 @@ import './style.scss';
 const DesignCarousel: Step = function DesignCarousel( { navigation } ) {
 	const { goNext, goBack, submit } = navigation;
 	const { __ } = useI18n();
-
 	const { setSelectedDesign } = useDispatch( ONBOARD_STORE );
 
 	function pickDesign( _selectedDesign: Design ) {
 		setSelectedDesign( _selectedDesign );
-		submit?.();
+		submit?.( { theme: _selectedDesign.slug, theme_type: _selectedDesign.design_type } );
 	}
 
 	return (


### PR DESCRIPTION
#### Proposed Changes

* Adds `theme` and `theme_type` props to the tracks event that fires upon choosing a design from the design carousel.

Example expected output:

<img width="641" alt="Screen Shot 2022-12-06 at 3 28 42 PM" src="https://user-images.githubusercontent.com/2124984/206016078-d58c6541-6b95-4128-96c7-b8b0ce6e7ecd.png">


#### Testing Instructions

* Switch to this PR, navigate to `/setup/ecommerce/designCarousel`
* Use Tracks Vigilante, or log Tracks events to your browser console: `localStorage.debug='calypso:analytics'`
* When choosing a design, the theme's slug and type should be reflected in the additional properties sent to Tracks.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- N/A [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- N/A Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- N/A Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- N/A Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- N/A  For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #70145
