### PR TITLE
Users management: Subscribers, unified followers and email subscribers type of users

### DIFF
--- a/client/my-sites/people/controller.js
+++ b/client/my-sites/people/controller.js
@@ -11,8 +11,7 @@ import PeopleList from './main';
 import PeopleAddSubscribers from './people-add-subscribers';
 import PeopleInviteDetails from './people-invite-details';
 import PeopleInvites from './people-invites';
-import Subscribers from './subscribers';
-import TeamMembers from './team-members';
+import SubscribersTeam from './subscribers-team';
 
 export default {
 	redirectToTeam,
@@ -130,7 +129,7 @@ function renderTeamMembers( context, next ) {
 	context.primary = (
 		<>
 			<TeamMembersTitle />
-			<TeamMembers filter={ context.params.filter } search={ context.query.s } />
+			<SubscribersTeam filter={ context.params.filter } search={ context.query.s } />
 		</>
 	);
 	next();
@@ -146,7 +145,7 @@ function renderSubscribers( context, next ) {
 	context.primary = (
 		<>
 			<SubscribersTitle />
-			<Subscribers filter={ context.params.filter } search={ context.query.s } />
+			<SubscribersTeam filter={ context.params.filter } search={ context.query.s } />
 		</>
 	);
 	next();

--- a/client/my-sites/people/people-add-subscribers/index.jsx
+++ b/client/my-sites/people/people-add-subscribers/index.jsx
@@ -33,7 +33,11 @@ class PeopleInvites extends PureComponent {
 
 	goBack = () => {
 		const siteSlug = get( this.props, 'site.slug' );
-		const fallback = siteSlug ? '/people/team/' + siteSlug : '/people/team';
+		let fallback = siteSlug ? '/people/team/' + siteSlug : '/people/team';
+
+		if ( isEnabled( 'user-management-revamp' ) ) {
+			fallback = '/people/subscribers/' + siteSlug;
+		}
 
 		// Go back to last route with /people/team/$site as the fallback
 		page.back( fallback );

--- a/client/my-sites/people/people-section-nav-compact/index.tsx
+++ b/client/my-sites/people/people-section-nav-compact/index.tsx
@@ -8,22 +8,23 @@ import PeopleSearch from '../people-section-nav/people-search';
 interface Props {
 	selectedFilter: string;
 	searchTerm?: string;
+	filterCount?: { [ key: string ]: undefined | number };
 }
 function PeopleSectionNavCompact( props: Props ) {
 	const _ = useTranslate();
-	const { selectedFilter, searchTerm } = props;
+	const { selectedFilter, searchTerm, filterCount } = props;
 	const site = useSelector( ( state ) => getSelectedSite( state ) );
 
 	const filters = [
 		{
+			id: 'subscribers',
 			title: _( 'Subscribers' ),
 			path: '/people/subscribers/' + site?.slug,
-			id: 'subscribers',
 		},
 		{
+			id: 'team-members',
 			title: _( 'Team' ),
 			path: '/people/team-members/' + site?.slug,
-			id: 'team-members',
 		},
 	];
 
@@ -36,6 +37,9 @@ function PeopleSectionNavCompact( props: Props ) {
 							key={ filterItem.id }
 							path={ filterItem.path }
 							selected={ filterItem.id === selectedFilter }
+							count={
+								filterCount && !! filterCount[ filterItem.id ] && filterCount[ filterItem.id ]
+							}
 						>
 							{ filterItem.title }
 						</NavItem>

--- a/client/my-sites/people/subscribers-team/index.tsx
+++ b/client/my-sites/people/subscribers-team/index.tsx
@@ -1,0 +1,77 @@
+import { useTranslate } from 'i18n-calypso';
+import { useSelector } from 'react-redux';
+import FormattedHeader from 'calypso/components/formatted-header';
+import Main from 'calypso/components/main';
+import SectionNav from 'calypso/components/section-nav';
+import useFollowersQuery from 'calypso/data/followers/use-followers-query';
+import useUsersQuery from 'calypso/data/users/use-users-query';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
+import PeopleSectionNavCompact from '../people-section-nav-compact';
+import Subscribers from '../subscribers';
+import type { FollowersQuery } from '../subscribers/types';
+import type { UsersQuery } from '../team-members/types';
+
+interface Props {
+	filter: string;
+	search?: string;
+}
+function SubscribersTeam( props: Props ) {
+	const _ = useTranslate();
+	const { filter, search } = props;
+	const site = useSelector( ( state ) => getSelectedSite( state ) );
+
+	// fetching data config
+	const followersFetchOptions = { search };
+	const teamFetchOptions = {
+		...followersFetchOptions,
+		search_columns: [ 'display_name', 'user_login' ],
+	};
+	const followersQuery = useFollowersQuery(
+		site?.ID,
+		'all',
+		followersFetchOptions
+	) as unknown as FollowersQuery;
+	const usersQuery = useUsersQuery( site?.ID, teamFetchOptions ) as unknown as UsersQuery;
+
+	return (
+		<Main>
+			<FormattedHeader
+				brandFont
+				className="people__page-heading"
+				headerText={ _( 'Users' ) }
+				subHeaderText={ _(
+					'Invite subscribers and team members to your site and manage their access settings.'
+				) }
+				align="left"
+				hasScreenOptions
+			/>
+			<div>
+				<SectionNav>
+					<PeopleSectionNavCompact
+						selectedFilter={ filter }
+						searchTerm={ search }
+						filterCount={ {
+							subscribers: followersQuery.data?.total,
+							'team-members': usersQuery.data?.total,
+						} }
+					/>
+				</SectionNav>
+
+				{ ( () => {
+					switch ( filter ) {
+						case 'subscribers':
+							return (
+								<Subscribers
+									filter={ filter }
+									search={ search }
+									followersQuery={ followersQuery }
+								/>
+							);
+					}
+				} )() }
+			</div>
+		</Main>
+	);
+}
+
+export default SubscribersTeam;

--- a/client/my-sites/people/subscribers/index.tsx
+++ b/client/my-sites/people/subscribers/index.tsx
@@ -1,34 +1,107 @@
+import { Card, Button } from '@automattic/components';
+import { AddSubscriberForm } from '@automattic/subscriber';
 import { useTranslate } from 'i18n-calypso';
-import FormattedHeader from 'calypso/components/formatted-header';
-import Main from 'calypso/components/main';
-import SectionNav from 'calypso/components/section-nav';
-import PeopleSectionNavCompact from '../people-section-nav-compact';
+import { useSelector } from 'react-redux';
+import EllipsisMenu from 'calypso/components/ellipsis-menu';
+import InfiniteList from 'calypso/components/infinite-list';
+import PopoverMenuItem from 'calypso/components/popover-menu/item';
+import { addQueryArgs } from 'calypso/lib/url';
+import NoResults from 'calypso/my-sites/no-results';
+import PeopleListItem from 'calypso/my-sites/people/people-list-item';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
+import PeopleListSectionHeader from '../people-list-section-header';
+import type { Follower, FollowersQuery } from './types';
+
+import './style.scss';
 
 interface Props {
 	filter: string;
 	search?: string;
+	followersQuery: FollowersQuery;
 }
 function Subscribers( props: Props ) {
 	const _ = useTranslate();
-	const { filter, search } = props;
+	const { search, followersQuery } = props;
+	const site = useSelector( ( state ) => getSelectedSite( state ) );
 
-	return (
-		<Main>
-			<FormattedHeader
-				brandFont
-				className="people__page-heading"
-				headerText={ _( 'Users' ) }
-				subHeaderText={ _( 'People who have subscribed to your site and team members.' ) }
-				align="left"
-				hasScreenOptions
-			/>
-			<div>
-				<SectionNav>
-					<PeopleSectionNavCompact selectedFilter={ filter } searchTerm={ search } />
-				</SectionNav>
-			</div>
-		</Main>
+	const listKey = [ 'subscribers', site?.ID, 'all', search ].join( '-' );
+	const { data, fetchNextPage, isFetchingNextPage, hasNextPage, refetch } = followersQuery;
+
+	const subscribers = data?.followers || [];
+	const subscribersTotal = data?.total;
+
+	const addSubscribersLink = `/people/add-subscribers/${ site?.slug }`;
+	const downloadCsvLink = addQueryArgs(
+		{ page: 'stats', blog: site?.ID, blog_subscribers: 'csv', type: 'email' },
+		'https://dashboard.wordpress.com/wp-admin/index.php'
 	);
+
+	const templateState =
+		search && ! subscribersTotal ? 'no-result' : ! subscribersTotal ? 'empty' : 'default';
+
+	function getFollowerRef( follower: Follower ) {
+		return 'follower-' + follower.ID;
+	}
+
+	function renderFollower( follower: Follower ) {
+		return <PeopleListItem key={ follower?.ID } user={ follower } site={ site } type="email" />;
+	}
+
+	function renderPlaceholders() {
+		return <PeopleListItem key="people-list-item-placeholder" />;
+	}
+
+	switch ( templateState ) {
+		case 'default':
+			return (
+				<>
+					<PeopleListSectionHeader
+						label={ _( 'You have %(number)d subscriber', 'You have %(number)d subscribers', {
+							args: { number: subscribersTotal },
+							count: subscribersTotal as number,
+						} ) }
+					>
+						<Button compact primary href={ addSubscribersLink }>
+							{ _( 'Add subscribers' ) }
+						</Button>
+						<EllipsisMenu compact position="bottom">
+							<PopoverMenuItem href={ downloadCsvLink }>{ _( 'Download as CSV' ) }</PopoverMenuItem>
+						</EllipsisMenu>
+					</PeopleListSectionHeader>
+					<Card className="people-subscribers-list">
+						<InfiniteList
+							listkey={ listKey }
+							items={ subscribers }
+							fetchNextPage={ fetchNextPage }
+							fetchingNextPage={ isFetchingNextPage }
+							lastPage={ ! hasNextPage }
+							renderItem={ renderFollower }
+							renderLoadingPlaceholders={ renderPlaceholders }
+							guessedItemHeight={ 126 }
+							getItemRef={ getFollowerRef }
+						/>
+					</Card>
+				</>
+			);
+
+		case 'empty':
+			return (
+				<Card>
+					{ site && <AddSubscriberForm siteId={ site?.ID } onImportFinished={ refetch } /> }
+				</Card>
+			);
+
+		case 'no-result':
+			return (
+				<NoResults
+					image="/calypso/images/people/mystery-person.svg"
+					text={ _( 'No results found for {{em}}%(searchTerm)s{{/em}}', {
+						args: { searchTerm: search },
+						components: { em: <em /> },
+					} ) }
+				/>
+			);
+	}
 }
 
 export default Subscribers;

--- a/client/my-sites/people/subscribers/index.tsx
+++ b/client/my-sites/people/subscribers/index.tsx
@@ -25,7 +25,8 @@ function Subscribers( props: Props ) {
 	const site = useSelector( ( state ) => getSelectedSite( state ) );
 
 	const listKey = [ 'subscribers', site?.ID, 'all', search ].join( '-' );
-	const { data, fetchNextPage, isFetchingNextPage, hasNextPage, refetch } = followersQuery;
+	const { data, fetchNextPage, isLoading, isFetchingNextPage, hasNextPage, refetch } =
+		followersQuery;
 
 	const subscribers = data?.followers || [];
 	const subscribersTotal = data?.total;
@@ -49,7 +50,9 @@ function Subscribers( props: Props ) {
 	}
 
 	let templateState;
-	if ( search && ! subscribersTotal ) {
+	if ( isLoading ) {
+		templateState = 'loading';
+	} else if ( search && ! subscribersTotal ) {
 		templateState = 'no-result';
 	} else if ( ! subscribersTotal ) {
 		templateState = 'empty';
@@ -59,9 +62,11 @@ function Subscribers( props: Props ) {
 
 	switch ( templateState ) {
 		case 'default':
+		case 'loading':
 			return (
 				<>
 					<PeopleListSectionHeader
+						isPlaceholder={ isLoading }
 						label={ _( 'You have %(number)d subscriber', 'You have %(number)d subscribers', {
 							args: { number: subscribersTotal },
 							count: subscribersTotal as number,
@@ -75,6 +80,7 @@ function Subscribers( props: Props ) {
 						</EllipsisMenu>
 					</PeopleListSectionHeader>
 					<Card className="people-subscribers-list">
+						{ isLoading && renderPlaceholders() }
 						<InfiniteList
 							listkey={ listKey }
 							items={ subscribers }

--- a/client/my-sites/people/subscribers/index.tsx
+++ b/client/my-sites/people/subscribers/index.tsx
@@ -76,7 +76,9 @@ function Subscribers( props: Props ) {
 							{ _( 'Add subscribers' ) }
 						</Button>
 						<EllipsisMenu compact position="bottom">
-							<PopoverMenuItem href={ downloadCsvLink }>{ _( 'Download as CSV' ) }</PopoverMenuItem>
+							<PopoverMenuItem href={ downloadCsvLink }>
+								{ _( 'Download email subscribers as CSV' ) }
+							</PopoverMenuItem>
 						</EllipsisMenu>
 					</PeopleListSectionHeader>
 					<Card className="people-subscribers-list">

--- a/client/my-sites/people/subscribers/index.tsx
+++ b/client/my-sites/people/subscribers/index.tsx
@@ -36,9 +36,6 @@ function Subscribers( props: Props ) {
 		'https://dashboard.wordpress.com/wp-admin/index.php'
 	);
 
-	const templateState =
-		search && ! subscribersTotal ? 'no-result' : ! subscribersTotal ? 'empty' : 'default';
-
 	function getFollowerRef( follower: Follower ) {
 		return 'follower-' + follower.ID;
 	}
@@ -49,6 +46,15 @@ function Subscribers( props: Props ) {
 
 	function renderPlaceholders() {
 		return <PeopleListItem key="people-list-item-placeholder" />;
+	}
+
+	let templateState;
+	if ( search && ! subscribersTotal ) {
+		templateState = 'no-result';
+	} else if ( ! subscribersTotal ) {
+		templateState = 'empty';
+	} else {
+		templateState = 'default';
 	}
 
 	switch ( templateState ) {
@@ -102,6 +108,8 @@ function Subscribers( props: Props ) {
 				/>
 			);
 	}
+
+	return null;
 }
 
 export default Subscribers;

--- a/client/my-sites/people/subscribers/style.scss
+++ b/client/my-sites/people/subscribers/style.scss
@@ -1,0 +1,10 @@
+.people-subscribers-list {
+	padding: 0;
+}
+
+.people-list-section-header {
+	.ellipsis-menu button {
+		padding: 0;
+		margin: 0;
+	}
+}

--- a/client/my-sites/people/subscribers/types.ts
+++ b/client/my-sites/people/subscribers/types.ts
@@ -1,0 +1,23 @@
+export type Follower = {
+	ID: number | string;
+	url?: string;
+	label: string;
+	login: string;
+	avatar: string;
+	avatar_URL: string;
+	date_subscribed: string;
+	follow_data?: any;
+};
+
+export type FollowersQueryData = {
+	followers: Follower[];
+	total: number;
+};
+
+export type FollowersQuery = {
+	data?: FollowersQueryData;
+	hasNextPage: boolean;
+	refetch: () => void;
+	fetchNextPage: () => void;
+	isFetchingNextPage: boolean;
+};

--- a/client/my-sites/people/subscribers/types.ts
+++ b/client/my-sites/people/subscribers/types.ts
@@ -19,5 +19,6 @@ export type FollowersQuery = {
 	hasNextPage: boolean;
 	refetch: () => void;
 	fetchNextPage: () => void;
+	isLoading: boolean;
 	isFetchingNextPage: boolean;
 };

--- a/client/my-sites/people/team-members/types.ts
+++ b/client/my-sites/people/team-members/types.ts
@@ -1,0 +1,13 @@
+import User from 'calypso/components/user';
+
+export type UsersQueryData = {
+	users: User[];
+	total: number;
+};
+
+export type UsersQuery = {
+	data?: UsersQueryData;
+	fetchNextPage: () => void;
+	isFetchingNextPage: boolean;
+	hasNextPage: boolean;
+};

--- a/config/development.json
+++ b/config/development.json
@@ -182,6 +182,7 @@
 		"upgrades/upcoming-renewals-notices": true,
 		"upgrades/wpcom-monthly-plans": true,
 		"upsell/concierge-session": true,
+		"user-management-revamp": true,
 		"woop": false,
 		"wordpress-action-search": false,
 		"wpcom-user-bootstrap": false


### PR DESCRIPTION
#### Proposed Changes

* Introduced `user-management-revamp` feature flag
* Created parent `SubscribersTeam` component for presenting Subscribers and Team tabs content and fetching data to show count badges in navigation.
* Adapted the Subscribers tab, unifying followers and email subscribers.

Out of scope (will be done in the following PRs):
* List item component adjustments
* Team tab component

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/people/subscribers/{USER_SLUG}`
* Check the screen when the email subscribers list is empty
* Check how the `Add subscribers` button works
* Check Import Subscribers integration

#### Screenshot
![Markup on 2022-12-13 at 10:08:04](https://user-images.githubusercontent.com/1241413/207275017-cc3a59cd-f576-4655-bc63-cc3a4da5747b.png)


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #70695 | #70700
