### PR TITLE
Theme Showcase: Show global styles in theme cards

### DIFF
--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -1,7 +1,11 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { WPCOM_FEATURES_PREMIUM_THEMES } from '@automattic/calypso-products';
 import { Card, Ribbon, Button, Gridicon } from '@automattic/components';
-import { PremiumBadge, WooCommerceBundledBadge } from '@automattic/design-picker';
+import {
+	PremiumBadge,
+	StyleVariationBadges,
+	WooCommerceBundledBadge,
+} from '@automattic/design-picker';
 import { Button as LinkButton } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { sprintf } from '@wordpress/i18n';
@@ -411,6 +415,7 @@ export class Theme extends Component {
 					<>
 						{ ( ! doesThemeBundleSoftwareSet || isExternallyManagedTheme ) && (
 							<PremiumBadge
+								className="theme__upsell-popover"
 								tooltipClassName="theme__upsell-popover info-popover__tooltip"
 								tooltipContent={ popoverContent }
 								tooltipPosition="top"
@@ -418,6 +423,7 @@ export class Theme extends Component {
 						) }
 						{ doesThemeBundleSoftwareSet && ! isExternallyManagedTheme && (
 							<WooCommerceBundledBadge
+								className="theme__upsell-popover"
 								tooltipClassName="theme__upsell-popover info-popover__tooltip"
 								tooltipContent={ popoverContent }
 								tooltipPosition="top"
@@ -438,6 +444,19 @@ export class Theme extends Component {
 					</InfoPopover>
 				) }
 			</span>
+		);
+	};
+
+	renderStyleVariations = () => {
+		const { theme } = this.props;
+		const { style_variations = [] } = theme;
+
+		return (
+			style_variations.length > 0 && (
+				<div className="theme__info-style-variations">
+					<StyleVariationBadges variations={ style_variations } />
+				</div>
+			)
 		);
 	};
 
@@ -556,9 +575,11 @@ export class Theme extends Component {
 						) }
 						{ showUpsell
 							? this.renderUpsell()
-							: isNewDetailsAndPreview && (
+							: isNewDetailsAndPreview &&
+							  ! active && (
 									<span className="theme__info-upsell-description">{ translate( 'Free' ) }</span>
 							  ) }
+						{ isNewDetailsAndPreview && ! active && this.renderStyleVariations() }
 						{ ! isEmpty( this.props.buttonContents ) ? (
 							<ThemeMoreButton
 								index={ this.props.index }

--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -573,7 +573,7 @@ export class Theme extends Component {
 						{ ! isNewDetailsAndPreview && active && (
 							<span className={ priceClass }>{ price }</span>
 						) }
-						{ showUpsell
+						{ isPremiumTheme && ! active
 							? this.renderUpsell()
 							: isNewDetailsAndPreview &&
 							  ! active && (

--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -580,7 +580,7 @@ export class Theme extends Component {
 									<span className="theme__info-upsell-description">{ translate( 'Free' ) }</span>
 							  ) }
 						{ isNewDetailsAndPreview && ! active && this.renderStyleVariations() }
-						{ ! isEmpty( this.props.buttonContents ) ? (
+						{ ! isNewDetailsAndPreview && ! isEmpty( this.props.buttonContents ) ? (
 							<ThemeMoreButton
 								index={ this.props.index }
 								themeId={ this.props.theme.id }

--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -573,12 +573,13 @@ export class Theme extends Component {
 						{ ! isNewDetailsAndPreview && active && (
 							<span className={ priceClass }>{ price }</span>
 						) }
-						{ isPremiumTheme && ! active
-							? this.renderUpsell()
-							: isNewDetailsAndPreview &&
-							  ! active && (
-									<span className="theme__info-upsell-description">{ translate( 'Free' ) }</span>
-							  ) }
+						{ upsellUrl && // Do not show any pricing related infomation if there's no upsell action link.
+							( showUpsell
+								? this.renderUpsell()
+								: isNewDetailsAndPreview &&
+								  ! active && (
+										<span className="theme__info-upsell-description">{ translate( 'Free' ) }</span>
+								  ) ) }
 						{ isNewDetailsAndPreview && ! active && this.renderStyleVariations() }
 						{ ! isNewDetailsAndPreview && ! isEmpty( this.props.buttonContents ) ? (
 							<ThemeMoreButton

--- a/client/my-sites/themes/logged-out.jsx
+++ b/client/my-sites/themes/logged-out.jsx
@@ -11,6 +11,9 @@ export default ( props ) => (
 		{ isEnabled( 'themes/showcase-i4/search-and-filter' ) && (
 			<BodySectionCssClass bodyClass={ [ 'is-section-themes-i4' ] } />
 		) }
+		{ isEnabled( 'themes/showcase-i4/details-and-preview' ) && (
+			<BodySectionCssClass bodyClass={ [ 'is-section-themes-i4-2' ] } />
+		) }
 		<ConnectedThemeShowcase
 			{ ...props }
 			origin="wpcom"

--- a/client/my-sites/themes/single-site-jetpack.jsx
+++ b/client/my-sites/themes/single-site-jetpack.jsx
@@ -51,6 +51,7 @@ const ConnectedSingleSiteJetpack = connectOptions( ( props ) => {
 		requestingSitePlans,
 	} = props;
 
+	const isNewDetailsAndPreview = isEnabled( 'themes/showcase-i4/details-and-preview' );
 	const isNewSearchAndFilter = isEnabled( 'themes/showcase-i4/search-and-filter' );
 	const displayUpsellBanner = isAtomic && ! requestingSitePlans && currentPlan;
 	const upsellUrl =
@@ -75,6 +76,9 @@ const ConnectedSingleSiteJetpack = connectOptions( ( props ) => {
 	return (
 		<Main fullWidthLayout className="themes">
 			{ isNewSearchAndFilter && <BodySectionCssClass bodyClass={ [ 'is-section-themes-i4' ] } /> }
+			{ isNewDetailsAndPreview && (
+				<BodySectionCssClass bodyClass={ [ 'is-section-themes-i4-2' ] } />
+			) }
 			<ThemesHeader isReskinned={ isNewSearchAndFilter } />
 			{ ! isNewSearchAndFilter ? (
 				<CurrentTheme siteId={ siteId } />

--- a/client/my-sites/themes/single-site-jetpack.jsx
+++ b/client/my-sites/themes/single-site-jetpack.jsx
@@ -20,25 +20,16 @@ import ThemeShowcase from './theme-showcase';
 import ThemesHeader from './themes-header';
 import ThemesSelection from './themes-selection';
 
-const noop = () => {};
-
 const ConnectedThemesSelection = connectOptions( ( props ) => {
-	const isNewDetailsAndPreview = isEnabled( 'themes/showcase-i4/details-and-preview' );
-
 	return (
 		<ThemesSelection
 			{ ...props }
-			getOptions={
-				! isNewDetailsAndPreview
-					? ( theme ) => {
-							return pickBy(
-								addTracking( props.options ),
-								( option ) =>
-									! ( option.hideForTheme && option.hideForTheme( theme, props.siteId ) )
-							);
-					  }
-					: noop
-			}
+			getOptions={ function ( theme ) {
+				return pickBy(
+					addTracking( props.options ),
+					( option ) => ! ( option.hideForTheme && option.hideForTheme( theme, props.siteId ) )
+				);
+			} }
 		/>
 	);
 } );

--- a/client/my-sites/themes/single-site-jetpack.jsx
+++ b/client/my-sites/themes/single-site-jetpack.jsx
@@ -20,16 +20,25 @@ import ThemeShowcase from './theme-showcase';
 import ThemesHeader from './themes-header';
 import ThemesSelection from './themes-selection';
 
+const noop = () => {};
+
 const ConnectedThemesSelection = connectOptions( ( props ) => {
+	const isNewDetailsAndPreview = isEnabled( 'themes/showcase-i4/details-and-preview' );
+
 	return (
 		<ThemesSelection
 			{ ...props }
-			getOptions={ function ( theme ) {
-				return pickBy(
-					addTracking( props.options ),
-					( option ) => ! ( option.hideForTheme && option.hideForTheme( theme, props.siteId ) )
-				);
-			} }
+			getOptions={
+				! isNewDetailsAndPreview
+					? ( theme ) => {
+							return pickBy(
+								addTracking( props.options ),
+								( option ) =>
+									! ( option.hideForTheme && option.hideForTheme( theme, props.siteId ) )
+							);
+					  }
+					: noop
+			}
 		/>
 	);
 } );

--- a/client/my-sites/themes/single-site-wpcom.jsx
+++ b/client/my-sites/themes/single-site-wpcom.jsx
@@ -28,6 +28,7 @@ const ConnectedSingleSiteWpcom = connectOptions( ( props ) => {
 	const { currentPlan, currentThemeId, isVip, requestingSitePlans, siteId, siteSlug, translate } =
 		props;
 
+	const isNewDetailsAndPreview = isEnabled( 'themes/showcase-i4/details-and-preview' );
 	const isNewSearchAndFilter = isEnabled( 'themes/showcase-i4/search-and-filter' );
 	const displayUpsellBanner = ! requestingSitePlans && currentPlan && ! isVip;
 	const upsellUrl = `/plans/${ siteSlug }`;
@@ -81,6 +82,9 @@ const ConnectedSingleSiteWpcom = connectOptions( ( props ) => {
 	return (
 		<Main fullWidthLayout className="themes">
 			{ isNewSearchAndFilter && <BodySectionCssClass bodyClass={ [ 'is-section-themes-i4' ] } /> }
+			{ isNewDetailsAndPreview && (
+				<BodySectionCssClass bodyClass={ [ 'is-section-themes-i4-2' ] } />
+			) }
 			<ThemesHeader isReskinned={ isNewSearchAndFilter } />
 			{ ! isNewSearchAndFilter ? (
 				<CurrentTheme siteId={ siteId } />

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -459,10 +459,9 @@ class ThemeShowcase extends Component {
 			locale,
 			premiumThemesEnabled,
 		} = this.props;
-
 		const tier = this.props.tier || '';
+
 		const canonicalUrl = 'https://wordpress.com' + pathName;
-		const isNewSearchAndFilter = config.isEnabled( 'themes/showcase-i4/search-and-filter' );
 
 		const metas = [
 			{ name: 'description', property: 'og:description', content: this.props.description },
@@ -511,6 +510,8 @@ class ThemeShowcase extends Component {
 					( option ) => ! ( option.hideForTheme && option.hideForTheme( theme, siteId ) )
 				),
 		};
+
+		const isNewSearchAndFilter = config.isEnabled( 'themes/showcase-i4/search-and-filter' );
 
 		// FIXME: Logged-in title should only be 'Themes'
 		return (

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -49,8 +49,6 @@ import TrendingThemes from './trending-themes';
 
 import './theme-showcase.scss';
 
-const noop = () => {};
-
 const optionShape = PropTypes.shape( {
 	label: PropTypes.string,
 	header: PropTypes.string,
@@ -464,7 +462,6 @@ class ThemeShowcase extends Component {
 
 		const tier = this.props.tier || '';
 		const canonicalUrl = 'https://wordpress.com' + pathName;
-		const isNewDetailsAndPreview = config.isEnabled( 'themes/showcase-i4/details-and-preview' );
 		const isNewSearchAndFilter = config.isEnabled( 'themes/showcase-i4/search-and-filter' );
 
 		const metas = [
@@ -508,13 +505,11 @@ class ThemeShowcase extends Component {
 			trackScrollPage: this.props.trackScrollPage,
 			emptyContent: this.props.emptyContent,
 			scrollToSearchInput: this.scrollToSearchInput,
-			getOptions: ! isNewDetailsAndPreview
-				? ( theme ) =>
-						pickBy(
-							addTracking( options ),
-							( option ) => ! ( option.hideForTheme && option.hideForTheme( theme, siteId ) )
-						)
-				: noop,
+			getOptions: ( theme ) =>
+				pickBy(
+					addTracking( options ),
+					( option ) => ! ( option.hideForTheme && option.hideForTheme( theme, siteId ) )
+				),
 		};
 
 		// FIXME: Logged-in title should only be 'Themes'

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -49,6 +49,8 @@ import TrendingThemes from './trending-themes';
 
 import './theme-showcase.scss';
 
+const noop = () => {};
+
 const optionShape = PropTypes.shape( {
 	label: PropTypes.string,
 	header: PropTypes.string,
@@ -459,9 +461,11 @@ class ThemeShowcase extends Component {
 			locale,
 			premiumThemesEnabled,
 		} = this.props;
-		const tier = this.props.tier || '';
 
+		const tier = this.props.tier || '';
 		const canonicalUrl = 'https://wordpress.com' + pathName;
+		const isNewDetailsAndPreview = config.isEnabled( 'themes/showcase-i4/details-and-preview' );
+		const isNewSearchAndFilter = config.isEnabled( 'themes/showcase-i4/search-and-filter' );
 
 		const metas = [
 			{ name: 'description', property: 'og:description', content: this.props.description },
@@ -504,14 +508,14 @@ class ThemeShowcase extends Component {
 			trackScrollPage: this.props.trackScrollPage,
 			emptyContent: this.props.emptyContent,
 			scrollToSearchInput: this.scrollToSearchInput,
-			getOptions: ( theme ) =>
-				pickBy(
-					addTracking( options ),
-					( option ) => ! ( option.hideForTheme && option.hideForTheme( theme, siteId ) )
-				),
+			getOptions: ! isNewDetailsAndPreview
+				? ( theme ) =>
+						pickBy(
+							addTracking( options ),
+							( option ) => ! ( option.hideForTheme && option.hideForTheme( theme, siteId ) )
+						)
+				: noop,
 		};
-
-		const isNewSearchAndFilter = config.isEnabled( 'themes/showcase-i4/search-and-filter' );
 
 		// FIXME: Logged-in title should only be 'Themes'
 		return (

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -104,8 +104,6 @@ body.is-section-themes-i4 {
 
 body.is-section-themes-i4-2 {
 	.themes__selection .themes-list .theme {
-		$theme-info-height: 76px;
-
 		background: none;
 		border-radius: 2px;
 		box-shadow: none;
@@ -122,7 +120,7 @@ body.is-section-themes-i4-2 {
 		}
 
 		.theme__content {
-			padding-bottom: $theme-info-height;
+			padding-bottom: 76px;
 		}
 
 		.theme__img {
@@ -134,7 +132,8 @@ body.is-section-themes-i4-2 {
 			box-sizing: border-box;
 			display: flex;
 			flex-direction: row;
-			height: $theme-info-height;
+			flex-wrap: wrap;
+			height: 75px;
 			gap: 4px;
 			padding-top: 24px;
 		}
@@ -152,18 +151,28 @@ body.is-section-themes-i4-2 {
 
 		.theme__upsell {
 			font-size: 0;
+			line-height: 24px;
 			padding: 0;
 
 			.premium-badge,
 			.woocommerce-bundled-badge {
 				margin: 0;
+				vertical-align: middle;
 			}
 		}
 
 		.theme__info-upsell-description {
 			color: var(--color-neutral-60);
 			font-size: 0.875rem;
-			line-height: 20px;
+			line-height: 24px;
+		}
+
+		.theme__info-style-variations {
+			align-self: center;
+			display: flex;
+			flex-basis: 100%;
+			font-size: 0;
+			gap: 4px;
 		}
 
 		.theme__badge-active {
@@ -178,6 +187,20 @@ body.is-section-themes-i4-2 {
 	}
 
 	.theme__upsell-popover {
+		svg {
+			height: inherit;
+			padding: 0;
+			transform: none;
+			width: inherit;
+		}
+
+		&.premium-badge {
+			svg {
+				height: initial;
+				width: initial;
+			}
+		}
+
 		.popover__inner {
 			background: #fff;
 			color: var(--color-neutral-50);

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -1,6 +1,12 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 
+$theme-img-filter:
+	drop-shadow(0 102px 61px rgba(0, 0, 0, 0.02))
+	drop-shadow(0 45px 45px rgba(0, 0, 0, 0.03))
+	drop-shadow(0 11px 25px rgba(0, 0, 0, 0.03))
+	drop-shadow(0 0 0 rgba(0, 0, 0, 0.03));
+
 body.is-section-themes-i4 {
 	&.theme-default.color-scheme {
 		--color-surface-backdrop: #fdfdfd;
@@ -107,46 +113,62 @@ body.is-section-themes-i4-2 {
 		background: none;
 		border-radius: 2px;
 		box-shadow: none;
+		cursor: default;
 		margin: 0 16px 48px;
-		overflow: hidden;
 
 		&.is-active {
 			.theme__info {
 				align-items: center;
+				background: var(--color-primary);
+				border-bottom-left-radius: 2px;
+				border-bottom-right-radius: 2px;
+				box-sizing: content-box;
 				flex-direction: row;
 				gap: 0;
-				padding: 0 24px;
+				padding: 4px 24px;
+			}
+
+			.theme__info-title {
+				color: var(--color-text-inverted);
 			}
 		}
 
 		.theme__content {
-			padding-bottom: 76px;
+			overflow: visible;
+			padding: 0;
+		}
+
+		.theme__thumbnail {
+			cursor: pointer;
 		}
 
 		.theme__img {
-			box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.05);
+			aspect-ratio: 4/3;
+			border: 1px solid rgba(0, 0, 0, 0.1);
+			filter: $theme-img-filter;
+			padding: 0;
+			position: relative;
 		}
 
 		.theme__info {
 			align-items: flex-start;
-			box-sizing: border-box;
+			background: transparent;
+			box-sizing: content-box;
 			display: flex;
 			flex-direction: row;
 			flex-wrap: wrap;
-			height: 75px;
+			height: 48px;
 			gap: 4px;
-			padding-top: 24px;
+			padding-top: 16px;
+			position: relative;
 		}
 
 		.theme__info-title {
+			color: var(--color-neutral-100);
 			font-size: 1rem;
 			line-height: 24px;
 			margin: 0;
 			padding: 0;
-
-			.theme:not(.is-active) & {
-				color: var(--color-neutral-100);
-			}
 		}
 
 		.theme__upsell {
@@ -173,6 +195,10 @@ body.is-section-themes-i4-2 {
 			flex-basis: 100%;
 			font-size: 0;
 			gap: 4px;
+
+			.style-variation__badge-more-wrapper > * {
+				background: transparent;
+			}
 		}
 
 		.theme__badge-active {

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -1,11 +1,7 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 
-$theme-img-filter:
-	drop-shadow(0 102px 61px rgba(0, 0, 0, 0.02))
-	drop-shadow(0 45px 45px rgba(0, 0, 0, 0.03))
-	drop-shadow(0 11px 25px rgba(0, 0, 0, 0.03))
-	drop-shadow(0 0 0 rgba(0, 0, 0, 0.03));
+$theme-img-filter: drop-shadow(0 15px 25px rgba(0, 0, 0, 0.05));
 
 body.is-section-themes-i4 {
 	&.theme-default.color-scheme {

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -23,12 +23,84 @@ body.is-section-themes-i4 {
 			width: 320px;
 		}
 
-		.theme {
-			margin: 0 16px 32px;
-		}
-
 		.themes-list__spacer {
 			margin: 0 16px;
+		}
+	}
+
+	.themes__selection .themes-list .theme {
+		$theme-info-height: 76px;
+
+		background: none;
+		border-radius: 2px;
+		box-shadow: none;
+		margin: 0 16px 32px;
+		overflow: hidden;
+
+		&.is-active {
+			.theme__info {
+				align-items: center;
+				flex-direction: row;
+				gap: 0;
+				padding: 0 24px;
+			}
+		}
+
+		.theme__content {
+			padding-bottom: $theme-info-height;
+		}
+
+		.theme__img {
+			box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.05);
+		}
+
+		.theme__info {
+			align-items: flex-start;
+			box-sizing: border-box;
+			display: flex;
+			flex-direction: column;
+			height: $theme-info-height;
+			gap: 8px;
+			padding-top: 24px;
+		}
+
+		.theme__info-title {
+			font-size: 1rem;
+			line-height: 24px;
+			margin: 0;
+			padding: 0;
+
+			.theme:not(.is-active) & {
+				color: var(--color-neutral-100);
+			}
+		}
+
+		.theme__info-pricing {
+			display: inline-flex;
+			align-items: flex-start;
+			font-size: 0;
+			gap: 10px;
+			justify-content: center;
+
+			> div {
+				margin: 0;
+			}
+
+			.theme__info-pricing-text {
+				color: var(--color-neutral-60);
+				font-size: 0.875rem;
+				line-height: 20px;
+			}
+		}
+
+		.theme__badge-active {
+			background-color: var(--color-primary-0);
+			border-radius: 20px; /* stylelint-disable-line scales/radii */
+			color: var(--color-neutral-100);
+			font-size: 0.75rem;
+			line-height: 20px;
+			padding: 0 10px;
+			text-transform: none;
 		}
 	}
 

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -23,84 +23,12 @@ body.is-section-themes-i4 {
 			width: 320px;
 		}
 
+		.theme {
+			margin: 0 16px 32px;
+		}
+
 		.themes-list__spacer {
 			margin: 0 16px;
-		}
-	}
-
-	.themes__selection .themes-list .theme {
-		$theme-info-height: 76px;
-
-		background: none;
-		border-radius: 2px;
-		box-shadow: none;
-		margin: 0 16px 32px;
-		overflow: hidden;
-
-		&.is-active {
-			.theme__info {
-				align-items: center;
-				flex-direction: row;
-				gap: 0;
-				padding: 0 24px;
-			}
-		}
-
-		.theme__content {
-			padding-bottom: $theme-info-height;
-		}
-
-		.theme__img {
-			box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.05);
-		}
-
-		.theme__info {
-			align-items: flex-start;
-			box-sizing: border-box;
-			display: flex;
-			flex-direction: column;
-			height: $theme-info-height;
-			gap: 8px;
-			padding-top: 24px;
-		}
-
-		.theme__info-title {
-			font-size: 1rem;
-			line-height: 24px;
-			margin: 0;
-			padding: 0;
-
-			.theme:not(.is-active) & {
-				color: var(--color-neutral-100);
-			}
-		}
-
-		.theme__info-pricing {
-			display: inline-flex;
-			align-items: flex-start;
-			font-size: 0;
-			gap: 10px;
-			justify-content: center;
-
-			> div {
-				margin: 0;
-			}
-
-			.theme__info-pricing-text {
-				color: var(--color-neutral-60);
-				font-size: 0.875rem;
-				line-height: 20px;
-			}
-		}
-
-		.theme__badge-active {
-			background-color: var(--color-primary-0);
-			border-radius: 20px; /* stylelint-disable-line scales/radii */
-			color: var(--color-neutral-100);
-			font-size: 0.75rem;
-			line-height: 20px;
-			padding: 0 10px;
-			text-transform: none;
 		}
 	}
 
@@ -170,6 +98,89 @@ body.is-section-themes-i4 {
 				box-shadow: 0 0 0 2px var(--color-primary-light);
 				outline: 0;
 			}
+		}
+	}
+}
+
+body.is-section-themes-i4-2 {
+	.themes__selection .themes-list .theme {
+		$theme-info-height: 76px;
+
+		background: none;
+		border-radius: 2px;
+		box-shadow: none;
+		margin: 0 16px 48px;
+		overflow: hidden;
+
+		&.is-active {
+			.theme__info {
+				align-items: center;
+				flex-direction: row;
+				gap: 0;
+				padding: 0 24px;
+			}
+		}
+
+		.theme__content {
+			padding-bottom: $theme-info-height;
+		}
+
+		.theme__img {
+			box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.05);
+		}
+
+		.theme__info {
+			align-items: flex-start;
+			box-sizing: border-box;
+			display: flex;
+			flex-direction: row;
+			height: $theme-info-height;
+			gap: 4px;
+			padding-top: 24px;
+		}
+
+		.theme__info-title {
+			font-size: 1rem;
+			line-height: 24px;
+			margin: 0;
+			padding: 0;
+
+			.theme:not(.is-active) & {
+				color: var(--color-neutral-100);
+			}
+		}
+
+		.theme__upsell {
+			font-size: 0;
+			padding: 0;
+
+			.premium-badge,
+			.woocommerce-bundled-badge {
+				margin: 0;
+			}
+		}
+
+		.theme__info-upsell-description {
+			color: var(--color-neutral-60);
+			font-size: 0.875rem;
+			line-height: 20px;
+		}
+
+		.theme__badge-active {
+			background-color: var(--color-primary-0);
+			border-radius: 20px; /* stylelint-disable-line scales/radii */
+			color: var(--color-neutral-100);
+			font-size: 0.75rem;
+			line-height: 20px;
+			padding: 0 10px;
+			text-transform: none;
+		}
+	}
+
+	.theme__upsell-popover {
+		.popover__inner {
+			background: #fff;
+			color: var(--color-neutral-50);
 		}
 	}
 }

--- a/config/development.json
+++ b/config/development.json
@@ -172,6 +172,7 @@
 		"themes/atomic-homepage-replace": true,
 		"themes/plugin-bundling": true,
 		"themes/premium": true,
+		"themes/showcase-i4/details-and-preview": true,
 		"themes/showcase-i4/search-and-filter": true,
 		"themes/subscription-purchases": true,
 		"themes/theme-switch-persist-template": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -116,6 +116,7 @@
 		"themes/atomic-homepage-replace": true,
 		"themes/plugin-bundling": true,
 		"themes/premium": true,
+		"themes/showcase-i4/details-and-preview": false,
 		"themes/showcase-i4/search-and-filter": true,
 		"themes/subscription-purchases": false,
 		"themes/theme-switch-persist-template": true,

--- a/config/production.json
+++ b/config/production.json
@@ -136,6 +136,7 @@
 		"themes/atomic-homepage-replace": true,
 		"themes/plugin-bundling": true,
 		"themes/premium": true,
+		"themes/showcase-i4/details-and-preview": false,
 		"themes/showcase-i4/search-and-filter": true,
 		"themes/subscription-purchases": false,
 		"themes/theme-switch-persist-template": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -133,6 +133,7 @@
 		"themes/atomic-homepage-replace": true,
 		"themes/plugin-bundling": true,
 		"themes/premium": true,
+		"themes/showcase-i4/details-and-preview": false,
 		"themes/showcase-i4/search-and-filter": true,
 		"themes/subscription-purchases": false,
 		"themes/theme-switch-persist-template": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -142,6 +142,7 @@
 		"themes/atomic-homepage-replace": true,
 		"themes/plugin-bundling": true,
 		"themes/premium": true,
+		"themes/showcase-i4/details-and-preview": false,
 		"themes/showcase-i4/search-and-filter": true,
 		"themes/subscription-purchases": false,
 		"themes/theme-switch-persist-template": false,

--- a/packages/design-picker/src/components/premium-badge/index.tsx
+++ b/packages/design-picker/src/components/premium-badge/index.tsx
@@ -7,12 +7,16 @@ import './style.scss';
 
 interface Props {
 	className?: string;
+	tooltipContent?: React.ReactElement;
+	tooltipClassName?: string;
 	tooltipPosition?: string;
 	isPremiumThemeAvailable?: boolean;
 }
 
 const PremiumBadge: FunctionComponent< Props > = ( {
 	className,
+	tooltipContent,
+	tooltipClassName,
 	tooltipPosition = 'bottom left',
 	isPremiumThemeAvailable,
 } ) => {
@@ -41,12 +45,12 @@ const PremiumBadge: FunctionComponent< Props > = ( {
 			<Gridicon className="premium-badge__logo" icon="star" size={ 14 } />
 			<span>{ __( 'Premium' ) }</span>
 			<Popover
-				className="premium-badge__popover"
+				className={ classNames( 'premium-badge__popover', tooltipClassName ) }
 				context={ divRef.current }
 				isVisible={ isPopoverVisible }
 				position={ tooltipPosition }
 			>
-				{ tooltipText }
+				{ tooltipContent || tooltipText }
 			</Popover>
 		</div>
 	);

--- a/packages/design-picker/src/components/woocommerce-bundled-badge/index.tsx
+++ b/packages/design-picker/src/components/woocommerce-bundled-badge/index.tsx
@@ -7,11 +7,15 @@ import './style.scss';
 
 interface Props {
 	className?: string;
+	tooltipContent?: React.ReactElement;
+	tooltipClassName?: string;
 	tooltipPosition?: string;
 }
 
 const WooCommerceBundledBadge: FunctionComponent< Props > = ( {
 	className,
+	tooltipContent,
+	tooltipClassName,
 	tooltipPosition = 'bottom right',
 } ) => {
 	const { __ } = useI18n();
@@ -53,12 +57,12 @@ const WooCommerceBundledBadge: FunctionComponent< Props > = ( {
 			</svg>
 			<span>WooCommerce</span>
 			<Popover
-				className="woocommerce-bundled-badge__popover"
+				className={ classNames( 'woocommerce-bundled-badge__popover', tooltipClassName ) }
 				context={ divRef.current }
 				isVisible={ isPopoverVisible }
 				position={ tooltipPosition }
 			>
-				{ tooltipText }
+				{ tooltipContent || tooltipText }
 			</Popover>
 		</div>
 	);

--- a/packages/design-picker/src/index.ts
+++ b/packages/design-picker/src/index.ts
@@ -5,6 +5,7 @@ export { default as BadgeContainer } from './components/badge-container';
 export { default as StyleVariationBadges } from './components/style-variation-badges';
 export { default as ThemePreview } from './components/theme-preview';
 export { default as UnifiedDesignPicker } from './components/unified-design-picker';
+export { default as WooCommerceBundledBadge } from './components/woocommerce-bundled-badge';
 export {
 	availableDesignsConfig,
 	getAvailableDesigns,


### PR DESCRIPTION
#### Proposed Changes

This PR updates the theme card in the Theme Showcase as per design spec in 0EogtxvlmxMGcnEEaMVECv-fi-2010%3A60733&t=jIa2A0qk2JM0UshY-0. See screenshot for reference:

![Screen Shot 2022-12-14 at 5 57 26 PM](https://user-images.githubusercontent.com/797888/207564606-73729abd-5eff-44dd-9907-4b9a622d8d8e.png)

Note that the current implementation has diverged from design spec as per discussions with @SaxonF. See below for the comparison of theme cards before and after this PR.

| Before | After |
| --- | --- |
| ![Screen Shot 2022-12-14 at 5 51 52 PM](https://user-images.githubusercontent.com/797888/207565356-ab97c066-57de-46e0-b153-d1b889d36095.png) | ![Screen Shot 2022-12-14 at 5 52 44 PM](https://user-images.githubusercontent.com/797888/207565390-d8625c29-75f1-4c63-bc9a-94757b8ceea0.png) |

| Before | After |
| --- | --- |
| ![Screen Shot 2022-12-14 at 5 54 52 PM](https://user-images.githubusercontent.com/797888/207565623-bca3e9ce-5b1e-4346-b074-1778c4c800d1.png) | ![Screen Shot 2022-12-14 at 5 54 43 PM](https://user-images.githubusercontent.com/797888/207565650-6075f818-5ba6-4c1f-9254-3b17491a7e15.png) |

The following is a list of changes to the theme card:
* The removal of ellipsis button.
* The addition of style variations.
* Show premium/WooCommerce badges instead of the star icon.
* Spacing and other UI updates.

Note that clicking style variations currently does nothing, for the sake of keeping this PR small(ish).

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the logged-in Theme Showcase `/themes/${site_slug}`.
  * If using calypso.live, the flag `themes/showcase-i4/details-and-preview` is required.
* Ensure that the theme card is updated as described above.
* Ensure that the logged-out Theme Showcase works as intended.
* Ensure that by disabling the flag, the old UI works as before. 

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #71039