### PR TITLE
Theme Page: Making some props more descriptive

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -82,7 +82,7 @@ class ThemeSheet extends Component {
 	static displayName = 'ThemeSheet';
 
 	static propTypes = {
-		id: PropTypes.string,
+		themeId: PropTypes.string,
 		name: PropTypes.string,
 		author: PropTypes.string,
 		screenshot: PropTypes.string,
@@ -101,7 +101,7 @@ class ThemeSheet extends Component {
 		// Connected props
 		isLoggedIn: PropTypes.bool,
 		isActive: PropTypes.bool,
-		isPurchased: PropTypes.bool,
+		isThemePurchased: PropTypes.bool,
 		isJetpack: PropTypes.bool,
 		isAtomic: PropTypes.bool,
 		isStandaloneJetpack: PropTypes.bool,
@@ -137,7 +137,7 @@ class ThemeSheet extends Component {
 	}
 
 	componentDidUpdate( prevProps ) {
-		if ( this.props.id !== prevProps.id ) {
+		if ( this.props.themeId !== prevProps.themeId ) {
 			this.scrollToTop();
 		}
 	}
@@ -158,13 +158,13 @@ class ThemeSheet extends Component {
 		!! this.props.taxonomies?.theme_status?.find( ( status ) => status.slug === 'removed' );
 
 	onButtonClick = () => {
-		const { defaultOption, id } = this.props;
-		defaultOption.action && defaultOption.action( id );
+		const { defaultOption, themeId } = this.props;
+		defaultOption.action && defaultOption.action( themeId );
 	};
 
 	onSecondaryButtonClick = () => {
 		const { secondaryOption } = this.props;
-		secondaryOption && secondaryOption.action && secondaryOption.action( this.props.id );
+		secondaryOption && secondaryOption.action && secondaryOption.action( this.props.themeId );
 	};
 
 	getValidSections = () => {
@@ -188,7 +188,7 @@ class ThemeSheet extends Component {
 
 	trackButtonClick = ( context ) => {
 		this.props.recordTracksEvent( 'calypso_theme_sheet_button_click', {
-			theme_name: this.props.id,
+			theme_name: this.props.themeId,
 			button_context: context,
 		} );
 	};
@@ -244,7 +244,7 @@ class ThemeSheet extends Component {
 
 		const { preview } = this.props.options;
 		this.props.setThemePreviewOptions( this.props.defaultOption, this.props.secondaryOption );
-		return preview.action( this.props.id );
+		return preview.action( this.props.themeId );
 	};
 
 	shouldRenderPreviewButton() {
@@ -316,7 +316,7 @@ class ThemeSheet extends Component {
 	}
 
 	renderSectionNav = ( currentSection ) => {
-		const { siteSlug, id, demoUrl, translate, locale, isLoggedIn } = this.props;
+		const { siteSlug, themeId, demoUrl, translate, locale, isLoggedIn } = this.props;
 		const filterStrings = {
 			'': translate( 'Overview', { context: 'Filter label for theme content' } ),
 			setup: translate( 'Setup', { context: 'Filter label for theme content' } ),
@@ -330,7 +330,7 @@ class ThemeSheet extends Component {
 					<NavItem
 						key={ section }
 						path={ localizeThemesPath(
-							`/theme/${ id }${ section ? '/' + section : '' }${ sitePart }`,
+							`/theme/${ themeId }${ section ? '/' + section : '' }${ sitePart }`,
 							locale,
 							! isLoggedIn
 						) }
@@ -559,7 +559,7 @@ class ThemeSheet extends Component {
 			isActive,
 			isLoggedIn,
 			isPremium,
-			isPurchased,
+			isThemePurchased,
 			translate,
 			isBundledSoftwareSet,
 			isExternallyManagedTheme,
@@ -575,12 +575,17 @@ class ThemeSheet extends Component {
 				</span>
 			);
 		} else if ( isLoggedIn ) {
-			if ( isPremium && ! isPurchased && ! isBundledSoftwareSet && ! isExternallyManagedTheme ) {
+			if (
+				isPremium &&
+				! isThemePurchased &&
+				! isBundledSoftwareSet &&
+				! isExternallyManagedTheme
+			) {
 				// purchase
 				return translate( 'Pick this design' );
 			} else if (
 				isPremium &&
-				! isPurchased &&
+				! isThemePurchased &&
 				isBundledSoftwareSet &&
 				! isExternallyManagedTheme
 			) {
@@ -675,7 +680,7 @@ class ThemeSheet extends Component {
 				href={
 					getUrl &&
 					( ! isExternallyManagedTheme || ! config.isEnabled( 'themes/third-party-premium' ) )
-						? getUrl( this.props.id )
+						? getUrl( this.props.themeId )
 						: null
 				}
 				onClick={ this.onButtonClick }
@@ -747,7 +752,7 @@ class ThemeSheet extends Component {
 	renderSheet = () => {
 		const section = this.validateSection( this.props.section );
 		const {
-			id,
+			themeId,
 			siteId,
 			siteSlug,
 			retired,
@@ -768,7 +773,7 @@ class ThemeSheet extends Component {
 			isMarketplaceThemeSubscribed,
 		} = this.props;
 
-		const analyticsPath = `/theme/${ id }${ section ? '/' + section : '' }${
+		const analyticsPath = `/theme/${ themeId }${ section ? '/' + section : '' }${
 			siteId ? '/:site' : ''
 		}`;
 		const analyticsPageTitle = `Themes > Details Sheet${
@@ -883,7 +888,7 @@ class ThemeSheet extends Component {
 					showIcon
 					event="theme_upsell_plan_click"
 					tracksClickName="calypso_theme_upsell_plan_click"
-					tracksClickProperties={ { theme_id: id, theme_name: themeName } }
+					tracksClickProperties={ { theme_id: themeId, theme_name: themeName } }
 				/>
 			);
 		}
@@ -903,7 +908,7 @@ class ThemeSheet extends Component {
 
 		return (
 			<Main className={ className }>
-				<QueryCanonicalTheme themeId={ this.props.id } siteId={ siteId } />
+				<QueryCanonicalTheme themeId={ this.props.themeId } siteId={ siteId } />
 				<QueryProductsList />
 				<QueryUserPurchases />
 				{
@@ -961,7 +966,7 @@ const ThemeSheetWithOptions = ( props ) => {
 		isActive,
 		isLoggedIn,
 		isPremium,
-		isPurchased,
+		isThemePurchased,
 		isStandaloneJetpack,
 		demoUrl,
 		showTryAndCustomize,
@@ -973,7 +978,7 @@ const ThemeSheetWithOptions = ( props ) => {
 
 	let defaultOption;
 	let secondaryOption = 'tryandcustomize';
-	const needsJetpackPlanUpgrade = isStandaloneJetpack && isPremium && ! isPurchased;
+	const needsJetpackPlanUpgrade = isStandaloneJetpack && isPremium && ! isThemePurchased;
 
 	if ( ! showTryAndCustomize ) {
 		secondaryOption = null;
@@ -994,9 +999,9 @@ const ThemeSheetWithOptions = ( props ) => {
 		! isMarketplaceThemeSubscribed
 	) {
 		defaultOption = 'subscribe';
-	} else if ( isPremium && ! isPurchased && ! isBundledSoftwareSet ) {
+	} else if ( isPremium && ! isThemePurchased && ! isBundledSoftwareSet ) {
 		defaultOption = 'purchase';
-	} else if ( isPremium && ! isPurchased && isBundledSoftwareSet ) {
+	} else if ( isPremium && ! isThemePurchased && isBundledSoftwareSet ) {
 		defaultOption = 'upgradePlanForBundledThemes';
 	} else {
 		defaultOption = 'activate';
@@ -1016,15 +1021,16 @@ const ThemeSheetWithOptions = ( props ) => {
 
 export default connect(
 	( state, { id } ) => {
+		const themeId = id;
 		const siteId = getSelectedSiteId( state );
 		const siteSlug = getSiteSlug( state, siteId );
-		const isWpcomTheme = isThemeWpcom( state, id );
+		const isWpcomTheme = isThemeWpcom( state, themeId );
 		const backPath = getBackPath( state );
 		const isCurrentUserPaid = isUserPaid( state );
-		const theme = getCanonicalTheme( state, siteId, id );
+		const theme = getCanonicalTheme( state, siteId, themeId );
 		const siteIdOrWpcom = siteId || 'wpcom';
-		const error = theme ? false : getThemeRequestErrors( state, id, siteIdOrWpcom );
-		const englishUrl = 'https://wordpress.com' + getThemeDetailsUrl( state, id );
+		const error = theme ? false : getThemeRequestErrors( state, themeId, siteIdOrWpcom );
+		const englishUrl = 'https://wordpress.com' + getThemeDetailsUrl( state, themeId );
 
 		const isAtomic = isSiteAutomatedTransfer( state, siteId );
 		const isJetpack = isJetpackSite( state, siteId );
@@ -1040,32 +1046,32 @@ export default connect(
 
 		return {
 			...theme,
-			id,
-			price: getPremiumThemePrice( state, id, siteId ),
+			themeId,
+			price: getPremiumThemePrice( state, themeId, siteId ),
 			error,
 			siteId,
 			siteSlug,
 			backPath,
 			isCurrentUserPaid,
 			isWpcomTheme,
-			isWporg: isWporgTheme( state, id ),
+			isWporg: isWporgTheme( state, themeId ),
 			isLoggedIn: isUserLoggedIn( state ),
-			isActive: isThemeActive( state, id, siteId ),
+			isActive: isThemeActive( state, themeId, siteId ),
 			isJetpack,
 			isAtomic,
 			isStandaloneJetpack,
 			isVip: isVipSite( state, siteId ),
-			isPremium: isThemePremium( state, id ),
-			isPurchased: isPremiumThemeAvailable( state, id, siteId ),
-			isBundledSoftwareSet: doesThemeBundleSoftwareSet( state, id ),
+			isPremium: isThemePremium( state, themeId ),
+			isThemePurchased: isPremiumThemeAvailable( state, themeId, siteId ),
+			isBundledSoftwareSet: doesThemeBundleSoftwareSet( state, themeId ),
 			isSiteBundleEligible: isSiteEligibleForBundledSoftware( state, siteId ),
-			forumUrl: getThemeForumUrl( state, id, siteId ),
+			forumUrl: getThemeForumUrl( state, themeId, siteId ),
 			hasUnlimitedPremiumThemes: siteHasFeature( state, siteId, WPCOM_FEATURES_PREMIUM_THEMES ),
-			showTryAndCustomize: shouldShowTryAndCustomize( state, id, siteId ),
+			showTryAndCustomize: shouldShowTryAndCustomize( state, themeId, siteId ),
 			canUserUploadThemes: siteHasFeature( state, siteId, FEATURE_UPLOAD_THEMES ),
 			// Remove the trailing slash because the page URL doesn't have one either.
 			canonicalUrl: localizeUrl( englishUrl, getLocaleSlug(), false ).replace( /\/$/, '' ),
-			demoUrl: getThemeDemoUrl( state, id, siteId ),
+			demoUrl: getThemeDemoUrl( state, themeId, siteId ),
 			isWPForTeamsSite: isSiteWPForTeams( state, siteId ),
 			softLaunched: theme?.soft_launched,
 			isExternallyManagedTheme,


### PR DESCRIPTION
#### Proposed Changes

We have some props on the `client/my-sites/theme/main.jsx` file that wasn't clear what it meant. The theme ID was being referred to simply as `id` and the information of the theme being purchased was being referred to as `isPurchased`.

* Rename the `isPurchased` prop to `isThemePurchased`
* Rename the `id` prop to `themeId`

#### Testing Instructions 

Since we renamed a lot of functions, we should test as much of the flows as we can:

* Test activating a free theme on a free site.
  * Navigate to `/theme/twentytwentythree/{SITE}`
  * Click on the CTA
* Test purchasing a bundled theme(thriving-artist) on a free site.
  * Navigate to `/theme/thriving-artist/{SITE}`
  * Click on the CTA
  * Make sure the Business plan was added to your cart
  * Go through the checkout flow
* Test subscribing to a marketplace theme(makoney) on a free site.
  * Navigate to `/theme/makoney{SITE}`
  * Click on the CTA
  * Make sure the Business plan and the subscription to the theme were added to your cart
  * Go through the checkout flow
* Test purchasing a premium theme.
  * Navigate to `/theme/cultivate{SITE}`
  * Click on the CTA
  * Make sure the Premium theme is added to your cart
  * Go through the checkout flow

Closes #69829 #69830
