### PR TITLE
Users management: Team, combine team members and invite blocks

### DIFF
--- a/client/my-sites/people/invite-people/index.jsx
+++ b/client/my-sites/people/invite-people/index.jsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { Card, Button } from '@automattic/components';
 import debugModule from 'debug';
 import { localize } from 'i18n-calypso';
@@ -375,7 +376,11 @@ class InvitePeople extends Component {
 
 	goBack = () => {
 		const siteSlug = get( this.props, 'site.slug' );
-		const fallback = siteSlug ? '/people/team/' + siteSlug : '/people/team';
+		let fallback = siteSlug ? '/people/team/' + siteSlug : '/people/team';
+
+		if ( isEnabled( 'user-management-revamp' ) ) {
+			fallback = '/people/team-members/' + siteSlug;
+		}
 
 		// Go back to last route with /people/team/$site as the fallback
 		page.back( fallback );

--- a/client/my-sites/people/subscribers-team/index.tsx
+++ b/client/my-sites/people/subscribers-team/index.tsx
@@ -8,6 +8,8 @@ import useUsersQuery from 'calypso/data/users/use-users-query';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import PeopleSectionNavCompact from '../people-section-nav-compact';
 import Subscribers from '../subscribers';
+import TeamInvites from '../team-invites';
+import TeamMembers from '../team-members';
 import type { FollowersQuery } from '../subscribers/types';
 import type { UsersQuery } from '../team-members/types';
 
@@ -22,10 +24,13 @@ function SubscribersTeam( props: Props ) {
 
 	// fetching data config
 	const followersFetchOptions = { search };
-	const teamFetchOptions = {
-		...followersFetchOptions,
-		search_columns: [ 'display_name', 'user_login' ],
-	};
+	const teamFetchOptions = search
+		? {
+				search: `*${ search }*`,
+				search_columns: [ 'display_name', 'user_login' ],
+		  }
+		: {};
+
 	const followersQuery = useFollowersQuery(
 		site?.ID,
 		'all',
@@ -66,6 +71,14 @@ function SubscribersTeam( props: Props ) {
 									search={ search }
 									followersQuery={ followersQuery }
 								/>
+							);
+
+						case 'team-members':
+							return (
+								<>
+									<TeamMembers search={ search } usersQuery={ usersQuery } />
+									<TeamInvites />
+								</>
 							);
 					}
 				} )() }

--- a/client/my-sites/people/team-invites/index.tsx
+++ b/client/my-sites/people/team-invites/index.tsx
@@ -1,0 +1,52 @@
+import { Card } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import { useSelector } from 'react-redux';
+import QuerySiteInvites from 'calypso/components/data/query-site-invites';
+import PeopleListItem from 'calypso/my-sites/people/people-list-item';
+import { getPendingInvitesForSite } from 'calypso/state/invites/selectors';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
+import PeopleListSectionHeader from '../people-list-section-header';
+import type { Invite } from './types';
+
+import './style.scss';
+
+function TeamInvites() {
+	const _ = useTranslate();
+	const site = useSelector( ( state ) => getSelectedSite( state ) );
+	const siteId = site?.ID as number;
+	const pendingInvites = useSelector( ( state ) => getPendingInvitesForSite( state, siteId ) );
+
+	function renderInvite( invite: Invite ) {
+		const user = invite.user;
+
+		return (
+			<PeopleListItem
+				key={ invite.key }
+				invite={ invite }
+				user={ user }
+				site={ site }
+				type="invite"
+				isSelectable={ false }
+			/>
+		);
+	}
+
+	return (
+		<>
+			<QuerySiteInvites siteId={ siteId } />
+			<PeopleListSectionHeader
+				label={ _(
+					'You have a pending invite for %(number)d user',
+					'You have a pending invite for %(number)d users',
+					{
+						args: { number: pendingInvites?.length },
+						count: pendingInvites?.length as number,
+					}
+				) }
+			/>
+			<Card className="people-team-invites-list">{ pendingInvites?.map( renderInvite ) }</Card>
+		</>
+	);
+}
+
+export default TeamInvites;

--- a/client/my-sites/people/team-invites/style.scss
+++ b/client/my-sites/people/team-invites/style.scss
@@ -1,0 +1,3 @@
+.people-team-invites-list {
+	padding: 0;
+}

--- a/client/my-sites/people/team-invites/types.ts
+++ b/client/my-sites/people/team-invites/types.ts
@@ -1,0 +1,11 @@
+import { UserData as User } from 'calypso/lib/user/user';
+
+export type Invite = {
+	key: string;
+	user: User;
+	role: string;
+	isPending: boolean;
+	invitedBy: User;
+	inviteDate: string;
+	acceptedDate?: string;
+};

--- a/client/my-sites/people/team-members/index.tsx
+++ b/client/my-sites/people/team-members/index.tsx
@@ -21,7 +21,7 @@ function TeamMembers( props: Props ) {
 	const site = useSelector( ( state ) => getSelectedSite( state ) );
 
 	const listKey = [ 'team-members', site?.ID, search ].join( '-' );
-	const { data, fetchNextPage, isFetchingNextPage, hasNextPage } = usersQuery;
+	const { data, fetchNextPage, isLoading, isFetchingNextPage, hasNextPage } = usersQuery;
 
 	const members = data?.users || [];
 	const membersTotal = data?.total;
@@ -58,8 +58,9 @@ function TeamMembers( props: Props ) {
 	}
 
 	let templateState;
-
-	if ( search && ! membersTotal ) {
+	if ( isLoading ) {
+		templateState = 'loading';
+	} else if ( search && ! membersTotal ) {
 		templateState = 'no-result';
 	} else if ( ! membersTotal ) {
 		templateState = 'empty';
@@ -69,14 +70,16 @@ function TeamMembers( props: Props ) {
 
 	switch ( templateState ) {
 		case 'default':
+		case 'loading':
 			return (
 				<>
-					<PeopleListSectionHeader label={ getHeaderLabel() }>
+					<PeopleListSectionHeader isPlaceholder={ isLoading } label={ getHeaderLabel() }>
 						<Button compact primary href={ addTeamMemberLink }>
 							{ _( 'Add a team member' ) }
 						</Button>
 					</PeopleListSectionHeader>
 					<Card className="people-team-members-list">
+						{ isLoading && renderLoadingPeople() }
 						<InfiniteList
 							listkey={ listKey }
 							items={ members }

--- a/client/my-sites/people/team-members/index.tsx
+++ b/client/my-sites/people/team-members/index.tsx
@@ -1,34 +1,111 @@
+import { Card, Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import FormattedHeader from 'calypso/components/formatted-header';
-import Main from 'calypso/components/main';
-import SectionNav from 'calypso/components/section-nav';
-import PeopleSectionNavCompact from '../people-section-nav-compact';
+import { useSelector } from 'react-redux';
+import InfiniteList from 'calypso/components/infinite-list';
+import { UserData as User } from 'calypso/lib/user/user';
+import NoResults from 'calypso/my-sites/no-results';
+import PeopleListItem from 'calypso/my-sites/people/people-list-item';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
+import PeopleListSectionHeader from '../people-list-section-header';
+import type { UsersQuery } from './types';
+
+import './style.scss';
 
 interface Props {
-	filter: string;
 	search?: string;
+	usersQuery: UsersQuery;
 }
 function TeamMembers( props: Props ) {
 	const _ = useTranslate();
-	const { filter, search } = props;
+	const { search, usersQuery } = props;
+	const site = useSelector( ( state ) => getSelectedSite( state ) );
 
-	return (
-		<Main>
-			<FormattedHeader
-				brandFont
-				className="people__page-heading"
-				headerText={ _( 'Users' ) }
-				subHeaderText={ _( 'People who have subscribed to your site and team members.' ) }
-				align="left"
-				hasScreenOptions
-			/>
-			<div>
-				<SectionNav>
-					<PeopleSectionNavCompact selectedFilter={ filter } searchTerm={ search } />
-				</SectionNav>
-			</div>
-		</Main>
-	);
+	const listKey = [ 'team-members', site?.ID, search ].join( '-' );
+	const { data, fetchNextPage, isFetchingNextPage, hasNextPage } = usersQuery;
+
+	const members = data?.users || [];
+	const membersTotal = data?.total;
+
+	const addTeamMemberLink = `/people/new/${ site?.slug }`;
+
+	function getPersonRef( user: User ) {
+		return 'user-' + user?.ID;
+	}
+
+	function getHeaderLabel() {
+		const options = {
+			args: { number: membersTotal, searchTerm: search },
+			count: membersTotal as number,
+		};
+
+		if ( search && membersTotal ) {
+			return _(
+				'%(number)d Person Matching {{em}}"%(searchTerm)s"{{/em}}',
+				'%(number)d People Matching {{em}}"%(searchTerm)s"{{/em}}',
+				{ ...options, components: { em: <em /> } }
+			);
+		}
+
+		return _( 'You have %(number)d team member', 'You have %(number)d team members', options );
+	}
+
+	function renderPerson( user: User ) {
+		return <PeopleListItem key={ user?.ID } user={ user } site={ site } type="email" />;
+	}
+
+	function renderLoadingPeople() {
+		return <PeopleListItem key="people-list-item-placeholder" />;
+	}
+
+	let templateState;
+
+	if ( search && ! membersTotal ) {
+		templateState = 'no-result';
+	} else if ( ! membersTotal ) {
+		templateState = 'empty';
+	} else {
+		templateState = 'default';
+	}
+
+	switch ( templateState ) {
+		case 'default':
+			return (
+				<>
+					<PeopleListSectionHeader label={ getHeaderLabel() }>
+						<Button compact primary href={ addTeamMemberLink }>
+							{ _( 'Add a team member' ) }
+						</Button>
+					</PeopleListSectionHeader>
+					<Card className="people-team-members-list">
+						<InfiniteList
+							listkey={ listKey }
+							items={ members }
+							fetchNextPage={ fetchNextPage }
+							fetchingNextPage={ isFetchingNextPage }
+							lastPage={ ! hasNextPage }
+							renderItem={ renderPerson }
+							renderLoadingPlaceholders={ renderLoadingPeople }
+							guessedItemHeight={ 126 }
+							getItemRef={ getPersonRef }
+						/>
+					</Card>
+				</>
+			);
+
+		case 'no-result':
+			return (
+				<Card>
+					<NoResults
+						image="/calypso/images/people/mystery-person.svg"
+						text={ _( 'No results found for {{em}}%(searchTerm)s{{/em}}', {
+							args: { searchTerm: search },
+							components: { em: <em /> },
+						} ) }
+					/>
+				</Card>
+			);
+	}
+	return null;
 }
 
 export default TeamMembers;

--- a/client/my-sites/people/team-members/style.scss
+++ b/client/my-sites/people/team-members/style.scss
@@ -1,0 +1,3 @@
+.people-team-members-list {
+	padding: 0;
+}

--- a/client/my-sites/people/team-members/types.ts
+++ b/client/my-sites/people/team-members/types.ts
@@ -10,5 +10,6 @@ export type UsersQuery = {
 	hasNextPage: boolean;
 	refetch: () => void;
 	fetchNextPage: () => void;
+	isLoading: boolean;
 	isFetchingNextPage: boolean;
 };

--- a/client/my-sites/people/team-members/types.ts
+++ b/client/my-sites/people/team-members/types.ts
@@ -1,4 +1,4 @@
-import User from 'calypso/components/user';
+import { UserData as User } from 'calypso/lib/user/user';
 
 export type UsersQueryData = {
 	users: User[];
@@ -7,7 +7,8 @@ export type UsersQueryData = {
 
 export type UsersQuery = {
 	data?: UsersQueryData;
+	hasNextPage: boolean;
+	refetch: () => void;
 	fetchNextPage: () => void;
 	isFetchingNextPage: boolean;
-	hasNextPage: boolean;
 };


### PR DESCRIPTION
#### Proposed Changes

* Adapted the Team tab, unifying team members and inviting block
* Integrate the Team block in SubscribersTeam component

Out of scope (will be done in the following PRs):

- List item component adjustments
- Invite form adjustments

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/people/team-members/{USER_SLUG}`
* Check the `Add team member` functionality
* Check the team member filtering feature
* Check pending invites block

#### Screenshot
![Markup on 2022-12-14 at 12:45:39](https://user-images.githubusercontent.com/1241413/207586978-6809cd59-4ad8-47d0-9d5d-2d777c7e1cbd.png)

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #70696
