### PR TITLE
Color Schemes: Add missing color-5 to modern theme

### DIFF
--- a/packages/calypso-color-schemes/src/shared/color-schemes/_modern.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_modern.scss
@@ -36,8 +36,8 @@ Uses custom theme highlight monochromatic palette for primary + accent
 	/* Theme highlight monochromatic palette */
 	--theme-highlight-color-0: #d5dffa;
 	--theme-highlight-color-0-rgb: 213, 223, 250;
-	--theme-highlight-color-5: #c0d0f8;
-	--theme-highlight-color-5-rgb: 192, 208, 248;
+	--theme-highlight-color-5: #d7defa;
+	--theme-highlight-color-5-rgb: 215, 222, 250;
 	--theme-highlight-color-10: #abc0f5;
 	--theme-highlight-color-10-rgb: 171, 192, 245;
 	--theme-highlight-color-20: #82a1f0;

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_modern.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_modern.scss
@@ -36,6 +36,8 @@ Uses custom theme highlight monochromatic palette for primary + accent
 	/* Theme highlight monochromatic palette */
 	--theme-highlight-color-0: #d5dffa;
 	--theme-highlight-color-0-rgb: 213, 223, 250;
+	--theme-highlight-color-5: #c0d0f8;
+	--theme-highlight-color-5-rgb: 192, 208, 248;
 	--theme-highlight-color-10: #abc0f5;
 	--theme-highlight-color-10-rgb: 171, 192, 245;
 	--theme-highlight-color-20: #82a1f0;


### PR DESCRIPTION
#### Proposed Changes

Adds missing `--theme-highlight-color-5`, which is used for `--color-primary-5` and `--color-accent-5`. This color was suggested by @keoshi [here](https://github.com/Automattic/wp-calypso/pull/70918#issuecomment-1346407708).

This color is currently broken in production and should be fixed expediently.

|Before|After|
|-|-|
|<img width="1240" alt="image" src="https://user-images.githubusercontent.com/4044428/206821397-632f6624-5466-489c-817f-c0e4ce98444b.png">|<img width="1239" alt="image" src="https://user-images.githubusercontent.com/4044428/207184772-775b0b5d-70dc-45c1-afb6-4e9fa5ed0eb8.png">|

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up the live branch for this PR.
* Enable the Modern theme via `/me/account`.
* Navigate to `/stats/insights/` and select a site with significant traffic.
* Ensure that the lightest shade of the table cells is `--color-primary-5` instead of `white`.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #71028.