### PR TITLE
Plugins: Update the Plugin icon handling to use the icons property value from the backend

### DIFF
--- a/client/data/marketplace/types.ts
+++ b/client/data/marketplace/types.ts
@@ -65,13 +65,6 @@ export type ESIndexResult = {
 	};
 };
 
-export type Icon = {
-	filename: string;
-	revision: string;
-	resolution: string;
-	location: string;
-};
-
 export type Railcar = Record< string, string | number >;
 
 export type ESHits = Array< { fields: ESIndexResult; railcar: Railcar } >;

--- a/client/data/marketplace/use-es-query.ts
+++ b/client/data/marketplace/use-es-query.ts
@@ -19,6 +19,19 @@ import { search } from './search-api';
 import { getPluginsListKey } from './utils';
 import type { ESHits, ESResponse, Plugin, PluginQueryOptions } from './types';
 
+const getIconUrl = ( pluginSlug: string, icon: string ): string => {
+	try {
+		const url = new URL( icon || '' );
+		return url.toString();
+	} catch ( _ ) {}
+
+	return buildDefaultIconUrl( pluginSlug );
+};
+
+function buildDefaultIconUrl( pluginSlug: string ) {
+	return `https://s.w.org/plugins/geopattern-icon/${ pluginSlug }.svg`;
+}
+
 const mapStarRatingToPercent = ( starRating?: number ) => ( ( starRating ?? 0 ) / 5 ) * 100;
 
 const mapIndexResultsToPluginData = ( results: ESHits ): Plugin[] => {
@@ -41,7 +54,7 @@ const mapIndexResultsToPluginData = ( results: ESHits ): Plugin[] => {
 			active_installs: hit.plugin.active_installs,
 			last_updated: hit.modified,
 			short_description: hit.plugin.excerpt, // TODO: add localization
-			icon: hit.plugin.icons,
+			icon: getIconUrl( hit.slug, hit.plugin.icons ),
 			variations: {
 				monthly: { product_id: hit.plugin.store_product_monthly_id },
 				yearly: { product_id: hit.plugin.store_product_yearly_id },

--- a/client/data/marketplace/use-es-query.ts
+++ b/client/data/marketplace/use-es-query.ts
@@ -17,65 +17,7 @@ import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
 import { DEFAULT_PAGE_SIZE } from './constants';
 import { search } from './search-api';
 import { getPluginsListKey } from './utils';
-import type { ESHits, ESResponse, Plugin, PluginQueryOptions, Icon } from './types';
-
-/**
- *
- * @param pluginSlug
- * @param icons
- * @returns A string containing an icon url or
- * 	a default generated url Icon if icons param is falsy, it is not JSON or it does not contain a valid resolution
- */
-const createIconUrl = ( pluginSlug: string, icons?: string ): string => {
-	try {
-		const url = new URL( icons || '' );
-		return url.toString();
-	} catch ( _ ) {}
-
-	const defaultIconUrl = buildDefaultIconUrl( pluginSlug );
-	if ( ! icons ) {
-		return defaultIconUrl;
-	}
-
-	let iconsObject: Record< string, Icon > = {};
-	try {
-		iconsObject = JSON.parse( icons );
-	} catch ( error ) {
-		return defaultIconUrl;
-	}
-
-	// Transform Icon response for easier handling
-	const iconByResolution = Object.values( iconsObject ).reduce(
-		( iconByResolution, currentIcon ) => {
-			const newKey = currentIcon.resolution;
-			iconByResolution[ newKey ] = currentIcon;
-			return iconByResolution;
-		},
-		{} as Record< string, Icon >
-	);
-
-	const icon =
-		iconByResolution[ '256x256' ] ||
-		iconByResolution[ '128x128' ] ||
-		iconByResolution[ '2x' ] ||
-		iconByResolution[ '1x' ] ||
-		iconByResolution.svg ||
-		iconByResolution.default;
-
-	if ( ! icon ) {
-		return defaultIconUrl;
-	}
-
-	return buildIconUrl( pluginSlug, icon.location, icon.filename, icon.revision );
-};
-
-function buildIconUrl( pluginSlug: string, location: string, filename: string, revision: string ) {
-	return `https://ps.w.org/${ pluginSlug }/${ location }/${ filename }?rev=${ revision }`;
-}
-
-function buildDefaultIconUrl( pluginSlug: string ) {
-	return `https://s.w.org/plugins/geopattern-icon/${ pluginSlug }.svg`;
-}
+import type { ESHits, ESResponse, Plugin, PluginQueryOptions } from './types';
 
 const mapStarRatingToPercent = ( starRating?: number ) => ( ( starRating ?? 0 ) / 5 ) * 100;
 
@@ -99,7 +41,7 @@ const mapIndexResultsToPluginData = ( results: ESHits ): Plugin[] => {
 			active_installs: hit.plugin.active_installs,
 			last_updated: hit.modified,
 			short_description: hit.plugin.excerpt, // TODO: add localization
-			icon: createIconUrl( hit.slug, hit.plugin.icons ),
+			icon: hit.plugin.icons,
 			variations: {
 				monthly: { product_id: hit.plugin.store_product_monthly_id },
 				yearly: { product_id: hit.plugin.store_product_yearly_id },


### PR DESCRIPTION
#### Proposed Changes

Remove the additional logic to handle the plugins icons, considering the URL is already being provided by the backend (Jetpack search).
If a proper URL is not passed by the backend, a placeholder will be used as icon.

The `Icon` type was also removed as there is no usage of it in the project.

#### Testing Instructions
* Go to `/plugins` page
* Make sure all plugins on that page presents an icon
* Do a search on WP.org plugins (ex: `wp`) and make sure all the results have an icon.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #70233