### PR TITLE
Featured image email toggle: Change `featured_image_email_enabled` option name to `wpcom_featured_image_in_email`

### DIFF
--- a/client/my-sites/site-settings/featured-image-toggle.jsx
+++ b/client/my-sites/site-settings/featured-image-toggle.jsx
@@ -7,7 +7,7 @@ const FeaturedImageTemplateToggle = ( props ) => {
 	const { isRequestingSettings, isSavingSettings, fields, handleAutosavingToggle, translate } =
 		props;
 	const isDisabled = isRequestingSettings || isSavingSettings;
-	const settingName = 'featured_image_email_enabled';
+	const settingName = 'wpcom_featured_image_in_email';
 
 	return (
 		<div className="featured-image-template-toggle-settings">

--- a/client/my-sites/site-settings/form-writing.jsx
+++ b/client/my-sites/site-settings/form-writing.jsx
@@ -213,8 +213,8 @@ const getFormSettings = ( settings ) => {
 		'time_format',
 		'timezone_string',
 		'podcasting_category_id',
+		'wpcom_featured_image_in_email',
 		'wpcom_publish_posts_with_markdown',
-		'featured_image_email_enabled',
 		'jetpack_blogging_prompts_enabled',
 	] );
 

--- a/client/my-sites/site-settings/reading-newsletter-settings/FeaturedImageEmailSetting.tsx
+++ b/client/my-sites/site-settings/reading-newsletter-settings/FeaturedImageEmailSetting.tsx
@@ -3,7 +3,7 @@ import { ToggleControl as OriginalToggleControl } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 
-export const FEATURED_IMAGE_EMAIL_OPTION = 'featured_image_email_enabled';
+export const FEATURED_IMAGE_IN_EMAIL_OPTION = 'wpcom_featured_image_in_email';
 
 const ToggleControl = OriginalToggleControl as React.ComponentType<
 	OriginalToggleControl.Props & {
@@ -28,7 +28,7 @@ export const FeaturedImageEmailSetting = ( {
 		<>
 			<ToggleControl
 				checked={ !! value }
-				onChange={ handleToggle( FEATURED_IMAGE_EMAIL_OPTION ) }
+				onChange={ handleToggle( FEATURED_IMAGE_IN_EMAIL_OPTION ) }
 				disabled={ disabled }
 				label={ translate( 'Enable featured image on your new post emails' ) }
 			/>

--- a/client/my-sites/site-settings/reading-newsletter-settings/index.tsx
+++ b/client/my-sites/site-settings/reading-newsletter-settings/index.tsx
@@ -4,7 +4,7 @@ import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-secti
 import { FeaturedImageEmailSetting } from './FeaturedImageEmailSetting';
 
 type Fields = {
-	featured_image_email_enabled?: boolean;
+	wpcom_featured_image_in_email?: boolean;
 };
 
 type NewsletterSettingsSectionProps = {
@@ -23,7 +23,7 @@ export const NewsletterSettingsSection = ( {
 	isSavingSettings,
 }: NewsletterSettingsSectionProps ) => {
 	const translate = useTranslate();
-	const { featured_image_email_enabled } = fields;
+	const { wpcom_featured_image_in_email } = fields;
 
 	return (
 		<>
@@ -37,7 +37,7 @@ export const NewsletterSettingsSection = ( {
 			/>
 			<Card>
 				<FeaturedImageEmailSetting
-					value={ featured_image_email_enabled }
+					value={ wpcom_featured_image_in_email }
 					handleToggle={ handleToggle }
 					disabled={ disabled }
 				/>

--- a/client/my-sites/site-settings/settings-reading/main.tsx
+++ b/client/my-sites/site-settings/settings-reading/main.tsx
@@ -22,11 +22,11 @@ const getFormSettings = ( settings: Settings = {} ) => {
 	}
 
 	// @ts-expect-error Settings are not typed yet, so we need to use `unknown` for now.
-	const { posts_per_page, posts_per_rss, featured_image_email_enabled } = settings;
+	const { posts_per_page, posts_per_rss, wpcom_featured_image_in_email } = settings;
 	return {
 		...( posts_per_page && { posts_per_page } ),
 		...( posts_per_rss && { posts_per_rss } ),
-		...( featured_image_email_enabled && { featured_image_email_enabled } ),
+		...( wpcom_featured_image_in_email && { wpcom_featured_image_in_email } ),
 	};
 };
 
@@ -41,7 +41,7 @@ const connectComponent = connect( ( state ) => {
 type Fields = {
 	posts_per_page?: number;
 	posts_per_rss?: number;
-	featured_image_email_enabled?: boolean;
+	wpcom_featured_image_in_email?: boolean;
 };
 
 type ReadingSettingsFormProps = {


### PR DESCRIPTION
#### Proposed Changes

* rename `featured_image_email_enabled` option to `wpcom_featured_image_in_email`

The new name:
- better represents the option usage
- includes `wpcom_` prefix to communicate it is WPCOM-related and to prevent potential name conflicts with third-party plugins

The option hasn't been used in production yet, so there are no consequences of this change to our users.

This PR builds on top of the related Jetpack PR: https://github.com/Automattic/jetpack/pull/27955.

Related issue / task: https://github.com/Automattic/wp-calypso/issues/71070

#### Testing Instructions

Since it will take time for the related (already merged) [JP PR changes](https://github.com/Automattic/wp-calypso/issues/71070) to be available in the production on WPCOM, Atomic and Jetpack platform, in order to test _this_ Calypso PR earlier, we need to apply the JP changes to the platforms manually.

For testing on WPCOM, you can sandbox `public-api.wordpress.com`, pull the latest JP trunk, build it and then sync it to your sandbox by following the steps in PCYsg-eg0-p2.

The same steps can be used to test with Jurassic Ninja Jetpack site.

For testing on Atomic, these steps can be followed: pb5gDS-1rQ-p2 - again with the latest JP trunk pulled and built.

General steps - for all platforms:

1. In the `development` environment navigate to `http://calypso.localhost:3000/settings/reading/<site-address>`.
2. Switch the Featured image toggle and save the settings.
3. When you reload the Reading settings page, the toggle state should still represent the correct value that was saved (enabled / disabled).
4. Use the Site Explorer to verify the `wpcom_featured_image_in_email` site option value was changed correctly. Keep in mind that you can run into the following issue when testing with Atomic and Jetpack-connected sites: https://github.com/Automattic/jetpack/issues/27763

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #71070