### PR TITLE
Fix the occasional flow loop from the dotlink version of Link in Bio flow.

### DIFF
--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -667,10 +667,12 @@ class Signup extends Component {
 
 		const midPoint = middleDestination ? middleDestination[ this.props.stepName ] : null;
 
-		if ( midPoint ) {
+		if ( midPoint && ! this.state.pendingMidpointTransition ) {
 			// save the resuming point and then navigate away.
-			this.setState( { resumingStep: nextStepName } );
-			page( midPoint( this.props.signupDependencies ) );
+			this.setState( {
+				resumingStep: nextStepName,
+				pendingMidpointTransition: midPoint( this.props.signupDependencies ),
+			} );
 			return;
 		}
 
@@ -858,6 +860,17 @@ class Signup extends Component {
 			( this.getPositionInFlow() > 0 && this.props.progress.length === 0 ) ||
 			this.state.resumingStep
 		) {
+			const { pendingMidpointTransition } = this.state;
+
+			if ( pendingMidpointTransition ) {
+				if (
+					this.props.progress[ 'domains-link-in-bio-tld' ]?.status === 'completed' ||
+					this.props.progress[ 'domains-link-in-bio-tld' ]?.status === 'pending'
+				) {
+					page( pendingMidpointTransition );
+				}
+			}
+
 			return null;
 		}
 

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -89,6 +89,7 @@ import {
 	getStepUrl,
 	isReskinnedFlow,
 	isP2Flow,
+	hasAllPreviousAndCurrentStepsCompleted,
 } from './utils';
 import WpcomLoginForm from './wpcom-login-form';
 import './style.scss';
@@ -862,13 +863,16 @@ class Signup extends Component {
 		) {
 			const { pendingMidpointTransition } = this.state;
 
-			if ( pendingMidpointTransition ) {
-				if (
-					this.props.progress[ 'domains-link-in-bio-tld' ]?.status === 'completed' ||
-					this.props.progress[ 'domains-link-in-bio-tld' ]?.status === 'pending'
-				) {
-					page( pendingMidpointTransition );
-				}
+			if (
+				pendingMidpointTransition &&
+				hasAllPreviousAndCurrentStepsCompleted(
+					this.props.flowName,
+					this.props.progress,
+					this.props.isLoggedIn,
+					this.props.stepName
+				)
+			) {
+				page( pendingMidpointTransition );
 			}
 
 			return null;

--- a/client/signup/utils.js
+++ b/client/signup/utils.js
@@ -143,6 +143,27 @@ export function getFirstInvalidStep( flowName, progress, isUserLoggedIn ) {
 	return find( getFilteredSteps( flowName, progress, isUserLoggedIn ), { status: 'invalid' } );
 }
 
+export function hasAllPreviousAndCurrentStepsCompleted(
+	flowName,
+	progress,
+	isUserLoggedIn,
+	currentStepName
+) {
+	// we don't use getFilteredSteps here since the order matters here.
+	const { steps: flowSteps } = flows.getFlow( flowName, isUserLoggedIn );
+	const currentStepIndex = flowSteps.indexOf( currentStepName );
+
+	for ( let stepIndex = 0; stepIndex <= currentStepIndex; ++stepIndex ) {
+		const progressStatus = progress[ flowSteps[ stepIndex ] ]?.status;
+
+		if ( progressStatus !== 'completed' && progressStatus !== 'pending' ) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
 export function getCompletedSteps( flowName, progress, options = {}, isUserLoggedIn ) {
 	// Option to check that the current `flowName` matches the `lastKnownFlow`.
 	// This is to ensure that when resuming progress, we only do so if


### PR DESCRIPTION
#### Proposed Changes

This PR is a simpler, anecdotal fix for the flow loop reported in p2-pdtkmj-Sc#comment-1393 experienced by @jordesign  and @semihakocer. 

The reason that sometimes the dotlink version of Link in Bio flow can stuck like this is because Calypso intentionally persists state on a periodical fashion instead of on every change. When transiting from /start/domain to /setup/pattern, if the domain step submission isn’t persisted, then the user will be redirected back to the domains step upon arrival of /start/plans latter, since the signup framework will consider the previous required step, i.e. the domains step, isn’t completed.

This PR addresses the issue by only performing the middle trainstion from `/start/link-in-bio-tld` to `/setup/link-in-bio` when all the steps before that transition has been successfully completed. I'm saying it's an "anecdotal" fix, because theoretically speaking I think this can still happen; just that by confirming that all the states has been updated to completion before navigating away makes it harder to happen. A stronger guarantee would be polling the IDB, but the cost of doing so would outweigh the benefit.

#### Testing Instructions

Going through `/start/link-in-bio-tld?tld=link` flow for multiple times. You can start by signing up a new account and then typing out the URL everytime you reach the launchpad. In production, I could reproduce the bug by doing in about 5~6 times. Once it is reproduced, trying out the whole flow many more times on the calypso.live instance of this PR to see if it's not reproducible.

From my testing, this bug can be reproduced locally, but somehow it's a lot harder. Using the calypso.live instance in this PR would be easier. 

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
