### PR TITLE
HappyChat: Add closure message for Christmas holiday

### DIFF
--- a/packages/help-center/src/components/help-center-contact-page.tsx
+++ b/packages/help-center/src/components/help-center-contact-page.tsx
@@ -116,9 +116,9 @@ export const HelpCenterContactPage: React.FC = () => {
 				<h3>{ __( 'Contact our WordPress.com experts', __i18n_text_domain__ ) }</h3>
 				<HelpCenterActiveTicketNotice tickets={ tickets } />
 				<GMClosureNotice
-					displayAt="2022-10-29 00:00Z"
-					closesAt="2022-11-05 00:00Z"
-					reopensAt="2022-11-14 07:00Z"
+					displayAt="2022-12-17 00:00Z"
+					closesAt="2022-12-24 00:00Z"
+					reopensAt="2022-12-26 07:00Z"
 					enabled={ hasAccessToLivechat }
 				/>
 				<div


### PR DESCRIPTION
#### Proposed Changes
Add message for Christmas holiday's limited availability
More context [here](p1671504597022099-slack-C029S5LLB7D)

#### Testing Instructions

- Pull this branch or use Calypso's live link
- Open HappyChat and and click on "still need help button "
- You should see a message
<img width="418" alt="image" src="https://user-images.githubusercontent.com/2653810/208867115-87f9b46f-36d6-4a5a-a5f5-bedf2f30fb8d.png">