### PR TITLE
Gifting: Remove log-in requirement on checkout

### DIFF
--- a/client/my-sites/checkout/checkout-main-wrapper.tsx
+++ b/client/my-sites/checkout/checkout-main-wrapper.tsx
@@ -87,6 +87,9 @@ export default function CheckoutMainWrapper( {
 	if ( ! siteSlug ) {
 		siteSlug = 'no-site';
 
+		/*
+		 * As Gifting purchases are for sites, we avoid to use no-user.
+		 */
 		if ( ( ! isGiftPurchase && isLoggedOutCart ) || isNoSiteCart ) {
 			siteSlug = 'no-user';
 		}

--- a/client/my-sites/checkout/checkout-main-wrapper.tsx
+++ b/client/my-sites/checkout/checkout-main-wrapper.tsx
@@ -87,7 +87,7 @@ export default function CheckoutMainWrapper( {
 	if ( ! siteSlug ) {
 		siteSlug = 'no-site';
 
-		if ( isLoggedOutCart || isNoSiteCart ) {
+		if ( ( ! isGiftPurchase && isLoggedOutCart ) || isNoSiteCart ) {
 			siteSlug = 'no-user';
 		}
 	}

--- a/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
@@ -91,6 +91,7 @@ export default function usePrepareProductsForCart( {
 		isLoggedOutCart,
 		isNoSiteCart,
 		isJetpackCheckout,
+		isGiftPurchase,
 	} );
 	debug( 'isLoading', state.isLoading );
 	debug( 'handler is', addHandler );
@@ -167,6 +168,7 @@ function chooseAddHandler( {
 	isLoggedOutCart,
 	isNoSiteCart,
 	isJetpackCheckout,
+	isGiftPurchase,
 }: {
 	isLoading: boolean;
 	originalPurchaseId: string | number | null | undefined;
@@ -174,6 +176,7 @@ function chooseAddHandler( {
 	isLoggedOutCart?: boolean;
 	isNoSiteCart?: boolean;
 	isJetpackCheckout?: boolean;
+	isGiftPurchase?: boolean;
 } ): AddHandler {
 	if ( isJetpackCheckout ) {
 		return 'addProductFromSlug';
@@ -183,7 +186,7 @@ function chooseAddHandler( {
 		return 'doNotAdd';
 	}
 
-	if ( isLoggedOutCart || isNoSiteCart ) {
+	if ( ( ! isGiftPurchase && isLoggedOutCart ) || isNoSiteCart ) {
 		return 'addFromLocalStorage';
 	}
 

--- a/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
@@ -186,6 +186,10 @@ function chooseAddHandler( {
 		return 'doNotAdd';
 	}
 
+	/*
+	 * As Gifting purchases are actually renewals and validate the subscriptionID + product
+	 * with the server, we have to avoid using localStorage.
+	 */
 	if ( ( ! isGiftPurchase && isLoggedOutCart ) || isNoSiteCart ) {
 		return 'addFromLocalStorage';
 	}

--- a/client/my-sites/checkout/composite-checkout/lib/create-wpcom-account-before-transaction.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/create-wpcom-account-before-transaction.ts
@@ -10,11 +10,15 @@ export async function createWpcomAccountBeforeTransaction(
 	const isJetpackUserLessCheckout = transactionCart.products.some(
 		( product ) => product.extra.isJetpackCheckout
 	);
+	const isGiftingCheckout = transactionCart.products.some(
+		( product ) => product.extra.isGiftPurchase
+	);
 
 	return createAccount( {
-		signupFlowName: isJetpackUserLessCheckout
-			? 'jetpack-userless-checkout'
-			: 'onboarding-registrationless',
+		signupFlowName:
+			isJetpackUserLessCheckout || isGiftingCheckout
+				? 'jetpack-userless-checkout'
+				: 'onboarding-registrationless',
 		email: transactionOptions.contactDetails?.email?.value,
 		siteId: transactionOptions.siteId,
 		recaptchaClientId: transactionOptions.recaptchaClientId,

--- a/client/my-sites/checkout/composite-checkout/lib/create-wpcom-account-before-transaction.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/create-wpcom-account-before-transaction.ts
@@ -15,8 +15,8 @@ export async function createWpcomAccountBeforeTransaction(
 	);
 
 	/*
-	 * Temporarily, we treat Gifting as jetpack-userless-checkout to
-	 * avoid user email validation
+	 * We treat Gifting as jetpack-userless-checkout to create and verify the user
+	 * on success checkout.
 	 */
 	return createAccount( {
 		signupFlowName:

--- a/client/my-sites/checkout/composite-checkout/lib/create-wpcom-account-before-transaction.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/create-wpcom-account-before-transaction.ts
@@ -14,6 +14,10 @@ export async function createWpcomAccountBeforeTransaction(
 		( product ) => product.extra.isGiftPurchase
 	);
 
+	/*
+	 * Temporarily, we treat Gifting as jetpack-userless-checkout to
+	 * avoid user email validation
+	 */
 	return createAccount( {
 		signupFlowName:
 			isJetpackUserLessCheckout || isGiftingCheckout

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -141,10 +141,9 @@ export function checkout( context, next ) {
 
 	const isLoggedOutCart =
 		isJetpackCheckout ||
-		( isLoggedOut && context.pathname.includes( '/checkout/no-site' ) ) ||
 		( isLoggedOut &&
-			context.pathname.includes( '/gift/' ) &&
-			context.pathname.startsWith( '/checkout/' ) );
+			( context.pathname.includes( '/checkout/no-site' ) ||
+				context.pathname.includes( '/gift/' ) ) );
 	const isNoSiteCart =
 		isJetpackCheckout ||
 		( ! isLoggedOut &&

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -140,7 +140,11 @@ export function checkout( context, next ) {
 	const couponCode = context.query.coupon || context.query.code || getRememberedCoupon();
 
 	const isLoggedOutCart =
-		isJetpackCheckout || ( isLoggedOut && context.pathname.includes( '/checkout/no-site' ) );
+		isJetpackCheckout ||
+		( isLoggedOut && context.pathname.includes( '/checkout/no-site' ) ) ||
+		( isLoggedOut &&
+			context.pathname.includes( '/gift/' ) &&
+			context.pathname.startsWith( '/checkout/' ) );
 	const isNoSiteCart =
 		isJetpackCheckout ||
 		( ! isLoggedOut &&

--- a/client/my-sites/checkout/index.js
+++ b/client/my-sites/checkout/index.js
@@ -96,13 +96,7 @@ export default function () {
 
 	// The no-site post-checkout route is for purchases not tied to a site so do
 	// not include the `siteSelection` middleware.
-	page(
-		'/checkout/gift/thank-you/:site',
-		redirectLoggedOut,
-		giftThankYou,
-		makeLayout,
-		clientRender
-	);
+	page( '/checkout/gift/thank-you/:site', giftThankYou, makeLayout, clientRender );
 
 	page(
 		'/checkout/thank-you/no-site/pending/:orderId',
@@ -264,14 +258,7 @@ export default function () {
 
 	// Gift purchases work without a site, so do not include the `siteSelection`
 	// middleware.
-	page(
-		'/checkout/:product/gift/:purchaseId',
-		redirectLoggedOut,
-		noSite,
-		checkout,
-		makeLayout,
-		clientRender
-	);
+	page( '/checkout/:product/gift/:purchaseId', noSite, checkout, makeLayout, clientRender );
 
 	page(
 		'/checkout/:site/with-gsuite/:domain/:receiptId?',


### PR DESCRIPTION
#### Proposed Changes

Add user-less checkout to gifting.

#### Screenshots
| Logged-in | Not Logged-in |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/402286/206053694-15f1552c-c68e-44a2-93cf-d90e3ba0d84d.png) | ![image](https://user-images.githubusercontent.com/402286/206053709-aea56a99-e66d-4c76-b78a-18c202c6b9ba.png) |

#### Testing Instructions
> **Warning**
> Apparently, there is a bug when using Chrome in incognito mode. Let me know if you have it

- Go to a site with Gifting Banner on incognito
- Try to Gift the subscription to the site.
- It should ask you for an email to create an account and let you following with the purchase.

##### Alternative testing method
- Make sure you are sandboxed.
- Add define( 'USE_STORE_SANDBOX', true ); to wp-content/mu-plugins/0-sandbox.php
- Go to my test site checkout: http://calypso.localhost:3000/checkout/personal-bundle/gift/1028117?cancel_to=/home#step2 
- You can use any Google account account and add `+something` at the end (ex: youremail+test123@gmail.com)
- Try to make a purchase using one of [these testing cards](https://stripe.com/docs/testing#cards)

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] ~~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~~
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~~
- [ ] ~~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~~
- [ ] ~~For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~~


Related to #70354 
