### PR TITLE
Free Flow: Add post-setup flow and screen

### DIFF
--- a/client/landing/stepper/declarative-flow/free-post-setup.ts
+++ b/client/landing/stepper/declarative-flow/free-post-setup.ts
@@ -1,0 +1,47 @@
+import { FREE_POST_SETUP_FLOW } from '@automattic/onboarding';
+import { translate } from 'i18n-calypso';
+import { useSiteSlug } from '../hooks/use-site-slug';
+import { recordSubmitStep } from './internals/analytics/record-submit-step';
+import FreePostSetup from './internals/steps-repository/free-post-setup';
+import { ProvidedDependencies } from './internals/types';
+import type { Flow } from './internals/types';
+
+export const freePostSetup: Flow = {
+	name: FREE_POST_SETUP_FLOW,
+	get title() {
+		return translate( 'Free' );
+	},
+	useSteps() {
+		return [ { slug: 'newsletterPostSetup', component: FreePostSetup } ];
+	},
+
+	useStepNavigation( currentStep, navigate ) {
+		const flowName = this.name;
+		const siteSlug = useSiteSlug();
+
+		function submit( providedDependencies: ProvidedDependencies = {} ) {
+			recordSubmitStep( providedDependencies, 'free-post-setup', flowName, currentStep );
+
+			switch ( currentStep ) {
+				case 'freePostSetup':
+					return window.location.assign(
+						`/setup/free/launchpad?siteSlug=${ siteSlug }&color=${ providedDependencies.color }`
+					);
+			}
+		}
+
+		const goBack = () => {
+			return;
+		};
+
+		const goNext = () => {
+			return;
+		};
+
+		const goToStep = ( step: string ) => {
+			navigate( step );
+		};
+
+		return { goNext, goBack, goToStep, submit };
+	},
+};

--- a/client/landing/stepper/declarative-flow/free-post-setup.ts
+++ b/client/landing/stepper/declarative-flow/free-post-setup.ts
@@ -6,13 +6,13 @@ import FreePostSetup from './internals/steps-repository/free-post-setup';
 import { ProvidedDependencies } from './internals/types';
 import type { Flow } from './internals/types';
 
-export const freePostSetup: Flow = {
+const freePostSetup: Flow = {
 	name: FREE_POST_SETUP_FLOW,
 	get title() {
 		return translate( 'Free' );
 	},
 	useSteps() {
-		return [ { slug: 'newsletterPostSetup', component: FreePostSetup } ];
+		return [ { slug: 'freePostSetup', component: FreePostSetup } ];
 	},
 
 	useStepNavigation( currentStep, navigate ) {
@@ -45,3 +45,5 @@ export const freePostSetup: Flow = {
 		return { goNext, goBack, goToStep, submit };
 	},
 };
+
+export default freePostSetup;

--- a/client/landing/stepper/declarative-flow/free.ts
+++ b/client/landing/stepper/declarative-flow/free.ts
@@ -16,9 +16,9 @@ import { useSiteSlug } from '../hooks/use-site-slug';
 import { USER_STORE, ONBOARD_STORE } from '../stores';
 import { recordSubmitStep } from './internals/analytics/record-submit-step';
 import DomainsStep from './internals/steps-repository/domains';
+import freeSetup from './internals/steps-repository/free-setup';
 import Intro from './internals/steps-repository/intro';
 import LaunchPad from './internals/steps-repository/launchpad';
-import LinkInBioSetup from './internals/steps-repository/link-in-bio-setup';
 import PatternsStep from './internals/steps-repository/patterns';
 import PlansStep from './internals/steps-repository/plans';
 import Processing from './internals/steps-repository/processing-step';
@@ -39,7 +39,7 @@ const free: Flow = {
 
 		return [
 			{ slug: 'intro', component: Intro },
-			{ slug: 'freeSetup', component: LinkInBioSetup },
+			{ slug: 'freeSetup', component: freeSetup },
 			{ slug: 'domains', component: DomainsStep },
 			{ slug: 'plans', component: PlansStep },
 			{ slug: 'patterns', component: PatternsStep },

--- a/client/landing/stepper/declarative-flow/free.ts
+++ b/client/landing/stepper/declarative-flow/free.ts
@@ -16,9 +16,9 @@ import { useSiteSlug } from '../hooks/use-site-slug';
 import { USER_STORE, ONBOARD_STORE } from '../stores';
 import { recordSubmitStep } from './internals/analytics/record-submit-step';
 import DomainsStep from './internals/steps-repository/domains';
-import freeSetup from './internals/steps-repository/free-setup';
 import Intro from './internals/steps-repository/intro';
 import LaunchPad from './internals/steps-repository/launchpad';
+import LinkInBioSetup from './internals/steps-repository/link-in-bio-setup';
 import PatternsStep from './internals/steps-repository/patterns';
 import PlansStep from './internals/steps-repository/plans';
 import Processing from './internals/steps-repository/processing-step';
@@ -39,7 +39,7 @@ const free: Flow = {
 
 		return [
 			{ slug: 'intro', component: Intro },
-			{ slug: 'freeSetup', component: freeSetup },
+			{ slug: 'freeSetup', component: LinkInBioSetup },
 			{ slug: 'domains', component: DomainsStep },
 			{ slug: 'plans', component: PlansStep },
 			{ slug: 'patterns', component: PatternsStep },

--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -68,7 +68,8 @@ button {
 .subscribers,
 .ecommerce,
 .intro,
-.free-setup {
+.free-setup,
+.free-post-setup {
 	padding: 60px 0 0;
 	box-sizing: border-box;
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/free-post-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/free-post-setup/index.tsx
@@ -1,0 +1,115 @@
+import { StepContainer, base64ImageToBlob, uploadAndSetSiteLogo } from '@automattic/onboarding';
+import { useDispatch } from '@wordpress/data';
+import { createInterpolateElement } from '@wordpress/element';
+import { useI18n } from '@wordpress/react-i18n';
+import { FormEvent, useEffect, useState } from 'react';
+import FormattedHeader from 'calypso/components/formatted-header';
+import { SITE_STORE } from 'calypso/landing/stepper/stores';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { useSite } from '../../../../hooks/use-site';
+import SetupForm from '../components/setup-form';
+import type { Step } from '../../types';
+
+import '../free-setup/styles.scss';
+
+const FreePostSetup: Step = ( { navigation } ) => {
+	const { submit } = navigation;
+	const { __ } = useI18n();
+	const site = useSite();
+
+	const formText = {
+		titlePlaceholder: __( 'My Website' ),
+		titleMissing: __( `Oops. Looks like your website doesn't have a name yet.` ),
+		taglinePlaceholder: __( 'Add a short description here' ),
+		iconPlaceholder: __( 'Upload a profile image' ),
+	};
+
+	const [ invalidSiteTitle, setInvalidSiteTitle ] = useState( false );
+	const [ siteTitle, setComponentSiteTitle ] = useState( '' );
+	const [ tagline, setTagline ] = useState( '' );
+	const [ base64Image, setBase64Image ] = useState< string | null >();
+	const [ selectedFile, setSelectedFile ] = useState< File | undefined >();
+	const [ isLoading, setIsLoading ] = useState( false );
+	const [ isSubmitError, setIsSubmitError ] = useState( false );
+
+	const { saveSiteSettings } = useDispatch( SITE_STORE );
+
+	useEffect( () => {
+		setComponentSiteTitle( site?.name || '' );
+		setTagline( site?.description || '' );
+	}, [ site ] );
+
+	useEffect( () => {
+		setIsSubmitError( false );
+	}, [ siteTitle, tagline, selectedFile, base64Image ] );
+
+	const handleSubmit = async ( event: FormEvent ) => {
+		event.preventDefault();
+
+		if ( ! siteTitle.trim().length ) {
+			setInvalidSiteTitle( true );
+			return;
+		}
+
+		try {
+			if ( site ) {
+				setIsLoading( true );
+				await saveSiteSettings( site.ID, {
+					blogname: siteTitle,
+					blogdescription: tagline,
+				} );
+				if ( base64Image ) {
+					await uploadAndSetSiteLogo(
+						site.ID,
+						new File( [ base64ImageToBlob( base64Image ) ], 'site-logo.png' )
+					);
+				}
+				setIsLoading( false );
+				submit?.();
+			}
+		} catch {
+			setIsSubmitError( true );
+			setIsLoading( false );
+		}
+	};
+
+	return (
+		<StepContainer
+			stepName="newsletter-setup"
+			isWideLayout={ true }
+			hideBack={ true }
+			flowName="newsletter"
+			formattedHeader={
+				<FormattedHeader
+					id="free-setup-header"
+					headerText={ createInterpolateElement( __( 'Personalize your<br />website' ), {
+						br: <br />,
+					} ) }
+					align="center"
+				/>
+			}
+			stepContent={
+				<SetupForm
+					site={ site }
+					siteTitle={ siteTitle }
+					setComponentSiteTitle={ setComponentSiteTitle }
+					invalidSiteTitle={ invalidSiteTitle }
+					setInvalidSiteTitle={ setInvalidSiteTitle }
+					tagline={ tagline }
+					setTagline={ setTagline }
+					selectedFile={ selectedFile }
+					setSelectedFile={ setSelectedFile }
+					setBase64Image={ setBase64Image }
+					handleSubmit={ handleSubmit }
+					translatedText={ formText }
+					isLoading={ isLoading }
+					isSubmitError={ isSubmitError }
+				/>
+			}
+			recordTracksEvent={ recordTracksEvent }
+			showJetpackPowered
+		/>
+	);
+};
+
+export default FreePostSetup;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/free-post-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/free-post-setup/index.tsx
@@ -75,14 +75,14 @@ const FreePostSetup: Step = ( { navigation } ) => {
 
 	return (
 		<StepContainer
-			stepName="newsletter-setup"
+			stepName="free-setup"
 			isWideLayout={ true }
 			hideBack={ true }
-			flowName="newsletter"
+			flowName="free"
 			formattedHeader={
 				<FormattedHeader
 					id="free-setup-header"
-					headerText={ createInterpolateElement( __( 'Personalize your<br />website' ), {
+					headerText={ createInterpolateElement( __( 'Personalize your<br />Website' ), {
 						br: <br />,
 					} ) }
 					align="center"

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/free-post-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/free-post-setup/index.tsx
@@ -1,7 +1,7 @@
 import { StepContainer, base64ImageToBlob, uploadAndSetSiteLogo } from '@automattic/onboarding';
 import { useDispatch } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
-import { useI18n } from '@wordpress/react-i18n';
+import { useTranslate } from 'i18n-calypso';
 import { FormEvent, useEffect, useState } from 'react';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { SITE_STORE } from 'calypso/landing/stepper/stores';
@@ -14,14 +14,14 @@ import '../free-setup/styles.scss';
 
 const FreePostSetup: Step = ( { navigation } ) => {
 	const { submit } = navigation;
-	const { __ } = useI18n();
+	const translate = useTranslate();
 	const site = useSite();
 
 	const formText = {
-		titlePlaceholder: __( 'My Website' ),
-		titleMissing: __( `Oops. Looks like your website doesn't have a name yet.` ),
-		taglinePlaceholder: __( 'Add a short description here' ),
-		iconPlaceholder: __( 'Upload a profile image' ),
+		titlePlaceholder: translate( 'My Website' ),
+		titleMissing: translate( `Oops. Looks like your website doesn't have a name yet.` ),
+		taglinePlaceholder: translate( 'Add a short description here' ),
+		iconPlaceholder: translate( 'Upload a profile image' ),
 	};
 
 	const [ invalidSiteTitle, setInvalidSiteTitle ] = useState( false );
@@ -82,7 +82,7 @@ const FreePostSetup: Step = ( { navigation } ) => {
 			formattedHeader={
 				<FormattedHeader
 					id="free-setup-header"
-					headerText={ createInterpolateElement( __( 'Personalize your<br />Website' ), {
+					headerText={ createInterpolateElement( translate( 'Personalize your<br />Website' ), {
 						br: <br />,
 					} ) }
 					align="center"

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -74,6 +74,12 @@ export function getEnhancedTasks(
 				case 'setup_free':
 					taskData = {
 						title: translate( 'Personalize your site' ),
+						actionDispatch: () => {
+							recordTaskClickTracksEvent( flow, task.completed, task.id );
+							window.location.assign(
+								`/setup/free-post-setup/freePostSetup?siteSlug=${ siteSlug }`
+							);
+						},
 					};
 					break;
 				case 'setup_newsletter':

--- a/client/landing/stepper/declarative-flow/registered-flows.ts
+++ b/client/landing/stepper/declarative-flow/registered-flows.ts
@@ -38,6 +38,9 @@ const availableFlows: Record< string, () => Promise< { default: Flow } > > = {
 		),
 
 	free: () => import( /* webpackChunkName: "free-flow" */ '../declarative-flow/free' ),
+
+	'free-post-setup': () =>
+		import( /* webpackChunkName: "free-post-setup-flow" */ '../declarative-flow/free-post-setup' ),
 };
 
 if ( config.isEnabled( 'themes/plugin-bundling' ) ) {

--- a/packages/onboarding/src/utils/flows.ts
+++ b/packages/onboarding/src/utils/flows.ts
@@ -7,6 +7,7 @@ export const VIDEOPRESS_FLOW = 'videopress';
 export const IMPORT_FOCUSED_FLOW = 'import-focused';
 export const ECOMMERCE_FLOW = 'ecommerce';
 export const FREE_FLOW = 'free';
+export const FREE_POST_SETUP_FLOW = 'free-post-setup';
 
 export const isLinkInBioFlow = ( flowName: string | null ) => {
 	return Boolean(
@@ -16,7 +17,7 @@ export const isLinkInBioFlow = ( flowName: string | null ) => {
 };
 
 export const isFreeFlow = ( flowName: string | null ) => {
-	return Boolean( flowName && FREE_FLOW === flowName );
+	return Boolean( flowName && [ FREE_FLOW, FREE_POST_SETUP_FLOW ].includes( flowName ) );
 };
 
 export const isNewsletterOrLinkInBioFlow = ( flowName: string | null ) => {


### PR DESCRIPTION
### Proposed Changes

Adds a post-setup flow and screen for the new Free Flow. If you go through free flow and arrive at the Launchpad, we want to be able to click 'Personalize your site' and go back to the setup screen to change your title/description/icon. Like the Link in Bio and Newsletter flows, rather than send a user back to the original setup screen, we set up a small extra stepper flow to handle this. 

Resolves: https://github.com/Automattic/wp-calypso/issues/70556

### Testing Instructions

1. Clone this repo and run yarn and yarn start if needed. 
2. Go to this url to start the free flow: http://calypso.localhost:3000/setup/free/intro
3. Go through the flow until you arrive at Launchpad
4. TEST: The `Personalize your site` should now be clickable. 
5. TEST: If you click `Personalize your site`, you should be taken to a setup screen where you can update your site title, description, and icon. These should all correctly load with the values that you selected earlier on the original setup screen. 
6. TEST: Update your site title, description, and icon, and click continue. You should be taken back to the Launchpad, and the Launchpad Web Preview should show your updated title, description, and icon. 
7. TEST: Repeat steps 4 through 7 to confirm. 

### Screenshot

For review reference and for translations, the new screen should looks like this: 

<img width="1506" alt="free-post-setup" src="https://user-images.githubusercontent.com/21228350/206300835-f25583c6-fed9-4fc5-83ec-bf08068799ab.png">

### Other

You can see past PRs to add post-setup screens for Newsletter and Link in Bio flows here: 
https://github.com/Automattic/wp-calypso/pull/68685
https://github.com/Automattic/wp-calypso/pull/67835


