### PR TITLE
Add a filter to ETK Jetpack global styles

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/global-styles/class-global-styles.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/global-styles/class-global-styles.php
@@ -78,6 +78,13 @@ class Global_Styles {
 	 */
 	private $plugin_name = 'jetpack-global-styles';
 
+	/**
+	 * The provider's root URL for retrieving font CSS.
+	 *
+	 * @var string
+	 */
+	private $root_url = 'https://fonts.googleapis.com/css2';
+
 	const VERSION = '2003121439';
 
 	const SYSTEM_FONT     = '-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif';
@@ -458,6 +465,13 @@ class Global_Styles {
 	 * @return string
 	 */
 	private function get_inline_css( $only_selected_fonts = false ) {
+		/**
+		 * Filters the Google Fonts API URL.
+		 *
+		 * @param string $url The Google Fonts API URL.
+		 */
+		$root_url = esc_url( apply_filters( 'jetpack_global_styles_google_fonts_api_url', $this->root_url ) );
+
 		$result = '';
 
 		$data = $this->rest_api_data->get_data();
@@ -489,7 +503,7 @@ class Global_Styles {
 				// the API will return only the regular and bold CSS for those.
 				$font_list_str = $font_list_str . $font . ':thin,extralight,light,regular,medium,semibold,bold,italic,bolditalic,extrabold,black|';
 			}
-			$result = $result . "@import url('https://fonts.googleapis.com/css?family=" . $font_list_str . "');";
+			$result = $result . "@import url('" . $root_url . '?family=' . $font_list_str . "');";
 		}
 
 		/*


### PR DESCRIPTION
Allows switching Google Fonts API to our own implementation.

#### Proposed Changes

* Filter Google Fonts API URL

#### Testing Instructions

* Upload ETK to Simple & Atomic
* Add a filter on simple sites at `google-fonts-proxy.php` (D96205-code) or [use wpcomsh PR](https://github.com/Automattic/wpcomsh/pull/1209) on Atomic sites.
* Have an older site with classic theme
* Open page editor, and "global styles" sidebar. Apply some fonts:

    <img width="1156" alt="Screenshot 2022-12-21 at 11 12 18 1" src="https://user-images.githubusercontent.com/87168/208870992-f1bac119-85f7-4525-96df-19749f407bbc.png">

* Confirm that fonts load from WP.com in the editor and at the frontend of the site.


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #