### PR TITLE
Themes plan upgrade: deconstructure props to recordTracksEvent

### DIFF
--- a/client/components/themes-list/index.jsx
+++ b/client/components/themes-list/index.jsx
@@ -172,6 +172,7 @@ function Empty( props ) {
 				selectedSite={ selectedSite }
 				searchTerm={ searchTerm }
 				translate={ translate }
+				recordTracksEvent={ props.recordTracksEvent }
 			/>
 		</div>
 	) : (

--- a/client/components/themes-list/index.jsx
+++ b/client/components/themes-list/index.jsx
@@ -128,7 +128,14 @@ function ThemeBlock( props ) {
 }
 
 function Empty( props ) {
-	const { wpOrgThemes, emptyContent, searchTerm, upsellCardDisplayed, translate } = props;
+	const {
+		wpOrgThemes,
+		emptyContent,
+		searchTerm,
+		upsellCardDisplayed,
+		translate,
+		recordTracksEvent,
+	} = props;
 	const selectedSite = useSelector( getSelectedSite );
 	const shouldUpgradeToInstallThemes = useSelector(
 		( state ) => ! siteHasFeature( state, selectedSite?.ID, FEATURE_INSTALL_THEMES )
@@ -172,7 +179,7 @@ function Empty( props ) {
 				selectedSite={ selectedSite }
 				searchTerm={ searchTerm }
 				translate={ translate }
-				recordTracksEvent={ props.recordTracksEvent }
+				recordTracksEvent={ recordTracksEvent }
 			/>
 		</div>
 	) : (


### PR DESCRIPTION
#### Proposed Changes

*

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
