### PR TITLE
Implement the dotlink version of Link in Bio flow on Stepper

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -146,7 +146,8 @@ button {
  * Tailored flow stylings
  */
 .newsletter,
-.link-in-bio:not(.domains) {
+.link-in-bio:not(.domains),
+.link-in-bio-tld:not(.domains) {
 	&:not(.launchpad):not(.subscribers) {
 		@include onboarding-break-mobile-landscape {
 			padding: 40px 0 0;
@@ -168,6 +169,7 @@ button {
 
 .newsletter,
 .link-in-bio,
+.link-in-bio-tld,
 .setup-form__form {
 	button {
 		&[type="submit"] {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 
-import { StepContainer } from '@automattic/onboarding';
+import { StepContainer, LINK_IN_BIO_FLOW, LINK_IN_BIO_TLD_FLOW } from '@automattic/onboarding';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
 import { useI18n } from '@wordpress/react-i18n';
@@ -92,6 +92,10 @@ const DomainsStep: Step = function DomainsStep( { navigation, flow } ) {
 		showExampleSuggestions = false;
 		includeWordPressDotCom = false;
 		showSkipButton = true;
+	}
+
+	if ( flow === LINK_IN_BIO_TLD_FLOW ) {
+		includeWordPressDotCom = false;
 	}
 
 	const domainsWithPlansOnly = true;
@@ -187,7 +191,8 @@ const DomainsStep: Step = function DomainsStep( { navigation, flow } ) {
 					),
 					decideLaterComponent
 				);
-			case 'link-in-bio':
+			case LINK_IN_BIO_FLOW:
+			case LINK_IN_BIO_TLD_FLOW:
 				return createInterpolateElement(
 					__(
 						'Set your Link in Bio apart with a custom domain. Not sure yet? <span>Decide later</span>.'
@@ -330,6 +335,24 @@ const DomainsStep: Step = function DomainsStep( { navigation, flow } ) {
 		);
 	};
 
+	const getOtherManagedSubdomains = () => {
+		if ( flow === LINK_IN_BIO_TLD_FLOW ) {
+			return [ 'link' ];
+		}
+	};
+
+	const getOtherManagedSubdomainsCountOverride = () => {
+		if ( flow === LINK_IN_BIO_TLD_FLOW ) {
+			return 2;
+		}
+	};
+
+	const getPromoTlds = () => {
+		if ( flow === LINK_IN_BIO_TLD_FLOW ) {
+			return [ 'link' ];
+		}
+	};
+
 	const renderDomainForm = () => {
 		let initialState: DomainForm = {};
 		if ( domainForm ) {
@@ -376,12 +399,15 @@ const DomainsStep: Step = function DomainsStep( { navigation, flow } ) {
 					key="domainForm"
 					mapDomainUrl={ getUseYourDomainUrl() }
 					offerUnavailableOption
+					otherManagedSubdomains={ getOtherManagedSubdomains() }
+					otherManagedSubdomainsCountOverride={ getOtherManagedSubdomainsCountOverride() }
 					onAddDomain={ handleAddDomain }
 					onAddMapping={ handleAddMapping }
 					onSave={ setDomainForm }
 					onSkip={ handleSkip }
 					path={ path }
 					products={ productsList }
+					promoTlds={ getPromoTlds() }
 					selectedSite={ selectedSite }
 					showExampleSuggestions={ showExampleSuggestions }
 					showSkipButton={ showSkipButton }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/intro/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/intro/index.tsx
@@ -1,9 +1,9 @@
 import {
-	LINK_IN_BIO_FLOW,
 	NEWSLETTER_FLOW,
 	ECOMMERCE_FLOW,
 	VIDEOPRESS_FLOW,
 	FREE_FLOW,
+	isLinkInBioFlow,
 } from '@automattic/onboarding';
 import { createInterpolateElement, useMemo } from '@wordpress/element';
 import { useI18n } from '@wordpress/react-i18n';
@@ -18,7 +18,7 @@ const useIntroContent = ( flowName: string | null ): IntroContent => {
 	const { __ } = useI18n();
 
 	return useMemo( () => {
-		if ( flowName === LINK_IN_BIO_FLOW ) {
+		if ( isLinkInBioFlow( flowName ) ) {
 			return {
 				title: createInterpolateElement(
 					__( 'You’re 3 minutes away from<br />a stand-out Link in Bio site.<br />Ready? ' ),

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
@@ -136,6 +136,7 @@
 
 .newsletter,
 .link-in-bio:not(.domains),
+.link-in-bio-tld:not(.domains),
 .free {
 	.step-container {
 		.step-container__content h1,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/tasks.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/tasks.tsx
@@ -1,3 +1,4 @@
+import { LINK_IN_BIO_FLOW, LINK_IN_BIO_TLD_FLOW } from '@automattic/onboarding';
 import { LaunchpadFlowTaskList, Task } from './types';
 
 export const tasks: Task[] = [
@@ -87,15 +88,18 @@ export const tasks: Task[] = [
 	},
 ];
 
+const linkInBioTaskList = [
+	'design_selected',
+	'setup_link_in_bio',
+	'plan_selected',
+	'links_added',
+	'link_in_bio_launched',
+];
+
 export const launchpadFlowTasks: LaunchpadFlowTaskList = {
 	newsletter: [ 'setup_newsletter', 'plan_selected', 'subscribers_added', 'first_post_published' ],
-	'link-in-bio': [
-		'design_selected',
-		'setup_link_in_bio',
-		'plan_selected',
-		'links_added',
-		'link_in_bio_launched',
-	],
+	[ LINK_IN_BIO_FLOW ]: linkInBioTaskList,
+	[ LINK_IN_BIO_TLD_FLOW ]: linkInBioTaskList,
 	free: [
 		'setup_free',
 		'design_selected',

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/translations.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/translations.tsx
@@ -1,5 +1,6 @@
 import {
 	LINK_IN_BIO_FLOW,
+	LINK_IN_BIO_TLD_FLOW,
 	NEWSLETTER_FLOW,
 	VIDEOPRESS_FLOW,
 	FREE_FLOW,
@@ -23,6 +24,7 @@ export function getLaunchpadTranslations( flow: string | null ): TranslatedLaunc
 			);
 			break;
 		case LINK_IN_BIO_FLOW:
+		case LINK_IN_BIO_TLD_FLOW:
 			translatedStrings.flowName = translate( 'Link in Bio' );
 			translatedStrings.title = translate( "You're ready to link and launch" );
 			translatedStrings.launchTitle = translate( "You're ready to link and launch" );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/link-in-bio-setup/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/link-in-bio-setup/styles.scss
@@ -2,7 +2,8 @@
 
 $font-family: "SF Pro Text", $sans;
 
-.link-in-bio-setup {
+.link-in-bio-setup,
+.link-in-bio-tld-setup {
 	.step-container__content {
 		display: flex;
 		justify-content: center;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/patterns/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/patterns/styles.scss
@@ -1,6 +1,7 @@
 @import "../style";
 
-.link-in-bio.patterns {
+.link-in-bio.patterns,
+.link-in-bio-tld.patterns {
 	height: 100vh;
 
 	@supports ( height: 100svh ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
@@ -1,7 +1,7 @@
 import {
 	StepContainer,
 	isNewsletterOrLinkInBioFlow,
-	LINK_IN_BIO_FLOW,
+	isLinkInBioFlow,
 	isFreeFlow,
 } from '@automattic/onboarding';
 import { useSelect } from '@wordpress/data';
@@ -118,7 +118,7 @@ const ProcessingStep: Step = function ( props ) {
 	const isJetpackPowered = isNewsletterOrLinkInBioFlow( flowName );
 
 	// Currently we have the Domains and Plans only for link in bio
-	if ( flowName === LINK_IN_BIO_FLOW || isFreeFlow( flowName ) ) {
+	if ( isLinkInBioFlow( flowName ) || isFreeFlow( flowName ) ) {
 		return <TailoredFlowPreCheckoutScreen flowName={ flowName } />;
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/tailored-flow-precheckout-screen/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/tailored-flow-precheckout-screen/index.tsx
@@ -1,4 +1,4 @@
-import { NEWSLETTER_FLOW, LINK_IN_BIO_FLOW } from '@automattic/onboarding';
+import { NEWSLETTER_FLOW, LINK_IN_BIO_FLOW, LINK_IN_BIO_TLD_FLOW } from '@automattic/onboarding';
 import { useI18n } from '@wordpress/react-i18n';
 import PropTypes from 'prop-types';
 import { useRef, useState, useEffect } from 'react';
@@ -15,6 +15,7 @@ const useSteps = ( flowName: string ) => {
 
 	switch ( flowName ) {
 		case LINK_IN_BIO_FLOW:
+		case LINK_IN_BIO_TLD_FLOW:
 			steps = [
 				{ title: __( 'Great choices. Nearly there!' ) },
 				{ title: __( 'Shining and polishing your Bio' ) },

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/tailored-flow-precheckout-screen/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/tailored-flow-precheckout-screen/style.scss
@@ -9,6 +9,7 @@
 	}
 	.newsletter,
 	.link-in-bio,
+	.link-in-bio-tld,
 	.free {
 		.signup-header {
 			.signup-header__right {
@@ -96,7 +97,8 @@
 		}
 	}
 
-	.link-in-bio {
+	.link-in-bio,
+	.link-in-bio-tld {
 		.processing-step__container {
 			background-color: #d0cce3;
 			background-image:

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
@@ -2,6 +2,7 @@ import { Site } from '@automattic/data-stores';
 import {
 	ECOMMERCE_FLOW,
 	LINK_IN_BIO_FLOW,
+	isLinkInBioFlow,
 	addPlanToCart,
 	createSiteWithCart,
 } from '@automattic/onboarding';
@@ -33,14 +34,14 @@ const SiteCreationStep: Step = function SiteCreationStep( { navigation, flow } )
 
 	const { setPendingAction } = useDispatch( ONBOARD_STORE );
 
-	const theme = flow === LINK_IN_BIO_FLOW ? 'pub/lynx' : 'pub/lettre';
+	const theme = isLinkInBioFlow( LINK_IN_BIO_FLOW ) ? 'pub/lynx' : 'pub/lettre';
 	const isPaidDomainItem = Boolean( domainCartItem?.product_slug );
 
 	// Default visibility is public
 	let siteVisibility = Site.Visibility.PublicIndexed;
 
 	// Link-in-bio flow defaults to "Coming Soon"
-	if ( flow === LINK_IN_BIO_FLOW ) {
+	if ( isLinkInBioFlow( flow ) ) {
 		siteVisibility = Site.Visibility.PublicNotIndexed;
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
@@ -1,7 +1,6 @@
 import { Site } from '@automattic/data-stores';
 import {
 	ECOMMERCE_FLOW,
-	LINK_IN_BIO_FLOW,
 	isLinkInBioFlow,
 	addPlanToCart,
 	createSiteWithCart,
@@ -34,7 +33,7 @@ const SiteCreationStep: Step = function SiteCreationStep( { navigation, flow } )
 
 	const { setPendingAction } = useDispatch( ONBOARD_STORE );
 
-	const theme = isLinkInBioFlow( LINK_IN_BIO_FLOW ) ? 'pub/lynx' : 'pub/lettre';
+	const theme = isLinkInBioFlow( flow ) ? 'pub/lynx' : 'pub/lettre';
 	const isPaidDomainItem = Boolean( domainCartItem?.product_slug );
 
 	// Default visibility is public

--- a/client/landing/stepper/declarative-flow/link-in-bio-tld.ts
+++ b/client/landing/stepper/declarative-flow/link-in-bio-tld.ts
@@ -1,0 +1,149 @@
+import { useLocale } from '@automattic/i18n-utils';
+import { useFlowProgress, LINK_IN_BIO_TLD_FLOW } from '@automattic/onboarding';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { translate } from 'i18n-calypso';
+import { useEffect } from 'react';
+import { recordFullStoryEvent } from 'calypso/lib/analytics/fullstory';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import wpcom from 'calypso/lib/wp';
+import {
+	clearSignupDestinationCookie,
+	setSignupCompleteSlug,
+	persistSignupDestination,
+	setSignupCompleteFlowName,
+} from 'calypso/signup/storageUtils';
+import { useSiteSlug } from '../hooks/use-site-slug';
+import { USER_STORE, ONBOARD_STORE } from '../stores';
+import { recordSubmitStep } from './internals/analytics/record-submit-step';
+import DomainsStep from './internals/steps-repository/domains';
+import LaunchPad from './internals/steps-repository/launchpad';
+import LinkInBioSetup from './internals/steps-repository/link-in-bio-setup';
+import PatternsStep from './internals/steps-repository/patterns';
+import PlansStep from './internals/steps-repository/plans';
+import Processing from './internals/steps-repository/processing-step';
+import SiteCreationStep from './internals/steps-repository/site-creation-step';
+import type { Flow, ProvidedDependencies } from './internals/types';
+
+const linkInBio: Flow = {
+	name: LINK_IN_BIO_TLD_FLOW,
+	get title() {
+		return translate( 'Link in Bio' );
+	},
+	useSteps() {
+		useEffect( () => {
+			recordTracksEvent( 'calypso_signup_start', { flow: this.name } );
+			recordFullStoryEvent( 'calypso_signup_start_link_in_bio', { flow: this.name } );
+		}, [] );
+
+		return [
+			{ slug: 'domains', component: DomainsStep },
+			{ slug: 'patterns', component: PatternsStep },
+			{ slug: 'linkInBioSetup', component: LinkInBioSetup },
+			{ slug: 'plans', component: PlansStep },
+			{ slug: 'siteCreationStep', component: SiteCreationStep },
+			{ slug: 'processing', component: Processing },
+			{ slug: 'launchpad', component: LaunchPad },
+		];
+	},
+
+	useStepNavigation( _currentStepSlug, navigate ) {
+		const flowName = this.name;
+		const { setStepProgress } = useDispatch( ONBOARD_STORE );
+		const flowProgress = useFlowProgress( { stepName: _currentStepSlug, flowName } );
+		const siteSlug = useSiteSlug();
+		const userIsLoggedIn = useSelect( ( select ) => select( USER_STORE ).isCurrentUserLoggedIn() );
+		const locale = useLocale();
+
+		setStepProgress( flowProgress );
+
+		// trigger guides on step movement, we don't care about failures or response
+		wpcom.req.post(
+			'guides/trigger',
+			{
+				apiNamespace: 'wpcom/v2/',
+			},
+			{
+				flow: flowName,
+				step: _currentStepSlug,
+			}
+		);
+
+		const logInUrl =
+			locale && locale !== 'en'
+				? `/start/account/user/${ locale }?variationName=${ flowName }&pageTitle=Link%20in%20Bio&redirect_to=/setup/${ flowName }/patterns`
+				: `/start/account/user?variationName=${ flowName }&pageTitle=Link%20in%20Bio&redirect_to=/setup/${ flowName }/patterns`;
+
+		// for the standard Link in Bio flow
+		const submit = ( providedDependencies: ProvidedDependencies = {} ) => {
+			recordSubmitStep( providedDependencies, '', flowName, _currentStepSlug );
+
+			switch ( _currentStepSlug ) {
+				case 'domains':
+					clearSignupDestinationCookie();
+
+					if ( userIsLoggedIn ) {
+						return navigate( 'plans' );
+					}
+
+					return window.location.assign( logInUrl );
+
+				case 'patterns':
+					return navigate( 'linkInBioSetup' );
+
+				case 'linkInBioSetup':
+					return navigate( 'plans' );
+
+				case 'plans':
+					return navigate( 'siteCreationStep' );
+
+				case 'siteCreationStep':
+					return navigate( 'processing' );
+
+				case 'processing':
+					if ( providedDependencies?.goToCheckout ) {
+						const destination = `/setup/${ flowName }/launchpad?siteSlug=${ providedDependencies.siteSlug }`;
+						persistSignupDestination( destination );
+						setSignupCompleteSlug( providedDependencies?.siteSlug );
+						setSignupCompleteFlowName( flowName );
+						const returnUrl = encodeURIComponent(
+							`/setup/${ flowName }/launchpad?siteSlug=${ providedDependencies?.siteSlug }`
+						);
+
+						return window.location.assign(
+							`/checkout/${ encodeURIComponent(
+								( providedDependencies?.siteSlug as string ) ?? ''
+							) }?redirect_to=${ returnUrl }&signup=1`
+						);
+					}
+					return navigate( `launchpad?siteSlug=${ providedDependencies?.siteSlug }` );
+
+				case 'launchpad': {
+					return navigate( 'processing' );
+				}
+			}
+			return providedDependencies;
+		};
+
+		const goBack = () => {
+			return;
+		};
+
+		const goNext = () => {
+			switch ( _currentStepSlug ) {
+				case 'launchpad':
+					return window.location.assign( `/view/${ siteSlug }` );
+
+				default:
+					return navigate( 'intro' );
+			}
+		};
+
+		const goToStep = ( step: string ) => {
+			navigate( step );
+		};
+
+		return { goNext, goBack, goToStep, submit };
+	},
+};
+
+export default linkInBio;

--- a/client/landing/stepper/declarative-flow/link-in-bio-tld.ts
+++ b/client/landing/stepper/declarative-flow/link-in-bio-tld.ts
@@ -73,7 +73,6 @@ const linkInBio: Flow = {
 				? `/start/account/user/${ locale }?variationName=${ flowName }&pageTitle=Link%20in%20Bio&redirect_to=/setup/${ flowName }/patterns`
 				: `/start/account/user?variationName=${ flowName }&pageTitle=Link%20in%20Bio&redirect_to=/setup/${ flowName }/patterns`;
 
-		
 		const submit = ( providedDependencies: ProvidedDependencies = {} ) => {
 			recordSubmitStep( providedDependencies, '', flowName, _currentStepSlug );
 

--- a/client/landing/stepper/declarative-flow/link-in-bio-tld.ts
+++ b/client/landing/stepper/declarative-flow/link-in-bio-tld.ts
@@ -73,7 +73,7 @@ const linkInBio: Flow = {
 				? `/start/account/user/${ locale }?variationName=${ flowName }&pageTitle=Link%20in%20Bio&redirect_to=/setup/${ flowName }/patterns`
 				: `/start/account/user?variationName=${ flowName }&pageTitle=Link%20in%20Bio&redirect_to=/setup/${ flowName }/patterns`;
 
-		// for the standard Link in Bio flow
+		
 		const submit = ( providedDependencies: ProvidedDependencies = {} ) => {
 			recordSubmitStep( providedDependencies, '', flowName, _currentStepSlug );
 

--- a/client/landing/stepper/declarative-flow/link-in-bio-tld.ts
+++ b/client/landing/stepper/declarative-flow/link-in-bio-tld.ts
@@ -82,7 +82,7 @@ const linkInBio: Flow = {
 					clearSignupDestinationCookie();
 
 					if ( userIsLoggedIn ) {
-						return navigate( 'plans' );
+						return navigate( 'patterns' );
 					}
 
 					return window.location.assign( logInUrl );

--- a/client/landing/stepper/declarative-flow/registered-flows.ts
+++ b/client/landing/stepper/declarative-flow/registered-flows.ts
@@ -20,6 +20,9 @@ const availableFlows: Record< string, () => Promise< { default: Flow } > > = {
 	'link-in-bio': () =>
 		import( /* webpackChunkName: "link-in-bio-flow" */ '../declarative-flow/link-in-bio' ),
 
+	'link-in-bio-tld': () =>
+		import( /* webpackChunkName: "link-in-bio-tld-flow" */ '../declarative-flow/link-in-bio-tld' ),
+
 	podcasts: () => import( /* webpackChunkName: "podcasts-flow" */ '../declarative-flow/podcasts' ),
 
 	'link-in-bio-post-setup': () =>

--- a/client/my-sites/plan-features-comparison/header.jsx
+++ b/client/my-sites/plan-features-comparison/header.jsx
@@ -1,6 +1,6 @@
 import { getPlans, getPlanClass } from '@automattic/calypso-products';
 import { getCurrencyObject } from '@automattic/format-currency';
-import { NEWSLETTER_FLOW, LINK_IN_BIO_FLOW } from '@automattic/onboarding';
+import { NEWSLETTER_FLOW, LINK_IN_BIO_FLOW, LINK_IN_BIO_TLD_FLOW } from '@automattic/onboarding';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -22,6 +22,7 @@ export class PlanFeaturesComparisonHeader extends Component {
 			case NEWSLETTER_FLOW:
 				return translate( 'Best for Newsletters' );
 			case LINK_IN_BIO_FLOW:
+			case LINK_IN_BIO_TLD_FLOW:
 				return translate( 'Best for Link in Bio' );
 			default:
 				return translate( 'Popular' );

--- a/client/signup/signup-header/index.tsx
+++ b/client/signup/signup-header/index.tsx
@@ -1,5 +1,10 @@
 import { ProgressBar } from '@automattic/components';
-import { useFlowProgress, FREE_FLOW } from '@automattic/onboarding';
+import {
+	useFlowProgress,
+	FREE_FLOW,
+	LINK_IN_BIO_FLOW,
+	LINK_IN_BIO_TLD_FLOW,
+} from '@automattic/onboarding';
 import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import WordPressLogo from 'calypso/components/wordpress-logo';
@@ -31,7 +36,8 @@ const SignupHeader = ( {
 	const translate = useTranslate();
 	const VARIATION_TITLES: Record< string, string > = {
 		newsletter: translate( 'Newsletter' ),
-		'link-in-bio': translate( 'Link in Bio' ),
+		[ LINK_IN_BIO_FLOW ]: translate( 'Link in Bio' ),
+		[ LINK_IN_BIO_TLD_FLOW ]: translate( 'Link in Bio' ),
 		videopress: translate( 'Video' ),
 	};
 	const params = new URLSearchParams( window.location.search );

--- a/client/signup/signup-header/style.scss
+++ b/client/signup/signup-header/style.scss
@@ -21,6 +21,7 @@
 
 	.newsletter.progress-bar,
 	.link-in-bio.progress-bar,
+	.link-in-bio-tld.progress-bar,
 	.import.progress-bar {
 		position: absolute;
 		top: -8px;

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -1,6 +1,5 @@
 import config from '@automattic/calypso-config';
 import { localizeUrl } from '@automattic/i18n-utils';
-import { LINK_IN_BIO_TLD_FLOW } from '@automattic/onboarding';
 import { isMobile } from '@automattic/viewport';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
@@ -544,7 +543,6 @@ export class UserStep extends Component {
 		// TODO: decouple hideBack flag from the flow name.
 		return (
 			<StepWrapper
-				hideBack={ this.props.flowName === LINK_IN_BIO_TLD_FLOW }
 				flowName={ this.props.flowName }
 				stepName={ this.props.stepName }
 				headerText={ this.getHeaderText() }

--- a/packages/calypso-products/src/main.ts
+++ b/packages/calypso-products/src/main.ts
@@ -633,7 +633,7 @@ export const getPopularPlanSpec = ( {
 
 	const group = GROUP_WPCOM;
 
-	if ( flowName === 'link-in-bio' ) {
+	if ( flowName === 'link-in-bio' || flowName === 'link-in-bio-tld' ) {
 		return {
 			type: TYPE_PERSONAL,
 			group,

--- a/packages/calypso-products/test/get-popular-plan-spec.js
+++ b/packages/calypso-products/test/get-popular-plan-spec.js
@@ -1,5 +1,5 @@
 import { getPopularPlanSpec } from '../src';
-import { GROUP_WPCOM, TYPE_BUSINESS, TYPE_PREMIUM } from '../src/constants';
+import { GROUP_WPCOM, TYPE_BUSINESS, TYPE_PREMIUM, TYPE_PERSONAL } from '../src/constants';
 
 describe( 'getPopularPlanSpec()', () => {
 	const availablePlans = [
@@ -69,5 +69,27 @@ describe( 'getPopularPlanSpec()', () => {
 				isJetpack: true,
 			} )
 		).toBe( false );
+	} );
+
+	test( 'Should return personal for link-in-bio flows', () => {
+		expect(
+			getPopularPlanSpec( {
+				availablePlans,
+				flowName: 'link-in-bio',
+			} )
+		).toEqual( {
+			type: TYPE_PERSONAL,
+			group: GROUP_WPCOM,
+		} );
+
+		expect(
+			getPopularPlanSpec( {
+				availablePlans,
+				flowName: 'link-in-bio-tld',
+			} )
+		).toEqual( {
+			type: TYPE_PERSONAL,
+			group: GROUP_WPCOM,
+		} );
 	} );
 } );

--- a/packages/onboarding/src/flow-progress/use-flow-progress.ts
+++ b/packages/onboarding/src/flow-progress/use-flow-progress.ts
@@ -1,3 +1,5 @@
+import { LINK_IN_BIO_FLOW, LINK_IN_BIO_TLD_FLOW } from '../utils/flows';
+
 /* eslint-disable no-restricted-imports */
 interface FlowProgress {
 	stepName?: string;
@@ -14,12 +16,20 @@ const flows: Record< string, { [ step: string ]: number } > = {
 		subscribers: 4,
 		launchpad: 5,
 	},
-	'link-in-bio': {
+	[ LINK_IN_BIO_FLOW ]: {
 		intro: 0,
 		user: 0,
 		patterns: 1,
 		linkInBioSetup: 2,
 		domains: 3,
+		plans: 4,
+		launchpad: 5,
+	},
+	[ LINK_IN_BIO_TLD_FLOW ]: {
+		domains: 0,
+		user: 1,
+		patterns: 2,
+		linkInBioSetup: 3,
 		plans: 4,
 		launchpad: 5,
 	},


### PR DESCRIPTION
#### Proposed Changes
This PR implements the dotlink version of Link in Bio flow on Stepper, aiming at completly replacing the previous `/start/link-in-bio-tld`. The TLD suffix is kept, since my understanding is that the possibilities of partnership with different TLDs are still there. The current implmentation is strictly .link only, but it should be enough to provide clues for a more general solution in the future.

Currently, the flow is implmeneted as interweaving of the signup framework and the Stepper framework, initiating from `/start/link-in-bio-tld?tld=link`. Unfortunately it has encountered an unsolvable issue given that approach(see p2-p4TIVU-akM). Overall the implementation is just:

1. Add a new flow, LINK_IN_BIO_TLD_FLOW
2. Add the required boilerplate code for making it functional like the regular Link in Bio flow.
3. Configure `link` as `promoTlds` and `managedSubdomains***` props.

By doing so, it also means there are some janitorial tasks that has to be done, and they will be completed by follow-up PRs to keep the scope of this PR. See 1348-gh-Automattic/martech.

Among testing, I've also found a few back-navigation issues: 

* https://github.com/Automattic/wp-calypso/issues/71260
* https://github.com/Automattic/wp-calypso/issues/71261
* https://github.com/Automattic/wp-calypso/issues/71262

However, they are more of the general issues that need to happen at the framework level, so this PR won't address them.

#### Testing Instructions

1. Access the flow via `/setup/link-in-bio-tld`
2. Go through the whole flow. It should be: domains -> users -> (brief processing screen from the signup framework) -> patterns -> Link in Bio site setup -> plans -> processing -> *checkout if there is anything in cart -> Launchpad
3. At the domains step, note that there should be only `link` domain to choose from. The free `w.link` domain should have 2 options.
4. In the end, you should create a Link in Bio site on `w.link` or `.link` successfully.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
