### PR TITLE
Components: Refactor `Card` tests to RTL

### DIFF
--- a/packages/components/src/card/test/__snapshots__/index.js.snap
+++ b/packages/components/src/card/test/__snapshots__/index.js.snap
@@ -2,73 +2,85 @@
 
 exports[`Card should be linkable 1`] = `
 <a
-  className="card is-card-link"
+  class="card is-card-link"
   href="/test"
 >
-  <Gridicon
-    className="card__link-indicator"
-    icon="chevron-right"
-  />
+  <svg
+    class="gridicon gridicons-chevron-right card__link-indicator"
+    height="24"
+    viewBox="0 0 24 24"
+    width="24"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <use
+      xlink:href="gridicons.svg#gridicons-chevron-right"
+    />
+  </svg>
   This is a linked card
 </a>
 `;
 
 exports[`Card should have \`card\` class 1`] = `
 <div
-  className="card"
+  class="card"
 />
 `;
 
 exports[`Card should have custom class of \`test__ace\` 1`] = `
 <div
-  className="card test__ace"
+  class="card test__ace"
 />
 `;
 
 exports[`Card should render as a clickable button which looks like a link 1`] = `
 <button
-  className="card is-card-link is-clickable"
-  onClick="test"
+  class="card is-card-link is-clickable"
 >
-  <Gridicon
-    className="card__link-indicator"
-    icon="chevron-right"
-  />
+  <svg
+    class="gridicon gridicons-chevron-right card__link-indicator"
+    height="24"
+    viewBox="0 0 24 24"
+    width="24"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <use
+      xlink:href="gridicons.svg#gridicons-chevron-right"
+    />
+  </svg>
   This is a button which looks like a link
 </button>
 `;
 
 exports[`Card should render children 1`] = `
 <div
-  className="card"
+  class="card"
 >
   This is a card
 </div>
 `;
 
 exports[`CompactCard should have \`compact\` prop 1`] = `
-<Memo(Card)
-  compact={true}
+<div
+  class="card is-compact"
 />
 `;
 
 exports[`CompactCard should have custom class of \`test__ace\` 1`] = `
-<Memo(Card)
-  className="test__ace"
-  compact={true}
+<div
+  class="card test__ace is-compact"
 />
 `;
 
 exports[`CompactCard should render children 1`] = `
-<Memo(Card)
-  compact={true}
+<div
+  class="card is-compact"
 >
   This is a compact card
-</Memo(Card)>
+</div>
 `;
 
 exports[`CompactCard should use the card component 1`] = `
-<Memo(Card)
-  compact={true}
+<div
+  class="card is-compact"
 />
 `;

--- a/packages/components/src/card/test/__snapshots__/index.js.snap
+++ b/packages/components/src/card/test/__snapshots__/index.js.snap
@@ -20,12 +20,6 @@ exports[`Card should be linkable 1`] = `
 </a>
 `;
 
-exports[`Card should have \`card\` class 1`] = `
-<div
-  class="card"
-/>
-`;
-
 exports[`Card should have custom class of \`test__ace\` 1`] = `
 <div
   class="card test__ace"
@@ -57,6 +51,12 @@ exports[`Card should render children 1`] = `
 >
   This is a card
 </div>
+`;
+
+exports[`Card should render properly and match snapshot 1`] = `
+<div
+  class="card"
+/>
 `;
 
 exports[`CompactCard should have \`compact\` prop 1`] = `

--- a/packages/components/src/card/test/index.js
+++ b/packages/components/src/card/test/index.js
@@ -1,78 +1,99 @@
-import { shallow } from 'enzyme';
+/**
+ * @jest-environment jsdom
+ */
+
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
 import Card from '../';
 import CompactCard from '../compact';
 
 describe( 'Card', () => {
 	// it should have a class of `card`
 	test( 'should have `card` class', () => {
-		const card = shallow( <Card /> );
-		expect( card.is( '.card' ) ).toBe( true );
-		expect( card ).toMatchSnapshot();
+		const { container } = render( <Card /> );
+
+		expect( container.firstChild ).toBeVisible();
+		expect( container.firstChild ).toMatchSnapshot();
 	} );
 
 	// it should accept a custom class of `test__ace`
 	test( 'should have custom class of `test__ace`', () => {
-		const card = shallow( <Card className="test__ace" /> );
-		expect( card.is( '.test__ace' ) ).toBe( true );
-		expect( card ).toMatchSnapshot();
+		const { container } = render( <Card className="test__ace" /> );
+
+		expect( container.firstChild ).toHaveClass( 'test__ace' );
+		expect( container.firstChild ).toMatchSnapshot();
 	} );
 
 	// check that content within a card renders correctly
 	test( 'should render children', () => {
-		const card = shallow( <Card>This is a card</Card> );
-		expect( card.contains( 'This is a card' ) ).toBe( true );
-		expect( card ).toMatchSnapshot();
+		const { container } = render( <Card>This is a card</Card> );
+
+		expect( container.firstChild ).toHaveTextContent( 'This is a card' );
+		expect( container.firstChild ).toMatchSnapshot();
 	} );
 
 	// check it will accept a href
 	test( 'should be linkable', () => {
-		const card = shallow( <Card href="/test">This is a linked card</Card> );
-		expect( card.find( 'a[href="/test"]' ) ).toHaveLength( 1 );
-		expect( card.props().href ).toBe( '/test' );
-		expect( card.is( '.is-card-link' ) ).toBe( true );
-		expect( card ).toMatchSnapshot();
+		const { container } = render( <Card href="/test">This is a linked card</Card> );
+
+		const link = screen.getByRole( 'link', { name: 'This is a linked card' } );
+
+		expect( link ).toBeVisible();
+		expect( link ).toHaveAttribute( 'href', '/test' );
+		expect( link ).toHaveClass( 'is-card-link' );
+		expect( container.firstChild ).toMatchSnapshot();
+
+		expect( screen.queryByRole( 'button' ) ).not.toBeInTheDocument();
 	} );
+
 	// check that it can be rendered as a clickable button displaying as a link
 	test( 'should render as a clickable button which looks like a link', () => {
-		const card = shallow(
-			<Card tagName="button" displayAsLink onClick="test">
+		const { container } = render(
+			<Card tagName="button" displayAsLink onClick={ () => {} }>
 				This is a button which looks like a link
 			</Card>
 		);
-		expect( card.is( 'a' ) ).toBe( false );
-		expect( card.is( 'button' ) ).toBe( true );
-		expect( card.is( '.is-card-link' ) ).toBe( true );
-		expect( card.is( '.is-clickable' ) ).toBe( true );
-		expect( card ).toMatchSnapshot();
+
+		const card = screen.getByRole( 'button', { name: 'This is a button which looks like a link' } );
+
+		expect( card.tagName ).toBe( 'BUTTON' );
+		expect( card ).toHaveClass( 'is-card-link' );
+		expect( card ).toHaveClass( 'is-clickable' );
+		expect( container.firstChild ).toMatchSnapshot();
+
+		expect( screen.queryByRole( 'link' ) ).not.toBeInTheDocument();
 	} );
 } );
 
 describe( 'CompactCard', () => {
 	// the inner `Card` should have a `compact` prop
 	test( 'should have `compact` prop', () => {
-		const compactCard = shallow( <CompactCard /> );
-		expect( compactCard.prop( 'compact' ) ).toBe( true );
-		expect( compactCard ).toMatchSnapshot();
+		const { container } = render( <CompactCard /> );
+
+		expect( container.firstChild ).toHaveClass( 'is-compact' );
+		expect( container.firstChild ).toMatchSnapshot();
 	} );
 
 	// it should accept a custom class of `test__ace`
 	test( 'should have custom class of `test__ace`', () => {
-		const compactCard = shallow( <CompactCard className="test__ace" /> );
-		expect( compactCard.is( '.test__ace' ) ).toBe( true );
-		expect( compactCard ).toMatchSnapshot();
+		const { container } = render( <CompactCard className="test__ace" /> );
+
+		expect( container.firstChild ).toHaveClass( 'test__ace' );
+		expect( container.firstChild ).toMatchSnapshot();
 	} );
 
 	// check that content within a CompactCard renders correctly
 	test( 'should render children', () => {
-		const compactCard = shallow( <CompactCard>This is a compact card</CompactCard> );
-		expect( compactCard.contains( 'This is a compact card' ) ).toBe( true );
-		expect( compactCard ).toMatchSnapshot();
+		const { container } = render( <CompactCard>This is a compact card</CompactCard> );
+		expect( container.firstChild ).toHaveTextContent( 'This is a compact card' );
+		expect( container.firstChild ).toMatchSnapshot();
 	} );
 
 	// test for card component
 	test( 'should use the card component', () => {
-		const compactCard = shallow( <CompactCard /> );
-		expect( compactCard.find( Card ) ).toHaveLength( 1 );
-		expect( compactCard ).toMatchSnapshot();
+		const { container } = render( <CompactCard /> );
+
+		expect( container.firstChild ).toHaveClass( 'card' );
+		expect( container.firstChild ).toMatchSnapshot();
 	} );
 } );

--- a/packages/components/src/card/test/index.js
+++ b/packages/components/src/card/test/index.js
@@ -9,7 +9,7 @@ import CompactCard from '../compact';
 
 describe( 'Card', () => {
 	// it should have a class of `card`
-	test( 'should have `card` class', () => {
+	test( 'should render properly and match snapshot', () => {
 		const { container } = render( <Card /> );
 
 		expect( container.firstChild ).toBeVisible();


### PR DESCRIPTION
#### Proposed Changes

This PR refactors the `Card` component tests to use `@testing-library/react`.

#### Testing Instructions

Verify tests still pass: `yarn run test-packages packages/components/src/card/test/index.js`

Related to #70873
