### PR TITLE
Theme Preview: Improve handling of sidebar overflow

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
@@ -656,7 +656,6 @@ $break-design-preview: 1024px;
 				// 60px = .site-setup
 				margin-top: - ( 60px - $preview-padding-top );
 				max-height: none;
-				padding-bottom: 32px;
 			}
 
 			.design-preview__sidebar {

--- a/packages/design-picker/src/components/theme-preview/style.scss
+++ b/packages/design-picker/src/components/theme-preview/style.scss
@@ -123,7 +123,7 @@
 					0 15px 13px rgb(0 0 0 / 2%),
 					0 6px 5px rgb(0 0 0 / 2%),
 					0 2px 3px rgb(0 0 0 / 1%);
-				height: 680px;
+				max-height: 680px;
 				max-width: 340px;
 			}
 		}

--- a/packages/design-preview/src/components/sidebar.tsx
+++ b/packages/design-preview/src/components/sidebar.tsx
@@ -23,30 +23,32 @@ const Sidebar: React.FC< SidebarProps > = ( {
 } ) => {
 	return (
 		<div className="design-preview__sidebar">
-			<div className="design-preview__sidebar-title">
-				<h1>{ title }</h1>
-			</div>
-
-			{ description && (
-				<div className="design-preview__sidebar-description">
-					<p>{ description }</p>
+			<div className="design-preview__sidebar-content">
+				<div className="design-preview__sidebar-title">
+					<h1>{ title }</h1>
 				</div>
-			) }
 
-			{ variations.length > 0 && (
-				<div className="design-preview__sidebar-variations">
-					<h2>{ translate( 'Choose your style' ) }</h2>
-					<p>{ translate( 'You can change your style at any time.' ) }</p>
-					<div className="design-preview__sidebar-variations-grid">
-						<StyleVariationPreviews
-							variations={ variations }
-							selectedVariation={ selectedVariation }
-							onClick={ onSelectVariation }
-							showGlobalStylesPremiumBadge={ showGlobalStylesPremiumBadge }
-						/>
+				{ description && (
+					<div className="design-preview__sidebar-description">
+						<p>{ description }</p>
 					</div>
-				</div>
-			) }
+				) }
+
+				{ variations.length > 0 && (
+					<div className="design-preview__sidebar-variations">
+						<h2>{ translate( 'Choose your style' ) }</h2>
+						<p>{ translate( 'You can change your style at any time.' ) }</p>
+						<div className="design-preview__sidebar-variations-grid">
+							<StyleVariationPreviews
+								variations={ variations }
+								selectedVariation={ selectedVariation }
+								onClick={ onSelectVariation }
+								showGlobalStylesPremiumBadge={ showGlobalStylesPremiumBadge }
+							/>
+						</div>
+					</div>
+				) }
+			</div>
 
 			{ actionButtons && (
 				<div className="design-preview__sidebar-action-buttons">{ actionButtons }</div>

--- a/packages/design-preview/src/components/style.scss
+++ b/packages/design-preview/src/components/style.scss
@@ -38,23 +38,54 @@ $break-design-preview: 1024px;
 	top: 0;
 	z-index: z-index(".is-section-stepper", ".design-preview__sticky-variations");
 
-	> div {
+	.design-preview__sidebar-action-buttons {
 		display: none;
+		position: absolute;
+		bottom: 0;
+		width: 100%;
 
-		&:first-of-type {
-			margin: 0;
+		button {
+			width: 100%;
+			border-radius: 4px;
+			box-shadow: 0 1px 2px rgb(0 0 0 / 5%);
 		}
 
-		h2 {
-			color: var(--studio-gray-100);
-			display: none;
-			font-size: $font-body-small;
-			font-weight: 500;
-			margin-bottom: 0.5rem;
+		@include break-design-preview {
+			bottom: 32px;
+			display: block;
 		}
 	}
 
+	@include break-small {
+		align-items: center;
+		justify-content: center;
+	}
+
+	@include break-design-preview {
+		border: 0;
+		box-shadow: none;
+		display: block;
+		height: auto;
+		overflow: visible;
+		padding: 0;
+		position: relative;
+		width: 280px;
+	}
+}
+
+.design-preview__sidebar-content {
+	h2 {
+		color: var(--studio-gray-100);
+		display: none;
+		font-size: $font-body-small;
+		font-weight: 500;
+		margin-bottom: 0.5rem;
+	}
+
 	.design-preview__sidebar-title {
+		display: none;
+		margin: 0;
+
 		h1 {
 			color: var(--studio-gray-100);
 			font-family: $brand-serif;
@@ -76,100 +107,87 @@ $break-design-preview: 1024px;
 				margin: 0;
 			}
 		}
+
+		@include break-design-preview {
+			display: block;
+		}
 	}
 
 	.design-preview__sidebar-description {
+		display: none;
+
 		> p {
 			color: var(--studio-gray-80);
 			font-size: 1rem;
 			line-height: 24px;
 		}
-	}
 
-	.design-preview__sidebar-variations {
-		display: block;
-
-		> p {
-			color: var(--studio-gray-100);
-			display: none;
-			font-size: 0.875rem;
-			line-height: 20px;
+		@include break-design-preview {
+			display: block;
+			margin-top: 1rem;
 		}
-
-		.design-preview__sidebar-variations-grid {
-			align-items: center;
-			display: flex;
-			gap: 8px;
-
-			.design-preview__style-variation {
-				flex-shrink: 0;
-				width: 100px;
-			}
-		}
-	}
-
-	.design-preview__sidebar-action-buttons {
-		position: absolute;
-		bottom: 0;
-		width: 100%;
-
-		button {
-			width: 100%;
-			border-radius: 4px;
-			box-shadow: 0 1px 2px rgb(0 0 0 / 5%);
-		}
-	}
-
-	@include break-small {
-		align-items: center;
-		justify-content: center;
 	}
 
 	@include break-design-preview {
-		border: 0;
-		box-shadow: none;
-		display: block;
-		height: auto;
-		overflow: visible;
-		padding: 0;
-		position: relative;
-		width: 280px;
+		margin: 0 -8px;
+		max-height: 100%;
+		overflow-y: scroll;
+		padding: 0 8px;
 
-		> div {
+		h2 {
 			display: block;
-			margin: 2rem 0 0;
-
-			h2,
-			&.design-preview__sidebar-variations > p {
-				display: block;
-			}
-
-			&.design-preview__sidebar-description {
-				margin-top: 1rem;
-			}
-		}
-
-		.design-preview__sidebar-variations {
-			.design-preview__sidebar-variations-grid {
-				box-sizing: border-box;
-				display: grid;
-				gap: 12px;
-				grid-template-columns: repeat(2, 1fr);
-				margin: 24px -5px 0;
-				padding: 2px;
-				width: 100%;
-
-				.design-preview__style-variation {
-					box-sizing: border-box;
-					width: 100%;
-				}
-			}
 		}
 	}
 }
 
 .design-preview__style-variation-wrapper {
 	padding: 3px;
+}
+
+.design-preview__sidebar-variations {
+	display: block;
+
+	> p {
+		color: var(--studio-gray-100);
+		display: none;
+		font-size: 0.875rem;
+		line-height: 20px;
+	}
+
+	.design-preview__sidebar-variations-grid {
+		align-items: center;
+		display: flex;
+		gap: 8px;
+
+		.design-preview__style-variation {
+			flex-shrink: 0;
+			width: 100px;
+		}
+	}
+
+	@include break-design-preview {
+		margin: 2rem 0 0;
+		padding-bottom: 96px;
+
+		> p {
+			display: block;
+		}
+
+		.design-preview__sidebar-variations-grid {
+			box-sizing: border-box;
+			display: grid;
+			gap: 12px;
+			grid-template-columns: repeat(2, 1fr);
+			margin: 24px -5px 0;
+			padding: 2px;
+			width: 100%;
+
+			.design-preview__style-variation {
+				box-sizing: border-box;
+				width: 100%;
+			}
+		}
+	}
 }
 
 .design-preview__style-variation {
@@ -233,6 +251,10 @@ $break-design-preview: 1024px;
 .design-preview__site-preview {
 	flex-grow: 1;
 	position: relative;
+
+	@include break-design-preview {
+		margin-bottom: 32px;
+	}
 
 	.theme-preview__frame-wrapper {
 		.theme-preview__frame {


### PR DESCRIPTION
#### Proposed Changes

This PR improves the handling of the theme preview sidebar overflow. Currently, when the sidebar overflows, the screen will follow the scroll, causing the action button and the site preview to move. See recording for reference:

https://user-images.githubusercontent.com/797888/206389126-b27670cc-4d80-435d-a999-3de2f5b23240.mp4

With this PR, we change the behavior so that when the sidebar overflows, only the sidebar is scrollable. As a result, both the action button and the site preview stay in place. See recording for reference: 

https://user-images.githubusercontent.com/797888/206389075-a1994d3c-32fe-4493-a4ef-10c31d22e76a.mp4

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the design picker `setup/site-setup/designSetup?siteSlug=${site_slug}`
* Click on any theme that has a lot of style variations, such as Pixl or Twenty Twenty-Three.
* Resize the browse so that the preview sidebar overflows.
* Ensure that the overflow behavior is as described above.
* Ensure that other elements in the preview works as before.
* Ensure that the mobile view of the preview works as before.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

