### PR TITLE
Add: `new` query parameter for the Stepper domain step

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
@@ -100,6 +100,7 @@ const DomainsStep: Step = function DomainsStep( { navigation, flow } ) {
 
 	const domainsWithPlansOnly = true;
 	const isPlanSelectionAvailableLaterInFlow = true;
+	const domainSearchInQuery = useQuery().get( 'new' ); // following the convention of /start/domains
 
 	const submitDomainStepSelection = ( suggestion: DomainSuggestion, section: string ) => {
 		let domainType = 'domain_reg';
@@ -358,7 +359,7 @@ const DomainsStep: Step = function DomainsStep( { navigation, flow } ) {
 		if ( domainForm ) {
 			initialState = domainForm;
 		}
-		const initialQuery = siteTitle;
+		const initialQuery = domainSearchInQuery || siteTitle;
 
 		if (
 			// If we landed here from /domains Search or with a suggested domain.
@@ -373,7 +374,8 @@ const DomainsStep: Step = function DomainsStep( { navigation, flow } ) {
 				// filter before counting length
 				initialState.loadingResults =
 					getDomainSuggestionSearch( getFixedDomainSearch( initialQuery ) ).length >= 2;
-				initialState.hideInitialQuery = true;
+				// when it's provided via the query arg, follow the convention of /start/domains to show it
+				initialState.hideInitialQuery = ! domainSearchInQuery;
 			}
 		}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
@@ -80,7 +80,7 @@ const DomainsStep: Step = function DomainsStep( { navigation, flow } ) {
 	// Checks if the user entered the signup flow via browser back from checkout page,
 	// and if they did, we'll show a modified domain step to prevent creating duplicate sites,
 	// check pau2Xa-1Io-p2#comment-6759.
-	const isAddNewSiteFlow = useQuery().get( 'ref' );
+	const isAddNewSiteFlow = useQuery().has( 'ref' );
 	const signupDestinationCookieExists = retrieveSignupDestination();
 	const isReEnteringFlow = getSignupCompleteFlowName() === flow;
 	const isReEnteringSignupViaBrowserBack =

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
@@ -40,6 +40,7 @@ import {
 } from 'calypso/state/domains/actions';
 import { getAvailableProductsList } from 'calypso/state/products-list/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
+import { useQuery } from '../../../../hooks/use-query';
 import { ONBOARD_STORE } from '../../../../stores';
 import type { Step } from '../../types';
 import type { DomainSuggestion, DomainForm } from '@automattic/data-stores';
@@ -79,8 +80,7 @@ const DomainsStep: Step = function DomainsStep( { navigation, flow } ) {
 	// Checks if the user entered the signup flow via browser back from checkout page,
 	// and if they did, we'll show a modified domain step to prevent creating duplicate sites,
 	// check pau2Xa-1Io-p2#comment-6759.
-	const searchParams = new URLSearchParams( window.location.search );
-	const isAddNewSiteFlow = searchParams.has( 'ref' );
+	const isAddNewSiteFlow = useQuery().get( 'ref' );
 	const signupDestinationCookieExists = retrieveSignupDestination();
 	const isReEnteringFlow = getSignupCompleteFlowName() === flow;
 	const isReEnteringSignupViaBrowserBack =


### PR DESCRIPTION
#### Proposed Changes

This PR enables the domains step of Stepper framework to populate its initial query data from the `new` query parameter. It's the convention of the classic `/start/domains`, and also the required feature for the dotlink version of Link in Bio flow.  

#### Testing Instructions

* Access `/setup/link-in-bio-tld/?new=blahblah`, and the search box should be pre-populated by the string given in `new`.
* Access `/setup/link-in-bio-tld/`, and the domains step should act normally.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

