### PR TITLE
Themes Showcase: Get localized URL for /start/with-themes

### DIFF
--- a/client/my-sites/themes/helpers.js
+++ b/client/my-sites/themes/helpers.js
@@ -59,7 +59,7 @@ export function localizeThemesPath( path, locale, isLoggedOut = true ) {
 			return `/${ locale }${ path }`;
 		}
 
-		if ( path.startsWith( '/start/theme' ) ) {
+		if ( path.startsWith( '/start/with-theme' ) ) {
 			return addLocaleToPath( path, locale );
 		}
 	}

--- a/client/my-sites/themes/helpers.js
+++ b/client/my-sites/themes/helpers.js
@@ -1,4 +1,4 @@
-import { isMagnificentLocale } from '@automattic/i18n-utils';
+import { isMagnificentLocale, addLocaleToPath } from '@automattic/i18n-utils';
 import { mapValues } from 'lodash';
 import titlecase from 'to-title-case';
 import { gaRecordEvent } from 'calypso/lib/analytics/ga';
@@ -52,7 +52,16 @@ export function getAnalyticsData( path, { filter, vertical, tier, site_id } ) {
 }
 
 export function localizeThemesPath( path, locale, isLoggedOut = true ) {
-	const shouldPrefix = isLoggedOut && isMagnificentLocale( locale ) && path.startsWith( '/theme' );
+	const shouldLocalizePath = isLoggedOut && isMagnificentLocale( locale );
 
-	return shouldPrefix ? `/${ locale }${ path }` : path;
+	if ( shouldLocalizePath ) {
+		if ( path.startsWith( '/theme' ) ) {
+			return `/${ locale }${ path }`;
+		}
+
+		if ( path.startsWith( '/start/theme' ) ) {
+			return addLocaleToPath( path, locale );
+		}
+	}
+	return path;
 }

--- a/client/my-sites/themes/helpers.js
+++ b/client/my-sites/themes/helpers.js
@@ -54,14 +54,17 @@ export function getAnalyticsData( path, { filter, vertical, tier, site_id } ) {
 export function localizeThemesPath( path, locale, isLoggedOut = true ) {
 	const shouldLocalizePath = isLoggedOut && isMagnificentLocale( locale );
 
-	if ( shouldLocalizePath ) {
-		if ( path.startsWith( '/theme' ) ) {
-			return `/${ locale }${ path }`;
-		}
-
-		if ( path.startsWith( '/start/with-theme' ) ) {
-			return addLocaleToPath( path, locale );
-		}
+	if ( ! shouldLocalizePath ) {
+		return path;
 	}
+
+	if ( path.startsWith( '/theme' ) ) {
+		return `/${ locale }${ path }`;
+	}
+
+	if ( path.startsWith( '/start/with-theme' ) ) {
+		return addLocaleToPath( path, locale );
+	}
+
 	return path;
 }

--- a/client/state/themes/selectors/get-theme-signup-url.js
+++ b/client/state/themes/selectors/get-theme-signup-url.js
@@ -1,5 +1,3 @@
-import { addLocaleToPath } from '@automattic/i18n-utils';
-import { getLocaleSlug } from 'i18n-calypso';
 import { isThemePremium } from 'calypso/state/themes/selectors/is-theme-premium';
 
 import 'calypso/state/themes/init';
@@ -22,6 +20,5 @@ export function getThemeSignupUrl( state, themeId ) {
 		url += '&premium=true';
 	}
 
-	const localeSlug = typeof getLocaleSlug === 'function' ? getLocaleSlug() : 'en';
-	return addLocaleToPath( url, localeSlug );
+	return url;
 }

--- a/client/state/themes/selectors/get-theme-signup-url.js
+++ b/client/state/themes/selectors/get-theme-signup-url.js
@@ -1,4 +1,4 @@
-import { localizeUrl } from '@automattic/i18n-utils';
+import { addLocaleToPath } from '@automattic/i18n-utils';
 import { isThemePremium } from 'calypso/state/themes/selectors/is-theme-premium';
 
 import 'calypso/state/themes/init';
@@ -21,5 +21,5 @@ export function getThemeSignupUrl( state, themeId ) {
 		url += '&premium=true';
 	}
 
-	return localizeUrl( url );
+	return addLocaleToPath( url );
 }

--- a/client/state/themes/selectors/get-theme-signup-url.js
+++ b/client/state/themes/selectors/get-theme-signup-url.js
@@ -1,3 +1,4 @@
+import { localizeUrl } from '@automattic/i18n-utils';
 import { isThemePremium } from 'calypso/state/themes/selectors/is-theme-premium';
 
 import 'calypso/state/themes/init';
@@ -20,5 +21,5 @@ export function getThemeSignupUrl( state, themeId ) {
 		url += '&premium=true';
 	}
 
-	return url;
+	return localizeUrl( url );
 }

--- a/client/state/themes/selectors/get-theme-signup-url.js
+++ b/client/state/themes/selectors/get-theme-signup-url.js
@@ -1,4 +1,5 @@
 import { addLocaleToPath } from '@automattic/i18n-utils';
+import { getLocaleSlug } from 'i18n-calypso';
 import { isThemePremium } from 'calypso/state/themes/selectors/is-theme-premium';
 
 import 'calypso/state/themes/init';
@@ -21,5 +22,6 @@ export function getThemeSignupUrl( state, themeId ) {
 		url += '&premium=true';
 	}
 
-	return addLocaleToPath( url );
+	const localeSlug = typeof getLocaleSlug === 'function' ? getLocaleSlug() : 'en';
+	return addLocaleToPath( url, localeSlug );
 }


### PR DESCRIPTION
#### Proposed Changes

* This PR localized the `/start/with-theme` signup URL in logged-out themes pages

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* **For testing logged-out non-EN locales, you can only use calypso.live URLs, local calypso will not work.**
* Logged-out, visit `/fr/themes` and verify that the signup URL on the ellipsis menu points to `/start/with-theme/fr/?<query_params>`.

<img width="479" alt="Screenshot 2022-12-13 at 12 25 11 PM" src="https://user-images.githubusercontent.com/1269602/207247223-8e28a5d9-2040-4f2a-a6fd-8241b62f8993.png">

* Click on a theme and verify that the "pick this design" CTA points to the localized signup URL.
<img width="515" alt="Screenshot 2022-12-13 at 12 26 43 PM" src="https://user-images.githubusercontent.com/1269602/207247422-eda5c86b-175d-46ad-8ca9-f6774afe02c6.png">

* On a new tab, load `/fr/theme/loudness` and verify that the CTA points to the localized signup URL.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


