### PR TITLE
Launchpad: use share codes to bypass Coming Soon

### DIFF
--- a/client/components/site-preview-link/use-site-preview-links.ts
+++ b/client/components/site-preview-link/use-site-preview-links.ts
@@ -1,6 +1,6 @@
 import { useQuery } from 'react-query';
 import wpcom from 'calypso/lib/wp';
-import type { SiteId } from 'calypso/types';
+import type { SiteId, SiteSlug } from 'calypso/types';
 
 export interface PreviewLink {
 	code: string;
@@ -12,7 +12,7 @@ export interface PreviewLink {
 export type PreviewLinksResponse = PreviewLink[];
 
 interface UseSitePreviewLinksOptions {
-	siteId: SiteId;
+	siteId: SiteId | SiteSlug;
 	onSuccess?: ( previewLinks: PreviewLink[] | undefined ) => void;
 }
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/launchpad-site-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/launchpad-site-preview.tsx
@@ -1,11 +1,26 @@
 import { NEWSLETTER_FLOW, VIDEOPRESS_FLOW } from '@automattic/onboarding';
 import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
+import { number } from 'yargs';
 import { DEVICE_TYPE } from 'calypso/../packages/design-picker/src/constants';
 import { Device } from 'calypso/../packages/design-picker/src/types';
+import { useSitePreviewLinks } from 'calypso/components/site-preview-link/use-site-preview-links';
 import WebPreview from 'calypso/components/web-preview/component';
 import { usePremiumGlobalStyles } from 'calypso/state/sites/hooks/use-premium-global-styles';
 import PreviewToolbar from '../design-setup/preview-toolbar';
+
+interface PreviewLink {
+	code: number;
+	created_at: string;
+}
+
+function getPreviewCode( links: PreviewLink[] ) {
+	if ( typeof links === 'undefined' ) {
+		return false;
+	}
+	const link = links[ 0 ];
+	return link.code ?? false;
+}
 
 const LaunchpadSitePreview = ( {
 	siteSlug,
@@ -14,6 +29,11 @@ const LaunchpadSitePreview = ( {
 	siteSlug: string | null;
 	flow: string | null;
 } ) => {
+	const siteId = siteSlug || '';
+	const { data: previewLinks, isLoading: isPreviewLinksLoading } = useSitePreviewLinks( {
+		siteId,
+	} );
+	const share = getPreviewCode( previewLinks );
 	const translate = useTranslate();
 	const { globalStylesInUse, shouldLimitGlobalStyles } = usePremiumGlobalStyles();
 
@@ -31,8 +51,12 @@ const LaunchpadSitePreview = ( {
 		if ( ! previewUrl ) {
 			return null;
 		}
+		if ( ! ( isPreviewLinksLoading || share ) ) {
+			return null;
+		}
 
 		return addQueryArgs( previewUrl, {
+			share,
 			iframe: true,
 			theme_preview: true,
 			// hide the "Create your website with WordPress.com" banner


### PR DESCRIPTION
## Needs Help:

1. Share codes are not automatically generated for new sites. This PR assumes one is present and should have its own `usePreviewCode` hook that creates one if one is not present (POST to the same endpoint).
2. We might be able to just use this share code stuff across Simple and Atomic and no longer need to use the unmapped `*.wordpress.com` subdomain in the case of mapped domains.
3. Generally TypeScript breaks my brain and it's not happy with me

#### Proposed Changes

* Use site preview link codes to bypass coming soon in Launchpad preview on Atomic

#### Testing Instructions

This is not done but testable.

1. On a newly created Launchpad site, go to Settings --> General and generate a share code.
<img width="735" alt="Screenshot 2022-12-19 at 16 17 48" src="https://user-images.githubusercontent.com/195089/208537506-179a9c68-9a5c-4273-9b4e-07ff342b3408.png">
2. If you haven't transferred to WoA yet, do.
4. With this PR, try to visit `calypso.localhost:3000/home/YOUR_ATOMIC_SITE_URL` and you should be redirected into Launchpad, where the preview URL will work

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #70965
