### PR TITLE
Fix IDR price display decimal

### DIFF
--- a/client/my-sites/plan-price/index.jsx
+++ b/client/my-sites/plan-price/index.jsx
@@ -104,7 +104,7 @@ export class PlanPrice extends Component {
 			let priceInteger = priceObj.price.integer;
 			// In some currencies like IDR, a dot is used to separate group of threes.
 			// Remove it so that it's not confused to be a decimal point by the subtraction operator.
-			priceInteger = priceInteger.replace( '.', '' );
+			priceInteger = priceInteger.replace( /[,.]/g, '' );
 
 			return (
 				<>

--- a/client/my-sites/plan-price/index.jsx
+++ b/client/my-sites/plan-price/index.jsx
@@ -101,11 +101,16 @@ export class PlanPrice extends Component {
 		}
 
 		const renderPriceHtml = ( priceObj ) => {
+			let priceInteger = priceObj.price.integer;
+			// In some currencies like IDR, a dot is used to separate group of threes.
+			// Remove it so that it's not confused to be a decimal point by the subtraction operator.
+			priceInteger = priceInteger.replace( '.', '' );
+
 			return (
 				<>
 					<span className="plan-price__integer">{ priceObj.price.integer }</span>
 					<sup className="plan-price__fraction">
-						{ priceObj.raw - priceObj.price.integer > 0 && priceObj.price.fraction }
+						{ priceObj.raw - priceInteger > 0 && priceObj.price.fraction }
 					</sup>
 				</>
 			);


### PR DESCRIPTION
#### Proposed Changes

* In IDR currency, the signup plans step and Calypso `/plans` display a `,00` fraction value for the price. This is unnecessary since we don't want to display zero value fractions.
* The reason is due to an incorrect subtraction of the raw price of a plan and integer value of the price. IDR and a few other currencies use dot as a group-of-three separator and the JS subtraction operator considers this to be a decimal point. 

**BEFORE**
<img width="1317" alt="Screenshot 2022-12-23 at 10 05 42 AM" src="https://user-images.githubusercontent.com/1269602/209272359-ac3d55fa-d6a3-4305-b229-f2fd4641a8c4.png">

<img width="1094" alt="Screenshot 2022-12-23 at 10 06 21 AM" src="https://user-images.githubusercontent.com/1269602/209272375-5bd5ee26-a642-46db-8f94-aad445039439.png">

**AFTER**
<img width="1276" alt="Screenshot 2022-12-23 at 10 05 23 AM" src="https://user-images.githubusercontent.com/1269602/209272395-8be6c84c-f9eb-4ff4-bd21-b2f0c3dca792.png">
<img width="1153" alt="Screenshot 2022-12-23 at 10 06 33 AM" src="https://user-images.githubusercontent.com/1269602/209272406-9138fefc-7400-4c18-8d45-9802b9913653.png">



#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* IN IDR currency, go through the signup flow and check the plans step currency. Verify that it does not have the `,00` fractional value.
* Verify the same in Calypso `/plans` step too that there's no `,00` fractional value.
* There should be no difference in USD, EUR, INR etc. Verify for a few currencies. 

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
