### PR TITLE
Launchpad: Remove domains and plans step

### DIFF
--- a/client/landing/stepper/declarative-flow/free.ts
+++ b/client/landing/stepper/declarative-flow/free.ts
@@ -91,12 +91,6 @@ const free: Flow = {
 					return navigate( 'freeSetup' );
 
 				case 'freeSetup':
-					return navigate( 'domains' );
-
-				case 'domains':
-					return navigate( 'plans' );
-
-				case 'plans':
 					return navigate( 'siteCreationStep' );
 
 				case 'siteCreationStep':

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
@@ -6,9 +6,10 @@ import {
 	createSiteWithCart,
 } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
+import { domainRegistration } from 'calypso/lib/cart-values/cart-items';
 import {
 	retrieveSignupDestination,
 	getSignupCompleteFlowName,
@@ -31,7 +32,7 @@ const SiteCreationStep: Step = function SiteCreationStep( { navigation, flow } )
 
 	const username = useSelector( ( state ) => getCurrentUserName( state ) );
 
-	const { setPendingAction } = useDispatch( ONBOARD_STORE );
+	const { setDomainCartItem, setPendingAction } = useDispatch( ONBOARD_STORE );
 
 	const theme = flow === LINK_IN_BIO_FLOW ? 'pub/lynx' : 'pub/lettre';
 	const isPaidDomainItem = Boolean( domainCartItem?.product_slug );
@@ -88,13 +89,32 @@ const SiteCreationStep: Step = function SiteCreationStep( { navigation, flow } )
 		};
 	}
 
+	const [ freeFlowDomainCartItemLoaded, setFreeFlowDomainCartItemLoaded ] = useState( false );
+
 	useEffect( () => {
-		if ( submit ) {
+		if ( flow === 'free' ) {
+			// We hydrate the redux store with a dynamically generated domain when this view is first loaded
+			// because the free flow has no domains step.
+			const domainCartItem = domainRegistration( {
+				// TODO: Insert dynamically generated Domain Here
+				domain: '',
+				productSlug: '',
+			} );
+
+			setDomainCartItem( domainCartItem );
+			setFreeFlowDomainCartItemLoaded( true );
+
+			if ( freeFlowDomainCartItemLoaded && submit ) {
+				setPendingAction( createSite );
+				submit();
+			}
+		} else if ( submit ) {
 			setPendingAction( createSite );
 			submit();
 		}
+
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [] );
+	}, [ freeFlowDomainCartItemLoaded ] );
 
 	return null;
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
@@ -6,10 +6,9 @@ import {
 	createSiteWithCart,
 } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
-import { domainRegistration } from 'calypso/lib/cart-values/cart-items';
 import {
 	retrieveSignupDestination,
 	getSignupCompleteFlowName,
@@ -32,7 +31,7 @@ const SiteCreationStep: Step = function SiteCreationStep( { navigation, flow } )
 
 	const username = useSelector( ( state ) => getCurrentUserName( state ) );
 
-	const { setDomainCartItem, setPendingAction } = useDispatch( ONBOARD_STORE );
+	const { setPendingAction } = useDispatch( ONBOARD_STORE );
 
 	const theme = flow === LINK_IN_BIO_FLOW ? 'pub/lynx' : 'pub/lettre';
 	const isPaidDomainItem = Boolean( domainCartItem?.product_slug );
@@ -89,32 +88,14 @@ const SiteCreationStep: Step = function SiteCreationStep( { navigation, flow } )
 		};
 	}
 
-	const [ freeFlowDomainCartItemLoaded, setFreeFlowDomainCartItemLoaded ] = useState( false );
-
 	useEffect( () => {
-		if ( flow === 'free' ) {
-			// We hydrate the redux store with a dynamically generated domain when this view is first loaded
-			// because the free flow has no domains step.
-			const domainCartItem = domainRegistration( {
-				// TODO: Insert dynamically generated Domain Here
-				domain: '',
-				productSlug: '',
-			} );
-
-			setDomainCartItem( domainCartItem );
-			setFreeFlowDomainCartItemLoaded( true );
-
-			if ( freeFlowDomainCartItemLoaded && submit ) {
-				setPendingAction( createSite );
-				submit();
-			}
-		} else if ( submit ) {
+		if ( submit ) {
 			setPendingAction( createSite );
 			submit();
 		}
 
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [ freeFlowDomainCartItemLoaded ] );
+	}, [] );
 
 	return null;
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
@@ -93,7 +93,6 @@ const SiteCreationStep: Step = function SiteCreationStep( { navigation, flow } )
 			setPendingAction( createSite );
 			submit();
 		}
-
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [] );
 


### PR DESCRIPTION
### Proposed Changes

* Remove Domains Step from free flow
* Remove Plans Step from free flow
* Use suggested domain name to auto-generate site
* Automatically select free plan for the user

**Note for context:** The domain used by the flow now is not what we ultimately want, but that will be address in subsequent PRs that introduce more intentional domain name generation.

### Screenshots

![2022-12-12 16 22 53](https://user-images.githubusercontent.com/5414230/207196187-d218ea5e-18c0-4f9d-a14b-d869c56bb6e2.gif)

### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this PR
* http://calypso.localhost:3000/setup/free/intro
* Navigate through stepper onboarding
* Verify that there is no domains or plans step
* Verify that a site is dynamically generated for the user

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
