### PR TITLE
Plugins: Update the plugin icons handling to use the URL if this is returned by the server

### DIFF
--- a/client/data/marketplace/use-es-query.ts
+++ b/client/data/marketplace/use-es-query.ts
@@ -27,6 +27,11 @@ import type { ESHits, ESResponse, Plugin, PluginQueryOptions, Icon } from './typ
  * 	a default generated url Icon if icons param is falsy, it is not JSON or it does not contain a valid resolution
  */
 const createIconUrl = ( pluginSlug: string, icons?: string ): string => {
+	try {
+		const url = new URL( icons || '' );
+		return url.toString();
+	} catch ( _ ) {}
+
 	const defaultIconUrl = buildDefaultIconUrl( pluginSlug );
 	if ( ! icons ) {
 		return defaultIconUrl;


### PR DESCRIPTION
#### Proposed Changes

Update the plugin icons handling to use the URL if this is returned by the server, this will start to happen after this deployment D95204-code

#### Testing Instructions

This shouldn't present any visible change, as the sever still sending a JSON, but it should change in the future after the deployment of D95204-code

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #70233