### PR TITLE
Include more details about how backup works on vaultpress backup cloud copy

### DIFF
--- a/client/components/jetpack/daily-backup-status/status-card/backup-tips.tsx
+++ b/client/components/jetpack/daily-backup-status/status-card/backup-tips.tsx
@@ -27,18 +27,7 @@ const BackupTips: React.FC< BackupTipsProps > = ( { location } ) => {
 								<b>{ translate( 'Did you know' ) }</b>
 							</div>
 							{ translate(
-								'The initial backup time depends on the size of your site and the stability of the connection. Subsequent backups are usually faster! {{link}}Learn more{{/link}}',
-								{
-									components: {
-										link: (
-											<a
-												href="https://jetpack.com/support/backup/"
-												target="_blank"
-												rel="noopener noreferrer"
-											/>
-										),
-									},
-								}
+								"We store your site backups securely in the cloud, with multiple copies saved across our global server network, so you'll never lose your content."
 							) }
 						</div>
 					)

--- a/client/my-sites/backup/backups-made-realtime-banner.tsx
+++ b/client/my-sites/backup/backups-made-realtime-banner.tsx
@@ -16,7 +16,7 @@ const BackupsMadeRealtimeBanner: FunctionComponent = () => {
 			callToAction={ translate( 'Learn more' ) }
 			className="backups-made-realtime-banner"
 			description={ translate(
-				'Your site is backed up as you make edits, and automatically once a day.'
+				'Your site is backed up as you edit, with multiple copies stored securely in the cloud'
 			) }
 			event="calypso_backups_made_realtime_banner"
 			dismissPreferenceName={ `backups-made-realtime-${ siteId }` }


### PR DESCRIPTION
#### Proposed Changes

Update copy on VaultPress Backup section of Jetpack Cloud to include information about how we save backups on multiple servers, etc.

Context: 1161179020265237-as-1203422028221773/f

Design:
![image](https://user-images.githubusercontent.com/65001528/206559234-6dbf8520-bb05-4b39-9d91-47854522ab46.png)

#### Testing Instructions

* Check out these changes via git switch update/jetpack-backup-copy-text
* Start up calypso via `yarn start-jetpack-cloud`
* Set up a jurassic ninja site with Jetpack VaultPress Backup installed and a subscription paid for
* Go to http://jetpack.cloud.localhost:3000/backup/{site-name}
* Fill out the server credentials to enable Jetpack Backup on the site
* You should now see the banner that looks like a JITM near the top of the page
![image](https://user-images.githubusercontent.com/65001528/206559069-f93ca70a-1e7f-40d5-8029-c54b15afdb4a.png)
* Ensure it matches the copy in the design
* To get the second part to show up, I had to go this line of text: 2e6d5-pb and replace the condition with `true`
* Go back to the page and refresh, you should now see the "Did you know" section
![image](https://user-images.githubusercontent.com/65001528/206559693-1c763e81-a43a-477c-b737-474f4a0cb2ae.png)
* Ensure the second section matches the copy in the design as well

#### Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?