### PR TITLE
Remove back button from Domains step from 'with-theme' flow

### DIFF
--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -716,6 +716,10 @@ class DomainsStep extends Component {
 		);
 	}
 
+	shouldHideNavButtons() {
+		return 'with-theme' === this.props.flowName || this.isTailoredFlow();
+	}
+
 	renderContent() {
 		let content;
 		let sideContent;
@@ -861,7 +865,7 @@ class DomainsStep extends Component {
 				isExternalBackUrl={ isExternalBackUrl }
 				fallbackHeaderText={ headerText }
 				fallbackSubHeaderText={ fallbackSubHeaderText }
-				shouldHideNavButtons={ this.isTailoredFlow() }
+				shouldHideNavButtons={ this.shouldHideNavButtons() }
 				stepContent={
 					<div>
 						<QueryProductsList />


### PR DESCRIPTION
#### Proposed Changes

* This PR adds a check to the domains step and, if the flow is `with-theme`, hides the Back button.

#### Testing Instructions

- While logged out
- Open a theme page, like `/theme/thriving-artist``
- Click "Pick design"
- Follow the flow (creating a new account)
- In the domains step (`/start/with-theme/domains-theme-preselected`) check if the Back button is gone. 

Before:
![image](https://user-images.githubusercontent.com/3801502/207185773-32ed3fc9-3858-4d6b-81b2-b93142bd897a.png)


After:
![image](https://user-images.githubusercontent.com/3801502/207185973-1f040803-0758-4173-b1b7-9a617252772d.png)


Closes https://github.com/Automattic/wp-calypso/issues/71077
