### PR TITLE
HappyChat: Add New Year's closure times

### DIFF
--- a/packages/help-center/src/components/help-center-contact-page.tsx
+++ b/packages/help-center/src/components/help-center-contact-page.tsx
@@ -116,9 +116,9 @@ export const HelpCenterContactPage: React.FC = () => {
 				<h3>{ __( 'Contact our WordPress.com experts', __i18n_text_domain__ ) }</h3>
 				<HelpCenterActiveTicketNotice tickets={ tickets } />
 				<GMClosureNotice
-					displayAt="2022-12-17 00:00Z"
-					closesAt="2022-12-24 00:00Z"
-					reopensAt="2022-12-26 07:00Z"
+					displayAt="2022-12-26 07:00Z"
+					closesAt="2022-12-31 00:00Z"
+					reopensAt="2023-01-02 07:00Z"
 					enabled={ hasAccessToLivechat }
 				/>
 				<div

--- a/packages/help-center/src/components/help-center-contact-page.tsx
+++ b/packages/help-center/src/components/help-center-contact-page.tsx
@@ -116,9 +116,9 @@ export const HelpCenterContactPage: React.FC = () => {
 				<h3>{ __( 'Contact our WordPress.com experts', __i18n_text_domain__ ) }</h3>
 				<HelpCenterActiveTicketNotice tickets={ tickets } />
 				<GMClosureNotice
-					displayAt="2022-10-29 00:00Z"
-					closesAt="2022-11-05 00:00Z"
-					reopensAt="2022-11-14 07:00Z"
+					displayAt="2022-12-17 00:00Z"
+					closesAt="2022-12-24 00:00Z"
+					reopensAt="2022-12-26 07:00Z"
 					enabled={ hasAccessToLivechat }
 				/>
 				<div

--- a/packages/help-center/src/components/help-center-contact-page.tsx
+++ b/packages/help-center/src/components/help-center-contact-page.tsx
@@ -115,6 +115,14 @@ export const HelpCenterContactPage: React.FC = () => {
 			<div className="help-center-contact-page__content">
 				<h3>{ __( 'Contact our WordPress.com experts', __i18n_text_domain__ ) }</h3>
 				<HelpCenterActiveTicketNotice tickets={ tickets } />
+				{ /* Christmas */ }
+				<GMClosureNotice
+					displayAt="2022-12-17 00:00Z"
+					closesAt="2022-12-24 00:00Z"
+					reopensAt="2022-12-26 07:00Z"
+					enabled={ hasAccessToLivechat }
+				/>
+				{ /* NY's */ }
 				<GMClosureNotice
 					displayAt="2022-12-26 07:00Z"
 					closesAt="2022-12-31 00:00Z"


### PR DESCRIPTION
#### Proposed Changes

Add message for New Year's holiday limited availability.
More context [here](https://github.com/Automattic/wp-calypso/pull/p1671504597022099-slack-C029S5LLB7D)

#### Testing Instructions


- Pull this branch or use Calypso's live link
- Open HappyChat and and click on "still need help button "
- You should see the December dates message
- Change your computer time to a date after December 25th 
- You should see the NY's  message like bellow

<img width="418" alt="image" src="https://user-images.githubusercontent.com/2653810/208890898-2c6990c6-2f4d-426e-a6fb-2d07b723699a.png">

