### PR TITLE
Update 'Full Site Editing' => Site Editing in theme switch modal

### DIFF
--- a/client/my-sites/themes/thanks-modal.jsx
+++ b/client/my-sites/themes/thanks-modal.jsx
@@ -181,7 +181,7 @@ class ThanksModal extends Component {
 				{ this.props.isFSEActive && (
 					<p className="themes__thanks-modal-fse-notice">
 						{ this.props.translate(
-							'This theme supports Site Editing that allows you to edit every aspect of your site all in one place, making it easier than ever to create exactly what you want!'
+							'This theme uses the Site Editor, which lets you edit every aspect of your site with blocks, making it easier than ever to create exactly what you want.'
 						) }
 					</p>
 				) }

--- a/client/my-sites/themes/thanks-modal.jsx
+++ b/client/my-sites/themes/thanks-modal.jsx
@@ -181,7 +181,7 @@ class ThanksModal extends Component {
 				{ this.props.isFSEActive && (
 					<p className="themes__thanks-modal-fse-notice">
 						{ this.props.translate(
-							'This theme uses Full Site Editing to allow you to edit every aspect of your site all in one place, making it easier than ever to create exactly what you want!'
+							'This theme supports Site Editing that allows you to edit every aspect of your site all in one place, making it easier than ever to create exactly what you want!'
 						) }
 					</p>
 				) }


### PR DESCRIPTION
#### Proposed Changes

With some paraphrasing. @SaxonF could you check if my English makes sense 😄 

| Before | After |
|-|-|
|<img width="345" alt="image" src="https://user-images.githubusercontent.com/1525580/207539133-16853821-9007-4aa5-af8f-68e138892b7f.png">|<img width="344" alt="image" src="https://user-images.githubusercontent.com/1525580/209494248-a34455dd-f9d6-43c1-ae49-70c34c2cc326.png">|

#### Testing Instructions

1. Go to `/themes/<siteSlug>`
2. Activate another block theme
3. Verify that the text in the success modal matches with above.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #70303
