### PR TITLE
Change default theme from zoologist to twentytwentythree

### DIFF
--- a/client/lib/signup/site-type.js
+++ b/client/lib/signup/site-type.js
@@ -4,7 +4,7 @@ import { find, get } from 'lodash';
 const getSiteTypePropertyDefaults = ( propertyKey ) =>
 	get(
 		{
-			theme: 'pub/zoologist',
+			theme: 'pub/twentytwentythree',
 			// General copy
 			siteMockupHelpTipCopy: i18n.translate(
 				"Scroll down to see how your site will look. You can customize it with your own text and photos when we're done with the setup basics."

--- a/client/lib/signup/site-type.js
+++ b/client/lib/signup/site-type.js
@@ -4,7 +4,6 @@ import { find, get } from 'lodash';
 const getSiteTypePropertyDefaults = ( propertyKey ) =>
 	get(
 		{
-			theme: 'pub/twentytwentythree',
 			// General copy
 			siteMockupHelpTipCopy: i18n.translate(
 				"Scroll down to see how your site will look. You can customize it with your own text and photos when we're done with the setup basics."


### PR DESCRIPTION
#### Proposed Changes

* Change the default theme for the build flow from Zoologist (fbhepr%2Skers%2Sjcpbz%2Qcho%2Qgurzrf%2Smbbybtvfg%2S-og) to Twentytwentythree (fbhepr%2Skers%2Sjcpbz%2Qcho%2Qgurzrf%2Sgjraglgjraglguerr%2S-og)

#### Testing Instructions
This is for the Build flow
* Using the Calypso Live link below
* Go to /start
* After you created a new site, you will land on the onboarding flow
* Continue until you land on the Design Picker
* On the Design Picker screen, don't pick a design. Instead, click "Skip for now" in the top right corner
* Check that the site theme is TT3 and that you have the correct starter content
* Check that the site's reading settings are correct: to "show posts"

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #70604