### PR TITLE
Limit Global Styles: Add More Tracks Events

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/accent-color-control/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/accent-color-control/index.tsx
@@ -18,6 +18,7 @@ import {
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
 import SelectDropdown from 'calypso/components/select-dropdown';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { tip } from 'calypso/signup/icons';
 import { usePremiumGlobalStyles } from 'calypso/state/sites/hooks/use-premium-global-styles';
 import './style.scss';
@@ -111,6 +112,11 @@ const AccentColorControl = ( { accentColor, setAccentColor }: AccentColorControl
 		// Hence ensure the color picker is closed after predefined color selection
 		setColorPickerOpen( false );
 
+		recordTracksEvent( 'calypso_signup_accent_color_select', {
+			color: value,
+			global_styles_gating: shouldLimitGlobalStyles,
+		} );
+
 		setAccentColor( {
 			hex: value,
 			rgb: hexToRgb( value ),
@@ -118,6 +124,11 @@ const AccentColorControl = ( { accentColor, setAccentColor }: AccentColorControl
 	};
 
 	const handleCustomColorSelect = ( { hex, rgb }: ColorPicker.OnChangeCompleteValue ) => {
+		recordTracksEvent( 'calypso_signup_accent_color_select', {
+			color: 'custom',
+			global_styles_gating: shouldLimitGlobalStyles,
+		} );
+
 		setCustomColor( { hex, rgb: rgb as unknown as RGB } );
 		setAccentColor( { hex, rgb: rgb as unknown as RGB } );
 	};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/accent-color-control/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/accent-color-control/index.tsx
@@ -93,7 +93,13 @@ const AccentColorControl = ( { accentColor, setAccentColor }: AccentColorControl
 		[ shouldLimitGlobalStyles ]
 	);
 
-	const handlePredefinedColorSelect = ( { value }: { value: string } ) => {
+	const handlePredefinedColorSelect = ( {
+		value,
+		isPremium,
+	}: {
+		value: string;
+		isPremium: boolean;
+	} ) => {
 		if ( value === 'custom' ) {
 			/**
 			 * Color picker is opened with the current accentColor selected by default
@@ -114,7 +120,7 @@ const AccentColorControl = ( { accentColor, setAccentColor }: AccentColorControl
 
 		recordTracksEvent( 'calypso_signup_accent_color_select', {
 			color: value,
-			global_styles_gating: shouldLimitGlobalStyles,
+			is_premium: isPremium,
 		} );
 
 		setAccentColor( {
@@ -126,7 +132,7 @@ const AccentColorControl = ( { accentColor, setAccentColor }: AccentColorControl
 	const handleCustomColorSelect = ( { hex, rgb }: ColorPicker.OnChangeCompleteValue ) => {
 		recordTracksEvent( 'calypso_signup_accent_color_select', {
 			color: 'custom',
-			global_styles_gating: shouldLimitGlobalStyles,
+			is_premium: shouldLimitGlobalStyles,
 		} );
 
 		setCustomColor( { hex, rgb: rgb as unknown as RGB } );
@@ -161,7 +167,9 @@ const AccentColorControl = ( { accentColor, setAccentColor }: AccentColorControl
 			<SelectDropdown.Item
 				key={ option.label }
 				icon={ option.icon }
-				onClick={ () => handlePredefinedColorSelect( { value: option.value } ) }
+				onClick={ () =>
+					handlePredefinedColorSelect( { value: option.value, isPremium: option.isPremium } )
+				}
 				selected={ option.value === accentColor.hex }
 				secondaryIcon={
 					shouldLimitGlobalStyles && option.isPremium ? (

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/accent-color-control/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/accent-color-control/index.tsx
@@ -93,6 +93,10 @@ const AccentColorControl = ( { accentColor, setAccentColor }: AccentColorControl
 		[ shouldLimitGlobalStyles ]
 	);
 
+	const isCustomColorPremium = useCallback( () => {
+		return !! getColorOptions().find( ( { value } ) => value === 'custom' )?.isPremium;
+	}, [ getColorOptions ] );
+
 	const handlePredefinedColorSelect = ( {
 		value,
 		isPremium,
@@ -132,7 +136,7 @@ const AccentColorControl = ( { accentColor, setAccentColor }: AccentColorControl
 	const handleCustomColorSelect = ( { hex, rgb }: ColorPicker.OnChangeCompleteValue ) => {
 		recordTracksEvent( 'calypso_signup_accent_color_select', {
 			color: 'custom',
-			is_premium: shouldLimitGlobalStyles,
+			is_premium: isCustomColorPremium(),
 		} );
 
 		setCustomColor( { hex, rgb: rgb as unknown as RGB } );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/premium-global-styles-upgrade-modal.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/premium-global-styles-upgrade-modal.tsx
@@ -10,14 +10,14 @@ interface PremiumGlobalStylesUpgradeModalProps {
 	checkout: () => void;
 	closeModal: () => void;
 	isOpen: boolean;
-	pickDesign: () => void;
+	tryStyle: () => void;
 }
 
 export default function PremiumGlobalStylesUpgradeModal( {
 	checkout,
 	closeModal,
 	isOpen,
-	pickDesign,
+	tryStyle,
 }: PremiumGlobalStylesUpgradeModalProps ) {
 	const translate = useTranslate();
 	const premiumPlanProduct = useSelect( ( select ) =>
@@ -55,7 +55,7 @@ export default function PremiumGlobalStylesUpgradeModal( {
 							) }
 						</p>
 						<div className="upgrade-modal__actions bundle">
-							<Button className="upgrade-modal__cancel" onClick={ () => pickDesign() }>
+							<Button className="upgrade-modal__cancel" onClick={ () => tryStyle() }>
 								{ translate( 'Try it out first' ) }
 							</Button>
 							<Button className="upgrade-modal__upgrade-plan" primary onClick={ () => checkout() }>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -370,6 +370,17 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 		}
 	}
 
+	function closePremiumGlobalStylesModal() {
+		// These conditions should be true at this point, but just in case...
+		if ( selectedDesign && selectedStyleVariation ) {
+			recordTracksEvent(
+				'calypso_signup_design_global_styles_gating_modal_close_button_click',
+				getEventPropsByDesign( selectedDesign, selectedStyleVariation )
+			);
+			setShowPremiumGlobalStylesModal( false );
+		}
+	}
+
 	function goToCheckoutForPremiumGlobalStyles() {
 		// These conditions should be true at this point, but just in case...
 		if ( selectedDesign && selectedStyleVariation && siteSlugOrId ) {
@@ -402,6 +413,17 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 		}
 	}
 
+	function tryPremiumGlobalStyles() {
+		// These conditions should be true at this point, but just in case...
+		if ( selectedDesign && selectedStyleVariation ) {
+			recordTracksEvent(
+				'calypso_signup_design_global_styles_gating_modal_try_button_click',
+				getEventPropsByDesign( selectedDesign, selectedStyleVariation )
+			);
+			pickDesign();
+		}
+	}
+
 	// ********** Logic for submitting the selected design
 
 	const { setDesignOnSite } = useDispatch( SITE_STORE );
@@ -429,13 +451,6 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 				...( positionIndex >= 0 && { position_index: positionIndex } ),
 				device: resolveDeviceTypeByViewPort(),
 			} );
-
-			if ( shouldLimitGlobalStyles ) {
-				recordTracksEvent(
-					'calypso_signup_design_global_styles_gating_modal_try_button_click',
-					getEventPropsByDesign( _selectedDesign, selectedStyleVariation )
-				);
-			}
 
 			if ( _selectedDesign.verticalizable ) {
 				recordTracksEvent(
@@ -583,9 +598,9 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 				/>
 				<PremiumGlobalStylesUpgradeModal
 					checkout={ goToCheckoutForPremiumGlobalStyles }
-					closeModal={ () => setShowPremiumGlobalStylesModal( false ) }
+					closeModal={ closePremiumGlobalStylesModal }
 					isOpen={ showPremiumGlobalStylesModal }
-					pickDesign={ pickDesign }
+					tryStyle={ tryPremiumGlobalStyles }
 				/>
 				{ selectedDesignHasStyleVariations ? (
 					<AsyncLoad

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -430,6 +430,13 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 				device: resolveDeviceTypeByViewPort(),
 			} );
 
+			if ( shouldLimitGlobalStyles ) {
+				recordTracksEvent(
+					'calypso_signup_design_global_styles_gating_modal_try_button_click',
+					getEventPropsByDesign( _selectedDesign, selectedStyleVariation )
+				);
+			}
+
 			if ( _selectedDesign.verticalizable ) {
 				recordTracksEvent(
 					'calypso_signup_select_verticalized_design',

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -363,7 +363,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 		// These conditions should be true at this point, but just in case...
 		if ( selectedDesign && selectedStyleVariation ) {
 			recordTracksEvent(
-				'calypso_signup_design_premium_global_styles_modal_show',
+				'calypso_signup_design_global_styles_gating_modal_show',
 				getEventPropsByDesign( selectedDesign, selectedStyleVariation )
 			);
 			setShowPremiumGlobalStylesModal( true );
@@ -374,7 +374,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 		// These conditions should be true at this point, but just in case...
 		if ( selectedDesign && selectedStyleVariation && siteSlugOrId ) {
 			recordTracksEvent(
-				'calypso_signup_design_premium_global_styles_modal_checkout_button_click',
+				'calypso_signup_design_global_styles_gating_modal_checkout_button_click',
 				getEventPropsByDesign( selectedDesign, selectedStyleVariation )
 			);
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -79,6 +79,11 @@ export function getEnhancedTasks(
 						disabled: isVideoPressFlow( flow ),
 						actionDispatch: () => {
 							recordTaskClickTracksEvent( flow, task.completed, task.id );
+							if ( displayGlobalStylesWarning ) {
+								recordTracksEvent(
+									'calypso_launchpad_global_styles_gating_plan_selected_task_clicked'
+								);
+							}
 							const plansUrl = addQueryArgs( `/plans/${ siteSlug }`, {
 								...( displayGlobalStylesWarning && {
 									plan: PLAN_PREMIUM,


### PR DESCRIPTION
#### Proposed Changes

* Rename the Limit Global Styles events in the design picker, replacing `premium_global_styles` with `global_styles_gating` for consistency.
* Add a `calypso_signup_design_global_styles_gating_modal_try_button_click` event, fired when clicking "Try it out first" from the Limit Global Styles modal in the design picker.
* Add a `calypso_signup_design_global_styles_gating_modal_close_button_click` event, fired when closing the Limited Global Styles modal in the design picker.
* Add a `calypso_signup_accent_color_select` event to the Newsletter accent color dropdown, with `color` and `is_premium` as properties.
* Add a `calypso_launchpad_global_styles_gating_plan_selected_task_clicked` event, fired when clicking on "Choose a plan" in the Launchpad while the Limit Global Styles notice is visible.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* In a Calypso development page, run `localStorage.setItem( 'debug', '*' );` in the browser console to monitor Calypso events (filter the console as needed to reduce the notice).
* Start the Newsletter flow: `/setup/newsletter/newsletterSetup`.
* Select the accent color.
* Ensure the `calypso_signup_accent_color_select` is recorded with `global_styles_gating: true`.
* Proceed until the checklist step.
* Apply the `wpcom-limit-global-styles` sticker and reload.
* Click on "Choose a plan".
* Ensure the `calypso_launchpad_global_styles_gating_plan_selected_task_clicked` event is recorded.
* Create a new site with the regular flow.
* Apply the `wpcom-limit-global-styles` sticker and reload.
* Proceed until the design picker.
* Select a theme with style variations.
* Select a premium style variation and click on "Unlock this style".
* Ensure the `calypso_signup_design_global_styles_gating_modal_show` is recorded.
* Try both modal buttons.
* Ensure the `calypso_signup_design_global_styles_gating_modal_checkout_button_click` or `calypso_signup_design_global_styles_gating_modal_try_button_click` are recorded.
 
#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/1359
