### PR TITLE
E2E: fix timeouts in specs and POMs as required, part 2

### DIFF
--- a/packages/calypso-e2e/src/element-helper.ts
+++ b/packages/calypso-e2e/src/element-helper.ts
@@ -76,11 +76,9 @@ export async function clickNavTab(
 
 	// Mobile view - navtabs become a dropdown and thus it must be opened first.
 	if ( envVariables.VIEWPORT_NAME === 'mobile' ) {
-		await page.waitForLoadState( 'networkidle', { timeout: 25 * 1000 } );
-
 		// Open the Navtabs which now act as a pseudo-dropdown menu.
 		const navTabsButtonLocator = page.locator( selectors.navTabMobileToggleButton );
-		await navTabsButtonLocator.click();
+		await navTabsButtonLocator.click( { noWaitAfter: true } );
 
 		const navTabIsOpenLocator = page.locator( `${ navTabParent }.is-open` );
 		await navTabIsOpenLocator.waitFor();
@@ -90,18 +88,21 @@ export async function clickNavTab(
 	const navTabItem = page.locator( selectors.navTabItem( { name: name, selected: false } ) );
 	await Promise.all( [ page.waitForNavigation(), navTabItem.click() ] );
 
-	// Final verification.
+	// Final verification, check that we are now on the expected
+	// navtab.
 	const newSelectedTabLocator = page.locator(
 		selectors.navTabItem( { name: name, selected: true } )
 	);
 	const newSelectedTabName = await newSelectedTabLocator.innerText();
 
-	// Strip numerals from the extracted tab name, similar to above.
 	if ( newSelectedTabName.replace( /[0-9]|,/g, '' ) !== name ) {
 		throw new Error(
 			`Failed to confirm NavTab is active: expected ${ name }, got ${ newSelectedTabName }`
 		);
 	}
+
+	// Wait for all network activity to cease.
+	await page.waitForLoadState( 'networkidle', { timeout: 20 * 1000 } );
 }
 
 /**

--- a/packages/calypso-e2e/src/element-helper.ts
+++ b/packages/calypso-e2e/src/element-helper.ts
@@ -88,8 +88,7 @@ export async function clickNavTab(
 	const navTabItem = page.locator( selectors.navTabItem( { name: name, selected: false } ) );
 	await Promise.all( [ page.waitForNavigation(), navTabItem.click() ] );
 
-	// Final verification, check that we are now on the expected
-	// navtab.
+	// Final verification, check that we are now on the expected navtab.
 	const newSelectedTabLocator = page.locator(
 		selectors.navTabItem( { name: name, selected: true } )
 	);
@@ -100,9 +99,6 @@ export async function clickNavTab(
 			`Failed to confirm NavTab is active: expected ${ name }, got ${ newSelectedTabName }`
 		);
 	}
-
-	// Wait for all network activity to cease.
-	await page.waitForLoadState( 'networkidle', { timeout: 20 * 1000 } );
 }
 
 /**

--- a/packages/calypso-e2e/src/lib/components/editor-sidebar-block-inserter-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-sidebar-block-inserter-component.ts
@@ -72,10 +72,12 @@ export class EditorSidebarBlockInserterComponent {
 		let locator;
 
 		if ( type === 'pattern' ) {
-			locator = this.editor.locator( selectors.patternResultItem( name ) );
+			locator = this.editor.locator( selectors.patternResultItem( name ) ).first();
 		} else {
-			locator = this.editor.locator( selectors.blockResultItem( name ) );
+			locator = this.editor.locator( selectors.blockResultItem( name ) ).first();
 		}
-		await locator.first().click();
+
+		await Promise.all( [ locator.hover(), locator.focus() ] );
+		await locator.click();
 	}
 }

--- a/packages/calypso-e2e/src/lib/pages/marketing-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/marketing-page.ts
@@ -32,7 +32,6 @@ export class MarketingPage {
 	 */
 	async clickTab( name: string ): Promise< void > {
 		await clickNavTab( this.page, name );
-		await this.page.waitForLoadState( 'networkidle', { timeout: 20 * 1000 } );
 	}
 
 	/* SEO Preview Methods */

--- a/packages/calypso-e2e/src/lib/pages/plugins-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plugins-page.ts
@@ -77,12 +77,7 @@ export class PluginsPage {
 	 * @param {string} site Optional site URL.
 	 */
 	async visit( site = '' ): Promise< void > {
-		await this.page.goto( getCalypsoURL( `plugins/${ site }` ), {
-			waitUntil: 'networkidle',
-			// Manual override of the timeout - `networkidle` can take longer
-			// to fire, especially for Simple sites.
-			timeout: 20 * 1000,
-		} );
+		await this.page.goto( getCalypsoURL( `plugins/${ site }` ) );
 	}
 
 	/**

--- a/test/e2e/specs/fse/fse__temp-smoke-test.ts
+++ b/test/e2e/specs/fse/fse__temp-smoke-test.ts
@@ -48,11 +48,6 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 	} );
 
 	it( 'Editor canvas loads', async function () {
-		// Because this is a temporary smoke test, adding the needed FSE selectors here instead of
-		// spinning up a POM class that we will later needed to redo.
-		// This should ensure the editor hasn't done a WSoD.
-		await page.waitForLoadState( 'networkidle', { timeout: 30 * 1000 } );
-
 		fullSiteEditorPage = new FullSiteEditorPage( page, { target: features.siteType } );
 		await fullSiteEditorPage.waitUntilLoaded();
 	} );

--- a/test/e2e/specs/plugins/plugins__search.ts
+++ b/test/e2e/specs/plugins/plugins__search.ts
@@ -2,7 +2,13 @@
  * @group calypso-pr
  */
 
-import { DataHelper, TestAccount, PluginsPage, envVariables } from '@automattic/calypso-e2e';
+import {
+	DataHelper,
+	TestAccount,
+	PluginsPage,
+	envVariables,
+	SidebarComponent,
+} from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
 
 declare const browser: Browser;
@@ -22,12 +28,13 @@ describe( DataHelper.createSuiteTitle( 'Plugins search' ), function () {
 		}
 	} );
 
-	it( 'Visit plugins page', async function () {
-		pluginsPage = new PluginsPage( page );
-		await pluginsPage.visit();
+	it( 'Navigate to the plugins page', async function () {
+		const sidebarCompoonent = new SidebarComponent( page );
+		await sidebarCompoonent.navigate( 'Plugins' );
 	} );
 
 	it( 'Search for "shipping"', async function () {
+		pluginsPage = new PluginsPage( page );
 		await pluginsPage.search( 'shipping' );
 		await pluginsPage.validateExpectedSearchResultFound( 'Royal Mail' );
 	} );


### PR DESCRIPTION
#### Proposed Changes

This PR selectively corrects timeouts and/or waits in specs and POMs. This is a follow-up to https://github.com/Automattic/wp-calypso/pull/70606 which itself is a follow-up to https://github.com/Automattic/wp-calypso/pull/70392.

#### Testing Instructions

Ensure the following build configurations are passing:
  - [x] Gutenberg E2E (desktop)
  - [x] Gutenberg E2E (mobile)
  - [x] Calypso E2E (desktop)
  - [x] Calypso E2E (mobile)
  - [x] Pre-Release E2E

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
