### PR TITLE
VideoPress Tailored Onboarding: Update launchpad plan step to encourage plan purchase

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -58,7 +58,9 @@ export function getEnhancedTasks(
 		isVideoPressFlow( flow ) && ! planHasFeature( productSlug as string, FEATURE_VIDEO_UPLOADS );
 
 	if ( isVideoPressFlowWithUnsupportedPlan ) {
-		planWarningText = translate( 'Purchase a plan that supports VideoPress.' );
+		planWarningText = translate(
+			'Upgrade to a plan with VideoPress support to upload your videos.'
+		);
 		displayWarning = true;
 	}
 
@@ -101,7 +103,9 @@ export function getEnhancedTasks(
 							const plansUrl = addQueryArgs( `/plans/${ siteSlug }`, {
 								...( displayWarning && {
 									plan: PLAN_PREMIUM,
-									feature: FEATURE_ADVANCED_DESIGN_CUSTOMIZATION,
+									feature: isVideoPressFlowWithUnsupportedPlan
+										? FEATURE_VIDEO_UPLOADS
+										: FEATURE_ADVANCED_DESIGN_CUSTOMIZATION,
 								} ),
 							} );
 							window.location.assign( plansUrl );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -22,7 +22,7 @@ export function getEnhancedTasks(
 	siteSlug: string | null,
 	site: SiteDetails | null,
 	submit: NavigationControls[ 'submit' ],
-	displayWarning: boolean,
+	displayGlobalStylesWarning: boolean,
 	goToStep?: NavigationControls[ 'goToStep' ],
 	flow?: string | null
 ) {
@@ -48,7 +48,7 @@ export function getEnhancedTasks(
 		? `/page/${ siteSlug }/${ homePageId }`
 		: `/site-editor/${ siteSlug }`;
 
-	let planWarningText = displayWarning
+	let planWarningText = displayGlobalStylesWarning
 		? translate(
 				'Your site contains custom colors that will only be visible once you upgrade to a Premium plan.'
 		  )
@@ -61,8 +61,9 @@ export function getEnhancedTasks(
 		planWarningText = translate(
 			'Upgrade to a plan with VideoPress support to upload your videos.'
 		);
-		displayWarning = true;
 	}
+
+	const shouldDisplayWarning = displayGlobalStylesWarning || isVideoPressFlowWithUnsupportedPlan;
 
 	tasks &&
 		tasks.map( ( task ) => {
@@ -95,13 +96,13 @@ export function getEnhancedTasks(
 						subtitle: planWarningText,
 						actionDispatch: () => {
 							recordTaskClickTracksEvent( flow, task.completed, task.id );
-							if ( displayWarning && ! isVideoPressFlowWithUnsupportedPlan ) {
+							if ( displayGlobalStylesWarning ) {
 								recordTracksEvent(
 									'calypso_launchpad_global_styles_gating_plan_selected_task_clicked'
 								);
 							}
 							const plansUrl = addQueryArgs( `/plans/${ siteSlug }`, {
-								...( displayWarning && {
+								...( shouldDisplayWarning && {
 									plan: PLAN_PREMIUM,
 									feature: isVideoPressFlowWithUnsupportedPlan
 										? FEATURE_VIDEO_UPLOADS
@@ -111,8 +112,8 @@ export function getEnhancedTasks(
 							window.location.assign( plansUrl );
 						},
 						badgeText: isVideoPressFlowWithUnsupportedPlan ? null : translatedPlanName,
-						completed: task.completed && ! displayWarning,
-						warning: displayWarning,
+						completed: task.completed && ! shouldDisplayWarning,
+						warning: shouldDisplayWarning,
 					};
 					break;
 				case 'subscribers_added':

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -95,7 +95,7 @@ export function getEnhancedTasks(
 						subtitle: planWarningText,
 						actionDispatch: () => {
 							recordTaskClickTracksEvent( flow, task.completed, task.id );
-							if ( displayGlobalStylesWarning ) {
+							if ( displayWarning && ! isVideoPressFlowWithUnsupportedPlan ) {
 								recordTracksEvent(
 									'calypso_launchpad_global_styles_gating_plan_selected_task_clicked'
 								);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/translations.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/translations.tsx
@@ -38,8 +38,8 @@ export function getLaunchpadTranslations( flow: string | null ): TranslatedLaunc
 			break;
 		case VIDEOPRESS_FLOW:
 			translatedStrings.flowName = translate( 'Video' );
-			translatedStrings.title = translate( 'Your video site is ready!' );
-			translatedStrings.launchTitle = translate( 'Your video site is ready!' );
+			translatedStrings.title = translate( 'Your site is almost ready!' );
+			translatedStrings.launchTitle = translate( 'Your site is almost ready!' );
 			break;
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/videopress.scss
+++ b/client/landing/stepper/declarative-flow/internals/videopress.scss
@@ -250,22 +250,49 @@ body.is-videopress-stepper {
 			}
 		}
 
+		.launchpad__checklist-item-chevron {
+			align-self: center;
+		}
+
 		.launchpad__task.pending .launchpad__checklist-item-chevron {
 			color: #fff;
 			fill: #fff;
 		}
 
-		.launchpad__task.pending:hover .launchpad__checklist-item-text,
-		.launchpad__task.pending > a:focus .launchpad__checklist-item-text,
-		.launchpad__task.pending:hover .launchpad__checklist-item-chevron,
-		.launchpad__task.pending:hover .launchpad__checklist-item-checkmark,
-		.launchpad__task.pending > a:focus .launchpad__checklist-item-chevron,
-		.launchpad__task.pending > a:focus .launchpad__checklist-item-checkmark,
+		.launchpad__task.pending:hover .launchpad__checklist-item:not([disabled]) .launchpad__checklist-item-text,
+		.launchpad__task.pending .launchpad__checklist-item:not([disabled]) > a:focus .launchpad__checklist-item-text,
+		.launchpad__task.pending:hover .launchpad__checklist-item:not([disabled]) .launchpad__checklist-item-chevron,
+		.launchpad__task.pending:hover .launchpad__checklist-item:not([disabled]) .launchpad__checklist-item-checkmark,
+		.launchpad__task.pending > a:focus .launchpad__checklist-item:not([disabled]) .launchpad__checklist-item-chevron,
+		.launchpad__task.pending > a:focus .launchpad__checklist-item:not([disabled]) .launchpad__checklist-item-checkmark,
+		.launchpad__task.completed.enabled:hover .launchpad__checklist-item-text,
+		.launchpad__task.completed.enabled:hover .launchpad__checklist-item-checkmark,
 		.button.launchpad__checklist-item:hover:not([disabled]),
 		.button.launchpad__checklist-item:focus:not([disabled]) {
 			color: $videopress-theme-yellow;
 			fill: $videopress-theme-yellow;
 		}
 
+		.launchpad__task.completed.enabled {
+			&:hover {
+				.badge {
+					background-color: $videopress-theme-yellow;
+					color: $videopress-theme-background-color;
+					border-color: $videopress-theme-yellow;
+				}
+			}
+
+			.launchpad__checklist-item-text {
+				color: $videopress-theme-header-subtitle-text-color;
+			}
+
+			.launchpad__checklist-item-checkmark {
+				fill: $videopress-theme-header-subtitle-text-color;
+			}
+		}
+
+		.launchpad__checklist-item-warning-container {
+			display: none;
+		}
 	}
 }

--- a/client/landing/stepper/declarative-flow/internals/videopress.scss
+++ b/client/landing/stepper/declarative-flow/internals/videopress.scss
@@ -294,5 +294,9 @@ body.is-videopress-stepper {
 		.launchpad__checklist-item-warning-container {
 			display: none;
 		}
+
+		.launchpad__checklist-item-subtext {
+			padding-right: 8px;
+		}
 	}
 }


### PR DESCRIPTION
#### Proposed Changes

* Add support for displaying a message that a VideoPress supported plan is required before uploading a video step. Fixes issue where a user could stuck with a free plan and not able to upload any videos to complete the launchpad.

<img width="419" alt="Screenshot 2022-12-12 at 9 32 02 AM" src="https://user-images.githubusercontent.com/789137/207100482-1280d5d9-56de-4fd2-a6fb-28a3d35759bc.png">

#### Testing Instructions

Test w/ free plan selected
* Start at `/setup/videopress`, and walk through the flow.
* When you get to the plans payment page, click the `X` to cancel the payment.
* Click on the button at the top-left of the dashboard to go back to the onboarding flow.
* You should see the plans step enabled with the `Purchase a plan that supports VideoPress` label.
* The `Upload your first video` step should be disabled.
* Click on the plans step. The `Supports VideoPress` row should be highlighted in blue.
* Purchase a plan. After purchase click the WordPress `W` at the top left to return to the flow.
* The plans step should be marked as completed and the video upload step should be enabled.

Test w/ paid plan selected.
* Go all the way through the flow at `setup/videopress` again, this time paying for a plan.
* The plan step should be completed and the `Upload your first video` step completed.
* Finish testing all the way through launching the site.

Test that Newsletter flow with custom colors still works
* Follow the test steps at https://github.com/Automattic/wp-calypso/pull/70708 (make sure to add the site sticker):

<img width="405" alt="Screenshot 2022-12-09 at 3 01 31 PM" src="https://user-images.githubusercontent.com/789137/206806124-dce58984-297a-4b1b-b774-6e537aaa0f14.png">

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
