### PR TITLE
ETK Global styles: switch to Google fonts api v1 instead of v2

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/global-styles/class-global-styles.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/global-styles/class-global-styles.php
@@ -83,7 +83,7 @@ class Global_Styles {
 	 *
 	 * @var string
 	 */
-	private $root_url = 'https://fonts.googleapis.com/css2';
+	private $root_url = 'https://fonts.googleapis.com/css';
 
 	const VERSION = '2003121439';
 


### PR DESCRIPTION
#### Proposed Changes

* Use Google Fonts API v1 instead of V2, as introduced in https://github.com/Automattic/wp-calypso/pull/71398 where I copypasted the API from another [identical implementation in Jetpack](https://github.com/Automattic/jetpack/blob/b313bd253afdf919adf7a71a866d0ab85b3a7bda/projects/packages/google-fonts-provider/src/class-google-fonts-provider.php#L31).

This was a bit confusing because all fonts work just fine; maybe because they've loaded before and are in browser's cache?

<img width="955" alt="image" src="https://user-images.githubusercontent.com/87168/209104267-b73e70e3-2dde-443c-88ab-3a2cfc1170fe.png">


Individual fonts seemed to load just fine but this one query failed: `https://fonts.googleapis.com/css2?family=Arvo:thin,extralight,light,regular,medium,semibold,bold,italic,bolditalic,extrabold,black|Bodoni Moda:thin,extralight,light,regular,medium,semibold,bold,italic,bolditalic,extrabold,black|Cabin:thin,extralight,light,regular,medium,semibold,bold,italic,bolditalic,extrabold,black|Chivo:thin,extralight,light,regular,medium,semibold,bold,italic,bolditalic,extrabold,black|Courier Prime:thin,extralight,light,regular,medium,semibold,bold,italic,bolditalic,extrabold,black|DM Sans:thin,extralight,light,regular,medium,semibold,bold,italic,bolditalic,extrabold,black|Domine:thin,extralight,light,regular,medium,semibold,bold,italic,bolditalic,extrabold,black|EB Garamond:thin,extralight,light,regular,medium,semibold,bold,italic,bolditalic,extrabold,black|Fira Sans:thin,extralight,light,regular,medium,semibold,bold,italic,bolditalic,extrabold,black|Inter:thin,extralight,light,regular,medium,semibold,bold,italic,bolditalic,extrabold,black|Josefin Sans:thin,extralight,light,regular,medium,semibold,bold,italic,bolditalic,extrabold,black|Libre Baskerville:thin,extralight,light,regular,medium,semibold,bold,italic,bolditalic,extrabold,black|Libre Franklin:thin,extralight,light,regular,medium,semibold,bold,italic,bolditalic,extrabold,black|Lora:thin,extralight,light,regular,medium,semibold,bold,italic,bolditalic,extrabold,black|Merriweather:thin,extralight,light,regular,medium,semibold,bold,italic,bolditalic,extrabold,black|Montserrat:thin,extralight,light,regular,medium,semibold,bold,italic,bolditalic,extrabold,black|Nunito:thin,extralight,light,regular,medium,semibold,bold,italic,bolditalic,extrabold,black|Open Sans:thin,extralight,light,regular,medium,semibold,bold,italic,bolditalic,extrabold,black|Overpass:thin,extralight,light,regular,medium,semibold,bold,italic,bolditalic,extrabold,black|Playfair Display:thin,extralight,light,regular,medium,semibold,bold,italic,bolditalic,extrabold,black|Poppins:thin,extralight,light,regular,medium,semibold,bold,italic,bolditalic,extrabold,black|Raleway:thin,extralight,light,regular,medium,semibold,bold,italic,bolditalic,extrabold,black|Roboto:thin,extralight,light,regular,medium,semibold,bold,italic,bolditalic,extrabold,black|Roboto Slab:thin,extralight,light,regular,medium,semibold,bold,italic,bolditalic,extrabold,black|Rubik:thin,extralight,light,regular,medium,semibold,bold,italic,bolditalic,extrabold,black|Source Sans Pro:thin,extralight,light,regular,medium,semibold,bold,italic,bolditalic,extrabold,black|Source Serif Pro:thin,extralight,light,regular,medium,semibold,bold,italic,bolditalic,extrabold,black|Space Mono:thin,extralight,light,regular,medium,semibold,bold,italic,bolditalic,extrabold,black|Work Sans:thin,extralight,light,regular,medium,semibold,bold,italic,bolditalic,extrabold,black|`

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
