### PR TITLE
Stats: Enhance the Highlight section of the post detail page

### DIFF
--- a/client/blocks/post-likes/index.jsx
+++ b/client/blocks/post-likes/index.jsx
@@ -50,6 +50,8 @@ class PostLikes extends PureComponent {
 	renderExtraCount() {
 		const { likes, likeCount, showDisplayNames, translate, numberFormat } = this.props;
 
+		const isFeatured = config.isEnabled( 'stats/enhance-post-detail' );
+
 		if ( ! likes || likeCount <= likes.length ) {
 			return null;
 		}
@@ -64,6 +66,12 @@ class PostLikes extends PureComponent {
 			} );
 		} else {
 			message = '+ ' + numberFormat( extraCount );
+		}
+
+		if ( isFeatured ) {
+			message = translate( '%(extraCount)s more', {
+				args: { extraCount: numberFormat( extraCount ) },
+			} );
 		}
 
 		return (

--- a/client/blocks/post-likes/index.jsx
+++ b/client/blocks/post-likes/index.jsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
 import { PureComponent } from 'react';
@@ -26,6 +27,8 @@ class PostLikes extends PureComponent {
 		const likeUrl = like.site_ID && like.site_visible ? '/read/blogs/' + like.site_ID : null;
 		const LikeWrapper = likeUrl ? 'a' : 'span';
 
+		const isFeatured = config.isEnabled( 'stats/enhance-post-detail' );
+
 		return (
 			<LikeWrapper
 				key={ like.ID }
@@ -33,7 +36,12 @@ class PostLikes extends PureComponent {
 				className="post-likes__item"
 				onClick={ likeUrl ? this.trackLikeClick : null }
 			>
-				<Gravatar user={ like } alt={ like.login } title={ like.login } size={ 24 } />
+				<Gravatar
+					user={ like }
+					alt={ like.login }
+					title={ like.login }
+					size={ isFeatured ? 32 : 24 }
+				/>
 				{ showDisplayNames && <span className="post-likes__display-name">{ like.name }</span> }
 			</LikeWrapper>
 		);

--- a/client/my-sites/stats/modernized-layout-styles.scss
+++ b/client/my-sites/stats/modernized-layout-styles.scss
@@ -21,7 +21,8 @@ $sidebar-appearance-break-point: 783px;
 	// Ensures vertical padding for certain sections.
 	> .highlight-cards,
 	> .stats__all-time-highlights-section,
-	> .stats__all-time-views-section {
+	> .stats__all-time-views-section,
+	> .stats__post-detail-highlights-section {
 		padding-top: $vertical-margin;
 		padding-bottom: $vertical-margin;
 	}

--- a/client/my-sites/stats/post-detail-highlights-section/index.tsx
+++ b/client/my-sites/stats/post-detail-highlights-section/index.tsx
@@ -1,0 +1,85 @@
+import { Card, PostStatsCard } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import { useSelector } from 'react-redux';
+import QuerySiteStats from 'calypso/components/data/query-site-stats';
+import { getPostStat } from 'calypso/state/stats/posts/selectors';
+import PostLikes from '../stats-post-likes';
+
+import './style.scss';
+
+type PostThumbnail = {
+	ID: number;
+	URL: string;
+};
+
+type PostDiscussion = {
+	comment_count: number;
+	comment_status: string;
+	comments_open: boolean;
+	ping_status: string;
+	pings_open: boolean;
+};
+
+type Post = {
+	date: string;
+	title: string;
+	type: string;
+	like_count: number;
+	post_thumbnail: PostThumbnail | null;
+	discussion: PostDiscussion;
+};
+
+export default function PostDetailHighlightsSection( {
+	siteId,
+	postId,
+	post,
+}: {
+	siteId: number;
+	postId: number;
+	post: Post;
+} ) {
+	const translate = useTranslate();
+
+	const viewCount = useSelector( ( state ) => getPostStat( state, siteId, postId, 'views' ) || 0 );
+
+	const postData = {
+		date: post?.date,
+		post_thumbnail: post?.post_thumbnail?.URL || null,
+		title: post?.title,
+	};
+
+	return (
+		<div className="stats__post-detail-highlights-section">
+			{ siteId && (
+				<>
+					<QuerySiteStats siteId={ siteId } statType="stats" query={ {} } />
+					<QuerySiteStats siteId={ siteId } statType="statsInsights" />
+				</>
+			) }
+
+			<div className="highlight-cards">
+				<h1 className="highlight-cards-heading">{ translate( 'Highlights' ) }</h1>
+
+				<div className="highlight-cards-list">
+					<PostStatsCard
+						heading={ translate( 'All-time stats' ) }
+						likeCount={ post?.like_count }
+						post={ postData }
+						viewCount={ viewCount }
+						commentCount={ post?.discussion?.comment_count }
+					/>
+
+					<Card className="highlight-card">
+						<div className="highlight-card-heading">
+							<span>{ translate( 'Post likes' ) }</span>
+							<span className="likes-count">{ post?.like_count || 0 }</span>
+						</div>
+						{ !! postId && (
+							<PostLikes siteId={ siteId } postId={ postId } postType={ post?.type } />
+						) }
+					</Card>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/client/my-sites/stats/post-detail-highlights-section/style.scss
+++ b/client/my-sites/stats/post-detail-highlights-section/style.scss
@@ -13,6 +13,7 @@
 		margin: 0;
 		flex: 1;
 		min-width: 600px;
+		max-height: 300px;
 	}
 
 	.highlight-cards-list .highlight-card {

--- a/client/my-sites/stats/post-detail-highlights-section/style.scss
+++ b/client/my-sites/stats/post-detail-highlights-section/style.scss
@@ -21,6 +21,8 @@
 		padding: 24px;
 		min-width: 320px;
 		max-width: 495px;
+		max-height: 300px;
+		overflow-y: auto;
 	}
 
 	.highlight-card-heading {
@@ -44,8 +46,9 @@
 		line-height: 20px;
 	}
 
-	.stats-post-likes {
+	.card.stats-post-likes {
 		padding: 0;
+		margin: 0 0 -7px 0;
 		box-shadow: none;
 
 		.module-header {

--- a/client/my-sites/stats/post-detail-highlights-section/style.scss
+++ b/client/my-sites/stats/post-detail-highlights-section/style.scss
@@ -1,0 +1,66 @@
+@import "@automattic/components/src/highlight-cards/variables.scss";
+
+.stats__post-detail-highlights-section {
+	padding-top: $vertical-margin;
+	padding-bottom: $vertical-margin;
+
+	.highlight-cards {
+		background-color: inherit;
+		box-shadow: none;
+	}
+
+	.post-stats-card {
+		margin: 0;
+		flex: 1;
+		min-width: 600px;
+	}
+
+	.highlight-cards-list .highlight-card {
+		margin: 0 0 0 10px;
+		padding: 24px;
+		min-width: 320px;
+		max-width: 495px;
+	}
+
+	.highlight-card-heading {
+		display: flex;
+		align-items: center;
+		margin-bottom: $vertical-margin;
+		color: var(--color-neutral-100);
+		font-family: inherit;
+		font-weight: 500;
+		font-size: $font-title-small;
+		line-height: 26px;
+	}
+
+	.likes-count {
+		margin-left: 8px;
+		padding: 4px 8px;
+		background-color: var(--color-neutral-5);
+		border-radius: 2px;
+		font-weight: 500;
+		font-size: $font-body-extra-small;
+		line-height: 20px;
+	}
+
+	.stats-post-likes {
+		padding: 0;
+		box-shadow: none;
+
+		.module-header {
+			display: none;
+		}
+
+		.stats-post-likes__content {
+			padding: 0;
+		}
+
+		.post-likes__item {
+			padding: 0;
+
+			&:not(:first-child) {
+				margin-left: 14px;
+			}
+		}
+	}
+}

--- a/client/my-sites/stats/post-detail-highlights-section/style.scss
+++ b/client/my-sites/stats/post-detail-highlights-section/style.scss
@@ -63,5 +63,16 @@
 		.post-likes__item {
 			padding: 7px;
 		}
+
+		.post-likes__count {
+			vertical-align: bottom;
+			margin: 0 0 7px 25px;
+			padding: 0;
+			border: 0;
+			color: var(--color-neutral-60);
+			font-size: $font-body-small;
+			font-weight: 400;
+			line-height: 20px;
+		}
 	}
 }

--- a/client/my-sites/stats/post-detail-highlights-section/style.scss
+++ b/client/my-sites/stats/post-detail-highlights-section/style.scss
@@ -9,20 +9,22 @@
 		box-shadow: none;
 	}
 
-	.post-stats-card {
-		margin: 0;
-		flex: 1;
-		min-width: 600px;
-		max-height: 300px;
-	}
+	.highlight-cards-list {
+		display: grid;
+		grid-template-columns: 3fr 2fr;
+		grid-template-rows: 1fr;
+		column-gap: 10px;
 
-	.highlight-cards-list .highlight-card {
-		margin: 0 0 0 10px;
-		padding: 24px;
-		min-width: 320px;
-		max-width: 495px;
-		max-height: 300px;
-		overflow-y: auto;
+		.post-stats-card {
+			margin: 0;
+			max-height: unset;
+		}
+
+		.highlight-card {
+			padding: 24px;
+			height: 300px;
+			overflow-y: auto;
+		}
 	}
 
 	.highlight-card-heading {

--- a/client/my-sites/stats/post-detail-highlights-section/style.scss
+++ b/client/my-sites/stats/post-detail-highlights-section/style.scss
@@ -55,12 +55,12 @@
 			padding: 0;
 		}
 
-		.post-likes__item {
-			padding: 0;
+		.post-likes {
+			margin: 0 -7px;
+		}
 
-			&:not(:first-child) {
-				margin-left: 14px;
-			}
+		.post-likes__item {
+			padding: 7px;
 		}
 	}
 }

--- a/client/my-sites/stats/stats-post-detail/index.jsx
+++ b/client/my-sites/stats/stats-post-detail/index.jsx
@@ -23,6 +23,7 @@ import {
 } from 'calypso/state/sites/selectors';
 import { getPostStat, isRequestingPostStats } from 'calypso/state/stats/posts/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import PostDetailHighlightsSection from '../post-detail-highlights-section';
 import PostDetailTableSection from '../post-detail-table-section';
 import PostMonths from '../stats-detail-months';
 import PostWeeks from '../stats-detail-weeks';
@@ -157,6 +158,10 @@ class StatsPostDetail extends Component {
 					) }
 				</FixedNavigationHeader>
 
+				{ isFeatured && (
+					<PostDetailHighlightsSection siteId={ siteId } postId={ postId } post={ post } />
+				) }
+
 				<StatsPlaceholder isLoading={ isLoading } />
 
 				{ ! isLoading && countViews === 0 && (
@@ -175,7 +180,9 @@ class StatsPostDetail extends Component {
 					<div>
 						<PostSummary siteId={ siteId } postId={ postId } />
 
-						{ !! postId && <PostLikes siteId={ siteId } postId={ postId } postType={ postType } /> }
+						{ ! isFeatured && !! postId && (
+							<PostLikes siteId={ siteId } postId={ postId } postType={ postType } />
+						) }
 
 						{ isFeatured && <PostDetailTableSection siteId={ siteId } postId={ postId } /> }
 

--- a/client/state/posts/selectors/count-post-likes.js
+++ b/client/state/posts/selectors/count-post-likes.js
@@ -5,10 +5,10 @@ import 'calypso/state/posts/init';
 /**
  * Returns the total of post likes for a given site ID, post ID.
  *
- * @param  {object}  state  Global state tree
- * @param  {number}  siteId Site ID
- * @param  {number}  postId Post ID
- * @returns {Array}          Post Likes
+ * @param   {object}  state		Global state tree
+ * @param   {number}  siteId	Site ID
+ * @param   {number}  postId  	Post ID
+ * @returns {number | null}		Post Likes count
  */
 export function countPostLikes( state, siteId, postId ) {
 	return get( state.posts.likes.items, [ siteId, postId, 'found' ], null );

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -39,3 +39,4 @@ export {
 } from './highlight-cards/highlight-card';
 export { default as MobilePromoCard } from './mobile-promo-card';
 export { default as ShortenedNumber } from './shortened-number';
+export { default as PostStatsCard } from './post-stats-card';


### PR DESCRIPTION
#### Proposed Changes

* Introduce `PostDetailHighlightsSection` to enhance the post detail page.
* Adjust the icon size of the likers' Gravatar.
* Gate the enhanced features with the feature flag `stats/enhance-post-detail`.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up this change with the Calypso Live link.
* Navigate to the Stats `Post Detail` page (`/stats/post/${post-id}/${site-id}`).
* Ensure the post detail page works as previously.
* Append the feature flag `?flags=stats/enhance-post-detail` to the URL.
* Ensure a display of the new Highlights section is in line with the design.

<img width="1142" alt="截圖 2022-12-19 下午3 31 39" src="https://user-images.githubusercontent.com/6869813/208371313-153fb4fd-dbef-4af6-a3b4-870ac8e93f8b.png">

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #70671 
