### PR TITLE
Pattern Assembler - Remove empty main group block when no sections are added

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/utils.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/utils.ts
@@ -47,7 +47,7 @@ export function createCustomHomeTemplateContent(
 		);
 	}
 
-	if ( hasHeader || hasFooter || hasSections ) {
+	if ( hasSections ) {
 		content.push( `
 	<!-- wp:group {"tagName":"main"} -->
 		<main class="wp-block-group">


### PR DESCRIPTION
#### Proposed Changes

* Only add the main group block if sections are added

This change removes the empty main block from the template when no sections are added because it is only required for the headstart process when sections are added in the pattern assembler.

### Why?
Because now the editor shows a placeholder to select a layout, which is not expected.

**Here is the empty block group in the editor**

<img width="616" alt="Screen Shot 2565-12-13 at 16 17 54" src="https://user-images.githubusercontent.com/1881481/207283865-c316ed28-9415-4222-98c3-7234cc79d16d.png">

**Here is in the code view:**

<img width="1075" alt="Screen Shot 2565-12-13 at 16 17 21" src="https://user-images.githubusercontent.com/1881481/207283990-0144f4c0-7aec-4c6b-95a6-f3026f503b09.png">

**Here is in the list view:**

<img width="352" alt="Screen Shot 2565-12-13 at 16 17 33" src="https://user-images.githubusercontent.com/1881481/207283957-c829bde1-d3a2-4f7e-85ec-c575d8a8db81.png">


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Access `/setup?siteSlug=[ YOUR SITE ]`
* Don't select any goal or vertical
* Scroll down to click on `Start designing` in the section `Design your own`
* Add a header only
* Click on `Continue`
* Check that the template doesn't have a main group block
* Check that the editor and the site preview show the header that you selected


https://user-images.githubusercontent.com/1881481/207290098-0a57e7fc-0da9-48d6-8dfa-9508ceee3673.mov


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [X] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [X] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [X] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [X] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [X] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/70684
