### PR TITLE
Odyssey: hide start a post button for Odyssey Stats

### DIFF
--- a/client/my-sites/stats/post-performance/index.jsx
+++ b/client/my-sites/stats/post-performance/index.jsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { Button, Card } from '@automattic/components';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
@@ -70,7 +71,8 @@ class StatsPostPerformance extends Component {
 	};
 
 	render() {
-		const { query, post, isRequesting, translate, moment, slug, siteId } = this.props;
+		const { query, post, isRequesting, translate, moment, slug, siteId, isOdysseyStats } =
+			this.props;
 		const loading = ! siteId || isRequesting;
 		const postTime = post ? moment( post.date ) : moment();
 		const cardClass = classNames( 'stats-module', 'stats-post-performance', 'is-site-overview' );
@@ -122,11 +124,13 @@ class StatsPostPerformance extends Component {
 							<p className="stats-post-performance__no-posts-message">
 								{ translate( "You haven't published any posts yet." ) }
 							</p>
-							<div className="stats-post-performance__start-post">
-								<Button primary href={ newPostUrl } onClick={ this.recordClickOnNewPostButton }>
-									{ translate( 'Start a Post' ) }
-								</Button>
-							</div>
+							{ ! isOdysseyStats && (
+								<div className="stats-post-performance__start-post">
+									<Button primary href={ newPostUrl } onClick={ this.recordClickOnNewPostButton }>
+										{ translate( 'Start a Post' ) }
+									</Button>
+								</div>
+							) }
 						</div>
 					) : null }
 					{ post ? <StatsTabs compact>{ this.buildTabs() }</StatsTabs> : null }
@@ -153,6 +157,7 @@ const connectComponent = connect(
 			query,
 			siteId,
 			viewCount,
+			isOdysseyStats: config.isEnabled( 'is_running_in_jetpack_site' ),
 		};
 	},
 	{ recordTracksEvent }


### PR DESCRIPTION
#### Proposed Changes

Hiden `Start a post` button for Odyssey Stats.

#### Testing Instructions

* Enable Odyssey Stats for your Jetpack site (`PejTkB-3E-p2`)
* Open `/wp-admin/admin.php?page=stats`
* Block requsts to `/wp-json/jetpack/v4/stats-app/sites/$siteId/posts` <- you could do this by inspecting network, right click on the request then blocking the URL
* Ensure the button is hidden on `Latest post summary`

<img width="795" alt="image" src="https://user-images.githubusercontent.com/1425433/207499479-1bb43845-ff2f-46de-822c-807b16b9ac6f.png">


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #71109 
