### PR TITLE
Tailored Ecommerce: Adding user settings query and verticals translation support.

### DIFF
--- a/client/data/site-verticals/use-site-verticals-featured.ts
+++ b/client/data/site-verticals/use-site-verticals-featured.ts
@@ -2,23 +2,28 @@ import { useQuery, UseQueryResult, QueryKey } from 'react-query';
 import wpcom from 'calypso/lib/wp';
 import type { SiteVerticalsResponse } from './types';
 
-const useSiteVerticalsFeatured = (): UseQueryResult< SiteVerticalsResponse[] > => {
-	return useQuery( getCacheKey(), () => fetchSiteVerticalsFeatured(), {
+const useSiteVerticalsFeatured = ( {
+	locale = 'en',
+} ): UseQueryResult< SiteVerticalsResponse[] > => {
+	return useQuery( getCacheKey( locale ), () => fetchSiteVerticalsFeatured( locale ), {
 		enabled: true,
 		staleTime: Infinity,
 		refetchInterval: false,
 	} );
 };
 
-export function fetchSiteVerticalsFeatured(): Promise< SiteVerticalsResponse[] > {
-	return wpcom.req.get( {
-		apiNamespace: 'wpcom/v2',
-		path: '/site-verticals/featured',
-	} );
+export function fetchSiteVerticalsFeatured( locale: string ): Promise< SiteVerticalsResponse[] > {
+	return wpcom.req.get(
+		{
+			apiNamespace: 'wpcom/v2',
+			path: '/site-verticals/featured',
+		},
+		{ _locale: locale }
+	);
 }
 
-export function getCacheKey(): QueryKey {
-	return [ 'site-verticals', 'featured' ];
+export function getCacheKey( locale: string ): QueryKey {
+	return [ 'site-verticals', 'featured', locale ];
 }
 
 export default useSiteVerticalsFeatured;

--- a/client/data/users/use-user-settings-query.js
+++ b/client/data/users/use-user-settings-query.js
@@ -1,0 +1,20 @@
+import { useQuery } from 'react-query';
+import wpcomRequest from 'wpcom-proxy-request';
+
+const useUserSettingsQuery = () => {
+	return useQuery( getCacheKey(), () => fetchUserSettings(), {
+		staleTime: Infinity,
+		refetchInterval: false,
+		refetchOnMount: 'always',
+	} );
+};
+
+export function fetchUserSettings() {
+	return wpcomRequest( { path: '/me/settings', apiVersion: '1.1' } );
+}
+
+export function getCacheKey() {
+	return [ 'user-settings' ];
+}
+
+export default useUserSettingsQuery;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/store-profiler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/store-profiler/index.tsx
@@ -10,6 +10,7 @@ import FormLabel from 'calypso/components/forms/form-label';
 import FormSelect from 'calypso/components/forms/form-select';
 import FormInput from 'calypso/components/forms/form-text-input';
 import useSiteVerticalsFeatured from 'calypso/data/site-verticals/use-site-verticals-featured';
+import useUserSettingsQuery from 'calypso/data/users/use-user-settings-query';
 import { useCountriesAndStates } from 'calypso/jetpack-cloud/sections/partner-portal/company-details-form/hooks/use-countries-and-states';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { ONBOARD_STORE, USER_STORE } from '../../../../stores';
@@ -30,7 +31,8 @@ const StoreProfiler: Step = function StoreProfiler( { navigation } ) {
 		setStoreLocationCountryCode: saveCountryCodeToStore,
 	} = useDispatch( ONBOARD_STORE );
 
-	const verticals = useSiteVerticalsFeatured();
+	const userSettings = useUserSettingsQuery();
+	const verticals = useSiteVerticalsFeatured( { locale: userSettings?.data?.language || 'en' } );
 	const verticalsOptions = React.useMemo( () => {
 		const sorted = verticals.data?.sort( ( a, b ) => {
 			if ( a.name === b.name ) {
@@ -40,7 +42,7 @@ const StoreProfiler: Step = function StoreProfiler( { navigation } ) {
 		} );
 		const options = sorted?.map( ( v ) => (
 			<option value={ v.id } key={ v.id }>
-				{ v.name }
+				{ v.title }
 			</option>
 		) );
 		options?.unshift(


### PR DESCRIPTION
#### Proposed Changes

* This PR adds a `react-query` version of the request necessary to fetch the current logged-in user's settings, and then uses the `language` property on that result to fetch a translated version of the verticals displayed on the `store-profiler` step.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this PR locally.
* Navigate to `/setup/ecommerce/storeProfiler`
* Verify that the options in the "industry" dropdown are translated into your account's current language.
* Change your account's language, repeat the above steps, and verify that the options are displayed in the new language.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #70766 
