### PR TITLE
E2E Test: Extended timeout for enter vertical

### DIFF
--- a/packages/calypso-e2e/src/lib/flows/start-site-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/start-site-flow.ts
@@ -97,7 +97,7 @@ export class StartSiteFlow {
 	 * @param {string} vertical Name of the vertical to select
 	 */
 	async enterVertical( vertical: string ): Promise< void > {
-		await this.page.waitForLoadState( 'networkidle', { timeout: 20 * 1000 } );
+		await this.page.waitForLoadState( 'networkidle', { timeout: 30 * 1000 } );
 
 		const input = this.page.locator( selectors.verticalInput );
 		await input.fill( vertical );


### PR DESCRIPTION
#### Proposed Changes

p1670497387258159-slack-C02DQP0FP

Timeout of 20 seconds seems to be too short for `await startSiteFlow.enterVertical( 'Travel Agencies & Services' );`

Extending it to 30 seconds

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check that the E2E tests do not timeout
