### PR TITLE
stepper: flowAddress: country field: fix bottom border being obscured

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/store-address/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/store-address/style.scss
@@ -7,6 +7,12 @@
 	.components-combobox-control__suggestions-container {
 		width: unset;
 		border-color: var(--color-neutral-10);
+		.components-flex {
+			padding-bottom: 5px;
+		}
+		.components-combobox-control__reset {
+			margin-top: 5px;
+		}
 	}
 	.step-container__header {
 		flex: 1;


### PR DESCRIPTION
#### Proposed Changes

* Fixes the bottom border being obscured in the flowAddress step on the ecommerce flow

**Before PR**
![2022-12-12_11-01_1](https://user-images.githubusercontent.com/937354/207107778-919be2e5-f2e7-40c9-a9e1-05c64106bb36.png)

**After PR**
![2022-12-12_11-01](https://user-images.githubusercontent.com/937354/207107837-1ebf1fd6-2975-4ddd-a378-502cff5772b7.png)

**Mechanism** - Caused by padding on inner `<input>` overlapping the outer decorative elements
![2022-12-12_11-03](https://user-images.githubusercontent.com/937354/207107971-04ecf3a4-e65e-4619-9748-3d5033f96ceb.png)

**Fix**: Add more padding on the decorate outer element to make room. Also adjust the reset button downward so it looks centered.

I also tried shortening the padding on the inner `<input>` element, but then the text typed in it looked bottom aligned and awkward.

#### Testing Instructions

* Visit `http://calypso.localhost:3000/setup/ecommerce/storeAddress?siteSlug=YOURSITE`. I used a free simple site and I was able to visit this step directly with no problems.
* Check before and after the PR. The border should look better after.

Related to #71072
