### PR TITLE
Marketplace Themes: Use the correct selector to check if the site subscribed to the theme

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -67,6 +67,7 @@ import {
 	shouldShowTryAndCustomize,
 	isExternallyManagedTheme as getIsExternallyManagedTheme,
 	isSiteEligibleForManagedExternalThemes as getIsSiteEligibleForManagedExternalThemes,
+	isMarketplaceThemeSubscribed as getIsMarketplaceThemeSubscribed,
 } from 'calypso/state/themes/selectors';
 import { getIsLoadingCart } from 'calypso/state/themes/selectors/get-is-loading-cart';
 import { getBackPath } from 'calypso/state/themes/themes-ui/selectors';
@@ -563,6 +564,7 @@ class ThemeSheet extends Component {
 			isBundledSoftwareSet,
 			isExternallyManagedTheme,
 			isSiteEligibleForManagedExternalThemes,
+			isMarketplaceThemeSubscribed,
 		} = this.props;
 		if ( isActive ) {
 			// Customize site
@@ -589,13 +591,13 @@ class ThemeSheet extends Component {
 				} );
 			} else if (
 				isExternallyManagedTheme &&
-				! isPurchased &&
+				! isMarketplaceThemeSubscribed &&
 				! isSiteEligibleForManagedExternalThemes
 			) {
 				return translate( 'Upgrade to subscribe' );
 			} else if (
 				isExternallyManagedTheme &&
-				! isPurchased &&
+				! isMarketplaceThemeSubscribed &&
 				isSiteEligibleForManagedExternalThemes
 			) {
 				return translate( 'Subscribe to activate' );
@@ -701,14 +703,14 @@ class ThemeSheet extends Component {
 			isBundledSoftwareSet,
 			isExternallyManagedTheme,
 			translate,
-			isPurchased,
 			isSiteEligibleForManagedExternalThemes,
+			isMarketplaceThemeSubscribed,
 		} = this.props;
 
 		if ( isBundledSoftwareSet && ! isExternallyManagedTheme ) {
 			return translate( 'Access this WooCommerce theme with a Business plan!' );
 		} else if ( isExternallyManagedTheme ) {
-			if ( ! isPurchased && ! isSiteEligibleForManagedExternalThemes ) {
+			if ( ! isMarketplaceThemeSubscribed && ! isSiteEligibleForManagedExternalThemes ) {
 				return translate( 'Upgrade to a Business plan and subscribe to this theme!' );
 			}
 			return translate( 'Subscribe to this premium theme!' );
@@ -721,8 +723,8 @@ class ThemeSheet extends Component {
 			isBundledSoftwareSet,
 			isExternallyManagedTheme,
 			translate,
-			isPurchased,
 			isSiteEligibleForManagedExternalThemes,
+			isMarketplaceThemeSubscribed,
 		} = this.props;
 
 		if ( isBundledSoftwareSet && ! isExternallyManagedTheme ) {
@@ -730,7 +732,7 @@ class ThemeSheet extends Component {
 				'This theme comes bundled with the WooCommerce plugin. Upgrade to a Business plan to select this theme and unlock all its features.'
 			);
 		} else if ( isExternallyManagedTheme ) {
-			if ( ! isPurchased && ! isSiteEligibleForManagedExternalThemes ) {
+			if ( ! isMarketplaceThemeSubscribed && ! isSiteEligibleForManagedExternalThemes ) {
 				return translate(
 					'Unlock this theme by upgrading to a Business plan and subscribing to this premium theme.'
 				);
@@ -762,8 +764,8 @@ class ThemeSheet extends Component {
 			isWPForTeamsSite,
 			isLoggedIn,
 			isExternallyManagedTheme,
-			isPurchased,
 			isSiteEligibleForManagedExternalThemes,
+			isMarketplaceThemeSubscribed,
 		} = this.props;
 
 		const analyticsPath = `/theme/${ id }${ section ? '/' + section : '' }${
@@ -843,7 +845,7 @@ class ThemeSheet extends Component {
 			const forceDisplay =
 				( isBundledSoftwareSet && ! isSiteBundleEligible ) ||
 				( isExternallyManagedTheme &&
-					( ! isPurchased || ! isSiteEligibleForManagedExternalThemes ) );
+					( ! isMarketplaceThemeSubscribed || ! isSiteEligibleForManagedExternalThemes ) );
 			pageUpsellBanner = (
 				<UpsellNudge
 					plan={ PLAN_PREMIUM }
@@ -966,6 +968,7 @@ const ThemeSheetWithOptions = ( props ) => {
 		isBundledSoftwareSet,
 		isExternallyManagedTheme,
 		isSiteEligibleForManagedExternalThemes,
+		isMarketplaceThemeSubscribed,
 	} = props;
 
 	let defaultOption;
@@ -988,7 +991,7 @@ const ThemeSheetWithOptions = ( props ) => {
 	} else if (
 		isExternallyManagedTheme &&
 		isSiteEligibleForManagedExternalThemes &&
-		! isPurchased
+		! isMarketplaceThemeSubscribed
 	) {
 		defaultOption = 'subscribe';
 	} else if ( isPremium && ! isPurchased && ! isBundledSoftwareSet ) {
@@ -1032,6 +1035,9 @@ export default connect(
 			getIsLoadingCart( state ) ||
 			( isExternallyManagedTheme && Object.values( getProductsList( state ) ).length === 0 );
 
+		const isMarketplaceThemeSubscribed =
+			isExternallyManagedTheme && getIsMarketplaceThemeSubscribed( state, theme?.id, siteId );
+
 		return {
 			...theme,
 			id,
@@ -1068,6 +1074,7 @@ export default connect(
 				siteId
 			),
 			isLoading,
+			isMarketplaceThemeSubscribed,
 		};
 	},
 	{

--- a/client/state/themes/selectors/index.js
+++ b/client/state/themes/selectors/index.js
@@ -48,6 +48,7 @@ export { isDownloadableFromWpcom } from 'calypso/state/themes/selectors/is-downl
 export { isExternallyManagedTheme } from 'calypso/state/themes/selectors/is-externally-managed-theme';
 export { isFulfilledThemesForQuery } from 'calypso/state/themes/selectors/is-fulfilled-request-themes-for-query';
 export { isInstallingTheme } from 'calypso/state/themes/selectors/is-installing-theme';
+export { isMarketplaceThemeSubscribed } from 'calypso/state/themes/selectors/is-marketplace-theme-subscribed';
 export { isPremiumThemeAvailable } from 'calypso/state/themes/selectors/is-premium-theme-available';
 export { isRequestingActiveTheme } from 'calypso/state/themes/selectors/is-requesting-active-theme';
 export { isRequestingTheme } from 'calypso/state/themes/selectors/is-requesting-theme';


### PR DESCRIPTION

#### Proposed Changes

Because we were using a fake theme based on Tsubaki, we used some functions that would also threaten the marketplace themes as premium themes. Now that we have a marketplace theme test, we noticed that some conditions wouldn't work correctly for this new test theme(Makoney).

* Fixes the CTA and banner texts for the marketplace themes

#### Testing Instructions

Follow the instructions in this link D92217-code to sandbox the public-api.

* On a free site, navigate to `/theme/makoney/{SITE}`
* The CTA should be `Upgrade to subscribe` and the banner should invite the user to do the same
* Upgrade your site to the Business plan(clicking on the `Upgrade to subscribe` option will add both the plan and the subscription for the theme to the cart. If you want to proceed with the testing in this path, remove the theme subscription before checking out)
* Navigate to `/theme/makoney/{SITE}` on a site with the Business plan.
* The CTA should now be `Subscribe to activate` and the banner should invite the user to do the same
* Click on the `Subscribe to activate` button(this should only include the Theme subscription to the cart) and proceed to checkout.
* After the checkout, navigate to `/theme/makoney/{SITE}`.
* The CTA should be `Activate this design` and the banner should not be displayed

Closes #71210
