### PR TITLE
Odyssey Stats: remove broken links from followers sections

### DIFF
--- a/apps/odyssey-stats/src/wp-admin.scss
+++ b/apps/odyssey-stats/src/wp-admin.scss
@@ -10,7 +10,7 @@
 .wp-admin {
 	& .layout__content,
 	&.theme-default .focus-content .layout__content {
-		padding-top: 0;
+		padding-top: 32px;
 		padding-left: 1px;
 	}
 	// Fixed header doesn't work well for WP-Admin, as the masterbar isn't fixed.
@@ -52,4 +52,5 @@
 		// Override WP-Admin styles.
 		float: none;
 	}
+
 }

--- a/apps/odyssey-stats/src/wp-admin.scss
+++ b/apps/odyssey-stats/src/wp-admin.scss
@@ -52,5 +52,4 @@
 		// Override WP-Admin styles.
 		float: none;
 	}
-
 }

--- a/client/my-sites/stats/stats-followers/index.jsx
+++ b/client/my-sites/stats/stats-followers/index.jsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { Card } from '@automattic/components';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
@@ -83,6 +84,7 @@ class StatModuleFollowers extends Component {
 			numberFormat,
 			emailQuery,
 			wpcomQuery,
+			isOdysseyStats,
 		} = this.props;
 		const isLoading = requestingWpcomFollowers || requestingEmailFollowers;
 		const hasEmailFollowers = !! get( emailData, 'subscribers', [] ).length;
@@ -104,9 +106,10 @@ class StatModuleFollowers extends Component {
 
 		const summaryPageSlug = siteSlug || '';
 		const summaryPageLink =
-			'email-followers' === activeFilter
+			! isOdysseyStats &&
+			( 'email-followers' === activeFilter
 				? '/people/email-followers/' + summaryPageSlug
-				: '/people/followers/' + summaryPageSlug;
+				: '/people/followers/' + summaryPageSlug );
 
 		return (
 			<div>
@@ -205,6 +208,7 @@ const connectComponent = connect(
 			wpcomQuery,
 			siteId,
 			siteSlug,
+			isOdysseyStats: config.isEnabled( 'is_running_in_jetpack_site' ),
 		};
 	},
 	{ recordGoogleEvent }

--- a/client/my-sites/stats/stats-followers/index.jsx
+++ b/client/my-sites/stats/stats-followers/index.jsx
@@ -105,11 +105,13 @@ class StatModuleFollowers extends Component {
 		];
 
 		const summaryPageSlug = siteSlug || '';
-		const summaryPageLink =
-			! isOdysseyStats &&
-			( 'email-followers' === activeFilter
+		let summaryPageLink =
+			'email-followers' === activeFilter
 				? '/people/email-followers/' + summaryPageSlug
-				: '/people/followers/' + summaryPageSlug );
+				: '/people/followers/' + summaryPageSlug;
+
+		// Limit scope for Odyssey stats, as the Followers page is not yet available.
+		summaryPageLink = ! isOdysseyStats ? summaryPageLink : '';
 
 		return (
 			<div>

--- a/client/my-sites/stats/stats-followers/index.jsx
+++ b/client/my-sites/stats/stats-followers/index.jsx
@@ -111,7 +111,7 @@ class StatModuleFollowers extends Component {
 				: '/people/followers/' + summaryPageSlug;
 
 		// Limit scope for Odyssey stats, as the Followers page is not yet available.
-		summaryPageLink = ! isOdysseyStats ? summaryPageLink : '';
+		summaryPageLink = ! isOdysseyStats ? summaryPageLink : null;
 
 		return (
 			<div>

--- a/client/my-sites/stats/stats-reach/index.jsx
+++ b/client/my-sites/stats/stats-reach/index.jsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { Card } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import { get, reduce } from 'lodash';
@@ -14,7 +15,15 @@ import StatsTabs from '../stats-tabs';
 import StatsTab from '../stats-tabs/tab';
 
 export const StatsReach = ( props ) => {
-	const { translate, siteId, followData, publicizeData, isLoadingPublicize, siteSlug } = props;
+	const {
+		translate,
+		siteId,
+		followData,
+		publicizeData,
+		isLoadingPublicize,
+		siteSlug,
+		isOdysseyStats,
+	} = props;
 
 	const isLoadingFollowData = ! followData;
 	const wpcomFollowCount = get( followData, 'total_wpcom', 0 );
@@ -38,7 +47,7 @@ export const StatsReach = ( props ) => {
 						gridicon="my-sites"
 						label={ translate( 'WordPress.com' ) }
 						loading={ isLoadingFollowData }
-						href={ `/people/followers/${ siteSlug }` }
+						href={ ! isOdysseyStats && `/people/followers/${ siteSlug }` }
 						value={ wpcomFollowCount }
 						compact
 					/>
@@ -46,7 +55,7 @@ export const StatsReach = ( props ) => {
 						gridicon="mail"
 						label={ translate( 'Email' ) }
 						loading={ isLoadingFollowData }
-						href={ `/people/email-followers/${ siteSlug }` }
+						href={ ! isOdysseyStats && `/people/email-followers/${ siteSlug }` }
 						value={ emailFollowCount }
 						compact
 					/>
@@ -77,5 +86,6 @@ export default connect( ( state ) => {
 		publicizeData,
 		isLoadingPublicize,
 		siteSlug,
+		isOdysseyStats: config.isEnabled( 'is_running_in_jetpack_site' ),
 	};
 } )( localize( StatsReach ) );

--- a/client/my-sites/stats/stats-reach/index.jsx
+++ b/client/my-sites/stats/stats-reach/index.jsx
@@ -47,7 +47,7 @@ export const StatsReach = ( props ) => {
 						gridicon="my-sites"
 						label={ translate( 'WordPress.com' ) }
 						loading={ isLoadingFollowData }
-						href={ ! isOdysseyStats && `/people/followers/${ siteSlug }` }
+						href={ ! isOdysseyStats ? `/people/followers/${ siteSlug }` : null }
 						value={ wpcomFollowCount }
 						compact
 					/>
@@ -55,7 +55,7 @@ export const StatsReach = ( props ) => {
 						gridicon="mail"
 						label={ translate( 'Email' ) }
 						loading={ isLoadingFollowData }
-						href={ ! isOdysseyStats && `/people/email-followers/${ siteSlug }` }
+						href={ ! isOdysseyStats ? `/people/email-followers/${ siteSlug }` : null }
 						value={ emailFollowCount }
 						compact
 					/>


### PR DESCRIPTION
#### Proposed Changes

The PR removes broken links in the followers sections so that we could limit the scope of the first Odyssey Stats release. The PR also took the chance to fix the `padding-top` to allow more space on top of the page title.

#### Testing Instructions

* Enable Odyssey Stats for your Jetpack site (`PejTkB-3E-p2`)
* Open `/wp-admin/admin.php?page=stats`
* Click Insights tab
* Ensure there are no broken links clickable on sections `Follower totals` and `Followers`

![image](https://user-images.githubusercontent.com/1425433/207761295-7d12464f-0927-45cb-bb29-d2427da63736.png)

![image](https://user-images.githubusercontent.com/1425433/207761385-460e15bc-d9ea-4186-a74a-efc0cf673ed7.png)



#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #71108 
