### PR TITLE
format-currency: Fix IDR locale formatting

### DIFF
--- a/packages/format-currency/src/currencies.ts
+++ b/packages/format-currency/src/currencies.ts
@@ -365,7 +365,7 @@ export const CURRENCIES: CurrenciesDictionary = {
 		symbol: 'Rp',
 		grouping: '.',
 		decimal: ',',
-		precision: 0,
+		precision: 2,
 	},
 	ILS: {
 		symbol: '₪',

--- a/packages/format-currency/test/index.ts
+++ b/packages/format-currency/test/index.ts
@@ -101,6 +101,10 @@ describe( 'formatCurrency', () => {
 			const money = formatCurrency( 9800900.32, 'BRL' );
 			expect( money ).toBe( 'R$9.800.900,32' );
 		} );
+		test( 'IDR', () => {
+			const money = formatCurrency( 107280000, 'IDR', { isSmallestUnit: true } );
+			expect( money ).toBe( 'Rp1.072.800,00' );
+		} );
 	} );
 
 	describe( 'getCurrencyDefaults()', () => {


### PR DESCRIPTION
#### Proposed Changes

This should fix formatting issues with IDR currencies when using `isSmallestUnit`.

IDR has cents, even though they are not commonly used. The backend was aware of this, but the frontend did not know about them, so when the backend provided a number like `107280000`, the frontend turned it into `Rp107.280.000` instead of `Rp1.072.800`. This PR adjusts the frontend to correctly notice cents.

Note: the backend is incorrectly formatting the price for the line item also. It is giving us `1,072,800 Rp` instead of `Rp1.072.800`, but that's a separate issue.

Before: 
<img width="568" alt="Screenshot 2022-12-19 at 11 30 47 AM" src="https://user-images.githubusercontent.com/2036909/208474375-2a959276-7a50-41eb-a496-4556dffea411.png">

After:
<img width="570" alt="Screenshot 2022-12-19 at 11 33 24 AM" src="https://user-images.githubusercontent.com/2036909/208474386-9aa92751-fb53-4ec4-bcb7-4e11f453a4dc.png">

The bug report was here: p1671431756395779-slack-C029GN3KD

#### Testing Instructions

Automated tests.