### PR TITLE
Stats: Polish post detail chart section with period header

### DIFF
--- a/client/my-sites/stats/stats-period-navigation/index.jsx
+++ b/client/my-sites/stats/stats-period-navigation/index.jsx
@@ -14,8 +14,9 @@ import './style.scss';
 class StatsPeriodNavigation extends PureComponent {
 	static propTypes = {
 		onPeriodChange: PropTypes.func,
-		hidePreviousArrow: PropTypes.bool,
-		hideNextArrow: PropTypes.bool,
+		showArrows: PropTypes.bool,
+		disablePreviousArrow: PropTypes.bool,
+		disableNextArrow: PropTypes.bool,
 		isRtl: PropTypes.bool,
 		queryParams: PropTypes.object,
 		startDate: PropTypes.bool,
@@ -23,8 +24,9 @@ class StatsPeriodNavigation extends PureComponent {
 	};
 
 	static defaultProps = {
-		hidePreviousArrow: false,
-		hideNextArrow: false,
+		showArrows: true,
+		disablePreviousArrow: false,
+		disableNextArrow: false,
 		isRtl: false,
 		queryParams: {},
 		startDate: false,
@@ -53,8 +55,17 @@ class StatsPeriodNavigation extends PureComponent {
 	};
 
 	render() {
-		const { children, date, moment, period, url, hidePreviousArrow, hideNextArrow, queryParams } =
-			this.props;
+		const {
+			children,
+			date,
+			moment,
+			period,
+			url,
+			showArrows,
+			disablePreviousArrow,
+			disableNextArrow,
+			queryParams,
+		} = this.props;
 
 		const isToday = moment( date ).isSame( moment(), period );
 		const previousDay = moment( date ).subtract( 1, period ).format( 'YYYY-MM-DD' );
@@ -70,24 +81,28 @@ class StatsPeriodNavigation extends PureComponent {
 		return (
 			<div className="stats-period-navigation">
 				<div className="stats-period-navigation__children">{ children }</div>
-				<a
-					className={ classNames( 'stats-period-navigation__previous', {
-						'is-disabled': hidePreviousArrow,
-					} ) }
-					href={ `${ url }${ previousDayQuery }` }
-					onClick={ this.handleClickPrevious }
-				>
-					<Icon className="gridicon" icon={ arrowLeft } />
-				</a>
-				<a
-					className={ classNames( 'stats-period-navigation__next', {
-						'is-disabled': hideNextArrow || isToday,
-					} ) }
-					href={ `${ url }${ nextDayQuery }` }
-					onClick={ this.handleClickNext }
-				>
-					<Icon className="gridicon" icon={ arrowRight } />
-				</a>
+				{ showArrows && (
+					<>
+						<a
+							className={ classNames( 'stats-period-navigation__previous', {
+								'is-disabled': disablePreviousArrow,
+							} ) }
+							href={ `${ url }${ previousDayQuery }` }
+							onClick={ this.handleClickPrevious }
+						>
+							<Icon className="gridicon" icon={ arrowLeft } />
+						</a>
+						<a
+							className={ classNames( 'stats-period-navigation__next', {
+								'is-disabled': disableNextArrow || isToday,
+							} ) }
+							href={ `${ url }${ nextDayQuery }` }
+							onClick={ this.handleClickNext }
+						>
+							<Icon className="gridicon" icon={ arrowRight } />
+						</a>
+					</>
+				) }
 			</div>
 		);
 	}

--- a/client/my-sites/stats/stats-post-summary/index.jsx
+++ b/client/my-sites/stats/stats-post-summary/index.jsx
@@ -155,7 +155,7 @@ class StatsPostSummary extends Component {
 					activeKey="period"
 					dataKey="value"
 					labelKey="periodLabel"
-					labelClass="visible"
+					chartType="views"
 					sectionClass="is-views"
 					tabLabel={ translate( 'Views' ) }
 					onClick={ this.selectRecord }

--- a/client/my-sites/stats/stats-summary/index.jsx
+++ b/client/my-sites/stats/stats-summary/index.jsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { Card } from '@automattic/components';
 import { Icon, video } from '@wordpress/icons';
 import classNames from 'classnames';
@@ -109,7 +110,16 @@ class StatsSummaryChart extends Component {
 			label: tabLabel + label,
 		};
 
-		return (
+		const isFeatured = config.isEnabled( 'stats/enhance-post-detail' );
+
+		return isFeatured ? (
+			<div
+				className={ classNames( 'stats-module', 'is-summary-chart', { 'is-loading': isLoading } ) }
+			>
+				<StatsModulePlaceholder className="is-chart" isLoading={ isLoading } />
+				<ElementChart data={ this.buildChartData() } barClick={ this.barClick } />
+			</div>
+		) : (
 			<Card
 				className={ classNames( 'stats-module', 'is-summary-chart', { 'is-loading': isLoading } ) }
 			>

--- a/client/my-sites/stats/stats-summary/index.jsx
+++ b/client/my-sites/stats/stats-summary/index.jsx
@@ -1,4 +1,5 @@
 import { Card } from '@automattic/components';
+import { Icon, video } from '@wordpress/icons';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import { isEqual, find, flowRight } from 'lodash';
@@ -16,7 +17,7 @@ class StatsSummaryChart extends Component {
 		data: PropTypes.array,
 		dataKey: PropTypes.string.isRequired,
 		isLoading: PropTypes.bool,
-		labelClass: PropTypes.string.isRequired,
+		chartType: PropTypes.string.isRequired,
 		labelKey: PropTypes.string.isRequired,
 		sectionClass: PropTypes.string.isRequired,
 		selected: PropTypes.object,
@@ -33,8 +34,39 @@ class StatsSummaryChart extends Component {
 		this.props.onClick( selectedBar );
 	};
 
+	iconByChartType( chartType ) {
+		let icon = null;
+
+		switch ( chartType ) {
+			case 'video':
+				icon = <Icon className="gridicon" icon={ video } />;
+				break;
+			case 'views':
+				icon = (
+					<svg
+						className="gridicon"
+						width="24"
+						height="24"
+						fill="none"
+						xmlns="http://www.w3.org/2000/svg"
+					>
+						<path
+							fillRule="evenodd"
+							clipRule="evenodd"
+							d="m4 13 .67.336.003-.005a2.42 2.42 0 0 1 .094-.17c.071-.122.18-.302.329-.52.298-.435.749-1.017 1.359-1.598C7.673 9.883 9.498 8.75 12 8.75s4.326 1.132 5.545 2.293c.61.581 1.061 1.163 1.36 1.599a8.29 8.29 0 0 1 .422.689l.002.005L20 13l.67-.336v-.003l-.003-.005-.008-.015-.028-.052a9.752 9.752 0 0 0-.489-.794 11.6 11.6 0 0 0-1.562-1.838C17.174 8.617 14.998 7.25 12 7.25S6.827 8.618 5.42 9.957c-.702.669-1.22 1.337-1.563 1.839a9.77 9.77 0 0 0-.516.845l-.008.015-.002.005-.001.002v.001L4 13Zm8 3a3.5 3.5 0 1 0 0-7 3.5 3.5 0 0 0 0 7Z"
+						/>
+					</svg>
+				);
+				break;
+			default:
+		}
+
+		return icon;
+	}
+
 	buildChartData() {
-		const { data, labelClass, numberFormat, sectionClass, selected, tabLabel } = this.props;
+		const { data, chartType, numberFormat, sectionClass, selected, tabLabel } = this.props;
+
 		return data.map( ( record ) => {
 			const className = classNames( {
 				'is-selected': isEqual( selected, record ),
@@ -50,7 +82,7 @@ class StatsSummaryChart extends Component {
 					label: tabLabel,
 					className: sectionClass,
 					value: numberFormat( record.value ),
-					icon: labelClass,
+					icon: this.iconByChartType( chartType ),
 				},
 			];
 
@@ -66,14 +98,14 @@ class StatsSummaryChart extends Component {
 	}
 
 	render() {
-		const { dataKey, isLoading, labelClass, labelKey, numberFormat, selected, tabLabel } =
+		const { dataKey, isLoading, chartType, labelKey, numberFormat, selected, tabLabel } =
 			this.props;
 		const label = selected ? ': ' + selected[ labelKey ] : '';
 		const tabOptions = {
 			attr: labelKey,
 			value: selected ? numberFormat( selected[ dataKey ] ) : null,
 			selected: true,
-			gridicon: labelClass,
+			icon: this.iconByChartType( chartType ),
 			label: tabLabel + label,
 		};
 

--- a/client/my-sites/stats/stats-video-summary/index.jsx
+++ b/client/my-sites/stats/stats-video-summary/index.jsx
@@ -63,7 +63,7 @@ class StatsVideoSummary extends Component {
 					activeKey="period"
 					dataKey="value"
 					labelKey="period"
-					labelClass="video"
+					chartType="video"
 					sectionClass="is-video"
 					selected={ selectedBar }
 					onClick={ this.selectBar }


### PR DESCRIPTION
#### Proposed Changes

> Note: Since the data manipulation inside `StatsPostSummary` is not acceptable for the existing `StatsPeriodNavigation` handling, the period navigation arrows on the post detail page have not been implemented for now.

* Introduce prop `showArrows` to control arrows displaying in `StatsPeriodNavigation`.
* Fix icons displaying in `StatsSummaryChart`.
* Gate the chart section polishing with the feature flag `stats/enhance-post-detail`.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up this change with the Calypso Live link.
* Navigate to the Stats `Post Detail` page (`/stats/post/${post-id}/${site-id}`).
* Ensure the post detail page works as previously.
* Append the feature flag `?flags=stats/enhance-post-detail` to the URL.
* Ensure the post detail page chart is polished in line with the design.

| Before | After |
| --- | --- |
| <img width="1129" alt="截圖 2022-12-16 上午11 53 57" src="https://user-images.githubusercontent.com/6869813/208018279-527a7761-1626-42ad-a4d9-4f34d294f6db.png"> | <img width="1113" alt="截圖 2022-12-16 上午11 54 13" src="https://user-images.githubusercontent.com/6869813/208018309-a14c53d8-5e1d-4169-a27f-5b06f0a019e9.png"> |

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #70671 
