### PR TITLE
Reader: Temporarily revert org left nav

### DIFF
--- a/client/reader/sidebar/index.jsx
+++ b/client/reader/sidebar/index.jsx
@@ -179,7 +179,10 @@ export class ReaderSidebar extends Component {
 					link="/read"
 				/>
 
-				<ReaderSidebarOrganizations organizations={ this.props.organizations } path={ path } />
+				<li>
+					<ReaderSidebarOrganizations organizations={ this.props.organizations } path={ path } />
+				</li>
+
 				<SidebarSeparator />
 
 				<SidebarItem

--- a/client/reader/sidebar/reader-sidebar-organizations/list-item.jsx
+++ b/client/reader/sidebar/reader-sidebar-organizations/list-item.jsx
@@ -1,0 +1,64 @@
+import PropTypes from 'prop-types';
+import { Component } from 'react';
+import { connect } from 'react-redux';
+import Count from 'calypso/components/count';
+import { withLocalizedMoment } from 'calypso/components/localized-moment';
+import Favicon from 'calypso/reader/components/favicon';
+import { recordAction, recordGaEvent } from 'calypso/reader/stats';
+import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
+import ReaderSidebarHelper from '../helper';
+
+/**
+ * Styles
+ */
+import '../style.scss';
+
+export class ReaderSidebarOrganizationsListItem extends Component {
+	static propTypes = {
+		site: PropTypes.object,
+		path: PropTypes.string,
+	};
+
+	handleSidebarClick = () => {
+		recordAction( 'clicked_reader_sidebar_organization_item' );
+		recordGaEvent( 'Clicked Reader Sidebar Organization Item' );
+		this.props.recordReaderTracksEvent( 'calypso_reader_sidebar_organization_item_clicked', {
+			blog: decodeURIComponent( this.props.site ),
+		} );
+	};
+
+	render() {
+		const { site, path, moment } = this.props;
+
+		/* eslint-disable wpcalypso/jsx-classname-namespace */
+		return (
+			<li
+				key={ this.props.title }
+				className={ ReaderSidebarHelper.itemLinkClass( '/read/feeds/' + site.feed_ID, path, {
+					'sidebar-dynamic-menu__blog': true,
+				} ) }
+			>
+				<a
+					className="sidebar__menu-link sidebar__menu-link-reader"
+					href={ `/read/feeds/${ site.feed_ID }` }
+					onClick={ this.handleSidebarClick }
+				>
+					<Favicon site={ site } className="sidebar__menu-item-siteicon" size={ 18 } />
+
+					<span className="sidebar__menu-item-sitename">
+						{ site.name }
+						<span className="sidebar__menu-item-last-updated">
+							{ site.last_updated > 0 && moment( new Date( site.last_updated ) ).fromNow() }
+						</span>
+					</span>
+					{ site.unseen_count > 0 && <Count count={ site.unseen_count } compact /> }
+				</a>
+			</li>
+		);
+		/* eslint-enable wpcalypso/jsx-classname-namespace */
+	}
+}
+
+export default connect( null, {
+	recordReaderTracksEvent,
+} )( withLocalizedMoment( ReaderSidebarOrganizationsListItem ) );

--- a/client/reader/sidebar/reader-sidebar-organizations/list.jsx
+++ b/client/reader/sidebar/reader-sidebar-organizations/list.jsx
@@ -1,15 +1,20 @@
 import { localize } from 'i18n-calypso';
+import { map } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import AutomatticLogo from 'calypso/assets/images/icons/a8c-logo.svg';
 import P2Logo from 'calypso/assets/images/icons/p2-logo.svg';
+import Count from 'calypso/components/count';
 import SVGIcon from 'calypso/components/svg-icon';
+import ExpandableSidebarMenu from 'calypso/layout/sidebar/expandable';
 import SidebarItem from 'calypso/layout/sidebar/item';
 import ReaderSidebarHelper from 'calypso/reader/sidebar/helper';
 import { toggleReaderSidebarOrganization } from 'calypso/state/reader-ui/sidebar/actions';
+import { isOrganizationOpen } from 'calypso/state/reader-ui/sidebar/selectors';
 import getOrganizationSites from 'calypso/state/reader/follows/selectors/get-reader-follows-organization';
 import { AUTOMATTIC_ORG_ID } from 'calypso/state/reader/organizations/constants';
+import ReaderSidebarOrganizationsListItem from './list-item';
 import '../style.scss';
 
 export class ReaderSidebarOrganizationsList extends Component {
@@ -20,6 +25,10 @@ export class ReaderSidebarOrganizationsList extends Component {
 		teams: PropTypes.array,
 	};
 
+	handleClick = () => {
+		this.props.toggleReaderSidebarOrganization( { organizationId: this.props.organization.id } );
+	};
+
 	renderIcon() {
 		const { organization } = this.props;
 		if ( organization.id === AUTOMATTIC_ORG_ID ) {
@@ -28,21 +37,60 @@ export class ReaderSidebarOrganizationsList extends Component {
 		return <SVGIcon name="p2-logo" icon={ P2Logo } classes="sidebar__menu-icon" />;
 	}
 
+	renderAll() {
+		const { translate, organization, path, sites } = this.props;
+		// have a selector
+		const sum = sites.reduce( ( acc, item ) => {
+			acc = acc + item.unseen_count;
+			return acc;
+		}, 0 );
+		return (
+			<>
+				<SidebarItem
+					link={ '/read/' + organization.slug }
+					key={ translate( 'All' ) }
+					label={ translate( 'All' ) }
+					className={ ReaderSidebarHelper.itemLinkClass( '/read/' + organization.slug, path, {
+						'sidebar-streams__all': true,
+					} ) }
+				>
+					{ sum > 0 && <Count count={ sum } compact /> }
+				</SidebarItem>
+			</>
+		);
+	}
+
+	renderSites() {
+		const { sites, path } = this.props;
+		return map(
+			sites,
+			( site ) =>
+				site && <ReaderSidebarOrganizationsListItem key={ site.ID } path={ path } site={ site } />
+		);
+	}
+
 	render() {
-		const { organization, path } = this.props;
+		const { organization, path, sites } = this.props;
 
 		if ( ! organization.sites_count ) {
 			return null;
 		}
 		return (
-			<SidebarItem
-				className={ ReaderSidebarHelper.itemLinkClass( '/read/' + organization.slug, path, {
-					'sidebar-streams__all': true,
-				} ) }
-				label={ organization.title }
-				link={ '/read/' + organization.slug }
+			<ExpandableSidebarMenu
+				expanded={ this.props.isOrganizationOpen }
+				title={ organization.title }
+				onClick={ this.handleClick }
 				customIcon={ this.renderIcon() }
-			/>
+				disableFlyout={ true }
+				className={
+					( '/read/' + organization.slug === path ||
+						sites.some( ( site ) => `/read/feeds/${ site.feed_ID }` === path ) ) &&
+					'sidebar__menu--selected'
+				}
+			>
+				{ this.renderAll() }
+				{ this.renderSites() }
+			</ExpandableSidebarMenu>
 		);
 	}
 }
@@ -50,6 +98,7 @@ export class ReaderSidebarOrganizationsList extends Component {
 export default connect(
 	( state, ownProps ) => {
 		return {
+			isOrganizationOpen: isOrganizationOpen( state, ownProps.organization.id ),
 			sites: getOrganizationSites( state, ownProps.organization.id ), // get p2 network organizations
 		};
 	},

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -45,7 +45,6 @@ import EmptyContent from './empty';
 import PostLifecycle from './post-lifecycle';
 import PostPlaceholder from './post-placeholder';
 import ReaderListFollowedSites from './reader-list-followed-sites';
-import ReaderListOrganizations from './reader-list-organizations';
 import './style.scss';
 
 const WIDE_DISPLAY_CUTOFF = 900;
@@ -55,6 +54,7 @@ const noop = () => {};
 const pagesByKey = new Map();
 const inputTags = [ 'INPUT', 'SELECT', 'TEXTAREA' ];
 const excludesSidebar = [
+	'a8c',
 	'conversations',
 	'conversations-a8c',
 	'feed',
@@ -62,6 +62,7 @@ const excludesSidebar = [
 	'search',
 	'custom_recs_posts_with_images',
 	'list',
+	'p2',
 	'tag',
 ];
 
@@ -472,12 +473,7 @@ class ReaderStream extends Component {
 					renderLoadingPlaceholders={ this.renderLoadingPlaceholders }
 				/>
 			);
-			let sidebarContent = <ReaderListFollowedSites path={ path } />;
-			if ( 'a8c' === streamType || 'p2' === streamType ) {
-				sidebarContent = (
-					<ReaderListOrganizations organizations={ this.props.organizations } path={ path } />
-				);
-			}
+			const sidebarContent = <ReaderListFollowedSites path={ path } />;
 
 			if ( excludesSidebar.includes( streamType ) ) {
 				body = bodyContent;


### PR DESCRIPTION
## Description

We deployed changes to the Reader left nav last week which pulled the following drop downs out of the left nav, and pulled them over to a new right sidebar. 

@dougaitken shared feedback that this made the flow of going through P2 posts unnatural since you now had to click back up a level to see the list of P2s. 

I've got an idea in mind for how to solve this, but our team is doing our support rotation this week and I will be AFK the last two weeks of the year. As such, I said that I would temporarily revert this change until I get a chance to code up my proposed fix.

This PR reverts the change we made last week, bringing the Automattic and P2 lists back to the left nav.

![CleanShot 2022-12-12 at 10 27 34@2x](https://user-images.githubusercontent.com/5634774/207084889-24018ffa-ae0d-4f23-ae5a-d4f7064a7e52.png)

## To test
1. Load the reader
2. Click into these drop downs in the left nav
3. Make sure there are no JS errors

## Related to
#67164