### PR TITLE
Limit Global Styles: Update privacy settings notice

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -1,8 +1,10 @@
 import { isEnabled } from '@automattic/calypso-config';
 import {
 	PLAN_BUSINESS,
+	PLAN_PREMIUM,
 	WPCOM_FEATURES_NO_WPCOM_BRANDING,
 	WPCOM_FEATURES_SITE_PREVIEW_LINKS,
+	FEATURE_ADVANCED_DESIGN_CUSTOMIZATION,
 } from '@automattic/calypso-products';
 import { WPCOM_FEATURES_SUBSCRIPTION_GIFTING } from '@automattic/calypso-products/src';
 import { Card, CompactCard, Button, Gridicon } from '@automattic/components';
@@ -806,7 +808,7 @@ export class SiteSettingsFormGeneral extends Component {
 
 	advancedCustomizationNotice() {
 		const { translate, selectedSite, siteSlug } = this.props;
-		const upgradeUrl = `/plans/${ siteSlug }?plan=value_bundle`;
+		const upgradeUrl = `/plans/${ siteSlug }?plan=${ PLAN_PREMIUM }&feature=${ FEATURE_ADVANCED_DESIGN_CUSTOMIZATION }`;
 
 		return (
 			<>
@@ -815,7 +817,7 @@ export class SiteSettingsFormGeneral extends Component {
 						<Gridicon icon="info-outline" />
 						<span>
 							{ translate(
-								'Publish your style changes and unlock tons of other features by upgrading to a Premium plan.'
+								'Your site contains customized styles that will only be visible once you upgrade to a Premium plan.'
 							) }
 						</span>
 					</div>

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -657,6 +657,10 @@ button.site-settings__general-settings-set-guessed-timezone.button.is-borderless
 	@include break-xlarge {
 		flex-direction: row;
 
+		.site-settings__advanced-customization-notice-cta {
+			margin-right: 20px;
+		}
+
 		.site-settings__advanced-customization-notice-buttons {
 			padding-top: 0;
 		}


### PR DESCRIPTION
#### Proposed Changes

- Updates the wording used in the Limited Global Styles notices that appears on the privacy settings so it's consistent with the copy changes introduced in https://github.com/Automattic/wp-calypso/pull/70880.
- Adds a `feature` param to the upgrade URL so the "Advanced design customization" feature is highlighted

Before | After
--- | ---
<img width="752" alt="Screenshot 2022-12-14 at 12 53 00" src="https://user-images.githubusercontent.com/1233880/207592535-f3d17c64-2eea-4ddb-b57f-bcd45efce120.png"> | <img width="749" alt="Screenshot 2022-12-14 at 12 57 26" src="https://user-images.githubusercontent.com/1233880/207592565-fdd9d52e-f93e-419c-9b53-b5ce34cff15e.png">



#### Testing Instructions

- Use the Calypso live link below
- Create a new site and launch it
- Add the `wpcom-limit-global-styles` blog sticker
- Go to Appearance > Editor and save some style changes
- Go to Settings
- Check the Privacy panel
- Make sure the wording is coherent with what was asked in paYJgx-2Hv-p2#comment-3010
- Click on the Upgrade button
- Make sure the Plans page highlights the "Advanced design customization" feature