### PR TITLE
Components: Create Circular Progress Bar for Launchpad

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/circular-progress-bar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/circular-progress-bar.tsx
@@ -1,0 +1,48 @@
+const CircularProgressBar = ( {
+	currentStep,
+	numberOfSteps,
+}: {
+	currentStep: number;
+	numberOfSteps: number;
+} ) => {
+	const SIZE = 48;
+	const STROKE_WIDTH = 5;
+	const RADIUS = SIZE / 2 - STROKE_WIDTH / 2;
+	const FULL_ARC = 2 * Math.PI * RADIUS;
+
+	return (
+		<div className="launchpad__progress" style={ { width: SIZE, height: SIZE } }>
+			<svg
+				viewBox={ `0 0 ${ SIZE } ${ SIZE }` }
+				style={ { width: SIZE, height: SIZE } }
+				fill="none"
+				xmlns="http://www.w3.org/2000/svg"
+			>
+				<circle
+					className="launchpad__progress-empty-circle"
+					fill="none"
+					cx={ SIZE / 2 }
+					cy={ SIZE / 2 }
+					r={ RADIUS }
+					strokeWidth={ STROKE_WIDTH }
+				/>
+				<circle
+					style={ {
+						strokeDasharray: `${ FULL_ARC * ( currentStep / numberOfSteps ) }, ${ FULL_ARC }`,
+					} }
+					className="launchpad__progress-fill-circle"
+					fill="none"
+					cx={ SIZE / 2 }
+					cy={ SIZE / 2 }
+					r={ RADIUS }
+					strokeWidth={ STROKE_WIDTH }
+				/>
+			</svg>
+			<div className="launchpad__progress-text">
+				{ currentStep }/{ numberOfSteps }
+			</div>
+		</div>
+	);
+};
+
+export default CircularProgressBar;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/circular-progress-bar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/circular-progress-bar.tsx
@@ -11,7 +11,7 @@ const CircularProgressBar = ( {
 	const FULL_ARC = 2 * Math.PI * RADIUS;
 
 	return (
-		<div className="launchpad__progress" style={ { width: SIZE, height: SIZE } }>
+		<div role="progressbar" className="launchpad__progress" style={ { width: SIZE, height: SIZE } }>
 			<svg
 				viewBox={ `0 0 ${ SIZE } ${ SIZE }` }
 				style={ { width: SIZE, height: SIZE } }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
@@ -1,4 +1,4 @@
-import { Gridicon, ProgressBar } from '@automattic/components';
+import { Gridicon } from '@automattic/components';
 import { useRef, useState } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
 import { StepNavigationLink } from 'calypso/../packages/onboarding/src';
@@ -12,6 +12,7 @@ import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { ResponseDomain } from 'calypso/lib/domains/types';
 import { usePremiumGlobalStyles } from 'calypso/state/sites/hooks/use-premium-global-styles';
 import Checklist from './checklist';
+import CircularProgressBar from './circular-progress-bar';
 import { getArrayOfFilteredTasks, getEnhancedTasks } from './task-helper';
 import { tasks } from './tasks';
 import { getLaunchpadTranslations } from './translations';
@@ -37,16 +38,19 @@ function getUrlInfo( url: string ) {
 	return [ siteName ? siteName[ 0 ] : '', topLevelDomain ? topLevelDomain[ 0 ] : '' ];
 }
 
-function getChecklistCompletionProgress( tasks: Task[] | null ) {
+function getTasksProgress( tasks: Task[] | null ) {
 	if ( ! tasks ) {
-		return;
+		// TODO: How do we want to handle that?
+		return [ null, null ];
 	}
 
-	const totalCompletedTasks = tasks.reduce( ( total, currentTask ) => {
+	const completedTasks = tasks.reduce( ( total, currentTask ) => {
 		return currentTask.completed ? total + 1 : total;
 	}, 0 );
 
-	return Math.round( ( totalCompletedTasks / tasks.length ) * 100 );
+	const totalTasks = tasks.length;
+
+	return [ completedTasks, totalTasks ];
 }
 
 const Sidebar = ( { sidebarDomain, siteSlug, submit, goNext, goToStep, flow }: SidebarProps ) => {
@@ -75,7 +79,7 @@ const Sidebar = ( { sidebarDomain, siteSlug, submit, goNext, goToStep, flow }: S
 			flow
 		);
 
-	const taskCompletionProgress = site && getChecklistCompletionProgress( enhancedTasks );
+	const [ currentTask, numberOfTasks ] = getTasksProgress( enhancedTasks );
 	const launchTask = enhancedTasks?.find( ( task ) => task.isLaunchTask === true );
 	const showLaunchTitle = launchTask && ! launchTask.disabled;
 
@@ -95,15 +99,9 @@ const Sidebar = ( { sidebarDomain, siteSlug, submit, goNext, goToStep, flow }: S
 				<span className="launchpad__sidebar-header-flow-name">{ flowName }</span>
 			</div>
 			<div className="launchpad__sidebar-content-container">
-				{ taskCompletionProgress && (
+				{ currentTask && numberOfTasks && (
 					<div className="launchpad__progress-bar-container">
-						<span className="launchpad__progress-value">{ taskCompletionProgress }%</span>
-						<ProgressBar
-							className="launchpad__progress-bar"
-							value={ taskCompletionProgress }
-							title={ translate( 'Launchpad checklist progress bar' ) }
-							compact={ true }
-						/>
+						<CircularProgressBar currentStep={ currentTask } numberOfSteps={ numberOfTasks } />
 					</div>
 				) }
 				{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace*/ }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
@@ -39,17 +39,14 @@ function getUrlInfo( url: string ) {
 
 function getTasksProgress( tasks: Task[] | null ) {
 	if ( ! tasks ) {
-		// TODO: How do we want to handle that?
-		return [ null, null ];
+		return null;
 	}
 
 	const completedTasks = tasks.reduce( ( total, currentTask ) => {
 		return currentTask.completed ? total + 1 : total;
 	}, 0 );
 
-	const totalTasks = tasks.length;
-
-	return [ completedTasks, totalTasks ];
+	return completedTasks;
 }
 
 const Sidebar = ( { sidebarDomain, siteSlug, submit, goNext, goToStep, flow }: SidebarProps ) => {
@@ -78,7 +75,7 @@ const Sidebar = ( { sidebarDomain, siteSlug, submit, goNext, goToStep, flow }: S
 			flow
 		);
 
-	const [ currentTask, numberOfTasks ] = getTasksProgress( enhancedTasks );
+	const currentTask = getTasksProgress( enhancedTasks );
 	const launchTask = enhancedTasks?.find( ( task ) => task.isLaunchTask === true );
 	const showLaunchTitle = launchTask && ! launchTask.disabled;
 
@@ -98,9 +95,12 @@ const Sidebar = ( { sidebarDomain, siteSlug, submit, goNext, goToStep, flow }: S
 				<span className="launchpad__sidebar-header-flow-name">{ flowName }</span>
 			</div>
 			<div className="launchpad__sidebar-content-container">
-				{ currentTask && numberOfTasks && (
+				{ currentTask && enhancedTasks?.length && (
 					<div className="launchpad__progress-bar-container">
-						<CircularProgressBar currentStep={ currentTask } numberOfSteps={ numberOfTasks } />
+						<CircularProgressBar
+							currentStep={ currentTask }
+							numberOfSteps={ enhancedTasks?.length }
+						/>
 					</div>
 				) }
 				{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace*/ }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
@@ -1,4 +1,4 @@
-import { Gridicon } from '@automattic/components';
+import { Gridicon, CircularProgressBar } from '@automattic/components';
 import { useRef, useState } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
 import { StepNavigationLink } from 'calypso/../packages/onboarding/src';
@@ -12,7 +12,6 @@ import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { ResponseDomain } from 'calypso/lib/domains/types';
 import { usePremiumGlobalStyles } from 'calypso/state/sites/hooks/use-premium-global-styles';
 import Checklist from './checklist';
-import CircularProgressBar from './circular-progress-bar';
 import { getArrayOfFilteredTasks, getEnhancedTasks } from './task-helper';
 import { tasks } from './tasks';
 import { getLaunchpadTranslations } from './translations';

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
@@ -281,35 +281,6 @@
 	}
 }
 
-// Launchpad - Progress Bar
-
-.launchpad__progress-bar-container {
-	margin-bottom: 32px;
-
-	.launchpad__progress-bar.progress-bar.is-compact {
-		.progress-bar__progress {
-			/* stylelint-disable-next-line scales/radii */
-			border-radius: 4.5px;
-		}
-	}
-}
-
-.launchpad__progress-value {
-	font-size: $font-body-extra-small;
-	font-weight: 700;
-	margin-right: 10px;
-}
-
-.launchpad__progress-bar {
-	width: 120px;
-	vertical-align: middle;
-}
-
-.launchpad__progress-bar.progress-bar.is-compact {
-	background-color: #dcdcde;
-	position: relative;
-}
-
 // Launchpad - Checklist
 
 .launchpad__checklist {
@@ -602,9 +573,11 @@
 	}
 }
 
+.launchpad__progress-bar-container {
+	margin-bottom: 32px;
+}
 
 // Free flow
-
 .free.launchpad {
 	padding: 0;
 	.signup-header {

--- a/packages/components/src/circular-progress-bar/README.md
+++ b/packages/components/src/circular-progress-bar/README.md
@@ -1,0 +1,1 @@
+# TODO: Update README

--- a/packages/components/src/circular-progress-bar/README.md
+++ b/packages/components/src/circular-progress-bar/README.md
@@ -1,6 +1,6 @@
-# Circular Progress Bar
+# Launchpad: Circular Progress Bar
 
-This component is used to display a circular progress bar as part of the cohesive Launchpad Experience
+This component is used to display a circular progress bar as part of the cohesive Launchpad Experience and is only meant to be used in the context of Launchpad.
 See https://cylonp2.wordpress.com/2022/12/14/a-cohesive-launchpad-experience/
 It displays a gray circle and another blue circle on top of it showing the progress.
 It renders text in the center in the center: X/Y where X is the current step and Y is the total number of steps

--- a/packages/components/src/circular-progress-bar/README.md
+++ b/packages/components/src/circular-progress-bar/README.md
@@ -1,7 +1,7 @@
 # Launchpad: Circular Progress Bar
 
 This component is used to display a circular progress bar as part of the cohesive Launchpad Experience and is only meant to be used in the context of Launchpad.
-See https://cylonp2.wordpress.com/2022/12/14/a-cohesive-launchpad-experience/
+See <https://cylonp2.wordpress.com/2022/12/14/a-cohesive-launchpad-experience>
 It displays a gray circle and another blue circle on top of it showing the progress.
 It renders text in the center in the center: X/Y where X is the current step and Y is the total number of steps
 The currentStep and numberOfSteps props are used to calculate represent the current progress as a fraction

--- a/packages/components/src/circular-progress-bar/README.md
+++ b/packages/components/src/circular-progress-bar/README.md
@@ -1,1 +1,22 @@
-# TODO: Update README
+# Circular Progress Bar
+
+This component is used to display a circular progress bar as part of the cohesive Launchpad Experience
+See https://cylonp2.wordpress.com/2022/12/14/a-cohesive-launchpad-experience/
+It displays a gray circle and another blue circle on top of it showing the progress.
+It renders text in the center in the center: X/Y where X is the current step and Y is the total number of steps
+The currentStep and numberOfSteps props are used to calculate represent the current progress as a fraction
+
+## How to use
+
+```js
+import { CircularProgressBar } from '@automattic/components';
+
+function render() {
+	<CircularProgressBar currentStep={ currentTask } numberOfSteps={ numberOfTasks } />;
+}
+```
+
+## Props
+
+- `currentStep`: a number representing the current completed step (required).
+- `numberOfSteps`: a number representing the total number of steps (required).

--- a/packages/components/src/circular-progress-bar/index.tsx
+++ b/packages/components/src/circular-progress-bar/index.tsx
@@ -1,3 +1,5 @@
+import './style.scss';
+
 const CircularProgressBar = ( {
 	currentStep,
 	numberOfSteps,
@@ -11,7 +13,11 @@ const CircularProgressBar = ( {
 	const FULL_ARC = 2 * Math.PI * RADIUS;
 
 	return (
-		<div role="progressbar" className="launchpad__progress" style={ { width: SIZE, height: SIZE } }>
+		<div
+			role="progressbar"
+			className="circular__progress-bar"
+			style={ { width: SIZE, height: SIZE } }
+		>
 			<svg
 				viewBox={ `0 0 ${ SIZE } ${ SIZE }` }
 				style={ { width: SIZE, height: SIZE } }
@@ -19,7 +25,7 @@ const CircularProgressBar = ( {
 				xmlns="http://www.w3.org/2000/svg"
 			>
 				<circle
-					className="launchpad__progress-empty-circle"
+					className="circular__progress-bar-empty-circle"
 					fill="none"
 					cx={ SIZE / 2 }
 					cy={ SIZE / 2 }
@@ -30,7 +36,7 @@ const CircularProgressBar = ( {
 					style={ {
 						strokeDasharray: `${ FULL_ARC * ( currentStep / numberOfSteps ) }, ${ FULL_ARC }`,
 					} }
-					className="launchpad__progress-fill-circle"
+					className="circular__progress-bar-fill-circle"
 					fill="none"
 					cx={ SIZE / 2 }
 					cy={ SIZE / 2 }
@@ -38,7 +44,7 @@ const CircularProgressBar = ( {
 					strokeWidth={ STROKE_WIDTH }
 				/>
 			</svg>
-			<div className="launchpad__progress-text">
+			<div className="circular__progress-bar-text">
 				{ currentStep }/{ numberOfSteps }
 			</div>
 		</div>

--- a/packages/components/src/circular-progress-bar/index.tsx
+++ b/packages/components/src/circular-progress-bar/index.tsx
@@ -7,8 +7,8 @@ const CircularProgressBar = ( {
 	currentStep: number;
 	numberOfSteps: number;
 } ) => {
-	const SIZE = 48;
-	const STROKE_WIDTH = 5;
+	const SIZE = 40;
+	const STROKE_WIDTH = 4;
 	const RADIUS = SIZE / 2 - STROKE_WIDTH / 2;
 	const FULL_ARC = 2 * Math.PI * RADIUS;
 

--- a/packages/components/src/circular-progress-bar/style.scss
+++ b/packages/components/src/circular-progress-bar/style.scss
@@ -1,5 +1,14 @@
+@import "@automattic/typography/styles/variables";
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
 .circular__progress-bar {
 	position: relative;
+
+	@include break-mobile {
+		// mobile: 40px, desktop: 48px (1.2x scale)
+		transform: scale(1.2);
+	}
 
 	&-empty-circle {
 		stroke: var(--studio-gray-5);

--- a/packages/components/src/circular-progress-bar/style.scss
+++ b/packages/components/src/circular-progress-bar/style.scss
@@ -1,0 +1,27 @@
+.circular__progress-bar {
+	position: relative;
+
+	&-empty-circle {
+		stroke: var(--studio-gray-5);
+	}
+
+	&-fill-circle {
+		stroke: var(--studio-blue-50);
+		transform-origin: center;
+		transform: rotate(-90deg);
+		stroke-linecap: round;
+	}
+
+	&-text {
+		font-family: Recoleta, "Noto Serif", Georgia, "Times New Roman", Times, serif;
+		font-size: 1rem;
+		letter-spacing: 0.05em;
+
+		// center the text inside the circle
+		position: absolute;
+		left: 50%;
+		transform: translate(-50%, -50%);
+		top: 50%;
+
+	}
+}

--- a/packages/components/src/circular-progress-bar/style.scss
+++ b/packages/components/src/circular-progress-bar/style.scss
@@ -23,7 +23,7 @@
 
 	&-text {
 		font-family: Recoleta, "Noto Serif", Georgia, "Times New Roman", Times, serif;
-		font-size: 1rem;
+		font-size: 0.75rem;
 		letter-spacing: 0.05em;
 
 		// center the text inside the circle

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -9,6 +9,7 @@ export { default as Gridicon } from './gridicon';
 export { default as Popover } from './popover';
 export { default as ProductIcon } from './product-icon';
 export { default as ProgressBar } from './progress-bar';
+export { default as CircularProgressBar } from './circular-progress-bar';
 export { default as ResponsiveToolbarGroup } from './responsive-toolbar-group';
 export { default as Ribbon } from './ribbon';
 export { default as RootChild } from './root-child';


### PR DESCRIPTION
#### Proposed Changes
Create a new `circular-progress-bar` component and display it on the Launchpad screen

<img width="433" alt="image" src="https://user-images.githubusercontent.com/20927667/208856066-9462d91a-2a5f-4795-93d2-d0af59702687.png">

#### Testing Instructions
You can test this with any Launchpad flow.

1. Checkout this branch
2. Go to `http://calypso.localhost:3000/setup/link-in-bio/intro`
3. Complete the flow until you arrive at Launchpad
4. You should see the new circular progress bar showing the number of completed tasks and the number of total tasks
5. Complete a task
6. You should see both the numbers and the progress circle on the progress bar update accordingly

https://user-images.githubusercontent.com/20927667/208854642-03151d2d-5bd0-41c1-a584-b460ecd3e6b4.mov


<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #71326