### PR TITLE
Global styles: Site editor wording

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
@@ -295,7 +295,7 @@ function wpcom_display_global_styles_launch_bar( $bar_controls ) {
 					<?php echo esc_html__( 'Styles', 'full-site-editing' ); ?>
 				</span>
 				<span class="is-desktop">
-					<?php echo esc_html__( 'Publish styles', 'full-site-editing' ); ?>
+					<?php echo esc_html__( 'Custom styles', 'full-site-editing' ); ?>
 				</span>
 			</a>
 		</div>

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
@@ -267,7 +267,7 @@ function wpcom_display_global_styles_launch_bar( $bar_controls ) {
 		$preview_text     = __( 'Hide premium styles', 'full-site-editing' );
 		$preview_location = remove_query_arg( 'preview-global-styles' );
 	} else {
-		$preview_text     = __( 'Preview styles before upgrading', 'full-site-editing' );
+		$preview_text     = __( 'Preview custom styles', 'full-site-editing' );
 		$preview_location = add_query_arg( 'preview-global-styles', '' );
 	}
 
@@ -275,7 +275,7 @@ function wpcom_display_global_styles_launch_bar( $bar_controls ) {
 		<div class="launch-bar-global-styles-button">
 			<div class="launch-bar-global-styles-popover hidden">
 				<div>
-					<?php echo esc_html__( 'Publish your style changes and unlock tons of other features by upgrading to a Premium plan.', 'full-site-editing' ); ?>
+					<?php echo esc_html__( 'Your site contains customised styles that will only be visible once you upgrade to a Premium plan.', 'full-site-editing' ); ?>
 				</div>
 				<a
 					class="launch-bar-global-styles-upgrade-button"

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
@@ -264,7 +264,7 @@ function wpcom_display_global_styles_launch_bar( $bar_controls ) {
 	$upgrade_url = 'https://wordpress.com/plans/' . $site_slug . '?plan=value_bundle';
 
 	if ( wpcom_is_previewing_global_styles() ) {
-		$preview_text     = __( 'Hide premium styles', 'full-site-editing' );
+		$preview_text     = __( 'Hide custom styles', 'full-site-editing' );
 		$preview_location = remove_query_arg( 'preview-global-styles' );
 	} else {
 		$preview_text     = __( 'Preview custom styles', 'full-site-editing' );

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
@@ -275,7 +275,7 @@ function wpcom_display_global_styles_launch_bar( $bar_controls ) {
 		<div class="launch-bar-global-styles-button">
 			<div class="launch-bar-global-styles-popover hidden">
 				<div>
-					<?php echo esc_html__( 'Your site contains customised styles that will only be visible once you upgrade to a Premium plan.', 'full-site-editing' ); ?>
+					<?php echo esc_html__( 'Your site contains customized styles that will only be visible once you upgrade to a Premium plan.', 'full-site-editing' ); ?>
 				</div>
 				<a
 					class="launch-bar-global-styles-upgrade-button"

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/notice.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/notice.js
@@ -65,7 +65,7 @@ function GlobalStylesNoticeComponent() {
 		<Notice status="warning" isDismissible={ false } className="wpcom-global-styles-notice">
 			{ createInterpolateElement(
 				__(
-					'Your changes include customised styles that will only be visible once you <a>upgrade to a Premium plan</a>.',
+					'Your changes include customized styles that will only be visible once you <a>upgrade to a Premium plan</a>.',
 					'full-site-editing'
 				),
 				{

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/notice.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/notice.js
@@ -65,7 +65,7 @@ function GlobalStylesNoticeComponent() {
 		<Notice status="warning" isDismissible={ false } className="wpcom-global-styles-notice">
 			{ createInterpolateElement(
 				__(
-					'To publish these styles, and to unlock tons of other features, <a>upgrade to a Premium plan</a>.',
+					'Your changes include customised styles that will only be visible once you <a>upgrade to a Premium plan</a>.',
 					'full-site-editing'
 				),
 				{

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/notice.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/notice.js
@@ -65,7 +65,7 @@ function GlobalStylesNoticeComponent() {
 		<Notice status="warning" isDismissible={ false } className="wpcom-global-styles-notice">
 			{ createInterpolateElement(
 				__(
-					'Your changes include customised styles that will only be visible once you <a>upgrade to a Premium plan</a>.',
+					'Your changes includes customised styles that will only be visible once you <a>upgrade to a Premium plan</a>.',
 					'full-site-editing'
 				),
 				{

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/notice.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/notice.js
@@ -65,7 +65,7 @@ function GlobalStylesNoticeComponent() {
 		<Notice status="warning" isDismissible={ false } className="wpcom-global-styles-notice">
 			{ createInterpolateElement(
 				__(
-					'Your changes includes customised styles that will only be visible once you <a>upgrade to a Premium plan</a>.',
+					'Your changes include customised styles that will only be visible once you <a>upgrade to a Premium plan</a>.',
 					'full-site-editing'
 				),
 				{


### PR DESCRIPTION
#### Proposed Changes

Change the wording when saving the global styles in the site editor and on the front-end Publish styles. New wording was suggested in paYJgx-2Hv-p2#comment-3010 : 'Your site contains color changes that will only be visible once you upgrade to a Premium plan' but I have varied that in the site editor because:
 * The site doesn't contain the color changes at this point - they haven't been saved yet.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Apply ETK to sandbox `install-plugin.sh editing-toolkit update/etk-gs-wording2-wordingharder`
2. Create a site, slap the wpcom-limit-global-styles sticker on, sandbox the site
3. Open up the site editor
4. Change some styles
5. Hit save
6. Look at the notice
7. Look at the front-end of the site
8. Click on 'Publish styles', look at the thing that appears


Before | After
-------|------
![image](https://user-images.githubusercontent.com/93301/206187005-464f4046-4f3c-466a-97cd-212311eae724.png) | ![image](https://user-images.githubusercontent.com/93301/206206287-82aaff7e-d61a-4fb1-83b6-7a4e569f6b4a.png)
![image](https://user-images.githubusercontent.com/93301/206195874-60c0e1f3-00e8-4276-9d81-b3e658ca118b.png) | ![image](https://user-images.githubusercontent.com/93301/206205123-f6f605f7-cfc9-4a6e-a0e2-6bf2e8965ee6.png)



#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/70871