### PR TITLE
Fix/link in bio tld reliable transit

### DIFF
--- a/client/landing/stepper/declarative-flow/link-in-bio.ts
+++ b/client/landing/stepper/declarative-flow/link-in-bio.ts
@@ -58,6 +58,7 @@ const linkInBio: Flow = {
 		const locale = useLocale();
 		const queryParams = useQuery();
 		const tld = queryParams.get( 'tld' );
+		const selectedDomain = queryParams.get( 'selectedDomain' );
 
 		// At the moment, the TLD variation relies on going back and forth from the classic signup framework
 		// and the Stepper framework. Since it begins from the former, the Stepper framework doesn't have a chance
@@ -162,7 +163,7 @@ const linkInBio: Flow = {
 
 				case 'linkInBioSetup':
 					return window.location.assign(
-						`/start/link-in-bio-tld/plans-link-in-bio?variationName=${ flowName }&pageTitle=Link%20in%20Bio&tld=${ tld }`
+						`/start/link-in-bio-tld/plans-link-in-bio?variationName=${ flowName }&pageTitle=Link%20in%20Bio&tld=${ tld }&selectedDomain=${ selectedDomain }`
 					);
 
 				case 'launchpad': {

--- a/client/lib/domains/get-root-domain.js
+++ b/client/lib/domains/get-root-domain.js
@@ -1,0 +1,20 @@
+/**
+ * Parse the root domain part from a given domain name. e.g.
+ * foo.wordpress.com should return wordpress.com.
+ * foo.blog should return foo.blog.
+ */
+export function getRootDomain( domainName ) {
+	const firstLastDot = domainName.lastIndexOf( '.' );
+
+	if ( firstLastDot === -1 ) {
+		return domainName;
+	}
+
+	const secondLastDot = domainName.lastIndexOf( '.', firstLastDot - 1 );
+
+	if ( secondLastDot === -1 ) {
+		return domainName;
+	}
+
+	return domainName.substring( secondLastDot + 1 );
+}

--- a/client/lib/domains/index.js
+++ b/client/lib/domains/index.js
@@ -17,6 +17,7 @@ export { getFixedDomainSearch } from './get-fixed-domain-search';
 export { getPrimaryDomain } from './get-primary-domain';
 export { getSelectedDomain } from './get-selection-domain';
 export { getTld } from './get-tld';
+export { getRootDomain } from './get-root-domain';
 export { getTopLevelOfTld } from './get-top-level-of-tld';
 export { getUnformattedDomainPrice } from './get-unformatted-domain-price';
 export { getUnformattedDomainSalePrice } from './get-unformatted-domain-sale-price';

--- a/client/lib/domains/test/index.js
+++ b/client/lib/domains/test/index.js
@@ -1,5 +1,9 @@
 import { forEach } from 'lodash';
-import { getFixedDomainSearch, getDomainSuggestionSearch } from 'calypso/lib/domains';
+import {
+	getFixedDomainSearch,
+	getDomainSuggestionSearch,
+	getRootDomain,
+} from 'calypso/lib/domains';
 
 describe( 'index', () => {
 	describe( '#getFixedDomainSearch', () => {
@@ -53,6 +57,21 @@ describe( 'index', () => {
 		test( 'should return the original search string if it is long enough and is not one of the ignored strings', () => {
 			const search = 'hippos';
 			expect( getDomainSuggestionSearch( search ) ).toEqual( search );
+		} );
+	} );
+
+	describe( '#getRootDomain', () => {
+		test( 'should return the string as it is when there is no dot seperator.', () => {
+			expect( getRootDomain( 'com' ) ).toEqual( 'com' );
+		} );
+
+		test( 'should return the root domain for a domain name in the 2nd level.', () => {
+			expect( getRootDomain( 'wordpress.com' ) ).toEqual( 'wordpress.com' );
+		} );
+
+		test( 'should return the root domain for a domain name in more than 2 levels.', () => {
+			expect( getRootDomain( 'foo.wordpress.com' ) ).toEqual( 'wordpress.com' );
+			expect( getRootDomain( 'fried.rice.rock.food.blog' ) ).toEqual( 'food.blog' );
 		} );
 	} );
 } );

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -144,17 +144,23 @@ export function generateFlows( {
 			name: LINK_IN_BIO_TLD_FLOW,
 			steps: [ 'domains-link-in-bio-tld', 'user', 'plans-link-in-bio' ],
 			middleDestination: {
-				user: ( dependencies ) => `/setup/link-in-bio/patterns?tld=${ dependencies.tld }`,
+				user: ( { tld }, progress ) => {
+					const selectedDomain = progress[ 'domains-link-in-bio-tld' ]?.siteUrl;
+					return `/setup/link-in-bio/patterns?tld=${ tld }&selectedDomain=${ encodeURIComponent(
+						selectedDomain
+					) }`;
+				},
 			},
-			destination: ( dependencies ) =>
-				`/setup/link-in-bio/launchpad?siteSlug=${ encodeURIComponent( dependencies.siteSlug ) }`,
+			destination: ( { siteSlug } ) =>
+				`/setup/link-in-bio/launchpad?siteSlug=${ encodeURIComponent( siteSlug ) }`,
 			description: 'Beginning of the flow to create a link in bio',
 			lastModified: '2022-11-03',
 			showRecaptcha: true,
 			get pageTitle() {
 				return translate( 'Link in Bio' );
 			},
-			providesDependenciesInQuery: [ 'tld' ],
+			providesDependenciesInQuery: [ 'tld', 'selectedDomain' ],
+			optionalDependenciesInQuery: [ 'selectedDomain' ], // optional because it's only populated after the domain step
 			postCompleteCallback: setupSiteAfterCreation,
 		},
 		{

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -254,7 +254,9 @@ const Flows = {
 			flow = removeP2DetailsStepFromFlow( flow );
 		}
 
-		return Flows.filterExcludedSteps( flow );
+		const result = Flows.filterExcludedSteps( flow );
+
+		return result;
 	},
 
 	getNextStepNameInFlow( flowName, currentStepName = '' ) {

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -129,6 +129,7 @@ export function generateSteps( {
 		'domains-link-in-bio-tld': {
 			stepName: 'domains-link-in-bio-tld',
 			apiRequestFunction: createSiteWithCart,
+			fulfilledStepCallback: isDomainFulfilled,
 			dependencies: [ 'tld' ],
 			providesDependencies: [
 				'siteId',

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -87,6 +87,7 @@ import {
 	getDestination,
 	getFirstInvalidStep,
 	getStepUrl,
+	processDependencyInQuery,
 	isReskinnedFlow,
 	isP2Flow,
 } from './utils';
@@ -599,7 +600,7 @@ class Signup extends Component {
 		for ( const dependencyKey of dependenciesInQuery ) {
 			const value = queryObject[ dependencyKey ];
 			if ( value != null ) {
-				result[ dependencyKey ] = value;
+				result[ dependencyKey ] = processDependencyInQuery( dependencyKey, value );
 			}
 		}
 

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -205,6 +205,7 @@ class Signup extends Component {
 			const destinationStep = flows.getFlow( this.props.flowName, this.props.isLoggedIn )
 				.steps[ 0 ];
 			this.setState( { resumingStep: destinationStep } );
+
 			const locale = ! this.props.isLoggedIn ? this.props.locale : '';
 			return page.redirect(
 				getStepUrl(
@@ -455,7 +456,7 @@ class Signup extends Component {
 		map( flowSteps, ( flowStepName ) => this.processFulfilledSteps( flowStepName, nextProps ) );
 
 		if ( includes( flows.excludedSteps, stepName ) ) {
-			this.goToNextStep( flowName );
+			this.goToNextStep( flowName, stepName );
 		}
 	};
 
@@ -600,7 +601,8 @@ class Signup extends Component {
 		for ( const dependencyKey of dependenciesInQuery ) {
 			const value = queryObject[ dependencyKey ];
 			if ( value != null ) {
-				result[ dependencyKey ] = processDependencyInQuery( dependencyKey, value );
+				// result[ dependencyKey ] = processDependencyInQuery( dependencyKey, value );
+				result[ dependencyKey ] = value;
 			}
 		}
 
@@ -652,12 +654,12 @@ class Signup extends Component {
 
 	// `nextFlowName` is an optional parameter used to redirect to another flow, i.e., from `main`
 	// to `ecommerce`. If not specified, the current flow (`this.props.flowName`) continues.
-	goToNextStep = ( nextFlowName = this.props.flowName ) => {
+	goToNextStep = ( nextFlowName = this.props.flowName, currentStepName = this.props.stepName ) => {
 		const { steps: flowSteps, middleDestination } = flows.getFlow(
 			nextFlowName,
 			this.props.isLoggedIn
 		);
-		const currentStepIndex = flowSteps.indexOf( this.props.stepName );
+		const currentStepIndex = flowSteps.indexOf( currentStepName );
 		const nextStepName = flowSteps[ currentStepIndex + 1 ];
 		const nextProgressItem = get( this.props.progress, nextStepName );
 		const nextStepSection = ( nextProgressItem && nextProgressItem.stepSectionName ) || '';
@@ -666,12 +668,16 @@ class Signup extends Component {
 			this.setState( { previousFlowName: this.props.flowName } );
 		}
 
-		const midPoint = middleDestination ? middleDestination[ this.props.stepName ] : null;
+		const midPoint = middleDestination ? middleDestination[ currentStepName ] : null;
+
+		if ( currentStepName === 'domains-link-in-bio-tld' ) {
+			debugger;
+		}
 
 		if ( midPoint ) {
 			// save the resuming point and then navigate away.
 			this.setState( { resumingStep: nextStepName } );
-			page( midPoint( this.props.signupDependencies ) );
+			page( midPoint( this.props.signupDependencies, this.props.progress ) );
 			return;
 		}
 

--- a/client/signup/utils.js
+++ b/client/signup/utils.js
@@ -220,7 +220,7 @@ export const isPlanSelectionAvailableLaterInFlow = ( flowSteps ) => {
 };
 
 export const processDependencyInQuery = ( key, value ) => {
-	if ( key === 'domain' ) {
+	if ( key === 'selectedDomain' ) {
 		const domain = value;
 		const productSlug = getDomainProductSlug( domain );
 		const domainItem = domainRegistration( { productSlug, domain } );

--- a/client/signup/utils.js
+++ b/client/signup/utils.js
@@ -1,6 +1,8 @@
 import config from '@automattic/calypso-config';
 import { translate } from 'i18n-calypso';
 import { filter, find, includes, isEmpty, pick, sortBy } from 'lodash';
+import { domainRegistration } from 'calypso/lib/cart-values/cart-items';
+import { getDomainProductSlug } from 'calypso/lib/domains';
 import { addQueryArgs } from 'calypso/lib/url';
 import flows from 'calypso/signup/config/flows';
 import { getStepModuleName } from 'calypso/signup/config/step-components';
@@ -215,4 +217,22 @@ export const isPlanSelectionAvailableLaterInFlow = ( flowSteps ) => {
 	const isPlansStepExistsInFutureOfFlow = plansIndex > 0 && plansIndex > domainsIndex;
 
 	return isPlansStepExistsInFutureOfFlow;
+};
+
+export const processDependencyInQuery = ( key, value ) => {
+	if ( key === 'domain' ) {
+		const domain = value;
+		const productSlug = getDomainProductSlug( domain );
+		const domainItem = domainRegistration( { productSlug, domain } );
+
+		// TODO: unify this object construction with
+		// the submitSignupStep() call in signup/steps/domains/index.jsx
+		return {
+			domainItem,
+			siteUrl: domain,
+			isPurchasingItem: true,
+		};
+	}
+
+	return value;
 };


### PR DESCRIPTION
#### Proposed Changes

This PR is an attempt to fix the recurring loop issue that is reported in p2-pdtkmj-Sc#comment-1393.
The reason that sometimes the dotlink version of Link in Bio flow can stuck like this is because Calypso intentionally persists state on a 5 secs period. When transiting from /start/domain to /setup/pattern, if the domain step submission isn’t persisted, then the user will be redirected back to the domains step upon arrival of /start/plans latter, since the signup framework will consider the previous required step, i.e. the domains step, isn’t completed.

This PR attempts to fix this by appending the selected domain as a query parameter. This *almost* works, but it requires a ton of paving new ways in the signup framework to fight the default routing behavior of the framework and to synthesize the domain step data solely through that query parameter, `selectedDomain`. The severe cons is that it introduces a chance for the user to change the selected domain through `selectedDomain`, which sounds terribly dangerous. 

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
