### PR TITLE
[Try] Limited Global Styles: In-Editor Checkout

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/notice.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/notice.js
@@ -3,9 +3,12 @@ import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { ExternalLink, Notice } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { createInterpolateElement, render, useEffect, useState } from '@wordpress/element';
+import { doAction, hasAction } from '@wordpress/hooks';
 import { __ } from '@wordpress/i18n';
 
 import './notice.scss';
+
+const HOOK_OPEN_CHECKOUT_MODAL = 'a8c.wpcom-block-editor.openCheckoutModal';
 
 function GlobalStylesNoticeComponent() {
 	const { globalStylesConfig, siteChanges } = useSelect( ( select ) => {
@@ -61,6 +64,21 @@ function GlobalStylesNoticeComponent() {
 		return null;
 	}
 
+	const openCheckout = ( event ) => {
+		event.preventDefault();
+
+		recordTracksEvent( 'calypso_global_styles_gating_notice_upgrade_click', {
+			context: 'site-editor',
+		} );
+
+		if ( ! hasAction( HOOK_OPEN_CHECKOUT_MODAL ) ) {
+			window.open( wpcomGlobalStyles.upgradeUrl, '_blank' );
+			return;
+		}
+
+		doAction( HOOK_OPEN_CHECKOUT_MODAL, { products: [ { product_slug: 'value_bundle' } ] } );
+	};
+
 	return (
 		<Notice status="warning" isDismissible={ false } className="wpcom-global-styles-notice">
 			{ createInterpolateElement(
@@ -73,11 +91,7 @@ function GlobalStylesNoticeComponent() {
 						<ExternalLink
 							href={ wpcomGlobalStyles.upgradeUrl }
 							target="_blank"
-							onClick={ () =>
-								recordTracksEvent( 'calypso_global_styles_gating_notice_upgrade_click', {
-									context: 'site-editor',
-								} )
-							}
+							onClick={ openCheckout }
 						/>
 					),
 				}


### PR DESCRIPTION
#### Proposed Changes

* Wire the Limited Global Styles pre-save notice with the checkout modal, so that users can upgrade from within the editor without disruptions.

⚠️ Note: this is a proof of concept!

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/1358
