### PR TITLE
Marketplace Themes: Add loading state to the banner

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -771,6 +771,7 @@ class ThemeSheet extends Component {
 			isExternallyManagedTheme,
 			isSiteEligibleForManagedExternalThemes,
 			isMarketplaceThemeSubscribed,
+			isLoading,
 		} = this.props;
 
 		const analyticsPath = `/theme/${ themeId }${ section ? '/' + section : '' }${
@@ -846,6 +847,10 @@ class ThemeSheet extends Component {
 			onClick = launchPricing;
 		}
 
+		const upsellNudgeClasses = classNames( 'theme__page-upsell-banner', {
+			'theme__page-upsell-disabled': isLoading,
+		} );
+
 		if ( hasWpComThemeUpsellBanner ) {
 			const forceDisplay =
 				( isBundledSoftwareSet && ! isSiteBundleEligible ) ||
@@ -854,7 +859,7 @@ class ThemeSheet extends Component {
 			pageUpsellBanner = (
 				<UpsellNudge
 					plan={ PLAN_PREMIUM }
-					className="theme__page-upsell-banner"
+					className={ upsellNudgeClasses }
 					title={ this.getBannerUpsellTitle() }
 					description={ preventWidows( this.getBannerUpsellDescription() ) }
 					event="themes_plan_particular_free_with_plan"

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -544,6 +544,11 @@
 	}
 }
 
+.banner.theme__page-upsell-disabled {
+	pointer-events: none;
+	opacity: 0.5;
+}
+
 .banner.theme__preview-upsell-banner {
 	@include banner-dark();
 	width: 100%;


### PR DESCRIPTION
#### Proposed Changes

*  Disables the banner on the theme page while adding the items to cart for marketplace themes.

https://user-images.githubusercontent.com/1234758/209195941-35ca112f-d7c7-40e9-8d45-c4c3d0531703.mov


#### Testing Instructions

* Navigate to `/theme/makoney/{SITE}` on a free site
* Click on the banner
* The banner should be disabled while loading the cart

Closes #71319
