### PR TITLE
Fix the two year plan upsell in checkout when browser window short

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
@@ -539,10 +539,10 @@ const CheckoutSummaryBody = styled.div`
 		width: 100%;
 		overflow-y: auto;
 		height: 100vh;
-	}
-	& .card {
-		border-left: 1px solid ${ ( props ) => props.theme.colors.borderColorLight };
-		border-right: 1px solid ${ ( props ) => props.theme.colors.borderColorLight };
+		& .card {
+			border-left: 1px solid ${ ( props ) => props.theme.colors.borderColorLight };
+			border-right: 1px solid ${ ( props ) => props.theme.colors.borderColorLight };
+		}
 	}
 `;
 

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
@@ -540,6 +540,9 @@ const CheckoutSummaryBody = styled.div`
 		overflow-y: auto;
 		height: 100vh;
 	}
+	.card {
+		border: 1px solid ${ ( props ) => props.theme.colors.borderColorLight };
+	}
 `;
 
 function SubmitButtonHeader() {

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
@@ -537,6 +537,8 @@ const CheckoutSummaryBody = styled.div`
 		max-width: 328px;
 		position: fixed;
 		width: 100%;
+		overflow-y: auto;
+		height: 100vh;
 	}
 `;
 

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
@@ -540,8 +540,9 @@ const CheckoutSummaryBody = styled.div`
 		overflow-y: auto;
 		height: 100vh;
 	}
-	.card {
-		border: 1px solid ${ ( props ) => props.theme.colors.borderColorLight };
+	& .card {
+		border-left: 1px solid ${ ( props ) => props.theme.colors.borderColorLight };
+		border-right: 1px solid ${ ( props ) => props.theme.colors.borderColorLight };
 	}
 `;
 


### PR DESCRIPTION
The upsell nudge for two-year plans in checkout can get cut off vertically, if your browser window is too short. This PR aims to fix that.

### Initial issue:

![M1C9Bf.gif](https://user-images.githubusercontent.com/552016/206310706-c526ca23-edaf-470a-a203-5660ee4f16a1.gif)


#### Proposed Changes

* We implement a `overflow-y` for the sidebar so that it gets a vertical scrollbar when the height is limited.
* We also add border 1 px to the Upsell card that gets displayed as earlier it was implemented as box shadow which does not work any more.

#### Testing Instructions

1. Put a non-two-year plan in your shopping cart.
2. Adjust the height of your browser window to make it shorter and you should see a vertical scroll appear that will allow you to view the upsell card like below.


### After Bug fix:

![jQMwLR.gif](https://user-images.githubusercontent.com/552016/206310970-da34ce20-685d-46c2-a821-1306d5eb5c46.gif)


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #70298