### PR TITLE
Fix the availabilty check for FQDNs in the signup flow

### DIFF
--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -525,7 +525,7 @@ class DomainsStep extends Component {
 		}
 
 		const includeWordPressDotCom = this.props.includeWordPressDotCom ?? ! this.props.isDomainOnly;
-		const promoTlds = this.props?.queryObject?.tld?.split( ',' ) ?? [];
+		const promoTlds = this.props?.queryObject?.tld?.split( ',' ) ?? null;
 
 		return (
 			<CalypsoShoppingCartProvider>


### PR DESCRIPTION
It seems that we've stopped doing availability checks in the signup flow. The issue is that in certain cases the domain suggestion engine doesn't return an exact match if you're searching for FQDN (I suppose it might be cached domain availability). In those cases a customer would search for a domain that is available but they won't get it in the signup domain suggestion step but it would show up if you search in the regular calypso add a domain flow though.

I did some investigations and it seems the reason is that `promoTlds` is an empty array which apparently doesn't work with the check we do in `RegisterDomainStep::checkDomainAvailability` method. This was introduced in #69797 about a month ago. I think a quick fix would be to just replace the empty array with `null`

#### Proposed Changes

* Replace the empty array value of `promoTlds` with `null`

#### Testing Instructions

* Enable browser dev tools network monitor
* Go to /start/domain and search for a FQDN
* Verify that `is-available` network request is triggered

#### Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] Have you checked for TypeScript, React or other console errors?

Related to #69797

see: p2MSmN-aKw-p2

