### PR TITLE
Odyssey Stats: optimize bundle size

### DIFF
--- a/apps/odyssey-stats/webpack.config.js
+++ b/apps/odyssey-stats/webpack.config.js
@@ -110,7 +110,25 @@ module.exports = {
 			useDefaults: false,
 			requestToHandle: defaultRequestToHandle,
 			requestToExternal: ( request ) => {
-				if ( request === '@wordpress/react-i18n' || request === 'moment' ) {
+				if (
+					! [
+						'lodash',
+						'lodash-es',
+						'react',
+						'react-dom',
+						'@wordpress/api-fetch',
+						'@wordpress/components',
+						'@wordpress/compose',
+						'@wordpress/element',
+						'@wordpress/html-entities',
+						'@wordpress/i18n',
+						'@wordpress/is-shallow-equal',
+						'@wordpress/polyfill',
+						'@wordpress/primitives',
+						'@wordpress/url',
+						'@wordpress/warning',
+					].includes( request )
+				) {
 					return;
 				}
 				return defaultRequestToExternal( request );

--- a/apps/odyssey-stats/webpack.config.js
+++ b/apps/odyssey-stats/webpack.config.js
@@ -110,7 +110,7 @@ module.exports = {
 			useDefaults: false,
 			requestToHandle: defaultRequestToHandle,
 			requestToExternal: ( request ) => {
-				if ( request !== 'react' && request !== 'react-dom' ) {
+				if ( request === '@wordpress/react-i18n' || request === 'moment' ) {
 					return;
 				}
 				return defaultRequestToExternal( request );
@@ -125,7 +125,7 @@ module.exports = {
 		),
 		new webpack.IgnorePlugin( { resourceRegExp: /^\.\/locale$/, contextRegExp: /moment$/ } ),
 		new ExtensiveLodashReplacementPlugin(),
-		new InlineConstantExportsPlugin( /\/client\/state\/action-types.js$/ ),
+		new InlineConstantExportsPlugin( /\/client\/state\/action-types.[tj]s$/ ),
 		new webpack.NormalModuleReplacementPlugin( /^path$/, 'path-browserify' ),
 		// Repalce the `packages/components/src/gridicon/index.tsx` with a replacement that does not enqueue the SVG sprite.
 		// The sprite is loaded separately in Jetpack.

--- a/apps/odyssey-stats/webpack.config.js
+++ b/apps/odyssey-stats/webpack.config.js
@@ -126,6 +126,7 @@ module.exports = {
 		new webpack.IgnorePlugin( { resourceRegExp: /^\.\/locale$/, contextRegExp: /moment$/ } ),
 		new ExtensiveLodashReplacementPlugin(),
 		new InlineConstantExportsPlugin( /\/client\/state\/action-types.[tj]s$/ ),
+		new InlineConstantExportsPlugin( /\/client\/state\/themes\/action-types.[tj]s$/ ),
 		new webpack.NormalModuleReplacementPlugin( /^path$/, 'path-browserify' ),
 		// Repalce the `packages/components/src/gridicon/index.tsx` with a replacement that does not enqueue the SVG sprite.
 		// The sprite is loaded separately in Jetpack.


### PR DESCRIPTION
#### Proposed Changes

- Request WP built in lib except for `@wordpress/react-i18n` and `moment` <- we use a fixed list here, as we don't want surprises
- Fixed broken `action-types` inline plugin setup
- Inline `client/state/themes/action-types.js`

The approaches reduces the size of `build.min.js` for about `200 KB` to about `1.01 MB`. The stats bundle on WordPress.com is about `1.07 MB`, so we are about at the limit now unless we perform some significant refactoring.

#### Testing Instructions

* Ensure the build succeeds
* Follow instructions in https://github.com/Automattic/jetpack/pull/28065

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
