### PR TITLE
Sites Sorting: Demote hidden sites to the bottom of the list

### DIFF
--- a/packages/sites/src/use-sites-list-sorting.tsx
+++ b/packages/sites/src/use-sites-list-sorting.tsx
@@ -4,10 +4,13 @@ import { MinimumSite } from './site-type';
 
 type SiteDetailsForSortingWithOptionalUserInteractions = Pick<
 	MinimumSite,
-	'title' | 'user_interactions' | 'options'
+	'title' | 'user_interactions' | 'options' | 'visible'
 >;
 
-type SiteDetailsForSortingWithUserInteractions = Pick< MinimumSite, 'title' | 'options' > &
+type SiteDetailsForSortingWithUserInteractions = Pick<
+	MinimumSite,
+	'title' | 'options' | 'visible'
+> &
 	Required< Pick< MinimumSite, 'user_interactions' > >;
 
 export type SiteDetailsForSorting =
@@ -139,15 +142,20 @@ function sortSitesByLastInteractedWith< T extends SiteDetailsForSorting >(
 	sites: T[],
 	sortOrder: SitesSortOrder
 ) {
-	const interactedItems = ( sites as SiteDetailsForSorting[] ).filter( hasInteractions );
+	const interactedItems = ( sites as SiteDetailsForSorting[] )
+		.filter( hasInteractions )
+		.filter( ( site ) => site?.visible !== false );
 
-	const remainingItems = sites.filter(
-		( site ) => ! site.user_interactions || site.user_interactions.length === 0
-	);
+	const remainingItems = sites
+		.filter( ( site ) => ! site.user_interactions || site.user_interactions.length === 0 )
+		.filter( ( site ) => site?.visible !== false );
+
+	const hiddenItems = sites.filter( ( site ) => site?.visible === false );
 
 	const sortedItems = [
 		...( sortInteractedItems( interactedItems ) as T[] ),
 		...remainingItems.sort( ( a, b ) => sortAlphabetically( a, b, 'asc' ) ),
+		...hiddenItems.sort( ( a, b ) => sortAlphabetically( a, b, 'asc' ) ),
 	];
 
 	return sortOrder === 'desc' ? sortedItems : sortedItems.reverse();

--- a/packages/sites/tests/use-sites-list-sorting.test.ts
+++ b/packages/sites/tests/use-sites-list-sorting.test.ts
@@ -14,6 +14,7 @@ describe( 'useSitesSorting', () => {
 				updated_at: '2022-05-27T07:19:20+00:00',
 			},
 			user_interactions: [ '2022-09-13' ],
+			visible: true,
 		},
 		{
 			ID: 2,
@@ -22,6 +23,7 @@ describe( 'useSitesSorting', () => {
 				updated_at: '2022-07-13T17:17:12+00:00',
 			},
 			user_interactions: [ '2022-09-14' ],
+			visible: true,
 		},
 		{
 			ID: 3,
@@ -29,6 +31,16 @@ describe( 'useSitesSorting', () => {
 			options: {
 				updated_at: '2022-06-14T13:32:34+00:00',
 			},
+			visible: true,
+		},
+		{
+			ID: 4,
+			title: 'B2',
+			options: {
+				updated_at: '2022-05-27T07:19:20+00:00',
+			},
+			user_interactions: [ '2022-09-13' ],
+			visible: false,
 		},
 	];
 	const frequentSites = [
@@ -66,10 +78,11 @@ describe( 'useSitesSorting', () => {
 			} )
 		);
 
-		expect( result.current.length ).toBe( 3 );
+		expect( result.current.length ).toBe( 4 );
 		expect( result.current[ 0 ].ID ).toBe( 1 );
 		expect( result.current[ 1 ].ID ).toBe( 2 );
 		expect( result.current[ 2 ].ID ).toBe( 3 );
+		expect( result.current[ 3 ].ID ).toBe( 4 );
 	} );
 
 	test( 'should sort sites alphabetically ascending', () => {
@@ -80,10 +93,11 @@ describe( 'useSitesSorting', () => {
 			} )
 		);
 
-		expect( result.current.length ).toBe( 3 );
+		expect( result.current.length ).toBe( 4 );
 		expect( result.current[ 0 ].title ).toBe( 'A' );
 		expect( result.current[ 1 ].title ).toBe( 'B' );
-		expect( result.current[ 2 ].title ).toBe( 'C' );
+		expect( result.current[ 2 ].title ).toBe( 'B2' );
+		expect( result.current[ 3 ].title ).toBe( 'C' );
 	} );
 
 	test( 'should sort sites alphabetically descending', () => {
@@ -94,10 +108,11 @@ describe( 'useSitesSorting', () => {
 			} )
 		);
 
-		expect( result.current.length ).toBe( 3 );
+		expect( result.current.length ).toBe( 4 );
 		expect( result.current[ 0 ].title ).toBe( 'C' );
-		expect( result.current[ 1 ].title ).toBe( 'B' );
-		expect( result.current[ 2 ].title ).toBe( 'A' );
+		expect( result.current[ 1 ].title ).toBe( 'B2' );
+		expect( result.current[ 2 ].title ).toBe( 'B' );
+		expect( result.current[ 3 ].title ).toBe( 'A' );
 	} );
 
 	test( 'should sort sites by last interaction descending', () => {
@@ -108,10 +123,11 @@ describe( 'useSitesSorting', () => {
 			} )
 		);
 
-		expect( result.current.length ).toBe( 3 );
+		expect( result.current.length ).toBe( 4 );
 		expect( result.current[ 0 ].title ).toBe( 'A' );
 		expect( result.current[ 1 ].title ).toBe( 'B' );
 		expect( result.current[ 2 ].title ).toBe( 'C' );
+		expect( result.current[ 3 ].title ).toBe( 'B2' );
 	} );
 
 	test( 'should sort sites by last interaction ascending', () => {
@@ -122,10 +138,11 @@ describe( 'useSitesSorting', () => {
 			} )
 		);
 
-		expect( result.current.length ).toBe( 3 );
-		expect( result.current[ 0 ].title ).toBe( 'C' );
-		expect( result.current[ 1 ].title ).toBe( 'B' );
-		expect( result.current[ 2 ].title ).toBe( 'A' );
+		expect( result.current.length ).toBe( 4 );
+		expect( result.current[ 0 ].title ).toBe( 'B2' );
+		expect( result.current[ 1 ].title ).toBe( 'C' );
+		expect( result.current[ 2 ].title ).toBe( 'B' );
+		expect( result.current[ 3 ].title ).toBe( 'A' );
 	} );
 
 	test( 'should pick the site more frequently interacted with ascending', () => {
@@ -162,10 +179,11 @@ describe( 'useSitesSorting', () => {
 			} )
 		);
 
-		expect( result.current.length ).toBe( 3 );
+		expect( result.current.length ).toBe( 4 );
 		expect( result.current[ 0 ].ID ).toBe( 2 );
 		expect( result.current[ 1 ].ID ).toBe( 3 );
 		expect( result.current[ 2 ].ID ).toBe( 1 );
+		expect( result.current[ 3 ].ID ).toBe( 4 );
 	} );
 
 	test( 'should sort sites by updatedAt ascending', () => {
@@ -176,10 +194,11 @@ describe( 'useSitesSorting', () => {
 			} )
 		);
 
-		expect( result.current.length ).toBe( 3 );
+		expect( result.current.length ).toBe( 4 );
 		expect( result.current[ 0 ].ID ).toBe( 1 );
-		expect( result.current[ 1 ].ID ).toBe( 3 );
-		expect( result.current[ 2 ].ID ).toBe( 2 );
+		expect( result.current[ 1 ].ID ).toBe( 4 );
+		expect( result.current[ 2 ].ID ).toBe( 3 );
+		expect( result.current[ 3 ].ID ).toBe( 2 );
 	} );
 
 	test( 'sorting maintains object equality', () => {
@@ -195,31 +214,35 @@ describe( 'useSitesSorting', () => {
 			}
 		);
 
-		expect( result.current ).toHaveLength( 3 );
+		expect( result.current ).toHaveLength( 4 );
 		expect( result.current[ 0 ] ).toBe( filteredSites[ 0 ] );
-		expect( result.current[ 1 ] ).toBe( filteredSites[ 2 ] );
-		expect( result.current[ 2 ] ).toBe( filteredSites[ 1 ] );
+		expect( result.current[ 1 ] ).toBe( filteredSites[ 3 ] );
+		expect( result.current[ 2 ] ).toBe( filteredSites[ 2 ] );
+		expect( result.current[ 3 ] ).toBe( filteredSites[ 1 ] );
 
 		rerender( { sortKey: 'updatedAt', sortOrder: 'desc' } );
 
-		// A (1) -> C (2) -> B (0)
-		expect( result.current ).toHaveLength( 3 );
+		// A (1) -> C (2) -> B (0) -> B2 (4)
+		expect( result.current ).toHaveLength( 4 );
 		expect( result.current[ 0 ] ).toBe( filteredSites[ 1 ] );
 		expect( result.current[ 1 ] ).toBe( filteredSites[ 2 ] );
 		expect( result.current[ 2 ] ).toBe( filteredSites[ 0 ] );
+		expect( result.current[ 3 ] ).toBe( filteredSites[ 3 ] );
 
-		// A (1) -> B (0) -> C (2)
+		// A (1) -> B (0) -> B2 (4) -> C (2)
 		rerender( { sortKey: 'alphabetically', sortOrder: 'asc' } );
-		expect( result.current ).toHaveLength( 3 );
+		expect( result.current ).toHaveLength( 4 );
 		expect( result.current[ 0 ] ).toBe( filteredSites[ 1 ] );
 		expect( result.current[ 1 ] ).toBe( filteredSites[ 0 ] );
-		expect( result.current[ 2 ] ).toBe( filteredSites[ 2 ] );
+		expect( result.current[ 2 ] ).toBe( filteredSites[ 3 ] );
+		expect( result.current[ 3 ] ).toBe( filteredSites[ 2 ] );
 
-		// A (1) -> B (0) -> C (2)
+		// A (1) -> B (0) -> C (2) -> B2 (4)
 		rerender( { sortKey: 'lastInteractedWith', sortOrder: 'desc' } );
-		expect( result.current ).toHaveLength( 3 );
+		expect( result.current ).toHaveLength( 4 );
 		expect( result.current[ 0 ] ).toBe( filteredSites[ 1 ] );
 		expect( result.current[ 1 ] ).toBe( filteredSites[ 0 ] );
 		expect( result.current[ 2 ] ).toBe( filteredSites[ 2 ] );
+		expect( result.current[ 3 ] ).toBe( filteredSites[ 3 ] );
 	} );
 } );


### PR DESCRIPTION
See https://github.com/Automattic/wp-calypso/issues/68455 and p1670539823414409-slack-C041RHH38NQ

## Proposed Changes

Updates `sortSitesByLastInteractedWith` to demote 'hidden' sites to the bottom of the list.

However, I don't personally love the results because I realized most of my sites are hidden 🙃 p1670543080538739/1670539823.414409-slack-C041RHH38NQ

## Testing Instructions

1. Navigate to `/sites`.
2. Verify any 'hidden' sites appear at the bottom of the list in Magic Sort mode.
3. Verify any 'hidden' sites appear in normal A-Z order in 'Sort Alphabetically'.

You can use My Blogs to manage site visibility: https://dashboard.wordpress.com/wp-admin/index.php?page=my-blogs