### PR TITLE
Handle /advertising redirecting on users without sites

### DIFF
--- a/client/my-sites/promote-post/controller.js
+++ b/client/my-sites/promote-post/controller.js
@@ -1,5 +1,6 @@
 import page from 'page';
 import { getSiteFragment } from 'calypso/lib/route';
+import { siteSelection } from 'calypso/my-sites/controller';
 import PromotedPosts from 'calypso/my-sites/promote-post/main';
 import getPrimarySiteSlug from 'calypso/state/selectors/get-primary-site-slug';
 
@@ -18,5 +19,10 @@ export const redirectToPrimarySite = ( context, next ) => {
 
 	const state = context.store.getState();
 	const primarySiteSlug = getPrimarySiteSlug( state );
-	page( `/advertising/${ primarySiteSlug }` );
+	if ( primarySiteSlug !== null ) {
+		page( `/advertising/${ primarySiteSlug }` );
+	} else {
+		siteSelection( context, next );
+		page( `/advertising` );
+	}
 };


### PR DESCRIPTION
#### Proposed Changes
- There is a flow where clients could open WordPress.com without any site. You could create a new account [here](https://wordpress.com/start/account/user) or remove all of your sites. If the user goes to /advertising it was trying to fetch their main site. Since there wasn't any, the user was being redirected to /advertising/null 
This PR handlers this route and will keep the user in /advertising, prompting them to create a new account

![image](https://user-images.githubusercontent.com/43957544/208466381-376999ee-79f8-4cd0-b904-43b0f6c20846.png)


#### Testing Instructions
- Create a new account without a site. Go to wordpress.com/advertising route
- EXPECTED: User should display /advertising route with a prompt to create a new site.


#### Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?


Related to #
