### PR TITLE
E2E: Restore the Page basic flow suite

### DIFF
--- a/packages/calypso-e2e/src/lib/components/editor-settings-sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-settings-sidebar-component.ts
@@ -35,10 +35,6 @@ const selectors = {
 	scheduleMeridianButton: ( meridian: 'am' | 'pm' ) => `role=button[name="${ meridian }"i]`,
 	scheduleMonthSelect: `role=combobox[name="month"i]`,
 
-	// Permalink
-	permalinkInput: '.components-base-control__field:has-text("URL Slug") input',
-	permalinkGeneratedURL: 'a.edit-post-post-link__link',
-
 	// Category
 	categoryCheckbox: ( categoryName: string ) =>
 		`${ panel } div[aria-label=Categories] label:text("${ categoryName }")`,
@@ -341,16 +337,9 @@ export class EditorSettingsSidebarComponent {
 	 * @param {string} slug URL slug to set.
 	 */
 	async enterUrlSlug( slug: string ) {
-		const inputLocator = this.editor.locator( selectors.permalinkInput );
-		await inputLocator.fill( slug );
-		// Hit the Tab key to confirm URL slug input and update the Post URL
-		// shown in this section.
-		await this.page.keyboard.press( 'Tab' );
-
-		const generatedURL = this.editor.locator(
-			`${ selectors.permalinkGeneratedURL } > text=/${ slug }`
-		);
-		await generatedURL.waitFor();
+		await this.editor.getByRole( 'button', { name: /Change URL:/ } ).click();
+		await this.editor.getByLabel( 'Permalink' ).fill( slug );
+		await this.editor.getByRole( 'button', { name: 'Close' } ).click();
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/components/editor-settings-sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-settings-sidebar-component.ts
@@ -339,7 +339,7 @@ export class EditorSettingsSidebarComponent {
 	async enterUrlSlug( slug: string ) {
 		await this.editor.getByRole( 'button', { name: /Change URL:/ } ).click();
 		await this.editor.getByLabel( 'Permalink' ).fill( slug );
-		await this.editor.getByRole( 'button', { name: 'Close' } ).click();
+		await this.editor.getByRole( 'button', { name: 'Close', exact: true } ).click();
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/components/page-template-modal-component.ts
+++ b/packages/calypso-e2e/src/lib/components/page-template-modal-component.ts
@@ -33,7 +33,7 @@ export class PageTemplateModalComponent {
 				category.toLowerCase()
 			);
 		} else {
-			await this.editorFrame.getByRole( 'menuitem', { name: category } ).click();
+			await this.editorFrame.getByRole( 'menuitem', { name: category, exact: true } ).click();
 		}
 	}
 
@@ -43,7 +43,7 @@ export class PageTemplateModalComponent {
 	 * @param {string} label Label for the template (the string underneath the preview).
 	 */
 	async selectTemplate( label: string ): Promise< void > {
-		await this.editorFrame.getByRole( 'button', { name: label } ).click();
+		await this.editorFrame.getByRole( 'button', { name: label, exact: true } ).click();
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/components/page-template-modal-component.ts
+++ b/packages/calypso-e2e/src/lib/components/page-template-modal-component.ts
@@ -3,14 +3,6 @@ import { envVariables } from '../..';
 
 type TemplateCategory = 'About';
 
-const selectors = {
-	templateCategoryButton: ( category: TemplateCategory ) =>
-		`.page-pattern-modal__category-list button:has-text("${ category }")`,
-	mobileTemplateCategorySelectBox: '.page-pattern-modal__mobile-category-dropdown',
-	template: ( label: string ) => `button.pattern-selector-item__label:has-text("${ label }")`,
-	blankPageButton: 'button:has-text("Blank page")',
-};
-
 /**
  * Represents the page template selection modal when first loading a new page in the editor.
  */
@@ -34,15 +26,14 @@ export class PageTemplateModalComponent {
 	 *
 	 * @param {TemplateCategory} category Name of the category to select.
 	 */
-	async selectTemplateCatagory( category: TemplateCategory ): Promise< void > {
+	async selectTemplateCategory( category: TemplateCategory ): Promise< void > {
 		if ( envVariables.VIEWPORT_NAME === 'mobile' ) {
 			await this.editorFrame.selectOption(
-				selectors.mobileTemplateCategorySelectBox,
+				'.page-pattern-modal__mobile-category-dropdown',
 				category.toLowerCase()
 			);
 		} else {
-			const locator = this.editorFrame.locator( selectors.templateCategoryButton( category ) );
-			await locator.click();
+			await this.editorFrame.getByRole( 'menuitem', { name: category } ).click();
 		}
 	}
 
@@ -52,15 +43,13 @@ export class PageTemplateModalComponent {
 	 * @param {string} label Label for the template (the string underneath the preview).
 	 */
 	async selectTemplate( label: string ): Promise< void > {
-		const locator = this.editorFrame.locator( selectors.template( label ) );
-		await locator.click();
+		await this.editorFrame.getByRole( 'button', { name: label } ).click();
 	}
 
 	/**
 	 * Select a blank page as your template.
 	 */
 	async selectBlankPage(): Promise< void > {
-		const locator = this.editorFrame.locator( selectors.blankPageButton );
-		await locator.click();
+		await this.editorFrame.getByRole( 'button', { name: 'Blank page' } ).click();
 	}
 }

--- a/packages/calypso-e2e/src/lib/pages/editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/editor-page.ts
@@ -527,7 +527,7 @@ export class EditorPage {
 			this.editorSettingsSidebarComponent.clickTab( 'Page' ),
 			this.editorSettingsSidebarComponent.clickTab( 'Post' ),
 		] );
-		await this.editorSettingsSidebarComponent.expandSection( 'Permalink' );
+		await this.editorSettingsSidebarComponent.expandSection( 'Summary' );
 		await this.editorSettingsSidebarComponent.enterUrlSlug( slug );
 	}
 

--- a/test/e2e/specs/editor-tracking/editor-tracking__block-inserted-event.ts
+++ b/test/e2e/specs/editor-tracking/editor-tracking__block-inserted-event.ts
@@ -161,7 +161,7 @@ describe(
 				it( 'Add "Two column about me layout" page template', async function () {
 					const editorFrame = await editorPage.getEditorHandle();
 					const pageTemplateModalComponent = new PageTemplateModalComponent( editorFrame, page );
-					await pageTemplateModalComponent.selectTemplateCatagory( 'About' );
+					await pageTemplateModalComponent.selectTemplateCategory( 'About' );
 					await pageTemplateModalComponent.selectTemplate( 'Two column about me layout' );
 				} );
 

--- a/test/e2e/specs/editor/editor__page-basic-flow.ts
+++ b/test/e2e/specs/editor/editor__page-basic-flow.ts
@@ -1,3 +1,7 @@
+/**
+ * @group gutenberg
+ */
+
 import {
 	DataHelper,
 	envVariables,
@@ -9,13 +13,10 @@ import {
 	getTestAccountByFeature,
 	envToFeatureKey,
 } from '@automattic/calypso-e2e';
-import { Browser, Page, Frame } from 'playwright';
+import { Browser, Page } from 'playwright';
 
 declare const browser: Browser;
 
-const pageTemplateCategory = 'About';
-const pageTemplateLable = 'About layout with intro and contact';
-const expectedTemplateText = 'Our Mission';
 const customUrlSlug = `about-${ DataHelper.getTimestamp() }-${ DataHelper.getRandomInteger(
 	0,
 	100
@@ -36,7 +37,6 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 
 	let page: Page;
 	let editorPage: EditorPage;
-	let editorIframe: Frame;
 	let pagesPage: PagesPage;
 	let publishedUrl: URL;
 
@@ -57,18 +57,21 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 	} );
 
 	it( 'Select page template', async function () {
-		editorPage = new EditorPage( page, { target: features.siteType } );
 		// @TODO Consider moving this to EditorPage.
+		editorPage = new EditorPage( page, { target: features.siteType } );
 		await editorPage.waitUntilLoaded();
+
 		const editorIframe = await editorPage.getEditorHandle();
 		const pageTemplateModalComponent = new PageTemplateModalComponent( editorIframe, page );
-		await pageTemplateModalComponent.selectTemplateCatagory( pageTemplateCategory );
-		await pageTemplateModalComponent.selectTemplate( pageTemplateLable );
+
+		await pageTemplateModalComponent.selectTemplateCategory( 'About' );
+		await pageTemplateModalComponent.selectTemplate( 'About me' );
 	} );
 
 	it( 'Template content loads into editor', async function () {
 		// @TODO Consider moving this to EditorPage.
-		await editorIframe.waitForSelector( `text=${ expectedTemplateText }` );
+		const editorIframe = await editorPage.getEditorHandle();
+		await editorIframe.waitForSelector( `h1:text-is("About Me")` );
 	} );
 
 	it( 'Open setting sidebar', async function () {
@@ -95,6 +98,6 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 	it( 'Published page contains template content', async function () {
 		// Not a typo, it's the POM page class for a WordPress page. :)
 		const publishedPagePage = new PublishedPostPage( page );
-		await publishedPagePage.validateTextInPost( expectedTemplateText );
+		await publishedPagePage.validateTextInPost( 'About Me' );
 	} );
 } );


### PR DESCRIPTION
#### Proposed Changes

Closes: #70133

The `editor__page-basic-flow.ts` suite hasn't been running for some time because it was [missing the group tag](https://github.com/Automattic/wp-calypso/pull/70985/files#diff-62d89bc54131b1f1bba8fd14ded781bc4a3fd8336a0a479fe1d311eda0b5b994R1-R4) required for the jest runner to see the test file. This PR updates the outdated code necessary to run the spec and defines the group, so it's being run in CI again.

#### Testing Instructions

The `editor__page-basic-flow.ts` suite should be running and passing for the `Gutenberg` related jobs:
- [Gutenberg simple E2E tests production (desktop)](https://teamcity.a8c.com/buildConfiguration/calypso_WPComTests_gutenberg_simple_production_desktop?branch=e2e%2Frestore-editor-page-tests&mode=builds)
- [Gutenberg simple E2E tests production (mobile)](https://teamcity.a8c.com/buildConfiguration/calypso_WPComTests_gutenberg_simple_production_mobile?branch=e2e%2Frestore-editor-page-tests&buildTypeTab=overview&mode=builds)
- [Gutenberg atomic E2E tests production (desktop)](https://teamcity.a8c.com/buildConfiguration/calypso_WPComTests_gutenberg_atomic_production_desktop?branch=e2e%2Frestore-editor-page-tests&mode=builds)
- [Gutenberg atomic E2E tests production (mobile)](https://teamcity.a8c.com/buildConfiguration/calypso_WPComTests_gutenberg_atomic_production_mobile?branch=e2e%2Frestore-editor-page-tests&mode=builds)
