### PR TITLE
Checkout 2Y plan upsell should show for `en-gb`

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/checkout-sidebar-plan-upsell/index.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-sidebar-plan-upsell/index.tsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { isPlan } from '@automattic/calypso-products';
 import { FormStatus, useFormStatus } from '@automattic/composite-checkout';
 import formatCurrency from '@automattic/format-currency';
@@ -94,8 +95,10 @@ export function CheckoutSidebarPlanUpsell() {
 		{ strong: createElement( 'strong' ) }
 	);
 
+	const isEnglish = ( config( 'english_locales' ) as string[] ).includes( locale || '' );
+
 	if (
-		'en' !== locale &&
+		! isEnglish &&
 		! hasTranslation( '<strong>Save %(percentSavings)d%%</strong> by paying for two years' )
 	) {
 		debug( "not 'en' and does not have translation", locale );

--- a/client/my-sites/checkout/composite-checkout/components/checkout-sidebar-plan-upsell/index.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-sidebar-plan-upsell/index.tsx
@@ -1,8 +1,6 @@
-import config from '@automattic/calypso-config';
 import { isPlan } from '@automattic/calypso-products';
 import { FormStatus, useFormStatus } from '@automattic/composite-checkout';
 import formatCurrency from '@automattic/format-currency';
-import { useLocale } from '@automattic/i18n-utils';
 import { useShoppingCart } from '@automattic/shopping-cart';
 import { createElement, createInterpolateElement } from '@wordpress/element';
 import { sprintf } from '@wordpress/i18n';
@@ -27,8 +25,7 @@ export function CheckoutSidebarPlanUpsell() {
 	const { formStatus } = useFormStatus();
 	const reduxDispatch = useDispatch();
 	const isFormLoading = FormStatus.READY !== formStatus;
-	const { __, hasTranslation } = useI18n();
-	const locale = useLocale();
+	const { __ } = useI18n();
 	const cartKey = useCartKey();
 	const { responseCart, replaceProductInCart } = useShoppingCart( cartKey );
 	const plan = responseCart.products.find( ( product ) => isPlan( product ) );
@@ -94,16 +91,6 @@ export function CheckoutSidebarPlanUpsell() {
 		),
 		{ strong: createElement( 'strong' ) }
 	);
-
-	const isEnglish = ( config( 'english_locales' ) as string[] ).includes( locale || '' );
-
-	if (
-		! isEnglish &&
-		! hasTranslation( '<strong>Save %(percentSavings)d%%</strong> by paying for two years' )
-	) {
-		debug( "not 'en' and does not have translation", locale );
-		return null;
-	}
 
 	return (
 		<PromoCard title={ cardTitle } className="checkout-sidebar-plan-upsell">


### PR DESCRIPTION
#### Proposed Changes

* This PR fixes the issue that the 2Y plan upsell in the checkout page does not show for `en-gb`.

**BEFORE**

<img width="1453" alt="Screenshot 2022-12-19 at 9 09 12 PM" src="https://user-images.githubusercontent.com/1269602/208463469-aaa41d86-0455-4f43-8c29-f0b1f7f4ee76.png">

**AFTER**

<img width="1239" alt="Screenshot 2022-12-19 at 9 09 30 PM" src="https://user-images.githubusercontent.com/1269602/208463488-7c437f85-779a-4817-9cd0-68577ffa2e95.png">


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch browser language to English (UK) and go through a fresh signup flow in an incognito window. 
* Add a Premium plan to cart
* Verify that you can see the 2Y plan upsell.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
