### PR TITLE
Remove the middle destination mechanism from the signup framework.

### DIFF
--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -164,27 +164,12 @@ function removeUserStepFromFlow( flow ) {
 		return;
 	}
 
-	// TODO: A more general middle destination fallback mechanism is needed
-	// The `midDestination` mechanism is tied to a specific step in the flow configuration.
-	// If it happens to be the user step, then we the middle destination is also removed.
-	// For addressing Automattic/martech#1260, here we introduce a limited fallback mechanism that only works
-	// for the user step. Whenever a step that provides an auth token is removed, we simply tie the middle destination
-	// to its previous step. If it's the first step, then it will be removed all together atm.
 	const steps = [];
-	let prevStep = flow.steps[ 0 ];
-
 	for ( const curStep of flow.steps ) {
 		if ( stepConfig[ curStep ].providesToken ) {
-			const curStepMiddleDestination = flow.middleDestination && flow.middleDestination[ curStep ];
-			if ( curStepMiddleDestination ) {
-				flow.middleDestination[ prevStep ] = curStepMiddleDestination;
-			}
-			prevStep = curStep;
 			continue;
 		}
-
 		steps.push( curStep );
-		prevStep = curStep;
 	}
 
 	return {

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -652,10 +652,7 @@ class Signup extends Component {
 	// `nextFlowName` is an optional parameter used to redirect to another flow, i.e., from `main`
 	// to `ecommerce`. If not specified, the current flow (`this.props.flowName`) continues.
 	goToNextStep = ( nextFlowName = this.props.flowName ) => {
-		const { steps: flowSteps, middleDestination } = flows.getFlow(
-			nextFlowName,
-			this.props.isLoggedIn
-		);
+		const { steps: flowSteps } = flows.getFlow( nextFlowName, this.props.isLoggedIn );
 		const currentStepIndex = flowSteps.indexOf( this.props.stepName );
 		const nextStepName = flowSteps[ currentStepIndex + 1 ];
 		const nextProgressItem = get( this.props.progress, nextStepName );
@@ -663,15 +660,6 @@ class Signup extends Component {
 
 		if ( nextFlowName !== this.props.flowName ) {
 			this.setState( { previousFlowName: this.props.flowName } );
-		}
-
-		const midPoint = middleDestination ? middleDestination[ this.props.stepName ] : null;
-
-		if ( midPoint ) {
-			// save the resuming point and then navigate away.
-			this.setState( { resumingStep: nextStepName } );
-			page( midPoint( this.props.signupDependencies ) );
-			return;
 		}
 
 		this.goToStep( nextStepName, nextStepSection, nextFlowName );


### PR DESCRIPTION
#### Proposed Changes

The middle destination mechanism was first introduced in https://github.com/Automattic/wp-calypso/pull/69797/ as a way to transit away from the signup framework in the middle. However, it is proven that doing so has unfixable state persistence issue: p2-p4TIVU-akM. This PR simply deprecates it.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Mainly code review to ensure that only the code related to middle destination mechanism is removed. There is no other flow using it except for /start/link-in-bio-tld, which will be deprecated as well by https://github.com/Automattic/wp-calypso/pull/71512. Thus, none of any other signup flows should be affected.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Automattic/martech#1348

