### PR TITLE
Stats: MobilePromoCard integration into Stats Traffic page

### DIFF
--- a/client/my-sites/stats/mobile-promo-cards/index.jsx
+++ b/client/my-sites/stats/mobile-promo-cards/index.jsx
@@ -25,6 +25,14 @@ export default function MobilePromoCardWrapper( { isJetpack, isOdysseyStats, slu
 			recordTracksEvent( EVENT_MOBILE_PROMO_VIEW );
 		}
 	}, [ showBothPromoCards ] );
+	// handle click events here
+	const promoCardDidReceiveClick = ( event ) => {
+		// Events need to incorporate the page and the click type.
+		// This will allow us to account for integraton across different pages.
+		// FORMAT: calypso_stats_PAGE_mobile_cta_EVENT
+		const tracksEventName = `calypso_stats_traffic_mobile_cta_${ event.replaceAll( '-', '_' ) }`;
+		recordTracksEvent( tracksEventName );
+	};
 	// handle view events here
 	const pagerDidSelectPage = ( index ) => {
 		const evenLookup = [ EVENT_YOAST_PROMO_VIEW, EVENT_MOBILE_PROMO_VIEW ];
@@ -39,7 +47,10 @@ export default function MobilePromoCardWrapper( { isJetpack, isOdysseyStats, slu
 			{ ! showBothPromoCards && (
 				<div className="stats__promo-container">
 					<div className="stats__promo-card">
-						<MobilePromoCard className="stats__promo-card-apps" />
+						<MobilePromoCard
+							className="stats__promo-card-apps"
+							clickHandler={ promoCardDidReceiveClick }
+						/>
 					</div>
 				</div>
 			) }
@@ -61,7 +72,10 @@ export default function MobilePromoCardWrapper( { isJetpack, isOdysseyStats, slu
 							/>
 
 							<div>
-								<MobilePromoCard className="stats__promo-card-apps" />
+								<MobilePromoCard
+									className="stats__promo-card-apps"
+									clickHandler={ promoCardDidReceiveClick }
+								/>
 							</div>
 						</DotPager>
 					</div>

--- a/client/my-sites/stats/mobile-promo-cards/index.jsx
+++ b/client/my-sites/stats/mobile-promo-cards/index.jsx
@@ -7,11 +7,11 @@ import DotPager from 'calypso/components/dot-pager';
 
 import './style.scss';
 
-export default function MobilePromoCardWrapper( { isAtomic, isOdysseyStats, slug } ) {
+export default function MobilePromoCardWrapper( { isJetpack, isOdysseyStats, slug } ) {
 	// do some stuff
 	// Yoast promo is disabled for Odyssey & self-hosted.
 	// Mobile apps promos are always shown.
-	const showYoastPromo = ! isOdysseyStats && ! isAtomic;
+	const showYoastPromo = ! isOdysseyStats && ! isJetpack;
 	const showBothPromoCards = showYoastPromo;
 	// handle view events here
 	const pagerDidSelectPage = ( index ) => {

--- a/client/my-sites/stats/mobile-promo-cards/index.jsx
+++ b/client/my-sites/stats/mobile-promo-cards/index.jsx
@@ -1,5 +1,6 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { translate } from 'i18n-calypso';
+import { useEffect } from 'react';
 import { MobilePromoCard } from 'calypso/../packages/components/src';
 import wordpressSeoIllustration from 'calypso/assets/images/illustrations/wordpress-seo-premium.svg';
 import PromoCardBlock from 'calypso/blocks/promo-card-block';
@@ -7,18 +8,26 @@ import DotPager from 'calypso/components/dot-pager';
 
 import './style.scss';
 
+const EVENT_YOAST_PROMO_VIEW = 'calypso_stats_wordpress_seo_premium_banner_view';
+const EVENT_MOBILE_PROMO_VIEW = 'calypso_stats_traffic_mobile_cta_jetpack_view';
+
 export default function MobilePromoCardWrapper( { isJetpack, isOdysseyStats, slug } ) {
 	// do some stuff
 	// Yoast promo is disabled for Odyssey & self-hosted.
 	// Mobile apps promos are always shown.
 	const showYoastPromo = ! isOdysseyStats && ! isJetpack;
 	const showBothPromoCards = showYoastPromo;
+	// send first impression if not using the DotPager UI
+	// we don't worry about the Yoast card as it sends on mount
+	useEffect( () => {
+		if ( ! showBothPromoCards ) {
+			// sent tracks event
+			recordTracksEvent( EVENT_MOBILE_PROMO_VIEW );
+		}
+	}, [ showBothPromoCards ] );
 	// handle view events here
 	const pagerDidSelectPage = ( index ) => {
-		const evenLookup = [
-			'calypso_stats_wordpress_seo_premium_banner_view',
-			'calypso_stats_traffic_mobile_cta_jetpack_view',
-		];
+		const evenLookup = [ EVENT_YOAST_PROMO_VIEW, EVENT_MOBILE_PROMO_VIEW ];
 		const eventName = evenLookup[ index ];
 		// console.log( `selected index: ${ index } -- event: ${ eventName }` );
 		// send an impression event
@@ -41,7 +50,7 @@ export default function MobilePromoCardWrapper( { isJetpack, isOdysseyStats, slu
 							<div>
 								<PromoCardBlock
 									productSlug="wordpress-seo-premium"
-									impressionEvent="calypso_stats_wordpress_seo_premium_banner_view"
+									impressionEvent={ EVENT_YOAST_PROMO_VIEW }
 									clickEvent="calypso_stats_wordpress_seo_premium_banner_click"
 									headerText={ translate( 'Increase site visitors with Yoast SEO Premium' ) }
 									contentText={ translate(

--- a/client/my-sites/stats/mobile-promo-cards/index.jsx
+++ b/client/my-sites/stats/mobile-promo-cards/index.jsx
@@ -47,20 +47,19 @@ export default function MobilePromoCardWrapper( { isJetpack, isOdysseyStats, slu
 				<div className="stats__promo-container">
 					<div className="stats__promo-card">
 						<DotPager className="stats__promo-pager" onPageSelected={ pagerDidSelectPage }>
-							<div>
-								<PromoCardBlock
-									productSlug="wordpress-seo-premium"
-									impressionEvent={ EVENT_YOAST_PROMO_VIEW }
-									clickEvent="calypso_stats_wordpress_seo_premium_banner_click"
-									headerText={ translate( 'Increase site visitors with Yoast SEO Premium' ) }
-									contentText={ translate(
-										'Purchase Yoast SEO Premium to ensure that more people find your incredible content.'
-									) }
-									ctaText={ translate( 'Learn more' ) }
-									image={ wordpressSeoIllustration }
-									href={ `/plugins/wordpress-seo-premium/${ slug }` }
-								/>
-							</div>
+							<PromoCardBlock
+								productSlug="wordpress-seo-premium"
+								impressionEvent={ EVENT_YOAST_PROMO_VIEW }
+								clickEvent="calypso_stats_wordpress_seo_premium_banner_click"
+								headerText={ translate( 'Increase site visitors with Yoast SEO Premium' ) }
+								contentText={ translate(
+									'Purchase Yoast SEO Premium to ensure that more people find your incredible content.'
+								) }
+								ctaText={ translate( 'Learn more' ) }
+								image={ wordpressSeoIllustration }
+								href={ `/plugins/wordpress-seo-premium/${ slug }` }
+							/>
+
 							<div>
 								<MobilePromoCard className="stats__promo-card-apps" />
 							</div>

--- a/client/my-sites/stats/mobile-promo-cards/index.jsx
+++ b/client/my-sites/stats/mobile-promo-cards/index.jsx
@@ -7,11 +7,12 @@ import DotPager from 'calypso/components/dot-pager';
 
 import './style.scss';
 
-export default function MobilePromoCardWrapper( slug ) {
+export default function MobilePromoCardWrapper( { isAtomic, isOdysseyStats, slug } ) {
 	// do some stuff
-	const showMobileAppsPromo = false;
-	const showYoastPromo = false;
-	const showBothPromoCards = true;
+	// Yoast promo is disabled for Odyssey & self-hosted.
+	// Mobile apps promos are always shown.
+	const showYoastPromo = ! isOdysseyStats && ! isAtomic;
+	const showBothPromoCards = showYoastPromo;
 	// handle view events here
 	const pagerDidSelectPage = ( index ) => {
 		const evenLookup = [
@@ -26,24 +27,7 @@ export default function MobilePromoCardWrapper( slug ) {
 	// render some stuff
 	return (
 		<>
-			{ /** Promo Card is disabled for Odyssey because it doesn't make much sense in the context, which also removes an API call to `plugins`. */ }
-			{ showYoastPromo && (
-				<div className="stats-content-promo">
-					<PromoCardBlock
-						productSlug="wordpress-seo-premium"
-						impressionEvent="calypso_stats_wordpress_seo_premium_banner_view"
-						clickEvent="calypso_stats_wordpress_seo_premium_banner_click"
-						headerText={ translate( 'Increase site visitors with Yoast SEO Premium' ) }
-						contentText={ translate(
-							'Purchase Yoast SEO Premium to ensure that more people find your incredible content.'
-						) }
-						ctaText={ translate( 'Learn more' ) }
-						image={ wordpressSeoIllustration }
-						href={ `/plugins/wordpress-seo-premium/${ slug }` }
-					/>
-				</div>
-			) }
-			{ showMobileAppsPromo && (
+			{ ! showBothPromoCards && (
 				<div className="stats__promo-container">
 					<div className="stats__promo-card">
 						<MobilePromoCard className="stats__promo-card-apps" />

--- a/client/my-sites/stats/mobile-promo-cards/index.jsx
+++ b/client/my-sites/stats/mobile-promo-cards/index.jsx
@@ -12,20 +12,18 @@ const EVENT_YOAST_PROMO_VIEW = 'calypso_stats_wordpress_seo_premium_banner_view'
 const EVENT_MOBILE_PROMO_VIEW = 'calypso_stats_traffic_mobile_cta_jetpack_view';
 
 export default function MobilePromoCardWrapper( { isJetpack, isOdysseyStats, slug } ) {
-	// do some stuff
 	// Yoast promo is disabled for Odyssey & self-hosted.
 	// Mobile apps promos are always shown.
 	const showYoastPromo = ! isOdysseyStats && ! isJetpack;
 	const showBothPromoCards = showYoastPromo;
-	// send first impression if not using the DotPager UI
-	// we don't worry about the Yoast card as it sends on mount
+	// Handle initial view event if not using the DotPager UI.
+	// We don't worry about the Yoast card as it sends on mount.
 	useEffect( () => {
 		if ( ! showBothPromoCards ) {
-			// sent tracks event
 			recordTracksEvent( EVENT_MOBILE_PROMO_VIEW );
 		}
 	}, [ showBothPromoCards ] );
-	// handle click events here
+	// Handle click events from promo card.
 	const promoCardDidReceiveClick = ( event ) => {
 		// Events need to incorporate the page and the click type.
 		// This will allow us to account for integraton across different pages.
@@ -33,15 +31,13 @@ export default function MobilePromoCardWrapper( { isJetpack, isOdysseyStats, slu
 		const tracksEventName = `calypso_stats_traffic_mobile_cta_${ event.replaceAll( '-', '_' ) }`;
 		recordTracksEvent( tracksEventName );
 	};
-	// handle view events here
+	// Handle view events from DotPager UI.
 	const pagerDidSelectPage = ( index ) => {
 		const evenLookup = [ EVENT_YOAST_PROMO_VIEW, EVENT_MOBILE_PROMO_VIEW ];
 		const eventName = evenLookup[ index ];
-		// console.log( `selected index: ${ index } -- event: ${ eventName }` );
-		// send an impression event
 		recordTracksEvent( eventName );
 	};
-	// render some stuff
+	// Render one or both promo cards.
 	return (
 		<>
 			{ ! showBothPromoCards && (

--- a/client/my-sites/stats/mobile-promo-cards/index.jsx
+++ b/client/my-sites/stats/mobile-promo-cards/index.jsx
@@ -2,6 +2,7 @@ import { translate } from 'i18n-calypso';
 import { MobilePromoCard } from 'calypso/../packages/components/src';
 import wordpressSeoIllustration from 'calypso/assets/images/illustrations/wordpress-seo-premium.svg';
 import PromoCardBlock from 'calypso/blocks/promo-card-block';
+import DotPager from 'calypso/components/dot-pager';
 
 import './style.scss';
 
@@ -9,6 +10,7 @@ export default function MobilePromoCardWrapper( slug ) {
 	// do some stuff
 	const showMobileAppsPromo = true;
 	const showYoastPromo = true;
+	const showBothPromoCards = true;
 	// render some stuff
 	return (
 		<>
@@ -33,6 +35,31 @@ export default function MobilePromoCardWrapper( slug ) {
 				<div className="stats__promo-container">
 					<div className="stats__promo-card">
 						<MobilePromoCard className="stats__promo-card-apps" />
+					</div>
+				</div>
+			) }
+			{ showBothPromoCards && (
+				<div className="stats__promo-container">
+					<div className="stats__promo-card">
+						<DotPager className="stats__promo-pager">
+							<div>
+								<PromoCardBlock
+									productSlug="wordpress-seo-premium"
+									impressionEvent="calypso_stats_wordpress_seo_premium_banner_view"
+									clickEvent="calypso_stats_wordpress_seo_premium_banner_click"
+									headerText={ translate( 'Increase site visitors with Yoast SEO Premium' ) }
+									contentText={ translate(
+										'Purchase Yoast SEO Premium to ensure that more people find your incredible content.'
+									) }
+									ctaText={ translate( 'Learn more' ) }
+									image={ wordpressSeoIllustration }
+									href={ `/plugins/wordpress-seo-premium/${ slug }` }
+								/>
+							</div>
+							<div>
+								<MobilePromoCard className="stats__promo-card-apps" />
+							</div>
+						</DotPager>
 					</div>
 				</div>
 			) }

--- a/client/my-sites/stats/mobile-promo-cards/index.jsx
+++ b/client/my-sites/stats/mobile-promo-cards/index.jsx
@@ -1,3 +1,4 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { translate } from 'i18n-calypso';
 import { MobilePromoCard } from 'calypso/../packages/components/src';
 import wordpressSeoIllustration from 'calypso/assets/images/illustrations/wordpress-seo-premium.svg';
@@ -8,9 +9,20 @@ import './style.scss';
 
 export default function MobilePromoCardWrapper( slug ) {
 	// do some stuff
-	const showMobileAppsPromo = true;
-	const showYoastPromo = true;
+	const showMobileAppsPromo = false;
+	const showYoastPromo = false;
 	const showBothPromoCards = true;
+	// handle view events here
+	const pagerDidSelectPage = ( index ) => {
+		const evenLookup = [
+			'calypso_stats_wordpress_seo_premium_banner_view',
+			'calypso_stats_traffic_mobile_cta_jetpack_view',
+		];
+		const eventName = evenLookup[ index ];
+		// console.log( `selected index: ${ index } -- event: ${ eventName }` );
+		// send an impression event
+		recordTracksEvent( eventName );
+	};
 	// render some stuff
 	return (
 		<>
@@ -41,7 +53,7 @@ export default function MobilePromoCardWrapper( slug ) {
 			{ showBothPromoCards && (
 				<div className="stats__promo-container">
 					<div className="stats__promo-card">
-						<DotPager className="stats__promo-pager">
+						<DotPager className="stats__promo-pager" onPageSelected={ pagerDidSelectPage }>
 							<div>
 								<PromoCardBlock
 									productSlug="wordpress-seo-premium"

--- a/client/my-sites/stats/mobile-promo-cards/index.jsx
+++ b/client/my-sites/stats/mobile-promo-cards/index.jsx
@@ -1,0 +1,31 @@
+import { translate } from 'i18n-calypso';
+import wordpressSeoIllustration from 'calypso/assets/images/illustrations/wordpress-seo-premium.svg';
+import PromoCardBlock from 'calypso/blocks/promo-card-block';
+
+import './style.scss';
+
+export default function MobilePromoCardWrapper( slug ) {
+	// do some stuff
+	// const slug = 'hello-slug';
+	// render some stuff
+	return (
+		<>
+			{ /** Promo Card is disabled for Odyssey because it doesn't make much sense in the context, which also removes an API call to `plugins`. */ }
+
+			<div className="stats-content-promo">
+				<PromoCardBlock
+					productSlug="wordpress-seo-premium"
+					impressionEvent="calypso_stats_wordpress_seo_premium_banner_view"
+					clickEvent="calypso_stats_wordpress_seo_premium_banner_click"
+					headerText={ translate( 'Increase site visitors with Yoast SEO Premium' ) }
+					contentText={ translate(
+						'Purchase Yoast SEO Premium to ensure that more people find your incredible content.'
+					) }
+					ctaText={ translate( 'Learn more' ) }
+					image={ wordpressSeoIllustration }
+					href={ `/plugins/wordpress-seo-premium/${ slug }` }
+				/>
+			</div>
+		</>
+	);
+}

--- a/client/my-sites/stats/mobile-promo-cards/index.jsx
+++ b/client/my-sites/stats/mobile-promo-cards/index.jsx
@@ -1,4 +1,5 @@
 import { translate } from 'i18n-calypso';
+import { MobilePromoCard } from 'calypso/../packages/components/src';
 import wordpressSeoIllustration from 'calypso/assets/images/illustrations/wordpress-seo-premium.svg';
 import PromoCardBlock from 'calypso/blocks/promo-card-block';
 
@@ -6,26 +7,35 @@ import './style.scss';
 
 export default function MobilePromoCardWrapper( slug ) {
 	// do some stuff
-	// const slug = 'hello-slug';
+	const showMobileAppsPromo = true;
+	const showYoastPromo = true;
 	// render some stuff
 	return (
 		<>
 			{ /** Promo Card is disabled for Odyssey because it doesn't make much sense in the context, which also removes an API call to `plugins`. */ }
-
-			<div className="stats-content-promo">
-				<PromoCardBlock
-					productSlug="wordpress-seo-premium"
-					impressionEvent="calypso_stats_wordpress_seo_premium_banner_view"
-					clickEvent="calypso_stats_wordpress_seo_premium_banner_click"
-					headerText={ translate( 'Increase site visitors with Yoast SEO Premium' ) }
-					contentText={ translate(
-						'Purchase Yoast SEO Premium to ensure that more people find your incredible content.'
-					) }
-					ctaText={ translate( 'Learn more' ) }
-					image={ wordpressSeoIllustration }
-					href={ `/plugins/wordpress-seo-premium/${ slug }` }
-				/>
-			</div>
+			{ showYoastPromo && (
+				<div className="stats-content-promo">
+					<PromoCardBlock
+						productSlug="wordpress-seo-premium"
+						impressionEvent="calypso_stats_wordpress_seo_premium_banner_view"
+						clickEvent="calypso_stats_wordpress_seo_premium_banner_click"
+						headerText={ translate( 'Increase site visitors with Yoast SEO Premium' ) }
+						contentText={ translate(
+							'Purchase Yoast SEO Premium to ensure that more people find your incredible content.'
+						) }
+						ctaText={ translate( 'Learn more' ) }
+						image={ wordpressSeoIllustration }
+						href={ `/plugins/wordpress-seo-premium/${ slug }` }
+					/>
+				</div>
+			) }
+			{ showMobileAppsPromo && (
+				<div className="stats__promo-container">
+					<div className="stats__promo-card">
+						<MobilePromoCard className="stats__promo-card-apps" />
+					</div>
+				</div>
+			) }
 		</>
 	);
 }

--- a/client/my-sites/stats/mobile-promo-cards/index.jsx
+++ b/client/my-sites/stats/mobile-promo-cards/index.jsx
@@ -1,7 +1,7 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { MobilePromoCard } from '@automattic/components';
 import { translate } from 'i18n-calypso';
 import { useEffect } from 'react';
-import { MobilePromoCard } from 'calypso/../packages/components/src';
 import wordpressSeoIllustration from 'calypso/assets/images/illustrations/wordpress-seo-premium.svg';
 import PromoCardBlock from 'calypso/blocks/promo-card-block';
 import DotPager from 'calypso/components/dot-pager';

--- a/client/my-sites/stats/mobile-promo-cards/style.scss
+++ b/client/my-sites/stats/mobile-promo-cards/style.scss
@@ -1,1 +1,32 @@
-// styles to come
+// Style overrides for when the MoblePromoCard is inside a DotPager component.
+
+.stats__promo-container {
+	margin-bottom: 20px;
+}
+
+.stats__promo-card {
+	background-color: var(--studio-white);
+	border: 1px solid var(--studio-gray-5);
+	border-radius: 5px; /* stylelint-disable-line scales/radii */
+
+	@media ( max-width: 782px ) {
+		border-radius: 0;
+		border-left: none;
+		border-right: none;
+	}
+}
+
+.stats__promo-pager {
+	// Overrides Yoast banner styles.
+	.dot-pager__controls {
+		margin: 16px 16px 0;
+	}
+	.card {
+		box-shadow: none;
+	}
+}
+
+.promo-card.stats__promo-card-apps {
+	// Overrides Mobile Apps banner styles.
+	border: none;
+}

--- a/client/my-sites/stats/mobile-promo-cards/style.scss
+++ b/client/my-sites/stats/mobile-promo-cards/style.scss
@@ -1,0 +1,1 @@
+// styles to come

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -11,9 +11,7 @@ import { connect } from 'react-redux';
 import titlecase from 'to-title-case';
 import rocketImage from 'calypso/assets/images/customer-home/illustration--rocket.svg';
 import illustration404 from 'calypso/assets/images/illustrations/illustration-404.svg';
-import wordpressSeoIllustration from 'calypso/assets/images/illustrations/wordpress-seo-premium.svg';
 import JetpackBackupCredsBanner from 'calypso/blocks/jetpack-backup-creds-banner';
-import PromoCardBlock from 'calypso/blocks/promo-card-block';
 import StatsNavigation from 'calypso/blocks/stats-navigation';
 import Intervals from 'calypso/blocks/stats-navigation/intervals';
 import Banner from 'calypso/components/banner';
@@ -41,6 +39,7 @@ import isPrivateSite from 'calypso/state/selectors/is-private-site';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import HighlightsSection from './highlights-section';
+import MobilePromoCardWrapper from './mobile-promo-cards';
 import ChartTabs from './stats-chart-tabs';
 import Countries from './stats-countries';
 import DatePicker from './stats-date-picker';
@@ -369,22 +368,7 @@ class StatsSite extends Component {
 					</div>
 				</div>
 				{ /** Promo Card is disabled for Odyssey because it doesn't make much sense in the context, which also removes an API call to `plugins`. */ }
-				{ ! isOdysseyStats && (
-					<div className="stats-content-promo">
-						<PromoCardBlock
-							productSlug="wordpress-seo-premium"
-							impressionEvent="calypso_stats_wordpress_seo_premium_banner_view"
-							clickEvent="calypso_stats_wordpress_seo_premium_banner_click"
-							headerText={ translate( 'Increase site visitors with Yoast SEO Premium' ) }
-							contentText={ translate(
-								'Purchase Yoast SEO Premium to ensure that more people find your incredible content.'
-							) }
-							ctaText={ translate( 'Learn more' ) }
-							image={ wordpressSeoIllustration }
-							href={ `/plugins/wordpress-seo-premium/${ slug }` }
-						/>
-					</div>
-				) }
+				{ ! isOdysseyStats && <MobilePromoCardWrapper slug={ slug } /> }
 				<JetpackColophon />
 			</div>
 		);

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -369,7 +369,7 @@ class StatsSite extends Component {
 				</div>
 				{ /** Promo Card is disabled for Odyssey because it doesn't make much sense in the context, which also removes an API call to `plugins`. */ }
 				<MobilePromoCardWrapper
-					isAtomic={ false }
+					isJetpack={ isJetpack }
 					isOdysseyStats={ isOdysseyStats }
 					slug={ slug }
 				/>

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -368,7 +368,11 @@ class StatsSite extends Component {
 					</div>
 				</div>
 				{ /** Promo Card is disabled for Odyssey because it doesn't make much sense in the context, which also removes an API call to `plugins`. */ }
-				{ ! isOdysseyStats && <MobilePromoCardWrapper slug={ slug } /> }
+				<MobilePromoCardWrapper
+					isAtomic={ false }
+					isOdysseyStats={ isOdysseyStats }
+					slug={ slug }
+				/>
 				<JetpackColophon />
 			</div>
 		);


### PR DESCRIPTION
#### Proposed Changes

Adds the Jetpack mobile apps promo card alongside the Yoast SEO one using the `DotPager` component. The Yoast card is still the default.

Before:

![APromoSEO](https://user-images.githubusercontent.com/40267301/202101081-db395e83-8d1a-4208-8bc1-8654833efe99.png)

After:

![NewPromoCards](https://user-images.githubusercontent.com/40267301/203266516-9b427729-7a0b-437f-9bd6-3b22ecbed058.png)

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Visit the Calypso Live link.
2. Visit the Stats page.
3. Scroll down and confirm the `DotPager` card is present.
4. Confirm the Yoast SEO card is the default. 
5. Confirm the mobile apps card is available on the 2nd page.
6. Confirm it behaves appropriately on smaller screen sizes.
7. Test on a self-hosted Jetpack site and confirm the Yoast card and the `DotPager` UI are not used. Only the Jetpack mobile apps CTA should be shown.

#### Confirming Tracks

1. After viewing the promo cards and clicking a few links, visit the internal Tracks Live dashboard.
2. Search for `calypso_stats_traffic_mobile_cta_jetpack_view` to confirm views are being measured.
3. Search for `calypso_stats_traffic_mobile_cta_jetpack_click_a8c` to confirm clicks are being measured.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #69230

Currently just updating the Stats page. The designs call for the same promo card on the Insights and Ads pages but it looks overpowering there with the older page layout. I'm thinking we should wait until we "grid" those layouts before adding this component in.