### PR TITLE
Update agency company information forms

### DIFF
--- a/client/jetpack-cloud/sections/agency-signup/agency-signup-form/index.tsx
+++ b/client/jetpack-cloud/sections/agency-signup/agency-signup-form/index.tsx
@@ -35,8 +35,7 @@ export default function AgencySignupForm() {
 			let message = error.message;
 
 			if ( error.code === 'rest_invalid_param' && typeof error?.data?.params !== 'undefined' ) {
-				const details = error?.data?.details ?? {};
-				message = translateInvalidPartnerParameterError( error.data.params, details );
+				message = translateInvalidPartnerParameterError( error.data.params, error.data.details );
 			}
 
 			dispatch( errorNotice( message, { id: notificationId } ) );

--- a/client/jetpack-cloud/sections/agency-signup/agency-signup-form/index.tsx
+++ b/client/jetpack-cloud/sections/agency-signup/agency-signup-form/index.tsx
@@ -35,7 +35,8 @@ export default function AgencySignupForm() {
 			let message = error.message;
 
 			if ( error.code === 'rest_invalid_param' && typeof error?.data?.params !== 'undefined' ) {
-				message = translateInvalidPartnerParameterError( error.data.params, error.data.details );
+				const details = error?.data?.details ?? {};
+				message = translateInvalidPartnerParameterError( error.data.params, details );
 			}
 
 			dispatch( errorNotice( message, { id: notificationId } ) );

--- a/client/jetpack-cloud/sections/agency-signup/agency-signup-form/index.tsx
+++ b/client/jetpack-cloud/sections/agency-signup/agency-signup-form/index.tsx
@@ -35,7 +35,7 @@ export default function AgencySignupForm() {
 			let message = error.message;
 
 			if ( error.code === 'rest_invalid_param' && typeof error?.data?.params !== 'undefined' ) {
-				message = translateInvalidPartnerParameterError( error.data.params );
+				message = translateInvalidPartnerParameterError( error.data.params, error.data.details );
 			}
 
 			dispatch( errorNotice( message, { id: notificationId } ) );

--- a/client/jetpack-cloud/sections/partner-portal/update-company-details-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/update-company-details-form/index.tsx
@@ -42,7 +42,8 @@ export default function UpdateCompanyDetailsForm() {
 			let message = error.message;
 
 			if ( error.code === 'rest_invalid_param' && typeof error?.data?.params !== 'undefined' ) {
-				message = translateInvalidPartnerParameterError( error.data.params, error.data.details );
+				const details = error?.data?.details ?? {};
+				message = translateInvalidPartnerParameterError( error.data.params, details );
 			}
 
 			dispatch( errorNotice( message, { id: notificationId } ) );

--- a/client/jetpack-cloud/sections/partner-portal/update-company-details-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/update-company-details-form/index.tsx
@@ -42,7 +42,7 @@ export default function UpdateCompanyDetailsForm() {
 			let message = error.message;
 
 			if ( error.code === 'rest_invalid_param' && typeof error?.data?.params !== 'undefined' ) {
-				message = translateInvalidPartnerParameterError( error.data.params );
+				message = translateInvalidPartnerParameterError( error.data.params, error.data.details );
 			}
 
 			dispatch( errorNotice( message, { id: notificationId } ) );

--- a/client/jetpack-cloud/sections/partner-portal/update-company-details-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/update-company-details-form/index.tsx
@@ -42,8 +42,7 @@ export default function UpdateCompanyDetailsForm() {
 			let message = error.message;
 
 			if ( error.code === 'rest_invalid_param' && typeof error?.data?.params !== 'undefined' ) {
-				const details = error?.data?.details ?? {};
-				message = translateInvalidPartnerParameterError( error.data.params, details );
+				message = translateInvalidPartnerParameterError( error.data.params, error.data.details );
 			}
 
 			dispatch( errorNotice( message, { id: notificationId } ) );

--- a/client/state/partner-portal/partner/utils.ts
+++ b/client/state/partner-portal/partner/utils.ts
@@ -6,7 +6,7 @@ import { sprintf, __ } from '@wordpress/i18n';
  * @param {object} parameters Parameters with errors.
  * @returns {string} Human-readable error message.
  */
-export function translateInvalidPartnerParameterError( parameters: object ) {
+export function translateInvalidPartnerParameterError( parameters: object, details: object ) {
 	const labels: { [ key: string ]: string } = {
 		name: __( 'Company name' ),
 		contact_person: __( 'Contact person' ),
@@ -23,6 +23,13 @@ export function translateInvalidPartnerParameterError( parameters: object ) {
 		return labels[ field ] || field;
 	} );
 
+	if ( 'company_website' in details ) {
+		return sprintf(
+			// Translators: %s = comma-separated list of form fields that need to be filled in by the user.
+			__( 'The following fields are required and must be valid: %s' ),
+			fieldNames.join( ', ' )
+		);
+	}
 	// Translators: %s = comma-separated list of form fields that need to be filled in by the user.
 	return sprintf( __( 'The following fields are required: %s' ), fieldNames.join( ', ' ) );
 }

--- a/client/state/partner-portal/partner/utils.ts
+++ b/client/state/partner-portal/partner/utils.ts
@@ -7,7 +7,7 @@ import { sprintf, __ } from '@wordpress/i18n';
  * @param {object} details Details of parameters with errors.
  * @returns {string} Human-readable error message.
  */
-export function translateInvalidPartnerParameterError( parameters: object, details: object ) {
+export function translateInvalidPartnerParameterError( parameters: object, details = {} ) {
 	const labels: { [ key: string ]: string } = {
 		name: __( 'Company name' ),
 		contact_person: __( 'Contact person' ),

--- a/client/state/partner-portal/partner/utils.ts
+++ b/client/state/partner-portal/partner/utils.ts
@@ -4,6 +4,7 @@ import { sprintf, __ } from '@wordpress/i18n';
  * Translate a REST API rest_invalid_param error message.
  *
  * @param {object} parameters Parameters with errors.
+ * @param {object} details Details of parameters with errors.
  * @returns {string} Human-readable error message.
  */
 export function translateInvalidPartnerParameterError( parameters: object, details: object ) {


### PR DESCRIPTION
Update the error message when on the agency sign up form and company update form to indicate when an invalid domain name has been entered.

#### Proposed Changes

* Update the error messaging for creating and updating company information to include when domain information is entered but invalid.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this PR.
* Run `yarn-start-jetpack-cloud` and visit `http://jetpack.cloud.localhost:3000/partner-portal/company-details`.
* Attempt to save the `Company website` field without a value and ensure that this still returns an error indicating that the value is required.
* Attempt to save the same field with an invalid domain name (a space in the domain, or no TLD) and ensure that the error message also indicates that the value must be valid.

<img width="641" alt="Screenshot 2022-12-12 at 4 26 00 PM" src="https://user-images.githubusercontent.com/1273880/207181322-e5fc9163-30bb-409d-b872-e577f9f8b6c3.png">


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
