### PR TITLE
Revert "Checkout: Use shopping cart items to provide product variants"

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/checkout-sidebar-plan-upsell/index.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-sidebar-plan-upsell/index.tsx
@@ -7,11 +7,12 @@ import { createElement, createInterpolateElement } from '@wordpress/element';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import debugFactory from 'debug';
-import { useDispatch } from 'react-redux';
+import { useSelector, useDispatch } from 'react-redux';
 import PromoCard from 'calypso/components/promo-section/promo-card';
 import PromoCardCTA from 'calypso/components/promo-section/promo-card/cta';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { useGetProductVariants } from '../../hooks/product-variants';
 import {
 	getItemVariantCompareToPrice,
@@ -30,8 +31,13 @@ export function CheckoutSidebarPlanUpsell() {
 	const locale = useLocale();
 	const cartKey = useCartKey();
 	const { responseCart, replaceProductInCart } = useShoppingCart( cartKey );
+	const siteId = useSelector( getSelectedSiteId );
 	const plan = responseCart.products.find( ( product ) => isPlan( product ) );
-	const variants = useGetProductVariants( plan );
+	const variants = useGetProductVariants(
+		siteId ?? undefined,
+		plan?.product_slug ?? '',
+		plan?.current_quantity ?? null
+	);
 
 	if ( ! plan ) {
 		debug( 'no plan found in cart' );
@@ -109,10 +115,7 @@ export function CheckoutSidebarPlanUpsell() {
 					{ currentVariant.variantLabel }
 				</div>
 				<div className="checkout-sidebar-plan-upsell__plan-grid-cell">
-					{ formatCurrency( currentVariant.priceInteger, currentVariant.currency, {
-						stripZeros: true,
-						isSmallestUnit: true,
-					} ) }
+					{ formatCurrency( currentVariant.price, currentVariant.currency, { stripZeros: true } ) }
 				</div>
 				<div className="checkout-sidebar-plan-upsell__plan-grid-cell">
 					{ biennialVariant.variantLabel }
@@ -122,13 +125,11 @@ export function CheckoutSidebarPlanUpsell() {
 						<del className="checkout-sidebar-plan-upsell__do-not-pay">
 							{ formatCurrency( compareToPriceForVariantTerm, currentVariant.currency, {
 								stripZeros: true,
-								isSmallestUnit: true,
 							} ) }
 						</del>
 					) }
-					{ formatCurrency( biennialVariant.priceInteger, biennialVariant.currency, {
+					{ formatCurrency( biennialVariant.price, biennialVariant.currency, {
 						stripZeros: true,
-						isSmallestUnit: true,
 					} ) }
 				</div>
 			</div>

--- a/client/my-sites/checkout/composite-checkout/components/item-variation-picker/types.ts
+++ b/client/my-sites/checkout/composite-checkout/components/item-variation-picker/types.ts
@@ -3,7 +3,9 @@ import type { ResponseCartProduct } from '@automattic/shopping-cart';
 export type WPCOMProductSlug = string;
 
 export type WPCOMProductVariant = {
-	priceInteger: number;
+	price: number;
+	pricePerMonth: number;
+	pricePerYear: number;
 	termIntervalInMonths: number;
 	termIntervalInDays: number;
 	currency: string;

--- a/client/my-sites/checkout/composite-checkout/components/item-variation-picker/util.ts
+++ b/client/my-sites/checkout/composite-checkout/components/item-variation-picker/util.ts
@@ -11,7 +11,7 @@ export function getItemVariantCompareToPrice(
 	// or 10 (per month). In this case, selecting the variant would save the user
 	// 50% (5 / 10).
 	const compareToPriceForVariantTerm = compareTo
-		? ( compareTo.priceInteger / compareTo.termIntervalInMonths ) * variant.termIntervalInMonths
+		? compareTo.pricePerMonth * variant.termIntervalInMonths
 		: undefined;
 	return compareToPriceForVariantTerm;
 }
@@ -24,7 +24,7 @@ export function getItemVariantDiscountPercentage(
 	// Extremely low "discounts" are possible if the price of the longer term has been rounded
 	// if they cannot be rounded to at least a percentage point we should not show them.
 	const discountPercentage = compareToPriceForVariantTerm
-		? Math.floor( 100 - ( variant.priceInteger / compareToPriceForVariantTerm ) * 100 )
+		? Math.floor( 100 - ( variant.price / compareToPriceForVariantTerm ) * 100 )
 		: 0;
 	return discountPercentage;
 }

--- a/client/my-sites/checkout/composite-checkout/components/item-variation-picker/variant-dropdown-price.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/item-variation-picker/variant-dropdown-price.tsx
@@ -89,15 +89,11 @@ export const ItemVariantDropDownPrice: FunctionComponent< {
 	const isMobile = useMobileBreakpoint();
 	const compareToPriceForVariantTerm = getItemVariantCompareToPrice( variant, compareTo );
 	const discountPercentage = getItemVariantDiscountPercentage( variant, compareTo );
-	const formattedCurrentPrice = formatCurrency( variant.priceInteger, variant.currency, {
+	const formattedCurrentPrice = formatCurrency( variant.price, variant.currency, {
 		stripZeros: true,
-		isSmallestUnit: true,
 	} );
 	const formattedCompareToPriceForVariantTerm = compareToPriceForVariantTerm
-		? formatCurrency( compareToPriceForVariantTerm, variant.currency, {
-				stripZeros: true,
-				isSmallestUnit: true,
-		  } )
+		? formatCurrency( compareToPriceForVariantTerm, variant.currency, { stripZeros: true } )
 		: undefined;
 
 	return (

--- a/client/my-sites/checkout/composite-checkout/components/item-variation-picker/variant-radio-price.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/item-variation-picker/variant-radio-price.tsx
@@ -69,21 +69,15 @@ export const ItemVariantRadioPrice: FunctionComponent< {
 } > = ( { variant, compareTo } ) => {
 	const translate = useTranslate();
 	const discountPercentage = getItemVariantDiscountPercentage( variant, compareTo );
-	const formattedCurrentPrice = formatCurrency( variant.priceInteger, variant.currency, {
+	const formattedCurrentPrice = formatCurrency( variant.price, variant.currency, {
 		stripZeros: true,
-		isSmallestUnit: true,
 	} );
 
-	const pricePerMonth = variant.priceInteger / variant.termIntervalInMonths;
-	const pricePerYear = pricePerMonth * 12;
-
-	const pricePerYearFormatted = formatCurrency( pricePerYear, variant.currency, {
+	const pricePerYearFormatted = formatCurrency( variant.pricePerYear, variant.currency, {
 		stripZeros: true,
-		isSmallestUnit: true,
 	} );
-	const pricePerMonthFormatted = formatCurrency( pricePerMonth, variant.currency, {
+	const pricePerMonthFormatted = formatCurrency( variant.pricePerMonth, variant.currency, {
 		stripZeros: true,
-		isSmallestUnit: true,
 	} );
 
 	const shouldShowMonthlyPrice =

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-review.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-review.tsx
@@ -7,6 +7,7 @@ import { FormStatus, useFormStatus } from '@automattic/composite-checkout';
 import { useShoppingCart } from '@automattic/shopping-cart';
 import { styled, joinClasses } from '@automattic/wpcom-checkout';
 import { useTranslate } from 'i18n-calypso';
+import PropTypes from 'prop-types';
 import { useState, useEffect, useCallback } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { hasP2PlusPlan } from 'calypso/lib/cart-values/cart-items';
@@ -70,6 +71,7 @@ export default function WPCheckoutOrderReview( {
 	couponFieldStateProps,
 	onChangePlanLength,
 	siteUrl,
+	siteId,
 	isSummary,
 	createUserAndSiteBeforeTransaction,
 	forceRadioButtons,
@@ -79,6 +81,7 @@ export default function WPCheckoutOrderReview( {
 	couponFieldStateProps: CouponFieldStateProps;
 	onChangePlanLength?: OnChangeItemVariant;
 	siteUrl?: string;
+	siteId?: number | undefined;
 	isSummary?: boolean;
 	createUserAndSiteBeforeTransaction?: boolean;
 	// TODO: This is just for unit tests. Remove forceRadioButtons everywhere
@@ -165,6 +168,7 @@ export default function WPCheckoutOrderReview( {
 			<WPOrderReviewSection>
 				<WPOrderReviewLineItems
 					forceRadioButtons={ forceRadioButtons }
+					siteId={ siteId }
 					removeProductFromCart={ removeProductFromCart }
 					removeCoupon={ removeCouponAndClearField }
 					onChangePlanLength={ onChangePlanLength }
@@ -188,6 +192,15 @@ export default function WPCheckoutOrderReview( {
 		</div>
 	);
 }
+
+WPCheckoutOrderReview.propTypes = {
+	isSummary: PropTypes.bool,
+	className: PropTypes.string,
+	removeProductFromCart: PropTypes.func,
+	onChangePlanLength: PropTypes.func,
+	siteUrl: PropTypes.string,
+	couponFieldStateProps: PropTypes.object.isRequired,
+};
 
 function CouponFieldArea( {
 	isCouponFieldVisible,

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
@@ -349,6 +349,7 @@ export default function WPCheckout( {
 						couponFieldStateProps={ couponFieldStateProps }
 						onChangePlanLength={ changePlanLength }
 						siteUrl={ siteUrl }
+						siteId={ siteId }
 						createUserAndSiteBeforeTransaction={ createUserAndSiteBeforeTransaction }
 					/>
 				}

--- a/client/my-sites/checkout/composite-checkout/hooks/product-variants.tsx
+++ b/client/my-sites/checkout/composite-checkout/hooks/product-variants.tsx
@@ -1,22 +1,45 @@
-import config from '@automattic/calypso-config';
 import {
+	isPlan,
+	findPlansKeys,
+	findProductKeys,
 	getBillingMonthsForTerm,
+	getBillingYearsForTerm,
+	getPlan,
+	getProductFromSlug,
 	getTermDuration,
-	getBillingTermForMonths,
+	GROUP_JETPACK,
+	GROUP_WPCOM,
+	objectIsProduct,
 	TERM_ANNUALLY,
 	TERM_BIENNIALLY,
 	TERM_MONTHLY,
 } from '@automattic/calypso-products';
-import { isValueTruthy } from '@automattic/wpcom-checkout';
 import debugFactory from 'debug';
 import { useTranslate } from 'i18n-calypso';
-import { useMemo } from 'react';
-import { logToLogstash } from 'calypso/lib/logstash';
+import { useEffect, useState, useMemo, useCallback } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
 import { useStableCallback } from 'calypso/lib/use-stable-callback';
+import { requestPlans } from 'calypso/state/plans/actions';
+import { requestProductsList } from 'calypso/state/products-list/actions';
+import { computeProductsWithPrices } from 'calypso/state/products-list/selectors';
 import type { WPCOMProductVariant } from '../components/item-variation-picker';
-import type { ResponseCartProduct, ResponseCartProductVariant } from '@automattic/shopping-cart';
+import type { Plan, Product } from '@automattic/calypso-products';
+import type { ProductListItem } from 'calypso/state/products-list/selectors/get-products-list';
 
 const debug = debugFactory( 'calypso:composite-checkout:product-variants' );
+
+export interface AvailableProductVariant {
+	planSlug: string;
+	plan: Plan | Product;
+	product: ProductListItem;
+	priceFull: number;
+	priceFinal: number;
+	introductoryOfferPrice: number | null;
+}
+
+export interface AvailableProductVariantAndCompared extends AvailableProductVariant {
+	priceFullBeforeDiscount: number;
+}
 
 export interface SitePlanData {
 	autoRenew?: boolean;
@@ -53,13 +76,13 @@ export interface SitesPlansResult {
 export type VariantFilterCallback = ( variant: WPCOMProductVariant ) => boolean;
 
 const fallbackFilter = () => true;
-const fallbackVariants: ResponseCartProductVariant[] = [];
 
 /**
  * Return all product variants for a particular product.
  *
  * This will return all available variants but you probably want to filter them
- * using the `filterCallback` argument.
+ * using the `filterCallback` argument. Consider using `canVariantBePurchased` as
+ * the filter if you are using this for a new purchase.
  *
  * `filterCallback` can safely be an anonymous function without causing
  * identity stability issues (no need to use `useMemo` or `useCallback`).
@@ -68,62 +91,146 @@ const fallbackVariants: ResponseCartProductVariant[] = [];
  * is the term interval of the currently active plan, if any.
  */
 export function useGetProductVariants(
-	product: ResponseCartProduct | undefined,
+	siteId: number | undefined,
+	productSlug: string,
+	currentQuantity: number | null,
 	filterCallback?: VariantFilterCallback
 ): WPCOMProductVariant[] {
 	const translate = useTranslate();
+	const reduxDispatch = useDispatch();
 	const filterCallbackMemoized = useStableCallback( filterCallback ?? fallbackFilter );
 
-	const variants = product?.product_variants ?? fallbackVariants;
-	const variantProductSlugs = variants.map( ( variant ) => variant.product_slug );
+	const variantProductSlugs = useVariantPlanProductSlugs( productSlug );
 	debug( 'variantProductSlugs', variantProductSlugs );
 
-	const filteredVariants = useMemo( () => {
-		const convertedVariants = variants
-			.sort( sortVariant )
-			.map( ( variant ): WPCOMProductVariant | undefined => {
-				try {
-					const term = getBillingTermForMonths( variant.bill_period_in_months );
-					return {
-						variantLabel: getTermText( term, translate ),
-						productSlug: variant.product_slug,
-						productId: variant.product_id,
-						priceInteger: variant.price_integer,
-						termIntervalInMonths: getBillingMonthsForTerm( term ),
-						termIntervalInDays: getTermDuration( term ) ?? 0,
-						currency: variant.currency,
-					};
-				} catch ( error ) {
-					// Three-year plans are not yet fully supported, so we need to guard
-					// against fatals here and ignore them.
-					logToLogstash( {
-						feature: 'calypso_client',
-						message: 'checkout variant picker variant error',
-						severity: config( 'env_id' ) === 'production' ? 'error' : 'debug',
-						extra: {
-							env: config( 'env_id' ),
-							variant: JSON.stringify( variant ),
-							message: ( error as Error ).message + '; Stack: ' + ( error as Error ).stack,
-						},
-					} );
-				}
-			} )
-			.filter( isValueTruthy );
+	const variantsWithPrices: AvailableProductVariant[] = useSelector( ( state ) => {
+		return computeProductsWithPrices( state, siteId, variantProductSlugs, currentQuantity );
+	} );
 
+	const [ haveFetchedProducts, setHaveFetchedProducts ] = useState( false );
+	const shouldFetchProducts = ! variantsWithPrices;
+
+	useEffect( () => {
+		if ( shouldFetchProducts && ! haveFetchedProducts ) {
+			debug( 'dispatching request for product variant data' );
+			reduxDispatch( requestPlans() );
+			reduxDispatch( requestProductsList() );
+			setHaveFetchedProducts( true );
+		}
+	}, [ shouldFetchProducts, haveFetchedProducts, reduxDispatch ] );
+
+	const getProductVariantFromAvailableVariant = useCallback(
+		( variant: AvailableProductVariant ): WPCOMProductVariant => {
+			const price =
+				variant.introductoryOfferPrice !== null
+					? variant.introductoryOfferPrice
+					: variant.priceFinal || variant.priceFull;
+
+			const termIntervalInMonths = getBillingMonthsForTerm( variant.plan.term );
+			const termIntervalInYears = getBillingYearsForTerm( variant.plan.term );
+			const pricePerMonth = price / termIntervalInMonths;
+			const pricePerYear = price / termIntervalInYears;
+
+			return {
+				variantLabel: getTermText( variant.plan.term, translate ),
+				productSlug: variant.planSlug,
+				productId: variant.product.product_id,
+				price,
+				termIntervalInMonths: getBillingMonthsForTerm( variant.plan.term ),
+				termIntervalInDays: getTermDuration( variant.plan.term ) ?? 0,
+				pricePerMonth,
+				pricePerYear,
+				currency: variant.product.currency_code,
+			};
+		},
+		[ translate ]
+	);
+
+	const convertedVariants = useMemo( () => {
+		return variantsWithPrices.map( getProductVariantFromAvailableVariant );
+	}, [ getProductVariantFromAvailableVariant, variantsWithPrices ] );
+
+	const filteredVariants = useMemo( () => {
 		return convertedVariants.filter( ( product ) => filterCallbackMemoized( product ) );
-	}, [ translate, variants, filterCallbackMemoized ] );
+	}, [ convertedVariants, filterCallbackMemoized ] );
 
 	return filteredVariants;
 }
 
-function sortVariant( a: ResponseCartProductVariant, b: ResponseCartProductVariant ) {
-	if ( a.bill_period_in_months < b.bill_period_in_months ) {
-		return -1;
+export function canVariantBePurchased(
+	variant: WPCOMProductVariant,
+	activePlanRenewalInterval: number | undefined,
+	activePlanSlug: string | undefined
+): boolean {
+	// Always allow the variant when the item added to the cart is not a plan.
+	if ( ! isPlan( variant ) ) {
+		return true;
 	}
-	if ( a.bill_period_in_months > b.bill_period_in_months ) {
-		return 1;
+
+	// If the variant is a plan and there is no active plan, always allow the variant.
+	if ( ! activePlanRenewalInterval || activePlanRenewalInterval < 1 ) {
+		return true;
 	}
-	return 0;
+
+	// If the variant is a plan and the site has an active plan, only allow the
+	// variant if the term of the variant is longer than the term of the active
+	// plan. This is because our backend does not support plan upgrades which are
+	// term downgrades.
+	const variantRenewalInterval = variant.termIntervalInDays;
+	if ( activePlanRenewalInterval > variantRenewalInterval ) {
+		debug(
+			'filtering out plan variant',
+			variant,
+			'with interval',
+			variantRenewalInterval,
+			'because it is a downgrade from',
+			activePlanRenewalInterval
+		);
+		return false;
+	}
+
+	// If the variant is a plan and the site has an active plan, only allow the
+	// variant it is not a variant of the active plan. In other words, do not
+	// show the variant picker when purchasing a term upgrade for the active
+	// plan. This is because such a case is already an upsell and does not
+	// benefit from a term picker.
+	if ( getVariantPlanProductSlugs( activePlanSlug ).includes( variant.productSlug ) ) {
+		return false;
+	}
+
+	return true;
+}
+
+export function getVariantPlanProductSlugs( productSlug: string | undefined ): string[] {
+	const chosenPlan = getPlan( productSlug ?? '' )
+		? getPlan( productSlug ?? '' )
+		: getProductFromSlug( productSlug ?? '' );
+
+	if ( ! chosenPlan || typeof chosenPlan === 'string' ) {
+		return [];
+	}
+
+	// Only construct variants for WP.com and Jetpack plans
+	if (
+		! objectIsProduct( chosenPlan ) &&
+		chosenPlan.group !== GROUP_WPCOM &&
+		chosenPlan.group !== GROUP_JETPACK
+	) {
+		return [];
+	}
+
+	return objectIsProduct( chosenPlan )
+		? findProductKeys( {
+				type: chosenPlan.type,
+		  } )
+		: findPlansKeys( {
+				group: chosenPlan.group,
+				type: chosenPlan.type,
+		  } );
+}
+
+function useVariantPlanProductSlugs( productSlug: string | undefined ): string[] {
+	return useMemo( () => getVariantPlanProductSlugs( productSlug ), [ productSlug ] );
 }
 
 function getTermText( term: string, translate: ReturnType< typeof useTranslate > ): string {

--- a/client/my-sites/checkout/composite-checkout/test/util/index.ts
+++ b/client/my-sites/checkout/composite-checkout/test/util/index.ts
@@ -1,9 +1,5 @@
 import config from '@automattic/calypso-config';
-import {
-	getEmptyResponseCart,
-	getEmptyResponseCartProduct,
-	ResponseCartProductVariant,
-} from '@automattic/shopping-cart';
+import { getEmptyResponseCart, getEmptyResponseCartProduct } from '@automattic/shopping-cart';
 import { prettyDOM } from '@testing-library/react';
 import nock from 'nock';
 import { createStore, applyMiddleware } from 'redux';
@@ -369,7 +365,7 @@ export function mockSetCartEndpointWith( { currency, locale } ): SetCart {
 function convertRequestProductToResponseProduct(
 	currency: string
 ): ( product: RequestCartProduct ) => ResponseCartProduct {
-	const getProductProperties = ( product ) => {
+	return ( product ) => {
 		const { product_slug } = product;
 
 		switch ( product_slug ) {
@@ -573,8 +569,6 @@ function convertRequestProductToResponseProduct(
 			item_tax: 0,
 		};
 	};
-
-	return ( product ) => addVariantsToCartItem( getProductProperties( product ) );
 }
 
 export function getBasicCart(): ResponseCart {
@@ -667,11 +661,11 @@ export function getActivePersonalPlanDataForType( type: string ) {
 export function getPersonalPlanForInterval( type: string ) {
 	switch ( type ) {
 		case 'monthly':
-			return addVariantsToCartItem( planWithoutDomainMonthly );
+			return planWithoutDomainMonthly;
 		case 'yearly':
-			return addVariantsToCartItem( planWithoutDomain );
+			return planWithoutDomain;
 		case 'two-year':
-			return addVariantsToCartItem( planWithoutDomainBiannual );
+			return planWithoutDomainBiannual;
 		default:
 			throw new Error( `Unknown plan type '${ type }'` );
 	}
@@ -680,11 +674,11 @@ export function getPersonalPlanForInterval( type: string ) {
 export function getBusinessPlanForInterval( type: string ) {
 	switch ( type ) {
 		case 'monthly':
-			return addVariantsToCartItem( planLevel2Monthly );
+			return planLevel2Monthly;
 		case 'yearly':
-			return addVariantsToCartItem( planLevel2 );
+			return planLevel2;
 		case 'two-year':
-			return addVariantsToCartItem( planLevel2Biannual );
+			return planLevel2Biannual;
 		default:
 			throw new Error( `Unknown plan type '${ type }'` );
 	}
@@ -1125,98 +1119,4 @@ export function mockUserAgent( agent ) {
 			return agent;
 		},
 	} );
-}
-
-function addVariantsToCartItem( data: ResponseCartProduct ): ResponseCartProduct {
-	return {
-		...data,
-		product_variants: buildVariantsForCartItem( data ),
-	};
-}
-
-function buildVariantsForCartItem( data: ResponseCartProduct ): ResponseCartProductVariant[] {
-	switch ( data.product_slug ) {
-		case planLevel2Monthly.product_slug:
-		case planLevel2.product_slug:
-		case planLevel2Biannual.product_slug:
-			return [
-				buildVariant( planLevel2Monthly ),
-				buildVariant( planLevel2 ),
-				buildVariant( planLevel2Biannual ),
-			];
-		case planWithoutDomainMonthly.product_slug:
-		case planWithoutDomain.product_slug:
-		case planWithoutDomainBiannual.product_slug:
-			return [
-				buildVariant( planWithoutDomainMonthly ),
-				buildVariant( planWithoutDomain ),
-				buildVariant( planWithoutDomainBiannual ),
-			];
-	}
-	return [];
-}
-
-function getVariantPrice( data: ResponseCartProduct ): number {
-	const variantData = getPlansItemsState().find(
-		( plan ) => plan.product_slug === data.product_slug
-	);
-	if ( ! variantData ) {
-		throw new Error( `Unknown price for variant ${ data.product_slug }` );
-	}
-	return variantData.raw_price;
-}
-
-function buildVariant( data: ResponseCartProduct ): ResponseCartProductVariant {
-	switch ( data.product_slug ) {
-		case planLevel2Monthly.product_slug:
-			return {
-				product_id: planLevel2Monthly.product_id,
-				bill_period_in_months: planLevel2Monthly.months_per_bill_period,
-				product_slug: data.product_slug,
-				currency: planLevel2Monthly.currency,
-				price_integer: getVariantPrice( planLevel2Monthly ),
-			};
-		case planLevel2.product_slug:
-			return {
-				product_id: planLevel2.product_id,
-				bill_period_in_months: planLevel2.months_per_bill_period,
-				product_slug: data.product_slug,
-				currency: planLevel2.currency,
-				price_integer: getVariantPrice( planLevel2 ),
-			};
-		case planLevel2Biannual.product_slug:
-			return {
-				product_id: planLevel2Biannual.product_id,
-				bill_period_in_months: planLevel2Biannual.months_per_bill_period,
-				product_slug: data.product_slug,
-				currency: planLevel2Biannual.currency,
-				price_integer: getVariantPrice( planLevel2Biannual ),
-			};
-		case planWithoutDomainMonthly.product_slug:
-			return {
-				product_id: planWithoutDomainMonthly.product_id,
-				bill_period_in_months: planWithoutDomainMonthly.months_per_bill_period,
-				product_slug: data.product_slug,
-				currency: planWithoutDomainMonthly.currency,
-				price_integer: getVariantPrice( planWithoutDomainMonthly ),
-			};
-		case planWithoutDomain.product_slug:
-			return {
-				product_id: planWithoutDomain.product_id,
-				bill_period_in_months: planWithoutDomain.months_per_bill_period,
-				product_slug: data.product_slug,
-				currency: planWithoutDomain.currency,
-				price_integer: getVariantPrice( planWithoutDomain ),
-			};
-		case planWithoutDomainBiannual.product_slug:
-			return {
-				product_id: planWithoutDomainBiannual.product_id,
-				bill_period_in_months: planWithoutDomainBiannual.months_per_bill_period,
-				product_slug: data.product_slug,
-				currency: planWithoutDomainBiannual.currency,
-				price_integer: getVariantPrice( planWithoutDomainBiannual ),
-			};
-	}
-
-	throw new Error( `No variants found for product_slug ${ data.product_slug }` );
 }

--- a/client/state/products-list/selectors/compute-full-and-monthly-prices-for-plan.ts
+++ b/client/state/products-list/selectors/compute-full-and-monthly-prices-for-plan.ts
@@ -1,0 +1,138 @@
+import {
+	getPriceTierForUnits,
+	GROUP_WPCOM,
+	JETPACK_SEARCH_PRODUCTS,
+} from '@automattic/calypso-products';
+import { getCurrencyDefaults } from '@automattic/format-currency';
+import { getPlanRawPrice } from 'calypso/state/plans/selectors';
+import getIntroOfferIsEligible from 'calypso/state/selectors/get-intro-offer-is-eligible';
+import getIntroOfferPrice from 'calypso/state/selectors/get-intro-offer-price';
+import { getPlanPrice } from './get-plan-price';
+import { getProductCost } from './get-product-cost';
+import { getProductPriceTierList } from './get-product-price-tiers';
+import { getProductSaleCouponCost } from './get-product-sale-coupon-cost';
+import { getProductSaleCouponDiscount } from './get-product-sale-coupon-discount';
+import type { Plan, PlanSlug, ProductSlug } from '@automattic/calypso-products';
+import type { AppState } from 'calypso/types';
+
+export interface FullAndMonthlyPrices {
+	priceFull: number | null;
+	priceFinal: number | null;
+	introductoryOfferPrice: number | null;
+}
+
+type PlanOrProductSlug = PlanSlug | ProductSlug;
+type Optional< T, K extends keyof T > = Pick< Partial< T >, K > & Omit< T, K >;
+export type PlanObject = Optional< Pick< Plan, 'group' | 'getProductId' >, 'group' > & {
+	getStoreSlug: () => PlanOrProductSlug;
+};
+
+/**
+ * Computes a full and monthly price for a given plan, based on its slug/constant
+ *
+ * planObject is the plan object returned by getPlan() from @automattic/calypso-products
+ */
+export const computeFullAndMonthlyPricesForPlan = (
+	state: AppState,
+	siteId: number | undefined,
+	planObject: PlanObject,
+	currentQuantity: number | null
+): FullAndMonthlyPrices => {
+	if ( planObject.group === GROUP_WPCOM ) {
+		return computePricesForWpComPlan( state, siteId, planObject );
+	}
+
+	const isJetpackSearchProduct = ( JETPACK_SEARCH_PRODUCTS as ReadonlyArray< string > ).includes(
+		planObject.getStoreSlug()
+	);
+
+	// eslint-disable-next-line no-nested-ternary
+	const planOrProductPrice = ! getPlanPrice( state, siteId, planObject, false )
+		? isJetpackSearchProduct
+			? getSearchProductTierPrice( state, siteId, planObject.getStoreSlug(), currentQuantity ?? 1 )
+			: getProductCost( state, planObject.getStoreSlug() )
+		: getPlanPrice( state, siteId, planObject, false );
+	const introOfferIsEligible = getIntroOfferIsEligible( state, planObject.getProductId(), siteId );
+	const saleCouponDiscount = getProductSaleCouponDiscount( state, planObject.getStoreSlug() ) || 0;
+	const introductoryOfferPrice = introOfferIsEligible
+		? getIntroOfferPrice( state, planObject.getProductId(), siteId )
+		: null;
+	const saleCouponCost = isJetpackSearchProduct
+		? calculateSaleCouponCostForJetpackProduct( planOrProductPrice, saleCouponDiscount )
+		: getProductSaleCouponCost( state, planObject.getStoreSlug() );
+
+	return {
+		priceFull: planOrProductPrice,
+		priceFinal: saleCouponCost || planOrProductPrice,
+		introductoryOfferPrice:
+			introductoryOfferPrice !== null ? introductoryOfferPrice * ( 1 - saleCouponDiscount ) : null,
+	};
+};
+
+function calculateSaleCouponCostForJetpackProduct(
+	price: number | null,
+	saleCouponDiscount: number
+): number | null {
+	if ( ! price ) {
+		return null;
+	}
+	return Math.floor( price * ( 1 - saleCouponDiscount ) * 100 ) / 100;
+}
+
+/**
+ * Compute a full and monthly price for a given wpcom plan.
+ *
+ * planObject is the plan object returned by getPlan() from @automattic/calypso-products
+ */
+function computePricesForWpComPlan(
+	state: AppState,
+	siteId: number | undefined,
+	planObject: PlanObject
+): FullAndMonthlyPrices {
+	const priceFull = getPlanRawPrice( state, planObject.getProductId(), false ) || 0;
+	const introductoryOfferPrice = getIntroOfferPrice( state, planObject.getProductId(), siteId );
+
+	return {
+		priceFull,
+		priceFinal: priceFull,
+		introductoryOfferPrice,
+	};
+}
+
+/**
+ * Compute the Jetpack Search product tiered price based on the site's number of published posts.
+ */
+function getSearchProductTierPrice(
+	state: AppState,
+	siteId: number | undefined,
+	productSlug: string,
+	currentQuantity: number
+): number | null {
+	const priceTierList = getProductPriceTierList( state, productSlug );
+	const tier = getPriceTierForUnits( priceTierList, currentQuantity );
+	if ( ! tier ) {
+		return null;
+	}
+	if ( ! tier.transform_quantity_divide_by || ! tier.per_unit_fee ) {
+		return null;
+	}
+	let units_used: number;
+	if ( tier.transform_quantity_round === 'down' ) {
+		units_used = Math.floor( currentQuantity / tier.transform_quantity_divide_by );
+	} else {
+		units_used = Math.ceil( currentQuantity / tier.transform_quantity_divide_by );
+	}
+	let price = units_used * tier.per_unit_fee;
+
+	if ( tier.flat_fee && tier.flat_fee > 0 ) {
+		price += tier.flat_fee;
+	}
+
+	const currencyDefaults = getCurrencyDefaults( state.currencyCode );
+	if ( ! currencyDefaults || isNaN( price ) ) {
+		return null;
+	}
+
+	// convert price from smallest unit to float (3550 to 35.50)
+	return price / 10 ** currencyDefaults.precision;
+}

--- a/client/state/products-list/selectors/compute-products-with-prices.ts
+++ b/client/state/products-list/selectors/compute-products-with-prices.ts
@@ -1,0 +1,72 @@
+import { getTermDuration } from '@automattic/calypso-products';
+import { get } from 'lodash';
+import { computeFullAndMonthlyPricesForPlan } from './compute-full-and-monthly-prices-for-plan';
+import { getProductsList } from './get-products-list';
+import { planSlugToPlanProduct } from './plan-slug-to-plan-product';
+import type { ProductListItem } from './get-products-list';
+import type { TestFilteredPlan, PlanAndProduct } from './plan-slug-to-plan-product';
+import type { AvailableProductVariant } from 'calypso/my-sites/checkout/composite-checkout/hooks/product-variants';
+import type { AppState } from 'calypso/types';
+
+interface NonNullablePlanAndProduct extends PlanAndProduct {
+	plan: TestFilteredPlan;
+	product: ProductListItem;
+}
+
+/**
+ * Turns a list of plan slugs into a list of plan objects, corresponding
+ * products, and their full and monthly prices
+ */
+export const computeProductsWithPrices = (
+	state: AppState,
+	siteId: number | undefined,
+	planSlugs: string[],
+	currentQuantity: number | null
+): AvailableProductVariant[] => {
+	const products = getProductsList( state );
+
+	const planAndProducts = planSlugs.map( ( plan ) => planSlugToPlanProduct( products, plan ) );
+	const filteredPlanAndProducts = planAndProducts.filter( hasAvailablePlan );
+	const constructedVariants = filteredPlanAndProducts.map( ( availablePlanProduct ) => ( {
+		...availablePlanProduct,
+		...computeFullAndMonthlyPricesForPlan(
+			state,
+			siteId,
+			availablePlanProduct.plan,
+			currentQuantity
+		),
+	} ) );
+	const filteredConstructedVariants = constructedVariants.filter( hasAvailablePrice );
+
+	return filteredConstructedVariants.sort( ( a, b ) => {
+		const durationA = getTermDuration( ( a.plan as TestFilteredPlan ).term );
+		const durationB = getTermDuration( ( b.plan as TestFilteredPlan ).term );
+		if ( durationA === undefined || durationB === undefined ) {
+			return 0;
+		}
+		return durationA - durationB;
+	} );
+};
+
+function hasAvailablePlan( planProduct: PlanAndProduct ): planProduct is NonNullablePlanAndProduct {
+	return !! (
+		planProduct.plan &&
+		planProduct.product &&
+		get( planProduct, [ 'product', 'available' ] )
+	);
+}
+
+interface PartialProductVariant {
+	priceFull: number | null;
+	priceFinal: number | null;
+	introductoryOfferPrice: number | null;
+	plan: TestFilteredPlan;
+	product: ProductListItem;
+	planSlug: string;
+}
+
+function hasAvailablePrice(
+	availablePlanProduct: PartialProductVariant
+): availablePlanProduct is AvailableProductVariant {
+	return Boolean( availablePlanProduct.priceFull );
+}

--- a/client/state/products-list/selectors/get-plan-price.ts
+++ b/client/state/products-list/selectors/get-plan-price.ts
@@ -1,13 +1,7 @@
 import { getPlanRawPrice } from 'calypso/state/plans/selectors';
 import { getPlanDiscountedRawPrice } from 'calypso/state/sites/plans/selectors';
-import type { Plan, PlanSlug, ProductSlug } from '@automattic/calypso-products';
+import type { PlanObject } from './compute-full-and-monthly-prices-for-plan';
 import type { AppState } from 'calypso/types';
-
-type PlanOrProductSlug = PlanSlug | ProductSlug;
-type Optional< T, K extends keyof T > = Pick< Partial< T >, K > & Omit< T, K >;
-type PlanObject = Optional< Pick< Plan, 'group' | 'getProductId' >, 'group' > & {
-	getStoreSlug: () => PlanOrProductSlug;
-};
 
 /**
  * Computes a price based on plan slug/constant, including any discounts available.

--- a/client/state/products-list/selectors/index.js
+++ b/client/state/products-list/selectors/index.js
@@ -1,3 +1,5 @@
+export { computeFullAndMonthlyPricesForPlan } from './compute-full-and-monthly-prices-for-plan';
+export { computeProductsWithPrices } from './compute-products-with-prices';
 export { getAvailableProductsList } from './get-available-products-list';
 export { getPlanPrice } from './get-plan-price';
 export { getProductBySlug } from './get-product-by-slug';
@@ -12,6 +14,7 @@ export { getProductsByBillingSlug } from './get-products-by-billing-slug';
 export { getProductsList } from './get-products-list';
 export { getProductsListType } from './get-products-list-type';
 export { isProductsListFetching } from './is-products-list-fetching';
+export { planSlugToPlanProduct } from './plan-slug-to-plan-product';
 export { isMarketplaceProduct } from './is-marketplace-product';
 export { isSaasProduct } from './is-saas-product';
 export { getProductSaleCouponCost } from './get-product-sale-coupon-cost';

--- a/client/state/products-list/selectors/plan-slug-to-plan-product.ts
+++ b/client/state/products-list/selectors/plan-slug-to-plan-product.ts
@@ -1,0 +1,36 @@
+import {
+	applyTestFiltersToPlansList,
+	applyTestFiltersToProductsList,
+	getPlan,
+	getProductFromSlug,
+	objectIsProduct,
+} from '@automattic/calypso-products';
+import type { ProductListItem } from './get-products-list';
+
+export type TestFilteredPlan =
+	| ReturnType< typeof applyTestFiltersToPlansList >
+	| ReturnType< typeof applyTestFiltersToProductsList >;
+export interface PlanAndProduct {
+	planSlug: string;
+	plan: TestFilteredPlan | null;
+	product: ProductListItem | undefined;
+}
+
+/**
+ * Computes a plan object and a related product object based on plan slug/constant
+ */
+export const planSlugToPlanProduct = (
+	products: Record< string, ProductListItem >,
+	planOrProductSlug: string
+): PlanAndProduct => {
+	const plan = getPlan( planOrProductSlug ) ?? getProductFromSlug( planOrProductSlug );
+	const constantObj = objectIsProduct( plan )
+		? applyTestFiltersToProductsList( plan.product_slug )
+		: applyTestFiltersToPlansList( plan, undefined );
+	const product = products[ planOrProductSlug ];
+	return {
+		planSlug: planOrProductSlug,
+		plan: plan === planOrProductSlug ? null : constantObj,
+		product,
+	};
+};

--- a/client/state/products-list/test/selectors.js
+++ b/client/state/products-list/test/selectors.js
@@ -1,15 +1,25 @@
-import { TERM_MONTHLY } from '@automattic/calypso-products';
+import { getPlan, TERM_MONTHLY, TERM_ANNUALLY } from '@automattic/calypso-products';
 import deepFreeze from 'deep-freeze';
 import { getPlanRawPrice } from 'calypso/state/plans/selectors';
+import getIntroOfferIsEligible from 'calypso/state/selectors/get-intro-offer-is-eligible';
+import getIntroOfferPrice from 'calypso/state/selectors/get-intro-offer-price';
 import { getPlanDiscountedRawPrice } from 'calypso/state/sites/plans/selectors';
 import {
+	computeFullAndMonthlyPricesForPlan,
+	computeProductsWithPrices,
 	getPlanPrice,
 	getProductDisplayCost,
+	getProductSaleCouponCost,
+	getProductSaleCouponDiscount,
+	getProductPriceTierList,
 	isProductsListFetching,
+	planSlugToPlanProduct,
 	getProductsByBillingSlug,
 } from '../selectors';
 
 jest.mock( 'calypso/state/selectors/get-intro-offer-price', () => jest.fn() );
+jest.mock( 'calypso/state/selectors/get-intro-offer-is-eligible', () => jest.fn() );
+jest.mock( 'calypso/state/selectors/get-intro-offer-is-eligible', () => jest.fn() );
 
 jest.mock( 'calypso/state/products-list/selectors/get-product-sale-coupon-cost', () => ( {
 	getProductSaleCouponCost: jest.fn( () => null ),
@@ -89,6 +99,375 @@ describe( 'selectors', () => {
 
 			getPlanPrice( {}, 1, { ...plan, term: TERM_MONTHLY }, true );
 			expect( getPlanDiscountedRawPrice.mock.calls[ 2 ][ 3 ] ).toEqual( { isMonthly: true } );
+		} );
+	} );
+
+	describe( '#planSlugToPlanProduct()', () => {
+		test( 'Should return shape { planSlug, plan, product }', () => {
+			const products = {
+				myPlanSlug: {
+					price: 10,
+				},
+			};
+			const planSlug = 'myPlanSlug';
+			const plan = {
+				storeId: 15,
+			};
+			getPlan.mockImplementation( () => plan );
+
+			expect( planSlugToPlanProduct( products, planSlug ) ).toEqual( {
+				planSlug,
+				plan,
+				product: products.myPlanSlug,
+			} );
+		} );
+
+		test( 'Should return shape { planSlug, plan, product } with empty values if plan or product couldnt be found', () => {
+			const planSlug = 'myPlanSlug';
+			getPlan.mockImplementation( () => null );
+
+			expect( planSlugToPlanProduct( {}, planSlug ) ).toEqual( {
+				planSlug,
+				plan: null,
+				product: undefined,
+			} );
+
+			expect( planSlugToPlanProduct( { myPlanSlug: null }, planSlug ) ).toEqual( {
+				planSlug,
+				plan: null,
+				product: null,
+			} );
+		} );
+	} );
+
+	describe( '#computeFullAndMonthlyPricesForPlan()', () => {
+		beforeEach( () => {
+			getIntroOfferPrice.mockReset();
+			getIntroOfferPrice.mockImplementation( () => null );
+			getIntroOfferIsEligible.mockReset();
+			getIntroOfferIsEligible.mockImplementation( () => false );
+			getProductSaleCouponCost.mockReset();
+			getProductSaleCouponCost.mockImplementation( () => false );
+			getProductSaleCouponDiscount.mockReset();
+			getProductSaleCouponDiscount.mockImplementation( () => false );
+		} );
+		test( 'Should return shape { priceFull }', () => {
+			getPlanDiscountedRawPrice.mockImplementation( ( a, b, c, { isMonthly } ) =>
+				isMonthly ? 10 : 120
+			);
+			getPlanRawPrice.mockImplementation( () => 150 );
+
+			const plan = { getStoreSlug: () => 'abc', getProductId: () => 'def' };
+			expect( computeFullAndMonthlyPricesForPlan( {}, 1, plan ) ).toEqual( {
+				introductoryOfferPrice: null,
+				priceFull: 120,
+				priceFinal: 120,
+			} );
+		} );
+
+		test( 'Should return the introductoryOfferPrice value', () => {
+			const plan = { getStoreSlug: () => 'abc', getProductId: () => 'def' };
+			getIntroOfferPrice.mockImplementation( () => 60 );
+			getIntroOfferIsEligible.mockImplementation( () => true );
+			expect( computeFullAndMonthlyPricesForPlan( {}, 1, plan ) ).toEqual( {
+				introductoryOfferPrice: 60,
+				priceFull: 120,
+				priceFinal: 120,
+			} );
+		} );
+
+		test( 'Should not return the introductoryOfferPrice value if ineligible', () => {
+			const plan = { getStoreSlug: () => 'abc', getProductId: () => 'def' };
+			getIntroOfferPrice.mockImplementation( () => 60 );
+			getIntroOfferIsEligible.mockImplementation( () => false );
+			expect( computeFullAndMonthlyPricesForPlan( {}, 1, plan ) ).toEqual( {
+				introductoryOfferPrice: null,
+				priceFull: 120,
+				priceFinal: 120,
+			} );
+		} );
+
+		test( 'Should return the correct tier 1 price for Jetpack Search product with < 100 posts', () => {
+			const SEARCH_PRICE_TIER_LIST = [
+				{
+					minimum_units: 0,
+					maximum_units: null,
+					transform_quantity_divide_by: 10000,
+					transform_quantity_round: 'up',
+					per_unit_fee: 896,
+				},
+			];
+			const plan = { getStoreSlug: () => 'jetpack_search', getProductId: () => '2104' };
+			// JP Search is a "product" not a plan, so `getPlanDiscountedRawPrice()` & `getPlanRawPrice()` should return null.
+			getPlanDiscountedRawPrice.mockImplementation( () => null );
+			getPlanRawPrice.mockImplementation( () => null );
+
+			getIntroOfferPrice.mockImplementation( () => null );
+			getIntroOfferIsEligible.mockImplementation( () => false );
+			getProductPriceTierList.mockImplementation( () => SEARCH_PRICE_TIER_LIST );
+			expect( computeFullAndMonthlyPricesForPlan( {}, 1, plan, 10 ) ).toEqual( {
+				introductoryOfferPrice: null,
+				priceFull: 8.96,
+				priceFinal: 8.96,
+			} );
+		} );
+
+		test( 'Should return the correct tier 2 price for Jetpack Search product with > 100 posts', () => {
+			const SEARCH_PRICE_TIER_LIST = [
+				{
+					minimum_units: 0,
+					maximum_units: null,
+					transform_quantity_divide_by: 10000,
+					transform_quantity_round: 'up',
+					per_unit_fee: 896,
+				},
+			];
+			const plan = { getStoreSlug: () => 'jetpack_search', getProductId: () => '2104' };
+			// JP Search is a "product" not a plan, so `getPlanDiscountedRawPrice()` & `getPlanRawPrice()` should return null.
+			getPlanDiscountedRawPrice.mockImplementation( () => null );
+			getPlanRawPrice.mockImplementation( () => null );
+
+			getIntroOfferPrice.mockImplementation( () => null );
+			getIntroOfferIsEligible.mockImplementation( () => false );
+			getProductPriceTierList.mockImplementation( () => SEARCH_PRICE_TIER_LIST );
+			expect( computeFullAndMonthlyPricesForPlan( {}, 1, plan, 10001 ) ).toEqual( {
+				introductoryOfferPrice: null,
+				priceFull: 17.92,
+				priceFinal: 17.92,
+			} );
+		} );
+	} );
+
+	describe( '#computeProductsWithPrices()', () => {
+		const testPlans = {
+			plan1: {
+				id: 1,
+				term: TERM_MONTHLY,
+				getStoreSlug: () => 'abc',
+				getProductId: () => 'def',
+			},
+
+			plan2: {
+				id: 2,
+				term: TERM_ANNUALLY,
+				getStoreSlug: () => 'jkl',
+				getProductId: () => 'mno',
+			},
+		};
+
+		beforeEach( () => {
+			getPlanRawPrice.mockImplementation( () => 150 );
+			getPlanDiscountedRawPrice.mockImplementation( ( a, b, storeSlug, { isMonthly } ) => {
+				if ( storeSlug === 'abc' ) {
+					return isMonthly ? 10 : 120;
+				}
+
+				return isMonthly ? 20 : 240;
+			} );
+
+			getPlan.mockImplementation( ( slug ) => testPlans[ slug ] );
+
+			getIntroOfferPrice.mockReset();
+			getIntroOfferPrice.mockImplementation( () => null );
+
+			getProductSaleCouponCost.mockReset();
+			getProductSaleCouponCost.mockImplementation( () => null );
+
+			getProductSaleCouponDiscount.mockReset();
+			getProductSaleCouponDiscount.mockImplementation( () => null );
+		} );
+
+		test( 'Should return list of shapes { priceFull, priceFinal, plan, product, planSlug, introductoryOfferPrice }', () => {
+			const state = {
+				productsList: {
+					items: {
+						plan1: { available: true },
+						plan2: { available: true },
+					},
+				},
+			};
+
+			expect( computeProductsWithPrices( state, 10, [ 'plan1', 'plan2' ] ) ).toEqual( [
+				{
+					planSlug: 'plan1',
+					plan: testPlans.plan1,
+					product: state.productsList.items.plan1,
+					priceFull: 120,
+					priceFinal: 120,
+					introductoryOfferPrice: null,
+				},
+				{
+					planSlug: 'plan2',
+					plan: testPlans.plan2,
+					product: state.productsList.items.plan2,
+					priceFull: 240,
+					priceFinal: 240,
+					introductoryOfferPrice: null,
+				},
+			] );
+		} );
+
+		test( 'sales coupon should discount priceFinal', () => {
+			getProductSaleCouponCost.mockImplementation( ( _, storeSlug ) => {
+				if ( storeSlug === 'abc' ) {
+					return 100;
+				}
+				return null;
+			} );
+
+			const state = {
+				productsList: {
+					items: {
+						plan1: { available: true },
+						plan2: { available: true },
+					},
+				},
+			};
+
+			expect( computeProductsWithPrices( state, 10, [ 'plan1', 'plan2' ] ) ).toEqual( [
+				{
+					planSlug: 'plan1',
+					plan: testPlans.plan1,
+					product: state.productsList.items.plan1,
+					priceFull: 120,
+					priceFinal: 100,
+					introductoryOfferPrice: null,
+				},
+				{
+					planSlug: 'plan2',
+					plan: testPlans.plan2,
+					product: state.productsList.items.plan2,
+					priceFull: 240,
+					priceFinal: 240,
+					introductoryOfferPrice: null,
+				},
+			] );
+		} );
+
+		test( 'sales coupon should discount priceFinal with introductoryOffer', () => {
+			getProductSaleCouponDiscount.mockImplementation( ( _, storeSlug ) => {
+				if ( storeSlug === 'jkl' ) {
+					return 0.3;
+				}
+				return null;
+			} );
+			getProductSaleCouponCost.mockImplementation( ( _, storeSlug ) => {
+				if ( storeSlug === 'jkl' ) {
+					return 168;
+				}
+				return null;
+			} );
+			getIntroOfferPrice.mockImplementation( ( _, productId ) => {
+				if ( productId === 'mno' ) {
+					return 120;
+				}
+				return null;
+			} );
+			getIntroOfferIsEligible.mockImplementation( () => true );
+
+			const state = {
+				productsList: {
+					items: {
+						plan1: { available: true },
+						plan2: { available: true },
+					},
+				},
+			};
+
+			expect( computeProductsWithPrices( state, 10, [ 'plan1', 'plan2' ] ) ).toEqual( [
+				{
+					planSlug: 'plan1',
+					plan: testPlans.plan1,
+					product: state.productsList.items.plan1,
+					priceFull: 120,
+					priceFinal: 120,
+					introductoryOfferPrice: null,
+				},
+				{
+					planSlug: 'plan2',
+					plan: testPlans.plan2,
+					product: state.productsList.items.plan2,
+					priceFull: 240,
+					priceFinal: 168,
+					introductoryOfferPrice: 84,
+				},
+			] );
+		} );
+
+		test( 'Should filter out unavailable products', () => {
+			const state = {
+				productsList: {
+					items: {
+						plan1: { available: true },
+						plan2: { available: false },
+					},
+				},
+			};
+
+			expect( computeProductsWithPrices( state, 10, [ 'plan1', 'plan2' ] ) ).toEqual( [
+				{
+					planSlug: 'plan1',
+					plan: testPlans.plan1,
+					product: state.productsList.items.plan1,
+					priceFinal: 120,
+					priceFull: 120,
+					introductoryOfferPrice: null,
+				},
+			] );
+		} );
+
+		test( 'Should filter out unavailable not found products', () => {
+			const state = {
+				productsList: {
+					items: {
+						plan1: { available: true },
+					},
+				},
+			};
+
+			expect( computeProductsWithPrices( state, 10, [ 'plan1', 'plan2' ] ) ).toEqual( [
+				{
+					planSlug: 'plan1',
+					plan: testPlans.plan1,
+					product: state.productsList.items.plan1,
+					priceFull: 120,
+					priceFinal: 120,
+					introductoryOfferPrice: null,
+				},
+			] );
+		} );
+
+		test( 'Should filter out unavailable not found products with no price', () => {
+			getPlanDiscountedRawPrice.mockImplementation( ( a, b, storeSlug, { isMonthly } ) => {
+				if ( storeSlug === 'abc' ) {
+					return isMonthly ? 10 : 120;
+				}
+			} );
+			getPlanRawPrice.mockImplementation( ( a, productId ) => {
+				if ( productId === 'def' ) {
+					return 150;
+				}
+			} );
+
+			const state = {
+				productsList: {
+					items: {
+						plan1: { available: true },
+						plan2: { available: true },
+					},
+				},
+			};
+
+			expect( computeProductsWithPrices( state, 10, [ 'plan1', 'plan2' ] ) ).toEqual( [
+				{
+					planSlug: 'plan1',
+					plan: testPlans.plan1,
+					product: state.productsList.items.plan1,
+					priceFull: 120,
+					priceFinal: 120,
+					introductoryOfferPrice: null,
+				},
+			] );
 		} );
 	} );
 

--- a/packages/calypso-products/src/main.ts
+++ b/packages/calypso-products/src/main.ts
@@ -496,17 +496,6 @@ export function getBillingYearsForTerm( term: string ): number {
 	throw new Error( `Unknown term: ${ term }` );
 }
 
-export function getBillingTermForMonths( term: number ): string {
-	if ( term === 1 ) {
-		return TERM_MONTHLY;
-	} else if ( term === 12 ) {
-		return TERM_ANNUALLY;
-	} else if ( term === 24 ) {
-		return TERM_BIENNIALLY;
-	}
-	throw new Error( `Unknown term: ${ term }` );
-}
-
 export function plansLink(
 	urlString: string,
 	siteSlug: string | undefined | null,

--- a/packages/shopping-cart/src/empty-carts.ts
+++ b/packages/shopping-cart/src/empty-carts.ts
@@ -69,6 +69,5 @@ export function getEmptyResponseCartProduct(): ResponseCartProduct {
 		item_tax: 0,
 		product_type: 'test',
 		included_domain_purchase_amount: 0,
-		product_variants: [],
 	};
 }

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -571,19 +571,9 @@ export interface ResponseCartProduct {
 	 */
 	is_gift_purchase?: boolean;
 
-	product_variants: ResponseCartProductVariant[];
-
 	// Temporary optional properties for the monthly pricing test
 	related_monthly_plan_cost_display?: string;
 	related_monthly_plan_cost_integer?: number;
-}
-
-export interface ResponseCartProductVariant {
-	product_id: number;
-	bill_period_in_months: number;
-	product_slug: string;
-	currency: string;
-	price_integer: number;
 }
 
 export interface IntroductoryOfferTerms {


### PR DESCRIPTION
Reverts Automattic/wp-calypso#70452, just in case