### PR TITLE
Deprecate /start/link-in-bio-tld

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -1,9 +1,5 @@
 import { isEnabled } from '@automattic/calypso-config';
-import {
-	LINK_IN_BIO_FLOW,
-	LINK_IN_BIO_TLD_FLOW,
-	setupSiteAfterCreation,
-} from '@automattic/onboarding';
+import { LINK_IN_BIO_FLOW, setupSiteAfterCreation } from '@automattic/onboarding';
 import { translate } from 'i18n-calypso';
 
 const noop = () => {};
@@ -147,23 +143,6 @@ export function generateFlows( {
 			get pageTitle() {
 				return translate( 'Link in Bio' );
 			},
-			postCompleteCallback: setupSiteAfterCreation,
-		},
-		{
-			name: LINK_IN_BIO_TLD_FLOW,
-			steps: [ 'domains-link-in-bio-tld', 'user', 'plans-link-in-bio' ],
-			middleDestination: {
-				user: ( dependencies ) => `/setup/link-in-bio/patterns?tld=${ dependencies.tld }`,
-			},
-			destination: ( dependencies ) =>
-				`/setup/link-in-bio/launchpad?siteSlug=${ encodeURIComponent( dependencies.siteSlug ) }`,
-			description: 'Beginning of the flow to create a link in bio',
-			lastModified: '2022-11-03',
-			showRecaptcha: true,
-			get pageTitle() {
-				return translate( 'Link in Bio' );
-			},
-			providesDependenciesInQuery: [ 'tld' ],
 			postCompleteCallback: setupSiteAfterCreation,
 		},
 		{


### PR DESCRIPTION
#### Proposed Changes

This PR removes /start/link-in-bio-tld and its related code in the original Link in Bio flow, since it is now completely replaced by its Stepper version, living at /setup/link-in-bio-tld.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* /start/link-in-bio-tld?tld=link should be no longer available.
* /setup/link-in-bio should work as expected.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Automattic/martech#1348
