### PR TITLE
Pattern Assembler: Introduce new feature flag to control fast preview components

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -1,8 +1,10 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { StepContainer } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
 import { useState, useRef, useEffect } from 'react';
 import { useDispatch as useReduxDispatch } from 'react-redux';
+import AsyncLoad from 'calypso/components/async-load';
 import DocumentHead from 'calypso/components/data/document-head';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { requestActiveTheme } from 'calypso/state/themes/actions';
@@ -10,7 +12,6 @@ import { useSite } from '../../../../hooks/use-site';
 import { useSiteIdParam } from '../../../../hooks/use-site-id-param';
 import { useSiteSlugParam } from '../../../../hooks/use-site-slug-param';
 import { SITE_STORE, ONBOARD_STORE } from '../../../../stores';
-import PatternAssemblerPreview from './pattern-assembler-preview';
 import PatternLayout from './pattern-layout';
 import PatternSelectorLoader from './pattern-selector-loader';
 import { encodePatternId, createCustomHomeTemplateContent } from './utils';
@@ -296,12 +297,24 @@ const PatternAssembler: Step = ( { navigation } ) => {
 					/>
 				) }
 			</div>
-			<PatternAssemblerPreview
-				header={ header }
-				sections={ sections }
-				footer={ footer }
-				scrollToSelector={ scrollToSelector }
-			/>
+			{ isEnabled( 'pattern-assembler/client-side-render' ) ? (
+				<AsyncLoad
+					require="./pattern-large-preview"
+					placeholder={ null }
+					header={ header }
+					sections={ sections }
+					footer={ footer }
+				/>
+			) : (
+				<AsyncLoad
+					require="./pattern-assembler-preview"
+					placeholder={ null }
+					header={ header }
+					sections={ sections }
+					footer={ footer }
+					scrollToSelector={ scrollToSelector }
+				/>
+			) }
 		</div>
 	);
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.scss
@@ -1,0 +1,38 @@
+.pattern-large-preview {
+	flex: 1;
+	position: relative;
+	height: 100vh;
+	padding: 32px 0;
+	margin-inline-start: 32px;
+	margin-top: -60px;
+	box-sizing: border-box;
+	z-index: 1;
+}
+
+.pattern-large-preview__placeholder {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	width: 100%;
+	color: var(--studio-gray-60);
+	background: #f8f8f8;
+
+	.pattern-large-preview__placeholder-icon {
+		margin-bottom: 28px;
+		fill: #c9c9c9;
+	}
+
+	h2 {
+		color: var(--studio-gray-100);
+		margin-bottom: 5px;
+		font-size: $font-title-small;
+		font-weight: 500;
+	}
+
+	span {
+		font-size: $font-body;
+		padding: 0 30px;
+		text-align: center;
+	}
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
@@ -1,0 +1,43 @@
+import { DeviceSwitcher } from '@automattic/components';
+import { Icon, layout } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
+import { useMemo } from 'react';
+import { encodePatternId } from './utils';
+import type { Pattern } from './types';
+import './pattern-large-preview.scss';
+
+interface Props {
+	header: Pattern | null;
+	sections: Pattern[];
+	footer: Pattern | null;
+}
+
+const PatternLargePreview = ( { header, sections, footer }: Props ) => {
+	const translate = useTranslate();
+	const patternIds = useMemo(
+		() =>
+			[ header, ...sections, footer ]
+				.filter( Boolean )
+				.map( ( pattern ) => encodePatternId( pattern!.id ) ),
+		[ header, sections, footer ]
+	);
+
+	return (
+		<DeviceSwitcher className="pattern-large-preview" isShowDeviceSwitcherToolbar isShowFrameBorder>
+			{ patternIds.length > 0 ? (
+				// TODO: render patterns on client side
+				JSON.stringify( patternIds )
+			) : (
+				<div className="pattern-large-preview__placeholder">
+					<Icon className="pattern-large-preview__placeholder-icon" icon={ layout } size={ 72 } />
+					<h2>{ translate( 'Welcome to your blank canvas' ) }</h2>
+					<span>
+						{ translate( "It's time to get creative. Add your first pattern to get started." ) }
+					</span>
+				</div>
+			) }
+		</DeviceSwitcher>
+	);
+};
+
+export default PatternLargePreview;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-list-renderer.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-list-renderer.tsx
@@ -1,0 +1,34 @@
+import { Button } from '@automattic/components';
+import classnames from 'classnames';
+import { encodePatternId } from './utils';
+import type { Pattern } from './types';
+
+interface Props {
+	patterns: Pattern[];
+	selectedPattern: Pattern | null;
+	show: boolean;
+	onSelect: ( selectedPattern: Pattern | null ) => void;
+}
+
+const PatternListRenderer = ( { patterns, selectedPattern, show, onSelect }: Props ) => {
+	return (
+		<>
+			{ patterns.map( ( pattern, index ) => (
+				<Button
+					key={ `${ index }-${ pattern.id }` }
+					tabIndex={ show ? 0 : -1 }
+					title={ pattern.category }
+					className={ classnames( {
+						'pattern-selector__block-list--selected-pattern': pattern.id === selectedPattern?.id,
+					} ) }
+					onClick={ () => onSelect( pattern ) }
+				>
+					{ /* TODO: render pattern */ }
+					{ encodePatternId( pattern.id ) }
+				</Button>
+			) ) }
+		</>
+	);
+};
+
+export default PatternListRenderer;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-list.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-list.tsx
@@ -1,0 +1,57 @@
+import { Button } from '@automattic/components';
+import { useLocale } from '@automattic/i18n-utils';
+import classnames from 'classnames';
+import { useSite } from '../../../../hooks/use-site';
+import Delayed from './delayed-render-hook';
+import PatternPreviewAutoHeight from './pattern-preview-auto-height';
+import { getPatternPreviewUrl } from './utils';
+import type { Pattern } from './types';
+
+interface Props {
+	stylesheet: string;
+	patterns: Pattern[];
+	selectedPattern: Pattern | null;
+	show: boolean;
+	onSelect: ( selectedPattern: Pattern | null ) => void;
+}
+
+const PatternList = ( { stylesheet, patterns, selectedPattern, show, onSelect }: Props ) => {
+	const locale = useLocale();
+	const site = useSite();
+	const [ firstPattern, ...restPatterns ] = patterns;
+
+	const renderPatterns = ( patternList: Pattern[] ) =>
+		patternList?.map( ( pattern: Pattern, index: number ) => (
+			<PatternPreviewAutoHeight
+				key={ `${ index }-${ pattern.id }` }
+				url={ getPatternPreviewUrl( {
+					id: pattern.id,
+					language: locale,
+					siteTitle: site?.name,
+					stylesheet,
+				} ) }
+				patternId={ pattern.id }
+				patternName={ pattern.category }
+			>
+				<Button
+					tabIndex={ show ? 0 : -1 }
+					title={ pattern.category }
+					className={ classnames( {
+						'pattern-selector__block-list--selected-pattern': pattern.id === selectedPattern?.id,
+					} ) }
+					onClick={ () => onSelect( pattern ) }
+				/>
+			</PatternPreviewAutoHeight>
+		) );
+
+	return (
+		<>
+			{ renderPatterns( [ firstPattern ] ) }
+			<Delayed>
+				<>{ renderPatterns( restPatterns ) }</>
+			</Delayed>
+		</>
+	);
+};
+
+export default PatternList;

--- a/config/development.json
+++ b/config/development.json
@@ -124,6 +124,7 @@
 		"onboarding/import-redirect-to-themes": true,
 		"p2/p2-plus": true,
 		"page/export": true,
+		"pattern-assembler/client-side-render": false,
 		"plans/personal-plan": true,
 		"plans/pro-plan": false,
 		"plans/starter-plan": false,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -76,6 +76,7 @@
 		"network-connection": true,
 		"onboarding/import-light-url-screen": true,
 		"p2/p2-plus": true,
+		"pattern-assembler/client-side-render": false,
 		"plans/personal-plan": true,
 		"plans/pro-plan": false,
 		"plans/starter-plan": false,

--- a/config/production.json
+++ b/config/production.json
@@ -90,6 +90,7 @@
 		"onboarding/import-light-url-screen": true,
 		"onboarding/import-redirect-to-themes": true,
 		"p2/p2-plus": true,
+		"pattern-assembler/client-side-render": false,
 		"plans/personal-plan": true,
 		"plans/pro-plan": false,
 		"plans/starter-plan": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -88,6 +88,7 @@
 		"onboarding/import-redirect-to-themes": true,
 		"p2/p2-plus": true,
 		"page/export": true,
+		"pattern-assembler/client-side-render": false,
 		"plans/personal-plan": true,
 		"plans/pro-plan": false,
 		"plans/starter-plan": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -97,6 +97,7 @@
 		"onboarding/import-light-url-screen": true,
 		"onboarding/import-redirect-to-themes": true,
 		"p2/p2-plus": true,
+		"pattern-assembler/client-side-render": false,
 		"plans/personal-plan": true,
 		"plans/pro-plan": false,
 		"plans/starter-plan": false,


### PR DESCRIPTION
#### Proposed Changes

* Introduce a new feature flag called `pattern-assembler/client-side-render` to control rendering the fast preview components or not.
* Introduce new components as followed
  | Description | Before | After |
  | - | - | - |
  | Render pattern list | `<PatternList />` | `<PatternListRenderer />` |
  | Render the large preview | `<PatternAssemblerPreview />` | `<PatternLargePreview />` |

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Disabled flag**

* Go to `/setup?siteSlug=<your_site>`
* Click the "Continue" button until you land on the design picker
* Select Blank Canvas CTA
* When you enter the Pattern Assembler, ensure everything looks as before

**Enabled flag**

* Go to `/setup?siteSlug=<your_site>&flags=pattern-assembler/client-side-render`
* Click the "Continue" button until you land on the design picker
* Select Blank Canvas CTA
* When you enter the Pattern Assembler, ensure the initial layout looks as before

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/67076, https://github.com/Automattic/wp-calypso/pull/70063
