### PR TITLE
Add a timeout for theme filters fetch

### DIFF
--- a/client/my-sites/themes/controller.jsx
+++ b/client/my-sites/themes/controller.jsx
@@ -99,13 +99,12 @@ export function fetchThemeFilters( context, next ) {
 		return next();
 	}
 
+	store.dispatch( requestThemeFilters( context.lang ) );
 	waitForFilters( store, next );
 }
 
 // Function which calls next when the store has been updated or a timeout has occured.
 function waitForFilters( store, next ) {
-	store.dispatch( requestThemeFilters( context.lang ) );
-
 	// We need to define these variables here so that we can use them in the onResult closure.
 	let timeout; // eslint-disable-line prefer-const
 	let unsubscribe; // eslint-disable-line prefer-const
@@ -136,7 +135,7 @@ function waitForFilters( store, next ) {
 	// not be happening frequently, and if it is, it should be investigated.
 	timeout = setTimeout( () => {
 		onResult( 'theme-filter-fetch-err: timeout' );
-	}, 500 );
+	}, 1 );
 }
 
 // Legacy (Atlas-based Theme Showcase v4) route redirects

--- a/client/my-sites/themes/controller.jsx
+++ b/client/my-sites/themes/controller.jsx
@@ -135,7 +135,7 @@ function waitForFilters( store, next ) {
 	// not be happening frequently, and if it is, it should be investigated.
 	timeout = setTimeout( () => {
 		onResult( 'theme-filter-fetch-err: timeout' );
-	}, 1 );
+	}, 500 );
 }
 
 // Legacy (Atlas-based Theme Showcase v4) route redirects


### PR DESCRIPTION
### Proposed changes:

edit: see #70860 for a different approach

#70198 fixed an issue where our request never checked for errors occurring in the theme filters fetch. While there are fewer timeouts now, they still persist, and still with the theme filters fetch middleware.

There is another improvement we can add, which is to handle request timeouts, which this PR accomplishes.

It's a little weird, but I wanted to be very safe and make sure we're clearing both the timeout and the subscriber functions so that we never accidentally call next() twice.

### Testing instructions:
This one is harder to test explicitly. You can follow the instructions in #70198 to verify the error catching is still working correctly.