### PR TITLE
Mark PHP8.2 as experimental

### DIFF
--- a/client/my-sites/hosting/web-server-settings-card/index.js
+++ b/client/my-sites/hosting/web-server-settings-card/index.js
@@ -114,7 +114,7 @@ const WebServerSettingsCard = ( {
 				value: '8.1',
 			},
 			{
-				label: translate( '8.2', {
+				label: translate( '8.2 (experimental)', {
 					comment: 'PHP Version for a version switcher',
 				} ),
 				value: '8.2',


### PR DESCRIPTION
Because Jetpack and WP core support isn't there yet.

![Screenshot from 2022-12-14 13-20-44](https://user-images.githubusercontent.com/1103398/207593904-80f034a5-58d8-404f-b4d3-ba9b6ce59855.png)
