### PR TITLE
Themes: Show a get started button for logged out users on empty searches

### DIFF
--- a/client/components/themes-list/index.jsx
+++ b/client/components/themes-list/index.jsx
@@ -10,6 +10,7 @@ import proThemesBanner from 'calypso/assets/images/themes/pro-themes-banner.svg'
 import EmptyContent from 'calypso/components/empty-content';
 import InfiniteScroll from 'calypso/components/infinite-scroll';
 import Theme from 'calypso/components/theme';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { upsellCardDisplayed as upsellCardDisplayedAction } from 'calypso/state/themes/actions';
 import { DEFAULT_THEME_QUERY } from 'calypso/state/themes/constants';
@@ -225,16 +226,30 @@ function WPOrgMatchingThemes( props ) {
 }
 
 function PlanUpgradeCTA( { selectedSite, searchTerm, translate, recordTracksEvent } ) {
+	const isLoggedIn = useSelector( isUserLoggedIn );
+
 	const onUpgradeClick = useCallback( () => {
 		recordTracksEvent( 'calypso_themeshowcase_search_empty_results_upgrade_plan', {
 			site_plan: selectedSite?.plan?.product_slug,
 			search_term: searchTerm,
 		} );
 
+		if ( ! selectedSite?.slug ) {
+			return page( `/checkout/${ PLAN_BUSINESS }?redirect_to=/themes` );
+		}
+
 		return page(
 			`/checkout/${ selectedSite.slug }/${ PLAN_BUSINESS }?redirect_to=/themes/${ selectedSite.slug }`
 		);
-	}, [ selectedSite, searchTerm ] );
+	}, [ selectedSite, searchTerm, recordTracksEvent ] );
+
+	const onGetStartedClick = useCallback( () => {
+		recordTracksEvent( 'calypso_themeshowcase_search_empty_results_get_started', {
+			search_term: searchTerm,
+		} );
+
+		return page( `/start/business` );
+	}, [ searchTerm, recordTracksEvent ] );
 
 	return (
 		<div className="themes-list__upgrade-section-wrapper">
@@ -247,9 +262,15 @@ function PlanUpgradeCTA( { selectedSite, searchTerm, translate, recordTracksEven
 				) }
 			</div>
 
-			<Button primary className="themes-list__upgrade-section-cta" onClick={ onUpgradeClick }>
-				{ translate( 'Upgrade your plan' ) }
-			</Button>
+			{ isLoggedIn ? (
+				<Button primary className="themes-list__upgrade-section-cta" onClick={ onUpgradeClick }>
+					{ translate( 'Upgrade your plan' ) }
+				</Button>
+			) : (
+				<Button primary className="themes-list__upgrade-section-cta" onClick={ onGetStartedClick }>
+					{ translate( 'Get started' ) }
+				</Button>
+			) }
 
 			<div className="themes-list__themes-images">
 				<img


### PR DESCRIPTION
#### Proposed Changes

Show a get started button for logged-out users on empty searches. For logged-out users, an upgrade plan button is shown.

#### Testing Instructions
* Go to `/themes` on an incognito window.
* Search for a non-existent theme on .com as `abc` or `astra`
* You should see a card with a CTA stating `Get started`
* Click on the CTA and you should be redirected to `/start/business/user`
* Check if this track event is being logged `calypso_themeshowcase_search_empty_results_get_started`

<img width="1450" alt="Screen Shot 2022-12-13 at 09 50 10" src="https://user-images.githubusercontent.com/5039531/207287251-4a20f649-c196-4d39-9a19-c01ecaf5f822.png">

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #71076
