### PR TITLE
Ensure we keep the recur URL parameter in our account redirect

### DIFF
--- a/client/landing/stepper/declarative-flow/tailored-ecommerce-flow.ts
+++ b/client/landing/stepper/declarative-flow/tailored-ecommerce-flow.ts
@@ -68,12 +68,27 @@ const ecommerceFlow: Flow = {
 		const flags = new URLSearchParams( window.location.search ).get( 'flags' );
 
 		const getStartUrl = () => {
+			let hasFlowParams = false;
+			const flowParams = new URLSearchParams();
+
+			if ( recurType !== ecommerceFlowRecurTypes.YEARLY ) {
+				flowParams.set( 'recur', recurType );
+				hasFlowParams = true;
+			}
+			if ( locale && locale !== 'en' ) {
+				flowParams.set( 'locale', locale );
+				hasFlowParams = true;
+			}
+
+			const redirectTarget =
+				`/setup/ecommerce/storeProfiler` +
+				( hasFlowParams ? encodeURIComponent( '?' + flowParams.toString() ) : '' );
 			const url =
 				locale && locale !== 'en'
-					? `/start/account/user/${ locale }?variationName=${ flowName }&redirect_to=/setup/ecommerce/storeProfiler`
-					: `/start/account/user?variationName=${ flowName }&redirect_to=/setup/ecommerce/storeProfiler`;
+					? `/start/account/user/${ locale }?variationName=${ flowName }&redirect_to=${ redirectTarget }`
+					: `/start/account/user?variationName=${ flowName }&redirect_to=${ redirectTarget }`;
 
-			return url + ( flags ? `?flags=${ flags }` : '' );
+			return url + ( flags ? `&flags=${ flags }` : '' );
 		};
 
 		function submit( providedDependencies: ProvidedDependencies = {} ) {


### PR DESCRIPTION
#### Proposed Changes

* This PR ensures that we correctly re-add the `locale` and `recur` URL parameters in the redirect back from the account step.
* The PR also ensures that we use an `&` separator for the `flags` URL parameter.

#### Testing Instructions

* Run this branch locally or via the Calypso live branch, and ensure you don't have a logged in user, which is easiest from an incognito/private browser window
* Navigate to `/setup/ecommerce?recur=monthly&locale=nl` (feel free to pick any other locale you prefer)
* Verify that you're taken to the `/intro` step
* Click on the "Create your store" button (or its translated equivalent)
* Verify that you're taken to the `/start/account/user/:locale` step and that the URL includes the `redirect_to` URL parameter with the following structure:
  - `redirect_to=/setup/ecommerce/storeProfiler%3Frecur%3Dmonthly%26locale%3Dnl` (where `nl` would be your chosen locale)
* Complete the signup step (preferably using a non-@automattic email address) and work through the remainder of the flow
* Verify that you get a monthly eCommerce plan in checkout

#### Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [N/A] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [N/A] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [N/A] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [N/A] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?