### PR TITLE
E2E: disable Chromium from using shared memory.

### DIFF
--- a/.teamcity/_self/bashNodeScript.kt
+++ b/.teamcity/_self/bashNodeScript.kt
@@ -33,7 +33,7 @@ fun BuildSteps.bashNodeScript(init: ScriptBuildStep.() -> Unit): ScriptBuildStep
 	result.dockerImagePlatform = ScriptBuildStep.ImagePlatform.Linux
 	result.dockerPull = true
 	result.dockerImage = result.dockerImage ?: "%docker_image%"
-	result.dockerRunParameters = result.dockerRunParameters ?: "-u %env.UID% --disable-dev-shm-usage"
+	result.dockerRunParameters = result.dockerRunParameters ?: "-u %env.UID% --shm-size=1g"
 	step(result)
 	return result
 }

--- a/.teamcity/_self/bashNodeScript.kt
+++ b/.teamcity/_self/bashNodeScript.kt
@@ -33,7 +33,7 @@ fun BuildSteps.bashNodeScript(init: ScriptBuildStep.() -> Unit): ScriptBuildStep
 	result.dockerImagePlatform = ScriptBuildStep.ImagePlatform.Linux
 	result.dockerPull = true
 	result.dockerImage = result.dockerImage ?: "%docker_image%"
-	result.dockerRunParameters = result.dockerRunParameters ?: "-u %env.UID%"
+	result.dockerRunParameters = result.dockerRunParameters ?: "-u %env.UID% --disable-dev-shm-usage"
 	step(result)
 	return result
 }

--- a/.teamcity/_self/bashNodeScript.kt
+++ b/.teamcity/_self/bashNodeScript.kt
@@ -33,7 +33,7 @@ fun BuildSteps.bashNodeScript(init: ScriptBuildStep.() -> Unit): ScriptBuildStep
 	result.dockerImagePlatform = ScriptBuildStep.ImagePlatform.Linux
 	result.dockerPull = true
 	result.dockerImage = result.dockerImage ?: "%docker_image%"
-	result.dockerRunParameters = result.dockerRunParameters ?: "-u %env.UID% --shm-size=1g"
+	result.dockerRunParameters = result.dockerRunParameters ?: "-u %env.UID%"
 	step(result)
 	return result
 }

--- a/packages/calypso-e2e/src/jest-playwright-config/environment.ts
+++ b/packages/calypso-e2e/src/jest-playwright-config/environment.ts
@@ -160,6 +160,7 @@ class JestEnvironmentPlaywright extends NodeEnvironment {
 		// Start the browser.
 		const browser = await browserType.launch( {
 			...config.launchOptions,
+			args: browserType === chromium ? [ '--disable-dev-shm-usage' ] : [], // Disable shm usage only for Chromium
 			logger: {
 				log: async ( name: string, severity: string, message: string ) => {
 					await fs.appendFile(


### PR DESCRIPTION
#### Proposed Changes

This PR attempts to fix the intermittent page crash observed in the CI environment.

Key changes:
- disable shared memory usage when launching Chromium.

#### Testing Instructions

Ensure the following build configurations are passing:
  - [x] Calypso E2E (desktop)
  - [x] Calypso E2E (mobile)
  - [x] Pre-Release E2E

I also ran a fairly large number of builds (manually) across both desktop and mobile viewports, and I did not observe the crash for this branch.

![image](https://user-images.githubusercontent.com/6549265/206590155-577e08b0-449f-4afe-b13c-eb0f275ae307.png)


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #70674