### PR TITLE
Limit Global Styles: Fix position of launchbar popover

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/wpcom-global-styles-view.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/wpcom-global-styles-view.scss
@@ -1,5 +1,9 @@
 /* stylelint-disable declaration-property-unit-allowed-list */
 
+.launch-bar-global-styles-button {
+	position: relative;
+}
+
 .launch-bar-global-styles-popover {
 	position: absolute;
 	width: 260px;
@@ -44,5 +48,18 @@
 			background: #fff;
 			color: #044b7a;
 		}
+	}
+}
+
+@media screen and (max-width: 460px) {
+	.launch-bar-global-styles-button {
+		position: static;
+	}
+
+	.launch-bar-global-styles-popover {
+		width: auto;
+		left: 20px;
+		right: 20px;
+		transform: none;
 	}
 }

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/wpcom-global-styles-view.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/wpcom-global-styles-view.scss
@@ -5,9 +5,10 @@
 	width: 260px;
 	top: 48px;
 	font-size: 14px;
+	left: 50%;
+	transform: translateX(-50%);
 	background-color: #fff;
 	padding: 16px;
-	margin-left: -70px;
 	line-height: 20px;
 	color: #24282d;
 	box-shadow: 0 3px 10px rgb(0 0 0 / 20%);
@@ -15,15 +16,6 @@
 	display: flex;
 	flex-direction: column;
 	align-items: center;
-
-	@media screen and ( max-width: 960px ) {
-		margin-left: -100px;
-	}
-	@media screen and ( max-width: 550px ) {
-		width: 70%;
-		margin-left: 10%;
-		left: 0;
-	}
 
 	.launch-bar-global-styles-upgrade-button {
 		font-size: 14px;


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/1325

#### Proposed Changes

Ensures the "Custom styles" launchbar popover is always centered below the button by removing the hardcoded position and using a `translateX` transform instead.

This approach doesn't work on small viewports because of a conflict with the `overflow: scroll` property of the container, so as a workaround, we display the popover with full width (props @BogdanUngureanu).


Before | After
--- | ---
![Dec-09-2022 15-07-34](https://user-images.githubusercontent.com/1233880/206745886-80060f22-2e7f-4fcf-a37b-6346053cac23.gif) | ![Dec-09-2022 17-13-49](https://user-images.githubusercontent.com/1233880/206745923-00799a6a-36cc-4253-84e6-c05cd4f12ed7.gif)



#### Testing Instructions

- Apply these changes to your sandbox: `install-plugin.sh editing-toolkit fix/limit-global-styles-launchbar-action-position`
- Create a new free site and add the `wpcom-limit-global-styles` blog sticker
- Go to the Site Editor and make some changes to the Global Styles
- Visit the frontend and observe the launchbar
- Click on the "Custom styles" action
- Make sure the popover is correctly center at any screen size (note that it should be full width at screens smaller than 460px).