### PR TITLE
[Try] Limit Global Styles: Preview in Any Block Editor

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
@@ -151,7 +151,13 @@ add_action( 'wp_enqueue_scripts', 'wpcom_global_styles_enqueue_assets' );
  * @return WP_Theme_JSON_Data|WP_Theme_JSON_Data_Gutenberg Filtered data.
  */
 function wpcom_block_global_styles_frontend( $theme_json ) {
-	if ( ! wpcom_should_limit_global_styles() || wpcom_is_previewing_global_styles() ) {
+	global $current_screen;
+
+	if (
+		$current_screen->is_block_editor ||
+		! wpcom_should_limit_global_styles() ||
+		wpcom_is_previewing_global_styles()
+	) {
 		return $theme_json;
 	}
 


### PR DESCRIPTION
#### Proposed Changes

* Use the full, unlimited, Global Styles in all block editors.

Practically speaking, this would only limit Global Styles on the front end.

Before proceeding with this, we should:
- Ensure we had a product decision on previewing GS on the regular post editor — or, we didn't have one _against_ doing it!
- Ensure it doesn't cause regressions on the various site previews such as Newsletter and Style Selection onboarding flows.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Install this PR on the sandbox.
* Add a `wpcom-limit-global-styles` sticker to a Free test site.
* In the site editor, select a non-default style variation and save.
* Open the post editor.
* 👉 Ensure the editor is rendering the style variation's styles.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
