### PR TITLE
Purchases: Change PurchaseMetaPrice to use billPeriodDays instead of label

### DIFF
--- a/client/me/purchases/manage-purchase/purchase-meta-price.tsx
+++ b/client/me/purchases/manage-purchase/purchase-meta-price.tsx
@@ -4,6 +4,8 @@ import {
 	isDIFMProduct,
 	isDomainTransfer,
 	isEmailMonthly,
+	PLAN_ANNUAL_PERIOD,
+	PLAN_MONTHLY_PERIOD,
 	TERM_BIENNIALLY,
 	TERM_MONTHLY,
 } from '@automattic/calypso-products';
@@ -91,15 +93,21 @@ function PurchaseMetaPrice( { purchase }: { purchase: Purchase } ) {
 			}
 		}
 
-		if ( purchase.billPeriodLabel ) {
-			switch ( purchase.billPeriodLabel ) {
-				case 'per year':
+		if ( purchase.billPeriodDays ) {
+			switch ( purchase.billPeriodDays ) {
+				case PLAN_ANNUAL_PERIOD:
 					return translate( 'year' );
-				case 'per month':
+				case PLAN_MONTHLY_PERIOD:
 					return translate( 'month' );
-				case 'per week':
+				case 7:
+					// Note: does this period ever happen? I don't think it does but it
+					// was added in https://github.com/Automattic/wp-calypso/pull/65006
+					// and so I'm leaving it for now.
 					return translate( 'week' );
-				case 'per day':
+				case 1:
+					// Note: does this period ever happen? I don't think it does but it
+					// was added in https://github.com/Automattic/wp-calypso/pull/65006
+					// and so I'm leaving it for now.
 					return translate( 'day' );
 			}
 		}

--- a/client/me/purchases/manage-purchase/purchase-meta-price.tsx
+++ b/client/me/purchases/manage-purchase/purchase-meta-price.tsx
@@ -82,10 +82,12 @@ function PurchaseMetaPrice( { purchase }: { purchase: Purchase } ) {
 	}
 
 	const getPeriod = () => {
+		// TODO: is this block needed or can we rely on billPeriodDays?
 		if ( isEmailMonthly( purchase ) ) {
 			return translate( 'month' );
 		}
 
+		// TODO: is this block needed or can we rely on billPeriodDays?
 		if ( typeof plan === 'object' && plan.term ) {
 			switch ( plan.term ) {
 				case TERM_BIENNIALLY:
@@ -118,6 +120,7 @@ function PurchaseMetaPrice( { purchase }: { purchase: Purchase } ) {
 			}
 		}
 
+		// TODO: is this fallback needed or can we rely on billPeriodDays?
 		return translate( 'year' );
 	};
 

--- a/client/me/purchases/manage-purchase/purchase-meta-price.tsx
+++ b/client/me/purchases/manage-purchase/purchase-meta-price.tsx
@@ -1,7 +1,6 @@
 import {
 	isDIFMProduct,
 	isDomainTransfer,
-	isEmailMonthly,
 	PLAN_ANNUAL_PERIOD,
 	PLAN_BIENNIAL_PERIOD,
 	PLAN_MONTHLY_PERIOD,
@@ -76,11 +75,6 @@ function PurchaseMetaPrice( { purchase }: { purchase: Purchase } ) {
 	}
 
 	const getPeriod = () => {
-		// TODO: is this block needed or can we rely on billPeriodDays?
-		if ( isEmailMonthly( purchase ) ) {
-			return translate( 'month' );
-		}
-
 		switch ( purchase.billPeriodDays ) {
 			case PLAN_BIENNIAL_PERIOD:
 				return translate( 'two years' );

--- a/client/me/purchases/manage-purchase/purchase-meta-price.tsx
+++ b/client/me/purchases/manage-purchase/purchase-meta-price.tsx
@@ -1,15 +1,10 @@
 import {
-	getPlan,
-	getProductFromSlug,
 	isDIFMProduct,
 	isDomainTransfer,
 	isEmailMonthly,
 	PLAN_ANNUAL_PERIOD,
 	PLAN_BIENNIAL_PERIOD,
 	PLAN_MONTHLY_PERIOD,
-	TERM_ANNUALLY,
-	TERM_BIENNIALLY,
-	TERM_MONTHLY,
 } from '@automattic/calypso-products';
 import { useTranslate } from 'i18n-calypso';
 import {
@@ -21,8 +16,7 @@ import type { Purchase } from 'calypso/lib/purchases/types';
 
 function PurchaseMetaPrice( { purchase }: { purchase: Purchase } ) {
 	const translate = useTranslate();
-	const { productSlug, productDisplayPrice } = purchase;
-	const plan = getPlan( productSlug ) || getProductFromSlug( productSlug );
+	const { productDisplayPrice } = purchase;
 
 	if ( isOneTimePurchase( purchase ) || isDomainTransfer( purchase ) ) {
 		if ( isDIFMProduct( purchase ) ) {
@@ -87,37 +81,23 @@ function PurchaseMetaPrice( { purchase }: { purchase: Purchase } ) {
 			return translate( 'month' );
 		}
 
-		// TODO: is this block needed or can we rely on billPeriodDays?
-		if ( typeof plan === 'object' && plan.term ) {
-			switch ( plan.term ) {
-				case TERM_BIENNIALLY:
-					return translate( 'two years' );
-				case TERM_MONTHLY:
-					return translate( 'month' );
-				case TERM_ANNUALLY:
-					return translate( 'year' );
-			}
-		}
-
-		if ( purchase.billPeriodDays ) {
-			switch ( purchase.billPeriodDays ) {
-				case PLAN_BIENNIAL_PERIOD:
-					return translate( 'two years' );
-				case PLAN_ANNUAL_PERIOD:
-					return translate( 'year' );
-				case PLAN_MONTHLY_PERIOD:
-					return translate( 'month' );
-				case 7:
-					// Note: does this period ever happen? I don't think it does but it
-					// was added in https://github.com/Automattic/wp-calypso/pull/65006
-					// and so I'm leaving it for now.
-					return translate( 'week' );
-				case 1:
-					// Note: does this period ever happen? I don't think it does but it
-					// was added in https://github.com/Automattic/wp-calypso/pull/65006
-					// and so I'm leaving it for now.
-					return translate( 'day' );
-			}
+		switch ( purchase.billPeriodDays ) {
+			case PLAN_BIENNIAL_PERIOD:
+				return translate( 'two years' );
+			case PLAN_ANNUAL_PERIOD:
+				return translate( 'year' );
+			case PLAN_MONTHLY_PERIOD:
+				return translate( 'month' );
+			case 7:
+				// Note: does this period ever happen? I don't think it does but it
+				// was added in https://github.com/Automattic/wp-calypso/pull/65006
+				// and so I'm leaving it for now.
+				return translate( 'week' );
+			case 1:
+				// Note: does this period ever happen? I don't think it does but it
+				// was added in https://github.com/Automattic/wp-calypso/pull/65006
+				// and so I'm leaving it for now.
+				return translate( 'day' );
 		}
 
 		// TODO: is this fallback needed or can we rely on billPeriodDays?

--- a/client/me/purchases/manage-purchase/purchase-meta-price.tsx
+++ b/client/me/purchases/manage-purchase/purchase-meta-price.tsx
@@ -5,6 +5,7 @@ import {
 	isDomainTransfer,
 	isEmailMonthly,
 	PLAN_ANNUAL_PERIOD,
+	PLAN_BIENNIAL_PERIOD,
 	PLAN_MONTHLY_PERIOD,
 	TERM_BIENNIALLY,
 	TERM_MONTHLY,
@@ -95,6 +96,8 @@ function PurchaseMetaPrice( { purchase }: { purchase: Purchase } ) {
 
 		if ( purchase.billPeriodDays ) {
 			switch ( purchase.billPeriodDays ) {
+				case PLAN_BIENNIAL_PERIOD:
+					return translate( 'two years' );
 				case PLAN_ANNUAL_PERIOD:
 					return translate( 'year' );
 				case PLAN_MONTHLY_PERIOD:

--- a/client/me/purchases/manage-purchase/purchase-meta-price.tsx
+++ b/client/me/purchases/manage-purchase/purchase-meta-price.tsx
@@ -100,11 +100,19 @@ function PurchaseMetaPrice( { purchase }: { purchase: Purchase } ) {
 				return translate( 'day' );
 		}
 
-		// TODO: is this fallback needed or can we rely on billPeriodDays?
-		return translate( 'year' );
+		return null;
 	};
 
-	const getPriceLabel = ( period: string ) => {
+	const getPriceLabel = ( period: string | null ) => {
+		if ( ! period ) {
+			return (
+				<span
+					// eslint-disable-next-line react/no-danger
+					dangerouslySetInnerHTML={ { __html: productDisplayPrice } }
+				/>
+			);
+		}
+
 		//translators: displayPrice is the price of the purchase with localized currency (i.e. "C$10"), %(period)s is how long the plan is active (i.e. "year")
 		return translate( '{{displayPrice/}} {{period}}/ %(period)s{{/period}}', {
 			args: { period },

--- a/client/me/purchases/manage-purchase/purchase-meta-price.tsx
+++ b/client/me/purchases/manage-purchase/purchase-meta-price.tsx
@@ -7,6 +7,7 @@ import {
 	PLAN_ANNUAL_PERIOD,
 	PLAN_BIENNIAL_PERIOD,
 	PLAN_MONTHLY_PERIOD,
+	TERM_ANNUALLY,
 	TERM_BIENNIALLY,
 	TERM_MONTHLY,
 } from '@automattic/calypso-products';
@@ -91,6 +92,8 @@ function PurchaseMetaPrice( { purchase }: { purchase: Purchase } ) {
 					return translate( 'two years' );
 				case TERM_MONTHLY:
 					return translate( 'month' );
+				case TERM_ANNUALLY:
+					return translate( 'year' );
 			}
 		}
 

--- a/client/me/purchases/manage-purchase/test/purchase-meta.js
+++ b/client/me/purchases/manage-purchase/test/purchase-meta.js
@@ -2,9 +2,6 @@
  * @jest-environment jsdom
  */
 
-/* eslint-disable jest/no-conditional-expect */
-/* eslint-disable jest/valid-title */
-
 import { render, screen } from '@testing-library/react';
 import { Provider as ReduxProvider } from 'react-redux';
 import { createReduxStore } from 'calypso/state';
@@ -54,6 +51,7 @@ describe( 'PurchaseMeta', () => {
 					data: [
 						{
 							ID: 1,
+							bill_period_days: 365,
 							bill_period_label: 'per year',
 						},
 					],
@@ -90,6 +88,7 @@ describe( 'PurchaseMeta', () => {
 					data: [
 						{
 							ID: 1,
+							bill_period_days: 365,
 							bill_period_label: 'par année',
 						},
 					],
@@ -127,6 +126,7 @@ describe( 'PurchaseMeta', () => {
 						{
 							ID: 1,
 							bill_period_label: 'per month',
+							bill_period_days: 31,
 						},
 					],
 				},
@@ -163,6 +163,7 @@ describe( 'PurchaseMeta', () => {
 						{
 							ID: 1,
 							bill_period_label: 'per week',
+							bill_period_days: 7,
 						},
 					],
 				},
@@ -199,6 +200,7 @@ describe( 'PurchaseMeta', () => {
 						{
 							ID: 1,
 							bill_period_label: 'per day',
+							bill_period_days: 1,
 						},
 					],
 				},
@@ -235,6 +237,7 @@ describe( 'PurchaseMeta', () => {
 						{
 							ID: 1,
 							product_slug: 'business-bundle-2y',
+							bill_period_days: 730,
 						},
 					],
 				},


### PR DESCRIPTION
#### Proposed Changes

`PurchaseMetaPrice` contains a switch statement that looks at the contents of the `billPeriodLabel` on the purchase to decide what term to show. However, `billPeriodLabel` is localized for the user's language, so the switch statement will fail for non-EN languages. It must be replaced.

This PR replaces it (and all the other logic that was being used) with `billPeriodDays` (aka `bill_period_days` on the data returned by the server), which, as far as I can tell, is set for every product returned by the purchases endpoint. In case a product does not match any of the options, it will be rendered with no label instead. This might be more accurate for one-time-purchases than the previous default of "yearly" (although I think that those may actually handled by a separate code path).

Fixes https://github.com/Automattic/wp-calypso/issues/70549

#### Testing Instructions

First, verify that the billing term is displayed correctly for various products:

* Use a site that has a monthly plan.
* Visit the purchases page (`/me/purchases`) and select the plan subscription.
* Verify that the period shown next to the price is `X / month`.
* Repeat the above steps with an annual plan and verify that the price is shown as `X / year`.
* Repeat the above steps for an email product and verify that the price is shown with the correct term.

Next, we must cover the testing instructions from https://github.com/Automattic/wp-calypso/pull/65006:

* Go to a marketplace Plugin page and buy the monthly subscription. Ex: `/plugins/woocommerce-subscriptions`
* Go to the purchases page (`/me/purchases`) and select the plugin subscription.
* Verify that the period shown next to the price is `X / month`.

<img width="325" alt="Screenshot 2022-12-23 at 1 01 52 PM" src="https://user-images.githubusercontent.com/2036909/209386013-84df638e-f1f6-4903-98a8-4317d73675a9.png">

