### PR TITLE
Theme showcase: show the My Themes tab when the source data changes

### DIFF
--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -2,7 +2,7 @@ import { recordTracksEvent } from '@automattic/calypso-analytics';
 import config from '@automattic/calypso-config';
 import { FEATURE_INSTALL_THEMES } from '@automattic/calypso-products';
 import { localize } from 'i18n-calypso';
-import { compact, omit, pickBy } from 'lodash';
+import { compact, isEqual, omit, pickBy } from 'lodash';
 import page from 'page';
 import PropTypes from 'prop-types';
 import { createRef, Component } from 'react';
@@ -126,7 +126,10 @@ class ThemeShowcase extends Component {
 			this.scrollToSearchInput();
 		}
 
-		if ( prevProps.subjects !== this.props.subjects ) {
+		if (
+			! isEqual( prevProps.subjects, this.props.subjects ) ||
+			prevProps.siteCanInstallThemes !== this.props.siteCanInstallThemes
+		) {
 			this.tabFilters = this.getTabFilters( this.props );
 			this.tabSubjectTermTable = this.getSubjectTermTable( this.props );
 		}

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -125,6 +125,11 @@ class ThemeShowcase extends Component {
 		) {
 			this.scrollToSearchInput();
 		}
+
+		if ( prevProps.subjects !== this.props.subjects ) {
+			this.tabFilters = this.getTabFilters( this.props );
+			this.tabSubjectTermTable = this.getSubjectTermTable( this.props );
+		}
 	}
 
 	getTabTiers = ( { translate } ) => {


### PR DESCRIPTION
#### Proposed Changes

In the `<ThemeShowcase />` component, we initialize the theme filters only once: in the constructor.

However, the `My Themes` filter depends on the site features (`FEATURE_INSTALL_THEMES`), which is fetched and not available the first time the component is instantiated. So, when the theme showcase page is accessed directly via URL, that filter will not be shown.

This PR fixes that by updating the constructor logic to only initialize static data, not derived data from props.

|Before|After|
|-|-|
|<img  alt="image" src="https://user-images.githubusercontent.com/1525580/208386648-b1b8d33e-1a68-49be-b38b-e22584ef6753.png">|<img alt="image" src="https://user-images.githubusercontent.com/1525580/208386518-f1f0b9d4-a5c7-4aa2-9e29-1eedc242c420.png">|

#### Testing Instructions

1. Create a site with Business plan.
2. Convert it to Atomic by installing any plugin.
3. Go to `Appearance` -> `Themes`, click `Install new theme`, and install any theme.
4. Go to `/themes/{siteSlug}.wpcomstaging.com` directly (or refresh the page)
5. Verify that the `My Themes` tab is shown (as per screenshot above)

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:

- #70477