### PR TITLE
Try direct theme filter fetch

### DIFF
--- a/client/my-sites/themes/controller.jsx
+++ b/client/my-sites/themes/controller.jsx
@@ -97,10 +97,9 @@ export function fetchThemeFilters( context, next ) {
 		return next();
 	}
 
-	const filtersRequest = wpcom.req.get( {
-		path: '/theme-filters',
+	const filtersRequest = wpcom.req.get( '/theme-filters', {
 		apiVersion: '1.2',
-		query: context.lang ? { locale: context.lang } : {},
+		locale: context.lang, // Note: undefined will be omitted by the query string builder.
 	} );
 
 	const timeout = new Promise( ( _, reject ) => {

--- a/packages/wpcom.js/src/lib/util/send-request.js
+++ b/packages/wpcom.js/src/lib/util/send-request.js
@@ -43,7 +43,8 @@ export default function sendRequest( params, query, body, fn ) {
 		params.apiVersion = query.apiVersion;
 		debug( 'apiVersion: %o', params.apiVersion );
 		delete query.apiVersion;
-	} else {
+	} else if ( ! params.apiVersion ) {
+		// Set to the default api version, but don't override a custom one if already set.
 		params.apiVersion = this.apiVersion;
 	}
 

--- a/packages/wpcom.js/src/lib/util/send-request.js
+++ b/packages/wpcom.js/src/lib/util/send-request.js
@@ -44,7 +44,6 @@ export default function sendRequest( params, query, body, fn ) {
 		debug( 'apiVersion: %o', params.apiVersion );
 		delete query.apiVersion;
 	} else {
-		// Set to the default api version, but don't override a custom one if already set.
 		params.apiVersion = this.apiVersion;
 	}
 

--- a/packages/wpcom.js/src/lib/util/send-request.js
+++ b/packages/wpcom.js/src/lib/util/send-request.js
@@ -43,7 +43,7 @@ export default function sendRequest( params, query, body, fn ) {
 		params.apiVersion = query.apiVersion;
 		debug( 'apiVersion: %o', params.apiVersion );
 		delete query.apiVersion;
-	} else if ( ! params.apiVersion ) {
+	} else {
 		// Set to the default api version, but don't override a custom one if already set.
 		params.apiVersion = this.apiVersion;
 	}


### PR DESCRIPTION
#### Proposed changes
Alternative to #70860. Feel free to take a look at that PR as well to see if that approach makes more sense to you!

This middleware is still timing out sometimes. We should add a timeout to the request for theme-filters so that the the user's request isn't completely blocked. The other plus side is that we can more directly access any errors thrown in the wpcom request. (Though in theory, the data layer should be providing those already.)

My other PR adds a timeout around the store subscription, which is really ugly. This PR calls `wpcom.req.get` directly, and dispatches the call to the store itself. We don't really _need_ the abstraction in the data layer. We don't want to retry the request; we don't want to dedupe requests; we just want to get data. So I think this works fine.

Downside: this is decoupled from how theme filters are _normally_ fetched, so the duplicated code could make it possible for discrepancies to exist. This seems like a solvable problem, though.

#### Testing Instructions
This one is harder to test explicitly. You can follow the instructions in https://github.com/Automattic/wp-calypso/pull/70198 to verify the error catching is still working correctly.

You can also set the timeout value to like 1ms and verify that a timeout shows up in the console.
