### PR TITLE
eCommerce Onboarding: Update goBack and goNext methods to match the expected flow

### DIFF
--- a/client/landing/stepper/declarative-flow/tailored-ecommerce-flow.ts
+++ b/client/landing/stepper/declarative-flow/tailored-ecommerce-flow.ts
@@ -165,9 +165,9 @@ export const ecommerceFlow: Flow = {
 		const goBack = () => {
 			switch ( _currentStepName ) {
 				case 'designCarousel':
-					return navigate( 'storeAddress' );
-				case 'storeAddress':
 					return navigate( 'storeProfiler' );
+				case 'storeAddress':
+					return navigate( 'designCarousel' );
 				default:
 					return navigate( 'intro' );
 			}
@@ -178,11 +178,11 @@ export const ecommerceFlow: Flow = {
 				case 'intro':
 					return navigate( 'storeProfiler' );
 				case 'storeProfiler':
-					return navigate( 'storeAddress' );
+					return navigate( 'designCarousel' );
 				case 'storeAddress':
-					return navigate( 'designCarousel' );
+					return window.location.assign( `${ site?.URL }/wp-admin/admin.php?page=wc-admin` );
 				case 'designCarousel':
-					return navigate( 'designCarousel' );
+					return navigate( 'domains' );
 				default:
 					return navigate( 'intro' );
 			}

--- a/client/landing/stepper/declarative-flow/tailored-ecommerce-flow.ts
+++ b/client/landing/stepper/declarative-flow/tailored-ecommerce-flow.ts
@@ -167,7 +167,7 @@ export const ecommerceFlow: Flow = {
 				case 'designCarousel':
 					return navigate( 'storeProfiler' );
 				case 'storeAddress':
-					return navigate( 'designCarousel' );
+					return navigate( 'domains' );
 				default:
 					return navigate( 'intro' );
 			}


### PR DESCRIPTION
#### Proposed Changes

* Update `goBack` and `goNext` methods for each stage of the flow based on the desired flow direction in `submit`. Fixes #70888

#### Testing Instructions

* Switch to this PR, navigate to `/setup/ecommerce/storeProfiler`
* Click "Skip for now" at the top right; you should be brought to the `designCarousel` step.
* The rest of the flow should continue to work as expected.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- N/A Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- N/A Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- N/A Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- N/A For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->