### PR TITLE
Add intro background image to ecommerce processing step

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/style.scss
@@ -78,3 +78,37 @@ $progress-duration: 800ms;
 		background-position-x: 0, 100%;
 	}
 }
+
+.processing {
+	&.ecommerce {
+		padding: 60px 0;
+		min-height: 100%;
+		min-width: 100%;
+		width: 100%;
+		height: auto;
+		position: fixed;
+		top: 0;
+		left: 0;
+		background-color: #fff;
+		background-image:
+			url(calypso/assets/images/onboarding/ecommerce-intro-1.jpg),
+			url(calypso/assets/images/onboarding/ecommerce-intro-2.jpg);
+		background-position-y: -40px, 110%;
+		/*!rtl:ignore*/
+		background-position-x: 109%, -10%;
+		background-repeat: no-repeat, no-repeat;
+		background-attachment: fixed;
+		background-size: auto 15%, auto 25%;
+		padding-top: 0;
+
+		@include break-huge {
+			background-size: auto 15%, auto 35%, auto 50%;
+			background-position-x: 65%, -100px, 120%;
+			background-position-y: 5%, 85%, 125%;
+			background-image:
+				url(calypso/assets/images/onboarding/ecommerce-intro-1.jpg),
+				url(calypso/assets/images/onboarding/ecommerce-intro-2.jpg),
+				url(calypso/assets/images/onboarding/ecommerce-intro-3.jpg);
+		}
+	}
+}


### PR DESCRIPTION
#### Proposed Changes

As part of #71244, we're adding the same intro step background image to the processing step.

#### Testing Instructions

After applying this patch, visit `/setup/ecommerce/processing` (sandboxing isn't necessary).

Verify that processing step has the background images pictured below:

![image](https://user-images.githubusercontent.com/917632/209226839-06912509-853e-4aec-aaf0-7bd17303a1cd.png)


<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [NA] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [NA] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [NA] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [NA] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [NA] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #71244
