### PR TITLE
Tailored Ecommerce: Remove the post-checkout storeAddress step for tailored ecommerce

### DIFF
--- a/client/landing/stepper/declarative-flow/tailored-ecommerce-flow.ts
+++ b/client/landing/stepper/declarative-flow/tailored-ecommerce-flow.ts
@@ -20,7 +20,6 @@ import DomainsStep from './internals/steps-repository/domains';
 import Intro from './internals/steps-repository/intro';
 import ProcessingStep from './internals/steps-repository/processing-step';
 import SiteCreationStep from './internals/steps-repository/site-creation-step';
-import StoreAddress from './internals/steps-repository/store-address';
 import StoreProfiler from './internals/steps-repository/store-profiler';
 import WaitForAtomic from './internals/steps-repository/wait-for-atomic';
 import type { Flow, ProvidedDependencies } from './internals/types';
@@ -41,7 +40,6 @@ const ecommerceFlow: Flow = {
 		return [
 			{ slug: 'intro', component: Intro },
 			{ slug: 'storeProfiler', component: StoreProfiler },
-			{ slug: 'storeAddress', component: StoreAddress },
 			{ slug: 'domains', component: DomainsStep },
 			{ slug: 'designCarousel', component: DesignCarousel },
 			{ slug: 'siteCreationStep', component: SiteCreationStep },
@@ -116,7 +114,7 @@ const ecommerceFlow: Flow = {
 
 				case 'processing':
 					if ( providedDependencies?.finishedWaitingForAtomic ) {
-						return navigate( 'storeAddress' );
+						return window.location.assign( `${ site?.URL }/wp-admin/admin.php?page=wc-admin` );
 					}
 
 					if ( providedDependencies?.siteSlug ) {
@@ -151,9 +149,6 @@ const ecommerceFlow: Flow = {
 
 				case 'storeProfiler':
 					return navigate( 'designCarousel' );
-
-				case 'storeAddress':
-					return window.location.assign( `${ site?.URL }/wp-admin/admin.php?page=wc-admin` );
 
 				case 'designCarousel':
 					return navigate( 'domains' );
@@ -192,8 +187,6 @@ const ecommerceFlow: Flow = {
 					return navigate( 'storeProfiler' );
 				case 'storeProfiler':
 					return navigate( 'designCarousel' );
-				case 'storeAddress':
-					return window.location.assign( `${ site?.URL }/wp-admin/admin.php?page=wc-admin` );
 				case 'designCarousel':
 					return navigate( 'domains' );
 				default:


### PR DESCRIPTION
#### Proposed Changes

Remove the `storeAddress` post-checkout step. After checkout is complete, the user is redirected back to their dashboard.

Related: 
* paYKcK-2xV-p2#comment-1926
* peapX7-1go-p2

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to `/setup/ecommerce` with a logged in user. You don't need to be sandboxed.
* Go through the entire signup process.
* After checkout, you should be taken back to the dashboard instead of the `storeAddress` step.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [NA] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [NA] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [NA] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [NA] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [NA] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
