### PR TITLE
Downtime Monitoring: Create Bulk Edit Menu

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/dashboard-bulk-actions/edit-button.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/dashboard-bulk-actions/edit-button.tsx
@@ -1,0 +1,37 @@
+import { Button } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import { useContext } from 'react';
+import ButtonGroup from 'calypso/components/button-group';
+import SitesOverviewContext from '../sites-overview/context';
+import type { SiteData } from '../sites-overview/types';
+
+import './style.scss';
+
+interface Props {
+	sites: Array< SiteData >;
+}
+
+export default function EditButton( { sites }: Props ) {
+	const translate = useTranslate();
+
+	const { setIsBulkManagementActive, setSelectedSites } = useContext( SitesOverviewContext );
+
+	const handleToggleSelect = () => {
+		// Filter sites with site error as they are not selectable.
+		const filteredSite = sites.filter( ( site ) => ! site.site.error );
+		setSelectedSites( filteredSite.map( ( item ) => item.site.value ) );
+	};
+
+	const handleEditAll = () => {
+		setIsBulkManagementActive( true );
+		handleToggleSelect();
+	};
+
+	return (
+		<ButtonGroup>
+			<Button className="dashboard-bulk-actions__edit-button" compact onClick={ handleEditAll }>
+				{ translate( 'Edit All', { context: 'button label' } ) }
+			</Button>
+		</ButtonGroup>
+	);
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/dashboard-bulk-actions/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/dashboard-bulk-actions/index.tsx
@@ -1,10 +1,11 @@
-import { Button } from '@automattic/components';
-import { useMobileBreakpoint } from '@automattic/viewport-react';
+import { Button, Gridicon } from '@automattic/components';
+import { useBreakpoint } from '@automattic/viewport-react';
 import { useTranslate } from 'i18n-calypso';
-import { useState } from 'react';
+import { useState, useContext } from 'react';
 import ButtonGroup from 'calypso/components/button-group';
 import SelectDropdown from 'calypso/components/select-dropdown';
 import NotificationSettings from '../downtime-monitoring/notification-settings';
+import SitesOverviewContext from '../sites-overview/context';
 import { useHandleToggleMonitor, useHandleResetNotification } from './hooks';
 import type { Site } from '../sites-overview/types';
 
@@ -16,8 +17,9 @@ interface Props {
 
 export default function DashboardBulkActions( { selectedSites }: Props ) {
 	const translate = useTranslate();
+	const { setIsBulkManagementActive } = useContext( SitesOverviewContext );
 
-	const isMobile = useMobileBreakpoint();
+	const isDesktop = useBreakpoint( '>1040px' );
 
 	const handleToggleActivateMonitor = useHandleToggleMonitor( selectedSites );
 	const handleResetNotification = useHandleResetNotification( selectedSites );
@@ -53,19 +55,19 @@ export default function DashboardBulkActions( { selectedSites }: Props ) {
 	let content = null;
 	const disabled = selectedSites.length === 0;
 
-	if ( ! isMobile ) {
+	if ( isDesktop ) {
 		content = (
 			<>
 				<ButtonGroup>
 					{ toggleMonitorActions.map( ( { label, action } ) => (
-						<Button key={ label } disabled={ disabled } onClick={ action }>
+						<Button compact key={ label } disabled={ disabled } onClick={ action }>
 							{ label }
 						</Button>
 					) ) }
 				</ButtonGroup>
 				{ otherMonitorActions.map( ( { label, action } ) => (
 					<ButtonGroup key={ label }>
-						<Button disabled={ disabled } onClick={ action }>
+						<Button compact disabled={ disabled } onClick={ action }>
 							{ label }
 						</Button>
 					</ButtonGroup>
@@ -86,7 +88,15 @@ export default function DashboardBulkActions( { selectedSites }: Props ) {
 
 	return (
 		<>
-			<div className="dashboard-bulk-actions">{ content }</div>
+			<div className="dashboard-bulk-actions">
+				{ content }
+				<ButtonGroup>
+					<Button compact borderless className="dashboard-bulk-actions__close-icon">
+						<Gridicon icon="cross" onClick={ () => setIsBulkManagementActive( false ) } />
+					</Button>
+				</ButtonGroup>
+			</div>
+
 			{ showNotificationSettingsPopup && (
 				<NotificationSettings sites={ selectedSites } onClose={ toggleNotificationSettingsPopup } />
 			) }

--- a/client/jetpack-cloud/sections/agency-dashboard/dashboard-bulk-actions/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/dashboard-bulk-actions/style.scss
@@ -27,20 +27,40 @@
 	width: 100%;
 	text-align: right;
 	display: inline-block;
-
 	.button-group {
 		margin-inline-start: 14px;
-
 		.button {
 			&:first-child {
 				border-top-left-radius: 4px;
 				border-bottom-left-radius: 4px;
 			}
-
 			&:last-child {
 				border-top-right-radius: 4px;
 				border-bottom-right-radius: 4px;
 			}
+			white-space: nowrap;
+			&:focus {
+				border-width: 1px !important;
+			}
 		}
+	}
+}
+
+.dashboard-bulk-actions__close-icon {
+	text-align: end;
+	float: right;
+	border: none;
+	padding: 4px 8px 4px 10px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	height: 100%;
+}
+
+button.dashboard-bulk-actions__edit-button {
+	white-space: nowrap;
+	border-radius: 4px !important;
+	&:active {
+		border-width: 1px !important;
 	}
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/dashboard-overview/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/dashboard-overview/index.tsx
@@ -28,13 +28,20 @@ export default function DashboardOverview( {
 		return <SelectPartnerKey />;
 	}
 
+	const handleSetBulkManagementActive = ( isActive: boolean ) => {
+		setIsBulkManagementActive( isActive );
+		if ( ! isActive ) {
+			setSelectedSites( [] );
+		}
+	};
+
 	if ( hasFetched ) {
 		const context = {
 			search,
 			currentPage,
 			filter,
 			isBulkManagementActive,
-			setIsBulkManagementActive,
+			setIsBulkManagementActive: handleSetBulkManagementActive,
 			selectedSites,
 			setSelectedSites,
 		};

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/toggle-activate-monitoring/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/toggle-activate-monitoring/style.scss
@@ -17,7 +17,7 @@
 		margin-bottom: 0;
 
 		.components-form-toggle {
-			@include break-large {
+			@include break-xlarge {
 				margin-right: 4px;
 			}
 

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-actions/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-actions/style.scss
@@ -9,8 +9,10 @@
 	text-align: center;
 	justify-content: center;
 	align-items: center;
-	@include break-large() {
+	@include break-xlarge() {
 		display: block;
+		float: right;
+		margin-inline-end: 30px;
 	}
 }
 .site-actions__actions-small-screen {
@@ -18,7 +20,7 @@
 	position: absolute;
 	right: 16px;
 	display: inline;
-	@include break-large() {
+	@include break-xlarge() {
 		display: none;
 	}
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/index.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { Card } from '@automattic/components';
 import { useMobileBreakpoint } from '@automattic/viewport-react';
 import page from 'page';
@@ -5,6 +6,7 @@ import { useContext } from 'react';
 import Pagination from 'calypso/components/pagination';
 import TextPlaceholder from 'calypso/jetpack-cloud/sections/partner-portal/text-placeholder';
 import { addQueryArgs } from 'calypso/lib/route';
+import EditButton from '../../dashboard-bulk-actions/edit-button';
 import SitesOverviewContext from '../context';
 import SiteBulkSelect from '../site-bulk-select';
 import SiteCard from '../site-card';
@@ -47,9 +49,16 @@ export default function SiteContent( { data, isLoading, currentPage, isFavorites
 				<SiteTable isLoading={ isLoading } columns={ siteColumns } items={ sites } />
 			</div>
 			<div className="site-content__small-screen-view">
-				{ isBulkManagementActive && (
+				{ isEnabled( 'jetpack/partner-portal-downtime-monitoring-updates' ) && (
 					<Card className="site-content__bulk-select">
-						<SiteBulkSelect sites={ sites } isLoading={ isLoading } />
+						{ isBulkManagementActive ? (
+							<SiteBulkSelect sites={ sites } isLoading={ isLoading } />
+						) : (
+							<>
+								<span className="site-content__bulk-select-label">{ siteColumns[ 0 ].title }</span>
+								<EditButton sites={ sites } />
+							</>
+						) }
 					</Card>
 				) }
 				<div className="site-content__mobile-view">

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/index.tsx
@@ -1,5 +1,5 @@
 import { Card } from '@automattic/components';
-import { useDesktopBreakpoint, useMobileBreakpoint } from '@automattic/viewport-react';
+import { useMobileBreakpoint } from '@automattic/viewport-react';
 import page from 'page';
 import { useContext } from 'react';
 import Pagination from 'calypso/components/pagination';
@@ -28,7 +28,6 @@ interface Props {
 
 export default function SiteContent( { data, isLoading, currentPage, isFavoritesTab }: Props ) {
 	const isMobile = useMobileBreakpoint();
-	const isDesktop = useDesktopBreakpoint();
 	const { isBulkManagementActive } = useContext( SitesOverviewContext );
 
 	const sites = formatSites( data?.sites );
@@ -39,33 +38,38 @@ export default function SiteContent( { data, isLoading, currentPage, isFavorites
 
 	return (
 		<>
-			{ isDesktop ? (
+			{
+				// We are using CSS to hide/show add email content on mobile/large screen view instead of the breakpoint
+				// hook since the hook returns true only when the width > some value, and we have some
+				// styles applied using the CSS breakpoint which is true for width >= some value
+			 }
+			<div className="site-content__large-screen-view">
 				<SiteTable isLoading={ isLoading } columns={ siteColumns } items={ sites } />
-			) : (
-				<>
-					<div className="site-content__mobile-view">
-						<>
-							{ isBulkManagementActive && (
-								<Card className="site-content__bulk-select">
-									<SiteBulkSelect sites={ sites } isLoading={ isLoading } />
-								</Card>
-							) }
-							{ isLoading ? (
-								<Card>
-									<TextPlaceholder />
-								</Card>
-							) : (
-								<>
-									{ sites.length > 0 &&
-										sites.map( ( rows, index ) => (
-											<SiteCard key={ index } columns={ siteColumns } rows={ rows } />
-										) ) }
-								</>
-							) }
-						</>
-					</div>
-				</>
-			) }
+			</div>
+			<div className="site-content__small-screen-view">
+				{ isBulkManagementActive && (
+					<Card className="site-content__bulk-select">
+						<SiteBulkSelect sites={ sites } isLoading={ isLoading } />
+					</Card>
+				) }
+				<div className="site-content__mobile-view">
+					<>
+						{ isLoading ? (
+							<Card>
+								<TextPlaceholder />
+							</Card>
+						) : (
+							<>
+								{ sites.length > 0 &&
+									sites.map( ( rows, index ) => (
+										<SiteCard key={ index } columns={ siteColumns } rows={ rows } />
+									) ) }
+							</>
+						) }
+					</>
+				</div>
+			</div>
+
 			{ data && data?.total > 0 && (
 				<Pagination
 					compact={ isMobile }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/style.scss
@@ -19,8 +19,6 @@
 }
 
 .edit-all__bulk-actions {
-	margin: 10px;
-	padding-inline-end: 11px;
 	button {
 		border: 1px solid var(--studio-gray-80);
 		padding-inline-end: 10px;
@@ -85,6 +83,7 @@ button.button.dashboard-list-header__bulk-action-buttons.is-compact {
 				border-top-right-radius: 4px;
 				border-bottom-right-radius: 4px;
 			}
+			white-space: nowrap;
 		}
 	}
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/style.scss
@@ -1,6 +1,19 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 
+.site-content__large-screen-view {
+	display: none;
+	@include break-xlarge {
+		display: block;
+	}
+}
+
+.site-content__small-screen-view {
+	@include break-xlarge {
+		display: none;
+	}
+}
+
 .site-content__mobile-view {
 	margin-bottom: 1.5rem;
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/style.scss
@@ -68,6 +68,11 @@ button.button.dashboard-list-header__bulk-action-buttons.is-compact {
 	margin-block-start: 4px;
 }
 
+button.button.dashboard-list-header__bulk-action-buttons.is-compact:active {
+	background: var(--color-accent-5);
+	border-color: var(--color-accent-40);
+	border-width: 1px;
+}
 // Bulk Edit Menu
 .dashboard-list-header {
 	height: 60px;

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/style.scss
@@ -22,6 +22,38 @@
 .edit-all__bulk-actions button {
 	border: 1px solid var(--color-neutral-20);
 }
-.edit-all__bulk-actions button .gridicon {
+button.edit-all__bulk-actions-close {
 	border: none;
+	padding: 4px 8px 4px 10px;
+}
+
+th.edit-all-buttons {
+	text-align: right;
+}
+
+.edit-all__bulk-actions-custom-notifications {
+	padding: 0 10px;
+}
+
+.button-group {
+	margin-top: 6px;
+}
+
+.site-bulk-edit-menu-container {
+	background-color: #fff;
+	text-align: right;
+}
+
+.select-dropdown__item-text {
+	text-align: left;
+}
+
+.edit-all__bulk-actions-close {
+	text-align: right;
+	justify-content: flex-end;
+	float: right;
+}
+
+.site-bulk-edit-menu-container.card {
+	padding: 10px;
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/style.scss
@@ -1,3 +1,6 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
 .site-content__mobile-view {
 	margin-bottom: 1.5rem;
 }
@@ -17,43 +20,71 @@
 
 .edit-all__bulk-actions {
 	margin: 10px;
-	padding-right: 5px;
-}
-.edit-all__bulk-actions button {
-	border: 1px solid var(--color-neutral-20);
-}
-button.edit-all__bulk-actions-close {
-	border: none;
-	padding: 4px 8px 4px 10px;
-}
-
-th.edit-all-buttons {
-	text-align: right;
-}
-
-.edit-all__bulk-actions-custom-notifications {
-	padding: 0 10px;
-}
-
-.button-group {
-	margin-top: 6px;
-}
-
-.site-bulk-edit-menu-container {
-	background-color: #fff;
-	text-align: right;
-}
-
-.select-dropdown__item-text {
-	text-align: left;
+	padding-inline-end: 11px;
+	button {
+		border: 1px solid var(--studio-gray-80);
+		padding-inline-end: 10px;
+	}
 }
 
 .edit-all__bulk-actions-close {
-	text-align: right;
+	text-align: end;
 	justify-content: flex-end;
 	float: right;
 }
 
-.site-bulk-edit-menu-container.card {
-	padding: 10px;
+button.edit-all__bulk-actions-close {
+	border: none;
+	padding: 4px 8px 4px 10px;
+	&:hover {
+		background-color: transparent;
+	}
+}
+
+th.edit-all-buttons {
+	text-align: end;
+}
+
+.site-bulk-edit-menu-container {
+	background-color: #fff;
+	text-align: end;
+	&.card {
+		padding: 10px;
+	}
+	& .select-dropdown__container {
+		display: inline-block;
+	}
+}
+
+.button .gridicon {
+	color: var(--color-neutral-80);
+	width: 24px;
+	height: 24px;
+}
+
+.select-dropdown__item-text {
+	text-align: start;
+}
+
+button.button.dashboard-list-header__bulk-action-buttons.is-compact {
+	margin-block-start: 4px;
+}
+
+// Bulk Edit Menu
+.dashboard-list-header {
+	height: 60px;
+	margin-block-start: 8px;
+	.button-group {
+		margin-inline-start: 14px;
+		.button {
+			&:first-child {
+				border-top-left-radius: 4px;
+				border-bottom-left-radius: 4px;
+			}
+			&:last-child {
+				border-top-right-radius: 4px;
+				border-bottom-right-radius: 4px;
+			}
+		}
+	}
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/style.scss
@@ -14,3 +14,14 @@
 		margin-inline-start: 12px;
 	}
 }
+
+.edit-all__bulk-actions {
+	margin: 10px;
+	padding-right: 5px;
+}
+.edit-all__bulk-actions button {
+	border: 1px solid var(--color-neutral-20);
+}
+.edit-all__bulk-actions button .gridicon {
+	border: none;
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/style.scss
@@ -22,48 +22,27 @@
 	.dashboard-bulk-actions {
 		display: flex;
 		justify-content: end;
+
 		.select-dropdown.is-compact {
-			width: 70%;
+			width: 65%;
+
+			@include break-small {
+				width: auto;
+			}
 		}
 	}
+
+	.dashboard-bulk-actions__edit-button {
+		float: right;
+	}
+
 	.site-bulk-select__bulk-select-label {
 		margin-inline-start: 12px;
 	}
-}
 
-.edit-all__bulk-actions {
-	button {
-		border: 1px solid var(--studio-gray-80);
-		padding-inline-end: 10px;
-	}
-}
-
-.edit-all__bulk-actions-close {
-	text-align: end;
-	justify-content: flex-end;
-	float: right;
-}
-
-button.edit-all__bulk-actions-close {
-	border: none;
-	padding: 4px 8px 4px 10px;
-	&:hover {
-		background-color: transparent;
-	}
-}
-
-th.edit-all-buttons {
-	text-align: end;
-}
-
-.site-bulk-edit-menu-container {
-	background-color: #fff;
-	text-align: end;
-	&.card {
-		padding: 10px;
-	}
-	& .select-dropdown__container {
-		display: inline-block;
+	.site-content__bulk-select-label {
+		color: var(--color-neutral-70);
+		font-size: 0.875rem;
 	}
 }
 
@@ -75,33 +54,4 @@ th.edit-all-buttons {
 
 .select-dropdown__item-text {
 	text-align: start;
-}
-
-button.button.dashboard-list-header__bulk-action-buttons.is-compact {
-	margin-block-start: 4px;
-}
-
-button.button.dashboard-list-header__bulk-action-buttons.is-compact:active {
-	background: var(--color-accent-5);
-	border-color: var(--color-accent-40);
-	border-width: 1px;
-}
-// Bulk Edit Menu
-.dashboard-list-header {
-	height: 60px;
-	margin-block-start: 8px;
-	.button-group {
-		margin-inline-start: 14px;
-		.button {
-			&:first-child {
-				border-top-left-radius: 4px;
-				border-bottom-left-radius: 4px;
-			}
-			&:last-child {
-				border-top-right-radius: 4px;
-				border-bottom-right-radius: 4px;
-			}
-			white-space: nowrap;
-		}
-	}
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-select-checkbox/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-select-checkbox/style.scss
@@ -8,5 +8,13 @@
 		inset-block-start: 50%;
 		transform: translateY(-50%);
 		inset-inline-start: 16px;
+
+		@include break-xlarge {
+			inset-inline-start: 8px;
+		}
+
+		@include break-wide {
+			inset-inline-start: 16px;
+		}
 	}
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-set-favorite/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-set-favorite/style.scss
@@ -5,15 +5,18 @@
 	position: absolute;
 	top: 6px;
 	color: var(--studio-gray-20) !important;
-	@include break-large() {
+
+	@include break-xlarge {
 		visibility: hidden;
 		color: var(--color-primary) !important;
 	}
 }
+
 .site-set-favorite__favorite-icon-active {
 	visibility: visible;
 	color: var(--color-primary) !important;
 }
+
 button.button.site-set-favorite__view-favorite {
 	color: var(--studio-white);
 	text-decoration: underline;
@@ -22,6 +25,7 @@ button.button.site-set-favorite__view-favorite {
 	top: 4px;
 	left: 4px;
 	padding: 0;
+
 	&:hover {
 		color: var(--studio-white);
 	}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/index.tsx
@@ -10,6 +10,7 @@ import type { SiteData, SiteColumns } from '../types';
 
 interface Props {
 	isLoading: boolean;
+	isSmallScreen?: boolean;
 	columns: SiteColumns;
 	items: Array< SiteData >;
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/index.tsx
@@ -1,8 +1,10 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { Icon, starFilled } from '@wordpress/icons';
 import classNames from 'classnames';
 import { useContext } from 'react';
 import TextPlaceholder from 'calypso/jetpack-cloud/sections/partner-portal/text-placeholder';
 import './style.scss';
+import EditButton from '../../dashboard-bulk-actions/edit-button';
 import SitesOverviewContext from '../context';
 import SiteBulkSelect from '../site-bulk-select';
 import SiteTableRow from '../site-table-row';
@@ -10,7 +12,6 @@ import type { SiteData, SiteColumns } from '../types';
 
 interface Props {
 	isLoading: boolean;
-	isSmallScreen?: boolean;
 	columns: SiteColumns;
 	items: Array< SiteData >;
 }
@@ -39,7 +40,15 @@ export default function SiteTable( { isLoading, columns, items }: Props ) {
 									</span>
 								</th>
 							) ) }
-							<th></th>
+							{ isEnabled( 'jetpack/partner-portal-downtime-monitoring-updates' ) ? (
+								<th>
+									<div className="plugin-common-table__bulk-actions">
+										<EditButton sites={ items } />
+									</div>
+								</th>
+							) : (
+								<th></th>
+							) }
 						</>
 					) }
 				</tr>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/style.scss
@@ -27,11 +27,11 @@
 			position: relative;
 			width: initial;
 
-			@include break-large() {
+			@include break-xlarge {
 				max-width: 200px;
 			}
 
-			@include break-huge() {
+			@include break-huge {
 				max-width: 300px;
 			}
 		}
@@ -53,11 +53,11 @@
 		border-collapse: collapse;
 		vertical-align: middle;
 
-		@include break-large() {
+		@include break-xlarge {
 			padding: 0 8px;
 		}
 
-		@include break-wide() {
+		@include break-wide {
 			padding: 0 16px;
 		}
 	}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
@@ -12,14 +12,14 @@
 	// The -123px is to undo the padding of .layout__content (79px + 32px) and .sites-overview_container ( 8px + 8px )
 	min-height: calc(100vh - 123px);
 	padding: 16px 0;
-	@include break-large() {
+	@include break-xlarge {
 		padding: 6px 0;
 	}
 }
 .sites-overview__content-wrapper {
 	max-width: 1500px;
 	margin: auto;
-	@include break-large() {
+	@include break-xlarge {
 		padding: 0;
 	}
 }
@@ -161,7 +161,7 @@
 		margin-inline-end: 5px;
 		font-size: 1rem !important;
 	}
-	@include break-large() {
+	@include break-xlarge {
 		width: calc(100% - 55px);
 		margin-inline-start: 55px;
 		font-size: 0.875rem !important;
@@ -175,7 +175,7 @@
 	background: linear-gradient(to right, rgba(255, 255, 255, 0.8) 30%, rgba(255, 255, 255, 1) 100%);
 	inset-block-start: 0;
 	inset-inline-end: 75px;
-	@include break-large() {
+	@include break-xlarge {
 		inset-inline-end: 0;
 	}
 }
@@ -188,7 +188,7 @@
 	display: flex;
 	align-items: center;
 	height: 40px;
-	@include break-large() {
+	@include break-xlarge {
 		margin: 8px;
 	}
 }
@@ -200,7 +200,7 @@
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	@include break-large() {
+	@include break-xlarge {
 		width: auto;
 	}
 }
@@ -212,13 +212,13 @@
 }
 .sites-overview__error-message-large-screen {
 	display: none;
-	@include break-large() {
+	@include break-xlarge {
 		display: inline-block;
 	}
 }
 .sites-overview__error-message-small-screen {
 	display: inline-block;
-	@include break-large() {
+	@include break-xlarge {
 		display: none;
 	}
 }
@@ -235,7 +235,7 @@
 	overflow: hidden;
 	text-overflow: ellipsis;
 	vertical-align: middle;
-	@include break-large() {
+	@include break-xlarge {
 		max-width: 70px;
 	}
 	@include break-wide() {
@@ -263,7 +263,7 @@
 	inset-block-start: 50%;
 	transform: translateY(-50%);
 	display: inline-flex;
-	@include break-xlarge() {
+	@include break-xlarge {
 		display: none;
 	}
 }
@@ -281,7 +281,7 @@
 	font-size: 0.75rem;
 	line-height: 20px;
 	box-sizing: border-box;
-	@include break-xlarge() {
+	@include break-xlarge {
 		display: none;
 	}
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
@@ -263,7 +263,7 @@
 	inset-block-start: 50%;
 	transform: translateY(-50%);
 	display: inline-flex;
-	@include break-large() {
+	@include break-xlarge() {
 		display: none;
 	}
 }
@@ -281,7 +281,7 @@
 	font-size: 0.75rem;
 	line-height: 20px;
 	box-sizing: border-box;
-	@include break-large() {
+	@include break-xlarge() {
 		display: none;
 	}
 }


### PR DESCRIPTION
#### Proposed Changes

This PR implements a bulk edit menu for large and small screen views.

#### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout add/jetpack-dashboard-downtime-monitoring-bulk-action-menu` and `yarn start-jetpack-cloud`
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Verify that you can now see the `Edit All` button. Clicking the button should toggle the bulk action menu, and all the actions should work as expected.

<img width="1566" alt="Screenshot 2023-01-17 at 12 25 11 PM" src="https://user-images.githubusercontent.com/10586875/212830451-5bd9f673-f189-4e56-bedb-6c71a04a4618.png">

<img width="1585" alt="Screenshot 2023-01-17 at 12 25 03 PM" src="https://user-images.githubusercontent.com/10586875/212830490-33ad2ec2-a0cf-4072-92b0-58a4770c22d0.png">

https://user-images.githubusercontent.com/10586875/212829910-06694891-d6f7-4647-9d5b-9f038c27dddd.mov

4. Switch the small screen view using the dev tool and verify step 3 works as expected.

<img width="368" alt="Screenshot 2023-01-17 at 12 26 42 PM" src="https://user-images.githubusercontent.com/10586875/212830530-0b3bd9f5-3381-4ca7-b68e-1a02e99805ea.png">

<img width="359" alt="Screenshot 2023-01-17 at 12 26 54 PM" src="https://user-images.githubusercontent.com/10586875/212830539-aed529e0-db9c-4c9e-afd1-2d7f1d1260e2.png">

<img width="368" alt="Screenshot 2023-01-17 at 12 26 58 PM" src="https://user-images.githubusercontent.com/10586875/212830542-7f82bd5d-df11-4cbd-9b27-43105ca47fb6.png">

https://user-images.githubusercontent.com/10586875/212830229-890e925a-cda7-42cf-83ff-83ca39f86e8a.mov

5. Set the feature flag `jetpack/partner-portal-downtime-monitoring-updates` to false and verify it works as in production.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1203448324265423-as-1203507036638751