### PR TITLE
Add SitesGridItem to DevDocs for easier testing different cases

### DIFF
--- a/client/devdocs/design/index.jsx
+++ b/client/devdocs/design/index.jsx
@@ -123,6 +123,7 @@ import Wizard from 'calypso/components/wizard/docs/example';
 import WpcomColophon from 'calypso/components/wpcom-colophon/docs/example';
 import Collection from 'calypso/devdocs/design/search-collection';
 import { slugToCamelCase } from 'calypso/devdocs/docs-example/util';
+import SitesGridItemExample from 'calypso/sites-dashboard/components/sites-grid-item/docs/example';
 import SitesTableRowExample from 'calypso/sites-dashboard/components/sites-table-row/docs/example';
 
 export default class DesignAssets extends Component {
@@ -271,6 +272,7 @@ export default class DesignAssets extends Component {
 					<SplitButton readmeFilePath="split-button" />
 					<Spotlight />
 					<SiteThumbnail readmeFilePath="/packages/components/src/site-thumbnail" />
+					<SitesGridItemExample readmeFilePath="/client/sites-dashboard/components/sites-grid-item" />
 					<SitesTableRowExample readmeFilePath="/client/sites-dashboard/components/sites-table-row" />
 					<StepProgress readmeFilePath="step-progress" />
 					<Suggestions readmeFilePath="/packages/components/src/suggestions" />

--- a/client/sites-dashboard/components/docs/sample-site-data.jsx
+++ b/client/sites-dashboard/components/docs/sample-site-data.jsx
@@ -1,0 +1,133 @@
+const exampleSite = {
+	URL: 'https://wpvip.com',
+	is_coming_soon: false,
+	is_private: false,
+	visible: true,
+	launch_status: 'launched',
+	name: 'The long title of the sample site',
+	jetpack: false,
+	site_owner: 12,
+	lang: 'en',
+	options: {
+		admin_url: 'https://wpvip.com/wp-admin/',
+		is_redirect: false,
+		is_wpforteams_site: false,
+		launchpad_screen: false,
+		site_intent: '',
+		unmapped_url: 'https://wpvip.com',
+		updated_at: new Date(),
+	},
+	p2_thumbnail_elements: null,
+	plan: {
+		product_id: 1,
+		product_slug: 'free_plan',
+		product_name_short: 'Free',
+		expired: false,
+		user_is_owner: false,
+		is_free: true,
+	},
+	is_wpcom_atomic: false,
+	title: 'The long title of the sample site',
+	slug: 'wpvip.wordpress.com',
+};
+
+const siteSimpleFree = {
+	...exampleSite,
+	ID: 1,
+	title: 'Free Simple Site',
+};
+
+const siteSimpleBusinessComingSoon = {
+	...exampleSite,
+	ID: 2,
+	options: {
+		...exampleSite.options,
+		updated_at: new Date( +new Date() - 60 * 60 * 24 * 1000 ),
+	},
+	plan: {
+		...exampleSite.plan,
+		product_id: 1008,
+		product_slug: 'business-bundle',
+		product_name_short: 'Business',
+		user_is_owner: true,
+		is_free: false,
+	},
+	is_coming_soon: true,
+	launch_status: 'unlaunched',
+	title: 'Business Simple Site with Coming Soon status',
+};
+
+const siteSimpleBusinessExpired = {
+	...exampleSite,
+	ID: 3,
+	options: {
+		...exampleSite.options,
+		updated_at: new Date( +new Date() - 60 * 60 * 24 * 1000 ),
+	},
+	plan: {
+		...exampleSite.plan,
+		product_id: 1008,
+		product_slug: 'business-bundle',
+		product_name_short: 'Business',
+		user_is_owner: true,
+		is_free: false,
+		expired: true,
+	},
+	title: 'Expired Business Simple Site',
+};
+
+const siteJetpackComplete = {
+	...exampleSite,
+	ID: 4,
+	jetpack: true,
+	options: {
+		...exampleSite.options,
+		updated_at: new Date( +new Date() - 60 * 60 * 24 * 2 * 1000 ),
+	},
+	plan: {
+		...exampleSite.plan,
+		product_id: 2014,
+		product_slug: 'jetpack_complete',
+		product_name_short: 'Complete',
+		user_is_owner: true,
+		is_free: false,
+	},
+	title: 'Jetpack Complete Site',
+};
+
+const siteSimplePrivateP2 = {
+	...exampleSite,
+	ID: 5,
+	is_private: true,
+	visible: false,
+	options: {
+		...exampleSite.options,
+		is_wpforteams_site: true,
+		updated_at: new Date( +new Date() - 60 * 60 * 24 * 30 * 1000 ),
+	},
+	plan: {
+		...exampleSite.plan,
+		product_id: 1040,
+		product_slug: '"wp_p2_plus_monthly"',
+		product_name_short: 'P2+',
+		is_free: false,
+	},
+	icon: {
+		ico: 'https://wpjobmanager.com/wp-content/uploads/2022/10/wp-job-manager-logo.webp?w=16',
+		img: 'https://wpjobmanager.com/wp-content/uploads/2022/10/wp-job-manager-logo.webp',
+	},
+	p2_thumbnail_elements: {
+		color_link: '#0267ff',
+		color_sidebar_background: '#d0ccb8',
+		header_image: 'https://wpjobmanager.com/wp-content/uploads/2022/11/hero-resized.png?resize=680',
+	},
+	title: 'Simple Private P2 Site',
+};
+
+export default [
+	siteSimpleFree,
+	siteSimpleBusinessComingSoon,
+	siteSimpleBusinessExpired,
+	siteJetpackComplete,
+	siteSimplePrivateP2,
+];

--- a/client/sites-dashboard/components/sites-grid-item/README.md
+++ b/client/sites-dashboard/components/sites-grid-item/README.md
@@ -11,7 +11,7 @@ function render() {
 	const site = {};
 	return (
 		<div>
-            <SitesGridItem site={ site } key={ site.ID }></SitesGridItem>
+			<SitesGridItem site={ site } key={ site.ID }></SitesGridItem>
 		</div>
 	);
 }

--- a/client/sites-dashboard/components/sites-grid-item/README.md
+++ b/client/sites-dashboard/components/sites-grid-item/README.md
@@ -1,0 +1,23 @@
+# SitesGridItem
+
+Renders a SitesGridItem component.
+
+## How to use
+
+```jsx
+import SitesGridItem from 'calypso/sites-dashboard/components/sites-grid-item';
+
+function render() {
+	const site = {};
+	return (
+		<div>
+            <SitesGridItem site={ site } key={ site.ID }></SitesGridItem>
+		</div>
+	);
+}
+```
+
+## Props
+
+- `site`: a site data  e.g. SiteExcerptData object.
+- `key`: unique key eg. Site ID.

--- a/client/sites-dashboard/components/sites-grid-item/docs/example.jsx
+++ b/client/sites-dashboard/components/sites-grid-item/docs/example.jsx
@@ -1,0 +1,46 @@
+import { css } from '@emotion/css';
+import classnames from 'classnames';
+import { MEDIA_QUERIES } from 'calypso/sites-dashboard/utils';
+import sampleSiteData from '../../docs/sample-site-data';
+import { SitesGridItem } from '../../sites-grid-item';
+
+const container = css( {
+	display: 'grid',
+	gap: '32px',
+
+	gridTemplateColumns: '1fr',
+
+	[ MEDIA_QUERIES.mediumOrLarger ]: {
+		gridTemplateColumns: 'repeat(2, 1fr)',
+	},
+
+	[ MEDIA_QUERIES.large ]: {
+		gridTemplateColumns: 'repeat(3, 1fr)',
+	},
+} );
+
+const className = css( {
+	marginBlockStart: 0,
+	marginInline: 0,
+	marginBlockEnd: '1.5em',
+} );
+
+const itemClassName = css( {
+	minWidth: 0,
+} );
+
+const SitesGridItemExample = () => {
+	return (
+		<div className={ classnames( container, className ) }>
+			{ sampleSiteData.map( ( site ) => (
+				<div className={ itemClassName } key={ site.ID }>
+					<SitesGridItem site={ site } />
+				</div>
+			) ) }
+		</div>
+	);
+};
+
+SitesGridItemExample.displayName = 'SitesGridItem';
+
+export default SitesGridItemExample;

--- a/client/sites-dashboard/components/sites-table-row/docs/example.jsx
+++ b/client/sites-dashboard/components/sites-table-row/docs/example.jsx
@@ -1,3 +1,4 @@
+import sampleSiteData from '../../docs/sample-site-data';
 import SitesTableRow from '../../sites-table-row';
 
 const CONTAINER_STYLES = {
@@ -6,145 +7,13 @@ const CONTAINER_STYLES = {
 	padding: '16px',
 };
 
-const exampleSite = {
-	URL: 'https://wpvip.com',
-	is_coming_soon: false,
-	is_private: false,
-	visible: true,
-	launch_status: 'launched',
-	name: 'The long title of the sample site',
-	jetpack: false,
-	site_owner: 12,
-	lang: 'en',
-	options: {
-		admin_url: 'https://wpvip.com/wp-admin/',
-		is_redirect: false,
-		is_wpforteams_site: false,
-		launchpad_screen: false,
-		site_intent: '',
-		unmapped_url: 'https://wpvip.com',
-		updated_at: new Date(),
-	},
-	p2_thumbnail_elements: null,
-	plan: {
-		product_id: 1,
-		product_slug: 'free_plan',
-		product_name_short: 'Free',
-		expired: false,
-		user_is_owner: false,
-		is_free: true,
-	},
-	is_wpcom_atomic: false,
-	title: 'The long title of the sample site',
-	slug: 'wpvip.wordpress.com',
-};
-
-const siteSimpleFree = {
-	...exampleSite,
-	ID: 1,
-	title: 'Free Simple Site',
-};
-
-const siteSimpleBusinessComingSoon = {
-	...exampleSite,
-	ID: 2,
-	options: {
-		...exampleSite.options,
-		updated_at: new Date( +new Date() - 60 * 60 * 24 * 1000 ),
-	},
-	plan: {
-		...exampleSite.plan,
-		product_id: 1008,
-		product_slug: 'business-bundle',
-		product_name_short: 'Business',
-		user_is_owner: true,
-		is_free: false,
-	},
-	is_coming_soon: true,
-	launch_status: 'unlaunched',
-	title: 'Business Simple Site with Coming Soon status',
-};
-
-const siteSimpleBusinessExpired = {
-	...exampleSite,
-	ID: 3,
-	options: {
-		...exampleSite.options,
-		updated_at: new Date( +new Date() - 60 * 60 * 24 * 1000 ),
-	},
-	plan: {
-		...exampleSite.plan,
-		product_id: 1008,
-		product_slug: 'business-bundle',
-		product_name_short: 'Business',
-		user_is_owner: true,
-		is_free: false,
-		expired: true,
-	},
-	title: 'Expired Business Simple Site',
-};
-
-const siteJetpackComplete = {
-	...exampleSite,
-	ID: 4,
-	jetpack: true,
-	options: {
-		...exampleSite.options,
-		updated_at: new Date( +new Date() - 60 * 60 * 24 * 2 * 1000 ),
-	},
-	plan: {
-		...exampleSite.plan,
-		product_id: 2014,
-		product_slug: 'jetpack_complete',
-		product_name_short: 'Complete',
-		user_is_owner: true,
-		is_free: false,
-	},
-	title: 'Jetpack Complete Site',
-};
-
-const siteSimplePrivateP2 = {
-	...exampleSite,
-	ID: 5,
-	is_private: true,
-	visible: false,
-	options: {
-		...exampleSite.options,
-		is_wpforteams_site: true,
-		updated_at: new Date( +new Date() - 60 * 60 * 24 * 30 * 1000 ),
-	},
-	plan: {
-		...exampleSite.plan,
-		product_id: 1040,
-		product_slug: '"wp_p2_plus_monthly"',
-		product_name_short: 'P2+',
-		is_free: false,
-	},
-	icon: {
-		ico: 'https://wpjobmanager.com/wp-content/uploads/2022/10/wp-job-manager-logo.webp?w=16',
-		img: 'https://wpjobmanager.com/wp-content/uploads/2022/10/wp-job-manager-logo.webp',
-	},
-	p2_thumbnail_elements: {
-		color_link: '#0267ff',
-		color_sidebar_background: '#d0ccb8',
-		header_image: 'https://wpjobmanager.com/wp-content/uploads/2022/11/hero-resized.png?resize=680',
-	},
-	title: 'Simple Private P2 Site',
-};
-
 const SitesTableRowExample = () => {
 	return (
 		<div>
 			<div style={ CONTAINER_STYLES }>
 				<table>
 					<tbody>
-						{ [
-							siteSimpleFree,
-							siteSimpleBusinessComingSoon,
-							siteSimpleBusinessExpired,
-							siteJetpackComplete,
-							siteSimplePrivateP2,
-						].map( ( site ) => (
+						{ sampleSiteData.map( ( site ) => (
 							<SitesTableRow site={ site } key={ site.ID } />
 						) ) }
 					</tbody>


### PR DESCRIPTION
#### Proposed Changes

In this PR, I propose to add the `SitesGridItem` component to DevDocs for easier testing of different cases. To avoid repetition, I extract test site data to separate file, and I reuse it in both `SitesGridItem` and `SitesTableRow`.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Navigate to `/devdocs/design`
2. Search for SitesGridItem
3. Click on the component name

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/71195
Fixes https://github.com/Automattic/wp-calypso/issues/71370
