### PR TITLE
Third-party Premium Themes: Display appropriate plan remove modal for marketplace themes

### DIFF
--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -893,7 +893,9 @@ function WPLineItem( {
 			product.is_bundled
 	);
 	const hasMarketplaceProductsInCart = responseCart.products.some(
-		( product ) => product.extra.is_marketplace_product === true
+		( product ) =>
+			product.extra.is_marketplace_product === true ||
+			product.product_slug.startsWith( 'wp_mp_theme' )
 	);
 	const { formStatus } = useFormStatus();
 	const itemSpanId = `checkout-line-item-${ id }`;


### PR DESCRIPTION
#### Proposed Changes

When a user has both an atomic plan (business or higher) in their cart along with one or more marketplace theme subscriptions, we want to display a modal warning them the themes will be removed when they remove the business plan from the cart.

The 'plan with marketplace dependencies' modal copy already says what we need so this is a small change to piggy back on that modal.

Prior to this change, we displayed the following modal when the user removes the Business plan from the cart:
![image](https://user-images.githubusercontent.com/917632/207688016-857051e6-733e-4149-9f39-4e8ba05ab4d6.png)

With this change, we display the `plan marketplace dependencies` modal instead:
![image](https://user-images.githubusercontent.com/917632/207688155-94800f4c-2d8f-4fde-bf23-87e6485ff75d.png)


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this patch to Calypso and apply D95349-code on your sandbox.
* Make sure `public-api.wordpress.com` is sandboxed.
* Make sure your sandbox is using the store sandbox.
* Visit `http://calypso.localhost:3000/theme/makoney/{site-slug}`.
* Click "Upgrade to subscribe".
* You should be taken to the checkout page with the Business plan and Makoney theme subscription in the cart.
* Remove the Business plan by clicking "Remove from cart".
* You should see the following modal:
![image](https://user-images.githubusercontent.com/917632/207687838-eb07b059-9585-4a7c-86cf-e6315818fc10.png)
* Click "Continue" and both the Business plan _and_ the Makoney theme subscription should be removed from the cart.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [NA] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [NA] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [NA] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [NA] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [NA] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #71091