### PR TITLE
Ecommerce Tailored Flow: Remove the intro step

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/store-profiler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/store-profiler/index.tsx
@@ -163,6 +163,7 @@ const StoreProfiler: Step = function StoreProfiler( { navigation, flow } ) {
 			skipButtonAlign="top"
 			shouldHideNavButtons={ flow === ECOMMERCE_FLOW }
 			goBack={ goBack }
+			hideBack={ true }
 			goNext={ goNext }
 			formattedHeader={
 				<FormattedHeader


### PR DESCRIPTION
#### Proposed Changes

* Removes the `intro` step and makes the `storeProfiler` as the first step.

Related: 
* paYKcK-2xV-p2#comment-1926
* peapX7-1go-p2

#### Testing Instructions

* Navigate to `/setup/ecommerce` with an authenticated user and make sure the flow works.
* Navigate to `/setup/ecommerce` without being logged in and make sure you are directed to the signup page. You can also add some flags to the URL to ensure that it's passing all the way after the signup.