### PR TITLE
Fix incorrect padding by increasing CSS rule specificity weight

### DIFF
--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/style.scss
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/style.scss
@@ -7,7 +7,7 @@
 		display: flex;
 	}
 
-	.ellipsis-menu__toggle {
+	.ellipsis-menu__toggle.button {
 		padding: 0 16px;
 		margin-right: -16px;
 	}


### PR DESCRIPTION
#### Proposed Changes

In this PR, I propose to fix missing padding occurring for the ellipsis menu on post pages on wpcalypso and local dev environments.

##### Technical Details

The issue happens on wpcalypso and local environments. We asynchronously require an account settings component there:

https://github.com/Automattic/wp-calypso/blob/6822bcdaae9dd4a96a5fc52a6fd86a8779684d25/client/lib/load-dev-helpers/index.js#L5

It loads the CSS asynchronously and the response contains styles for `.button.is-borderless` which set padding to 0:

https://github.com/Automattic/wp-calypso/blob/trunk/packages/components/src/button/style.scss#L197

That rule loaded by async request has higher specificity. I'm fixing it by increasing the specificity of the rule defined for the post actions menu.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Navigate to the single blog posts list (`/posts/<SLUG>`)
2. Confirm that ellipsis has proper padding, and it's not glued to right box border

| **Before** | **After** |
|-|-|
| ![Screen Shot 2022-12-14 at 11 17 32](https://user-images.githubusercontent.com/727413/207569014-f288dbdf-ddc2-437b-aba1-81cd8e4a03b5.png) | ![Screen Shot 2022-12-14 at 11 17 41](https://user-images.githubusercontent.com/727413/207568975-b7be3bb5-106c-41ab-bd54-fdf567c69cd5.png) | 


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/71007
