### PR TITLE
Virtual Page: Disable it on Jetpack sites

### DIFF
--- a/client/my-sites/pages/page-list.jsx
+++ b/client/my-sites/pages/page-list.jsx
@@ -23,6 +23,7 @@ import {
 } from 'calypso/state/posts/selectors';
 import getEditorUrl from 'calypso/state/selectors/get-editor-url';
 import hasInitializedSites from 'calypso/state/selectors/has-initialized-sites';
+import isSiteAtomic from 'calypso/state/selectors/is-site-automated-transfer';
 import { getSite, getSiteFrontPage, getSiteFrontPageType } from 'calypso/state/sites/selectors';
 import BlogPostsPage from './blog-posts-page';
 import { sortPagesHierarchically } from './helpers';
@@ -49,6 +50,7 @@ class Pages extends Component {
 		areBlockEditorSettingsLoading: PropTypes.bool,
 		isFSEActive: PropTypes.bool,
 		isFSEActiveLoading: PropTypes.bool,
+		isAtomicSite: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -187,13 +189,15 @@ class Pages extends Component {
 	}
 
 	showBlogPostsPage() {
-		const { site, homepageType, homepageId, isFSEActive } = this.props;
+		const { site, homepageType, homepageId, isFSEActive, isAtomicSite } = this.props;
 		const { search, status } = this.props.query;
 
 		return (
 			( ! config.isEnabled( 'unified-pages/virtual-home-page' ) ||
 				/** Blog posts page is for themes that don't support FSE */
-				! isFSEActive ) &&
+				! isFSEActive ||
+				/** Virtual homepage doesn't support AT site, so make it fall back to render blog posts page */
+				isAtomicSite ) &&
 			site &&
 			( homepageType === 'posts' || ( homepageType === 'page' && ! homepageId ) ) &&
 			/** Under the "Published" tab */
@@ -207,14 +211,22 @@ class Pages extends Component {
 	 * Show the virtual homepage
 	 */
 	showVirtualHomepage() {
-		const { site, homepageType, homepageId, blockEditorSettings, isFSEActive, translate } =
-			this.props;
+		const {
+			site,
+			homepageType,
+			homepageId,
+			blockEditorSettings,
+			isFSEActive,
+			isAtomicSite,
+			translate,
+		} = this.props;
 		const { search, status } = this.props.query;
 
 		return (
 			config.isEnabled( 'unified-pages/virtual-home-page' ) &&
 			/** Virtual homepage is for themes that support FSE */
 			isFSEActive &&
+			! isAtomicSite &&
 			site &&
 			( homepageType === 'posts' || ( homepageType === 'page' && ! homepageId ) ) &&
 			blockEditorSettings?.home_template &&
@@ -414,6 +426,7 @@ const mapState = ( state, { query, siteId } ) => ( {
 	site: getSite( state, siteId ),
 	newPageLink: getEditorUrl( state, siteId, null, 'page' ),
 	homepageType: getSiteFrontPageType( state, siteId ),
+	isAtomicSite: isSiteAtomic( state, siteId ),
 } );
 
 const ConnectedPages = flowRight(

--- a/client/my-sites/pages/page-list.jsx
+++ b/client/my-sites/pages/page-list.jsx
@@ -23,8 +23,12 @@ import {
 } from 'calypso/state/posts/selectors';
 import getEditorUrl from 'calypso/state/selectors/get-editor-url';
 import hasInitializedSites from 'calypso/state/selectors/has-initialized-sites';
-import isSiteAtomic from 'calypso/state/selectors/is-site-automated-transfer';
-import { getSite, getSiteFrontPage, getSiteFrontPageType } from 'calypso/state/sites/selectors';
+import {
+	getSite,
+	getSiteFrontPage,
+	getSiteFrontPageType,
+	isJetpackSite,
+} from 'calypso/state/sites/selectors';
 import BlogPostsPage from './blog-posts-page';
 import { sortPagesHierarchically } from './helpers';
 import Page from './page';
@@ -50,7 +54,7 @@ class Pages extends Component {
 		areBlockEditorSettingsLoading: PropTypes.bool,
 		isFSEActive: PropTypes.bool,
 		isFSEActiveLoading: PropTypes.bool,
-		isAtomicSite: PropTypes.bool,
+		isJetpack: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -189,15 +193,15 @@ class Pages extends Component {
 	}
 
 	showBlogPostsPage() {
-		const { site, homepageType, homepageId, isFSEActive, isAtomicSite } = this.props;
+		const { site, homepageType, homepageId, isFSEActive, isJetpack } = this.props;
 		const { search, status } = this.props.query;
 
 		return (
 			( ! config.isEnabled( 'unified-pages/virtual-home-page' ) ||
 				/** Blog posts page is for themes that don't support FSE */
 				! isFSEActive ||
-				/** Virtual homepage doesn't support AT site, so make it fall back to render blog posts page */
-				isAtomicSite ) &&
+				/** Virtual homepage doesn't support jetpack site, so make it fall back to render blog posts page */
+				isJetpack ) &&
 			site &&
 			( homepageType === 'posts' || ( homepageType === 'page' && ! homepageId ) ) &&
 			/** Under the "Published" tab */
@@ -217,7 +221,7 @@ class Pages extends Component {
 			homepageId,
 			blockEditorSettings,
 			isFSEActive,
-			isAtomicSite,
+			isJetpack,
 			translate,
 		} = this.props;
 		const { search, status } = this.props.query;
@@ -226,7 +230,8 @@ class Pages extends Component {
 			config.isEnabled( 'unified-pages/virtual-home-page' ) &&
 			/** Virtual homepage is for themes that support FSE */
 			isFSEActive &&
-			! isAtomicSite &&
+			/** Virtual homepage doesn't support jetpack site */
+			! isJetpack &&
 			site &&
 			( homepageType === 'posts' || ( homepageType === 'page' && ! homepageId ) ) &&
 			blockEditorSettings?.home_template &&
@@ -426,7 +431,7 @@ const mapState = ( state, { query, siteId } ) => ( {
 	site: getSite( state, siteId ),
 	newPageLink: getEditorUrl( state, siteId, null, 'page' ),
 	homepageType: getSiteFrontPageType( state, siteId ),
-	isAtomicSite: isSiteAtomic( state, siteId ),
+	isJetpack: isJetpackSite( state, siteId ),
 } );
 
 const ConnectedPages = flowRight(


### PR DESCRIPTION
#### Proposed Changes

* As noted in the title, disable the virtual page on AT sites and fall back to the blog posts page. We'll create another PR to enable it on AT sites later. See https://github.com/Automattic/wp-calypso/issues/70867

| Before | After |
| - | - |
| ![image](https://user-images.githubusercontent.com/13596067/206130221-8549c9ea-b35b-4a7b-9231-016560aa808b.png) | ![image](https://user-images.githubusercontent.com/13596067/206130606-97261e95-3655-43ec-bc1b-5fc4fd3c4013.png) |

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/pages/<your_atomic_site>` with template as homepage
* Verify the blog posts page shows there instead of loading forever

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/70867
