### PR TITLE
Fix pricing plan tabs margin and width

### DIFF
--- a/apps/happy-blocks/src/pricing-plans/view.scss
+++ b/apps/happy-blocks/src/pricing-plans/view.scss
@@ -80,6 +80,8 @@ $brand-display: "SF Pro Display", $sans;
 		/* stylelint-disable-next-line scales/radii */
 		border-radius: 6px;
 		padding: 4px;
+		width: min-content;
+		margin-bottom: 16px;
 
 		&-label {
 			background: $studio-gray-0;


### PR DESCRIPTION
#### Proposed Changes

This PR fixes the width and margin for the Pricing Plans tabs in the happy-blocks Pricing Plan block.

<img width="430" alt="image" src="https://user-images.githubusercontent.com/112691742/208652842-2fbf3703-45b5-4c10-a82e-adfb6d723dd2.png">



#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


* Run `yarn dev --sync` in `apps/happy-blocks` to sync code to your sandbox
* Create a new topic, in the editor press `/` and search for "Upgrade" block.
* Ensure the tabs look as in the screenshot above. It should not be full-width and should have a bottom margin following the design specs.


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
