### PR TITLE
E2E: fix flaky load waits during onboarding stepper flow.

### DIFF
--- a/packages/calypso-e2e/src/lib/flows/start-site-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/start-site-flow.ts
@@ -27,6 +27,7 @@ const selectors = {
 	selectedGoalButton: ( goal: string ) => `.select-card__container.selected:has-text("${ goal }")`,
 
 	// Step containers
+	contentAgnosticContainer: '.step-container',
 	themePickerContainer: '.design-picker',
 	goalsStepContainer: '.goals-step',
 	verticalsStepContainer: '.site-vertical',
@@ -62,7 +63,8 @@ export class StartSiteFlow {
 	 * Returns the step name of the current page
 	 */
 	async getCurrentStep(): Promise< StepName > {
-		await this.page.waitForLoadState( 'networkidle' );
+		// Make sure the container is loaded first, then we can see which it is.
+		await this.page.waitForSelector( selectors.contentAgnosticContainer );
 		if ( ( await this.page.locator( selectors.goalsStepContainer ).count() ) > 0 ) {
 			return 'goals';
 		}
@@ -97,8 +99,6 @@ export class StartSiteFlow {
 	 * @param {string} vertical Name of the vertical to select
 	 */
 	async enterVertical( vertical: string ): Promise< void > {
-		await this.page.waitForLoadState( 'networkidle', { timeout: 30 * 1000 } );
-
 		const input = this.page.locator( selectors.verticalInput );
 		await input.fill( vertical );
 
@@ -117,7 +117,6 @@ export class StartSiteFlow {
 	 * @param {string} name Name for the blog.
 	 */
 	async enterBlogName( name: string ): Promise< void > {
-		await this.page.waitForLoadState( 'networkidle' );
 		const defaultInputlocator = this.page.locator( selectors.blogNameInput );
 
 		await defaultInputlocator.fill( name );
@@ -136,7 +135,6 @@ export class StartSiteFlow {
 	 * @param {string} tagline Tagline for the blog.
 	 */
 	async enterTagline( tagline: string ): Promise< void > {
-		await this.page.waitForLoadState( 'networkidle' );
 		const locator = this.page.locator( selectors.taglineInput );
 		await locator.fill( tagline );
 

--- a/packages/calypso-e2e/src/lib/pages/plans-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plans-page.ts
@@ -82,7 +82,10 @@ export class PlansPage {
 		const locator = this.page.locator( selectors.selectPlanButton( plan ) );
 		// In the /plans view, there are two buttons for "Upgrade" on the
 		// plan comparison chart.
-		await Promise.all( [ this.page.waitForNavigation(), locator.first().click() ] );
+		await Promise.all( [
+			this.page.waitForNavigation( { timeout: 30 * 1000 } ),
+			locator.first().click(),
+		] );
 	}
 
 	/* Generic */

--- a/test/e2e/specs/onboarding/ftme__sell.ts
+++ b/test/e2e/specs/onboarding/ftme__sell.ts
@@ -135,6 +135,10 @@ describe( DataHelper.createSuiteTitle( 'FTME: Sell' ), function () {
 			startSiteFlow = new StartSiteFlow( page );
 		} );
 
+		it( 'Land on goal selection step', async function () {
+			page.waitForURL( /setup\/site-setup\/goals\?/, { timeout: 30 * 1000 } );
+		} );
+
 		it( 'Select "Sell" goal', async function () {
 			await startSiteFlow.selectGoal( 'Sell' );
 			await startSiteFlow.clickButton( 'Continue' );

--- a/test/e2e/specs/onboarding/ftme__write.ts
+++ b/test/e2e/specs/onboarding/ftme__write.ts
@@ -61,7 +61,9 @@ describe( DataHelper.createSuiteTitle( 'FTME: Write' ), function () {
 		} );
 
 		it( 'Enter Onboarding flow for the selected domain', async function () {
-			await expect( page.waitForURL( /setup\/site-setup\/goals\?/ ) ).resolves.not.toThrow();
+			await expect(
+				page.waitForURL( /setup\/site-setup\/goals\?/, { timeout: 30 * 1000 } )
+			).resolves.not.toThrow();
 
 			const urlRegex = `/setup/site-setup/goals?siteSlug=${ selectedFreeDomain }`;
 			expect( page.url() ).toMatch( urlRegex );

--- a/test/e2e/specs/onboarding/setup__build.ts
+++ b/test/e2e/specs/onboarding/setup__build.ts
@@ -1,5 +1,5 @@
 /**
- * @group quarantined
+ * @group calypso-pr
  */
 
 import { DataHelper, SecretsManager, StartSiteFlow, TestAccount } from '@automattic/calypso-e2e';

--- a/test/e2e/specs/onboarding/setup__build.ts
+++ b/test/e2e/specs/onboarding/setup__build.ts
@@ -30,7 +30,9 @@ describe(
 			} );
 
 			it( 'Enter Onboarding flow', async function () {
-				await page.goto( DataHelper.getCalypsoURL( '/setup/site-setup', { siteSlug } ) );
+				await page.goto( DataHelper.getCalypsoURL( '/setup/site-setup', { siteSlug } ), {
+					timeout: 30 * 1000,
+				} );
 			} );
 
 			it( 'Select "Promote" goal', async function () {


### PR DESCRIPTION
#### Proposed Changes

We've been having a lot of E2E flakiness in the onboarding flow, especially in the verticals step.
See: 
- p1670852066688369-slack-C02DQP0FP
- p1670857803973569-slack-C02DQP0FP

It seems like the problem was a bunch of `page.waitForLoadState( 'networkidle' )` calls during the various action methods for the stepper flow.

Each one of those new "steps" is not a new document load, it is just a React re-render of a top-level component. So adding a bunch of load state waits as we move through steps is risky.

From what I can tell, I think why this may have been passing sometimes before is that we move through the stepper flow _so fast_ that we happen to not trigger the `networkidle` event until later in the flow. 

Instead now, we move all the big waits to _entering_ the stepper flow in the first place. 

I've also extended a timeout when loading the cart that seems to be too short.

#### Testing Instructions

- [ ] Pre release tests pass
- [ ] E2E PR tests pass

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #