### PR TITLE
CI: increase shared memory for the E2E execution step to 3GB.

### DIFF
--- a/.teamcity/_self/bashNodeScript.kt
+++ b/.teamcity/_self/bashNodeScript.kt
@@ -33,7 +33,7 @@ fun BuildSteps.bashNodeScript(init: ScriptBuildStep.() -> Unit): ScriptBuildStep
 	result.dockerImagePlatform = ScriptBuildStep.ImagePlatform.Linux
 	result.dockerPull = true
 	result.dockerImage = result.dockerImage ?: "%docker_image%"
-	result.dockerRunParameters = result.dockerRunParameters ?: "-u %env.UID% --shm-size=1g"
+	result.dockerRunParameters = result.dockerRunParameters ?: "-u %env.UID%"
 	step(result)
 	return result
 }

--- a/.teamcity/_self/lib/customBuildType/E2EBuildType.kt
+++ b/.teamcity/_self/lib/customBuildType/E2EBuildType.kt
@@ -138,6 +138,7 @@ open class E2EBuildType(
 					xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --maxWorkers=%E2E_WORKERS% --group=$testGroup
 				"""
 				dockerImage = "%docker_image_e2e%"
+				dockerRunParameters = "-u %env.UID% --shm-size=3g"
 			}
 
 			bashNodeScript {


### PR DESCRIPTION
### Proposed Changes

This PR increases the shared memory to 3GB but only for the step executing the E2E tests inside `E2EBuildType`.

Key changes:
- remove default definition of 1gb shm from `bashNodeScript`.
- pass in custom parameter specifying 3gb shm when the `Run tests` step is being executed in `E2EBuildType`.

Context:
The two previous attempts https://github.com/Automattic/wp-calypso/pull/70970 and https://github.com/Automattic/wp-calypso/pull/71154 appears to have reduced the occurrence of Chromium crashes, however this is anecdotal as TeamCity does not provide a way to filter by the test name that failed independently from the spec file itself.

In any case, on 2022/12/19 for example, 5-6 instances of this failure were observed out of 25 builds that failed on the `E2E (desktop` build configuration. This is likely much lower than the initial occurrence prior to the deployment of previous fixes.

#### Testing Instructions

As long as all configurations do not report a critical failure, the changes are okay to merge.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #70674.
