### PR TITLE
ETK: add check before loading coming-soon feature

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -344,7 +344,10 @@ function load_coming_soon() {
 		require_once __DIR__ . '/coming-soon/coming-soon.php';
 	}
 }
-add_action( 'plugins_loaded', __NAMESPACE__ . '\load_coming_soon' );
+// Todo: once coming-soon is migrated to the new jetpack-mu-wpcom plugin, coming-soon can be removed from ETK.
+if ( has_action( 'plugins_loaded', 'Jetpack\Mu_Wpcom\load_coming_soon' ) === false ) {
+	add_action( 'plugins_loaded', __NAMESPACE__ . '\load_coming_soon' );
+}
 
 /**
  * What's New section of the Tools menu.


### PR DESCRIPTION
#### Proposed Changes

The coming-soon feature from ETK is being migrated to a new Jetpack plugin. This PR adds a check so we can smoothly transition the feature between the two plugins.

See: https://github.com/Automattic/jetpack/pull/27815#issuecomment-1343462513
Internal, PT: p9dueE-6jY-p2

#### Testing Instructions

Not much to test here, and the new `jetpack-mu-wpcom` is not active on sites yet. We'll be sure to test things once we do activate the plugin.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #