### PR TITLE
Apps: remove unused enzyme dependency

### DIFF
--- a/apps/editing-toolkit/package.json
+++ b/apps/editing-toolkit/package.json
@@ -107,7 +107,6 @@
 		"@wordpress/url": "^3.10.0",
 		"calypso": "workspace:^",
 		"classnames": "^2.3.1",
-		"enzyme": "^3.11.0",
 		"eslint": "^8.6.0",
 		"jest": "^27.3.1",
 		"lodash": "^4.17.21",

--- a/apps/happychat/package.json
+++ b/apps/happychat/package.json
@@ -48,7 +48,6 @@
 		"@automattic/webpack-inline-constant-exports-plugin": "workspace:^",
 		"autoprefixer": "^10.2.5",
 		"copy-webpack-plugin": "^10.1.0",
-		"enzyme": "^3.11.0",
 		"html-webpack-plugin": "^5.0.0-beta.4",
 		"jest": "^27.2.4",
 		"postcss": "^8.3.11",

--- a/apps/inline-help/package.json
+++ b/apps/inline-help/package.json
@@ -43,7 +43,6 @@
 		"@automattic/webpack-extensive-lodash-replacement-plugin": "workspace:^",
 		"@automattic/webpack-inline-constant-exports-plugin": "workspace:^",
 		"autoprefixer": "^10.2.5",
-		"enzyme": "^3.11.0",
 		"html-webpack-plugin": "^5.0.0-beta.4",
 		"jest": "^27.2.4",
 		"path-browserify": "^1.0.1",

--- a/apps/notifications/package.json
+++ b/apps/notifications/package.json
@@ -49,7 +49,6 @@
 		"@automattic/calypso-apps-builder": "workspace:^",
 		"@automattic/calypso-build": "workspace:^",
 		"@automattic/calypso-eslint-overrides": "workspace:^",
-		"enzyme": "^3.11.0",
 		"html-webpack-plugin": "^5.0.0-beta.4",
 		"jest": "^27.3.1",
 		"postcss": "^8.4.5",

--- a/apps/o2-blocks/package.json
+++ b/apps/o2-blocks/package.json
@@ -48,7 +48,6 @@
 		"@automattic/calypso-apps-builder": "workspace:^",
 		"@automattic/calypso-eslint-overrides": "workspace:^",
 		"@wordpress/readable-js-assets-webpack-plugin": "^1.0.4",
-		"enzyme": "^3.11.0",
 		"jest": "^27.3.1",
 		"postcss": "^8.4.5",
 		"webpack": "^5.68.0"

--- a/apps/odyssey-stats/package.json
+++ b/apps/odyssey-stats/package.json
@@ -50,7 +50,6 @@
 		"@automattic/webpack-inline-constant-exports-plugin": "workspace:^",
 		"@wordpress/dependency-extraction-webpack-plugin": "^4.4.0",
 		"autoprefixer": "^10.2.5",
-		"enzyme": "^3.11.0",
 		"html-webpack-plugin": "^5.0.0-beta.4",
 		"jest": "^27.2.4",
 		"path-browserify": "^1.0.1",

--- a/apps/wpcom-block-editor/package.json
+++ b/apps/wpcom-block-editor/package.json
@@ -54,7 +54,6 @@
 		"@automattic/calypso-build": "workspace:^",
 		"@automattic/calypso-eslint-overrides": "workspace:^",
 		"@wordpress/dependency-extraction-webpack-plugin": "^3.5.0",
-		"enzyme": "^3.11.0",
 		"jest": "^27.3.1",
 		"npm-run-all": "^4.1.5",
 		"postcss": "^8.4.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -336,7 +336,6 @@ __metadata:
     calypso: "workspace:^"
     classnames: ^2.3.1
     debug: ^4.3.4
-    enzyme: ^3.11.0
     html-webpack-plugin: ^5.0.0-beta.4
     jest: ^27.2.4
     page: ^1.11.5
@@ -751,7 +750,6 @@ __metadata:
     autoprefixer: ^10.2.5
     calypso: "workspace:^"
     copy-webpack-plugin: ^10.1.0
-    enzyme: ^3.11.0
     html-webpack-plugin: ^5.0.0-beta.4
     jest: ^27.2.4
     postcss: ^8.3.11
@@ -857,7 +855,6 @@ __metadata:
     "@automattic/webpack-inline-constant-exports-plugin": "workspace:^"
     autoprefixer: ^10.2.5
     calypso: "workspace:^"
-    enzyme: ^3.11.0
     html-webpack-plugin: ^5.0.0-beta.4
     jest: ^27.2.4
     path-browserify: ^1.0.1
@@ -1091,7 +1088,6 @@ __metadata:
     calypso: "workspace:^"
     classnames: ^2.3.1
     debug: ^4.3.3
-    enzyme: ^3.11.0
     html-webpack-plugin: ^5.0.0-beta.4
     i18n-calypso: "workspace:^"
     jest: ^27.3.1
@@ -1135,7 +1131,6 @@ __metadata:
     "@wordpress/primitives": ^3.7.0
     "@wordpress/readable-js-assets-webpack-plugin": ^1.0.4
     classnames: ^2.3.1
-    enzyme: ^3.11.0
     jest: ^27.3.1
     lodash: ^4.17.21
     moment: ^2.26.0
@@ -1700,7 +1695,6 @@ __metadata:
     "@wordpress/rich-text": ^5.7.0
     "@wordpress/url": ^3.10.0
     debug: ^4.3.3
-    enzyme: ^3.11.0
     jest: ^27.3.1
     lodash: ^4.17.21
     npm-run-all: ^4.1.5
@@ -1817,7 +1811,6 @@ __metadata:
     babel-jest: ^27.5.1
     calypso: "workspace:^"
     classnames: ^2.3.1
-    enzyme: ^3.11.0
     eslint: ^8.6.0
     jest: ^27.3.1
     jest-teamcity: ^1.9.0


### PR DESCRIPTION
#### Proposed Changes

While refactoring tests from `enzyme` to `@testing-library/react`, I noticed that our apps declare `enzyme` as a dependency, but they don't utilize it in any way. 

This PR removes that dependency from all Calypso apps.

#### Testing Instructions

* Manually ensure no Calypso app uses `enzyme`.
* Verify all checks are green.
