### PR TITLE
Add PHP 8.2 to version switcher

### DIFF
--- a/client/my-sites/hosting/web-server-settings-card/index.js
+++ b/client/my-sites/hosting/web-server-settings-card/index.js
@@ -113,6 +113,12 @@ const WebServerSettingsCard = ( {
 				} ),
 				value: '8.1',
 			},
+			{
+				label: translate( '8.2 (release candidate)', {
+					comment: 'PHP Version for a version switcher',
+				} ),
+				value: '8.2',
+			},
 		];
 	};
 

--- a/client/my-sites/hosting/web-server-settings-card/index.js
+++ b/client/my-sites/hosting/web-server-settings-card/index.js
@@ -114,7 +114,7 @@ const WebServerSettingsCard = ( {
 				value: '8.1',
 			},
 			{
-				label: translate( '8.2 (release candidate)', {
+				label: translate( '8.2', {
 					comment: 'PHP Version for a version switcher',
 				} ),
 				value: '8.2',


### PR DESCRIPTION
PHP 8.2.0 was released today, add it to the version switcher.

![Screenshot from 2022-12-08 15-23-13](https://user-images.githubusercontent.com/1103398/206470846-90c5f890-f312-4a2b-940c-3a17380287f4.png)
