### PR TITLE
Design Picker: Fix misalignment by replacing margin-top with row-gap

### DIFF
--- a/packages/design-picker/src/components/style.scss
+++ b/packages/design-picker/src/components/style.scss
@@ -413,27 +413,11 @@
 
 	.design-picker__grid {
 		@supports ( display: grid ) {
-			row-gap: 0;
+			row-gap: 32px;
 
 			@include break-medium {
 				grid-template-columns: 1fr 1fr 1fr;
 				column-gap: 24px;
-
-				.design-button-container:nth-child(-n+3) {
-					margin-top: 0;
-				}
-			}
-
-			.pattern-assembler-cta-wrapper {
-				margin-top: 32px;
-			}
-
-			.design-button-container {
-				margin-top: 32px;
-
-				&:first-child {
-					margin-top: 0;
-				}
 			}
 
 			.design-button-container--is-generated {
@@ -448,7 +432,6 @@
 			}
 
 			.design-button-container--is-generated--is-showing {
-				margin-top: 32px;
 				max-height: none;
 
 				.theme-preview__container {

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -414,16 +414,17 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 						currentPlanFeatures={ currentPlanFeatures }
 					/>
 				) ) }
-				{ generatedDesigns.map( ( design ) => (
-					<GeneratedDesignButtonContainer
-						key={ `generated-design__${ design.slug }` }
-						design={ design }
-						locale={ locale }
-						verticalId={ verticalId }
-						isShowing={ categorization?.selection === SHOW_GENERATED_DESIGNS_SLUG }
-						onPreview={ onPreview }
-					/>
-				) ) }
+				{ categorization?.selection === SHOW_GENERATED_DESIGNS_SLUG &&
+					generatedDesigns.map( ( design ) => (
+						<GeneratedDesignButtonContainer
+							key={ `generated-design__${ design.slug }` }
+							design={ design }
+							locale={ locale }
+							verticalId={ verticalId }
+							isShowing
+							onPreview={ onPreview }
+						/>
+					) ) }
 			</div>
 		</div>
 	);


### PR DESCRIPTION
#### Proposed Changes

* The blank canvas CTA with order makes the nth-child rules broken, so fix this as the title.

| Before | After |
| - | - |
| ![image](https://user-images.githubusercontent.com/13596067/208079994-4896d56b-b6a8-4aca-9369-294fab4d8030.png) | ![image](https://user-images.githubusercontent.com/13596067/208080152-9cb78444-56f4-4fd9-a579-74543d58f5fa.png) |
| ![image](https://user-images.githubusercontent.com/13596067/208080212-aa273ea6-f99d-47fd-bf15-f3b97a69fb24.png) | ![image](https://user-images.githubusercontent.com/13596067/208080255-dcd0be21-cb12-4fd9-abd1-79f0ff070d01.png) |

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup?siteSlug=<your_site>`
* Click the "Continue" without selecting any goal
* Select any vertical
* When you land on the design picker, verify the row-gap is the same as before under every category

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/71225
