### PR TITLE
E2E: add 502 handler when launching a new page.

### DIFF
--- a/packages/calypso-e2e/src/jest-playwright-config/environment.ts
+++ b/packages/calypso-e2e/src/jest-playwright-config/environment.ts
@@ -384,11 +384,9 @@ function setupBrowserProxyTrap( browser: Browser ): Browser {
 					// to capture instances of 502 Bad Gateway.
 					// This remains active until the page is
 					// closed.
-					page.on( 'response', ( response ) => {
+					page.on( 'response', async ( response ) => {
 						if ( response.status() === 502 ) {
-							throw new Error(
-								`Encountered HTTP ${ response.status } on request to URL ${ response.url() } }`
-							);
+							await page.reload();
 						}
 					} );
 

--- a/packages/calypso-e2e/src/jest-playwright-config/environment.ts
+++ b/packages/calypso-e2e/src/jest-playwright-config/environment.ts
@@ -373,6 +373,18 @@ function setupBrowserProxyTrap( browser: Browser ): Browser {
 					// Default value is 15000ms, defined in env-variables.ts.
 					page.setDefaultTimeout( env.TIMEOUT );
 
+					// Set up a HTTP response status interceptor
+					// to capture instances of 502 Bad Gateway.
+					// This remains active until the page is
+					// closed.
+					page.on( 'response', ( response ) => {
+						if ( response.status() === 502 ) {
+							throw new Error(
+								`Encountered HTTP ${ response.status } on request to URL ${ response.url() } }`
+							);
+						}
+					} );
+
 					const context = page.context();
 
 					await context.tracing.start( {

--- a/packages/calypso-e2e/src/jest-playwright-config/environment.ts
+++ b/packages/calypso-e2e/src/jest-playwright-config/environment.ts
@@ -292,39 +292,46 @@ class JestEnvironmentPlaywright extends NodeEnvironment {
  * To specify a different browser than default,
  * use the @browser tag in the docblock.
  *
+ * Declaration of multiple browsers in the docblock is not supported at this time.
+ *
  * Example:
  *
  * 	`@browser firefox`
  */
 async function determineBrowser( testFilePath: string ): Promise< BrowserType > {
 	const parsed = parseDocBlock( await fs.readFile( testFilePath, 'utf8' ) );
-	const defaultBrowser = env.BROWSER_NAME;
 
-	// Parsed docblock can return any one of the following:
+	// Parsed docblock can return any one of the following for the `browser` prop:
 	// 	- undefined: if a tag was not found.
 	// 	- single string: if only one instance of a tag was found.
 	//	- string array: if multiple instances of the tag was found.
-	// In this case, we only want to throw if the tag has been defined
-	// multiple times.
-	if ( parsed.browser && typeof parsed.browser !== 'string' ) {
+	if ( typeof parsed.browser === 'object' ) {
+		// Multiple browser declarations are not supported.
 		throw new Error( 'Multiple browsers defined in docblock.' );
-	}
+	} else if ( typeof parsed.browser === 'string' ) {
+		// Single browser declaration is supported, but must be a valid browser.
+		const browserFromDocblock = supportedBrowsers.find(
+			( browser ) => browser.name().toLowerCase() === parsed.browser.toString().toLowerCase()
+		);
 
-	// If the browser tag was found in the docblock, look for the
-	// matches in the supported browsers list.
-	// If the browser tag was **not** found, then match based on
-	// the default broswser specified in the BROWSER_NAME
-	// environment variable.
-	const match = supportedBrowsers.find( ( browser ) => {
-		return parsed.browser === undefined
-			? browser.name() === defaultBrowser.toLowerCase()
-			: browser.name() === parsed.browser;
-	} );
+		if ( ! browserFromDocblock ) {
+			throw new Error( `Unsupported browser defined in DocBlock: ${ parsed.browser }` );
+		}
 
-	if ( ! match ) {
-		throw new Error( 'Unsupported browser defined in docblock.' );
+		return browserFromDocblock;
+	} else {
+		// Fall back on the default browser specified in `BROWSER_NAME` environment
+		// variable.
+		const browserFromEnvironmentVariable = supportedBrowsers.find(
+			( browser ) => browser.name().toLowerCase() === env.BROWSER_NAME.toLowerCase()
+		);
+
+		if ( ! browserFromEnvironmentVariable ) {
+			throw new Error( `Unsupported default browser: ${ env.BROWSER_NAME }` );
+		}
+
+		return browserFromEnvironmentVariable;
 	}
-	return match;
 }
 
 /**


### PR DESCRIPTION
#### Proposed Changes

This PR aims to address one persistent source of incorrect failure messages, the 502 Bad Gateway errors.

Key changes:
- add an interceptor to throw an error if the page encounters a 502 Bad Gateway at any point.

Context: 
- p1668544662978699/1668544403.825969-slack-C0E1C5NCR
- p1660161473109199-slack-C02DQP0FP
- p1660149287187909/1660149015.737279-slack-C0E1C5NCR
- p1669765647847149-slack-C03N25JPCE4
- p1669832419708729/1669812675.854889-slack-C1A1EKDGQ

Background:
While our production/staging environment is pretty robust, sometimes there are spikes in instances of HTTP 502 being returned during an E2E test run. 

From the perspective of the test script, it does not know what an HTTP 502 is - just that it expected some element/selector to be present on the page following navigation, and it could not locate it, resulting in a timeout. 

By adding a `page.on` handler at time of page creation, the idea is to watch for any 502 Bad Gateway responses and subsequently throw an error that _should_ interrupt Jest execution flow and be reported under a consistent failure message.

#### Testing Instructions

Ensure the following build configurations are passing:
  - [x] Gutenberg E2E (desktop)
  - [x] Gutenberg E2E (mobile)
  - [x] Calypso E2E (desktop)
  - [x] Calypso E2E (mobile)
  - [x] Pre-Release E2E
  - [x] Code Style
  - [x] Unit Tests

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #