### PR TITLE
Fix misaligned labels in post list view

### DIFF
--- a/client/my-sites/post-relative-time-status/index.jsx
+++ b/client/my-sites/post-relative-time-status/index.jsx
@@ -225,12 +225,12 @@ class PostRelativeTime extends PureComponent {
 		const { showPublishedStatus, post } = this.props;
 		const timeText = this.getTimeText();
 		let innerText = (
-			<span>
+			<>
 				{ showPublishedStatus ? this.getStatus() : timeText }
 				{ post.status === 'pending' && this.getPendingLabel() }
 				{ post.status === 'private' && this.getPrivateLabel() }
 				{ post.sticky && this.getStickyLabel() }
-			</span>
+			</>
 		);
 
 		if ( this.props.link ) {

--- a/client/my-sites/post-relative-time-status/style.scss
+++ b/client/my-sites/post-relative-time-status/style.scss
@@ -33,9 +33,9 @@ a.post-relative-time-status__link {
 
 .post-relative-time-status__time,
 .post-relative-time-status__status {
-	display: flex;
+	display: inline-flex;
 	align-items: center;
-	margin-right: 2em;
+	margin-right: math.div(11, 12)  * 1em;
 }
 
 .post-relative-time-status__time-text,

--- a/client/my-sites/post-relative-time-status/style.scss
+++ b/client/my-sites/post-relative-time-status/style.scss
@@ -34,7 +34,7 @@ a.post-relative-time-status__link {
 .post-relative-time-status__time,
 .post-relative-time-status__status {
 	display: inline-block;
-	margin-right: math.div(11, 12)  * 1em;
+	margin-right: 2em;
 }
 
 .post-relative-time-status__time-text,

--- a/client/my-sites/post-relative-time-status/style.scss
+++ b/client/my-sites/post-relative-time-status/style.scss
@@ -33,7 +33,8 @@ a.post-relative-time-status__link {
 
 .post-relative-time-status__time,
 .post-relative-time-status__status {
-	display: inline-block;
+	display: flex;
+	align-items: center;
 	margin-right: 2em;
 }
 


### PR DESCRIPTION
#### Proposed Changes

In this PR, I propose to fix the alignment problem in the post block on the list of posts.

The issue was reported for Chrome, but I couldn't reproduce it in Chrome. I reproduced it in Safari, though.

![fixed](https://user-images.githubusercontent.com/727413/206424222-5e2bd993-738c-4a35-bb97-f2d3d8b287d6.png)

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Navigate to the site's Post list page
2. Confirm that date is not misaligned with post stats

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] ~~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~~
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~~
- [ ] ~~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~~
- [ ] ~~For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~~
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/67104
