### PR TITLE
Use vertical.title for site verticals dropdown in Store Profiler

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/store-profiler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/store-profiler/index.tsx
@@ -33,14 +33,14 @@ const StoreProfiler: Step = function StoreProfiler( { navigation } ) {
 	const verticals = useSiteVerticalsFeatured();
 	const verticalsOptions = React.useMemo( () => {
 		const sorted = verticals.data?.sort( ( a, b ) => {
-			if ( a.name === b.name ) {
+			if ( a.title === b.title ) {
 				return 0;
 			}
-			return a.name > b.name ? 1 : -1;
+			return a.title > b.title ? 1 : -1;
 		} );
 		const options = sorted?.map( ( v ) => (
 			<option value={ v.id } key={ v.id }>
-				{ v.name }
+				{ v.title }
 			</option>
 		) );
 		options?.unshift(


### PR DESCRIPTION
#### Proposed Changes

* This PR was based on the work in #70896, but is stripped down to ensure that we use `vertical.title` as the display value in the verticals dropdown on the Store Profiler step in the new eCommerce flow, and sort the values in the drop-down based on the title.
  - We were already getting translated values back in the response payload, but we were using the un-translated `name` property for both sorting and display

#### Testing Instructions

* Check out this PR locally, or access the Calypso live branch
* Navigate to `/setup/ecommerce/storeProfiler`
* Verify that the options in the "industry" dropdown are translated into your account's current language and are sorted alphabetically.
* Change your account's language, repeat the above steps, and verify that the options are displayed in the new language, and are sorted by the values in the new language.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [N/A] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [N/A] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [N/A] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?

Related to #70766 and #70896
