### PR TITLE
Pattern Assembler - Enable feature flag in all env

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -114,7 +114,7 @@
 		"settings/security/monitor": true,
 		"sign-in-with-apple": true,
 		"sign-in-with-apple/redirect": true,
-		"signup/design-picker-pattern-assembler": false,
+		"signup/design-picker-pattern-assembler": true,
 		"signup/free-flow": false,
 		"signup/inline-help": false,
 		"signup/professional-email-step": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -112,7 +112,7 @@
 		"settings/security/monitor": true,
 		"sign-in-with-apple": true,
 		"sign-in-with-apple/redirect": true,
-		"signup/design-picker-pattern-assembler": false,
+		"signup/design-picker-pattern-assembler": true,
 		"signup/free-flow": false,
 		"signup/inline-help": false,
 		"signup/professional-email-step": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -123,6 +123,7 @@
 		"settings/security/monitor": true,
 		"sign-in-with-apple": true,
 		"sign-in-with-apple/redirect": true,
+		"signup/design-picker-pattern-assembler": true,
 		"signup/inline-help": false,
 		"signup/professional-email-step": false,
 		"signup/social": true,


### PR DESCRIPTION
#### Proposed Changes

* Enable feature flag signup/design-picker-pattern-assembler in all env

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/1251
