### PR TITLE
Ecommerce Tailored Flow: Fixing ecommerce flow progress bar

### DIFF
--- a/packages/onboarding/src/flow-progress/use-flow-progress.ts
+++ b/packages/onboarding/src/flow-progress/use-flow-progress.ts
@@ -1,4 +1,4 @@
-import { LINK_IN_BIO_FLOW, LINK_IN_BIO_TLD_FLOW, ECOMMERCE_FLOW } from '../utils/flows';
+import { ECOMMERCE_FLOW, LINK_IN_BIO_FLOW, LINK_IN_BIO_TLD_FLOW } from '../utils/flows';
 
 /* eslint-disable no-restricted-imports */
 interface FlowProgress {

--- a/packages/onboarding/src/flow-progress/use-flow-progress.ts
+++ b/packages/onboarding/src/flow-progress/use-flow-progress.ts
@@ -53,13 +53,13 @@ const flows: Record< string, { [ step: string ]: number } > = {
 	[ ECOMMERCE_FLOW ]: {
 		intro: 0,
 		storeProfiler: 1,
-		storeAddress: 2,
+		designCarousel: 2,
 		domains: 3,
-		designCarousel: 4,
-		siteCreationStep: 5,
-		processing: 5,
-		waitForAtomic: 5,
-		checkPlan: 5,
+		siteCreationStep: 4,
+		processing: 4,
+		waitForAtomic: 4,
+		checkPlan: 4,
+		storeAddress: 5,
 	},
 };
 

--- a/packages/onboarding/src/flow-progress/use-flow-progress.ts
+++ b/packages/onboarding/src/flow-progress/use-flow-progress.ts
@@ -1,4 +1,4 @@
-import { LINK_IN_BIO_FLOW, LINK_IN_BIO_TLD_FLOW } from '../utils/flows';
+import { LINK_IN_BIO_FLOW, LINK_IN_BIO_TLD_FLOW, ECOMMERCE_FLOW } from '../utils/flows';
 
 /* eslint-disable no-restricted-imports */
 interface FlowProgress {
@@ -49,6 +49,17 @@ const flows: Record< string, { [ step: string ]: number } > = {
 		chooseAPlan: 5,
 		processing: 6,
 		launchpad: 7,
+	},
+	[ ECOMMERCE_FLOW ]: {
+		intro: 0,
+		storeProfiler: 1,
+		storeAddress: 2,
+		domains: 3,
+		designCarousel: 4,
+		siteCreationStep: 5,
+		processing: 5,
+		waitForAtomic: 5,
+		checkPlan: 5,
 	},
 };
 


### PR DESCRIPTION
#### Proposed Changes

* This PR fixes a missing set of config values for the ecommerce flow, allowing it to properly show a progress bar across the top of the screen as steps progress.

Before:
<img width="1179" alt="image" src="https://user-images.githubusercontent.com/13437011/208488316-811cd0ed-d604-49c3-8ae2-17a72e65d711.png">


After: 
<img width="1164" alt="image" src="https://user-images.githubusercontent.com/13437011/208487729-9c3453e5-27cf-471b-ac38-98fe0ddd642f.png">


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this PR to testing environment and navigate to `/setup/ecommerce`
* Navigate through the flow and verify that the progress bar appears and progresses appropriately through each step.

Related to #71244
