### PR TITLE
Fix WooCommerce account creation ui

### DIFF
--- a/client/blocks/login/two-factor-authentication/verification-code-form.scss
+++ b/client/blocks/login/two-factor-authentication/verification-code-form.scss
@@ -10,7 +10,7 @@
 
 .woo .two-factor-authentication__verification-code-form {
 	margin-bottom: 52px;
-	padding-bottom: 0;
+	padding: 16px 0 0;
 	text-align: center;
 
 	@media screen and ( max-width: 660px ) {
@@ -53,7 +53,6 @@
 		}
 	}
 }
-
 
 .security-key-form__add-wait-for-key {
 	text-align: center;

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -144,6 +144,7 @@
 	}
 
 	.button.is-primary,
+	.button.is-primary[disabled],
 	.login .button.is-primary {
 		background: $woo-purple-60;
 		border: none;
@@ -421,7 +422,7 @@
 
 			.continue-as-user__username {
 				font-size: 1rem;
-				font-weight: 500;
+				font-weight: 600;
 				line-height: 24px;
 				color: var(--color-gray-100);
 				grid-area: username;


### PR DESCRIPTION
#### Proposed Changes

Fixes the following UI improvements:

<img width="1106" alt="Screen Shot 2022-12-13 at 11 45 09" src="https://user-images.githubusercontent.com/4344253/207221491-7b30d12a-fec1-4341-bc0a-81ce8ef9d458.png">

<img width="1105" alt="Screen Shot 2022-12-13 at 11 45 15" src="https://user-images.githubusercontent.com/4344253/207221499-35bd757b-db3c-4691-a0c8-19249f1927d5.png">

<img width="1107" alt="Screen Shot 2022-12-13 at 11 45 25" src="https://user-images.githubusercontent.com/4344253/207221503-a3bbaa26-3cb5-4e14-81be-3b1c5d12a438.png">

figma:
4ixWMlzrxllx93tSFsCW6k-fi-6255%3A84481&t=wiwuxy9s474tduyS-0

After:

<img width="1350" alt="Screen Shot 2022-12-14 at 14 10 30" src="https://user-images.githubusercontent.com/4344253/207523164-92854f09-19ec-4bd2-a8fd-58e0b603c794.png">

<img width="1352" alt="Screen Shot 2022-12-14 at 14 10 18" src="https://user-images.githubusercontent.com/4344253/207523167-22297275-bfe6-40b5-8f82-2feed199d801.png">

<img width="1349" alt="Screen Shot 2022-12-14 at 14 22 05" src="https://user-images.githubusercontent.com/4344253/207523135-50819bb9-8c19-43ed-9081-1c16c905c57f.png">


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Set up a local wpcalypso.wordpress.com env
* Log out WP and WC account or use incognito mode
* Go to https://woocommerce.com/
* Click "Get Started"
* Replace URL wordpress.com with wpcalypso.wordpress.com
* Observe that the "Get Started" disable button is visible. 
* Go to Log in screen
* Log in with your account (Make sure you enable 2FA and secret key auth for you account)
* The buttons should have the same width
* Continue with 2FA (secret key doesn't work locally because secure limitation)
*  Go to woocommerce.com and logout
* Go to woocommerce.com
* Click "Get Started"
* Observe that the username font-weight is bold on "Continue as ..." screen

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #71112 