### PR TITLE
Update JITM CSS for stats page

### DIFF
--- a/client/blocks/jitm/style.scss
+++ b/client/blocks/jitm/style.scss
@@ -5,7 +5,22 @@
 	max-width: 1040px;
 }
 
+// Customization for the /themes page.
 .is-section-themes-i4 .layout__content > .upsell-nudge {
 	max-width: 100%;
 	margin: 40px 0 0 0;
+}
+
+// Customization for the /stats page.
+.is-section-stats .layout__content > .upsell-nudge {
+	max-width: 1224px;
+	margin: -25px max(calc(50% - 612px), 32px) 0;
+
+	@media ( max-width: 660px ) {
+		margin: -15px 16px 0;
+	}
+
+	@media ( min-width: 659px ) and ( max-width: 782px ) {
+		margin: -10px 32px 0;
+	}
 }


### PR DESCRIPTION
#### Proposed Changes

* Update the CSS so the JITM fits well on the /stats page.

Before | After
--|--
![stats-before](https://user-images.githubusercontent.com/140841/209240634-72602730-1baf-46c3-944b-4fce72605f2a.png)  | ![stats-after](https://user-images.githubusercontent.com/140841/209240628-1aa76b01-b4de-4ac4-976e-1ecb752a433c.png)

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Load this branch
* Use a Simple test site with any paid plan
* Go to http://calypso.localhost:3000/stats/yourtestsite.wordpress.com
* If you're lucky the JITM loaded (because you happened to be included in an upcoming experiment) and you can view the changes. 😅 
  * If the JITM did not load you can load this test JITM in your Sandbox and Sandbox the API D95264-code That diff should make a test JITM appear.
* View that the banner is spaced nicely.
* Try resizing the page to make sure the JITM banner looks good in all sizes.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
