### PR TITLE
SSR: Fix calculation of markup cache hit rate

### DIFF
--- a/client/server/render/index.js
+++ b/client/server/render/index.js
@@ -83,6 +83,7 @@ function render( element, key, req ) {
 
 		// If the cached layout was stored earlier in the request, no need to get it again.
 		let renderedLayout = req.context.cachedMarkup ?? markupCache.get( key );
+		const markupFromCache = !! renderedLayout; // Store this before updating renderedLayout.
 		if ( ! renderedLayout ) {
 			bumpStat( 'calypso-ssr', 'loggedout-design-cache-miss' );
 			debug( 'cache miss for key', key );
@@ -110,7 +111,7 @@ function render( element, key, req ) {
 
 		logServerEvent( req.context.sectionName, [
 			{
-				name: `ssr.markup_cache.${ renderedLayout ? 'hit' : 'miss' }`,
+				name: `ssr.markup_cache.${ markupFromCache ? 'hit' : 'miss' }`,
 				type: 'counting',
 			},
 			{


### PR DESCRIPTION
#### Proposed Changes
In a [previous PR](https://github.com/Automattic/wp-calypso/pull/69593/files#diff-b08f83671429891171931aee66db1aab6662b7f3304661e5ae4319c682df7252R113), I broke the markup cache calculation. It currently says incorrectly that markup cache is accessed 100% of the time. This is because I moved the place where we calculate whether it was hit or missed to a point where the markup gets defined after render. E.g. it says that we hit the cache even when we missed it and rendered it 

#### Testing instructions:

CI; this is a small logic fix.
