### PR TITLE
Sites Page: Fix 'Launch Guide' link to the onboarding flow

### DIFF
--- a/client/sites-dashboard/utils.ts
+++ b/client/sites-dashboard/utils.ts
@@ -1,7 +1,7 @@
 import { SiteExcerptNetworkData } from 'calypso/data/sites/site-excerpt-types';
 
 export const getLaunchpadUrl = ( slug: string, flow: string ) => {
-	return `/setup/launchpad?flow=${ flow }&siteSlug=${ slug }`;
+	return `/setup/${ flow }/launchpad?siteSlug=${ slug }`;
 };
 
 export const getDashboardUrl = ( slug: string ) => {


### PR DESCRIPTION
Reported in p1670428170546529-slack-C029GN3KD

## Proposed Changes

Updates the 'Launch Guide' link so it takes you directly to the Launchpad:

<img width="487" alt="image" src="https://user-images.githubusercontent.com/36432/206235833-c5156622-ac8a-4b93-bf98-88048d0806d3.png">

It looks like the URL structure was updated on November 3rd with https://github.com/Automattic/wp-calypso/pull/69561, so it's been broken for a month.

Our nag was originally added on October 4th https://github.com/Automattic/wp-calypso/pull/68533

## Testing Instructions

1. Create a new LIB site.
2. Navigate to `/sites`.
3. Verify clicking on 'Launch Guide' for the site takes you to the Launchpad.