### PR TITLE
Third-Party Premium Themes: Include marketplace themes in the showcase

### DIFF
--- a/client/state/themes/actions/request-themes.js
+++ b/client/state/themes/actions/request-themes.js
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { map, property } from 'lodash';
 import wpcom from 'calypso/lib/wp';
 import { fetchThemesList as fetchWporgThemesList } from 'calypso/lib/wporg';
@@ -45,7 +46,16 @@ export function requestThemes( siteId, query = {}, locale ) {
 			request = () =>
 				wpcom.req.get(
 					'/themes',
-					Object.assign( { ...query, apiVersion: '1.2' }, locale ? { locale } : null )
+					Object.assign(
+						{
+							...query,
+							apiVersion: '1.2',
+							include_marketplace_themes: config.isEnabled( 'themes/third-party-premium' )
+								? 'true'
+								: null,
+						},
+						locale ? { locale } : null
+					)
 				);
 		} else {
 			request = () => wpcom.req.get( `/sites/${ siteId }/themes`, { ...query, apiVersion: '1' } );

--- a/client/state/themes/test/actions.js
+++ b/client/state/themes/test/actions.js
@@ -1,5 +1,6 @@
 // Importing `jest-fetch-mock` adds a jest-friendly `fetch` polyfill to the global scope.
 import 'jest-fetch-mock';
+import config from '@automattic/calypso-config';
 import ThemeQueryManager from 'calypso/lib/query-manager/theme';
 import {
 	ACTIVE_THEME_REQUEST,
@@ -192,8 +193,14 @@ describe( 'actions', () => {
 		describe( 'with a wpcom site', () => {
 			let nockScope;
 			useNock( ( nock ) => {
+				const url =
+					'/rest/v1.2/themes' +
+					( config.isEnabled( 'themes/third-party-premium' )
+						? '?include_marketplace_themes=true'
+						: '' );
+
 				nockScope = nock( 'https://public-api.wordpress.com:443' )
-					.get( '/rest/v1.2/themes' )
+					.get( url )
 					.reply( 200, {
 						found: 2,
 						themes: [


### PR DESCRIPTION
#### Proposed Changes

When the themes/third-party-premium flag is enabled, append the include_marketplace_themes=true parameter to wpcom /rest/v1.2/themes calls so that marketplace themes are included

#### Testing Instructions

If you're running this branch on calypso.localhost, you don't need to do anything special. If you're using the calypso.live link, you'll need to enable the `themes/third-party-premium` flag.

You'll also need to have the public-api sandboxed and the store sandbox enabled.

Visit the theme showcase and verify that the Makoney theme is present. It may be easiest to search for it by name.

You can also manually run the theme tests with
```
npx jest -c=test/client/jest.config.js client/state/themes/test
```

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [NA] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [NA] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [NA] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [NA] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [NA] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [NA] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #71073
