### PR TITLE
eCommerce Onboarding: Add theme data to checkout params

### DIFF
--- a/client/landing/stepper/declarative-flow/tailored-ecommerce-flow.ts
+++ b/client/landing/stepper/declarative-flow/tailored-ecommerce-flow.ts
@@ -107,7 +107,10 @@ const ecommerceFlow: Flow = {
 						from_section: 'default',
 					} );
 
-					setPlanCartItem( { product_slug: selectedPlan } );
+					setPlanCartItem( {
+						product_slug: selectedPlan,
+						extra: { headstart_theme: selectedDesign?.recipe?.stylesheet },
+					} );
 					return navigate( 'siteCreationStep' );
 
 				case 'siteCreationStep':

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -647,6 +647,7 @@ export interface RequestCartProductExtra extends ResponseCartProductExtra {
 	site_title?: string;
 	signup_flow?: string;
 	signup?: boolean;
+	headstart_theme?: string;
 }
 
 export interface GSuiteProductUser {


### PR DESCRIPTION
#### Proposed Changes

* Add `headstart_theme` data to checkout extra parameters so we can Headstart the site with the chosen theme before transferring to Atomic.
* Split off from #71200 so we can launch this first without potentially breaking things.

#### Testing Instructions

* Switch to this PR, run through `/setup/ecommerce`
* Check the cart to confirm the `headstart_theme` information is being set:
<img width="1205" alt="Screen Shot 2022-12-15 at 5 03 19 PM" src="https://user-images.githubusercontent.com/2124984/207976681-08f56de1-a884-4105-b5a4-d704bde35c3e.png">

* Nothing should break; this patch only passes metadata to the cart, but we won't use it until D95250-code is deployed

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
