### PR TITLE
Stats: Add Mobile Apps promo card via DotPager UI, take 3

### DIFF
--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -9,6 +9,7 @@ import { parse as parseQs, stringify as stringifyQs } from 'qs';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import titlecase from 'to-title-case';
+import { MobilePromoCard } from 'calypso/../packages/components/src';
 import rocketImage from 'calypso/assets/images/customer-home/illustration--rocket.svg';
 import illustration404 from 'calypso/assets/images/illustrations/illustration-404.svg';
 import wordpressSeoIllustration from 'calypso/assets/images/illustrations/wordpress-seo-premium.svg';
@@ -21,6 +22,7 @@ import DocumentHead from 'calypso/components/data/document-head';
 import QueryJetpackModules from 'calypso/components/data/query-jetpack-modules';
 import QueryKeyringConnections from 'calypso/components/data/query-keyring-connections';
 import QuerySiteKeyrings from 'calypso/components/data/query-site-keyrings';
+import DotPager from 'calypso/components/dot-pager';
 import EmptyContent from 'calypso/components/empty-content';
 import FormattedHeader from 'calypso/components/formatted-header';
 import InlineSupportLink from 'calypso/components/inline-support-link';
@@ -38,6 +40,7 @@ import { activateModule } from 'calypso/state/jetpack/modules/actions';
 import getCurrentRouteParameterized from 'calypso/state/selectors/get-current-route-parameterized';
 import isJetpackModuleActive from 'calypso/state/selectors/is-jetpack-module-active';
 import isPrivateSite from 'calypso/state/selectors/is-private-site';
+import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import HighlightsSection from './highlights-section';
@@ -189,7 +192,10 @@ class StatsSite extends Component {
 	}
 
 	renderStats() {
-		const { date, siteId, slug, isJetpack, isSitePrivate, isOdysseyStats } = this.props;
+		const { date, siteId, slug, isAtomic, isJetpack, isSitePrivate, isOdysseyStats } = this.props;
+
+		// Yoast promo card is only shown on Atomic sites.
+		const isJetpackNonAtomic = isJetpack && ! isAtomic;
 
 		const queryDate = date.format( 'YYYY-MM-DD' );
 		const { period, endOf } = this.props.period;
@@ -368,20 +374,36 @@ class StatsSite extends Component {
 					</div>
 				</div>
 				{ /** Promo Card is disabled for Odyssey because it doesn't make much sense in the context, which also removes an API call to `plugins`. */ }
-				{ ! isOdysseyStats && (
-					<div className="stats-content-promo">
-						<PromoCardBlock
-							productSlug="wordpress-seo-premium"
-							impressionEvent="calypso_stats_wordpress_seo_premium_banner_view"
-							clickEvent="calypso_stats_wordpress_seo_premium_banner_click"
-							headerText={ translate( 'Increase site visitors with Yoast SEO Premium' ) }
-							contentText={ translate(
-								'Purchase Yoast SEO Premium to ensure that more people find your incredible content.'
-							) }
-							ctaText={ translate( 'Learn more' ) }
-							image={ wordpressSeoIllustration }
-							href={ `/plugins/wordpress-seo-premium/${ slug }` }
-						/>
+				{ ! isOdysseyStats && isJetpackNonAtomic && (
+					<div className="stats__promo-container">
+						<div className="stats__promo-card">
+							<MobilePromoCard className="stats__promo-card-apps" />
+						</div>
+					</div>
+				) }
+				{ ! isJetpackNonAtomic && (
+					<div className="stats__promo-container">
+						<div className="stats__promo-card">
+							<DotPager className="stats__promo-pager">
+								<div>
+									<PromoCardBlock
+										productSlug="wordpress-seo-premium"
+										impressionEvent="calypso_stats_wordpress_seo_premium_banner_view"
+										clickEvent="calypso_stats_wordpress_seo_premium_banner_click"
+										headerText={ translate( 'Increase site visitors with Yoast SEO Premium' ) }
+										contentText={ translate(
+											'Purchase Yoast SEO Premium to ensure that more people find your incredible content.'
+										) }
+										ctaText={ translate( 'Learn more' ) }
+										image={ wordpressSeoIllustration }
+										href={ `/plugins/wordpress-seo-premium/${ slug }` }
+									/>
+								</div>
+								<div>
+									<MobilePromoCard className="stats__promo-card-apps" />
+								</div>
+							</DotPager>
+						</div>
 					</div>
 				) }
 				<JetpackColophon />
@@ -462,6 +484,7 @@ export default connect(
 			isJetpack &&
 			isJetpackModuleActive( state, siteId, 'stats' ) === false;
 		return {
+			isAtomic: isAtomicSite( state, siteId ),
 			isJetpack,
 			isSitePrivate: isPrivateSite( state, siteId ),
 			siteId,

--- a/client/my-sites/stats/style.scss
+++ b/client/my-sites/stats/style.scss
@@ -231,4 +231,35 @@
 	background: var(--studio-white);
 }
 
+.stats__promo-container {
+	margin-bottom: 20px;
+}
+
+.stats__promo-card {
+	background-color: var(--studio-white);
+	border: 1px solid var(--studio-gray-5);
+	border-radius: 5px; /* stylelint-disable-line scales/radii */
+
+	@media ( max-width: 782px ) {
+		border-radius: 0;
+		border-left: none;
+		border-right: none;
+	}
+}
+
+.stats__promo-pager {
+	// Overrides Yoast banner styles.
+	.dot-pager__controls {
+		margin: 16px 16px 0;
+	}
+	.card {
+		box-shadow: none;
+	}
+}
+
+.stats__promo-card-apps {
+	// Overrides Mobile Apps banner styles.
+	border: none;
+}
+
 @import "calypso/my-sites/stats/grid-layout.scss";


### PR DESCRIPTION
#### Proposed Changes

Adds the Jetpack mobile apps promo card alongside the Yoast SEO one using the `DotPager` component. The Yoast card is still the default.

Before:

![APromoSEO](https://user-images.githubusercontent.com/40267301/202101081-db395e83-8d1a-4208-8bc1-8654833efe99.png)

After:

![NewPromoCards](https://user-images.githubusercontent.com/40267301/203266516-9b427729-7a0b-437f-9bd6-3b22ecbed058.png)

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Visit the Calypso Live link.
2. Visit the Stats page.
3. Scroll down and confirm the `DotPager` card is present.
4. Confirm the Yoast SEO card is the default. 
5. Confirm the mobile apps card is available on the 2nd page.
6. Confirm it behaves appropriately on smaller screen sizes.
7. Test on a self-hosted Jetpack site and confirm the Yoast card and the `DotPager` UI are not used. Only the Jetpack mobile apps CTA should be shown.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #69230 and supersedes #70463.

Currently just updating the Stats page. The designs call for the same promo card on the Insights and Ads pages but it looks overpowering there with the older page layout. I'm thinking we should wait until we "grid" those layouts before adding this component in.