### PR TITLE
Move /stats/ banner above the fold

### DIFF
--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -248,6 +248,12 @@ class StatsSite extends Component {
 
 				<div id="my-stats-content" className={ wrapperClass }>
 					<>
+						{ /** Promo Card is disabled for Odyssey because it doesn't make much sense in the context, which also removes an API call to `plugins`. */ }
+						<MobilePromoCardWrapper
+							isJetpack={ isJetpack }
+							isOdysseyStats={ isOdysseyStats }
+							slug={ slug }
+						/>
 						<StatsPeriodHeader>
 							<StatsPeriodNavigation
 								date={ date }
@@ -367,12 +373,6 @@ class StatsSite extends Component {
 						}
 					</div>
 				</div>
-				{ /** Promo Card is disabled for Odyssey because it doesn't make much sense in the context, which also removes an API call to `plugins`. */ }
-				<MobilePromoCardWrapper
-					isJetpack={ isJetpack }
-					isOdysseyStats={ isOdysseyStats }
-					slug={ slug }
-				/>
 				<JetpackColophon />
 			</div>
 		);


### PR DESCRIPTION
#### Proposed Changes

Move the banner on /stats/ above the fold to increase impressions and potentially clicks.

Before | After
--|--
![stats-banner-location-before](https://user-images.githubusercontent.com/140841/208186608-f2fc506b-ccd8-42fe-afa7-4796d6443e16.png)  | ![stats-banner-location-after](https://user-images.githubusercontent.com/140841/208186614-d786edd1-d604-49a7-817f-0c15cdc9f8a3.png)


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Load this PR
* View the banner is above the fold on /stats/day/{site}
* Banner still functions properly

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/1389
