### PR TITLE
Checkout: Select first available payment method

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/checkout-main.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-main.tsx
@@ -698,7 +698,7 @@ export default function CheckoutMain( {
 				isLoading={ isLoading }
 				isValidating={ isCartPendingUpdate }
 				theme={ theme }
-				initiallySelectedPaymentMethodId={ paymentMethods?.length ? paymentMethods[ 0 ].id : null }
+				selectFirstAvailablePaymentMethod
 			>
 				<WPCheckout
 					forceRadioButtons={ forceRadioButtons }

--- a/client/my-sites/checkout/composite-checkout/test/credit-card.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/credit-card.tsx
@@ -31,7 +31,7 @@ function TestWrapper( { paymentMethods, paymentProcessors = undefined } ) {
 				<StripeHookProvider fetchStripeConfiguration={ fetchStripeConfiguration }>
 					<CheckoutProvider
 						paymentMethods={ paymentMethods }
-						initiallySelectedPaymentMethodId={ paymentMethods[ 0 ].id }
+						selectFirstAvailablePaymentMethod
 						paymentProcessors={ paymentProcessors ?? {} }
 					>
 						<CheckoutStepGroup>

--- a/client/my-sites/checkout/composite-checkout/test/existing-credit-card.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/existing-credit-card.tsx
@@ -24,7 +24,7 @@ function TestWrapper( { paymentMethods, paymentProcessors = undefined } ) {
 			<QueryClientProvider client={ queryClient }>
 				<CheckoutProvider
 					paymentMethods={ paymentMethods }
-					initiallySelectedPaymentMethodId={ paymentMethods[ 0 ].id }
+					selectFirstAvailablePaymentMethod
 					paymentProcessors={ paymentProcessors ?? {} }
 				>
 					<CheckoutStepGroup>

--- a/client/my-sites/checkout/composite-checkout/test/netbanking.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/netbanking.tsx
@@ -26,7 +26,7 @@ function TestWrapper( { paymentMethods, paymentProcessors = undefined } ) {
 			<QueryClientProvider client={ queryClient }>
 				<CheckoutProvider
 					paymentMethods={ paymentMethods }
-					initiallySelectedPaymentMethodId={ paymentMethods[ 0 ].id }
+					selectFirstAvailablePaymentMethod
 					paymentProcessors={ paymentProcessors ?? {} }
 				>
 					<CheckoutStepGroup>

--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -129,7 +129,8 @@ It has the following props.
 - `isLoading?: boolean`. If set and true, the form will be replaced with a loading placeholder and the form status will be set to [`.LOADING`](#FormStatus) (see [useFormStatus](#useFormStatus)).
 - `isValidating?: boolean`. If set and true, the form status will be set to [`.VALIDATING`](#FormStatus) (see [useFormStatus](#useFormStatus)).
 - `redirectToUrl?: (url: string) => void`. Will be used by [useTransactionStatus](#useTransactionStatus) if it needs to redirect. If not set, it will change `window.location.href`.
-- `initiallySelectedPaymentMethodId?: string | null`. If set, is used to preselect a payment method when the `paymentMethods` array changes. Default is `null`, which yields no initial selection. To change the selection in code, see the [`usePaymentMethodId`](#usePaymentMethodId) hook.
+- `initiallySelectedPaymentMethodId?: string | null`. If set, is used to preselect a payment method on first load or when the `paymentMethods` array changes. Default is `null`, which yields no initial selection. To change the selection in code, see the [`usePaymentMethodId`](#usePaymentMethodId) hook. If a disabled payment method is chosen, it will appear that no payment method is selected.
+- `selectFirstAvailablePaymentMethod?: boolean`. If set and `initiallySelectedPaymentMethodId` is _not_ set, this is used to preselect a payment method on first load or when the `paymentMethods` array changes.
 
 The line items are for display purposes only. They should also include subtotals, discounts, and taxes. No math will be performed on the line items. Instead, the amount to be charged will be specified by the required prop `total`, which is another line item.
 

--- a/packages/composite-checkout/src/components/checkout-provider.tsx
+++ b/packages/composite-checkout/src/components/checkout-provider.tsx
@@ -47,6 +47,7 @@ export function CheckoutProvider( {
 	paymentProcessors,
 	isLoading,
 	isValidating,
+	selectFirstAvailablePaymentMethod,
 	initiallySelectedPaymentMethodId = null,
 	children,
 }: CheckoutProviderProps ) {
@@ -64,14 +65,24 @@ export function CheckoutProvider( {
 	};
 	const [ disabledPaymentMethodIds, setDisabledPaymentMethodIds ] = useState< string[] >( [] );
 
+	const availablePaymentMethodIds = paymentMethods
+		.filter( ( method ) => ! disabledPaymentMethodIds.includes( method.id ) )
+		.map( ( method ) => method.id );
+
+	if (
+		selectFirstAvailablePaymentMethod &&
+		! initiallySelectedPaymentMethodId &&
+		availablePaymentMethodIds.length > 0
+	) {
+		initiallySelectedPaymentMethodId = availablePaymentMethodIds[ 0 ];
+	}
+
 	const [ paymentMethodId, setPaymentMethodId ] = useState< string | null >(
 		initiallySelectedPaymentMethodId
 	);
 
 	useResetSelectedPaymentMethodWhenListChanges(
-		paymentMethods
-			.filter( ( method ) => ! disabledPaymentMethodIds.includes( method.id ) )
-			.map( ( method ) => method.id ),
+		availablePaymentMethodIds,
 		initiallySelectedPaymentMethodId,
 		setPaymentMethodId
 	);

--- a/packages/composite-checkout/src/types.ts
+++ b/packages/composite-checkout/src/types.ts
@@ -120,6 +120,7 @@ export interface CheckoutProviderProps {
 	paymentProcessors: PaymentProcessorProp;
 	isValidating?: boolean;
 	initiallySelectedPaymentMethodId?: string | null;
+	selectFirstAvailablePaymentMethod?: boolean;
 	children: React.ReactNode;
 }
 


### PR DESCRIPTION
#### Proposed Changes

When first rendered or when the list of payment methods change, checkout relies on the `initiallySelectedPaymentMethodId` prop of `CheckoutProvider` to decide which payment method to pre-select. Since https://github.com/Automattic/wp-calypso/pull/71103 that prop is also used if any payment methods are disabled. However, this presents a new problem: we might not know if the `initiallySelectedPaymentMethodId` is disabled or not at the time when the props are provided.

In this PR we add a new prop, `selectFirstAvailablePaymentMethod`, which will instead select the first available payment method without needing to know ahead of time which method that is.

Should fix the issue described in https://github.com/Automattic/wp-calypso/pull/70614#issuecomment-1357163371

Before:

<img width="572" alt="Screenshot 2022-12-19 at 3 05 05 PM" src="https://user-images.githubusercontent.com/2036909/208510749-f33ea91f-b73f-4588-bd09-ca181b177ed1.png">

After:

<img width="593" alt="Screenshot 2022-12-19 at 3 04 16 PM" src="https://user-images.githubusercontent.com/2036909/208510771-4d8a8737-eb6c-43cb-a74c-47a1d69d4362.png">


#### Testing Instructions

- Use an account with no saved credit cards. 
- Using a locale where only credit cards are allowed (I believe INR works for this purpose), add a product to your cart and visit checkout.
- Proceed to the last step of checkout (it may already be active depending on your cached contact details).
- Verify that the credit card payment method is pre-selected.