### PR TITLE
Added Zaino to eCommerce flow

### DIFF
--- a/packages/design-carousel/src/index.tsx
+++ b/packages/design-carousel/src/index.tsx
@@ -25,7 +25,7 @@ export default function DesignCarousel( { onPick }: Props ) {
 	} );
 
 	// Cherry-picked designs
-	const designSlugs = [ 'tsubaki', 'tazza', 'thriving-artist', 'twentytwentytwo' ];
+	const designSlugs = [ 'tsubaki', 'tazza', 'thriving-artist', 'twentytwentytwo', 'zaino' ];
 
 	const selectedDesigns = designSlugs
 		.map( ( designSlug ) =>


### PR DESCRIPTION
#### Proposed Changes

* Added Zaino to the list of themes for the eCommerce flow (`/setup/ecommerce`)

#### Testing
- Make sure it didn't brake the flow.
- Zaino should be shown in the flow for A12s (soft-launched)

** The thumbnail is broken but should be fixed when the cache is cleared
![image](https://user-images.githubusercontent.com/3801502/207438839-74eb7e37-5eb0-4e36-8722-12605a9aeee8.png)
