### PR TITLE
Stats: remove fade-in animation for spinner

### DIFF
--- a/client/my-sites/stats/stats-module/placeholder.scss
+++ b/client/my-sites/stats/stats-module/placeholder.scss
@@ -15,7 +15,6 @@
 		justify-content: center;
 		align-items: center;
 		opacity: 1;
-		-webkit-animation: delay-fade-in 2s 1; // Animating in this silly way to have the graphic actually be visible once the animation is completed
 	}
 
 	&.is-chart {
@@ -24,18 +23,6 @@
 }
 
 // Module Placeholder
-
-@keyframes delay-fade-in {
-	0%,
-	66% {
-		opacity: 0;
-	}
-
-	100% {
-		opacity: 1;
-	}
-}
-
 .stats-module.is-loading {
 	// Hide elements
 	.module-header .site-icon,


### PR DESCRIPTION
#### Proposed Changes

The PR removes the fade-in animation for spinners which leave the screen blank for almost 2 seconds.

#### Testing Instructions
- Open Calypso Live [(direct link)](https://calypso.live/?image=registry.a8c.com/calypso/app:commit-7632fd6a441f0dea5246e02f512faa1f27d09c7a)
- Open Traffic page
- Ensure loading spinner shows up instantly on reload or periods switch, i.e. no blank screen

Note: It'll be great if the reviewer helps check whether this would break anything. Thanks.

|Before|After|
|------|------|
|  <video  controls  src="https://user-images.githubusercontent.com/1425433/208320537-6f3c439a-1f06-4788-8d16-2ae4d18061fa.mov">   |  <video  controls  src="https://user-images.githubusercontent.com/1425433/208320557-91d46798-9723-436d-acd9-628dfcb4784e.mov">  |

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
