### PR TITLE
Pattern Assembler - Add prop goes_to_pattern_assembler_flow in calypso_signup_select_design

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -57,6 +57,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 	const locale = useLocale();
 
 	const isMobile = ! useViewportMatch( 'small' );
+	const isDesktop = useViewportMatch( 'large' );
 
 	const intent = useSelect( ( select ) => select( ONBOARD_STORE ).getIntent() );
 
@@ -450,6 +451,10 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 				...getEventPropsByDesign( _selectedDesign, selectedStyleVariation ),
 				...( positionIndex >= 0 && { position_index: positionIndex } ),
 				device: resolveDeviceTypeByViewPort(),
+				goes_to_pattern_assembler_flow:
+					isEnabled( 'signup/design-picker-pattern-assembler' ) &&
+					isBlankCanvasDesign( _selectedDesign ) &&
+					isDesktop,
 			} );
 
 			if ( _selectedDesign.verticalizable ) {


### PR DESCRIPTION
#### Proposed Changes

* Add a boolean prop `goes_to_pattern_assembler_flow` in `calypso_signup_select_design` to indicate whether a user passes through to the pattern assembler flow or goes directly to the editor. 

This is needed for accurately filtering on analytics. p1671222974120229/1671046220.169319-slack-C048CUFRGFQ

**Note:** From the CTA button in the design picker, users go to the Pattern Assembler flow when the device width is greater than `960px` (this is called the desktop viewport), and only in this case the prop `goes_to_pattern_assembler_flow` is `true`.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to `/setup?siteSlug=[ YOUR SITE ]`

**1) Test a device width lower or equal to `960px`**
* On the goals screen, don't mark any goal.
* On the verticals screen, don't select any vertical but before you click on `Continue`, open the Dev tools, click to toggle device toolbar and set the viewport width with a value lower or equal than `960`:
<img width="70" alt="Screenshot 2565-12-19 at 11 52 24" src="https://user-images.githubusercontent.com/1881481/208353637-87001160-e0d3-401e-b775-1d785c7ef9d4.png">
<img width="966" alt="Screenshot 2565-12-19 at 12 08 20" src="https://user-images.githubusercontent.com/1881481/208353753-97a70393-e3b7-4610-9f82-00ac08b2562f.png">

* On the design picker, scroll down to find the CTA `Design your own` and the CTA button should say `Open the editor` and the prop `goes_to_pattern_assembler_flow` should be `false` 
* Check that using the extension Tracks vigilante: 
<img width="779" alt="Screenshot 2565-12-19 at 11 34 21" src="https://user-images.githubusercontent.com/1881481/208351125-ccc60ade-8e86-45dc-895a-844e28721107.png">

**2) Test a device width greater than `960px`**
* Go back to the goals screen, don't mark any goal
* On the verticals screen, don't select any vertical but before you click on `Continue`, set the viewport width with a value greater than `960`:
<img width="970" alt="Screenshot 2565-12-19 at 12 07 34" src="https://user-images.githubusercontent.com/1881481/208354470-496eb859-22ff-4bd7-a496-23b35c425189.png">

* On the design picker, the CTA button should say `Start designing` and when you click we send the prop `goes_to_pattern_assembler_flow` as `true`. 
* Check that using the extension Tracks vigilante: 
<img width="781" alt="Screenshot 2565-12-19 at 11 33 31" src="https://user-images.githubusercontent.com/1881481/208351074-bfd06a2d-883d-474e-8242-b5d0218f481b.png">

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [X] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [X] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [X] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [X] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/822