### PR TITLE
Plugin Details: Show the Premium Plugin USP based on the 'premium_slug' property

### DIFF
--- a/client/my-sites/plugins/plugin-details-sidebar/index.jsx
+++ b/client/my-sites/plugins/plugin-details-sidebar/index.jsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import {
 	isFreePlanProduct,
 	FEATURE_INSTALL_PLUGINS,
@@ -26,6 +25,7 @@ const PluginDetailsSidebar = ( {
 		demo_url = null,
 		documentation_url = null,
 		requirements = {},
+		premium_slug,
 	},
 } ) => {
 	const translate = useTranslate();
@@ -62,12 +62,8 @@ const PluginDetailsSidebar = ( {
 			label: translate( 'View documentation' ),
 		} );
 
-	/**
-	 * TODO: Update the isPremiumVersionAvailable check and the premiumVersionLink property
-	 * to read from plugins data
-	 */
-	const isPremiumVersionAvailable = config.isEnabled( 'plugins/premium-version-available' );
-	const premiumVersionLink = 'https://WP.com';
+	const isPremiumVersionAvailable = !! premium_slug;
+	const premiumVersionLink = `/plugins/${ premium_slug }/${ selectedSite?.slug || '' }`;
 
 	return (
 		<div className="plugin-details-sidebar__plugin-details-content">

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -14,6 +14,7 @@ import InlineSupportLink from 'calypso/components/inline-support-link';
 import MainComponent from 'calypso/components/main';
 import Notice from 'calypso/components/notice';
 import NoticeAction from 'calypso/components/notice/notice-action';
+import { useESPlugin } from 'calypso/data/marketplace/use-es-query';
 import { useWPCOMPlugin } from 'calypso/data/marketplace/use-wpcom-plugins-query';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import PluginNotices from 'calypso/my-sites/plugins/notices';
@@ -85,6 +86,8 @@ function PluginDetails( props ) {
 	const { localizePath } = useLocalizedPlugins();
 
 	// Plugin information.
+	const PREMIUM_SLUG_FIELD = 'plugin.premium_slug';
+	const { data: esPlugin = {} } = useESPlugin( props.pluginSlug, [ PREMIUM_SLUG_FIELD ] );
 	const plugin = useSelector( ( state ) => getPluginOnSites( state, siteIds, props.pluginSlug ) );
 	const wporgPlugin = useSelector( ( state ) => getWporgPluginSelector( state, props.pluginSlug ) );
 	const isWporgPluginFetching = useSelector( ( state ) =>
@@ -162,6 +165,7 @@ function PluginDetails( props ) {
 			fetched: isWpComPluginFetched,
 		};
 		return {
+			...esPlugin,
 			...wpcomPlugin,
 			...wporgPlugin,
 			...plugin,
@@ -171,6 +175,7 @@ function PluginDetails( props ) {
 		};
 	}, [
 		plugin,
+		esPlugin,
 		wporgPlugin,
 		wpComPluginData,
 		isWpComPluginFetched,


### PR DESCRIPTION

#### Proposed Changes

* Search for a `premium_slug` field for the given plugin on Elasticsearch 
* Update the Premium Plugin USP logic to use this field to show or hide it

| Before  | After |
| ------------- | ------------- |
|<img width="1138" alt="Screen Shot 2022-12-21 at 12 02 58" src="https://user-images.githubusercontent.com/5039531/208949041-737e21bc-8d9b-4212-af18-f30a97798319.png">|<img width="1138" alt="Screen Shot 2022-12-21 at 12 03 12" src="https://user-images.githubusercontent.com/5039531/208949175-b354f031-10f9-4c6c-881a-109d1ca02e7f.png">|

#### Testing Instructions
#### Negative validation
* Go to a plugin that doesn't have a premium plugin associated, ex: `/plugins/woocommerce`
* Verify the Premium Plugin USP is NOT displayed

#### Positive Validation 
* Go to a plugin wich a premium plugin associated. Ex: `/plugins/mailpoet` and `/plugins/wordpress-seo` 
*  Verify the Premium Plugin USP IS displayed
* Click on the link provided and verify it opens the premium plugin page on a new tab


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #60769
