### PR TITLE
Stats: Sorting search data to include Unknown Search Terms

### DIFF
--- a/client/my-sites/stats/stats-list/stats-list-card.jsx
+++ b/client/my-sites/stats/stats-list/stats-list-card.jsx
@@ -60,6 +60,13 @@ const StatsListCard = ( {
 		? Math.max( ...data.map( ( item ) => item?.value || 0 ).filter( Number.isFinite ) )
 		: 0;
 
+	let sortedData = data;
+
+	// Include 'Unknown search terms' at a proper place according to its value.
+	if ( moduleType === 'searchterms' ) {
+		sortedData = data?.sort( ( a, b ) => b.value - a.value );
+	}
+
 	return (
 		<StatsCard
 			title={ title }
@@ -81,7 +88,7 @@ const StatsListCard = ( {
 			{ !! loader && loader }
 			{ !! error && error }
 			<HorizontalBarList>
-				{ data?.map( ( item, index ) => {
+				{ sortedData?.map( ( item, index ) => {
 					let leftSideItem;
 					const isInteractive = item?.link || item?.page || item?.children;
 


### PR DESCRIPTION
#### Proposed Changes

* sorting search terms data based on the number of views to avoid pushing `Unknown Search Terms` to the very bottom

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* open stats for a website that has some old data (e.g. our documentation)
* switch the time period for the chart to `Years`
* navigate to a period that has search data (e.g. 2017)
* verify that `Unknown Serch Terms` is not last on the list (if it doesn't have the lowest view count)

Before
![Screenshot 2022-12-07 at 12 18 02 PM](https://user-images.githubusercontent.com/112354940/206045970-7fac3959-880d-46c7-8dff-68fe71067ca0.png)

After
![Screenshot 2022-12-07 at 12 15 13 PM](https://user-images.githubusercontent.com/112354940/206046035-9a8771d8-9aee-469c-996f-1825cf13d418.png)

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #70212
