### PR TITLE
Shopping Cart: stop clearing cart messages after displaying them

### DIFF
--- a/client/my-sites/checkout/cart/cart-messages.tsx
+++ b/client/my-sites/checkout/cart/cart-messages.tsx
@@ -25,11 +25,7 @@ function CartMessage( { message }: { message: ResponseCartMessage } ) {
 
 export default function CartMessages(): null {
 	const cartKey = useCartKey();
-	const {
-		responseCart: cart,
-		isLoading: isLoadingCart,
-		clearMessages,
-	} = useShoppingCart( cartKey );
+	const { responseCart: cart, isLoading: isLoadingCart } = useShoppingCart( cartKey );
 	const reduxDispatch = useDispatch();
 
 	const showErrorMessages = useCallback(
@@ -48,7 +44,6 @@ export default function CartMessages(): null {
 
 	useDisplayCartMessages( {
 		cart,
-		clearMessages,
 		isLoadingCart,
 		showErrorMessages,
 		showSuccessMessages,

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
@@ -373,12 +373,19 @@ export default function WPCheckout( {
 						);
 						if ( validationResponse ) {
 							// When the contact details change, update the cart's tax location to match.
-							await updateCartContactDetailsForCheckout(
-								countriesList,
-								responseCart,
-								updateLocation,
-								contactInfo
-							);
+							try {
+								await updateCartContactDetailsForCheckout(
+									countriesList,
+									responseCart,
+									updateLocation,
+									contactInfo
+								);
+							} catch {
+								// If updating the cart fails, we should not continue. No need
+								// to do anything else, though, because CartMessages will
+								// display the error.
+								return false;
+							}
 
 							// When the contact details change, update the cached contact details on
 							// the server. This can fail if validation fails but we will silently

--- a/client/my-sites/checkout/composite-checkout/hooks/use-add-products-from-url.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-add-products-from-url.ts
@@ -94,10 +94,15 @@ export default function useAddProductsFromUrl( {
 		if ( couponCodeFromUrl ) {
 			cartPromises.push( applyCoupon( couponCodeFromUrl ) );
 		}
-		Promise.allSettled( cartPromises ).then( () => {
-			debug( 'initial cart requests have completed' );
-			isMounted.current && setIsLoading( false );
-		} );
+		Promise.allSettled( cartPromises )
+			.then( () => {
+				debug( 'initial cart requests have completed' );
+				isMounted.current && setIsLoading( false );
+			} )
+			.catch( () => {
+				debug( 'initial cart requests have failed' );
+				isMounted.current && setIsLoading( false );
+			} );
 		hasRequestedInitialProducts.current = true;
 	}, [
 		isLoading,

--- a/packages/shopping-cart/src/managers.ts
+++ b/packages/shopping-cart/src/managers.ts
@@ -78,6 +78,15 @@ export function createSubscriptionManager( cartKey: CartKey | undefined ): Subsc
 	return { subscribe, notifySubscribers };
 }
 
+/**
+ * Create an object that manages the Promises returned by cart actions.
+ *
+ * When an action is requested, we create a Promise for that action dispatcher
+ * to return and store it in this object. Later when we know if the action
+ * resulted in a success or a failure, the resolve or reject methods are called
+ * on this object; those methods then resolve or reject each Promise that was
+ * waiting for a response.
+ */
 export function createActionPromisesManager(): ActionPromises {
 	let actionPromises: SavedActionPromise[] = [];
 

--- a/packages/shopping-cart/src/shopping-cart-manager.ts
+++ b/packages/shopping-cart/src/shopping-cart-manager.ts
@@ -105,12 +105,18 @@ function createShoppingCartManager(
 		}
 
 		if ( ! isStatePendingUpdateOrQueuedAction( state ) ) {
-			// action promises are resolved even if state hasn't changed so that
-			// noop actions resolve immediately.
+			// action promises are resolved even if state hasn't changed so that noop
+			// actions resolve immediately. However, if the state did not change and
+			// there are errors, they have already been reported and we don't want to
+			// reject action promises a second time.
 			const error = getErrorFromState( state );
-			if ( error ) {
+			if ( error && isStateChanged ) {
+				debug( 'no state updates pending and there is an error, so rejecting action promises' );
 				actionPromises.reject( error );
 			} else {
+				debug(
+					'no state updates pending and there are no new errors, so resolving action promises'
+				);
 				actionPromises.resolve( state.responseCart );
 			}
 		}

--- a/packages/shopping-cart/src/use-shopping-cart.ts
+++ b/packages/shopping-cart/src/use-shopping-cart.ts
@@ -15,7 +15,10 @@ export default function useShoppingCart( cartKey: CartKey | undefined ): UseShop
 	useRefetchOnFocus( finalCartKey );
 
 	useEffect( () => {
-		manager.fetchInitialCart();
+		manager.fetchInitialCart().catch( () => {
+			// The consumer of the cart data can display any errors returned by the
+			// endpoint, so we will ignore them here.
+		} );
 	}, [ manager ] );
 
 	const isMounted = useRef( true );

--- a/packages/shopping-cart/test/cart-manager.ts
+++ b/packages/shopping-cart/test/cart-manager.ts
@@ -1,5 +1,6 @@
 import { createShoppingCartManagerClient, getEmptyResponseCart } from '../src/index';
 import { getCart, setCart, mainCartKey, planOne, planTwo } from './utils/mock-cart-api';
+import type { ResponseCart } from '../src/types';
 
 /* eslint-disable jest/no-done-callback, jest/no-conditional-expect */
 
@@ -169,6 +170,37 @@ describe( 'ShoppingCartManager', () => {
 		const slugsInCart = responseCart.products.map( ( prod ) => prod.product_slug );
 		expect( slugsInCart ).toContain( planOne.product_slug );
 		expect( slugsInCart ).toContain( planTwo.product_slug );
+	} );
+
+	it( 'noop actions taken when the cart already has errors do not reject their promises', async () => {
+		const errorCode = 'test-error';
+		const errorMessage = 'test error message';
+		const countryCode = 'CA';
+		const mockSetCart = jest.fn().mockResolvedValue( {
+			...getEmptyResponseCart(),
+			messages: { errors: [ { code: errorCode, message: errorMessage } ] },
+			tax: {
+				location: {
+					country_code: countryCode,
+				},
+			},
+		} as ResponseCart );
+		const cartManagerClient = createShoppingCartManagerClient( {
+			getCart,
+			setCart: mockSetCart,
+		} );
+		const manager = cartManagerClient.forCartKey( mainCartKey );
+		await manager.fetchInitialCart();
+		try {
+			await manager.actions.addProductsToCart( [ planOne ] );
+		} catch {
+			// This will reject because of the error, but that's expected.
+		}
+
+		// updateLocation with the same data should be a noop.
+		const p1 = manager.actions.updateLocation( { countryCode } );
+		const completeCart = await p1;
+		expect( p1 ).resolves.toEqual( completeCart );
 	} );
 
 	it( 'multiple actions triggered sequentially all modify the cart', async () => {

--- a/packages/shopping-cart/test/cart-manager.ts
+++ b/packages/shopping-cart/test/cart-manager.ts
@@ -192,10 +192,37 @@ describe( 'ShoppingCartManager', () => {
 		const manager = cartManagerClient.forCartKey( mainCartKey );
 		await manager.fetchInitialCart();
 		try {
+			// Create the error state by sending an action which will cause setCart
+			// to set an error.
 			await manager.actions.addProductsToCart( [ planOne ] );
 		} catch {
 			// This will reject because of the error, but that's expected.
 		}
+
+		// updateLocation with the same data should be a noop.
+		const p1 = manager.actions.updateLocation( { countryCode } );
+		const completeCart = await p1;
+		expect( p1 ).resolves.toEqual( completeCart );
+	} );
+
+	it( 'noop actions taken when the cart has a loading error are not rejected', async () => {
+		const errorMessage = 'test error message';
+		const countryCode = 'CA';
+		const mockGetCart = jest.fn().mockResolvedValue( {
+			...getEmptyResponseCart(),
+			tax: {
+				location: {
+					country_code: countryCode,
+				},
+			},
+		} as ResponseCart );
+		const mockSetCart = jest.fn().mockRejectedValue( new Error( errorMessage ) );
+		const cartManagerClient = createShoppingCartManagerClient( {
+			getCart: mockGetCart,
+			setCart: mockSetCart,
+		} );
+		const manager = cartManagerClient.forCartKey( mainCartKey );
+		await manager.fetchInitialCart();
 
 		// updateLocation with the same data should be a noop.
 		const p1 = manager.actions.updateLocation( { countryCode } );

--- a/packages/wpcom-checkout/src/use-display-cart-messages.tsx
+++ b/packages/wpcom-checkout/src/use-display-cart-messages.tsx
@@ -3,20 +3,17 @@ import type {
 	ResponseCart,
 	ResponseCartMessages,
 	ResponseCartMessage,
-	ClearCartMessages,
 } from '@automattic/shopping-cart';
 
 export type ShowMessages = ( messages: ResponseCartMessage[] ) => void;
 
 export default function useDisplayCartMessages( {
 	cart,
-	clearMessages,
 	isLoadingCart,
 	showErrorMessages,
 	showSuccessMessages,
 }: {
 	cart: ResponseCart;
-	clearMessages: ClearCartMessages;
 	isLoadingCart: boolean;
 	showSuccessMessages: ShowMessages;
 	showErrorMessages: ShowMessages;
@@ -24,28 +21,28 @@ export default function useDisplayCartMessages( {
 	const previousCart = useRef< ResponseCart | null >( null );
 
 	useEffect( () => {
+		if ( previousCart.current === cart ) {
+			return;
+		}
 		displayCartMessages( {
 			cart,
-			clearMessages,
 			isLoadingCart,
 			previousCart: previousCart.current,
 			showErrorMessages,
 			showSuccessMessages,
 		} );
 		previousCart.current = cart;
-	}, [ cart, clearMessages, isLoadingCart, showErrorMessages, showSuccessMessages ] );
+	}, [ cart, isLoadingCart, showErrorMessages, showSuccessMessages ] );
 }
 
 function displayCartMessages( {
 	cart,
-	clearMessages,
 	isLoadingCart,
 	previousCart,
 	showErrorMessages,
 	showSuccessMessages,
 }: {
 	cart: ResponseCart;
-	clearMessages: ClearCartMessages;
 	isLoadingCart: boolean;
 	previousCart: ResponseCart | null;
 	showErrorMessages: ShowMessages;
@@ -72,10 +69,6 @@ function displayCartMessages( {
 	if ( successMessages && successMessageCount > 0 ) {
 		showSuccessMessages( successMessages );
 	}
-
-	// Clear messages from the cart so that other components that might call this
-	// function don't cause a message to be displayed more than once.
-	clearMessages();
 }
 
 // Compare two different cart objects and get the messages of newest one


### PR DESCRIPTION
#### Proposed Changes

The `CartMessages` component is in charge of displaying any error or success messages returned by the shopping-cart endpoint any time that it is fetched. It includes code to clear the messages from the cart after they've been displayed, but this means that other components which may want to react to errors in the cart may not have time to do so.

In this PR, we remove the code that clears the cart messages.

To do this safely, we need to fix some issues with the shopping cart manager which clearing the errors was hiding:

1. Prior to this PR, if adding initial products to the cart fails during checkout, the cart will appear to be loading indefinitely. Now the cart will finish loading even if the products fail to be added (either way the user will receive an error message).
2. Prior to this PR, if a cart action caused an error (rejecting its Promise), any subsequent noop actions (eg: updating the cart's tax location if it is unchanged, which often happens upon loading checkout) will appear to fail (rejecting their Promises). Now such noop actions will appear successful since by that time the rejection will already have happened (and the cart will still contain an error).

Noticed in https://github.com/Automattic/wp-calypso/issues/71310

#### Testing Instructions

- Cause a shopping cart error. One way to do this is to try and add an invalid product to the cart via URL like `/checkout/foobar`.
- Verify that the error is displayed.
- Verify that checkout still loads, even with the error displayed.
- Without changing the cart, navigate to other pages in calypso and make sure that they do not show any additional versions of the error message (it's ok if the original message remains, although it should stay gone if dismissed).
- Next, we need to create a shopping cart success message and repeat the steps. One way to do this is to add a coupon to the cart.