### PR TITLE
Fix SSR error where window is not available

### DIFF
--- a/client/landing/gutenboarding/utils.ts
+++ b/client/landing/gutenboarding/utils.ts
@@ -5,9 +5,13 @@ export function getIsAnchorFmSignup( urlString: string ): boolean {
 	if ( ! urlString ) {
 		return false;
 	}
-	const url = new URL( urlString, window.location.origin );
-	const decodedUrl = decodeURIComponent( url.search );
-	const searchParams = new URLSearchParams( decodedUrl );
+
+	// Assemble search params if there is actually a query in the string.
+	const queryParamIndex = urlString.indexOf( '?' );
+	if ( queryParamIndex === -1 ) {
+		return false;
+	}
+	const searchParams = new URLSearchParams( urlString.slice( queryParamIndex ) );
 	const anchorFmPodcastId = searchParams.get( 'anchor_podcast' );
 	return Boolean( anchorFmPodcastId && anchorFmPodcastId.match( /^[0-9a-f]{7,8}$/i ) );
 }

--- a/client/landing/gutenboarding/utils.ts
+++ b/client/landing/gutenboarding/utils.ts
@@ -11,7 +11,9 @@ export function getIsAnchorFmSignup( urlString: string ): boolean {
 	if ( queryParamIndex === -1 ) {
 		return false;
 	}
-	const searchParams = new URLSearchParams( urlString.slice( queryParamIndex ) );
+	const searchParams = new URLSearchParams(
+		decodeURIComponent( urlString.slice( queryParamIndex ) )
+	);
 	const anchorFmPodcastId = searchParams.get( 'anchor_podcast' );
 	return Boolean( anchorFmPodcastId && anchorFmPodcastId.match( /^[0-9a-f]{7,8}$/i ) );
 }


### PR DESCRIPTION
#### Proposed Changes
While monitoring a recent deployment, I noticed this error in our server logs:

```sh
ReferenceError: window is not defined at getIsAnchorFmSignup (/calypso/build/server.js:64173:34)......
```

It happens on requests to `/log-in`. (see /logstash/goto/e8b4c3536b2a80236d66e94670efa565 and look for "window is not defined")

In the previous approach, a url string (just path and/or query params) is passed in, and added to `new URL`. However, `new URL` fails without a base origin, so `window.location.origin` was added to fix that when it's not defined in the query string.

But we never really need it -- [`new URLSearchParams()`](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams/URLSearchParams) can parse the string itself.

On top of that, it's easy to get _just_ the query string portion by slicing the string after the first "?" character. `new URL` never populates url search params if there is no question mark, after all.

So this should work pretty exactly the same, given the URL's provided in #49280

#### Testing Instructions

Make sure this change works correctly in JS. I don't know if there is a clear/easy way to test this flow 