### PR TITLE
Pricing Grid: Add new signup flow and feature flag

### DIFF
--- a/client/my-sites/plan-features-2023-grid/actions.jsx
+++ b/client/my-sites/plan-features-2023-grid/actions.jsx
@@ -86,8 +86,8 @@ const PlanFeaturesActionsButton = ( {
 
 const PlanFeatures2023GridActions = ( props ) => {
 	return (
-		<div className="plan-features-comparison__actions">
-			<div className="plan-features-comparison__actions-buttons">
+		<div className="plan-features-2023-gridrison__actions">
+			<div className="plan-features-2023-gridrison__actions-buttons">
 				<PlanFeaturesActionsButton { ...props } />
 			</div>
 		</div>

--- a/client/my-sites/plan-features-2023-grid/actions.jsx
+++ b/client/my-sites/plan-features-2023-grid/actions.jsx
@@ -1,0 +1,110 @@
+import { Button } from '@automattic/components';
+import classNames from 'classnames';
+import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+
+const noop = () => {};
+
+const PlanFeaturesActionsButton = ( {
+	availableForPurchase = true,
+	className,
+	current = false,
+	freePlan = false,
+	isPlaceholder = false,
+	isPopular,
+	isInSignup,
+	isLaunchPage,
+	onUpgradeClick = noop,
+	planName,
+	planType,
+	primaryUpgrade = false,
+	translate,
+} ) => {
+	const classes = classNames(
+		'plan-features__actions-button',
+		{
+			'is-current': current,
+			'is-primary': ( primaryUpgrade && ! isPlaceholder ) || isPopular,
+		},
+		className
+	);
+
+	const handleUpgradeButtonClick = () => {
+		if ( isPlaceholder ) {
+			return;
+		}
+
+		recordTracksEvent( 'calypso_plan_features_upgrade_click', {
+			current_plan: null,
+			upgrading_to: planType,
+		} );
+
+		onUpgradeClick();
+	};
+
+	if ( ( availableForPurchase || isPlaceholder ) && ! isLaunchPage && isInSignup ) {
+		return (
+			<Button className={ classes } onClick={ handleUpgradeButtonClick } disabled={ isPlaceholder }>
+				{ translate( 'Select', {
+					args: {
+						plan: planName,
+					},
+				} ) }
+			</Button>
+		);
+	}
+
+	if ( ( availableForPurchase || isPlaceholder ) && isLaunchPage && ! freePlan ) {
+		return (
+			<Button className={ classes } onClick={ handleUpgradeButtonClick } disabled={ isPlaceholder }>
+				{ translate( 'Select %(plan)s', {
+					args: {
+						plan: planName,
+					},
+					context: 'Button to select a paid plan by plan name, e.g., "Select Personal"',
+					comment:
+						'A button to select a new paid plan. Check screenshot - https://cloudup.com/cb_9FMG_R01',
+				} ) }
+			</Button>
+		);
+	}
+
+	if ( ( availableForPurchase || isPlaceholder ) && isLaunchPage && freePlan ) {
+		return (
+			<Button className={ classes } onClick={ handleUpgradeButtonClick } disabled={ isPlaceholder }>
+				{ translate( 'Keep this plan', {
+					comment:
+						'A selection to keep the current plan. Check screenshot - https://cloudup.com/cb_9FMG_R01',
+				} ) }
+			</Button>
+		);
+	}
+
+	return null;
+};
+
+const PlanFeatures2023GridActions = ( props ) => {
+	return (
+		<div className="plan-features-comparison__actions">
+			<div className="plan-features-comparison__actions-buttons">
+				<PlanFeaturesActionsButton { ...props } />
+			</div>
+		</div>
+	);
+};
+
+PlanFeatures2023GridActions.propTypes = {
+	availableForPurchase: PropTypes.bool,
+	className: PropTypes.string,
+	current: PropTypes.bool,
+	freePlan: PropTypes.bool,
+	isDisabled: PropTypes.bool,
+	isPlaceholder: PropTypes.bool,
+	isLaunchPage: PropTypes.bool,
+	onUpgradeClick: PropTypes.func,
+	planType: PropTypes.string,
+	primaryUpgrade: PropTypes.bool,
+};
+
+export default localize( PlanFeatures2023GridActions );

--- a/client/my-sites/plan-features-2023-grid/header.jsx
+++ b/client/my-sites/plan-features-2023-grid/header.jsx
@@ -1,0 +1,173 @@
+import { getPlans, getPlanClass } from '@automattic/calypso-products';
+import { getCurrencyObject } from '@automattic/format-currency';
+import { NEWSLETTER_FLOW, LINK_IN_BIO_FLOW, LINK_IN_BIO_TLD_FLOW } from '@automattic/onboarding';
+import classNames from 'classnames';
+import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import { Component } from 'react';
+import PlanPill from 'calypso/components/plans/plan-pill';
+import PlanPrice from 'calypso/my-sites/plan-price';
+
+const PLANS_LIST = getPlans();
+
+export class PlanFeatures2023GridHeader extends Component {
+	render() {
+		return this.renderPlansHeaderNoTabs();
+	}
+
+	getPlanPillText() {
+		const { flow, translate } = this.props;
+
+		switch ( flow ) {
+			case NEWSLETTER_FLOW:
+				return translate( 'Best for Newsletters' );
+			case LINK_IN_BIO_FLOW:
+			case LINK_IN_BIO_TLD_FLOW:
+				return translate( 'Best for Link in Bio' );
+			default:
+				return translate( 'Popular' );
+		}
+	}
+
+	renderPlansHeaderNoTabs() {
+		const { planType, popular, selectedPlan, title } = this.props;
+
+		const headerClasses = classNames( 'plan-features-2023-grid__header', getPlanClass( planType ) );
+
+		return (
+			<span>
+				<div>
+					{ popular && ! selectedPlan && (
+						<PlanPill isInSignup={ true }>{ this.getPlanPillText() }</PlanPill>
+					) }
+				</div>
+				<header className={ headerClasses }>
+					<h4 className="plan-features-2023-grid__header-title">{ title }</h4>
+				</header>
+				<div className="plan-features-2023-grid__pricing">
+					{ this.renderPriceGroup() }
+					{ this.getBillingTimeframe() }
+				</div>
+				{ this.getAnnualDiscount() }
+			</span>
+		);
+	}
+
+	getPerMonthDescription() {
+		const {
+			rawPrice,
+			rawPriceAnnual,
+			currencyCode,
+			translate,
+			annualPricePerMonth,
+			isMonthlyPlan,
+		} = this.props;
+
+		if ( isMonthlyPlan && annualPricePerMonth < rawPrice ) {
+			const discountRate = Math.round( ( 100 * ( rawPrice - annualPricePerMonth ) ) / rawPrice );
+			return translate( `Save %(discountRate)s%% by paying annually`, { args: { discountRate } } );
+		}
+
+		if ( ! isMonthlyPlan ) {
+			const annualPriceObj = getCurrencyObject( rawPriceAnnual, currencyCode );
+			const annualPriceText = `${ annualPriceObj.symbol }${ annualPriceObj.integer }`;
+
+			return translate( 'billed as %(price)s annually', {
+				args: { price: annualPriceText },
+			} );
+		}
+
+		return null;
+	}
+
+	getAnnualDiscount() {
+		const { isMonthlyPlan, rawPriceForMonthlyPlan, annualPricePerMonth, translate } = this.props;
+
+		if ( ! isMonthlyPlan ) {
+			const isLoading = typeof rawPriceForMonthlyPlan !== 'number';
+
+			const discountRate = Math.round(
+				( 100 * ( rawPriceForMonthlyPlan - annualPricePerMonth ) ) / rawPriceForMonthlyPlan
+			);
+			const annualDiscountText = translate( `You're saving %(discountRate)s%% by paying annually`, {
+				args: { discountRate },
+			} );
+
+			return (
+				<div
+					className={ classNames( {
+						'plan-features-2023-grid__header-annual-discount': true,
+						'plan-features-2023-grid__header-annual-discount-is-loading': isLoading,
+					} ) }
+				>
+					<span>{ annualDiscountText }</span>
+				</div>
+			);
+		}
+	}
+
+	getBillingTimeframe() {
+		const { billingTimeFrame } = this.props;
+		const perMonthDescription = this.getPerMonthDescription() || billingTimeFrame;
+
+		return (
+			<div className="plan-features-2023-grid__header-billing-info">
+				<span>{ perMonthDescription }</span>
+			</div>
+		);
+	}
+
+	renderPriceGroup() {
+		const { currencyCode, rawPrice, discountPrice } = this.props;
+
+		if ( discountPrice ) {
+			return (
+				<span className="plan-features-2023-grid__header-price-group">
+					<div className="plan-features-2023-grid__header-price-group-prices">
+						<PlanPrice
+							currencyCode={ currencyCode }
+							rawPrice={ rawPrice }
+							displayPerMonthNotation={ true }
+							original
+						/>
+						<PlanPrice
+							currencyCode={ currencyCode }
+							rawPrice={ discountPrice }
+							displayPerMonthNotation={ true }
+							discounted
+						/>
+					</div>
+				</span>
+			);
+		}
+
+		return (
+			<PlanPrice
+				currencyCode={ currencyCode }
+				rawPrice={ rawPrice }
+				displayPerMonthNotation={ true }
+			/>
+		);
+	}
+}
+
+PlanFeatures2023GridHeader.propTypes = {
+	billingTimeFrame: PropTypes.oneOfType( [ PropTypes.string, PropTypes.array ] ),
+	currencyCode: PropTypes.string,
+	discountPrice: PropTypes.number,
+	planType: PropTypes.oneOf( Object.keys( PLANS_LIST ) ).isRequired,
+	popular: PropTypes.bool,
+	rawPrice: PropTypes.number,
+	title: PropTypes.string.isRequired,
+	translate: PropTypes.func,
+
+	// For Monthly Pricing test
+	annualPricePerMonth: PropTypes.number,
+	flow: PropTypes.string,
+};
+
+PlanFeatures2023GridHeader.defaultProps = {
+	popular: false,
+};
+
+export default localize( PlanFeatures2023GridHeader );

--- a/client/my-sites/plan-features-2023-grid/index.jsx
+++ b/client/my-sites/plan-features-2023-grid/index.jsx
@@ -1,0 +1,479 @@
+import {
+	planMatches,
+	applyTestFiltersToPlansList,
+	getMonthlyPlanByYearly,
+	getYearlyPlanByMonthly,
+	findPlansKeys,
+	getPlan as getPlanFromKey,
+	getPlanClass,
+	isFreePlan,
+	isMonthly,
+	TERM_MONTHLY,
+} from '@automattic/calypso-products';
+import classNames from 'classnames';
+import { localize } from 'i18n-calypso';
+import { compact, get, map, reduce } from 'lodash';
+import PropTypes from 'prop-types';
+import { Component } from 'react';
+import { connect } from 'react-redux';
+import QueryActivePromotions from 'calypso/components/data/query-active-promotions';
+import { retargetViewPlans } from 'calypso/lib/analytics/ad-tracking';
+import { planItem as getCartItemForPlan } from 'calypso/lib/cart-values/cart-items';
+import { getPlanFeaturesObject } from 'calypso/lib/plans/features-list';
+import {
+	getHighlightedFeatures,
+	getPlanFeatureAccessor,
+} from 'calypso/my-sites/plan-features-2023-grid/util';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
+import {
+	getPlan,
+	getPlanBySlug,
+	getPlanRawPrice,
+	getPlanSlug,
+	getDiscountedRawPrice,
+} from 'calypso/state/plans/selectors';
+import getCurrentPlanPurchaseId from 'calypso/state/selectors/get-current-plan-purchase-id';
+import { getSignupDependencyStore } from 'calypso/state/signup/dependency-store/selectors';
+import { getCurrentFlowName } from 'calypso/state/signup/flow/selectors';
+import {
+	getPlanDiscountedRawPrice,
+	getSitePlanRawPrice,
+} from 'calypso/state/sites/plans/selectors';
+import PlanFeatures2023GridActions from './actions';
+import PlanFeatures2023GridHeader from './header';
+import { PlanFeaturesItem } from './item';
+import './style.scss';
+
+const noop = () => {};
+
+export class PlanFeatures2023Grid extends Component {
+	componentDidMount() {
+		this.props.recordTracksEvent( 'calypso_wp_plans_test_view' );
+		retargetViewPlans();
+	}
+
+	render() {
+		const { isInSignup, planProperties, translate } = this.props;
+		const tableClasses = classNames(
+			'plan-features-2023-grid__table',
+			`has-${ planProperties.length }-cols`
+		);
+		const planClasses = classNames( 'plan-features', {
+			'plan-features--signup': isInSignup,
+		} );
+		const planWrapperClasses = classNames( {
+			'plans-wrapper': isInSignup,
+		} );
+
+		return (
+			<div className={ planWrapperClasses }>
+				<QueryActivePromotions />
+				<div className={ planClasses }>
+					<div ref={ this.contentRef } className="plan-features-2023-grid__content">
+						<div>
+							<table className={ tableClasses }>
+								<caption className="plan-features-2023-grid__screen-reader-text screen-reader-text">
+									{ translate( 'Available plans to choose from' ) }
+								</caption>
+								<tbody>
+									<tr>{ this.renderPlanHeaders() }</tr>
+									<tr>{ this.renderTopButtons() }</tr>
+									{ this.renderPlanFeatureRows() }
+								</tbody>
+							</table>
+						</div>
+					</div>
+				</div>
+			</div>
+		);
+	}
+
+	renderPlanHeaders() {
+		const { basePlansPath, planProperties, isReskinned, flowName } = this.props;
+
+		return map( planProperties, ( properties ) => {
+			const {
+				annualPricePerMonth,
+				availableForPurchase,
+				currencyCode,
+				current,
+				discountPrice,
+				planConstantObj,
+				planName,
+				popular,
+				relatedMonthlyPlan,
+				isMonthlyPlan,
+				isPlaceholder,
+				hideMonthly,
+				rawPrice,
+				rawPriceAnnual,
+				rawPriceForMonthlyPlan,
+			} = properties;
+
+			const classes = classNames( 'plan-features-2023-grid__table-item', {
+				'has-border-top': ! isReskinned,
+			} );
+			const audience = planConstantObj.getAudience?.();
+			const billingTimeFrame = planConstantObj.getBillingTimeFrame();
+
+			return (
+				<th scope="col" key={ planName } className={ classes }>
+					<PlanFeatures2023GridHeader
+						audience={ audience }
+						availableForPurchase={ availableForPurchase }
+						basePlansPath={ basePlansPath }
+						billingTimeFrame={ billingTimeFrame }
+						current={ current }
+						currencyCode={ currencyCode }
+						discountPrice={ discountPrice }
+						hideMonthly={ hideMonthly }
+						isPlaceholder={ isPlaceholder }
+						planType={ planName }
+						popular={ popular }
+						rawPrice={ rawPrice }
+						rawPriceAnnual={ rawPriceAnnual }
+						rawPriceForMonthlyPlan={ rawPriceForMonthlyPlan }
+						relatedMonthlyPlan={ relatedMonthlyPlan }
+						title={ planConstantObj.getTitle() }
+						annualPricePerMonth={ annualPricePerMonth }
+						isMonthlyPlan={ isMonthlyPlan }
+						flow={ flowName }
+					/>
+				</th>
+			);
+		} );
+	}
+
+	handleUpgradeClick( singlePlanProperties ) {
+		const { onUpgradeClick: ownPropsOnUpgradeClick } = this.props;
+		const { cartItemForPlan } = singlePlanProperties;
+
+		if ( ownPropsOnUpgradeClick && ownPropsOnUpgradeClick !== noop && cartItemForPlan ) {
+			ownPropsOnUpgradeClick( cartItemForPlan );
+			return;
+		}
+
+		return `/checkout`;
+	}
+
+	renderTopButtons() {
+		const { isInSignup, isLaunchPage, planProperties } = this.props;
+
+		return map( planProperties, ( properties ) => {
+			const {
+				availableForPurchase,
+				current,
+				planName,
+				primaryUpgrade,
+				isPlaceholder,
+				planConstantObj,
+				popular,
+			} = properties;
+			const classes = classNames( 'plan-features-2023-grid__table-item', 'is-top-buttons' );
+
+			return (
+				<td key={ planName } className={ classes }>
+					<PlanFeatures2023GridActions
+						availableForPurchase={ availableForPurchase }
+						className={ getPlanClass( planName ) }
+						current={ current }
+						freePlan={ isFreePlan( planName ) }
+						isPlaceholder={ isPlaceholder }
+						isPopular={ popular }
+						isInSignup={ isInSignup }
+						isLaunchPage={ isLaunchPage }
+						onUpgradeClick={ () => this.handleUpgradeClick( properties ) }
+						planName={ planConstantObj.getTitle() }
+						planType={ planName }
+						primaryUpgrade={ primaryUpgrade }
+					/>
+				</td>
+			);
+		} );
+	}
+
+	getLongestFeaturesList() {
+		const { planProperties } = this.props;
+
+		return reduce(
+			planProperties,
+			( longest, properties ) => {
+				const currentFeatures = Object.keys( properties.features );
+				return currentFeatures.length > longest.length ? currentFeatures : longest;
+			},
+			[]
+		);
+	}
+
+	renderPlanFeatureRows() {
+		const longestFeatures = this.getLongestFeaturesList();
+		return map( longestFeatures, ( featureKey, rowIndex ) => {
+			return (
+				<tr key={ rowIndex } className="plan-features-2023-grid__row">
+					{ this.renderPlanFeatureColumns( rowIndex ) }
+				</tr>
+			);
+		} );
+	}
+
+	renderAnnualPlansFeatureNotice( feature ) {
+		const { translate, isInSignup } = this.props;
+
+		if (
+			! isInSignup ||
+			! feature.availableOnlyForAnnualPlans ||
+			feature.availableForCurrentPlan
+		) {
+			return '';
+		}
+
+		return (
+			<span className="plan-features-2023-grid__item-annual-plan">
+				{ translate( 'Included with annual plans' ) }
+			</span>
+		);
+	}
+
+	renderFeatureItem( feature, index ) {
+		const classes = classNames( 'plan-features-2023-grid__item-info', {
+			'is-annual-plan-feature': feature.availableOnlyForAnnualPlans,
+			'is-available': feature.availableForCurrentPlan,
+		} );
+
+		return (
+			<>
+				<PlanFeaturesItem
+					key={ index }
+					annualOnlyContent={ this.renderAnnualPlansFeatureNotice( feature ) }
+					isFeatureAvailable={ feature.availableForCurrentPlan }
+				>
+					<span className={ classes }>
+						<span className="plan-features-2023-grid__item-title">
+							{ feature.getTitle( this.props.domainName ) }
+						</span>
+					</span>
+				</PlanFeaturesItem>
+			</>
+		);
+	}
+
+	renderPlanFeatureColumns( rowIndex ) {
+		const { planProperties, selectedFeature } = this.props;
+
+		return map( planProperties, ( properties, mapIndex ) => {
+			const { features, planName } = properties;
+			const featureKeys = Object.keys( features );
+			const key = featureKeys[ rowIndex ];
+			const currentFeature = features[ key ];
+			const classes = classNames( 'plan-features-2023-grid__table-item', getPlanClass( planName ), {
+				'is-last-feature': rowIndex + 1 === featureKeys.length,
+				'is-highlighted':
+					selectedFeature && currentFeature && selectedFeature === currentFeature.getSlug(),
+				'is-bold': rowIndex === 0 || currentFeature?.isHighlightedFeature,
+			} );
+
+			return currentFeature ? (
+				<td key={ `${ planName }-${ key }` } className={ classes }>
+					{ this.renderFeatureItem( currentFeature, mapIndex ) }
+				</td>
+			) : (
+				<td key={ `${ planName }-none` } className="plan-features-2023-grid__table-item" />
+			);
+		} );
+	}
+}
+
+PlanFeatures2023Grid.propTypes = {
+	basePlansPath: PropTypes.string,
+	isInSignup: PropTypes.bool,
+	onUpgradeClick: PropTypes.func,
+	// either you specify the plans prop or isPlaceholder prop
+	plans: PropTypes.array,
+	popularPlan: PropTypes.object,
+	visiblePlans: PropTypes.array,
+	planProperties: PropTypes.array,
+	selectedFeature: PropTypes.string,
+	purchaseId: PropTypes.number,
+	flowName: PropTypes.string,
+	siteId: PropTypes.number,
+};
+
+PlanFeatures2023Grid.defaultProps = {
+	basePlansPath: null,
+	isInSignup: true,
+	siteId: null,
+	onUpgradeClick: noop,
+};
+
+export const calculatePlanCredits = ( state, siteId, planProperties ) =>
+	planProperties
+		.map( ( { planName, availableForPurchase } ) => {
+			if ( ! availableForPurchase ) {
+				return 0;
+			}
+			const annualDiscountPrice = getPlanDiscountedRawPrice( state, siteId, planName );
+			const annualRawPrice = getSitePlanRawPrice( state, siteId, planName );
+			if ( typeof annualDiscountPrice !== 'number' || typeof annualRawPrice !== 'number' ) {
+				return 0;
+			}
+
+			return annualRawPrice - annualDiscountPrice;
+		} )
+		.reduce( ( max, credits ) => Math.max( max, credits ), 0 );
+
+const hasPlaceholders = ( planProperties ) =>
+	planProperties.filter( ( planProps ) => planProps.isPlaceholder ).length > 0;
+
+/* eslint-disable wpcalypso/redux-no-bound-selectors */
+export default connect(
+	( state, ownProps ) => {
+		const {
+			isInSignup,
+			placeholder,
+			plans,
+			isLandingPage,
+			siteId,
+			visiblePlans,
+			popularPlanSpec,
+			flowName = getCurrentFlowName( state ),
+		} = ownProps;
+		const signupDependencies = getSignupDependencyStore( state );
+		const siteType = signupDependencies.designType;
+
+		let planProperties = compact(
+			map( plans, ( plan ) => {
+				let isPlaceholder = false;
+				const planConstantObj = applyTestFiltersToPlansList( plan, undefined );
+				const planProductId = planConstantObj.getProductId();
+				const planObject = getPlan( state, planProductId );
+				const isMonthlyPlan = isMonthly( plan );
+				const showMonthly = ! isMonthlyPlan;
+				const availableForPurchase = true;
+				const relatedMonthlyPlan = showMonthly
+					? getPlanBySlug( state, getMonthlyPlanByYearly( plan ) )
+					: null;
+				const popular = popularPlanSpec && planMatches( plan, popularPlanSpec );
+
+				// Show price divided by 12? Only for non JP plans, or if plan is only available yearly.
+				const showMonthlyPrice = true;
+
+				const features = planConstantObj.getPlanCompareFeatures();
+
+				let planFeatures = getPlanFeaturesObject( features );
+				if ( placeholder || ! planObject ) {
+					isPlaceholder = true;
+				}
+
+				const featureAccessor = getPlanFeatureAccessor( { flowName, plan: planConstantObj } );
+				if ( featureAccessor ) {
+					planFeatures = getPlanFeaturesObject( featureAccessor() );
+				}
+
+				const rawPrice = getPlanRawPrice( state, planProductId, showMonthlyPrice );
+				const discountPrice = getDiscountedRawPrice( state, planProductId, showMonthlyPrice );
+
+				let annualPricePerMonth = discountPrice || rawPrice;
+				if ( isMonthlyPlan ) {
+					// Get annual price per month for comparison
+					const yearlyPlan = getPlanBySlug( state, getYearlyPlanByMonthly( plan ) );
+					if ( yearlyPlan ) {
+						const yearlyPlanDiscount = getDiscountedRawPrice(
+							state,
+							yearlyPlan.product_id,
+							showMonthlyPrice
+						);
+						annualPricePerMonth =
+							yearlyPlanDiscount ||
+							getPlanRawPrice( state, yearlyPlan.product_id, showMonthlyPrice );
+					}
+				}
+
+				const monthlyPlanKey = findPlansKeys( {
+					group: planConstantObj.group,
+					term: TERM_MONTHLY,
+					type: planConstantObj.type,
+				} )[ 0 ];
+				const monthlyPlanProductId = getPlanFromKey( monthlyPlanKey )?.getProductId();
+				// This is the per month price of a monthly plan. E.g. $14 for Premium monthly.
+				const rawPriceForMonthlyPlan = getPlanRawPrice( state, monthlyPlanProductId, true );
+				const annualPlansOnlyFeatures = planConstantObj.getAnnualPlansOnlyFeatures?.() || [];
+				if ( annualPlansOnlyFeatures.length > 0 ) {
+					planFeatures = planFeatures.map( ( feature ) => {
+						const availableOnlyForAnnualPlans = annualPlansOnlyFeatures.includes(
+							feature.getSlug()
+						);
+
+						return {
+							...feature,
+							availableOnlyForAnnualPlans,
+							availableForCurrentPlan: ! isMonthlyPlan || ! availableOnlyForAnnualPlans,
+						};
+					} );
+				}
+
+				const highlightedFeatures = getHighlightedFeatures( flowName, planConstantObj );
+				if ( highlightedFeatures.length ) {
+					planFeatures = planFeatures.map( ( feature ) => {
+						return {
+							...feature,
+							isHighlightedFeature: highlightedFeatures.includes( feature.getSlug() ),
+						};
+					} );
+				}
+
+				// Strip annual-only features out for the site's /plans page
+				if ( ! isInSignup || isPlaceholder ) {
+					planFeatures = planFeatures.filter(
+						( { availableForCurrentPlan = true } ) => availableForCurrentPlan
+					);
+				}
+
+				const rawPriceAnnual =
+					null !== discountPrice
+						? discountPrice * 12
+						: getPlanRawPrice( state, planProductId, false );
+
+				return {
+					availableForPurchase,
+					cartItemForPlan: getCartItemForPlan( getPlanSlug( state, planProductId ) ),
+					currencyCode: getCurrentUserCurrencyCode( state ),
+					discountPrice,
+					features: planFeatures,
+					isLandingPage,
+					isPlaceholder,
+					planConstantObj,
+					planName: plan,
+					planObject: planObject,
+					popular,
+					productSlug: get( planObject, 'product_slug' ),
+					hideMonthly: false,
+					primaryUpgrade: popular || plans.length === 1,
+					rawPrice,
+					rawPriceAnnual,
+					rawPriceForMonthlyPlan,
+					relatedMonthlyPlan,
+					annualPricePerMonth,
+					isMonthlyPlan,
+				};
+			} )
+		);
+
+		if ( Array.isArray( visiblePlans ) ) {
+			planProperties = planProperties.filter( ( p ) => visiblePlans.indexOf( p.planName ) !== -1 );
+		}
+
+		const purchaseId = getCurrentPlanPurchaseId( state, siteId );
+
+		return {
+			planProperties,
+			purchaseId,
+			siteType,
+			hasPlaceholders: hasPlaceholders( planProperties ),
+		};
+	},
+	{
+		recordTracksEvent,
+	}
+)( localize( PlanFeatures2023Grid ) );
+/* eslint-enable wpcalypso/redux-no-bound-selectors */

--- a/client/my-sites/plan-features-2023-grid/item.jsx
+++ b/client/my-sites/plan-features-2023-grid/item.jsx
@@ -1,0 +1,27 @@
+import { Gridicon } from '@automattic/components';
+import classNames from 'classnames';
+
+export function PlanFeaturesItem( props ) {
+	const itemInfoClasses = classNames( 'plan-features-2023-grid__item-info-container', {
+		'plan-features-2023-grid__item-info-annual-only': props.annualOnlyContent,
+	} );
+	const icon = props.isFeatureAvailable ? 'checkmark' : 'cross';
+	const gridIconClasses = classNames( {
+		'plan-features-2023-grid__item-checkmark': props.isFeatureAvailable,
+		'plan-features-2023-grid__item-cross': ! props.isFeatureAvailable,
+	} );
+
+	return (
+		<div className="plan-features-2023-grid__item plan-features-2023-grid__item-available">
+			{ props.annualOnlyContent && (
+				<div className="plan-features-2023-grid__item-annual-plan-container">
+					{ props.annualOnlyContent }
+				</div>
+			) }
+			<div className={ itemInfoClasses }>
+				<Gridicon className={ gridIconClasses } size={ 18 } icon={ icon } />
+				{ props.children }
+			</div>
+		</div>
+	);
+}

--- a/client/my-sites/plan-features-2023-grid/style.scss
+++ b/client/my-sites/plan-features-2023-grid/style.scss
@@ -1,0 +1,475 @@
+$plan-features-header-banner-height: 20px;
+$plan-features-sidebar-width: 272px;
+
+.plan-features--loading-container {
+	margin-top: 300px;
+}
+
+.plan-features-2023-grid__table.has-2-cols {
+	display: block;
+	margin-left: auto;
+	margin-right: auto;
+	max-width: 800px;
+}
+
+.plan-features-2023-grid__table.has-1-cols {
+	margin-left: auto;
+	margin-right: auto;
+	max-width: 337px;
+}
+
+.plan-features-2023-grid__table-item.has-border-top {
+	border-top: solid 1px var(--color-neutral-5);
+}
+
+.plan-features-2023-grid__table-item.is-top-buttons {
+	padding-top: 8px;
+}
+
+.plan-features-2023-grid__header {
+	position: relative;
+	display: flex;
+	align-items: flex-start;
+	padding: 12px 24px 12px 15px;
+	background-color: var(--color-surface);
+	justify-content: center;
+	font-weight: 400;
+	margin-top: 30px;
+}
+
+.plan-features-2023-grid__header-text {
+	flex: 1;
+	padding: 6px 0 0;
+}
+
+.plan-features-2023-grid__actions-buttons {
+	text-align: center;
+}
+
+.plans-wrapper {
+	margin: 0 auto;
+	padding: 20px 0 10px;
+	transform: translateY(-20px);
+	overflow-x: auto;
+}
+
+.plan-features--signup {
+	margin: 0 auto;
+
+	.signup__steps & {
+		width: auto;
+
+		@include breakpoint-deprecated( ">660px" ) {
+			max-width: 1100px;
+		}
+	}
+
+	.signup__steps .plans-features-main__group.is-scrollable & {
+		max-width: 100%;
+	}
+
+	.plan-features-2023-grid__table {
+		display: none;
+		font-size: $font-body-small;
+		color: var(--color-text-subtle);
+		border-spacing: 16px 0;
+		margin-top: -16px;
+		table-layout: fixed;
+		width: 80%;
+
+		@include breakpoint-deprecated( ">660px" ) {
+			display: table;
+			margin: 0 auto;
+			padding: 0 16px;
+		}
+
+		@include breakpoint-deprecated( "<1040px" ) {
+			border-spacing: 0;
+			margin-left: 15px;
+			margin-right: 15px;
+			width: calc(100% - 30px);
+		}
+
+		@include breakpoint-deprecated( ">1040px" ) {
+			border-spacing: 0;
+			padding: 0;
+		}
+	}
+
+	.plan-features-2023-grid__header-title {
+		margin-bottom: 5px;
+		font-size: $font-title-small;
+		line-height: 0.7;
+		color: var(--studio-gray-80);
+		font-weight: 400;
+	}
+
+	.is-premium-plan .plan-features-2023-grid__header-title {
+		color: var(--studio-gray-100);
+		font-weight: 600;
+	}
+
+	.plan-features-2023-grid__table-item {
+		text-align: center;
+		transition: opacity 0.05s;
+		border-right: solid 1px var(--color-neutral-5);
+		border-left: solid 1px var(--color-neutral-5);
+		background-color: var(--color-surface);
+		position: relative;
+
+		&.is-bold {
+			font-weight: bold;
+		}
+	}
+
+	.plan-features-2023-grid__pricing,
+	.plan-price.is-discounted {
+		color: var(--color-neutral-70);
+	}
+
+	.plan-features-2023-grid__pricing {
+		padding: 8px 16px;
+		margin: 0;
+
+		.plan-price {
+			font-weight: 600;
+			color: var(--color-text);
+			margin-right: 10px;
+			font-size: $font-title-large;
+			line-height: $font-title-large;
+			padding-bottom: 12px;
+			font-family: "Helvetica Neue", helvetica, arial, sans-serif;
+		}
+
+		.plan-price__currency-symbol {
+			font-size: $font-title-large;
+			vertical-align: unset;
+			color: var(--color-text);
+		}
+
+		.plan-price__integer {
+			font-weight: 600;
+			margin-left: 2px;
+		}
+
+		.plan-price__term {
+			font-size: $font-body-extra-small;
+			font-weight: 400;
+		}
+
+		.plan-features-2023-grid__header-billing-info {
+			color: var(--studio-gray-40);
+			font-weight: 600;
+			font-size: $font-body-extra-small;
+			padding-bottom: 5px;
+		}
+
+		.plan-price.is-original {
+			color: var(--color-neutral-light);
+
+			&::before {
+				border-color: var(--color-success);
+			}
+
+			.plan-price__currency-symbol,
+			.plan-price__tax-amount {
+				color: var(--color-text-subtle);
+			}
+		}
+	}
+
+	.plan-features-2023-grid__header-annual-discount {
+		color: var(--studio-green-60);
+		&-is-loading {
+			@include placeholder();
+		}
+	}
+
+	.is-placeholder {
+		width: 60%;
+		margin: 5px auto;
+	}
+
+	.plan-features-2023-grid__item-info {
+		padding: 0 5px;
+		display: flex;
+		flex-direction: column;
+		flex: 1 0 0;
+		width: 100%;
+
+		.plan-features-2023-grid__item-title {
+			line-height: 18px;
+			overflow-wrap: break-word;
+			margin: 0;
+			flex: 1 0 0;
+			width: 100%;
+		}
+
+		&:not(.is-available) {
+			color: var(--studio-gray-20);
+
+			.plan-features-2023-grid__item-title {
+				text-decoration: line-through;
+				color: var(--color-neutral-30);
+			}
+		}
+	}
+
+	.plan-features-2023-grid__actions {
+		padding: 0 15px 15px;
+
+		@include breakpoint-deprecated( "<1040px" ) {
+			padding: 0 12px 12px;
+		}
+
+		@include breakpoint-deprecated( "<660px" ) {
+			padding: 0 20px 20px;
+			border-bottom: solid 1px var(--color-neutral-0);
+		}
+	}
+
+	.plan-features-2023-grid__actions-button {
+		margin-top: 8px;
+		width: 100%;
+
+		@include breakpoint-deprecated( "<660px" ) {
+			margin-top: 20px;
+		}
+
+		&.disabled,
+		&[disabled] {
+			color: var(--color-neutral-light);
+		}
+	}
+
+	.plan-features-2023-grid__row:last-of-type .plan-features-2023-grid__table-item {
+		border-bottom: solid 1px var(--color-neutral-5);
+
+		&.is-last-feature {
+			.plan-features-2023-grid__item-info {
+				padding-bottom: 30px;
+			}
+		}
+	}
+
+	.plan-features-2023-grid__item {
+		padding: 0.5rem;
+		margin: 0 15px;
+		text-align: left;
+
+		&.plan-features-2023-grid__item-available {
+			display: flex;
+			flex-direction: column;
+			position: relative;
+
+			& .plan-features-2023-grid__item-annual-plan-container {
+				display: flex;
+				position: absolute;
+				margin-left: 21px;
+				top: 5px;
+
+				& .plan-features-2023-grid__item-annual-plan {
+					font-weight: 600;
+					color: var(--color-error);
+					font-size: 0.6rem; /* stylelint-disable-line scales/font-sizes */
+					text-transform: uppercase;
+				}
+			}
+
+			& .plan-features-2023-grid__item-info-container {
+				display: flex;
+
+				&.plan-features-2023-grid__item-info-annual-only {
+					margin-top: 10px;
+				}
+			}
+		}
+
+		.plan-features-2023-grid__item-checkmark,
+		.plan-features-2023-grid__item-cross {
+			fill: var(--studio-green-50);
+			width: 16px;
+			height: 16px;
+			margin-right: 0;
+			flex: 0 0 auto;
+		}
+
+		.plan-features-2023-grid__item-cross {
+			fill: #a7aaad;
+		}
+	}
+}
+
+.plan-features-2023-grid__content {
+	.plans-features-main__group.is-scrollable & {
+		margin: -16px 0 0;
+		padding-top: $plan-features-header-banner-height;
+	}
+}
+
+.notouch .signup__step .segmented-control.price-toggle,
+.notouch .plans .segmented-control.price-toggle {
+	background-color: var(--studio-gray-5);
+	border-color: var(--studio-gray-5);
+	border-radius: 6px; /* stylelint-disable-line scales/radii */
+	color: var(--color-text);
+	margin-top: 16px;
+
+	.segmented-control__item {
+		border: 1px solid;
+		border-radius: 6px; /* stylelint-disable-line scales/radii */
+		border-color: var(--studio-gray-5);
+
+		&.is-selected {
+			padding: 1px 0 0 1px;
+		}
+
+		&:hover:not(.is-selected) {
+			border-color: var(--studio-gray-30);
+		}
+
+		&:first-child {
+			margin-right: 5px;
+		}
+
+		& .segmented-control__link {
+			color: var(--color-text);
+			padding: 10px 20px;
+
+			&:hover {
+				background-color: unset;
+			}
+		}
+
+		&.is-selected .segmented-control__link {
+			border-radius: 5px; /* stylelint-disable-line scales/radii */
+			background-color: var(--studio-white);
+			border-color: var(--studio-white);
+			box-shadow:
+				0 4px 4px rgba(0, 0, 0, 0.25),
+				0 3px 8px rgba(0, 0, 0, 0.12),
+				inset 0 0 0 rgba(0, 0, 0, 0.2);
+			border: 0.5px solid rgba(0, 0, 0, 0.07);
+			padding: 11px 20px;
+			color: var(--color-text);
+
+			&:hover {
+				background-color: var(--studio-white);
+			}
+		}
+	}
+}
+
+.plan-features__actions-button {
+	border-radius: 4px;
+}
+
+.plan-features-2023-grid__header-price-group {
+	display: inline;
+	width: calc(100% + 20px);
+
+	@include breakpoint-deprecated( "<960px" ) {
+		width: calc(100% + 10px);
+	}
+}
+
+.plan-features-2023-grid__header-price-group-prices {
+	display: inline-block;
+}
+
+body.is-section-signup.is-white-signup {
+	.plan-features-2023-grid__table-item {
+		border-left: none;
+		background-color: transparent;
+
+		&:last-of-type {
+			border-right: none;
+		}
+
+		.plan-pill.is-in-signup {
+			font-size: 0.75rem;
+			font-weight: 500;
+			letter-spacing: 0.2px;
+			/* stylelint-disable-next-line declaration-property-unit-allowed-list */
+			line-height: 1.25rem;
+			padding: 0 8px;
+			right: 52%;
+			transform: translate(50%);
+			border-radius: 4px;
+			background-color: var(--studio-green-5);
+			color: var(--studio-gray-80);
+		}
+	}
+
+	.plan-features-2023-grid__header {
+		background-color: transparent;
+	}
+
+	.plan-features-2023-grid__row:last-of-type .plan-features-2023-grid__table-item {
+		border-bottom: none;
+	}
+
+	.plan-features--signup .is-premium-plan .plan-features-2023-grid__header-title {
+		font-weight: 500;
+	}
+
+	.plan-features--signup .plan-features-2023-grid__pricing {
+		.plan-price {
+			font-weight: 500;
+
+			.plan-price__integer {
+				font-weight: 500;
+			}
+		}
+
+		.plan-features-2023-grid__header-billing-info {
+			font-weight: 500;
+		}
+	}
+
+	.plan-features-2023-grid__item-title {
+		color: var(--studio-gray-60);
+	}
+
+	.plan-features-2023-grid__item.plan-features-2023-grid__item-available {
+		.plan-features-2023-grid__item-annual-plan-container
+		.plan-features-2023-grid__item-annual-plan {
+			color: var(--studio-orange-40);
+		}
+	}
+}
+
+.notouch body.is-section-signup.is-white-signup .signup__step .segmented-control.price-toggle,
+.notouch body.is-section-plans.is-section-plans .plans .segmented-control.price-toggle {
+	background-color: #f2f2f2;
+	margin-top: 0;
+
+	.segmented-control__link {
+		padding: 6px 11px;
+	}
+
+	.segmented-control__item {
+		border: 6px;
+		padding: 2px;
+
+		& .segmented-control__link {
+			border: 1px solid #f2f2f2;
+			&:hover {
+				border: 1px solid var(--studio-gray-10);
+				background-color: unset;
+				border-radius: 5px; /* stylelint-disable-line scales/radii */
+			}
+		}
+
+		&.is-selected .segmented-control__link {
+			border: 0.5px solid rgba(0, 0, 0, 0.04);
+			box-shadow: 0 3px 8px rgba(0, 0, 0, 0.12), 0 3px 1px rgba(0, 0, 0, 0.04);
+			border-radius: 5px; /* stylelint-disable-line scales/radii */
+
+			&:hover {
+				background-color: #fff;
+				border-color: rgba(0, 0, 0, 0.04);
+			}
+		}
+	}
+}

--- a/client/my-sites/plan-features-2023-grid/util.ts
+++ b/client/my-sites/plan-features-2023-grid/util.ts
@@ -1,0 +1,87 @@
+import { IncompleteWPcomPlan } from '@automattic/calypso-products';
+import {
+	NEWSLETTER_FLOW,
+	isLinkInBioFlow,
+	isNewsletterOrLinkInBioFlow,
+} from '@automattic/onboarding';
+
+const newsletterFeatures = ( flowName: string, plan: IncompleteWPcomPlan ) => {
+	return flowName === NEWSLETTER_FLOW && plan.getNewsletterSignupFeatures;
+};
+
+const linkInBioFeatures = ( flowName: string, plan: IncompleteWPcomPlan ) => {
+	return isLinkInBioFlow( flowName ) && plan.getLinkInBioSignupFeatures;
+};
+
+const signupFlowDefaultFeatures = (
+	flowName: string,
+	plan: IncompleteWPcomPlan,
+	isInVerticalScrollingPlansExperiment: boolean
+) => {
+	if ( ! flowName || isNewsletterOrLinkInBioFlow( flowName ) ) {
+		return;
+	}
+
+	return isInVerticalScrollingPlansExperiment
+		? plan.getSignupFeatures
+		: plan.getSignupCompareAvailableFeatures;
+};
+
+export const getPlanFeatureAccessor = ( {
+	flowName = '',
+	isInVerticalScrollingPlansExperiment = false,
+	plan,
+}: {
+	flowName?: string;
+	isInVerticalScrollingPlansExperiment?: boolean;
+	plan: IncompleteWPcomPlan;
+} ) => {
+	return [
+		newsletterFeatures( flowName, plan ),
+		linkInBioFeatures( flowName, plan ),
+		signupFlowDefaultFeatures( flowName, plan, isInVerticalScrollingPlansExperiment ),
+	].find( ( accessor ) => {
+		return accessor instanceof Function;
+	} );
+};
+
+const newsletterHighlightedFeatures = ( flowName: string, plan: IncompleteWPcomPlan ) => {
+	return flowName === NEWSLETTER_FLOW && plan.getNewsletterHighlightedFeatures;
+};
+
+const linkInBioHighlightedFeatures = ( flowName: string, plan: IncompleteWPcomPlan ) => {
+	return isLinkInBioFlow( flowName ) && plan.getLinkInBioHighlightedFeatures;
+};
+
+export const getHighlightedFeatures = ( flowName: string, plan: IncompleteWPcomPlan ) => {
+	const accessor = [
+		newsletterHighlightedFeatures( flowName, plan ),
+		linkInBioHighlightedFeatures( flowName, plan ),
+	].find( ( accessor ) => {
+		return accessor instanceof Function;
+	} );
+
+	return ( accessor && accessor() ) || [];
+};
+
+export const getPlanDescriptionForMobile = ( {
+	flowName,
+	isInVerticalScrollingPlansExperiment,
+	plan,
+}: {
+	flowName: string;
+	isInVerticalScrollingPlansExperiment: boolean;
+	plan: IncompleteWPcomPlan;
+} ) => {
+	if ( flowName === NEWSLETTER_FLOW && plan.getNewsletterDescription ) {
+		return plan.getNewsletterDescription();
+	}
+
+	if ( isLinkInBioFlow( flowName ) && plan.getLinkInBioDescription ) {
+		return plan.getLinkInBioDescription();
+	}
+
+	return plan.getShortDescription && isInVerticalScrollingPlansExperiment
+		? plan.getShortDescription()
+		: plan.getDescription();
+};

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -37,6 +37,7 @@ import { get } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
+import AsyncLoad from 'calypso/components/async-load';
 import QueryPlans from 'calypso/components/data/query-plans';
 import QuerySitePlans from 'calypso/components/data/query-site-plans';
 import QuerySites from 'calypso/components/data/query-sites';
@@ -46,7 +47,6 @@ import Notice from 'calypso/components/notice';
 import { getTld } from 'calypso/lib/domains';
 import { isValidFeatureKey } from 'calypso/lib/plans/features-list';
 import PlanFeatures from 'calypso/my-sites/plan-features';
-import PlanFeatures2023Grid from 'calypso/my-sites/plan-features-2023-grid';
 import PlanFeaturesComparison from 'calypso/my-sites/plan-features-comparison';
 import isHappychatAvailable from 'calypso/state/happychat/selectors/is-happychat-available';
 import { selectSiteId as selectHappychatSiteId } from 'calypso/state/help/actions';
@@ -129,6 +129,35 @@ export class PlansFeaturesMain extends Component {
 			isEnabled( 'onboarding/2023-pricing-grid' ) &&
 			flowName === 'onboarding-2023-pricing-grid'
 		) {
+			const asyncProps = {
+				basePlansPath,
+				domainName,
+				isInSignup,
+				isLandingPage,
+				isLaunchPage,
+				onUpgradeClick,
+				plans,
+				flowName,
+				redirectTo,
+				visiblePlans,
+				selectedFeature,
+				selectedPlan,
+				withDiscount,
+				discountEndDate,
+				withScroll: plansWithScroll,
+				popularPlanSpec: getPopularPlanSpec( {
+					flowName,
+					customerType,
+					isJetpack,
+					availablePlans: visiblePlans,
+				} ),
+				siteId,
+				isReskinned,
+				isPlansInsideStepper,
+			};
+			const asyncPlanFeatures2023Grid = (
+				<AsyncLoad require="calypso/my-sites/plan-features-2023-grid" { ...asyncProps } />
+			);
 			return (
 				<div
 					className={ classNames(
@@ -141,33 +170,7 @@ export class PlansFeaturesMain extends Component {
 					) }
 					data-e2e-plans="wpcom"
 				>
-					<PlanFeatures2023Grid
-						basePlansPath={ basePlansPath }
-						domainName={ domainName }
-						isInSignup={ isInSignup }
-						isLandingPage={ isLandingPage }
-						isLaunchPage={ isLaunchPage }
-						onUpgradeClick={ onUpgradeClick }
-						plans={ plans }
-						flowName={ flowName }
-						redirectTo={ redirectTo }
-						visiblePlans={ visiblePlans }
-						selectedFeature={ selectedFeature }
-						selectedPlan={ selectedPlan }
-						withDiscount={ withDiscount }
-						discountEndDate={ discountEndDate }
-						withScroll={ plansWithScroll }
-						popularPlanSpec={ getPopularPlanSpec( {
-							flowName,
-							customerType,
-							isJetpack,
-							availablePlans: visiblePlans,
-						} ) }
-						siteId={ siteId }
-						isReskinned={ isReskinned }
-						isFAQCondensedExperiment={ isFAQCondensedExperiment }
-						isPlansInsideStepper={ isPlansInsideStepper }
-					/>
+					{ asyncPlanFeatures2023Grid }
 				</div>
 			);
 		}

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -46,6 +46,7 @@ import Notice from 'calypso/components/notice';
 import { getTld } from 'calypso/lib/domains';
 import { isValidFeatureKey } from 'calypso/lib/plans/features-list';
 import PlanFeatures from 'calypso/my-sites/plan-features';
+import PlanFeatures2023Grid from 'calypso/my-sites/plan-features-2023-grid';
 import PlanFeaturesComparison from 'calypso/my-sites/plan-features-comparison';
 import isHappychatAvailable from 'calypso/state/happychat/selectors/is-happychat-available';
 import { selectSiteId as selectHappychatSiteId } from 'calypso/state/help/actions';
@@ -123,6 +124,50 @@ export class PlansFeaturesMain extends Component {
 
 		const plans = this.getPlansForPlanFeatures();
 		const visiblePlans = this.getVisiblePlansForPlanFeatures( plans );
+
+		if ( isEnabled( 'onboarding/2023-pricing-grid' ) ) {
+			return (
+				<div
+					className={ classNames(
+						'plans-features-main__group',
+						'is-wpcom',
+						`is-customer-${ customerType }`,
+						{
+							'is-scrollable': plansWithScroll,
+						}
+					) }
+					data-e2e-plans="wpcom"
+				>
+					<PlanFeatures2023Grid
+						basePlansPath={ basePlansPath }
+						domainName={ domainName }
+						isInSignup={ isInSignup }
+						isLandingPage={ isLandingPage }
+						isLaunchPage={ isLaunchPage }
+						onUpgradeClick={ onUpgradeClick }
+						plans={ plans }
+						flowName={ flowName }
+						redirectTo={ redirectTo }
+						visiblePlans={ visiblePlans }
+						selectedFeature={ selectedFeature }
+						selectedPlan={ selectedPlan }
+						withDiscount={ withDiscount }
+						discountEndDate={ discountEndDate }
+						withScroll={ plansWithScroll }
+						popularPlanSpec={ getPopularPlanSpec( {
+							flowName,
+							customerType,
+							isJetpack,
+							availablePlans: visiblePlans,
+						} ) }
+						siteId={ siteId }
+						isReskinned={ isReskinned }
+						isFAQCondensedExperiment={ isFAQCondensedExperiment }
+						isPlansInsideStepper={ isPlansInsideStepper }
+					/>
+				</div>
+			);
+		}
 
 		return (
 			<div

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -125,7 +125,10 @@ export class PlansFeaturesMain extends Component {
 		const plans = this.getPlansForPlanFeatures();
 		const visiblePlans = this.getVisiblePlansForPlanFeatures( plans );
 
-		if ( isEnabled( 'onboarding/2023-pricing-grid' ) ) {
+		if (
+			isEnabled( 'onboarding/2023-pricing-grid' ) &&
+			flowName === 'onboarding-2023-pricing-grid'
+		) {
 			return (
 				<div
 					className={ classNames(

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -115,6 +115,16 @@ export function generateFlows( {
 			showRecaptcha: true,
 		},
 		{
+			name: 'onboarding-2023-pricing-grid',
+			steps: isEnabled( 'signup/professional-email-step' )
+				? [ 'user', 'domains', 'emails', 'plans' ]
+				: [ 'user', 'domains', 'plans' ],
+			destination: getSignupDestination,
+			description: 'Abridged version of the onboarding flow. Read more in https://wp.me/pau2Xa-Vs.',
+			lastModified: '2020-12-10',
+			showRecaptcha: true,
+		},
+		{
 			name: 'newsletter',
 			steps: [ 'domains', 'plans-newsletter' ],
 			destination: ( dependencies ) =>

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -209,7 +209,8 @@
 		"ecommerce-monthly",
 		"pro",
 		"starter",
-		"domain"
+		"domain",
+		"onboarding-2023-pricing-grid"
 	],
 	"bilmur_url": "https://s0.wp.com/wp-content/js/bilmur.min.js"
 }

--- a/config/development.json
+++ b/config/development.json
@@ -122,6 +122,7 @@
 		"onboarding/import-light": false,
 		"onboarding/import-light-url-screen": true,
 		"onboarding/import-redirect-to-themes": true,
+		"onboarding/2023-pricing-grid": true,
 		"p2/p2-plus": true,
 		"page/export": true,
 		"plans/personal-plan": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -96,6 +96,7 @@
 		"onboarding/import-light": false,
 		"onboarding/import-light-url-screen": true,
 		"onboarding/import-redirect-to-themes": true,
+		"onboarding/2023-pricing-grid": true,
 		"p2/p2-plus": true,
 		"plans/personal-plan": true,
 		"plans/pro-plan": false,


### PR DESCRIPTION
#### Proposed Changes

* This PR copies over the existing `plan-features-comparison` folder to a new folder, creating a new `PlanFeatures2023Grid` component.
* The new `PlanFeatures2023Grid` component, which is right now exactly the same as the current `PlanFeaturesComparison` component, is hidden behind a feature flag and will be rendered only in a new `/start/onboarding-2023-pricing-grid` signup flow. 
* Copying over to a new folder helps separate the new pricing grid work, and this PR will set the base for upcoming PRs to style the plans step to the new designs shared in pdgrnI-1Qp-p2.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go through the signup flow `/start/` and verify that the signup flow plans step works well on desktop and mobile without any console errors or issues. 
* Go through `/start/onboarding-2023-pricing-grid` and everything should work normally. There are no UI changes of any sort introduced. 

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
