### PR TITLE
Add new image border div to reader images

### DIFF
--- a/client/blocks/reader-full-post/_content.scss
+++ b/client/blocks/reader-full-post/_content.scss
@@ -65,11 +65,24 @@
 		border-radius: 6px; /* stylelint-disable-line scales/radii */
 		display: inherit;
 	}
+
 	.wp-block-gallery .wp-block-image,
-	.image-wrapper.two-three,
-	.image-wrapper.three-two,
-	.image-wrapper.wide {
+	.image-wrapper {
 		position: relative;
+
+		.image-border {
+			content: "";
+			position: absolute;
+			pointer-events: none;
+			top: 0;
+			left: 0;
+			bottom: 0;
+			right: 0;
+			box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.1);
+			border-radius: 6px; /* stylelint-disable-line scales/radii */
+			margin: auto;
+			max-width: 100%;
+		}
 
 		figcaption {
 			border-bottom-left-radius: 6px; /* stylelint-disable-line scales/radii */

--- a/client/blocks/reader-full-post/_content.scss
+++ b/client/blocks/reader-full-post/_content.scss
@@ -70,21 +70,6 @@
 	.image-wrapper.three-two,
 	.image-wrapper.wide {
 		position: relative;
-		&::after {
-			content: "";
-			position: absolute;
-			pointer-events: none;
-			top: 0;
-			left: 0;
-			bottom: 0;
-			right: 0;
-			box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.1);
-			border-radius: 6px; /* stylelint-disable-line scales/radii */
-		}
-
-		img {
-			width: 100%;
-		}
 
 		figcaption {
 			border-bottom-left-radius: 6px; /* stylelint-disable-line scales/radii */

--- a/client/lib/post-normalizer/rule-add-image-wrapper-element.js
+++ b/client/lib/post-normalizer/rule-add-image-wrapper-element.js
@@ -51,6 +51,30 @@ const getImageAspectRatioClass = ( image ) => {
 	return '';
 };
 
+/**
+ * Gets the current image width (rather than original width)
+ * Checks the image width attribute
+ * Checks if width set in img src URL query params, i.e. {image-url}?w={width}
+ * Returns 0 if no current width found
+ *
+ * @param image
+ * @returns {number}
+ */
+const getCurrentImageWidth = ( image ) => {
+	let width = image.width || 0;
+
+	if ( width === 0 && image.src !== undefined ) {
+		// Parse width from src
+		const params = image.src.split( '?' )[ 1 ];
+		if ( params !== undefined ) {
+			const searchParams = new URLSearchParams( params );
+			width = searchParams.get( 'w' ) || '0';
+		}
+	}
+
+	return parseInt( width );
+};
+
 export default function addImageWrapperElement( post, dom ) {
 	if ( ! dom ) {
 		throw new Error( 'this transform must be used as part of withContentDOM' );
@@ -67,6 +91,17 @@ export default function addImageWrapperElement( post, dom ) {
 		parent.replaceChild( imageWrapper, image );
 		// set element as child of wrapper
 		imageWrapper.appendChild( image );
+
+		// Add div to allow image border with an inset box-shadow
+		const imageWidth = getCurrentImageWidth( image );
+		if ( imageWidth > 0 ) {
+			const imageBorder = document.createElement( 'div' );
+			const borderStyle = document.createAttribute( 'style' );
+			imageBorder.className = 'image-border';
+			borderStyle.value = 'width: ' + imageWidth + 'px';
+			imageBorder.setAttributeNode( borderStyle );
+			imageWrapper.appendChild( imageBorder );
+		}
 	} );
 
 	return post;


### PR DESCRIPTION
In order to support the box shadow we introduced for images in reader in recent changes, we updated images in the full page post to be full width. 

This means images that were not intended by the author to be full width were being expanded to support this style choice.

This PR adds a new div to reader images that allows us to style an inset box-shadow border around images. This only works as we are able to set the width of this new div to match the image width when rendering images in reader.

Ref: https://github.com/Automattic/wp-calypso/issues/69603

### Test

To make the border stand out more, update the css in your browser for the `image-border` div to something like
`box-shadow: inset 0 0 0 10px red;` 
Go to a site like http://calypso.localhost:3000/read/blogs/125457285/posts/9736 
Browse posts on reader and see if you can find any images not rendering properly