### PR TITLE
Reading Settings: Add new email template text settings

### DIFF
--- a/client/my-sites/site-settings/reading-newsletter-settings/EmailsTextSetting.tsx
+++ b/client/my-sites/site-settings/reading-newsletter-settings/EmailsTextSetting.tsx
@@ -60,8 +60,6 @@ export const EmailsTextSetting = ( { value, disabled, updateFields }: EmailsText
 						'The welcome message sent out to new readers when they subscribe to your blog.'
 					) }
 				</FormSettingExplanation>
-			</FormFieldset>
-			<FormFieldset>
 				<FormLabel htmlFor="comment_follow_email_text">
 					{ translate( 'Comment follow email text' ) }
 				</FormLabel>

--- a/client/my-sites/site-settings/reading-newsletter-settings/EmailsTextSetting.tsx
+++ b/client/my-sites/site-settings/reading-newsletter-settings/EmailsTextSetting.tsx
@@ -17,25 +17,23 @@ type SubscriptionOption = {
 	[ key: string ]: string;
 };
 
-export const EmailsTextSetting = ( {
-	value,
-	disabled,
-	updateFields,
-}: EmailsTextSettingProps ) => {
+export const EmailsTextSetting = ( { value, disabled, updateFields }: EmailsTextSettingProps ) => {
 	const translate = useTranslate();
 
-	const onChangeFieldSubscriptionOptions =
-		( field: string ) => ( event: React.ChangeEvent< HTMLInputElement > ) => {
-			const textFieldValue = event.target.value;
+	const updateSubscriptionOptions =
+		( option: string ) => ( event: React.ChangeEvent< HTMLInputElement > ) => {
+			const textAreaValue = event.target.value;
+			const currentSubscriptionOptions = value;
 
-			const newValue: SubscriptionOption = {};
-			newValue[ field ] = textFieldValue;
+			const newSubscriptionOption: SubscriptionOption = {};
+			newSubscriptionOption[ option ] = textAreaValue;
 
-			const valueToSave = { ...value, ...newValue };
+			const mergedOptions = { ...currentSubscriptionOptions, ...newSubscriptionOption };
+			const fieldToUpdate = {
+				subscription_options: mergedOptions,
+			};
 
-			updateFields( {
-				[ 'subscription_options' ]: valueToSave,
-			} );
+			updateFields( fieldToUpdate );
 		};
 
 	return (
@@ -46,7 +44,7 @@ export const EmailsTextSetting = ( {
 					name=""
 					id=""
 					value={ value?.invitation }
-					onChange={ onChangeFieldSubscriptionOptions( 'invitation' ) }
+					onChange={ updateSubscriptionOptions( 'invitation' ) }
 					disabled={ disabled }
 					autoCapitalize="none"
 					onClick={ null }
@@ -64,7 +62,7 @@ export const EmailsTextSetting = ( {
 					name=""
 					id=""
 					value={ value?.comment_follow }
-					onChange={ onChangeFieldSubscriptionOptions( 'comment_follow' ) }
+					onChange={ updateSubscriptionOptions( 'comment_follow' ) }
 					disabled={ disabled }
 					autoCapitalize="none"
 					onClick={ null }

--- a/client/my-sites/site-settings/reading-newsletter-settings/EmailsTextSetting.tsx
+++ b/client/my-sites/site-settings/reading-newsletter-settings/EmailsTextSetting.tsx
@@ -1,6 +1,7 @@
 import { useTranslate } from 'i18n-calypso';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
+import FormLegend from 'calypso/components/forms/form-legend';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import FormTextarea from 'calypso/components/forms/form-textarea';
 
@@ -37,8 +38,12 @@ export const EmailsTextSetting = ( { value, disabled, updateFields }: EmailsText
 		};
 
 	return (
-		<>
+		<div className="site-settings__emails-test-settings-container">
 			<FormFieldset>
+				{ /* @ts-expect-error FormLegend is not typed and is causing errors */ }
+				<FormLegend>
+					These settings change the emails sent from your site to your readers
+				</FormLegend>
 				<FormLabel htmlFor="welcome_email_text">{ translate( 'Welcome email text' ) }</FormLabel>
 				<FormTextarea
 					name="welcome_email_text"
@@ -74,6 +79,6 @@ export const EmailsTextSetting = ( { value, disabled, updateFields }: EmailsText
 					{ translate( 'The email sent out when someone follows one of your posts.' ) }
 				</FormSettingExplanation>
 			</FormFieldset>
-		</>
+		</div>
 	);
 };

--- a/client/my-sites/site-settings/reading-newsletter-settings/EmailsTextSetting.tsx
+++ b/client/my-sites/site-settings/reading-newsletter-settings/EmailsTextSetting.tsx
@@ -39,10 +39,10 @@ export const EmailsTextSetting = ( { value, disabled, updateFields }: EmailsText
 	return (
 		<>
 			<FormFieldset>
-				<FormLabel>Welcome email text</FormLabel>
+				<FormLabel htmlFor="welcome_email_text">Welcome email text</FormLabel>
 				<FormTextarea
-					name=""
-					id=""
+					name="welcome_email_text"
+					id="welcome_email_text"
 					value={ value?.invitation }
 					onChange={ updateSubscriptionOptions( 'invitation' ) }
 					disabled={ disabled }
@@ -57,10 +57,10 @@ export const EmailsTextSetting = ( { value, disabled, updateFields }: EmailsText
 				</FormSettingExplanation>
 			</FormFieldset>
 			<FormFieldset>
-				<FormLabel>Comment follow email text</FormLabel>
+				<FormLabel htmlFor="comment_follow_email_text">Comment follow email text</FormLabel>
 				<FormTextarea
-					name=""
-					id=""
+					name="comment_follow_email_text"
+					id="comment_follow_email_text"
 					value={ value?.comment_follow }
 					onChange={ updateSubscriptionOptions( 'comment_follow' ) }
 					disabled={ disabled }

--- a/client/my-sites/site-settings/reading-newsletter-settings/EmailsTextSetting.tsx
+++ b/client/my-sites/site-settings/reading-newsletter-settings/EmailsTextSetting.tsx
@@ -39,7 +39,7 @@ export const EmailsTextSetting = ( { value, disabled, updateFields }: EmailsText
 	return (
 		<>
 			<FormFieldset>
-				<FormLabel htmlFor="welcome_email_text">Welcome email text</FormLabel>
+				<FormLabel htmlFor="welcome_email_text">{ translate( 'Welcome email text' ) }</FormLabel>
 				<FormTextarea
 					name="welcome_email_text"
 					id="welcome_email_text"
@@ -57,7 +57,9 @@ export const EmailsTextSetting = ( { value, disabled, updateFields }: EmailsText
 				</FormSettingExplanation>
 			</FormFieldset>
 			<FormFieldset>
-				<FormLabel htmlFor="comment_follow_email_text">Comment follow email text</FormLabel>
+				<FormLabel htmlFor="comment_follow_email_text">
+					{ translate( 'Comment follow email text' ) }
+				</FormLabel>
 				<FormTextarea
 					name="comment_follow_email_text"
 					id="comment_follow_email_text"

--- a/client/my-sites/site-settings/reading-newsletter-settings/EmailsTextSetting.tsx
+++ b/client/my-sites/site-settings/reading-newsletter-settings/EmailsTextSetting.tsx
@@ -52,8 +52,6 @@ export const EmailsTextSetting = ( { value, disabled, updateFields }: EmailsText
 					onChange={ updateSubscriptionOptions( 'invitation' ) }
 					disabled={ disabled }
 					autoCapitalize="none"
-					onClick={ null }
-					onKeyPress={ null }
 				/>
 				<FormSettingExplanation>
 					{ translate(
@@ -70,8 +68,6 @@ export const EmailsTextSetting = ( { value, disabled, updateFields }: EmailsText
 					onChange={ updateSubscriptionOptions( 'comment_follow' ) }
 					disabled={ disabled }
 					autoCapitalize="none"
-					onClick={ null }
-					onKeyPress={ null }
 				/>
 				<FormSettingExplanation>
 					{ translate( 'The email sent out when someone follows one of your posts.' ) }

--- a/client/my-sites/site-settings/reading-newsletter-settings/EmailsTextSetting.tsx
+++ b/client/my-sites/site-settings/reading-newsletter-settings/EmailsTextSetting.tsx
@@ -4,7 +4,7 @@ import FormLabel from 'calypso/components/forms/form-label';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import FormTextarea from 'calypso/components/forms/form-textarea';
 
-type WelcomeEmailTextSettingProps = {
+type EmailsTextSettingProps = {
 	value?: {
 		invitation: string;
 		comment_follow: string;
@@ -17,11 +17,11 @@ type SubscriptionOption = {
 	[ key: string ]: string;
 };
 
-export const WelcomeEmailTextSetting = ( {
+export const EmailsTextSetting = ( {
 	value,
 	disabled,
 	updateFields,
-}: WelcomeEmailTextSettingProps ) => {
+}: EmailsTextSettingProps ) => {
 	const translate = useTranslate();
 
 	const onChangeFieldSubscriptionOptions =

--- a/client/my-sites/site-settings/reading-newsletter-settings/WelcomeEmailTextSetting.tsx
+++ b/client/my-sites/site-settings/reading-newsletter-settings/WelcomeEmailTextSetting.tsx
@@ -56,6 +56,20 @@ export const WelcomeEmailTextSetting = ( {
 					'The welcome message sent out to new readers when they subscribe to your blog.'
 				) }
 			</FormSettingExplanation>
+			<FormLabel>Comment follow email text</FormLabel>
+			<FormTextarea
+				name=""
+				id=""
+				value={ value?.comment_follow }
+				onChange={ onChangeFieldSubscriptionOptions( 'comment_follow' ) }
+				disabled={ disabled }
+				autoCapitalize="none"
+				onClick={ null }
+				onKeyPress={ null }
+			/>
+			<FormSettingExplanation>
+				{ translate( 'The email sent out when someone follows one of your posts.' ) }
+			</FormSettingExplanation>
 		</FormFieldset>
 	);
 };

--- a/client/my-sites/site-settings/reading-newsletter-settings/WelcomeEmailTextSetting.tsx
+++ b/client/my-sites/site-settings/reading-newsletter-settings/WelcomeEmailTextSetting.tsx
@@ -39,37 +39,41 @@ export const WelcomeEmailTextSetting = ( {
 		};
 
 	return (
-		<FormFieldset>
-			<FormLabel>Welcome email text</FormLabel>
-			<FormTextarea
-				name=""
-				id=""
-				value={ value?.invitation }
-				onChange={ onChangeFieldSubscriptionOptions( 'invitation' ) }
-				disabled={ disabled }
-				autoCapitalize="none"
-				onClick={ null }
-				onKeyPress={ null }
-			/>
-			<FormSettingExplanation>
-				{ translate(
-					'The welcome message sent out to new readers when they subscribe to your blog.'
-				) }
-			</FormSettingExplanation>
-			<FormLabel>Comment follow email text</FormLabel>
-			<FormTextarea
-				name=""
-				id=""
-				value={ value?.comment_follow }
-				onChange={ onChangeFieldSubscriptionOptions( 'comment_follow' ) }
-				disabled={ disabled }
-				autoCapitalize="none"
-				onClick={ null }
-				onKeyPress={ null }
-			/>
-			<FormSettingExplanation>
-				{ translate( 'The email sent out when someone follows one of your posts.' ) }
-			</FormSettingExplanation>
-		</FormFieldset>
+		<>
+			<FormFieldset>
+				<FormLabel>Welcome email text</FormLabel>
+				<FormTextarea
+					name=""
+					id=""
+					value={ value?.invitation }
+					onChange={ onChangeFieldSubscriptionOptions( 'invitation' ) }
+					disabled={ disabled }
+					autoCapitalize="none"
+					onClick={ null }
+					onKeyPress={ null }
+				/>
+				<FormSettingExplanation>
+					{ translate(
+						'The welcome message sent out to new readers when they subscribe to your blog.'
+					) }
+				</FormSettingExplanation>
+			</FormFieldset>
+			<FormFieldset>
+				<FormLabel>Comment follow email text</FormLabel>
+				<FormTextarea
+					name=""
+					id=""
+					value={ value?.comment_follow }
+					onChange={ onChangeFieldSubscriptionOptions( 'comment_follow' ) }
+					disabled={ disabled }
+					autoCapitalize="none"
+					onClick={ null }
+					onKeyPress={ null }
+				/>
+				<FormSettingExplanation>
+					{ translate( 'The email sent out when someone follows one of your posts.' ) }
+				</FormSettingExplanation>
+			</FormFieldset>
+		</>
 	);
 };

--- a/client/my-sites/site-settings/reading-newsletter-settings/WelcomeEmailTextSetting.tsx
+++ b/client/my-sites/site-settings/reading-newsletter-settings/WelcomeEmailTextSetting.tsx
@@ -13,6 +13,10 @@ type WelcomeEmailTextSettingProps = {
 	updateFields: ( fields: { [ key: string ]: unknown } ) => void;
 };
 
+type SubscriptionOption = {
+	[ key: string ]: string;
+};
+
 export const WelcomeEmailTextSetting = ( {
 	value,
 	disabled,
@@ -23,16 +27,15 @@ export const WelcomeEmailTextSetting = ( {
 	const onChangeFieldSubscriptionOptions =
 		( field: string ) => ( event: React.ChangeEvent< HTMLInputElement > ) => {
 			const textFieldValue = event.target.value;
-			if ( field === 'invitation' ) {
-				const newValue = { invitation: textFieldValue };
-				const valueToSave = { ...value, ...newValue };
-				updateFields( {
-					[ 'subscription_options' ]: valueToSave,
-				} );
-			} else if ( field === 'welcome_text' ) {
-				//const newValue = { welcome_text: textFieldValue };
-				//const valueToSave = { ...value, ...newValue };
-			}
+
+			const newValue: SubscriptionOption = {};
+			newValue[ field ] = textFieldValue;
+
+			const valueToSave = { ...value, ...newValue };
+
+			updateFields( {
+				[ 'subscription_options' ]: valueToSave,
+			} );
 		};
 
 	return (

--- a/client/my-sites/site-settings/reading-newsletter-settings/WelcomeEmailTextSetting.tsx
+++ b/client/my-sites/site-settings/reading-newsletter-settings/WelcomeEmailTextSetting.tsx
@@ -1,0 +1,58 @@
+import { useTranslate } from 'i18n-calypso';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+import FormLabel from 'calypso/components/forms/form-label';
+import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
+import FormTextarea from 'calypso/components/forms/form-textarea';
+
+type WelcomeEmailTextSettingProps = {
+	value?: {
+		invitation: string;
+		comment_follow: string;
+	};
+	disabled?: boolean;
+	updateFields: ( fields: { [ key: string ]: unknown } ) => void;
+};
+
+export const WelcomeEmailTextSetting = ( {
+	value,
+	disabled,
+	updateFields,
+}: WelcomeEmailTextSettingProps ) => {
+	const translate = useTranslate();
+
+	const onChangeFieldSubscriptionOptions =
+		( field: string ) => ( event: React.ChangeEvent< HTMLInputElement > ) => {
+			const textFieldValue = event.target.value;
+			if ( field === 'invitation' ) {
+				const newValue = { invitation: textFieldValue };
+				const valueToSave = { ...value, ...newValue };
+				updateFields( {
+					[ 'subscription_options' ]: valueToSave,
+				} );
+			} else if ( field === 'welcome_text' ) {
+				//const newValue = { welcome_text: textFieldValue };
+				//const valueToSave = { ...value, ...newValue };
+			}
+		};
+
+	return (
+		<FormFieldset>
+			<FormLabel>Welcome email text</FormLabel>
+			<FormTextarea
+				name=""
+				id=""
+				value={ value?.invitation }
+				onChange={ onChangeFieldSubscriptionOptions( 'invitation' ) }
+				disabled={ disabled }
+				autoCapitalize="none"
+				onClick={ null }
+				onKeyPress={ null }
+			/>
+			<FormSettingExplanation>
+				{ translate(
+					'The welcome message sent out to new readers when they subscribe to your blog.'
+				) }
+			</FormSettingExplanation>
+		</FormFieldset>
+	);
+};

--- a/client/my-sites/site-settings/reading-newsletter-settings/index.tsx
+++ b/client/my-sites/site-settings/reading-newsletter-settings/index.tsx
@@ -3,10 +3,15 @@ import { useTranslate } from 'i18n-calypso';
 import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
 import { ExcerptSetting } from './ExcerptSetting';
 import { FeaturedImageEmailSetting } from './FeaturedImageEmailSetting';
+import { WelcomeEmailTextSetting } from './WelcomeEmailTextSetting';
 
 type Fields = {
 	wpcom_featured_image_in_email?: boolean;
 	wpcom_subscription_emails_use_excerpt?: boolean;
+	subscription_options?: {
+		invitation: string;
+		comment_follow: string;
+	};
 };
 
 type NewsletterSettingsSectionProps = {
@@ -27,7 +32,11 @@ export const NewsletterSettingsSection = ( {
 	updateFields,
 }: NewsletterSettingsSectionProps ) => {
 	const translate = useTranslate();
-	const { wpcom_featured_image_in_email, wpcom_subscription_emails_use_excerpt } = fields;
+	const {
+		wpcom_featured_image_in_email,
+		wpcom_subscription_emails_use_excerpt,
+		subscription_options,
+	} = fields;
 
 	return (
 		<>
@@ -39,6 +48,13 @@ export const NewsletterSettingsSection = ( {
 				disabled={ disabled }
 				isSaving={ isSavingSettings }
 			/>
+			<Card className="site-settings__card">
+				<WelcomeEmailTextSetting
+					value={ subscription_options }
+					updateFields={ updateFields }
+					disabled={ disabled }
+				/>
+			</Card>
 			<Card className="site-settings__card">
 				<FeaturedImageEmailSetting
 					value={ wpcom_featured_image_in_email }

--- a/client/my-sites/site-settings/reading-newsletter-settings/index.tsx
+++ b/client/my-sites/site-settings/reading-newsletter-settings/index.tsx
@@ -1,9 +1,9 @@
 import { Card } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
+import { EmailsTextSetting } from './EmailsTextSetting';
 import { ExcerptSetting } from './ExcerptSetting';
 import { FeaturedImageEmailSetting } from './FeaturedImageEmailSetting';
-import { WelcomeEmailTextSetting } from './WelcomeEmailTextSetting';
 
 type Fields = {
 	wpcom_featured_image_in_email?: boolean;
@@ -49,7 +49,7 @@ export const NewsletterSettingsSection = ( {
 				isSaving={ isSavingSettings }
 			/>
 			<Card className="site-settings__card">
-				<WelcomeEmailTextSetting
+				<EmailsTextSetting
 					value={ subscription_options }
 					updateFields={ updateFields }
 					disabled={ disabled }

--- a/client/my-sites/site-settings/settings-reading/main.tsx
+++ b/client/my-sites/site-settings/settings-reading/main.tsx
@@ -22,6 +22,10 @@ type Settings = {
 	rss_use_excerpt?: boolean;
 	wpcom_featured_image_in_email?: boolean;
 	wpcom_subscription_emails_use_excerpt?: boolean;
+	subscription_options?: {
+		invitation: string;
+		comment_follow: string;
+	};
 };
 
 const getFormSettings = ( settings: Settings ) => {
@@ -38,6 +42,7 @@ const getFormSettings = ( settings: Settings ) => {
 		rss_use_excerpt,
 		wpcom_featured_image_in_email,
 		wpcom_subscription_emails_use_excerpt,
+		subscription_options,
 	} = settings;
 
 	return {
@@ -49,6 +54,7 @@ const getFormSettings = ( settings: Settings ) => {
 		...( rss_use_excerpt && { rss_use_excerpt } ),
 		...( wpcom_featured_image_in_email && { wpcom_featured_image_in_email } ),
 		...( wpcom_subscription_emails_use_excerpt && { wpcom_subscription_emails_use_excerpt } ),
+		...( subscription_options && { subscription_options } ),
 	};
 };
 
@@ -66,6 +72,10 @@ type Fields = {
 	rss_use_excerpt?: boolean;
 	wpcom_featured_image_in_email?: boolean;
 	wpcom_subscription_emails_use_excerpt?: boolean;
+	subscription_settings?: {
+		invitation: string;
+		comment_follow: string;
+	};
 };
 
 type ReadingSettingsFormProps = {

--- a/client/my-sites/site-settings/settings-reading/main.tsx
+++ b/client/my-sites/site-settings/settings-reading/main.tsx
@@ -72,7 +72,7 @@ type Fields = {
 	rss_use_excerpt?: boolean;
 	wpcom_featured_image_in_email?: boolean;
 	wpcom_subscription_emails_use_excerpt?: boolean;
-	subscription_settings?: {
+	subscription_options?: {
 		invitation: string;
 		comment_follow: string;
 	};

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -676,3 +676,13 @@ button.site-settings__general-settings-set-guessed-timezone.button.is-borderless
 		padding-left: 5px;
 	}
 }
+
+.site-settings__emails-test-settings-container {
+	legend {
+		font-weight: 400;
+		margin-bottom: 32px;
+	}
+	legend + label {
+		font-weight: 700;
+	}
+}

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -680,9 +680,12 @@ button.site-settings__general-settings-set-guessed-timezone.button.is-borderless
 .site-settings__emails-test-settings-container {
 	legend {
 		font-weight: 400;
-		margin-bottom: 32px;
+		margin-bottom: 0;
 	}
 	legend + label {
 		font-weight: 700;
+	}
+	label {
+		margin-top: 24px;
 	}
 }


### PR DESCRIPTION
#### Proposed Changes

The proposed changes add two text areas to the new Reading settings page (as outlined in the design: wdlTywgHNsHnVw1IMre1eQ-fi-1%3A3):

* Welcome email text
* Comment follow email text

![Markup on 2023-01-04 at 14:31:37](https://user-images.githubusercontent.com/25105483/210566038-674d689d-d347-4f36-bf81-ca84d034daa5.png)

The PR includes the necessary logic for the settings to be saved to the site. Both fields are included in one PR because they are part of a single site option `subscription_options`.

If you would like to learn more about the endpoint implementation that handles the retrieving and saving of the option, please review the related Jetpack PR: https://github.com/Automattic/jetpack/pull/28036.

---

Related project thread: Modernize Reading Settings (pdDOJh-17o-p2)

Related tasks:
- https://github.com/Automattic/wp-calypso/issues/70415
- https://github.com/Automattic/wp-calypso/issues/70414

---

#### Testing Instructions

1. Checkout this Calypso PR and build it.
2. If https://github.com/Automattic/jetpack/pull/28036 Jetpack PR hasn't been merged and deployed to WPCOM yet, it is necessary to use [this script](https://github.com/Automattic/jetpack/pull/28036#issuecomment-1361259623) to sync the Jetpack changes to your WPCOM sandbox as well.
3. Sandbox `public-api.wordpress.com`.
4. Navigate to `http://calypso.localhost:3000/settings/reading/<site-address>`.
5. Experiment with both: "Welcome email text" and "Comment follow email text" settings. For instance: Change both values, one value only, save settings, reload page, change other - unrelated settings...
6. Review the saved values in the Reading settings in WP Admin: `/wp-admin/options-reading.php`.
7. The saved values can be also verified through Developer Console (as can be seen in the Jetpack PR test instructions: https://github.com/Automattic/jetpack/pull/28036) and also through the Site Explorer - when listing site options of your site.

ℹ️ If you are testing on a new site - or - the settings haven't been touched before, both text fields will be empty (until you add text to them). We will address this in a separate PR. Related discussion: p1671718726381529/1671717628.207919-slack-C02TCEHP3HA. → This issue will be resolved separately: https://github.com/Automattic/wp-calypso/issues/71711.

ℹ️ The endpoint filters out unwanted content and will let in plain text and anchor tags in. There's one edge case related to that which I haven't addressed yet → [more info](https://github.com/Automattic/wp-calypso/pull/71475#issuecomment-1371080418).

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #