### PR TITLE
Reading Settings: Add new 'For each new post email, include..' newsletter setting

### DIFF
--- a/client/my-sites/site-settings/reading-newsletter-settings/ExcerptSetting.tsx
+++ b/client/my-sites/site-settings/reading-newsletter-settings/ExcerptSetting.tsx
@@ -1,0 +1,47 @@
+import { useTranslate } from 'i18n-calypso';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+import FormLabel from 'calypso/components/forms/form-label';
+import FormRadio from 'calypso/components/forms/form-radio';
+import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
+
+type ExcerptSettingProps = {
+	value?: boolean;
+	disabled?: boolean;
+	updateFields?: ( fields: { [ key: string ]: unknown } ) => void;
+};
+
+export const ExcerptSetting = ( {
+	value = false,
+	disabled,
+	updateFields,
+}: ExcerptSettingProps ) => {
+	const translate = useTranslate();
+	return (
+		<FormFieldset>
+			<FormLabel>For each new post email, include</FormLabel>
+			<FormLabel>
+				{ /* @ts-expect-error FormRadio is not typed and is causing errors */ }
+				<FormRadio
+					checked={ ! value }
+					onChange={ () => updateFields?.( { wpcom_subscription_emails_use_excerpt: false } ) }
+					disabled={ disabled }
+					label={ translate( 'Full text' ) }
+				/>
+			</FormLabel>
+			<FormLabel>
+				{ /* @ts-expect-error FormRadio is not typed and is causing errors */ }
+				<FormRadio
+					checked={ value }
+					onChange={ () => updateFields?.( { wpcom_subscription_emails_use_excerpt: true } ) }
+					disabled={ disabled }
+					label={ translate( 'Excerpt' ) }
+				/>
+			</FormLabel>
+			<FormSettingExplanation>
+				{ translate(
+					'Sets whether email subscribers can read full posts in emails or just an excerpt and link to the full version of the post. Learn more about sending emails.'
+				) }
+			</FormSettingExplanation>
+		</FormFieldset>
+	);
+};

--- a/client/my-sites/site-settings/reading-newsletter-settings/ExcerptSetting.tsx
+++ b/client/my-sites/site-settings/reading-newsletter-settings/ExcerptSetting.tsx
@@ -1,3 +1,4 @@
+import { localizeUrl } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
@@ -39,7 +40,7 @@ export const ExcerptSetting = ( {
 			</FormLabel>
 			<FormSettingExplanation>
 				{ translate(
-					"Sets whether email subscribers can read full posts in emails or just an excerpt and link to the full version of the post. {{link}}Learn more about sending emails{{/link}}.",
+					'Sets whether email subscribers can read full posts in emails or just an excerpt and link to the full version of the post. {{link}}Learn more about sending emails{{/link}}.',
 					{
 						components: {
 							link: (

--- a/client/my-sites/site-settings/reading-newsletter-settings/ExcerptSetting.tsx
+++ b/client/my-sites/site-settings/reading-newsletter-settings/ExcerptSetting.tsx
@@ -39,7 +39,18 @@ export const ExcerptSetting = ( {
 			</FormLabel>
 			<FormSettingExplanation>
 				{ translate(
-					'Sets whether email subscribers can read full posts in emails or just an excerpt and link to the full version of the post. Learn more about sending emails.'
+					"Sets whether email subscribers can read full posts in emails or just an excerpt and link to the full version of the post. {{link}}Learn more about sending emails{{/link}}.",
+					{
+						components: {
+							link: (
+								<a
+									href={ localizeUrl( 'https://wordpress.com/support/launch-a-newsletter/' ) }
+									target="_blank"
+									rel="noreferrer"
+								/>
+							),
+						},
+					}
 				) }
 			</FormSettingExplanation>
 		</FormFieldset>

--- a/client/my-sites/site-settings/reading-newsletter-settings/index.tsx
+++ b/client/my-sites/site-settings/reading-newsletter-settings/index.tsx
@@ -1,10 +1,12 @@
 import { Card } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
+import { ExcerptSetting } from './ExcerptSetting';
 import { FeaturedImageEmailSetting } from './FeaturedImageEmailSetting';
 
 type Fields = {
 	wpcom_featured_image_in_email?: boolean;
+	wpcom_subscription_emails_use_excerpt?: boolean;
 };
 
 type NewsletterSettingsSectionProps = {
@@ -13,6 +15,7 @@ type NewsletterSettingsSectionProps = {
 	handleSubmitForm: ( event: React.FormEvent< HTMLFormElement > ) => void;
 	disabled?: boolean;
 	isSavingSettings: boolean;
+	updateFields: ( fields: Fields ) => void;
 };
 
 export const NewsletterSettingsSection = ( {
@@ -21,9 +24,10 @@ export const NewsletterSettingsSection = ( {
 	handleSubmitForm,
 	disabled,
 	isSavingSettings,
+	updateFields,
 }: NewsletterSettingsSectionProps ) => {
 	const translate = useTranslate();
-	const { wpcom_featured_image_in_email } = fields;
+	const { wpcom_featured_image_in_email, wpcom_subscription_emails_use_excerpt } = fields;
 
 	return (
 		<>
@@ -35,10 +39,17 @@ export const NewsletterSettingsSection = ( {
 				disabled={ disabled }
 				isSaving={ isSavingSettings }
 			/>
-			<Card>
+			<Card className="site-settings__card">
 				<FeaturedImageEmailSetting
 					value={ wpcom_featured_image_in_email }
 					handleToggle={ handleToggle }
+					disabled={ disabled }
+				/>
+			</Card>
+			<Card className="site-settings__card">
+				<ExcerptSetting
+					value={ wpcom_subscription_emails_use_excerpt }
+					updateFields={ updateFields }
 					disabled={ disabled }
 				/>
 			</Card>

--- a/client/my-sites/site-settings/settings-reading/main.tsx
+++ b/client/my-sites/site-settings/settings-reading/main.tsx
@@ -13,7 +13,6 @@ import wrapSettingsForm from '../wrap-settings-form';
 
 const isEnabled = config.isEnabled( 'settings/modernize-reading-settings' );
 
-// Settings are not typed yet, so we need to use `unknown` for now.
 type Settings = {
 	posts_per_page?: boolean;
 	posts_per_rss?: boolean;

--- a/client/my-sites/site-settings/settings-reading/main.tsx
+++ b/client/my-sites/site-settings/settings-reading/main.tsx
@@ -14,19 +14,30 @@ import wrapSettingsForm from '../wrap-settings-form';
 const isEnabled = config.isEnabled( 'settings/modernize-reading-settings' );
 
 // Settings are not typed yet, so we need to use `unknown` for now.
-type Settings = unknown;
+type Settings = {
+	posts_per_page?: boolean;
+	posts_per_rss?: boolean;
+	wpcom_featured_image_in_email?: boolean;
+	wpcom_subscription_emails_use_excerpt?: boolean;
+};
 
-const getFormSettings = ( settings: Settings = {} ) => {
+const getFormSettings = ( settings: Settings ) => {
 	if ( ! settings ) {
 		return {};
 	}
 
-	// @ts-expect-error Settings are not typed yet, so we need to use `unknown` for now.
-	const { posts_per_page, posts_per_rss, wpcom_featured_image_in_email } = settings;
+	const {
+		posts_per_page,
+		posts_per_rss,
+		wpcom_featured_image_in_email,
+		wpcom_subscription_emails_use_excerpt,
+	} = settings;
+
 	return {
 		...( posts_per_page && { posts_per_page } ),
 		...( posts_per_rss && { posts_per_rss } ),
 		...( wpcom_featured_image_in_email && { wpcom_featured_image_in_email } ),
+		...( wpcom_subscription_emails_use_excerpt && { wpcom_subscription_emails_use_excerpt } ),
 	};
 };
 
@@ -42,6 +53,7 @@ type Fields = {
 	posts_per_page?: number;
 	posts_per_rss?: number;
 	wpcom_featured_image_in_email?: boolean;
+	wpcom_subscription_emails_use_excerpt?: boolean;
 };
 
 type ReadingSettingsFormProps = {
@@ -52,6 +64,7 @@ type ReadingSettingsFormProps = {
 	isRequestingSettings: boolean;
 	isSavingSettings: boolean;
 	siteUrl?: string;
+	updateFields: ( fields: Fields ) => void;
 };
 
 const ReadingSettingsForm = wrapSettingsForm( getFormSettings )(
@@ -64,6 +77,7 @@ const ReadingSettingsForm = wrapSettingsForm( getFormSettings )(
 			isRequestingSettings,
 			isSavingSettings,
 			siteUrl,
+			updateFields,
 		}: ReadingSettingsFormProps ) => {
 			const disabled = isRequestingSettings || isSavingSettings;
 			return (
@@ -89,6 +103,7 @@ const ReadingSettingsForm = wrapSettingsForm( getFormSettings )(
 						handleSubmitForm={ handleSubmitForm }
 						disabled={ disabled }
 						isSavingSettings={ isSavingSettings }
+						updateFields={ updateFields }
 					/>
 				</form>
 			);


### PR DESCRIPTION
#### Proposed Changes

* introduce new setting field that is responsible for defining whether the current site's subscription emails containing site's posts are meant to display full posts' content, or post excerpts. 
* the `wpcom_subscription_emails_use_excerpt` site option is used to store the setting's value on the backend

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
The changes are dependent on the `/sites/<BLOG-ID>/settings` endpoint being able to store and provide the `wpcom_subscription_emails_use_excerpt` site option. The site option was only recently implemented. The latest release of jetpack does not contain those changes yet. As a result, for testing purposes, we need to sandbox the `public-api.wordpress.com` with the latest trunk version applied to it.

* Apply jetpack's trunk to your sandbox
* Sandbox `public-api.wordpress.com`
* Checkout this branch and run calypso locally
* Go to `http://calypso.localhost:3000/settings/reading/<YOUR-BLOG>`
* Ensure that the new setting UI behaves as expected, including after page reloads etc. You can help yourself by inspecting GET and POST calls to `/site/<BLOG-ID>/settings` endpoints.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #70427

![Screen Shot 2022-12-15 at 19 20 54](https://user-images.githubusercontent.com/2019970/207937753-f0a0ee72-3942-41b1-9e58-38a92984c188.png)

