### PR TITLE
Welcome Tour: Update first slide copy

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-steps.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-steps.tsx
@@ -87,7 +87,7 @@ function getTourSteps(
 						if ( isPatternAssemblerFlow ) {
 							return createInterpolateElement(
 								__(
-									'This is the Site Editor, it’s where you can change everything about your site, including adding content to your homepage. <link_to_site_editor_course>Watch these short videos</link_to_site_editor_course> and take this tour to get started.',
+									'This is the Site Editor, where you can change everything about your site, including adding content to your homepage. <link_to_site_editor_course>Watch these short videos</link_to_site_editor_course> and take this tour to get started.',
 									'full-site-editing'
 								),
 								{

--- a/packages/tour-kit/src/variants/wpcom/components/wpcom-tour-kit-step-card-navigation.tsx
+++ b/packages/tour-kit/src/variants/wpcom/components/wpcom-tour-kit-step-card-navigation.tsx
@@ -36,7 +36,7 @@ const WpcomTourKitStepCardNavigation: React.FunctionComponent< Props > = ( {
 							onClick={ onNextStep }
 							ref={ setInitialFocusedElement }
 						>
-							{ __( 'Take tour', __i18n_text_domain__ ) }
+							{ __( 'Take the tour', __i18n_text_domain__ ) }
 						</Button>
 					</div>
 				) : (


### PR DESCRIPTION
#### Proposed Changes

* This is a follow-up PR based on https://github.com/Automattic/wp-calypso/pull/70641. Update the copy of the first slide in the Welcome Tour according to the [comment](https://github.com/Automattic/wp-calypso/issues/70386#issuecomment-1347836781)

```diff
- Take tour
+ Take the tour

- This is the Site Editor, it’s where you can change everything about your site, including adding content to your homepage. Watch these short videos or take a tour to get started.
+ This is the Site Editor, where you can change everything about your site, including adding content to your homepage. Watch these short videos or take a tour to get started.
```

| Before | After |
| - | - |
| ![image](https://user-images.githubusercontent.com/13596067/207524392-b44a7270-0b3f-4213-9bc6-55f91a565dbd.png) | ![image](https://user-images.githubusercontent.com/13596067/207524481-42d51647-9687-4a98-9db5-46d20db40188.png) |

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open another terminal and run `cd apps/editing-toolkit && yarn dev --sync` to sync the ETK plugin to your sandbox. Or you can run `install-plugin.sh editing-toolkit feat/pa-welcome-tour` on your sandbox.
* Sandbox **_your site_**
* Go to `/setup?siteSlug=<your_site>&flags=signup/design-picker-pattern-assembler` 
* Continue until you land on the Design Picker step
* Scroll to the bottom and click the Blank Canvas CTA
* Select any patterns and continue
* When you land on the site editor, verify the first slide is updated.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/70386#issuecomment-1347836781
