### PR TITLE
E2E: Fix flaky likes test

### DIFF
--- a/test/e2e/specs/published-content/likes__comment.ts
+++ b/test/e2e/specs/published-content/likes__comment.ts
@@ -64,7 +64,9 @@ describe( DataHelper.createSuiteTitle( 'Likes (Comment) ' ), function () {
 
 	it( 'Post a comment', async function () {
 		commentsComponent = new CommentsComponent( page );
-		await commentsComponent.postComment( comment );
+		// Same as the Like button below, the comment box is sometimes not
+		// available initially. Let's retry if that happens.
+		await ElementHelper.reloadAndRetry( page, () => commentsComponent.postComment( comment ) );
 	} );
 
 	it( 'Like the comment', async function () {

--- a/test/e2e/specs/published-content/likes__post.ts
+++ b/test/e2e/specs/published-content/likes__post.ts
@@ -4,6 +4,7 @@
 
 import {
 	DataHelper,
+	ElementHelper,
 	EditorPage,
 	PublishedPostPage,
 	TestAccount,
@@ -66,12 +67,17 @@ describe( DataHelper.createSuiteTitle( 'Likes (Post)' ), function () {
 		} );
 
 		it( 'Like post', async function () {
-			publishedPostPage = new PublishedPostPage( page );
-			await publishedPostPage.likePost();
+			await ElementHelper.reloadAndRetry( page, async () => {
+				publishedPostPage = new PublishedPostPage( page );
+				await publishedPostPage.likePost();
+			} );
 		} );
 
 		it( 'Unlike post', async function () {
-			await publishedPostPage.unlikePost();
+			await ElementHelper.reloadAndRetry( page, async () => {
+				publishedPostPage = new PublishedPostPage( page );
+				await publishedPostPage.unlikePost();
+			} );
 		} );
 	} );
 
@@ -89,8 +95,10 @@ describe( DataHelper.createSuiteTitle( 'Likes (Post)' ), function () {
 				await likeUser.logInViaPopupPage( popup );
 			} );
 
-			publishedPostPage = new PublishedPostPage( page );
-			await publishedPostPage.likePost();
+			await ElementHelper.reloadAndRetry( page, async () => {
+				publishedPostPage = new PublishedPostPage( page );
+				await publishedPostPage.likePost();
+			} );
 		} );
 	} );
 } );


### PR DESCRIPTION
This is a follow-up to #69180.

Sometimes, the framework is still too fast for the iframed (Atomic) like button. Retrying, in this case, sounds like a valid solution to me.

#### Proposed Changes

Use the `ElementHelper.reloadAndRetry` for the post `like` & `unlike` actions.

#### Testing Instructions

All the `likes__post.ts` specs should be 🟢.