### PR TITLE
eCommerce Onboarding: Add plan recurrence prop to Tracks on signup start

### DIFF
--- a/client/landing/stepper/declarative-flow/tailored-ecommerce-flow.ts
+++ b/client/landing/stepper/declarative-flow/tailored-ecommerce-flow.ts
@@ -30,8 +30,12 @@ import type { SiteDetailsPlan } from '@automattic/data-stores';
 const ecommerceFlow: Flow = {
 	name: ECOMMERCE_FLOW,
 	useSteps() {
+		const recurType = useSelect( ( select ) =>
+			select( ONBOARD_STORE ).getEcommerceFlowRecurType()
+		);
+
 		useEffect( () => {
-			recordTracksEvent( 'calypso_signup_start', { flow: this.name } );
+			recordTracksEvent( 'calypso_signup_start', { flow: this.name, recur: recurType } );
 			recordFullStoryEvent( 'calypso_signup_start_ecommerce', { flow: this.name } );
 		}, [] );
 


### PR DESCRIPTION
#### Proposed Changes

* Adds the plan recurrence parameter to `calypso_signup_start` with prop key `recur`
* This value comes from the onboard store, and is originally set from the query parameter `?recur=monthly` when stepper is first launched

<img width="487" alt="Screen Shot 2022-12-14 at 2 14 37 PM" src="https://user-images.githubusercontent.com/2124984/207692489-33d5a2ec-d8d7-417b-9c91-2ae481644f55.png">
<img width="489" alt="Screen Shot 2022-12-14 at 2 15 02 PM" src="https://user-images.githubusercontent.com/2124984/207692491-9941fe02-3a81-4381-94d4-0527c3e670f3.png">


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to this PR, navigate to `/setup/ecommerce`
* Check the Tracks value for `calypso_signup_start` -- it should have a prop `recur: yearly`
* Navigate to `/setup/ecommerce?recur=monthly`
* The tracks value for `calypso_signup_start` should have a prop `recur: monthly`

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1671044323642599-slack-C0Q664T29