### PR TITLE
Stats: Add callback for link-clicked events in MobilePromoCard

### DIFF
--- a/packages/components/src/mobile-promo-card/index.tsx
+++ b/packages/components/src/mobile-promo-card/index.tsx
@@ -8,11 +8,6 @@ import storeBadgeApple from './images/store-apple.png';
 import storeBadgeGoogle from './images/store-google.png';
 import { WordPressJetpackSVG } from './svg-icons';
 
-export type MobilePromoCardProps = {
-	className?: string;
-	isWoo?: boolean;
-};
-
 // Slugs as used by Jetpack Redirects.
 // See https://jetpack.com/redirect for current URLs.
 // Two _QRCode constants are included for reference only.
@@ -40,12 +35,36 @@ function getRedirectUrl( key: string ): string | null {
 	return 'https://jetpack.com/redirect/?source=' + REDIRECT_SLUGS[ key ];
 }
 
-export default function MobilePromoCard( { className, isWoo }: MobilePromoCardProps ) {
+// For relaying click events to the caller.
+const CLICK_EVENTS = {
+	jetpackClickA8C: 'jetpack-click-a8c',
+	jetpackClickApple: 'jetpack-click-apple',
+	jetpackClickGoogle: 'jetpack-click-google',
+	wooClickA8C: 'woo-click-a8c',
+	wooClickApple: 'woo-click-apple',
+	wooClickGoogle: 'woo-click-google',
+};
+
+export type MobilePromoCardProps = {
+	className?: string;
+	isWoo?: boolean;
+	clickHandler?: ( eventName: string ) => void;
+};
+
+export default function MobilePromoCard( {
+	className,
+	isWoo,
+	clickHandler,
+}: MobilePromoCardProps ) {
 	const translate = useTranslate();
 	// Basic user agent testing so we can show app store badges on moble.
 	const userAgent = window.navigator.userAgent.toLowerCase();
 	const isApple = userAgent.includes( 'iphone' ) || userAgent.includes( 'ipad' );
 	const isGoogle = userAgent.includes( 'android' );
+
+	const onClickHandler = ( eventName: string ) => {
+		clickHandler?.( eventName );
+	};
 
 	// Determines message text based on mobile, tablet, or Desktop.
 	const getMessage = () => {
@@ -67,7 +86,11 @@ export default function MobilePromoCard( { className, isWoo }: MobilePromoCardPr
 				{
 					components: {
 						a: (
-							<a className="woo" href={ getRedirectUrl( 'wooA8C' ) ?? 'https://woo.com/mobile' } />
+							<a
+								className="woo"
+								href={ getRedirectUrl( 'wooA8C' ) ?? 'https://woo.com/mobile' }
+								onClick={ () => onClickHandler( CLICK_EVENTS.wooClickA8C ) }
+							/>
 						),
 					},
 				}
@@ -81,6 +104,7 @@ export default function MobilePromoCard( { className, isWoo }: MobilePromoCardPr
 						<a
 							className="jetpack"
 							href={ getRedirectUrl( 'jetpackA8C' ) ?? 'https://jetpack.com/app' }
+							onClick={ () => onClickHandler( CLICK_EVENTS.jetpackClickA8C ) }
 						/>
 					),
 				},
@@ -93,8 +117,12 @@ export default function MobilePromoCard( { className, isWoo }: MobilePromoCardPr
 		const fallbackLink = isWoo ? 'https://woo.com/mobile' : 'https://jetpack.com/app';
 		if ( isApple ) {
 			const appStoreLink = isWoo ? getRedirectUrl( 'wooApple' ) : getRedirectUrl( 'jetpackApple' );
+			const tracksEventName = isWoo ? CLICK_EVENTS.wooClickApple : CLICK_EVENTS.jetpackClickApple;
 			return (
-				<a href={ appStoreLink ?? fallbackLink }>
+				<a
+					href={ appStoreLink ?? fallbackLink }
+					onClick={ () => onClickHandler( tracksEventName ) }
+				>
 					<img
 						className="promo-store-badge"
 						src={ storeBadgeApple }
@@ -107,8 +135,12 @@ export default function MobilePromoCard( { className, isWoo }: MobilePromoCardPr
 			const appStoreLink = isWoo
 				? getRedirectUrl( 'wooGoogle' )
 				: getRedirectUrl( 'jetpackGoogle' );
+			const tracksEventName = isWoo ? CLICK_EVENTS.wooClickGoogle : CLICK_EVENTS.jetpackClickGoogle;
 			return (
-				<a href={ appStoreLink ?? fallbackLink }>
+				<a
+					href={ appStoreLink ?? fallbackLink }
+					onClick={ () => onClickHandler( tracksEventName ) }
+				>
 					<img
 						className="promo-store-badge"
 						src={ storeBadgeGoogle }

--- a/packages/components/src/mobile-promo-card/stories/index.stories.jsx
+++ b/packages/components/src/mobile-promo-card/stories/index.stories.jsx
@@ -10,10 +10,18 @@ const Template = ( args ) => <MobilePromoCard { ...args } />;
 export const Default = Template.bind( {} );
 Default.args = {
 	className: 'jetpack-promo',
+	clickHandler: ( eventName ) => {
+		// eslint-disable-next-line no-console
+		console.log( 'click event! ' + eventName );
+	},
 };
 
 export const WooPromo = Template.bind( {} );
 WooPromo.args = {
 	className: 'woo-promo',
 	isWoo: true,
+	clickHandler: ( eventName ) => {
+		// eslint-disable-next-line no-console
+		console.log( 'click event! ' + eventName );
+	},
 };


### PR DESCRIPTION
#### Proposed Changes

Adds a callback property so the caller can do things (like support Tracks) when links are clicked. Returns three event types per card (Jetpack or Woo):

- `click-a8c`
- `click-apple`
- `click-google`

Events are prefaced with either `jetpack` or `woo` depending on the promo card displayed.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this branch.
* Run `yarn workspace @automattic/components run storybook`.
* Visit the Mobile Promo Card entry.
* Click a few links and check the Console view for events being logged.

**Note:** Logging is only in the story via a test callback. No calls to `console.log` exist in the end component.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #69230
