### PR TITLE
Stats: Introduce the AllTimeViewsSection to replace the StatsViews module

### DIFF
--- a/client/my-sites/stats/all-time-views-section/index.tsx
+++ b/client/my-sites/stats/all-time-views-section/index.tsx
@@ -1,0 +1,79 @@
+import { Card } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import { useMemo, useState } from 'react';
+import { useSelector } from 'react-redux';
+import QuerySiteStats from 'calypso/components/data/query-site-stats';
+import SimplifiedSegmentedControl from 'calypso/components/segmented-control/simplified';
+import { getSiteStatsViewSummary } from 'calypso/state/stats/lists/selectors';
+import StatsModulePlaceholder from '../stats-module/placeholder';
+import Months from '../stats-views/months';
+
+import './style.scss';
+
+type chartOption = {
+	value: string;
+	label: string;
+	path: string;
+};
+
+export default function AllTimeViewsSection( { siteId, slug }: { siteId: number; slug: string } ) {
+	const query = { quantity: -1, stat_fields: 'views' };
+	const translate = useTranslate();
+	const [ chartOption, setChartOption ] = useState( 'total' );
+	const viewData = useSelector( ( state ) => getSiteStatsViewSummary( state, siteId ) );
+	const monthViewOptions = useMemo( () => {
+		return [
+			{ value: 'total', label: translate( 'Months and years' ) },
+			{ value: 'average', label: translate( 'Average per day' ) },
+		];
+	}, [ translate ] );
+
+	const toggleViews = ( option?: chartOption ) => {
+		setChartOption( option?.value || '' );
+	};
+
+	return (
+		<div className="stats__all-time-views-section">
+			{ siteId && <QuerySiteStats statType="statsVisits" siteId={ siteId } query={ query } /> }
+
+			<div className="highlight-cards">
+				<h1 className="highlight-cards-heading">{ translate( 'All-time Insights' ) }</h1>
+
+				<div className="highlight-cards-list">
+					<Card className="highlight-card">
+						<div className="highlight-card-heading">
+							<span>{ translate( 'Total views' ) }</span>
+							{ viewData && (
+								<SimplifiedSegmentedControl options={ monthViewOptions } onSelect={ toggleViews } />
+							) }
+						</div>
+
+						<StatsModulePlaceholder isLoading={ ! viewData } />
+
+						<Months dataKey={ chartOption } data={ viewData } siteSlug={ slug } showYearTotal />
+
+						<div className="stats-views__key-container">
+							<span className="stats-views__key-label">
+								{ translate( 'Fewer Views', {
+									context: 'Legend label in stats all-time views table',
+								} ) }
+							</span>
+							<ul className="stats-views__key">
+								<li className="stats-views__key-item level-1" />
+								<li className="stats-views__key-item level-2" />
+								<li className="stats-views__key-item level-3" />
+								<li className="stats-views__key-item level-4" />
+								<li className="stats-views__key-item level-5" />
+							</ul>
+							<span className="stats-views__key-label">
+								{ translate( 'More Views', {
+									context: 'Legend label in stats all-time views table',
+								} ) }
+							</span>
+						</div>
+					</Card>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/client/my-sites/stats/all-time-views-section/index.tsx
+++ b/client/my-sites/stats/all-time-views-section/index.tsx
@@ -48,9 +48,10 @@ export default function AllTimeViewsSection( { siteId, slug }: { siteId: number;
 							) }
 						</div>
 
-						<StatsModulePlaceholder isLoading={ ! viewData } />
-
-						<Months dataKey={ chartOption } data={ viewData } siteSlug={ slug } showYearTotal />
+						<div className="stats__all-time-views-table-wrapper">
+							<StatsModulePlaceholder isLoading={ ! viewData } />
+							<Months dataKey={ chartOption } data={ viewData } siteSlug={ slug } showYearTotal />
+						</div>
 
 						<div className="stats-views__key-container">
 							<span className="stats-views__key-label">

--- a/client/my-sites/stats/all-time-views-section/index.tsx
+++ b/client/my-sites/stats/all-time-views-section/index.tsx
@@ -29,7 +29,7 @@ export default function AllTimeViewsSection( { siteId, slug }: { siteId: number;
 	}, [ translate ] );
 
 	const toggleViews = ( option?: chartOption ) => {
-		setChartOption( option?.value || '' );
+		setChartOption( option?.value || 'total' );
 	};
 
 	return (

--- a/client/my-sites/stats/all-time-views-section/style.scss
+++ b/client/my-sites/stats/all-time-views-section/style.scss
@@ -97,6 +97,7 @@ $common-border-radius: 4px;
 	}
 
 	table.stats-views__months {
+		table-layout: fixed;
 		min-width: 900px;
 
 		td,
@@ -125,6 +126,7 @@ $common-border-radius: 4px;
 
 			&:last-child {
 				text-align: right;
+				width: 100px;
 			}
 
 			@media ( max-width: $custom-mobile-breakpoint ) {

--- a/client/my-sites/stats/all-time-views-section/style.scss
+++ b/client/my-sites/stats/all-time-views-section/style.scss
@@ -20,7 +20,7 @@ $common-border-radius: 4px;
 
 	.highlight-cards-list {
 		.highlight-card {
-			padding: 24px;
+			padding: 32px;
 			min-width: 380px;
 		}
 
@@ -43,7 +43,7 @@ $common-border-radius: 4px;
 		font-size: $font-title-small;
 		line-height: 26px;
 		color: var(--color-neutral-100);
-		margin-bottom: 16px;
+		margin-bottom: 32px;
 		display: flex;
 		align-items: center;
 		justify-content: space-between;
@@ -97,7 +97,6 @@ $common-border-radius: 4px;
 	}
 
 	table.stats-views__months {
-		table-layout: fixed;
 		min-width: 900px;
 
 		td,
@@ -155,7 +154,7 @@ $common-border-radius: 4px;
 	}
 
 	.stats-views__key-container {
-		padding: 0;
+		padding: 16px;
 		float: none;
 		display: flex;
 		align-items: center;

--- a/client/my-sites/stats/all-time-views-section/style.scss
+++ b/client/my-sites/stats/all-time-views-section/style.scss
@@ -1,0 +1,152 @@
+@import "@automattic/typography/styles/variables";
+@import "@wordpress/base-styles/breakpoints";
+
+$header-font: Recoleta, $sans;
+$mobile-layout-breakpoint: $break-small;
+$common-border-radius: 4px;
+
+.stats__all-time-views-section {
+	.highlight-cards {
+		background-color: inherit;
+		box-shadow: none;
+
+		@media ( max-width: $mobile-layout-breakpoint ) {
+			display: none;
+		}
+	}
+
+	.highlight-cards-list .highlight-card {
+		padding: 24px;
+		min-width: 320px;
+	}
+
+	.highlight-card-heading {
+		font-family: inherit;
+		font-weight: 500;
+		font-size: $font-title-small;
+		line-height: 26px;
+		color: var(--color-neutral-100);
+		margin-bottom: 16px;
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+	}
+
+	.segmented-control {
+		.segmented-control__link {
+			padding: 10px 12px;
+			font-weight: 500;
+			line-height: 20px;
+			color: #000;
+
+			&:focus {
+				outline: none;
+			}
+		}
+
+		.segmented-control__item {
+			&.is-selected {
+				.segmented-control__link {
+					background-color: var(--color-primary);
+					border-color: var(--color-primary);
+					color: var(--studio-white);
+				}
+			}
+
+			&:first-of-type .segmented-control__link {
+				border-top-left-radius: $common-border-radius;
+				border-bottom-left-radius: $common-border-radius;
+				border-right: 0;
+			}
+
+			&:last-of-type .segmented-control__link {
+				border-top-right-radius: $common-border-radius;
+				border-bottom-right-radius: $common-border-radius;
+				border-left: 0;
+			}
+		}
+	}
+
+	table.stats-views__months {
+		table-layout: fixed;
+
+		td,
+		th {
+			text-transform: none;
+			font-weight: 400;
+			font-size: $font-body-small;
+			line-height: 20px;
+			color: var(--color-neutral-60);
+			letter-spacing: -0.15px;
+
+			&.is-total {
+				font-weight: 600;
+				text-align: right;
+			}
+
+			&.level-3,
+			&.level-4,
+			&.level-5 {
+				color: var(--studio-white);
+			}
+		}
+
+		th {
+			padding-bottom: 24px;
+
+			&:last-child {
+				text-align: right;
+			}
+		}
+
+		tr:first-child {
+			td:nth-child(2) {
+				border-top-left-radius: $common-border-radius;
+			}
+
+			td:nth-last-child(2) {
+				border-top-right-radius: $common-border-radius;
+			}
+		}
+
+		tr:last-child {
+			td:nth-child(2) {
+				border-bottom-left-radius: $common-border-radius;
+			}
+
+			td:nth-last-child(2) {
+				border-bottom-right-radius: $common-border-radius;
+			}
+		}
+	}
+
+	.stats-views__key-container {
+		padding: 0;
+		float: none;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+	}
+
+	.stats-views__key-label {
+		font-weight: 400;
+		font-size: $font-body-small;
+		line-height: 18px;
+		color: #000;
+		text-transform: none;
+		letter-spacing: normal;
+	}
+
+	.stats-views__key {
+		border-radius: $common-border-radius;
+		overflow: hidden;
+		padding: 0;
+		margin: 0 16px;
+
+		.stats-views__key-item {
+			width: 25px;
+			height: 25px;
+			margin: 0;
+		}
+	}
+}

--- a/client/my-sites/stats/all-time-views-section/style.scss
+++ b/client/my-sites/stats/all-time-views-section/style.scss
@@ -1,23 +1,40 @@
 @import "@automattic/typography/styles/variables";
 @import "@wordpress/base-styles/breakpoints";
+@import "@automattic/components/src/highlight-cards/variables.scss";
 
 $header-font: Recoleta, $sans;
 $mobile-layout-breakpoint: $break-small;
 $common-border-radius: 4px;
 
 .stats__all-time-views-section {
+
+	.stats__all-time-views-table-wrapper {
+		width: 100%;
+		overflow-x: auto;
+	}
+
 	.highlight-cards {
 		background-color: inherit;
 		box-shadow: none;
-
-		@media ( max-width: $mobile-layout-breakpoint ) {
-			display: none;
-		}
 	}
 
-	.highlight-cards-list .highlight-card {
-		padding: 24px;
-		min-width: 320px;
+	.highlight-cards-list {
+		.highlight-card {
+			padding: 24px;
+			min-width: 380px;
+		}
+
+		@media ( max-width: $custom-mobile-breakpoint ) {
+			padding: 0;
+			border: 1px solid var(--color-neutral-5);
+			border-left: 0;
+			border-right: 0;
+
+			.highlight-card {
+				padding: 24px 16px;
+				border-radius: 0;
+			}
+		}
 	}
 
 	.highlight-card-heading {
@@ -30,6 +47,10 @@ $common-border-radius: 4px;
 		display: flex;
 		align-items: center;
 		justify-content: space-between;
+
+		@media ( max-width: $custom-mobile-breakpoint ) {
+			display: block;
+		}
 	}
 
 	.segmented-control {
@@ -65,10 +86,19 @@ $common-border-radius: 4px;
 				border-left: 0;
 			}
 		}
+
+		@media ( max-width: $custom-mobile-breakpoint ) {
+			margin-top: 16px;
+
+			.segmented-control__link {
+				padding: 6px 26px;
+			}
+		}
 	}
 
 	table.stats-views__months {
 		table-layout: fixed;
+		min-width: 900px;
 
 		td,
 		th {
@@ -96,6 +126,10 @@ $common-border-radius: 4px;
 
 			&:last-child {
 				text-align: right;
+			}
+
+			@media ( max-width: $custom-mobile-breakpoint ) {
+				padding-bottom: 12px;
 			}
 		}
 
@@ -126,6 +160,10 @@ $common-border-radius: 4px;
 		display: flex;
 		align-items: center;
 		justify-content: center;
+
+		@media ( max-width: $break-large ) {
+			margin-bottom: 0;
+		}
 	}
 
 	.stats-views__key-label {

--- a/client/my-sites/stats/modernized-layout-styles.scss
+++ b/client/my-sites/stats/modernized-layout-styles.scss
@@ -20,7 +20,8 @@ $sidebar-appearance-break-point: 783px;
 
 	// Ensures vertical padding for certain sections.
 	> .highlight-cards,
-	> .stats__all-time-highlights-section {
+	> .stats__all-time-highlights-section,
+	> .stats__all-time-views-section {
 		padding-top: $vertical-margin;
 		padding-bottom: $vertical-margin;
 	}

--- a/client/my-sites/stats/stats-insights/index.jsx
+++ b/client/my-sites/stats/stats-insights/index.jsx
@@ -14,6 +14,7 @@ import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { getSuggestionsVendor } from 'calypso/lib/domains/suggestions';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import AllTimelHighlightsSection from '../all-time-highlights-section';
+import AllTimelViewsSection from '../all-time-views-section';
 import AnnualHighlightsSection from '../annual-highlights-section';
 import LatestPostSummary from '../post-performance';
 import PostingActivity from '../post-trends';
@@ -30,6 +31,7 @@ const StatsInsights = ( props ) => {
 	const moduleStrings = statsStrings();
 
 	const isNewMainChart = config.isEnabled( 'stats/new-main-chart' );
+	const isNewAllTimeViews = config.isEnabled( 'stats/all-time-views' );
 
 	// Track the last viewed tab.
 	// Necessary to properly configure the fixed navigation headers.
@@ -52,10 +54,15 @@ const StatsInsights = ( props ) => {
 				<StatsNavigation selectedItem="insights" siteId={ siteId } slug={ siteSlug } />
 				<AnnualHighlightsSection siteId={ siteId } />
 				<AllTimelHighlightsSection siteId={ siteId } />
+				{ isNewAllTimeViews && <AllTimelViewsSection siteId={ siteId } slug={ siteSlug } /> }
 				<div className="stats__module--insights-unified">
 					<PostingActivity />
-					<SectionHeader label={ translate( 'All-time views' ) } />
-					<StatsViews />
+					{ ! isNewAllTimeViews && (
+						<>
+							<SectionHeader label={ translate( 'All-time views' ) } />
+							<StatsViews />
+						</>
+					) }
 				</div>
 				{ siteId && (
 					<DomainTip

--- a/client/my-sites/stats/stats-views/months.jsx
+++ b/client/my-sites/stats/stats-views/months.jsx
@@ -64,7 +64,7 @@ class Month extends PureComponent {
 }
 
 const StatsViewsMonths = ( props ) => {
-	const { translate, dataKey, data, numberFormat, moment, siteSlug } = props;
+	const { translate, dataKey, data, numberFormat, moment, siteSlug, showYearTotal = false } = props;
 	const dataEntries = data ? Object.entries( data ) : [];
 	const isAverageChart = dataKey === 'average';
 	let earliestDate = moment();
@@ -106,6 +106,8 @@ const StatsViewsMonths = ( props ) => {
 		monthsCount: { ...monthsObject },
 	};
 
+	let totalValue = 0;
+
 	const years = dataEntries.map( ( [ year, item ] ) => {
 		const cells = monthsArray.map( ( month ) => {
 			let value = item[ month ]?.[ dataKey ] ?? null;
@@ -132,6 +134,9 @@ const StatsViewsMonths = ( props ) => {
 				totals.monthsCount[ month ] += 1;
 				displayValue = formatNumberMetric( value );
 			}
+
+			totalValue += value;
+
 			return (
 				<Month
 					href={ `/stats/month/${ siteSlug }?startDate=${ year }-${ month + 1 }-1` }
@@ -143,6 +148,7 @@ const StatsViewsMonths = ( props ) => {
 				</Month>
 			);
 		} );
+
 		const yearTotal = isAverageChart
 			? Math.round( totals.years[ year ] / totals.yearsCount[ year ] )
 			: totals.years[ year ];
@@ -156,6 +162,14 @@ const StatsViewsMonths = ( props ) => {
 				{ year }
 			</Month>
 		);
+		if ( showYearTotal ) {
+			cells.push(
+				<td key={ `label-${ year }-total` } className="stats-views__month is-total">
+					{ numberFormat( yearTotal ) }
+				</td>
+			);
+		}
+
 		return <tr key={ `year-${ year }` }>{ cells }</tr>;
 	} );
 
@@ -200,6 +214,11 @@ const StatsViewsMonths = ( props ) => {
 					<Month value={ numberFormat( getMonthTotal( totals, 11 ) ) } isHeader>
 						{ translate( 'Dec' ) }
 					</Month>
+					{ showYearTotal && (
+						<Month value={ numberFormat( totalValue ) } isHeader>
+							{ translate( 'Totals' ) }
+						</Month>
+					) }
 				</tr>
 			</thead>
 			<tbody>{ years }</tbody>

--- a/client/my-sites/stats/stats-views/style.scss
+++ b/client/my-sites/stats/stats-views/style.scss
@@ -28,6 +28,11 @@
 .stats-views__key-item {
 	background-color: none;
 
+	&.is-total {
+		background: none;
+		cursor: text;
+	}
+
 	&.is-year {
 		background: none;
 		text-align: left;

--- a/config/client.json
+++ b/config/client.json
@@ -25,6 +25,7 @@
 	"readerFollowingSource",
 	"siftscience_key",
 	"signup_url",
+	"stats/all-time-views",
 	"stats/new-main-chart",
 	"stats/new-stats-module-component",
 	"wpcom_concierge_schedule_id",

--- a/config/development.json
+++ b/config/development.json
@@ -163,6 +163,7 @@
 		"signup/woo-verify-email": false,
 		"site-indicator": true,
 		"ssr/prefetch-timebox": false,
+		"stats/all-time-views": true,
 		"stats/new-main-chart": true,
 		"stats/new-stats-module-component": true,
 		"stepper-woocommerce-poc": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -107,6 +107,7 @@
 		"signup/woo-verify-email": false,
 		"site-indicator": true,
 		"ssr/prefetch-timebox": true,
+		"stats/all-time-views": false,
 		"stats/new-main-chart": true,
 		"stats/new-stats-module-component": true,
 		"stepper-woocommerce-poc": true,

--- a/config/production.json
+++ b/config/production.json
@@ -127,6 +127,7 @@
 		"ssr/log-prefetch-errors": true,
 		"ssr/prefetch-timebox": true,
 		"ssr/sample-log-cache-misses": true,
+		"stats/all-time-views": false,
 		"stats/new-main-chart": true,
 		"stats/new-stats-module-component": true,
 		"stepper-woocommerce-poc": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -123,6 +123,7 @@
 		"signup/woo-verify-email": false,
 		"site-indicator": true,
 		"ssr/prefetch-timebox": true,
+		"stats/all-time-views": false,
 		"stats/new-main-chart": true,
 		"stats/new-stats-module-component": true,
 		"stepper-woocommerce-poc": true,

--- a/config/test.json
+++ b/config/test.json
@@ -89,6 +89,7 @@
 		"signup/social": true,
 		"site-indicator": true,
 		"ssr/prefetch-timebox": true,
+		"stats/all-time-views": false,
 		"stats/new-main-chart": true,
 		"stats/new-stats-module-component": true,
 		"stepper-woocommerce-poc": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -132,6 +132,7 @@
 		"signup/woo-verify-email": false,
 		"site-indicator": true,
 		"ssr/prefetch-timebox": true,
+		"stats/all-time-views": false,
 		"stats/new-main-chart": true,
 		"stats/new-stats-module-component": true,
 		"stepper-woocommerce-poc": true,


### PR DESCRIPTION
#### Proposed Changes

* Introduce prop `showYearTotal` to display the view sum of each year.
* Add the feature flag `stats/all-time-views` to gate the AllTimeViewsSection.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up this change with the Calypso Live link.
* Navigate to the Stats `Insight` page.
* Append the feature flag `?flags=stats/all-time-views` to the URL.
* Ensure the `All-time Insights` section is displayed in line with the design.

<img width="1327" alt="截圖 2022-12-08 上午10 35 04" src="https://user-images.githubusercontent.com/6869813/206342619-c9ab888c-e5cc-46cf-9153-f629b5f96248.png">

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #70610 
