### PR TITLE
Theme Showcase: The activated theme might not be the first one

### DIFF
--- a/client/state/themes/selectors/get-themes-for-query-ignoring-page.js
+++ b/client/state/themes/selectors/get-themes-for-query-ignoring-page.js
@@ -1,7 +1,7 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { createSelector } from '@automattic/state-utils';
 import { flatMap } from 'lodash';
-import { getActiveTheme, getCanonicalTheme } from 'calypso/state/themes/selectors';
+import { getActiveTheme } from 'calypso/state/themes/selectors';
 import { getSerializedThemesQueryWithoutPage } from 'calypso/state/themes/utils';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
@@ -30,25 +30,23 @@ export const getThemesForQueryIgnoringPage = createSelector(
 
 		// If query is default, filter out recommended themes.
 		if ( ! ( query.search || query.filter || query.tier ) ) {
-			const selectedSiteId = state.ui ? getSelectedSiteId( state ) : null;
 			const recommendedThemes = state.themes.recommendedThemes.themes;
 			const themeIds = flatMap( recommendedThemes, ( theme ) => theme.id );
 
 			themesForQueryIgnoringPage = themesForQueryIgnoringPage.filter(
 				( theme ) => ! themeIds.includes( theme.id )
 			);
+		}
 
-			// Set active theme to be the first theme in the array.
-			if ( isEnabled( 'themes/showcase-i4/search-and-filter' ) && selectedSiteId ) {
-				const currentThemeId = getActiveTheme( state, selectedSiteId );
-				const currentTheme = getCanonicalTheme( state, selectedSiteId, currentThemeId );
-
-				if ( currentTheme ) {
-					themesForQueryIgnoringPage = themesForQueryIgnoringPage.filter(
-						( theme ) => theme.id !== currentTheme.id
-					);
-					themesForQueryIgnoringPage.unshift( currentTheme );
-				}
+		// Set active theme to be the first theme in the array.
+		const selectedSiteId = state.ui ? getSelectedSiteId( state ) : null;
+		if ( isEnabled( 'themes/showcase-i4/search-and-filter' ) && selectedSiteId ) {
+			const currentThemeId = getActiveTheme( state, selectedSiteId );
+			const index = themesForQueryIgnoringPage.findIndex(
+				( theme ) => theme.id === currentThemeId
+			);
+			if ( index >= 0 ) {
+				themesForQueryIgnoringPage.unshift( ...themesForQueryIgnoringPage.splice( index, 1 ) );
 			}
 		}
 


### PR DESCRIPTION
#### Proposed Changes

* The self-hosted Jetpack site only queries the free themes as the [arePremiumThemesEnabled](https://github.com/Automattic/wp-calypso/blob/4cb39a0cdfcd6afcc38b1e29e1274a2741624f6e/client/my-sites/themes/themes-selection.jsx#L256) always returns false and it leads the query doesn't match the default one so that we don't move the activated theme to the first one. As a result, this PR always moves the activated theme to the first one if it's in the theme list.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a self-hosted site (e.g. using Jurassic Ninja) and connect to Jetpack
* Activate TT3
* Open /themes/<your_site> and verify the activated theme is the first one

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/71367
