### PR TITLE
E2E: refactor the Jest environment.

### DIFF
--- a/packages/calypso-e2e/src/jest-playwright-config/environment.ts
+++ b/packages/calypso-e2e/src/jest-playwright-config/environment.ts
@@ -177,10 +177,6 @@ class JestEnvironmentPlaywright extends NodeEnvironment {
 					await page.close();
 					pageIndex++;
 				}
-				// Close the context.
-				// Strongly suggested by Playwright maintainers
-				// before shutting down the browser.
-				await context.close();
 				contextIndex++;
 			}
 			// Print paths to captured artifacts for faster triaging.

--- a/packages/calypso-e2e/src/jest-playwright-config/environment.ts
+++ b/packages/calypso-e2e/src/jest-playwright-config/environment.ts
@@ -169,12 +169,11 @@ class JestEnvironmentPlaywright extends NodeEnvironment {
 					// Screenshots and video are saved per page, where numerous
 					// pages may exist within a context.
 					await page.screenshot( { path: `${ mediaFilePath }.png`, timeout: env.TIMEOUT } );
-					await page.video()?.saveAs( `${ mediaFilePath }.webm` );
 
-					// Close the unnecessary page.
-					// Doing so also triggers a save of the video
-					// to the disk.
+					// Close the now unnecessary page which also
+					// triggers saving of video to the disk.
 					await page.close();
+					await page.video()?.saveAs( `${ mediaFilePath }.webm` );
 					pageIndex++;
 				}
 				contextIndex++;

--- a/packages/calypso-e2e/src/jest-playwright-config/environment.ts
+++ b/packages/calypso-e2e/src/jest-playwright-config/environment.ts
@@ -241,9 +241,6 @@ class JestEnvironmentPlaywright extends NodeEnvironment {
 				}
 				break;
 			case 'test_fn_start':
-				console.log(
-					`In test_fn_start, is browser connected: ${ this.global.browser.isConnected() }`
-				);
 				// This event is fired after both the `beforeAll` and `beforeEach` hooks.
 				// Since this event fires after `beforeEach` hooks, it is the best way to detect
 				// an actual `it/test` step as having started.
@@ -263,9 +260,6 @@ class JestEnvironmentPlaywright extends NodeEnvironment {
 				break;
 			}
 			case 'test_fn_failure': {
-				console.log(
-					`In test_fn_failure, is browser connected: ${ this.global.browser.isConnected() }`
-				);
 				this.failure = { type: 'test', name: event.test.name };
 				this.allure?.failTestStep( event.error );
 				break;

--- a/packages/calypso-e2e/src/jest-playwright-config/environment.ts
+++ b/packages/calypso-e2e/src/jest-playwright-config/environment.ts
@@ -105,7 +105,7 @@ class JestEnvironmentPlaywright extends NodeEnvironment {
 	 *
 	 * 	`@browser firefox`
 	 */
-	async determineBrowser(): Promise< BrowserType > {
+	private async determineBrowser(): Promise< BrowserType > {
 		const parsed = parseDocBlock( await fs.readFile( this.testFilePath, 'utf8' ) );
 		const defaultBrowser = env.BROWSER_NAME;
 
@@ -272,9 +272,17 @@ class JestEnvironmentPlaywright extends NodeEnvironment {
 						this.testArtifactsPath,
 						`${ artifactFilename }__${ contextIndex }-${ pageIndex }`
 					);
-					await page.screenshot( { path: `${ mediaFilePath }.png` } );
+					try {
+						await page.screenshot( { path: `${ mediaFilePath }.png`, timeout: env.TIMEOUT } );
+					} catch {
+						console.error( `Failed to capture screenshot for test: ${ this.testFilename }}.` );
+					}
 					await page.close(); // Needed before saving video.
-					await page.video()?.saveAs( `${ mediaFilePath }.webm` );
+					try {
+						await page.video()?.saveAs( `${ mediaFilePath }.webm` );
+					} catch {
+						console.error( `Failed to save replay for test: ${ this.testFilePath }.` );
+					}
 					pageIndex++;
 				}
 				contextIndex++;

--- a/packages/calypso-e2e/src/jest-playwright-config/environment.ts
+++ b/packages/calypso-e2e/src/jest-playwright-config/environment.ts
@@ -272,10 +272,11 @@ class JestEnvironmentPlaywright extends NodeEnvironment {
 						this.testArtifactsPath,
 						`${ artifactFilename }__${ contextIndex }-${ pageIndex }`
 					);
+					console.log( `Browser is connected: ${ this.global.browser.isConnected() }` );
 					try {
 						await page.screenshot( { path: `${ mediaFilePath }.png`, timeout: env.TIMEOUT } );
 					} catch {
-						console.error( `Failed to capture screenshot for test: ${ this.testFilename }}.` );
+						console.error( `Failed to capture screenshot for test: ${ this.testFilename }.` );
 					}
 					await page.close(); // Needed before saving video.
 					try {
@@ -345,6 +346,9 @@ class JestEnvironmentPlaywright extends NodeEnvironment {
 				}
 				break;
 			case 'test_fn_start':
+				console.log(
+					`In test_fn_start, is browser connected: ${ this.global.browser.isConnected() }`
+				);
 				// This event is fired after both the `beforeAll` and `beforeEach` hooks.
 				// Since this event fires after `beforeEach` hooks, it is the best way to detect
 				// an actual `it/test` step as having started.
@@ -364,6 +368,9 @@ class JestEnvironmentPlaywright extends NodeEnvironment {
 				break;
 			}
 			case 'test_fn_failure': {
+				console.log(
+					`In test_fn_failure, is browser connected: ${ this.global.browser.isConnected() }`
+				);
 				this.failure = { type: 'test', name: event.test.name };
 				this.allure?.failTestStep( event.error );
 				break;


### PR DESCRIPTION
#### Proposed Changes

This PR arose as a follow-up to https://github.com/Automattic/wp-calypso/pull/70795. 
The intention here is to refactor the Playwright Jest environment definition to be better modularized and maintainable by developers.

Key changes:
- extract wpBrowser proxy trap setup to its own method.
- call the global `teardown` after tearing down the environment.

#### Testing Instructions

Ensure the following build configurations are passing:
  - [ ] Calypso E2E (desktop)
  - [ ] Calypso E2E (mobile)
  - [ ] Unit Tests
  - [ ] Code Style

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
