### PR TITLE
Components: Colorize the Jetpack Colophon.

### DIFF
--- a/client/components/jetpack-colophon/index.jsx
+++ b/client/components/jetpack-colophon/index.jsx
@@ -8,11 +8,9 @@ const JetpackColophon = ( { className, translate, grayscale = false } ) => {
 	return (
 		<div className={ classNames( 'jetpack-colophon', className ) }>
 			<span
-				className={
-					grayscale
-						? 'jetpack-colophon__power jetpack-colophon__grayscale'
-						: 'jetpack-colophon__power'
-				}
+				className={ classNames( 'jetpack-colophon__power', {
+					'jetpack-colophon__grayscale': grayscale,
+				} ) }
 			>
 				{ translate( 'Powered by {{jetpackLogo /}}', {
 					components: {

--- a/client/components/jetpack-colophon/index.jsx
+++ b/client/components/jetpack-colophon/index.jsx
@@ -4,10 +4,16 @@ import JetpackLogo from 'calypso/components/jetpack-logo';
 
 import './style.scss';
 
-const JetpackColophon = ( { className, translate } ) => {
+const JetpackColophon = ( { className, translate, grayscale = false } ) => {
 	return (
 		<div className={ classNames( 'jetpack-colophon', className ) }>
-			<span className="jetpack-colophon__power">
+			<span
+				className={
+					grayscale
+						? 'jetpack-colophon__power jetpack-colophon__grayscale'
+						: 'jetpack-colophon__power'
+				}
+			>
 				{ translate( 'Powered by {{jetpackLogo /}}', {
 					components: {
 						jetpackLogo: <JetpackLogo size={ 32 } full />,

--- a/client/components/jetpack-colophon/style.scss
+++ b/client/components/jetpack-colophon/style.scss
@@ -1,13 +1,9 @@
 .jetpack-colophon {
 	margin-top: 40px;
 	text-align: center;
-	color: var(--color-neutral-40);
 
 	.jetpack-logo {
 		display: inline-block;
-		fill: currentColor;
-	}
-	.jetpack-logo__icon-circle {
 		fill: currentColor;
 	}
 	@include breakpoint-deprecated( "<660px" ) {
@@ -24,5 +20,12 @@
 		vertical-align: inherit;
 		margin-top: -5px;
 		margin-left: 4px;
+	}
+}
+
+.jetpack-colophon__grayscale {
+	color: var(--color-neutral-40);
+	.jetpack-logo__icon-circle {
+		fill: currentColor;
 	}
 }


### PR DESCRIPTION
#### Proposed Changes

Colorizes the Jetpack Colophon by default.

Maintains the grayscale option via a new property. All existing callers will get the colorized styling though. Currently used by Stats (various pages) and on the Activity Log.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit the Calypso Live branch.
* Select a site and visit the Stats section.
* Confirm the colophon shows as green icon with black text.
* Check Traffic, Insights, Store.
* Any subpage that has the colophon should be updated as well. For example, Posts & pages → View all.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #70608.
