### PR TITLE
Free Flow: Add blog title to free flow createSiteWithCart()

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
@@ -24,11 +24,14 @@ import './styles.scss';
 const SiteCreationStep: Step = function SiteCreationStep( { navigation, flow } ) {
 	const { submit } = navigation;
 
-	const { domainCartItem, planCartItem, siteAccentColor } = useSelect( ( select ) => ( {
-		domainCartItem: select( ONBOARD_STORE ).getDomainCartItem(),
-		siteAccentColor: select( ONBOARD_STORE ).getSelectedSiteAccentColor(),
-		planCartItem: select( ONBOARD_STORE ).getPlanCartItem(),
-	} ) );
+	const { domainCartItem, planCartItem, siteAccentColor, getSelectedSiteTitle } = useSelect(
+		( select ) => ( {
+			domainCartItem: select( ONBOARD_STORE ).getDomainCartItem(),
+			siteAccentColor: select( ONBOARD_STORE ).getSelectedSiteAccentColor(),
+			planCartItem: select( ONBOARD_STORE ).getPlanCartItem(),
+			getSelectedSiteTitle: select( ONBOARD_STORE ).getSelectedSiteTitle(),
+		} )
+	);
 
 	const username = useSelector( ( state ) => getCurrentUserName( state ) );
 
@@ -57,6 +60,7 @@ const SiteCreationStep: Step = function SiteCreationStep( { navigation, flow } )
 	const isManageSiteFlow = Boolean(
 		wasSignupCheckoutPageUnloaded() && signupDestinationCookieExists && isReEnteringFlow
 	);
+	const blogTitle = isFreeFlow( 'free' ) ? getSelectedSiteTitle : '';
 
 	async function createSite() {
 		if ( isManageSiteFlow ) {
@@ -72,7 +76,7 @@ const SiteCreationStep: Step = function SiteCreationStep( { navigation, flow } )
 			isPaidDomainItem,
 			theme,
 			siteVisibility,
-			'',
+			blogTitle,
 			siteAccentColor,
 			true,
 			username,


### PR DESCRIPTION
#### Proposed Changes

* Pass site title (blog title) to `createSiteWithCart()` function for free flow step creation step.
This PR requires backend diff: D96193-code 

#### Testing Instructions

1. Check out this PR
2. Setup backend diff: D96193-code
3. Go through the free flow (`/setup/free`).

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #