### PR TITLE
Add plans tabs to Pricing Plans block

### DIFF
--- a/apps/happy-blocks/index.php
+++ b/apps/happy-blocks/index.php
@@ -141,8 +141,11 @@ function a8c_happyblocks_pricing_plans_get_domain() {
 function a8c_happyblocks_get_config() {
 
 	return array(
-		'locale' => get_user_locale(),
-		'domain' => a8c_happyblocks_pricing_plans_get_domain(),
+		'features' => array(
+			'planTabs' => apply_filters( 'support_forums_use_upsell_block_tabs', false ),
+		),
+		'locale'   => get_user_locale(),
+		'domain'   => a8c_happyblocks_pricing_plans_get_domain(),
 	);
 }
 
@@ -168,7 +171,6 @@ function a8c_happyblocks_register() {
 	register_block_type(
 		'happy-blocks/pricing-plans',
 		array(
-			'api_version'     => 2,
 			'render_callback' => 'a8c_happyblocks_render_pricing_plans_callback',
 		)
 	);

--- a/apps/happy-blocks/package.json
+++ b/apps/happy-blocks/package.json
@@ -32,6 +32,7 @@
 		"@wordpress/components": "^19.15.0",
 		"@wordpress/element": "^4.7.0",
 		"@wordpress/i18n": "^4.9.0",
+		"classnames": "^2.3.2",
 		"react": "^17.0.2",
 		"react-dom": "^17.0.2"
 	},

--- a/apps/happy-blocks/src/pricing-plans/components/billing-options.tsx
+++ b/apps/happy-blocks/src/pricing-plans/components/billing-options.tsx
@@ -12,7 +12,7 @@ const Promo: FunctionComponent = ( { children } ) => (
 interface Props {
 	plans: BlockPlan[];
 	value: string;
-	onChange: ( value?: string ) => void;
+	onChange: ( value: string ) => void;
 }
 
 const BillingOptions: FunctionComponent< Props > = ( { plans, value, onChange } ) => {

--- a/apps/happy-blocks/src/pricing-plans/components/block-settings.tsx
+++ b/apps/happy-blocks/src/pricing-plans/components/block-settings.tsx
@@ -1,9 +1,17 @@
 import { TERM_ANNUALLY, TERM_MONTHLY } from '@automattic/calypso-products';
 import { InspectorControls } from '@wordpress/block-editor';
 import { BlockEditProps } from '@wordpress/blocks';
-import { SelectControl, PanelRow, PanelBody, RadioControl } from '@wordpress/components';
+import {
+	PanelRow,
+	PanelBody,
+	RadioControl,
+	CheckboxControl,
+	SelectControl,
+} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import classNames from 'classnames';
 import { FunctionComponent } from 'react';
+import config from '../config';
 import usePlanOptions from '../hooks/plan-options';
 import { BlockPlan } from '../hooks/pricing-plans';
 import { BlockAttributes } from '../types';
@@ -15,21 +23,43 @@ interface Props {
 const BlockSettings: FunctionComponent<
 	Pick< BlockEditProps< BlockAttributes >, 'attributes' | 'setAttributes' > & Props
 > = ( { attributes, setAttributes, plans } ) => {
-	const planTypeOptions = usePlanOptions( plans );
-	const currentPlan = plans?.find( ( plan ) => plan.productSlug === attributes.productSlug );
+	const { productSlug, planTypeOptions } = attributes;
+
+	const planOptions = usePlanOptions( plans );
+	const currentPlan = plans?.find( ( plan ) => plan.productSlug === productSlug );
 
 	const setPlan = ( type: string, term: string ) => {
 		const plan = plans?.find( ( plan ) => plan.type === type && plan.term === term );
 		setAttributes( { productSlug: plan?.productSlug } );
 	};
 
+	const onPlanTermChange = ( newPlanTerm: string ) => {
+		setPlan( currentPlan?.type ?? plans[ 0 ].type, newPlanTerm );
+	};
+
+	const onPlanTypeToggle = ( planType: string, checked: boolean ) => {
+		if ( checked ) {
+			const newPlanTypeOptions = [ ...new Set( [ ...planTypeOptions, planType ] ) ];
+			setAttributes( { planTypeOptions: newPlanTypeOptions } );
+		} else {
+			const newPlanTypeOptions = planTypeOptions.filter( ( type ) => type !== planType );
+			setAttributes( {
+				planTypeOptions: newPlanTypeOptions,
+			} );
+			if ( newPlanTypeOptions.length === 1 ) {
+				setPlan( newPlanTypeOptions[ 0 ], currentPlan?.term ?? plans[ 0 ].term );
+			}
+		}
+	};
+
 	const onPlanTypeChange = ( newPlanType: string ) => {
 		setPlan( newPlanType, currentPlan?.term ?? plans[ 0 ].term );
 	};
 
-	const onPlanTermChange = ( newPlanTerm: string ) => {
-		setPlan( currentPlan?.type ?? plans[ 0 ].type, newPlanTerm );
-	};
+	const isDisabled = ( value: string ) =>
+		planTypeOptions.includes( value ) && planTypeOptions.length === 1;
+
+	const isChecked = ( value: string ) => planTypeOptions.includes( value );
 
 	return (
 		<InspectorControls>
@@ -39,14 +69,27 @@ const BlockSettings: FunctionComponent<
 				initialOpen={ true }
 			>
 				<PanelRow>
-					<SelectControl
-						label={ __( 'Plan', 'happy-blocks' ) }
-						value={ currentPlan?.type }
-						options={ planTypeOptions }
-						onChange={ onPlanTypeChange }
-					/>
-				</PanelRow>
-				<PanelRow>
+					{ ! config.features.planTabs && (
+						<SelectControl
+							label={ __( 'Plan', 'happy-blocks' ) }
+							value={ currentPlan?.type }
+							options={ planOptions }
+							onChange={ onPlanTypeChange }
+						/>
+					) }
+					{ config.features.planTabs &&
+						planOptions.map( ( option ) => (
+							<CheckboxControl
+								className={ classNames( {
+									'hb-pricing-plans-embed__settings-checkbox--disabled': isDisabled( option.value ),
+								} ) }
+								key={ option.value }
+								label={ option.label }
+								checked={ isChecked( option.value ) }
+								disabled={ isDisabled( option.value ) }
+								onChange={ ( checked ) => onPlanTypeToggle( option.value, checked ) }
+							/>
+						) ) }
 					<RadioControl
 						label={ __( 'Price', 'happy-blocks' ) }
 						selected={ currentPlan?.term }

--- a/apps/happy-blocks/src/pricing-plans/components/pricing-plan-detail.tsx
+++ b/apps/happy-blocks/src/pricing-plans/components/pricing-plan-detail.tsx
@@ -14,36 +14,36 @@ const CHECKOUT_URL = 'https' + '://' + 'wordpress.com/checkout';
 const PLANS_URL = 'https' + '://' + 'wordpress.com/plans';
 
 interface Props {
-	plan: BlockPlan;
+	currentPlan: BlockPlan;
 	plans: BlockPlan[];
-	setPlan: ( productSlug?: string ) => void;
+	setPlan: ( productSlug: string ) => void;
 }
 
 const PricingPlanDetail: FunctionComponent< BlockSaveProps< BlockAttributes > & Props > = ( {
-	plan,
+	currentPlan,
 	plans,
 	attributes,
 	setPlan,
 } ) => {
 	const onCtaClick = () => {
 		recordTracksEvent( 'calypso_happyblocks_upgrade_plan_click', {
-			plan: plan.productSlug,
+			plan: currentPlan.productSlug,
 			domain: attributes.domain,
 		} );
 	};
 
 	const CtaLink = attributes.domain
-		? `${ CHECKOUT_URL }/${ attributes.domain }/${ plan.pathSlug }`
+		? `${ CHECKOUT_URL }/${ attributes.domain }/${ currentPlan.pathSlug }`
 		: PLANS_URL;
 
 	return (
 		<section className="hb-pricing-plans-embed__detail">
 			<div>
-				<BillingInfo plan={ plan } />
+				<BillingInfo plan={ currentPlan } />
 				<BillingOptions plans={ plans } value={ attributes.productSlug } onChange={ setPlan } />
 			</div>
 			<BillingButton onClick={ onCtaClick } href={ CtaLink }>
-				{ plan.upgradeLabel }
+				{ currentPlan.upgradeLabel }
 			</BillingButton>
 		</section>
 	);

--- a/apps/happy-blocks/src/pricing-plans/components/pricing-plans-header.tsx
+++ b/apps/happy-blocks/src/pricing-plans/components/pricing-plans-header.tsx
@@ -5,18 +5,18 @@ import { BlockPlan } from '../hooks/pricing-plans';
 import { BlockAttributes } from '../types';
 
 interface Props {
-	plan: BlockPlan;
+	currentPlan: BlockPlan;
 	attributes: BlockAttributes;
 }
 
-const PricingPlansHeader: FunctionComponent< Props > = ( { plan, attributes } ) => {
+const PricingPlansHeader: FunctionComponent< Props > = ( { currentPlan, attributes } ) => {
 	const learnMoreLink = attributes.domain
 		? `https://wordpress.com/plans/${ attributes.domain }`
 		: `https://wordpress.com/pricing`;
 
 	return (
 		<section className="hb-pricing-plans-embed__header">
-			<div className="hb-pricing-plans-embed__header-label">{ plan.getTitle() }</div>
+			<div className="hb-pricing-plans-embed__header-label">{ currentPlan.getTitle() }</div>
 			{ attributes.domain && (
 				<div className="hb-pricing-plans-embed__header-domain">
 					{
@@ -26,7 +26,7 @@ const PricingPlansHeader: FunctionComponent< Props > = ( { plan, attributes } ) 
 				</div>
 			) }
 			<div className="hb-pricing-plans-embed__header-description">
-				<p>{ plan.getDescription() }</p>
+				<p>{ currentPlan.getDescription() }</p>
 				<p>
 					{ createInterpolateElement( __( '<a>Learn more</a>', 'happy-blocks' ), {
 						a: (

--- a/apps/happy-blocks/src/pricing-plans/components/pricing-plans-tabs.tsx
+++ b/apps/happy-blocks/src/pricing-plans/components/pricing-plans-tabs.tsx
@@ -1,0 +1,51 @@
+import classnames from 'classnames';
+import { FunctionComponent } from 'react';
+import usePlanOptions from '../hooks/plan-options';
+import { BlockPlan } from '../hooks/pricing-plans';
+import { BlockAttributes } from '../types';
+
+interface Props {
+	currentPlan: BlockPlan;
+	plans: BlockPlan[];
+	setPlan: ( productSlug: string ) => void;
+	attributes: BlockAttributes;
+}
+
+const PricingPlansTabs: FunctionComponent< Props > = ( {
+	currentPlan,
+	attributes,
+	plans,
+	setPlan,
+} ) => {
+	const planOptions = usePlanOptions( plans );
+
+	const availablePlanOptions = planOptions.filter( ( { value } ) =>
+		attributes.planTypeOptions.includes( value )
+	);
+
+	const onTabButtonClick = ( type: string ) => {
+		const plan = plans.find( ( plan ) => plan.type === type && currentPlan.term === plan.term );
+		if ( plan ) {
+			setPlan( plan.productSlug );
+		}
+	};
+
+	return (
+		<section className="hb-pricing-plans-embed__tabs">
+			{ availablePlanOptions.map( ( planOption ) => (
+				<button
+					onClick={ () => onTabButtonClick( planOption.value ) }
+					className={ classnames( {
+						'hb-pricing-plans-embed__tabs-label': true,
+						'hb-pricing-plans-embed__tabs-label--active': planOption.value === currentPlan.type,
+					} ) }
+					key={ planOption.value }
+				>
+					{ planOption.label }
+				</button>
+			) ) }
+		</section>
+	);
+};
+
+export default PricingPlansTabs;

--- a/apps/happy-blocks/src/pricing-plans/components/pricing-plans-tabs.tsx
+++ b/apps/happy-blocks/src/pricing-plans/components/pricing-plans-tabs.tsx
@@ -35,8 +35,7 @@ const PricingPlansTabs: FunctionComponent< Props > = ( {
 			{ availablePlanOptions.map( ( planOption ) => (
 				<button
 					onClick={ () => onTabButtonClick( planOption.value ) }
-					className={ classnames( {
-						'hb-pricing-plans-embed__tabs-label': true,
+					className={ classnames( 'hb-pricing-plans-embed__tabs-label', {
 						'hb-pricing-plans-embed__tabs-label--active': planOption.value === currentPlan.type,
 					} ) }
 					key={ planOption.value }

--- a/apps/happy-blocks/src/pricing-plans/components/pricing-plans.tsx
+++ b/apps/happy-blocks/src/pricing-plans/components/pricing-plans.tsx
@@ -1,10 +1,12 @@
 import { BlockEditProps } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
 import { FunctionComponent } from 'react';
+import config from '../config';
 import { BlockPlan } from '../hooks/pricing-plans';
 import { BlockAttributes } from '../types';
 import PricingPlanDetail from './pricing-plan-detail';
 import PricingPlansHeader from './pricing-plans-header';
+import PricingPlansTabs from './pricing-plans-tabs';
 
 interface Props {
 	plans: BlockPlan[];
@@ -19,15 +21,27 @@ const PricingPlans: FunctionComponent<
 		return <div>{ __( 'The selected plan is not available at this moment', 'happy-blocks' ) }</div>;
 	}
 
+	const onSetPlan = ( productSlug: string ) => setAttributes( { productSlug } );
+
 	return (
 		<div className="hb-pricing-plans-embed">
-			<PricingPlansHeader attributes={ attributes } plan={ currentPlan } />
-			<PricingPlanDetail
-				plan={ currentPlan }
-				plans={ plans }
-				attributes={ attributes }
-				setPlan={ ( productSlug ) => setAttributes( { productSlug } ) }
-			/>
+			{ config.features.planTabs && attributes.planTypeOptions.length > 1 && (
+				<PricingPlansTabs
+					attributes={ attributes }
+					plans={ plans }
+					currentPlan={ currentPlan }
+					setPlan={ onSetPlan }
+				/>
+			) }
+			<div className="hb-pricing-plans-embed__tab">
+				<PricingPlansHeader attributes={ attributes } currentPlan={ currentPlan } />
+				<PricingPlanDetail
+					currentPlan={ currentPlan }
+					plans={ plans }
+					attributes={ attributes }
+					setPlan={ onSetPlan }
+				/>
+			</div>
 		</div>
 	);
 };

--- a/apps/happy-blocks/src/pricing-plans/edit.tsx
+++ b/apps/happy-blocks/src/pricing-plans/edit.tsx
@@ -24,6 +24,24 @@ export const Edit: FunctionComponent< BlockEditProps< BlockAttributes > > = ( {
 	}, [ attributes.defaultProductSlug, attributes.domain, attributes.productSlug, setAttributes ] );
 
 	useEffect( () => {
+		if ( ! plans.length ) {
+			return;
+		}
+
+		if ( attributes.planTypeOptions.length > 0 ) {
+			return;
+		}
+
+		const defaultPlanTypeOption = plans.find(
+			( plan ) => plan.productSlug === attributes.productSlug
+		);
+
+		setAttributes( {
+			planTypeOptions: defaultPlanTypeOption ? [ defaultPlanTypeOption.type ] : [],
+		} );
+	}, [ attributes.planTypeOptions.length, attributes.productSlug, plans, setAttributes ] );
+
+	useEffect( () => {
 		const blogIdSelect: HTMLSelectElement | null =
 			document.querySelector( 'select[name="blog_id"]' );
 

--- a/apps/happy-blocks/src/pricing-plans/index.jsx
+++ b/apps/happy-blocks/src/pricing-plans/index.jsx
@@ -19,11 +19,14 @@ const blockAttributes = {
 	domain: {
 		type: 'string',
 	},
+	planTypeOptions: {
+		type: 'array',
+		default: [],
+	},
 };
 
 function registerBlocks() {
 	registerBlockType( 'happy-blocks/pricing-plans', {
-		apiVersion: 2,
 		title: __( 'Upgrade Pricing Plan', 'happy-blocks' ),
 		icon: 'money-alt',
 		category: 'embed',

--- a/apps/happy-blocks/src/pricing-plans/types.d.ts
+++ b/apps/happy-blocks/src/pricing-plans/types.d.ts
@@ -2,6 +2,7 @@ export interface BlockAttributes {
 	defaultProductSlug: string;
 	productSlug: string;
 	domain: string | boolean;
+	planTypeOptions: string[];
 }
 
 /**
@@ -20,6 +21,9 @@ declare global {
 		A8C_HAPPY_BLOCKS_CONFIG: {
 			domain: string;
 			locale: string;
+			features: {
+				planTabs: boolean;
+			};
 		};
 	}
 }

--- a/apps/happy-blocks/src/pricing-plans/view.scss
+++ b/apps/happy-blocks/src/pricing-plans/view.scss
@@ -20,13 +20,12 @@ $brand-display: "SF Pro Display", $sans;
 }
 
 .hb-pricing-plans-embed {
-	display: flex;
 	flex-wrap: wrap;
 	padding: 28px;
 	margin: 24px 0;
 	border: 1px solid $studio-gray-5;
 	border-radius: 2px;
-	gap: 32px;
+	gap: 22px;
 	background-color: $studio-white;
 
 
@@ -55,6 +54,10 @@ $brand-display: "SF Pro Display", $sans;
 			gap: 17px;
 			justify-content: flex-start;
 		}
+
+		&-checkbox--disabled {
+			opacity: 0.6;
+		}
 	}
 
 	&__skeleton {
@@ -69,6 +72,45 @@ $brand-display: "SF Pro Display", $sans;
 		&::after {
 			content: "";
 		}
+	}
+
+	&__tabs {
+		display: flex;
+		background: $studio-gray-0;
+		/* stylelint-disable-next-line scales/radii */
+		border-radius: 6px;
+		padding: 4px;
+
+		&-label {
+			background: $studio-gray-0;
+			padding: 4px 16px;
+			height: 28px;
+			font-family: $brand-display;
+			font-weight: 500;
+			font-size: 0.875rem;
+			line-height: 20px;
+			border: none;
+			/* stylelint-disable-next-line scales/radii */
+			border-radius: 5px;
+			margin: 0;
+
+			&:hover {
+				background: $studio-gray-0;
+			}
+
+			&--active {
+				background: $white;
+				border: 0.5px solid rgba(0, 0, 0, 0.04);
+				box-shadow: 0 3px 8px rgba(0, 0, 0, 0.12), 0 3px 1px rgba(0, 0, 0, 0.04);
+				/* stylelint-disable-next-line scales/radii */
+				border-radius: 5px;
+				z-index: 1;
+			}
+		}
+	}
+
+	&__tab {
+		display: flex;
 	}
 
 	&__header {

--- a/apps/happy-blocks/src/pricing-plans/view.scss
+++ b/apps/happy-blocks/src/pricing-plans/view.scss
@@ -111,6 +111,7 @@ $brand-display: "SF Pro Display", $sans;
 
 	&__tab {
 		display: flex;
+		gap: 24px;
 	}
 
 	&__header {

--- a/yarn.lock
+++ b/yarn.lock
@@ -13218,7 +13218,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"classnames@npm:*, classnames@npm:^2.2.5, classnames@npm:^2.2.6, classnames@npm:^2.3.1":
+"classnames@npm:*, classnames@npm:^2.2.5, classnames@npm:^2.2.6, classnames@npm:^2.3.1, classnames@npm:^2.3.2":
   version: 2.3.2
   resolution: "classnames@npm:2.3.2"
   checksum: cd50ead57b4f97436aaa9f9885c6926323efc7c2bea8e3d4eb10e4e972aa6a1cfca1c7a0e06f8a199ca7498d4339e30bb6002e589e61c9f21248cbf3e8b0b18d
@@ -19284,6 +19284,7 @@ __metadata:
     "@wordpress/i18n": ^4.9.0
     "@wordpress/readable-js-assets-webpack-plugin": ^1.0.4
     "@wordpress/scripts": ^23.1.0
+    classnames: ^2.3.2
     jest: ^27.3.1
     postcss: ^8.4.5
     react: ^17.0.2


### PR DESCRIPTION
#### Proposed Changes

This pull request implements the new Plans Tabs feature for the Pricing Plans block.

The feature is feature flagged and will be only available in testing sites for now.


https://user-images.githubusercontent.com/112691742/208048131-8d1041f1-a218-493c-8801-843238b51d70.mp4




#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run `yarn dev --sync` in `apps/happy-blocks` to sync code to your sandbox
* Create a new topic, in the editor press `/` and search for "Upgrade" block.
* Ensure the block works as shown in the attached video
* Ensure the block matches the design specs


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
