### PR TITLE
Domains: Update copy in the domain ownership verification auth code step

### DIFF
--- a/client/components/domains/connect-domain-step/connect-domain-step-ownership-auth-code.jsx
+++ b/client/components/domains/connect-domain-step/connect-domain-step-ownership-auth-code.jsx
@@ -1,3 +1,4 @@
+import { createElement, createInterpolateElement } from '@wordpress/element';
 import { useI18n } from '@wordpress/react-i18n';
 import { useCallback } from 'react';
 import { connect } from 'react-redux';
@@ -28,6 +29,14 @@ const ConnectDomainStepOwnershipAuthCode = ( {
 				) }
 			</p>
 			<p className="connect-domain-step__text">{ authCodeStepDefaultDescription.label }</p>
+			<p className="connect-domain-step__text">
+				{ createInterpolateElement(
+					__(
+						'This will only be used for verification purposes, a domain transfer <strong>will not</strong> be initiated.'
+					),
+					{ strong: createElement( 'strong' ) }
+				) }
+			</p>
 		</>
 	);
 	return (

--- a/client/components/domains/connect-domain-step/connect-domain-step-ownership-auth-code.jsx
+++ b/client/components/domains/connect-domain-step/connect-domain-step-ownership-auth-code.jsx
@@ -32,7 +32,7 @@ const ConnectDomainStepOwnershipAuthCode = ( {
 			<p className="connect-domain-step__text">
 				{ createInterpolateElement(
 					__(
-						'This will only be used for verification purposes, a domain transfer <strong>will not</strong> be initiated.'
+						'This will only be used to verify that you own this domain, <strong>we will not transfer it</strong>.'
 					),
 					{ strong: createElement( 'strong' ) }
 				) }


### PR DESCRIPTION
### Proposed Changes

The copy in the domain ownership verification auth code step was updated to make it clear that a domain transfer will not be initiated when the user provides their domain's auth code.

Screenshot:

![Markup on 2022-12-23 at 13:51:56](https://user-images.githubusercontent.com/5324818/209372471-6d932f1d-ab33-4287-9073-a522c2e2b0f3.png)

### Testing Instructions

- Build this branch locally or open the live Calypso link
- Go to Upgrades > Domains > + Add a domain > Use a domain I own
- Try to connect a domain to a site which will ask for auth code verification (you can hack that in the backend)
- Ensure the new paragraph explaining a domain transfer will not be initiated is present

### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
