### PR TITLE
Tailored Ecommerce: Make storeProfiler form labels consistent with newsletter

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -169,6 +169,7 @@ button {
 	}
 }
 
+.store-profiler__form,
 .newsletter,
 .link-in-bio,
 .link-in-bio-tld,
@@ -235,6 +236,7 @@ button {
 		label {
 			font-size: $font-body;
 			color: var(--studio-gray-60);
+			font-weight: 400;
 		}
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/store-profiler/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/store-profiler/style.scss
@@ -1,3 +1,5 @@
+@import "../../global";
+
 .store-profiler {
 	.step-container {
 		padding: 20px;


### PR DESCRIPTION
#### Proposed Changes

As part of the UI cleanup in #71244, we've made the storeProfiler step form labels consistent with the Newsletter flow forms.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Visit `/setup/ecommerce/storeProfiler` and verify the form labels look correct.

**Before**
![image](https://user-images.githubusercontent.com/917632/209010048-8c9ee61e-30a1-407d-8869-755ddada0139.png)

**After**
![image](https://user-images.githubusercontent.com/917632/209010095-c6fd6c6d-69bc-4a70-82bf-128b8f6ad86c.png)


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [NA] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [NA] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [NA] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [NA] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [NA] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #71244
