### PR TITLE
Enable pre-sales chat for logged-in users in Staging for testing.

### DIFF
--- a/client/my-sites/plans/jetpack-plans/product-store/zendesk-presales-chat-widget/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/zendesk-presales-chat-widget/index.tsx
@@ -24,12 +24,12 @@ export const ZendeskPreSalesChat: React.VFC = () => {
 		);
 		const currentTime = new Date();
 
-		return (
-			! isLoggedIn &&
-			isEnglishLocale &&
-			isJetpackCloud() &&
-			isWithinAvailableChatDays( currentTime )
-		);
+		return config.isEnabled( 'jetpack/zendesk-chat-for-logged-in-users' )
+			? isEnglishLocale && isJetpackCloud() && isWithinAvailableChatDays( currentTime )
+			: ! isLoggedIn &&
+					isEnglishLocale &&
+					isJetpackCloud() &&
+					isWithinAvailableChatDays( currentTime );
 	}, [ isLoggedIn ] );
 
 	return shouldShowZendeskPresalesChat ? <ZendeskChat chatKey={ zendeskChatKey } /> : null;

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -52,6 +52,7 @@
 		"jetpack/server-credentials-advanced-flow": true,
 		"jetpack/simplify-pricing-structure": false,
 		"jetpack/standalone-plugin-onboarding-update-v1": true,
+		"jetpack/zendesk-chat-for-logged-in-users": true,
 		"layout/app-banner": false,
 		"layout/guided-tours": false,
 		"layout/query-selected-editor": false,

--- a/config/jetpack-cloud-horizon.json
+++ b/config/jetpack-cloud-horizon.json
@@ -46,6 +46,7 @@
 		"jetpack/server-credentials-advanced-flow": true,
 		"jetpack/simplify-pricing-structure": false,
 		"jetpack/standalone-plugin-onboarding-update-v1": true,
+		"jetpack/zendesk-chat-for-logged-in-users": true,
 		"layout/app-banner": false,
 		"layout/guided-tours": false,
 		"layout/query-selected-editor": false,

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -48,6 +48,7 @@
 		"jetpack/server-credentials-advanced-flow": true,
 		"jetpack/simplify-pricing-structure": false,
 		"jetpack/standalone-plugin-onboarding-update-v1": true,
+		"jetpack/zendesk-chat-for-logged-in-users": false,
 		"layout/app-banner": false,
 		"layout/guided-tours": false,
 		"layout/query-selected-editor": false,

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -49,6 +49,7 @@
 		"jetpack/server-credentials-advanced-flow": true,
 		"jetpack/simplify-pricing-structure": false,
 		"jetpack/standalone-plugin-onboarding-update-v1": true,
+		"jetpack/zendesk-chat-for-logged-in-users": true,
 		"layout/app-banner": false,
 		"layout/guided-tours": false,
 		"layout/query-selected-editor": false,


### PR DESCRIPTION
#### Proposed Changes

We implemented a Zendesk pre-sales chat interface ( #70590 ) that would only display for logged-out users, however now we want to increase the chat volume. We would also like to test it before going live.

This PR enables the Zendesk pre-sales chat for logged-in users on the Jetpack Cloud pricing page and only in development & staging environments so that it can be tested (in staging by proxied A18Ns') first.

So this is the "testing" PR that once deployed will allow proxied A18N's to test the chat while logged-in, and a follow-up PR will be created that removes the feature-flag (but still enables chat for logged-in users) for when JPOP HE's are ready (which is planned for Jan 3rd).

P2 - JPOP Presales Phase 2 Planning: p7pQDF-7I9-p2
Asana Task: 1202858161751496-as-1203542170185432/f


#### Testing Instructions

- This PR assumes you are a logged-in A18N (proxied). And the current day is Mon - Fri, not Sat or Sun.
- First go to https://cloud.jetpack.com/pricing . Verify you are logged-in (you should see your profile picture in the top-right master-bar), and verify you **do not** see the pre-sales chat UI in the lower-right corner of viewport.
- Do any one of these
    - Open Jetpack Cloud Live link below. 
    - or spin up this PR 
        - Run `git fetch && git checkout  update/enable-presales-chat-logged-in`
        - Run `yarn start-jetpack-cloud`
- In the browser address bar, append `/pricing` or `/pricing/:site` to the _hostname_. (Depending on which testing environment you chose above, the _hostname_ will either be something like, `https://container-some-name.calypso.live` or it will be `http://jetpack.cloud.localhost:3000`.  Just add `/pricing` to that and press enter.
- Make sure you are logged-in and Verify you see the Zendesk chat interface in the bottom right corner of the viewport window. (It must be Mon - Fri UTC, chat doesn't show weekends (Sat & Sun))
- Turn of the feature-flag by appending to the URL, `?flags=-jetpack/zendesk-chat-for-logged-in-users` (notice the minus(-) sign).
- Verify you do not see the chat UI anymore. (Because the feature-flag is turned off, which allows the chat to show for logged-in users).


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203562282240423