### PR TITLE
Do not remove the user step if it's the only one in the flow.

### DIFF
--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -243,9 +243,12 @@ const Flows = {
 		if ( isUserLoggedIn ) {
 			const urlParams = new URLSearchParams( window.location.search );
 			const param = urlParams.get( 'user_completed' );
+			const isUserStepOnly = flow.steps.length === 1 && stepConfig[ flow.steps[ 0 ] ].providesToken;
+
 			// Remove the user step unless the user has just completed the step
 			// and then clicked the back button.
-			if ( ! param && ! detectHistoryNavigation.loadedViaHistory() ) {
+			// If the user step is the only step in the whole flow, e.g. /start/account, don't remove it as well.
+			if ( ! param && ! detectHistoryNavigation.loadedViaHistory() && ! isUserStepOnly ) {
 				flow = removeUserStepFromFlow( flow );
 			}
 		}


### PR DESCRIPTION
#### Proposed Changes

This PR fixes #71260 by preventing the user step from being removed if it's the only step in the whole flow. The iconic flow that has only the user step in the whole flow is `/start/account`. Once completing the sign-up, upon back navigation, the signup framework will remove the only one flow. That way the user will end up in the admin dashboard(i.e. the root path, `/`) , escaping from the signup flow completely. 

Since the tailored flows, e.g. /setup/link-in-bio, /setup/link-in-bio-tld, /setup/newsletters are relying on it to create user account, 

Before, /setup/link-in-bio/ :

https://user-images.githubusercontent.com/1842898/208359933-6380f78a-33bf-4e4a-9657-65281ce1a88b.mov

After, /setup/link-in-bio/:

https://user-images.githubusercontent.com/1842898/208359967-368af96e-337d-4e92-a57d-aeeaab25b92f.mov

#### Testing Instructions

* Sign-up a new account from `/start/account`
* After completion, navigate back and you should get back to the user step, showing your account and a continue CTA. Without this fix, you will arrive at the admin dashboard.
* Go through `/setup/link-in-bio/` flow til you've completed the user step.
* Now navigate back. You should arrive the user step, again showing your account and a continue CTA. Without this fix, you will arrive at the admin dashboard, completely escaping from the signup flow.
* Clicking the "continue" CTA, you will be back to the patterns step.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
