### PR TITLE
Add/ Email open stats card in stats dashboard

### DIFF
--- a/client/my-sites/stats/grid-layout.scss
+++ b/client/my-sites/stats/grid-layout.scss
@@ -7,30 +7,33 @@ $grid-vertical-gutters: 32px;
 	align-items: stretch;
 	display: grid;
 	grid-template-columns: repeat(12, 1fr);
-	grid-template-rows: repeat(4, min-content);
+	grid-template-rows: repeat(5, min-content);
 	gap: $grid-vertical-gutters $grid-horizontal-gutters;
 	grid-template-areas:
 		"posts posts posts posts posts posts posts referrers referrers referrers referrers referrers"
 		"country country country country country country country country country country country country"
 		"authors authors authors authors search search search search clicks clicks clicks clicks"
-		"videos videos videos videos videos videos downloads downloads downloads downloads downloads downloads";
+		"videos videos videos videos videos videos downloads downloads downloads downloads downloads downloads"
+		"emails-open emails-open emails-open emails-open emails-open emails-open emails-open emails-open emails-open emails-open emails-open emails-open";
 
 	// Tablets
 	@media ( max-width: $break-large ) {
 		grid-template-columns: repeat(8, 1fr);
-		grid-template-rows: repeat(5, min-content);
+		grid-template-rows: repeat(6, min-content);
 		grid-template-areas:
 			"posts posts posts posts referrers referrers referrers referrers"
 			"country country country country country country country country"
 			"authors authors authors authors search search search search"
 			"clicks clicks clicks clicks videos videos videos videos"
-			"downloads downloads downloads downloads downloads downloads downloads downloads";
+			"downloads downloads downloads downloads downloads downloads downloads downloads"
+			"emails-open emails-open emails-open emails-open emails-open emails-open emails-open emails-open";
+
 	}
 
 	// Mobile
 	@media ( max-width: $break-medium ) {
 		grid-template-columns: repeat(4, 1fr);
-		grid-template-rows: repeat(8, min-content);
+		grid-template-rows: repeat(9, min-content);
 		gap: 0;
 		grid-template-areas:
 			"posts posts posts posts"
@@ -40,7 +43,9 @@ $grid-vertical-gutters: 32px;
 			"search search search search"
 			"clicks clicks clicks clicks"
 			"videos videos videos videos"
-			"downloads downloads downloads downloads";
+			"downloads downloads downloads downloads"
+			"emails-open emails-open emails-open emails-open";
+
 	}
 
 	.card.stats-module {
@@ -106,5 +111,9 @@ $grid-vertical-gutters: 32px;
 	.stats__module-wrapper--filedownloads,
 	.list-filedownloads {
 		grid-area: downloads;
+	}
+	.stats__module-wrapper--emails,
+	.list-emails-open {
+		grid-area: emails-open;
 	}
 }

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -284,6 +284,17 @@ class StatsSite extends Component {
 					</>
 
 					<div className="stats__module-list stats__module-list--traffic is-events stats__module--unified">
+						{ config.isEnabled( 'newsletter/stats' ) && (
+							<StatsModule
+								path="emails-open"
+								moduleStrings={ moduleStrings.emailsOpenStats }
+								period={ this.props.period }
+								query={ query }
+								statType="statsEmailsOpen"
+								showSummaryLink
+								showNewModules
+							/>
+						) }
 						<StatsModule
 							path="posts"
 							moduleStrings={ moduleStrings.posts }

--- a/client/my-sites/stats/stats-strings.js
+++ b/client/my-sites/stats/stats-strings.js
@@ -113,5 +113,14 @@ export default function () {
 		} ),
 	};
 
+	statsStrings.emailsOpenStats = {
+		title: translate( 'Email opens', { context: 'Stats: title of module' } ),
+		item: translate( 'Title', { context: 'Stats: module row header for post title.' } ),
+		value: translate( 'Views', { context: 'Stats: module row header for number of post views.' } ),
+		empty: translate( 'No email opens', {
+			context: 'Stats: Info box label when the Email Open module is empty',
+		} ),
+	};
+
 	return statsStrings;
 }

--- a/client/state/stats/lists/actions.js
+++ b/client/state/stats/lists/actions.js
@@ -33,6 +33,7 @@ const wpcomV1Endpoints = {
 	statsInsights: 'stats/insights',
 	statsFileDownloads: 'stats/file-downloads',
 	statsAds: 'wordads/stats',
+	statsEmailsOpen: 'stats/opens/emails',
 };
 
 const wpcomV2Endpoints = {

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -946,4 +946,32 @@ export const normalizers = {
 			};
 		} );
 	},
+
+	/**
+	 * Returns a normalized statsEmailsOpen array, ready for use in stats-module
+	 *
+	 * @param   {object} data   Stats data
+	 * @param   {object} query  Stats query
+	 * @returns {Array}       Normalized stats data
+	 */
+	statsEmailsOpen( data, query = {} ) {
+		if ( ! data || ! query.period || ! query.date ) {
+			return [];
+		}
+		const { startOf } = rangeOfPeriod( query.period, query.date );
+		const emailsData = get( data, [ 'days', startOf, 'email_opens' ], [] );
+
+		return emailsData.map( ( { id, href, date, title, type, opens } ) => {
+			const record = {
+				id,
+				href,
+				date,
+				label: title,
+				type,
+				value: opens || '0',
+			};
+
+			return record;
+		} );
+	},
 };


### PR DESCRIPTION
#### Proposed Changes

This PR adds the email open stat card in the stats dashboard, in it's first version. It's using the right endpoint, but the endpoint is still returning mocked data. That's not important as everything is hidden behind a feature the `newsletter/stats` feature flag.

<img width="784" alt="Screenshot 2022-12-20 at 14 58 31" src="https://user-images.githubusercontent.com/3832570/208684076-875a2525-8070-479f-97d2-4455a85f1168.png">

#### Testing Instructions

1. Apply this branch in your local repository.
2. Set the `newsletter/stats` flag to `true` in the `config/development.json` file.
3. Start the application with `yarn start`.
4. Go to the stats dashboard (see image)
5. The email open stat card should be visible with the mocked data.

<img width="1078" alt="Screenshot 2022-12-20 at 15 00 43" src="https://user-images.githubusercontent.com/3832570/208684684-1de135cb-1d55-478d-9c6f-4956aa8ddb0f.png">
