### PR TITLE
Use new import flow on Sites page

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/index.tsx
@@ -30,7 +30,6 @@ const { serializeGoals, goalsToIntent } = Onboard.utils;
 
 const refGoals: Record< string, Onboard.SiteGoal[] > = {
 	'create-blog-lp': [ SiteGoal.Write ],
-	'smp-import': [ SiteGoal.Import ],
 };
 
 /**

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -830,9 +830,6 @@ class DomainsStep extends Component {
 			} else if ( 'general-settings' === source && siteSlug ) {
 				backUrl = `/settings/general/${ siteSlug }`;
 				backLabelText = translate( 'Back to General Settings' );
-			} else if ( 'sites-dashboard' === source ) {
-				backUrl = '/sites';
-				backLabelText = translate( 'Back to Sites' );
 			} else if ( backUrl === this.removeQueryParam( this.props.path ) ) {
 				backUrl = defaultBackUrl;
 				backLabelText = sitesBackLabelText;

--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -193,9 +193,8 @@ export function SitesDashboard( {
 							onClick={ () => {
 								recordTracksEvent( 'calypso_sites_dashboard_new_site_action_click_import' );
 							} }
-							href={ addQueryArgs( '/start', {
+							href={ addQueryArgs( '/start/import', {
 								source: TRACK_SOURCE_NAME,
-								ref: 'smp-import',
 							} ) }
 							icon="arrow-down"
 						>

--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -173,7 +173,6 @@ export function SitesDashboard( {
 							recordTracksEvent( 'calypso_sites_dashboard_new_site_action_click_add' );
 						} }
 						href={ addQueryArgs( '/start', {
-							source: TRACK_SOURCE_NAME,
 							ref: TRACK_SOURCE_NAME,
 						} ) }
 					>
@@ -193,9 +192,7 @@ export function SitesDashboard( {
 							onClick={ () => {
 								recordTracksEvent( 'calypso_sites_dashboard_new_site_action_click_import' );
 							} }
-							href={ addQueryArgs( '/start/import', {
-								source: TRACK_SOURCE_NAME,
-							} ) }
+							href={ addQueryArgs( '/start/import' ) }
 							icon="arrow-down"
 						>
 							<span>{ __( 'Import an existing site' ) }</span>


### PR DESCRIPTION
#### Proposed Changes

In this PR, I propose to point the import link on the Sites page to use the new import flow.

Related discussion: pdKhl6-Jm-p2#comment-1161

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

##### New import flow

1. Open the `/sites` URL
2. Click the arrow in the "Add new site" button to open the menu
3. Click "Import an existing site"
4. Choose a domain, go to the next step
5. Choose a free plan on the "Choose a plan" page
6. Confirm that the import UI is shown

##### Back button for new site flow

1. Open the `/sites` URL
2. Click the "Add new site" button
3. Click the "Back to Sites" button
4. Confirm that the Sites page is displayed

##### Back button for import flow

1. Open the `/sites` URL
2. Click the arrow in the "Add new site" button to open the menu
3. Click "Import an existing site"
4. Click the "Back to Sites" button
5. Confirm that the Sites page is displayed

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1183-gh-Automattic/dotcom-forge