### PR TITLE
eCommerce Onboarding: Remove `setThemeStep` in favor of backend patch

### DIFF
--- a/client/landing/stepper/declarative-flow/tailored-ecommerce-flow.ts
+++ b/client/landing/stepper/declarative-flow/tailored-ecommerce-flow.ts
@@ -19,7 +19,6 @@ import DesignCarousel from './internals/steps-repository/design-carousel';
 import DomainsStep from './internals/steps-repository/domains';
 import Intro from './internals/steps-repository/intro';
 import ProcessingStep from './internals/steps-repository/processing-step';
-import SetThemeStep from './internals/steps-repository/set-theme-step';
 import SiteCreationStep from './internals/steps-repository/site-creation-step';
 import StoreAddress from './internals/steps-repository/store-address';
 import StoreProfiler from './internals/steps-repository/store-profiler';
@@ -44,7 +43,6 @@ const ecommerceFlow: Flow = {
 			{ slug: 'siteCreationStep', component: SiteCreationStep },
 			{ slug: 'processing', component: ProcessingStep },
 			{ slug: 'waitForAtomic', component: WaitForAtomic },
-			{ slug: 'setThemeStep', component: SetThemeStep },
 			{ slug: 'checkPlan', component: CheckPlan },
 		];
 	},
@@ -103,20 +101,18 @@ const ecommerceFlow: Flow = {
 						from_section: 'default',
 					} );
 
-					setPlanCartItem( { product_slug: selectedPlan } );
+					setPlanCartItem( {
+						product_slug: selectedPlan,
+						extra: { design: selectedDesign?.recipe?.stylesheet },
+					} );
 					return navigate( 'siteCreationStep' );
 
 				case 'siteCreationStep':
 					return navigate( 'processing' );
 
 				case 'processing':
-					// Coming from setThemeStep
-					if ( providedDependencies?.selectedDesign ) {
-						return navigate( 'storeAddress' );
-					}
-
 					if ( providedDependencies?.finishedWaitingForAtomic ) {
-						return navigate( 'setThemeStep' );
+						return navigate( 'storeAddress' );
 					}
 
 					if ( providedDependencies?.siteSlug ) {
@@ -157,9 +153,6 @@ const ecommerceFlow: Flow = {
 
 				case 'designCarousel':
 					return navigate( 'domains' );
-
-				case 'setThemeStep':
-					return navigate( 'processing' );
 
 				case 'waitForAtomic':
 					return navigate( 'processing' );

--- a/client/landing/stepper/declarative-flow/tailored-ecommerce-flow.ts
+++ b/client/landing/stepper/declarative-flow/tailored-ecommerce-flow.ts
@@ -101,10 +101,7 @@ const ecommerceFlow: Flow = {
 						from_section: 'default',
 					} );
 
-					setPlanCartItem( {
-						product_slug: selectedPlan,
-						extra: { headstart_theme: selectedDesign?.recipe?.stylesheet },
-					} );
+					setPlanCartItem( { product_slug: selectedPlan } );
 					return navigate( 'siteCreationStep' );
 
 				case 'siteCreationStep':

--- a/client/landing/stepper/declarative-flow/tailored-ecommerce-flow.ts
+++ b/client/landing/stepper/declarative-flow/tailored-ecommerce-flow.ts
@@ -103,7 +103,7 @@ const ecommerceFlow: Flow = {
 
 					setPlanCartItem( {
 						product_slug: selectedPlan,
-						extra: { design: selectedDesign?.recipe?.stylesheet },
+						extra: { headstart_theme: selectedDesign?.recipe?.stylesheet },
 					} );
 					return navigate( 'siteCreationStep' );
 

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -637,6 +637,7 @@ export interface RequestCartProductExtra extends ResponseCartProductExtra {
 	site_title?: string;
 	signup_flow?: string;
 	signup?: boolean;
+	design?: string;
 }
 
 export interface GSuiteProductUser {

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -637,7 +637,7 @@ export interface RequestCartProductExtra extends ResponseCartProductExtra {
 	site_title?: string;
 	signup_flow?: string;
 	signup?: boolean;
-	design?: string;
+	headstart_theme?: string;
 }
 
 export interface GSuiteProductUser {

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -637,7 +637,6 @@ export interface RequestCartProductExtra extends ResponseCartProductExtra {
 	site_title?: string;
 	signup_flow?: string;
 	signup?: boolean;
-	headstart_theme?: string;
 }
 
 export interface GSuiteProductUser {


### PR DESCRIPTION
#### Proposed Changes

This PR removes the `SetThemeStep` from the eCommerce flow; we'll be moving that logic/handling to the backend in D95250-code

#### Testing Instructions

With this diff applied (D95250-code) and #71251 deployed, the new site should be created with the new theme and have products created as well.