### PR TITLE
Theme Showcase: Update plans link when logged out

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -765,7 +765,13 @@ class ThemeSheet extends Component {
 			section ? ' > ' + titlecase( section ) : ''
 		}${ siteId ? ' > Site' : '' }`;
 
-		const plansUrl = siteSlug ? `/plans/${ siteSlug }/?plan=value_bundle` : '/plans';
+		let plansUrl = '/plans';
+
+		if ( ! isLoggedIn ) {
+			plansUrl = localizeUrl( 'https://wordpress.com/pricing' );
+		} else if ( siteSlug ) {
+			plansUrl = plansUrl + `/${ siteSlug }/?plan=value_bundle`;
+		}
 
 		const { canonicalUrl, description, name: themeName } = this.props;
 		const title =


### PR DESCRIPTION
#### Proposed Changes

* Point to localized `/pricing` URL when looking at plans/pricing from the logged-out theme Showcase, otherwise use `/plans`
* This prevents a redirect from occurring to `/log-in` when you click on the upsell nudge from the logged out theme showcase
* This also localizes the `/pricing` URL in case we have the user's locale information in the URL, ie. `wordpress.com/fr/themes` so we can direct them to the correct pricing page.

<img width="1743" alt="Capture d’écran 2022-12-12 à 12 18 05 PM" src="https://user-images.githubusercontent.com/2124984/207110873-030a8336-cf65-46c6-b574-87de50aeea3b.png">

#### Testing Instructions

Logged out

* Switch to this PR, navigate to `/themes` while logged out.
* Click on a paid theme like Tazza or Thriving Artist
* Click on the banner 
* You should be brought to the `/pricing` page.

Logged in

* Now log in
* Using a site with a Free plan, return to `/themes` and click on a paid theme like Tazza or Thriving Artist
* The same banner should point to `/plans` rather than `/pricing`

Localized/Logged out

Note this won't work with `calypso.localhost` but should with this branch's `calypso.live` link.

* Visit `/[localeslug]/themes/` while logged out (I tested `/fr/themes` and `/es/themes` for example)
* Click on a paid theme like Tazza or Thriving Artist
* The same banner should point to `/[locale-slug]/pricing`

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- NA [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- NA Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- NA Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- NA For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #71075
