### PR TITLE
Hide incorrect privacy link

### DIFF
--- a/client/my-sites/people/followers-list/style.scss
+++ b/client/my-sites/people/followers-list/style.scss
@@ -2,3 +2,7 @@
 	font-size: $font-title-small;
 	margin-bottom: 16px;
 }
+
+.is-section-people .info-popover__tooltip .popover__inner .support-info__privacy {
+	display: none;
+}


### PR DESCRIPTION
#### Proposed Changes
This [issue](https://github.com/Automattic/wp-calypso/issues/69947) relating to this PR has a greater impact and requires a bigger refactor than this immediate fix that's done here.

What's happening is that the popover for _Users>Followers_ is rendering a privacy link when It should not have. 
![image](https://user-images.githubusercontent.com/47489215/209209545-96820db0-713b-48ce-893e-f4ebddb3b0ae.png)
All the link does is reloads the followers page. This happens because of how the `<SupportInfo/>` component works by making `privacyLink` defaults to `true` so that even if an empty link is passed it still generates a privacyLink with `#privacy`. This design was call into question [here](https://github.com/Automattic/wp-calypso/pull/61260#pullrequestreview-887775837).

- We could make `privacyLink=false` that way the link doesn't render but that would require modifying components `PeopleListSectionHeader > SectionHeader ` to pass this prop down to  `<SupportInfo/>`. 
- We could also modify the `<SupportInfo/>` component to accept as props a privacy link or a general link instead of the component trying to be smart.

Both approaches will have a larger impact on the codebase and would require more refactoring. 

* For this fix I'm using css to remove the incorrect privacy link. 

#### Testing Instructions

1. Visit Users>Followers and ensure the popover doesn't show "Privacy Information" link.
![image](https://user-images.githubusercontent.com/47489215/209212202-b71245f5-8062-422e-8de7-a9271e9ed7da.png)


<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/69947
