### PR TITLE
Update themes for eCommerce flow and push design filter into props

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-carousel/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-carousel/index.tsx
@@ -31,6 +31,7 @@ const DesignCarousel: Step = function DesignCarousel( { navigation } ) {
 					require="@automattic/design-carousel"
 					placeholder={ null }
 					onPick={ pickDesign }
+					selectedDesignSlugs={ [ 'tsubaki', 'tazza', 'zaino', 'thriving-artist' ] }
 				/>
 			}
 			recordTracksEvent={ recordTracksEvent }

--- a/packages/design-carousel/src/index.tsx
+++ b/packages/design-carousel/src/index.tsx
@@ -9,9 +9,12 @@ import { Item } from './item';
 import 'swiper/dist/css/swiper.css';
 import type { Design } from '@automattic/design-picker/src/types';
 
-type Props = { onPick: ( design: Design ) => void };
+type DesignCarouselProps = {
+	onPick: ( design: Design ) => void;
+	selectedDesignSlugs?: string[];
+};
 
-export default function DesignCarousel( { onPick }: Props ) {
+export default function DesignCarousel( { onPick, selectedDesignSlugs }: DesignCarouselProps ) {
 	const { __ } = useI18n();
 
 	const swiperInstance = useRef< Swiper | null >( null );
@@ -24,15 +27,21 @@ export default function DesignCarousel( { onPick }: Props ) {
 		_locale: locale,
 	} );
 
-	// Cherry-picked designs
-	const designSlugs = [ 'tsubaki', 'tazza', 'thriving-artist', 'twentytwentytwo', 'zaino' ];
+	let selectedDesigns = allDesigns?.static.designs;
 
-	const selectedDesigns = designSlugs
-		.map( ( designSlug ) =>
-			allDesigns?.static.designs.find( ( design ) => design.slug === designSlug )
-		)
-		// Remove not found (not launched) items
-		.filter( ( design ) => !! design ) as Design[];
+	if ( selectedDesigns && selectedDesignSlugs ) {
+		// If we have a restricted set of designs, filter out all unwanted designs
+		const filteredDesigns = selectedDesigns.filter( ( design ) =>
+			selectedDesignSlugs.includes( design.slug )
+		);
+
+		// Now order the filtered set based on the supplied slugs.
+		selectedDesigns = selectedDesignSlugs
+			.map( ( selectedDesignSlug ) =>
+				filteredDesigns.find( ( design ) => design.slug === selectedDesignSlug )
+			)
+			.filter( ( selectedDesign ) => !! selectedDesign ) as Design[];
+	}
 
 	useEffect( () => {
 		if ( selectedDesigns ) {

--- a/packages/design-carousel/src/index.tsx
+++ b/packages/design-carousel/src/index.tsx
@@ -97,7 +97,7 @@ export default function DesignCarousel( { onPick, selectedDesignSlugs }: DesignC
 					className="design-carousel__select"
 					isPrimary
 					onClick={ () => {
-						if ( swiperInstance.current ) {
+						if ( swiperInstance.current && selectedDesigns ) {
 							onPick( selectedDesigns[ swiperInstance.current?.activeIndex ] );
 						}
 					} }


### PR DESCRIPTION
#### Proposed Changes

This PR implements two changes:
* I've updated the set of themes used in the eCommerce tailored flow to remove Twenty Twenty Two (as it was only a placeholder until Zaino launched), and pushed the Zaino theme ahead of Thriving Artist in the display order
* I've refactored the code such that the filtered set of designs need to be specified via the `selectedDesignSlugs` prop on the component

#### Testing Instructions

* On a branch with this patch applied (either local or via Calypso.live), navigate to `/setup/ecommerce/designCarousel`
* Verify that you see the following four themes presented in this order: Tsubaki, Tazza, Zaino, Thriving Artist

#### Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [N/A] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [N/A] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [N/A] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [N/A] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?

Related to #71155, which added Zaino to the list of themes.