### PR TITLE
Design Picker: Fix skip for now doesn't work

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
@@ -56,29 +56,27 @@ const ProcessingStep: Step = function ( props ) {
 	const captureFlowException = useCaptureFlowException( props.flow, 'ProcessingStep' );
 
 	useEffect( () => {
-		if ( action ) {
-			( async () => {
-				if ( typeof action === 'function' ) {
-					try {
-						const destination = await action();
-						// Don't call submit() directly; instead, turn on a flag that signals we should call submit() next.
-						// This allows us to call the newest submit() created. Otherwise, we would be calling a submit()
-						// that is frozen from before we called action().
-						// We can now get the most up to date values from hooks inside the flow creating submit(),
-						// including the values that were updated during the action() running.
-						setDestinationState( destination );
-						setHasActionSuccessfullyRun( true );
-					} catch ( e ) {
-						// eslint-disable-next-line no-console
-						console.error( 'ProcessingStep failed:', e );
-						captureFlowException( e );
-						submit?.( {}, ProcessingResult.FAILURE );
-					}
-				} else {
-					submit?.( {}, ProcessingResult.NO_ACTION );
+		( async () => {
+			if ( typeof action === 'function' ) {
+				try {
+					const destination = await action();
+					// Don't call submit() directly; instead, turn on a flag that signals we should call submit() next.
+					// This allows us to call the newest submit() created. Otherwise, we would be calling a submit()
+					// that is frozen from before we called action().
+					// We can now get the most up to date values from hooks inside the flow creating submit(),
+					// including the values that were updated during the action() running.
+					setDestinationState( destination );
+					setHasActionSuccessfullyRun( true );
+				} catch ( e ) {
+					// eslint-disable-next-line no-console
+					console.error( 'ProcessingStep failed:', e );
+					captureFlowException( e );
+					submit?.( {}, ProcessingResult.FAILURE );
 				}
-			} )();
-		}
+			} else {
+				submit?.( {}, ProcessingResult.NO_ACTION );
+			}
+		} )();
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ action ] );
 


### PR DESCRIPTION
#### Proposed Changes

* Remove the check of the `action` that is from the [commit](https://github.com/Automattic/wp-calypso/commit/70011367f103054443593856e2468bacc0fccc85) of this [PR](https://github.com/Automattic/wp-calypso/pull/68722), and then we can finish the process step even if there is no pending action set

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup?siteSlug=<your_site>`
* Click the "Continue" button until you land on the design picker step
* Click "Skip for now" at the top-right corner, and you have to the "My Home"

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/71484
