### PR TITLE
Reading Settings: Add saving state to 'Site settings' section

### DIFF
--- a/client/my-sites/site-settings/reading-site-settings/index.tsx
+++ b/client/my-sites/site-settings/reading-site-settings/index.tsx
@@ -12,6 +12,7 @@ type SiteSettingsSectionProps = {
 	onChangeField: ( field: string ) => ( event: React.ChangeEvent< HTMLInputElement > ) => void;
 	handleSubmitForm: ( event: React.FormEvent< HTMLFormElement > ) => void;
 	disabled?: boolean;
+	isSavingSettings?: boolean;
 };
 
 export const SiteSettingsSection = ( {
@@ -19,6 +20,7 @@ export const SiteSettingsSection = ( {
 	onChangeField,
 	handleSubmitForm,
 	disabled,
+	isSavingSettings,
 }: SiteSettingsSectionProps ) => {
 	const translate = useTranslate();
 	const { posts_per_page } = fields;
@@ -31,6 +33,7 @@ export const SiteSettingsSection = ( {
 				showButton
 				onButtonClick={ handleSubmitForm }
 				disabled={ disabled }
+				isSaving={ isSavingSettings }
 			/>
 			<Card>
 				<BlogsPostsSetting

--- a/client/my-sites/site-settings/settings-reading/main.tsx
+++ b/client/my-sites/site-settings/settings-reading/main.tsx
@@ -73,14 +73,15 @@ const ReadingSettingsForm = wrapSettingsForm( getFormSettings )(
 						onChangeField={ onChangeField }
 						handleSubmitForm={ handleSubmitForm }
 						disabled={ disabled }
+						isSavingSettings={ isSavingSettings }
 					/>
 					<RssFeedSettingsSection
 						fields={ fields }
 						onChangeField={ onChangeField }
 						handleSubmitForm={ handleSubmitForm }
 						disabled={ disabled }
-						siteUrl={ siteUrl }
 						isSavingSettings={ isSavingSettings }
+						siteUrl={ siteUrl }
 					/>
 					<NewsletterSettingsSection
 						fields={ fields }


### PR DESCRIPTION
#### Proposed Changes

* Set saving state on the 'Site settings' section's header component

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to http://calypso.localhost:3000/settings/reading/<YOUR-BLOG>
* Click on `Save settings` button on any of the section headers and watch the button change its style and its copy to `Saving...`
Note: all the other section headers on the page have the state already applied, i.e. they are all meant to display the saving state when submitting

![Screen Shot 2022-12-14 at 13 53 33](https://user-images.githubusercontent.com/2019970/207600488-58a108ca-2586-47c5-9362-a51d343064d7.png)


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #71088
