### PR TITLE
Feature Flag to enable cart in the Jetpack Pricing Page

### DIFF
--- a/client/state/sites/selectors/is-jetpack-cloud-cart-enabled.js
+++ b/client/state/sites/selectors/is-jetpack-cloud-cart-enabled.js
@@ -1,3 +1,5 @@
+import { isEnabled } from '@automattic/calypso-config';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import getSiteSlug from './get-site-slug';
 
@@ -9,6 +11,10 @@ import getSiteSlug from './get-site-slug';
 export default function isJetpackCloudCartEnabled( state ) {
 	const siteId = getSelectedSiteId( state );
 	const siteSlug = getSiteSlug( state, siteId );
-	// We would want to change `true` to the param from A/B testing
-	return true && siteSlug;
+	return (
+		isEnabled( 'jetpack/pricing-page-rework-v1' ) &&
+		isEnabled( 'jetpack/pricing-page-cart' ) &&
+		isUserLoggedIn( state ) &&
+		siteSlug
+	);
 }

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -62,7 +62,8 @@
 		"purchases/new-payment-methods": true,
 		"realtime-site-count": true,
 		"site-indicator": false,
-		"upgrades/redirect-payments": true
+		"upgrades/redirect-payments": true,
+		"jetpack/pricing-page-cart": true
 	},
 	"enable_all_sections": false,
 	"sections": {

--- a/config/jetpack-cloud-horizon.json
+++ b/config/jetpack-cloud-horizon.json
@@ -55,7 +55,8 @@
 		"oauth": false,
 		"purchases/new-payment-methods": true,
 		"site-indicator": false,
-		"upgrades/redirect-payments": true
+		"upgrades/redirect-payments": true,
+		"jetpack/pricing-page-cart": false
 	},
 	"enable_all_sections": false,
 	"sections": {

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -58,7 +58,8 @@
 		"purchases/new-payment-methods": true,
 		"realtime-site-count": true,
 		"site-indicator": false,
-		"upgrades/redirect-payments": false
+		"upgrades/redirect-payments": false,
+		"jetpack/pricing-page-cart": false
 	},
 	"enable_all_sections": false,
 	"sections": {

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -59,7 +59,8 @@
 		"purchases/new-payment-methods": true,
 		"realtime-site-count": true,
 		"site-indicator": false,
-		"upgrades/redirect-payments": true
+		"upgrades/redirect-payments": true,
+		"jetpack/pricing-page-cart": false
 	},
 	"enable_all_sections": false,
 	"sections": {


### PR DESCRIPTION
#### Proposed Changes

* Add feature flag to enable cart in Jetpack cloud Pricing page
* Enable cart only if it is a new pricing page, the above feature flag is enabled, the user is logged in and has a site selected

#### Testing Instructions

* click on Jetpack Cloud live link below
    * Goto `/pricing`
* or boot up this PR 
    * Run `git fetch && git checkout feature/cloud-cart-feature-flag
    * Run `yarn start-jetpack-cloud`
    * Goto http://jetpack.cloud.localhost:3000/pricing
* Validate the following cases
    * Pricing page with no site selected
         * navigate to `/pricing` and don't add any site-slug in the URL 
         *  Make sure no cart icon is shown in the header
    * Pricing Page with site selected and user logged-in 
         * Login to you WPCOM account and navigate to `/pricing/:site-id` for your site
         *  Make sure no cart icon is shown in the header (since we didn't add feature flag here)
     * Pricing Page with feature flag enabled and user is logged in with a site
         * Continuing the previous scenario also add this `?flags=jetpack/pricing-page-cart`to the url
         * Make sure cart icon is shown in the header
         * Clicking on it should open the cart
     * Pricing page with feature flag enabled but user is not logged in
         * Continuing the following scenario, now logout from your account
         * Make sure cart icon is not shown 



#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203534015891075