### PR TITLE
Show relevant cancellation message when license is not attached to a site

### DIFF
--- a/client/blocks/jetpack-benefits/site-backups.tsx
+++ b/client/blocks/jetpack-benefits/site-backups.tsx
@@ -11,6 +11,7 @@ import { EVERY_SECOND, Interval } from 'calypso/lib/interval';
 import { requestRewindBackups } from 'calypso/state/rewind/backups/actions';
 import { getInProgressBackupForSite } from 'calypso/state/rewind/selectors';
 import getRewindBackups from 'calypso/state/selectors/get-rewind-backups';
+import { getSiteSlug } from 'calypso/state/sites/selectors';
 
 interface Props {
 	siteId: number;
@@ -26,11 +27,13 @@ interface Backup {
 				published: string;
 			};
 		};
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		[ key: string ]: any;
 	};
 }
 
 const JetpackBenefitsSiteBackups: React.FC< Props > = ( { siteId, isStandalone } ) => {
+	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) );
 	const translate = useTranslate();
 	const moment = useLocalizedMoment();
 	const backups = useSelector( ( state ) => getRewindBackups( state, siteId ) );
@@ -100,6 +103,16 @@ const JetpackBenefitsSiteBackups: React.FC< Props > = ( { siteId, isStandalone }
 
 	// now that backups are loaded and any in progress are complete, get the most recent one
 	const mostRecentBackup = backups?.[ 0 ] || null;
+
+	// License is not attached to a site yet
+	if ( ! siteSlug ) {
+		return (
+			<JetpackBenefitsCard
+				headline={ translate( 'Site Backups' ) }
+				description={ translate( 'License key awaiting activation' ) }
+			/>
+		);
+	}
 
 	// no backups taken yet
 	if ( ! mostRecentBackup ) {

--- a/client/blocks/jetpack-benefits/test/site-backups.jsx
+++ b/client/blocks/jetpack-benefits/test/site-backups.jsx
@@ -3,6 +3,7 @@
  */
 import { render, screen } from '@testing-library/react';
 import getRewindBackups from 'calypso/state/selectors/get-rewind-backups';
+import { getSiteSlug } from 'calypso/state/sites/selectors';
 import JetpackBenefitsSiteBackups from '../site-backups';
 
 jest.mock( 'react-redux', () => ( {
@@ -12,14 +13,26 @@ jest.mock( 'react-redux', () => ( {
 } ) );
 
 jest.mock( 'calypso/state/selectors/get-rewind-backups' );
+jest.mock( 'calypso/state/sites/selectors' );
 
 describe( 'Jetpack Benefits site backups card', () => {
 	beforeEach( () => {
 		getRewindBackups.mockReset();
+		getSiteSlug.mockReset();
+	} );
+
+	test( 'If backup license is not assigned to a site, show a license needs activation message', () => {
+		getSiteSlug.mockReturnValue( undefined );
+
+		render( <JetpackBenefitsSiteBackups /> );
+
+		expect( screen.getByText( /License key awaiting activation/i ) ).toBeInTheDocument();
 	} );
 
 	test( 'If backups are still loading, show a placeholder output', () => {
 		getRewindBackups.mockReturnValue( null );
+		getSiteSlug.mockReturnValue( 'test-site' );
+
 		render( <JetpackBenefitsSiteBackups /> );
 
 		expect( screen.getByText( /loading backup data/i ) ).toBeInTheDocument();
@@ -27,6 +40,8 @@ describe( 'Jetpack Benefits site backups card', () => {
 
 	test( 'If no backups are found, show a no-backups output', () => {
 		getRewindBackups.mockReturnValue( [] );
+		getSiteSlug.mockReturnValue( 'test-site' );
+
 		render( <JetpackBenefitsSiteBackups /> );
 
 		expect( screen.getByText( /will back up your site soon/i ) ).toBeInTheDocument();
@@ -34,6 +49,8 @@ describe( 'Jetpack Benefits site backups card', () => {
 
 	test( 'If last backup was an error, show an error message', () => {
 		getRewindBackups.mockReturnValue( [ { status: 'error-will-retry' } ] );
+		getSiteSlug.mockReturnValue( 'test-site' );
+
 		render( <JetpackBenefitsSiteBackups /> );
 
 		expect( screen.getByText( /error/i ) ).toBeInTheDocument();
@@ -41,6 +58,8 @@ describe( 'Jetpack Benefits site backups card', () => {
 
 	test( 'If last backup is good, show default backup card output', () => {
 		getRewindBackups.mockReturnValue( [ { status: 'finished' } ] );
+		getSiteSlug.mockReturnValue( 'test-site' );
+
 		render( <JetpackBenefitsSiteBackups /> );
 
 		expect( screen.getByText( /your latest site backup/i ) ).toBeInTheDocument();


### PR DESCRIPTION
#### Proposed Changes

This PR adds a check to the backups cancellation messages to ensure the license is attached to a site. If it is not, it will relay that information instead of saying "Jetpack will back up your site soon." as it does in the current iteration

Context: p1HpG7-j9Q-p2#comment-59021

#### Testing Instructions

* Check out these changes via `git switch fix/backups-cancellation-message-on-siteless-licenses`

* Follow the instructions at this link 2e845-pb before moving on

* When purchasing the license, make sure not to attach it to any site
![image](https://user-images.githubusercontent.com/65001528/207978373-29018d89-24d2-49fc-9ae9-f1997e059d0a.png)
* Now, purchase another VaultPress backup subscription and attach it to any site you want
* Start up Calypso locally via `yarn start`
* Go to http://calypso.localhost:3000/me/purchases/, you should see both of the new licenses
![Screenshot 2022-12-15 at 3 20 30 PM](https://user-images.githubusercontent.com/65001528/207979738-0c49f909-d8ea-4a2c-b6d3-fd3b8ffe8f6a.jpg)
* Click on the one that is attached to a site, and proceed to try to cancel the plan. You should see something like this
![image](https://user-images.githubusercontent.com/65001528/207979834-a9d22316-8791-4fc2-b2a3-84bcc0134d73.png)
* Now go try to cancel the siteless license, and you should see the new message "License key awaiting activation"
![image](https://user-images.githubusercontent.com/65001528/207979944-ff99a9a3-b625-444f-8333-ddbe13599265.png)


#### Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #