### PR TITLE
Pattern Assembler - In tracks events, change bcpa to pattern_assembler

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -48,7 +48,7 @@ const PatternAssembler: Step = ( { navigation } ) => {
 		[ header, ...sections, footer ].filter( ( pattern ) => pattern ) as Pattern[];
 
 	const trackEventPatternAdd = ( patternType: string ) => {
-		recordTracksEvent( 'calypso_signup_bcpa_pattern_add_click', {
+		recordTracksEvent( 'calypso_signup_pattern_assembler_pattern_add_click', {
 			pattern_type: patternType,
 		} );
 	};
@@ -60,7 +60,7 @@ const PatternAssembler: Step = ( { navigation } ) => {
 		patternType: string;
 		patternId: number;
 	} ) => {
-		recordTracksEvent( 'calypso_signup_bcpa_pattern_select_click', {
+		recordTracksEvent( 'calypso_signup_pattern_assembler_pattern_select_click', {
 			pattern_type: patternType,
 			pattern_id: patternId,
 		} );
@@ -68,13 +68,13 @@ const PatternAssembler: Step = ( { navigation } ) => {
 
 	const trackEventContinue = () => {
 		const patterns = getPatterns();
-		recordTracksEvent( 'calypso_signup_bcpa_continue_click', {
+		recordTracksEvent( 'calypso_signup_pattern_assembler_continue_click', {
 			pattern_ids: patterns.map( ( { id } ) => id ).join( ',' ),
 			pattern_names: patterns.map( ( { name } ) => name ).join( ',' ),
 			pattern_count: patterns.length,
 		} );
 		patterns.forEach( ( { id, name } ) => {
-			recordTracksEvent( 'calypso_signup_bcpa_pattern_final_select', {
+			recordTracksEvent( 'calypso_signup_pattern_assembler_pattern_final_select', {
 				pattern_id: id,
 				pattern_name: name,
 			} );
@@ -171,7 +171,7 @@ const PatternAssembler: Step = ( { navigation } ) => {
 
 	const onBack = () => {
 		const patterns = getPatterns();
-		recordTracksEvent( 'calypso_signup_bcpa_back_click', {
+		recordTracksEvent( 'calypso_signup_pattern_assembler_back_click', {
 			has_selected_patterns: patterns.length > 0,
 			pattern_count: patterns.length,
 		} );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-action-bar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-action-bar.tsx
@@ -39,7 +39,7 @@ const PatternActionBar = ( {
 						role="menuitem"
 						label={ translate( 'Move up' ) }
 						onClick={ () => {
-							recordTracksEvent( 'calypso_signup_bcpa_pattern_moveup_click' );
+							recordTracksEvent( 'calypso_signup_pattern_assembler_pattern_moveup_click' );
 							onMoveUp?.();
 						} }
 						icon={ chevronUp }
@@ -51,7 +51,7 @@ const PatternActionBar = ( {
 						role="menuitem"
 						label={ translate( 'Move down' ) }
 						onClick={ () => {
-							recordTracksEvent( 'calypso_signup_bcpa_pattern_movedown_click' );
+							recordTracksEvent( 'calypso_signup_pattern_assembler_pattern_movedown_click' );
 							onMoveDown?.();
 						} }
 						icon={ chevronDown }
@@ -64,7 +64,7 @@ const PatternActionBar = ( {
 				role="menuitem"
 				label={ translate( 'Replace' ) }
 				onClick={ () => {
-					recordTracksEvent( 'calypso_signup_bcpa_pattern_replace_click', {
+					recordTracksEvent( 'calypso_signup_pattern_assembler_pattern_replace_click', {
 						pattern_type: patternType,
 					} );
 					onReplace();
@@ -77,7 +77,7 @@ const PatternActionBar = ( {
 				role="menuitem"
 				label={ translate( 'Delete' ) }
 				onClick={ () => {
-					recordTracksEvent( 'calypso_signup_bcpa_pattern_delete_click', {
+					recordTracksEvent( 'calypso_signup_pattern_assembler_pattern_delete_click', {
 						pattern_type: patternType,
 					} );
 					onDelete();

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-assembler-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-assembler-preview.tsx
@@ -105,7 +105,7 @@ const PatternAssemblerPreview = ( { header, sections = [], footer, scrollToSelec
 				recordTracksEvent={ recordTracksEvent }
 				scrollToSelector={ scrollToSelector }
 				onDeviceUpdate={ ( device: string ) => {
-					recordTracksEvent( 'calypso_signup_bcpa_preview_device_click', { device } );
+					recordTracksEvent( 'calypso_signup_pattern_assembler_preview_device_click', { device } );
 				} }
 			/>
 		</div>


### PR DESCRIPTION
#### Proposed Changes

* Rename events to use `pattern_assembler` rather than `bcpa`

Follow-up tasks:

- [x] Update event registration in tracks
- [x] Update the event names in the initial [PR](https://github.com/Automattic/wp-calypso/pull/68507) because it's used as documentation.
- [x] https://github.com/Automattic/dotcom-forge/issues/1348

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Review the text replacement.
* Access the pattern assembler on `/setup?siteSlug=[ YOUR SITE ]&flags=signup/design-picker-pattern-assembler`
* Confirm that the PA flow still works as expected


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [X] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [X] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [X] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [X] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [X] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/1378 https://github.com/Automattic/wp-calypso/pull/68507
