### PR TITLE
Pattern Assembler - Add footer patterns from dotcomfsepatterns

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/patterns-data.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/patterns-data.ts
@@ -76,7 +76,6 @@ const useFooterPatterns = () => {
 	const footer = translate( 'Footer' );
 
 	// All footers in dotcompatterns
-	// Missing footers in dotcomfsepatterns
 	const footerPatterns: Pattern[] = [
 		{
 			id: 5316,
@@ -131,6 +130,36 @@ const useFooterPatterns = () => {
 		{
 			id: 5880,
 			name: 'Footer with background color and three columns',
+			category: footer,
+		},
+		{
+			id: 8666,
+			name: 'Left-aligned minimal footer',
+			category: footer,
+		},
+		{
+			id: 8662,
+			name: 'Center-aligned minimal footer',
+			category: footer,
+		},
+		{
+			id: 8654,
+			name: 'Three columns with address and open times',
+			category: footer,
+		},
+		{
+			id: 8659,
+			name: 'Center-aligned minimal footer with dark background',
+			category: footer,
+		},
+		{
+			id: 8656,
+			name: 'Center-aligned minimal footer with dark background and social icons',
+			category: footer,
+		},
+		{
+			id: 8650,
+			name: 'Three columns with contact info and social icons',
 			category: footer,
 		},
 	];


### PR DESCRIPTION
#### Proposed Changes

* Added the footer patterns that were moved from `dotcomfsepatterns` to `dotcompatterns`

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Access `/setup?siteSlug=[ YOUR SITE ]` to get to the PA screen
* Check that the last 6 footer patterns have previews, their names are correct and they are added as expected

**Footer previews**

<img width="311" alt="Screen Shot 2565-12-07 at 17 47 47" src="https://user-images.githubusercontent.com/1881481/206159622-e97fa493-c513-4e66-bb6c-89ef818c346c.png">

**Footer added**

<img width="739" alt="Screen Shot 2565-12-07 at 17 50 07" src="https://user-images.githubusercontent.com/1881481/206159782-2ba3c381-7913-4314-b2b3-fc70fd91d5f4.png">


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/1251
