### PR TITLE
Use `translate()` only where needed

### DIFF
--- a/client/my-sites/hosting/web-server-settings-card/index.js
+++ b/client/my-sites/hosting/web-server-settings-card/index.js
@@ -89,32 +89,28 @@ const WebServerSettingsCard = ( {
 	const getPhpVersions = () => {
 		return [
 			{
-				label: translate( '7.3', {
-					comment: 'PHP Version for a version switcher',
-				} ),
+				label: '7.3',
 				value: '7.3',
 				disabled: true, // EOL 6th December, 2021
 			},
 			{
-				label: translate( '7.4', {
-					comment: 'PHP Version for a version switcher',
-				} ),
+				label: '7.4',
 				value: '7.4',
 			},
 			{
-				label: translate( '8.0 (recommended)', {
+				label: translate( '%s (recommended)', {
+					args: '8.0',
 					comment: 'PHP Version for a version switcher',
 				} ),
 				value: recommendedValue,
 			},
 			{
-				label: translate( '8.1', {
-					comment: 'PHP Version for a version switcher',
-				} ),
+				label: '8.1',
 				value: '8.1',
 			},
 			{
-				label: translate( '8.2 (experimental)', {
+				label: translate( '%s (experimental)', {
+					args: '8.2',
 					comment: 'PHP Version for a version switcher',
 				} ),
 				value: '8.2',


### PR DESCRIPTION
No need to `translate()` static version numbers. Also improve translation strings.

![Screenshot from 2022-12-15 12-20-47](https://user-images.githubusercontent.com/1103398/207846681-5e990056-f5e1-4854-b275-bc6ec646ae92.png)

![Screenshot from 2022-12-15 12-20-53](https://user-images.githubusercontent.com/1103398/207846703-09142fa8-fa6a-4f3b-9170-0d63e6c88d40.png)

