### PR TITLE
Checkout: Show next renewal price for Jetpack introductory offers

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/item-variation-picker/types.ts
+++ b/client/my-sites/checkout/composite-checkout/components/item-variation-picker/types.ts
@@ -13,7 +13,7 @@ export type WPCOMProductVariant = {
 	introductoryTerm: string;
 	introductoryInterval: number;
 	priceBeforeDiscounts: number;
-	planLength: number;
+	productBillingTermInMonths: number;
 };
 
 export type ItemVariationPickerProps = {

--- a/client/my-sites/checkout/composite-checkout/components/item-variation-picker/types.ts
+++ b/client/my-sites/checkout/composite-checkout/components/item-variation-picker/types.ts
@@ -10,6 +10,10 @@ export type WPCOMProductVariant = {
 	productId: number;
 	productSlug: WPCOMProductSlug;
 	variantLabel: string;
+	introductoryTerm: string;
+	introductoryInterval: number;
+	priceBeforeDiscounts: number;
+	planLength: number;
 };
 
 export type ItemVariationPickerProps = {

--- a/client/my-sites/checkout/composite-checkout/components/item-variation-picker/variant-dropdown-price.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/item-variation-picker/variant-dropdown-price.tsx
@@ -40,7 +40,7 @@ const DoNotPayThis = styled.del`
 `;
 
 const Price = styled.span`
-	display: flex;
+	display: inline-flex;
 	justify-content: right;
 	color: #646970;
 	.item-variant-option--selected & {
@@ -81,6 +81,10 @@ const IntroPricingText = styled.span`
 	display: block;
 	text-align: right;
 	margin-bottom: 0rem;
+`;
+
+const PriceTextContainer = styled.span`
+	text-align: right;
 `;
 
 const DiscountPercentage: FunctionComponent< { percent: number } > = ( { percent } ) => {
@@ -224,7 +228,7 @@ export const ItemVariantDropDownPrice: FunctionComponent< {
 					<DiscountPercentage percent={ discountPercentage } />
 				) }
 			</Label>
-			<span>
+			<PriceTextContainer>
 				{ discountPercentage > 0 && ! isMobile && ! isIntroductoryOffer && (
 					<DiscountPercentage percent={ discountPercentage } />
 				) }
@@ -237,7 +241,7 @@ export const ItemVariantDropDownPrice: FunctionComponent< {
 						{ isIntroductoryOffer && translatedIntroOfferDetails() }
 					</IntroPricingText>
 				</IntroPricing>
-			</span>
+			</PriceTextContainer>
 		</Variant>
 	);
 };

--- a/client/my-sites/checkout/composite-checkout/components/item-variation-picker/variant-dropdown-price.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/item-variation-picker/variant-dropdown-price.tsx
@@ -1,3 +1,4 @@
+import { isJetpackProduct } from '@automattic/calypso-products';
 import formatCurrency from '@automattic/format-currency';
 import { useMobileBreakpoint } from '@automattic/viewport-react';
 import { styled } from '@automattic/wpcom-checkout';
@@ -86,7 +87,12 @@ export const ItemVariantDropDownPrice: FunctionComponent< {
 	variant: WPCOMProductVariant;
 	compareTo?: WPCOMProductVariant;
 } > = ( { variant, compareTo } ) => {
+	const planTerm = variant.termIntervalInDays > 31 ? 'year' : 'month';
+	const introTerm = variant.introIntervalUnit;
+	const introCount = variant.introIntervalCount;
 	const isMobile = useMobileBreakpoint();
+	const isJetpackIntroductoryOffer = isJetpackProduct( variant ) && introCount > 0;
+	const formattedRegularPrice = formatCurrency( variant.regularPrice, variant.currency );
 	const compareToPriceForVariantTerm = getItemVariantCompareToPrice( variant, compareTo );
 	const discountPercentage = getItemVariantDiscountPercentage( variant, compareTo );
 	const formattedCurrentPrice = formatCurrency( variant.priceInteger, variant.currency, {
@@ -99,6 +105,17 @@ export const ItemVariantDropDownPrice: FunctionComponent< {
 				isSmallestUnit: true,
 		  } )
 		: undefined;
+	const translate = useTranslate();
+	const translatedIntroOfferPrice = translate(
+		' for the first %(introTerm)s then %(formattedRegularPrice)s per %(planTerm)s',
+		{
+			args: {
+				formattedRegularPrice,
+				planTerm,
+				introTerm,
+			},
+		}
+	);
 
 	return (
 		<Variant>
@@ -109,13 +126,16 @@ export const ItemVariantDropDownPrice: FunctionComponent< {
 				) }
 			</Label>
 			<span>
-				{ discountPercentage > 0 && ! isMobile && (
+				{ discountPercentage > 0 && ! isMobile && ! isJetpackIntroductoryOffer && (
 					<DiscountPercentage percent={ discountPercentage } />
 				) }
-				{ discountPercentage > 0 && (
+				{ discountPercentage > 0 && ! isJetpackIntroductoryOffer && (
 					<DoNotPayThis>{ formattedCompareToPriceForVariantTerm }</DoNotPayThis>
 				) }
-				<Price>{ formattedCurrentPrice }</Price>
+				<Price>
+					{ formattedCurrentPrice }
+					{ isJetpackIntroductoryOffer && translatedIntroOfferPrice }
+				</Price>
 			</span>
 		</Variant>
 	);

--- a/client/my-sites/checkout/composite-checkout/components/item-variation-picker/variant-dropdown-price.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/item-variation-picker/variant-dropdown-price.tsx
@@ -101,23 +101,33 @@ export const ItemVariantDropDownPrice: FunctionComponent< {
 		  } )
 		: undefined;
 	// Jetpack introductory pricing displays the introductory price for the first term, then the regular price for the remaining term.
-	const planTerm = variant.termIntervalInDays > 31 ? 'year' : 'month';
+	// const planTerm = variant.termIntervalInDays > 31 ? 'year' : 'month';
 	const introTerm = variant.introIntervalUnit;
 	const introCount = variant.introIntervalCount;
 	const formattedRegularPrice = formatCurrency( variant.regularPrice, variant.currency );
 	const isJetpackIntroductoryOffer = isJetpackProduct( variant ) && introCount > 0;
 	const translate = useTranslate();
+	const planTerm = () => {
+		let termToTranslate = translate( 'month' );
+		if ( variant.termIntervalInYears > 1 ) {
+			//biannual is currently the only possible term past 1 year
+			termToTranslate = translate( '2 years' );
+		} else if ( variant.termIntervalInYears > 0 ) {
+			termToTranslate = translate( 'year' );
+		}
+		return termToTranslate;
+	};
 	const translatedIntroOfferPrice = translate(
-		' for the first %(introTerm)s then %(formattedRegularPrice)s per %(planTerm)s',
+		'for the first %(introTerm)s then %(formattedRegularPrice)s per %(planTerm)s',
+		// translation example: $4.99 for the first month then $9.99 per year
 		{
 			args: {
 				formattedRegularPrice,
-				planTerm,
 				introTerm,
+				planTerm: planTerm(),
 			},
 		}
 	);
-
 	return (
 		<Variant>
 			<Label>

--- a/client/my-sites/checkout/composite-checkout/components/item-variation-picker/variant-dropdown-price.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/item-variation-picker/variant-dropdown-price.tsx
@@ -171,7 +171,7 @@ export const ItemVariantDropDownPrice: FunctionComponent< {
 				{ discountPercentage > 0 && ! isJetpackIntroductoryOffer && (
 					<DoNotPayThis>{ formattedCompareToPriceForVariantTerm }</DoNotPayThis>
 				) }
-				<Price>{ formattedCurrentPrice }</Price>
+				<Price aria-hidden={ isJetpackIntroductoryOffer }>{ formattedCurrentPrice }</Price>
 				<IntroPricing>
 					{ isJetpackIntroductoryOffer && ! isMobile && translatedIntroOfferPrice }
 					{ isJetpackIntroductoryOffer && isMobile && translatedIntroOfferPriceMobile }

--- a/client/my-sites/checkout/composite-checkout/components/item-variation-picker/variant-dropdown-price.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/item-variation-picker/variant-dropdown-price.tsx
@@ -87,12 +87,7 @@ export const ItemVariantDropDownPrice: FunctionComponent< {
 	variant: WPCOMProductVariant;
 	compareTo?: WPCOMProductVariant;
 } > = ( { variant, compareTo } ) => {
-	const planTerm = variant.termIntervalInDays > 31 ? 'year' : 'month';
-	const introTerm = variant.introIntervalUnit;
-	const introCount = variant.introIntervalCount;
 	const isMobile = useMobileBreakpoint();
-	const isJetpackIntroductoryOffer = isJetpackProduct( variant ) && introCount > 0;
-	const formattedRegularPrice = formatCurrency( variant.regularPrice, variant.currency );
 	const compareToPriceForVariantTerm = getItemVariantCompareToPrice( variant, compareTo );
 	const discountPercentage = getItemVariantDiscountPercentage( variant, compareTo );
 	const formattedCurrentPrice = formatCurrency( variant.priceInteger, variant.currency, {
@@ -105,6 +100,12 @@ export const ItemVariantDropDownPrice: FunctionComponent< {
 				isSmallestUnit: true,
 		  } )
 		: undefined;
+	// Jetpack introductory pricing displays the introductory price for the first term, then the regular price for the remaining term.
+	const planTerm = variant.termIntervalInDays > 31 ? 'year' : 'month';
+	const introTerm = variant.introIntervalUnit;
+	const introCount = variant.introIntervalCount;
+	const formattedRegularPrice = formatCurrency( variant.regularPrice, variant.currency );
+	const isJetpackIntroductoryOffer = isJetpackProduct( variant ) && introCount > 0;
 	const translate = useTranslate();
 	const translatedIntroOfferPrice = translate(
 		' for the first %(introTerm)s then %(formattedRegularPrice)s per %(planTerm)s',

--- a/client/my-sites/checkout/composite-checkout/components/item-variation-picker/variant-dropdown-price.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/item-variation-picker/variant-dropdown-price.tsx
@@ -56,6 +56,7 @@ const Variant = styled.div`
 	justify-content: space-between;
 	line-height: 20px;
 	width: 100%;
+	column-gap: 10%;
 
 	.item-variant-option--selected & {
 		color: #fff;
@@ -74,10 +75,16 @@ const IntroPricing = styled.span`
 	display: flex;
 	flex-direction: column;
 	font-size: 0.8rem;
-	margin-left: auto;
-	p {
-		text-align: right;
+	.div {
+		display: block;
+		margin-bottom: 0rem;
 	}
+`;
+
+const IntroPricingText = styled.span`
+	display: block;
+	text-align: right;
+	margin-bottom: 0rem;
 `;
 
 const DiscountPercentage: FunctionComponent< { percent: number } > = ( { percent } ) => {
@@ -230,7 +237,9 @@ export const ItemVariantDropDownPrice: FunctionComponent< {
 				) }
 				<Price aria-hidden={ isIntroductoryOffer }>{ formattedCurrentPrice }</Price>
 				<IntroPricing>
-					<p>{ isIntroductoryOffer && translatedIntroOfferDetails() }</p>
+					<IntroPricingText>
+						{ isIntroductoryOffer && translatedIntroOfferDetails() }
+					</IntroPricingText>
 				</IntroPricing>
 			</span>
 		</Variant>

--- a/client/my-sites/checkout/composite-checkout/components/item-variation-picker/variant-dropdown-price.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/item-variation-picker/variant-dropdown-price.tsx
@@ -74,6 +74,7 @@ const Label = styled.span`
 const IntroPricing = styled.span`
 	display: flex;
 	flex-direction: column;
+	font-size: 0.8rem;
 `;
 
 const DiscountPercentage: FunctionComponent< { percent: number } > = ( { percent } ) => {
@@ -107,7 +108,6 @@ export const ItemVariantDropDownPrice: FunctionComponent< {
 		  } )
 		: undefined;
 	// Jetpack introductory pricing displays the introductory price for the first term, then the regular price for the remaining term.
-	// const planTerm = variant.termIntervalInDays > 31 ? 'year' : 'month';
 	const introTerm = variant.introductoryTerm;
 	const introCount = variant.introductoryInterval;
 	const formattedPriceBeforeDiscounts = formatCurrency(
@@ -118,16 +118,16 @@ export const ItemVariantDropDownPrice: FunctionComponent< {
 			isSmallestUnit: true,
 		}
 	);
-	const planLength = variant.planLength;
+	const productBillingTermInMonths = variant.productBillingTermInMonths;
 	const isJetpackIntroductoryOffer = isJetpackProduct( variant ) && introCount > 0;
 	const translate = useTranslate();
 	// the backend returns the term in text, but it it adds "one" like One year, which looks off so we're creating our own.
 	const planTerm = () => {
 		let termToTranslate = translate( 'month' );
-		if ( planLength > 12 ) {
+		if ( productBillingTermInMonths > 12 ) {
 			//biannual is currently the only possible term past 1 year
 			termToTranslate = translate( '2 years' );
-		} else if ( planLength > 1 ) {
+		} else if ( productBillingTermInMonths > 1 ) {
 			termToTranslate = translate( 'year' );
 		}
 		return termToTranslate;
@@ -173,10 +173,8 @@ export const ItemVariantDropDownPrice: FunctionComponent< {
 				) }
 				<Price>{ formattedCurrentPrice }</Price>
 				<IntroPricing>
-					<small>{ isJetpackIntroductoryOffer && ! isMobile && translatedIntroOfferPrice }</small>
-					<small>
-						{ isJetpackIntroductoryOffer && isMobile && translatedIntroOfferPriceMobile }
-					</small>
+					{ isJetpackIntroductoryOffer && ! isMobile && translatedIntroOfferPrice }
+					{ isJetpackIntroductoryOffer && isMobile && translatedIntroOfferPriceMobile }
 				</IntroPricing>
 			</span>
 		</Variant>

--- a/client/my-sites/checkout/composite-checkout/components/item-variation-picker/variant-dropdown-price.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/item-variation-picker/variant-dropdown-price.tsx
@@ -108,28 +108,37 @@ export const ItemVariantDropDownPrice: FunctionComponent< {
 		: undefined;
 	// Jetpack introductory pricing displays the introductory price for the first term, then the regular price for the remaining term.
 	// const planTerm = variant.termIntervalInDays > 31 ? 'year' : 'month';
-	const introTerm = variant.introIntervalUnit;
-	const introCount = variant.introIntervalCount;
-	const formattedRegularPrice = formatCurrency( variant.regularPrice, variant.currency );
+	const introTerm = variant.introductoryTerm;
+	const introCount = variant.introductoryInterval;
+	const formattedPriceBeforeDiscounts = formatCurrency(
+		variant.priceBeforeDiscounts,
+		variant.currency,
+		{
+			stripZeros: true,
+			isSmallestUnit: true,
+		}
+	);
+	const planLength = variant.planLength;
 	const isJetpackIntroductoryOffer = isJetpackProduct( variant ) && introCount > 0;
 	const translate = useTranslate();
+	// the backend returns the term in text, but it it adds "one" like One year, which looks off so we're creating our own.
 	const planTerm = () => {
 		let termToTranslate = translate( 'month' );
-		if ( variant.termIntervalInYears > 1 ) {
+		if ( planLength > 12 ) {
 			//biannual is currently the only possible term past 1 year
 			termToTranslate = translate( '2 years' );
-		} else if ( variant.termIntervalInYears > 0 ) {
+		} else if ( planLength > 1 ) {
 			termToTranslate = translate( 'year' );
 		}
 		return termToTranslate;
 	};
 	const translatedIntroOfferPrice = translate(
-		'%(formattedCurrentPrice)s first %(introTerm)s then %(formattedRegularPrice)s per %(planTerm)s',
+		'%(formattedCurrentPrice)s first %(introTerm)s then %(formattedPriceBeforeDiscounts)s per %(planTerm)s',
 		// translation example: $4.99 first month then $9.99 per year
 		{
 			args: {
 				formattedCurrentPrice,
-				formattedRegularPrice,
+				formattedPriceBeforeDiscounts,
 				introTerm,
 				planTerm: planTerm(),
 			},

--- a/client/my-sites/checkout/composite-checkout/components/item-variation-picker/variant-dropdown-price.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/item-variation-picker/variant-dropdown-price.tsx
@@ -41,8 +41,9 @@ const DoNotPayThis = styled.del`
 `;
 
 const Price = styled.span`
+	display: flex;
+	justify-content: right;
 	color: #646970;
-
 	.item-variant-option--selected & {
 		color: #fff;
 	}
@@ -68,6 +69,11 @@ const Label = styled.span`
 	@media ( max-width: 480px ) {
 		flex-direction: column;
 	}
+`;
+
+const IntroPricing = styled.span`
+	display: flex;
+	flex-direction: column;
 `;
 
 const DiscountPercentage: FunctionComponent< { percent: number } > = ( { percent } ) => {
@@ -118,16 +124,29 @@ export const ItemVariantDropDownPrice: FunctionComponent< {
 		return termToTranslate;
 	};
 	const translatedIntroOfferPrice = translate(
-		'for the first %(introTerm)s then %(formattedRegularPrice)s per %(planTerm)s',
-		// translation example: $4.99 for the first month then $9.99 per year
+		'%(formattedCurrentPrice)s first %(introTerm)s then %(formattedRegularPrice)s per %(planTerm)s',
+		// translation example: $4.99 first month then $9.99 per year
 		{
 			args: {
+				formattedCurrentPrice,
 				formattedRegularPrice,
 				introTerm,
 				planTerm: planTerm(),
 			},
 		}
 	);
+
+	const translatedIntroOfferPriceMobile = translate(
+		'%(formattedCurrentPrice)s first %(introTerm)s',
+		// translation example: $4.99 first month
+		{
+			args: {
+				formattedCurrentPrice,
+				introTerm,
+			},
+		}
+	);
+
 	return (
 		<Variant>
 			<Label>
@@ -143,10 +162,13 @@ export const ItemVariantDropDownPrice: FunctionComponent< {
 				{ discountPercentage > 0 && ! isJetpackIntroductoryOffer && (
 					<DoNotPayThis>{ formattedCompareToPriceForVariantTerm }</DoNotPayThis>
 				) }
-				<Price>
-					{ formattedCurrentPrice }
-					{ isJetpackIntroductoryOffer && translatedIntroOfferPrice }
-				</Price>
+				<Price>{ formattedCurrentPrice }</Price>
+				<IntroPricing>
+					<small>{ isJetpackIntroductoryOffer && ! isMobile && translatedIntroOfferPrice }</small>
+					<small>
+						{ isJetpackIntroductoryOffer && isMobile && translatedIntroOfferPriceMobile }
+					</small>
+				</IntroPricing>
 			</span>
 		</Variant>
 	);

--- a/client/my-sites/checkout/composite-checkout/components/item-variation-picker/variant-dropdown-price.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/item-variation-picker/variant-dropdown-price.tsx
@@ -75,10 +75,6 @@ const IntroPricing = styled.span`
 	display: flex;
 	flex-direction: column;
 	font-size: 0.8rem;
-	.div {
-		display: block;
-		margin-bottom: 0rem;
-	}
 `;
 
 const IntroPricingText = styled.span`

--- a/client/my-sites/checkout/composite-checkout/hooks/product-variants.tsx
+++ b/client/my-sites/checkout/composite-checkout/hooks/product-variants.tsx
@@ -96,7 +96,7 @@ export function useGetProductVariants(
 						introductoryTerm: introductoryTerms?.interval_unit,
 						priceBeforeDiscounts: variant.price_before_discounts_integer,
 						currency: variant.currency,
-						planLength: variant.bill_period_in_months,
+						productBillingTermInMonths: variant.bill_period_in_months,
 					};
 				} catch ( error ) {
 					// Three-year plans are not yet fully supported, so we need to guard

--- a/client/my-sites/checkout/composite-checkout/hooks/product-variants.tsx
+++ b/client/my-sites/checkout/composite-checkout/hooks/product-variants.tsx
@@ -84,6 +84,7 @@ export function useGetProductVariants(
 			.map( ( variant ): WPCOMProductVariant | undefined => {
 				try {
 					const term = getBillingTermForMonths( variant.bill_period_in_months );
+					const introductoryTerms = variant.introductory_offer_terms;
 					return {
 						variantLabel: getTermText( term, translate ),
 						productSlug: variant.product_slug,
@@ -91,7 +92,11 @@ export function useGetProductVariants(
 						priceInteger: variant.price_integer,
 						termIntervalInMonths: getBillingMonthsForTerm( term ),
 						termIntervalInDays: getTermDuration( term ) ?? 0,
+						introductoryInterval: introductoryTerms?.interval_count,
+						introductoryTerm: introductoryTerms?.interval_unit,
+						priceBeforeDiscounts: variant.price_before_discounts_integer,
 						currency: variant.currency,
+						planLength: variant.bill_period_in_months,
 					};
 				} catch ( error ) {
 					// Three-year plans are not yet fully supported, so we need to guard

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -584,6 +584,8 @@ export interface ResponseCartProductVariant {
 	product_slug: string;
 	currency: string;
 	price_integer: number;
+	price_before_discounts_integer: number;
+	introductory_offer_terms: IntroductoryOfferTerms;
 }
 
 export interface IntroductoryOfferTerms {

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -585,7 +585,9 @@ export interface ResponseCartProductVariant {
 	currency: string;
 	price_integer: number;
 	price_before_discounts_integer: number;
-	introductory_offer_terms: IntroductoryOfferTerms;
+	introductory_offer_terms:
+		| Record< string, never >
+		| Pick< IntroductoryOfferTerms, 'interval_unit' | 'interval_count' >;
 }
 
 export interface IntroductoryOfferTerms {


### PR DESCRIPTION
#### Proposed Changes

* There has been some user confusion with Jetpack Intro offers (such as first month of Social for $1) when the plan renews at full price
* This PR clearly states at check out when the next renewal will be and what price per pdrWKz-El-p2#comment-891

Images for translators:

Desktop:

![Screenshot 2022-12-22 at 9 42 48 AM](https://user-images.githubusercontent.com/12895386/209158904-508ae56c-31d5-4460-b726-ed01f4269ea3.png)

Mobile:

![Screenshot 2022-12-22 at 9 43 22 AM](https://user-images.githubusercontent.com/12895386/209158957-195ad2b8-e14b-407f-a0a5-c562e9658a29.png)


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the Calypso live link below (or build this PR locally) and append /checkout/jetpack/jetpack_social_basic_yearly to the URL
* You'll see the checkout page with Social yearly selected (Social is currently the only product with an intro)
* Click the drop down to see the offerings for both yearly and monthly purchase of the plan.
* Verify that the price shows the initial price, term and then renewal term and price as in the screenshot above

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #