### PR TITLE
Test changes for design picker without siteSlug [WIP]

### DIFF
--- a/client/landing/stepper/declarative-flow/free.ts
+++ b/client/landing/stepper/declarative-flow/free.ts
@@ -15,6 +15,7 @@ import {
 import { useSiteSlug } from '../hooks/use-site-slug';
 import { USER_STORE, ONBOARD_STORE } from '../stores';
 import { recordSubmitStep } from './internals/analytics/record-submit-step';
+import DesignSetup from './internals/steps-repository/design-setup';
 import DomainsStep from './internals/steps-repository/domains';
 import Intro from './internals/steps-repository/intro';
 import LaunchPad from './internals/steps-repository/launchpad';
@@ -22,7 +23,6 @@ import LinkInBioSetup from './internals/steps-repository/link-in-bio-setup';
 import PatternsStep from './internals/steps-repository/patterns';
 import PlansStep from './internals/steps-repository/plans';
 import Processing from './internals/steps-repository/processing-step';
-import SiteCreationStep from './internals/steps-repository/site-creation-step';
 import type { Flow, ProvidedDependencies } from './internals/types';
 
 const free: Flow = {
@@ -43,7 +43,7 @@ const free: Flow = {
 			{ slug: 'domains', component: DomainsStep },
 			{ slug: 'plans', component: PlansStep },
 			{ slug: 'patterns', component: PatternsStep },
-			{ slug: 'siteCreationStep', component: SiteCreationStep },
+			{ slug: 'designSetup', component: DesignSetup },
 			{ slug: 'processing', component: Processing },
 			{ slug: 'launchpad', component: LaunchPad },
 		];
@@ -83,15 +83,15 @@ const free: Flow = {
 					clearSignupDestinationCookie();
 
 					if ( userIsLoggedIn ) {
-						return navigate( 'patterns' );
+						return navigate( 'freeSetup' );
 					}
 					return window.location.assign( logInUrl );
 
-				case 'patterns':
-					return navigate( 'freeSetup' );
-
 				case 'freeSetup':
-					return navigate( 'domains' );
+					return navigate( 'designSetup' );
+
+				case 'designSetup':
+					return navigate( 'siteCreationStep' );
 
 				case 'domains':
 					return navigate( 'plans' );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -121,8 +121,18 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 		}
 	);
 
-	const generatedDesigns = allDesigns?.generated?.designs || [];
-	const staticDesigns = allDesigns?.static?.designs || [];
+	// Only display free designs if siteSlugOrId does not exist
+	function filterFreeDesigns( designs: Design[] | undefined ) {
+		if ( designs && ! siteSlugOrId ) {
+			return designs.filter( ( design ) => {
+				return ! design.is_premium;
+			} );
+		}
+		return designs;
+	}
+
+	const generatedDesigns = filterFreeDesigns( allDesigns?.generated?.designs ) || [];
+	const staticDesigns = filterFreeDesigns( allDesigns?.static?.designs ) || [];
 
 	const hasTrackedView = useRef( false );
 	useEffect( () => {
@@ -489,7 +499,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 	}
 
 	function showGlobalStylesPremiumBadge() {
-		if ( ! shouldLimitGlobalStyles ) {
+		if ( ! site || ! shouldLimitGlobalStyles ) {
 			return null;
 		}
 
@@ -514,6 +524,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 		}
 
 		if (
+			site &&
 			shouldLimitGlobalStyles &&
 			selectedStyleVariation &&
 			selectedStyleVariation.slug !== DEFAULT_VARIATION_SLUG

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -9,7 +9,7 @@ import {
 	isBlankCanvasDesign,
 } from '@automattic/design-picker';
 import { useLocale } from '@automattic/i18n-utils';
-import { isFreeFlow, StepContainer } from '@automattic/onboarding';
+import { StepContainer } from '@automattic/onboarding';
 import { resolveDeviceTypeByViewPort } from '@automattic/viewport';
 import { useViewportMatch } from '@wordpress/compose';
 import { useSelect, useDispatch } from '@wordpress/data';
@@ -409,7 +409,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 
 	function pickDesign( _selectedDesign: Design | undefined = selectedDesign ) {
 		setSelectedDesign( _selectedDesign );
-		if ( ( isFreeFlow( flow ) || siteSlugOrId ) && _selectedDesign ) {
+		if ( _selectedDesign ) {
 			let positionIndex = generatedDesigns.findIndex(
 				( design ) => design.slug === _selectedDesign.slug
 			);
@@ -418,13 +418,14 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 					( design ) => design.slug === _selectedDesign.slug
 				);
 			}
-			siteSlugOrId &&
+			if ( siteSlugOrId ) {
 				setPendingAction( () =>
 					setDesignOnSite( siteSlugOrId, _selectedDesign, {
 						styleVariation: selectedStyleVariation,
 						verticalId: siteVerticalId,
 					} ).then( () => reduxDispatch( requestActiveTheme( site?.ID || -1 ) ) )
 				);
+			}
 			recordTracksEvent( 'calypso_signup_select_design', {
 				...getEventPropsByDesign( _selectedDesign, selectedStyleVariation ),
 				...( positionIndex >= 0 && { position_index: positionIndex } ),
@@ -531,17 +532,10 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 		);
 	}
 
-	function setDesignPickerSkipLabelText() {
-		if ( intent === SiteIntent.Write || isFreeFlow( flow ) ) {
-			return translate( 'Skip and draft first post' );
-		}
-		return translate( 'Skip for now' );
-	}
-
 	// ********** Main render logic
 
 	// Don't render until we've done fetching all the data needed for initial render.
-	if ( ( ! site && ! isFreeFlow( flow ) ) || isLoadingSiteVertical || isLoadingDesigns ) {
+	if ( isLoadingSiteVertical || isLoadingDesigns ) {
 		return null;
 	}
 
@@ -694,7 +688,11 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 			skipButtonAlign="top"
 			hideFormattedHeader
 			backLabelText={ translate( 'Back' ) }
-			skipLabelText={ setDesignPickerSkipLabelText() }
+			skipLabelText={
+				intent === SiteIntent.Write
+					? translate( 'Skip and draft first post' )
+					: translate( 'Skip for now' )
+			}
 			stepContent={ stepContent }
 			recordTracksEvent={ recordStepContainerTracksEvent }
 			goNext={ handleSubmit }


### PR DESCRIPTION
#### Proposed Changes

* Changes to make Stepper Design Picker work without a siteSlug query param.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout PR
* Navigate to `/setup/free/designSetup`
* The designSetup page should still render without a `siteSlug` query parameter.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
