### PR TITLE
Plugin Management: fix the search box on the plugins page getting hidden when there is only one plugin

### DIFF
--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -525,19 +525,22 @@ export class PluginsMain extends Component {
 				</div>
 				<div className="plugins__main-content">
 					<div className="plugins__content-wrapper">
-						{ currentPlugins?.length > 1 && (
-							<div className="plugins__search">
-								<Search
-									hideFocus
-									isOpen
-									onSearch={ this.props.doSearch }
-									initialValue={ this.props.search }
-									hideClose={ ! this.props.search }
-									analyticsGroup="Plugins"
-									placeholder={ this.props.translate( 'Search plugins' ) }
-								/>
-							</div>
-						) }
+						{
+							// Hide the search box only when the request to fetch plugins fail, and there are no sites.
+							! ( this.props.requestPluginsError && ! currentPlugins?.length ) && (
+								<div className="plugins__search">
+									<Search
+										hideFocus
+										isOpen
+										onSearch={ this.props.doSearch }
+										initialValue={ this.props.search }
+										hideClose={ ! this.props.search }
+										analyticsGroup="Plugins"
+										placeholder={ this.props.translate( 'Search plugins' ) }
+									/>
+								</div>
+							)
+						}
 						{ this.renderPluginsContent() }
 					</div>
 				</div>


### PR DESCRIPTION
#### Proposed Changes

This PR fixes a bug where the search box gets hidden when there is less than one plugin available after applying the search filter.

#### Testing Instructions

**Prerequisites**

Since this change is made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout fix/search-box-in-plugins-page` and `yarn start-jetpack-cloud`
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Go to **[Plugins](http://jetpack.cloud.localhost:3000/plugins/manage)** page -> Search any term in the search box such that less than one plugin is available, and verify that the search box is still shown even when there are no plugins.
4. Also, please follow the testing instructions here - https://github.com/Automattic/wp-calypso/pull/68742

<table>
<tr>
<th>
Before
</th>
<th>
After
</th>
</tr>
<tr>
<td>
<img width="1566" alt="Screenshot 2022-12-15 at 6 14 42 PM" src="https://user-images.githubusercontent.com/10586875/207862488-f6ffcb9d-e489-4fbb-a4b7-fb4f5f5adff1.png">
</td>
<td>
<img width="1566" alt="Screenshot 2022-12-15 at 6 14 27 PM" src="https://user-images.githubusercontent.com/10586875/207862475-f9e69f2e-79bb-4f8a-907a-8a2d7d394850.png">
</td>
</tr>
<tr>
<td>
<img width="1566" alt="Screenshot 2022-12-15 at 6 14 51 PM" src="https://user-images.githubusercontent.com/10586875/207862497-f5ae6f3b-974b-4a6b-a612-b7c505662370.png">
</td>
<td>
<img width="1566" alt="Screenshot 2022-12-15 at 6 14 37 PM" src="https://user-images.githubusercontent.com/10586875/207862482-8e90e3c0-5f6a-424d-b2fe-14c340f574cc.png">
</td>
</tr>
</table>


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1202619025189113-as-1203560175374120