### PR TITLE
Update Jetpack onboarding flow: Update instructions copy and enable Feature Flag

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/jetpack-standalone-activation-instructions.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-standalone-activation-instructions.tsx
@@ -63,7 +63,7 @@ const JetpackStandaloneActivationInstructions: React.FC< Props > = ( { product, 
 			},
 			{
 				id: 3,
-				content: translate( 'Go to {{strong}}Jetpack > Dashboard > My Jetpack{{/strong}}.', {
+				content: translate( 'Go to {{strong}}Jetpack > My Jetpack{{/strong}}.', {
 					components: { strong: <strong /> },
 				} ),
 			},

--- a/client/my-sites/checkout/checkout-thank-you/jetpack-standalone-activation-instructions.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-standalone-activation-instructions.tsx
@@ -70,7 +70,7 @@ const JetpackStandaloneActivationInstructions: React.FC< Props > = ( { product, 
 			{
 				id: 4,
 				content: translate(
-					'Click “Activate license key” (at the bottom of the page) and enter the key below.'
+					'Click “Activate a license” (at the bottom of the page) and enter the key below.'
 				),
 			},
 		],

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -55,7 +55,7 @@
 		"jetpack/pricing-page-annual-only": true,
 		"jetpack/pricing-page-rework-v1": true,
 		"jetpack/simplify-pricing-structure": false,
-		"jetpack/standalone-plugin-onboarding-update-v1": false,
+		"jetpack/standalone-plugin-onboarding-update-v1": true,
 		"jitms": true,
 		"lasagna": true,
 		"layout/app-banner": true,

--- a/config/jetpack-cloud-horizon.json
+++ b/config/jetpack-cloud-horizon.json
@@ -44,7 +44,7 @@
 		"jetpack/search-product": true,
 		"jetpack/server-credentials-advanced-flow": true,
 		"jetpack/simplify-pricing-structure": false,
-		"jetpack/standalone-plugin-onboarding-update-v1": false,
+		"jetpack/standalone-plugin-onboarding-update-v1": true,
 		"layout/app-banner": false,
 		"layout/guided-tours": false,
 		"layout/query-selected-editor": false,

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -46,7 +46,7 @@
 		"jetpack/pricing-page-rework-v1": true,
 		"jetpack/server-credentials-advanced-flow": true,
 		"jetpack/simplify-pricing-structure": false,
-		"jetpack/standalone-plugin-onboarding-update-v1": false,
+		"jetpack/standalone-plugin-onboarding-update-v1": true,
 		"layout/app-banner": false,
 		"layout/guided-tours": false,
 		"layout/query-selected-editor": false,

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -47,7 +47,7 @@
 		"jetpack/search-product": true,
 		"jetpack/server-credentials-advanced-flow": true,
 		"jetpack/simplify-pricing-structure": false,
-		"jetpack/standalone-plugin-onboarding-update-v1": false,
+		"jetpack/standalone-plugin-onboarding-update-v1": true,
 		"layout/app-banner": false,
 		"layout/guided-tours": false,
 		"layout/query-selected-editor": false,

--- a/config/production.json
+++ b/config/production.json
@@ -59,7 +59,7 @@
 		"jetpack/pricing-page-annual-only": true,
 		"jetpack/pricing-page-rework-v1": true,
 		"jetpack/simplify-pricing-structure": false,
-		"jetpack/standalone-plugin-onboarding-update-v1": false,
+		"jetpack/standalone-plugin-onboarding-update-v1": true,
 		"jitms": true,
 		"lasagna": true,
 		"layout/app-banner": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -56,7 +56,7 @@
 		"jetpack/pricing-page-annual-only": true,
 		"jetpack/pricing-page-rework-v1": true,
 		"jetpack/simplify-pricing-structure": false,
-		"jetpack/standalone-plugin-onboarding-update-v1": false,
+		"jetpack/standalone-plugin-onboarding-update-v1": true,
 		"jitms": true,
 		"lasagna": true,
 		"layout/app-banner": true,


### PR DESCRIPTION
#### Proposed Changes

* This PR updates the instructions on the Thank You page for Jetpack product purchases to remove the word "Dashboard" when guiding users to goto "My Jetpack"
* It also enables `jetpack/standalone-plugin-onboarding-update-v1` for production

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Do any one of these
    - Open Calypso Live link below and wait for the redirect to complete
    - or boot up this PR 
        - Run `git fetch && git checkout update/jp-onboarding/enable-ff`
        - Run `yarn start`
* Open a new incognito/private browser window and go to https://cloud.jetpack.com/pricing
* Purchase a product like Backup or Boost
* On the Thank You page, replace `https://wordpress.com` with `http://calypso.localhost:3000` or with the Calypso Live link above
* Add `&flags=jetpack/standalone-plugin-onboarding-update-v1` query parameter to the URL to activate the feature flag.
* Confirm that you see the updated instructions
* Confirm that the feature flag is set to true in production config files

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1203097885147382-as-1203504709788020/f


| BEFORE | AFTER |
| - | - |
| <img width="1210" alt="Screenshot 2022-12-07 at 2 09 14 PM" src="https://user-images.githubusercontent.com/18226415/206129912-22024a7e-095f-476f-9d70-6e8636e7c191.png"> | <img width="1219" alt="Screenshot 2022-12-07 at 8 34 06 PM" src="https://user-images.githubusercontent.com/18226415/206214651-4d16d8f5-dafe-4488-88b2-9be828dc170a.png"> |

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - 0-as-1203504709788020