### PR TITLE
composite-checkout: Allow disabling payment methods

### DIFF
--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -43,7 +43,7 @@ The steps can contain any sort of data, but one of the steps should typically be
 
 ### The list of payment method options
 
-The [PaymentMethodStep](#PaymentMethodStep) is a pre-built [CheckoutStep](#CheckoutStep) which lists all the available payment methods passed to the [CheckoutProvider](#CheckoutProvider) as radio buttons.
+The [PaymentMethodStep](#PaymentMethodStep) is a pre-built [CheckoutStep](#CheckoutStep) which lists all the available payment methods passed to the [CheckoutProvider](#CheckoutProvider) as radio buttons (unless they have been disabled by [useTogglePaymentMethod](#useTogglePaymentMethod)).
 
 ### The transaction system
 
@@ -124,7 +124,7 @@ It has the following props.
 - `onPageLoadError?: ( errorType: string, errorMessage: string, errorData?: Record< string, string | number | undefined > ) => void`. A function to call when an internal error boundary triggered.
 - `onStepChanged?: ({ stepNumber: number | null; previousStepNumber: number; paymentMethodId: string }) => void`. A function to call when the active checkout step is changed.
 - `onPaymentMethodChanged?: (method: string) => void`. A function to call when the active payment method is changed. The argument will be the method's id.
-- `paymentMethods: object[]`. An array of [Payment Method objects](#payment-methods).
+- `paymentMethods: object[]`. An array of [Payment Method objects](#payment-methods). Can be disabled by [useTogglePaymentMethod](#useTogglePaymentMethod).
 - `paymentProcessors: object`. A key-value map of payment processor functions (see [Payment Methods](#payment-methods)).
 - `isLoading?: boolean`. If set and true, the form will be replaced with a loading placeholder and the form status will be set to [`.LOADING`](#FormStatus) (see [useFormStatus](#useFormStatus)).
 - `isValidating?: boolean`. If set and true, the form status will be set to [`.VALIDATING`](#FormStatus) (see [useFormStatus](#useFormStatus)).
@@ -407,6 +407,12 @@ A React Hook that will return a function to set a step to "complete". Only works
 ### useTotal
 
 A React Hook that returns the `total` property provided to the [CheckoutProvider](#checkoutprovider). This is the same as the second return value of [useLineItems](#useLineItems) but may be more semantic in some cases. Only works within `CheckoutProvider`.
+
+### useTogglePaymentMethod
+
+A React Hook that returns a function which can be called to enable or disable a payment method from the list of payment methods provided to [CheckoutProvider](#CheckoutProvider). Only works within `CheckoutProvider`.
+
+The signature of the function returned by this hook is: `( paymentMethodId: string, available: boolean ) => void`.
 
 ### useTransactionStatus
 

--- a/packages/composite-checkout/src/components/checkout-payment-methods.tsx
+++ b/packages/composite-checkout/src/components/checkout-payment-methods.tsx
@@ -5,6 +5,7 @@ import debugFactory from 'debug';
 import { useCallback, useContext } from 'react';
 import CheckoutContext from '../lib/checkout-context';
 import joinClasses from '../lib/join-classes';
+import { useAvailablePaymentMethodIds } from '../lib/payment-methods';
 import {
 	useAllPaymentMethods,
 	usePaymentMethod,
@@ -132,6 +133,7 @@ function PaymentMethod( {
 	ariaLabel,
 	summary,
 }: PaymentMethodProps ) {
+	const availablePaymentMethodIds = useAvailablePaymentMethodIds();
 	const { formStatus } = useFormStatus();
 	if ( summary ) {
 		return <>{ inactiveContent && inactiveContent }</>;
@@ -144,6 +146,7 @@ function PaymentMethod( {
 			id={ id }
 			checked={ checked }
 			disabled={ formStatus !== FormStatus.READY }
+			hidden={ ! availablePaymentMethodIds.includes( id ) }
 			onChange={ onClick ? () => onClick( id ) : undefined }
 			ariaLabel={ ariaLabel }
 			label={ label }

--- a/packages/composite-checkout/src/components/checkout-provider.tsx
+++ b/packages/composite-checkout/src/components/checkout-provider.tsx
@@ -16,6 +16,7 @@ import {
 import { LineItem, CheckoutProviderProps, FormStatus, TransactionStatus } from '../types';
 import CheckoutErrorBoundary from './checkout-error-boundary';
 import TransactionStatusHandler from './transaction-status-handler';
+import type { CheckoutContextInterface } from '../lib/checkout-context';
 import type {
 	PaymentEventCallback,
 	PaymentErrorCallback,
@@ -61,6 +62,8 @@ export function CheckoutProvider( {
 		children,
 		initiallySelectedPaymentMethodId,
 	};
+	const [ disabledPaymentMethodIds, setDisabledPaymentMethodIds ] = useState< string[] >( [] );
+
 	const [ paymentMethodId, setPaymentMethodId ] = useState< string | null >(
 		initiallySelectedPaymentMethodId
 	);
@@ -91,9 +94,11 @@ export function CheckoutProvider( {
 		transactionLastResponse,
 	} );
 
-	const value = useMemo(
+	const value: CheckoutContextInterface = useMemo(
 		() => ( {
 			allPaymentMethods: paymentMethods,
+			disabledPaymentMethodIds,
+			setDisabledPaymentMethodIds,
 			paymentMethodId,
 			setPaymentMethodId,
 			formStatus,
@@ -108,6 +113,7 @@ export function CheckoutProvider( {
 			formStatus,
 			paymentMethodId,
 			paymentMethods,
+			disabledPaymentMethodIds,
 			setFormStatus,
 			transactionStatusManager,
 			paymentProcessors,

--- a/packages/composite-checkout/src/components/checkout-submit-button.tsx
+++ b/packages/composite-checkout/src/components/checkout-submit-button.tsx
@@ -3,7 +3,7 @@ import { cloneElement } from 'react';
 import joinClasses from '../lib/join-classes';
 import { useFormStatus, FormStatus, usePaymentMethod, useProcessPayment } from '../public-api';
 import CheckoutErrorBoundary from './checkout-error-boundary';
-import type { PaymentProcessorSubmitData } from '../types';
+import type { PaymentMethod, PaymentProcessorSubmitData } from '../types';
 
 export default function CheckoutSubmitButton( {
 	validateForm,
@@ -16,10 +16,42 @@ export default function CheckoutSubmitButton( {
 	disabled?: boolean;
 	onLoadError?: ( error: Error ) => void;
 } ) {
+	const paymentMethod = usePaymentMethod();
+	if ( ! paymentMethod ) {
+		return null;
+	}
+	const { submitButton } = paymentMethod;
+	if ( ! submitButton ) {
+		return null;
+	}
+
+	return (
+		<CheckoutSubmitButtonForPaymentMethod
+			paymentMethod={ paymentMethod }
+			validateForm={ validateForm }
+			className={ className }
+			disabled={ disabled }
+			onLoadError={ onLoadError }
+		/>
+	);
+}
+
+function CheckoutSubmitButtonForPaymentMethod( {
+	paymentMethod,
+	validateForm,
+	className,
+	disabled,
+	onLoadError,
+}: {
+	paymentMethod: PaymentMethod;
+	validateForm?: () => Promise< boolean >;
+	className?: string;
+	disabled?: boolean;
+	onLoadError?: ( error: Error ) => void;
+} ) {
 	const { formStatus } = useFormStatus();
 	const { __ } = useI18n();
 	const isDisabled = disabled || formStatus !== FormStatus.READY;
-	const paymentMethod = usePaymentMethod();
 	const onClick = useProcessPayment( paymentMethod?.paymentProcessorId ?? '' );
 	const onClickWithValidation = ( processorData: PaymentProcessorSubmitData ) => {
 		if ( validateForm ) {
@@ -36,9 +68,6 @@ export default function CheckoutSubmitButton( {
 		return onClick( processorData );
 	};
 
-	if ( ! paymentMethod ) {
-		return null;
-	}
 	const { submitButton } = paymentMethod;
 	if ( ! submitButton ) {
 		return null;

--- a/packages/composite-checkout/src/components/checkout-submit-button.tsx
+++ b/packages/composite-checkout/src/components/checkout-submit-button.tsx
@@ -61,9 +61,12 @@ function CheckoutSubmitButtonForPaymentMethod( {
 	const isActive = paymentMethod.id === activePaymentMethodId;
 	const { formStatus } = useFormStatus();
 	const { __ } = useI18n();
-	const isDisabled = disabled || formStatus !== FormStatus.READY;
+	const isDisabled = disabled || formStatus !== FormStatus.READY || ! isActive;
 	const onClick = useProcessPayment( paymentMethod?.paymentProcessorId ?? '' );
 	const onClickWithValidation = ( processorData: PaymentProcessorSubmitData ) => {
+		if ( ! isActive ) {
+			return;
+		}
 		if ( validateForm ) {
 			validateForm().then( ( validationResult: boolean ) => {
 				if ( validationResult ) {

--- a/packages/composite-checkout/src/components/radio-button.tsx
+++ b/packages/composite-checkout/src/components/radio-button.tsx
@@ -8,6 +8,7 @@ const RadioButtonWrapper = styled.div<
 	RadioButtonWrapperProps & React.HTMLAttributes< HTMLDivElement >
 >`
 	position: relative;
+	display: ${ ( props ) => ( props.hidden ? 'none' : 'block' ) };
 	margin-top: 8px;
 	border-radius: 3px;
 	box-sizing: border-box;
@@ -19,7 +20,7 @@ const RadioButtonWrapper = styled.div<
 	}
 
 	::before {
-		display: block;
+		display: ${ ( props ) => ( props.hidden ? 'none' : 'block' ) };
 		width: 100%;
 		height: 100%;
 		position: absolute;
@@ -175,6 +176,7 @@ export default function RadioButton( {
 	children,
 	label,
 	disabled,
+	hidden,
 	id,
 	isFixedHeight,
 	ariaLabel,
@@ -183,7 +185,12 @@ export default function RadioButton( {
 	const [ isFocused, changeFocus ] = useState( false );
 
 	return (
-		<RadioButtonWrapper disabled={ disabled } isFocused={ isFocused } checked={ checked }>
+		<RadioButtonWrapper
+			disabled={ disabled }
+			isFocused={ isFocused }
+			checked={ checked }
+			hidden={ hidden }
+		>
 			<Radio
 				type="radio"
 				name={ name }
@@ -220,6 +227,7 @@ interface RadioButtonProps {
 	id: string;
 	label: React.ReactNode;
 	disabled?: boolean;
+	hidden?: boolean;
 	checked?: boolean;
 	value: string;
 	onChange?: () => void;

--- a/packages/composite-checkout/src/lib/checkout-context.ts
+++ b/packages/composite-checkout/src/lib/checkout-context.ts
@@ -9,8 +9,10 @@ import {
 	PaymentMethodChangedCallback,
 } from '../types';
 
-interface CheckoutContext {
+export interface CheckoutContextInterface {
 	allPaymentMethods: PaymentMethod[];
+	disabledPaymentMethodIds: string[];
+	setDisabledPaymentMethodIds: ( methods: string[] ) => void;
 	paymentMethodId: string | null;
 	setPaymentMethodId: ( id: string ) => void;
 	formStatus: FormStatus;
@@ -22,8 +24,10 @@ interface CheckoutContext {
 	onPaymentMethodChanged?: PaymentMethodChangedCallback;
 }
 
-const defaultCheckoutContext: CheckoutContext = {
+const defaultCheckoutContext: CheckoutContextInterface = {
 	allPaymentMethods: [],
+	disabledPaymentMethodIds: [],
+	setDisabledPaymentMethodIds: noop,
 	paymentMethodId: null,
 	setPaymentMethodId: noop,
 	formStatus: FormStatus.LOADING,

--- a/packages/composite-checkout/src/lib/payment-methods/index.ts
+++ b/packages/composite-checkout/src/lib/payment-methods/index.ts
@@ -1,7 +1,7 @@
 import debugFactory from 'debug';
 import { useContext, useMemo } from 'react';
-import { PaymentMethod } from '../../types';
 import CheckoutContext from '../checkout-context';
+import type { PaymentMethod, TogglePaymentMethod } from '../../types';
 
 const debug = debugFactory( 'composite-checkout:payment-methods' );
 
@@ -52,7 +52,7 @@ export function useAvailablePaymentMethodIds(): string[] {
 	return availablePaymentMethodIds;
 }
 
-export function useTogglePaymentMethod(): ( paymentMethodId: string, available: boolean ) => void {
+export function useTogglePaymentMethod(): TogglePaymentMethod {
 	const { allPaymentMethods, disabledPaymentMethodIds, setDisabledPaymentMethodIds } =
 		useContext( CheckoutContext );
 	if ( ! allPaymentMethods ) {

--- a/packages/composite-checkout/src/lib/payment-methods/index.ts
+++ b/packages/composite-checkout/src/lib/payment-methods/index.ts
@@ -1,5 +1,5 @@
 import debugFactory from 'debug';
-import { useContext } from 'react';
+import { useContext, useMemo } from 'react';
 import { PaymentMethod } from '../../types';
 import CheckoutContext from '../checkout-context';
 
@@ -36,4 +36,18 @@ export function useAllPaymentMethods() {
 		throw new Error( 'useAllPaymentMethods cannot be used outside of CheckoutProvider' );
 	}
 	return allPaymentMethods;
+}
+
+export function useAvailablePaymentMethodIds(): string[] {
+	const { allPaymentMethods, disabledPaymentMethodIds } = useContext( CheckoutContext );
+	if ( ! allPaymentMethods ) {
+		throw new Error( 'useAvailablePaymentMethodIds cannot be used outside of CheckoutProvider' );
+	}
+	const paymentMethodIds = allPaymentMethods.map( ( method ) => method.id );
+	const availablePaymentMethodIds = useMemo(
+		() => paymentMethodIds.filter( ( id ) => ! disabledPaymentMethodIds.includes( id ) ),
+		[ paymentMethodIds, disabledPaymentMethodIds ]
+	);
+	debug( 'Returning available payment methods', availablePaymentMethodIds );
+	return availablePaymentMethodIds;
 }

--- a/packages/composite-checkout/src/lib/payment-methods/index.ts
+++ b/packages/composite-checkout/src/lib/payment-methods/index.ts
@@ -51,3 +51,30 @@ export function useAvailablePaymentMethodIds(): string[] {
 	debug( 'Returning available payment methods', availablePaymentMethodIds );
 	return availablePaymentMethodIds;
 }
+
+export function useTogglePaymentMethod(): ( paymentMethodId: string, available: boolean ) => void {
+	const { allPaymentMethods, disabledPaymentMethodIds, setDisabledPaymentMethodIds } =
+		useContext( CheckoutContext );
+	if ( ! allPaymentMethods ) {
+		throw new Error( 'useTogglePaymentMethod cannot be used outside of CheckoutProvider' );
+	}
+	return ( paymentMethodId: string, available: boolean ) => {
+		const paymentMethod = allPaymentMethods.find( ( { id } ) => id === paymentMethodId );
+		if ( ! paymentMethod ) {
+			debug( `No payment method found matching id '${ paymentMethodId }' in`, allPaymentMethods );
+			return;
+		}
+
+		if ( available && disabledPaymentMethodIds.includes( paymentMethodId ) ) {
+			debug( 'Adding available payment method', paymentMethodId );
+			setDisabledPaymentMethodIds(
+				disabledPaymentMethodIds.filter( ( id ) => id !== paymentMethodId )
+			);
+		}
+
+		if ( ! available && ! disabledPaymentMethodIds.includes( paymentMethodId ) ) {
+			debug( 'Removing available payment method', paymentMethodId );
+			setDisabledPaymentMethodIds( [ ...disabledPaymentMethodIds, paymentMethodId ] );
+		}
+	};
+}

--- a/packages/composite-checkout/src/public-api.ts
+++ b/packages/composite-checkout/src/public-api.ts
@@ -41,7 +41,12 @@ import useProcessPayment from './components/use-process-payment';
 import { useFormStatus } from './lib/form-status';
 import InvalidPaymentProcessorResponseError from './lib/invalid-payment-processor-response-error';
 import { useLineItems, useTotal, useLineItemsOfType } from './lib/line-items';
-import { usePaymentMethod, usePaymentMethodId, useAllPaymentMethods } from './lib/payment-methods';
+import {
+	usePaymentMethod,
+	usePaymentMethodId,
+	useAllPaymentMethods,
+	useTogglePaymentMethod,
+} from './lib/payment-methods';
 import PaymentLogo from './lib/payment-methods/payment-logo';
 import {
 	usePaymentProcessor,
@@ -107,6 +112,7 @@ export {
 	usePaymentProcessors,
 	useProcessPayment,
 	useSetStepComplete,
+	useTogglePaymentMethod,
 	useTotal,
 	useTransactionStatus,
 };

--- a/packages/composite-checkout/src/types.ts
+++ b/packages/composite-checkout/src/types.ts
@@ -313,3 +313,5 @@ export interface CheckoutStepGroupActions {
 	getStepCompleteCallback: ( stepNumber: number ) => StepCompleteCallback;
 	setTotalSteps: ( totalSteps: number ) => void;
 }
+
+export type TogglePaymentMethod = ( paymentMethodId: string, available: boolean ) => void;

--- a/packages/composite-checkout/test/checkout.js
+++ b/packages/composite-checkout/test/checkout.js
@@ -19,12 +19,28 @@ import {
 	CheckoutStepGroup,
 	useSetStepComplete,
 	makeManualResponse,
+	useTogglePaymentMethod,
 } from '../src/public-api';
 import { PaymentProcessorResponseType } from '../src/types';
 import { DefaultCheckoutSteps } from './utils/default-checkout-steps';
 
 const myContext = createContext();
 const usePaymentData = () => useContext( myContext );
+
+function TogglePaymentMethodBlock( { mockMethod } ) {
+	const togglePaymentMethod = useTogglePaymentMethod();
+
+	return (
+		<div>
+			<button onClick={ () => togglePaymentMethod( mockMethod.id, false ) }>
+				Disable Payment Method
+			</button>
+			<button onClick={ () => togglePaymentMethod( mockMethod.id, true ) }>
+				Enable Payment Method
+			</button>
+		</div>
+	);
+}
 
 describe( 'Checkout', () => {
 	describe( 'using the default steps', function () {
@@ -43,6 +59,7 @@ describe( 'Checkout', () => {
 						initiallySelectedPaymentMethodId={ mockMethod.id }
 					>
 						<DefaultCheckoutSteps />
+						<TogglePaymentMethodBlock mockMethod={ mockMethod } />
 					</CheckoutProvider>
 				);
 			} );
@@ -67,6 +84,23 @@ describe( 'Checkout', () => {
 			it( 'renders the payment method label', () => {
 				const { getAllByText } = render( <MyCheckout /> );
 				expect( getAllByText( 'Mock Label' )[ 0 ] ).toBeInTheDocument();
+			} );
+
+			it( 'does not render the payment method label if the payment method is disabled', async () => {
+				const { queryByText, getByText, getAllByText } = render( <MyCheckout /> );
+				const user = userEvent.setup();
+				await user.click( getAllByText( 'Continue' )[ 0 ] );
+				await user.click( getByText( 'Disable Payment Method' ) );
+				expect( queryByText( 'Mock Label' ) ).not.toBeVisible();
+			} );
+
+			it( 'does render the payment method label if the payment method is disabled then enabled', async () => {
+				const { getAllByText, getByText } = render( <MyCheckout /> );
+				const user = userEvent.setup();
+				await user.click( getAllByText( 'Continue' )[ 0 ] );
+				await user.click( getByText( 'Disable Payment Method' ) );
+				await user.click( getByText( 'Enable Payment Method' ) );
+				expect( getAllByText( 'Mock Label' )[ 0 ] ).toBeVisible();
 			} );
 
 			it( 'renders the payment method activeContent', () => {


### PR DESCRIPTION
#### Proposed Changes

When using the `@automattic/composite-checkout` package to render a checkout UI, you begin by wrapping everything inside a `CheckoutProvider` component. Amongst other things, you provide this component with a list of payment method objects that it uses to construct its form, generating a series of radio buttons; when the radio button for a payment method is selected, the custom submit button for that payment method is displayed.

One challenge I encountered with this system is that if you want to remove a payment method, you must do so by changing the list of payment methods passed into the provider, and therefore must be accomplished at the level of the provider or higher. In https://github.com/Automattic/wp-calypso/pull/70614 I want to be able to disable payment methods from _within the payment methods themselves_.

In this PR we refactor the `CheckoutProvider` to add a new piece of state: a list of disabled payment methods. This list can be manipulated with the custom React hook `useTogglePaymentMethod()` to turn payment methods off and on without altering the list of payment methods itself.

To do this we first make the list of payment method radio buttons (rendered by the `CheckoutPaymentMethods` component) hide disabled methods using CSS.

To give the payment method submit buttons the option to make decisions about their visibility, we next make the `CheckoutSubmitButton` component render _all_ payment method submit buttons (instead of just the active one), using CSS to hide the buttons that are not active.

The result is that after this PR, all payment methods submit buttons will be rendered onto the page at once, regardless of which one is selected, but because only the active one is visible (and clickable), there should be no visible change to the user.

![Screenshot 2022-12-12 at 8 10 01 PM](https://user-images.githubusercontent.com/2036909/207201857-aa8b44fb-827e-45c8-ac06-4ac0a06fd595.png)

![Screenshot 2022-12-12 at 8 10 14 PM](https://user-images.githubusercontent.com/2036909/207201864-09913800-8d76-40e0-8eb0-cdee593dc51c.png)


#### Testing Instructions

Automated tests for the new (and old) behavior are included.

See https://github.com/Automattic/wp-calypso/pull/70614 for full testing instructions, but for the sake of this PR, just make sure that selecting different payment methods in checkout looks the same as it did before (particularly that you only see one submit button at a time).