### PR TITLE
VideoPress launchpad: indent pending tasks

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/videopress.scss
+++ b/client/landing/stepper/declarative-flow/internals/videopress.scss
@@ -254,6 +254,10 @@ body.is-videopress-stepper {
 			align-self: center;
 		}
 
+		.launchpad__task.pending .launchpad__checklist-item {
+			padding-left: 44px;
+		}
+
 		.launchpad__task.pending .launchpad__checklist-item-chevron {
 			color: #fff;
 			fill: #fff;


### PR DESCRIPTION
#### Proposed Changes

This PR indents pending tasks in the VideoPress launchpad so they're aligned with done tasks.

#### Testing Instructions

* Apply PR
* Go through the VideoPress site creation flow, and cancel the payment
* Go to the launchpad `/setup/videopress/launchpad?siteSlug=<your_site_slug>`
* ✅ Pending items text in the checklist should be aligned with the done items

Fixes Automattic/greenhouse#1450
