### PR TITLE
Odyssey Stats: add style overrides for WP Admin and move related style in

### DIFF
--- a/apps/odyssey-stats/src/app.jsx
+++ b/apps/odyssey-stats/src/app.jsx
@@ -18,7 +18,7 @@ import { setupContextMiddleware } from './page-middleware/setup-context';
 import registerStatsPages from './routes';
 
 import 'calypso/assets/stylesheets/style.scss';
-import './jetpack.scss';
+import './wp-admin.scss';
 
 const setLocale = ( dispatch ) => {
 	const defaultLocale = config( 'i18n_default_locale_slug' ) || 'en';

--- a/apps/odyssey-stats/src/app.jsx
+++ b/apps/odyssey-stats/src/app.jsx
@@ -18,6 +18,7 @@ import { setupContextMiddleware } from './page-middleware/setup-context';
 import registerStatsPages from './routes';
 
 import 'calypso/assets/stylesheets/style.scss';
+import './jetpack.scss';
 
 const setLocale = ( dispatch ) => {
 	const defaultLocale = config( 'i18n_default_locale_slug' ) || 'en';

--- a/apps/odyssey-stats/src/jetpack.scss
+++ b/apps/odyssey-stats/src/jetpack.scss
@@ -1,0 +1,43 @@
+// Override spinner styles
+.stats-module__placeholder {
+	.spinner {
+		visibility: initial;
+		background-image: none;
+	}
+}
+
+// Overrides layout for WP Admin pages.
+.wp-admin {
+	& .layout__content,
+	&.theme-default .focus-content .layout__content {
+		padding-top: 0;
+		padding-left: 1px;
+	}
+	// Fixed header doesn't work well for WP-Admin, as the masterbar isn't fixed.
+	& .is-section-stats .has-fixed-nav .fixed-navigation-header__header {
+		position: relative;
+		top: initial;
+		left: initial;
+	}
+	& .is-section-stats .has-fixed-nav {
+		padding-top: 0;
+	}
+	#wpcontent {
+		padding-left: 1px;
+	}
+}
+
+.jp-stats-dashboard .card {
+	border: 0;
+	max-width: initial;
+	min-width: initial;
+}
+
+ul.wp-submenu,
+ul.wp-submenu-wrap {
+	margin-left: 0;
+}
+
+.jp-stats-dashboard .followers-count {
+	display: none;
+}

--- a/apps/odyssey-stats/src/wp-admin.scss
+++ b/apps/odyssey-stats/src/wp-admin.scss
@@ -6,7 +6,7 @@
 	}
 }
 
-// Overrides layout for WP Admin pages.
+// Overrides layout for WP Admin.
 .wp-admin {
 	& .layout__content,
 	&.theme-default .focus-content .layout__content {
@@ -25,6 +25,11 @@
 	#wpcontent {
 		padding-left: 1px;
 	}
+	// Offset margin of menu items set in Calypso.
+	ul.wp-submenu,
+	ul.wp-submenu-wrap {
+		margin-left: 0;
+	}
 }
 
 .jp-stats-dashboard {
@@ -38,7 +43,7 @@
 	}
 	.form-checkbox:checked::before {
 		// Increase Calypso styles specificity.
-		content: url( calypso/assets/images/checkbox-icons/checkmark-primary.svg );
+		content: url(calypso/assets/images/checkbox-icons/checkmark-primary.svg);
 		width: 12px;
 		height: 12px;
 		margin: 3px auto;
@@ -47,10 +52,4 @@
 		// Override WP-Admin styles.
 		float: none;
 	}
-}
-
-// Offset margin of menu items set in Calypso.
-ul.wp-submenu,
-ul.wp-submenu-wrap {
-	margin-left: 0;
 }

--- a/apps/odyssey-stats/src/wp-admin.scss
+++ b/apps/odyssey-stats/src/wp-admin.scss
@@ -27,17 +27,30 @@
 	}
 }
 
-.jp-stats-dashboard .card {
-	border: 0;
-	max-width: initial;
-	min-width: initial;
+.jp-stats-dashboard {
+	.card {
+		border: 0;
+		max-width: initial;
+		min-width: initial;
+	}
+	.followers-count {
+		display: none;
+	}
+	.form-checkbox:checked::before {
+		// Increase Calypso styles specificity.
+		content: url( calypso/assets/images/checkbox-icons/checkmark-primary.svg );
+		width: 12px;
+		height: 12px;
+		margin: 3px auto;
+		display: inline-block;
+
+		// Override WP-Admin styles.
+		float: none;
+	}
 }
 
+// Offset margin of menu items set in Calypso.
 ul.wp-submenu,
 ul.wp-submenu-wrap {
 	margin-left: 0;
-}
-
-.jp-stats-dashboard .followers-count {
-	display: none;
 }

--- a/client/my-sites/stats/modernized-layout-styles.scss
+++ b/client/my-sites/stats/modernized-layout-styles.scss
@@ -55,24 +55,3 @@ $sidebar-appearance-break-point: 783px;
 		}
 	}
 }
-
-// Overrides paddings for WP Admin pages.
-.wp-admin {
-	& .layout__content,
-	&.theme-default .focus-content .layout__content {
-		padding-top: 0;
-		padding-left: 1px;
-	}
-	// Fixed header doesn't work well for WP-Admin, as the masterbar isn't fixed.
-	& .is-section-stats .has-fixed-nav .fixed-navigation-header__header {
-		position: relative;
-		top: initial;
-		left: initial;
-	}
-	& .is-section-stats .has-fixed-nav {
-		padding-top: 0;
-	}
-	#wpcontent {
-		padding-left: 1px;
-	}
-}


### PR DESCRIPTION
#### Proposed Changes

Adds `wp-admin.scss` to override styles for Jetpack sites and moves related code inside.

The PR takes the chance to,
- fix the spinner not showing issue #71105 
- fix the styling of the checkbox #71106 

Discussion: https://github.com/Automattic/jetpack/pull/27582


#### Testing Instructions

* Enable Odyssey Stats for your Jetpack site (`PejTkB-3E-p2`)
* Open `/wp-admin/admin.php?page=stats`
* Ensure loading spinners show up
* Ensure visitor checkbox looks okay
* Ensure everything works well except for the follower sections on the Insights page

<img width="1269" alt="image" src="https://user-images.githubusercontent.com/1425433/207443174-6f9c5bda-2ae7-4738-8d36-73af7ac6d91b.png">


#### Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?


Fixes #71105, fixes #71106.
