### PR TITLE
Checkout: Defer state updates when step group store changes

### DIFF
--- a/packages/composite-checkout/package.json
+++ b/packages/composite-checkout/package.json
@@ -47,8 +47,10 @@
 		"@automattic/calypso-storybook": "workspace:^",
 		"@automattic/calypso-typescript-config": "workspace:^",
 		"@storybook/react": "^6.4.18",
+		"@testing-library/dom": "^8.13.0",
 		"@testing-library/jest-dom": "^5.16.2",
 		"@testing-library/react": "^12.1.3",
+		"@testing-library/user-event": "^14.2.0",
 		"react": "^17.0.2",
 		"react-dom": "^17.0.2",
 		"typescript": "^4.7.4"

--- a/packages/composite-checkout/src/components/checkout-steps.tsx
+++ b/packages/composite-checkout/src/components/checkout-steps.tsx
@@ -362,7 +362,9 @@ function CheckoutStepGroupWrapper( {
 			// a duplicate of the store object to the React context. This way all
 			// context consumers get the modified store because its identity has
 			// changed.
-			isMounted.current && setContextValue( { ...store } );
+			setTimeout( () => {
+				isMounted.current && setContextValue( { ...store } );
+			}, 0 );
 		} );
 	}, [ store ] );
 

--- a/packages/composite-checkout/test/checkout.js
+++ b/packages/composite-checkout/test/checkout.js
@@ -3,11 +3,9 @@ import {
 	getAllByLabelText as getAllByLabelTextInNode,
 	getByText as getByTextInNode,
 	queryByText as queryByTextInNode,
-	fireEvent,
-	act,
 	screen,
-	waitFor,
 } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { createContext, useState, useContext } from 'react';
 import '@testing-library/jest-dom/extend-expect';
 import {
@@ -157,9 +155,8 @@ describe( 'Checkout', () => {
 				const renderResult = render( <MyCheckout /> );
 				container = renderResult.container;
 				const firstStepContinue = renderResult.getAllByText( 'Continue' )[ 0 ];
-				await act( async () => {
-					return fireEvent.click( firstStepContinue );
-				} );
+				const user = userEvent.setup();
+				await user.click( firstStepContinue );
 			} );
 
 			it( 'makes the first step invisible', () => {
@@ -317,9 +314,8 @@ describe( 'Checkout', () => {
 			const firstStep = container.querySelector( '.' + steps[ 0 ].className );
 			const firstStepContent = firstStep.querySelector( '.checkout-steps__step-content' );
 			expect( firstStepContent ).toHaveStyle( 'display: block' );
-			await act( async () => {
-				return fireEvent.click( firstStepContinue );
-			} );
+			const user = userEvent.setup();
+			await user.click( firstStepContinue );
 			expect( firstStepContent ).toHaveStyle( 'display: block' );
 		} );
 
@@ -332,9 +328,8 @@ describe( 'Checkout', () => {
 			const firstStep = container.querySelector( '.custom-summary-step-class' );
 			const firstStepContent = firstStep.querySelector( '.checkout-steps__step-content' );
 			expect( firstStepContent ).toHaveStyle( 'display: block' );
-			await act( async () => {
-				return fireEvent.click( firstStepContinue );
-			} );
+			const user = userEvent.setup();
+			await user.click( firstStepContinue );
 			expect( firstStepContent ).toHaveStyle( 'display: none' );
 		} );
 
@@ -348,9 +343,8 @@ describe( 'Checkout', () => {
 			);
 			const firstStepContinue = getAllByText( 'Continue' )[ 0 ];
 			expect( firstStepContinue ).not.toBeDisabled();
-			await act( async () => {
-				return fireEvent.click( firstStepContinue );
-			} );
+			const user = userEvent.setup();
+			await user.click( firstStepContinue );
 			expect( firstStepContinue ).toBeDisabled();
 		} );
 
@@ -366,9 +360,8 @@ describe( 'Checkout', () => {
 			const firstStep = container.querySelector( '.' + steps[ 1 ].className );
 			const firstStepContent = firstStep.querySelector( '.checkout-steps__step-content' );
 			expect( firstStepContent ).toHaveStyle( 'display: block' );
-			await act( async () => {
-				return fireEvent.click( firstStepContinue );
-			} );
+			const user = userEvent.setup();
+			await user.click( firstStepContinue );
 			expect( firstStepContent ).toHaveStyle( 'display: none' );
 		} );
 
@@ -405,9 +398,8 @@ describe( 'Checkout', () => {
 			const thirdStepContent = thirdStep.querySelector( '.checkout-steps__step-content' );
 			expect( firstStepContent ).toHaveStyle( 'display: block' );
 			expect( secondStepContent ).toHaveStyle( 'display: none' );
-			await act( async () => {
-				return fireEvent.click( manualContinue );
-			} );
+			const user = userEvent.setup();
+			await user.click( manualContinue );
 			expect( firstStepContent ).toHaveStyle( 'display: none' );
 			expect( secondStepContent ).toHaveStyle( 'display: none' );
 			expect( thirdStepContent ).toHaveStyle( 'display: block' );
@@ -444,9 +436,8 @@ describe( 'Checkout', () => {
 			const secondStepContent = secondStep.querySelector( '.checkout-steps__step-content' );
 			expect( firstStepContent ).toHaveStyle( 'display: block' );
 			expect( secondStepContent ).toHaveStyle( 'display: none' );
-			await act( async () => {
-				return fireEvent.click( manualContinue );
-			} );
+			const user = userEvent.setup();
+			await user.click( manualContinue );
 			expect( firstStepContent ).toHaveStyle( 'display: block' );
 			expect( secondStepContent ).toHaveStyle( 'display: none' );
 		} );
@@ -463,9 +454,8 @@ describe( 'Checkout', () => {
 			const firstStep = container.querySelector( '.' + steps[ 1 ].className );
 			const firstStepContent = firstStep.querySelector( '.checkout-steps__step-content' );
 			expect( firstStepContent ).toHaveStyle( 'display: block' );
-			await act( async () => {
-				return fireEvent.click( firstStepContinue );
-			} );
+			const user = userEvent.setup();
+			await user.click( firstStepContinue );
 			expect( firstStepContent ).toHaveStyle( 'display: block' );
 		} );
 
@@ -491,18 +481,18 @@ describe( 'Checkout', () => {
 			const firstStep = container.querySelector( '.' + steps[ 1 ].className );
 			const firstStepContent = firstStep.querySelector( '.checkout-steps__step-content' );
 			expect( firstStepContent ).toHaveStyle( 'display: block' );
-			await act( async () => {
-				return fireEvent.click( manualContinue );
-			} );
+			const user = userEvent.setup();
+			await user.click( manualContinue );
 			expect( firstStepContent ).toHaveStyle( 'display: block' );
 		} );
 
-		it( 'renders the continue button enabled if the step is active and complete', () => {
+		it( 'renders the continue button enabled if the step is active and complete', async () => {
 			const { container, getByLabelText } = render(
 				<MyCheckout steps={ [ steps[ 0 ], steps[ 4 ], steps[ 1 ] ] } />
 			);
 
-			fireEvent.change( getByLabelText( 'User Name' ), { target: { value: 'Lyra' } } );
+			const user = userEvent.setup();
+			await user.type( getByLabelText( 'User Name' ), 'Lyra' );
 			const step = container.querySelector( '.' + steps[ 4 ].className );
 			expect( getByTextInNode( step, 'Continue' ) ).not.toBeDisabled();
 		} );
@@ -528,9 +518,8 @@ describe( 'Checkout', () => {
 		it( 'renders the edit button for editable steps with a lower index than the active step', async () => {
 			const { container, getAllByText } = render( <MyCheckout /> );
 			const firstStepContinue = getAllByText( 'Continue' )[ 0 ];
-			await act( async () => {
-				return fireEvent.click( firstStepContinue );
-			} );
+			const user = userEvent.setup();
+			await user.click( firstStepContinue );
 			const step = container.querySelector( '.' + steps[ 1 ].className );
 			expect( getByTextInNode( step, 'Edit' ) ).toBeInTheDocument();
 		} );
@@ -540,14 +529,11 @@ describe( 'Checkout', () => {
 				<MyCheckout steps={ [ steps[ 0 ], steps[ 1 ], steps[ 2 ] ] } />
 			);
 			const firstStepContinue = getAllByText( 'Continue' )[ 0 ];
-			await act( async () => {
-				return fireEvent.click( firstStepContinue );
-			} );
+			const user = userEvent.setup();
+			await user.click( firstStepContinue );
 			expect( queryByText( 'Edit' ) ).toBeInTheDocument();
 			const submitButton = getAllByText( 'Pay Please' )[ 0 ];
-			await act( async () => {
-				return fireEvent.click( submitButton );
-			} );
+			await user.click( submitButton );
 			expect( queryByText( 'Edit' ) ).not.toBeInTheDocument();
 		} );
 
@@ -586,14 +572,11 @@ describe( 'Checkout', () => {
 			);
 			expect( getByText( 'Possibly Complete isComplete false' ) ).toBeInTheDocument();
 			const firstStepContinue = getAllByText( 'Continue' )[ 0 ];
-			await act( async () => {
-				return fireEvent.click( firstStepContinue );
-			} );
-			fireEvent.change( getByLabelText( 'User Name' ), { target: { value: 'Lyra' } } );
-			await act( async () => {
-				// isComplete does not update until we press continue
-				return fireEvent.click( firstStepContinue );
-			} );
+			const user = userEvent.setup();
+			await user.click( firstStepContinue );
+			await user.type( getByLabelText( 'User Name' ), 'Lyra' );
+			// isComplete does not update until we press continue
+			await user.click( firstStepContinue );
 			expect( getByText( 'Possibly Complete isComplete true' ) ).toBeInTheDocument();
 		} );
 	} );
@@ -644,9 +627,8 @@ describe( 'Checkout', () => {
 			);
 			const submitButton = screen.getByText( 'Pay Please' );
 
-			await waitFor( () => {
-				fireEvent.click( submitButton );
-			} );
+			const user = userEvent.setup();
+			await user.click( submitButton );
 
 			expect( processor ).not.toHaveBeenCalled();
 		} );
@@ -664,9 +646,8 @@ describe( 'Checkout', () => {
 			);
 			const submitButton = screen.getByText( 'Pay Please' );
 
-			await waitFor( () => {
-				fireEvent.click( submitButton );
-			} );
+			const user = userEvent.setup();
+			await user.click( submitButton );
 
 			expect( processor ).toHaveBeenCalled();
 		} );
@@ -676,9 +657,8 @@ describe( 'Checkout', () => {
 			render( <MyCheckout steps={ [ steps[ 0 ] ] } paymentProcessor={ processor } /> );
 			const submitButton = screen.getByText( 'Pay Please' );
 
-			await waitFor( () => {
-				fireEvent.click( submitButton );
-			} );
+			const user = userEvent.setup();
+			await user.click( submitButton );
 
 			expect( processor ).toHaveBeenCalled();
 		} );
@@ -786,7 +766,7 @@ function createStepObjectConverter( paymentData ) {
 		}
 		return (
 			<CheckoutStepBody
-				errorMessage={ 'error' }
+				errorMessage="error"
 				editButtonAriaLabel={ stepObject.getEditButtonAriaLabel() }
 				nextStepButtonAriaLabel={ stepObject.getNextStepButtonAriaLabel() }
 				isStepActive={ false }

--- a/yarn.lock
+++ b/yarn.lock
@@ -460,8 +460,10 @@ __metadata:
     "@emotion/react": ^11.4.1
     "@emotion/styled": ^11.3.0
     "@storybook/react": ^6.4.18
+    "@testing-library/dom": ^8.13.0
     "@testing-library/jest-dom": ^5.16.2
     "@testing-library/react": ^12.1.3
+    "@testing-library/user-event": ^14.2.0
     "@wordpress/i18n": ^4.9.0
     "@wordpress/react-i18n": ^3.7.0
     debug: ^4.3.3


### PR DESCRIPTION
#### Proposed Changes

This is a follow-up to https://github.com/Automattic/wp-calypso/pull/70778 which modified the way that `CheckoutStepGroup` keeps its internal state by moving it into its own store object outside of React. React then subscribes to changes in that store and uses `useState()` to force a re-render when that happens.

This works, but it can sometimes result in an error message printed to the console (this is mostly noticeable only in automated tests) that reads,

```
Warning: Cannot update a component (`CheckoutStepGroupWrapper`) while rendering a different component (`CheckoutStepGroupInner`). To locate the bad setS
tate() call inside `CheckoutStepGroupInner`, follow the stack trace as described in https://reactjs.org/link/setstate-in-render
```

This warning happens because one of the pieces of state we keep is the total number of steps, which is saved [during every render](https://github.com/Automattic/wp-calypso/blob/b3bc3bfb70c88c1c17fceb23393fa507fbc4d449/packages/composite-checkout/src/components/checkout-steps.tsx#L292) if it changes. When that causes a state update, the store sends out a synchronous message to all its subscribers, triggering a `setState` while we're still in the middle of rendering.

In this PR, we modify the subscription to defer the `setState` call until rendering is complete. This fixes the warning and should not affect the UI.

#### Testing Instructions

- Load checkout and try to switch back and forth between steps a few times.
- Verify that they respond as expected.