### PR TITLE
Rely on GS to preview accent color

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/launchpad-site-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/launchpad-site-preview.tsx
@@ -4,7 +4,6 @@ import { useTranslate } from 'i18n-calypso';
 import { DEVICE_TYPE } from 'calypso/../packages/design-picker/src/constants';
 import { Device } from 'calypso/../packages/design-picker/src/types';
 import WebPreview from 'calypso/components/web-preview/component';
-import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { usePremiumGlobalStyles } from 'calypso/state/sites/hooks/use-premium-global-styles';
 import PreviewToolbar from '../design-setup/preview-toolbar';
 
@@ -16,7 +15,6 @@ const LaunchpadSitePreview = ( {
 	flow: string | null;
 } ) => {
 	const translate = useTranslate();
-	const color = useQuery().get( 'color' );
 	const { globalStylesInUse, shouldLimitGlobalStyles } = usePremiumGlobalStyles();
 
 	const previewUrl = siteSlug ? 'https://' + siteSlug : null;
@@ -42,7 +40,6 @@ const LaunchpadSitePreview = ( {
 			// hide cookies popup
 			preview: true,
 			do_preview_no_interactions: ! isVideoPressFlow,
-			...( color && { preview_accent_color: color } ),
 			...( globalStylesInUse && shouldLimitGlobalStyles && { 'preview-global-styles': true } ),
 		} );
 	}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/launchpad-site-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/launchpad-site-preview.tsx
@@ -5,6 +5,7 @@ import { DEVICE_TYPE } from 'calypso/../packages/design-picker/src/constants';
 import { Device } from 'calypso/../packages/design-picker/src/types';
 import WebPreview from 'calypso/components/web-preview/component';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
+import { usePremiumGlobalStyles } from 'calypso/state/sites/hooks/use-premium-global-styles';
 import PreviewToolbar from '../design-setup/preview-toolbar';
 
 const LaunchpadSitePreview = ( {
@@ -16,6 +17,8 @@ const LaunchpadSitePreview = ( {
 } ) => {
 	const translate = useTranslate();
 	const color = useQuery().get( 'color' );
+	const { globalStylesInUse, shouldLimitGlobalStyles } = usePremiumGlobalStyles();
+
 	const previewUrl = siteSlug ? 'https://' + siteSlug : null;
 	const devicesToShow: Device[] = [ DEVICE_TYPE.COMPUTER, DEVICE_TYPE.PHONE ];
 	let defaultDevice = flow === NEWSLETTER_FLOW ? DEVICE_TYPE.COMPUTER : DEVICE_TYPE.PHONE;
@@ -40,6 +43,7 @@ const LaunchpadSitePreview = ( {
 			preview: true,
 			do_preview_no_interactions: ! isVideoPressFlow,
 			...( color && { preview_accent_color: color } ),
+			...( globalStylesInUse && shouldLimitGlobalStyles && { 'preview-global-styles': true } ),
 		} );
 	}
 


### PR DESCRIPTION
#### Proposed Changes
   
Newsletter accent colours are implemented using Global Styles. They are
previewed using an accent color specific parameter and serverside code
(D89679-code). PR #70834 introduces a more generic method of previewing,
which previews all of the global styles for a site.
    
This change removes the accent colour specific preview so we can just
rely on the generic global styles preview implementation.

Note that this PR is branched from PR #70834

Post-merge, I'll revert D89679-code

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Open `/setup/newsletter/newsletterSetup` in a dev environment to get the correct feature flag (`limit-global-styles`).
2. Pick a "premium" color.
3. As soon as the site is created, add the `wpcom-limit-global-styles` sticker.
4. Get to the Launchpad's last step.
5. ➡️ Ensure the preview is using the "premium" color.

![image](https://user-images.githubusercontent.com/93301/206534495-c5811b2f-01a8-4fe3-a19a-8508308037c5.png)


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
  - No - it's an onboarding feature and can only be a simple site 
- [x] Have you checked for TypeScript, React or other console errors?
  - Didn't see anything new
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
  - There are no expensive computations
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
  - There are no new strings computations
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
  - Not relevant to Jetpack, it's a wpcom specific onboarding change.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
