### PR TITLE
Add: navigator.globalprivacycontrol as an opt-out indicator in CCPA regions

### DIFF
--- a/client/lib/analytics/test/gpc-opt-out.js
+++ b/client/lib/analytics/test/gpc-opt-out.js
@@ -1,7 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import { mayWeTrackUserGpcInCCPARegion } from '../utils';
+import { mayWeTrackUserGpcInCcpaRegion } from '../utils';
 import isRegionInCcpaZone from '../utils/is-region-in-ccpa-zone';
 
 // Return a predictable value for whether the user is in a CCPA region.
@@ -10,7 +10,7 @@ jest.mock( '../utils/is-region-in-ccpa-zone' );
 let windowSpy = jest.SpyInstance;
 
 // Return a predictable value for window.navigator.globalPrivacyControl.
-const setMockGPCValue = ( gpcValue ) => {
+const setMockGpcValue = ( gpcValue ) => {
 	windowSpy.mockImplementation( () => ( {
 		navigator: {
 			globalPrivacyControl: gpcValue,
@@ -27,40 +27,40 @@ describe( 'global privacy control', () => {
 		windowSpy.mockRestore();
 	} );
 
-	describe( 'mayWeTrackUserGpcInCCPARegion', () => {
+	describe( 'mayWeTrackUserGpcInCcpaRegion', () => {
 		test( 'we may track a user in CCPA if GPC is not set', () => {
-			setMockGPCValue( undefined );
+			setMockGpcValue( undefined );
 			isRegionInCcpaZone.mockReturnValue( true );
 
-			expect( mayWeTrackUserGpcInCCPARegion() ).toBe( true );
+			expect( mayWeTrackUserGpcInCcpaRegion() ).toBe( true );
 		} );
 
 		test( 'we may track a user in CCPA if GPC is set to false', () => {
-			setMockGPCValue( false );
+			setMockGpcValue( false );
 			isRegionInCcpaZone.mockReturnValue( true );
 
-			expect( mayWeTrackUserGpcInCCPARegion() ).toBe( true );
+			expect( mayWeTrackUserGpcInCcpaRegion() ).toBe( true );
 		} );
 
 		test( 'we may not track a user in CCPA if GPC is set', () => {
-			setMockGPCValue( true );
+			setMockGpcValue( true );
 			isRegionInCcpaZone.mockReturnValue( true );
 
-			expect( mayWeTrackUserGpcInCCPARegion() ).toBe( false );
+			expect( mayWeTrackUserGpcInCcpaRegion() ).toBe( false );
 		} );
 
 		test( 'we may track a user outside CCPA if GPC is set', () => {
-			setMockGPCValue( true );
+			setMockGpcValue( true );
 			isRegionInCcpaZone.mockReturnValue( false );
 
-			expect( mayWeTrackUserGpcInCCPARegion() ).toBe( true );
+			expect( mayWeTrackUserGpcInCcpaRegion() ).toBe( true );
 		} );
 
 		test( 'we may track a user outside CCPA if GPC is undefined', () => {
-			setMockGPCValue( undefined );
+			setMockGpcValue( undefined );
 			isRegionInCcpaZone.mockReturnValue( false );
 
-			expect( mayWeTrackUserGpcInCCPARegion() ).toBe( true );
+			expect( mayWeTrackUserGpcInCcpaRegion() ).toBe( true );
 		} );
 	} );
 } );

--- a/client/lib/analytics/test/gpc-opt-out.js
+++ b/client/lib/analytics/test/gpc-opt-out.js
@@ -1,0 +1,83 @@
+/**
+ * @jest-environment jsdom
+ */
+import { mayWeTrackUserGpcInCCPARegion, isGpcFlagSetOptOut } from '../utils';
+import isRegionInCcpaZone from '../utils/is-region-in-ccpa-zone';
+
+// Return a predictable value for whether the user is in a CCPA region.
+jest.mock( '../utils/is-region-in-ccpa-zone' );
+
+let windowSpy = jest.SpyInstance;
+
+// Return a predictable value for window.navigator.globalPrivacyControl.
+const setMockGPCValue = ( gpcValue ) => {
+	windowSpy.mockImplementation( () => ( {
+		navigator: {
+			globalPrivacyControl: gpcValue,
+		},
+	} ) );
+};
+
+describe( 'global privacy control', () => {
+	beforeEach( () => {
+		windowSpy = jest.spyOn( global, 'window', 'get' );
+	} );
+
+	afterEach( () => {
+		windowSpy.mockRestore();
+	} );
+
+	describe( 'mayWeTrackUserGpcInCCPARegion', () => {
+		test( 'we may track a user in CCPA if GPC is not set', () => {
+			setMockGPCValue( undefined );
+			isRegionInCcpaZone.mockReturnValue( true );
+
+			expect( mayWeTrackUserGpcInCCPARegion() ).toBe( true );
+		} );
+
+		test( 'we may track a user in CCPA if GPC is set to false', () => {
+			setMockGPCValue( false );
+			isRegionInCcpaZone.mockReturnValue( true );
+
+			expect( mayWeTrackUserGpcInCCPARegion() ).toBe( true );
+		} );
+
+		test( 'we may not track a user in CCPA if GPC is set', () => {
+			setMockGPCValue( true );
+			isRegionInCcpaZone.mockReturnValue( true );
+
+			expect( mayWeTrackUserGpcInCCPARegion() ).toBe( false );
+		} );
+
+		test( 'we may track a user outside CCPA if GPC is set', () => {
+			setMockGPCValue( true );
+			isRegionInCcpaZone.mockReturnValue( false );
+
+			expect( mayWeTrackUserGpcInCCPARegion() ).toBe( true );
+		} );
+
+		test( 'we may track a user outside CCPA if GPC is undefined', () => {
+			setMockGPCValue( undefined );
+			isRegionInCcpaZone.mockReturnValue( false );
+
+			expect( mayWeTrackUserGpcInCCPARegion() ).toBe( true );
+		} );
+	} );
+
+	describe( 'isGpcFlagSetOptOut', () => {
+		test( 'if GPC is set to true in browser, return true', () => {
+			setMockGPCValue( true );
+			expect( mayWeTrackUserGpcInCCPARegion() ).toBe( true );
+		} );
+
+		test( 'if GPC is set to false in browser, return false', () => {
+			setMockGPCValue( false );
+			expect( isGpcFlagSetOptOut() ).toBe( false );
+		} );
+
+		test( 'if GPC is undefined in browser, return false', () => {
+			setMockGPCValue( undefined );
+			expect( isGpcFlagSetOptOut() ).toBe( false );
+		} );
+	} );
+} );

--- a/client/lib/analytics/test/gpc-opt-out.js
+++ b/client/lib/analytics/test/gpc-opt-out.js
@@ -1,7 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import { mayWeTrackUserGpcInCCPARegion, isGpcFlagSetOptOut } from '../utils';
+import { mayWeTrackUserGpcInCCPARegion } from '../utils';
 import isRegionInCcpaZone from '../utils/is-region-in-ccpa-zone';
 
 // Return a predictable value for whether the user is in a CCPA region.
@@ -61,23 +61,6 @@ describe( 'global privacy control', () => {
 			isRegionInCcpaZone.mockReturnValue( false );
 
 			expect( mayWeTrackUserGpcInCCPARegion() ).toBe( true );
-		} );
-	} );
-
-	describe( 'isGpcFlagSetOptOut', () => {
-		test( 'if GPC is set to true in browser, return true', () => {
-			setMockGPCValue( true );
-			expect( mayWeTrackUserGpcInCCPARegion() ).toBe( true );
-		} );
-
-		test( 'if GPC is set to false in browser, return false', () => {
-			setMockGPCValue( false );
-			expect( isGpcFlagSetOptOut() ).toBe( false );
-		} );
-
-		test( 'if GPC is undefined in browser, return false', () => {
-			setMockGPCValue( undefined );
-			expect( isGpcFlagSetOptOut() ).toBe( false );
 		} );
 	} );
 } );

--- a/client/lib/analytics/tracker-buckets.ts
+++ b/client/lib/analytics/tracker-buckets.ts
@@ -4,6 +4,7 @@ import {
 	isPiiUrl,
 	isUrlExcludedForPerformance,
 	getTrackingPrefs,
+	mayWeTrackUserGpcInCCPARegion,
 } from 'calypso/lib/analytics/utils';
 import { isE2ETest } from 'calypso/lib/e2e';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
@@ -105,6 +106,11 @@ export const mayWeTrackByBucket = ( bucket: Bucket ) => {
 
 	// Disable advertising trackers on specific urls
 	if ( Bucket.ADVERTISING === bucket && isUrlExcludedForPerformance() ) {
+		return false;
+	}
+
+	// Disable advertising trackers if GPC browser flag is set, and the user location pertains to CCPA.
+	if ( Bucket.ADVERTISING && mayWeTrackUserGpcInCCPARegion() ) {
 		return false;
 	}
 

--- a/client/lib/analytics/tracker-buckets.ts
+++ b/client/lib/analytics/tracker-buckets.ts
@@ -104,14 +104,15 @@ export const mayWeTrackByBucket = ( bucket: Bucket ) => {
 		return false;
 	}
 
-	// Disable advertising trackers on specific urls
-	if ( Bucket.ADVERTISING === bucket && isUrlExcludedForPerformance() ) {
-		return false;
-	}
-
-	// Disable advertising trackers if GPC browser flag is set, and the user location pertains to CCPA.
-	if ( Bucket.ADVERTISING && mayWeTrackUserGpcInCCPARegion() ) {
-		return false;
+	if ( Bucket.ADVERTISING === bucket ) {
+		// Disable advertising trackers on specific urls
+		if ( isUrlExcludedForPerformance() ) {
+			return false;
+		}
+		// Disable advertising trackers if GPC browser flag is set, and the user location pertains to CCPA.
+		if ( ! mayWeTrackUserGpcInCCPARegion() ) {
+			return false;
+		}
 	}
 
 	const prefs = getTrackingPrefs();

--- a/client/lib/analytics/tracker-buckets.ts
+++ b/client/lib/analytics/tracker-buckets.ts
@@ -4,7 +4,7 @@ import {
 	isPiiUrl,
 	isUrlExcludedForPerformance,
 	getTrackingPrefs,
-	mayWeTrackUserGpcInCCPARegion,
+	mayWeTrackUserGpcInCcpaRegion,
 } from 'calypso/lib/analytics/utils';
 import { isE2ETest } from 'calypso/lib/e2e';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
@@ -110,7 +110,7 @@ export const mayWeTrackByBucket = ( bucket: Bucket ) => {
 			return false;
 		}
 		// Disable advertising trackers if GPC browser flag is set, and the user location pertains to CCPA.
-		if ( ! mayWeTrackUserGpcInCCPARegion() ) {
+		if ( ! mayWeTrackUserGpcInCcpaRegion() ) {
 			return false;
 		}
 	}

--- a/client/lib/analytics/utils/index.ts
+++ b/client/lib/analytics/utils/index.ts
@@ -13,7 +13,7 @@ export { default as shouldReportOmitSiteMainProduct } from './should-report-omit
 export { default as saveCouponQueryArgument } from './save-coupon-query-argument';
 export { default as refreshCountryCodeCookieGdpr } from './refresh-country-code-cookie-gdpr';
 export { default as shouldSeeCookieBanner } from './should-see-cookie-banner';
-export { mayWeTrackUserGpcInCCPARegion, isGpcFlagSetOptOut } from './is-gpc-flag-set';
+export { mayWeTrackUserGpcInCcpaRegion, isGpcFlagSetOptOut } from './is-gpc-flag-set';
 export {
 	default as getTrackingPrefs,
 	parseTrackingPrefs,

--- a/client/lib/analytics/utils/index.ts
+++ b/client/lib/analytics/utils/index.ts
@@ -13,7 +13,7 @@ export { default as shouldReportOmitSiteMainProduct } from './should-report-omit
 export { default as saveCouponQueryArgument } from './save-coupon-query-argument';
 export { default as refreshCountryCodeCookieGdpr } from './refresh-country-code-cookie-gdpr';
 export { default as shouldSeeCookieBanner } from './should-see-cookie-banner';
-export { default as mayWeTrackUserGpcInCCPARegion, isGpcFlagSet } from './is-gpc-flag-set';
+export { mayWeTrackUserGpcInCCPARegion, isGpcFlagSetOptOut } from './is-gpc-flag-set';
 export {
 	default as getTrackingPrefs,
 	parseTrackingPrefs,

--- a/client/lib/analytics/utils/index.ts
+++ b/client/lib/analytics/utils/index.ts
@@ -13,6 +13,7 @@ export { default as shouldReportOmitSiteMainProduct } from './should-report-omit
 export { default as saveCouponQueryArgument } from './save-coupon-query-argument';
 export { default as refreshCountryCodeCookieGdpr } from './refresh-country-code-cookie-gdpr';
 export { default as shouldSeeCookieBanner } from './should-see-cookie-banner';
+export { default as mayWeTrackUserGpcInCCPARegion, isGpcFlagSet } from './is-gpc-flag-set';
 export {
 	default as getTrackingPrefs,
 	parseTrackingPrefs,

--- a/client/lib/analytics/utils/is-gpc-flag-set.ts
+++ b/client/lib/analytics/utils/is-gpc-flag-set.ts
@@ -1,5 +1,5 @@
 import cookie from 'cookie';
-import isRegionInCcpaZone from 'calypso/lib/analytics/utils/is-region-in-ccpa-zone';
+import isRegionInCcpaZone from './is-region-in-ccpa-zone';
 
 /**
  * The Global Privacy Control (GPC) flag is a browser setting that allows users to signal their privacy preference to websites.

--- a/client/lib/analytics/utils/is-gpc-flag-set.ts
+++ b/client/lib/analytics/utils/is-gpc-flag-set.ts
@@ -26,7 +26,7 @@ export const isGpcFlagSetOptOut = (): boolean => {
  *
  * @returns {boolean} - False if the user is in the CCPA region and the GPC flag is set, true otherwise.
  */
-export const mayWeTrackUserGpcInCCPARegion = (): boolean => {
+export const mayWeTrackUserGpcInCcpaRegion = (): boolean => {
 	const cookies = cookie.parse( document.cookie );
 	if ( isRegionInCcpaZone( cookies.country_code, cookies.region ) && isGpcFlagSetOptOut() ) {
 		return false;

--- a/client/lib/analytics/utils/is-gpc-flag-set.ts
+++ b/client/lib/analytics/utils/is-gpc-flag-set.ts
@@ -17,18 +17,19 @@ declare global {
  *
  * @returns {boolean} - True if the GPC flag is set, false otherwise (flag is undefined or false).
  */
-export const isGpcFlagSet = (): boolean => {
+export const isGpcFlagSetOptOut = (): boolean => {
 	return window.navigator?.globalPrivacyControl === true;
 };
 
 /**
  * May we track the user with GPC flag in CCPA region?
  *
- * @returns {boolean} - True if the user is in the CCPA region and the GPC flag is set, false otherwise.
+ * @returns {boolean} - False if the user is in the CCPA region and the GPC flag is set, true otherwise.
  */
-const mayWeTrackUserGpcInCCPARegion = (): boolean => {
+export const mayWeTrackUserGpcInCCPARegion = (): boolean => {
 	const cookies = cookie.parse( document.cookie );
-	return isRegionInCcpaZone( cookies.country_code, cookies.region ) && isGpcFlagSet();
+	if ( isRegionInCcpaZone( cookies.country_code, cookies.region ) && isGpcFlagSetOptOut() ) {
+		return false;
+	}
+	return true;
 };
-
-export default mayWeTrackUserGpcInCCPARegion;

--- a/client/lib/analytics/utils/is-gpc-flag-set.ts
+++ b/client/lib/analytics/utils/is-gpc-flag-set.ts
@@ -1,0 +1,34 @@
+import cookie from 'cookie';
+import isRegionInCcpaZone from 'calypso/lib/analytics/utils/is-region-in-ccpa-zone';
+
+/**
+ * The Global Privacy Control (GPC) flag is a browser setting that allows users to signal their privacy preference to websites.
+ * It's still not implemented across browsers, so adding it here.
+ * See: <https://globalprivacycontrol.org/>
+ */
+declare global {
+	interface Navigator {
+		globalPrivacyControl?: boolean;
+	}
+}
+
+/**
+ * Checks if the GPC flag is set in the user's browser.
+ *
+ * @returns {boolean} - True if the GPC flag is set, false otherwise (flag is undefined or false).
+ */
+export const isGpcFlagSet = (): boolean => {
+	return window.navigator?.globalPrivacyControl === true;
+};
+
+/**
+ * May we track the user with GPC flag in CCPA region?
+ *
+ * @returns {boolean} - True if the user is in the CCPA region and the GPC flag is set, false otherwise.
+ */
+const mayWeTrackUserGpcInCCPARegion = (): boolean => {
+	const cookies = cookie.parse( document.cookie );
+	return isRegionInCcpaZone( cookies.country_code, cookies.region ) && isGpcFlagSet();
+};
+
+export default mayWeTrackUserGpcInCCPARegion;


### PR DESCRIPTION
Checks the `window.navigator.globalPrivacyControl` in the browser, and treats it as an opt-out signal for US users in the "CCPA regions".
#### Proposed Changes

* Checks the above flag, and if it's set (and the user is in a "CCPA region") we won't fire advertising trackers.
* To do: If this signal is detected in CCPA, we need to also set it as a cookie, similar to the cookie banner, or if the user were to opt out of the "Do not sell or share my personal data" modal.

#### Testing Instructions
* D95088-code for the equivalent backend diff.
* Use Firefox (as they have implemented GPC)
    * Go to `about:config`
    * Set `privacy.globalprivacycontrol.enabled` and `privacy.globalprivacycontrol.functionality.enabled` to `true`
* Test 1:  
    * Set the region cookie to `Colorado` and the `country_code` to `US`
    * Load Calypso with ad-tracking enabled, and observe that no advertising trackers (e.g. Facebook) are firing. 
* Test 2:
    * Set the region cookie to `New York` and the `country_code` to `US`
    * Load Calypso with ad-tracking enabled, and observe that advertising trackers are firing again.
 * Test 3:
     * Set the two GPC settings above to false
     * Set the region cookie to `Colorado` and the `country_code` to `US`
     * Observe that advertising trackers are firing again.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #