### PR TITLE
Move styles to 'view' so they're loaded when the editor is not present

### DIFF
--- a/apps/happy-blocks/index.php
+++ b/apps/happy-blocks/index.php
@@ -41,7 +41,7 @@
 function a8c_happyblocks_assets() {
 	$assets = require_once plugin_dir_path( __FILE__ ) . 'dist/editor.min.asset.php';
 
-	wp_register_script( 'a8c-happyblocks-pricing-plans', '', array(), '20221117', true );
+	wp_register_script( 'a8c-happyblocks-pricing-plans', '', array(), '20221212', true );
 	wp_enqueue_script( 'a8c-happyblocks-pricing-plans' );
 	wp_add_inline_script(
 		'a8c-happyblocks-pricing-plans',

--- a/apps/happy-blocks/src/pricing-plans/edit.tsx
+++ b/apps/happy-blocks/src/pricing-plans/edit.tsx
@@ -1,4 +1,3 @@
-import './edit.scss';
 import { useBlockProps } from '@wordpress/block-editor';
 import { BlockEditProps } from '@wordpress/blocks';
 import { useEffect } from '@wordpress/element';

--- a/apps/happy-blocks/src/pricing-plans/view.scss
+++ b/apps/happy-blocks/src/pricing-plans/view.scss
@@ -2,13 +2,8 @@
 @import "~@automattic/color-studio/dist/color-variables";
 @import "~@wordpress/base-styles/colors";
 
-/*
-Note:
-  There are several usages of !important in this file due to 104-gh-Automattic/lighthouse-forums.
-	Once this issue is resolved, we can remove the !important declarations.
-*/
-
 $brand-text: "SF Pro Text", $sans;
+$brand-display: "SF Pro Display", $sans;
 
 @keyframes hb-pricing-plans-embed__skeleton__animation {
 	0% {
@@ -37,11 +32,11 @@ $brand-text: "SF Pro Text", $sans;
 
 	&__settings {
 		select {
-			min-height: 30px !important;
-			height: 36px !important;
-			padding: 0 26px 0 16px !important;
-			margin: 0 !important;
-			border-color: $gray-600 !important;
+			min-height: 30px;
+			height: 36px;
+			padding: 0 26px 0 16px;
+			margin: 0;
+			border-color: $gray-600;
 		}
 
 		.components-panel__row {
@@ -99,10 +94,10 @@ $brand-text: "SF Pro Text", $sans;
 		}
 
 		&-learn-more {
-			text-decoration: none !important;
+			text-decoration: none;
 
 			&:hover {
-				text-decoration: underline !important;
+				text-decoration: underline;
 			}
 		}
 
@@ -125,8 +120,8 @@ $brand-text: "SF Pro Text", $sans;
 			}
 
 			p {
-				margin: 0 !important;
-				line-height: inherit !important;
+				margin: 0;
+				line-height: 1.57;
 			}
 		}
 	}
@@ -147,10 +142,10 @@ $brand-text: "SF Pro Text", $sans;
 
 		&-description {
 			font-family: $brand-text;
-			font-weight: 400 !important;
-			font-size: 0.75rem !important;
-			line-height: 1.66 !important;
-			color: $studio-gray-60 !important;
+			font-weight: 400;
+			font-size: 0.75rem;
+			line-height: 1.66;
+			color: $studio-gray-60;
 		}
 	}
 
@@ -173,13 +168,13 @@ $brand-text: "SF Pro Text", $sans;
 	}
 
 	&__billing-option-input {
-		margin: 0 !important;
+		margin: 0;
 		height: 20px;
 		width: 20px;
 	}
 
 	&__billing-option-label {
-		display: flex !important;
+		display: flex;
 		align-items: center;
 		gap: 8px;
 		font-family: $brand-text;
@@ -199,13 +194,64 @@ $brand-text: "SF Pro Text", $sans;
 		justify-content: space-between;
 
 		&-cta {
-			background: var(--wp-admin-theme-color) !important;
-			text-decoration: none !important;
+			color: $studio-blue-0;
+			font-family: $brand-display;
+			font-size: 0.875rem;
+			font-weight: 500;
+			background: $studio-blue-50;
+			text-decoration: none;
 			width: 100%;
-			border-radius: 4px !important;
-			display: flex !important;
+			border-radius: 4px;
+			display: flex;
 			justify-content: center;
-			padding: 20px 12px !important;
+			padding: 10px 0;
 		}
+	}
+}
+
+/*
+Note:
+  These are overrides for BBPress due to 104-gh-Automattic/lighthouse-forums.
+	Once this issue is resolved, we can remove the declarations below.
+*/
+#bbpress-forums {
+	a.hb-pricing-plans-embed__detail-cta {
+		&:link,
+		&:visited {
+			color: $studio-blue-0;
+			font-family: $brand-display;
+			font-size: 0.875rem;
+			font-weight: 500;
+			background: $studio-blue-50;
+			text-decoration: none;
+			width: 100%;
+			border-radius: 4px;
+			display: flex;
+			justify-content: center;
+			padding: 10px 0;
+		}
+	}
+
+	fieldset.bbp-form label.hb-pricing-plans-embed__billing-option-label {
+		display: flex;
+	}
+
+	fieldset.bbp-form input.hb-pricing-plans-embed__billing-option-input {
+		margin: 0;
+	}
+
+	div.bbp-reply-content a.hb-pricing-plans-embed__header-learn-more {
+		text-decoration: none;
+		&:hover {
+			text-decoration: underline;
+		}
+	}
+
+	fieldset.bbp-form select.components-select-control__input {
+		min-height: 30px;
+		height: 36px;
+		padding: 0 26px 0 16px;
+		margin: 0;
+		border-color: $gray-600;
 	}
 }

--- a/apps/happy-blocks/src/pricing-plans/view.tsx
+++ b/apps/happy-blocks/src/pricing-plans/view.tsx
@@ -1,3 +1,4 @@
+import './view.scss';
 import { BlockEditProps } from '@wordpress/blocks';
 import { useState } from '@wordpress/element';
 import { FunctionComponent } from 'react';


### PR DESCRIPTION
#### Proposed Changes

This pull request fixes an issue where some styles for the Pricing Plans block would not load when the user is not logged in. See 146-gh-Automattic/lighthouse-forums for details.

Additionally, it replaces the workaround for 104-gh-Automattic/lighthouse-forums from using `important` to specific overrides for bbpress.


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run `yarn dev --sync` in `apps/happy-blocks` to sync code to your sandbox
* In the Gutenberg editor press `/` and search for "Upgrade" block, insert any of them.
* Publish the topic
* Ensure the reported issue is solved by checking that the block looks as it should in the editor, viewing the post as a logged in user, and viewing the post as a logged out user.


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
