### PR TITLE
Site Editor - Update exit tracking event and close iframe handling.

### DIFF
--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -1073,11 +1073,33 @@ function handleSiteEditorBackButton( calypsoPort ) {
 	// have to do this event delegation style because the Editor isn't fully initialized yet.
 	document.getElementById( 'wpwrap' ).addEventListener( 'click', ( event ) => {
 		const clickedElement = event.target;
-		if ( clickedElement.classList.contains( 'edit-site-navigation-panel__back-to-dashboard' ) ) {
+		const isOldDashboardButton =
+			clickedElement.classList.contains( 'edit-site-navigation-panel__back-to-dashboard' ) ||
+			// The above fails if user clicked internal SVG. So check the parent again.
+			clickedElement.parentElement?.classList.contains(
+				'edit-site-navigation-panel__back-to-dashboard'
+			) ||
+			// The above fails if the user clicked the internal path. So check the parent's parent...
+			clickedElement.parentElement?.parentElement?.classList.contains(
+				'edit-site-navigation-panel__back-to-dashboard'
+			);
+
+		// The new dashboard button proposed with Gutenberg 14.8 has no useful class selector for
+		// this state. Instead, lets treat any element with an href corresponding to the
+		// dashboardLink setting as the close button.
+		const dashboardLink = select( 'core/edit-site' )?.getSettings?.().__experimentalDashboardLink;
+		const isNewDashboardButton =
+			clickedElement.attributes?.href?.value &&
+			clickedElement.attributes?.href?.value === dashboardLink;
+
+		// Since the clicked element may not have an href (as noted by internal SVG and path woes above).
+		const returnHref = clickedElement.href || dashboardLink;
+
+		if ( isOldDashboardButton || isNewDashboardButton ) {
 			event.preventDefault();
 			calypsoPort.postMessage( {
 				action: 'openLinkInParentFrame',
-				payload: { postUrl: clickedElement.href },
+				payload: { postUrl: returnHref },
 			} );
 		}
 	} );

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-site-editor-exit-click.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-site-editor-exit-click.js
@@ -7,7 +7,11 @@ import tracksRecordEvent from './track-record-event';
  */
 export default () => ( {
 	id: 'wpcom-site-editor-exit-click',
-	selector: '.edit-site-navigation-panel .edit-site-navigation-panel__back-to-dashboard',
+	// Gutenberg v14.8 changes the close button and related class structure. When
+	// '.edit-site-layout__view-mode-toggle' is set to an anchor instead of a button, this serves as
+	// the close button.
+	selector:
+		'.edit-site-navigation-panel .edit-site-navigation-panel__back-to-dashboard, .edit-site-layout__logo a.edit-site-layout__view-mode-toggle',
 	type: 'click',
 	handler: () => tracksRecordEvent( 'wpcom_site_editor_exit_click' ),
 } );


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/71336, Gutenberg v14.8 is updating the close button used in the site editor.

As a result, we need to:
* update our handling of closing the calypso editor iframe -  otherwise users will be trapped inside this iframe even after exiting the editor.
* Update our tracking event for `wpcom_site_editor_exit_click` event

this PR aims to resolve both of these issues.

## Testing Instructions
Setup
* Run this wpcom-block-editor build on your sandbox (generally `yarn dev --sync` from apps/wpcom-block-editor on this branch will do the trick)
* sandbox the public-api, widgets, and a simple site test site.

Test with Gutenberg Edge (v14.8) active:
* Visit the blog RC for your test site and enable the "gutenberg-edge" sticker toggle.
* Visit the site editor, play around to smoke test.
* Exit the site editor via the new close button (picture in issue description linked above).
* Verify you are not in the `*/site-editor/*` iframe after leaving the site editor.
* Verify the `wpcom_site_editor_exit_click` event fires.
* Smoke test the post/page editor.

Test with the currently active Gutenberg version:
* Visit the blog RC for your test site and ensure "gutenberg-edge" sticker toggle is disabled.
* Ensure the `< Dashboard` button and event continue to work as expected.
* Smoke test the post/page editor.