### PR TITLE
Jetpack Pro Dashboard: add toggle to activate monitor on the Jetpack pro dashboard

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/toggle-activate-monitoring/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/toggle-activate-monitoring/index.tsx
@@ -1,0 +1,36 @@
+import { ToggleControl as OriginalToggleControl } from '@wordpress/components';
+import { useUpdateMonitorSettings } from '../../hooks';
+import type { AllowedStatusTypes } from '../../sites-overview/types';
+
+import './style.scss';
+
+interface Props {
+	siteId: number;
+	status: AllowedStatusTypes | string;
+}
+
+export default function ToggleActivateMonitoring( { siteId, status }: Props ) {
+	const ToggleControl = OriginalToggleControl as React.ComponentType<
+		OriginalToggleControl.Props & {
+			disabled?: boolean;
+		}
+	>;
+
+	const [ updateMonitorSettings, isLoading ] = useUpdateMonitorSettings( siteId );
+
+	function handleToggleActivateMonitoring( checked: boolean ) {
+		updateMonitorSettings( { monitor_active: checked } );
+	}
+
+	const isChecked = status !== 'disabled';
+
+	return (
+		<span className="toggle-activate-monitoring__toggle-button">
+			<ToggleControl
+				onChange={ handleToggleActivateMonitoring }
+				checked={ isChecked }
+				disabled={ isLoading }
+			/>
+		</span>
+	);
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/toggle-activate-monitoring/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/toggle-activate-monitoring/index.tsx
@@ -1,25 +1,25 @@
 import { ToggleControl as OriginalToggleControl } from '@wordpress/components';
-import { useUpdateMonitorSettings } from '../../hooks';
+import { useToggleActivateMonitor } from '../../hooks';
 import type { AllowedStatusTypes } from '../../sites-overview/types';
 
 import './style.scss';
 
 interface Props {
-	siteId: number;
+	site: { blog_id: number; url: string };
 	status: AllowedStatusTypes | string;
 }
 
-export default function ToggleActivateMonitoring( { siteId, status }: Props ) {
+export default function ToggleActivateMonitoring( { site, status }: Props ) {
 	const ToggleControl = OriginalToggleControl as React.ComponentType<
 		OriginalToggleControl.Props & {
 			disabled?: boolean;
 		}
 	>;
 
-	const [ updateMonitorSettings, isLoading ] = useUpdateMonitorSettings( siteId );
+	const [ toggleActivateMonitor, isLoading ] = useToggleActivateMonitor( site );
 
 	function handleToggleActivateMonitoring( checked: boolean ) {
-		updateMonitorSettings( { monitor_active: checked } );
+		toggleActivateMonitor( checked );
 	}
 
 	const isChecked = status !== 'disabled';

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/toggle-activate-monitoring/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/toggle-activate-monitoring/style.scss
@@ -1,0 +1,14 @@
+@import "@wordpress/base-styles/mixins";
+
+.components-form-toggle.is-checked .components-form-toggle__track {
+	background-color: var(--studio-jetpack-green-50);
+}
+
+.components-toggle-control .components-base-control__field {
+	margin-bottom: 0;
+}
+
+.toggle-activate-monitoring__toggle-button {
+	display: inline-flex;
+	align-items: center;
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/hooks.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/hooks.tsx
@@ -1,0 +1,72 @@
+import { useTranslate } from 'i18n-calypso';
+import { useCallback, useContext } from 'react';
+import { useQueryClient } from 'react-query';
+import { useDispatch } from 'react-redux';
+import useUpdateMonitorSettingsMutation from 'calypso/state/jetpack-agency-dashboard/hooks/use-update-monitor-settings-mutation';
+import { errorNotice } from 'calypso/state/notices/actions';
+import SitesOverviewContext from './sites-overview/context';
+import type {
+	Site,
+	APIError,
+	UpdateMonitorSettingsParams,
+} from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/types';
+
+export function useUpdateMonitorSettings(
+	siteId: number
+): [ ( params: object ) => void, boolean ] {
+	const dispatch = useDispatch();
+	const translate = useTranslate();
+	const queryClient = useQueryClient();
+	const { filter, search, currentPage } = useContext( SitesOverviewContext );
+	const queryKey = [ 'jetpack-agency-dashboard-sites', search, currentPage, filter ];
+
+	const updateMonitorSettings = useUpdateMonitorSettingsMutation( {
+		onMutate: async () => {
+			// Cancel any current refetches, so they don't overwrite our optimistic update
+			await queryClient.cancelQueries( queryKey );
+
+			// Snapshot the previous value
+			const previousSites = queryClient.getQueryData( queryKey );
+
+			// Optimistically update to the new value
+			queryClient.setQueryData( queryKey, ( oldSites: any ) => {
+				return {
+					...oldSites,
+					sites: oldSites?.sites.map( ( site: Site ) => {
+						if ( site.blog_id === siteId ) {
+							return {
+								...site,
+								monitor_active: ! site.monitor_active,
+							};
+						}
+						return site;
+					} ),
+				};
+			} );
+
+			// Store previous settings in case of failure
+			return { previousSites };
+		},
+		onError: ( error: APIError, options: any, context: any ) => {
+			queryClient.setQueryData( queryKey, context?.previousSites );
+			const errorMessage =
+				error.message ??
+				translate(
+					'Sorry, something went wrong when trying to update monitor settings. Please try again.'
+				);
+			dispatch( errorNotice( errorMessage, { isPersistent: true } ) );
+		},
+		retry: ( errorCount ) => {
+			return errorCount < 3;
+		},
+	} );
+
+	const updateSettings = useCallback(
+		( params: UpdateMonitorSettingsParams ) => {
+			updateMonitorSettings.mutate( { siteId, params } );
+		},
+		[ siteId, updateMonitorSettings ]
+	);
+
+	return [ updateSettings, updateMonitorSettings.isLoading ];
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { Button, Gridicon } from '@automattic/components';
 import { addQueryArgs } from '@wordpress/url';
 import classNames from 'classnames';
@@ -10,6 +11,7 @@ import Tooltip from 'calypso/components/tooltip';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { selectLicense, unselectLicense } from 'calypso/state/jetpack-agency-dashboard/actions';
 import { hasSelectedLicensesOfType } from 'calypso/state/jetpack-agency-dashboard/selectors';
+import ToggleActivateMonitoring from '../downtime-monitoring/toggle-activate-monitoring';
 import SiteSetFavorite from './site-set-favorite';
 import { getRowMetaData, getProductSlugFromProductType } from './utils';
 import type { AllowedTypes, SiteData } from './types';
@@ -41,7 +43,7 @@ export default function SiteStatusContent( {
 	} = getRowMetaData( rows, type, isLargeScreen );
 
 	const siteId = rows.site.value.blog_id;
-	const siteUrl = value?.url;
+	const siteUrl = rows.site.value.url;
 
 	const isLicenseSelected = useSelector( ( state ) =>
 		hasSelectedLicensesOfType( state, siteId, type )
@@ -142,6 +144,14 @@ export default function SiteStatusContent( {
 				{ errorContent }
 			</>
 		);
+	}
+
+	const isDownTimeMonitorEnabled = isEnabled(
+		'jetpack/partner-portal-downtime-monitoring-updates'
+	);
+
+	if ( isDownTimeMonitorEnabled && type === 'monitor' ) {
+		return <ToggleActivateMonitoring siteId={ siteId } status={ status } />;
 	}
 
 	let content;

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content.tsx
@@ -151,7 +151,7 @@ export default function SiteStatusContent( {
 	);
 
 	if ( isDownTimeMonitorEnabled && type === 'monitor' ) {
-		return <ToggleActivateMonitoring siteId={ siteId } status={ status } />;
+		return <ToggleActivateMonitoring site={ rows.site.value } status={ status } />;
 	}
 
 	let content;

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
@@ -140,3 +140,20 @@ export interface APIError {
 export interface APIToggleFavorite {
 	[ key: string ]: any;
 }
+
+export interface UpdateMonitorSettingsAPIResponse {
+	success: boolean;
+	settings: {
+		monitor_active: boolean;
+		email_notifications: boolean;
+		wp_note_notifications: boolean;
+	};
+}
+
+export interface UpdateMonitorSettingsParams {
+	monitor_active?: boolean;
+}
+export interface UpdateMonitorSettingsArgs {
+	siteId: number;
+	params: UpdateMonitorSettingsParams;
+}

--- a/client/state/jetpack-agency-dashboard/hooks/use-update-monitor-settings-mutation.ts
+++ b/client/state/jetpack-agency-dashboard/hooks/use-update-monitor-settings-mutation.ts
@@ -1,0 +1,27 @@
+import { useMutation, UseMutationOptions, UseMutationResult } from 'react-query';
+import wpcom from 'calypso/lib/wp';
+import type {
+	APIError,
+	UpdateMonitorSettingsAPIResponse as APIResponse,
+	UpdateMonitorSettingsArgs,
+} from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/types';
+
+function mutationUpdateMonitorSettings( {
+	siteId,
+	params,
+}: UpdateMonitorSettingsArgs ): Promise< APIResponse > {
+	return wpcom.req.post( {
+		apiNamespace: 'wpcom/v2',
+		path: `/sites/${ siteId }/jetpack-monitor-settings`,
+		body: params,
+	} );
+}
+
+export default function useUpdateMonitorSettingsMutation< TContext = unknown >(
+	options?: UseMutationOptions< APIResponse, APIError, UpdateMonitorSettingsArgs, TContext >
+): UseMutationResult< APIResponse, APIError, UpdateMonitorSettingsArgs, TContext > {
+	return useMutation< APIResponse, APIError, UpdateMonitorSettingsArgs, TContext >(
+		mutationUpdateMonitorSettings,
+		options
+	);
+}


### PR DESCRIPTION
#### Proposed Changes

This PR adds a toggle switch to the monitor column in the Jetpack Pro Dashboard that allows users to enable or disable monitor for a particular site.

#### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout add/create-toggle-to-activate-monitor-on-agency-dashboard` and `yarn start-jetpack-cloud`
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Verify that you see a toggle in the monitor column as below

<img width="1597" alt="Screenshot 2022-12-15 at 12 49 42 PM" src="https://user-images.githubusercontent.com/10586875/207807370-9b3f7ea9-901a-4642-9a04-c03e24dfcc97.png">

4. Verify that you can enable/disable the monitor for a site and that a success/error notification is shown based on the scenario.
5. Verify that the changes made are behind the feature flag.

Success notification (Activate)

<img width="1074" alt="Screenshot 2022-12-15 at 12 50 23 PM" src="https://user-images.githubusercontent.com/10586875/207807886-626b3b53-0f77-4f84-9762-34836b78aa7d.png">

-----

Success Notification (Deactivate)

<img width="1072" alt="Screenshot 2022-12-15 at 12 51 00 PM" src="https://user-images.githubusercontent.com/10586875/207807896-1b60fe2c-4621-4f37-a3c8-e50fb9b75ff3.png">

-----

Error Notification (Deactivate)

<img width="882" alt="Screenshot 2022-12-15 at 12 54 16 PM" src="https://user-images.githubusercontent.com/10586875/207807902-882fac9f-6c02-44f6-b21a-61c507599d8f.png">

-----

Error Notification (Activate)

<img width="934" alt="Screenshot 2022-12-15 at 12 55 21 PM" src="https://user-images.githubusercontent.com/10586875/207807910-771635a3-58c5-453d-8e9c-0115e907d9d7.png">

-----

> **_NOTE:_** We are not doing an optimistic update to the table because of the following reason - pedEI5-dz-p2

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1203448324265423-as-1203507036638713