### PR TITLE
Tailored Flows: Fix flows CTA focus style

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/setup-form/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/setup-form/index.tsx
@@ -114,7 +114,7 @@ const SetupForm = ( {
 				/>
 			</FormFieldset>
 			{ children }
-			<Button className="setup-form__submit" disabled={ isLoading } primary type="submit">
+			<Button className="setup-form__submit" disabled={ isLoading } type="submit">
 				{ isLoading ? __( 'Loading' ) : __( 'Continue' ) }
 			</Button>
 			{ isSubmitError && (

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/setup-form/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/setup-form/style.scss
@@ -88,6 +88,7 @@
 			box-shadow: none;
 			outline: 2px solid var(--studio-blue-60);
 			outline-offset: 1px;
+			background: var(--studio-blue-60);
 		}
 		&:hover:not([disabled]) {
 			background-color: var(--wp-admin-theme-color-darker-10);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/setup-form/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/setup-form/style.scss
@@ -84,7 +84,11 @@
 		// adds +2 px of padding to the button to match the input field height
 		padding: 10px 14px;
 		margin-top: 16px;
-
+		&:focus {
+			box-shadow: none;
+			outline: 2px solid var(--studio-blue-60);
+			outline-offset: 1px;
+		}
 		&:hover:not([disabled]) {
 			background-color: var(--wp-admin-theme-color-darker-10);
 		}


### PR DESCRIPTION
#### Proposed Changes


The current CTA focus style is pink and the it does not match the design
More context p1671610248894319-slack-C02NQ4HMJKV

#### Testing Instructions

- Pull this branch or use calypso live link
- Go to LIB or NL and advance to the setup step
- Navigate using tab key until the button
- Should look like the image with a blue outline
<img width="706" alt="image" src="https://user-images.githubusercontent.com/2653810/208955951-05efafb1-bd27-4d59-8874-c2b3282f988e.png">



Wrong focus state:
<img width="528" alt="image" src="https://user-images.githubusercontent.com/2653810/208956173-3e681eb1-1453-4add-9ba3-199634dc2da8.png">