### PR TITLE
stylelintrc: Allow `%` for `border-radius`

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -28,7 +28,7 @@
 			{
 				"/^font-size$|^font$/": [ "rem" ],
 				"line-height": [ "px" ],
-				"/radius$/": [ "px" ]
+				"/radius$/": [ "px", "%" ]
 			},
 			{ "ignore": [ "inside-function" ] }
 		],

--- a/apps/editing-toolkit/editing-toolkit-plugin/event-countdown-block/blocks/src/style.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/event-countdown-block/blocks/src/style.scss
@@ -117,7 +117,6 @@ $ecf_color6: #b82806;
 		top: 0;
 		width: 4px;
 		height: 4px;
-		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 		border-radius: 50%;
 		animation: 1s event_countdown_bang ease-out infinite backwards, 1s event_countdown_gravity ease-in infinite backwards, 5s event_countdown_position linear infinite backwards;
 		mix-blend-mode: overlay;

--- a/apps/notifications/src/panel/boot/stylesheets/main.scss
+++ b/apps/notifications/src/panel/boot/stylesheets/main.scss
@@ -290,7 +290,7 @@
 			border: {
 				width: 1px;
 				style: solid;
-				radius: 50%; /* stylelint-disable-line declaration-property-unit-allowed-list */
+				radius: 50%;
 			}
 		}
 	}
@@ -376,7 +376,7 @@
 		}
 
 		.wpnc__note .wpnc__note-icon img {
-			border-radius: 50%; /* stylelint-disable-line declaration-property-unit-allowed-list */
+			border-radius: 50%;
 		}
 
 		.unread .wpnc__note-icon .wpnc__gridicon {

--- a/apps/notifications/src/panel/boot/stylesheets/spinner.scss
+++ b/apps/notifications/src/panel/boot/stylesheets/spinner.scss
@@ -17,7 +17,6 @@
 		margin: auto;
 		box-sizing: border-box;
 		border: 0.1em solid transparent;
-		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 		border-radius: 50%;
 		animation: 3s linear infinite;
 		animation-name: wpnc__rotate-spinner;

--- a/apps/notifications/src/panel/suggestions/styles.scss
+++ b/apps/notifications/src/panel/suggestions/styles.scss
@@ -6,7 +6,6 @@ $text-color: var(--color-neutral-70);
 $name-color: var(--color-neutral-light);
 $selected-color: var(--color-primary);
 $img-size: 24px;
-/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 $img-border-radius: 50%;
 $border-radius: 3px; /* stylelint-disable-line scales/radii */
 $box-shadow: 0 5px 6px rgba(var(--color-neutral-10-rgb), 0.5);

--- a/apps/o2-blocks/src/p2-autocomplete/editor.scss
+++ b/apps/o2-blocks/src/p2-autocomplete/editor.scss
@@ -13,7 +13,6 @@
 }
 .p2-autocomplete__blavatar-placeholder {
 	background-color: #24354a;
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	border-radius: 100%;
 	position: relative;
 }

--- a/apps/o2-blocks/src/task/editor.scss
+++ b/apps/o2-blocks/src/task/editor.scss
@@ -96,6 +96,5 @@
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 	font-weight: 100; /* stylelint-disable-line scales/font-weights */
 	background: #eb6565;
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	border-radius: 50%;
 }

--- a/apps/o2-blocks/src/todo/editor.scss
+++ b/apps/o2-blocks/src/todo/editor.scss
@@ -28,7 +28,6 @@ $color-add-button-icon: #7e8993; // dark-gray-200
 		display: inline-block;
 		content: "";
 		border: 1px solid $gray-200;
-		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 		border-radius: 50%;
 		margin: 7px 8px 0 0;
 		height: 16px;

--- a/client/assets/stylesheets/shared/_loading.scss
+++ b/client/assets/stylesheets/shared/_loading.scss
@@ -31,7 +31,7 @@
 		top: 33px;
 		width: 13px;
 		height: 13px;
-		border-radius: 50%; /*stylelint-disable-line declaration-property-unit-allowed-list*/
+		border-radius: 50%;
 		background: var(--studio-gray-60);
 		animation-timing-function: cubic-bezier(0, 1, 1, 0);
 

--- a/client/blocks/app-banner/style.scss
+++ b/client/blocks/app-banner/style.scss
@@ -42,7 +42,7 @@ body.app-banner-is-visible {
 .app-banner__circle {
 	position: absolute;
 	border: 2px solid;
-	border-radius: 50%; /* stylelint-disable-line declaration-property-unit-allowed-list */
+	border-radius: 50%;
 	z-index: z-index("root", ".app-banner__circle");
 
 	&.is-blue {

--- a/client/blocks/comments/post-comment.scss
+++ b/client/blocks/comments/post-comment.scss
@@ -92,7 +92,6 @@ a.comments__comment-username {
 
 .comments__comment-trackbackicon {
 	background-color: var(--color-neutral-0);
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	border-radius: 50%;
 	height: 32px;
 	margin-right: 9px;

--- a/client/blocks/edit-gravatar/style.scss
+++ b/client/blocks/edit-gravatar/style.scss
@@ -13,7 +13,7 @@
 		top: 0;
 		left: 0;
 		background-color: rgba(var(--color-neutral-70-rgb), 0.5);
-		border-radius: 50%; /* stylelint-disable-line declaration-property-unit-allowed-list */
+		border-radius: 50%;
 		height: 150px;
 		width: 150px;
 	}
@@ -36,7 +36,7 @@
 		display: block;
 		width: 150px;
 		height: 150px;
-		border-radius: 50%; /* stylelint-disable-line declaration-property-unit-allowed-list */
+		border-radius: 50%;
 	}
 	.edit-gravatar__explanation-placeholder {
 		height: 24px;
@@ -91,7 +91,7 @@
 	top: 0;
 	width: 150px;
 	height: 150px;
-	border-radius: 50%; /* stylelint-disable-line declaration-property-unit-allowed-list */
+	border-radius: 50%;
 	background: rgba(var(--color-neutral-70-rgb), 0.5);
 	color: #fff;
 	text-align: center;
@@ -160,7 +160,7 @@
 }
 
 .edit-gravatar .drop-zone {
-	border-radius: 50%; /* stylelint-disable-line declaration-property-unit-allowed-list */
+	border-radius: 50%;
 	width: 150px;
 	height: 150px;
 	border: 0;

--- a/client/blocks/image-editor/style.scss
+++ b/client/blocks/image-editor/style.scss
@@ -93,13 +93,11 @@
 	margin-top: -4px;
 	/*!rtl:ignore*/
 	margin-left: -4px;
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	border-radius: 50%;
 	border: 2px solid var(--color-border-inverted);
 	background: var(--color-neutral-90);
 
 	&::before {
-		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 		border-radius: 100%;
 		content: " ";
 		display: block;

--- a/client/blocks/import/ready/style.scss
+++ b/client/blocks/import/ready/style.scss
@@ -56,7 +56,7 @@
 			background: var(--studio-gray-5);
 			width: 4px;
 			height: 4px;
-			border-radius: 50%; /* stylelint-disable-line declaration-property-unit-allowed-list */
+			border-radius: 50%;
 			margin: 0 2px;
 
 			@include break-small {

--- a/client/blocks/post-share/style.scss
+++ b/client/blocks/post-share/style.scss
@@ -181,7 +181,6 @@ $section-border: solid 1px var(--color-neutral-5);
 		top: 11px;
 
 		&::before {
-			/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 			border-radius: 50%;
 			height: 24px;
 			width: 24px;
@@ -204,7 +203,6 @@ $section-border: solid 1px var(--color-neutral-5);
 	background-size: cover;
 	width: 32px;
 	height: 32px;
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	border-radius: 50%;
 	position: relative;
 	flex: 0 0 32px;

--- a/client/blocks/reader-feed-header/style.scss
+++ b/client/blocks/reader-feed-header/style.scss
@@ -28,7 +28,6 @@
 	padding-bottom: 16px;
 	img,
 	.site-icon.is-blank {
-		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 		border-radius: 100%;
 	}
 }

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -421,7 +421,6 @@
 	}
 
 	img {
-		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 		border-radius: 100%;
 	}
 }
@@ -659,7 +658,6 @@
 }
 
 .reader-post-card__gallery-circle {
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	border-radius: 50%;
 	width: 7px;
 	height: 7px;

--- a/client/blocks/reader-share/style.scss
+++ b/client/blocks/reader-share/style.scss
@@ -158,7 +158,6 @@
 .reader-share__site-selector .site__domain {
 	&::after {
 		@include long-content-fade( $color: var( --color-surface-rgb ) );
-		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 		border-radius: 50%;
 	}
 }

--- a/client/blocks/user-mentions/suggestion.scss
+++ b/client/blocks/user-mentions/suggestion.scss
@@ -2,7 +2,6 @@ $user-mentions-avatar-size: 24px;
 $user-mentions-avatar-margin: 10px;
 
 .user-mentions__avatar {
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	border-radius: 50%;
 	width: $user-mentions-avatar-size;
 	height: $user-mentions-avatar-size;

--- a/client/components/activity-card-list/style.scss
+++ b/client/components/activity-card-list/style.scss
@@ -111,7 +111,7 @@
 		top: calc(100% + 16px);
 		visibility: visible;
 		z-index: -1;
-		border-radius: 50%; /* stylelint-disable-line declaration-property-unit-allowed-list */
+		border-radius: 50%;
 	}
 }
 
@@ -181,7 +181,7 @@
 				top: calc(100% - 9px);
 				visibility: visible;
 				z-index: -1;
-				border-radius: 50%; /* stylelint-disable-line declaration-property-unit-allowed-list */
+				border-radius: 50%;
 			}
 		}
 	}

--- a/client/components/banner/style.scss
+++ b/client/components/banner/style.scss
@@ -79,7 +79,7 @@
 
 	.banner__icon,
 	.banner__icon-circle {
-		border-radius: 50%; /* stylelint-disable-line declaration-property-unit-allowed-list */
+		border-radius: 50%;
 		flex-shrink: 0;
 		height: 24px;
 		margin-right: 12px;

--- a/client/components/date-picker/style.scss
+++ b/client/components/date-picker/style.scss
@@ -205,7 +205,6 @@ $date-picker_nav_button_size: 20px;
 	height: 24px;
 	width: 24px;
 	line-height: 24px;
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	border-radius: 50%;
 	cursor: pointer;
 	border: 1px solid rgba(var(--color-surface-rgb), 0);

--- a/client/components/domains/connect-domain-step/style.scss
+++ b/client/components/domains/connect-domain-step/style.scss
@@ -148,7 +148,6 @@ body.connect-domain-setup__body-white {
 			font-size: $font-body-small;
 			color: var(--color-text-subtle);
 			box-sizing: border-box;
-			/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 			border-radius: 50%;
 			flex-shrink: 0;
 

--- a/client/components/domains/transfer-domain-step/style.scss
+++ b/client/components/domains/transfer-domain-step/style.scss
@@ -137,7 +137,6 @@
 	width: 28px;
 	height: 28px;
 	line-height: 28px;
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	border-radius: 50%;
 	border: 1px solid var(--color-neutral-10);
 	background-color: var(--color-neutral-0);

--- a/client/components/dot-pager/style.scss
+++ b/client/components/dot-pager/style.scss
@@ -69,8 +69,6 @@
 }
 
 .dot-pager__control-choose-page {
-	// Drawing a CSS circle
-	// stylelint-disable-next-line  declaration-property-unit-allowed-list
 	border-radius: 50%;
 	width: 6px;
 	height: 6px;

--- a/client/components/environment-badge/style.scss
+++ b/client/components/environment-badge/style.scss
@@ -27,7 +27,6 @@
 		height: 26px;
 		background-color: var(--color-surface);
 		border: solid 1px var(--color-neutral-70);
-		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 		border-radius: 50%;
 		color: var(--color-neutral-70);
 		margin-left: -4px;

--- a/client/components/forms/form-radio/style.scss
+++ b/client/components/forms/form-radio/style.scss
@@ -13,7 +13,6 @@
 	min-width: 16px;
 	appearance: none;
 
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	border-radius: 50%;
 	margin-right: 4px;
 	line-height: 10px;
@@ -26,7 +25,6 @@
 		height: 8px;
 		text-indent: -9999px;
 		background: var(--color-primary);
-		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 		border-radius: 50%;
 		animation: grow 0.2s ease-in-out;
 	}

--- a/client/components/forms/sortable-list/style.scss
+++ b/client/components/forms/sortable-list/style.scss
@@ -63,18 +63,14 @@
 
 	&.is-previous {
 		padding-left: 12px;
-		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 		border-top-left-radius: 50%;
-		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 		border-bottom-left-radius: 50%;
 	}
 
 	&.is-next {
 		margin-left: -1px;
 		padding-right: 12px;
-		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 		border-top-right-radius: 50%;
-		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 		border-bottom-right-radius: 50%;
 	}
 }
@@ -88,17 +84,13 @@
 	margin-left: auto;
 
 	&.is-previous {
-		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 		border-top-right-radius: 50%;
-		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 		border-top-left-radius: 50%;
 	}
 
 	&.is-next {
 		margin-top: -1px;
-		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 		border-bottom-right-radius: 50%;
-		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 		border-bottom-left-radius: 50%;
 	}
 }

--- a/client/components/happychat/button.scss
+++ b/client/components/happychat/button.scss
@@ -5,7 +5,6 @@
 	z-index: z-index("root", ".floating-help");
 	line-height: 0;
 	padding: 1px;
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	border-radius: 100%;
 	background: var(--color-primary);
 	box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);

--- a/client/components/jetpack/jetpack-welcome-page/style.scss
+++ b/client/components/jetpack/jetpack-welcome-page/style.scss
@@ -83,7 +83,7 @@
 				color: var(--color-text-inverted);
 				background-color: var(--studio-jetpack-green-40);
 				text-align: center;
-				border-radius: 50%; /* stylelint-disable-line declaration-property-unit-allowed-list */
+				border-radius: 50%;
 				font-size: $font-title-small;
 				font-weight: 600;
 				width: rem(32px);

--- a/client/components/marketing-survey/cancel-purchase-form/style.scss
+++ b/client/components/marketing-survey/cancel-purchase-form/style.scss
@@ -326,7 +326,7 @@
 	width: 44px;
 	height: 44px;
 	flex: 0 0 44px;
-	border-radius: 50%; /* stylelint-disable-line declaration-property-unit-allowed-list */
+	border-radius: 50%;
 	background-color: #50575e;
 
 	.material-icon {

--- a/client/components/pulsing-dot/style.scss
+++ b/client/components/pulsing-dot/style.scss
@@ -10,7 +10,6 @@
 	height: 6px;
 	border: none;
 	box-shadow: 0 0 0 0 rgba(168, 190, 206, 0.7);
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	border-radius: 100%;
 	animation: dot-pulse 1.25s infinite cubic-bezier(0.66, 0, 0, 1);
 	animation-play-state: paused;

--- a/client/components/purchase-detail/style.scss
+++ b/client/components/purchase-detail/style.scss
@@ -83,7 +83,6 @@
 
 .purchase-detail__icon {
 	background: var(--color-neutral-50);
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	border-radius: 50%;
 	color: var(--color-text-inverted);
 	padding: 16px;

--- a/client/components/share/facebook-share-preview/style.scss
+++ b/client/components/share/facebook-share-preview/style.scss
@@ -30,7 +30,6 @@
 	width: 40px;
 	&::after {
 		border: 1px solid rgba(0, 0, 0, 0.1);
-		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 		border-radius: 50%;
 		bottom: 0;
 		content: "";
@@ -47,7 +46,6 @@
 }
 
 .facebook-share-preview__profile-picture {
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	border-radius: 50%;
 }
 

--- a/client/components/share/linkedin-share-preview/style.scss
+++ b/client/components/share/linkedin-share-preview/style.scss
@@ -16,7 +16,6 @@
 }
 
 .linkedin-share-preview__profile-picture {
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	border-radius: 50%;
 	display: block;
 	height: 48px;

--- a/client/components/share/twitter-share-preview/style.scss
+++ b/client/components/share/twitter-share-preview/style.scss
@@ -21,7 +21,6 @@
 }
 
 .twitter-share-preview__profile-picture {
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	border-radius: 50%;
 	display: block;
 }

--- a/client/components/site-icon-with-picker/style.scss
+++ b/client/components/site-icon-with-picker/style.scss
@@ -2,7 +2,7 @@
 @import "@wordpress/base-styles/mixins";
 
 $icon-size: 80px;
-$icon-border-radius: 50%; /* stylelint-disable-line declaration-property-unit-allowed-list */
+$icon-border-radius: 50%;
 
 .site-icon-with-picker__background {
 	min-width: calc(100vw - 16px);

--- a/client/components/step-progress/style.scss
+++ b/client/components/step-progress/style.scss
@@ -44,7 +44,6 @@
 }
 
 .step-progress__element-button {
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	border-radius: 50%;
 	font-size: 0.8rem; /* stylelint-disable-line scales/font-sizes */
 	font-weight: 700;

--- a/client/components/theme/style.scss
+++ b/client/components/theme/style.scss
@@ -102,7 +102,6 @@ $soft-launch-badge-font-size: 0.725rem;
 .theme__upsell-icon svg {
 	transform: scale(0.8);
 	border: 2px solid var(--color-neutral-20);
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	border-radius: 100%;
 	display: inline-block;
 	width: 22px;
@@ -120,7 +119,6 @@ $soft-launch-badge-font-size: 0.725rem;
 	text-align: center;
 	svg {
 		transform: scale(0.8);
-		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 		border-radius: 100%;
 		display: inline-block;
 		width: 30px;

--- a/client/components/timeline/style.scss
+++ b/client/components/timeline/style.scss
@@ -60,7 +60,6 @@
 				height: 32px;
 				text-align: center;
 				color: var(--color-surface);
-				/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 				border-radius: 50%;
 				display: flex;
 				align-items: center;

--- a/client/components/videos-ui/style.scss
+++ b/client/components/videos-ui/style.scss
@@ -166,7 +166,7 @@
 					flex-shrink: 0;
 					flex-grow: 0;
 					height: 22px;
-					border-radius: 50%; /* stylelint-disable-line declaration-property-unit-allowed-list */
+					border-radius: 50%;
 
 					svg {
 						margin-top: 5px;

--- a/client/components/woocommerce-connect-cart-header/style.scss
+++ b/client/components/woocommerce-connect-cart-header/style.scss
@@ -68,7 +68,6 @@
 	margin-right: 12px;
 	background: var(--studio-gray-5);
 	color: var(--studio-gray-60);
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	border-radius: 50%;
 }
 

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
@@ -272,7 +272,7 @@
 	inset-inline-end: 42px;
 	inset-block-start: 50%;
 	transform: translateY(-50%);
-	border-radius: 50%; /* stylelint-disable-line declaration-property-unit-allowed-list */
+	border-radius: 50%;
 	border-width: 2px;
 	border-style: solid;
 	width: 24px;

--- a/client/jetpack-cloud/sections/partner-portal/assign-license-step-progress/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/assign-license-step-progress/style.scss
@@ -28,7 +28,7 @@
 		width: 20px;
 		height: 20px;
 		display: flex;
-		border-radius: 50%; /* stylelint-disable-line declaration-property-unit-allowed-list */
+		border-radius: 50%;
 		justify-content: center;
 		align-content: center;
 		align-items: center;

--- a/client/jetpack-cloud/sections/pricing/jpcom-masterbar/style.scss
+++ b/client/jetpack-cloud/sections/pricing/jpcom-masterbar/style.scss
@@ -1020,7 +1020,6 @@
 		padding: 0;
 		background: transparent;
 		border: none;
-		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 		border-radius: 50%;
 		transition: transform 0.1s ease-in-out;
 	}

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -314,7 +314,6 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 	background-color: var(--color-neutral-20);
 	width: 8px;
 	height: 8px;
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	border-radius: 50%;
 }
 

--- a/client/landing/browsehappy/circle.scss
+++ b/client/landing/browsehappy/circle.scss
@@ -1,7 +1,7 @@
 .circle {
 	z-index: -1;
 	border: 2px solid;
-	border-radius: 50%; /* stylelint-disable-line declaration-property-unit-allowed-list */
+	border-radius: 50%;
 	position: fixed;
 
 	&.is-red {

--- a/client/landing/gutenboarding/onboarding-block/style-preview/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/style.scss
@@ -310,7 +310,6 @@ $gutenboarding-style-preview-bar-height-mobile: 15px;
 	background: var(--studio-gray-5);
 	width: 3px;
 	height: 3px;
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	border-radius: 50%;
 	margin: 0 2px;
 

--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -184,7 +184,7 @@ button {
 			border: 1px solid rgba($color: #000, $alpha: 0.2);
 
 			&.site-icon-with-picker__upload-button {
-				border-radius: 50%; /* stylelint-disable-line declaration-property-unit-allowed-list */
+				border-radius: 50%;
 				font-family: "SF Pro Text", $sans;
 				transition: ease 300ms;
 

--- a/client/layout/guided-tours/style.scss
+++ b/client/layout/guided-tours/style.scss
@@ -63,7 +63,6 @@
 
 	.tours__completed-icon-wrapper {
 		background: var(--color-success);
-		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 		border-radius: 100%;
 		display: inline-block;
 		margin-right: 10px;

--- a/client/mailing-lists/style.scss
+++ b/client/mailing-lists/style.scss
@@ -36,7 +36,6 @@
 			left: 40px;
 			fill: var(--studio-white);
 			background: var(--color-neutral-70);
-			/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 			border-radius: 100%;
 			box-shadow: 0 0 0 3px var(--color-neutral-0);
 

--- a/client/me/concierge/style.scss
+++ b/client/me/concierge/style.scss
@@ -29,7 +29,6 @@
 .shared__available-time-card-header-icon {
 	color: var(--color-neutral-light);
 	border: 1px solid var(--color-neutral-10);
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	border-radius: 100%;
 	padding: 6px;
 	margin-right: 12px;

--- a/client/me/help/help-teaser-button.scss
+++ b/client/me/help/help-teaser-button.scss
@@ -19,7 +19,6 @@
 
 .help__help-teaser-button-icon {
 	color: var(--color-primary);
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	border-radius: 50%;
 	margin-right: 16px;
 	background-color: var(--color-surface);

--- a/client/me/purchases/manage-purchase/style.scss
+++ b/client/me/purchases/manage-purchase/style.scss
@@ -69,7 +69,6 @@
 
 		.manage-purchase__plan-icon {
 			height: 56px;
-			/* stylelint-disable-next-line  declaration-property-unit-allowed-list */
 			border-radius: 50%;
 		}
 
@@ -158,7 +157,6 @@
 	.gridicon {
 		box-sizing: border-box;
 		padding: 4px;
-		/* stylelint-disable-next-line  declaration-property-unit-allowed-list */
 		border-radius: 50%;
 		background: var(--color-accent);
 		fill: var(--color-text-inverted);

--- a/client/me/purchases/style.scss
+++ b/client/me/purchases/style.scss
@@ -183,7 +183,7 @@ a.purchase-item__link {
 				top: calc(50% - 4px);
 				left: -16px;
 				background: var(--color-error-50);
-				border-radius: 100%; /* stylelint-disable-line declaration-property-unit-allowed-list */
+				border-radius: 100%;
 			}
 		}
 	}

--- a/client/me/security-2fa-progress/style.scss
+++ b/client/me/security-2fa-progress/style.scss
@@ -73,7 +73,6 @@
 			.gridicon {
 				background: var(--color-surface);
 				border: 1px var(--color-neutral-10) solid;
-				/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 				border-radius: 50%;
 				color: var(--color-neutral-10);
 				display: block;

--- a/client/my-sites/activity/activity-log-banner/style.scss
+++ b/client/my-sites/activity/activity-log-banner/style.scss
@@ -41,7 +41,6 @@
 	padding: 8px;
 	margin-left: -5px;
 	margin-right: 16px;
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	border-radius: 50%;
 	color: var(--color-text-inverted);
 

--- a/client/my-sites/activity/activity-log-item/style.scss
+++ b/client/my-sites/activity/activity-log-item/style.scss
@@ -114,7 +114,6 @@
 	padding: 12px;
 	background: var(--color-neutral-20);
 	color: var(--color-text-inverted);
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	border-radius: 50%;
 
 	@include breakpoint-deprecated( "<480px" ) {
@@ -237,7 +236,6 @@
 	.social-logo {
 		fill: var(--color-text-inverted);
 		background: var(--color-wordpress-org);
-		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 		border-radius: 50%;
 	}
 
@@ -252,7 +250,6 @@
 		color: var(--color-text-inverted);
 		display: flex;
 		padding: 8px;
-		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 		border-radius: 50%;
 		margin-right: 14px;
 		margin-top: 2px;

--- a/client/my-sites/activity/filterbar/style.scss
+++ b/client/my-sites/activity/filterbar/style.scss
@@ -194,15 +194,15 @@
 	.DayPicker-Day.DayPicker-Day--start {
 		background-color: var(--color-primary-light);
 		border-radius: 0;
-		border-top-left-radius: 50%; /* stylelint-disable-line declaration-property-unit-allowed-list */
-		border-bottom-left-radius: 50%; /* stylelint-disable-line declaration-property-unit-allowed-list */
+		border-top-left-radius: 50%;
+		border-bottom-left-radius: 50%;
 	}
 
 	.DayPicker-Day.DayPicker-Day--end {
 		background-color: var(--color-primary-light);
 		border-radius: 0;
-		border-top-right-radius: 50%; /* stylelint-disable-line declaration-property-unit-allowed-list */
-		border-bottom-right-radius: 50%; /* stylelint-disable-line declaration-property-unit-allowed-list */
+		border-top-right-radius: 50%;
+		border-bottom-right-radius: 50%;
 	}
 
 	.DayPicker-Day.DayPicker-Day--today .date-picker__day {
@@ -222,7 +222,6 @@
 		position: absolute;
 		display: block;
 		background-color: var(--color-neutral-70);
-		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 		border-radius: 50%;
 		width: 26px;
 		height: 26px;
@@ -243,7 +242,6 @@
 
 	.DayPicker-Day.DayPicker-Day--start .date-picker__day,
 	.DayPicker-Day.DayPicker-Day--end .date-picker__day {
-		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 		border-radius: 50%;
 		color: var(--color-text-inverted);
 		padding: 0;
@@ -283,7 +281,6 @@
 		right: auto;
 		z-index: -1;
 		background-color: var(--color-primary);
-		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 		border-radius: 50%;
 	}
 

--- a/client/my-sites/checkout/checkout-thank-you/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/style.scss
@@ -862,7 +862,7 @@
 		margin-inline-end: 0.75em;
 
 		background-color: var(--studio-gray-5);
-		border-radius: 50%; /* stylelint-disable-line declaration-property-unit-allowed-list */
+		border-radius: 50%;
 		color: var(--color-text-black);
 
 		font-weight: 700;

--- a/client/my-sites/comments/comment/style.scss
+++ b/client/my-sites/comments/comment/style.scss
@@ -72,7 +72,6 @@
 
 	.gridicon {
 		background-color: var(--color-neutral-light);
-		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 		border-radius: 50%;
 		fill: var(--color-text-inverted);
 		padding: 4px;
@@ -663,7 +662,6 @@
 
 	.comment__author-gravatar-placeholder {
 		background-color: var(--color-neutral-0);
-		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 		border-radius: 50%;
 		display: block;
 		height: 32px;

--- a/client/my-sites/customer-home/cards/features/help-search/style.scss
+++ b/client/my-sites/customer-home/cards/features/help-search/style.scss
@@ -61,8 +61,6 @@ $min_results_height: 180px;
 		background: var(--color-primary);
 		box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
 		border: 1px solid var(--color-primary);
-		// Using percentage because we're drawing a circle in CSS
-		// stylelint-disable-next-line declaration-property-unit-allowed-list
 		border-radius: 100%;
 
 		&::before {
@@ -74,8 +72,6 @@ $min_results_height: 180px;
 			left: 4px;
 			content: "";
 			background: var(--color-surface);
-			// Using percentage because we're drawing a circle in CSS
-			// stylelint-disable-next-line declaration-property-unit-allowed-list
 			border-radius: 100%;
 		}
 

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/style.scss
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/style.scss
@@ -153,8 +153,6 @@
 		width: 8px;
 		height: 8px;
 		border: 1px solid var(--studio-gray-10);
-		// Using percentage because we're drawing a circle in CSS
-		// stylelint-disable-next-line declaration-property-unit-allowed-list
 		border-radius: 50%;
 		margin: 5px;
 		transition: all 0.1s;

--- a/client/my-sites/domains/domain-management/list/domain-row.scss
+++ b/client/my-sites/domains/domain-management/list/domain-row.scss
@@ -50,7 +50,7 @@
 		width: 8px;
 		height: 8px;
 		margin-right: 8px;
-		border-radius: 50%; /* stylelint-disable-line declaration-property-unit-allowed-list */
+		border-radius: 50%;
 		background-color: var(--studio-green-50);
 	}
 

--- a/client/my-sites/google-my-business/location/style.scss
+++ b/client/my-sites/google-my-business/location/style.scss
@@ -31,7 +31,6 @@
 }
 
 .gmb-location__picture {
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	border-radius: 50%;
 	height: 60px;
 	width: 60px;

--- a/client/my-sites/marketing/style.scss
+++ b/client/my-sites/marketing/style.scss
@@ -835,7 +835,7 @@
 	padding: 1px 8px 0 5px;
 
 	&.style-icon {
-		border-radius: 50%; /* stylelint-disable-line declaration-property-unit-allowed-list */
+		border-radius: 50%;
 		border: 0;
 		box-shadow: none;
 		padding: 7px;

--- a/client/my-sites/media-library/list-item.scss
+++ b/client/my-sites/media-library/list-item.scss
@@ -17,7 +17,6 @@
 		transition: color 90ms ease;
 		box-shadow: 0 0 8px rgba(var(--color-neutral-70-rgb), 0.4);
 		background: var(--color-accent);
-		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 		border-radius: 50%;
 		font-size: $font-body-small;
 		line-height: 28px;

--- a/client/my-sites/plans/current-plan/my-plan-card/style.scss
+++ b/client/my-sites/plans/current-plan/my-plan-card/style.scss
@@ -86,7 +86,6 @@
 			display: inline-block;
 			width: 64px;
 			height: 64px;
-			/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 			border-radius: 99%;
 		}
 	}

--- a/client/my-sites/plans/jetpack-plans/product-lightbox/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-lightbox/style.scss
@@ -317,7 +317,6 @@
 		width: 8px;
 		height: 8px;
 		background: var(--studio-jetpack-green-50);
-		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 		border-radius: 50%;
 		margin-inline-end: 4px;
 	}

--- a/client/my-sites/plans/jetpack-plans/product-store/item-price/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/item-price/style.scss
@@ -119,7 +119,6 @@ Hack to fix line-through not showing in the middle of the text in firefox browse
 	width: 8px;
 	height: 8px;
 	background: var(--studio-jetpack-green-50);
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	border-radius: 50%;
 	margin-inline-end: 4px;
 }

--- a/client/my-sites/plugins/plugins-browser-item/style.scss
+++ b/client/my-sites/plugins/plugins-browser-item/style.scss
@@ -223,7 +223,7 @@
 	.gridicon {
 		margin-top: 3px;
 		margin-right: 6px;
-		border-radius: 50%; /* stylelint-disable-line declaration-property-unit-allowed-list */
+		border-radius: 50%;
 	}
 
 	.gridicon.checkmark--active {

--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -301,7 +301,6 @@ $font-size: rem(14px);
 					left: calc(50% - 9px);
 					width: 18px;
 					height: 18px;
-					/* stylelint-disable-next-line  declaration-property-unit-allowed-list */
 					border-radius: 50%;
 				}
 			}
@@ -478,7 +477,6 @@ $font-size: rem(14px);
 				line-height: 20px;
 				background-color: #a7aaad;
 				color: var(--color-text-inverted);
-				/* stylelint-disable-next-line  declaration-property-unit-allowed-list */
 				border-radius: 50%;
 				margin: 3px 0 3px 1px;
 			}

--- a/client/my-sites/site-indicator/style.scss
+++ b/client/my-sites/site-indicator/style.scss
@@ -16,7 +16,7 @@
 	align-self: center;
 	background: var(--color-neutral-0);
 	border: none;
-	border-radius: 50%; /* stylelint-disable-line declaration-property-unit-allowed-list */
+	border-radius: 50%;
 	box-shadow: none;
 	color: var(--color-neutral-light);
 	cursor: default;

--- a/client/post-editor/media-modal/gallery/style.scss
+++ b/client/post-editor/media-modal/gallery/style.scss
@@ -85,7 +85,6 @@
 	/*!rtl:ignore*/
 	transform: translate(25%, -25%);
 	border: 1px solid var(--color-neutral-20);
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	border-radius: 50%;
 	background-color: var(--color-neutral-0);
 	color: var(--color-neutral-20);

--- a/client/post-editor/media-modal/index.scss
+++ b/client/post-editor/media-modal/index.scss
@@ -21,7 +21,6 @@
 	height: 34px;
 	float: left;
 	margin: 4px 12px 12px 0;
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	border-radius: 50%;
 	background-color: var(--color-neutral-0);
 	color: var(--color-neutral-70);

--- a/client/reader/stream/style.scss
+++ b/client/reader/stream/style.scss
@@ -398,7 +398,6 @@
 		fill: var(--color-text-inverted);
 		background: var(--color-neutral-light);
 		padding: 4px;
-		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 		border-radius: 100%;
 		position: absolute;
 		top: 0;
@@ -594,7 +593,6 @@
 		}
 
 		img {
-			/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 			border-radius: 100%;
 			position: relative;
 			top: 4px;

--- a/client/reader/style.scss
+++ b/client/reader/style.scss
@@ -323,7 +323,6 @@
 -------------------------------------------------------------- */
 
 .tiled-gallery.type-circle .tiled-gallery-item img {
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	border-radius: 50%;
 }
 .tiled-gallery.type-circle .tiled-gallery-caption {

--- a/client/signup/steps/p2-confirm-email/style.scss
+++ b/client/signup/steps/p2-confirm-email/style.scss
@@ -19,7 +19,6 @@
 		width: 36px;
 		height: 36px;
 		border: 1px solid var(--p2-color-link);
-		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 		border-radius: 50%;
 		padding: 8px;
 	}

--- a/packages/components/src/gravatar/style.scss
+++ b/packages/components/src/gravatar/style.scss
@@ -3,7 +3,6 @@
  */
 
 .gravatar {
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	border-radius: 50%;
 
 	&.is-placeholder {

--- a/packages/components/src/horizontal-bar-list/stats-card.scss
+++ b/packages/components/src/horizontal-bar-list/stats-card.scss
@@ -75,6 +75,6 @@
 	.stats-card-avatar-image {
 		width: $stats-avatar-size;
 		height: $stats-avatar-size;
-		border-radius: 50%; /* stylelint-disable-line declaration-property-unit-allowed-list */
+		border-radius: 50%;
 	}
 }

--- a/packages/components/src/pagination-control/style.scss
+++ b/packages/components/src/pagination-control/style.scss
@@ -24,7 +24,7 @@
 		padding: 0;
 		width: 6px;
 		height: 6px;
-		border-radius: 50%; /* stylelint-disable-line declaration-property-unit-allowed-list */
+		border-radius: 50%;
 		cursor: pointer;
 		transition: all 0.2s ease-in-out;
 		background-color: var(--color-neutral-10);

--- a/packages/components/src/spinner/style.scss
+++ b/packages/components/src/spinner/style.scss
@@ -14,7 +14,6 @@
 	margin: auto;
 	box-sizing: border-box;
 	border: 0.1em solid transparent;
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	border-radius: 50%;
 	animation: 3s linear infinite;
 	animation-name: rotate-spinner;

--- a/packages/design-carousel/src/styles.scss
+++ b/packages/design-carousel/src/styles.scss
@@ -115,7 +115,6 @@ $patterns: "17-2", "black", "ella-d", "link-cloud", "matt-smith", "ose-maiko", "
 	background: #fff;
 	border: 1px solid #eee;
 	align-items: center;
-	// stylelint-disable-next-line declaration-property-unit-allowed-list
 	border-radius: 50%;
 	opacity: 0.5;
 	display: flex;

--- a/packages/design-picker/src/components/style-variation-badges/style.scss
+++ b/packages/design-picker/src/components/style-variation-badges/style.scss
@@ -9,7 +9,7 @@
 		align-items: center;
 		background: #fff;
 		border: none;
-		border-radius: 50%; /* stylelint-disable-line declaration-property-unit-allowed-list */
+		border-radius: 50%;
 		box-shadow: inset 0 0 0 1px rgb(0 0 0 / 20%);
 		color: var(--studio-gray-80);
 		cursor: pointer;

--- a/packages/domain-picker/src/components/style.scss
+++ b/packages/domain-picker/src/components/style.scss
@@ -245,7 +245,6 @@ $accent-blue: #117ac9;
 				width: 100%;
 				height: 100%;
 				border: 2px solid var(--studio-white);
-				/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 				border-radius: 50%;
 				position: absolute;
 				margin: 0;

--- a/packages/help-center/src/components/help-center-contact-form.scss
+++ b/packages/help-center/src/components/help-center-contact-form.scss
@@ -16,7 +16,7 @@
 		width: 32px;
 		height: 32px;
 		border: 2px solid #fff;
-		border-radius: 50%; // stylelint-disable-line declaration-property-unit-allowed-list
+		border-radius: 50%;
 	}
 
 	img + img {

--- a/packages/help-center/src/styles.scss
+++ b/packages/help-center/src/styles.scss
@@ -149,7 +149,6 @@ $head-foot-height: 50px;
 			margin-left: 8px;
 			padding: 2px 8px;
 			background: var(--studio-pink-50);
-			/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 			border-radius: 50%;
 			font-size: $font-body-extra-small;
 			color: #fff;

--- a/packages/pattern-picker/src/styles.scss
+++ b/packages/pattern-picker/src/styles.scss
@@ -90,7 +90,6 @@ $patterns: "17-2", "black", "ella-d", "link-cloud", "matt-smith", "ose-maiko", "
 	background: #fff;
 	border: 1px solid #eee;
 	align-items: center;
-	// stylelint-disable-next-line declaration-property-unit-allowed-list
 	border-radius: 50%;
 	opacity: 0.5;
 	display: flex;

--- a/packages/tour-kit/src/variants/wpcom/styles.scss
+++ b/packages/tour-kit/src/variants/wpcom/styles.scss
@@ -92,7 +92,7 @@ $wpcom-tour-kit-step-card-overlay-controls-button-bg-color: #32373c; // former $
 
 		.wpcom-tour-kit-rating__end-icon.components-button.has-icon {
 			background-color: #f6f7f7;
-			border-radius: 50%; /* stylelint-disable-line declaration-property-unit-allowed-list */
+			border-radius: 50%;
 			color: $gray-600;
 			margin-left: 8px;
 


### PR DESCRIPTION
From https://github.com/Automattic/wp-calypso/pull/71355#discussion_r1053348700

## Proposed Changes

Adds `%` to allowed list of units for `border-radius`. Percentages are really helpful for creating rounded elements.

## Testing Instructions

1. Verify nothing breaks.