### PR TITLE
Components: Refactor `Suggestions` tests to RTL

### DIFF
--- a/packages/components/src/suggestions/test/__snapshots__/index.js.snap
+++ b/packages/components/src/suggestions/test/__snapshots__/index.js.snap
@@ -2,34 +2,130 @@
 
 exports[`<Suggestions> render basic list of suggestions 1`] = `
 <div
-  className="suggestions"
+  class="suggestions"
 >
-  <Memo(ForwardRef(Item))
-    hasHighlight={true}
-    key="0"
-    label="Apple"
-    onMount={[Function]}
-    onMouseDown={[Function]}
-    onMouseOver={[Function]}
-    query=""
-  />
-  <Memo(ForwardRef(Item))
-    hasHighlight={false}
-    key="1"
-    label="Pear"
-    onMount={[Function]}
-    onMouseDown={[Function]}
-    onMouseOver={[Function]}
-    query=""
-  />
-  <Memo(ForwardRef(Item))
-    hasHighlight={false}
-    key="2"
-    label="Orange"
-    onMount={[Function]}
-    onMouseDown={[Function]}
-    onMouseOver={[Function]}
-    query=""
-  />
+  <button
+    class="suggestions__item has-highlight"
+  >
+    <span
+      class="suggestions__label"
+    >
+      A
+    </span>
+    <span
+      class="suggestions__label is-emphasized"
+    />
+    <span
+      class="suggestions__label"
+    >
+      p
+    </span>
+    <span
+      class="suggestions__label is-emphasized"
+    />
+    <span
+      class="suggestions__label"
+    >
+      p
+    </span>
+    <span
+      class="suggestions__label is-emphasized"
+    />
+    <span
+      class="suggestions__label"
+    >
+      l
+    </span>
+    <span
+      class="suggestions__label is-emphasized"
+    />
+    <span
+      class="suggestions__label"
+    >
+      e
+    </span>
+  </button>
+  <button
+    class="suggestions__item"
+  >
+    <span
+      class="suggestions__label"
+    >
+      P
+    </span>
+    <span
+      class="suggestions__label is-emphasized"
+    />
+    <span
+      class="suggestions__label"
+    >
+      e
+    </span>
+    <span
+      class="suggestions__label is-emphasized"
+    />
+    <span
+      class="suggestions__label"
+    >
+      a
+    </span>
+    <span
+      class="suggestions__label is-emphasized"
+    />
+    <span
+      class="suggestions__label"
+    >
+      r
+    </span>
+  </button>
+  <button
+    class="suggestions__item"
+  >
+    <span
+      class="suggestions__label"
+    >
+      O
+    </span>
+    <span
+      class="suggestions__label is-emphasized"
+    />
+    <span
+      class="suggestions__label"
+    >
+      r
+    </span>
+    <span
+      class="suggestions__label is-emphasized"
+    />
+    <span
+      class="suggestions__label"
+    >
+      a
+    </span>
+    <span
+      class="suggestions__label is-emphasized"
+    />
+    <span
+      class="suggestions__label"
+    >
+      n
+    </span>
+    <span
+      class="suggestions__label is-emphasized"
+    />
+    <span
+      class="suggestions__label"
+    >
+      g
+    </span>
+    <span
+      class="suggestions__label is-emphasized"
+    />
+    <span
+      class="suggestions__label"
+    >
+      e
+    </span>
+  </button>
 </div>
 `;

--- a/packages/components/src/suggestions/test/index.js
+++ b/packages/components/src/suggestions/test/index.js
@@ -39,6 +39,10 @@ describe( '<Suggestions>', () => {
 
 		const suggestions = screen.getAllByRole( 'button' );
 
+		expect( suggestions[ 0 ] ).toHaveTextContent( 'Apple' );
+		expect( suggestions[ 1 ] ).toHaveTextContent( 'Pear' );
+		expect( suggestions[ 2 ] ).toHaveTextContent( 'Orange' );
+
 		expect( suggestions[ 0 ] ).toHaveClass( 'has-highlight' );
 		expect( suggestions[ 1 ] ).not.toHaveClass( 'has-highlight' );
 		expect( suggestions[ 2 ] ).not.toHaveClass( 'has-highlight' );

--- a/packages/components/src/suggestions/test/index.js
+++ b/packages/components/src/suggestions/test/index.js
@@ -1,6 +1,10 @@
-import { shallow } from 'enzyme';
+/**
+ * @jest-environment jsdom
+ */
+
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
 import Suggestions from '..';
-import Item from '../item';
 
 const defaultProps = {
 	suggest: jest.fn(),
@@ -23,32 +27,38 @@ describe( '<Suggestions>', () => {
 	} );
 
 	test( 'render basic list of suggestions', () => {
-		const wrapper = shallow( <Suggestions { ...defaultProps } /> );
-		expect( wrapper.find( Item ) ).toHaveLength( 3 );
-		expect( wrapper ).toMatchSnapshot();
+		const { container } = render( <Suggestions { ...defaultProps } /> );
+
+		expect( screen.getAllByRole( 'button' ) ).toHaveLength( 3 );
+
+		expect( container.firstChild ).toMatchSnapshot();
 	} );
 
 	test( 'highlights the query inside the suggestions', () => {
-		const wrapper = shallow( <Suggestions { ...defaultProps } query="LE" /> );
-		expect( wrapper.find( { label: 'Pear' } ).prop( 'hasHighlight' ) ).toBe( false );
-		expect( wrapper.find( { label: 'Orange' } ).prop( 'hasHighlight' ) ).toBe( false );
-		expect( wrapper.find( { label: 'Apple' } ).prop( 'hasHighlight' ) ).toBe( true );
-		expect( wrapper.find( { label: 'Apple' } ).prop( 'query' ) ).toBe( 'LE' );
+		render( <Suggestions { ...defaultProps } query="LE" /> );
+
+		const suggestions = screen.getAllByRole( 'button' );
+
+		expect( suggestions[ 0 ] ).toHaveClass( 'has-highlight' );
+		expect( suggestions[ 1 ] ).not.toHaveClass( 'has-highlight' );
+		expect( suggestions[ 2 ] ).not.toHaveClass( 'has-highlight' );
+
+		expect( screen.getByText( 'le' ) ).toHaveClass( 'is-emphasized' );
 	} );
 
 	test( 'uncategorized suggestions always appear first', () => {
-		const wrapper = shallow(
+		render(
 			<Suggestions
 				{ ...defaultProps }
 				suggestions={ [ { label: 'Carrot', category: 'Vegetable' }, ...defaultProps.suggestions ] }
 			/>
 		);
 
-		const suggestions = wrapper.find( Item );
+		const suggestions = screen.getAllByRole( 'button' );
 
-		expect( suggestions.at( 0 ).prop( 'label' ) ).toBe( 'Apple' );
-		expect( suggestions.at( 1 ).prop( 'label' ) ).toBe( 'Pear' );
-		expect( suggestions.at( 2 ).prop( 'label' ) ).toBe( 'Orange' );
-		expect( suggestions.at( 3 ).prop( 'label' ) ).toBe( 'Carrot' );
+		expect( suggestions[ 0 ] ).toHaveTextContent( 'Apple' );
+		expect( suggestions[ 1 ] ).toHaveTextContent( 'Pear' );
+		expect( suggestions[ 2 ] ).toHaveTextContent( 'Orange' );
+		expect( suggestions[ 3 ] ).toHaveTextContent( 'Carrot' );
 	} );
 } );


### PR DESCRIPTION
#### Proposed Changes

This PR refactors the `Suggestions` component tests to use `@testing-library/react`.

#### Testing Instructions

Verify tests still pass: `yarn run test-packages packages/components/src/suggestions/test/index.js`

Related to #70873
