### PR TITLE
Stepper: add processing step styles for ecommerece

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -287,3 +287,12 @@ button {
 		}
 	}
 }
+
+.ecommerce {
+	.step-container {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		margin-top: 25vh;
+	}
+}

--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -289,7 +289,7 @@ button {
 }
 
 .ecommerce {
-	.step-container {
+	.step-container.processing-step {
 		display: flex;
 		flex-direction: column;
 		align-items: center;


### PR DESCRIPTION
#### Proposed Changes

* When all flows were loaded, some flows implicitly depended on other flows for styling. This resulted in some missing CSS when the flows are loaded individually after https://github.com/Automattic/wp-calypso/pull/70478. 
* This adds the missing CSS of processing step that was coming from Launchpad.

#### Testing Instructions
1. Go to /setup/ecommerce?recur=monthly
2. Reach the processing step.
3. It should be centered. 