### PR TITLE
VideoPress onboarding: fix "pick a free domain" link

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-plan/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-plan/index.tsx
@@ -25,7 +25,7 @@ import 'calypso/../packages/plans-grid/src/plans-table/style.scss';
 import './style.scss';
 
 const ChooseAPlan: Step = function ChooseAPlan( { navigation, flow } ) {
-	const { goNext, goBack, submit } = navigation;
+	const { goNext, goBack, submit, goToStep } = navigation;
 	const isVideoPressFlow = 'videopress' === flow;
 
 	const [ billingPeriod, setBillingPeriod ] =
@@ -241,7 +241,7 @@ const ChooseAPlan: Step = function ChooseAPlan( { navigation, flow } ) {
 													getPlanProduct( plan.periodAgnosticSlug, billingPeriod )?.productId
 											}
 											onSelect={ ( id ) => onPlanSelect( id, plan ) }
-											onPickDomainClick={ undefined }
+											onPickDomainClick={ () => goToStep && goToStep( 'chooseADomain' ) }
 											onToggleExpandAll={ () => setAllPlansExpanded( ( expand ) => ! expand ) }
 											// translators: Placeholder refers to the name of a WordPress.com plan.
 											CTAButtonLabel={ __( 'Get %s' ).replace( '%s', plan.title ) }


### PR DESCRIPTION
#### Proposed Changes

This PR fixes the "pick a free domain" link on plan selection step for the VideoPress onboarding.

#### Testing Instructions

* Apply PR
* Go to the VideoPress onboarding flow
* Skip the domain selection step
* At the plan selection step click on "Free domain included"
* ✅ You should be redirected to the domain selection step
* Pick a somain
* At the plan selection step click the "<domain name> included" link
* ✅ You should also be redirected to the domain selection step


Fixes Automattic/greenhouse#1429
