### PR TITLE
Pricing page: Fix lightbox translations not loaded when activated via URL.

### DIFF
--- a/client/my-sites/plans/jetpack-plans/product-lightbox/included-product-list.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-lightbox/included-product-list.tsx
@@ -47,11 +47,10 @@ const IncludedProductList: React.FC< IncludedProductsProps > = ( { products, des
 
 			<ul>
 				{ products.map( ( productSlug ) => (
-					<li>
+					<li key={ productSlug }>
 						<IncludedProductListItem
 							productSlug={ productSlug }
 							descriptionMap={ descriptionMap }
-							key={ productSlug }
 						/>
 					</li>
 				) ) }

--- a/client/my-sites/plans/jetpack-plans/product-store/hooks/use-product-lightbox.ts
+++ b/client/my-sites/plans/jetpack-plans/product-store/hooks/use-product-lightbox.ts
@@ -1,4 +1,5 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useTranslate } from 'i18n-calypso';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
 import { EXTERNAL_PRODUCTS_LIST } from '../../constants';
@@ -8,9 +9,12 @@ import { sanitizeLocationHash } from '../utils/sanitize-location-hash';
 
 export const useProductLightbox = () => {
 	const dispatch = useDispatch();
-	const [ currentProduct, setCurrentProduct ] = useState< SelectorProduct | null >( () =>
-		slugToSelectorProduct( sanitizeLocationHash( window.location.hash ) )
-	);
+	const translate = useTranslate();
+	const [ currentProduct, setCurrentProduct ] = useState< SelectorProduct | null >( null );
+
+	useEffect( () => {
+		setCurrentProduct( slugToSelectorProduct( sanitizeLocationHash( window.location.hash ) ) );
+	}, [ translate ] );
 
 	const setCurrentProductAndLocationHash = useCallback( ( product: SelectorProduct | null ) => {
 		setCurrentProduct( product );

--- a/client/my-sites/plans/jetpack-plans/product-store/hooks/use-product-lightbox.ts
+++ b/client/my-sites/plans/jetpack-plans/product-store/hooks/use-product-lightbox.ts
@@ -12,6 +12,11 @@ export const useProductLightbox = () => {
 	const translate = useTranslate();
 	const [ currentProduct, setCurrentProduct ] = useState< SelectorProduct | null >( null );
 
+	/*
+	 * TO-DO: Ideally we want PlanList (holds all translatable data related to Jetpack plans) to be a react hook so it is aware of translation
+	 * changes. While fixing it will require huge refactoring, for now we useEffect here to manually recreate the product object.
+	 * This should be removed once we have converted PlanList and slugToSelectorProduct into a react hook.
+	 */
 	useEffect( () => {
 		setCurrentProduct( slugToSelectorProduct( sanitizeLocationHash( window.location.hash ) ) );
 	}, [ translate ] );


### PR DESCRIPTION
#### Description
When activating the pricing page lightbox. The translations are not loaded properly for non-english locale. 

eg. https://cloud.jetpack.com/ko/pricing?view=products#jetpack_videopress
<img width="1114" alt="Screen Shot 2022-12-12 at 7 39 55 PM" src="https://user-images.githubusercontent.com/56598660/207036373-52ba356b-b0e9-48df-bcd1-6df9fbd5e5cc.png">

#### Proposed Changes

* Reload Product info everytime translation changes to ensure lightbox content ins translated in the correct language.

#### Testing Instructions
1. Run this branch by following the steps below (or you can use the Jetpack Cloud live link commented on this PR)
    * Run `git fetch && git checkout fix/lightbox-translation-not-loading`
    * Run `yarn start-jetpack-cloud`

2. Goto http://jetpack.cloud.localhost:3000/ko/pricing?view=products#jetpack_videopress or use the Jetpack cloud live link below and append `/ko/pricing?view=products#jetpack_videopress`

3. Confirm that all lightbox content are translated properly. (_note that Product names are not expected to be translated_)
<img width="1105" alt="Screen Shot 2022-12-12 at 7 38 15 PM" src="https://user-images.githubusercontent.com/56598660/207035986-f24c5495-8eeb-4959-af3c-a5f45656b3c1.png">

⚠️  **_I would also like to point out that there is another issue that is not fix in this PR. Notice that for a brief moment, the english translation appears before displaying the correct translation. This issue is not limited to the lightbox but for the entire Pricing page. We will need to figure out how to properly fix this in a separate PR._**

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

