### PR TITLE
Components: Refactor `RootChild` tests to RTL

### DIFF
--- a/packages/components/src/root-child/test/index.jsx
+++ b/packages/components/src/root-child/test/index.jsx
@@ -1,32 +1,24 @@
 /**
  * @jest-environment jsdom
  */
-
-import { mount } from 'enzyme';
-import { createRef, Component, createElement } from 'react';
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
 import ReactDom from 'react-dom';
 import RootChild from '..';
 
 /**
  * Module variables
  */
-class Greeting extends Component {
-	static defaultProps = { toWhom: 'World' };
-
-	parentChildRef = createRef();
-	rootChildRef = createRef();
-
-	render() {
-		return (
-			/* eslint-disable-next-line wpcalypso/jsx-classname-namespace */
-			<div className="parent">
-				<h1 ref={ this.parentChildRef }>Greeting</h1>
-				<RootChild>
-					<span ref={ this.rootChildRef }>Hello { this.props.toWhom }!</span>
-				</RootChild>
-			</div>
-		);
-	}
+function Greeting( { toWhom = 'World' } ) {
+	return (
+		/* eslint-disable-next-line wpcalypso/jsx-classname-namespace */
+		<div className="parent">
+			<h1 data-testid="parent-child">Greeting</h1>
+			<RootChild>
+				<span data-testid="root-child">Hello { toWhom }!</span>
+			</RootChild>
+		</div>
+	);
 }
 
 describe( 'RootChild', () => {
@@ -43,27 +35,28 @@ describe( 'RootChild', () => {
 
 	describe( 'rendering', () => {
 		test( 'should render any children as descendants of body', () => {
-			const tree = ReactDom.render( createElement( Greeting ), container );
+			render( <Greeting />, { container } );
 
-			expect( tree.parentChildRef.current.parentNode.className ).toBe( 'parent' );
-			expect( tree.rootChildRef.current.parentNode.parentNode ).toBe( document.body );
+			const wrapper = screen.getByTestId( 'parent-child' ).parentNode;
+
+			expect( wrapper ).toHaveClass( 'parent' );
+			expect( wrapper.parentNode ).toBe( container );
 		} );
 
 		test( 'should update the children if parent is re-rendered', () => {
-			const tree = mount( createElement( Greeting ), { attachTo: container } );
-			tree.setProps( { toWhom: 'Universe' } );
+			render( <Greeting toWhom="Universe" />, { container } );
 
-			expect( tree.instance().rootChildRef.current.innerHTML ).toBe( 'Hello Universe!' );
-			tree.detach();
+			expect( screen.getByTestId( 'root-child' ) ).toHaveTextContent( 'Hello Universe!' );
 		} );
 	} );
 
 	describe( 'unmounting', () => {
 		test( 'should destroy the root child when the component is unmounted', () => {
-			ReactDom.render( createElement( Greeting ), container );
-			ReactDom.unmountComponentAtNode( container );
+			const { container: body, unmount } = render( <Greeting toWhom="Universe" />, { container } );
 
-			expect( Array.from( document.body.querySelectorAll( '*' ) ) ).toEqual( [ container ] );
+			unmount();
+
+			expect( body ).toBeEmptyDOMElement();
 		} );
 	} );
 } );

--- a/packages/components/src/root-child/test/index.jsx
+++ b/packages/components/src/root-child/test/index.jsx
@@ -44,7 +44,9 @@ describe( 'RootChild', () => {
 		} );
 
 		test( 'should update the children if parent is re-rendered', () => {
-			render( <Greeting toWhom="Universe" />, { container } );
+			const { rerender } = render( <Greeting />, { container } );
+
+			rerender( <Greeting toWhom="Universe" /> );
 
 			expect( screen.getByTestId( 'root-child' ) ).toHaveTextContent( 'Hello Universe!' );
 		} );


### PR DESCRIPTION
#### Proposed Changes

This PR refactors the `RootChild` component tests to use `@testing-library/react`.

#### Testing Instructions

Verify tests still pass: `yarn run test-packages packages/components/src/root-child/test/index.jsx`

Related to #70873
