### PR TITLE
E2E: remove check for media storage capacity on WordPress.com Business spec.

### DIFF
--- a/test/e2e/specs/plans/plans__signup-business.ts
+++ b/test/e2e/specs/plans/plans__signup-business.ts
@@ -12,7 +12,6 @@ import {
 	CartCheckoutPage,
 	TestAccount,
 	SignupDomainPage,
-	MediaPage,
 	NewSiteResponse,
 } from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
@@ -89,12 +88,6 @@ describe(
 				sidebarComponent = new SidebarComponent( page );
 				const currentPlan = await sidebarComponent.getCurrentPlanName();
 				expect( currentPlan ).toBe( planName );
-			} );
-
-			it( 'Validate storage capacity', async function () {
-				await sidebarComponent.navigate( 'Media' );
-				const mediaPage = new MediaPage( page );
-				expect( await mediaPage.hasStorageCapacity( 200 ) ).toBe( true );
 			} );
 		} );
 


### PR DESCRIPTION
#### Proposed Changes

This PR removes a step from the `Signup: Business` suite that is too closely tied to the exact implementation of a plan.

Key changes:
- remove test step checking for storage capacity

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Ensure the following build configurations are passing:
  - [x] Pre-Release E2E

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #70955.
