### PR TITLE
Design Preview: Fix border-radius with overflow hidden issue on safari

### DIFF
--- a/packages/components/src/device-switcher/device-switcher.scss
+++ b/packages/components/src/device-switcher/device-switcher.scss
@@ -22,6 +22,9 @@
 	transition: max-width 0.2s ease-out, max-height 0.2s ease-out;
 	max-width: 100%;
 	max-height: 100%;
+	// Create a new stacking context to fix border-radius with overflow hidden issue on safari
+	// See https://github.com/Automattic/wp-calypso/issues/71440
+	isolation: isolate;
 
 	.device-switcher__container--frame-bordered & {
 		$frame-border-width: 10px;


### PR DESCRIPTION
#### Proposed Changes

* The border radius with overflow hidden doesn't work on safari. A possible solution is to create a new painting layer, e.g: `transform: translateZ(0)` or `isolation: isolate`, so this PR adds the latter css.

| Before | After | 
| - | - |
| ![image](https://user-images.githubusercontent.com/13596067/209117480-3d7a3ae7-ab2d-4734-ad59-de5c04435a50.png) | ![image](https://user-images.githubusercontent.com/13596067/209117383-b572b99c-a5ad-49d0-b765-9258e37200a7.png) |

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup?siteSlug=<your_site>` via safari
* Click the "Continue" button until you land on the Design Picker step
* Preview any theme with style variation
* Verify the border radius is fixed on safari

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/71440
