### PR TITLE
Stats: Consolidate Post Detail page tables

### DIFF
--- a/client/my-sites/stats/post-detail-table-section/index.tsx
+++ b/client/my-sites/stats/post-detail-table-section/index.tsx
@@ -1,0 +1,56 @@
+import { translate } from 'i18n-calypso';
+import { useState } from 'react';
+import SimplifiedSegmentedControl from 'calypso/components/segmented-control/simplified';
+import PostMonths from '../stats-detail-months';
+import PostWeeks from '../stats-detail-weeks';
+
+import './style.scss';
+
+type TableOption = {
+	value: string;
+	label: string;
+};
+
+// Meant to replace tables of stats-post-detail
+export default function PostDetailTableSection( {
+	siteId,
+	postId,
+}: {
+	siteId: number;
+	postId: number;
+} ) {
+	const [ tableKey, setTableKey ] = useState( 'years' );
+
+	const tableOptions = [
+		{ value: 'years', label: translate( 'Months and years' ) },
+		{ value: 'averages', label: translate( 'Average per day' ) },
+		{ value: 'weeks', label: translate( 'Recent Weeks' ) },
+	];
+
+	const toggleTable = ( option?: TableOption ) => {
+		setTableKey( option?.value || 'years' );
+	};
+
+	return (
+		<>
+			<SimplifiedSegmentedControl
+				className="stats-views__table-control"
+				options={ tableOptions }
+				onSelect={ toggleTable }
+				compact
+			/>
+
+			{ [ 'years', 'averages' ].includes( tableKey ) ? (
+				<PostMonths
+					dataKey={ tableKey }
+					title={ tableOptions.find( ( o ) => o.value === tableKey )?.label || 'Title' }
+					total={ tableKey === 'years' ? translate( 'Total' ) : translate( 'Overall' ) }
+					siteId={ siteId }
+					postId={ postId }
+				/>
+			) : (
+				<PostWeeks siteId={ siteId } postId={ postId } />
+			) }
+		</>
+	);
+}

--- a/client/my-sites/stats/post-detail-table-section/style.scss
+++ b/client/my-sites/stats/post-detail-table-section/style.scss
@@ -1,0 +1,4 @@
+.segmented-control.stats-views__table-control {
+	max-width: 280px;
+	margin: 0 auto 10px;
+}

--- a/client/my-sites/stats/stats-post-detail/index.jsx
+++ b/client/my-sites/stats/stats-post-detail/index.jsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { Button } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import { flowRight } from 'lodash';
@@ -22,6 +23,7 @@ import {
 } from 'calypso/state/sites/selectors';
 import { getPostStat, isRequestingPostStats } from 'calypso/state/stats/posts/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import PostDetailTableSection from '../post-detail-table-section';
 import PostMonths from '../stats-detail-months';
 import PostWeeks from '../stats-detail-weeks';
 import StatsPlaceholder from '../stats-module/placeholder';
@@ -134,6 +136,8 @@ class StatsPostDetail extends Component {
 			noViewsLabel = translate( 'Your post has not received any views yet!' );
 		}
 
+		const isFeatured = config.isEnabled( 'stats/enhance-post-detail' );
+
 		return (
 			<Main className="has-fixed-nav" wideLayout>
 				<PageViewTracker
@@ -173,23 +177,29 @@ class StatsPostDetail extends Component {
 
 						{ !! postId && <PostLikes siteId={ siteId } postId={ postId } postType={ postType } /> }
 
-						<PostMonths
-							dataKey="years"
-							title={ translate( 'Months and years' ) }
-							total={ translate( 'Total' ) }
-							siteId={ siteId }
-							postId={ postId }
-						/>
+						{ isFeatured && <PostDetailTableSection siteId={ siteId } postId={ postId } /> }
 
-						<PostMonths
-							dataKey="averages"
-							title={ translate( 'Average per day' ) }
-							total={ translate( 'Overall' ) }
-							siteId={ siteId }
-							postId={ postId }
-						/>
+						{ ! isFeatured && (
+							<>
+								<PostMonths
+									dataKey="years"
+									title={ translate( 'Months and years' ) }
+									total={ translate( 'Total' ) }
+									siteId={ siteId }
+									postId={ postId }
+								/>
 
-						<PostWeeks siteId={ siteId } postId={ postId } />
+								<PostMonths
+									dataKey="averages"
+									title={ translate( 'Average per day' ) }
+									total={ translate( 'Overall' ) }
+									siteId={ siteId }
+									postId={ postId }
+								/>
+
+								<PostWeeks siteId={ siteId } postId={ postId } />
+							</>
+						) }
 					</div>
 				) }
 


### PR DESCRIPTION
#### Proposed Changes

* Introduce PostDetailTableSection to accommodate tables for toggling.
* Introduce the feature flag `stats/enhance-post-detail` to gate the consolidated tables.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up this change with the Calypso Live link.
* Navigate to the Stats `Post Detail` page (`/stats/post/${post-id}/${site-id}`).
* Ensure the post detail page works as previously.
* Append the feature flag `?flags=stats/enhance-post-detail` to the URL.
* Ensure the post detail page tables are consolidated into a togglable section.

| Before | After |
| --- | --- |
| <img width="1143" alt="截圖 2022-12-14 上午5 17 57" src="https://user-images.githubusercontent.com/6869813/207445606-94f6f930-efed-4593-bce3-cee4f93ceac1.png"> | <img width="1114" alt="截圖 2022-12-14 上午5 18 06" src="https://user-images.githubusercontent.com/6869813/207445826-73328eca-14cb-4876-9a12-356dea18f140.png"> |

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #70671 
