### PR TITLE
Add/ Skeleton for Email Stats page

### DIFF
--- a/client/my-sites/stats/controller.jsx
+++ b/client/my-sites/stats/controller.jsx
@@ -11,6 +11,7 @@ import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import StatsCommentFollows from './comment-follows';
 import StatsOverview from './overview';
 import StatsSite from './site';
+import StatsEmailOpenDetail from './stats-email-open-detail';
 import StatsInsights from './stats-insights';
 import StatsPostDetail from './stats-post-detail';
 import StatsSummary from './summary';
@@ -434,6 +435,12 @@ export function wordAds( context, next ) {
 			period={ rangeOfPeriod( activeFilter.period, date ) }
 		/>
 	);
+
+	next();
+}
+
+export function emailOpen( context, next ) {
+	context.primary = <StatsEmailOpenDetail />;
 
 	next();
 }

--- a/client/my-sites/stats/index.js
+++ b/client/my-sites/stats/index.js
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import page from 'page';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import { navigation, siteSelection, sites } from 'calypso/my-sites/controller';
@@ -13,6 +14,7 @@ import {
 	redirectToDefaultModulePage,
 	redirectToDefaultSitePage,
 	redirectToDefaultWordAdsPeriod,
+	emailOpen,
 } from './controller';
 
 import './style.scss';
@@ -75,6 +77,11 @@ export default function () {
 	// Anything else should redirect to default WordAds stats page
 	page( '/stats/wordads/(.*)', redirectToDefaultWordAdsPeriod );
 	page( '/stats/ads/(.*)', redirectToDefaultWordAdsPeriod );
+
+	// Email stats Pages
+	if ( config.isEnabled( 'newsletter/stats' ) ) {
+		statsPage( `/stats/email/open/:site/:period(${ validPeriods })/:email_id`, emailOpen );
+	}
 
 	// Anything else should redirect to default stats page
 	page( '/stats/(.*)', redirectToDefaultSitePage );

--- a/client/my-sites/stats/stats-email-open-detail/index.jsx
+++ b/client/my-sites/stats/stats-email-open-detail/index.jsx
@@ -1,0 +1,9 @@
+import { Component } from 'react';
+
+class StatsEmailOpenDetail extends Component {
+	render() {
+		return <div>Email Stats placeholder</div>;
+	}
+}
+
+export default StatsEmailOpenDetail;

--- a/client/my-sites/stats/stats-module/index.jsx
+++ b/client/my-sites/stats/stats-module/index.jsx
@@ -109,6 +109,7 @@ class StatsModule extends Component {
 			'statsSearchTerms',
 			'statsClicks',
 			'statsReferrers',
+			'statsEmailsOpen',
 		];
 		return summary && includes( summarizedTypes, statType );
 	}


### PR DESCRIPTION
#### Proposed Changes

This PR adds the skeleton and the route for the Email Stats page. It's empty at the moment, but it's hidden behind the `newsletter/stats` feature flag.

#### Testing Instructions

1. Checkout this branch on your local repository and start the application.
2. Go to a route in this format `calypso.localhost:3000/stats/email/open/<SITE_DOMAIN>/day/<POST_ID>?flags=newsletter/stats` (for example: `calypso.localhost:3000/stats/email/open/testingrightnow.blog/day/37?flags=newsletter/stats`).
3. You should see the placeholder text on the screen like this:

<img width="723" alt="Screenshot 2022-12-21 at 12 09 02" src="https://user-images.githubusercontent.com/3832570/208893590-338b85c0-51f1-4b5b-854a-ba50221a93c1.png">



