### PR TITLE
Gifting: Add is_gift_purchase prop to calypso_checkout_page_view event

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/checkout-main.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-main.tsx
@@ -531,6 +531,7 @@ export default function CheckoutMain( {
 		storedCards,
 		productAliasFromUrl,
 		checkoutFlow,
+		isGiftPurchase,
 	} );
 
 	const onPageLoadError: CheckoutPageErrorCallback = useCallback(

--- a/client/my-sites/checkout/composite-checkout/hooks/use-record-checkout-loaded.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-record-checkout-loaded.ts
@@ -23,7 +23,7 @@ export default function useRecordCheckoutLoaded( {
 	storedCards: StoredCard[];
 	productAliasFromUrl: string | undefined | null;
 	checkoutFlow: string;
-	isGiftPurchase: boolean;
+	isGiftPurchase?: boolean;
 } ): void {
 	const reduxDispatch = useDispatch();
 	const hasRecordedCheckoutLoad = useRef( false );

--- a/client/my-sites/checkout/composite-checkout/hooks/use-record-checkout-loaded.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-record-checkout-loaded.ts
@@ -15,6 +15,7 @@ export default function useRecordCheckoutLoaded( {
 	storedCards,
 	productAliasFromUrl,
 	checkoutFlow,
+	isGiftPurchase,
 }: {
 	isLoading: boolean;
 	isApplePayAvailable: boolean;
@@ -22,6 +23,7 @@ export default function useRecordCheckoutLoaded( {
 	storedCards: StoredCard[];
 	productAliasFromUrl: string | undefined | null;
 	checkoutFlow: string;
+	isGiftPurchase: boolean;
 } ): void {
 	const reduxDispatch = useDispatch();
 	const hasRecordedCheckoutLoad = useRef( false );
@@ -31,6 +33,7 @@ export default function useRecordCheckoutLoaded( {
 			recordTracksEvent( 'calypso_checkout_page_view', {
 				saved_cards: storedCards.length,
 				is_renewal: hasRenewalItem( responseCart ),
+				is_gift_purchase: isGiftPurchase,
 				apple_pay_available: isApplePayAvailable,
 				product_slug: productAliasFromUrl,
 				is_composite: true,


### PR DESCRIPTION
#### Proposed Changes

* Add is_gift_purchase prop to calypso_checkout_page_view event

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the Chrome extension / t.gif in the Network tab / console debugging to see Tracks events fire (see PCYsg-cae-p2)
* Click on a gifting banner to open checkout with a gift, and look for the `calypso_checkout_page_view` event. Verify it has a `is_gift_purchase` and it's `true`
* Purchase a regular subscription, and look for the `calypso_checkout_page_view` event. Verify it has a `is_gift_purchase` and it's `false`

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/1355