### PR TITLE
Virtual Page: Enable it on Jetpack sites

### DIFF
--- a/client/my-sites/pages/page-list.jsx
+++ b/client/my-sites/pages/page-list.jsx
@@ -23,12 +23,7 @@ import {
 } from 'calypso/state/posts/selectors';
 import getEditorUrl from 'calypso/state/selectors/get-editor-url';
 import hasInitializedSites from 'calypso/state/selectors/has-initialized-sites';
-import {
-	getSite,
-	getSiteFrontPage,
-	getSiteFrontPageType,
-	isJetpackSite,
-} from 'calypso/state/sites/selectors';
+import { getSite, getSiteFrontPage, getSiteFrontPageType } from 'calypso/state/sites/selectors';
 import BlogPostsPage from './blog-posts-page';
 import { sortPagesHierarchically } from './helpers';
 import Page from './page';
@@ -54,7 +49,6 @@ class Pages extends Component {
 		areBlockEditorSettingsLoading: PropTypes.bool,
 		isFSEActive: PropTypes.bool,
 		isFSEActiveLoading: PropTypes.bool,
-		isJetpack: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -193,15 +187,13 @@ class Pages extends Component {
 	}
 
 	showBlogPostsPage() {
-		const { site, homepageType, homepageId, isFSEActive, isJetpack } = this.props;
+		const { site, homepageType, homepageId, isFSEActive } = this.props;
 		const { search, status } = this.props.query;
 
 		return (
 			( ! config.isEnabled( 'unified-pages/virtual-home-page' ) ||
 				/** Blog posts page is for themes that don't support FSE */
-				! isFSEActive ||
-				/** Virtual homepage doesn't support jetpack site, so make it fall back to render blog posts page */
-				isJetpack ) &&
+				! isFSEActive ) &&
 			site &&
 			( homepageType === 'posts' || ( homepageType === 'page' && ! homepageId ) ) &&
 			/** Under the "Published" tab */
@@ -215,23 +207,14 @@ class Pages extends Component {
 	 * Show the virtual homepage
 	 */
 	showVirtualHomepage() {
-		const {
-			site,
-			homepageType,
-			homepageId,
-			blockEditorSettings,
-			isFSEActive,
-			isJetpack,
-			translate,
-		} = this.props;
+		const { site, homepageType, homepageId, blockEditorSettings, isFSEActive, translate } =
+			this.props;
 		const { search, status } = this.props.query;
 
 		return (
 			config.isEnabled( 'unified-pages/virtual-home-page' ) &&
 			/** Virtual homepage is for themes that support FSE */
 			isFSEActive &&
-			/** Virtual homepage doesn't support jetpack site */
-			! isJetpack &&
 			site &&
 			( homepageType === 'posts' || ( homepageType === 'page' && ! homepageId ) ) &&
 			blockEditorSettings?.home_template &&
@@ -431,7 +414,6 @@ const mapState = ( state, { query, siteId } ) => ( {
 	site: getSite( state, siteId ),
 	newPageLink: getEditorUrl( state, siteId, null, 'page' ),
 	homepageType: getSiteFrontPageType( state, siteId ),
-	isJetpack: isJetpackSite( state, siteId ),
 } );
 
 const ConnectedPages = flowRight(


### PR DESCRIPTION
#### Proposed Changes

* Enable virtual home page on Jetpack sites

- [x] TODO: Need to check disconnected jetpack site

| Atomic site | Self-hosted site |
| - | - |
| <img width="1343" alt="image" src="https://user-images.githubusercontent.com/13596067/206441547-6b6d44bd-d911-4cfa-b7aa-b30530fb99e9.png"> | <img width="1347" alt="image" src="https://user-images.githubusercontent.com/13596067/206441367-7d3f8248-9de6-4ffe-9642-5e35cdaa108c.png"> |

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply D94705-code to your sandbox
* Go to `/pages/<your_jetpack_site>` with template as homepage
* Verify the virtual home page shows correctly
* Click on the virtual home page, verify you land on the site editor correctly
* Go to `/pages/<your_jetpack_site>` with page as homepage
* Verify the virtual home page doesn't show

Note that the redirection after you logged in to the self-hosted site is weird, `wp-login.php` will redirect you to `/wp-admin` instead of the URL from `redirect_to`. But I think it's out of scope 🤔

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/70867