### PR TITLE
Revert "composite-checkout: Allow disabling payment methods"

### DIFF
--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -43,7 +43,7 @@ The steps can contain any sort of data, but one of the steps should typically be
 
 ### The list of payment method options
 
-The [PaymentMethodStep](#PaymentMethodStep) is a pre-built [CheckoutStep](#CheckoutStep) which lists all the available payment methods passed to the [CheckoutProvider](#CheckoutProvider) as radio buttons (unless they have been disabled by [useTogglePaymentMethod](#useTogglePaymentMethod)).
+The [PaymentMethodStep](#PaymentMethodStep) is a pre-built [CheckoutStep](#CheckoutStep) which lists all the available payment methods passed to the [CheckoutProvider](#CheckoutProvider) as radio buttons.
 
 ### The transaction system
 
@@ -124,7 +124,7 @@ It has the following props.
 - `onPageLoadError?: ( errorType: string, errorMessage: string, errorData?: Record< string, string | number | undefined > ) => void`. A function to call when an internal error boundary triggered.
 - `onStepChanged?: ({ stepNumber: number | null; previousStepNumber: number; paymentMethodId: string }) => void`. A function to call when the active checkout step is changed.
 - `onPaymentMethodChanged?: (method: string) => void`. A function to call when the active payment method is changed. The argument will be the method's id.
-- `paymentMethods: object[]`. An array of [Payment Method objects](#payment-methods). Can be disabled by [useTogglePaymentMethod](#useTogglePaymentMethod).
+- `paymentMethods: object[]`. An array of [Payment Method objects](#payment-methods).
 - `paymentProcessors: object`. A key-value map of payment processor functions (see [Payment Methods](#payment-methods)).
 - `isLoading?: boolean`. If set and true, the form will be replaced with a loading placeholder and the form status will be set to [`.LOADING`](#FormStatus) (see [useFormStatus](#useFormStatus)).
 - `isValidating?: boolean`. If set and true, the form status will be set to [`.VALIDATING`](#FormStatus) (see [useFormStatus](#useFormStatus)).
@@ -407,12 +407,6 @@ A React Hook that will return a function to set a step to "complete". Only works
 ### useTotal
 
 A React Hook that returns the `total` property provided to the [CheckoutProvider](#checkoutprovider). This is the same as the second return value of [useLineItems](#useLineItems) but may be more semantic in some cases. Only works within `CheckoutProvider`.
-
-### useTogglePaymentMethod
-
-A React Hook that returns a function which can be called to enable or disable a payment method from the list of payment methods provided to [CheckoutProvider](#CheckoutProvider). Only works within `CheckoutProvider`.
-
-The signature of the function returned by this hook is: `( paymentMethodId: string, available: boolean ) => void`.
 
 ### useTransactionStatus
 

--- a/packages/composite-checkout/src/components/checkout-payment-methods.tsx
+++ b/packages/composite-checkout/src/components/checkout-payment-methods.tsx
@@ -5,7 +5,6 @@ import debugFactory from 'debug';
 import { useCallback, useContext } from 'react';
 import CheckoutContext from '../lib/checkout-context';
 import joinClasses from '../lib/join-classes';
-import { useAvailablePaymentMethodIds } from '../lib/payment-methods';
 import {
 	useAllPaymentMethods,
 	usePaymentMethod,
@@ -133,7 +132,6 @@ function PaymentMethod( {
 	ariaLabel,
 	summary,
 }: PaymentMethodProps ) {
-	const availablePaymentMethodIds = useAvailablePaymentMethodIds();
 	const { formStatus } = useFormStatus();
 	if ( summary ) {
 		return <>{ inactiveContent && inactiveContent }</>;
@@ -146,7 +144,6 @@ function PaymentMethod( {
 			id={ id }
 			checked={ checked }
 			disabled={ formStatus !== FormStatus.READY }
-			hidden={ ! availablePaymentMethodIds.includes( id ) }
 			onChange={ onClick ? () => onClick( id ) : undefined }
 			ariaLabel={ ariaLabel }
 			label={ label }

--- a/packages/composite-checkout/src/components/checkout-provider.tsx
+++ b/packages/composite-checkout/src/components/checkout-provider.tsx
@@ -13,10 +13,15 @@ import {
 	validatePaymentMethods,
 	validateTotal,
 } from '../lib/validation';
-import { LineItem, CheckoutProviderProps, FormStatus, TransactionStatus } from '../types';
+import {
+	LineItem,
+	CheckoutProviderProps,
+	FormStatus,
+	TransactionStatus,
+	PaymentMethod,
+} from '../types';
 import CheckoutErrorBoundary from './checkout-error-boundary';
 import TransactionStatusHandler from './transaction-status-handler';
-import type { CheckoutContextInterface } from '../lib/checkout-context';
 import type {
 	PaymentEventCallback,
 	PaymentErrorCallback,
@@ -62,19 +67,27 @@ export function CheckoutProvider( {
 		children,
 		initiallySelectedPaymentMethodId,
 	};
-	const [ disabledPaymentMethodIds, setDisabledPaymentMethodIds ] = useState< string[] >( [] );
-
 	const [ paymentMethodId, setPaymentMethodId ] = useState< string | null >(
 		initiallySelectedPaymentMethodId
 	);
-
-	useResetSelectedPaymentMethodWhenListChanges(
-		paymentMethods
-			.filter( ( method ) => ! disabledPaymentMethodIds.includes( method.id ) )
-			.map( ( method ) => method.id ),
-		initiallySelectedPaymentMethodId,
-		setPaymentMethodId
-	);
+	const [ prevPaymentMethods, setPrevPaymentMethods ] = useState< PaymentMethod[] >( [] );
+	useEffect( () => {
+		const paymentMethodIds = paymentMethods.map( ( x ) => x?.id );
+		const prevPaymentMethodIds = prevPaymentMethods.map( ( x ) => x?.id );
+		const paymentMethodsChanged =
+			paymentMethodIds.some( ( x ) => ! prevPaymentMethodIds.includes( x ) ) ||
+			prevPaymentMethodIds.some( ( x ) => ! paymentMethodIds.includes( x ) );
+		if ( paymentMethodsChanged ) {
+			debug(
+				'paymentMethods changed; setting payment method to initial selection ',
+				initiallySelectedPaymentMethodId,
+				'from',
+				paymentMethods
+			);
+			setPrevPaymentMethods( paymentMethods );
+			setPaymentMethodId( initiallySelectedPaymentMethodId );
+		}
+	}, [ paymentMethods, prevPaymentMethods, initiallySelectedPaymentMethodId ] );
 
 	const [ formStatus, setFormStatus ] = useFormStatusManager(
 		Boolean( isLoading ),
@@ -94,11 +107,9 @@ export function CheckoutProvider( {
 		transactionLastResponse,
 	} );
 
-	const value: CheckoutContextInterface = useMemo(
+	const value = useMemo(
 		() => ( {
 			allPaymentMethods: paymentMethods,
-			disabledPaymentMethodIds,
-			setDisabledPaymentMethodIds,
 			paymentMethodId,
 			setPaymentMethodId,
 			formStatus,
@@ -113,7 +124,6 @@ export function CheckoutProvider( {
 			formStatus,
 			paymentMethodId,
 			paymentMethods,
-			disabledPaymentMethodIds,
 			setFormStatus,
 			transactionStatusManager,
 			paymentProcessors,
@@ -229,25 +239,4 @@ function useCallEventCallbacks( {
 		}
 		prevTransactionStatus.current = transactionStatus;
 	}, [ transactionStatus, paymentMethodId, transactionLastResponse, transactionError ] );
-}
-
-function useResetSelectedPaymentMethodWhenListChanges(
-	availablePaymentMethodIds: string[],
-	initiallySelectedPaymentMethodId: string | null,
-	setPaymentMethodId: ( id: string | null ) => void
-) {
-	const hashKey = availablePaymentMethodIds.join( '-_-' );
-	const previousKey = useRef< string >();
-
-	useEffect( () => {
-		if ( previousKey.current !== hashKey ) {
-			debug(
-				'paymentMethods changed; setting payment method to initial selection ',
-				initiallySelectedPaymentMethodId
-			);
-
-			previousKey.current = hashKey;
-			setPaymentMethodId( initiallySelectedPaymentMethodId );
-		}
-	}, [ hashKey, setPaymentMethodId, initiallySelectedPaymentMethodId ] );
 }

--- a/packages/composite-checkout/src/components/radio-button.tsx
+++ b/packages/composite-checkout/src/components/radio-button.tsx
@@ -8,7 +8,6 @@ const RadioButtonWrapper = styled.div<
 	RadioButtonWrapperProps & React.HTMLAttributes< HTMLDivElement >
 >`
 	position: relative;
-	display: ${ ( props ) => ( props.hidden ? 'none' : 'block' ) };
 	margin-top: 8px;
 	border-radius: 3px;
 	box-sizing: border-box;
@@ -20,7 +19,7 @@ const RadioButtonWrapper = styled.div<
 	}
 
 	::before {
-		display: ${ ( props ) => ( props.hidden ? 'none' : 'block' ) };
+		display: block;
 		width: 100%;
 		height: 100%;
 		position: absolute;
@@ -176,7 +175,6 @@ export default function RadioButton( {
 	children,
 	label,
 	disabled,
-	hidden,
 	id,
 	isFixedHeight,
 	ariaLabel,
@@ -185,12 +183,7 @@ export default function RadioButton( {
 	const [ isFocused, changeFocus ] = useState( false );
 
 	return (
-		<RadioButtonWrapper
-			disabled={ disabled }
-			isFocused={ isFocused }
-			checked={ checked }
-			hidden={ hidden }
-		>
+		<RadioButtonWrapper disabled={ disabled } isFocused={ isFocused } checked={ checked }>
 			<Radio
 				type="radio"
 				name={ name }
@@ -227,7 +220,6 @@ interface RadioButtonProps {
 	id: string;
 	label: React.ReactNode;
 	disabled?: boolean;
-	hidden?: boolean;
 	checked?: boolean;
 	value: string;
 	onChange?: () => void;

--- a/packages/composite-checkout/src/lib/checkout-context.ts
+++ b/packages/composite-checkout/src/lib/checkout-context.ts
@@ -9,10 +9,8 @@ import {
 	PaymentMethodChangedCallback,
 } from '../types';
 
-export interface CheckoutContextInterface {
+interface CheckoutContext {
 	allPaymentMethods: PaymentMethod[];
-	disabledPaymentMethodIds: string[];
-	setDisabledPaymentMethodIds: ( methods: string[] ) => void;
 	paymentMethodId: string | null;
 	setPaymentMethodId: ( id: string ) => void;
 	formStatus: FormStatus;
@@ -24,10 +22,8 @@ export interface CheckoutContextInterface {
 	onPaymentMethodChanged?: PaymentMethodChangedCallback;
 }
 
-const defaultCheckoutContext: CheckoutContextInterface = {
+const defaultCheckoutContext: CheckoutContext = {
 	allPaymentMethods: [],
-	disabledPaymentMethodIds: [],
-	setDisabledPaymentMethodIds: noop,
 	paymentMethodId: null,
 	setPaymentMethodId: noop,
 	formStatus: FormStatus.LOADING,

--- a/packages/composite-checkout/src/lib/payment-methods/index.ts
+++ b/packages/composite-checkout/src/lib/payment-methods/index.ts
@@ -1,7 +1,7 @@
 import debugFactory from 'debug';
-import { useContext, useMemo } from 'react';
+import { useContext } from 'react';
+import { PaymentMethod } from '../../types';
 import CheckoutContext from '../checkout-context';
-import type { PaymentMethod, TogglePaymentMethod } from '../../types';
 
 const debug = debugFactory( 'composite-checkout:payment-methods' );
 
@@ -36,45 +36,4 @@ export function useAllPaymentMethods() {
 		throw new Error( 'useAllPaymentMethods cannot be used outside of CheckoutProvider' );
 	}
 	return allPaymentMethods;
-}
-
-export function useAvailablePaymentMethodIds(): string[] {
-	const { allPaymentMethods, disabledPaymentMethodIds } = useContext( CheckoutContext );
-	if ( ! allPaymentMethods ) {
-		throw new Error( 'useAvailablePaymentMethodIds cannot be used outside of CheckoutProvider' );
-	}
-	const paymentMethodIds = allPaymentMethods.map( ( method ) => method.id );
-	const availablePaymentMethodIds = useMemo(
-		() => paymentMethodIds.filter( ( id ) => ! disabledPaymentMethodIds.includes( id ) ),
-		[ paymentMethodIds, disabledPaymentMethodIds ]
-	);
-	debug( 'Returning available payment methods', availablePaymentMethodIds );
-	return availablePaymentMethodIds;
-}
-
-export function useTogglePaymentMethod(): TogglePaymentMethod {
-	const { allPaymentMethods, disabledPaymentMethodIds, setDisabledPaymentMethodIds } =
-		useContext( CheckoutContext );
-	if ( ! allPaymentMethods ) {
-		throw new Error( 'useTogglePaymentMethod cannot be used outside of CheckoutProvider' );
-	}
-	return ( paymentMethodId: string, available: boolean ) => {
-		const paymentMethod = allPaymentMethods.find( ( { id } ) => id === paymentMethodId );
-		if ( ! paymentMethod ) {
-			debug( `No payment method found matching id '${ paymentMethodId }' in`, allPaymentMethods );
-			return;
-		}
-
-		if ( available && disabledPaymentMethodIds.includes( paymentMethodId ) ) {
-			debug( 'Adding available payment method', paymentMethodId );
-			setDisabledPaymentMethodIds(
-				disabledPaymentMethodIds.filter( ( id ) => id !== paymentMethodId )
-			);
-		}
-
-		if ( ! available && ! disabledPaymentMethodIds.includes( paymentMethodId ) ) {
-			debug( 'Removing available payment method', paymentMethodId );
-			setDisabledPaymentMethodIds( [ ...disabledPaymentMethodIds, paymentMethodId ] );
-		}
-	};
 }

--- a/packages/composite-checkout/src/public-api.ts
+++ b/packages/composite-checkout/src/public-api.ts
@@ -41,12 +41,7 @@ import useProcessPayment from './components/use-process-payment';
 import { useFormStatus } from './lib/form-status';
 import InvalidPaymentProcessorResponseError from './lib/invalid-payment-processor-response-error';
 import { useLineItems, useTotal, useLineItemsOfType } from './lib/line-items';
-import {
-	usePaymentMethod,
-	usePaymentMethodId,
-	useAllPaymentMethods,
-	useTogglePaymentMethod,
-} from './lib/payment-methods';
+import { usePaymentMethod, usePaymentMethodId, useAllPaymentMethods } from './lib/payment-methods';
 import PaymentLogo from './lib/payment-methods/payment-logo';
 import {
 	usePaymentProcessor,
@@ -112,7 +107,6 @@ export {
 	usePaymentProcessors,
 	useProcessPayment,
 	useSetStepComplete,
-	useTogglePaymentMethod,
 	useTotal,
 	useTransactionStatus,
 };

--- a/packages/composite-checkout/src/types.ts
+++ b/packages/composite-checkout/src/types.ts
@@ -313,5 +313,3 @@ export interface CheckoutStepGroupActions {
 	getStepCompleteCallback: ( stepNumber: number ) => StepCompleteCallback;
 	setTotalSteps: ( totalSteps: number ) => void;
 }
-
-export type TogglePaymentMethod = ( paymentMethodId: string, available: boolean ) => void;

--- a/packages/composite-checkout/test/checkout.js
+++ b/packages/composite-checkout/test/checkout.js
@@ -19,28 +19,12 @@ import {
 	CheckoutStepGroup,
 	useSetStepComplete,
 	makeManualResponse,
-	useTogglePaymentMethod,
 } from '../src/public-api';
 import { PaymentProcessorResponseType } from '../src/types';
 import { DefaultCheckoutSteps } from './utils/default-checkout-steps';
 
 const myContext = createContext();
 const usePaymentData = () => useContext( myContext );
-
-function TogglePaymentMethodBlock( { mockMethod } ) {
-	const togglePaymentMethod = useTogglePaymentMethod();
-
-	return (
-		<div>
-			<button onClick={ () => togglePaymentMethod( mockMethod.id, false ) }>
-				Disable Payment Method
-			</button>
-			<button onClick={ () => togglePaymentMethod( mockMethod.id, true ) }>
-				Enable Payment Method
-			</button>
-		</div>
-	);
-}
 
 describe( 'Checkout', () => {
 	describe( 'using the default steps', function () {
@@ -59,7 +43,6 @@ describe( 'Checkout', () => {
 						initiallySelectedPaymentMethodId={ mockMethod.id }
 					>
 						<DefaultCheckoutSteps />
-						<TogglePaymentMethodBlock mockMethod={ mockMethod } />
 					</CheckoutProvider>
 				);
 			} );
@@ -84,23 +67,6 @@ describe( 'Checkout', () => {
 			it( 'renders the payment method label', () => {
 				const { getAllByText } = render( <MyCheckout /> );
 				expect( getAllByText( 'Mock Label' )[ 0 ] ).toBeInTheDocument();
-			} );
-
-			it( 'does not render the payment method label if the payment method is disabled', async () => {
-				const { queryByText, getByText, getAllByText } = render( <MyCheckout /> );
-				const user = userEvent.setup();
-				await user.click( getAllByText( 'Continue' )[ 0 ] );
-				await user.click( getByText( 'Disable Payment Method' ) );
-				expect( queryByText( 'Mock Label' ) ).not.toBeVisible();
-			} );
-
-			it( 'does render the payment method label if the payment method is disabled then enabled', async () => {
-				const { getAllByText, getByText } = render( <MyCheckout /> );
-				const user = userEvent.setup();
-				await user.click( getAllByText( 'Continue' )[ 0 ] );
-				await user.click( getByText( 'Disable Payment Method' ) );
-				await user.click( getByText( 'Enable Payment Method' ) );
-				expect( getAllByText( 'Mock Label' )[ 0 ] ).toBeVisible();
 			} );
 
 			it( 'renders the payment method activeContent', () => {


### PR DESCRIPTION
Reverts Automattic/wp-calypso#71103, just in case