### PR TITLE
Stats: deprecate flag stats/new-stats-module-component

### DIFF
--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -291,6 +291,7 @@ class StatsSite extends Component {
 							query={ query }
 							statType="statsTopPosts"
 							showSummaryLink
+							showNewModules
 						/>
 						<StatsModule
 							path="referrers"
@@ -299,6 +300,7 @@ class StatsSite extends Component {
 							query={ query }
 							statType="statsReferrers"
 							showSummaryLink
+							showNewModules
 						/>
 
 						<Countries
@@ -306,6 +308,7 @@ class StatsSite extends Component {
 							period={ this.props.period }
 							query={ query }
 							summary={ false }
+							showNewModules
 						/>
 
 						<StatsModule
@@ -316,6 +319,7 @@ class StatsSite extends Component {
 							statType="statsTopAuthors"
 							className="stats__author-views"
 							showSummaryLink
+							showNewModules
 						/>
 						<StatsModule
 							path="searchterms"
@@ -324,6 +328,7 @@ class StatsSite extends Component {
 							query={ query }
 							statType="statsSearchTerms"
 							showSummaryLink
+							showNewModules
 						/>
 
 						<StatsModule
@@ -333,6 +338,7 @@ class StatsSite extends Component {
 							query={ query }
 							statType="statsClicks"
 							showSummaryLink
+							showNewModules
 						/>
 						<StatsModule
 							path="videoplays"
@@ -341,6 +347,7 @@ class StatsSite extends Component {
 							query={ query }
 							statType="statsVideoPlays"
 							showSummaryLink
+							showNewModules
 						/>
 						{
 							// File downloads are not yet supported in Jetpack Stats
@@ -354,6 +361,7 @@ class StatsSite extends Component {
 									statType="statsFileDownloads"
 									showSummaryLink
 									useShortLabel={ true }
+									showNewModules
 								/>
 							)
 						}

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -197,8 +197,6 @@ class StatsSite extends Component {
 
 		const query = memoizedQuery( period, endOf );
 
-		const showNewModules = config.isEnabled( 'stats/new-stats-module-component' );
-
 		// For period option links
 		const traffic = {
 			label: translate( 'Traffic' ),
@@ -293,7 +291,6 @@ class StatsSite extends Component {
 							query={ query }
 							statType="statsTopPosts"
 							showSummaryLink
-							showNewModules={ showNewModules }
 						/>
 						<StatsModule
 							path="referrers"
@@ -302,7 +299,6 @@ class StatsSite extends Component {
 							query={ query }
 							statType="statsReferrers"
 							showSummaryLink
-							showNewModules={ showNewModules }
 						/>
 
 						<Countries
@@ -310,7 +306,6 @@ class StatsSite extends Component {
 							period={ this.props.period }
 							query={ query }
 							summary={ false }
-							showNewModules={ showNewModules }
 						/>
 
 						<StatsModule
@@ -321,7 +316,6 @@ class StatsSite extends Component {
 							statType="statsTopAuthors"
 							className="stats__author-views"
 							showSummaryLink
-							showNewModules={ showNewModules }
 						/>
 						<StatsModule
 							path="searchterms"
@@ -330,7 +324,6 @@ class StatsSite extends Component {
 							query={ query }
 							statType="statsSearchTerms"
 							showSummaryLink
-							showNewModules={ showNewModules }
 						/>
 
 						<StatsModule
@@ -340,7 +333,6 @@ class StatsSite extends Component {
 							query={ query }
 							statType="statsClicks"
 							showSummaryLink
-							showNewModules={ showNewModules }
 						/>
 						<StatsModule
 							path="videoplays"
@@ -349,7 +341,6 @@ class StatsSite extends Component {
 							query={ query }
 							statType="statsVideoPlays"
 							showSummaryLink
-							showNewModules={ showNewModules }
 						/>
 						{
 							// File downloads are not yet supported in Jetpack Stats
@@ -363,7 +354,6 @@ class StatsSite extends Component {
 									statType="statsFileDownloads"
 									showSummaryLink
 									useShortLabel={ true }
-									showNewModules={ showNewModules }
 								/>
 							)
 						}

--- a/client/my-sites/stats/stats-countries/index.jsx
+++ b/client/my-sites/stats/stats-countries/index.jsx
@@ -16,7 +16,7 @@ class StatCountries extends Component {
 	};
 
 	render() {
-		const { summary, query, period, showNewModules } = this.props;
+		const { summary, query, period } = this.props;
 		const moduleStrings = statsStrings();
 
 		return (
@@ -28,7 +28,6 @@ class StatCountries extends Component {
 				summary={ summary }
 				moduleStrings={ moduleStrings.countries }
 				statType="statsCountryViews"
-				showNewModules={ showNewModules }
 			>
 				<Geochart query={ query } />
 			</StatsModule>

--- a/client/my-sites/stats/stats-countries/index.jsx
+++ b/client/my-sites/stats/stats-countries/index.jsx
@@ -16,7 +16,7 @@ class StatCountries extends Component {
 	};
 
 	render() {
-		const { summary, query, period } = this.props;
+		const { summary, query, period, showNewModules } = this.props;
 		const moduleStrings = statsStrings();
 
 		return (
@@ -28,6 +28,7 @@ class StatCountries extends Component {
 				summary={ summary }
 				moduleStrings={ moduleStrings.countries }
 				statType="statsCountryViews"
+				showNewModules={ showNewModules }
 			>
 				<Geochart query={ query } />
 			</StatsModule>

--- a/client/my-sites/stats/stats-module/index.jsx
+++ b/client/my-sites/stats/stats-module/index.jsx
@@ -127,6 +127,7 @@ class StatsModule extends Component {
 			period,
 			translate,
 			useShortLabel,
+			showNewModules,
 		} = this.props;
 
 		const noData = data && this.state.loaded && ! data.length;
@@ -154,7 +155,7 @@ class StatsModule extends Component {
 			'is-refreshing': requesting && ! isLoading,
 		} );
 
-		const shouldShowNewModule = ! summary;
+		const shouldShowNewModule = showNewModules && ! summary;
 
 		return (
 			<>

--- a/client/my-sites/stats/stats-module/index.jsx
+++ b/client/my-sites/stats/stats-module/index.jsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { FEATURE_GOOGLE_ANALYTICS, PLAN_PREMIUM } from '@automattic/calypso-products';
 import { Card } from '@automattic/components';
 import classNames from 'classnames';
@@ -128,7 +127,6 @@ class StatsModule extends Component {
 			period,
 			translate,
 			useShortLabel,
-			showNewModules,
 		} = this.props;
 
 		const noData = data && this.state.loaded && ! data.length;
@@ -156,8 +154,7 @@ class StatsModule extends Component {
 			'is-refreshing': requesting && ! isLoading,
 		} );
 
-		const shouldShowNewModule =
-			showNewModules && isEnabled( 'stats/new-stats-module-component' ) && ! summary;
+		const shouldShowNewModule = ! summary;
 
 		return (
 			<>

--- a/config/client.json
+++ b/config/client.json
@@ -26,7 +26,6 @@
 	"siftscience_key",
 	"signup_url",
 	"stats/new-main-chart",
-	"stats/new-stats-module-component",
 	"wpcom_concierge_schedule_id",
 	"wpcom_signup_id",
 	"wpcom_signup_key",

--- a/config/development.json
+++ b/config/development.json
@@ -164,7 +164,6 @@
 		"site-indicator": true,
 		"ssr/prefetch-timebox": false,
 		"stats/new-main-chart": true,
-		"stats/new-stats-module-component": true,
 		"stepper-woocommerce-poc": true,
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -108,7 +108,6 @@
 		"site-indicator": true,
 		"ssr/prefetch-timebox": true,
 		"stats/new-main-chart": true,
-		"stats/new-stats-module-component": true,
 		"stepper-woocommerce-poc": true,
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,

--- a/config/production.json
+++ b/config/production.json
@@ -128,7 +128,6 @@
 		"ssr/prefetch-timebox": true,
 		"ssr/sample-log-cache-misses": true,
 		"stats/new-main-chart": true,
-		"stats/new-stats-module-component": true,
 		"stepper-woocommerce-poc": true,
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -125,7 +125,6 @@
 		"site-indicator": true,
 		"ssr/prefetch-timebox": true,
 		"stats/new-main-chart": true,
-		"stats/new-stats-module-component": true,
 		"stepper-woocommerce-poc": true,
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,

--- a/config/test.json
+++ b/config/test.json
@@ -90,7 +90,6 @@
 		"site-indicator": true,
 		"ssr/prefetch-timebox": true,
 		"stats/new-main-chart": true,
-		"stats/new-stats-module-component": true,
 		"stepper-woocommerce-poc": true,
 		"themes/premium": true,
 		"upgrades/redirect-payments": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -134,7 +134,6 @@
 		"site-indicator": true,
 		"ssr/prefetch-timebox": true,
 		"stats/new-main-chart": true,
-		"stats/new-stats-module-component": true,
 		"stepper-woocommerce-poc": true,
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,


### PR DESCRIPTION
#### Proposed Changes

* Remove all usage of feature flag stats/new-stats-module-component.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up this change with the Calypso Live link.
* Navigate to the Stats page Traffic.
* Ensure everything on the page is the same as the previous one.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #70210 
