### PR TITLE
Add happy-blocks pricing plans domain edit setting

### DIFF
--- a/apps/happy-blocks/index.php
+++ b/apps/happy-blocks/index.php
@@ -97,20 +97,18 @@ add_action( 'enqueue_block_editor_assets', 'a8c_happyblocks_assets' );
 add_action( 'wp_enqueue_scripts', 'a8c_happyblocks_view_assets' );
 
 /**
- * Get the domain to use in the Pricing Plans block.
+ * Decide if the current logged in user is the topic author.
  *
- * The function should return false when the domain is not set, see https://github.com/Automattic/wp-calypso/pull/70402#discussion_r1033299970
- *
- * @return string|bool The domain host (or false if no domain is available)
+ * @return bool true if the current user is the topic author, false otherwise.
  */
-function a8c_happyblocks_pricing_plans_get_domain() {
+function a8c_happyblocks_pricing_plans_is_author() {
 
 	// If the user is not authenticated, then we can't get their domain.
 	if ( ! is_user_logged_in() ) {
 		return false;
 	}
 
-	// If BBPress is not active, then just don't return any domain and let the user choose.
+	// If BBPress is not active, we can't tell if the current user is the author.
 	if ( ! function_exists( 'bbp_get_topic_id' ) ) {
 		return false;
 	}
@@ -118,19 +116,7 @@ function a8c_happyblocks_pricing_plans_get_domain() {
 	$topic_id  = bbp_get_topic_id();
 	$author_id = intval( get_post_field( 'post_author', $topic_id ) );
 
-	/*
-	If the current user is the author of the topic, return the topic's domain selected
-	in the "Site you need help with" field.
-	*/
-	if ( get_current_user_id() === $author_id ) {
-		$topic_domain = get_post_meta( $topic_id, 'which_blog_domain', true );
-		if ( $topic_domain ) {
-			return $topic_domain;
-		}
-	}
-
-	// If the current user is not the author of the topic, then don't return any domain.
-	return false;
+	return get_current_user_id() === $author_id;
 }
 
 /**
@@ -145,7 +131,6 @@ function a8c_happyblocks_get_config() {
 			'planTabs' => apply_filters( 'support_forums_use_upsell_block_tabs', false ),
 		),
 		'locale'   => get_user_locale(),
-		'domain'   => a8c_happyblocks_pricing_plans_get_domain(),
 	);
 }
 
@@ -156,8 +141,10 @@ function a8c_happyblocks_get_config() {
  * @return string
  */
 function a8c_happyblocks_render_pricing_plans_callback( $attributes ) {
-	$attributes['domain'] = a8c_happyblocks_pricing_plans_get_domain();
-	$json_attributes      = htmlspecialchars( wp_json_encode( $attributes ), ENT_QUOTES, 'UTF-8' );
+	// The domain should be set to false instead of null when not available, see https://github.com/Automattic/wp-calypso/pull/70402#discussion_r1033299970.
+	$attributes['domain'] = a8c_happyblocks_pricing_plans_is_author() ? $attributes['domain'] : false;
+
+	$json_attributes = htmlspecialchars( wp_json_encode( $attributes ), ENT_QUOTES, 'UTF-8' );
 
 	return <<<HTML
 		<div data-attributes="${json_attributes}" class="a8c-happy-tools-pricing-plans-block-placeholder" />

--- a/apps/happy-blocks/src/pricing-plans/edit.tsx
+++ b/apps/happy-blocks/src/pricing-plans/edit.tsx
@@ -5,7 +5,6 @@ import { FunctionComponent } from 'react';
 import BlockSettings from './components/block-settings';
 import PricingPlans from './components/pricing-plans';
 import Skeleton from './components/skeleton';
-import config from './config';
 import usePricingPlans from './hooks/pricing-plans';
 import { BlockAttributes } from './types';
 
@@ -19,7 +18,7 @@ export const Edit: FunctionComponent< BlockEditProps< BlockAttributes > > = ( {
 	useEffect( () => {
 		setAttributes( {
 			productSlug: attributes.productSlug ?? attributes.defaultProductSlug,
-			domain: attributes.domain ?? config.domain,
+			domain: attributes.domain,
 		} );
 	}, [ attributes.defaultProductSlug, attributes.domain, attributes.productSlug, setAttributes ] );
 
@@ -42,6 +41,10 @@ export const Edit: FunctionComponent< BlockEditProps< BlockAttributes > > = ( {
 	}, [ attributes.planTypeOptions.length, attributes.productSlug, plans, setAttributes ] );
 
 	useEffect( () => {
+		if ( attributes.domain ) {
+			return;
+		}
+
 		const blogIdSelect: HTMLSelectElement | null =
 			document.querySelector( 'select[name="blog_id"]' );
 
@@ -67,7 +70,7 @@ export const Edit: FunctionComponent< BlockEditProps< BlockAttributes > > = ( {
 		return () => {
 			blogIdSelect.removeEventListener( 'change', updateBlogId );
 		};
-	}, [ setAttributes ] );
+	}, [ attributes.domain, setAttributes ] );
 
 	const blockProps = useBlockProps();
 

--- a/apps/happy-blocks/src/pricing-plans/types.d.ts
+++ b/apps/happy-blocks/src/pricing-plans/types.d.ts
@@ -1,7 +1,7 @@
 export interface BlockAttributes {
 	defaultProductSlug: string;
 	productSlug: string;
-	domain: string | boolean;
+	domain: string | false;
 	planTypeOptions: string[];
 }
 
@@ -19,7 +19,6 @@ export interface ApiPricingPlan {
 declare global {
 	interface Window {
 		A8C_HAPPY_BLOCKS_CONFIG: {
-			domain: string;
 			locale: string;
 			features: {
 				planTabs: boolean;

--- a/apps/happy-blocks/src/pricing-plans/view.scss
+++ b/apps/happy-blocks/src/pricing-plans/view.scss
@@ -58,6 +58,12 @@ $brand-display: "SF Pro Display", $sans;
 		&-checkbox--disabled {
 			opacity: 0.6;
 		}
+
+		&-domain:has(.components-base-control__help) {
+			.components-base-control__field {
+				margin-bottom: 0;
+			}
+		}
 	}
 
 	&__skeleton {


### PR DESCRIPTION
#### Proposed Changes
This PR adds a new setting to manually configure the domain the block is tailored for.

It also improves the logic and implementation so that the domain, whatever it is, is never shown if the current logged in user is not the topic author.


<img width="743" alt="image" src="https://user-images.githubusercontent.com/112691742/208623779-f5d86a19-7f08-48e9-907e-7411cc7c0a81.png">



#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run `yarn dev --sync` in `apps/happy-blocks` to sync code to your sandbox
* Create a new topic, select a domain from the "site you need help with"  field
* in the editor press `/` and search for "Upgrade", pick any of the plans block.
* Ensure the block shows the `for [domain]` by-line right below the plan name, and that this domain is the same selected in the "site you need help with" field
* Go to the block settings, and edit the domain to any other domain
* Submit the post, ensure the block renders in the view showing the custom domain
* Logged in as another user, view the post and ensure it doesn't show any domain
* Back to the original user, edit the post and ensure the custom domain is still shown in the settings.


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
