### PR TITLE
Pattern assembler: use Build intent always

### DIFF
--- a/client/landing/stepper/declarative-flow/import-flow.ts
+++ b/client/landing/stepper/declarative-flow/import-flow.ts
@@ -1,4 +1,4 @@
-import { SiteIntent } from '@automattic/data-stores/src/onboard';
+import { Design } from '@automattic/design-picker';
 import { IMPORT_FOCUSED_FLOW } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { ImporterMainPlatform } from 'calypso/blocks/import/types';
@@ -49,7 +49,7 @@ const importFlow: Flow = {
 		const urlQueryParams = useQuery();
 		const siteSlugParam = useSiteSlugParam();
 		const { setPendingAction } = useDispatch( ONBOARD_STORE );
-		const intent = useSelect( ( select ) => select( ONBOARD_STORE ).getIntent() );
+		const selectedDesign = useSelect( ( select ) => select( ONBOARD_STORE ).getSelectedDesign() );
 		const flowProgress = useSiteSetupFlowProgress( _currentStep, 'import', '' );
 
 		if ( flowProgress ) {
@@ -103,7 +103,8 @@ const importFlow: Flow = {
 				}
 
 				case 'designSetup': {
-					if ( providedDependencies?.selectedIntent === SiteIntent.SiteAssembler ) {
+					const _selectedDesign = providedDependencies?.selectedDesign as Design;
+					if ( _selectedDesign?.design_type === 'assembler' ) {
 						return navigate( 'patternAssembler' );
 					}
 
@@ -115,7 +116,7 @@ const importFlow: Flow = {
 
 				case 'processing': {
 					// End of Pattern Assembler flow
-					if ( intent === SiteIntent.SiteAssembler ) {
+					if ( selectedDesign?.design_type === 'assembler' ) {
 						return exitFlow( `/site-editor/${ siteSlugParam }` );
 					}
 

--- a/client/landing/stepper/declarative-flow/internals/analytics/record-design.ts
+++ b/client/landing/stepper/declarative-flow/internals/analytics/record-design.ts
@@ -1,4 +1,3 @@
-import { SiteIntent } from '@automattic/data-stores/src/onboard';
 import { Design, StyleVariation } from '@automattic/design-picker/src';
 import { resolveDeviceTypeByViewPort } from '@automattic/viewport';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -16,7 +15,7 @@ export function recordPreviewedDesign( {
 } ) {
 	recordTracksEvent( 'calypso_signup_design_preview_select', {
 		...getDesignEventProps( { flow, intent, design, styleVariation } ),
-		goes_to_assembler_step: design.design_type === 'assembler',
+		...getDesignTypeProps( design ),
 	} );
 }
 
@@ -43,7 +42,7 @@ export function recordSelectedDesign( {
 	if ( design ) {
 		recordTracksEvent( 'calypso_signup_select_design', {
 			...getDesignEventProps( { flow, intent, design, styleVariation } ),
-			...getDesignIntentProps( intent ),
+			...getDesignTypeProps( design ),
 			...optionalProps,
 		} );
 
@@ -56,9 +55,9 @@ export function recordSelectedDesign( {
 	}
 }
 
-export function getDesignIntentProps( intent: string ) {
+export function getDesignTypeProps( design?: Design ) {
 	return {
-		goes_to_assembler_step: intent === SiteIntent.SiteAssembler,
+		goes_to_assembler_step: design?.design_type === 'assembler',
 	};
 }
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -35,7 +35,7 @@ import { useSiteSlugParam } from '../../../../hooks/use-site-slug-param';
 import { ONBOARD_STORE, SITE_STORE } from '../../../../stores';
 import {
 	getDesignEventProps,
-	getDesignIntentProps,
+	getDesignTypeProps,
 	recordPreviewedDesign,
 	recordSelectedDesign,
 } from '../../analytics/record-design';
@@ -458,7 +458,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 
 	function pickBlankCanvasDesign( blankCanvasDesign: Design, shouldGoToAssemblerStep: boolean ) {
 		if ( shouldGoToAssemblerStep ) {
-			const selectedDesign = {
+			const _selectedDesign = {
 				...blankCanvasDesign,
 				design_type: 'assembler',
 			} as Design;
@@ -466,14 +466,13 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 			recordPreviewedDesign( {
 				flow,
 				intent,
-				design: selectedDesign,
+				design: _selectedDesign,
 			} );
 
-			setSelectedDesign( selectedDesign );
+			setSelectedDesign( _selectedDesign );
 
 			handleSubmit( {
-				selectedIntent: SiteIntent.SiteAssembler,
-				selectedDesign,
+				selectedDesign: _selectedDesign,
 				selectedSiteCategory: categorization.selection,
 			} );
 		} else {
@@ -482,14 +481,12 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 	}
 
 	function handleSubmit( providedDependencies?: ProvidedDependencies, optionalProps?: object ) {
-		const selectedIntent = providedDependencies?.selectedIntent as string;
-		const selectedDesign = providedDependencies?.selectedDesign as Design;
-
-		if ( selectedIntent !== SiteIntent.SiteAssembler ) {
+		const _selectedDesign = providedDependencies?.selectedDesign as Design;
+		if ( _selectedDesign?.design_type !== 'assembler' ) {
 			recordSelectedDesign( {
 				flow,
 				intent,
-				design: selectedDesign,
+				design: _selectedDesign,
 				styleVariation: selectedStyleVariation,
 				optionalProps,
 			} );
@@ -497,7 +494,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 
 		submit?.( {
 			...providedDependencies,
-			...getDesignIntentProps( selectedIntent ),
+			...getDesignTypeProps( _selectedDesign ),
 		} );
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -1,5 +1,4 @@
 import { isEnabled } from '@automattic/calypso-config';
-import { SiteIntent } from '@automattic/data-stores/src/onboard';
 import { StepContainer } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
@@ -34,7 +33,7 @@ const PatternAssembler: Step = ( { navigation, flow } ) => {
 	const { goBack, goNext, submit, goToStep } = navigation;
 	const { setThemeOnSite, runThemeSetupOnSite, createCustomTemplate } = useDispatch( SITE_STORE );
 	const reduxDispatch = useReduxDispatch();
-	const { setIntent, setPendingAction } = useDispatch( ONBOARD_STORE );
+	const { setPendingAction } = useDispatch( ONBOARD_STORE );
 	const selectedDesign = useSelect( ( select ) => select( ONBOARD_STORE ).getSelectedDesign() );
 	const intent = useSelect( ( select ) => select( ONBOARD_STORE ).getIntent() );
 	const site = useSite();
@@ -332,7 +331,7 @@ const PatternAssembler: Step = ( { navigation, flow } ) => {
 						} }
 						onContinueClick={ () => {
 							trackEventContinue();
-							setIntent( SiteIntent.SiteAssembler );
+							onSubmit();
 						} }
 					/>
 				) }
@@ -357,12 +356,6 @@ const PatternAssembler: Step = ( { navigation, flow } ) => {
 			) }
 		</div>
 	);
-
-	useEffect( () => {
-		if ( siteSlugOrId && intent === SiteIntent.SiteAssembler ) {
-			onSubmit();
-		}
-	}, [ siteSlugOrId, intent ] );
 
 	return (
 		<>

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -1,5 +1,6 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { Onboard } from '@automattic/data-stores';
+import { Design } from '@automattic/design-picker';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useDispatch as reduxDispatch, useSelector } from 'react-redux';
 import { ImporterMainPlatform } from 'calypso/blocks/import/types';
@@ -205,13 +206,14 @@ const siteSetupFlow: Flow = {
 					return navigate( 'bloggerStartingPoint' );
 				}
 
-				case 'designSetup':
-					if ( providedDependencies?.selectedIntent === SiteIntent.SiteAssembler ) {
+				case 'designSetup': {
+					const _selectedDesign = providedDependencies?.selectedDesign as Design;
+					if ( _selectedDesign?.design_type === 'assembler' ) {
 						return navigate( 'patternAssembler' );
 					}
 
 					return navigate( 'processing' );
-
+				}
 				case 'patternAssembler':
 					return navigate( 'processing' );
 
@@ -223,7 +225,7 @@ const siteSetupFlow: Flow = {
 					}
 
 					// End of Pattern Assembler flow
-					if ( intent === SiteIntent.SiteAssembler ) {
+					if ( selectedDesign?.design_type === 'assembler' ) {
 						return exitFlow( `/site-editor/${ siteSlug }` );
 					}
 

--- a/packages/data-stores/src/onboard/constants.ts
+++ b/packages/data-stores/src/onboard/constants.ts
@@ -13,7 +13,6 @@ export enum SiteIntent {
 	Write = 'write',
 	Sell = 'sell',
 	Build = 'build',
-	SiteAssembler = 'site-assembler',
 	DIFM = 'difm', // "Do It For Me"
 	WpAdmin = 'wpadmin',
 	Import = 'import', // deprecated


### PR DESCRIPTION
#### Proposed Changes

In the Pattern Assembler flow, we want to keep the `build` intent instead of the new `site-assembler` intent. This is because the My Home page uses the stored intent to show the checklist etc.

#### Testing Instructions

- Similar to #71461, but verify that all intents are `build` instead of `site-assembler`.
- Verify that PA flow can be successfully completed.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
