### PR TITLE
Marketplace Themes: Fix the visibility for the marketplace theme options

### DIFF
--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -69,7 +69,6 @@ function getAllThemeOptions( { translate, isFSEActive } ) {
 		hideForTheme: ( state, themeId, siteId ) =>
 			( isJetpackSite( state, siteId ) && ! isSiteWpcomAtomic( state, siteId ) ) || // No individual theme purchase on a JP site
 			! isUserLoggedIn( state ) || // Not logged in
-			! isThemePremium( state, themeId ) || // Not a premium theme
 			isPremiumThemeAvailable( state, themeId, siteId ) || // Already purchased individually, or thru a plan
 			doesThemeBundleSoftwareSet( state, themeId ) || // Premium themes with bundled Software Sets cannot be purchased ||
 			! isExternallyManagedTheme( state, themeId ) || // We're currently only subscribing to third-party themes
@@ -151,7 +150,6 @@ function getAllThemeOptions( { translate, isFSEActive } ) {
 			isJetpackSite( state, siteId ) ||
 			isSiteWpcomAtomic( state, siteId ) ||
 			! isUserLoggedIn( state ) ||
-			! isThemePremium( state, themeId ) ||
 			! isExternallyManagedTheme( state, themeId ) ||
 			( isExternallyManagedTheme( state, themeId ) &&
 				isSiteEligibleForManagedExternalThemes( state, siteId ) ) ||
@@ -169,6 +167,8 @@ function getAllThemeOptions( { translate, isFSEActive } ) {
 		hideForTheme: ( state, themeId, siteId ) =>
 			! isUserLoggedIn( state ) ||
 			isJetpackSiteMultiSite( state, siteId ) ||
+			( isExternallyManagedTheme( state, themeId ) &&
+				! isPremiumThemeAvailable( state, themeId, siteId ) ) ||
 			isThemeActive( state, themeId, siteId ) ||
 			( ! isWpcomTheme( state, themeId ) && ! isSiteWpcomAtomic( state, siteId ) ) ||
 			( isThemePremium( state, themeId ) && ! isPremiumThemeAvailable( state, themeId, siteId ) ),

--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -32,6 +32,7 @@ import {
 	isSiteEligibleForManagedExternalThemes,
 	isWpcomTheme,
 } from 'calypso/state/themes/selectors';
+import { isMarketplaceThemeSubscribed } from 'calypso/state/themes/selectors/is-marketplace-theme-subscribed';
 
 const identity = ( theme ) => theme;
 
@@ -69,7 +70,7 @@ function getAllThemeOptions( { translate, isFSEActive } ) {
 		hideForTheme: ( state, themeId, siteId ) =>
 			( isJetpackSite( state, siteId ) && ! isSiteWpcomAtomic( state, siteId ) ) || // No individual theme purchase on a JP site
 			! isUserLoggedIn( state ) || // Not logged in
-			isPremiumThemeAvailable( state, themeId, siteId ) || // Already purchased individually, or thru a plan
+			isMarketplaceThemeSubscribed( state, themeId, siteId ) || // Already purchased individually, or thru a plan
 			doesThemeBundleSoftwareSet( state, themeId ) || // Premium themes with bundled Software Sets cannot be purchased ||
 			! isExternallyManagedTheme( state, themeId ) || // We're currently only subscribing to third-party themes
 			( isExternallyManagedTheme( state, themeId ) &&
@@ -168,7 +169,7 @@ function getAllThemeOptions( { translate, isFSEActive } ) {
 			! isUserLoggedIn( state ) ||
 			isJetpackSiteMultiSite( state, siteId ) ||
 			( isExternallyManagedTheme( state, themeId ) &&
-				! isPremiumThemeAvailable( state, themeId, siteId ) ) ||
+				! isMarketplaceThemeSubscribed( state, themeId, siteId ) ) ||
 			isThemeActive( state, themeId, siteId ) ||
 			( ! isWpcomTheme( state, themeId ) && ! isSiteWpcomAtomic( state, siteId ) ) ||
 			( isThemePremium( state, themeId ) && ! isPremiumThemeAvailable( state, themeId, siteId ) ),

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -10,6 +10,7 @@ import { connect } from 'react-redux';
 import UpworkBanner from 'calypso/blocks/upwork-banner';
 import { isUpworkBannerDismissed } from 'calypso/blocks/upwork-banner/selector';
 import DocumentHead from 'calypso/components/data/document-head';
+import QueryProductsList from 'calypso/components/data/query-products-list';
 import QuerySitePlans from 'calypso/components/data/query-site-plans';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import QueryThemeFilters from 'calypso/components/data/query-theme-filters';
@@ -582,6 +583,7 @@ class ThemeShowcase extends Component {
 					{ this.renderThemes( themeProps ) }
 					{ siteId && <QuerySitePlans siteId={ siteId } /> }
 					{ siteId && <QuerySitePurchases siteId={ siteId } /> }
+					<QueryProductsList />
 					<ThanksModal source="list" />
 					<AutoLoadingHomepageModal source="list" />
 					<ThemePreview />

--- a/client/state/themes/selectors/is-marketplace-theme-subscribed.ts
+++ b/client/state/themes/selectors/is-marketplace-theme-subscribed.ts
@@ -15,7 +15,7 @@ export function isMarketplaceThemeSubscribed( state = {}, themeId: string, siteI
 
 	const sitePurchases = getSitePurchases( state, siteId );
 
-	return (
+	return !! (
 		sitePurchases &&
 		sitePurchases.find( ( purchase ) => {
 			return (

--- a/client/state/themes/selectors/is-marketplace-theme-subscribed.ts
+++ b/client/state/themes/selectors/is-marketplace-theme-subscribed.ts
@@ -3,7 +3,7 @@ import { getProductsByBillingSlug } from 'calypso/state/products-list/selectors'
 import { getSitePurchases } from 'calypso/state/purchases/selectors';
 
 /**
- * Checks if the user has a subscription to the theme.
+ * Checks if the site has a subscription to the theme.
  *
  * @param {object} state global state
  * @param {string} themeId theme id

--- a/client/state/themes/selectors/is-marketplace-theme-subscribed.ts
+++ b/client/state/themes/selectors/is-marketplace-theme-subscribed.ts
@@ -8,7 +8,7 @@ import { getSitePurchases } from 'calypso/state/purchases/selectors';
  * @param {object} state global state
  * @param {string} themeId theme id
  * @param {number} siteId site id
- * @returns {boolean} true if the user subscribed to the theme
+ * @returns {boolean} true if the site subscribed to the theme
  */
 export function isMarketplaceThemeSubscribed( state = {}, themeId: string, siteId: number ) {
 	const products = getProductsByBillingSlug( state, marketplaceThemeBillingProductSlug( themeId ) );

--- a/client/state/themes/selectors/is-marketplace-theme-subscribed.ts
+++ b/client/state/themes/selectors/is-marketplace-theme-subscribed.ts
@@ -1,0 +1,26 @@
+import { marketplaceThemeBillingProductSlug } from 'calypso/my-sites/themes/helpers';
+import { getProductsByBillingSlug } from 'calypso/state/products-list/selectors';
+import { getSitePurchases } from 'calypso/state/purchases/selectors';
+
+/**
+ * Checks if the user has a subscription to the theme.
+ *
+ * @param {object} state global state
+ * @param {string} themeId theme id
+ * @param {number} siteId site id
+ * @returns {boolean} true if the user subscribed to the theme
+ */
+export function isMarketplaceThemeSubscribed( state = {}, themeId: string, siteId: number ) {
+	const products = getProductsByBillingSlug( state, marketplaceThemeBillingProductSlug( themeId ) );
+
+	const sitePurchases = getSitePurchases( state, siteId );
+
+	return (
+		sitePurchases &&
+		sitePurchases.find( ( purchase ) => {
+			return (
+				products && products.find( ( product ) => purchase.productSlug === product.product_slug )
+			);
+		} )
+	);
+}


### PR DESCRIPTION
#### Proposed Changes

Because we were using a fake theme based on Tsubaki, we used some functions that would also threaten the marketplace themes as premium themes. Now that we have a marketplace theme test, we noticed that some conditions wouldn't work properly for this new test theme(Makoney).

* This PR fixes the behavior on the kebab menu for Marketplace themes. 

#### Testing Instructions

Follow the instructions in this link D92217-code to sandbox the public-api.

* On a free site, navigate to `/themes/{SITE}?s=makoney`
* Clicking on the kebab menu should show the option to `Upgrade to subscribe`
* Upgrade your site to the Business plan(clicking on the `Upgrade to subscribe` option will add both the plan and the subscription for the theme to the cart. If you want to proceed with the testing in this path, remove the theme subscription before checking out)
* Navigate to `/themes/{SITE}?s=makoney` on a site with the Business plan.
* Clicking on the kebab menu should show the option to `Subscribe`
* Click on the `Subscribe` option(this should only include the Theme subscription to the cart) and proceed to checkout.
* After the checkout, navigate to `/themes/{SITE}?s=makoney`.
* Clicking on the kebab menu should show the option to `Activate` the theme

Related to #70406
Closes #71174 #71173