### PR TITLE
Add new tracking events on Jetpack cloud shopping cart

### DIFF
--- a/client/jetpack-cloud/sections/pricing/controller.tsx
+++ b/client/jetpack-cloud/sections/pricing/controller.tsx
@@ -2,6 +2,7 @@ import { isEnabled } from '@automattic/calypso-config';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
 import { addQueryArgs } from 'calypso/lib/route';
+import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 import { hideMasterbar } from 'calypso/state/ui/actions';
 import Header from './header';
 import JetpackComFooter from './jpcom-footer';
@@ -32,7 +33,11 @@ export function jetpackPricingContext( context: PageJS.Context, next: () => void
 	};
 
 	context.store.dispatch( hideMasterbar() );
-	context.nav = <JetpackComMasterbar pathname={ lang ? path.replace( `/${ lang }`, '' ) : path } />;
+	context.nav = (
+		<CalypsoShoppingCartProvider>
+			<JetpackComMasterbar pathname={ lang ? path.replace( `/${ lang }`, '' ) : path } />
+		</CalypsoShoppingCartProvider>
+	);
 	context.header = <PricingHeader />;
 	context.footer = <JetpackComFooter />;
 	next();

--- a/client/jetpack-cloud/sections/pricing/jpcom-masterbar/index.tsx
+++ b/client/jetpack-cloud/sections/pricing/jpcom-masterbar/index.tsx
@@ -13,6 +13,7 @@ import JetpackSaleBanner from 'calypso/jetpack-cloud/sections/pricing/sale-banne
 import MasterbarCartWrapper from 'calypso/layout/masterbar/masterbar-cart/masterbar-cart-wrapper';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { trailingslashit } from 'calypso/lib/route';
+import { useShoppingCartTracker } from 'calypso/my-sites/plans/jetpack-plans/product-store/hooks/use-shopping-cart-tracker';
 import { isUserLoggedIn, getCurrentUser } from 'calypso/state/current-user/selectors';
 import { getJetpackSaleCoupon } from 'calypso/state/marketing/selectors';
 import { getSiteSlug, isJetpackCloudCartEnabled } from 'calypso/state/sites/selectors';
@@ -31,10 +32,6 @@ type Props = {
 	pathname?: string;
 };
 
-const goToCheckout = ( siteSlug: string ) => {
-	page( `https://wordpress.com/checkout/${ siteSlug }` );
-};
-
 /**
  * WARNING: this component is a reflection of the Jetpack.com header, whose markup is located here:
  * https://opengrok.a8c.com/source/xref/a8c/jetpackme-new/parts/shared/header.php
@@ -47,6 +44,22 @@ const JetpackComMasterbar: React.FC< Props > = ( { pathname } ) => {
 	const jetpackSaleCoupon = useSelector( getJetpackSaleCoupon );
 	const isLoggedIn = useSelector( isUserLoggedIn );
 	const user = useSelector( getCurrentUser );
+
+	const shoppingCartTracker = useShoppingCartTracker();
+
+	const onRemoveProductFromCart = ( productSlug: string ) => {
+		shoppingCartTracker( 'calypso_jetpack_shopping_cart_remove_product', {
+			productSlug,
+		} );
+	};
+
+	const goToCheckout = ( siteSlug: string ) => {
+		shoppingCartTracker( 'calypso_jetpack_shopping_cart_checkout_from_cart', {
+			addProducts: true,
+		} );
+		page( `https://wordpress.com/checkout/${ siteSlug }` );
+	};
+
 	const sections = useMemo(
 		() => [
 			{
@@ -262,6 +275,7 @@ const JetpackComMasterbar: React.FC< Props > = ( { pathname } ) => {
 							{ shouldShowCart && (
 								<MasterbarCartWrapper
 									goToCheckout={ goToCheckout }
+									onRemoveProduct={ onRemoveProductFromCart }
 									selectedSiteSlug={ siteSlug || undefined }
 									selectedSiteId={ siteId || undefined }
 									forceShow

--- a/client/jetpack-cloud/sections/pricing/jpcom-masterbar/index.tsx
+++ b/client/jetpack-cloud/sections/pricing/jpcom-masterbar/index.tsx
@@ -57,7 +57,7 @@ const JetpackComMasterbar: React.FC< Props > = ( { pathname } ) => {
 		shoppingCartTracker( 'calypso_jetpack_shopping_cart_checkout_from_cart', {
 			addProducts: true,
 		} );
-		page( `https://wordpress.com/checkout/${ siteSlug }` );
+		window.location.href = `https://wordpress.com/checkout/${ siteSlug }`;
 	};
 
 	const sections = useMemo(

--- a/client/jetpack-cloud/sections/pricing/jpcom-masterbar/index.tsx
+++ b/client/jetpack-cloud/sections/pricing/jpcom-masterbar/index.tsx
@@ -2,7 +2,6 @@ import { Gridicon } from '@automattic/components';
 import { useLocale, localizeUrl } from '@automattic/i18n-utils';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import page from 'page';
 import { useCallback, useMemo } from 'react';
 import * as React from 'react';
 import { useSelector } from 'react-redux';

--- a/client/my-sites/plans/jetpack-plans/product-store/hooks/use-shopping-cart-tracker.ts
+++ b/client/my-sites/plans/jetpack-plans/product-store/hooks/use-shopping-cart-tracker.ts
@@ -1,4 +1,4 @@
-import { ResponseCartProduct, useShoppingCart } from '@automattic/shopping-cart';
+import { useShoppingCart } from '@automattic/shopping-cart';
 import { useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
@@ -17,14 +17,6 @@ type EventDataOptions = {
 	productSlug?: string;
 	addProducts?: boolean;
 };
-
-// Record tracks are not allowing objects inside track events
-// so this little hack to provide array reduced into object so it can be spread in the event
-const reduceProducts = ( products: ResponseCartProduct[] ) =>
-	products.reduce( ( res, item, index ) => {
-		res[ `cart_product_${ index }` ] = item.product_slug;
-		return res;
-	}, {} as any ); //eslint-disable-line @typescript-eslint/no-explicit-any
 
 export const useShoppingCartTracker = () => {
 	const siteId = useSelector( getSelectedSiteId );
@@ -51,7 +43,7 @@ export const useShoppingCartTracker = () => {
 			if ( addProducts ) {
 				eventData = {
 					...eventData,
-					...reduceProducts( responseCart.products ),
+					product_slugs_concatenated: responseCart.products.sort().join( '-' ),
 					number_of_products: responseCart.products.length,
 				};
 			}

--- a/client/my-sites/plans/jetpack-plans/product-store/hooks/use-shopping-cart-tracker.ts
+++ b/client/my-sites/plans/jetpack-plans/product-store/hooks/use-shopping-cart-tracker.ts
@@ -1,4 +1,4 @@
-import { useShoppingCart } from '@automattic/shopping-cart';
+import { ResponseCartProduct, useShoppingCart } from '@automattic/shopping-cart';
 import { useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
@@ -17,6 +17,14 @@ type EventDataOptions = {
 	productSlug?: string;
 	addProducts?: boolean;
 };
+
+// Record tracks are not allowing objects inside track events
+// so this little hack to provide array reduced into object so it can be spread in the event
+const reduceProducts = ( products: ResponseCartProduct[] ) =>
+	products.reduce( ( res, item ) => {
+		res[ `cart_has_product_slug_${ item.product_slug }` ] = true;
+		return res;
+	}, {} as any ); //eslint-disable-line @typescript-eslint/no-explicit-any
 
 export const useShoppingCartTracker = () => {
 	const siteId = useSelector( getSelectedSiteId );
@@ -43,6 +51,7 @@ export const useShoppingCartTracker = () => {
 			if ( addProducts ) {
 				eventData = {
 					...eventData,
+					...reduceProducts( responseCart.products ),
 					product_slugs_concatenated: responseCart.products.sort().join( '-' ),
 					number_of_products: responseCart.products.length,
 				};

--- a/client/my-sites/plans/jetpack-plans/product-store/hooks/use-shopping-cart-tracker.ts
+++ b/client/my-sites/plans/jetpack-plans/product-store/hooks/use-shopping-cart-tracker.ts
@@ -1,0 +1,63 @@
+import { ResponseCartProduct, useShoppingCart } from '@automattic/shopping-cart';
+import { useCallback } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
+import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+
+type EventData = {
+	site_id: number | null;
+	selected_product?: string;
+	number_of_products?: number;
+	[ key: string ]: string | number | null | undefined;
+};
+
+type EventDataOptions = {
+	productSlug?: string;
+	addProducts?: boolean;
+};
+
+// Record tracks are not allowing objects inside track events
+// so this little hack to provide array reduced into object so it can be spread in the event
+const reduceProducts = ( products: ResponseCartProduct[] ) =>
+	products.reduce( ( res, item, index ) => {
+		res[ `cart_product_${ index }` ] = item.product_slug;
+		return res;
+	}, {} as any ); //eslint-disable-line @typescript-eslint/no-explicit-any
+
+export const useShoppingCartTracker = () => {
+	const siteId = useSelector( getSelectedSiteId );
+	const cartKey = useCartKey();
+	const { responseCart } = useShoppingCart( cartKey );
+	const dispatch = useDispatch();
+
+	return useCallback(
+		( eventName: string, { productSlug, addProducts }: EventDataOptions ) => {
+			// We do need this only for Jetpack cloud
+			// If we want to use it everywhere we could move it as a parameter in event
+			if ( ! isJetpackCloud() ) {
+				return;
+			}
+
+			let eventData: EventData = {
+				site_id: siteId,
+			};
+
+			if ( productSlug ) {
+				eventData[ 'selected_product' ] = productSlug;
+			}
+
+			if ( addProducts ) {
+				eventData = {
+					...eventData,
+					...reduceProducts( responseCart.products ),
+					number_of_products: responseCart.products.length,
+				};
+			}
+
+			dispatch( recordTracksEvent( eventName, eventData ) );
+		},
+		[ dispatch, siteId, responseCart ]
+	);
+};


### PR DESCRIPTION
#### Proposed Changes

This PR adds tracking events on Shopping cart actions in order to see users' behaviour.  The list of things we want to track:
- Every time the user clicks on “Add to cart”
- Every time the users click on “Go to checkout” (include data of all products in the cart)
- Every time the user removes an item from the cart (in the confirm popup/dialog)
- Every time the user opens an empty cart

**Note** Changes end up a bit tricky due to tracking event limitations, so please share if you see a better way.

#### Testing Instructions
- Clone the branch locally and run it **OR** use Jetpack Cloud live links from this PR
- Create new JN site
- navigate to http://jetpack.cloud.localhost:3000/pricing/:site?view=products or [live link]/pricing/:site?view=products
- Open redux helper in your browser and observe events sent on different actions.
- Make sure that there is no errors in the console and that events are sent.


<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->



#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
1203495437860512-as-1203534015891195/f

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203534015891195