### PR TITLE
Launchpad: Free flow site setup screen

### DIFF
--- a/client/landing/stepper/declarative-flow/free.ts
+++ b/client/landing/stepper/declarative-flow/free.ts
@@ -17,9 +17,9 @@ import { useSiteSlug } from '../hooks/use-site-slug';
 import { USER_STORE, ONBOARD_STORE } from '../stores';
 import { recordSubmitStep } from './internals/analytics/record-submit-step';
 import DomainsStep from './internals/steps-repository/domains';
+import FreeSetup from './internals/steps-repository/free-setup';
 import Intro from './internals/steps-repository/intro';
 import LaunchPad from './internals/steps-repository/launchpad';
-import LinkInBioSetup from './internals/steps-repository/link-in-bio-setup';
 import PatternsStep from './internals/steps-repository/patterns';
 import PlansStep from './internals/steps-repository/plans';
 import Processing from './internals/steps-repository/processing-step';
@@ -42,7 +42,7 @@ const free: Flow = {
 
 		return [
 			{ slug: 'intro', component: Intro },
-			{ slug: 'freeSetup', component: LinkInBioSetup },
+			{ slug: 'freeSetup', component: FreeSetup },
 			{ slug: 'domains', component: DomainsStep },
 			{ slug: 'plans', component: PlansStep },
 			{ slug: 'patterns', component: PatternsStep },

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/free-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/free-setup/index.tsx
@@ -20,7 +20,7 @@ const FreeSetup: Step = function FreeSetup( { navigation } ) {
 	const formText = {
 		titlePlaceholder: translate( 'My Website' ),
 		titleMissing: translate( `Oops. Looks like your website doesn't have a name yet.` ),
-		taglinePlaceholder: translate( 'Add a short description here' ),
+		taglinePlaceholder: translate( 'Describe your website in a line or two' ),
 		iconPlaceholder: translate( 'Add a site icon' ),
 	};
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/free-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/free-setup/index.tsx
@@ -21,7 +21,7 @@ const FreeSetup: Step = function FreeSetup( { navigation } ) {
 		titlePlaceholder: translate( 'My Website' ),
 		titleMissing: translate( `Oops. Looks like your website doesn't have a name yet.` ),
 		taglinePlaceholder: translate( 'Add a short description here' ),
-		iconPlaceholder: translate( 'Upload a profile image' ),
+		iconPlaceholder: translate( 'Add a site icon' ),
 	};
 
 	const [ invalidSiteTitle, setInvalidSiteTitle ] = React.useState( false );
@@ -34,6 +34,7 @@ const FreeSetup: Step = function FreeSetup( { navigation } ) {
 
 	useEffect( () => {
 		const { siteTitle, siteDescription, siteLogo } = state;
+
 		setTagline( siteDescription );
 		setComponentSiteTitle( siteTitle );
 
@@ -43,18 +44,13 @@ const FreeSetup: Step = function FreeSetup( { navigation } ) {
 		}
 	}, [ state ] );
 
-	useEffect( () => {
-		if ( ! site ) {
-			return;
-		}
-
-		setComponentSiteTitle( site.name || '' );
-		setTagline( site.description );
-	}, [ site ] );
-
 	const handleSubmit = async ( event: FormEvent ) => {
 		event.preventDefault();
-		setInvalidSiteTitle( ! siteTitle.trim().length );
+
+		if ( ! siteTitle.trim().length ) {
+			setInvalidSiteTitle( true );
+			return;
+		}
 
 		setSiteDescription( tagline );
 		setSiteTitle( siteTitle );
@@ -68,7 +64,7 @@ const FreeSetup: Step = function FreeSetup( { navigation } ) {
 		}
 
 		if ( siteTitle.trim().length ) {
-			submit?.( { siteTitle, tagline } );
+			submit?.();
 		}
 	};
 
@@ -81,7 +77,7 @@ const FreeSetup: Step = function FreeSetup( { navigation } ) {
 			formattedHeader={
 				<FormattedHeader
 					id="free-setup-header"
-					headerText={ createInterpolateElement( translate( 'Personalize your<br />Website' ), {
+					headerText={ createInterpolateElement( translate( 'Personalize your Site' ), {
 						br: <br />,
 					} ) }
 					align="center"
@@ -104,6 +100,7 @@ const FreeSetup: Step = function FreeSetup( { navigation } ) {
 				/>
 			}
 			recordTracksEvent={ recordTracksEvent }
+			showJetpackPowered
 		/>
 	);
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/free-setup/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/free-setup/styles.scss
@@ -13,4 +13,13 @@ $font-family: "SF Pro Text", $sans;
 	.step-container__header {
 		margin-bottom: 32px;
 	}
+
+	.step-container__jetpack-powered {
+		margin-top: 128px;
+		margin-bottom: 60px;
+
+		@include break-small {
+			margin-top: 198px;
+		}
+	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/free-setup/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/free-setup/test/index.tsx
@@ -1,0 +1,94 @@
+/**
+ * @jest-environment jsdom
+ */
+import { act, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { QueryClient, QueryClientProvider } from 'react-query';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import FreeSetup from '../index';
+
+jest.mock( 'react-router-dom', () => ( {
+	...jest.requireActual( 'react-router-dom' ),
+	useLocation: jest.fn().mockImplementation( () => ( {
+		pathname: '/setup/free/freeSetup',
+		hash: '',
+		state: undefined,
+	} ) ),
+} ) );
+
+const middlewares = [ thunk ];
+
+const mockStore = configureStore( middlewares );
+
+const renderComponent = ( component, initialState = {} ) => {
+	const queryClient = new QueryClient();
+	const store = mockStore( {
+		'automattic/onboard': {},
+		...initialState,
+	} );
+
+	return render(
+		<Provider store={ store }>
+			<QueryClientProvider client={ queryClient }>{ component }</QueryClientProvider>
+		</Provider>
+	);
+};
+
+describe( 'Onboarding Free Flow - FreeSetup', () => {
+	const user = userEvent.setup();
+	const navigation = {
+		goBack: jest.fn(),
+		goNext: jest.fn(),
+		submit: jest.fn(),
+	};
+
+	afterEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	describe( 'Initial screen render', () => {
+		it( 'should render successfully', async () => {
+			renderComponent( <FreeSetup flow="free" navigation={ navigation } /> );
+
+			await waitFor( () => {
+				expect( screen.getByText( 'Personalize your Site' ) ).toBeInTheDocument();
+				expect( screen.getByText( 'Site name' ) ).toBeInTheDocument();
+				expect( screen.getByText( 'Brief description' ) ).toBeInTheDocument();
+				expect( screen.getByText( 'Jetpack powered' ) ).toBeInTheDocument();
+			} );
+		} );
+	} );
+
+	describe( 'FreeSetup form submission', () => {
+		it( 'should submit form if Site name field is not empty', async () => {
+			const freeSetupComponent = renderComponent(
+				<FreeSetup flow="free" navigation={ navigation } />
+			);
+
+			await act( async () => {
+				const siteNameInputField = await freeSetupComponent.getByPlaceholderText( 'My Website' );
+				await userEvent.type( siteNameInputField, 'site name' );
+				await user.click( screen.getByText( 'Continue' ) );
+			} );
+
+			expect( navigation.submit ).toHaveBeenCalled();
+		} );
+
+		it( 'should not submit form if Site name field is empty', async () => {
+			const freeSetupComponent = renderComponent(
+				<FreeSetup flow="free" navigation={ navigation } />
+			);
+
+			await waitFor( async () => {
+				const siteNameInputField = await freeSetupComponent.getByPlaceholderText( 'My Website' );
+				await userEvent.clear( siteNameInputField );
+				await user.click( screen.getByText( 'Continue' ) );
+			} );
+
+			expect( navigation.submit ).not.toHaveBeenCalled();
+		} );
+	} );
+} );


### PR DESCRIPTION
#### Proposed Changes

* Updated Free Flow `Site setup` screen to use new `freeSetup` step instead of `LinkInBioSetup`
* Added Jetpack powered text below the site setup form.
* Updated Form header to `Personalize your Site`

The "Free" title next to the WordPress logo and progress bar will be updated in a follow up PR.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout PR or use calypso.live link
* Navigate to `/setup/free/freeSetup` (If youre using calypso.live navigate to `/setup/free/freeSetup?flags=signup/free-flow`
* Compare to designs: YTe1seBsKUaFPqjwiuqc7U-fi-1364%3A24079&t=ZAHBsmR7leNls3Us-0

**Before:**
<img width="1506" alt="image" src="https://user-images.githubusercontent.com/10482592/208180893-4f777b33-823b-4064-adaf-ff329d456472.png">


**After:**
<img width="1510" alt="image" src="https://user-images.githubusercontent.com/10482592/208169846-355446ce-37fc-4f6c-9828-198a5fc76af3.png">

**Figma Design:**
<img width="921" alt="image" src="https://user-images.githubusercontent.com/10482592/208180516-42d28c65-4a7d-4a85-bf6e-ac2e8e4eeb96.png">




#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #70554