### PR TITLE
Desktop: Remove enzyme dependency

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -41,7 +41,6 @@
 		"electron-builder": "^22.11.7",
 		"electron-notarize": "^0.1.1",
 		"electron-rebuild": "^2.3.5",
-		"enzyme": "^3.11.0",
 		"jest": "^27.3.1",
 		"lodash": "^4.17.21",
 		"playwright": "^1.28",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10313,7 +10313,6 @@ __metadata:
     electron-notarize: ^0.1.1
     electron-rebuild: ^2.3.5
     electron-updater: ^4.2.5
-    enzyme: ^3.11.0
     jest: ^27.3.1
     js-yaml: ^4.0.0
     keytar: ^7.7.0


### PR DESCRIPTION
#### Proposed Changes

While refactoring tests from `enzyme` to `@testing-library/react`, I noticed that the desktop app declares `enzyme` as a dependency, but doesn't utilize it in any way. 

This PR removes that dependency from the Desktop app.

#### Testing Instructions

* Verify all checks are green.
