### PR TITLE
Update dotcom-fse to use types from data store directly

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/lib/site-plan/use-site-plan.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/lib/site-plan/use-site-plan.ts
@@ -1,11 +1,11 @@
+import { Site } from '@automattic/data-stores';
 import { SiteDetails } from '@automattic/data-stores/src/site';
-import { SiteDetailsPlan } from '@automattic/launch/src/stores';
 import { useState, useEffect } from '@wordpress/element';
 import { useCallback } from 'react';
 import request from 'wpcom-proxy-request';
 
 const useSitePlan = ( siteIdOrSlug: string | number ) => {
-	const [ sitePlan, setSitePlan ] = useState( {} as SiteDetailsPlan );
+	const [ sitePlan, setSitePlan ] = useState( {} as Site.SiteDetailsPlan );
 
 	const fetchSite = useCallback( async () => {
 		const siteObj: SiteDetails = await request( {


### PR DESCRIPTION
#### Proposed Changes

* Update `apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/lib/site-plan/use-site-plan.ts` import types from `@automattic/data-stores` directly instead of [roundabout way from `@automattic/launch`](https://github.com/Automattic/wp-calypso/blob/177560ab0f4e9e6d3b788dfd840ae3da278d282f/packages/launch/src/stores.ts#L18). After the change together with https://github.com/Automattic/wp-calypso/pull/71047, launch-package becomes un-used and can be [removed safely](https://github.com/Automattic/wp-calypso/pull/71051).

Feel free to deploy after testing/reviewing!

#### Testing Instructions

* TS should compile as previously.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
