### PR TITLE
Theme Showcase: Fix My Themes tab might not able to be clicked

### DIFF
--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -58,6 +58,9 @@ const optionShape = PropTypes.shape( {
 	action: PropTypes.func,
 } );
 
+const findTabFilter = ( tabFilters, filterKey, defaultValue ) =>
+	Object.values( tabFilters ).find( ( filter ) => filter.key === filterKey ) || defaultValue;
+
 class ThemeShowcase extends Component {
 	constructor( props ) {
 		super( props );
@@ -206,19 +209,12 @@ class ThemeShowcase extends Component {
 			filterArray.includes( value )
 		);
 
-		let tabFilter = this.staticFilters.ALL;
 		if ( ! matches.length ) {
-			return tabFilter;
+			return findTabFilter( this.staticFilters, this.state?.tabFilter.key, this.staticFilters.ALL );
 		}
 
 		const filterKey = matches[ matches.length - 1 ].split( ':' ).pop();
-		Object.values( this.subjectFilters ).forEach( ( filter ) => {
-			if ( filter.key === filterKey ) {
-				tabFilter = filter;
-			}
-		} );
-
-		return tabFilter;
+		return findTabFilter( this.subjectFilters, filterKey, this.staticFilters.ALL );
 	};
 
 	scrollToSearchInput = () => {
@@ -318,7 +314,6 @@ class ThemeShowcase extends Component {
 
 		recordTracksEvent( 'calypso_themeshowcase_filter_category_click', { category: tabFilter.key } );
 		trackClick( 'section nav filter', tabFilter );
-		this.setState( { tabFilter } );
 
 		let callback = () => null;
 		// In this state: tabFilter = [ Recommended | ##All(1)## ]  tier = [ All(2) | Free | ##Premium## ]
@@ -343,10 +338,11 @@ class ThemeShowcase extends Component {
 				.filter( ( key ) => ! subjectFilters.includes( key ) )
 				.join( '+' );
 
-			const newFilter =
-				tabFilter.key !== this.staticFilters.ALL.key
-					? [ filterWithoutSubjects, subjectTerm ].join( '+' )
-					: filterWithoutSubjects;
+			const newFilter = ! [ this.staticFilters.ALL.key, this.staticFilters.MYTHEMES.key ].includes(
+				tabFilter.key
+			)
+				? [ filterWithoutSubjects, subjectTerm ].join( '+' )
+				: filterWithoutSubjects;
 
 			page( this.constructUrl( { filter: newFilter, searchString: search } ) );
 		}

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -302,6 +302,7 @@ class ThemesSelectionWithPage extends React.Component {
 
 	componentDidUpdate( nextProps ) {
 		if (
+			nextProps.siteId !== this.props.siteId ||
 			nextProps.search !== this.props.search ||
 			nextProps.tier !== this.props.tier ||
 			nextProps.filter !== this.props.filter ||


### PR DESCRIPTION
#### Proposed Changes

* When you click "My Themes" filter from another filter except "All", the URL will be changed and theme showcase component will try to resolve the current filter from the URL. However, the resolved filter will be "All" as we don't have any information in the URL to indicate the current filter is "My Themes". As a result, this PR avoids resolving the filter from the URL if the current filter is the static filter.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open /themes/<your_ecommerce_site>
* Click on a filter other than "All" (e.g. "Blog")
* Now click on the "My Themes" filter and verify it works!

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/71368
