### PR TITLE
Theme Showcase: Fix broken external link behavior

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -768,7 +768,7 @@ class ThemeSheet extends Component {
 		let plansUrl = '/plans';
 
 		if ( ! isLoggedIn ) {
-			plansUrl = localizeUrl( '/pricing' );
+			plansUrl = localizeUrl( 'https://wordpress.com/pricing' );
 		} else if ( siteSlug ) {
 			plansUrl = plansUrl + `/${ siteSlug }/?plan=value_bundle`;
 		}

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -768,7 +768,7 @@ class ThemeSheet extends Component {
 		let plansUrl = '/plans';
 
 		if ( ! isLoggedIn ) {
-			plansUrl = localizeUrl( 'https://wordpress.com/pricing' );
+			plansUrl = localizeUrl( '/pricing' );
 		} else if ( siteSlug ) {
 			plansUrl = plansUrl + `/${ siteSlug }/?plan=value_bundle`;
 		}

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -773,6 +773,8 @@ class ThemeSheet extends Component {
 			plansUrl = plansUrl + `/${ siteSlug }/?plan=value_bundle`;
 		}
 
+		const launchPricing = () => window.open( plansUrl, '_blank' );
+
 		const { canonicalUrl, description, name: themeName } = this.props;
 		const title =
 			themeName &&
@@ -829,13 +831,14 @@ class ThemeSheet extends Component {
 			pageUpsellBanner = (
 				<UpsellNudge
 					plan={ PLAN_PREMIUM }
+					onClick={ ! isLoggedIn && launchPricing }
 					className="theme__page-upsell-banner"
 					title={ this.getBannerUpsellTitle() }
 					description={ preventWidows( this.getBannerUpsellDescription() ) }
 					event="themes_plan_particular_free_with_plan"
 					feature={ WPCOM_FEATURES_PREMIUM_THEMES }
 					forceHref={ true }
-					href={ plansUrl }
+					href={ isLoggedIn && plansUrl }
 					showIcon={ true }
 					forceDisplay={ forceDisplay }
 				/>

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -838,7 +838,7 @@ class ThemeSheet extends Component {
 					event="themes_plan_particular_free_with_plan"
 					feature={ WPCOM_FEATURES_PREMIUM_THEMES }
 					forceHref={ true }
-					href={ isLoggedIn && plansUrl }
+					href={ isLoggedIn ? plansUrl : '#' }
 					showIcon={ true }
 					forceDisplay={ forceDisplay }
 				/>


### PR DESCRIPTION
#### Proposed Changes

* Followup to fix a bug introduced in #71085 -- clicking on the upsell nudge when logged out does not bring you to the `/pricing` page because it's an external link.
* Clicking the nudge works fine in testing environments but does not work on production.  Similar to the issue encountered in #54628
* We need to force it using the `onClick` property to redirect to an external link rather than the component's built-in `href` property.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Logged out

* Switch to this PR, navigate to `/themes` while logged out.
* Click on a paid theme like Tazza or Thriving Artist
* Click on the banner 
* You should be brought to the `/pricing` page.

Logged in

* Now log in
* Using a site with a Free plan, return to `/themes` and click on a paid theme like Tazza or Thriving Artist
* The same banner should point to `/plans` rather than `/pricing`

Localized/Logged out

Note this won't work with `calypso.localhost` but should with this branch's `calypso.live` link.

* Visit `/[localeslug]/themes/` while logged out (I tested `/fr/themes` and `/es/themes` for example)
* Click on a paid theme like Tazza or Thriving Artist
* The same banner should point to `/[locale-slug]/pricing`

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
