### PR TITLE
Reenable the livechat cancellation solution

### DIFF
--- a/config/_shared.json
+++ b/config/_shared.json
@@ -33,7 +33,6 @@
 	"google_oauth_client_id": "108380595987-j91sm1alavcdgd81i2655kp8q1lbtvrc.apps.googleusercontent.com",
 	"facebook_app_id": "611241942420191",
 	"livechat_support_locales": [ "en", "en-gb" ],
-	"livechat_solution": false,
 	"dsp_stripe_pub_key": "pk_live_51LYYzQF53KN4RFN0ePTwefdm7seki4pRuc4a19gPMGUba5mzuosz0IBR0cp4T57FiBgxK911ky0LNwlX2IHbm0SS00uPHEQNBO",
 	"dsp_widget_js_src": "https://widgets.wp.com/promote/widget.js",
 	"zendesk_presales_chat_key": false,

--- a/config/development.json
+++ b/config/development.json
@@ -97,6 +97,7 @@
 		"layout/support-article-dialog": true,
 		"legal-updates-banner": true,
 		"limit-global-styles": true,
+		"livechat_solution": true,
 		"login/magic-login": true,
 		"login/react-lost-password-screen": true,
 		"logmein": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -63,6 +63,7 @@
 		"layout/query-selected-editor": true,
 		"layout/support-article-dialog": true,
 		"legal-updates-banner": false,
+		"livechat_solution": true,
 		"mailchimp": false,
 		"marketplace-domain-bundle": false,
 		"marketplace-jetpack-plugin-search": true,

--- a/config/production.json
+++ b/config/production.json
@@ -67,6 +67,7 @@
 		"layout/query-selected-editor": true,
 		"layout/support-article-dialog": true,
 		"legal-updates-banner": false,
+		"livechat_solution": true,
 		"login/magic-login": true,
 		"login/react-lost-password-screen": true,
 		"mailchimp": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -64,6 +64,7 @@
 		"layout/query-selected-editor": true,
 		"layout/support-article-dialog": true,
 		"legal-updates-banner": false,
+		"livechat_solution": true,
 		"login/magic-login": true,
 		"login/react-lost-password-screen": true,
 		"mailchimp": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -74,6 +74,7 @@
 		"layout/support-article-dialog": true,
 		"legal-updates-banner": false,
 		"limit-global-styles": true,
+		"livechat_solution": true,
 		"login/magic-login": true,
 		"logmein": true,
 		"mailchimp": true,


### PR DESCRIPTION
#### Proposed Changes

This reenables the livechat cancellation solution that [was disabled](https://github.com/Automattic/wp-calypso/pull/70358) due to Happiness concerns.

livechat_solution was not enabled as a feature and I was presented with an option to either change the if in multiple places or add it as a feature. I decided to add it as a feature.

#### Testing Instructions

1. Before moving to the p2 with steps for testing with Happychat HUD, keep in mind that in order to see the step, you may need to try a little different cancellation options than what's described in the post. Come back here after completing step 2
2. In order to start livechat, you'll have to follow the steps from pebzTe-sj-p2
3. Make sure Missing Features/Themes shows this:

<img width="1040" alt="Screenshot 2022-12-07 at 11 23 55" src="https://user-images.githubusercontent.com/82778/206141325-fa181ed5-bfa4-469c-8e15-a7d083ed6f59.png">

4. Clicking it starts live chat like this
<img width="1184" alt="Screenshot 2022-12-07 at 11 24 19" src="https://user-images.githubusercontent.com/82778/206141305-f1eb4410-7215-486e-bd43-0870f37c1f20.png">


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
