### PR TITLE
Theme Showcase: Fix categories is gone when accessing the page via URL directly on mobile

### DIFF
--- a/client/my-sites/themes/controller.jsx
+++ b/client/my-sites/themes/controller.jsx
@@ -97,18 +97,11 @@ export function fetchThemeFilters( context, next ) {
 		return next();
 	}
 
-	const filtersRequest = wpcom.req.get( '/theme-filters', {
-		apiVersion: '1.2',
-		locale: context.lang, // Note: undefined will be omitted by the query string builder.
-	} );
-
-	const timeout = new Promise( ( _, reject ) => {
-		setTimeout( () => {
-			reject( new Error( 'Theme filters request timed out' ) );
-		}, 500 );
-	} );
-
-	Promise.race( [ filtersRequest, timeout ] )
+	wpcom.req
+		.get( '/theme-filters', {
+			apiVersion: '1.2',
+			locale: context.lang, // Note: undefined will be omitted by the query string builder.
+		} )
 		.then( ( filters ) => {
 			store.dispatch( { type: THEME_FILTERS_ADD, filters } );
 			next();

--- a/client/my-sites/themes/index.web.js
+++ b/client/my-sites/themes/index.web.js
@@ -3,6 +3,7 @@ import {
 	makeLayout,
 	redirectLoggedOut,
 	redirectWithoutLocaleParamIfLoggedIn,
+	render as clientRender,
 } from 'calypso/controller';
 import {
 	navigation,
@@ -35,14 +36,15 @@ export default function ( router ) {
 	];
 
 	// Upload routes are valid only when logged in. In logged-out sessions they redirect to login page.
-	router( '/themes/upload', redirectLoggedOut, siteSelection, sites, makeLayout );
+	router( '/themes/upload', redirectLoggedOut, siteSelection, sites, makeLayout, clientRender );
 	router(
 		'/themes/upload/:site_id',
 		redirectLoggedOut,
 		siteSelection,
 		upload,
 		navigation,
-		makeLayout
+		makeLayout,
+		clientRender
 	);
 
 	router(
@@ -53,7 +55,8 @@ export default function ( router ) {
 		siteSelection,
 		loggedIn,
 		navigation,
-		makeLayout
+		makeLayout,
+		clientRender
 	);
 
 	router(
@@ -62,6 +65,7 @@ export default function ( router ) {
 		selectSiteIfLoggedIn,
 		fetchAndValidateVerticalsAndFilters,
 		loggedOut,
-		makeLayout
+		makeLayout,
+		clientRender
 	);
 }

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -266,7 +266,7 @@ body.is-section-themes-i4-2 {
 	min-height: 100vh;
 
 	@include breakpoint-deprecated( "<660px" ) {
-		margin: 0 16px;
+		margin: 16px 16px 0;
 	}
 }
 

--- a/client/my-sites/themes/themes-toolbar-group/index.tsx
+++ b/client/my-sites/themes/themes-toolbar-group/index.tsx
@@ -27,6 +27,7 @@ const ThemesToolbarGroup: React.FC< ThemesToolbarGroupProps > = ( {
 		<ResponsiveToolbarGroup
 			className="themes-toolbar-group"
 			initialActiveIndex={ activeIndex }
+			forceSwipe={ 'undefined' === typeof window }
 			onClick={ ( index: number ) => onSelect( items[ index ]?.key ) }
 		>
 			{ items.map( ( item ) => (


### PR DESCRIPTION
#### Proposed Changes

Referring to https://github.com/Automattic/wp-calypso/pull/71288, the category filters might be invisible if you access the Theme Showcase via the URL directly. That being said, there are a few issues when calypso renders the Theme Showcase on the server side
* The theme filters endpoint is slow, so it might cause the timeout error
  ![image](https://user-images.githubusercontent.com/13596067/208370173-a3f380a6-1fda-4e0d-a5ca-2d6a8d1f3af8.png)
* The theme toolbar group will render `DropdownGroup` and it's invisible at the beginning. However, the client-side render doesn't match the result of the server-side render, so it won't be visible after re-rendering
* The client-side rendering of the Theme Showcase doesn't contain `clientRender` and it leads to the result of the server-render and client-side render doesn't match

Hence, this PR tries to
* Remove the timeout mechanism when we fetch the theme filters on the server side
* Force `ThemesToolbarGroup` to render `SwipeGroup` on the server side and it's the same as the `/plugins` page does
* Apply `clientRender` to the Theme Showcase page.

| Logged out |Logged in |
| - | - |
| ![image](https://user-images.githubusercontent.com/13596067/208369505-1d571d0f-52b1-4572-b27d-f2cd1b842e48.png) | ![image](https://user-images.githubusercontent.com/13596067/208370415-b4675801-56d0-477a-a082-1021f6324a7c.png) |
| ![image](https://user-images.githubusercontent.com/13596067/208369622-76c30c9a-fc65-4d04-bb7a-9110d6c457d9.png) | ![image](https://user-images.githubusercontent.com/13596067/208370315-9a9a01a6-77e9-4a47-8b13-cd48ce8e6d63.png) |

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Logged out**

* Head to the Theme Showcase `/themes` on both desktop and mobile viewport.
* Ensure that the logged-out Theme Showcase works as before.

**Logged in**

* Head to the Theme Showcase `/themes/<your_site>` on both desktop and mobile viewport.
* Ensure that the list of category filters works as before.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/71288
