### PR TITLE
Pattern assembler: Fire submission events with new intent

### DIFF
--- a/client/landing/stepper/declarative-flow/import-flow.ts
+++ b/client/landing/stepper/declarative-flow/import-flow.ts
@@ -1,6 +1,6 @@
+import { SiteIntent } from '@automattic/data-stores/src/onboard';
 import { IMPORT_FOCUSED_FLOW } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { SiteIntent } from 'calypso/../packages/data-stores/src/onboard';
 import { ImporterMainPlatform } from 'calypso/blocks/import/types';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { useSiteSlugParam } from 'calypso/landing/stepper/hooks/use-site-slug-param';

--- a/client/landing/stepper/declarative-flow/import-flow.ts
+++ b/client/landing/stepper/declarative-flow/import-flow.ts
@@ -1,8 +1,6 @@
-import { isEnabled } from '@automattic/calypso-config';
-import { Design, isBlankCanvasDesign } from '@automattic/design-picker';
 import { IMPORT_FOCUSED_FLOW } from '@automattic/onboarding';
-import { useViewportMatch } from '@wordpress/compose';
 import { useDispatch, useSelect } from '@wordpress/data';
+import { SiteIntent } from 'calypso/../packages/data-stores/src/onboard';
 import { ImporterMainPlatform } from 'calypso/blocks/import/types';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { useSiteSlugParam } from 'calypso/landing/stepper/hooks/use-site-slug-param';
@@ -50,9 +48,8 @@ const importFlow: Flow = {
 		const { setStepProgress } = useDispatch( ONBOARD_STORE );
 		const urlQueryParams = useQuery();
 		const siteSlugParam = useSiteSlugParam();
-		const isDesktop = useViewportMatch( 'large' );
 		const { setPendingAction } = useDispatch( ONBOARD_STORE );
-		const selectedDesign = useSelect( ( select ) => select( ONBOARD_STORE ).getSelectedDesign() );
+		const intent = useSelect( ( select ) => select( ONBOARD_STORE ).getIntent() );
 		const flowProgress = useSiteSetupFlowProgress( _currentStep, 'import', '' );
 
 		if ( flowProgress ) {
@@ -106,10 +103,7 @@ const importFlow: Flow = {
 				}
 
 				case 'designSetup': {
-					if (
-						isDesktop &&
-						isBlankCanvasDesign( providedDependencies?.selectedDesign as Design )
-					) {
+					if ( intent === SiteIntent.Assembler ) {
 						return navigate( 'patternAssembler' );
 					}
 
@@ -121,10 +115,7 @@ const importFlow: Flow = {
 
 				case 'processing': {
 					// End of Pattern Assembler flow
-					if (
-						isEnabled( 'signup/design-picker-pattern-assembler' ) &&
-						isBlankCanvasDesign( selectedDesign as Design )
-					) {
+					if ( intent === SiteIntent.Assembler ) {
 						return exitFlow( `/site-editor/${ siteSlugParam }` );
 					}
 

--- a/client/landing/stepper/declarative-flow/import-flow.ts
+++ b/client/landing/stepper/declarative-flow/import-flow.ts
@@ -103,7 +103,7 @@ const importFlow: Flow = {
 				}
 
 				case 'designSetup': {
-					if ( intent === SiteIntent.Assembler ) {
+					if ( intent === SiteIntent.SiteAssembler ) {
 						return navigate( 'patternAssembler' );
 					}
 
@@ -115,7 +115,7 @@ const importFlow: Flow = {
 
 				case 'processing': {
 					// End of Pattern Assembler flow
-					if ( intent === SiteIntent.Assembler ) {
+					if ( intent === SiteIntent.SiteAssembler ) {
 						return exitFlow( `/site-editor/${ siteSlugParam }` );
 					}
 

--- a/client/landing/stepper/declarative-flow/import-flow.ts
+++ b/client/landing/stepper/declarative-flow/import-flow.ts
@@ -103,7 +103,7 @@ const importFlow: Flow = {
 				}
 
 				case 'designSetup': {
-					if ( intent === SiteIntent.SiteAssembler ) {
+					if ( providedDependencies?.selectedIntent === SiteIntent.SiteAssembler ) {
 						return navigate( 'patternAssembler' );
 					}
 

--- a/client/landing/stepper/declarative-flow/internals/analytics/record-design.ts
+++ b/client/landing/stepper/declarative-flow/internals/analytics/record-design.ts
@@ -1,6 +1,6 @@
+import { SiteIntent } from '@automattic/data-stores/src/onboard';
+import { Design, StyleVariation } from '@automattic/design-picker/src';
 import { resolveDeviceTypeByViewPort } from '@automattic/viewport';
-import { SiteIntent } from 'calypso/../packages/data-stores/src/onboard';
-import { Design, StyleVariation } from 'calypso/../packages/design-picker/src';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 
 export function recordPreviewedDesign( {

--- a/client/landing/stepper/declarative-flow/internals/analytics/record-design.ts
+++ b/client/landing/stepper/declarative-flow/internals/analytics/record-design.ts
@@ -16,7 +16,7 @@ export function recordPreviewedDesign( {
 } ) {
 	recordTracksEvent( 'calypso_signup_design_preview_select', {
 		...getDesignEventProps( { flow, intent, design, styleVariation } ),
-		goes_to_assembler_step: intent === SiteIntent.Assembler,
+		goes_to_assembler_step: intent === SiteIntent.SiteAssembler,
 	} );
 }
 
@@ -58,7 +58,7 @@ export function recordSelectedDesign( {
 
 export function getDesignIntentProps( intent: string ) {
 	return {
-		goes_to_assembler_step: intent === SiteIntent.Assembler,
+		goes_to_assembler_step: intent === SiteIntent.SiteAssembler,
 	};
 }
 

--- a/client/landing/stepper/declarative-flow/internals/analytics/record-design.ts
+++ b/client/landing/stepper/declarative-flow/internals/analytics/record-design.ts
@@ -1,0 +1,90 @@
+import { resolveDeviceTypeByViewPort } from '@automattic/viewport';
+import { SiteIntent } from 'calypso/../packages/data-stores/src/onboard';
+import { Design, StyleVariation } from 'calypso/../packages/design-picker/src';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+
+export function recordPreviewedDesign( {
+	flow,
+	intent,
+	design,
+	styleVariation,
+}: {
+	flow: string | null;
+	intent: string;
+	design: Design;
+	styleVariation?: StyleVariation;
+} ) {
+	recordTracksEvent( 'calypso_signup_design_preview_select', {
+		...getDesignEventProps( { flow, intent, design, styleVariation } ),
+		goes_to_assembler_step: intent === SiteIntent.Assembler,
+	} );
+}
+
+export function recordSelectedDesign( {
+	flow,
+	intent,
+	design,
+	styleVariation,
+	optionalProps,
+}: {
+	flow: string | null;
+	intent: string;
+	design?: Design;
+	styleVariation?: StyleVariation;
+	optionalProps?: object;
+} ) {
+	recordTracksEvent( 'calypso_signup_design_type_submit', {
+		flow,
+		intent,
+		design_type: design?.design_type ?? 'default',
+		has_style_variations: ( design?.style_variations || [] ).length > 0,
+	} );
+
+	if ( design ) {
+		recordTracksEvent( 'calypso_signup_select_design', {
+			...getDesignEventProps( { flow, intent, design, styleVariation } ),
+			...getDesignIntentProps( intent ),
+			...optionalProps,
+		} );
+
+		if ( design.verticalizable ) {
+			recordTracksEvent(
+				'calypso_signup_select_verticalized_design',
+				getDesignEventProps( { flow, intent, design, styleVariation } )
+			);
+		}
+	}
+}
+
+export function getDesignIntentProps( intent: string ) {
+	return {
+		goes_to_assembler_step: intent === SiteIntent.Assembler,
+	};
+}
+
+export function getDesignEventProps( {
+	flow,
+	intent,
+	design,
+	styleVariation,
+}: {
+	flow: string | null;
+	intent: string;
+	design: Design;
+	styleVariation?: StyleVariation;
+} ) {
+	const variationSlugSuffix =
+		styleVariation && styleVariation.slug !== 'default' ? `-${ styleVariation.slug }` : '';
+
+	return {
+		flow,
+		intent,
+		device: resolveDeviceTypeByViewPort(),
+		slug: design.slug + variationSlugSuffix,
+		theme: design.recipe?.stylesheet,
+		theme_style: design.recipe?.stylesheet + variationSlugSuffix,
+		design_type: design.design_type,
+		is_premium: design.is_premium,
+		has_style_variations: ( design.style_variations || [] ).length > 0,
+	};
+}

--- a/client/landing/stepper/declarative-flow/internals/analytics/record-design.ts
+++ b/client/landing/stepper/declarative-flow/internals/analytics/record-design.ts
@@ -16,7 +16,7 @@ export function recordPreviewedDesign( {
 } ) {
 	recordTracksEvent( 'calypso_signup_design_preview_select', {
 		...getDesignEventProps( { flow, intent, design, styleVariation } ),
-		goes_to_assembler_step: intent === SiteIntent.SiteAssembler,
+		goes_to_assembler_step: design.design_type === 'assembler',
 	} );
 }
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -458,7 +458,6 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 
 	function pickBlankCanvasDesign( blankCanvasDesign: Design, shouldGoToAssemblerStep: boolean ) {
 		if ( shouldGoToAssemblerStep ) {
-			const selectedIntent = SiteIntent.SiteAssembler;
 			const selectedDesign = {
 				...blankCanvasDesign,
 				design_type: 'assembler',
@@ -466,14 +465,14 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 
 			recordPreviewedDesign( {
 				flow,
-				intent: selectedIntent,
+				intent,
 				design: selectedDesign,
 			} );
 
 			setSelectedDesign( selectedDesign );
 
 			handleSubmit( {
-				selectedIntent,
+				selectedIntent: SiteIntent.SiteAssembler,
 				selectedDesign,
 				selectedSiteCategory: categorization.selection,
 			} );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -475,6 +475,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 			handleSubmit( {
 				selectedIntent,
 				selectedDesign,
+				selectedSiteCategory: categorization.selection,
 			} );
 		} else {
 			pickDesign( blankCanvasDesign );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -458,7 +458,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 
 	function pickBlankCanvasDesign( blankCanvasDesign: Design, shouldGoToAssemblerStep: boolean ) {
 		if ( shouldGoToAssemblerStep ) {
-			setIntent( SiteIntent.Assembler );
+			setIntent( SiteIntent.SiteAssembler );
 			setSelectedDesign( {
 				...blankCanvasDesign,
 				design_type: 'assembler',
@@ -469,7 +469,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 	}
 
 	useEffect( () => {
-		if ( intent === SiteIntent.Assembler && selectedDesign ) {
+		if ( intent === SiteIntent.SiteAssembler && selectedDesign ) {
 			recordPreviewedDesign( { flow, intent, design: selectedDesign } );
 			handleSubmit( {
 				selectedDesign,
@@ -478,7 +478,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 	}, [ intent, selectedDesign ] );
 
 	function handleSubmit( providedDependencies?: ProvidedDependencies, optionalProps?: object ) {
-		if ( intent !== SiteIntent.Assembler ) {
+		if ( intent !== SiteIntent.SiteAssembler ) {
 			recordSelectedDesign( {
 				flow,
 				intent,
@@ -569,7 +569,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 
 	// ********** Main render logic
 
-	if ( intent === SiteIntent.Assembler || isAtomic ) {
+	if ( intent === SiteIntent.SiteAssembler || isAtomic ) {
 		return null;
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -1,10 +1,10 @@
 import { isEnabled } from '@automattic/calypso-config';
+import { SiteIntent } from '@automattic/data-stores/src/onboard';
 import { StepContainer } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
 import { useState, useRef, useEffect } from 'react';
 import { useDispatch as useReduxDispatch } from 'react-redux';
-import { SiteIntent } from 'calypso/../packages/data-stores/src/onboard';
 import AsyncLoad from 'calypso/components/async-load';
 import DocumentHead from 'calypso/components/data/document-head';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -206,7 +206,7 @@ const siteSetupFlow: Flow = {
 				}
 
 				case 'designSetup':
-					if ( intent === SiteIntent.Assembler ) {
+					if ( intent === SiteIntent.SiteAssembler ) {
 						return navigate( 'patternAssembler' );
 					}
 
@@ -223,7 +223,7 @@ const siteSetupFlow: Flow = {
 					}
 
 					// End of Pattern Assembler flow
-					if ( intent === SiteIntent.Assembler ) {
+					if ( intent === SiteIntent.SiteAssembler ) {
 						return exitFlow( `/site-editor/${ siteSlug }` );
 					}
 

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -206,7 +206,7 @@ const siteSetupFlow: Flow = {
 				}
 
 				case 'designSetup':
-					if ( intent === SiteIntent.SiteAssembler ) {
+					if ( providedDependencies?.selectedIntent === SiteIntent.SiteAssembler ) {
 						return navigate( 'patternAssembler' );
 					}
 

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -1,7 +1,5 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { Onboard } from '@automattic/data-stores';
-import { Design, isBlankCanvasDesign } from '@automattic/design-picker';
-import { useViewportMatch } from '@wordpress/compose';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useDispatch as reduxDispatch, useSelector } from 'react-redux';
 import { ImporterMainPlatform } from 'calypso/blocks/import/types';
@@ -122,7 +120,6 @@ const siteSetupFlow: Flow = {
 
 		const urlQueryParams = useQuery();
 		const isPluginBundleEligible = useIsPluginBundleEligible();
-		const isDesktop = useViewportMatch( 'large' );
 
 		let siteSlug: string | null = null;
 		if ( siteSlugParam ) {
@@ -209,10 +206,7 @@ const siteSetupFlow: Flow = {
 				}
 
 				case 'designSetup':
-					if (
-						isDesktop &&
-						isBlankCanvasDesign( providedDependencies?.selectedDesign as Design )
-					) {
+					if ( intent === SiteIntent.Assembler ) {
 						return navigate( 'patternAssembler' );
 					}
 
@@ -229,10 +223,7 @@ const siteSetupFlow: Flow = {
 					}
 
 					// End of Pattern Assembler flow
-					if (
-						isEnabled( 'signup/design-picker-pattern-assembler' ) &&
-						isBlankCanvasDesign( selectedDesign as Design )
-					) {
+					if ( intent === SiteIntent.Assembler ) {
 						return exitFlow( `/site-editor/${ siteSlug }` );
 					}
 

--- a/packages/data-stores/src/onboard/constants.ts
+++ b/packages/data-stores/src/onboard/constants.ts
@@ -13,7 +13,7 @@ export enum SiteIntent {
 	Write = 'write',
 	Sell = 'sell',
 	Build = 'build',
-	Assembler = 'site-assembler',
+	SiteAssembler = 'site-assembler',
 	DIFM = 'difm', // "Do It For Me"
 	WpAdmin = 'wpadmin',
 	Import = 'import', // deprecated

--- a/packages/data-stores/src/onboard/constants.ts
+++ b/packages/data-stores/src/onboard/constants.ts
@@ -13,6 +13,7 @@ export enum SiteIntent {
 	Write = 'write',
 	Sell = 'sell',
 	Build = 'build',
+	Assembler = 'site-assembler',
 	DIFM = 'difm', // "Do It For Me"
 	WpAdmin = 'wpadmin',
 	Import = 'import', // deprecated

--- a/packages/design-picker/src/components/pattern-assembler-cta/index.tsx
+++ b/packages/design-picker/src/components/pattern-assembler-cta/index.tsx
@@ -5,12 +5,18 @@ import blankCanvasImage from '../assets/images/blank-canvas-cta.svg';
 import './style.scss';
 
 type PatternAssemblerCtaProps = {
-	onButtonClick: () => void;
+	onButtonClick: ( shouldGoToAssemblerStep: boolean ) => void;
 };
 
 const PatternAssemblerCta = ( { onButtonClick }: PatternAssemblerCtaProps ) => {
 	const translate = useTranslate();
 	const isDesktop = useViewportMatch( 'large' );
+
+	const shouldGoToAssemblerStep = isDesktop;
+
+	const handleButtonClick = () => {
+		onButtonClick( shouldGoToAssemblerStep );
+	};
 
 	return (
 		<div className="pattern-assembler-cta-wrapper">
@@ -19,16 +25,18 @@ const PatternAssemblerCta = ( { onButtonClick }: PatternAssemblerCtaProps ) => {
 			</div>
 			<h3 className="pattern-assembler-cta__title">{ translate( 'Design your own' ) }</h3>
 			<p className="pattern-assembler-cta__subtitle">
-				{ ! isDesktop
+				{ shouldGoToAssemblerStep
 					? translate(
-							"Can't find something you like? Jump right into the editor to design your homepage from scratch."
+							"Can't find something you like? Start with a blank canvas and design your own homepage using our library of patterns."
 					  )
 					: translate(
-							"Can't find something you like? Start with a blank canvas and design your own homepage using our library of patterns."
+							"Can't find something you like? Jump right into the editor to design your homepage from scratch."
 					  ) }
 			</p>
-			<Button className="pattern-assembler-cta__button" onClick={ onButtonClick } primary>
-				{ ! isDesktop ? translate( 'Open the editor' ) : translate( 'Start designing' ) }
+			<Button className="pattern-assembler-cta__button" onClick={ handleButtonClick } primary>
+				{ shouldGoToAssemblerStep
+					? translate( 'Start designing' )
+					: translate( 'Open the editor' ) }
 			</Button>
 		</div>
 	);

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -144,6 +144,7 @@ const useTrackDesignView = ( {
 interface DesignButtonProps {
 	design: Design;
 	locale: string;
+	onSelect: ( design: Design ) => void;
 	onPreview: ( design: Design, variation?: StyleVariation ) => void;
 	isPremiumThemeAvailable?: boolean;
 	hasPurchasedTheme?: boolean;
@@ -245,12 +246,12 @@ const DesignButton: React.FC< DesignButtonProps > = ( {
 
 interface DesignButtonContainerProps extends DesignButtonProps {
 	category?: string | null;
-	onSelect: ( design: Design ) => void;
+	onSelectBlankCanvas: ( design: Design, shouldGoToAssemblerStep: boolean ) => void;
 }
 
 const DesignButtonContainer: React.FC< DesignButtonContainerProps > = ( {
 	category,
-	onSelect,
+	onSelectBlankCanvas,
 	...props
 } ) => {
 	const trackingDivRef = useTrackDesignView( {
@@ -260,7 +261,13 @@ const DesignButtonContainer: React.FC< DesignButtonContainerProps > = ( {
 	} );
 
 	if ( isBlankCanvasDesign( props.design ) ) {
-		return <PatternAssemblerCta onButtonClick={ () => onSelect( props.design ) } />;
+		return (
+			<PatternAssemblerCta
+				onButtonClick={ ( shouldGoToAssemblerStep ) =>
+					onSelectBlankCanvas( props.design, shouldGoToAssemblerStep )
+				}
+			/>
+		);
 	}
 
 	return (
@@ -358,6 +365,7 @@ interface DesignPickerProps {
 	locale: string;
 	verticalId?: string;
 	onSelect: ( design: Design ) => void;
+	onSelectBlankCanvas: ( design: Design, shouldGoToAssemblerStep: boolean ) => void;
 	onPreview: ( design: Design, variation?: StyleVariation ) => void;
 	staticDesigns: Design[];
 	generatedDesigns: Design[];
@@ -371,6 +379,7 @@ interface DesignPickerProps {
 const DesignPicker: React.FC< DesignPickerProps > = ( {
 	locale,
 	onSelect,
+	onSelectBlankCanvas,
 	onPreview,
 	staticDesigns,
 	generatedDesigns,
@@ -407,6 +416,7 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 						design={ design }
 						locale={ locale }
 						onSelect={ onSelect }
+						onSelectBlankCanvas={ onSelectBlankCanvas }
 						onPreview={ onPreview }
 						isPremiumThemeAvailable={ isPremiumThemeAvailable }
 						onCheckout={ onCheckout }
@@ -435,6 +445,7 @@ export interface UnifiedDesignPickerProps {
 	locale: string;
 	verticalId?: string;
 	onSelect: ( design: Design ) => void;
+	onSelectBlankCanvas: ( design: Design, shouldGoToAssemblerStep: boolean ) => void;
 	onPreview: ( design: Design, variation?: StyleVariation ) => void;
 	onViewAllDesigns: () => void;
 	generatedDesigns: Design[];
@@ -450,6 +461,7 @@ export interface UnifiedDesignPickerProps {
 const UnifiedDesignPicker: React.FC< UnifiedDesignPickerProps > = ( {
 	locale,
 	onSelect,
+	onSelectBlankCanvas,
 	onPreview,
 	onViewAllDesigns,
 	verticalId,
@@ -487,6 +499,7 @@ const UnifiedDesignPicker: React.FC< UnifiedDesignPickerProps > = ( {
 				<DesignPicker
 					locale={ locale }
 					onSelect={ onSelect }
+					onSelectBlankCanvas={ onSelectBlankCanvas }
 					onPreview={ onPreview }
 					staticDesigns={ staticDesigns }
 					generatedDesigns={ generatedDesigns }

--- a/packages/design-picker/src/types.ts
+++ b/packages/design-picker/src/types.ts
@@ -76,7 +76,8 @@ export type DesignType =
 	| 'premium'
 	| 'standard' // The design is free.
 	| 'default' // The default design and it means user skipped the step and didn't select any design.
-	| 'anchor-fm';
+	| 'anchor-fm'
+	| 'assembler';
 
 export interface Design {
 	slug: string;


### PR DESCRIPTION
#### Proposed Changes

- Upon clicking the Pattern/Site Assembler CTA, we don't immediately fire the `calypso_signup_{select_design,design_type_submit}` events. But rather, we fire the `calypso_signup_design_preview_select` with new prop `goes_to_assembler_step`: `true`.
- This new `goes_to_assembler_step` is added to:

   * `calypso_signup_select_design`
   * `calypso_signup_design_preview_select`
   * `calypso_signup_actions_submit_step` (for `designSetup` step only)

- A new `design_type` is added: `assembler`, if the user passes the Assembler flow.
- A new `intent` is added: `site-assembler`, if the user passes the Assembler flow.

  * HOWEVER! Due to technical difficulties (one of which is to handle the Back button while preserving the previous `build` intent), this new intent will take effect only after the user clicks the final "Continue" button at the end of the Assembler flow. cc: @autumnfjeld . I hope this is OK, as we still have the `goes_to_assembler_step` prop.

#### Testing Instructions

|Trigger|Events|
|-|-|
|Click "Open the editor"<br><br><img width="450" alt="image" src="https://user-images.githubusercontent.com/1525580/209293740-b71c5289-9f40-4f69-8b71-4dc5e5ef383a.png">|<img alt="image" src="https://user-images.githubusercontent.com/1525580/209292227-b621832e-cbd0-4f9a-b0e4-c5d43032a637.png">|
|Click "Start designing"<br><br><img width="450"  alt="image" src="https://user-images.githubusercontent.com/1525580/209271747-fc3abcbc-1a9f-44b4-b695-f14ef4559cde.png">|<img alt="image" src="https://user-images.githubusercontent.com/1525580/209293476-e33bc286-7df7-4ef6-9201-484b9203e7dc.png">|
|Click "Continue"<br><br><img width="450" alt="image" src="https://user-images.githubusercontent.com/1525580/209293985-bc268df0-1e26-4b96-bc61-f13761808f85.png">|<img  alt="image" src="https://user-images.githubusercontent.com/1525580/209294350-f839358e-e03f-427b-b6c1-2c2d8e0c97ec.png">|


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to

- https://github.com/Automattic/dotcom-forge/issues/1408
