### PR TITLE
Update and validate PA metrics

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -2,7 +2,7 @@ import { isEnabled } from '@automattic/calypso-config';
 import { StepContainer } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
-import { map, uniqBy } from 'lodash';
+import { uniqBy } from 'lodash';
 import { useState, useRef, useEffect } from 'react';
 import { useDispatch as useReduxDispatch } from 'react-redux';
 import AsyncLoad from 'calypso/components/async-load';
@@ -225,12 +225,10 @@ const PatternAssembler: Step = ( { navigation } ) => {
 					onSelect={ onSelect }
 					onBack={ () => {
 						const uniquePatterns = uniqBy( getPatterns( showPatternSelectorType ), 'id' );
-						const pattern_ids = map( uniquePatterns, 'id' );
-						const pattern_names = map( uniquePatterns, 'name' );
 						recordTracksEvent( 'calypso_signup_pattern_assembler_pattern_select_done_click', {
 							pattern_type: showPatternSelectorType,
-							pattern_id: pattern_ids.length ? pattern_ids.join( ',' ) : null,
-							pattern_name: pattern_names.length ? pattern_names.join( ',' ) : null,
+							pattern_ids: uniquePatterns.map( ( { id } ) => id ).join( ',' ),
+							pattern_names: uniquePatterns.map( ( { name } ) => name ).join( ',' ),
 						} );
 
 						setShowPatternSelectorType( null );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -1,8 +1,8 @@
 import { isEnabled } from '@automattic/calypso-config';
+import { uniqueBy } from '@automattic/js-utils';
 import { StepContainer } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
-import { uniqBy } from 'lodash';
 import { useState, useRef, useEffect } from 'react';
 import { useDispatch as useReduxDispatch } from 'react-redux';
 import AsyncLoad from 'calypso/components/async-load';
@@ -88,6 +88,9 @@ const PatternAssembler: Step = ( { navigation } ) => {
 	const trackEventContinue = () => {
 		const patterns = getPatterns();
 		recordTracksEvent( 'calypso_signup_pattern_assembler_continue_click', {
+			pattern_types: [ header && 'header', sections.length && 'section', footer && 'footer' ]
+				.filter( Boolean )
+				.join( ',' ),
 			pattern_ids: patterns.map( ( { id } ) => id ).join( ',' ),
 			pattern_names: patterns.map( ( { name } ) => name ).join( ',' ),
 			pattern_count: patterns.length,
@@ -223,12 +226,22 @@ const PatternAssembler: Step = ( { navigation } ) => {
 				<PatternSelectorLoader
 					showPatternSelectorType={ showPatternSelectorType }
 					onSelect={ onSelect }
-					onBack={ () => {
-						const uniquePatterns = uniqBy( getPatterns( showPatternSelectorType ), 'id' );
+					onDoneClick={ () => {
+						const uniquePatterns = uniqueBy(
+							getPatterns( showPatternSelectorType ),
+							( a, b ) => a.id === b.id
+						);
 						recordTracksEvent( 'calypso_signup_pattern_assembler_pattern_select_done_click', {
 							pattern_type: showPatternSelectorType,
 							pattern_ids: uniquePatterns.map( ( { id } ) => id ).join( ',' ),
 							pattern_names: uniquePatterns.map( ( { name } ) => name ).join( ',' ),
+						} );
+
+						setShowPatternSelectorType( null );
+					} }
+					onBack={ () => {
+						recordTracksEvent( 'calypso_signup_pattern_assembler_pattern_select_back_click', {
+							pattern_type: showPatternSelectorType,
 						} );
 
 						setShowPatternSelectorType( null );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -58,13 +58,16 @@ const PatternAssembler: Step = ( { navigation } ) => {
 	const trackEventPatternSelect = ( {
 		patternType,
 		patternId,
+		patternName,
 	}: {
 		patternType: string;
 		patternId: number;
+		patternName: string;
 	} ) => {
 		recordTracksEvent( 'calypso_signup_pattern_assembler_pattern_select_click', {
 			pattern_type: patternType,
 			pattern_id: patternId,
+			pattern_name: patternName,
 		} );
 	};
 
@@ -157,6 +160,7 @@ const PatternAssembler: Step = ( { navigation } ) => {
 			trackEventPatternSelect( {
 				patternType: showPatternSelectorType,
 				patternId: selectedPattern.id,
+				patternName: selectedPattern.name,
 			} );
 		}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -1,5 +1,4 @@
 import { isEnabled } from '@automattic/calypso-config';
-import { uniqueBy } from '@automattic/js-utils';
 import { StepContainer } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
@@ -227,14 +226,11 @@ const PatternAssembler: Step = ( { navigation } ) => {
 					showPatternSelectorType={ showPatternSelectorType }
 					onSelect={ onSelect }
 					onDoneClick={ () => {
-						const uniquePatterns = uniqueBy(
-							getPatterns( showPatternSelectorType ),
-							( a, b ) => a.id === b.id
-						);
+						const patterns = getPatterns( showPatternSelectorType );
 						recordTracksEvent( 'calypso_signup_pattern_assembler_pattern_select_done_click', {
 							pattern_type: showPatternSelectorType,
-							pattern_ids: uniquePatterns.map( ( { id } ) => id ).join( ',' ),
-							pattern_names: uniquePatterns.map( ( { name } ) => name ).join( ',' ),
+							pattern_ids: patterns.map( ( { id } ) => id ).join( ',' ),
+							pattern_names: patterns.map( ( { name } ) => name ).join( ',' ),
 						} );
 
 						setShowPatternSelectorType( null );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-selector-loader.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-selector-loader.tsx
@@ -8,12 +8,14 @@ type PatternSelectorLoaderProps = {
 	selectedPattern: Pattern | null;
 	onSelect: ( selectedPattern: Pattern ) => void;
 	onBack: () => void;
+	onDoneClick: () => void;
 };
 
 const PatternSelectorLoader = ( {
 	showPatternSelectorType,
 	onSelect,
 	onBack,
+	onDoneClick,
 	selectedPattern,
 }: PatternSelectorLoaderProps ) => {
 	const translate = useTranslate();
@@ -28,6 +30,7 @@ const PatternSelectorLoader = ( {
 				patterns={ headerPatterns }
 				onSelect={ onSelect }
 				onBack={ onBack }
+				onDoneClick={ onDoneClick }
 				title={ translate( 'Add a header' ) }
 				selectedPattern={ selectedPattern }
 			/>
@@ -36,6 +39,7 @@ const PatternSelectorLoader = ( {
 				patterns={ footerPatterns }
 				onSelect={ onSelect }
 				onBack={ onBack }
+				onDoneClick={ onDoneClick }
 				title={ translate( 'Add a footer' ) }
 				selectedPattern={ selectedPattern }
 			/>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-selector-loader.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-selector-loader.tsx
@@ -48,6 +48,7 @@ const PatternSelectorLoader = ( {
 				patterns={ sectionPatterns }
 				onSelect={ onSelect }
 				onBack={ onBack }
+				onDoneClick={ onDoneClick }
 				title={ selectedPattern ? translate( 'Replace section' ) : translate( 'Add sections' ) }
 				selectedPattern={ selectedPattern }
 			/>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-selector.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-selector.tsx
@@ -12,6 +12,7 @@ type PatternSelectorProps = {
 	patterns: Pattern[];
 	onSelect: ( selectedPattern: Pattern ) => void;
 	onBack: () => void;
+	onDoneClick: () => void;
 	title: string | null;
 	show: boolean;
 	selectedPattern: Pattern | null;
@@ -21,6 +22,7 @@ const PatternSelector = ( {
 	patterns,
 	onSelect,
 	onBack,
+	onDoneClick,
 	title,
 	show,
 	selectedPattern,
@@ -72,7 +74,7 @@ const PatternSelector = ( {
 				</div>
 			</div>
 			<div className="pattern-selector__footer">
-				<Button className="pattern-assembler__button" onClick={ onBack } primary>
+				<Button className="pattern-assembler__button" onClick={ onDoneClick } primary>
 					{ translate( 'Done' ) }
 				</Button>
 			</div>


### PR DESCRIPTION
## Proposed Changes

* Update and validate PA metrics according to this convo p1671660133331369/1671621979.904449-slack-CRWCHQGUB

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

## Set up.
Open your dev tools, go to the Network tab, and clear all entries so you can monitor new network activity.
In the search/filter box on the network tab, type t.gif. This will filter network activity so you can see events.
When making some actions, click on the request and navigate to Payload tab to check all the event parameters

## Expected
Head to the Onboarding pattern assembler step from Goals screen
Follow the event description below and confirm the event record is correct
* [calypso_signup_pattern_assembler_pattern_select_click](https://github.com/Automattic/wp-calypso/pull/71445#issuecomment-1362563079) 
* [calypso_signup_pattern_assembler_pattern_select_done_click](https://github.com/Automattic/wp-calypso/pull/71445#issuecomment-1362583991)
* [calypso_signup_pattern_assembler_pattern_select_back_click](https://github.com/Automattic/wp-calypso/pull/71445#issuecomment-1363581149)
* [calypso_signup_pattern_assembler_pattern_final_select](https://github.com/Automattic/wp-calypso/pull/71445#issuecomment-1362603051)
* [calypso_signup_pattern_assembler_continue_click](https://github.com/Automattic/wp-calypso/pull/71445#issuecomment-1362603051)
#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to [#1408](https://github.com/Automattic/dotcom-forge/issues/1408)