### PR TITLE
Disable the pre-sales chat on the Cloud pricing page for the Holidays.

### DIFF
--- a/client/my-sites/plans/jetpack-plans/product-store/zendesk-presales-chat-widget/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/zendesk-presales-chat-widget/index.tsx
@@ -16,7 +16,7 @@ const isWithinAvailableChatDays = ( currentTime: Date ) => {
 
 const isWithinShutdownDates = ( currentTime: Date ) => {
 	const startTime = new Date( Date.UTC( 2022, 11, 23 ) ); // Thu Dec 22 2022 19:00:00 (7:00pm) GMT-0500 (Eastern Standard Time)
-	const endTime = new Date( Date.UTC( 2023, 0, 2 ) ); // Mon Jan 02 2023 19:00:00 (7:00pm) GMT-0500 (Eastern Standard Time)
+	const endTime = new Date( Date.UTC( 2023, 0, 2 ) ); // Sun Jan 01 2023 19:00:00 (7:00pm) GMT-0500 (Eastern Standard Time)
 	const currentDateUTC = new Date( currentTime.toUTCString() );
 	if ( currentDateUTC > startTime && currentDateUTC < endTime ) {
 		return true;

--- a/client/my-sites/plans/jetpack-plans/product-store/zendesk-presales-chat-widget/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/zendesk-presales-chat-widget/index.tsx
@@ -14,15 +14,28 @@ const isWithinAvailableChatDays = ( currentTime: Date ) => {
 	return utcWeekDay !== SUNDAY && utcWeekDay !== SATURDAY;
 };
 
+const isWithinShutdownDates = ( currentTime: Date ) => {
+	const startTime = new Date( Date.UTC( 2022, 12, 23 ) ); // Thu Dec 22 2022 19:00:00 (7:00pm) GMT-0500 (Eastern Standard Time)
+	const endTime = new Date( Date.UTC( 2023, 0, 3 ) ); // Mon Jan 02 2023 19:00:00 (7:00pm) GMT-0500 (Eastern Standard Time)
+	const currentDateUTC = new Date( currentTime.toUTCString() );
+	if ( currentDateUTC > startTime && currentDateUTC < endTime ) {
+		return true;
+	}
+	return false;
+};
+
 export const ZendeskPreSalesChat: React.VFC = () => {
 	const zendeskChatKey = config( 'zendesk_presales_chat_key' ) as keyof ConfigData;
 	const isLoggedIn = useSelector( isUserLoggedIn );
 
 	const shouldShowZendeskPresalesChat = useMemo( () => {
+		const currentTime = new Date();
+		if ( isWithinShutdownDates( currentTime ) ) {
+			return false;
+		}
 		const isEnglishLocale = ( config( 'english_locales' ) as string[] ).includes(
 			getLocaleSlug() ?? ''
 		);
-		const currentTime = new Date();
 
 		return config.isEnabled( 'jetpack/zendesk-chat-for-logged-in-users' )
 			? isEnglishLocale && isJetpackCloud() && isWithinAvailableChatDays( currentTime )

--- a/client/my-sites/plans/jetpack-plans/product-store/zendesk-presales-chat-widget/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/zendesk-presales-chat-widget/index.tsx
@@ -15,7 +15,7 @@ const isWithinAvailableChatDays = ( currentTime: Date ) => {
 };
 
 const isWithinShutdownDates = ( currentTime: Date ) => {
-	const startTime = new Date( Date.UTC( 2022, 11, 22 ) ); // Thu Dec 22 2022 19:00:00 (7:00pm) GMT-0500 (Eastern Standard Time)
+	const startTime = new Date( Date.UTC( 2022, 11, 23 ) ); // Thu Dec 22 2022 19:00:00 (7:00pm) GMT-0500 (Eastern Standard Time)
 	const endTime = new Date( Date.UTC( 2023, 0, 3 ) ); // Mon Jan 02 2023 19:00:00 (7:00pm) GMT-0500 (Eastern Standard Time)
 	const currentDateUTC = new Date( currentTime.toUTCString() );
 	if ( currentDateUTC > startTime && currentDateUTC < endTime ) {

--- a/client/my-sites/plans/jetpack-plans/product-store/zendesk-presales-chat-widget/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/zendesk-presales-chat-widget/index.tsx
@@ -16,7 +16,7 @@ const isWithinAvailableChatDays = ( currentTime: Date ) => {
 
 const isWithinShutdownDates = ( currentTime: Date ) => {
 	const startTime = new Date( Date.UTC( 2022, 11, 23 ) ); // Thu Dec 22 2022 19:00:00 (7:00pm) GMT-0500 (Eastern Standard Time)
-	const endTime = new Date( Date.UTC( 2023, 0, 3 ) ); // Mon Jan 02 2023 19:00:00 (7:00pm) GMT-0500 (Eastern Standard Time)
+	const endTime = new Date( Date.UTC( 2023, 0, 2 ) ); // Mon Jan 02 2023 19:00:00 (7:00pm) GMT-0500 (Eastern Standard Time)
 	const currentDateUTC = new Date( currentTime.toUTCString() );
 	if ( currentDateUTC > startTime && currentDateUTC < endTime ) {
 		return true;

--- a/client/my-sites/plans/jetpack-plans/product-store/zendesk-presales-chat-widget/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/zendesk-presales-chat-widget/index.tsx
@@ -15,7 +15,7 @@ const isWithinAvailableChatDays = ( currentTime: Date ) => {
 };
 
 const isWithinShutdownDates = ( currentTime: Date ) => {
-	const startTime = new Date( Date.UTC( 2022, 12, 23 ) ); // Thu Dec 22 2022 19:00:00 (7:00pm) GMT-0500 (Eastern Standard Time)
+	const startTime = new Date( Date.UTC( 2022, 11, 22 ) ); // Thu Dec 22 2022 19:00:00 (7:00pm) GMT-0500 (Eastern Standard Time)
 	const endTime = new Date( Date.UTC( 2023, 0, 3 ) ); // Mon Jan 02 2023 19:00:00 (7:00pm) GMT-0500 (Eastern Standard Time)
 	const currentDateUTC = new Date( currentTime.toUTCString() );
 	if ( currentDateUTC > startTime && currentDateUTC < endTime ) {


### PR DESCRIPTION
#### Proposed Changes

This PR disables the Zendesk pre-sales Chat interface on the Jetpack Cloud pricing page automatically between the dates of Dec 23, 2022 midnight UTC **_thru_** Jan 3, 2023 midnight UTC.

Related to: p1671473237696439-slack-C04BZQFCWE9

#### Testing Instructions

Note: The pre-sales chat does not run on weekends (UTC), so if you're testing this PR on a weekend day and the chat is not showing, this is why.  You'll need to change your local computer date/time to a non-weekend day.

- Do any one of these
    * Click on Jetpack Cloud live link below and wait for the redirect to complete, then goto `/pricing`
    * or boot up this PR 
        * Run `git fetch && git checkout update/disable-presales-chat-for-holidays`
        * Run `yarn start-jetpack-cloud`
        * Goto [http://jetpack.cloud.localhost:3000/pricing](http://jetpack.cloud.localhost:3000/pricing)
- Assuming you are **not** testing this between the shutdown dates (listed above), verify you see the chat box in the lower right corner of the page.
- Now change your local computer's clock to some time(s) between the shutdown dates (listed above). 
    - One way to test would be to go to worldtimebuddy.com and create a row with your own location and then create another row with UTC location. Then find what time it is for you at Dec 23, 2022 midnight UTC and also at Jan 2, 2023 midnight UTC. Write down or keep note of these local date/times.
    - Then change your local computer time to a time just _after_ the **start** shutdown time for you locally. Reload the page and verify the chat is not showing.
    - set your local computer date/time to a time just _before_ the **end** shutdown time, and verify the chat is still not showing.
    - Then set your local computer date/time to a time just _after_ the **end** shutdown time for you locally. Verify the chat is now showing again.


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->