### PR TITLE
Reading Settings: Rename 'Blog posts' setting to 'Blog pages'

### DIFF
--- a/client/my-sites/site-settings/reading-site-settings/BlogPagesSetting.tsx
+++ b/client/my-sites/site-settings/reading-site-settings/BlogPagesSetting.tsx
@@ -4,20 +4,20 @@ import FormLabel from 'calypso/components/forms/form-label';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 
-export const BLOGS_POST_OPTION = 'posts_per_page';
+export const BLOG_PAGES_OPTION = 'posts_per_page';
 
-type BlogsPostSettingProps = {
+type BlogPagesSettingProps = {
 	value?: number;
 	onChange: ( event: React.ChangeEvent< HTMLInputElement > ) => void;
 	disabled?: boolean;
 };
 
-export const BlogsPostsSetting = ( { value = 10, onChange, disabled }: BlogsPostSettingProps ) => {
+export const BlogPagesSetting = ( { value = 10, onChange, disabled }: BlogPagesSettingProps ) => {
 	const translate = useTranslate();
 	return (
 		<FormFieldset>
-			<FormLabel id={ `${ BLOGS_POST_OPTION }-label` } htmlFor={ BLOGS_POST_OPTION }>
-				{ translate( 'Blogs post' ) }
+			<FormLabel id={ `${ BLOG_PAGES_OPTION }-label` } htmlFor={ BLOG_PAGES_OPTION }>
+				{ translate( 'Blog pages' ) }
 			</FormLabel>
 			<div>
 				{ translate( 'Show at most {{field /}} posts', {
@@ -26,12 +26,12 @@ export const BlogsPostsSetting = ( { value = 10, onChange, disabled }: BlogsPost
 					components: {
 						field: (
 							<FormTextInput
-								id={ BLOGS_POST_OPTION }
-								name={ BLOGS_POST_OPTION }
+								id={ BLOG_PAGES_OPTION }
+								name={ BLOG_PAGES_OPTION }
 								type="number"
 								step="1"
 								min="0"
-								aria-labelledby={ `${ BLOGS_POST_OPTION }-label` }
+								aria-labelledby={ `${ BLOG_PAGES_OPTION }-label` }
 								value={ value }
 								onChange={ onChange }
 								disabled={ disabled }

--- a/client/my-sites/site-settings/reading-site-settings/index.tsx
+++ b/client/my-sites/site-settings/reading-site-settings/index.tsx
@@ -1,7 +1,7 @@
 import { Card } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
-import { BlogsPostsSetting, BLOGS_POST_OPTION } from './BlogPostSetting';
+import { BlogPagesSetting, BLOG_PAGES_OPTION } from './BlogPagesSetting';
 
 type Fields = {
 	posts_per_page?: number;
@@ -36,9 +36,9 @@ export const SiteSettingsSection = ( {
 				isSaving={ isSavingSettings }
 			/>
 			<Card>
-				<BlogsPostsSetting
+				<BlogPagesSetting
 					value={ posts_per_page }
-					onChange={ onChangeField( BLOGS_POST_OPTION ) }
+					onChange={ onChangeField( BLOG_PAGES_OPTION ) }
 					disabled={ disabled }
 				/>
 			</Card>


### PR DESCRIPTION
#### Proposed Changes

* Rename the "Blog posts" setting, from the new Reading Settings page, to "Blog pages"

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `http://calypso.localhost:3000/settings/reading/<YOUR-SITE>`
* Validate the setting is now title as "Blog pages"

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1670874582166179/1670873954.183339-slack-C02TCEHP3HA
Closes #71207 

![Screen Shot 2022-12-14 at 17 05 47](https://user-images.githubusercontent.com/2019970/207646989-fc1d8115-d7a0-41d5-8833-aadd1997117f.png)
