### PR TITLE
Purchase Management: Hide 'remove product' button when auto-renew is enabled

### DIFF
--- a/client/lib/purchases/assembler.ts
+++ b/client/lib/purchases/assembler.ts
@@ -107,7 +107,7 @@ function createPurchaseObject( purchase: RawPurchase | RawPurchaseCreditCard ): 
 		taxText: purchase.tax_text,
 		purchaseRenewalQuantity: purchase.renewal_price_tier_usage_quantity || null,
 		userId: Number( purchase.user_id ),
-		isAutoRenewEnabled: purchase.auto_renew === '1',
+		isAutoRenewEnabled: parseInt( purchase.auto_renew ?? '' ) === 1,
 	};
 
 	if ( isCreditCardPurchase( purchase ) ) {

--- a/client/lib/purchases/index.ts
+++ b/client/lib/purchases/index.ts
@@ -419,6 +419,29 @@ export function isCancelable( purchase: Purchase ) {
 	return purchase.canDisableAutoRenew;
 }
 
+/**
+ * Similar to isCancelable, but doesn't rely on the purchase's cancelability
+ * Checks if auto-renew is enabled for purchase, returns true if auto-renew is ON
+ * Returns false if purchase is included in plan, purchases included with a plan can't be cancelled
+ * Returns false if purchase is expired
+ */
+
+export function canAutoRenewBeTurnedOff( purchase: Purchase ) {
+	if ( isIncludedWithPlan( purchase ) ) {
+		return false;
+	}
+
+	if ( isExpired( purchase ) ) {
+		return false;
+	}
+
+	if ( hasAmountAvailableToRefund( purchase ) ) {
+		return true;
+	}
+
+	return purchase.isAutoRenewEnabled;
+}
+
 export function isExpired( purchase: Purchase ) {
 	return 'expired' === purchase.expiryStatus;
 }

--- a/client/me/purchases/cancel-purchase/index.jsx
+++ b/client/me/purchases/cancel-purchase/index.jsx
@@ -20,7 +20,7 @@ import {
 	getName,
 	purchaseType,
 	hasAmountAvailableToRefund,
-	isCancelable,
+	canAutoRenewBeTurnedOff,
 	isOneTimePurchase,
 	isRefundable,
 	isSubscription,
@@ -98,14 +98,18 @@ class CancelPurchase extends Component {
 		// For domain transfers, we only allow cancel if it's also refundable
 		const isDomainTransferCancelable = isRefundable( purchase ) || ! isDomainTransfer( purchase );
 
-		return isCancelable( purchase ) && isDomainTransferCancelable;
+		return canAutoRenewBeTurnedOff( purchase ) && isDomainTransferCancelable;
 	};
 
 	redirect = () => {
 		const { purchase, siteSlug } = this.props;
 		let redirectPath = this.props.purchaseListUrl;
 
-		if ( siteSlug && purchase && ( ! isCancelable( purchase ) || isDomainTransfer( purchase ) ) ) {
+		if (
+			siteSlug &&
+			purchase &&
+			( ! canAutoRenewBeTurnedOff( purchase ) || isDomainTransfer( purchase ) )
+		) {
 			redirectPath = this.props.getManagePurchaseUrlFor( siteSlug, purchase.id );
 		}
 

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -457,6 +457,10 @@ class ManagePurchase extends Component {
 			translate,
 		} = this.props;
 
+		if ( isCancelable( purchase ) ) {
+			return null;
+		}
+
 		let text = translate( 'Remove subscription' );
 		if ( isPlan( purchase ) ) {
 			text = translate( 'Remove plan' );

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -462,6 +462,7 @@ class ManagePurchase extends Component {
 		}
 
 		let text = translate( 'Remove subscription' );
+
 		if ( isPlan( purchase ) ) {
 			text = translate( 'Remove plan' );
 		} else if ( isDomainRegistration( purchase ) ) {
@@ -1023,6 +1024,7 @@ class ManagePurchase extends Component {
 			getChangePaymentMethodUrlFor,
 			isProductOwner,
 		} = this.props;
+
 		let changePaymentMethodPath = false;
 		if ( ! this.isDataLoading( this.props ) && site && canEditPaymentDetails( purchase ) ) {
 			changePaymentMethodPath = getChangePaymentMethodUrlFor( siteSlug, purchase );
@@ -1146,6 +1148,7 @@ function PurchasesQueryComponent( { isSiteLevel, selectedSiteId } ) {
 export default connect(
 	( state, props ) => {
 		const purchase = getByPurchaseId( state, props.purchaseId );
+
 		const purchaseAttachedTo =
 			purchase && purchase.attachedToPurchaseId
 				? getByPurchaseId( state, purchase.attachedToPurchaseId )

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -64,7 +64,7 @@ import {
 	hasAmountAvailableToRefund,
 	hasPaymentMethod,
 	isPaidWithCredits,
-	isCancelable,
+	canAutoRenewBeTurnedOff,
 	isExpired,
 	isOneTimePurchase,
 	isPartnerPurchase,
@@ -457,7 +457,7 @@ class ManagePurchase extends Component {
 			translate,
 		} = this.props;
 
-		if ( isCancelable( purchase ) ) {
+		if ( canAutoRenewBeTurnedOff( purchase ) ) {
 			return null;
 		}
 
@@ -601,7 +601,7 @@ class ManagePurchase extends Component {
 		const { isAtomicSite, purchase, translate } = this.props;
 		const { id } = purchase;
 
-		if ( ! isCancelable( purchase ) ) {
+		if ( ! canAutoRenewBeTurnedOff( purchase ) ) {
 			return null;
 		}
 

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -298,7 +298,7 @@ function PurchaseMetaExpiration( {
 		const shouldRenderToggle = site && isProductOwner;
 		const autoRenewToggle = shouldRenderToggle ? (
 			<AutoRenewToggle
-				planName={ site.plan.product_name_short }
+				planName={ site.plan?.product_name_short }
 				siteDomain={ site.domain }
 				siteSlug={ site.slug }
 				purchase={ purchase }

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -298,7 +298,7 @@ function PurchaseMetaExpiration( {
 		const shouldRenderToggle = site && isProductOwner;
 		const autoRenewToggle = shouldRenderToggle ? (
 			<AutoRenewToggle
-				planName={ site.plan?.product_name_short }
+				planName={ site.plan?.product_name_short ?? '' }
 				siteDomain={ site.domain }
 				siteSlug={ site.slug }
 				purchase={ purchase }

--- a/client/me/purchases/manage-purchase/test/purchase-management-buttons.js
+++ b/client/me/purchases/manage-purchase/test/purchase-management-buttons.js
@@ -28,7 +28,7 @@ const purchase = {
 	product_type: 'bundle',
 	blog_created_date: '2022-11-21T05:50:39+00:00',
 	blogname: '',
-	domain: 'bahamashouse.wordpress.com',
+	domain: 'onecooltestsite.com',
 	description:
 		'<p>All the benefits of our Premium plan, plus the ability to: </p><ul><li>Try any one of our 200+ themes and change as often as you like, no extra charge.</li><li>Upload all the video and audio files you want with unlimited storage.</li><li>Chat live with a WordPress.com specialist Monday to Friday between 7am and 7pm Eastern time.</li></ul><p>See the <a href="http://store.wordpress.com/premium-upgrades/wordpress-business/">WordPress.com Business</a> page for more information.</p>',
 	attached_to_purchase_id: null,
@@ -80,10 +80,9 @@ describe( 'Purchase Management Buttons', () => {
 
 		const store = createReduxStore(
 			{
-				currentUser: { id: purchase.user_id },
+				currentUser: { id: Number( purchase.user_id ) },
 				happychat: { chat: { status: '' } },
 				plans: { items: [] },
-
 				purchases: {
 					data: [ { ...purchase, auto_renew: 1 } ],
 					hasLoadedUserPurchasesFromServer: true,
@@ -91,6 +90,7 @@ describe( 'Purchase Management Buttons', () => {
 				},
 				productsList: { items: {} },
 				sites: {
+					items: { 212628935: { ID: 212628935 } },
 					plans: {},
 					requesting: {},
 					domains: { requesting: {}, items: { [ purchase.site_id ]: {} } },
@@ -124,17 +124,17 @@ describe( 'Purchase Management Buttons', () => {
 
 		const store = createReduxStore(
 			{
-				currentUser: { id: purchase.user_id },
+				currentUser: { id: Number( purchase.user_id ) },
 				happychat: { chat: { status: '' } },
 				plans: { items: [] },
-
 				purchases: {
-					data: [ { ...purchase, auto_renew: 1 } ],
+					data: [ { ...purchase, auto_renew: 0 } ],
 					hasLoadedUserPurchasesFromServer: true,
 					hasLoadedSitePurchasesFromServer: true,
 				},
 				productsList: { items: {} },
 				sites: {
+					items: { 212628935: { ID: 212628935 } },
 					plans: {},
 					requesting: {},
 					domains: { requesting: {}, items: { [ purchase.site_id ]: {} } },
@@ -160,9 +160,4 @@ describe( 'Purchase Management Buttons', () => {
 		);
 		expect( await screen.findByText( /Remove/ ) ).toBeInTheDocument();
 	} );
-
-	// eslint-disable-next-line jest/no-commented-out-tests
-	// it.skip( 'renders a cancel button and does NOT render a remove button', () => {} );
-	// eslint-disable-next-line jest/no-commented-out-tests
-	// it.skip( 'renders a remove button and does NOT render a cancel button', () => {} );
 } );

--- a/client/me/purchases/manage-purchase/test/purchase-management-buttons.js
+++ b/client/me/purchases/manage-purchase/test/purchase-management-buttons.js
@@ -1,0 +1,168 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render, screen } from '@testing-library/react';
+import nock from 'nock';
+import { Provider as ReduxProvider } from 'react-redux';
+import { createReduxStore } from 'calypso/state';
+import ManagePurchase from '../index.jsx';
+
+const purchase = {
+	ID: '19823155',
+	user_id: '56924323',
+	blog_id: '212628935',
+	product_id: '1008',
+	subscribed_date: '2022-11-27T03:37:13+00:00',
+	renew: '1',
+	auto_renew: '1',
+	renew_date: '',
+	active: '1',
+	meta: '',
+	ownership_id: '36454407',
+	most_recent_renew_date: '2022-11-27T03:37:14+00:00',
+	subscription_status: 'active',
+	payment_type: 'credits',
+	product_name: 'WordPress.com Business',
+	product_slug: 'business-bundle',
+	product_type: 'bundle',
+	blog_created_date: '2022-11-21T05:50:39+00:00',
+	blogname: '',
+	domain: 'bahamashouse.wordpress.com',
+	description:
+		'<p>All the benefits of our Premium plan, plus the ability to: </p><ul><li>Try any one of our 200+ themes and change as often as you like, no extra charge.</li><li>Upload all the video and audio files you want with unlimited storage.</li><li>Chat live with a WordPress.com specialist Monday to Friday between 7am and 7pm Eastern time.</li></ul><p>See the <a href="http://store.wordpress.com/premium-upgrades/wordpress-business/">WordPress.com Business</a> page for more information.</p>',
+	attached_to_purchase_id: null,
+	included_domain: '',
+	included_domain_purchase_amount: 0,
+	amount: 300,
+	currency_code: 'USD',
+	currency_symbol: '$',
+	renewal_price_tier_slug: null,
+	renewal_price_tier_usage_quantity: null,
+	current_price_tier_slug: null,
+	current_price_tier_usage_quantity: null,
+	price_tier_list: [],
+	expiry_date: '2023-11-27T00:00:00+00:00',
+	expiry_message: 'Expires on November 27, 2023',
+	expiry_sub_message: null,
+	expiry_status: 'manual-renew',
+	price_text: '$300',
+	bill_period_label: 'per year',
+	bill_period_days: 365,
+	regular_price_text: '$300',
+	product_display_price: '<abbr title="United States Dollars">$</abbr>300',
+	is_cancelable: false,
+	can_explicit_renew: true,
+	can_disable_auto_renew: false,
+	can_reenable_auto_renewal: false,
+	iap_purchase_management_link: null,
+	is_iap_purchase: false,
+	is_locked: false,
+	is_refundable: false,
+	refund_period_in_days: 14,
+	is_renewable: true,
+	is_renewal: false,
+	has_private_registration: false,
+	refund_amount: 0,
+	refund_currency_symbol: '$',
+	refund_text: '$0',
+	refund_options: null,
+	total_refund_amount: 0,
+	total_refund_text: '$0',
+	check_dns: false,
+};
+
+describe( 'Purchase Management Buttons', () => {
+	it( 'renders a cancel button when auto-renew is ON', async () => {
+		nock( 'https://public-api.wordpress.com' )
+			.get( '/rest/v1.1/me/payment-methods?expired=include' )
+			.reply( 200 );
+
+		const store = createReduxStore(
+			{
+				currentUser: { id: purchase.user_id },
+				happychat: { chat: { status: '' } },
+				plans: { items: [] },
+
+				purchases: {
+					data: [ { ...purchase, auto_renew: 1 } ],
+					hasLoadedUserPurchasesFromServer: true,
+					hasLoadedSitePurchasesFromServer: true,
+				},
+				productsList: { items: {} },
+				sites: {
+					plans: {},
+					requesting: {},
+					domains: { requesting: {}, items: { [ purchase.site_id ]: {} } },
+				},
+				plugins: {
+					premium: { plugins: {} },
+				},
+				ui: { selectSiteId: purchase.site_id },
+			},
+			( state ) => {
+				return state;
+			}
+		);
+
+		render(
+			<ReduxProvider store={ store }>
+				<ManagePurchase
+					purchaseId={ Number( purchase.ID ) }
+					isSiteLevel
+					siteSlug="onecooltestsite.com"
+				/>
+			</ReduxProvider>
+		);
+		expect( await screen.findByText( /Cancel/ ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders a remove button when auto-renew is OFF', async () => {
+		nock( 'https://public-api.wordpress.com' )
+			.get( '/rest/v1.1/me/payment-methods?expired=include' )
+			.reply( 200 );
+
+		const store = createReduxStore(
+			{
+				currentUser: { id: purchase.user_id },
+				happychat: { chat: { status: '' } },
+				plans: { items: [] },
+
+				purchases: {
+					data: [ { ...purchase, auto_renew: 1 } ],
+					hasLoadedUserPurchasesFromServer: true,
+					hasLoadedSitePurchasesFromServer: true,
+				},
+				productsList: { items: {} },
+				sites: {
+					plans: {},
+					requesting: {},
+					domains: { requesting: {}, items: { [ purchase.site_id ]: {} } },
+				},
+				plugins: {
+					premium: { plugins: {} },
+				},
+				ui: { selectSiteId: purchase.site_id },
+			},
+			( state ) => {
+				return state;
+			}
+		);
+
+		render(
+			<ReduxProvider store={ store }>
+				<ManagePurchase
+					purchaseId={ Number( purchase.ID ) }
+					isSiteLevel
+					siteSlug="onecooltestsite.com"
+				/>
+			</ReduxProvider>
+		);
+		expect( await screen.findByText( /Remove/ ) ).toBeInTheDocument();
+	} );
+
+	// eslint-disable-next-line jest/no-commented-out-tests
+	// it.skip( 'renders a cancel button and does NOT render a remove button', () => {} );
+	// eslint-disable-next-line jest/no-commented-out-tests
+	// it.skip( 'renders a remove button and does NOT render a cancel button', () => {} );
+} );

--- a/client/me/purchases/manage-purchase/test/purchase-management-buttons.js
+++ b/client/me/purchases/manage-purchase/test/purchase-management-buttons.js
@@ -115,6 +115,7 @@ describe( 'Purchase Management Buttons', () => {
 			</ReduxProvider>
 		);
 		expect( await screen.findByText( /Cancel/ ) ).toBeInTheDocument();
+		expect( screen.queryByText( /Remove/ ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'renders a remove button when auto-renew is OFF', async () => {
@@ -159,5 +160,6 @@ describe( 'Purchase Management Buttons', () => {
 			</ReduxProvider>
 		);
 		expect( await screen.findByText( /Remove/ ) ).toBeInTheDocument();
+		expect( screen.queryByText( /Cancel/ ) ).not.toBeInTheDocument();
 	} );
 } );

--- a/client/me/purchases/manage-purchase/test/purchase-management-buttons.js
+++ b/client/me/purchases/manage-purchase/test/purchase-management-buttons.js
@@ -72,38 +72,58 @@ const purchase = {
 	check_dns: false,
 };
 
+function getSiteForPurchase( purchaseForSite ) {
+	return {
+		ID: parseInt( purchaseForSite.blog_id ),
+		URL: 'example.com',
+		capabilities: {},
+		description: '',
+		domain: '',
+		launch_status: '',
+		locale: 'en-US',
+		logo: { id: '', sizes: [], url: '' },
+		name: '',
+		options: {},
+		slug: 'example.com',
+	};
+}
+
+function createMockReduxStoreForPurchase( purchaseForRedux ) {
+	return createReduxStore(
+		{
+			currentUser: { id: Number( purchaseForRedux.user_id ) },
+			happychat: { chat: { status: '' } },
+			plans: { items: [] },
+			purchases: {
+				data: [ purchaseForRedux ],
+				hasLoadedUserPurchasesFromServer: true,
+				hasLoadedSitePurchasesFromServer: true,
+			},
+			productsList: { items: {} },
+			sites: {
+				items: { [ purchaseForRedux.blog_id ]: getSiteForPurchase( purchaseForRedux ) },
+				plans: {},
+				requesting: {},
+				domains: { requesting: {}, items: {} },
+			},
+			plugins: {
+				premium: { plugins: {} },
+			},
+			ui: { selectSiteId: purchaseForRedux.blog_id },
+		},
+		( state ) => {
+			return state;
+		}
+	);
+}
+
 describe( 'Purchase Management Buttons', () => {
 	it( 'renders a cancel button when auto-renew is ON', async () => {
 		nock( 'https://public-api.wordpress.com' )
 			.get( '/rest/v1.1/me/payment-methods?expired=include' )
 			.reply( 200 );
 
-		const store = createReduxStore(
-			{
-				currentUser: { id: Number( purchase.user_id ) },
-				happychat: { chat: { status: '' } },
-				plans: { items: [] },
-				purchases: {
-					data: [ { ...purchase, auto_renew: 1 } ],
-					hasLoadedUserPurchasesFromServer: true,
-					hasLoadedSitePurchasesFromServer: true,
-				},
-				productsList: { items: {} },
-				sites: {
-					items: { 212628935: { ID: 212628935 } },
-					plans: {},
-					requesting: {},
-					domains: { requesting: {}, items: { [ purchase.site_id ]: {} } },
-				},
-				plugins: {
-					premium: { plugins: {} },
-				},
-				ui: { selectSiteId: purchase.site_id },
-			},
-			( state ) => {
-				return state;
-			}
-		);
+		const store = createMockReduxStoreForPurchase( { ...purchase, auto_renew: 1 } );
 
 		render(
 			<ReduxProvider store={ store }>
@@ -123,32 +143,7 @@ describe( 'Purchase Management Buttons', () => {
 			.get( '/rest/v1.1/me/payment-methods?expired=include' )
 			.reply( 200 );
 
-		const store = createReduxStore(
-			{
-				currentUser: { id: Number( purchase.user_id ) },
-				happychat: { chat: { status: '' } },
-				plans: { items: [] },
-				purchases: {
-					data: [ { ...purchase, auto_renew: 0 } ],
-					hasLoadedUserPurchasesFromServer: true,
-					hasLoadedSitePurchasesFromServer: true,
-				},
-				productsList: { items: {} },
-				sites: {
-					items: { 212628935: { ID: 212628935 } },
-					plans: {},
-					requesting: {},
-					domains: { requesting: {}, items: { [ purchase.site_id ]: {} } },
-				},
-				plugins: {
-					premium: { plugins: {} },
-				},
-				ui: { selectSiteId: purchase.site_id },
-			},
-			( state ) => {
-				return state;
-			}
-		);
+		const store = createMockReduxStoreForPurchase( { ...purchase, auto_renew: 0 } );
 
 		render(
 			<ReduxProvider store={ store }>

--- a/client/state/selectors/get-media-query-manager.js
+++ b/client/state/selectors/get-media-query-manager.js
@@ -7,5 +7,5 @@ import 'calypso/state/media/init';
  * @param {number} siteId The site ID
  */
 export default function getMediaQueryManager( state, siteId ) {
-	return state.media.queries?.[ siteId ] ?? null;
+	return state.media?.queries?.[ siteId ] ?? null;
 }


### PR DESCRIPTION
#### Proposed Changes

When auto-renew is enabled for a product, the cancelation button should be shown rather than the remove button.

This PR implements a `canAutoRenewBeTurnedOff` condition that checks if the purchase has auto-renew enabled, if it does, then the remove button is hidden and the cancelation button is shown.

TODOS:

- [x] ~Check all instances of isCancelable and ensure that the new condition in D94814-code does not break the intended functionality~ No longer updating isCancelable, instead using a new function `canAutoRenewBeTurnedOff` to avoid breaking existing instances of isCancelable
- [x] Write tests for different purchase scenarios to ensure cancelation button is shown when auto-renew is ON (and not shown when OFF, and that at least cancel or remove are shown in all instances)

#### Testing Instructions

**Regular purchase flows - within refund window**

Repeat this for a simple and atomic site
- Add a plan to your site with a credit card, ensure that auto renew is ON, then check that _only_ the **Cancel Subscription** button is shown on the Manage Purchase page. 
- Use plan credit to add a domain to the site (i.e. domain included with plan), check that only the Remove option shows as the auto-renew toggle will read "Renews with Plan".
- Go back to plan and turn auto-renew OFF, complete cancelation flow, ensure that the **Cancel Subscription** button is replaced with a **Remove Subscription** button after you complete the cancelation form flow. Turn auto-renew back ON and ensure the cancel button shows, and remove is now hidden.
- Add a stand alone domain (not included with plan) and check that the cancel/remove functionality exists and is correct

**Regular purchase flows - outside refund window**

- Go into Store Admin and set the plan and domain purchase date back one month to effectively take the products outside their refund periods (make them no longer refundable).
- Go to Manage Purchase and it should read **Cancel Subscription**, turn OFF auto renew, it should read **Remove Subscription**.

**Regular purchase flows - expired**

- Set a plan to expired from Store Admin, then go to Manage Purchase and you should see that the purchase details are greyed out and the Remove Subscription button is showing.


**Miscellaneous purchase flows (OTP, Jetpack siteless products, etc)**

Test some of the above scenarios, but with the following payment options:

- [x] Plan purchased with credits
- [ ] Plan purchased with One Time Payment option
- [x] Plan with missing payment method
- [ ] Domain transfers at different statuses

Related to https://github.com/Automattic/payments-shilling/issues/1104