### PR TITLE
Remove temporary fix for ToggleControl DefinitelyTyped bug

### DIFF
--- a/client/my-sites/site-settings/reading-newsletter-settings/FeaturedImageEmailSetting.tsx
+++ b/client/my-sites/site-settings/reading-newsletter-settings/FeaturedImageEmailSetting.tsx
@@ -1,15 +1,9 @@
 import { localizeUrl } from '@automattic/i18n-utils';
-import { ToggleControl as OriginalToggleControl } from '@wordpress/components';
+import { ToggleControl } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 
 export const FEATURED_IMAGE_IN_EMAIL_OPTION = 'wpcom_featured_image_in_email';
-
-const ToggleControl = OriginalToggleControl as React.ComponentType<
-	OriginalToggleControl.Props & {
-		disabled?: boolean;
-	}
->;
 
 type FeaturedImageEmailSettingProps = {
 	value?: boolean;

--- a/package.json
+++ b/package.json
@@ -171,7 +171,7 @@
 		"@types/wordpress__api-fetch": "^3.2.4",
 		"@types/wordpress__block-editor": "^6.0.5",
 		"@types/wordpress__block-library": "^2.6.1",
-		"@types/wordpress__components": "^19.10.5",
+		"@types/wordpress__components": "^23.0.1",
 		"@types/wordpress__compose": "^4.0.1",
 		"@types/wordpress__data": "^4.6.10",
 		"@types/wordpress__data-controls": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -171,7 +171,7 @@
 		"@types/wordpress__api-fetch": "^3.2.4",
 		"@types/wordpress__block-editor": "^6.0.5",
 		"@types/wordpress__block-library": "^2.6.1",
-		"@types/wordpress__components": "^14.0.10",
+		"@types/wordpress__components": "^19.10.5",
 		"@types/wordpress__compose": "^4.0.1",
 		"@types/wordpress__data": "^4.6.10",
 		"@types/wordpress__data-controls": "^2.2.0",

--- a/packages/page-pattern-modal/src/components/page-pattern-modal.tsx
+++ b/packages/page-pattern-modal/src/components/page-pattern-modal.tsx
@@ -326,11 +326,6 @@ class PagePatternModal extends Component< PagePatternModalProps, PagePatternModa
 			<Modal
 				title="" // We're providing the title with the `aria.labelledby` prop
 				className="page-pattern-modal"
-				// @ts-expect-error `onRequestClose`'s type is () => void but ideally but
-				// in reality, it might receive an event object that might be one of multiple
-				// types (see the `CloseModalEvent` type above for more info). We ignore the
-				// error for now until the type is updated in DefinitelyTyped.
-				// DT PR: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/60127.
 				onRequestClose={ this.closeModal }
 				aria={ {
 					labelledby: `page-pattern-modal__heading-${ instanceId }`,

--- a/yarn.lock
+++ b/yarn.lock
@@ -7359,7 +7359,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/wordpress__components@npm:*, @types/wordpress__components@npm:^14.0.10":
+"@types/wordpress__components@npm:*":
   version: 14.0.10
   resolution: "@types/wordpress__components@npm:14.0.10"
   dependencies:
@@ -7372,6 +7372,22 @@ __metadata:
     downshift: ^6.0.15
     re-resizable: ^6.4.0
   checksum: 1032751b2a5e37642f64b1a97b79d150c6da21e1c7e40d2b8337133b59c10260310f04a3f5911f4bc8f4eb068f009a61bf18d92c476e899b3df11cef347e5b46
+  languageName: node
+  linkType: hard
+
+"@types/wordpress__components@npm:^19.10.5":
+  version: 19.10.5
+  resolution: "@types/wordpress__components@npm:19.10.5"
+  dependencies:
+    "@types/react": "*"
+    "@types/tinycolor2": "*"
+    "@types/wordpress__components": "*"
+    "@types/wordpress__notices": "*"
+    "@types/wordpress__rich-text": "*"
+    "@wordpress/element": ^4.1.0
+    downshift: ^6.0.15
+    re-resizable: ^6.4.0
+  checksum: 043fa8c2be49722d0111d983d449132ff68d81c51ec7b9c973445000cc7a922c9252991deea7f88345b29ce9485f00330071fe4cc77aabf26017c91e1ca3779b
   languageName: node
   linkType: hard
 
@@ -8726,6 +8742,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@wordpress/element@npm:^4.1.0":
+  version: 4.20.0
+  resolution: "@wordpress/element@npm:4.20.0"
+  dependencies:
+    "@babel/runtime": ^7.16.0
+    "@types/react": ^17.0.37
+    "@types/react-dom": ^17.0.11
+    "@wordpress/escape-html": ^2.22.0
+    change-case: ^4.1.2
+    is-plain-object: ^5.0.0
+    react: ^17.0.2
+    react-dom: ^17.0.2
+  checksum: 729a1acd675bcecccb43804afe40a38c8be561a205e556a22faade0638331955389da6a9fc2f8ea103f8eefc8035067464c44f2b91fa4e200f2f9cb3dc2b2d94
+  languageName: node
+  linkType: hard
+
 "@wordpress/element@npm:^4.1.1, @wordpress/element@npm:^4.11.0, @wordpress/element@npm:^4.18.0, @wordpress/element@npm:^4.19.0, @wordpress/element@npm:^4.5.0, @wordpress/element@npm:^4.7.0":
   version: 4.19.0
   resolution: "@wordpress/element@npm:4.19.0"
@@ -8779,6 +8811,15 @@ __metadata:
   dependencies:
     "@babel/runtime": ^7.16.0
   checksum: 25ab1bd24162945858458f1efffe9642d63a217cd41ebbd01856b9f855110f44c9e47d752744c2ed06715c62a43e2ecc5f8310d2adc4ab88c571cccf095593bf
+  languageName: node
+  linkType: hard
+
+"@wordpress/escape-html@npm:^2.22.0":
+  version: 2.25.0
+  resolution: "@wordpress/escape-html@npm:2.25.0"
+  dependencies:
+    "@babel/runtime": ^7.16.0
+  checksum: 54d2a3e4ace3aa376a1dc1ef790cea8ecdeb65ec3cc9794951716b11aee6c6e12febdc803674d20946c21834515d047b202e7e10b7bff585f1d6ead5fde12614
   languageName: node
   linkType: hard
 
@@ -34112,7 +34153,7 @@ resolve@^2.0.0-next.3:
     "@types/wordpress__api-fetch": ^3.2.4
     "@types/wordpress__block-editor": ^6.0.5
     "@types/wordpress__block-library": ^2.6.1
-    "@types/wordpress__components": ^14.0.10
+    "@types/wordpress__components": ^19.10.5
     "@types/wordpress__compose": ^4.0.1
     "@types/wordpress__data": ^4.6.10
     "@types/wordpress__data-controls": ^2.2.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -7018,6 +7018,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/react-dom@npm:^18.0.6":
+  version: 18.0.10
+  resolution: "@types/react-dom@npm:18.0.10"
+  dependencies:
+    "@types/react": "*"
+  checksum: a07b900a2d5559830f88b3e525cf279f9f04b4893f4d17e64f5adb08d8abe0e3151e0d3c0ea17d836104ae47594be577529a004265600e4304a43a93b0d5d61e
+  languageName: node
+  linkType: hard
+
 "@types/react-modal@npm:^3.13.1":
   version: 3.13.1
   resolution: "@types/react-modal@npm:3.13.1"
@@ -7375,19 +7384,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/wordpress__components@npm:^19.10.5":
-  version: 19.10.5
-  resolution: "@types/wordpress__components@npm:19.10.5"
+"@types/wordpress__components@npm:^23.0.1":
+  version: 23.0.1
+  resolution: "@types/wordpress__components@npm:23.0.1"
   dependencies:
     "@types/react": "*"
     "@types/tinycolor2": "*"
     "@types/wordpress__components": "*"
     "@types/wordpress__notices": "*"
     "@types/wordpress__rich-text": "*"
-    "@wordpress/element": ^4.1.0
+    "@wordpress/element": ^5.0.0
     downshift: ^6.0.15
     re-resizable: ^6.4.0
-  checksum: 043fa8c2be49722d0111d983d449132ff68d81c51ec7b9c973445000cc7a922c9252991deea7f88345b29ce9485f00330071fe4cc77aabf26017c91e1ca3779b
+  checksum: 3adce6d6350f790fb1f310fb40a4981a95a7b3b0fb63bc292afacf557095ddd3f33eea13485514f164c4125f06db9b40c82ee8cd0375dcc22c12c18a5db55586
   languageName: node
   linkType: hard
 
@@ -8742,22 +8751,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wordpress/element@npm:^4.1.0":
-  version: 4.20.0
-  resolution: "@wordpress/element@npm:4.20.0"
-  dependencies:
-    "@babel/runtime": ^7.16.0
-    "@types/react": ^17.0.37
-    "@types/react-dom": ^17.0.11
-    "@wordpress/escape-html": ^2.22.0
-    change-case: ^4.1.2
-    is-plain-object: ^5.0.0
-    react: ^17.0.2
-    react-dom: ^17.0.2
-  checksum: 729a1acd675bcecccb43804afe40a38c8be561a205e556a22faade0638331955389da6a9fc2f8ea103f8eefc8035067464c44f2b91fa4e200f2f9cb3dc2b2d94
-  languageName: node
-  linkType: hard
-
 "@wordpress/element@npm:^4.1.1, @wordpress/element@npm:^4.11.0, @wordpress/element@npm:^4.18.0, @wordpress/element@npm:^4.19.0, @wordpress/element@npm:^4.5.0, @wordpress/element@npm:^4.7.0":
   version: 4.19.0
   resolution: "@wordpress/element@npm:4.19.0"
@@ -8771,6 +8764,22 @@ __metadata:
     react: ^17.0.2
     react-dom: ^17.0.2
   checksum: cde942333d2910491f23953d1421308ff424544660d7e4066383120f18fd53561b917d79d4d9977a5fdb8f0826c9f8083876eaf50d97ce35256c937040ffa0ad
+  languageName: node
+  linkType: hard
+
+"@wordpress/element@npm:^5.0.0":
+  version: 5.3.1
+  resolution: "@wordpress/element@npm:5.3.1"
+  dependencies:
+    "@babel/runtime": ^7.16.0
+    "@types/react": ^18.0.21
+    "@types/react-dom": ^18.0.6
+    "@wordpress/escape-html": ^2.26.1
+    change-case: ^4.1.2
+    is-plain-object: ^5.0.0
+    react: ^18.2.0
+    react-dom: ^18.2.0
+  checksum: 7f2a2590fa4cabc9d2c9fbfdfe60fa7e6b9b765faecf10ddd938eeb2574888136bbb060ca0cd834ee332b56d5ba7e4ab5d1f7ffc8b86f2a2d5a25ef8349007d3
   languageName: node
   linkType: hard
 
@@ -8814,12 +8823,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wordpress/escape-html@npm:^2.22.0":
-  version: 2.25.0
-  resolution: "@wordpress/escape-html@npm:2.25.0"
+"@wordpress/escape-html@npm:^2.26.1":
+  version: 2.26.1
+  resolution: "@wordpress/escape-html@npm:2.26.1"
   dependencies:
     "@babel/runtime": ^7.16.0
-  checksum: 54d2a3e4ace3aa376a1dc1ef790cea8ecdeb65ec3cc9794951716b11aee6c6e12febdc803674d20946c21834515d047b202e7e10b7bff585f1d6ead5fde12614
+  checksum: aff5f803b4815f86af6769808b71fe52d28682443b322337b8dccdee5c236fff8e328438a3d15b29b73b5b6370edd58979a93966e24db31c2853aa18517bf048
   languageName: node
   linkType: hard
 
@@ -27316,6 +27325,18 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"react-dom@npm:^18.2.0":
+  version: 18.2.0
+  resolution: "react-dom@npm:18.2.0"
+  dependencies:
+    loose-envify: ^1.1.0
+    scheduler: ^0.23.0
+  peerDependencies:
+    react: ^18.2.0
+  checksum: 66dfc5f93e13d0674e78ef41f92ed21dfb80f9c4ac4ac25a4b51046d41d4d2186abc915b897f69d3d0ebbffe6184e7c5876f2af26bfa956f179225d921be713a
+  languageName: node
+  linkType: hard
+
 "react-draggable@npm:^4.4.3, react-draggable@npm:^4.4.4":
   version: 4.4.4
   resolution: "react-draggable@npm:4.4.4"
@@ -27787,6 +27808,15 @@ fsevents@^1.2.7:
     object-assign: ^4.1.1
     prop-types: ^15.6.2
   checksum: 4d6ad44cd5c12511218ad179df94919b5c1c328d078160a9f39ae7d31738c427a9b6bbcf9fb4745f4c4f534ddab8529acc24e7cd9dce086c76e3478422256fb3
+  languageName: node
+  linkType: hard
+
+"react@npm:^18.2.0":
+  version: 18.2.0
+  resolution: "react@npm:18.2.0"
+  dependencies:
+    loose-envify: ^1.1.0
+  checksum: b562d9b569b0cb315e44b48099f7712283d93df36b19a39a67c254c6686479d3980b7f013dc931f4a5a3ae7645eae6386b4aa5eea933baa54ecd0f9acb0902b8
   languageName: node
   linkType: hard
 
@@ -29693,6 +29723,15 @@ resolve@^2.0.0-next.3:
     loose-envify: ^1.1.0
     object-assign: ^4.1.1
   checksum: b0982e4b0f34f4ffa4f2f486161c0fd9ce9b88680b045dccbf250eb1aa4fd27413570645455187a83535e2370f5c667a251045547765408492bd883cbe95fcdb
+  languageName: node
+  linkType: hard
+
+"scheduler@npm:^0.23.0":
+  version: 0.23.0
+  resolution: "scheduler@npm:0.23.0"
+  dependencies:
+    loose-envify: ^1.1.0
+  checksum: b777f7ca0115e6d93e126ac490dbd82642d14983b3079f58f35519d992fa46260be7d6e6cede433a92db70306310c6f5f06e144f0e40c484199e09c1f7be53dd
   languageName: node
   linkType: hard
 
@@ -34153,7 +34192,7 @@ resolve@^2.0.0-next.3:
     "@types/wordpress__api-fetch": ^3.2.4
     "@types/wordpress__block-editor": ^6.0.5
     "@types/wordpress__block-library": ^2.6.1
-    "@types/wordpress__components": ^19.10.5
+    "@types/wordpress__components": ^23.0.1
     "@types/wordpress__compose": ^4.0.1
     "@types/wordpress__data": ^4.6.10
     "@types/wordpress__data-controls": ^2.2.0


### PR DESCRIPTION
#### Proposed Changes

The proposed changes remove temporary workaround that was needed until the https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/63582 was resolved.

Since the bug is resolved now, the workaround is no longer necessary and can be cleaned up from the Calypso codebase.

In other words, this PR reverts the following commit: https://github.com/Automattic/wp-calypso/commit/e57da8952ea965218560f3c7da4d6a1b60cf4af7.

Fixes #71054.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Checkout the PR branch and navigate to `client/my-sites/site-settings/reading-newsletter-settings/FeaturedImageEmailSetting.tsx`.
2. There should be no TypeScript errors related to the ToggleControl component used.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #71054.
