### PR TITLE
Checkout 2Y Upsell: CSS specificity for promo card

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/checkout-sidebar-plan-upsell/style.scss
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-sidebar-plan-upsell/style.scss
@@ -2,6 +2,10 @@
 	margin-top: 24px;
 }
 
+.promo-card.checkout-sidebar-plan-upsell {
+	padding: 20px;
+}
+
 .promo-card.checkout-sidebar-plan-upsell .action-panel__title {
 	color: var(--studio-blue-50);
 	display: block;


### PR DESCRIPTION
#### Proposed Changes

* The 2Y plan upsell section in the checkout page gets excess padding when you do the following steps when logged in to Calypso:
    * First log in to Calypso from an incognito window. 
    * Visit Stats page at `/stats`
    * Then visit Upgrades > Plans and add a plan to cart
    * The checkout page now looks like this:

<img width="1119" alt="Screenshot 2022-12-24 at 5 48 52 PM" src="https://user-images.githubusercontent.com/1269602/209438981-5030d3c9-4de2-49e2-b5f5-419a6a027eba.png">

The issue is that the 2Y plan upsell section relies on `.card` to provide padding but when you visit the stats page, the following CSS gets higher specificity, resulting in `padding: 48px 64px` getting applied:

https://github.com/Automattic/wp-calypso/blob/e9dfc697473e910a69330b6ca680d01e42b0f942/packages/components/src/mobile-promo-card/style.scss#L3-L19

This PR fixes the issue by specifying the padding in the upsell CSS file. 

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* In an incognito window, log in to Calypso and visit `/stats`. Then visit Upgrades > Plans page and add a plan to cart.
* Verify that the 2Y plan upsell section in checkout has appropriate padding.

<img width="461" alt="Screenshot 2022-12-24 at 7 31 29 PM" src="https://user-images.githubusercontent.com/1269602/209439174-2087d852-8f86-4161-8aae-5cc8a474450e.png">


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
