### PR TITLE
Featured image email toggle: Remove `settings/featured-image-template-toggle` feature flag

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -148,7 +148,6 @@
 		"security/security-checkup": true,
 		"seller-experience": true,
 		"server-side-rendering": true,
-		"settings/featured-image-template-toggle": true,
 		"settings/modernize-reading-settings": true,
 		"settings/security/monitor": true,
 		"sign-in-with-apple": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -95,7 +95,6 @@
 		"security/security-checkup": true,
 		"seller-experience": true,
 		"server-side-rendering": true,
-		"settings/featured-image-template-toggle": false,
 		"settings/modernize-reading-settings": true,
 		"settings/security/monitor": true,
 		"sign-in-with-apple": false,

--- a/config/production.json
+++ b/config/production.json
@@ -112,7 +112,6 @@
 		"security/security-checkup": true,
 		"seller-experience": true,
 		"server-side-rendering": true,
-		"settings/featured-image-template-toggle": false,
 		"settings/modernize-reading-settings": false,
 		"settings/security/monitor": true,
 		"sign-in-with-apple": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -110,7 +110,6 @@
 		"security/security-checkup": true,
 		"seller-experience": true,
 		"server-side-rendering": true,
-		"settings/featured-image-template-toggle": false,
 		"settings/modernize-reading-settings": true,
 		"settings/security/monitor": true,
 		"sign-in-with-apple": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -119,7 +119,6 @@
 		"security/security-checkup": true,
 		"seller-experience": true,
 		"server-side-rendering": true,
-		"settings/featured-image-template-toggle": false,
 		"settings/modernize-reading-settings": true,
 		"settings/security/monitor": true,
 		"sign-in-with-apple": true,


### PR DESCRIPTION
#### Proposed Changes

* Remove `settings/featured-image-template-toggle` feature flag. The flag is no longer used, nor needed. Fixes #71133.

Related project threads:

* Featured Image Template Toggle (pdDOJh-Nu-p2)
* Modernize Reading Settings (pdDOJh-17o-p2)

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

The PR doesn't introduce any visible nor easily-tested change. Once the PR is checked out and built, it shouldn't cause any unexpected issues / errors / warnings.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Is the following related PR merged already? https://github.com/Automattic/wp-calypso/pull/71312
- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #71133.
