### PR TITLE
ETK: make PHP linting PHP 8 compatible

### DIFF
--- a/apps/phpcs.xml
+++ b/apps/phpcs.xml
@@ -3,7 +3,9 @@
 	<description>Editing Toolkit Plugin Rules</description>
 
 	<!--
-	Prevent errors caused by WordPress Coding Standards not supporting PHP 8.0+.
+	Suppress all PHP run-time notices across all PHP versions, thus preventing
+	errors caused by WordPress Coding Standards not supporting PHP 8.0+ yet.
+	Once WPCS supports PHP8, this can be removed.
 	See https://github.com/WordPress/WordPress-Coding-Standards/issues/2035
 	-->
 	<ini name="error_reporting" value="E_ALL &#38; ~E_DEPRECATED" />

--- a/apps/phpcs.xml
+++ b/apps/phpcs.xml
@@ -2,6 +2,12 @@
 <ruleset name="editing-toolkit">
 	<description>Editing Toolkit Plugin Rules</description>
 
+	<!--
+	Prevent errors caused by WordPress Coding Standards not supporting PHP 8.0+.
+	See https://github.com/WordPress/WordPress-Coding-Standards/issues/2035
+	-->
+	<ini name="error_reporting" value="E_ALL &#38; ~E_DEPRECATED" />
+
 	<rule ref="Jetpack"/>
 	<rule ref="WordPress.Utils.I18nTextDomainFixer">
 		<properties>


### PR DESCRIPTION
#### Proposed Changes

* Add config to `phpcs.xml` suppressing PHP run-time notices (`E_DEPRECATED`) which allows running the linter with PHP8. 

The issue is fixed in `WordPress-Coding-Standards` develop branch but hasn't been released yet. Their [latest release 2.3.0](https://github.com/WordPress/WordPress-Coding-Standards/releases/tag/2.3.0) is from May 2020. The slution was suggested in a comment https://github.com/WordPress/WordPress-Coding-Standards/issues/2035#issuecomment-1325532520

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open `apps/editing-toolkit`
* In PHP8, run `yarn lint:php`

Before the change, you see errors like:
```
FILE: editing-toolkit/editing-toolkit-plugin/newspack-blocks/synced-newspack-blocks/class-newspack-blocks-api.php
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 1 | ERROR | An error occurred during processing; checking has been aborted. The error message was: trim(): Passing null to parameter #1 ($string) of type string is deprecated in
   |       | /wp-calypso/vendor/wp-coding-standards/wpcs/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php on line 280
   |       | (Internal.Exception)
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```

After the change you see only regular linting errors/warnings.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
