### PR TITLE
Hosting Configuration: Update to handle `null` geo affinity API response

### DIFF
--- a/client/my-sites/hosting/web-server-settings-card/index.js
+++ b/client/my-sites/hosting/web-server-settings-card/index.js
@@ -41,7 +41,7 @@ const WebServerSettingsCard = ( {
 	const [ selectedStaticFile404, setSelectedStaticFile404 ] = useState( '' );
 
 	const getGeoAffinityContent = () => {
-		if ( isGettingGeoAffinity || 'auto' === geoAffinity ) {
+		if ( isGettingGeoAffinity || ! geoAffinity ) {
 			return;
 		}
 


### PR DESCRIPTION
See https://github.com/Automattic/dotcom-forge/issues/1409

## Proposed Changes

Updates the 'Web Server Settings' component to correctly handle a `null` geo affinity API response.

## Testing Instructions

Apply D96005-code

When a site has a specified geo affinity, the UI should appear:

<img width="765" alt="image" src="https://user-images.githubusercontent.com/36432/208527968-c3e454f4-8288-4bc2-885f-bd023d1d1cc8.png">

When it doesn't have a specified geo affinity, the UI doesn't appear:

<img width="761" alt="image" src="https://user-images.githubusercontent.com/36432/208528338-c2169643-c839-4f04-9af6-08cc2be1379e.png">