### PR TITLE
CI: streamline the `WPComPlugin` build configuration to reduce queue sizes.

### DIFF
--- a/.teamcity/_self/lib/wpcom/WPComPluginBuild.kt
+++ b/.teamcity/_self/lib/wpcom/WPComPluginBuild.kt
@@ -51,6 +51,7 @@ open class WPComPluginBuild(
 		params.buildParams()
 		maxRunningBuildsPerBranch = """
 			<default>: 0
+			revert*: 0
 			*: 1
 		""".trimIndent()
 

--- a/.teamcity/_self/lib/wpcom/WPComPluginBuild.kt
+++ b/.teamcity/_self/lib/wpcom/WPComPluginBuild.kt
@@ -49,6 +49,10 @@ open class WPComPluginBuild(
 		}
 
 		params.buildParams()
+		maxRunningBuildsPerBranch = """
+			<default>: 0
+			*: 1
+		""".trimIndent()
 
 		artifactRules = "$pluginSlug.zip"
 		buildNumberPattern = "%build.prefix%.%build.counter%"


### PR DESCRIPTION
#### Proposed Changes

This PR attempts to limit the number of concurrent builds of the `WPComPlugin` project to just 1 per feature branch.

To clarify, this is not intended to limit the number of `WPComPlugin` builds to 1 at any given time - concurrent builds will continue to be permitted. The intention here is to prevent a situation where two or more successive pushed commits trigger multiple nearly identical builds.

For example, take a look at the timeline:

1. git commit A is pushed
2. TeamCity triggers `InlineHelp` build configuration.
3. git commit B is pushed shortly after
4. TeamCity triggers `InlineHelp` build configuration again.

In this case, 2 builds are now pushed to the queue where realistically one combined build would have sufficed.

This restriction **does not apply** to branches with `revert-` prefix nor does it apply to `trunk`.

#### Testing Instructions

Ensure that TeamCity configurations do not encounter DSL errors.


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
