### PR TITLE
Checkout: Change logstash error when autocompleting steps to decrease severity

### DIFF
--- a/client/my-sites/checkout/composite-checkout/hooks/use-cached-domain-contact-details.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-cached-domain-contact-details.ts
@@ -118,10 +118,10 @@ function useCachedContactDetailsForCheckoutForm(
 				setShouldShowContactDetailsValidationErrors( true );
 				isMounted.current && setComplete( true );
 				// eslint-disable-next-line no-console
-				console.error( error );
+				console.error( 'Error while autocompleting contact details:', error );
 				logToLogstash( {
 					feature: 'calypso_client',
-					message: 'composite checkout load error',
+					message: 'composite checkout autocomplete error',
 					severity: config( 'env_id' ) === 'production' ? 'error' : 'debug',
 					extra: {
 						env: config( 'env_id' ),

--- a/client/my-sites/checkout/composite-checkout/hooks/use-cached-domain-contact-details.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-cached-domain-contact-details.ts
@@ -122,7 +122,7 @@ function useCachedContactDetailsForCheckoutForm(
 				logToLogstash( {
 					feature: 'calypso_client',
 					message: 'composite checkout autocomplete error',
-					severity: config( 'env_id' ) === 'production' ? 'error' : 'debug',
+					severity: config( 'env_id' ) === 'production' ? 'warning' : 'debug',
 					extra: {
 						env: config( 'env_id' ),
 						type: 'checkout_contact_details_autocomplete',


### PR DESCRIPTION
#### Proposed Changes

When attempting to autocomplete the checkout contact details step, https://github.com/Automattic/wp-calypso/pull/71024 added a logstash call if the completion fails.

However, failed autocompletion is normal and can happen anytime the validation fails.

This PR decreases the severity of these logstash calls to avoid pinging the payments team.

#### Testing Instructions

- Force the shopping-cart endpoint to return an error by disabling the guard in `add_blocked_purchases_error`.
- Sandbox the API and load checkout with this PR.
- Using your browser's devtools, verify that the logstash call has changed so that its `severity` is now `'warning'` and its log message is different.
