### PR TITLE
Packages: Remove unused `enzyme` dependency

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -34,7 +34,6 @@
 		"@wordpress/base-styles": "^4.5.0",
 		"@wordpress/icons": "^9.11.0",
 		"classnames": "^2.3.1",
-		"enzyme": "^3.11.0",
 		"framer-motion": "6.2.8",
 		"gridicons": "^3.4.0",
 		"i18n-calypso": "workspace:^",

--- a/packages/languages/package.json
+++ b/packages/languages/package.json
@@ -34,7 +34,6 @@
 		"@automattic/calypso-build": "workspace:^",
 		"@automattic/calypso-eslint-overrides": "workspace:^",
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"enzyme": "^3.11.0",
 		"jest": "^27.3.1",
 		"postcss": "^8.4.5",
 		"react": "^17.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -434,7 +434,6 @@ __metadata:
     "@wordpress/base-styles": ^4.5.0
     "@wordpress/icons": ^9.11.0
     classnames: ^2.3.1
-    enzyme: ^3.11.0
     framer-motion: 6.2.8
     gridicons: ^3.4.0
     i18n-calypso: "workspace:^"
@@ -943,7 +942,6 @@ __metadata:
     "@automattic/calypso-build": "workspace:^"
     "@automattic/calypso-eslint-overrides": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
-    enzyme: ^3.11.0
     jest: ^27.3.1
     postcss: ^8.4.5
     react: ^17.0.2


### PR DESCRIPTION
#### Proposed Changes

While refactoring tests from `enzyme` to `@testing-library/react`, I noticed that a few of our packages declare `enzyme` as a dependency, but they don't utilize it in any way. The components package used it recently, but no longer since we refactored all tests to use `@testing-library/react` - see #70873.

This PR removes that dependency from all Calypso packages, except the one that actually still uses it - `@automattic/calypso-jest`.

#### Testing Instructions

* Manually none of the affected packages uses `enzyme`.
* Verify all checks are green.
