### PR TITLE
Purchases: Fix chat button position on remove domain dialog

### DIFF
--- a/client/components/marketing-survey/cancel-purchase-form/precancellation-chat-button/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/precancellation-chat-button/index.jsx
@@ -1,4 +1,5 @@
 import { isDomainRegistration, isPlan } from '@automattic/calypso-products';
+import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
@@ -18,6 +19,7 @@ class PrecancellationChatButton extends Component {
 		onClick: PropTypes.func.isRequired,
 		translate: PropTypes.func.isRequired,
 		atBottom: PropTypes.bool,
+		className: PropTypes.string,
 	};
 
 	static defaultProps = {
@@ -39,7 +41,7 @@ class PrecancellationChatButton extends Component {
 	};
 
 	render() {
-		const { isAvailable, icon, translate, atBottom } = this.props;
+		const { isAvailable, icon, translate, atBottom, className } = this.props;
 
 		if ( ! isAvailable ) {
 			return null;
@@ -47,7 +49,9 @@ class PrecancellationChatButton extends Component {
 
 		return (
 			<HappychatButton
-				className={ `precancellation-chat-button__main-button ${ atBottom && 'at-bottom' }` }
+				className={ classNames( 'precancellation-chat-button__main-button', className, {
+					'at-bottom': atBottom,
+				} ) }
 				onClick={ this.handleClick }
 			>
 				{ icon && <MaterialIcon icon={ icon } /> }

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -197,6 +197,7 @@ class RemovePurchase extends Component {
 		<PrecancellationChatButton
 			onClick={ this.onClickChatButton }
 			purchase={ this.props.purchase }
+			className="remove-domain-dialog__chat-button"
 		/>
 	);
 

--- a/client/me/purchases/remove-purchase/style.scss
+++ b/client/me/purchases/remove-purchase/style.scss
@@ -33,3 +33,14 @@
 		margin: 16px auto;
 	}
 }
+
+.dialog__action-buttons {
+	.remove-domain-dialog__chat-button.precancellation-chat-button__main-button.button {
+		display: block;
+		float: left;
+		font-size: 0.875rem;
+		margin-left: 0;
+		position: initial;
+		transform: none;
+	}
+}


### PR DESCRIPTION
#### Proposed Changes

There was a regression introduced in #69482, which caused the pre-cancellation chat button to draw over the action buttons on the remove domain dialog. See #70639 for more details.

The changes introduced in #69482 are too big to revert, so this PR adds an extra CSS rule only for this button to restore it to it's former position.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /me/purchases and select a domain purchase.
* Click on the "Remove Domain" button.
* Confirm that the chat button is shown separately on the left side.
* Confirm that the button displays correctly on mobile/tablet screens. There are a few other issues which on mobile screens which I have described in #71447.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #70639