### PR TITLE
Data Stores: Add handling for undefined site options in getSite

### DIFF
--- a/packages/data-stores/src/site/selectors.ts
+++ b/packages/data-stores/src/site/selectors.ts
@@ -28,7 +28,7 @@ export const getSite = ( state: State, siteId: number | string ) => {
 		// Then try matching second domain
 		Object.values( state.sites ).find(
 			( site ) =>
-				site && site.options.unmapped_url && new URL( site.options.unmapped_url ).host === siteId
+				site?.options?.unmapped_url && new URL( site.options.unmapped_url ).host === siteId
 		)
 	);
 };


### PR DESCRIPTION
#### Proposed Changes

Discovered while investigating #71282.

Addresses an edge case introduced by #69671. Some sites will not have a defined `options` object, as noted in [this comment](https://github.com/Automattic/wp-calypso/issues/71282#issuecomment-1355536647). 

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Try navigating to `wordpress.com/stats/day/:siteSlug` for a Jetpack site. I used site 103325115.
2. Note the errors thrown in the browser console:

<img width="783" alt="image" src="https://user-images.githubusercontent.com/4044428/208184885-6ce3d9bb-271e-4112-81ac-76a46dd5b498.png">

3. Try step 1 again, but with either a live branch or this branch in a local instance.
4. Ensure that no errors are thrown in the browser console.
5. Also, ensure all the unit tests pass.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
