### PR TITLE
Change CCPA default opt mechanism to opt-out

### DIFF
--- a/client/lib/analytics/utils/get-tracking-prefs.ts
+++ b/client/lib/analytics/utils/get-tracking-prefs.ts
@@ -26,7 +26,7 @@ const allowTrackingPrefs: TrackingPrefs = {
 const disallowTrackingPrefs: TrackingPrefs = {
 	ok: false,
 	buckets: {
-		essential: false,
+		essential: true,
 		analytics: false,
 		advertising: false,
 	},

--- a/client/lib/analytics/utils/get-tracking-prefs.ts
+++ b/client/lib/analytics/utils/get-tracking-prefs.ts
@@ -49,8 +49,8 @@ export const parseTrackingPrefs = (
 		};
 	} else if ( cookieV1 && [ 'yes', 'no' ].includes( cookieV1 ) ) {
 		return {
-			...prefsAllowAll,
 			ok: cookieV1 === 'yes',
+			buckets: prefsAllowAll.buckets,
 		};
 	}
 
@@ -77,11 +77,13 @@ export default function getTrackingPrefs(): TrackingPrefs {
 		return prefsAllowAll;
 	}
 
+	// default tracking mechanism for GDPR is opt-in, for CCPA is opt-out:
+	const defaultPrefs = isCountryGdpr ? prefsDisallowAll : prefsAllowAll;
+
 	const { ok, buckets } = parseTrackingPrefs(
 		cookies[ TRACKING_PREFS_COOKIE_V2 ],
 		cookies[ TRACKING_PREFS_COOKIE_V1 ],
-		// default tracking mechanism for GDPR is opt-in, for CCPA is opt-out:
-		isCountryGdpr ? prefsDisallowAll : prefsAllowAll
+		defaultPrefs
 	);
 
 	if ( isCountryCcpa ) {

--- a/client/lib/analytics/utils/get-tracking-prefs.ts
+++ b/client/lib/analytics/utils/get-tracking-prefs.ts
@@ -26,14 +26,18 @@ const allBucketsTrue: TrackingPrefs[ 'buckets' ] = {
 	advertising: true,
 };
 
-export const parseTrackingPrefs = ( cookieV2?: string, cookieV1?: string ): TrackingPrefs => {
+export const parseTrackingPrefs = (
+	cookieV2?: string,
+	cookieV1?: string,
+	defaultBuckets = allBucketsFalse
+): TrackingPrefs => {
 	const { ok, buckets }: Partial< TrackingPrefs > = cookieV2 ? JSON.parse( cookieV2 ) : {};
 
 	if ( typeof ok === 'boolean' ) {
 		return {
 			ok,
 			buckets: {
-				...allBucketsFalse,
+				...defaultBuckets,
 				...buckets,
 			},
 		};
@@ -46,7 +50,7 @@ export const parseTrackingPrefs = ( cookieV2?: string, cookieV1?: string ): Trac
 
 	return {
 		ok: false,
-		buckets: allBucketsFalse,
+		buckets: defaultBuckets,
 	};
 };
 
@@ -76,6 +80,8 @@ export default function getTrackingPrefs(): TrackingPrefs {
 
 	return parseTrackingPrefs(
 		cookies[ TRACKING_PREFS_COOKIE_V2 ],
-		cookies[ TRACKING_PREFS_COOKIE_V1 ]
+		cookies[ TRACKING_PREFS_COOKIE_V1 ],
+		// default tracking mechanism for GDPR is opt-in, for CCPA is opt-out:
+		isCountryInGdprZone( cookies.country_code ) ? allBucketsFalse : allBucketsTrue
 	);
 }


### PR DESCRIPTION
#### Proposed Changes

- Implement an opt-out mechanism for CCPA
- Limit buckets to advertising for CCPA

#### Testing Instructions

* Ensure `ad-tracking` is enabled on your development environment
* Launch Calypso
* Make sure you have you don't have "sensitive_pixel_option" (legacy) cookie in your session: `document.cookie='sensitive_pixel_option=; expires=Thu, 01 Jan 1970 00:00:01 GMT;'`
* * Make sure you have you don't have "sensitive_pixel_options" cookie in your session: `document.cookie='sensitive_pixel_options=; expires=Thu, 01 Jan 1970 00:00:01 GMT;'`
* Change your region to US California: `document.cookie = 'country_code=US'; document.cookie = 'region=California';`
* Go to `http://calypso.localhost:3001/me/privacy?flags=ad-tracking
* Notice that FB Pixel is loading: `https://connect.facebook.net/signals/config/` script is included in page DOM
* Add cookie to disallow advertising: `document.cookie = 'sensitive_pixel_options=%7B%22version%22%3A20201224%2C%22ok%22%3Afalse%2C%22buckets%22%3A%7B%22essential%22%3Atrue%2C%22analytics%22%3Afalse%2C%22advertising%22%3Afalse%7D%7D';`
* Reload the page
* Notice that FB Pixel is not loading: `https://connect.facebook.net/signals/config/` script is NOT included in page DOM

Related to #66493 and #70552
