### PR TITLE
Jetpack pricing page: Fix lightbox checkout button tracks event

### DIFF
--- a/client/my-sites/plans/jetpack-plans/product-lightbox/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-lightbox/index.tsx
@@ -74,7 +74,7 @@ const ProductLightbox: React.FC< Props > = ( {
 		getOnClickPurchase( product )();
 		// Tracking when checkout is clicked
 		dispatch(
-			recordTracksEvent( 'calyspo_product_lightbox_checkout_click', {
+			recordTracksEvent( 'calypso_product_lightbox_checkout_click', {
 				site_id: siteId,
 				product_slug: product.productSlug,
 			} )


### PR DESCRIPTION
#### Proposed Changes

On the pricing page, in the lightbox, there's a "Proceed to checkout" button which had a misspelled tracks event.

The event before (mispelled):
`calyspo_product_lightbox_checkout_click`

The event after (fixed):
`calypso_product_lightbox_checkout_click`

Since the tracking name prefix (`calyspo_`) was misspelled, this causes the event to be rejected and not work at all.

#### Testing Instructions

I would say that just a quick code inspection should be enough to test this PR.

Otherwise, if you really wanted to you could:
- Checkout this PR and spin up calypso green (`yarn start-jetpack-cloud`)
- Go to http://jetpack.cloud.localhost:3000/pricing/
- Open your browser console and enter, `localStorage.setItem( "debug", "calypso:analytics" );`
- Reload the page, view your console to confirm that you are now receiving Tracks event information.
- On any product, click the "More about {product_name}" link. Lightbox will open.
- Clear out your console (cmd + k)
- Click the "Proceed to checkout" button.
- Verify in the console that you see the `calypso_product_lightbox_checkout_click` event fires.
- **_For reference_**, if needed: Detailed steps on How to See Calypso Tracks Events Fire in Real Time: PCYsg-cae-p2

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # p1670949293983369/1670944038.246039-slack-C03RCHNVC0H