### PR TITLE
Tailored Ecommerce: Removing references to feature flag

### DIFF
--- a/client/landing/stepper/declarative-flow/registered-flows.ts
+++ b/client/landing/stepper/declarative-flow/registered-flows.ts
@@ -32,6 +32,11 @@ const availableFlows: Record< string, () => Promise< { default: Flow } > > = {
 			/* webpackChunkName: "newsletter-post-setup-flow" */ '../declarative-flow/newsletter-post-setup'
 		),
 
+	ecommerce: () =>
+		import(
+			/* webpackChunkName: "tailored-ecommerce-flow" */ '../declarative-flow/tailored-ecommerce-flow'
+		),
+
 	free: () => import( /* webpackChunkName: "free-flow" */ '../declarative-flow/free' ),
 };
 
@@ -39,11 +44,4 @@ if ( config.isEnabled( 'themes/plugin-bundling' ) ) {
 	availableFlows[ 'plugin-bundle' ] = () =>
 		import( /* webpackChunkName: "plugin-bundle-flow" */ '../declarative-flow/plugin-bundle-flow' );
 }
-if ( config.isEnabled( 'signup/tailored-ecommerce' ) ) {
-	availableFlows[ 'ecommerce' ] = () =>
-		import(
-			/* webpackChunkName: "tailored-ecommerce-flow" */ '../declarative-flow/tailored-ecommerce-flow'
-		);
-}
-
 export default availableFlows;

--- a/client/landing/stepper/declarative-flow/tailored-ecommerce-flow.ts
+++ b/client/landing/stepper/declarative-flow/tailored-ecommerce-flow.ts
@@ -105,7 +105,7 @@ const ecommerceFlow: Flow = {
 					}
 
 					if ( providedDependencies?.siteSlug ) {
-						const destination = `/setup/${ flowName }/checkPlan?siteSlug=${ siteSlug }&flags=signup/tailored-ecommerce`;
+						const destination = `/setup/${ flowName }/checkPlan?siteSlug=${ siteSlug }`;
 						persistSignupDestination( destination );
 						setSignupCompleteSlug( siteSlug );
 						setSignupCompleteFlowName( flowName );
@@ -115,7 +115,6 @@ const ecommerceFlow: Flow = {
 						const urlParams = new URLSearchParams( {
 							theme: selectedDesign?.slug || '',
 							siteSlug: siteSlug.replace( '.wordpress.com', '.wpcomstaging.com' ),
-							flags: 'signup/tailored-ecommerce',
 						} );
 
 						const returnUrl = encodeURIComponent( `/setup/${ flowName }/checkPlan?${ urlParams }` );

--- a/config/development.json
+++ b/config/development.json
@@ -159,7 +159,6 @@
 		"signup/inline-help": false,
 		"signup/professional-email-step": false,
 		"signup/social": true,
-		"signup/tailored-ecommerce": true,
 		"signup/woo-verify-email": false,
 		"site-indicator": true,
 		"ssr/prefetch-timebox": false,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -103,7 +103,6 @@
 		"signup/inline-help": false,
 		"signup/professional-email-step": false,
 		"signup/social": true,
-		"signup/tailored-ecommerce": true,
 		"signup/woo-verify-email": false,
 		"site-indicator": true,
 		"ssr/prefetch-timebox": true,

--- a/config/production.json
+++ b/config/production.json
@@ -121,7 +121,6 @@
 		"signup/inline-help": false,
 		"signup/professional-email-step": false,
 		"signup/social": true,
-		"signup/tailored-ecommerce": true,
 		"signup/woo-verify-email": false,
 		"site-indicator": true,
 		"ssr/log-prefetch-errors": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -120,7 +120,6 @@
 		"signup/inline-help": false,
 		"signup/professional-email-step": false,
 		"signup/social": true,
-		"signup/tailored-ecommerce": true,
 		"signup/woo-verify-email": false,
 		"site-indicator": true,
 		"ssr/prefetch-timebox": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -129,7 +129,6 @@
 		"signup/inline-help": false,
 		"signup/professional-email-step": false,
 		"signup/social": true,
-		"signup/tailored-ecommerce": true,
 		"signup/woo-verify-email": false,
 		"site-indicator": true,
 		"ssr/prefetch-timebox": true,


### PR DESCRIPTION
#### Proposed Changes

* This PR removes references to the `signup/tailored-ecommerce` feature flag, which is no longer necessary since the feature is live

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* This change should not introduce any user-facing changes, but smoke test the ecommerce flow to ensure nothing has broken.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
