### PR TITLE
Tiny fix: fix sites page when sites do not have titles

### DIFF
--- a/packages/sites/src/use-sites-list-sorting.tsx
+++ b/packages/sites/src/use-sites-list-sorting.tsx
@@ -158,8 +158,8 @@ function sortAlphabetically< T extends SiteDetailsForSorting >(
 	b: T,
 	sortOrder: SitesSortOrder
 ) {
-	const normalizedA = a.title.toLocaleLowerCase();
-	const normalizedB = b.title.toLocaleLowerCase();
+	const normalizedA = a.title?.toLocaleLowerCase();
+	const normalizedB = b.title?.toLocaleLowerCase();
 
 	if ( normalizedA > normalizedB ) {
 		return sortOrder === 'asc' ? 1 : -1;


### PR DESCRIPTION
#### Proposed Changes

* In some cases, when you're trying to convert a simple site to Atomic and the process fails, you still have a shell site belonging to you (called purged blog). Use MGS to search for "Purged blog detected” and you'll find many instances of such blogs. This type of site only has an ID and some skeletal details. No title, no URL, nothing of that. 
* Nonetheless, this site is returned by the /me/sites endpoint. 
* Since these sites have `null` title, they break the sorting in sites page. 
* `sitename2343432324122609808 .wordpress.com` is one of these sites.
