### PR TITLE
Checkout: Make sure pricePerMonth is an integer in ItemVariantRadioPrice

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/item-variation-picker/variant-radio-price.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/item-variation-picker/variant-radio-price.tsx
@@ -6,6 +6,7 @@ import { getItemVariantDiscountPercentage } from './util';
 import type { WPCOMProductVariant } from './types';
 
 const Discount = styled.span`
+	text-align: center;
 	color: #234929;
 	display: block;
 	background-color: #b8e6bf;

--- a/client/my-sites/checkout/composite-checkout/components/item-variation-picker/variant-radio-price.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/item-variation-picker/variant-radio-price.tsx
@@ -74,7 +74,7 @@ export const ItemVariantRadioPrice: FunctionComponent< {
 		isSmallestUnit: true,
 	} );
 
-	const pricePerMonth = variant.priceInteger / variant.termIntervalInMonths;
+	const pricePerMonth = Math.round( variant.priceInteger / variant.termIntervalInMonths );
 	const pricePerYear = pricePerMonth * 12;
 
 	const pricePerYearFormatted = formatCurrency( pricePerYear, variant.currency, {

--- a/packages/format-currency/src/currencies.ts
+++ b/packages/format-currency/src/currencies.ts
@@ -969,12 +969,6 @@ export const CURRENCIES: CurrenciesDictionary = {
 	},
 };
 
-/**
- * Returns currency defaults.
- *
- * @param   {string} code      currency code
- * @returns {?object}          currency defaults
- */
 export function getCurrencyDefaults( code: string ): CurrencyDefinition {
 	const defaultCurrency = {
 		symbol: '$',
@@ -984,4 +978,8 @@ export function getCurrencyDefaults( code: string ): CurrencyDefinition {
 	};
 
 	return CURRENCIES[ code ] || defaultCurrency;
+}
+
+export function doesCurrencyExist( code: string ): boolean {
+	return Boolean( CURRENCIES[ code ] );
 }

--- a/packages/format-currency/src/index.ts
+++ b/packages/format-currency/src/index.ts
@@ -1,4 +1,4 @@
-import { getCurrencyDefaults } from './currencies';
+import { doesCurrencyExist, getCurrencyDefaults } from './currencies';
 import numberFormat from './number-format';
 import { FormatCurrencyOptions, CurrencyObject } from './types';
 
@@ -28,23 +28,33 @@ export * from './types';
  * function will format the amount `1025` in `USD` as `$1,025.00`, but when the
  * option is true, it will return `$10.25` instead.
  *
- * Will return null if the currency code is unknown or if the number is not a
- * number. Will also return null if `isSmallestUnit` is set and the number is
- * not an integer.
+ * If the number is NaN, it will be treated as 0.
+ *
+ * If the currency code is not known, this will assume a default currency
+ * similar to USD.
+ *
+ * If `isSmallestUnit` is set and the number is not an integer, it will be
+ * rounded to an integer.
  *
  * @param      {number}                   number     number to format; assumed to be a float unless isSmallestUnit is set.
  * @param      {string}                   code       currency code e.g. 'USD'
  * @param      {FormatCurrencyOptions}    options    options object
- * @returns    {?string}                  A formatted string.
+ * @returns    {string}                  A formatted string.
  */
 export function formatCurrency(
 	number: number,
 	code: string,
 	options: FormatCurrencyOptions = {}
 ): string | null {
+	if ( ! doesCurrencyExist( code ) ) {
+		// eslint-disable-next-line no-console
+		console.warn( `formatCurrency was called with an unknown currency "${ code }"` );
+	}
 	const currencyDefaults = getCurrencyDefaults( code );
-	if ( ! currencyDefaults || isNaN( number ) ) {
-		return null;
+	if ( isNaN( number ) ) {
+		// eslint-disable-next-line no-console
+		console.warn( 'formatCurrency was called with NaN' );
+		number = 0;
 	}
 	const { decimal, grouping, precision, symbol, isSmallestUnit } = {
 		...currencyDefaults,
@@ -53,7 +63,12 @@ export function formatCurrency(
 	const sign = number < 0 ? '-' : '';
 	if ( isSmallestUnit ) {
 		if ( ! Number.isInteger( number ) ) {
-			return null;
+			// eslint-disable-next-line no-console
+			console.warn(
+				'formatCurrency was called with isSmallestUnit and a float which will be rounded',
+				number
+			);
+			number = Math.round( number );
 		}
 		number = convertPriceForSmallestUnit( number, precision );
 	}
@@ -86,9 +101,13 @@ export function formatCurrency(
  * function will format the amount `1025` in `USD` as `$1,025.00`, but when the
  * option is true, it will return `$10.25` instead.
  *
- * Will return null if the currency code is unknown or if the number is not a
- * number. Will also return null if `isSmallestUnit` is set and the number is
- * not an integer.
+ * If the number is NaN, this will return null.
+ *
+ * If the currency code is not known, this will assume a default currency
+ * similar to USD.
+ *
+ * If `isSmallestUnit` is set and the number is not an integer, it will be
+ * rounded to an integer.
  *
  * @param      {number}                   number     number to format; assumed to be a float unless isSmallestUnit is set.
  * @param      {string}                   code       currency code e.g. 'USD'
@@ -100,8 +119,14 @@ export function getCurrencyObject(
 	code: string,
 	options: FormatCurrencyOptions = {}
 ): CurrencyObject | null {
+	if ( ! doesCurrencyExist( code ) ) {
+		// eslint-disable-next-line no-console
+		console.warn( `getCurrencyObject was called with an unknown currency "${ code }"` );
+	}
 	const currencyDefaults = getCurrencyDefaults( code );
-	if ( ! currencyDefaults || isNaN( number ) ) {
+	if ( isNaN( number ) ) {
+		// eslint-disable-next-line no-console
+		console.warn( 'getCurrencyObject was called with NaN' );
 		return null;
 	}
 	const { decimal, grouping, precision, symbol, isSmallestUnit } = {
@@ -111,7 +136,12 @@ export function getCurrencyObject(
 	const sign = number < 0 ? '-' : '';
 	if ( isSmallestUnit ) {
 		if ( ! Number.isInteger( number ) ) {
-			return null;
+			// eslint-disable-next-line no-console
+			console.warn(
+				'getCurrencyObject was called with isSmallestUnit and a float which will be rounded',
+				number
+			);
+			number = Math.round( number );
 		}
 		number = convertPriceForSmallestUnit( number, precision );
 	}

--- a/packages/format-currency/test/index.ts
+++ b/packages/format-currency/test/index.ts
@@ -41,9 +41,9 @@ describe( 'formatCurrency', () => {
 		expect( money ).toBe( '¥9,932' );
 	} );
 
-	test( 'returns null if the number is a float and smallest unit is true', () => {
+	test( 'formats a rounded number if the number is a float and smallest unit is true', () => {
 		const money = formatCurrency( 9932.1, 'USD', { isSmallestUnit: true } );
-		expect( money ).toBe( null );
+		expect( money ).toBe( '$99.32' );
 	} );
 
 	test( 'returns no trailing zero cents when stripZeros set to true (USD)', () => {
@@ -177,9 +177,14 @@ describe( 'formatCurrency', () => {
 			} );
 		} );
 
-		test( 'returns null if the number is a float and the smallest unit is set', () => {
+		test( 'handles the number as rounded if the number is a float and smallest unit is set', () => {
 			const money = getCurrencyObject( 9932.1, 'USD', { isSmallestUnit: true } );
-			expect( money ).toEqual( null );
+			expect( money ).toEqual( {
+				symbol: '$',
+				integer: '99',
+				fraction: '.32',
+				sign: '',
+			} );
 		} );
 
 		describe( 'supported currencies', () => {


### PR DESCRIPTION
#### Proposed Changes

The checkout line item term variant picker in its radio button form (`ItemVariantRadioPrice`) displays the monthly price of an annual plan if the currently selected variant is the monthly plan. The price math to accomplish this is performed by dividing the annual integer price by the number of months before being formatted by `formatCurrency()`. However, `formatCurrency()` with `isSmallestUnit: true` only operates on integers, and after the dividing operation, the price may no longer be an integer. The result is that the monthly price will be null, and will display nothing.

In this PR we round the price before passing it to `formatCurrency()`.

In case this happens anywhere else in the future (it's hard to prevent since TS has no concept of an integer type), this also modifies `formatCurrency()` to perform rounding itself (with a warning) if passed a non-integer price with `isSmallestUnit`.

Before:

<img width="574" alt="Screenshot 2022-12-23 at 1 17 01 PM" src="https://user-images.githubusercontent.com/2036909/209390071-dac18d72-0724-4180-979f-866a702671a3.png">

After: 

<img width="573" alt="Screenshot 2022-12-23 at 2 23 34 PM" src="https://user-images.githubusercontent.com/2036909/209396969-901d5c4d-c082-43f6-9002-5e993c622127.png">


#### Testing Instructions

- First we have to get a monthly product into the cart with a total that does not divide evenly into 12. Here's how I did it: using an account set to IDR currency, visit `/plugins/woocommerce-subscriptions`. Click "Purchase and Activate" for the monthly plan. 
- Make sure your account is in the AB test to view the radio button variant picker. This is outside the scope of this PR explanation so ping me if you don't see it.
- Verify that the annual term variant shows a price per month ("X / month").