### PR TITLE
Enable pre-sales chat for logged-in users in Production env.

### DIFF
--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -48,7 +48,7 @@
 		"jetpack/server-credentials-advanced-flow": true,
 		"jetpack/simplify-pricing-structure": false,
 		"jetpack/standalone-plugin-onboarding-update-v1": true,
-		"jetpack/zendesk-chat-for-logged-in-users": false,
+		"jetpack/zendesk-chat-for-logged-in-users": true,
 		"layout/app-banner": false,
 		"layout/guided-tours": false,
 		"layout/query-selected-editor": false,


### PR DESCRIPTION
#### Proposed Changes

This PR enables the Zendesk pre-sales chat for **_logged-in_** users on the Jetpack Cloud pricing page.

Additional context: We implemented a Zendesk pre-sales chat interface ( https://github.com/Automattic/wp-calypso/pull/70590 ) that would only display for logged-out users, however now we want to increase the chat volume by enabling the chat interface to _**logged-in**_ users also.

**Implementation notes:**

Enabled feature-flag: `jetpack/zendesk-chat-for-logged-in-users` in production env (in file: `jetpack-cloud-production.json`).

Related to #71253

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Just simply review the code. Verify that in the file `config/jetpack-cloud-production.json` the feature property `jetpack/zendesk-chat-for-logged-in-users` is set to `true`.

I don't think there is any other"manual" way to test this PR, other than to just manually inspect the code. And then once deployed, we can then test that the chat is showing for logged-in users.  🤷‍♂️

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


