### PR TITLE
Tailored Flows: Update translations to useTranslate hook

### DIFF
--- a/client/landing/stepper/declarative-flow/free.ts
+++ b/client/landing/stepper/declarative-flow/free.ts
@@ -2,6 +2,7 @@ import { isEnabled } from '@automattic/calypso-config';
 import { useLocale } from '@automattic/i18n-utils';
 import { useFlowProgress, FREE_FLOW } from '@automattic/onboarding';
 import { useSelect, useDispatch } from '@wordpress/data';
+import { translate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import { recordFullStoryEvent } from 'calypso/lib/analytics/fullstory';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -27,7 +28,9 @@ import type { Flow, ProvidedDependencies } from './internals/types';
 
 const free: Flow = {
 	name: FREE_FLOW,
-	title: 'Free',
+	get title() {
+		return translate( 'Free' );
+	},
 	useSteps() {
 		useEffect( () => {
 			if ( ! isEnabled( 'signup/free-flow' ) ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/free-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/free-setup/index.tsx
@@ -1,7 +1,7 @@
 import { StepContainer, base64ImageToBlob } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
-import { useI18n } from '@wordpress/react-i18n';
+import { useTranslate } from 'i18n-calypso';
 import React, { FormEvent, useEffect } from 'react';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
@@ -14,14 +14,14 @@ import './styles.scss';
 
 const FreeSetup: Step = function FreeSetup( { navigation } ) {
 	const { submit } = navigation;
-	const { __ } = useI18n();
+	const translate = useTranslate();
 	const site = useSite();
 
 	const formText = {
-		titlePlaceholder: __( 'My Website' ),
-		titleMissing: __( `Oops. Looks like your website doesn't have a name yet.` ),
-		taglinePlaceholder: __( 'Add a short description here' ),
-		iconPlaceholder: __( 'Upload a profile image' ),
+		titlePlaceholder: translate( 'My Website' ),
+		titleMissing: translate( `Oops. Looks like your website doesn't have a name yet.` ),
+		taglinePlaceholder: translate( 'Add a short description here' ),
+		iconPlaceholder: translate( 'Upload a profile image' ),
 	};
 
 	const [ invalidSiteTitle, setInvalidSiteTitle ] = React.useState( false );
@@ -81,7 +81,7 @@ const FreeSetup: Step = function FreeSetup( { navigation } ) {
 			formattedHeader={
 				<FormattedHeader
 					id="free-setup-header"
-					headerText={ createInterpolateElement( __( 'Personalize your<br />Website' ), {
+					headerText={ createInterpolateElement( translate( 'Personalize your<br />Website' ), {
 						br: <br />,
 					} ) }
 					align="center"

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/link-in-bio-post-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/link-in-bio-post-setup/index.tsx
@@ -2,7 +2,7 @@
 import { StepContainer, base64ImageToBlob, uploadAndSetSiteLogo } from '@automattic/onboarding';
 import { useDispatch } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
-import { useI18n } from '@wordpress/react-i18n';
+import { useTranslate } from 'i18n-calypso';
 import { FormEvent, useEffect, useState } from 'react';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { SITE_STORE } from 'calypso/landing/stepper/stores';
@@ -15,13 +15,13 @@ import '../link-in-bio-setup/styles.scss';
 
 const LinkInBioPostSetup: Step = function LinkInBioPostSetup( { navigation } ) {
 	const { submit } = navigation;
-	const { __ } = useI18n();
+	const translate = useTranslate();
 	const site = useSite();
 
 	const linkInBioFormText = {
-		titlePlaceholder: __( 'My Link in Bio' ),
-		titleMissing: __( `Oops. Looks like your Link in Bio name is missing.` ),
-		taglinePlaceholder: __( 'Add a short biography here' ),
+		titlePlaceholder: translate( 'My Link in Bio' ),
+		titleMissing: translate( `Oops. Looks like your Link in Bio name is missing.` ),
+		taglinePlaceholder: translate( 'Add a short biography here' ),
 	};
 
 	const [ siteTitle, setComponentSiteTitle ] = useState( '' );
@@ -82,7 +82,7 @@ const LinkInBioPostSetup: Step = function LinkInBioPostSetup( { navigation } ) {
 			formattedHeader={
 				<FormattedHeader
 					id="link-in-bio-setup-header"
-					headerText={ createInterpolateElement( __( 'Personalize your<br />Link in Bio' ), {
+					headerText={ createInterpolateElement( translate( 'Personalize your<br />Link in Bio' ), {
 						br: <br />,
 					} ) }
 					align="center"

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/link-in-bio-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/link-in-bio-setup/index.tsx
@@ -1,7 +1,7 @@
 import { StepContainer, base64ImageToBlob } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
-import { useI18n } from '@wordpress/react-i18n';
+import { useTranslate } from 'i18n-calypso';
 import React, { FormEvent, useEffect } from 'react';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
@@ -14,14 +14,14 @@ import './styles.scss';
 
 const LinkInBioSetup: Step = function LinkInBioSetup( { navigation } ) {
 	const { submit } = navigation;
-	const { __ } = useI18n();
+	const translate = useTranslate();
 	const site = useSite();
 
 	const linkInBioFormText = {
-		titlePlaceholder: __( 'My Link in Bio' ),
-		titleMissing: __( `Oops. Looks like your Link in Bio doesn't have a name yet.` ),
-		taglinePlaceholder: __( 'Add a short biography here' ),
-		iconPlaceholder: __( 'Upload a profile image' ),
+		titlePlaceholder: translate( 'My Link in Bio' ),
+		titleMissing: translate( `Oops. Looks like your Link in Bio doesn't have a name yet.` ),
+		taglinePlaceholder: translate( 'Add a short biography here' ),
+		iconPlaceholder: translate( 'Upload a profile image' ),
 	};
 
 	const [ invalidSiteTitle, setInvalidSiteTitle ] = React.useState( false );
@@ -81,7 +81,7 @@ const LinkInBioSetup: Step = function LinkInBioSetup( { navigation } ) {
 			formattedHeader={
 				<FormattedHeader
 					id="link-in-bio-setup-header"
-					headerText={ createInterpolateElement( __( 'Personalize your<br />Link in Bio' ), {
+					headerText={ createInterpolateElement( translate( 'Personalize your<br />Link in Bio' ), {
 						br: <br />,
 					} ) }
 					align="center"

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-post-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-post-setup/index.tsx
@@ -6,7 +6,7 @@ import {
 } from '@automattic/onboarding';
 import { useDispatch } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
-import { useI18n } from '@wordpress/react-i18n';
+import { useTranslate } from 'i18n-calypso';
 import { FormEvent, useEffect, useState } from 'react';
 import FormattedHeader from 'calypso/components/formatted-header';
 import useAccentColor from 'calypso/landing/stepper/hooks/use-accent-color';
@@ -23,15 +23,15 @@ import '../newsletter-setup/style.scss';
 
 const NewsletterPostSetup: Step = ( { navigation } ) => {
 	const { submit } = navigation;
-	const { __ } = useI18n();
+	const translate = useTranslate();
 	const site = useSite();
 	const fetchedAccentColor = useAccentColor();
 	const saveAccentColor = useSaveAccentColor();
 	const newsletterFormText = {
-		titlePlaceholder: __( 'My newsletter' ),
-		titleMissing: __( `Oops. Looks like your Newsletter doesn't have a name yet.` ),
-		taglinePlaceholder: __( 'Describe your Newsletter in a line or two' ),
-		iconPlaceholder: __( 'Add a site icon' ),
+		titlePlaceholder: translate( 'My newsletter' ),
+		titleMissing: translate( `Oops. Looks like your Newsletter doesn't have a name yet.` ),
+		taglinePlaceholder: translate( 'Describe your Newsletter in a line or two' ),
+		iconPlaceholder: translate( 'Add a site icon' ),
 	};
 
 	const [ invalidSiteTitle, setInvalidSiteTitle ] = useState( false );
@@ -106,7 +106,7 @@ const NewsletterPostSetup: Step = ( { navigation } ) => {
 			formattedHeader={
 				<FormattedHeader
 					id="newsletter-setup-header"
-					headerText={ createInterpolateElement( __( 'Personalize your<br />Newsletter' ), {
+					headerText={ createInterpolateElement( translate( 'Personalize your<br />Newsletter' ), {
 						br: <br />,
 					} ) }
 					align="center"

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/index.tsx
@@ -3,6 +3,7 @@ import { hexToRgb, StepContainer, base64ImageToBlob } from '@automattic/onboardi
 import { useDispatch, useSelect } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
 import { useI18n } from '@wordpress/react-i18n';
+import { useTranslate } from 'i18n-calypso';
 import { FormEvent, useEffect, useState } from 'react';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
@@ -21,18 +22,19 @@ export const defaultAccentColor = {
 
 const NewsletterSetup: Step = ( { navigation } ) => {
 	const { submit } = navigation;
-	const { __, hasTranslation } = useI18n();
+	const translate = useTranslate();
+	const { hasTranslation } = useI18n();
 	const locale = useLocale();
 	const site = useSite();
 
 	const newsletterFormText = {
-		titlePlaceholder: __( 'My newsletter' ),
-		titleMissing: __( `Oops. Looks like your Newsletter doesn't have a name yet.` ),
-		taglinePlaceholder: __( 'Describe your Newsletter in a line or two' ),
+		titlePlaceholder: translate( 'My newsletter' ),
+		titleMissing: translate( `Oops. Looks like your Newsletter doesn't have a name yet.` ),
+		taglinePlaceholder: translate( 'Describe your Newsletter in a line or two' ),
 		iconPlaceholder:
 			hasTranslation( 'Add a logo or profile picture' ) || locale === 'en'
-				? __( 'Add a logo or profile picture' )
-				: __( 'Add a site icon' ),
+				? translate( 'Add a logo or profile picture' )
+				: translate( 'Add a site icon' ),
 	};
 
 	const { setSiteTitle, setSiteAccentColor, setSiteDescription, setSiteLogo } =
@@ -103,8 +105,8 @@ const NewsletterSetup: Step = ( { navigation } ) => {
 					id="newsletter-setup-header"
 					headerText={ createInterpolateElement(
 						hasTranslation( 'Set up your<br />Newsletter' ) || locale === 'en'
-							? __( 'Set up your<br />Newsletter' )
-							: __( 'Personalize your<br />Newsletter' ),
+							? translate( 'Set up your<br />Newsletter' )
+							: translate( 'Personalize your<br />Newsletter' ),
 						{
 							br: <br />,
 						}


### PR DESCRIPTION
### Proposed Changes

This PR simply updates uses of __() (WordPress core method) to the useTranslate() hook (Calypso's method) for code consistency. It was inspired in part by a recent P2 on defaulting to useTranslate in Calypso, and is also a follow up to [feedback on a prior PR](https://github.com/Automattic/wp-calypso/pull/70908#discussion_r1047625053). 

### Testing Instruction

1) Checkout this branch and run yarn and yarn start if needed. 
2) Test the Newsletter flow. 
    - Start at https://wordpress.com/hp-2022-tailored-flows/ and select Newsletter flow. On intro screen update url from `https://wordpress.com/` to `http://calypso.localhost:3000/`.
    - Go through flow and confirm the Setup and Post-Setup (accessed via Personalize link on Launchpad) pages load correctly with correct text. 
3) Test the Link in Bio flow. 
    - Start at https://wordpress.com/hp-2022-tailored-flows/ and select Newsletter flow. On intro screen update url from `https://wordpress.com/` to `http://calypso.localhost:3000/`.
    - Go through flow and confirm the Setup and Post-Setup (accessed via Personalize link on Launchpad) pages load correctly with correct text. 
4) Test the Free flow. Starting at 
    - Start at http://calypso.localhost:3000/setup/free/intro, go through flow, and confirm the Setup and Post-Setup (accessed via Personalize link on Launchpad) pages load correctly with correct text. 