### PR TITLE
Reader: Bug fix for site icons that aren't showing

### DIFF
--- a/client/reader/stream/reader-list-followed-sites/item.jsx
+++ b/client/reader/stream/reader-list-followed-sites/item.jsx
@@ -48,8 +48,9 @@ const ReaderListFollowingItem = ( props ) => {
 				href={ streamLink }
 				onClick={ () => handleSidebarClick( site ) }
 			>
-				<Favicon site={ site } className="reader-sidebar-site_siteicon" size={ 32 } />
-
+				<span className="reader-sidebar-site_siteicon-container">
+					<Favicon site={ site } size={ 32 } />
+				</span>
 				<span className="reader-sidebar-site_sitename">
 					<span className="reader-sidebar-site_nameurl">
 						{ site.name || formatUrlForDisplay( site.URL ) }

--- a/client/reader/stream/reader-list-followed-sites/item.jsx
+++ b/client/reader/stream/reader-list-followed-sites/item.jsx
@@ -48,7 +48,7 @@ const ReaderListFollowingItem = ( props ) => {
 				href={ streamLink }
 				onClick={ () => handleSidebarClick( site ) }
 			>
-				<span className="reader-sidebar-site_siteicon-container">
+				<span className="reader-sidebar-site_siteicon">
 					<Favicon site={ site } size={ 32 } />
 				</span>
 				<span className="reader-sidebar-site_sitename">

--- a/client/reader/stream/reader-list-organizations/list-item.jsx
+++ b/client/reader/stream/reader-list-organizations/list-item.jsx
@@ -43,8 +43,9 @@ export class ReaderListOrganizationsListItem extends Component {
 					href={ `/read/feeds/${ site.feed_ID }` }
 					onClick={ this.handleSidebarClick }
 				>
-					<Favicon site={ site } className="reader-sidebar-site_siteicon" size={ 32 } />
-
+					<span className="reader-sidebar-site_siteicon-container">
+						<Favicon site={ site } size={ 32 } />
+					</span>
 					<span className="reader-sidebar-site_sitename">
 						<span className="reader-sidebar-site_nameurl">{ site.name }</span>
 						<span className="reader-sidebar-site_updated">

--- a/client/reader/stream/reader-list-organizations/list-item.jsx
+++ b/client/reader/stream/reader-list-organizations/list-item.jsx
@@ -43,7 +43,7 @@ export class ReaderListOrganizationsListItem extends Component {
 					href={ `/read/feeds/${ site.feed_ID }` }
 					onClick={ this.handleSidebarClick }
 				>
-					<span className="reader-sidebar-site_siteicon-container">
+					<span className="reader-sidebar-site_siteicon">
 						<Favicon site={ site } size={ 32 } />
 					</span>
 					<span className="reader-sidebar-site_sitename">

--- a/client/reader/stream/style.scss
+++ b/client/reader/stream/style.scss
@@ -599,6 +599,10 @@
 		}
 	}
 
+	.reader-sidebar-site_siteicon {
+		min-width: 32px;
+	}
+
 	.reader-sidebar-site_sitename {
 		color: var(--color-neutral-100);
 		font-weight: 600;

--- a/client/reader/stream/style.scss
+++ b/client/reader/stream/style.scss
@@ -600,6 +600,7 @@
 	}
 
 	.reader-sidebar-site_siteicon {
+		min-height: 32px;
 		min-width: 32px;
 	}
 


### PR DESCRIPTION
## Description

Occasionally, when a site icon is missing, the default globe wouldn't show. I think this is because no min-width was being applied. Added a span around it (in case for some reason a site icon actually doesn't load) and applied a min-width. Seems to have fixed the issue.

### Before

<img width="298" alt="CleanShot 2022-12-09 at 16 11 53@2x" src="https://user-images.githubusercontent.com/5634774/206797187-9eb1d874-ddf2-4d33-a9c2-d88ce2b91200.png">

### After

<img width="340" alt="CleanShot 2022-12-09 at 16 11 11@2x" src="https://user-images.githubusercontent.com/5634774/206797230-76bc43fc-d04d-46e8-9d9b-0335f948617b.png">

## To replicate

1. Follow cgkYu-p2
2. Visit http://calypso.localhost:3000/read/p2

## Related

#67164