### PR TITLE
Fix JITM onDismiss not calling API for default template

### DIFF
--- a/client/blocks/jitm/templates/default.jsx
+++ b/client/blocks/jitm/templates/default.jsx
@@ -22,7 +22,7 @@ export default function DefaultTemplate( {
 				disableHref
 				dismissPreferenceName={ featureClass }
 				dismissTemporary={ true }
-				onDismiss={ onDismiss }
+				onDismissClick={ onDismiss }
 				onClick={ onClick }
 				event={ get( tracks, [ 'click', 'name' ] ) || `jitm_nudge_click_${ id }` }
 				href={ CTA.link }

--- a/client/blocks/jitm/test/index.jsx
+++ b/client/blocks/jitm/test/index.jsx
@@ -1,0 +1,61 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import DefaultTemplate from '../templates/default';
+
+// mock the QueryPreferences component because it is not needed for this test
+jest.mock( '../../../components/data/query-preferences/index.jsx', () => () => {
+	return null;
+} );
+
+function createState( siteId = 1 ) {
+	return {
+		currentUser: {
+			capabilities: {
+				[ siteId ]: {
+					publish_posts: true,
+				},
+			},
+		},
+		sites: {
+			plans: {
+				[ siteId ]: {},
+			},
+		},
+		ui: { selectedSiteId: siteId },
+		preferences: {
+			remoteValues: {},
+		},
+	};
+}
+
+describe( 'DefaultTemplate JITM', () => {
+	const mockStore = configureStore();
+
+	const store = mockStore( createState() );
+	test( 'onDismiss should be called when the dismiss button is clicked', () => {
+		const mockOnDismiss = jest.fn();
+		const mockProps = {
+			CTA: {
+				message: '',
+				link: '',
+			},
+			onDismiss: mockOnDismiss,
+			featureClass: 'notice',
+			message: '',
+		};
+		render(
+			<Provider store={ store }>
+				<DefaultTemplate { ...mockProps } />
+			</Provider>
+		);
+
+		fireEvent.click( screen.getByLabelText( 'Dismiss' ) );
+
+		expect( mockOnDismiss ).toHaveBeenCalledTimes( 1 );
+	} );
+} );


### PR DESCRIPTION
#### Proposed Changes

* Pass in the correct prop name so that [`onDismiss`](https://github.com/Automattic/wp-calypso/blob/b60c812eb7800dae60365c82389ef9cb1f6b47e1/client/blocks/jitm/index.jsx#L82) from  gets triggered
* This will dispatch the action to call the API so that dismissal data are passed to the API

Before
* Redux: No`JITM_DISMISS` action dispatched
* API: not called

After
* Redux: `JITM_DISMISS` action dispatched
* API: called

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
Unit test:
```
yarn test-client client/blocks/jitm/test/index.jsx
```

Manual test:

* Checkout to this branch
* Set user churn as specified in D94719-code, where we are using `update_user_attribute`, this makes sure the churn JITM will show
* Open Network tab in browser
* Open Redux dev tools in browser (optional)
* Click on dismiss and there should be a Network request. In Redux dev tools, you shall see the `JITM_DISMISS` action being dispatched

https://user-images.githubusercontent.com/6586048/207112540-9a4f9920-5e12-4f81-a739-87dad2310212.mp4

Feel free to test around the issue!

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~
- [ ] ~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~
- [ ] ~For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes: https://github.com/Automattic/dotcom-forge/issues/1373