### PR TITLE
DRAFT | Launchpad: Enable Launchpad for General Onboarding

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -113,6 +113,7 @@ export function generateFlows( {
 			description: 'Abridged version of the onboarding flow. Read more in https://wp.me/pau2Xa-Vs.',
 			lastModified: '2020-12-10',
 			showRecaptcha: true,
+			postCompleteCallback: setupSiteAfterCreation,
 		},
 		{
 			name: 'newsletter',

--- a/packages/data-stores/src/onboard/constants.ts
+++ b/packages/data-stores/src/onboard/constants.ts
@@ -16,4 +16,5 @@ export enum SiteIntent {
 	DIFM = 'difm', // "Do It For Me"
 	WpAdmin = 'wpadmin',
 	Import = 'import', // deprecated
+	Free = 'free',
 }

--- a/packages/data-stores/src/onboard/test/utils.ts
+++ b/packages/data-stores/src/onboard/test/utils.ts
@@ -5,7 +5,7 @@ describe( 'Test onboard utils', () => {
 	it.each( [
 		{
 			goals: [],
-			expectedIntent: SiteIntent.Build,
+			expectedIntent: SiteIntent.Free,
 		},
 		{
 			goals: [ SiteGoal.Write, SiteGoal.Import, SiteGoal.DIFM ],

--- a/packages/data-stores/src/onboard/utils.ts
+++ b/packages/data-stores/src/onboard/utils.ts
@@ -32,7 +32,7 @@ export const goalsToIntent = ( goals: SiteGoal[] ): SiteIntent => {
 		return GOAL_TO_INTENT_MAP[ intentDecidingGoal ];
 	}
 
-	return SiteIntent.Build;
+	return SiteIntent.Free;
 };
 
 export const serializeGoals = ( goals: SiteGoal[] ): string => {

--- a/packages/onboarding/src/setup-tailored-site-after-creation.ts
+++ b/packages/onboarding/src/setup-tailored-site-after-creation.ts
@@ -8,6 +8,7 @@ import {
 	LINK_IN_BIO_FLOW,
 	FREE_FLOW,
 	isFreeFlow,
+	isGeneralOnboardingFlow,
 } from './utils';
 
 const ONBOARD_STORE = Onboard.register();
@@ -49,31 +50,35 @@ export function setupSiteAfterCreation( { siteId, flowName }: SetupOnboardingSit
 	if ( siteId && flowName ) {
 		const formData: ( string | File )[][] = [];
 		const settings: {
-			blogname: string;
-			blogdescription: string;
+			blogname?: string;
+			blogdescription?: string;
 			launchpad_screen?: string;
 			site_intent?: string;
-		} = {
-			blogname: siteTitle,
-			blogdescription: siteDescription,
-		};
+		} = {};
 
-		if ( isNewsletterOrLinkInBioFlow( flowName ) || isFreeFlow( flowName ) ) {
-			// link-in-bio and link-in-bio-tld are considered the same intent.
-			if ( isLinkInBioFlow( flowName ) || isFreeFlow( flowName ) ) {
-				settings.site_intent = isLinkInBioFlow( flowName ) ? LINK_IN_BIO_FLOW : FREE_FLOW;
-				if ( selectedPatternContent ) {
-					const pattern = {
-						content: selectedPatternContent,
-						template: 'blank',
-					};
-					formData.push( [ 'pattern', JSON.stringify( pattern ) ] );
-				}
-			} else {
-				settings.site_intent = flowName;
-			}
-
+		if ( isGeneralOnboardingFlow( flowName ) ) {
 			settings.launchpad_screen = 'full';
+		} else {
+			settings.blogname = siteTitle;
+			settings.blogdescription = siteDescription;
+
+			if ( isNewsletterOrLinkInBioFlow( flowName ) || isFreeFlow( flowName ) ) {
+				// link-in-bio and link-in-bio-tld are considered the same intent.
+				if ( isLinkInBioFlow( flowName ) || isFreeFlow( flowName ) ) {
+					settings.site_intent = isLinkInBioFlow( flowName ) ? LINK_IN_BIO_FLOW : FREE_FLOW;
+					if ( selectedPatternContent ) {
+						const pattern = {
+							content: selectedPatternContent,
+							template: 'blank',
+						};
+						formData.push( [ 'pattern', JSON.stringify( pattern ) ] );
+					}
+				} else {
+					settings.site_intent = flowName;
+				}
+
+				settings.launchpad_screen = 'full';
+			}
 		}
 
 		formData.push( [ 'settings', JSON.stringify( settings ) ] );

--- a/packages/onboarding/src/utils/flows.ts
+++ b/packages/onboarding/src/utils/flows.ts
@@ -8,6 +8,7 @@ export const IMPORT_FOCUSED_FLOW = 'import-focused';
 export const ECOMMERCE_FLOW = 'ecommerce';
 export const FREE_FLOW = 'free';
 export const FREE_POST_SETUP_FLOW = 'free-post-setup';
+export const GENERAL_ONBOARDING_FLOW = 'onboarding';
 
 export const isLinkInBioFlow = ( flowName: string | null ) => {
 	return Boolean(
@@ -18,6 +19,10 @@ export const isLinkInBioFlow = ( flowName: string | null ) => {
 
 export const isFreeFlow = ( flowName: string | null ) => {
 	return Boolean( flowName && [ FREE_FLOW, FREE_POST_SETUP_FLOW ].includes( flowName ) );
+};
+
+export const isGeneralOnboardingFlow = ( flowName: string | null ) => {
+	return Boolean( flowName && flowName === GENERAL_ONBOARDING_FLOW );
 };
 
 export const isNewsletterOrLinkInBioFlow = ( flowName: string | null ) => {


### PR DESCRIPTION
#### Proposed Changes
This PR sets the `launchpad_screen` and `site_intent` options for new sites using the general onboarding flow to enable the Launchpad redirect from my home.

#### Testing Instructions
1. Checkout this branch
2. Go to `calypso.localhost:3000/start`
3. Go through the onboarding flow to create a new site

**IMPORTANT: Make sure you don't select any site goal when you are at the Goals screen so that you get the correct site intent. More info in the comment below**

4. After completing the flow you should be redirected to a Launchpad with the Free flow.

https://user-images.githubusercontent.com/20927667/208500198-a8f65875-b8f7-410a-86bf-6f99852f4510.mov

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #70825 
