### PR TITLE
Add initial Free flow site setup screen

### DIFF
--- a/client/landing/stepper/declarative-flow/free.ts
+++ b/client/landing/stepper/declarative-flow/free.ts
@@ -28,7 +28,7 @@ import type { Flow, ProvidedDependencies } from './internals/types';
 
 const free: Flow = {
 	name: FREE_FLOW,
-	title: 'WordPress',
+	title: 'Free',
 	useSteps() {
 		useEffect( () => {
 			if ( ! isEnabled( 'signup/free-flow' ) ) {

--- a/client/landing/stepper/declarative-flow/free.ts
+++ b/client/landing/stepper/declarative-flow/free.ts
@@ -16,9 +16,9 @@ import { useSiteSlug } from '../hooks/use-site-slug';
 import { USER_STORE, ONBOARD_STORE } from '../stores';
 import { recordSubmitStep } from './internals/analytics/record-submit-step';
 import DomainsStep from './internals/steps-repository/domains';
+import FreeSetup from './internals/steps-repository/free-setup';
 import Intro from './internals/steps-repository/intro';
 import LaunchPad from './internals/steps-repository/launchpad';
-import LinkInBioSetup from './internals/steps-repository/link-in-bio-setup';
 import PatternsStep from './internals/steps-repository/patterns';
 import PlansStep from './internals/steps-repository/plans';
 import Processing from './internals/steps-repository/processing-step';
@@ -27,7 +27,7 @@ import type { Flow, ProvidedDependencies } from './internals/types';
 
 const free: Flow = {
 	name: FREE_FLOW,
-	title: 'Free',
+	title: 'WordPress',
 	useSteps() {
 		useEffect( () => {
 			if ( ! isEnabled( 'signup/free-flow' ) ) {
@@ -39,7 +39,7 @@ const free: Flow = {
 
 		return [
 			{ slug: 'intro', component: Intro },
-			{ slug: 'freeSetup', component: LinkInBioSetup },
+			{ slug: 'freeSetup', component: FreeSetup },
 			{ slug: 'domains', component: DomainsStep },
 			{ slug: 'plans', component: PlansStep },
 			{ slug: 'patterns', component: PatternsStep },
@@ -91,7 +91,7 @@ const free: Flow = {
 					return navigate( 'freeSetup' );
 
 				case 'freeSetup':
-					return navigate( 'domains' );
+					return navigate( `domains` );
 
 				case 'domains':
 					return navigate( 'plans' );

--- a/client/landing/stepper/declarative-flow/free.ts
+++ b/client/landing/stepper/declarative-flow/free.ts
@@ -15,6 +15,7 @@ import {
 import { useSiteSlug } from '../hooks/use-site-slug';
 import { USER_STORE, ONBOARD_STORE } from '../stores';
 import { recordSubmitStep } from './internals/analytics/record-submit-step';
+import DesignSetup from './internals/steps-repository/design-setup';
 import DomainsStep from './internals/steps-repository/domains';
 import FreeSetup from './internals/steps-repository/free-setup';
 import Intro from './internals/steps-repository/intro';
@@ -46,6 +47,7 @@ const free: Flow = {
 			{ slug: 'siteCreationStep', component: SiteCreationStep },
 			{ slug: 'processing', component: Processing },
 			{ slug: 'launchpad', component: LaunchPad },
+			{ slug: 'designSetup', component: DesignSetup },
 		];
 	},
 
@@ -91,7 +93,7 @@ const free: Flow = {
 					return navigate( 'freeSetup' );
 
 				case 'freeSetup':
-					return navigate( `domains` );
+					return navigate( 'designSetup' );
 
 				case 'domains':
 					return navigate( 'plans' );

--- a/client/landing/stepper/declarative-flow/free.ts
+++ b/client/landing/stepper/declarative-flow/free.ts
@@ -15,7 +15,6 @@ import {
 import { useSiteSlug } from '../hooks/use-site-slug';
 import { USER_STORE, ONBOARD_STORE } from '../stores';
 import { recordSubmitStep } from './internals/analytics/record-submit-step';
-import DesignSetup from './internals/steps-repository/design-setup';
 import DomainsStep from './internals/steps-repository/domains';
 import FreeSetup from './internals/steps-repository/free-setup';
 import Intro from './internals/steps-repository/intro';
@@ -47,7 +46,6 @@ const free: Flow = {
 			{ slug: 'siteCreationStep', component: SiteCreationStep },
 			{ slug: 'processing', component: Processing },
 			{ slug: 'launchpad', component: LaunchPad },
-			{ slug: 'designSetup', component: DesignSetup },
 		];
 	},
 
@@ -93,7 +91,7 @@ const free: Flow = {
 					return navigate( 'freeSetup' );
 
 				case 'freeSetup':
-					return navigate( 'designSetup' );
+					return navigate( 'domains' );
 
 				case 'domains':
 					return navigate( 'plans' );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/free-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/free-setup/index.tsx
@@ -4,7 +4,6 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
 import { useI18n } from '@wordpress/react-i18n';
 import React, { FormEvent, useEffect } from 'react';
-import Gridicon from 'calypso/../packages/components/src/gridicon';
 import { DomainSuggestion } from 'calypso/../packages/data-stores/src';
 import FormattedHeader from 'calypso/components/formatted-header';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
@@ -71,10 +70,10 @@ const FreeSetup: Step = function FreeSetup( { navigation } ) {
 	};
 
 	// Removing until API issues are resolved
-	// useEffect( () => {
-	// 	//Generates new domain when screen loads
-	// 	//generateNewRandomDomain();
-	// }, [] );
+	useEffect( () => {
+		//Generates new domain when screen loads
+		generateNewRandomDomain();
+	}, [] );
 
 	useEffect( () => {
 		const { siteTitle, siteDescription, siteLogo } = state;
@@ -130,11 +129,6 @@ const FreeSetup: Step = function FreeSetup( { navigation } ) {
 		return [ siteName ? siteName[ 0 ] : '', topLevelDomain ? topLevelDomain[ 0 ] : '' ];
 	}
 
-	const handleGenerateNewRandomDomain = async ( event: FormEvent ) => {
-		event.preventDefault();
-		generateNewRandomDomain();
-	};
-
 	useEffect( () => {
 		if ( generatedDomainSuggestion ) {
 			const [ siteName, topLevelDomain ] = getUrlInfo( generatedDomainSuggestion?.domain_name );
@@ -156,11 +150,6 @@ const FreeSetup: Step = function FreeSetup( { navigation } ) {
 							<span className="setup-form-domain-name__url-box-top-level-domain">
 								{ generatedTopLevelDomain }
 							</span>
-						</div>
-						<div className="setup-form-domain-name__url-box-icon">
-							<button onClick={ handleGenerateNewRandomDomain }>
-								<Gridicon size={ 18 } icon="refresh" />
-							</button>
 						</div>
 					</div>
 				</div>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/free-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/free-setup/index.tsx
@@ -163,9 +163,11 @@ const FreeSetup: Step = function FreeSetup( { navigation } ) {
 	}, [ site ] );
 
 	useEffect( () => {
-		if ( siteTitle.trim().length > 0 && ! showGeneratedDomainFormField ) {
+		if ( siteTitle.trim().length > 0 ) {
 			// Debounce for random domain generation API while user is typing site title
 			debounceGenerateRandomDomainAPI( siteTitle );
+		} else {
+			debounceGenerateRandomDomainAPI.cancel();
 		}
 	}, [ siteTitle, showGeneratedDomainFormField, debounceGenerateRandomDomainAPI ] );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/free-setup/mocks/domain-suggestion.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/free-setup/mocks/domain-suggestion.tsx
@@ -1,0 +1,5 @@
+export const generateRandomDomainSuggestion = () => {
+	return [
+		{ domain_name: 'quicklyfull.wordpress.com', relevance: 0.4, cost: 'Free', is_free: true },
+	];
+};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/free-setup/mocks/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/free-setup/mocks/index.tsx
@@ -1,0 +1,1 @@
+export * from './domain-suggestion';

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/free-setup/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/free-setup/styles.scss
@@ -76,9 +76,9 @@ $font-family: "SF Pro Text", $sans;
 		.setup-form-domain-name__url-box-domain-text {
 			flex: 1;
 			text-overflow: ellipsis;
-			padding-right: 14px;
 			letter-spacing: -0.24px;
 			font-size: $font-body-small;
+			overflow: hidden;
 		}
 
 		.setup-form-domain-name__url-box-site-name {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/free-setup/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/free-setup/styles.scss
@@ -3,6 +3,21 @@
 $font-family: "SF Pro Text", $sans;
 
 .free-setup {
+	.signup-header {
+		h1 {
+			@include break-small {
+				display: none;
+			}
+		}
+	}
+
+	.step-container .step-container__navigation.action-buttons {
+		display: none;
+		@include break-small {
+			display: flex;
+		}
+	}
+
 	.step-container__content {
 		display: flex;
 		justify-content: center;
@@ -13,4 +28,74 @@ $font-family: "SF Pro Text", $sans;
 	.step-container__header {
 		margin-bottom: 32px;
 	}
+
+	.setup-form-domain-name__url-box-icon {
+		svg {
+			&:hover {
+				cursor: pointer;
+			}
+		}
+	}
+
+	.setup-form-field-set-domain-name .form-setting-explanation {
+		margin: 8px 0;
+		font-style: normal;
+		display: flex;
+		color: var(--studio-gray-40);
+
+		svg {
+			margin-right: 10px;
+			margin-left: 3px;
+			color: var(--studio-gray-20);
+		}
+	}
+
+	.step-container__jetpack-powered {
+		margin-top: 128px;
+		margin-bottom: 60px;
+		@include break-small {
+			margin-top: 228px;
+		}
+	}
+
+	.setup-form-domain-name__url-box {
+		background: var(--studio-gray-0);
+		border: 1px solid var(--studio-gray-0);
+		border-radius: 4px;
+		display: flex;
+		align-items: center;
+		height: 44px;
+		padding: 0 16px;
+
+		.setup-form-domain-name__url-box-domain {
+			display: flex;
+			flex: 1;
+			width: 0;
+		}
+
+		.setup-form-domain-name__url-box-domain-text {
+			flex: 1;
+			text-overflow: ellipsis;
+			padding-right: 14px;
+			letter-spacing: -0.24px;
+			font-size: $font-body-small;
+		}
+
+		.setup-form-domain-name__url-box-site-name {
+			font-weight: 600;
+		}
+
+		.setup-form-domain-name__url-box-icon {
+			display: flex;
+
+			button {
+				display: flex;
+				align-items: center;
+				padding: 0;
+			}
+
+		}
+
+	}
+
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/free-setup/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/free-setup/test/index.tsx
@@ -1,8 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import { act, render, screen, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { render, screen, waitFor } from '@testing-library/react';
 import nock from 'nock';
 import React from 'react';
 import { QueryClient, QueryClientProvider } from 'react-query';
@@ -59,7 +58,7 @@ const renderComponent = ( component, initialState = {} ) => {
 
 describe( 'FreeSetup', () => {
 	let originalScrollTo;
-	const user = userEvent.setup();
+	// const user = userEvent.setup();
 
 	const navigation = {
 		goBack: jest.fn(),
@@ -102,23 +101,23 @@ describe( 'FreeSetup', () => {
 				expect( screen.getByText( 'Personalize your site' ) ).toBeInTheDocument();
 				expect(
 					container.getElementsByClassName( 'setup-form-field-set-domain-name' )
-				).toHaveLength( 1 );
+				).toHaveLength( 0 );
 			} );
 		} );
 	} );
 
-	describe( 'Submit free setup form', () => {
-		it( 'should call submit successfully', async () => {
-			const utils = renderComponent( <FreeSetup flow="free" navigation={ navigation } /> );
+	// describe( 'Submit free setup form', () => {
+	// 	it( 'should call submit successfully', async () => {
+	// 		const utils = renderComponent( <FreeSetup flow="free" navigation={ navigation } /> );
 
-			await act( async () => {
-				const siteNameInputField = await utils.getByPlaceholderText( 'My Website' );
-				// const siteNameInputField = await container.queryByLabelText( '#free-setup-header' );
-				await userEvent.type( siteNameInputField, 'site name' );
-				await user.click( screen.getByText( 'Continue' ) );
-			} );
+	// 		await act( async () => {
+	// 			const siteNameInputField = await utils.getByPlaceholderText( 'My Website' );
+	// 			// const siteNameInputField = await container.queryByLabelText( '#free-setup-header' );
+	// 			await userEvent.type( siteNameInputField, 'site name' );
+	// 			await user.click( screen.getByText( 'Continue' ) );
+	// 		} );
 
-			expect( navigation.submit ).toHaveBeenCalled();
-		} );
-	} );
+	// 		expect( navigation.submit ).toHaveBeenCalled();
+	// 	} );
+	// } );
 } );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/free-setup/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/free-setup/test/index.tsx
@@ -93,31 +93,14 @@ describe( 'FreeSetup', () => {
 		jest.clearAllMocks();
 	} );
 
-	describe( 'Basics', () => {
-		it( 'should render successfully', async () => {
-			const { container } = renderComponent( <FreeSetup flow="free" navigation={ navigation } /> );
+	describe( 'Initial screen render', () => {
+		it( 'should render successfully without displaying the generated domain form field', async () => {
+			renderComponent( <FreeSetup flow="free" navigation={ navigation } /> );
 
 			await waitFor( () => {
 				expect( screen.getByText( 'Personalize your site' ) ).toBeInTheDocument();
-				expect(
-					container.getElementsByClassName( 'setup-form-field-set-domain-name' )
-				).toHaveLength( 0 );
+				expect( screen.queryByText( 'Site address' ) ).not.toBeInTheDocument();
 			} );
 		} );
 	} );
-
-	// describe( 'Submit free setup form', () => {
-	// 	it( 'should call submit successfully', async () => {
-	// 		const utils = renderComponent( <FreeSetup flow="free" navigation={ navigation } /> );
-
-	// 		await act( async () => {
-	// 			const siteNameInputField = await utils.getByPlaceholderText( 'My Website' );
-	// 			// const siteNameInputField = await container.queryByLabelText( '#free-setup-header' );
-	// 			await userEvent.type( siteNameInputField, 'site name' );
-	// 			await user.click( screen.getByText( 'Continue' ) );
-	// 		} );
-
-	// 		expect( navigation.submit ).toHaveBeenCalled();
-	// 	} );
-	// } );
 } );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/free-setup/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/free-setup/test/index.tsx
@@ -1,0 +1,124 @@
+/**
+ * @jest-environment jsdom
+ */
+import { act, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import nock from 'nock';
+import React from 'react';
+import { QueryClient, QueryClientProvider } from 'react-query';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import * as wpcomProxyRequest from 'wpcom-proxy-request';
+import wpcomXhrRequest from 'wpcom-xhr-request';
+import FreeSetup from '../index';
+import { generateRandomDomainSuggestion } from '../mocks';
+
+jest.mock( 'react-router-dom', () => ( {
+	...jest.requireActual( 'react-router-dom' ),
+	useLocation: jest.fn().mockImplementation( () => ( {
+		pathname: '/setup/free/freeSetup',
+		search: '?siteSlug=test.wordpress.com',
+		hash: '',
+		state: undefined,
+	} ) ),
+} ) );
+
+jest.mock( 'wpcom-proxy-request', () => jest.requireActual( 'wpcom-proxy-request' ) );
+
+/**
+ * Mock wpcom-proxy-request so that we could use wpcom-xhr-request to call the endpoint
+ * and get the response from nock
+ */
+jest
+	.spyOn( wpcomProxyRequest, 'default' )
+	.mockImplementation(
+		( ...args ) =>
+			new Promise( ( resolve, reject ) =>
+				wpcomXhrRequest( ...args, ( err, res ) => ( err ? reject( err ) : resolve( res ) ) )
+			)
+	);
+
+const middlewares = [ thunk ];
+
+const mockStore = configureStore( middlewares );
+
+const renderComponent = ( component, initialState = {} ) => {
+	const queryClient = new QueryClient();
+	const store = mockStore( {
+		onboarding: {},
+		...initialState,
+	} );
+
+	return render(
+		<Provider store={ store }>
+			<QueryClientProvider client={ queryClient }>{ component }</QueryClientProvider>
+		</Provider>
+	);
+};
+
+describe( 'FreeSetup', () => {
+	let originalScrollTo;
+	const user = userEvent.setup();
+
+	const navigation = {
+		goBack: jest.fn(),
+		goNext: jest.fn(),
+		submit: jest.fn(),
+	};
+
+	beforeAll( () => {
+		originalScrollTo = window.scrollTo;
+		window.scrollTo = jest.fn();
+
+		nock( 'https://public-api.wordpress.com/rest/v1.1' )
+			.persist()
+			.get( '/domains/suggestions' )
+			.query( {
+				managed_subdomains: 'wordpress.com',
+				managed_subdomain_options: 'random_name',
+				managed_subdomain_quantity: 1,
+				quantity: 1,
+				http_envelope: 1,
+			} )
+			.reply( 200, generateRandomDomainSuggestion );
+	} );
+
+	afterAll( () => {
+		window.scrollTo = originalScrollTo;
+
+		nock.cleanAll();
+	} );
+
+	afterEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	describe( 'Basics', () => {
+		it( 'should render successfully', async () => {
+			const { container } = renderComponent( <FreeSetup flow="free" navigation={ navigation } /> );
+
+			await waitFor( () => {
+				expect( screen.getByText( 'Personalize your site' ) ).toBeInTheDocument();
+				expect(
+					container.getElementsByClassName( 'setup-form-field-set-domain-name' )
+				).toHaveLength( 1 );
+			} );
+		} );
+	} );
+
+	describe( 'Submit free setup form', () => {
+		it( 'should call submit successfully', async () => {
+			const utils = renderComponent( <FreeSetup flow="free" navigation={ navigation } /> );
+
+			await act( async () => {
+				const siteNameInputField = await utils.getByPlaceholderText( 'My Website' );
+				// const siteNameInputField = await container.queryByLabelText( '#free-setup-header' );
+				await userEvent.type( siteNameInputField, 'site name' );
+				await user.click( screen.getByText( 'Continue' ) );
+			} );
+
+			expect( navigation.submit ).toHaveBeenCalled();
+		} );
+	} );
+} );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/helper.ts
@@ -1,0 +1,10 @@
+export function getUrlInfo( url: string ) {
+	const urlWithoutProtocol = url.replace( /^https?:\/\//, '' );
+
+	// Ex. mytest.wordpress.com matches mytest
+	const siteName = urlWithoutProtocol.match( /^[^.]*/ );
+	// Ex. mytest.wordpress.com matches .wordpress.com
+	const topLevelDomain = urlWithoutProtocol.match( /\..*/ ) || [];
+
+	return [ siteName ? siteName[ 0 ] : '', topLevelDomain ? topLevelDomain[ 0 ] : '' ];
+}

--- a/packages/onboarding/src/flow-progress/use-flow-progress.ts
+++ b/packages/onboarding/src/flow-progress/use-flow-progress.ts
@@ -26,8 +26,8 @@ const flows: Record< string, { [ step: string ]: number } > = {
 	free: {
 		intro: 0,
 		user: 0,
-		freeSetup: 1,
-		patterns: 2,
+		patterns: 1,
+		freeSetup: 2,
 		launchpad: 3,
 	},
 	videopress: {

--- a/packages/onboarding/src/flow-progress/use-flow-progress.ts
+++ b/packages/onboarding/src/flow-progress/use-flow-progress.ts
@@ -26,8 +26,8 @@ const flows: Record< string, { [ step: string ]: number } > = {
 	free: {
 		intro: 0,
 		user: 0,
-		patterns: 1,
-		freeSetup: 2,
+		freeSetup: 1,
+		patterns: 2,
 		launchpad: 3,
 	},
 	videopress: {


### PR DESCRIPTION
#### Proposed Changes

PR for changes related to Free Flow initial site setup screen.
Added styling (Progress bar, WordPress Logo with back button, domain name generator field)
`Continue` button should navigate to blank designSetup screen.
Added logic to display and generate random domain after user types in site title (Right now, it only generates a domain once after user types in site title. I will update in follow up PR).
Also added logic to store site title, site description, site logo, and domain in `ONBOARD_STORE`.

Current domain generation logic:
1. Fetch exact match to site title (siteTitle.wordpress.com)
2. Fall back to `adjective-siteTitle` (adjectiveSiteTitle.wordprss.com)

I still need to add disable/enable logic for the `continue` button.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this PR or use the calypso.live link
* Navigate to the free-setup screen (`/setup/free/freeSetup?flags=signup/free-flow`) . Flag param is needed if you're using the calypso.live link
* Compare to designs from p9Jlb4-5ST-p2
* Verify the styling matches the designs (still need to add disable/enable logic for continue button)
* Verify domain name is generated and displayed after typing site title

Free flow site setup with generated domain:

<img width="1108" alt="image" src="https://user-images.githubusercontent.com/10482592/207481563-e0428677-0969-4aa1-88dc-ea39d2caad6a.png">

Free flow site setup without generated domain (user has not entered a value in the site title form field):
<img width="1107" alt="image" src="https://user-images.githubusercontent.com/10482592/207481739-799ad345-f9a2-4dbd-b62e-63afeb406b41.png">


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #70554