### PR TITLE
Checkout: Hide contact validation errors during auto-completion, with flag

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
@@ -193,7 +193,7 @@ export default function WPCheckout( {
 	} = useDispatch( 'wpcom-checkout' );
 
 	const [ shouldShowContactDetailsValidationErrors, setShouldShowContactDetailsValidationErrors ] =
-		useState( false );
+		useState( true );
 
 	// The "Summary" view is displayed in the sidebar at desktop (wide) widths
 	// and before the first step at mobile (smaller) widths. At smaller widths it
@@ -359,9 +359,8 @@ export default function WPCheckout( {
 				<CheckoutStep
 					stepId="contact-form"
 					isCompleteCallback={ async () => {
-						setShouldShowContactDetailsValidationErrors( true );
 						// Touch the fields so they display validation errors
-						touchContactFields();
+						shouldShowContactDetailsValidationErrors && touchContactFields();
 						const validationResponse = await validateContactDetails(
 							contactInfo,
 							isLoggedOutCart,
@@ -371,7 +370,7 @@ export default function WPCheckout( {
 							clearDomainContactErrorMessages,
 							reduxDispatch,
 							translate,
-							true
+							shouldShowContactDetailsValidationErrors
 						);
 						if ( validationResponse ) {
 							// When the contact details change, update the cart's tax location to match.

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
@@ -404,6 +404,9 @@ export default function WPCheckout( {
 							shouldShowContactDetailsValidationErrors={ shouldShowContactDetailsValidationErrors }
 							contactDetailsType={ contactDetailsType }
 							isLoggedOutCart={ isLoggedOutCart }
+							setShouldShowContactDetailsValidationErrors={
+								setShouldShowContactDetailsValidationErrors
+							}
 						/>
 					}
 					completeStepContent={

--- a/client/my-sites/checkout/composite-checkout/components/wp-contact-form.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-contact-form.tsx
@@ -30,11 +30,13 @@ export default function WPContactForm( {
 	shouldShowContactDetailsValidationErrors,
 	contactDetailsType,
 	isLoggedOutCart,
+	setShouldShowContactDetailsValidationErrors,
 }: {
 	countriesList: CountryListItem[];
 	shouldShowContactDetailsValidationErrors: boolean;
 	contactDetailsType: Exclude< ContactDetailsType, 'none' >;
 	isLoggedOutCart: boolean;
+	setShouldShowContactDetailsValidationErrors: ( allowed: boolean ) => void;
 } ) {
 	const contactInfo: ManagedContactDetails = useSelect( ( select ) =>
 		select( 'wpcom-checkout' ).getContactInfo()
@@ -43,7 +45,7 @@ export default function WPContactForm( {
 	const isStepActive = useIsStepActive();
 	const isDisabled = ! isStepActive || formStatus !== FormStatus.READY;
 
-	useCachedDomainContactDetails( countriesList );
+	useCachedDomainContactDetails( setShouldShowContactDetailsValidationErrors, countriesList );
 
 	return (
 		<BillingFormFields>

--- a/client/my-sites/checkout/composite-checkout/hooks/use-cached-domain-contact-details.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-cached-domain-contact-details.ts
@@ -1,9 +1,11 @@
+import config from '@automattic/calypso-config';
 import { useSetStepComplete } from '@automattic/composite-checkout';
 import { getCountryPostalCodeSupport } from '@automattic/wpcom-checkout';
 import { useDispatch } from '@wordpress/data';
 import debugFactory from 'debug';
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useSelector, useDispatch as useReduxDispatch } from 'react-redux';
+import { logToLogstash } from 'calypso/lib/logstash';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { requestContactDetailsCache } from 'calypso/state/domains/management/actions';
 import getContactDetailsCache from 'calypso/state/selectors/get-contact-details-cache';
@@ -35,11 +37,13 @@ function useCachedContactDetails(): PossiblyCompleteDomainContactDetails | null 
 
 function useCachedContactDetailsForCheckoutForm(
 	cachedContactDetails: PossiblyCompleteDomainContactDetails | null,
+	setShouldShowContactDetailsValidationErrors: ( allowed: boolean ) => void,
 	overrideCountryList?: CountryListItem[]
-): void {
+): boolean {
 	const countriesList = useCountryList( overrideCountryList );
 	const reduxDispatch = useReduxDispatch();
 	const setStepCompleteStatus = useSetStepComplete();
+	const [ isComplete, setComplete ] = useState( false );
 	const didFillForm = useRef( false );
 
 	const arePostalCodesSupported =
@@ -54,6 +58,14 @@ function useCachedContactDetailsForCheckoutForm(
 		);
 	}
 	const { loadDomainContactDetailsFromCache } = checkoutStoreActions;
+
+	const isMounted = useRef( true );
+	useEffect( () => {
+		isMounted.current = true;
+		return () => {
+			isMounted.current = false;
+		};
+	}, [] );
 
 	// When we have fetched or loaded contact details, send them to the
 	// `wpcom-checkout` data store for use by the checkout contact form.
@@ -82,18 +94,44 @@ function useCachedContactDetailsForCheckoutForm(
 			postalCode: arePostalCodesSupported ? cachedContactDetails.postalCode : '',
 		} )
 			.then( () => {
+				if ( ! isMounted.current ) {
+					return false;
+				}
 				if ( cachedContactDetails.countryCode ) {
+					setShouldShowContactDetailsValidationErrors( false );
 					debug( 'Contact details are populated; attempting to skip to payment method step' );
 					return setStepCompleteStatus( 'contact-form' );
 				}
 				return false;
 			} )
 			.then( ( didSkip: boolean ) => {
+				if ( ! isMounted.current ) {
+					return false;
+				}
 				if ( didSkip ) {
 					reduxDispatch( recordTracksEvent( 'calypso_checkout_skip_to_last_step' ) );
 				}
+				setShouldShowContactDetailsValidationErrors( true );
+				setComplete( true );
+			} )
+			.catch( ( error ) => {
+				setShouldShowContactDetailsValidationErrors( true );
+				isMounted.current && setComplete( true );
+				// eslint-disable-next-line no-console
+				console.error( error );
+				logToLogstash( {
+					feature: 'calypso_client',
+					message: 'composite checkout load error',
+					severity: config( 'env_id' ) === 'production' ? 'error' : 'debug',
+					extra: {
+						env: config( 'env_id' ),
+						type: 'checkout_contact_details_autocomplete',
+						message: error.message + '; Stack: ' + error.stack,
+					},
+				} );
 			} );
 	}, [
+		setShouldShowContactDetailsValidationErrors,
 		reduxDispatch,
 		setStepCompleteStatus,
 		cachedContactDetails,
@@ -101,6 +139,8 @@ function useCachedContactDetailsForCheckoutForm(
 		loadDomainContactDetailsFromCache,
 		countriesList,
 	] );
+
+	return isComplete;
 }
 
 /**
@@ -108,8 +148,13 @@ function useCachedContactDetailsForCheckoutForm(
  * checkout contact form and the shopping cart tax location.
  */
 export default function useCachedDomainContactDetails(
+	setShouldShowContactDetailsValidationErrors: ( allowed: boolean ) => void,
 	overrideCountryList?: CountryListItem[]
 ): void {
 	const cachedContactDetails = useCachedContactDetails();
-	useCachedContactDetailsForCheckoutForm( cachedContactDetails, overrideCountryList );
+	useCachedContactDetailsForCheckoutForm(
+		cachedContactDetails,
+		setShouldShowContactDetailsValidationErrors,
+		overrideCountryList
+	);
 }

--- a/client/my-sites/checkout/composite-checkout/test/checkout-contact-step.js
+++ b/client/my-sites/checkout/composite-checkout/test/checkout-contact-step.js
@@ -246,6 +246,22 @@ describe( 'Checkout contact step', () => {
 		await expect( screen.findByTestId( 'payment-method-step--visible' ) ).toNeverAppear();
 	} );
 
+	it( 'does not show errors when autocompleting the contact step when there are invalid cached details', async () => {
+		mockCachedContactDetailsEndpoint( {
+			country_code: 'US',
+			postal_code: 'ABCD',
+		} );
+		mockContactDetailsValidationEndpoint( 'tax', {
+			success: false,
+			messages: { postal_code: [ 'Postal code error message' ] },
+		} );
+		const cartChanges = { products: [ planWithoutDomain ] };
+		render( <MyCheckout cartChanges={ cartChanges } />, container );
+		// Wait for the cart to load
+		await screen.findByText( 'Country' );
+		await expect( screen.findByText( 'Postal code error message' ) ).toNeverAppear();
+	} );
+
 	it.each( [
 		{ complete: 'does', valid: 'valid', name: 'plan', email: 'fails', logged: 'in' },
 		{ complete: 'does not', valid: 'invalid', name: 'plan', email: 'fails', logged: 'in' },

--- a/client/my-sites/checkout/composite-checkout/test/checkout-contact-step.js
+++ b/client/my-sites/checkout/composite-checkout/test/checkout-contact-step.js
@@ -256,7 +256,7 @@ describe( 'Checkout contact step', () => {
 			messages: { postal_code: [ 'Postal code error message' ] },
 		} );
 		const cartChanges = { products: [ planWithoutDomain ] };
-		render( <MyCheckout cartChanges={ cartChanges } />, container );
+		render( <MyCheckout cartChanges={ cartChanges } /> );
 		// Wait for the cart to load
 		await screen.findByText( 'Country' );
 		await expect( screen.findByText( 'Postal code error message' ) ).toNeverAppear();

--- a/client/my-sites/checkout/composite-checkout/test/use-cached-domain-contact-details.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/use-cached-domain-contact-details.tsx
@@ -63,7 +63,7 @@ function MyTestContent( { countries }: { countries: CountryListItem[] } ) {
 	const { responseCart, reloadFromServer, updateLocation } = useShoppingCart(
 		initialCart.cart_key
 	);
-	useCachedDomainContactDetails( countries );
+	useCachedDomainContactDetails( () => null, countries );
 	const contactInfo: ManagedContactDetails = useSelect( ( select ) =>
 		select( 'wpcom-checkout' ).getContactInfo()
 	);


### PR DESCRIPTION
#### Proposed Changes

When checkout loads, it fetches saved contact details from an API endpoint, pre-fills the contact form with those details, and attempts to auto-complete the contact details step. Since https://github.com/Automattic/wp-calypso/pull/64344, this process uses the same logic as if a user filled out the form and clicked "Continue" manually. 

However, there is a downside of this approach: the contact details are validated every time someone clicks "Continue" and since this uses the same process, if the saved details are invalid the user will see an error reported as soon as checkout loads. Since the user didn't actually take any action at this point, this can be very confusing.

<img width="977" alt="validation-error" src="https://user-images.githubusercontent.com/2036909/201235660-6c218f93-0ae4-418d-bb69-29e953fe404f.png">

In this PR, we refactor the placement of the auto-completion code so that its validation call will not report any errors on failure. This is done by having the auto-completion code turn off the validation errors during validation and then turning them back on.

Fixes https://github.com/Automattic/wp-calypso/issues/69211

#### Differences compared to the previous version of this PR

This is the second attempt at solving this issue after https://github.com/Automattic/wp-calypso/pull/69943 was reverted in https://github.com/Automattic/wp-calypso/pull/70721 because there was a bug with free purchases. 

In the previous PR, we moved the checkout contact details step into a wrapper component due to a leaky abstraction. There is one case where no contact details step is needed: when the purchase is free ($0 total, not full credits). Before https://github.com/Automattic/wp-calypso/pull/69943, we did not render the step in this case, but after that PR, we _did_ render the step, except that the wrapper returned null. The result was that, if the purchase was free, checkout would think that the contact details step was present and _active_ even though it was null, effectively blocking checkout.

This PR performs additional refactoring to remove the leaky abstraction and gets rid of the wrapper. In addition, https://github.com/Automattic/wp-calypso/pull/70776 adds a test to prevent the bug from happening again.

#### Testing Instructions

There are unit tests for this behavior but you can test it manually as follows:

First test that successful validation still works:

- Make sure you have valid cached _domain_ contact details for a user (using a domain product will cause more fields to be visible). You can do this by visiting checkout when a domain product is in your cart, filling out the contact information step and pressing "Continue". Assuming they are valid, they will be saved for future visits to checkout.
- Add a _domain_ product to your cart and visit checkout (or reload if you are already there).
- Verify that you see the contact information step load before it is auto-completed.
- Verify that the active step is now the payment method step.

Next test that manual validation displays error messages:

- Add a _domain_ product to your cart and visit checkout.
- Click to edit the contact information step if it is not already active.
- Enter invalid contact information (eg: by clearing the "Last name" field).
- Press "Continue".
- Verify that you see a validation error.
- Verify that the active step is still the contact information step.

Finally, test that auto-completion does not display error messages:

- Apply D92139-code and sandbox the API. This will break the domain contact details validation endpoint.
- Add a _domain_ product to your cart and visit checkout.
- Verify that you see the contact information step load before it is auto-completed.
- Verify that you _do not see_ a validation error.
- Verify that the active step is still the contact information step.
