### PR TITLE
Allow self-service Atomic site deletion.

### DIFF
--- a/client/my-sites/site-settings/delete-site/index.jsx
+++ b/client/my-sites/site-settings/delete-site/index.jsx
@@ -17,7 +17,6 @@ import Notice from 'calypso/components/notice';
 import DeleteSiteWarningDialog from 'calypso/my-sites/site-settings/delete-site-warning-dialog';
 import { hasLoadedSitePurchasesFromServer } from 'calypso/state/purchases/selectors';
 import hasCancelableSitePurchases from 'calypso/state/selectors/has-cancelable-site-purchases';
-import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import { deleteSite } from 'calypso/state/sites/actions';
 import { getSite, getSiteDomain } from 'calypso/state/sites/selectors';
 import { setSelectedSiteId } from 'calypso/state/ui/actions';
@@ -121,7 +120,7 @@ class DeleteSite extends Component {
 	};
 
 	render() {
-		const { isAtomic, siteDomain, siteId, siteSlug, translate } = this.props;
+		const { siteDomain, siteId, siteSlug, translate } = this.props;
 		const exportLink = '/export/' + siteSlug;
 		const deleteDisabled =
 			typeof this.state.confirmDomain !== 'string' ||
@@ -257,68 +256,43 @@ class DeleteSite extends Component {
 								</li>
 							</ul>
 						</ActionPanelFigure>
-						{ ! isAtomic && (
-							<div>
-								<p>
-									{ translate(
-										'Deletion {{strong}}can not{{/strong}} be undone, ' +
-											'and will remove all content, contributors, domains, themes and upgrades from this site.',
-										{
-											components: {
-												strong: <strong />,
-											},
-										}
-									) }
-								</p>
-								<p>
-									{ translate(
-										"If you're unsure about what deletion means or have any other questions, " +
-											'please chat with someone from our support team before proceeding.'
-									) }
-								</p>
-								<p>
-									<a
-										className="delete-site__body-text-link action-panel__body-text-link"
-										href="/help/contact"
-									>
-										{ strings.contactSupport }
-									</a>
-								</p>
-							</div>
-						) }
-						{ isAtomic && (
-							<div>
-								<p>
-									{ translate(
-										"To delete this site, you'll need to contact our support team. Deletion can not be undone, " +
-											'and will remove all content, contributors, domains, themes and upgrades from this site.'
-									) }
-								</p>
-								<p>
-									{ translate(
-										"If you're unsure about what deletion means or have any other questions, " +
-											"you'll have a chance to chat with someone from our support team before anything happens."
-									) }
-								</p>
-							</div>
-						) }
+						<div>
+							<p>
+								{ translate(
+									'Deletion {{strong}}can not{{/strong}} be undone, ' +
+										'and will remove all content, contributors, domains, themes and upgrades from this site.',
+									{
+										components: {
+											strong: <strong />,
+										},
+									}
+								) }
+							</p>
+							<p>
+								{ translate(
+									"If you're unsure about what deletion means or have any other questions, " +
+										'please chat with someone from our support team before proceeding.'
+								) }
+							</p>
+							<p>
+								<a
+									className="delete-site__body-text-link action-panel__body-text-link"
+									href="/help/contact"
+								>
+									{ strings.contactSupport }
+								</a>
+							</p>
+						</div>
 					</ActionPanelBody>
 					<ActionPanelFooter>
-						{ ! isAtomic && (
-							<Button
-								scary
-								disabled={ ! siteId || ! this.props.hasLoadedSitePurchasesFromServer }
-								onClick={ this.handleDeleteSiteClick }
-							>
-								<Gridicon icon="trash" />
-								{ strings.deleteSite }
-							</Button>
-						) }
-						{ isAtomic && (
-							<Button primary href="/help/contact">
-								{ strings.contactSupport }
-							</Button>
-						) }
+						<Button
+							scary
+							disabled={ ! siteId || ! this.props.hasLoadedSitePurchasesFromServer }
+							onClick={ this.handleDeleteSiteClick }
+						>
+							<Gridicon icon="trash" />
+							{ strings.deleteSite }
+						</Button>
 					</ActionPanelFooter>
 					<DeleteSiteWarningDialog
 						isVisible={ this.state.showWarningDialog }
@@ -367,7 +341,6 @@ export default connect(
 		const siteSlug = getSelectedSiteSlug( state );
 		return {
 			hasLoadedSitePurchasesFromServer: hasLoadedSitePurchasesFromServer( state ),
-			isAtomic: isSiteAutomatedTransfer( state, siteId ),
 			siteDomain,
 			siteId,
 			siteSlug,

--- a/client/my-sites/site-settings/delete-site/style.scss
+++ b/client/my-sites/site-settings/delete-site/style.scss
@@ -58,3 +58,8 @@ h1.delete-site__confirm-header {
 .delete-site__target-domain {
 	color: var(--color-error);
 }
+
+.delete-site__cannot-delete-message {
+	font-size: $font-body-small;
+	color: var(--color-error);
+}

--- a/client/state/sites/actions.js
+++ b/client/state/sites/actions.js
@@ -231,6 +231,20 @@ export function deleteSite( siteId ) {
 					return;
 				}
 
+				if ( error.error === 'unauthorized' ) {
+					// this error is used when you try to delete an Atomic site
+					// right after removing the plan(s) from it. Normally the
+					// message will be 'User cannot delete jetpack site via API.'
+					// The user needs to wait a minute before self-service deletion is available.
+					dispatch(
+						errorNotice(
+							'Unable to delete site. If you recently removed the plan(s) then please wait a couple of minutes and retry.',
+							siteDeletionNoticeOptions
+						)
+					);
+					return;
+				}
+
 				dispatch( errorNotice( error.message, siteDeletionNoticeOptions ) );
 			} );
 	};

--- a/client/state/sites/actions.js
+++ b/client/state/sites/actions.js
@@ -230,21 +230,6 @@ export function deleteSite( siteId ) {
 					);
 					return;
 				}
-
-				if ( error.error === 'unauthorized' ) {
-					// this error is used when you try to delete an Atomic site
-					// right after removing the plan(s) from it. Normally the
-					// message will be 'User cannot delete jetpack site via API.'
-					// The user needs to wait a minute before self-service deletion is available.
-					dispatch(
-						errorNotice(
-							'Unable to delete site. If you recently removed the plan(s) then please wait a couple of minutes and retry.',
-							siteDeletionNoticeOptions
-						)
-					);
-					return;
-				}
-
 				dispatch( errorNotice( error.message, siteDeletionNoticeOptions ) );
 			} );
 	};


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/71233

#### Proposed Changes

* You can now delete an Atomic site after removing any plans

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new site with a monthly Business plan
* Note the site ID and use that to make a WoA site 
* Install any plugin to trigger migration to Atomic infrastructure
* Try to delete the site at `/settings/general/:site`, and you should be told to remove the plan
* Remove the plan
* Return back to `/settings/general/:site` immediately and try again to delete the site
* Confirm that the delete button is disabled, and you're shown the warning as shown below
* After a minute, return to the page, and it should delete the site

![image](https://user-images.githubusercontent.com/6851384/209159118-91695ebf-12ce-434a-a8a2-41067304458f.png)



#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
