### PR TITLE
Fix: Universal Navbar and Footer links

### DIFF
--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -139,13 +139,14 @@ const LayoutLoggedOut = ( {
 			{ config.isEnabled( 'cookie-banner' ) && (
 				<CookieBannerContainerSSR serverShow={ showGdprBanner } />
 			) }
-			{ config.isEnabled( 'layout/support-article-dialog' ) && (
-				<AsyncLoad require="calypso/blocks/support-article-dialog" placeholder={ null } />
-			) }
+
 			{ sectionName === 'plugins' && (
 				<>
 					<UniversalNavbarFooter />
 					<UniversalNavbarFooterAutomattic />
+					{ config.isEnabled( 'layout/support-article-dialog' ) && (
+						<AsyncLoad require="calypso/blocks/support-article-dialog" placeholder={ null } />
+					) }
 				</>
 			) }
 		</div>

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -139,6 +139,9 @@ const LayoutLoggedOut = ( {
 			{ config.isEnabled( 'cookie-banner' ) && (
 				<CookieBannerContainerSSR serverShow={ showGdprBanner } />
 			) }
+			{ config.isEnabled( 'layout/support-article-dialog' ) && (
+				<AsyncLoad require="calypso/blocks/support-article-dialog" placeholder={ null } />
+			) }
 			{ sectionName === 'plugins' && (
 				<>
 					<UniversalNavbarFooter />

--- a/client/layout/universal-navbar-footer/index.tsx
+++ b/client/layout/universal-navbar-footer/index.tsx
@@ -20,31 +20,37 @@ const UniversalNavbarFooter = () => {
 							<h3>{ translate( 'Products' ) }</h3>
 							<ul>
 								<li>
-									<a href="https://wordpress.com/hosting/">{ translate( 'WordPress Hosting' ) }</a>
+									<a href="https://wordpress.com/hosting/" target="_self">
+										{ translate( 'WordPress Hosting' ) }
+									</a>
 								</li>
 								<li>
-									<a href="https://wordpress.com/domains/">{ translate( 'Domain Names' ) }</a>
+									<a href="https://wordpress.com/domains/" target="_self">
+										{ translate( 'Domain Names' ) }
+									</a>
 								</li>
 								<li>
-									<a href="https://wordpress.com/website-builder/">
+									<a href="https://wordpress.com/website-builder/" target="_self">
 										{ translate( 'Website Builder' ) }
 									</a>
 								</li>
 								<li>
-									<a href="https://wordpress.com/create-blog/">{ translate( 'Create a Blog' ) }</a>
+									<a href="https://wordpress.com/create-blog/" target="_self">
+										{ translate( 'Create a Blog' ) }
+									</a>
 								</li>
 								<li>
-									<a href="https://wordpress.com/professional-email/">
+									<a href="https://wordpress.com/professional-email/" target="_self">
 										{ translate( 'Professional Email' ) }
 									</a>
 								</li>
 								<li>
-									<a href="https://wordpress.com/p2/?ref=wpcom-product-menu">
+									<a href="https://wordpress.com/p2/?ref=wpcom-product-menu" target="_self">
 										{ translate( 'P2: WordPress for Teams' ) }
 									</a>
 								</li>
 								<li>
-									<a href="https://wpvip.com/" data-is_external="1">
+									<a href="https://wpvip.com/" data-is_external="1" target="_self">
 										{ translate( 'Enterprise' ) }{ ' ' }
 										<span className="lp-link-chevron-external">{ translate( 'Solutions' ) }</span>
 									</a>
@@ -53,6 +59,7 @@ const UniversalNavbarFooter = () => {
 									<a
 										href="https://wordpress.com/do-it-for-me/?ref=footer_pricing"
 										title="WordPress Website Building Service"
+										target="_self"
 									>
 										{ translate( 'Built by WordPress.com' ) }
 									</a>
@@ -63,20 +70,28 @@ const UniversalNavbarFooter = () => {
 							<h3>{ translate( 'Features' ) }</h3>
 							<ul>
 								<li>
-									<a href="https://wordpress.com/features/" title="WordPress.com Features">
+									<a
+										href="https://wordpress.com/features/"
+										title="WordPress.com Features"
+										target="_self"
+									>
 										{ translate( 'Overview' ) }
 									</a>
 								</li>
 								<li>
-									<a href="https://wordpress.com/themes">{ translate( 'WordPress Themes' ) }</a>
+									<a href="https://wordpress.com/themes" target="_self">
+										{ translate( 'WordPress Themes' ) }
+									</a>
 								</li>
 								<li>
-									<a href="https://wordpress.com/install-plugins/">
+									<a href="https://wordpress.com/install-plugins/" target="_self">
 										{ translate( 'WordPress Plugins' ) }
 									</a>
 								</li>
 								<li>
-									<a href="https://wordpress.com/google/">{ translate( 'Google Apps' ) }</a>
+									<a href="https://wordpress.com/google/" target="_self">
+										{ translate( 'Google Apps' ) }
+									</a>
 								</li>
 							</ul>
 						</div>
@@ -84,32 +99,44 @@ const UniversalNavbarFooter = () => {
 							<h3>{ translate( 'Resources' ) }</h3>
 							<ul>
 								<li>
-									<a href="https://wordpress.com/support/">
+									<a href="https://wordpress.com/support/" target="_self">
 										{ translate( 'WordPress.com Support' ) }
 									</a>
 								</li>
 								<li>
-									<a href="https://wordpress.com/forums/">{ translate( 'WordPress Forums' ) }</a>
+									<a href="https://wordpress.com/forums/" target="_self">
+										{ translate( 'WordPress Forums' ) }
+									</a>
 								</li>
 								<li>
-									<a href="https://wordpress.com/blog/">{ translate( 'WordPress News' ) }</a>
+									<a href="https://wordpress.com/blog/" target="_self">
+										{ translate( 'WordPress News' ) }
+									</a>
 								</li>
 								<li>
-									<a href="https://wordpress.com/go/">{ translate( 'Website Building Tips' ) }</a>
+									<a href="https://wordpress.com/go/" target="_self">
+										{ translate( 'Website Building Tips' ) }
+									</a>
 								</li>
 								<li>
-									<a href="https://wordpress.com/business-name-generator/">
+									<a href="https://wordpress.com/business-name-generator/" target="_self">
 										{ translate( 'Business Name Generator' ) }
 									</a>
 								</li>
 								<li>
-									<a href="https://wordpress.com/logo-maker/">{ translate( 'Logo Maker' ) }</a>
+									<a href="https://wordpress.com/logo-maker/" target="_self">
+										{ translate( 'Logo Maker' ) }
+									</a>
 								</li>
 								<li>
-									<a href="https://wordpress.com/webinars/">{ translate( 'Daily Webinars' ) }</a>
+									<a href="https://wordpress.com/webinars/" target="_self">
+										{ translate( 'Daily Webinars' ) }
+									</a>
 								</li>
 								<li>
-									<a href="https://wordpress.com/courses/">{ translate( 'WordPress Courses' ) }</a>
+									<a href="https://wordpress.com/courses/" target="_self">
+										{ translate( 'WordPress Courses' ) }
+									</a>
 								</li>
 								<li>
 									<a href="https://developer.wordpress.com/" data-is_external="1">
@@ -123,10 +150,14 @@ const UniversalNavbarFooter = () => {
 							<h3>{ translate( 'Company' ) }</h3>
 							<ul>
 								<li>
-									<a href="https://wordpress.com/about/">{ translate( 'About' ) }</a>
+									<a href="https://wordpress.com/about/" target="_self">
+										{ translate( 'About' ) }
+									</a>
 								</li>
 								<li>
-									<a href="https://wordpress.com/partners/">{ translate( 'Partners' ) }</a>
+									<a href="https://wordpress.com/partners/" target="_self">
+										{ translate( 'Partners' ) }
+									</a>
 								</li>
 								<li>
 									<a href="https://automattic.com/press/" data-is_external="1">
@@ -134,7 +165,9 @@ const UniversalNavbarFooter = () => {
 									</a>
 								</li>
 								<li>
-									<a href="https://wordpress.com/tos/">{ translate( 'Terms of Service' ) }</a>
+									<a href="https://wordpress.com/tos/" target="_self">
+										{ translate( 'Terms of Service' ) }
+									</a>
 								</li>
 								<li>
 									<a href="https://automattic.com/privacy/" data-is_external="1">

--- a/client/layout/universal-navbar-header/index.jsx
+++ b/client/layout/universal-navbar-header/index.jsx
@@ -12,6 +12,8 @@ const UniversalNavbarHeader = () => {
 	const [ isMobileMenuOpen, setMobileMenuOpen ] = useState( false );
 	const sectionName = useSelector( getSectionName );
 
+	let startUrl = sectionName === 'plugins' ? '/start/business' : '/start';
+	startUrl += `/?ref=${ sectionName }-lp`;
 	return (
 		<div>
 			<div className="x-root lpc-header-nav-wrapper">
@@ -203,7 +205,7 @@ const UniversalNavbarHeader = () => {
 										className="x-nav-item x-nav-item__wide"
 										titleValue={ translate( 'Get Started' ) }
 										elementContent={ translate( 'Get Started' ) }
-										urlValue={ `/start/business/?ref=${ sectionName }-lp` }
+										urlValue={ startUrl }
 										type="nav"
 										typeClassName="x-nav-link x-nav-link__primary x-link cta-btn-nav"
 									/>
@@ -255,7 +257,7 @@ const UniversalNavbarHeader = () => {
 									<UniversalNavbarLiMenuItem
 										titleValue={ translate( 'Sign Up' ) }
 										elementContent={ translate( 'Sign Up' ) }
-										urlValue="//wordpress.com/start"
+										urlValue={ startUrl }
 										type="menu"
 									/>
 									<UniversalNavbarLiMenuItem

--- a/client/layout/universal-navbar-header/index.jsx
+++ b/client/layout/universal-navbar-header/index.jsx
@@ -30,7 +30,12 @@ const UniversalNavbarHeader = () => {
 							<nav className="x-nav" aria-label="WordPress.com">
 								<ul className="x-nav-list x-nav-list__left">
 									<li className="x-nav-item">
-										<a role="menuitem" className="x-nav-link x-nav-link__logo x-link" href="/">
+										<a
+											role="menuitem"
+											className="x-nav-link x-nav-link__logo x-link"
+											href="/"
+											target="_self"
+										>
 											<WordPressWordmark className="x-icon x-icon__logo" />
 											<span className="x-hidden">WordPress.com</span>
 										</a>

--- a/client/layout/universal-navbar-header/index.jsx
+++ b/client/layout/universal-navbar-header/index.jsx
@@ -13,13 +13,13 @@ const UniversalNavbarHeader = () => {
 	const [ isMobileMenuOpen, setMobileMenuOpen ] = useState( false );
 	const sectionName = useSelector( getSectionName );
 
-	let startUrl = sectionName === 'plugins' ? '/start/business' : '/start';
-	startUrl = addQueryArgs(
+	const startUrl = addQueryArgs(
 		{
-			ref: sectionName,
+			ref: sectionName + '-lp',
 		},
-		startUrl
+		sectionName === 'plugins' ? '/start/business' : '/start'
 	);
+
 	return (
 		<div>
 			<div className="x-root lpc-header-nav-wrapper">

--- a/client/layout/universal-navbar-header/index.jsx
+++ b/client/layout/universal-navbar-header/index.jsx
@@ -5,6 +5,7 @@ import { useSelector } from 'react-redux';
 import WordPressWordmark from 'calypso/components/wordpress-wordmark';
 import UniversalNavbarBtnMenuItem from 'calypso/layout/universal-navbar-header/btn-menu-item.jsx';
 import UniversalNavbarLiMenuItem from 'calypso/layout/universal-navbar-header/li-menu-item.jsx';
+import { addQueryArgs } from 'calypso/lib/route';
 import { getSectionName } from 'calypso/state/ui/selectors';
 
 const UniversalNavbarHeader = () => {
@@ -13,7 +14,12 @@ const UniversalNavbarHeader = () => {
 	const sectionName = useSelector( getSectionName );
 
 	let startUrl = sectionName === 'plugins' ? '/start/business' : '/start';
-	startUrl += `/?ref=${ sectionName }-lp`;
+	startUrl = addQueryArgs(
+		{
+			ref: sectionName,
+		},
+		startUrl
+	);
 	return (
 		<div>
 			<div className="x-root lpc-header-nav-wrapper">

--- a/client/layout/universal-navbar-header/index.jsx
+++ b/client/layout/universal-navbar-header/index.jsx
@@ -47,30 +47,35 @@ const UniversalNavbarHeader = () => {
 													elementContent={ translate( 'WordPress Hosting' ) }
 													urlValue="//wordpress.com/hosting/"
 													type="dropdown"
+													target="_self"
 												/>
 												<UniversalNavbarLiMenuItem
 													titleValue={ translate( 'Domain Names' ) }
 													elementContent={ translate( 'Domain Names' ) }
 													urlValue="//wordpress.com/domains/"
 													type="dropdown"
+													target="_self"
 												/>
 												<UniversalNavbarLiMenuItem
 													titleValue={ translate( 'Website Builder' ) }
 													elementContent={ translate( 'Website Builder' ) }
 													urlValue="//wordpress.com/website-builder/"
 													type="dropdown"
+													target="_self"
 												/>
 												<UniversalNavbarLiMenuItem
 													titleValue={ translate( 'Create a Blog' ) }
 													elementContent={ translate( 'Create a Blog' ) }
 													urlValue="//wordpress.com/create-blog/"
 													type="dropdown"
+													target="_self"
 												/>
 												<UniversalNavbarLiMenuItem
 													titleValue={ translate( 'Professional Email' ) }
 													elementContent={ translate( 'Professional Email' ) }
 													urlValue="//wordpress.com/professional-email/"
 													type="dropdown"
+													target="_self"
 												/>
 											</ul>
 											<div className="x-dropdown-content-separator"></div>
@@ -102,6 +107,7 @@ const UniversalNavbarHeader = () => {
 													elementContent={ translate( 'Overview' ) }
 													urlValue="//wordpress.com/features/"
 													type="dropdown"
+													target="_self"
 												/>
 											</ul>
 											<div className="x-dropdown-content-separator"></div>
@@ -123,6 +129,7 @@ const UniversalNavbarHeader = () => {
 													elementContent={ translate( 'Google Apps' ) }
 													urlValue="//wordpress.com/google/"
 													type="dropdown"
+													target="_self"
 												/>
 											</ul>
 										</div>
@@ -151,36 +158,42 @@ const UniversalNavbarHeader = () => {
 													elementContent={ translate( 'News' ) }
 													urlValue="//wordpress.com/blog/"
 													type="dropdown"
+													target="_self"
 												/>
 												<UniversalNavbarLiMenuItem
 													titleValue={ translate( 'Website Building Tips' ) }
 													elementContent={ translate( 'Website Building Tips' ) }
 													urlValue="//wordpress.com/go/"
 													type="dropdown"
+													target="_self"
 												/>
 												<UniversalNavbarLiMenuItem
 													titleValue={ translate( 'Business Name Generator' ) }
 													elementContent={ translate( 'Business Name Generator' ) }
 													urlValue="//wordpress.com/business-name-generator/"
 													type="dropdown"
+													target="_self"
 												/>
 												<UniversalNavbarLiMenuItem
 													titleValue={ translate( 'Logo Maker' ) }
 													elementContent={ translate( 'Logo Maker' ) }
 													urlValue="//wordpress.com/logo-maker/"
 													type="dropdown"
+													target="_self"
 												/>
 												<UniversalNavbarLiMenuItem
 													titleValue={ translate( 'Daily Webinars' ) }
 													elementContent={ translate( 'Daily Webinars' ) }
 													urlValue="//wordpress.com/webinars/"
 													type="dropdown"
+													target="_self"
 												/>
 												<UniversalNavbarLiMenuItem
 													titleValue={ translate( 'WordPress Courses' ) }
 													elementContent={ translate( 'WordPress Courses' ) }
 													urlValue="//wordpress.com/courses/"
 													type="dropdown"
+													target="_self"
 												/>
 											</ul>
 										</div>
@@ -191,6 +204,7 @@ const UniversalNavbarHeader = () => {
 										elementContent={ translate( 'Plans & Pricing' ) }
 										urlValue="//wordpress.com/pricing/"
 										type="nav"
+										target="_self"
 									/>
 								</ul>
 								<ul className="x-nav-list x-nav-list__right">

--- a/client/layout/universal-navbar-header/li-menu-item.jsx
+++ b/client/layout/universal-navbar-header/li-menu-item.jsx
@@ -5,6 +5,7 @@ const UniversalNavbarLiMenuItem = ( {
 	className,
 	type,
 	typeClassName,
+	target,
 } ) => {
 	let liClassName = '';
 	if ( type === 'menu' ) {
@@ -21,7 +22,7 @@ const UniversalNavbarLiMenuItem = ( {
 				href={ urlValue }
 				title={ titleValue }
 				tabIndex="-1"
-				target="_self"
+				target={ target }
 			>
 				{ elementContent }
 				{ /* <span className="x-menu-link-chevron" aria-hidden="true"></span> */ }

--- a/client/layout/universal-navbar-header/li-menu-item.jsx
+++ b/client/layout/universal-navbar-header/li-menu-item.jsx
@@ -21,6 +21,7 @@ const UniversalNavbarLiMenuItem = ( {
 				href={ urlValue }
 				title={ titleValue }
 				tabIndex="-1"
+				target="_self"
 			>
 				{ elementContent }
 				{ /* <span className="x-menu-link-chevron" aria-hidden="true"></span> */ }

--- a/client/my-sites/plugins/education-footer/index.tsx
+++ b/client/my-sites/plugins/education-footer/index.tsx
@@ -82,12 +82,11 @@ export const MarketplaceFooter = () => {
 
 	const sectionName = useSelector( getSectionName );
 
-	let startUrl = sectionName === 'plugins' ? '/start/business' : '/start';
-	startUrl = addQueryArgs(
+	const startUrl = addQueryArgs(
 		{
-			ref: sectionName,
+			ref: sectionName + '-lp',
 		},
-		startUrl
+		sectionName === 'plugins' ? '/start/business' : '/start'
 	);
 
 	return (

--- a/client/my-sites/plugins/education-footer/index.tsx
+++ b/client/my-sites/plugins/education-footer/index.tsx
@@ -8,6 +8,7 @@ import FeatureItem from 'calypso/components/feature-item';
 import LinkCard from 'calypso/components/link-card';
 import Section, { SectionContainer } from 'calypso/components/section';
 import { preventWidows } from 'calypso/lib/formatting';
+import { addQueryArgs } from 'calypso/lib/route';
 import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { getSectionName } from 'calypso/state/ui/selectors';
@@ -82,7 +83,12 @@ export const MarketplaceFooter = () => {
 	const sectionName = useSelector( getSectionName );
 
 	let startUrl = sectionName === 'plugins' ? '/start/business' : '/start';
-	startUrl += `/?ref=${ sectionName }-lp`;
+	startUrl = addQueryArgs(
+		{
+			ref: sectionName,
+		},
+		startUrl
+	);
 
 	return (
 		<MarketplaceContainer isloggedIn={ isLoggedIn }>

--- a/client/my-sites/plugins/education-footer/index.tsx
+++ b/client/my-sites/plugins/education-footer/index.tsx
@@ -10,6 +10,7 @@ import Section, { SectionContainer } from 'calypso/components/section';
 import { preventWidows } from 'calypso/lib/formatting';
 import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import { getSectionName } from 'calypso/state/ui/selectors';
 
 const ThreeColumnContainer = styled.div`
 	@media ( max-width: 660px ) {
@@ -78,6 +79,11 @@ export const MarketplaceFooter = () => {
 	const { __ } = useI18n();
 	const isLoggedIn = useSelector( isUserLoggedIn );
 
+	const sectionName = useSelector( getSectionName );
+
+	let startUrl = sectionName === 'plugins' ? '/start/business' : '/start';
+	startUrl += `/?ref=${ sectionName }-lp`;
+
 	return (
 		<MarketplaceContainer isloggedIn={ isLoggedIn }>
 			<Section
@@ -85,7 +91,7 @@ export const MarketplaceFooter = () => {
 			>
 				<>
 					{ ! isLoggedIn && (
-						<Button className="is-primary marketplace-cta" href="/start/business">
+						<Button className="is-primary marketplace-cta" href={ startUrl }>
 							{ __( 'Get Started' ) }
 						</Button>
 					) }


### PR DESCRIPTION
#### Proposed Changes
More info: pcNC1U-mF-p2

This makes the following changes to the links within the Logged out Universal Navbar and Footer:
* `Get Started` CTAs point to `/start/business` only in the Plugins section
* adds `target=_self` so that WordPress.com links don't go through Calypso's router. This solves an issue where links pointing to a page on the same domain don't work.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Log out
NOTE: To best test the same domain link fix, you'll need to run Calypso from the `wordpress.com` domain
* Go to /plugins and /themes
* Verify that Navbar and Footer same domain links (ex. [Website Builder](https://wordpress.com/website-builder/))
* `Get Started` CTAs from the Navbar and Educational Footer should point to `/start/business` in Plugins and `/start` in Themes

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
