### PR TITLE
VideoPress Tailored Onboarding: Update Videomaker Screenshots

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/videomaker-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/videomaker-setup/index.tsx
@@ -38,7 +38,7 @@ const VideomakerSetup: Step = function VideomakerSetup( { navigation } ) {
 					onClick={ () => onSelectTheme( 'premium/videomaker' ) }
 				>
 					<img
-						src="https://videopress2.files.wordpress.com/2022/10/videomaker-theme-dark.jpg"
+						src="https://videopress2.files.wordpress.com/2022/12/videomaker-dark.jpg"
 						alt={ __( 'Videomaker dark' ) }
 					/>
 				</button>
@@ -47,7 +47,7 @@ const VideomakerSetup: Step = function VideomakerSetup( { navigation } ) {
 					onClick={ () => onSelectTheme( 'premium/videomaker-white' ) }
 				>
 					<img
-						src="https://videopress2.files.wordpress.com/2022/10/videomaker-theme-light.jpg"
+						src="https://videopress2.files.wordpress.com/2022/12/videomaker-light.jpg"
 						alt={ __( 'Videomaker white' ) }
 					/>
 				</button>


### PR DESCRIPTION
#### Proposed Changes

* Updates the screenshots used in the Videomaker design selection step of the VideoPress tailored onboarding flow.

Before:
<img width="1215" alt="Screenshot 2022-12-14 at 3 38 12 PM" src="https://user-images.githubusercontent.com/789137/207731327-0cdc2a96-6299-401f-b577-6ea7b10ece47.png">

After:
<img width="1198" alt="Screenshot 2022-12-14 at 3 43 28 PM" src="https://user-images.githubusercontent.com/789137/207731368-185c2c73-b617-4d9a-af72-81396283c0cb.png">


#### Testing Instructions

* Start at `/setup/videopress` and proceed to the design selection screen. You should see the new screenshots with `FACTUAL FILMS` as the site title.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
