### PR TITLE
Gifting: Add a new signup flow

### DIFF
--- a/client/my-sites/checkout/composite-checkout/lib/create-wpcom-account-before-transaction.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/create-wpcom-account-before-transaction.ts
@@ -19,10 +19,12 @@ export async function createWpcomAccountBeforeTransaction(
 	 * on success checkout.
 	 */
 	return createAccount( {
-		signupFlowName:
-			isJetpackUserLessCheckout || isGiftingCheckout
-				? 'jetpack-userless-checkout'
-				: 'onboarding-registrationless',
+		// eslint-disable-next-line no-nested-ternary
+		signupFlowName: isJetpackUserLessCheckout
+			? 'jetpack-userless-checkout'
+			: isGiftingCheckout
+			? 'gifting-userless-checkout'
+			: 'onboarding-registrationless',
 		email: transactionOptions.contactDetails?.email?.value,
 		siteId: transactionOptions.siteId,
 		recaptchaClientId: transactionOptions.recaptchaClientId,


### PR DESCRIPTION
#### Proposed Changes

Create a new signup flow to validate the user and send a Welcome email on successful checkout.

#### Testing Instructions
> **Warning**
> The process doesn't work on Chrome+Incognito. You can use Chrome + Guest profile instead.

- Patch your sandbox with this diff: D94876-code
- Go to a site with Gifting Banner on ~~incognito~~ Guest profile
- Try to Gift the subscription to the site.
- It should ask you for an email to create an account and let you following with the purchase.
- You should receive 2 emails, a Wordpress.com Welcome email, and the gift receipt.

##### Alternative testing method
- Make sure you are sandboxed and patch it with this diff: D94876-code.
- Add define( 'USE_STORE_SANDBOX', true ); to wp-content/mu-plugins/0-sandbox.php
- Go to my test site checkout: http://calypso.localhost:3000/checkout/personal-bundle/gift/1028117?cancel_to=/home#step2 
- You can use any Google account and add `+something` at the end (ex: youremail+test123@gmail.com)
- Try to make a purchase using one of [these testing cards](https://stripe.com/docs/testing#cards)
- You should receive 2 emails, a Wordpress.com Welcome email, and the gift receipt.

#### Screenshots
![image](https://user-images.githubusercontent.com/402286/206729644-10054dee-6746-4de0-989c-e0da753371fa.png)


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] ~~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~~
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~~
- [ ] ~~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~~
- [ ] ~~For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~~


Fixes https://github.com/Automattic/dotcom-forge/issues/1360