### PR TITLE
Limit Global Styles: Highlight "Advanced design customization" feature

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
@@ -94,7 +94,7 @@ function wpcom_global_styles_enqueue_block_editor_assets() {
 		'wpcomGlobalStyles',
 		array(
 			'assetsUrl'  => plugins_url( 'dist/', __FILE__ ),
-			'upgradeUrl' => "$calypso_domain/plans/$site_slug?plan=value_bundle",
+			'upgradeUrl' => "$calypso_domain/plans/$site_slug?plan=value_bundle&feature=advanced-design-customization",
 		)
 	);
 	wp_enqueue_style(
@@ -261,7 +261,7 @@ function wpcom_display_global_styles_launch_bar( $bar_controls ) {
 		$site_slug = wp_parse_url( $home_url, PHP_URL_HOST );
 	}
 
-	$upgrade_url = 'https://wordpress.com/plans/' . $site_slug . '?plan=value_bundle';
+	$upgrade_url = 'https://wordpress.com/plans/' . $site_slug . '?plan=value_bundle&feature=advanced-design-customization';
 
 	if ( wpcom_is_previewing_global_styles() ) {
 		$preview_text     = __( 'Hide custom styles', 'full-site-editing' );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -1,6 +1,7 @@
-import { PLAN_PREMIUM } from '@automattic/calypso-products';
+import { PLAN_PREMIUM, FEATURE_ADVANCED_DESIGN_CUSTOMIZATION } from '@automattic/calypso-products';
 import { dispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
+import { addQueryArgs } from '@wordpress/url';
 import { translate } from 'i18n-calypso';
 import { PLANS_LIST } from 'calypso/../packages/calypso-products/src/plans-list';
 import { SiteDetails } from 'calypso/../packages/data-stores/src';
@@ -75,9 +76,13 @@ export function getEnhancedTasks(
 						disabled: isVideoPressFlow( flow ),
 						actionDispatch: () => {
 							recordTaskClickTracksEvent( flow, task.completed, task.id );
-							window.location.assign(
-								`/plans/${ siteSlug }${ displayGlobalStylesWarning ? '?plan=' + PLAN_PREMIUM : '' }`
-							);
+							const plansUrl = addQueryArgs( `/plans/${ siteSlug }`, {
+								...( displayGlobalStylesWarning && {
+									plan: PLAN_PREMIUM,
+									feature: FEATURE_ADVANCED_DESIGN_CUSTOMIZATION,
+								} ),
+							} );
+							window.location.assign( plansUrl );
 						},
 						badgeText: translatedPlanName,
 						completed: task.completed && ! displayGlobalStylesWarning,


### PR DESCRIPTION
#### Proposed Changes

Adds an extra param to all the upgrade links displayed when Global Styles are limited in order to highlight the "Advanced design customization" feature in the Plans page.

Before | After
--- | ---
<img width="1075" alt="Screenshot 2022-12-08 at 11 57 30" src="https://user-images.githubusercontent.com/1233880/206433140-c973c445-9531-43a5-b844-975ba4086bf5.png"> | <img width="1080" alt="Screenshot 2022-12-08 at 11 57 42" src="https://user-images.githubusercontent.com/1233880/206433155-d14f306c-13e3-4700-9ed3-19b0fba15012.png">

#### Testing Instructions

- Apply these changes to your sandbox
- Go to https://wordpress.com/start and create a new free site
- Add the `wpcom-limit-global-styles` blog sticker to the new site
- Sandbox the new site
- Open the Site Editor
- Open the Global Styles sidebar
- The Global Styles upgrade modal should appear – click on the upgrade button
- Make sure it redirects to the Plans page with the "Advanced design customization" feature highlighted
- Do some style changes and click "Save"
- The pre-save notice should appear – click on the upgrade link
- Make sure it redirects to the Plans page with the "Advanced design customization" feature highlighted
- Save the custom styles
- Visit the frontend
- Open the Custom Styles action from the launchbar and click on the upgrade button
- Make sure it redirects to the Plans page with the "Advanced design customization" feature highlighted


- Use the Calypso live link below and go to `/setup/newsletter`
- Pick a custom color and proceed without upgrading
- Once the site is created, add the `wpcom-limit-global-styles` blog sticker
- Go to `/setup/newsletter/launchpad?siteSlug=<SITE_SLUG>
- The "Choose a plan" should appear as incomplete – click on it
- Make sure it redirects to the Plans page with the "Advanced design customization" feature highlighted
