### PR TITLE
Jetpack Pricing Bundles | Replace tooltip with an info popover for the saved amount

### DIFF
--- a/client/my-sites/plans/jetpack-plans/product-store/items-list/amount-saved.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/items-list/amount-saved.tsx
@@ -1,49 +1,53 @@
-import { Gridicon } from '@automattic/components';
-import { Tooltip } from '@wordpress/components';
+import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
+import InfoPopover from 'calypso/components/info-popover';
 import { usePricingBreakdown } from '../hooks/use-pricing-breakdown';
 import { RenderPrice } from '../pricing-breakdown/render-price';
 import { AmountSavedProps } from '../types';
 
-export const AmountSaved: React.FC< AmountSavedProps > = ( { product, siteId } ) => {
+export const AmountSaved: React.FC< AmountSavedProps > = ( {
+	product,
+	siteId,
+	onClickMoreInfo,
+} ) => {
 	const includedProductSlugs = product.productsIncluded || [];
 	const translate = useTranslate();
 
-	const { amountSaved, isFetching } = usePricingBreakdown( {
+	const { amountSaved, isFetching, total } = usePricingBreakdown( {
 		includedProductSlugs,
 		product,
 		siteId,
 	} );
 
 	return amountSaved && ! isFetching ? (
-		<Tooltip
-			position="top left"
-			text={
-				<span>
-					{ translate( 'For details, click on "{{moreInfo/}}"', {
-						components: {
-							moreInfo: (
-								<span>
-									{ translate( 'More about {{productName/}}', {
-										components: { productName: <>{ product.shortName }</> },
-									} ) }
-								</span>
-							),
-						},
-					} ) }{ ' ' }
-				</span>
-			}
-		>
-			<div className="amount-saved--tooltip-text">
-				<span>
-					{ translate( 'Save {{amount/}}/mo vs buying individually', {
-						components: {
-							amount: <RenderPrice price={ amountSaved } />,
-						},
-					} ) }
-				</span>
-				<Gridicon icon="info-outline" size={ 16 } />
-			</div>
-		</Tooltip>
+		<div className="amount-saved--text">
+			<span>
+				{ translate( 'Save {{amount/}}/mo vs buying individually', {
+					components: {
+						amount: <RenderPrice price={ amountSaved } />,
+					},
+				} ) }
+			</span>
+			<InfoPopover
+				position="right"
+				screenReaderText={ translate( 'Learn more' ) }
+				className="amount-saved--popover"
+			>
+				{ translate( 'If purchased individually, all products would cost {{amount/}}/month', {
+					components: {
+						amount: <RenderPrice price={ total } />,
+					},
+				} ) }
+				<hr />
+				<Button
+					className="more-info-link"
+					onClick={ onClickMoreInfo }
+					href={ `#${ product.productSlug }` }
+					plain
+				>
+					{ translate( 'More about bundle savings' ) }
+				</Button>
+			</InfoPopover>
+		</div>
 	) : null;
 };

--- a/client/my-sites/plans/jetpack-plans/product-store/items-list/amount-saved.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/items-list/amount-saved.tsx
@@ -33,7 +33,7 @@ export const AmountSaved: React.FC< AmountSavedProps > = ( {
 				screenReaderText={ translate( 'Learn more' ) }
 				className="amount-saved--popover"
 			>
-				{ translate( 'If purchased individually, all products would cost {{amount/}}/month', {
+				{ translate( 'If purchased individually, all products would cost {{amount/}}/month.', {
 					components: {
 						amount: <RenderPrice price={ total } />,
 					},

--- a/client/my-sites/plans/jetpack-plans/product-store/items-list/most-popular.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/items-list/most-popular.tsx
@@ -93,7 +93,11 @@ export const MostPopular: React.FC< MostPopularProps > = ( {
 					// TODO remove this isEnglish check once we have translations for the new strings
 					const amountSaved =
 						isEnglish && item.productsIncluded?.length ? (
-							<AmountSaved siteId={ siteId } product={ item } />
+							<AmountSaved
+								siteId={ siteId }
+								product={ item }
+								onClickMoreInfo={ onClickMoreInfoFactory( item ) }
+							/>
 						) : null;
 
 					return (

--- a/client/my-sites/plans/jetpack-plans/product-store/items-list/style-bundle-list.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/items-list/style-bundle-list.scss
@@ -7,7 +7,7 @@
 	margin-top: -4px;
 	margin-bottom: 8px;
 
-	.amount-saved--tooltip-text {
+	.amount-saved--text {
 		font-weight: 600;
 		color: var(--studio-gray-70);
 		display: flex;
@@ -17,5 +17,15 @@
 
 	.plan-price {
 		font-size: inherit;
+	}
+}
+
+.amount-saved--popover {
+	.plan-price {
+		font-size: inherit;
+		color: inherit;
+	}
+	hr {
+		margin-bottom: 1rem;
 	}
 }

--- a/client/my-sites/plans/jetpack-plans/product-store/types.ts
+++ b/client/my-sites/plans/jetpack-plans/product-store/types.ts
@@ -127,4 +127,5 @@ export type PricingBreakdownItem = {
 
 export type AmountSavedProps = ProductStoreBaseProps & {
 	product: SelectorProduct;
+	onClickMoreInfo: VoidFunction;
 };


### PR DESCRIPTION
Slack conversation: p1670442553433289-slack-C03V4PXKUGP

#### Proposed Changes

* This PR replaces the tooltip displayed on the featured item card on Jetpack pricing page when hovering over the saved amount text with a popover that is shown on clicking on the info icon. Tooltip was added in #70631

#### Testing Instructions

- Do any one of these
    * Click on Jetpack Cloud live link below and wait for the redirect to complete, then goto `/pricing`
    * or boot up this PR 
        * Run `git fetch && git checkout update/jp-pricing-bundles-save-amnt-tooltip-to-popover`
        * Run `yarn start-jetpack-cloud`
        * Goto [http://jetpack.cloud.localhost:3000/pricing](http://jetpack.cloud.localhost:3000/pricing)
- Go to Bundles tab
- Confirm that you see "Save {{amount}}/mo vs buying individually" text inside featured card
- Confirm that you see info icon beside it
- Click on the info icon
- Confirm that a popover opens up with the text as `If purchased individually, all products would cost {{amount/}}/month`
- Confirm that there is a link at the end with text as `More about bundle savings`
- Click on the link
- Confirm that it opens the "More info" lightbox/modal for the item
- Confirm that the URL changes accordingly
- Confirm that the design matches figma

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Completes 0-as-1203504709788041/f


<img width="1279" alt="Screenshot 2022-12-09 at 5 00 13 PM" src="https://user-images.githubusercontent.com/18226415/206693095-80fdf6d7-7d0e-4e83-a671-6cede4b5dd94.png">


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - 0-as-1203504709788041