### PR TITLE
Hosted Woo Onboarding: Initial boilerplate hosted woo flow with styling proof of concept

### DIFF
--- a/client/landing/stepper/declarative-flow/hosted-woo-flow.ts
+++ b/client/landing/stepper/declarative-flow/hosted-woo-flow.ts
@@ -17,7 +17,6 @@ import { recordSubmitStep } from './internals/analytics/record-submit-step';
 import CheckPlan from './internals/steps-repository/check-plan';
 import DesignCarousel from './internals/steps-repository/design-carousel';
 import DomainsStep from './internals/steps-repository/domains';
-import Intro from './internals/steps-repository/intro';
 import ProcessingStep from './internals/steps-repository/processing-step';
 import SetThemeStep from './internals/steps-repository/set-theme-step';
 import SiteCreationStep from './internals/steps-repository/site-creation-step';
@@ -36,7 +35,6 @@ const hostedWooFlow: Flow = {
 		}, [] );
 
 		return [
-			{ slug: 'intro', component: Intro },
 			{ slug: 'storeProfiler', component: StoreProfiler },
 			{ slug: 'storeAddress', component: StoreAddress },
 			{ slug: 'domains', component: DomainsStep },

--- a/client/landing/stepper/declarative-flow/hosted-woo-flow.ts
+++ b/client/landing/stepper/declarative-flow/hosted-woo-flow.ts
@@ -1,0 +1,215 @@
+import { PLAN_ECOMMERCE, PLAN_ECOMMERCE_MONTHLY } from '@automattic/calypso-products';
+import { useLocale } from '@automattic/i18n-utils';
+import { useFlowProgress, HOSTED_WOO_FLOW, ecommerceFlowRecurTypes } from '@automattic/onboarding';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { useEffect } from 'react';
+import { recordFullStoryEvent } from 'calypso/lib/analytics/fullstory';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import {
+	setSignupCompleteSlug,
+	persistSignupDestination,
+	setSignupCompleteFlowName,
+} from 'calypso/signup/storageUtils';
+import { useSite } from '../hooks/use-site';
+import { useSiteSlugParam } from '../hooks/use-site-slug-param';
+import { USER_STORE, ONBOARD_STORE } from '../stores';
+import { recordSubmitStep } from './internals/analytics/record-submit-step';
+import CheckPlan from './internals/steps-repository/check-plan';
+import DesignCarousel from './internals/steps-repository/design-carousel';
+import DomainsStep from './internals/steps-repository/domains';
+import Intro from './internals/steps-repository/intro';
+import ProcessingStep from './internals/steps-repository/processing-step';
+import SetThemeStep from './internals/steps-repository/set-theme-step';
+import SiteCreationStep from './internals/steps-repository/site-creation-step';
+import StoreAddress from './internals/steps-repository/store-address';
+import StoreProfiler from './internals/steps-repository/store-profiler';
+import WaitForAtomic from './internals/steps-repository/wait-for-atomic';
+import type { Flow, ProvidedDependencies } from './internals/types';
+import type { SiteDetailsPlan } from '@automattic/data-stores';
+
+const hostedWooFlow: Flow = {
+	name: HOSTED_WOO_FLOW,
+	useSteps() {
+		useEffect( () => {
+			recordTracksEvent( 'calypso_signup_start', { flow: this.name } );
+			recordFullStoryEvent( 'calypso_signup_start_hosted_woo', { flow: this.name } );
+		}, [] );
+
+		return [
+			{ slug: 'intro', component: Intro },
+			{ slug: 'storeProfiler', component: StoreProfiler },
+			{ slug: 'storeAddress', component: StoreAddress },
+			{ slug: 'domains', component: DomainsStep },
+			{ slug: 'designCarousel', component: DesignCarousel },
+			{ slug: 'siteCreationStep', component: SiteCreationStep },
+			{ slug: 'processing', component: ProcessingStep },
+			{ slug: 'waitForAtomic', component: WaitForAtomic },
+			{ slug: 'setThemeStep', component: SetThemeStep },
+			{ slug: 'checkPlan', component: CheckPlan },
+		];
+	},
+
+	useStepNavigation( _currentStepName, navigate ) {
+		const flowName = this.name;
+		const { setStepProgress, setPlanCartItem, resetOnboardStore } = useDispatch( ONBOARD_STORE );
+		const flowProgress = useFlowProgress( { stepName: _currentStepName, flowName } );
+		setStepProgress( flowProgress );
+		const userIsLoggedIn = useSelect( ( select ) => select( USER_STORE ).isCurrentUserLoggedIn() );
+		const { selectedDesign, recurType } = useSelect( ( select ) => ( {
+			selectedDesign: select( ONBOARD_STORE ).getSelectedDesign(),
+			recurType: select( ONBOARD_STORE ).getEcommerceFlowRecurType(),
+		} ) );
+		const selectedPlan =
+			recurType === ecommerceFlowRecurTypes.YEARLY ? PLAN_ECOMMERCE : PLAN_ECOMMERCE_MONTHLY;
+
+		const locale = useLocale();
+		const siteSlugParam = useSiteSlugParam();
+		const site = useSite();
+		const flags = new URLSearchParams( window.location.search ).get( 'flags' );
+
+		const getStartUrl = () => {
+			let hasFlowParams = false;
+			const flowParams = new URLSearchParams();
+
+			if ( recurType !== ecommerceFlowRecurTypes.YEARLY ) {
+				flowParams.set( 'recur', recurType );
+				hasFlowParams = true;
+			}
+			if ( locale && locale !== 'en' ) {
+				flowParams.set( 'locale', locale );
+				hasFlowParams = true;
+			}
+
+			const redirectTarget =
+				`/setup/hosted-woo/storeProfiler` +
+				( hasFlowParams ? encodeURIComponent( '?' + flowParams.toString() ) : '' );
+			const url =
+				locale && locale !== 'en'
+					? `/start/account/user/${ locale }?variationName=${ flowName }&redirect_to=${ redirectTarget }`
+					: `/start/account/user?variationName=${ flowName }&redirect_to=${ redirectTarget }`;
+
+			return url + ( flags ? `&flags=${ flags }` : '' );
+		};
+
+		function submit( providedDependencies: ProvidedDependencies = {} ) {
+			recordSubmitStep( providedDependencies, '', flowName, _currentStepName );
+			const logInUrl = getStartUrl();
+			const siteSlug = ( providedDependencies?.siteSlug as string ) || siteSlugParam || '';
+
+			switch ( _currentStepName ) {
+				case 'domains':
+					recordTracksEvent( 'calypso_signup_plan_select', {
+						product_slug: selectedPlan,
+						from_section: 'default',
+					} );
+
+					setPlanCartItem( { product_slug: selectedPlan } );
+					return navigate( 'siteCreationStep' );
+
+				case 'siteCreationStep':
+					return navigate( 'processing' );
+
+				case 'processing':
+					// Coming from setThemeStep
+					if ( providedDependencies?.selectedDesign ) {
+						return navigate( 'storeAddress' );
+					}
+
+					if ( providedDependencies?.finishedWaitingForAtomic ) {
+						return navigate( 'setThemeStep' );
+					}
+
+					if ( providedDependencies?.siteSlug ) {
+						const destination = `/setup/${ flowName }/checkPlan?siteSlug=${ siteSlug }`;
+						persistSignupDestination( destination );
+						setSignupCompleteSlug( siteSlug );
+						setSignupCompleteFlowName( flowName );
+
+						// The site is coming from the checkout already Atomic (and with the new URL)
+						// There's probably a better way of handling this change
+						const urlParams = new URLSearchParams( {
+							theme: selectedDesign?.slug || '',
+							siteSlug: siteSlug.replace( '.wordpress.com', '.wpcomstaging.com' ),
+						} );
+
+						const returnUrl = encodeURIComponent( `/setup/${ flowName }/checkPlan?${ urlParams }` );
+
+						return window.location.assign(
+							`/checkout/${ encodeURIComponent(
+								( siteSlug as string ) ?? ''
+							) }?redirect_to=${ returnUrl }&signup=1`
+						);
+					}
+					return navigate( `checkPlan?siteSlug=${ siteSlug }` );
+
+				case 'intro':
+					resetOnboardStore();
+					if ( userIsLoggedIn ) {
+						return navigate( 'storeProfiler' );
+					}
+					return window.location.assign( logInUrl );
+
+				case 'storeProfiler':
+					return navigate( 'designCarousel' );
+
+				case 'storeAddress':
+					return window.location.assign( `${ site?.URL }/wp-admin/admin.php?page=wc-admin` );
+
+				case 'designCarousel':
+					return navigate( 'domains' );
+
+				case 'setThemeStep':
+					return navigate( 'processing' );
+
+				case 'waitForAtomic':
+					return navigate( 'processing' );
+
+				case 'checkPlan':
+					// eCommerce Plan
+					if (
+						[ PLAN_ECOMMERCE, PLAN_ECOMMERCE_MONTHLY ].includes(
+							( providedDependencies?.currentPlan as SiteDetailsPlan )?.product_slug
+						)
+					) {
+						return navigate( 'waitForAtomic' );
+					}
+
+					// Not eCommerce Plan
+					return window.location.assign( `/setup/site-setup/goals?siteSlug=${ siteSlug }` );
+			}
+			return providedDependencies;
+		}
+
+		const goBack = () => {
+			switch ( _currentStepName ) {
+				case 'designCarousel':
+					return navigate( 'storeProfiler' );
+				default:
+					return navigate( 'intro' );
+			}
+		};
+
+		const goNext = () => {
+			switch ( _currentStepName ) {
+				case 'intro':
+					return navigate( 'storeProfiler' );
+				case 'storeProfiler':
+					return navigate( 'designCarousel' );
+				case 'storeAddress':
+					return window.location.assign( `${ site?.URL }/wp-admin/admin.php?page=wc-admin` );
+				case 'designCarousel':
+					return navigate( 'domains' );
+				default:
+					return navigate( 'intro' );
+			}
+		};
+
+		const goToStep = ( step: string ) => {
+			navigate( step );
+		};
+
+		return { goNext, goBack, goToStep, submit };
+	},
+};
+
+export default hostedWooFlow;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/intro/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/intro/index.tsx
@@ -4,6 +4,7 @@ import {
 	ECOMMERCE_FLOW,
 	VIDEOPRESS_FLOW,
 	FREE_FLOW,
+	HOSTED_WOO_FLOW,
 } from '@automattic/onboarding';
 import { createInterpolateElement, useMemo } from '@wordpress/element';
 import { useI18n } from '@wordpress/react-i18n';
@@ -28,7 +29,7 @@ const useIntroContent = ( flowName: string | null ): IntroContent => {
 			};
 		}
 
-		if ( flowName === ECOMMERCE_FLOW ) {
+		if ( flowName === ECOMMERCE_FLOW || flowName === HOSTED_WOO_FLOW ) {
 			return {
 				title: createInterpolateElement( __( 'Set up your online store<br />in minutes' ), {
 					br: <br />,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/intro/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/intro/styles.scss
@@ -77,17 +77,6 @@
 				url(calypso/assets/images/onboarding/ecommerce-intro-3.jpg);
 		}
 	}
-	&.hosted-woo {
-		.signup-header {
-
-			svg.wordpress-logo {
-				fill: #674399;
-			}
-		}
-		.button.is-primary {
-			background-color: #674399;
-		}
-	}
 
 	&.videopress {
 		padding: 0;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/intro/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/intro/styles.scss
@@ -77,6 +77,17 @@
 				url(calypso/assets/images/onboarding/ecommerce-intro-3.jpg);
 		}
 	}
+	&.hosted-woo {
+		.signup-header {
+
+			svg.wordpress-logo {
+				fill: #674399;
+			}
+		}
+		.button.is-primary {
+			background-color: #674399;
+		}
+	}
 
 	&.videopress {
 		padding: 0;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/store-profiler/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/store-profiler/style.scss
@@ -16,4 +16,10 @@
 			}
 		}
 	}
+
+	&.hosted-woo {
+		.button.is-primary {
+			background-color: #674399;
+		}
+	}
 }

--- a/client/landing/stepper/declarative-flow/registered-flows.ts
+++ b/client/landing/stepper/declarative-flow/registered-flows.ts
@@ -44,4 +44,9 @@ if ( config.isEnabled( 'themes/plugin-bundling' ) ) {
 	availableFlows[ 'plugin-bundle' ] = () =>
 		import( /* webpackChunkName: "plugin-bundle-flow" */ '../declarative-flow/plugin-bundle-flow' );
 }
+
+if ( config.isEnabled( 'signup/hosted-woo-onboarding' ) ) {
+	availableFlows[ 'hosted-woo' ] = () =>
+		import( /* webpackChunkName: "hosted-woo-flow" */ '../declarative-flow/hosted-woo-flow' );
+}
 export default availableFlows;

--- a/config/development.json
+++ b/config/development.json
@@ -155,6 +155,7 @@
 		"sign-in-with-apple/redirect": true,
 		"signup/design-picker-pattern-assembler": true,
 		"signup/free-flow": true,
+		"signup/hosted-woo-onboarding": true,
 		"signup/inline-help": false,
 		"signup/professional-email-step": false,
 		"signup/social": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -100,6 +100,7 @@
 		"sign-in-with-apple": false,
 		"signup/design-picker-pattern-assembler": true,
 		"signup/free-flow": true,
+		"signup/hosted-woo-onboarding": false,
 		"signup/inline-help": false,
 		"signup/professional-email-step": false,
 		"signup/social": true,

--- a/config/production.json
+++ b/config/production.json
@@ -118,6 +118,7 @@
 		"sign-in-with-apple/redirect": true,
 		"signup/design-picker-pattern-assembler": true,
 		"signup/free-flow": false,
+		"signup/hosted-woo-onboarding": false,
 		"signup/inline-help": false,
 		"signup/professional-email-step": false,
 		"signup/social": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -116,6 +116,7 @@
 		"sign-in-with-apple/redirect": true,
 		"signup/design-picker-pattern-assembler": true,
 		"signup/free-flow": false,
+		"signup/hosted-woo-onboarding": false,
 		"signup/inline-help": false,
 		"signup/professional-email-step": false,
 		"signup/social": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -125,6 +125,7 @@
 		"sign-in-with-apple": true,
 		"sign-in-with-apple/redirect": true,
 		"signup/design-picker-pattern-assembler": true,
+		"signup/hosted-woo-onboarding": false,
 		"signup/inline-help": false,
 		"signup/professional-email-step": false,
 		"signup/social": true,

--- a/packages/onboarding/src/utils/flows.ts
+++ b/packages/onboarding/src/utils/flows.ts
@@ -6,6 +6,7 @@ export const LINK_IN_BIO_POST_SETUP_FLOW = 'link-in-bio-post-setup';
 export const VIDEOPRESS_FLOW = 'videopress';
 export const IMPORT_FOCUSED_FLOW = 'import-focused';
 export const ECOMMERCE_FLOW = 'ecommerce';
+export const HOSTED_WOO_FLOW = 'hosted-woo';
 export const FREE_FLOW = 'free';
 
 export const isLinkInBioFlow = ( flowName: string | null ) => {


### PR DESCRIPTION
#### Proposed Changes

* This PR initializes a boilerplate version of the Hosted Woo onboarding flow. It places this flow at `/setup/hosted-woo` and hides it behind the feature flag `signup/hosted-woo-onboarding`. It is otherwise completely functionally equivalent at this point to the ecommerce tailored onboarding flow, except that the Intro step has been removed and some custom styling has been applied to the store profiler step to use Woo brand coloring when in this flow.
* From here, further updates can be made to support the designs expressed in pbIJXs-2Hl-p2

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* With the `signup/hosted-woo-onboarding` feature flag enabled in your local environment, verify that you can navigate to `/setup/hosted-woo` and see a store profiler view with purple button.
* Verify that this flow is not yet accessible without the feature flag enabled.
* Verify that the ecommerce flow is unaffected in both cases.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to paYKcK-2sx-p2