### PR TITLE
Fix: siteSlug and siteId falsely being pulled as dependencies data

### DIFF
--- a/client/components/site-selector/add-site.tsx
+++ b/client/components/site-selector/add-site.tsx
@@ -1,16 +1,18 @@
 import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { FunctionComponent, useCallback } from 'react';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { onboardingUrl } from 'calypso/lib/paths';
 import { addQueryArgs } from 'calypso/lib/url';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 
 const SiteSelectorAddSite: FunctionComponent = () => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
+	const siteSlug = useSelector( getSelectedSiteSlug );
 	const recordAddNewSite = useCallback( () => {
 		const event = isJetpackCloud()
 			? 'calypso_add_new_jetpack_click'
@@ -26,6 +28,7 @@ const SiteSelectorAddSite: FunctionComponent = () => {
 				{
 					ref: 'calypso-selector',
 					source: 'my-home',
+					siteSlug,
 				},
 				onboardingUrl()
 			) }

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -161,9 +161,14 @@ class Signup extends Component {
 
 	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
 	UNSAFE_componentWillMount() {
-		let providedDependencies = this.getCurrentFlowSupportedQueryParams();
+		let providedDependencies = this.getDependenciesInQuery();
 
 		// Prevent duplicate sites, check pau2Xa-1Io-p2#comment-6759.
+		// Note that there are in general three ways of touching this code that can be obscured:
+		// 1. signup as a new user through any of the /start/* flows.
+		// 2. log in and go through a /start/* flow to add a new site under the logged-in account.
+		// 3. signup as a new user, and then navigate back by the browser's back button.
+		// *Only* in the 3rd conditon will isManageSiteFlow be true.
 		if ( this.props.isManageSiteFlow ) {
 			providedDependencies = {
 				...providedDependencies,
@@ -201,7 +206,13 @@ class Signup extends Component {
 			this.setState( { resumingStep: destinationStep } );
 			const locale = ! this.props.isLoggedIn ? this.props.locale : '';
 			return page.redirect(
-				getStepUrl( this.props.flowName, destinationStep, undefined, locale, providedDependencies )
+				getStepUrl(
+					this.props.flowName,
+					destinationStep,
+					undefined,
+					locale,
+					this.getCurrentFlowSupportedQueryParams()
+				)
 			);
 		}
 	}
@@ -578,25 +589,42 @@ class Signup extends Component {
 		return window.location.origin + path;
 	};
 
-	getCurrentFlowSupportedQueryParams = () => {
+	getDependenciesInQuery = () => {
 		const queryObject = this.props.initialContext?.query ?? {};
-		const flow = flows.getFlow( this.props.flowName, this.props.isLoggedIn );
-		const supportedParams = [
-			'siteId',
-			'siteSlug',
-			'flags', // for the feature flags
-			...( flow?.providesDependenciesInQuery ?? [] ),
-		];
+		const dependenciesInQuery =
+			flows.getFlow( this.props.flowName, this.props.isLoggedIn )?.providesDependenciesInQuery ??
+			[];
 
 		const result = {};
-		for ( const param of supportedParams ) {
-			const value = queryObject[ param ];
+		for ( const dependencyKey of dependenciesInQuery ) {
+			const value = queryObject[ dependencyKey ];
 			if ( value != null ) {
-				result[ param ] = value;
+				result[ dependencyKey ] = value;
 			}
 		}
 
 		return result;
+	};
+
+	getCurrentFlowSupportedQueryParams = () => {
+		const queryObject = this.props.initialContext?.query ?? {};
+		const dependenciesInQuery = this.getDependenciesInQuery( queryObject );
+
+		// TODO
+		// siteSlug and siteId are currently both being used as either just a query parameter in some area or dependencies data recognized by the signup framework.
+		// The confusion caused by this naming conflict could lead to the breakage that first introduced by
+		// https://github.com/Automattic/wp-calypso/commit/1d5968a3df62f849c58ea1d0854f472021214ff3 and then fixed by https://github.com/Automattic/wp-calypso/pull/70760
+		// For now, we simply make sure they are considered as dependency data when they are explicitly designated.
+		// It works, but the code could have been cleaner if there is no naming conflict.
+		// We should do a query parameter audit to make sure each query parameter means one and only one thing, and then seek for a future-proof solution.
+		const { siteId, siteSlug, flags } = queryObject;
+
+		return {
+			siteId,
+			siteSlug,
+			flags,
+			...dependenciesInQuery,
+		};
 	};
 
 	// `flowName` is an optional parameter used to redirect to another flow, i.e., from `main`


### PR DESCRIPTION
#### Proposed Changes
This PR addresses the previous outage introduced by #70571 from the framework level (see: C029GN3KD/p1670240472927109-slack-C029GN3KD. The outage was first indentified by @JanaMW27 and then fixed by @danielbachhuber and @simison. The symptom was:

1. Log ins as an account having multiple sites, and one of them must be on a paid plan.
2. Make sure you select the site on a paid plan. Also, be cautious that the other free sites must not have been selected within this particular session. Otherwise there is another bug that put the previously selected site slug into the siteSlug query parameter. This PR won't address this bug to stay scoped.
3. Click on the “add site” button in the site list sidebar to access the new site creation flow.
4. Proceed through the flow, and the plans step would be skipped.

The cause is that in #70571 I falsely assumed that `siteSlug` should always consider part of the dependency data when presents. However, it's actually being used in various places across calypso with different meaning, e.g. in the new site creation flow it is used to know where to navigate back. What happened underneath in this case was:

1. The siteSlug of the site on a paid plan was being pulled into the signup dependencies data store, so now `siteId` now pointed to that site here: https://github.com/Automattic/wp-calypso/blob/trunk/client/signup/main.jsx#L891
2. As a result, `isPaidPlan` prop would be true: https://github.com/Automattic/wp-calypso/blob/trunk/client/signup/main.jsx#L905
3. `isPlanFulfilled()` would then returne true because https://github.com/Automattic/wp-calypso/blob/trunk/client/lib/signup/step-actions/index.js#L1184
4. Finally, the plans step was removed by `removeFulfilledSteps()`: https://github.com/Automattic/wp-calypso/blob/trunk/client/lib/signup/step-actions/index.js#L1184, causing the step step to be skipped completely.

This PR makes sure `siteId`, `siteSlug` and `flags` are only considered as part of the dependencies data when they are explicitly configured, by separating what is conisdered legit query parameters(`getCurrentFlowSupportedQueryParams()`) and what is considered dependency data(`getDependenciesInQuery()`) . The `siteSlug` is also brought back to the "Add new site" button.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Signing up a new account from `/start` should work as expected
* Launching a private site work as expected.
* The tailored flows using the Stepper framework, e.g. `/setup/link-in-bio`, `/setup/newsletters`, should work as expected.
* The site managing flow, i.e. signing up a new account and navigating back from checkout, should work as expected.
* Adding a new site should work as expected. Notably, the original outage should be fixed even now that we've brought back `siteSlug`.
* The back navigation button from the adding a new site flow should bring you back to My Home. Notbly, it should show "Back to My Home" instead of "Back to Sites" for the account that uses My Home as their primary dashboard page. 

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
