### PR TITLE
Featured image email toggle: Add docs link to the toggle description

### DIFF
--- a/client/my-sites/site-settings/featured-image-toggle.jsx
+++ b/client/my-sites/site-settings/featured-image-toggle.jsx
@@ -29,7 +29,11 @@ const FeaturedImageTemplateToggle = ( props ) => {
 						{
 							components: {
 								link: (
-									<a href={ localizeUrl( 'https://wordpress.com/support/featured-images/' ) } />
+									<a
+										href={ localizeUrl( 'https://wordpress.com/support/featured-images/' ) }
+										target="_blank"
+										rel="noreferrer"
+									/>
 								),
 							},
 						}

--- a/client/my-sites/site-settings/featured-image-toggle.jsx
+++ b/client/my-sites/site-settings/featured-image-toggle.jsx
@@ -1,4 +1,5 @@
 import { Card } from '@automattic/components';
+import { localizeUrl } from '@automattic/i18n-utils';
 import { ToggleControl } from '@wordpress/components';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
@@ -24,7 +25,14 @@ const FeaturedImageTemplateToggle = ( props ) => {
 				/>
 				<FormSettingExplanation>
 					{ translate(
-						"Includes your post's featured image in the email sent out to your readers."
+						"Includes your post's featured image in the email sent out to your readers. {{link}}Learn more about the featured image{{/link}}.",
+						{
+							components: {
+								link: (
+									<a href={ localizeUrl( 'https://wordpress.com/support/featured-images/' ) } />
+								),
+							},
+						}
 					) }
 				</FormSettingExplanation>
 			</Card>


### PR DESCRIPTION
#### Proposed Changes

The proposed changes add docs link to the Featured image toggle description (`<FormSettingExplanation>`):

![Markup on 2022-12-07 at 10:44:42](https://user-images.githubusercontent.com/25105483/206144660-f2c1d25f-a015-46e6-a8d2-96cd9af7e261.png)

#### Testing Instructions

1. Navigate to _Settings → Writing_.
2. Review the Featured image setting card. It should include the `Learn more about the featured image` link pointing to https://wordpress.com/support/featured-images/.
3. The link should open in a new tab.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #69786
