### PR TITLE
Launchpad: Allow launching Free Flow sites from Launchpad

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
@@ -4,6 +4,7 @@ import {
 	isLinkInBioFlow,
 	addPlanToCart,
 	createSiteWithCart,
+	isFreeFlow,
 } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect } from 'react';
@@ -40,7 +41,7 @@ const SiteCreationStep: Step = function SiteCreationStep( { navigation, flow } )
 	let siteVisibility = Site.Visibility.PublicIndexed;
 
 	// Link-in-bio flow defaults to "Coming Soon"
-	if ( isLinkInBioFlow( flow ) ) {
+	if ( isLinkInBioFlow( flow ) || isFreeFlow( flow ) ) {
 		siteVisibility = Site.Visibility.PublicNotIndexed;
 	}
 


### PR DESCRIPTION
#### Proposed Changes
This PR allows Free Flow sites to be launched from the Launchpad screen. Should be tested with this [BE diff](D95584-code) (D95584-code). By default, the site is launched shortly after creation so we need to set the site's visibility manually to prevent that.

#### Testing Instructions
1. Checkout this branch
2. Checkout the BE diff `arc patch D95584`
3. Go through the free flow `http://calypso.localhost:3000/setup/free/intro` and create a new site
4. Sandbox `public-api.wordpress.com` and your new site URL
5. Once you arrive at Launchpad, click the "Launch your site" button
6. You should get redirected to Home without getting redirected back to Launchpad. This shows that the `launchpad_screen` option was successfully set to `off`.


https://user-images.githubusercontent.com/20927667/207956002-2c339985-086d-4cef-b358-b5ead8696f7d.mov

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #70844