### PR TITLE
Theme Showcase: Fix issue where category filters are not rendered

### DIFF
--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -222,7 +222,7 @@ class ThemeShowcase extends Component {
 			return tabFilter;
 		}
 
-		const filterKey = matches[ matches.length - 1 ].split( ':' ).pop();
+		const filterKey = matches[ matches.length - 1 ];
 		Object.values( this.tabFilters ).map( ( filter ) => {
 			if ( filter.key === filterKey ) {
 				tabFilter = filter;


### PR DESCRIPTION
#### Proposed Changes

**The problem**
In my local development environment, I noticed that the category filters are no longer rendering. 
![Screen Shot 2022-12-17 at 2 19 58 PM](https://user-images.githubusercontent.com/797888/208232254-07272f38-f8c0-42c6-8039-98cca1c4395c.png)

This only happens when the Theme Showcase is accessed directly via URL. Opening the dashboard and navigating to the Theme Showcase worked fine, for instance. After some investigation, I realized that this the because (1) sandbox API is slower than production, and (2) there are A LOT of network requests for the Theme Showcase, and much more when accessed directly.

**Why didn't it happen before?**
Short answer: The Theme Showcase is getting more, and more features added in. Just in the last week, we've added global styles (#71041) and product query (#70406). This results in a very congested initial load for the Theme Showcase.

| Accessed directly via URL | Access from navigating within the dashboard |
| --- | --- |
| ![Screen Shot 2022-12-17 at 10 12 56 PM](https://user-images.githubusercontent.com/797888/208246809-660f0ce5-6611-47d1-b4f5-68fb9120c2c2.png) | ![Screen Shot 2022-12-17 at 10 13 41 PM](https://user-images.githubusercontent.com/797888/208246813-b655288c-3eea-4502-8839-cd8c3208db3b.png)|

And as to why the category filters are no longer rendering, well, we prepare the data needed for the category filters in the Theme Showcase constructor, and assume that the Redux store would have the data available by then. Turns out that's not the case anymore.

**The solution**
Instead of depending on the Redux store to build our category filters, we hard-code the list of category filters, since it's the same for all users and unlikely to change frequently.  We actually already curate the list of category filters by filtering out the subject "newsletters," since we don't have many themes there. 

The downside of this approach is that we will need to update the code whenever subjects in the taxonomy change, but I think it's worth the trade-off for now. Ideally, long-term wise, we spend proper time and make the Theme Showcase leaner.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the Theme Showcase `/themes/${site_slug}`.
* Ensure that the list of category filters works as before.
* Ensure that the logged-out Theme Showcase works as before.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
