### PR TITLE
Stats: Add new section header to Annual insights summary page

### DIFF
--- a/client/my-sites/stats/annual-site-stats/index.js
+++ b/client/my-sites/stats/annual-site-stats/index.js
@@ -167,7 +167,7 @@ class AnnualSiteStats extends Component {
 				{ isWidget && (
 					<SectionHeader
 						href={ viewAllLink }
-						label={ translate( 'Annual site stats', { args: [ currentYear ] } ) }
+						label={ translate( 'Annual insights', { args: [ currentYear ] } ) }
 					/>
 				) }
 				{ ! isWidget && (

--- a/client/my-sites/stats/annual-site-stats/index.js
+++ b/client/my-sites/stats/annual-site-stats/index.js
@@ -170,6 +170,9 @@ class AnnualSiteStats extends Component {
 						label={ translate( 'Annual site stats', { args: [ currentYear ] } ) }
 					/>
 				) }
+				{ ! isWidget && (
+					<h1 className="highlight-cards-heading">{ translate( 'All-time annual insights' ) }</h1>
+				) }
 				<Card className="stats-module">
 					<StatsModulePlaceholder isLoading={ isLoading } />
 					{ isError && <ErrorPanel message={ translate( 'Oops! Something went wrong.' ) } /> }

--- a/client/my-sites/stats/summary/index.jsx
+++ b/client/my-sites/stats/summary/index.jsx
@@ -18,6 +18,8 @@ import VideoPlayDetails from '../stats-video-details';
 import StatsVideoSummary from '../stats-video-summary';
 import VideoPressStatsModule from '../videopress-stats-module';
 
+import './style.scss';
+
 const StatsStrings = statsStringsFactory();
 
 class StatsSummary extends Component {
@@ -241,7 +243,9 @@ class StatsSummary extends Component {
 				/>
 				<FixedNavigationHeader navigationItems={ navigationItems } />
 
-				<div id="my-stats-content">{ summaryViews }</div>
+				<div id="my-stats-content" className=" stats-summary-view">
+					{ summaryViews }
+				</div>
 				<JetpackColophon />
 			</Main>
 		);

--- a/client/my-sites/stats/summary/index.jsx
+++ b/client/my-sites/stats/summary/index.jsx
@@ -217,7 +217,7 @@ class StatsSummary extends Component {
 				);
 				break;
 			case 'annualstats':
-				title = translate( 'Annual site stats' );
+				title = translate( 'Annual insights' );
 				backLabel = localizedTabNames.insights;
 				backLink = `/stats/insights/`;
 				summaryView = <AnnualSiteStats key="annualstats" />;

--- a/client/my-sites/stats/summary/style.scss
+++ b/client/my-sites/stats/summary/style.scss
@@ -1,9 +1,12 @@
 .stats-summary-view {
-	padding: 0 32px 0;
-	@media ( max-width: 660px ) {
-		padding: 0 0.875rem 0;
-	}
-	@media ( max-width: 480px ) {
-		padding: 0;
+	.highlight-cards-heading {
+		@media ( max-width: 1380px ) {
+			margin-left: 32px;
+			margin-right: 32px;
+		}
+		@media ( max-width: 660px ) {
+			margin-left: 0.875rem;
+			margin-right: 0.875rem;
+		}
 	}
 }

--- a/client/my-sites/stats/summary/style.scss
+++ b/client/my-sites/stats/summary/style.scss
@@ -1,12 +1,8 @@
 .stats-summary-view {
 	.highlight-cards-heading {
-		@media ( max-width: 1380px ) {
+		@media ( min-width: 661px ) and ( max-width: 1380px ) {
 			margin-left: 32px;
 			margin-right: 32px;
-		}
-		@media ( max-width: 660px ) {
-			margin-left: 0.875rem;
-			margin-right: 0.875rem;
 		}
 	}
 }

--- a/client/my-sites/stats/summary/style.scss
+++ b/client/my-sites/stats/summary/style.scss
@@ -1,0 +1,9 @@
+.stats-summary-view {
+	padding: 0 32px 0;
+	@media ( max-width: 660px ) {
+		padding: 0 0.875rem 0;
+	}
+	@media ( max-width: 480px ) {
+		padding: 0;
+	}
+}


### PR DESCRIPTION
#### Proposed Changes

Adds a section header to the Annual insights summary page.

BEFORE:
![StatsBefore](https://user-images.githubusercontent.com/40267301/208676062-157a54c8-27f9-4f2f-9323-2205cac8e5c0.png)

AFTER:
<!--![StatsAfter](https://user-images.githubusercontent.com/40267301/208676088-93aae689-7658-42fe-a2f6-470979960744.png)-->

<img width="1091" alt="image" src="https://user-images.githubusercontent.com/4044428/208996041-331a7666-df99-44ac-af84-d71b87af6d62.png">


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit the Calypso Live branch.
* Select a site and visit Stats → Insights → View all annual insights.
* Confirm the new section header is visible.
* Confirm the header looks okay at different screen sizes.

**Note:** Changes to table will be part of a separate PR. Likewise the info icon. [Waiting on design feedback](https://github.com/Automattic/wp-calypso/issues/70608#issuecomment-1338240574) before implementing that.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #70608 