### PR TITLE
Fix checkmark alignment on Unlock Style modal

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/upgrade-modal.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/upgrade-modal.scss
@@ -162,7 +162,7 @@ $design-button-primary-hover-color: var(--color-primary-60);
 
 		li {
 			display: flex;
-			align-self: flex-start;
+			align-items: flex-start;
 		}
 
 		.gridicon {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/upgrade-modal.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/upgrade-modal.scss
@@ -169,6 +169,8 @@ $design-button-primary-hover-color: var(--color-primary-60);
 			fill: var(--studio-green-50);
 			flex-shrink: 0;
 			margin-right: 10px;
+			align-self: flex-start;
+			margin-top: 4px;
 		}
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/upgrade-modal.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/upgrade-modal.scss
@@ -162,14 +162,13 @@ $design-button-primary-hover-color: var(--color-primary-60);
 
 		li {
 			display: flex;
-			align-items: center;
+			align-self: flex-start;
 		}
 
 		.gridicon {
 			fill: var(--studio-green-50);
 			flex-shrink: 0;
 			margin-right: 10px;
-			align-self: flex-start;
 			margin-top: 4px;
 		}
 	}


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/71060

#### Proposed Changes

Align the checkmarks displayed on the "Unlock this style" modal to the top.

Before | After
--- | ---
<img width="296" alt="Screenshot 2022-12-14 at 11 50 46" src="https://user-images.githubusercontent.com/1233880/207579179-0c27a76d-824f-45d3-8e88-43eb6d79b7ad.png"> | <img width="290" alt="Screenshot 2022-12-14 at 12 03 21" src="https://user-images.githubusercontent.com/1233880/207579196-b867b28b-633f-4035-bf59-05abbe1fb580.png">


#### Testing Instructions

- Use the Calypso live link below
- Create a new site
- Add the `wpcom-limit-global-styles` blog sticker
- Go to `/setup/site-setup/designSetup?siteSlug=<SITE_DOMAIN>
- Select a theme with style variations
- Pick a premium style variation
- Click on the "Unlock this style" button
- Make sure the checkmarks used by the features highlighted in the modal are aligned to the top
