### PR TITLE
WIP: editing-toolkit: nux: Use react-query to fetch site-intent

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/common/block-editor-nux-query-client.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/common/block-editor-nux-query-client.tsx
@@ -1,0 +1,3 @@
+import { QueryClient } from 'react-query';
+
+export const blockEditorNuxQueryClient = new QueryClient();

--- a/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/lib/site-intent/use-site-intent.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/lib/site-intent/use-site-intent.js
@@ -1,18 +1,28 @@
 import apiFetch from '@wordpress/api-fetch';
-import { useState, useEffect, useCallback } from '@wordpress/element';
+import { useQuery } from 'react-query';
 
 const useSiteIntent = () => {
-	const [ siteIntent, setSiteIntent ] = useState( '' );
-
-	const fetchSiteIntent = useCallback( () => {
-		apiFetch( { path: '/wpcom/v2/site-intent' } )
-			.then( ( result ) => setSiteIntent( result.site_intent ) )
-			.catch( () => setSiteIntent( '' ) );
-	}, [] );
-
-	useEffect( () => {
-		fetchSiteIntent();
-	}, [ fetchSiteIntent ] );
-	return siteIntent;
+	const queryInfo = useQuery(
+		'site-intent', // add Site ID ?
+		() =>
+			apiFetch( { path: '/wpcom/v2/site-intent' } )
+				.then( ( result ) => result.site_intent )
+				.catch( () => '' ),
+		{
+			refetchOnWindowFocus: false,
+			staleTime: Infinity,
+			//enabled: !! siteId,
+		}
+	);
+	return queryInfo.data || '';
 };
 export default useSiteIntent;
+
+/*
+	different endpoint / request mechanism used outside of editing-toolkit:
+
+	await wpcomRequest( {
+		path: `/sites/${ encodeURIComponent( siteId as string ) }/site-intent`,
+		apiNamespace: 'wpcom/v2',
+	} ),
+*/

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/block-editor-nux.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/block-editor-nux.js
@@ -9,6 +9,8 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect, useState } from '@wordpress/element';
 import { registerPlugin } from '@wordpress/plugins';
 import { getQueryArg } from '@wordpress/url';
+import { QueryClientProvider } from 'react-query';
+import { blockEditorNuxQueryClient } from '../../common/block-editor-nux-query-client';
 import DraftPostModal from './draft-post-modal';
 import PostPublishedModal from './post-published-modal';
 import PurchaseNotice from './purchase-notice';
@@ -80,11 +82,13 @@ function WelcomeTour() {
 registerPlugin( 'wpcom-block-editor-nux', {
 	render: () => (
 		<>
-			<WelcomeTour />
-			<PostPublishedModal />
-			<SellerCelebrationModal />
-			<PurchaseNotice />
-			<VideoPressCelebrationModal />
+			<QueryClientProvider client={ blockEditorNuxQueryClient }>
+				<WelcomeTour />
+				<PostPublishedModal />
+				<SellerCelebrationModal />
+				<PurchaseNotice />
+				<VideoPressCelebrationModal />
+			</QueryClientProvider>
 		</>
 	),
 } );

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/seller-celebration-modal/index.jsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/seller-celebration-modal/index.jsx
@@ -104,6 +104,7 @@ const SellerCelebrationModalInner = () => {
 	} );
 
 	const intent = useSiteIntent();
+	console.log( { intent } );
 
 	useEffect( () => {
 		if (
@@ -161,6 +162,7 @@ const SellerCelebrationModalInner = () => {
 
 const SellerCelebrationModal = () => {
 	const intent = useSiteIntent();
+	console.log( { intent } );
 	if ( intent === 'sell' ) {
 		return <SellerCelebrationModalInner />;
 	}


### PR DESCRIPTION
#### Proposed Changes

* In the NUX, both `SellerCelebrationModal` and `VideoCelebrationModal` check for site-intent which causes two requests to be fired off
  * Solution: Use react-query which has an internal cache and can reuse previously fetched data

#### Testing Instructions

**SIMPLE**
* Start calypso locally
* Also `cd apps/editing-toolkit` and run `yarn dev --sync` with a sandbox set up
* **Make sure the simple site you're using is sandboxed and your browser dns cache is reset**
* Visit `http://calypso.localhost:3000/post/YOURSITE`
* Watch the network tab. After the PR, there should only be one request to the site-intent endpoint, not two
* The app should still be able figure out the site-intent

**ATOMIC**
* More complicated - need to build the editing toolkit and get it on your atomic site

Related to #71055
