### PR TITLE
eCommerce Onboarding: Remove back step from storeAddress

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/store-address/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/store-address/index.tsx
@@ -47,7 +47,7 @@ const CityZipRow = styled.div`
 `;
 
 const StoreAddress: Step = function StoreAddress( { navigation } ) {
-	const { goBack, goNext, submit } = navigation;
+	const { goNext, submit } = navigation;
 	const intent = useSelect( ( select ) => select( ONBOARD_STORE ).getIntent() );
 	const site = useSite();
 	const settings = useSelect(
@@ -299,8 +299,6 @@ const StoreAddress: Step = function StoreAddress( { navigation } ) {
 		<StepContainer
 			stepName="store-address"
 			className={ `is-step-${ intent }` }
-			skipButtonAlign="top"
-			goBack={ goBack }
 			goNext={ goNext }
 			isHorizontalLayout={ true }
 			formattedHeader={
@@ -318,6 +316,7 @@ const StoreAddress: Step = function StoreAddress( { navigation } ) {
 			recordTracksEvent={ recordTracksEvent }
 			stepProgress={ stepProgress }
 			hideSkip
+			hideBack
 		/>
 	);
 };

--- a/client/landing/stepper/declarative-flow/tailored-ecommerce-flow.ts
+++ b/client/landing/stepper/declarative-flow/tailored-ecommerce-flow.ts
@@ -170,8 +170,6 @@ const ecommerceFlow: Flow = {
 			switch ( _currentStepName ) {
 				case 'designCarousel':
 					return navigate( 'storeProfiler' );
-				case 'storeAddress':
-					return navigate( 'domains' );
 				default:
 					return navigate( 'intro' );
 			}


### PR DESCRIPTION
#### Proposed Changes

* As noted in #70900, this PR removes the `goBack` method for `storeAddress` to prevent breaking the flow.

**Before**

<img width="1121" alt="Screen Shot 2022-12-08 at 9 21 56 AM" src="https://user-images.githubusercontent.com/2124984/206471400-37d51e6c-3658-4150-8ceb-2798b81c1ca4.png">

**After**

<img width="1001" alt="Screen Shot 2022-12-08 at 9 22 07 AM" src="https://user-images.githubusercontent.com/2124984/206471422-5b90256b-eaba-40ee-87f0-c3af6934b08c.png">


#### Testing Instructions

* Switch to this PR, navigate to `setup/ecommerce/`
* Go through the flow and checkout to land on `storeAddress`
* There should be no Back button at the top left of the screen

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
