### PR TITLE
E2E: QoL updates to package scripts and update documentation.

### DIFF
--- a/packages/calypso-e2e/package.json
+++ b/packages/calypso-e2e/package.json
@@ -43,6 +43,6 @@
 		"clean": "yarn build --clean && rm -rf dist",
 		"build": "tsc --build ./tsconfig.json",
 		"encrypt-secrets": "openssl enc -md sha1 -aes-256-cbc -pass env:E2E_SECRETS_KEY -out ./src/secrets/encrypted.enc -in ./src/secrets/decrypted-secrets.json",
-		"decrypt-secrets": "rm -r ./src/secrets/decrypted-secrets.json && openssl enc -md sha1 -aes-256-cbc -d -pass env:E2E_SECRETS_KEY -in ./src/secrets/encrypted.enc -out ./src/secrets/decrypted-secrets.json"
+		"decrypt-secrets": "rm ./src/secrets/decrypted-secrets.json; openssl enc -md sha1 -aes-256-cbc -d -pass env:E2E_SECRETS_KEY -in ./src/secrets/encrypted.enc -out ./src/secrets/decrypted-secrets.json"
 	}
 }

--- a/packages/calypso-e2e/package.json
+++ b/packages/calypso-e2e/package.json
@@ -43,6 +43,6 @@
 		"clean": "yarn build --clean && rm -rf dist",
 		"build": "tsc --build ./tsconfig.json",
 		"encrypt-secrets": "openssl enc -md sha1 -aes-256-cbc -pass env:E2E_SECRETS_KEY -out ./src/secrets/encrypted.enc -in ./src/secrets/decrypted-secrets.json",
-		"decrypt-secrets": "openssl enc -md sha1 -aes-256-cbc -d -pass env:E2E_SECRETS_KEY -in ./src/secrets/encrypted.enc -out ./src/secrets/decrypted-secrets.json"
+		"decrypt-secrets": "rm -r ./src/secrets/decrypted-secrets.json && openssl enc -md sha1 -aes-256-cbc -d -pass env:E2E_SECRETS_KEY -in ./src/secrets/encrypted.enc -out ./src/secrets/decrypted-secrets.json"
 	}
 }

--- a/packages/calypso-e2e/src/jest-playwright-config/global-setup.ts
+++ b/packages/calypso-e2e/src/jest-playwright-config/global-setup.ts
@@ -7,6 +7,12 @@ import pwConfig from './playwright-config';
 export default async (): Promise< void > => {
 	const { AUTHENTICATE_ACCOUNTS } = envVariables;
 
+	// If PWDEBUG mode is enabled (stepping through each step)
+	// don't execute the cookie refresh.
+	if ( process.env.PWDEBUG ) {
+		return;
+	}
+
 	if ( AUTHENTICATE_ACCOUNTS.length > 0 ) {
 		const browser = await chromium.launch( {
 			...pwConfig.launchOptions,
@@ -21,6 +27,7 @@ export default async (): Promise< void > => {
 				}
 
 				const page = await browser.newPage( pwConfig.contextOptions );
+				page.setDefaultTimeout( envVariables.TIMEOUT );
 
 				await testAccount.logInViaLoginPage( page );
 				await testAccount.saveAuthCookies( page.context() );

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -23,86 +23,85 @@ Automated end-to-end acceptance tests for the [wp-calypso](https://github.com/Au
 
 Calypso E2E requires the following:
 
-- [NodeJS 16.13](https://nodejs.org/en/blog/release/v16.17.0/) or higher
+- [NodeJS 16.17.0](https://nodejs.org/en/blog/release/v16.17.0/) or higher
 - [TypeScript 4.5](https://www.staging-typescript.org/docs/handbook/release-notes/typescript-4-5.html) or higher
-- [Playwright 1.24](https://playwright.dev/docs/release-notes#version-123) or higher
+- [Playwright 1.28](https://playwright.dev/docs/release-notes#version-128) or higher
 - [yarn 3.1](https://github.com/yarnpkg/berry) or higher
 
 ## Quick start
 
 1. install `homebrew`.
 
-```
+```bash
 mkdir homebrew && curl -L https://github.com/Homebrew/brew/tarball/master | tar xz --strip 1 -C homebrew
 ```
 
 2. install `nvm`.
 
-```
+```bash
 brew install nvm
 ```
 
 3. install the required nodeJS version.
 
-```
+```bash
 nvm install <node_version>
 ```
 
 4. use the installed nodeJS version.
 
-```
+```bash
 nvm use <node_version>
 ```
 
-5. install `yarn`.
+5. enable `yarn` package manager.
 
-See [this guide](https://yarnpkg.com/getting-started/install).
-
-```
+```bash
 corepack enable
 ```
 
 6. clone this repository
 
-```
+```bash
 git clone https://github.com/Automattic/wp-calypso.git
 ```
 
 7. navigate to the cloned directory.
 
-```
+```bash
 cd wp-calypso
 ```
 
+_From this point on, all commands are executed within the `wp-calypso` root directory._
+
 8. install project dependencies.
 
-```
+```bash
 yarn install
 ```
 
-9. navigate to e2e directory.
+9. obtain the secrets decryption key.
 
-```
-cd test/e2e
+```bash
+export E2E_SECRETS_KEY='Calypso E2E Config decode key from the Automattic secret store>'
 ```
 
 10. [decrypt](docs/test_environment.md) the secrets file.
 
-```
-export E2E_SECRETS_KEY='Calypso E2E Config decode key from the Automattic secret store>'
-yarn decrypt-secrets
+```bash
+yarn workspace wp-e2e-tests decrypt-secrets
 ```
 
-11. transpile the `@automattic/calypso-e2e` package.
+11. transpile the packages.
 
-```
-yarn workspace @automattic/calypso-e2e build
+```bash
+yarn workspace wp-e2e-tests build --watch
 ```
 
 12. run test.
 
-```
-yarn jest specs/<group>/<spec_name>
+```bash
+yarn workspace wp-e2e-tests start -- <test_path>
 ```
 
 ## Advanced setup
@@ -115,4 +114,4 @@ Please refer to the [Writing Tests](docs/writing_tests.md) and [Style Guide](doc
 
 ## Troubleshooting
 
-Please refer to the [Troubleshooting](docs/troubleshooting.md) page.
+Please refer to the [Troubleshooting](docs/troubleshooting.md) page, or ask at [#kitkat](https://a8c.slack.com/archives/CQD1HH4MA).

--- a/test/e2e/docs/debugging.md
+++ b/test/e2e/docs/debugging.md
@@ -39,7 +39,11 @@ Launch Playwright with the following parameters to:
 - output verbose logs to the command line
 
 ```bash
-PWDEBUG=1 DEBUG=pw:api yarn jest <path_to_spec>
+# If within test/e2e directory
+yarn debug <path_to_spec>
+
+# If at repo root
+yarn workspace wp-e2e-tests debug -- <path_to_spec>
 ```
 
 ## Playwright Developer Console and Gutenberg iFrame

--- a/test/e2e/docs/setup.md
+++ b/test/e2e/docs/setup.md
@@ -12,7 +12,6 @@
   - [Regular setup](#regular-setup)
   - [Apple Silicon emulated x86_64](#apple-silicon-emulated-x86_64)
   - [Apple Silicon arm64](#apple-silicon-arm64)
-  - [Help](#help)
 
 <!-- /TOC -->
 
@@ -87,7 +86,3 @@ PUPPETEER_SKIP_DOWNLOAD=true
 ```
 yarn install
 ```
-
-## Help
-
-See the [Troubleshooting](troubleshooting.md) section.

--- a/test/e2e/docs/test_environment.md
+++ b/test/e2e/docs/test_environment.md
@@ -28,7 +28,7 @@ For example:
 VIEWPORT_NAME=mobile yarn jest specs/<etc>
 ```
 
-The list of supported environment variables are found in [`env-variables.ts`](../../../packages/calypso-e2e//src/env-variables.ts). This file also adds static type checking and is the most up-to-date resource. The [Envionment Variables](./environment_variables.md) page may be out of date but will contain explanations of what the individual variables mean.
+The list of supported environment variables are found in [`env-variables.ts`](../../../packages/calypso-e2e//src/env-variables.ts). This file also adds static type checking and is the most up-to-date resource. The [Environment Variables](./environment_variables.md) page may be out of date but will contain explanations of what the individual variables mean.
 
 To use:
 
@@ -48,19 +48,27 @@ if ( envVariables.VIEWPORT_NAME === 'mobile' ) {
 
 Within `@automattic/calypso-e2e/src/secrets` is an encrypted file that holds various sensitive secrets, such as API keys and test account information. This must be decrypted prior to use.
 
-To decrypt the secrets, set the environment variable `E2E_SECRETS_KEY` to the "Calypso E2E Config decode key" from the Automattic secret store.
+**Automatticians**: please refer to the [Field Guide page](PCYsg-vnR-p2) for more information.
 
-```
+**Trialmatticians**: please contact a team member in your Slack chat for the decryption key.
+
+First set the environment variable `E2E_SECRETS_KEY` to the "Calypso E2E Config decode key" from the Automattic secret store.
+
+```bash
 export E2E_SECRETS_KEY='<Calypso E2E Config decode key from the secret store>'
 ```
 
-Then, either here or in the `@automattic/calypso-e2e` workspace, run `yarn decrypt-secrets`.
+Then run the following command to decrypt the secrets:
 
-The decrypted version of these secrets must **NEVER be committed.** There are .gitignore rules to protect against this, but be vigilant nonetheless!
+```bash
+# If within test/e2e directory
+yarn decrypt-secrets
 
-**Automatticians**: please refer to the Field Guide page for instructions on decrypting/encrypting this file.
+# If at repo root
+yarn workspace wp-e2e-tests decrypt-secrets
+```
 
-**Trialmatticians**: please contact a team member in your Slack chat for the decryption key.
+The decrypted file must **NEVER be committed.** There are `.gitignore` rules to protect against this, but be vigilant nonetheless!
 
 ### Using the Secrets
 
@@ -71,7 +79,8 @@ To use:
 ```typescript
 import { SecretsManager } from '@automattic/calypso-e2e';
 
-// Later
+// Later in the spec
 
-const x = SecretsManager.secrets.keyName;
+const credentials = SecretsManager.secrets.testAccounts.<test_account_name>;
+
 ```

--- a/test/e2e/docs/tests_ci.md
+++ b/test/e2e/docs/tests_ci.md
@@ -64,8 +64,9 @@ The Pre-Release E2E tests are connected directly to the Calypso Deploy page and 
 
 In addition to build configurations that are automatically triggered based on branch workflow, there exists build configurations that run on a regular schedule though **only on `trunk`**!
 
-| Build configuration name            | Frequency  |
-| ----------------------------------- | ---------- |
-| WPCOM/Gutenberg E2E Tests (mobile)  | once a day |
-| WPCOM/Gutenberg E2E Tests (desktop) | once a day |
-| Quarantined E2E                     | once a day |
+| Build configuration name            | Frequency          |
+| ----------------------------------- | ------------------ |
+| WPCOM/Gutenberg E2E Tests (mobile)  | once a day         |
+| WPCOM/Gutenberg E2E Tests (desktop) | once a day         |
+| Quarantined E2E                     | once a day         |
+| Authentication E2E                  | once every 6 hours |

--- a/test/e2e/docs/tests_local.md
+++ b/test/e2e/docs/tests_local.md
@@ -26,14 +26,22 @@
 
 Prior to running any tests, transpile TypeScript code:
 
-```
-yarn workspace @automattic/calypso-e2e build
+```bash
+# If within test/e2e directory
+yarn build
+
+# If at repo root
+yarn workspace wp-e2e-tests build
 ```
 
 Alternatively, open a separate Terminal window:
 
-```
-yarn workspace @automattic/calypso-e2e build --watch
+```bash
+# If within test/e2e directory
+yarn build --watch
+
+# If at repo root
+yarn workspace wp-e2e-tests build --watch
 ```
 
 ## Running tests
@@ -42,8 +50,8 @@ yarn workspace @automattic/calypso-e2e build --watch
 
 Specify the file(s) directly:
 
-```
-yarn jest <path_to-File_1> <path_to_file_2>
+```bash
+yarn test -- <path_to-File_1> <path_to_file_2>
 ```
 
 ### Test Group
@@ -52,8 +60,12 @@ We use [jest-runner-groups](https://github.com/eugene-manuilov/jest-runner-group
 
 Use the `--group` arg to provide a suite to test `Jest`. For example, to run all specs that are executed on CI for a commit:
 
-```
-yarn jest --group=calypso-pr
+```bash
+# If within test/e2e directory
+yarn test --group=calypso-pr
+
+# If at repo root
+yarn workspace wp-e2e-tests test --group=calypso-pr
 ```
 
 See the [list of groups](tests_ci.md#featuretest-groups).
@@ -66,7 +78,7 @@ Specified accounts will be pre-authenticated prior to the main test suite execut
 
 Specify a list of user accounts found in [Secret Manager](packages/calypso-e2e/src/secrets/secrets-manager.ts), separated by commas:
 
-```test/e2e/docs/tests_local.md
+```bash
 export AUTHENTICATE_ACCOUNTS=simpleSitePersonalPlanUser,eCommerceUser,defaultUser
 ```
 
@@ -77,15 +89,17 @@ By default, tests run against the `desktop` viewport size, approximately 1920x10
 - mobile
 - desktop
 
-To specify the viewport size:
+To launch a spec with mobile viewport:
+
+```bash
+yarn test:mobile -- <path_to_spec>
+```
+
+To use the manual method, either:
 
 a. set the viewport size to persist in the shell: `export VIEWPORT_NAME=<viewport>`
 
 b. set the viewport size for the command only: `VIEWPORT_NAME=<viewport> yarn jest <test_path>`
-
-```bash
-VIEWPORT_NAME=mobile yarn jest ...
-```
 
 ### Target a different environment
 

--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -19,8 +19,10 @@
 		"clean:packages": "yarn workspace @automattic/jest-circus-allure-reporter clean && yarn workspace @automattic/calypso-e2e clean",
 		"clean:output": "rm -rf ./allure-results && rm -rf ./results",
 		"build": "yarn workspace @automattic/jest-circus-allure-reporter build && yarn workspace @automattic/calypso-e2e build",
-		"start": "yarn jest",
-		"start:debug": "PWDEBUG=1 DEBUG=pw:api yarn run start"
+		"test": "yarn jest",
+		"test:mobile": "VIEWPORT_NAME=mobile yarn jest",
+		"debug": "PWDEBUG=1 DEBUG=pw:api yarn run test",
+		"debug:mobile": "PWDEBUG=1 DEBUG=pw:api yarn run test:mobile"
 	},
 	"devDependencies": {
 		"@automattic/calypso-eslint-overrides": "workspace:^",

--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -18,7 +18,9 @@
 		"clean": "yarn clean:packages && yarn clean:output && rm -rf ./cookies && rm -rf ./node_modules",
 		"clean:packages": "yarn workspace @automattic/jest-circus-allure-reporter clean && yarn workspace @automattic/calypso-e2e clean",
 		"clean:output": "rm -rf ./allure-results && rm -rf ./results",
-		"build": "yarn workspace @automattic/jest-circus-allure-reporter build && yarn workspace @automattic/calypso-e2e build"
+		"build": "yarn workspace @automattic/jest-circus-allure-reporter build && yarn workspace @automattic/calypso-e2e build",
+		"start": "yarn jest",
+		"start:debug": "PWDEBUG=1 DEBUG=pw:api yarn run start"
 	},
 	"devDependencies": {
 		"@automattic/calypso-eslint-overrides": "workspace:^",


### PR DESCRIPTION
#### Proposed Changes

This PR arose as a result of the conversation [here](p1671038940457179-slack-CQD1HH4MA).

Key changes:
- remove existing decrypted secrets file prior to decrypting the new one, to prevent errors.
- add package scripts in `test/e2e` to make it easier to launch a debug instance of Playwright.
- short circuit the cookie saving mechanism if PWDEBUG mode is enabled.
- update `yarn` commands in the documentation.

#### Testing Instructions

Ensure the following build configurations are passing:
  - [x] Calypso E2E (desktop)
  - [x] Calypso E2E (mobile)
  - [x] Code Style

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #