### PR TITLE
Checkout: add VAT fields to tax fields

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/tax-fields.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/tax-fields.tsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import {
 	Field,
 	tryToGuessPostalCodeFormat,
@@ -53,7 +54,9 @@ export default function TaxFields( {
 		countriesList.length && countryCode?.value
 			? getCountryPostalCodeSupport( countriesList, countryCode.value )
 			: false;
-	const isVatSupported = Boolean( countryCode?.value && isVatSupportedFor( countryCode.value ) );
+	const isVatSupported =
+		config.isEnabled( 'checkout/vat-form' ) &&
+		Boolean( countryCode?.value && isVatSupportedFor( countryCode.value ) );
 
 	return (
 		<>

--- a/client/my-sites/checkout/composite-checkout/components/tax-fields.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/tax-fields.tsx
@@ -8,6 +8,7 @@ import { useTranslate } from 'i18n-calypso';
 import { isValid } from '../types/wpcom-store-state';
 import CountrySelectMenu from './country-select-menu';
 import { LeftColumn, RightColumn } from './ie-fallback';
+import { VatForm, isVatSupportedFor } from './vat-form';
 import type {
 	CountryListItem,
 	ManagedContactDetails,
@@ -52,53 +53,59 @@ export default function TaxFields( {
 		countriesList.length && countryCode?.value
 			? getCountryPostalCodeSupport( countriesList, countryCode.value )
 			: false;
+	const isVatSupported = Boolean( countryCode?.value && isVatSupportedFor( countryCode.value ) );
 
 	return (
-		<FieldRow>
-			<LeftColumn>
-				<CountrySelectMenu
-					translate={ translate }
-					onChange={ ( event: ChangeEvent< HTMLSelectElement > ) => {
-						onChange( {
-							countryCode: { value: event.target.value, errors: [], isTouched: true },
-							postalCode: updatePostalCodeForCountry( postalCode, countryCode, countriesList ),
-						} );
-					} }
-					isError={ countryCode?.isTouched && ! isValid( countryCode ) }
-					isDisabled={ isDisabled }
-					errorMessage={ countryCode?.errors[ 0 ] ?? translate( 'This field is required.' ) }
-					currentValue={ countryCode?.value }
-					countriesList={ countriesList }
-				/>
-			</LeftColumn>
-
-			{ arePostalCodesSupported && (
-				<RightColumn>
-					<Field
-						id={ section + '-postal-code' }
-						type="text"
-						label={ String( translate( 'Postal code' ) ) }
-						value={ postalCode?.value ?? '' }
-						disabled={ isDisabled }
-						onChange={ ( newValue: string ) => {
+		<>
+			<FieldRow>
+				<LeftColumn>
+					<CountrySelectMenu
+						translate={ translate }
+						onChange={ ( event: ChangeEvent< HTMLSelectElement > ) => {
 							onChange( {
-								countryCode,
-								postalCode: updatePostalCodeForCountry(
-									{ value: newValue.toUpperCase(), errors: [], isTouched: true },
-									countryCode,
-									countriesList
-								),
+								countryCode: { value: event.target.value, errors: [], isTouched: true },
+								postalCode: updatePostalCodeForCountry( postalCode, countryCode, countriesList ),
 							} );
 						} }
-						autoComplete={ section + ' postal-code' }
-						isError={ postalCode?.isTouched && ! isValid( postalCode ) }
-						errorMessage={
-							postalCode?.errors[ 0 ] ?? String( translate( 'This field is required.' ) )
-						}
+						isError={ countryCode?.isTouched && ! isValid( countryCode ) }
+						isDisabled={ isDisabled }
+						errorMessage={ countryCode?.errors[ 0 ] ?? translate( 'This field is required.' ) }
+						currentValue={ countryCode?.value }
+						countriesList={ countriesList }
 					/>
-				</RightColumn>
+				</LeftColumn>
+
+				{ arePostalCodesSupported && (
+					<RightColumn>
+						<Field
+							id={ section + '-postal-code' }
+							type="text"
+							label={ String( translate( 'Postal code' ) ) }
+							value={ postalCode?.value ?? '' }
+							disabled={ isDisabled }
+							onChange={ ( newValue: string ) => {
+								onChange( {
+									countryCode,
+									postalCode: updatePostalCodeForCountry(
+										{ value: newValue.toUpperCase(), errors: [], isTouched: true },
+										countryCode,
+										countriesList
+									),
+								} );
+							} }
+							autoComplete={ section + ' postal-code' }
+							isError={ postalCode?.isTouched && ! isValid( postalCode ) }
+							errorMessage={
+								postalCode?.errors[ 0 ] ?? String( translate( 'This field is required.' ) )
+							}
+						/>
+					</RightColumn>
+				) }
+			</FieldRow>
+			{ isVatSupported && (
+				<VatForm section={ section } isDisabled={ isDisabled } countryCode={ countryCode?.value } />
 			) }
-		</FieldRow>
+		</>
 	);
 }
 

--- a/client/my-sites/checkout/composite-checkout/components/vat-form/index.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/vat-form/index.tsx
@@ -1,0 +1,210 @@
+import { Field, VatDetails } from '@automattic/wpcom-checkout';
+import { CheckboxControl } from '@wordpress/components';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { useTranslate } from 'i18n-calypso';
+import { useState, useEffect, useRef } from 'react';
+import { useDispatch as useReduxDispatch } from 'react-redux';
+import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
+import { CALYPSO_CONTACT } from 'calypso/lib/url/support';
+import useVatDetails from 'calypso/me/purchases/vat-info/use-vat-details';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+
+import './style.css';
+
+const countriesSupportingVat = [
+	'AT',
+	'BE',
+	'BG',
+	'CY',
+	'CZ',
+	'DE',
+	'DK',
+	'EE',
+	'EL',
+	'ES',
+	'FI',
+	'FR',
+	'HR',
+	'HU',
+	'IE',
+	'IT',
+	'LT',
+	'LU',
+	'LV',
+	'MT',
+	'NL',
+	'PL',
+	'PT',
+	'RO',
+	'SE',
+	'SI',
+	'SK',
+	'GB',
+	'XI',
+];
+
+export function isVatSupportedFor( countryCode: string ): boolean {
+	return Boolean( countriesSupportingVat.includes( countryCode ) );
+}
+
+export function VatForm( {
+	section,
+	isDisabled,
+	countryCode,
+}: {
+	section: string;
+	isDisabled?: boolean;
+	countryCode: string | undefined;
+} ) {
+	const translate = useTranslate();
+	const vatDetails: VatDetails = useSelect( ( select ) =>
+		select( 'wpcom-checkout' ).getVatDetails()
+	);
+	const wpcomStoreActions = useDispatch( 'wpcom-checkout' );
+	const setVatDetails = wpcomStoreActions.setVatDetails as ( vat: VatDetails ) => void;
+	const { vatDetails: savedVatDetails, isLoading: isLoadingVatDetails } = useVatDetails();
+	const [ isFormActive, setIsFormActive ] = useState< boolean >( false );
+
+	// Pre-populate the fields based on the VAT details endpoint. The cached
+	// contact details endpoint _does_ store organization, but does not store
+	// vatId, and anyway we have a different endpoint for VAT details which is
+	// what this form should use.
+	const didPreFill = useRef( false );
+	useEffect( () => {
+		if ( isLoadingVatDetails ) {
+			return;
+		}
+		if ( didPreFill.current ) {
+			return;
+		}
+		didPreFill.current = true;
+		setVatDetails( savedVatDetails );
+		setIsFormActive( Boolean( savedVatDetails.id ) );
+	}, [ setVatDetails, savedVatDetails, isLoadingVatDetails ] );
+
+	const reduxDispatch = useReduxDispatch();
+
+	if ( isLoadingVatDetails ) {
+		return null;
+	}
+
+	const toggleVatForm = ( isChecked: boolean ) => {
+		if ( ! isChecked ) {
+			// Clear the VAT form when the checkbox is unchecked so that the VAT
+			// details are not sent to the server.
+			setVatDetails( {} );
+		} else {
+			// Pre-fill the VAT form when the checkbox is checked.
+			setVatDetails( savedVatDetails );
+		}
+		setIsFormActive( isChecked );
+	};
+
+	// Northern Ireland is technically in GB but its VAT details need to be
+	// registered with the special (non-ISO) 'XI' country code.
+	const toggleNorthernIreland = ( isChecked: boolean ) => {
+		if ( ! isChecked ) {
+			setVatDetails( {
+				...vatDetails,
+				country: countryCode,
+			} );
+		} else {
+			setVatDetails( {
+				...vatDetails,
+				country: 'XI',
+			} );
+		}
+	};
+
+	const clickSupport = () => {
+		reduxDispatch( recordTracksEvent( 'calypso_vat_details_support_click' ) );
+	};
+
+	if ( ! isFormActive ) {
+		return (
+			<div className="vat-form__row">
+				<CheckboxControl
+					className="vat-form__expand-button"
+					checked={ isFormActive }
+					onChange={ toggleVatForm }
+					label={ translate( 'Add VAT details' ) }
+					disabled={ isDisabled }
+				/>
+			</div>
+		);
+	}
+
+	return (
+		<>
+			<div className="vat-form__row">
+				<CheckboxControl
+					className="vat-form__expand-button"
+					checked={ isFormActive }
+					onChange={ toggleVatForm }
+					label={ translate( 'Add VAT details' ) }
+				/>
+				{ countryCode === 'GB' && (
+					<CheckboxControl
+						className="vat-form__expand-button"
+						checked={ vatDetails.country === 'XI' }
+						onChange={ toggleNorthernIreland }
+						label={ translate( 'Is the VAT for Northern Ireland?' ) }
+						disabled={ isDisabled }
+					/>
+				) }
+			</div>
+			<div className="vat-form__row">
+				<Field
+					id={ section + '-organization' }
+					type="text"
+					label={ String( translate( 'Organization for VAT' ) ) }
+					value={ vatDetails.name ?? '' }
+					autoComplete="organization"
+					disabled={ isDisabled }
+					onChange={ ( newValue: string ) => {
+						setVatDetails( {
+							...vatDetails,
+							country: vatDetails.country || countryCode,
+							name: newValue,
+						} );
+					} }
+				/>
+				<Field
+					id={ section + '-vat-id' }
+					type="text"
+					label={ String( translate( 'VAT Number' ) ) }
+					value={ vatDetails.id ?? '' }
+					disabled={ isDisabled || Boolean( savedVatDetails.id ) }
+					onChange={ ( newValue: string ) => {
+						setVatDetails( {
+							...vatDetails,
+							country: vatDetails.country || countryCode,
+							id: newValue,
+						} );
+					} }
+				/>
+			</div>
+			{ savedVatDetails.id && (
+				<div>
+					<FormSettingExplanation>
+						{ translate(
+							'To change your VAT number, {{contactSupportLink}}please contact support{{/contactSupportLink}}.',
+							{
+								components: {
+									contactSupportLink: (
+										<a
+											target="_blank"
+											href={ CALYPSO_CONTACT }
+											rel="noreferrer"
+											onClick={ clickSupport }
+										/>
+									),
+								},
+							}
+						) }
+					</FormSettingExplanation>
+				</div>
+			) }
+		</>
+	);
+}

--- a/client/my-sites/checkout/composite-checkout/components/vat-form/style.css
+++ b/client/my-sites/checkout/composite-checkout/components/vat-form/style.css
@@ -1,0 +1,11 @@
+.vat-form__row {
+	display: -ms-grid;
+	display: grid;
+	width: 100%;
+	-ms-grid-columns: 48% 4% 48%;
+	grid-template-columns: 48% 48%;
+	grid-column-gap: 4%;
+	justify-items: stretch;
+	margin-top: 16px;
+}
+

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
@@ -64,7 +64,11 @@ import WPContactFormSummary from './wp-contact-form-summary';
 import type { OnChangeItemVariant } from './item-variation-picker';
 import type { CheckoutPageErrorCallback } from '@automattic/composite-checkout';
 import type { RemoveProductFromCart, MinimalRequestCartProduct } from '@automattic/shopping-cart';
-import type { CountryListItem, ManagedContactDetails } from '@automattic/wpcom-checkout';
+import type {
+	CountryListItem,
+	ManagedContactDetails,
+	VatDetails,
+} from '@automattic/wpcom-checkout';
 
 const debug = debugFactory( 'calypso:composite-checkout:wp-checkout' );
 
@@ -185,6 +189,8 @@ export default function WPCheckout( {
 	const contactInfo: ManagedContactDetails = useSelect( ( sel ) =>
 		sel( 'wpcom-checkout' ).getContactInfo()
 	);
+
+	const vatDetails: VatDetails = useSelect( ( sel ) => sel( 'wpcom-checkout' ).getVatDetails() );
 
 	const {
 		touchContactFields,
@@ -378,7 +384,8 @@ export default function WPCheckout( {
 									countriesList,
 									responseCart,
 									updateLocation,
-									contactInfo
+									contactInfo,
+									vatDetails
 								);
 							} catch {
 								// If updating the cart fails, we should not continue. No need

--- a/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts
@@ -99,12 +99,14 @@ export function createTransactionEndpointCartFromResponseCart( {
 function createTransactionEndpointTaxFromResponseCartTax(
 	tax: ResponseCartTaxData
 ): RequestCartTaxData {
-	const { country_code, postal_code, subdivision_code } = tax.location;
+	const { country_code, postal_code, subdivision_code, vat_id, organization } = tax.location;
 	return {
 		location: {
 			country_code,
 			postal_code,
 			subdivision_code,
+			vat_id,
+			organization,
 		},
 	};
 }

--- a/client/my-sites/checkout/composite-checkout/lib/update-cart-contact-details-for-checkout.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/update-cart-contact-details-for-checkout.ts
@@ -1,13 +1,21 @@
 import { getCountryPostalCodeSupport } from '@automattic/wpcom-checkout';
 import getContactDetailsType from '../lib/get-contact-details-type';
 import type { ResponseCart, UpdateTaxLocationInCart } from '@automattic/shopping-cart';
-import type { ManagedContactDetails, CountryListItem } from '@automattic/wpcom-checkout';
+import type {
+	ManagedContactDetails,
+	CountryListItem,
+	VatDetails,
+} from '@automattic/wpcom-checkout';
 
+/**
+ * Update the shopping cart's tax location to adjust its prices.
+ */
 export async function updateCartContactDetailsForCheckout(
 	countriesList: CountryListItem[],
 	responseCart: ResponseCart,
 	updateLocation: UpdateTaxLocationInCart,
-	contactInfo: ManagedContactDetails | undefined
+	contactInfo: ManagedContactDetails | undefined,
+	vatDetails: VatDetails
 ): Promise< void | ResponseCart > {
 	const areCountriesLoaded = !! countriesList.length;
 	const arePostalCodesSupported =
@@ -25,8 +33,14 @@ export async function updateCartContactDetailsForCheckout(
 	// try to update it when the field does not exist.
 	const subdivisionCode = contactDetailsType === 'tax' ? undefined : contactInfo.state?.value;
 	return updateLocation( {
-		countryCode: contactInfo.countryCode?.value,
+		// Typically the contact country code and the VAT country code will be the
+		// same, but the VAT form has special country codes it sometimes uses like
+		// `XI` for Northern Ireland so we keep track of them separately and will
+		// use whichever one for taxes that is more appropriate.
+		countryCode: vatDetails.country || contactInfo.countryCode?.value || '',
 		postalCode: arePostalCodesSupported ? contactInfo.postalCode?.value : '',
 		subdivisionCode,
+		vatId: vatDetails.id ?? '',
+		organization: vatDetails.name ?? '',
 	} );
 }

--- a/client/my-sites/checkout/composite-checkout/test/checkout-payment-method-list.js
+++ b/client/my-sites/checkout/composite-checkout/test/checkout-payment-method-list.js
@@ -5,6 +5,7 @@ import { StripeHookProvider } from '@automattic/calypso-stripe';
 import { ShoppingCartProvider, createShoppingCartManagerClient } from '@automattic/shopping-cart';
 import { render, screen, waitFor } from '@testing-library/react';
 import nock from 'nock';
+import { QueryClient, QueryClientProvider } from 'react-query';
 import { Provider as ReduxProvider } from 'react-redux';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import { isMarketplaceProduct } from 'calypso/state/products-list/selectors';
@@ -60,6 +61,7 @@ describe( 'Checkout payment methods list', () => {
 		} );
 
 		const store = createTestReduxStore();
+		const queryClient = new QueryClient();
 
 		MyCheckout = ( { cartChanges, additionalProps, additionalCartProps, useUndefinedCartKey } ) => {
 			const managerClient = createShoppingCartManagerClient( {
@@ -69,26 +71,29 @@ describe( 'Checkout payment methods list', () => {
 			const mainCartKey = 'foo.com';
 			useCartKey.mockImplementation( () => ( useUndefinedCartKey ? undefined : mainCartKey ) );
 			nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
+			nock( 'https://public-api.wordpress.com' ).get( '/rest/v1.1/me/vat-info' ).reply( 200, {} );
 			mockMatchMediaOnWindow();
 			return (
 				<ReduxProvider store={ store }>
-					<ShoppingCartProvider
-						managerClient={ managerClient }
-						options={ {
-							defaultCartKey: useUndefinedCartKey ? undefined : mainCartKey,
-						} }
-						{ ...additionalCartProps }
-					>
-						<StripeHookProvider fetchStripeConfiguration={ fetchStripeConfiguration }>
-							<CheckoutMain
-								siteId={ siteId }
-								siteSlug="foo.com"
-								getStoredCards={ async () => [] }
-								overrideCountryList={ countryList }
-								{ ...additionalProps }
-							/>
-						</StripeHookProvider>
-					</ShoppingCartProvider>
+					<QueryClientProvider client={ queryClient }>
+						<ShoppingCartProvider
+							managerClient={ managerClient }
+							options={ {
+								defaultCartKey: useUndefinedCartKey ? undefined : mainCartKey,
+							} }
+							{ ...additionalCartProps }
+						>
+							<StripeHookProvider fetchStripeConfiguration={ fetchStripeConfiguration }>
+								<CheckoutMain
+									siteId={ siteId }
+									siteSlug="foo.com"
+									getStoredCards={ async () => [] }
+									overrideCountryList={ countryList }
+									{ ...additionalProps }
+								/>
+							</StripeHookProvider>
+						</ShoppingCartProvider>
+					</QueryClientProvider>
 				</ReduxProvider>
 			);
 		};

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout-variant-picker.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout-variant-picker.tsx
@@ -6,6 +6,7 @@ import { ShoppingCartProvider, createShoppingCartManagerClient } from '@automatt
 import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import nock from 'nock';
+import { QueryClient, QueryClientProvider } from 'react-query';
 import { Provider as ReduxProvider } from 'react-redux';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import { isMarketplaceProduct } from 'calypso/state/products-list/selectors';
@@ -82,7 +83,9 @@ describe( 'CheckoutMain with a variant picker', () => {
 		} );
 
 		const store = createTestReduxStore();
+		const queryClient = new QueryClient();
 		nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
+		nock( 'https://public-api.wordpress.com' ).get( '/rest/v1.1/me/vat-info' ).reply( 200, {} );
 		Object.defineProperty( window, 'matchMedia', {
 			writable: true,
 			value: jest.fn().mockImplementation( ( query ) => ( {
@@ -108,24 +111,26 @@ describe( 'CheckoutMain with a variant picker', () => {
 			);
 			return (
 				<ReduxProvider store={ store }>
-					<ShoppingCartProvider
-						managerClient={ managerClient }
-						options={ {
-							defaultCartKey: useUndefinedCartKey ? undefined : mainCartKey,
-						} }
-						{ ...additionalCartProps }
-					>
-						<StripeHookProvider fetchStripeConfiguration={ fetchStripeConfiguration }>
-							<CheckoutMain
-								forceRadioButtons={ true }
-								siteId={ siteId }
-								siteSlug="foo.com"
-								getStoredCards={ async () => [] }
-								overrideCountryList={ countryList }
-								{ ...additionalProps }
-							/>
-						</StripeHookProvider>
-					</ShoppingCartProvider>
+					<QueryClientProvider client={ queryClient }>
+						<ShoppingCartProvider
+							managerClient={ managerClient }
+							options={ {
+								defaultCartKey: useUndefinedCartKey ? undefined : mainCartKey,
+							} }
+							{ ...additionalCartProps }
+						>
+							<StripeHookProvider fetchStripeConfiguration={ fetchStripeConfiguration }>
+								<CheckoutMain
+									forceRadioButtons={ true }
+									siteId={ siteId }
+									siteSlug="foo.com"
+									getStoredCards={ async () => [] }
+									overrideCountryList={ countryList }
+									{ ...additionalProps }
+								/>
+							</StripeHookProvider>
+						</ShoppingCartProvider>
+					</QueryClientProvider>
 				</ReduxProvider>
 			);
 		};
@@ -203,6 +208,7 @@ describe( 'CheckoutMain with a variant picker', () => {
 			} ) );
 			const cartChanges = { products: [ getBusinessPlanForInterval( cartPlan ) ] };
 			nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
+			nock( 'https://public-api.wordpress.com' ).get( '/rest/v1.1/me/vat-info' ).reply( 200, {} );
 			render( <MyCheckout cartChanges={ cartChanges } /> );
 
 			await screen.findByLabelText( 'Pick a product term' );

--- a/client/my-sites/checkout/composite-checkout/test/util/index.ts
+++ b/client/my-sites/checkout/composite-checkout/test/util/index.ts
@@ -74,6 +74,21 @@ export const countryList: CountryListItem[] = [
 		name: 'Australia',
 		has_postal_codes: true,
 	},
+	{
+		code: 'ES',
+		name: 'Spain',
+		has_postal_codes: true,
+	},
+	{
+		code: 'CA',
+		name: 'Canada',
+		has_postal_codes: true,
+	},
+	{
+		code: 'GB',
+		name: 'United Kingdom',
+		has_postal_codes: true,
+	},
 ];
 
 export const siteId = 13579;

--- a/config/development.json
+++ b/config/development.json
@@ -31,6 +31,7 @@
 		"calypsoify/plugins": true,
 		"cancellation-offers": true,
 		"checkout/google-pay": true,
+		"checkout/vat-form": true,
 		"cloudflare": true,
 		"comments/filters-in-posts": true,
 		"current-site/domain-warning": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -17,6 +17,7 @@
 		"cancellation-offers": true,
 		"catch-js-errors": true,
 		"checkout/google-pay": true,
+		"checkout/vat-form": false,
 		"cloudflare": true,
 		"composite-checkout-testing": true,
 		"current-site/domain-warning": true,

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -31,6 +31,7 @@
 		"activity-log/v2": true,
 		"always_use_logout_url": true,
 		"checkout/google-pay": false,
+		"checkout/vat-form": false,
 		"current-site/domain-warning": false,
 		"current-site/notice": false,
 		"current-site/stale-cart-notice": false,

--- a/config/jetpack-cloud-horizon.json
+++ b/config/jetpack-cloud-horizon.json
@@ -28,6 +28,7 @@
 		"activity-log/v2": true,
 		"always_use_logout_url": false,
 		"checkout/google-pay": true,
+		"checkout/vat-form": false,
 		"current-site/domain-warning": false,
 		"current-site/notice": false,
 		"current-site/stale-cart-notice": false,

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -30,6 +30,7 @@
 		"ad-tracking": true,
 		"always_use_logout_url": true,
 		"checkout/google-pay": false,
+		"checkout/vat-form": false,
 		"current-site/domain-warning": false,
 		"current-site/notice": false,
 		"current-site/stale-cart-notice": false,

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -30,6 +30,7 @@
 		"ad-tracking": false,
 		"always_use_logout_url": true,
 		"checkout/google-pay": false,
+		"checkout/vat-form": false,
 		"current-site/domain-warning": false,
 		"current-site/notice": false,
 		"current-site/stale-cart-notice": false,

--- a/config/production.json
+++ b/config/production.json
@@ -23,6 +23,7 @@
 		"cancellation-offers": true,
 		"catch-js-errors": true,
 		"checkout/google-pay": true,
+		"checkout/vat-form": false,
 		"cloudflare": true,
 		"current-site/domain-warning": true,
 		"current-site/notice": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -20,6 +20,7 @@
 		"cancellation-offers": true,
 		"catch-js-errors": true,
 		"checkout/google-pay": true,
+		"checkout/vat-form": false,
 		"cloudflare": true,
 		"current-site/domain-warning": true,
 		"current-site/notice": true,

--- a/config/test.json
+++ b/config/test.json
@@ -28,6 +28,7 @@
 		"cancellation-offers": true,
 		"catch-js-errors": false,
 		"checkout/google-pay": true,
+		"checkout/vat-form": true,
 		"cloudflare": true,
 		"current-site/domain-warning": true,
 		"current-site/notice": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -20,6 +20,7 @@
 		"cancellation-offers": true,
 		"catch-js-errors": true,
 		"checkout/google-pay": true,
+		"checkout/vat-form": true,
 		"cloudflare": true,
 		"current-site/domain-warning": true,
 		"current-site/notice": true,


### PR DESCRIPTION
#### Proposed Changes

This PR adds a VAT and an Organization field to the `TaxFields` component which is rendered as the first step of checkout if there is no domain product or GSuite product in the cart.

The fields are only made available if the country code selected in the tax form is one of a set of hard-coded countries that support VAT.

**Currently this new field will not be visible in production as it is behind a feature flag.**

Unlike the other fields in the contact form which pre-populate from and update the cached contact details endpoints, the VAT fields pre-populate from and send their updates to the existing VAT details endpoints used by the calypso VAT pages (see https://github.com/Automattic/wp-calypso/pull/53133). This means that the fields are subject to the same validation and restrictions of that form (eg: it's not possible to edit the VAT ID once it's been set for the user). In effect, these fields are just another interface to the existing VAT form under `/me/purchases/vat-details`. _However_, there are two differences: 

First, the checkout version of the form does not include the "Address" field. I did this intentionally because I felt that it cluttered the form, added friction, and may not actually be required. I also did it because once we add this form to the domain form, which already includes address fields, it's likely to feel redundant and awkward (we can't use those address fields because they are separated into address1/address2/city/state/etc.).

Second, the `/me/purchases/vat-details` form uses the country code `UK` for the United Kingdom (which is incorrect; see https://github.com/Automattic/payments-shilling/issues/1276) and this form uses `GB`. This won't be as much of an issue after https://github.com/Automattic/wp-calypso/pull/72513.

The information collected by this form is sent to three endpoints: the VAT details endpoint, the shopping-cart endpoint (along with other tax data), and the transactions endpoint (as part of the shopping-cart data). **It's worth noting that if the checkbox that displays the form is _not checked_, the data _will not_ be sent to the shopping-cart endpoint or the transactions endpoint even if it's saved to the VAT details endpoint.** This is by design so that users can chose to apply their VAT information on a per-transaction basis.

Part of https://github.com/Automattic/payments-shilling/issues/1278

#### Screenshots

VAT checkbox unchecked:

<img width="566" alt="vat-unchecked" src="https://user-images.githubusercontent.com/2036909/214172441-8574719e-ed57-49ee-a6dd-8b3595067f0b.png">

VAT checkbox checked:

<img width="568" alt="vat-unfilled" src="https://user-images.githubusercontent.com/2036909/214172466-d4d4feb2-c204-47f2-bfcf-31f2050a984e.png">

VAT checkbox checked for UK:

<img width="569" alt="vat-uk-unfilled" src="https://user-images.githubusercontent.com/2036909/214172490-df778587-54a9-4dde-bf8e-51be4cd49957.png">

VAT checkbox pre-filled:

<img width="572" alt="vat-pre-filled" src="https://user-images.githubusercontent.com/2036909/214172522-daa438ea-7f4f-4c04-b118-638d4a258f8a.png">

#### To do

- [x] Show fields for applicable countries.
- [x] Toggle fields with checkbox.
- [x] When fields are hidden (due to checkbox or unsupported country), do not send their values to any endpoints (validate, cache, transactions, cart).
- [x] ~Send fields for validation when completing contact details step.~ This may not be a blocker since the VAT endpoint does its own validation.
- [x] Send fields to shopping cart. Requires D96395-code
- [x] ~Send fields to cached contact details. This works for organization but VAT isn't stored by the endpoint currently, which is fine because we'll be using the VAT endpoint.~ This is no longer needed. We will use the vat details endpoint to handle caching.
- [x] Send fields to VAT endpoint when completing (valid) contact details step.
- [x] Display error if updating VAT endpoint fails.
- [x] Prefill fields from VAT endpoint.
- [x] Make fields non-editable if they have already been set for the user.
- [x] Send fields to transactions endpoint as part of cart when checkout is submitted.
- [x] Add tests for these fields.
- [x] Use a special country code for Northern Ireland.

#### Testing Instructions

##### Testing normal behavior

- On this branch, add a non-domain, non-gsuite product to your cart and visit checkout.
- If the checkout contact/billing details step is automatically completed, click the "Edit" button to make it active.
- Select a non-VAT country like "United States" in the country field.
- Verify that you see _only_ the country and (optionally) postal code fields. Neither the VAT fields nor the VAT checkbox should be visible.
- Click to continue past the step and verify that no VAT errors occur.

##### Testing that the fields work

- Click to edit the step again.
- Select a VAT country like "United Kingdom" in the country field and a valid postal code number like `NW1 4NP`.
- Verify that you see the VAT checkbox appear.
- Click the checkbox and verify that the VAT fields appear. Set the VAT Number to an invalid one like `1234` and the company name to `Test company` and click continue to complete the step.
- Verify that you see a validation error and that the step remains active.
- Change the VAT Number to a valid one like `553557881` and click continue to complete the step. (Note: this is a test number that will only work when the API is sandboxed).
- Verify that the validation is successful and that the step completes.
- Click to edit the step again.
- Verify that you can no longer edit the VAT Number.
- Visit `/me/purchases/vat-details` and verify that the form there has the same information entered in checkout.
- Return to checkout, edit the step again, and verify that the form is pre-populated with the VAT details you entered before.

##### Verifying the data is sent correctly

- Open your browser's devtools panel to monitor network traffic and look for transactions to the `/me/shopping-cart` endpoint.
- Click to complete the step and verify that the shopping-cart endpoint request includes the VAT information in its `tax` property.
- Edit the step again and uncheck the VAT checkbox, hiding the new fields.
- Click to complete the step and verify that the shopping-cart endpoint request _does not_ include the VAT information in its `tax` property.

