### PR TITLE
Add/ Email stats endpoint function

### DIFF
--- a/packages/wpcom.js/src/lib/site.js
+++ b/packages/wpcom.js/src/lib/site.js
@@ -385,6 +385,21 @@ class Site {
 	}
 
 	/**
+	 * Get detailed stats about a specific email
+	 *
+	 * @param {string} postId - id of the post which email we are querying
+	 * @param {object} [query] - query object parameter
+	 * @param {Function} fn - callback function
+	 * @returns {Function} request handler
+	 */
+	statsEmailOpens( postId, query, fn ) {
+		const path = `${ this.path }/stats/opens/emails/${ postId }`;
+		query.stats_fields = 'timeline'; // Possible values: timeline,client,country,device
+
+		return this.wpcom.req.get( path, query, fn );
+	}
+
+	/**
 	 * Return a `SiteWordAds` instance.
 	 *
 	 * Example:*


### PR DESCRIPTION
#### Proposed Changes

This PR adds the function that will be called by the Redux actions to retrieve the Email stats for the specified post id. The parameter `query` can have the shape `{ period, date, quantity }` where `period` is the unit of each element of the retrieved array (like `year`, `month` and such), `date` is the date from which we want to retrieve the data, and `quantity` is the number of elements described in `period` we want to retrieve. For example, if we set `period` to `days` and `quantity` to `10` we will retrieve 10 days worth of data.

#### Testing Instructions

1. Checkout this branch into your local repository and start the application
2. Load the calypso.localhost:3000 url on a browser
3. Open the console of the browser and check the function like this (you can change all parameters and check the different results):
```js
const site = wpcom.site();
site.path='/sites/<site_id>';
site.statsEmailOpens(<post_id>, {period: 'month', date: '2022-11-23T18:00:00', quantity: 6}).then(value => console.log(value));
```

The resulting object should have this shape:
<img width="506" alt="Screenshot 2022-12-21 at 19 36 48" src="https://user-images.githubusercontent.com/3832570/208979066-9e6bb966-869d-4a55-9fc1-669bebbb7447.png">
