### PR TITLE
Marketplace Themes: Hide the 'Live Demo' theme option for themes with no demo uri

### DIFF
--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -19,6 +19,7 @@ import {
 import {
 	getJetpackUpgradeUrlIfPremiumTheme,
 	getTheme,
+	getThemeDemoUrl,
 	getThemeDetailsUrl,
 	getThemeHelpUrl,
 	getThemePurchaseUrl,
@@ -223,6 +224,11 @@ function getAllThemeOptions( { translate, isFSEActive } ) {
 			comment: 'label for previewing the theme demo website',
 		} ),
 		action: themePreview,
+		hideForTheme: ( state, themeId, siteId ) => {
+			const demoUrl = getThemeDemoUrl( state, themeId, siteId );
+
+			return ! demoUrl;
+		},
 	};
 
 	const signupLabel = translate( 'Pick this design', {


### PR DESCRIPTION
#### Proposed Changes

This will hide the 'Live Demo' theme option in the kebab menu for themes that don't have a demo uri specified.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this patch to your local calypso.
* Ensure the public-api is sandboxed.
* Ensure your sandbox is using the store sandbox.
* Go to `http://calypso.localhost:3000/themes/{site-slug}?s=makoney`
* Click the kebab menu for Makoney and verify the 'Live Demo; option isn't present.
* Other themes should still have 'Live Demo' as an option.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [NA] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [NA] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [NA] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [NA] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [NA] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #71211
