### PR TITLE
Revert "Checkout: Hide contact validation errors during auto-completion, with flag"

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
@@ -193,7 +193,7 @@ export default function WPCheckout( {
 	} = useDispatch( 'wpcom-checkout' );
 
 	const [ shouldShowContactDetailsValidationErrors, setShouldShowContactDetailsValidationErrors ] =
-		useState( true );
+		useState( false );
 
 	// The "Summary" view is displayed in the sidebar at desktop (wide) widths
 	// and before the first step at mobile (smaller) widths. At smaller widths it
@@ -359,8 +359,9 @@ export default function WPCheckout( {
 				<CheckoutStep
 					stepId="contact-form"
 					isCompleteCallback={ async () => {
+						setShouldShowContactDetailsValidationErrors( true );
 						// Touch the fields so they display validation errors
-						shouldShowContactDetailsValidationErrors && touchContactFields();
+						touchContactFields();
 						const validationResponse = await validateContactDetails(
 							contactInfo,
 							isLoggedOutCart,
@@ -370,7 +371,7 @@ export default function WPCheckout( {
 							clearDomainContactErrorMessages,
 							reduxDispatch,
 							translate,
-							shouldShowContactDetailsValidationErrors
+							true
 						);
 						if ( validationResponse ) {
 							// When the contact details change, update the cart's tax location to match.
@@ -404,9 +405,6 @@ export default function WPCheckout( {
 							shouldShowContactDetailsValidationErrors={ shouldShowContactDetailsValidationErrors }
 							contactDetailsType={ contactDetailsType }
 							isLoggedOutCart={ isLoggedOutCart }
-							setShouldShowContactDetailsValidationErrors={
-								setShouldShowContactDetailsValidationErrors
-							}
 						/>
 					}
 					completeStepContent={

--- a/client/my-sites/checkout/composite-checkout/components/wp-contact-form.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-contact-form.tsx
@@ -30,13 +30,11 @@ export default function WPContactForm( {
 	shouldShowContactDetailsValidationErrors,
 	contactDetailsType,
 	isLoggedOutCart,
-	setShouldShowContactDetailsValidationErrors,
 }: {
 	countriesList: CountryListItem[];
 	shouldShowContactDetailsValidationErrors: boolean;
 	contactDetailsType: Exclude< ContactDetailsType, 'none' >;
 	isLoggedOutCart: boolean;
-	setShouldShowContactDetailsValidationErrors: ( allowed: boolean ) => void;
 } ) {
 	const contactInfo: ManagedContactDetails = useSelect( ( select ) =>
 		select( 'wpcom-checkout' ).getContactInfo()
@@ -45,7 +43,7 @@ export default function WPContactForm( {
 	const isStepActive = useIsStepActive();
 	const isDisabled = ! isStepActive || formStatus !== FormStatus.READY;
 
-	useCachedDomainContactDetails( setShouldShowContactDetailsValidationErrors, countriesList );
+	useCachedDomainContactDetails( countriesList );
 
 	return (
 		<BillingFormFields>

--- a/client/my-sites/checkout/composite-checkout/test/checkout-contact-step.js
+++ b/client/my-sites/checkout/composite-checkout/test/checkout-contact-step.js
@@ -246,22 +246,6 @@ describe( 'Checkout contact step', () => {
 		await expect( screen.findByTestId( 'payment-method-step--visible' ) ).toNeverAppear();
 	} );
 
-	it( 'does not show errors when autocompleting the contact step when there are invalid cached details', async () => {
-		mockCachedContactDetailsEndpoint( {
-			country_code: 'US',
-			postal_code: 'ABCD',
-		} );
-		mockContactDetailsValidationEndpoint( 'tax', {
-			success: false,
-			messages: { postal_code: [ 'Postal code error message' ] },
-		} );
-		const cartChanges = { products: [ planWithoutDomain ] };
-		render( <MyCheckout cartChanges={ cartChanges } /> );
-		// Wait for the cart to load
-		await screen.findByText( 'Country' );
-		await expect( screen.findByText( 'Postal code error message' ) ).toNeverAppear();
-	} );
-
 	it.each( [
 		{ complete: 'does', valid: 'valid', name: 'plan', email: 'fails', logged: 'in' },
 		{ complete: 'does not', valid: 'invalid', name: 'plan', email: 'fails', logged: 'in' },

--- a/client/my-sites/checkout/composite-checkout/test/use-cached-domain-contact-details.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/use-cached-domain-contact-details.tsx
@@ -63,7 +63,7 @@ function MyTestContent( { countries }: { countries: CountryListItem[] } ) {
 	const { responseCart, reloadFromServer, updateLocation } = useShoppingCart(
 		initialCart.cart_key
 	);
-	useCachedDomainContactDetails( () => null, countries );
+	useCachedDomainContactDetails( countries );
 	const contactInfo: ManagedContactDetails = useSelect( ( select ) =>
 		select( 'wpcom-checkout' ).getContactInfo()
 	);


### PR DESCRIPTION
Reverts Automattic/wp-calypso#71024