### PR TITLE
E2E (Atomic): Skip the editor exit check if in mobile classic (wp-admin) view

### DIFF
--- a/test/e2e/specs/editor/editor__navbar.ts
+++ b/test/e2e/specs/editor/editor__navbar.ts
@@ -47,7 +47,9 @@ describe( DataHelper.createSuiteTitle( `Editor: Navbar` ), function () {
 		const isMobileClassicView =
 			envVariables.VIEWPORT_NAME === 'mobile' && ( await WPAdminBarLocator.isVisible() );
 
-		// The Classic View on mobile viewport doesn't have the "return" button.
+		// The classic WP Admin Bar on mobile viewport doesn't have the
+		// "return" button, so let's not fail this test if it's the case.
+		// See https://github.com/Automattic/wp-calypso/pull/70982
 		if ( ! isMobileClassicView ) {
 			await editorPage.exitEditor();
 		}

--- a/test/e2e/specs/editor/editor__navbar.ts
+++ b/test/e2e/specs/editor/editor__navbar.ts
@@ -43,8 +43,9 @@ describe( DataHelper.createSuiteTitle( `Editor: Navbar` ), function () {
 	} );
 
 	it( 'Return to Calypso dashboard', async function () {
+		const WPAdminBarLocator = page.locator( '#wpadminbar' );
 		const isMobileClassicView =
-			envVariables.VIEWPORT_NAME === 'mobile' && ( await page.isVisible( '#wpadminbar' ) );
+			envVariables.VIEWPORT_NAME === 'mobile' && ( await WPAdminBarLocator.isVisible() );
 
 		// The Classic View on mobile viewport doesn't have the "return" button.
 		if ( ! isMobileClassicView ) {

--- a/test/e2e/specs/editor/editor__navbar.ts
+++ b/test/e2e/specs/editor/editor__navbar.ts
@@ -43,6 +43,12 @@ describe( DataHelper.createSuiteTitle( `Editor: Navbar` ), function () {
 	} );
 
 	it( 'Return to Calypso dashboard', async function () {
-		await editorPage.exitEditor();
+		const isMobileClassicView =
+			envVariables.VIEWPORT_NAME === 'mobile' && ( await page.isVisible( '#wpadminbar' ) );
+
+		// The Classic View on mobile viewport doesn't have the "return" button.
+		if ( ! isMobileClassicView ) {
+			await editorPage.exitEditor();
+		}
 	} );
 } );


### PR DESCRIPTION
#### Proposed Changes

We're currently using the Classic View on our Atomic test site, which forces the wp-admin top nav in mobile view. Let's make the "Return to Calypso dashboard" check only when the Calypso nav is present. 

@Automattic/team-calypso-platform, it seems odd that when selecting the `Classic view` on the `posts` page, the wp-admin nav is forced, but **only** for the mobile viewport. The desktop viewport has the same navbar regardless of the `View` setting. What do you think? Do you know if this is intended for the mobile viewport?

| Desktop nav for both Classic and Default views |
| ------------- |
| <img width="902" alt="Screenshot 2022-12-09 at 11 43 24" src="https://user-images.githubusercontent.com/1451471/206684704-4293ad5a-e963-4b07-8c84-35fa9604f4fc.png"> |

| Mobile nav w/ Classic view | Mobile nav w/ Default view |
| ------------- | ------------- |
| <img width="484" alt="Screenshot 2022-12-09 at 11 38 24" src="https://user-images.githubusercontent.com/1451471/206684116-0c873b9b-aee6-46db-9520-94739a7ccc61.png"> | <img width="447" alt="Screenshot 2022-12-09 at 11 37 49" src="https://user-images.githubusercontent.com/1451471/206684140-9bd183b7-65bf-49f2-9890-1771147fb752.png"> |




#### Testing Instructions

The `editor__navbar.ts` suite should be passing for the [Gutenberg Atomic](https://teamcity.a8c.com/buildConfiguration/calypso_WPComTests_gutenberg_atomic_production_mobile) job.

Related: p1669253368977539/1669227776.675969-slack-CBTN58FTJ