### PR TITLE
Plugin Details: Update the Premium version USP link font-size

### DIFF
--- a/client/my-sites/plugins/plugin-details-sidebar-usp/index.jsx
+++ b/client/my-sites/plugins/plugin-details-sidebar-usp/index.jsx
@@ -58,6 +58,10 @@ const Description = styled.div`
 	font-size: 14px;
 `;
 
+const Link = styled( ExternalLink )`
+	font-size: 14px;
+`;
+
 const PluginDetailsSidebarUSP = ( {
 	id,
 	title,
@@ -95,9 +99,9 @@ const PluginDetailsSidebarUSP = ( {
 				links.map( ( link, idx ) => {
 					return (
 						<Fragment key={ idx }>
-							<ExternalLink icon href={ link.href }>
+							<Link icon href={ link.href }>
 								{ link.label }
-							</ExternalLink>
+							</Link>
 							<br />
 						</Fragment>
 					);


### PR DESCRIPTION
#### Proposed Changes

Update the Premium version USP link font-size.

| Before  | After |
| ------------- | ------------- |
|<img width="397" alt="Screen Shot 2022-12-21 at 12 47 34" src="https://user-images.githubusercontent.com/5039531/209129239-fbc9a718-28d0-46bb-9f2c-fdf2848c3911.png">|<img width="397" alt="Screen Shot 2022-12-21 at 12 47 47" src="https://user-images.githubusercontent.com/5039531/209129282-9c5925fc-d717-41b8-a7b2-88dbfc9c9142.png">|


#### Testing Instructions
* Go to a plugin details page enabling the `plugins/premium-version-available` feature flag. Ex: `/plugins/mailpoet?flags=plugins/premium-version-available`
* Check if the font-size of the link is `14px` similar to the image above

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
