### PR TITLE
Migrate PurchaseMetaPaymentDetails component to TypeScript

### DIFF
--- a/client/lib/purchases/types.ts
+++ b/client/lib/purchases/types.ts
@@ -269,3 +269,5 @@ export interface MembershipSubscriptionsSite {
 	domain: string;
 	subscriptions: MembershipSubscription[];
 }
+
+export type GetChangePaymentMethodUrlFor = ( siteSlug: string, purchase: Purchase ) => string;

--- a/client/me/purchases/manage-purchase/purchase-meta-payment-details.tsx
+++ b/client/me/purchases/manage-purchase/purchase-meta-payment-details.tsx
@@ -5,8 +5,21 @@ import { isOneTimePurchase, isPaidWithCreditCard } from 'calypso/lib/purchases';
 import { getAllStoredCards } from 'calypso/state/stored-cards/selectors';
 import { canEditPaymentDetails } from '../utils';
 import PaymentInfoBlock from './payment-info-block';
+import type { Purchase, GetChangePaymentMethodUrlFor } from 'calypso/lib/purchases/types';
 
-function PurchaseMetaPaymentDetails( { purchase, getChangePaymentMethodUrlFor, siteSlug, site } ) {
+interface PaymentProps {
+	purchase: Purchase;
+	getChangePaymentMethodUrlFor: GetChangePaymentMethodUrlFor;
+	siteSlug?: string;
+	site?: string;
+}
+
+function PurchaseMetaPaymentDetails( {
+	purchase,
+	getChangePaymentMethodUrlFor,
+	siteSlug,
+	site,
+}: PaymentProps ) {
 	const cards = useSelector( getAllStoredCards );
 	const handleEditPaymentMethodClick = () => {
 		recordTracksEvent( 'calypso_purchases_edit_payment_method' );
@@ -24,12 +37,15 @@ function PurchaseMetaPaymentDetails( { purchase, getChangePaymentMethodUrlFor, s
 
 	return (
 		<li>
-			<a
-				href={ getChangePaymentMethodUrlFor( siteSlug, purchase ) }
-				onClick={ handleEditPaymentMethodClick }
-			>
-				{ paymentDetails }
-			</a>
+			{ siteSlug && (
+				<a
+					href={ getChangePaymentMethodUrlFor( siteSlug, purchase ) }
+					onClick={ handleEditPaymentMethodClick }
+				>
+					{ paymentDetails }
+				</a>
+			) }
+			{ ! siteSlug && paymentDetails }
 		</li>
 	);
 }

--- a/client/me/purchases/manage-purchase/purchase-meta-payment-details.tsx
+++ b/client/me/purchases/manage-purchase/purchase-meta-payment-details.tsx
@@ -31,21 +31,23 @@ function PurchaseMetaPaymentDetails( {
 
 	const paymentDetails = <PaymentInfoBlock purchase={ purchase } cards={ cards } />;
 
-	if ( ! canEditPaymentDetails( purchase ) || ! isPaidWithCreditCard( purchase ) || ! site ) {
+	if (
+		! canEditPaymentDetails( purchase ) ||
+		! isPaidWithCreditCard( purchase ) ||
+		! site ||
+		! siteSlug
+	) {
 		return <li>{ paymentDetails }</li>;
 	}
 
 	return (
 		<li>
-			{ siteSlug && (
-				<a
-					href={ getChangePaymentMethodUrlFor( siteSlug, purchase ) }
-					onClick={ handleEditPaymentMethodClick }
-				>
-					{ paymentDetails }
-				</a>
-			) }
-			{ ! siteSlug && paymentDetails }
+			<a
+				href={ getChangePaymentMethodUrlFor( siteSlug, purchase ) }
+				onClick={ handleEditPaymentMethodClick }
+			>
+				{ paymentDetails }
+			</a>
 		</li>
 	);
 }

--- a/client/me/purchases/manage-purchase/purchase-meta-payment-details.tsx
+++ b/client/me/purchases/manage-purchase/purchase-meta-payment-details.tsx
@@ -1,0 +1,37 @@
+import { isDomainTransfer } from '@automattic/calypso-products';
+import { useSelector } from 'react-redux';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { isOneTimePurchase, isPaidWithCreditCard } from 'calypso/lib/purchases';
+import { getAllStoredCards } from 'calypso/state/stored-cards/selectors';
+import { canEditPaymentDetails } from '../utils';
+import PaymentInfoBlock from './payment-info-block';
+
+function PurchaseMetaPaymentDetails( { purchase, getChangePaymentMethodUrlFor, siteSlug, site } ) {
+	const cards = useSelector( getAllStoredCards );
+	const handleEditPaymentMethodClick = () => {
+		recordTracksEvent( 'calypso_purchases_edit_payment_method' );
+	};
+
+	if ( isOneTimePurchase( purchase ) || isDomainTransfer( purchase ) ) {
+		return null;
+	}
+
+	const paymentDetails = <PaymentInfoBlock purchase={ purchase } cards={ cards } />;
+
+	if ( ! canEditPaymentDetails( purchase ) || ! isPaidWithCreditCard( purchase ) || ! site ) {
+		return <li>{ paymentDetails }</li>;
+	}
+
+	return (
+		<li>
+			<a
+				href={ getChangePaymentMethodUrlFor( siteSlug, purchase ) }
+				onClick={ handleEditPaymentMethodClick }
+			>
+				{ paymentDetails }
+			</a>
+		</li>
+	);
+}
+
+export default PurchaseMetaPaymentDetails;

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -20,7 +20,6 @@ import FormTextInput from 'calypso/components/forms/form-text-input';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import UserItem from 'calypso/components/user';
 import useUserLicenseBySubscriptionQuery from 'calypso/data/jetpack-licensing/use-user-license-by-subscription-query';
-import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import {
 	getName,
 	hasPaymentMethod,
@@ -28,7 +27,6 @@ import {
 	isExpiring,
 	isIncludedWithPlan,
 	isOneTimePurchase,
-	isPaidWithCreditCard,
 	isRechargeable,
 	isRenewing,
 	isSubscription,
@@ -39,12 +37,11 @@ import { CALYPSO_CONTACT, JETPACK_SUPPORT } from 'calypso/lib/url/support';
 import { getCurrentUser, getCurrentUserId } from 'calypso/state/current-user/selectors';
 import { getByPurchaseId } from 'calypso/state/purchases/selectors';
 import { getSite, isRequestingSites } from 'calypso/state/sites/selectors';
-import { getAllStoredCards } from 'calypso/state/stored-cards/selectors';
 import { managePurchase } from '../paths';
-import { canEditPaymentDetails, isJetpackTemporarySitePurchase } from '../utils';
+import { isJetpackTemporarySitePurchase } from '../utils';
 import AutoRenewToggle from './auto-renew-toggle';
-import PaymentInfoBlock from './payment-info-block';
 import PurchaseMetaIntroductoryOfferDetail from './purchase-meta-introductory-offer-detail';
+import PurchaseMetaPaymentDetails from './purchase-meta-payment-details';
 import PurchaseMetaPrice from './purchase-meta-price';
 
 export default function PurchaseMeta( {
@@ -213,34 +210,6 @@ function PurchaseMetaOwner( { owner } ) {
 			<span className="manage-purchase__detail">
 				<UserItem user={ { ...owner, name: owner.display_name } } />
 			</span>
-		</li>
-	);
-}
-
-function PurchaseMetaPaymentDetails( { purchase, getChangePaymentMethodUrlFor, siteSlug, site } ) {
-	const cards = useSelector( getAllStoredCards );
-	const handleEditPaymentMethodClick = () => {
-		recordTracksEvent( 'calypso_purchases_edit_payment_method' );
-	};
-
-	if ( isOneTimePurchase( purchase ) || isDomainTransfer( purchase ) ) {
-		return null;
-	}
-
-	const paymentDetails = <PaymentInfoBlock purchase={ purchase } cards={ cards } />;
-
-	if ( ! canEditPaymentDetails( purchase ) || ! isPaidWithCreditCard( purchase ) || ! site ) {
-		return <li>{ paymentDetails }</li>;
-	}
-
-	return (
-		<li>
-			<a
-				href={ getChangePaymentMethodUrlFor( siteSlug, purchase ) }
-				onClick={ handleEditPaymentMethodClick }
-			>
-				{ paymentDetails }
-			</a>
 		</li>
 	);
 }


### PR DESCRIPTION
#### Proposed Changes

Migrate PurchaseMetaPaymentDetails component from the Purchases page to TypeScript

#### Testing Instructions

* As it is a TypeScript migration, it should not change anything so ensure that the usual functionality described below on the purchases page just works as expected.
* Goto this page `/purchases/subscriptions/:site/:purchaseID` ,  for any purchase you should see the `payment method` component as usual without any changes.  ![u7gaw2.png](https://user-images.githubusercontent.com/552016/209408723-9b9426d2-c307-4887-84b7-e828dd25234a.png)
Related to https://github.com/Automattic/payments-shilling/issues/1294

Fixes: https://github.com/Automattic/payments-shilling/issues/1305