### PR TITLE
Stats: Add support for Tracks in MobilePromoCard

### DIFF
--- a/packages/components/src/mobile-promo-card/index.tsx
+++ b/packages/components/src/mobile-promo-card/index.tsx
@@ -2,6 +2,7 @@ import { recordTracksEvent } from '@automattic/calypso-analytics';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import './style.scss';
+import { useEffect } from 'react';
 import iconWoo from './images/icon-woo.png';
 import qrCodeJetpack from './images/qr-code-jetpack.png';
 import qrCodeWoo from './images/qr-code-woo.png';
@@ -45,9 +46,11 @@ function getRedirectUrl( key: string ): string | null {
 const TRACKS_EVENTS: {
 	[ key: string ]: string | undefined;
 } = {
+	jetpackView: 'calypso_stats_mobile_cta_jetpack_view',
 	jetpackClickA8C: 'calypso_stats_mobile_cta_jetpack_click',
 	jetpackClickApple: 'calypso_stats_mobile_cta_jetpack_apple_click',
 	jetpackClickGoogle: 'calypso_stats_mobile_cta_jetpack_google_click',
+	wooView: 'calypso_stats_mobile_cta_woo_view',
 	wooClickA8C: 'calypso_stats_mobile_cta_woo_click',
 	wooClickApple: 'calypso_stats_mobile_cta_woo_apple_click',
 	wooClickGoogle: 'calypso_stats_mobile_cta_woo_google_click',
@@ -158,6 +161,15 @@ export default function MobilePromoCard( { className, isWoo }: MobilePromoCardPr
 			<img className="promo-qr-code" src={ qrCodeJetpack } alt="QR Code for Jetpack mobile app" />
 		);
 	};
+
+	// Track "views" of this card.
+	useEffect( () => {
+		if ( isWoo ) {
+			sendTracksEvent( 'wooView' );
+		} else {
+			sendTracksEvent( 'jetpackView' );
+		}
+	}, [ isWoo ] );
 
 	return (
 		<div className={ classNames( 'promo-card', className ?? null ) }>

--- a/packages/components/src/mobile-promo-card/index.tsx
+++ b/packages/components/src/mobile-promo-card/index.tsx
@@ -1,4 +1,4 @@
-import { recordTracksEvent } from '@automattic/calypso-analytics';
+// import { recordTracksEvent } from '@automattic/calypso-analytics';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import './style.scss';
@@ -50,6 +50,11 @@ const TRACKS_EVENTS: {
 	wooClickApple: 'calypso_stats_mobile_cta_woo_apple_click',
 	wooClickGoogle: 'calypso_stats_mobile_cta_woo_google_click',
 };
+
+function recordTracksEvent( key: string ): void {
+	// eslint-disable-next-line no-console
+	console.log( key );
+}
 
 function sendTracksEvent( key: string ): void {
 	// Limit to known events.

--- a/packages/components/src/mobile-promo-card/index.tsx
+++ b/packages/components/src/mobile-promo-card/index.tsx
@@ -10,11 +10,6 @@ import storeBadgeApple from './images/store-apple.png';
 import storeBadgeGoogle from './images/store-google.png';
 import { WordPressJetpackSVG } from './svg-icons';
 
-export type MobilePromoCardProps = {
-	className?: string;
-	isWoo?: boolean;
-};
-
 // Slugs as used by Jetpack Redirects.
 // See https://jetpack.com/redirect for current URLs.
 // Two _QRCode constants are included for reference only.
@@ -64,6 +59,11 @@ function sendTracksEvent( key: string ): void {
 		recordTracksEvent( eventName );
 	}
 }
+
+export type MobilePromoCardProps = {
+	className?: string;
+	isWoo?: boolean;
+};
 
 export default function MobilePromoCard( { className, isWoo }: MobilePromoCardProps ) {
 	const translate = useTranslate();

--- a/packages/components/src/mobile-promo-card/index.tsx
+++ b/packages/components/src/mobile-promo-card/index.tsx
@@ -1,3 +1,4 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import './style.scss';
@@ -40,6 +41,27 @@ function getRedirectUrl( key: string ): string | null {
 	return 'https://jetpack.com/redirect/?source=' + REDIRECT_SLUGS[ key ];
 }
 
+// Event names used for Tracks.
+const TRACKS_EVENTS: {
+	[ key: string ]: string | undefined;
+} = {
+	jetpackClickA8C: 'calypso_stats_mobile_cta_jetpack_click',
+	jetpackClickApple: 'calypso_stats_mobile_cta_jetpack_apple_click',
+	jetpackClickGoogle: 'calypso_stats_mobile_cta_jetpack_google_click',
+	wooClickA8C: 'calypso_stats_mobile_cta_woo_click',
+	wooClickApple: 'calypso_stats_mobile_cta_woo_apple_click',
+	wooClickGoogle: 'calypso_stats_mobile_cta_woo_google_click',
+};
+
+function sendTracksEvent( key: string ): void {
+	// Limit to known events.
+	const eventName = TRACKS_EVENTS[ key ];
+	// Forward the Tracks call if we have a valid event.
+	if ( eventName ) {
+		recordTracksEvent( eventName );
+	}
+}
+
 export default function MobilePromoCard( { className, isWoo }: MobilePromoCardProps ) {
 	const translate = useTranslate();
 	// Basic user agent testing so we can show app store badges on moble.
@@ -67,7 +89,11 @@ export default function MobilePromoCard( { className, isWoo }: MobilePromoCardPr
 				{
 					components: {
 						a: (
-							<a className="woo" href={ getRedirectUrl( 'wooA8C' ) ?? 'https://woo.com/mobile' } />
+							<a
+								className="woo"
+								href={ getRedirectUrl( 'wooA8C' ) ?? 'https://woo.com/mobile' }
+								onClick={ () => sendTracksEvent( 'wooClickA8C' ) }
+							/>
 						),
 					},
 				}
@@ -81,6 +107,7 @@ export default function MobilePromoCard( { className, isWoo }: MobilePromoCardPr
 						<a
 							className="jetpack"
 							href={ getRedirectUrl( 'jetpackA8C' ) ?? 'https://jetpack.com/app' }
+							onClick={ () => sendTracksEvent( 'jetpackClickA8C' ) }
 						/>
 					),
 				},
@@ -93,8 +120,12 @@ export default function MobilePromoCard( { className, isWoo }: MobilePromoCardPr
 		const fallbackLink = isWoo ? 'https://woo.com/mobile' : 'https://jetpack.com/app';
 		if ( isApple ) {
 			const appStoreLink = isWoo ? getRedirectUrl( 'wooApple' ) : getRedirectUrl( 'jetpackApple' );
+			const tracksEventName = isWoo ? 'wooClickApple' : 'jetpackClickApple';
 			return (
-				<a href={ appStoreLink ?? fallbackLink }>
+				<a
+					href={ appStoreLink ?? fallbackLink }
+					onClick={ () => sendTracksEvent( tracksEventName ) }
+				>
 					<img
 						className="promo-store-badge"
 						src={ storeBadgeApple }
@@ -107,8 +138,12 @@ export default function MobilePromoCard( { className, isWoo }: MobilePromoCardPr
 			const appStoreLink = isWoo
 				? getRedirectUrl( 'wooGoogle' )
 				: getRedirectUrl( 'jetpackGoogle' );
+			const tracksEventName = isWoo ? 'wooClickGoogle' : 'jetpackClickGoogle';
 			return (
-				<a href={ appStoreLink ?? fallbackLink }>
+				<a
+					href={ appStoreLink ?? fallbackLink }
+					onClick={ () => sendTracksEvent( tracksEventName ) }
+				>
 					<img
 						className="promo-store-badge"
 						src={ storeBadgeGoogle }

--- a/packages/components/src/mobile-promo-card/index.tsx
+++ b/packages/components/src/mobile-promo-card/index.tsx
@@ -1,4 +1,4 @@
-// import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import './style.scss';
@@ -50,11 +50,6 @@ const TRACKS_EVENTS: {
 	wooClickApple: 'calypso_stats_mobile_cta_woo_apple_click',
 	wooClickGoogle: 'calypso_stats_mobile_cta_woo_google_click',
 };
-
-function recordTracksEvent( key: string ): void {
-	// eslint-disable-next-line no-console
-	console.log( key );
-}
 
 function sendTracksEvent( key: string ): void {
 	// Limit to known events.

--- a/packages/components/src/site-thumbnail/use-mshots-img.tsx
+++ b/packages/components/src/site-thumbnail/use-mshots-img.tsx
@@ -96,7 +96,7 @@ export const useMshotsImg = (
 		}
 
 		return () => {
-			clearTimeout( timeout.current );
+			// clearTimeout( timeout.current );
 		};
 	}, [ isLoading, mshotUrl, retryCount, src ] );
 


### PR DESCRIPTION
#### Proposed Changes

Introduces Tracks support so we can properly monitor the views/clicks of the promo card.

**FOR JETPACK:**
* `calypso_stats_mobile_cta_jetpack_view` — The Jetpack CTA is rendered.
* `calypso_stats_mobile_cta_jetpack_click` — User clicks link to jetpack.com/apps
* `calypso_stats_mobile_cta_jetpack_apple_click` — User clicks App Store badge for Jetpack app
* `calypso_stats_mobile_cta_jetpack_google_click` — User clicks Google Play badge for Jetpack app

**FOR WOO**
* `calypso_stats_mobile_cta_woo_view` — The Woo CTA is rendered.
* `calypso_stats_mobile_cta_woo_click` — User clicks link to woo.com/mobile
* `calypso_stats_mobile_cta_woo_apple_click` — User clicks App Store badge for Woo app
* `calypso_stats_mobile_cta_woo_google_click` — User clicks Google Play badge for Woo app

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this branch.
* Run `yarn workspace @automattic/components run storybook`.
* Visit the Mobile Promo Card entry.
* Click a few links and change views in Storybook to trigger the events.
* Wait 24 hours to confirm our events are being recorded correctly?!

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #70463.
