### PR TITLE
Odyssey Stats: disable translation chunks

### DIFF
--- a/apps/odyssey-stats/src/load-config.js
+++ b/apps/odyssey-stats/src/load-config.js
@@ -5,5 +5,9 @@ import productionConfig from '../../../config/production.json';
 productionConfig.features.is_running_in_jetpack_site =
 	window.configData.features.is_running_in_jetpack_site ?? true;
 
+// The option enables loading of the whole translation file, and could be optimized by setting it to `true`, which needs the translation chunks in place.
+// @see https://github.com/Automattic/wp-calypso/blob/trunk/docs/translation-chunks.md
+productionConfig.features[ 'use-translation-chunks' ] = false;
+
 // Note: configData is hydrated in https://github.com/Automattic/jetpack/blob/d4d0f987cbf63a864b03b542b7813aabe87e0ed3/projects/packages/stats-admin/src/class-dashboard.php#L214
 window.configData.features = productionConfig.features;


### PR DESCRIPTION
#### Proposed Changes

The PR disables 'use-translation-chunks' for Odyssey Stats, because currently the chunked language files are not accessible for Odyssey. As a result tho, the whole translation file would be loaded which is not ideal. We'll look into enabling this again.

#### Testing Instructions

* Build and enable Odyssey Stats for your Jetpack site (`PejTkB-3E-p2` - **Option 1**)
* Switch site language to a language other than English, for example French
* Open `/wp-admin/admin.php?page=stats`
* Ensure strings are translated



#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
