### PR TITLE
HelpCenter: fix broken tracks events

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/admin-bar.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/admin-bar.js
@@ -22,7 +22,7 @@ function AdminHelpCenterContent() {
 
 	const handleToggleHelpCenter = () => {
 		recordTracksEvent( `calypso_inlinehelp_${ show ? 'close' : 'show' }`, {
-			forceSiteId: true,
+			force_site_id: true,
 			location: 'help-center',
 			section: 'wp-admin',
 		} );

--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/help-center.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/help-center.js
@@ -25,7 +25,7 @@ function HelpCenterContent() {
 
 	const handleToggleHelpCenter = () => {
 		recordTracksEvent( `calypso_inlinehelp_${ show ? 'close' : 'show' }`, {
-			forceSiteId: true,
+			force_site_id: true,
 			location: 'help-center',
 			section: sectionName,
 		} );

--- a/client/layout/masterbar/masterbar-help-center.jsx
+++ b/client/layout/masterbar/masterbar-help-center.jsx
@@ -24,7 +24,7 @@ const MasterbarHelpCenter = ( { tooltip } ) => {
 
 	const handleToggleHelpCenter = () => {
 		recordTracksEvent( `calypso_inlinehelp_${ helpCenterVisible ? 'close' : 'show' }`, {
-			forceSiteId: true,
+			force_site_id: true,
 			location: 'help-center',
 			section: sectionName,
 		} );

--- a/client/lib/analytics/super-props.js
+++ b/client/lib/analytics/super-props.js
@@ -15,7 +15,7 @@ const getSuperProps = ( reduxStore ) => ( eventProperties ) => {
 	};
 
 	const omitSelectedSite =
-		! eventProperties.forceSiteId && shouldReportOmitBlogId( eventProperties.path );
+		! eventProperties.force_site_id && shouldReportOmitBlogId( eventProperties.path );
 	const selectedSite = omitSelectedSite ? null : getSelectedSite( state );
 
 	if ( selectedSite ) {

--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -185,7 +185,7 @@ export const HelpCenterContactForm = () => {
 		const supportVariation = getSupportVariationFromMode( mode );
 		recordTracksEvent( 'calypso_inlinehelp_contact_view', {
 			support_variation: supportVariation,
-			forceSiteId: true,
+			force_site_id: true,
 			location: 'help-center',
 			section: sectionName,
 		} );
@@ -265,7 +265,7 @@ export const HelpCenterContactForm = () => {
 				if ( supportSite ) {
 					recordTracksEvent( 'calypso_inlinehelp_contact_submit', {
 						support_variation: 'happychat',
-						forceSiteId: true,
+						force_site_id: true,
 						location: 'help-center',
 						section: sectionName,
 					} );
@@ -273,7 +273,7 @@ export const HelpCenterContactForm = () => {
 					recordTracksEvent( 'calypso_help_live_chat_begin', {
 						site_plan_product_id: productId,
 						is_automated_transfer: supportSite.is_wpcom_atomic,
-						forceSiteId: true,
+						force_site_id: true,
 						location: 'help-center',
 						section: sectionName,
 					} );
@@ -303,7 +303,7 @@ export const HelpCenterContactForm = () => {
 						.then( () => {
 							recordTracksEvent( 'calypso_inlinehelp_contact_submit', {
 								support_variation: 'kayako',
-								forceSiteId: true,
+								force_site_id: true,
 								location: 'help-center',
 								section: sectionName,
 							} );
@@ -334,7 +334,7 @@ export const HelpCenterContactForm = () => {
 					.then( ( response ) => {
 						recordTracksEvent( 'calypso_inlinehelp_contact_submit', {
 							support_variation: 'forums',
-							forceSiteId: true,
+							force_site_id: true,
 							location: 'help-center',
 							section: sectionName,
 						} );

--- a/packages/help-center/src/components/help-center-contact-page.tsx
+++ b/packages/help-center/src/components/help-center-contact-page.tsx
@@ -55,7 +55,7 @@ export const HelpCenterContactPage: React.FC = () => {
 			return;
 		}
 		recordTracksEvent( 'calypso_helpcenter_contact_options_impression', {
-			forceSiteId: true,
+			force_site_id: true,
 			location: 'help-center',
 			chat_available: renderChat.state === 'AVAILABLE',
 			email_available: renderEmail.render,
@@ -204,7 +204,7 @@ export const HelpCenterContactButton: React.FC = () => {
 
 	const trackContactButtonClicked = () => {
 		recordTracksEvent( 'calypso_inlinehelp_morehelp_click', {
-			forceSiteId: true,
+			force_site_id: true,
 			location: 'help-center',
 			section: sectionName,
 		} );

--- a/packages/help-center/src/components/help-center-content.tsx
+++ b/packages/help-center/src/components/help-center-content.tsx
@@ -30,7 +30,7 @@ const HelpCenterContent: React.FC = () => {
 			pathname: location.pathname,
 			search: location.search,
 			section,
-			forceSiteId: true,
+			force_site_id: true,
 			location: 'help-center',
 		} );
 	}, [ location, section ] );

--- a/packages/help-center/src/components/help-center-embed-result.tsx
+++ b/packages/help-center/src/components/help-center-embed-result.tsx
@@ -28,7 +28,7 @@ export const HelpCenterEmbedResult: React.FC = () => {
 	useEffect( () => {
 		const tracksData = {
 			search_query: query,
-			forceSiteId: true,
+			force_site_id: true,
 			location: 'help-center',
 			section: sectionName,
 			result_url: link,

--- a/packages/help-center/src/components/help-center-more-resources.tsx
+++ b/packages/help-center/src/components/help-center-more-resources.tsx
@@ -55,7 +55,7 @@ export const HelpCenterMoreResources = () => {
 		recordTracksEvent( 'calypso_help_moreresources_click', {
 			is_business_or_ecommerce_plan_user: isBusinessOrEcomPlanUser,
 			resource: resource,
-			forceSiteId: true,
+			force_site_id: true,
 			location: 'help-center',
 			section: sectionName,
 		} );
@@ -64,7 +64,7 @@ export const HelpCenterMoreResources = () => {
 	const trackWebinairsButtonClick = () => {
 		recordTracksEvent( 'calypso_help_courses_click', {
 			is_business_or_ecommerce_plan_user: isBusinessOrEcomPlanUser,
-			forceSiteId: true,
+			force_site_id: true,
 			location: 'help-center',
 			section: sectionName,
 		} );

--- a/packages/help-center/src/components/help-center-sibyl-articles.tsx
+++ b/packages/help-center/src/components/help-center-sibyl-articles.tsx
@@ -34,7 +34,7 @@ function recordSibylArticleClick(
 ) {
 	return () =>
 		recordTracksEvent( 'calypso_helpcenter_page_open_sibyl_article', {
-			forceSiteId: true,
+			force_site_id: true,
 			location: 'help-center',
 			article_link: article.link,
 			article_title: article.title,

--- a/packages/help-center/src/components/ticket-success-screen.tsx
+++ b/packages/help-center/src/components/ticket-success-screen.tsx
@@ -17,7 +17,7 @@ export const SuccessScreen: React.FC = () => {
 
 	const trackForumOpen = () =>
 		recordTracksEvent( 'calypso_inlinehelp_forums_open', {
-			forceSiteId: true,
+			force_site_id: true,
 			location: 'help-center',
 			section: sectionName,
 		} );


### PR DESCRIPTION
## Proposed Changes

This PR broke the tracks recording for Help Center events. The newly added prop was not in the correct case so it was rejected. Despite showing in the tracks vigilante where I was testing. This adjusts the property to be the correct case.

The Broken PR ⇢ https://github.com/Automattic/wp-calypso/pull/70710

<img width="1636" alt="Markup 2022-12-08 at 19 04 02" src="https://user-images.githubusercontent.com/33258733/206531409-97eb5d54-586e-485c-aa11-53c02dee7385.png">

## Testing Instructions

Open Local Calypso and use Tracks Vigilante to make sure the output is correct and check console for rejected errors.