### PR TITLE
Users management: Update users profiles

### DIFF
--- a/client/my-sites/people/controller.js
+++ b/client/my-sites/people/controller.js
@@ -174,7 +174,7 @@ function renderPeopleInviteDetails( context, next ) {
 	const PeopleInviteDetailsTitle = () => {
 		const translate = useTranslate();
 
-		return <DocumentHead title={ translate( 'Invite Details', { textOnly: true } ) } />;
+		return <DocumentHead title={ translate( 'User Details', { textOnly: true } ) } />;
 	};
 
 	context.primary = (

--- a/client/my-sites/people/controller.js
+++ b/client/my-sites/people/controller.js
@@ -12,6 +12,7 @@ import PeopleList from './main';
 import PeopleAddSubscribers from './people-add-subscribers';
 import PeopleInviteDetails from './people-invite-details';
 import PeopleInvites from './people-invites';
+import SubscriberDetails from './subscriber-details';
 import SubscribersTeam from './subscribers-team';
 import TeamInvite from './team-invite';
 
@@ -54,6 +55,10 @@ export default {
 
 	subscribers( context, next ) {
 		renderSubscribers( context, next );
+	},
+
+	subscriberDetails( context, next ) {
+		renderSubscribersDetails( context, next );
 	},
 
 	peopleAddSubscribers( context, next ) {
@@ -149,6 +154,22 @@ function renderSubscribers( context, next ) {
 		<>
 			<SubscribersTitle />
 			<SubscribersTeam filter={ context.params.filter } search={ context.query.s } />
+		</>
+	);
+	next();
+}
+
+function renderSubscribersDetails( context, next ) {
+	const SubscriberDetailsTitle = () => {
+		const translate = useTranslate();
+
+		return <DocumentHead title={ translate( 'User Details', { textOnly: true } ) } />;
+	};
+
+	context.primary = (
+		<>
+			<SubscriberDetailsTitle />
+			<SubscriberDetails subscriberId={ context.params.id } />
 		</>
 	);
 	next();

--- a/client/my-sites/people/edit-team-member-form/edit-user-form.jsx
+++ b/client/my-sites/people/edit-team-member-form/edit-user-form.jsx
@@ -201,6 +201,7 @@ class EditUserForm extends Component {
 				returnField = (
 					<RoleSelect
 						key="role-select"
+						formControlType="select"
 						id={ fieldKeys.roles }
 						name={ fieldKeys.roles }
 						siteId={ this.props.siteId }

--- a/client/my-sites/people/edit-team-member-form/edit-user-form.jsx
+++ b/client/my-sites/people/edit-team-member-form/edit-user-form.jsx
@@ -220,7 +220,7 @@ class EditUserForm extends Component {
 						key="isExternalContributor"
 						id={ fieldKeys.isExternalContributor }
 						onChange={ this.handleExternalChange }
-						checked={ this.state.isExternalContributor }
+						checked={ !! this.state.isExternalContributor }
 						disabled={ isDisabled || this.state.isExternalContributor === undefined }
 					/>
 				);

--- a/client/my-sites/people/edit-team-member-form/index.jsx
+++ b/client/my-sites/people/edit-team-member-form/index.jsx
@@ -1,7 +1,10 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { Card } from '@automattic/components';
+import { localize } from 'i18n-calypso';
 import page from 'page';
 import { useEffect } from 'react';
 import { connect } from 'react-redux';
+import FormattedHeader from 'calypso/components/formatted-header';
 import HeaderCake from 'calypso/components/header-cake';
 import Main from 'calypso/components/main';
 import useUserQuery from 'calypso/data/users/use-user-query';
@@ -29,18 +32,22 @@ export const EditTeamMemberForm = ( {
 	previousRoute,
 	siteSlug,
 	recordGoogleEvent,
+	translate,
 } ) => {
 	const goBack = () => {
 		recordGoogleEvent( 'People', 'Clicked Back Button on User Edit' );
+
+		const teamRoute = isEnabled( 'user-management-revamp' ) ? 'team-members' : 'team';
+
 		if ( previousRoute ) {
 			page.back( previousRoute );
 			return;
 		}
 		if ( siteSlug ) {
-			page( '/people/team/' + siteSlug );
+			page( `/people/${ teamRoute }/${ siteSlug }` );
 			return;
 		}
-		page( '/people/team' );
+		page( `/people/${ teamRoute }` );
 	};
 
 	const { markChanged, markSaved } = useProtectForm();
@@ -53,6 +60,16 @@ export const EditTeamMemberForm = ( {
 	return (
 		<Main className="edit-team-member-form">
 			<PageViewTracker path="people/edit/:site/:user" title="People > View Team Member" />
+			{ isEnabled( 'user-management-revamp' ) && (
+				<FormattedHeader
+					brandFont
+					className="people__page-heading"
+					headerText={ translate( 'Users' ) }
+					subHeaderText={ translate( 'People who have subscribed to your site and team members.' ) }
+					align="left"
+					hasScreenOptions
+				/>
+			) }
 			<HeaderCake onClick={ goBack } isCompact />
 			<Card className="edit-team-member-form__user-profile">
 				<PeopleProfile siteId={ siteId } user={ user } />
@@ -99,4 +116,4 @@ export default connect(
 		};
 	},
 	{ recordGoogleEvent: recordGoogleEventAction }
-)( EditTeamMemberForm );
+)( localize( EditTeamMemberForm ) );

--- a/client/my-sites/people/edit-team-member-form/style.scss
+++ b/client/my-sites/people/edit-team-member-form/style.scss
@@ -1,7 +1,11 @@
 .edit-team-member-form__form {
-	border-top: 1px solid var(--color-neutral-0);
+	border-top: 1px solid var(--color-border-subtle);
 	padding-top: 24px;
 	margin-top: 24px;
+
+	.form-select {
+		width: 100%;
+	}
 }
 
 .edit-team-member-form__user-profile {

--- a/client/my-sites/people/index.js
+++ b/client/my-sites/people/index.js
@@ -65,6 +65,16 @@ export default function () {
 	);
 
 	page(
+		'/people/:filter(subscribers)/:site_id/:id',
+		peopleController.enforceSiteEnding,
+		siteSelection,
+		navigation,
+		peopleController.subscriberDetails,
+		makeLayout,
+		clientRender
+	);
+
+	page(
 		'/people/add-subscribers/:site_id',
 		peopleController.enforceSiteEnding,
 		siteSelection,

--- a/client/my-sites/people/invite-people/index.jsx
+++ b/client/my-sites/people/invite-people/index.jsx
@@ -376,13 +376,10 @@ class InvitePeople extends Component {
 
 	goBack = () => {
 		const siteSlug = get( this.props, 'site.slug' );
-		let fallback = siteSlug ? '/people/team/' + siteSlug : '/people/team';
+		const route = isEnabled( 'user-management-revamp' ) ? 'team' : 'team-members';
+		const fallback = siteSlug ? `/people/${ route }/${ siteSlug }` : `/people/${ route }`;
 
-		if ( isEnabled( 'user-management-revamp' ) ) {
-			fallback = '/people/team-members/' + siteSlug;
-		}
-
-		// Go back to last route with /people/team/$site as the fallback
+		// Go back to last route with provided route as the fallback
 		page.back( fallback );
 	};
 

--- a/client/my-sites/people/people-invite-details/index.jsx
+++ b/client/my-sites/people/people-invite-details/index.jsx
@@ -7,7 +7,6 @@ import { PureComponent } from 'react';
 import { connect } from 'react-redux';
 import QuerySiteInvites from 'calypso/components/data/query-site-invites';
 import EmptyContent from 'calypso/components/empty-content';
-import Gravatar from 'calypso/components/gravatar';
 import HeaderCake from 'calypso/components/header-cake';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import Main from 'calypso/components/main';
@@ -53,30 +52,14 @@ export class PeopleInviteDetails extends PureComponent {
 		this.props.deleteInvite( site.ID, invite.key );
 	};
 
-	renderClearOrRevoke = () => {
+	renderClearOrRevoke = ( props = {} ) => {
 		const { deleting, invite, translate } = this.props;
 		const { isPending } = invite;
-		const revokeMessage = translate(
-			'Revoking an invite will no longer allow this person to become a member of ' +
-				'your site. You can always invite them again if you change your mind.'
-		);
-		const clearMessage = translate(
-			'If you no longer wish to see this record, you can clear it. ' +
-				'The person will still remain a member of this site.'
-		);
 
 		return (
-			<div className="people-invite-details__clear-revoke">
-				<div>{ isPending ? revokeMessage : clearMessage }</div>
-				<Button
-					busy={ deleting }
-					primary={ isPending }
-					scary={ isPending }
-					onClick={ this.handleDelete }
-				>
-					{ isPending ? translate( 'Revoke invite' ) : translate( 'Clear invite' ) }
-				</Button>
-			</div>
+			<Button className={ props.className || '' } busy={ deleting } onClick={ this.handleDelete }>
+				{ isPending ? translate( 'Revoke' ) : translate( 'Clear' ) }
+			</Button>
 		);
 	};
 
@@ -114,10 +97,11 @@ export class PeopleInviteDetails extends PureComponent {
 						site={ site }
 						type="invite-details"
 						isSelectable={ false }
+						showStatus={ true }
+						RevokeClearBtn={ this.renderClearOrRevoke }
 					/>
 					{ this.renderInviteDetails() }
 				</Card>
-				{ this.renderClearOrRevoke() }
 			</div>
 		);
 	}
@@ -129,33 +113,33 @@ export class PeopleInviteDetails extends PureComponent {
 		return (
 			<div className="people-invite-details__meta">
 				<div className="people-invite-details__meta-item">
-					<span className="people-invite-details__meta-item-label">
-						{ translate( 'Invited By' ) }
-					</span>
-					<Gravatar user={ invite.invitedBy } size={ 24 } />
-					{ showName && (
-						<span className="people-invite-details__meta-item-user">{ invite.invitedBy.name }</span>
-					) }
-					<span className="people-invite-details__meta-item-username">
-						{ '@' + invite.invitedBy.login }
-					</span>
+					<strong>{ translate( 'Status' ) }</strong>
+					<div>
+						{ invite.isPending && (
+							<span className="people-invite-details__meta-status-pending">
+								{ translate( 'Pending' ) }
+							</span>
+						) }
+						{ !! invite.acceptedDate && (
+							<span className="people-invite-details__meta-status-active">
+								{ translate( 'Active' ) }
+							</span>
+						) }
+					</div>
 				</div>
 				<div className="people-invite-details__meta-item">
-					<span className="people-invite-details__meta-item-label">{ translate( 'Sent' ) }</span>
-					<span className="people-invite-details__meta-item-date">
-						{ moment( invite.inviteDate ).format( 'LLL' ) }
-					</span>
-				</div>
-				{ invite.acceptedDate && (
-					<div className="people-invite-details__meta-item">
-						<span className="people-invite-details__meta-item-label">
-							{ translate( 'Accepted' ) }
-						</span>
-						<span className="people-invite-details__meta-item-date">
-							{ moment( invite.acceptedDate ).format( 'LLL' ) }
+					<strong>{ translate( 'Invited By' ) }</strong>
+					<div>
+						<span>
+							{ showName && <>{ invite.invitedBy.name }</> } { '@' + invite.invitedBy.login }
 						</span>
 					</div>
-				) }
+				</div>
+
+				<div className="people-invite-details__meta-item">
+					<strong>{ translate( 'Invite date' ) }</strong>
+					<div>{ moment( invite.inviteDate ).format( 'LLL' ) }</div>
+				</div>
 			</div>
 		);
 	}

--- a/client/my-sites/people/people-invite-details/index.jsx
+++ b/client/my-sites/people/people-invite-details/index.jsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { Card, Button } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import { get } from 'lodash';
@@ -7,6 +8,7 @@ import { PureComponent } from 'react';
 import { connect } from 'react-redux';
 import QuerySiteInvites from 'calypso/components/data/query-site-invites';
 import EmptyContent from 'calypso/components/empty-content';
+import FormattedHeader from 'calypso/components/formatted-header';
 import HeaderCake from 'calypso/components/header-cake';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import Main from 'calypso/components/main';
@@ -164,6 +166,19 @@ export class PeopleInviteDetails extends PureComponent {
 			<Main className="people-invite-details">
 				<PageViewTracker path="/people/invites/:site/:invite" title="People > User Details" />
 				{ siteId && <QuerySiteInvites siteId={ siteId } /> }
+
+				{ isEnabled( 'user-management-revamp' ) && (
+					<FormattedHeader
+						brandFont
+						className="people__page-heading"
+						headerText={ translate( 'Users' ) }
+						subHeaderText={ translate(
+							'People who have subscribed to your site and team members.'
+						) }
+						align="left"
+						hasScreenOptions
+					/>
+				) }
 
 				<HeaderCake isCompact onClick={ this.goBack }>
 					{ translate( 'User Details' ) }

--- a/client/my-sites/people/people-invite-details/index.jsx
+++ b/client/my-sites/people/people-invite-details/index.jsx
@@ -40,9 +40,10 @@ export class PeopleInviteDetails extends PureComponent {
 
 	goBack = () => {
 		const siteSlug = get( this.props, 'site.slug' );
-		const fallback = siteSlug ? '/people/invites/' + siteSlug : '/people/invites/';
+		const route = isEnabled( 'user-management-revamp' ) ? 'team-members' : 'invites';
+		const fallback = siteSlug ? `/people/${ route }/${ siteSlug }` : `/people/${ route }/`;
 
-		// Go back to last route with /people/invites as the fallback
+		// Go back to last route with provided route as the fallback
 		page.back( fallback );
 	};
 

--- a/client/my-sites/people/people-invite-details/index.jsx
+++ b/client/my-sites/people/people-invite-details/index.jsx
@@ -151,7 +151,7 @@ export class PeopleInviteDetails extends PureComponent {
 		if ( siteId && ! canViewPeople ) {
 			return (
 				<Main>
-					<PageViewTracker path="/people/invites/:site/:invite" title="People > Invite Details" />
+					<PageViewTracker path="/people/invites/:site/:invite" title="People > User Details" />
 					<EmptyContent
 						title={ this.props.translate( 'You are not authorized to view this page' ) }
 						illustration="/calypso/images/illustrations/illustration-404.svg"
@@ -162,11 +162,11 @@ export class PeopleInviteDetails extends PureComponent {
 
 		return (
 			<Main className="people-invite-details">
-				<PageViewTracker path="/people/invites/:site/:invite" title="People > Invite Details" />
+				<PageViewTracker path="/people/invites/:site/:invite" title="People > User Details" />
 				{ siteId && <QuerySiteInvites siteId={ siteId } /> }
 
 				<HeaderCake isCompact onClick={ this.goBack }>
-					{ translate( 'Invite Details' ) }
+					{ translate( 'User Details' ) }
 				</HeaderCake>
 
 				{ this.renderInvite() }

--- a/client/my-sites/people/people-invite-details/style.scss
+++ b/client/my-sites/people/people-invite-details/style.scss
@@ -2,15 +2,18 @@
 	margin-right: 0;
 }
 
+.people-invite-details .card.people-list-item {
+	padding: 0;
+}
+
 .people-invite-details__meta {
-	border-top: 1px solid var(--color-neutral-0);
+	border-top: 1px solid var(--color-border-subtle);
 	padding-top: 24px;
 	margin-top: 24px;
 }
 
 .people-invite-details__meta-item {
-	margin-bottom: 12px;
-	color: var(--color-text-subtle);
+	margin-bottom: 1rem;
 	overflow: hidden;
 	white-space: nowrap;
 	text-overflow: ellipsis;
@@ -34,6 +37,20 @@
 	.gravatar {
 		vertical-align: middle;
 		margin-right: 6px;
+	}
+
+	strong {
+		color: var(--studio-gray-70);
+	}
+
+	.people-invite-details__meta-status {
+		&-pending {
+			color: var(--color-warning);
+		}
+
+		&-active {
+			color: var(--color-success);
+		}
 	}
 }
 

--- a/client/my-sites/people/people-invite-details/test/index.jsx
+++ b/client/my-sites/people/people-invite-details/test/index.jsx
@@ -14,9 +14,7 @@ const render = ( el, options ) =>
 
 const mockGoBack = jest.fn();
 jest.mock( 'page', () => ( { back: mockGoBack } ) );
-jest.mock( 'calypso/my-sites/people/people-list-item', () => ( { user } ) => (
-	<div data-testid="people-list-item">{ user?.ID }</div>
-) );
+jest.mock( 'calypso/data/external-contributors/use-external-contributors', () => () => false );
 
 describe( 'PeopleInviteDetails', () => {
 	let PeopleInviteDetails;
@@ -95,7 +93,7 @@ describe( 'PeopleInviteDetails', () => {
 			/>
 		);
 
-		const revokeInviteButton = screen.getByRole( 'button', { name: /^Revoke invite$/i } );
+		const revokeInviteButton = screen.getByRole( 'button', { name: /^Revoke$/i } );
 		expect( revokeInviteButton ).toBeVisible();
 
 		expect( mockDeleteInvite ).not.toHaveBeenCalled();
@@ -122,7 +120,7 @@ describe( 'PeopleInviteDetails', () => {
 			/>
 		);
 
-		const clearInviteButton = screen.getByRole( 'button', { name: /^Clear invite$/i } );
+		const clearInviteButton = screen.getByRole( 'button', { name: /^Clear$/i } );
 		expect( clearInviteButton ).toBeVisible();
 
 		expect( mockDeleteInvite ).not.toHaveBeenCalled();
@@ -154,8 +152,8 @@ describe( 'PeopleInviteDetails', () => {
 
 		// Verify that a placeholder is rendered while waiting for `page.back`
 		// to take effect.
-		const peopleListItem = screen.queryByTestId( 'people-list-item' );
-		expect( peopleListItem ).toBeEmptyDOMElement();
+		const loadingUsersEl2 = screen.queryByText( 'Loading Users' );
+		expect( loadingUsersEl2 ).toBeInTheDocument();
 
 		// Change another prop and verify that `page.back` isn't called again.
 		rerender( <PeopleInviteDetails { ...props } invite={ { ...acceptedInviteObject } } /> );

--- a/client/my-sites/people/people-list-item/index.jsx
+++ b/client/my-sites/people/people-list-item/index.jsx
@@ -1,4 +1,4 @@
-import { Button, CompactCard, Gridicon } from '@automattic/components';
+import { Button, CompactCard } from '@automattic/components';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import { get } from 'lodash';
@@ -53,6 +53,12 @@ class PeopleListItem extends PureComponent {
 		);
 	};
 
+	canLinkToSubscriberProfile = () => {
+		const { site, user } = this.props;
+
+		return site && site.slug && user && user.ID;
+	};
+
 	maybeGetCardLink = () => {
 		const { invite, site, type, user } = this.props;
 
@@ -62,8 +68,19 @@ class PeopleListItem extends PureComponent {
 
 		const editLink = this.canLinkToProfile() && `/people/edit/${ site.slug }/${ user.login }`;
 		const inviteLink = invite && `/people/invites/${ site.slug }/${ invite.key }`;
+		const subscriberDetailsLink =
+			this.canLinkToSubscriberProfile() && `/people/subscribers/${ site.slug }/${ user.ID }`;
 
-		return type === 'invite' ? inviteLink : editLink;
+		switch ( type ) {
+			case 'invite':
+				return inviteLink;
+
+			case 'subscriber-details':
+				return subscriberDetailsLink;
+
+			default:
+				return editLink;
+		}
 	};
 
 	onResend = ( event ) => {
@@ -159,12 +176,10 @@ class PeopleListItem extends PureComponent {
 				{ onRemove && (
 					<div className="people-list-item__actions">
 						<Button
-							compact
 							className="people-list-item__remove-button"
 							onClick={ onRemove }
 							data-e2e-remove-login={ get( user, 'login', '' ) }
 						>
-							<Gridicon icon="cross" />
 							<span>
 								{ translate( 'Remove', {
 									context: 'Verb: Remove a user or follower from the blog.',

--- a/client/my-sites/people/people-list-item/index.jsx
+++ b/client/my-sites/people/people-list-item/index.jsx
@@ -3,7 +3,7 @@ import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import { get } from 'lodash';
 import PropTypes from 'prop-types';
-import { PureComponent, Fragment } from 'react';
+import { PureComponent } from 'react';
 import { connect } from 'react-redux';
 import PeopleProfile from 'calypso/my-sites/people/people-profile';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
@@ -22,6 +22,12 @@ class PeopleListItem extends PureComponent {
 	static propTypes = {
 		site: PropTypes.object,
 		invite: PropTypes.object,
+		showStatus: PropTypes.bool,
+		RevokeClearBtn: PropTypes.elementType,
+	};
+
+	static defaultProps = {
+		RevokeClearBtn: null,
 	};
 
 	navigateToUser = () => {
@@ -75,44 +81,46 @@ class PeopleListItem extends PureComponent {
 	};
 
 	renderInviteStatus = () => {
-		const { type, invite, translate, requestingResend, resendSuccess } = this.props;
+		const { type, invite, translate, requestingResend, resendSuccess, RevokeClearBtn } = this.props;
 		const { isPending } = invite;
 		const className = classNames( 'people-list-item__invite-status', {
 			'is-pending': isPending,
 			'is-invite-details': type === 'invite-details',
 		} );
-		const buttonClassName = classNames( 'people-list-item__invite-resend', {
+		const btnResendClassName = classNames( 'people-list-item__invite-resend', {
 			'is-success': resendSuccess,
 		} );
+		const btnRevokeClassName = classNames( 'people-list-item__invite-revoke' );
 
 		return (
 			<div className={ className }>
-				{ type === 'invite-details' &&
-					( isPending ? (
-						translate( 'Pending' )
-					) : (
-						<Fragment>
-							<Gridicon icon="checkmark" size={ 18 } />
-							{ translate( 'Accepted' ) }
-						</Fragment>
-					) ) }
 				{ isPending && (
 					<Button
-						className={ buttonClassName }
+						className={ btnResendClassName }
 						onClick={ this.onResend }
 						busy={ requestingResend }
-						compact
 					>
 						{ resendSuccess ? translate( 'Invite Sent!' ) : translate( 'Resend Invite' ) }
 					</Button>
 				) }
+
+				<RevokeClearBtn className={ btnRevokeClassName } />
 			</div>
 		);
 	};
 
 	render() {
-		const { className, invite, onRemove, siteId, translate, type, user, inviteWasDeleted } =
-			this.props;
+		const {
+			className,
+			invite,
+			onRemove,
+			siteId,
+			translate,
+			type,
+			user,
+			inviteWasDeleted,
+			showStatus,
+		} = this.props;
 
 		const isInvite = invite && ( 'invite' === type || 'invite-details' === type );
 
@@ -146,7 +154,7 @@ class PeopleListItem extends PureComponent {
 					<PeopleProfile invite={ invite } siteId={ siteId } type={ type } user={ user } />
 				</div>
 
-				{ isInvite && this.renderInviteStatus() }
+				{ isInvite && showStatus && this.renderInviteStatus() }
 
 				{ onRemove && (
 					<div className="people-list-item__actions">

--- a/client/my-sites/people/people-list-item/index.jsx
+++ b/client/my-sites/people/people-list-item/index.jsx
@@ -168,7 +168,14 @@ class PeopleListItem extends PureComponent {
 				onClick={ canLinkToProfile && this.navigateToUser }
 			>
 				<div className="people-list-item__profile-container">
-					<PeopleProfile invite={ invite } siteId={ siteId } type={ type } user={ user } />
+					<PeopleProfile
+						invite={ invite }
+						siteId={ siteId }
+						type={ type }
+						user={ user }
+						showDate={ ! this.maybeGetCardLink() }
+						showRole={ !! this.maybeGetCardLink() }
+					/>
 				</div>
 
 				{ isInvite && showStatus && this.renderInviteStatus() }

--- a/client/my-sites/people/people-list-item/style.scss
+++ b/client/my-sites/people/people-list-item/style.scss
@@ -85,12 +85,10 @@
 	}
 }
 
-.people-list-item__invite-resend {
-	display: inline-block;
-	min-width: 95px;
-	height: 30px;
-	margin-left: 12px;
+.people-list-item__invite-resend.button,
+.people-list-item__invite-revoke.button {
 	vertical-align: baseline;
+	margin-left: 0.75rem;
 
 	&.is-success {
 		background-color: var(--color-neutral-0);

--- a/client/my-sites/people/people-profile/index.jsx
+++ b/client/my-sites/people/people-profile/index.jsx
@@ -6,7 +6,6 @@ import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
 import Gravatar from 'calypso/components/gravatar';
 import InfoPopover from 'calypso/components/info-popover';
-import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import useExternalContributorsQuery from 'calypso/data/external-contributors/use-external-contributors';
 import useP2GuestsQuery from 'calypso/data/p2/use-p2-guests-query';
 import { decodeEntities } from 'calypso/lib/formatting';
@@ -18,7 +17,6 @@ import './style.scss';
 
 const PeopleProfile = ( { siteId, type, user, invite } ) => {
 	const translate = useTranslate();
-	const moment = useLocalizedMoment();
 	const { data: externalContributors } = useExternalContributorsQuery( siteId );
 	const { data: p2Guests } = useP2GuestsQuery( siteId );
 
@@ -251,19 +249,22 @@ const PeopleProfile = ( { siteId, type, user, invite } ) => {
 		);
 	};
 
-	const renderSubscribedDate = () => {
+	const renderSubscribedRole = () => {
 		if ( ! user || ! user.date_subscribed ) {
-			return;
+			return null;
 		}
 
 		return (
-			<div className="people-profile__subscribed">
-				{ translate( 'Since %(formattedDate)s', {
-					context: 'How long a user has been subscribed to a blog. Example: "Since Sep 16, 2015"',
-					args: {
-						formattedDate: moment( user.date_subscribed ).format( 'll' ),
-					},
-				} ) }
+			<div className="people-profile__badges">
+				<div
+					className={ classNames(
+						'people-profile__role-badge',
+						getRoleBadgeClass( 'subscriber' )
+					) }
+				>
+					{ user.login && translate( 'Follower' ) }
+					{ ! user.login && translate( 'Email subscriber' ) }
+				</div>
 			</div>
 		);
 	};
@@ -284,7 +285,7 @@ const PeopleProfile = ( { siteId, type, user, invite } ) => {
 			<div className="people-profile__detail">
 				{ renderNameOrEmail() }
 				{ renderLogin() }
-				{ isFollowerType() ? renderSubscribedDate() : renderRole() }
+				{ isFollowerType() ? renderSubscribedRole() : renderRole() }
 			</div>
 		</div>
 	);

--- a/client/my-sites/people/people-profile/index.jsx
+++ b/client/my-sites/people/people-profile/index.jsx
@@ -6,6 +6,7 @@ import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
 import Gravatar from 'calypso/components/gravatar';
 import InfoPopover from 'calypso/components/info-popover';
+import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import useExternalContributorsQuery from 'calypso/data/external-contributors/use-external-contributors';
 import useP2GuestsQuery from 'calypso/data/p2/use-p2-guests-query';
 import { decodeEntities } from 'calypso/lib/formatting';
@@ -15,8 +16,10 @@ import isPrivateSite from 'calypso/state/selectors/is-private-site';
 
 import './style.scss';
 
-const PeopleProfile = ( { siteId, type, user, invite } ) => {
+const PeopleProfile = ( { siteId, type, user, invite, showDate, showRole = true } ) => {
 	const translate = useTranslate();
+	const moment = useLocalizedMoment();
+
 	const { data: externalContributors } = useExternalContributorsQuery( siteId );
 	const { data: p2Guests } = useP2GuestsQuery( siteId );
 
@@ -249,6 +252,23 @@ const PeopleProfile = ( { siteId, type, user, invite } ) => {
 		);
 	};
 
+	const renderSubscribedDate = () => {
+		if ( ! user || ! user.date_subscribed ) {
+			return;
+		}
+
+		return (
+			<div className="people-profile__subscribed">
+				{ translate( 'Since %(formattedDate)s', {
+					context: 'How long a user has been subscribed to a blog. Example: "Since Sep 16, 2015"',
+					args: {
+						formattedDate: moment( user.date_subscribed ).format( 'll' ),
+					},
+				} ) }
+			</div>
+		);
+	};
+
 	const renderSubscribedRole = () => {
 		if ( ! user || ! user.date_subscribed ) {
 			return null;
@@ -285,7 +305,8 @@ const PeopleProfile = ( { siteId, type, user, invite } ) => {
 			<div className="people-profile__detail">
 				{ renderNameOrEmail() }
 				{ renderLogin() }
-				{ isFollowerType() ? renderSubscribedRole() : renderRole() }
+				{ showDate && renderSubscribedDate() }
+				{ showRole && isFollowerType() ? renderSubscribedRole() : renderRole() }
 			</div>
 		</div>
 	);

--- a/client/my-sites/people/people-profile/style.scss
+++ b/client/my-sites/people/people-profile/style.scss
@@ -109,31 +109,6 @@
 		border: none;
 		color: var(--color-text-inverted);
 	}
-
-	&.role-editor {
-		background: var(--color-primary-dark);
-		border: none;
-		color: var(--color-text-inverted);
-	}
-
-	&.role-author,
-	&.role-contributor {
-		background: var(--color-primary);
-		border: none;
-		color: var(--color-text-inverted);
-	}
-
-	&.role-contractor {
-		background: var(--color-neutral-10);
-		border: none;
-		color: var(--color-neutral-70);
-	}
-
-	&.role-p2-guest {
-		background: rgb(112, 71, 227);
-		border: none;
-		color: var(--color-neutral-0);
-	}
 }
 
 .people-profile__role-badge-info {

--- a/client/my-sites/people/subscriber-details/index.tsx
+++ b/client/my-sites/people/subscriber-details/index.tsx
@@ -1,0 +1,205 @@
+import { Card } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import { find } from 'lodash';
+import page from 'page';
+import { useEffect, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import EmptyContent from 'calypso/components/empty-content';
+import FormattedHeader from 'calypso/components/formatted-header';
+import HeaderCake from 'calypso/components/header-cake';
+import { useLocalizedMoment } from 'calypso/components/localized-moment';
+import Main from 'calypso/components/main';
+import useFollowersQuery from 'calypso/data/followers/use-followers-query';
+import useRemoveFollowerMutation from 'calypso/data/followers/use-remove-follower-mutation';
+import accept from 'calypso/lib/accept';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import PeopleListItem from 'calypso/my-sites/people/people-list-item';
+import { recordGoogleEvent } from 'calypso/state/analytics/actions';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
+import type { Follower, FollowersQuery } from 'calypso/my-sites/people/subscribers/types';
+
+import './style.scss';
+
+interface Props {
+	subscriberId: string;
+}
+export default function SubscriberDetails( props: Props ) {
+	const _ = useTranslate();
+	const moment = useLocalizedMoment();
+	const dispatch = useDispatch();
+	const { removeFollower, isSuccess: isRemoveFollowerSuccess } = useRemoveFollowerMutation();
+
+	const site = useSelector( ( state ) => getSelectedSite( state ) );
+	const { subscriberId } = props;
+	const [ subscriber, setSubscriber ] = useState< Follower >();
+	const [ subscriberType, setSubscriberType ] = useState< 'wpcom' | 'email' >();
+	const [ templateState, setTemplateState ] = useState( 'loading' );
+
+	const followersQuery = useFollowersQuery( site?.ID, 'all' ) as unknown as FollowersQuery;
+	useEffect( () => checkCurrentSubscriber(), [ followersQuery ] );
+	useEffect( () => checkSubscriberType(), [ subscriber ] );
+	useEffect( () => checkTemplateState(), [ subscriber, followersQuery.isLoading ] );
+	useEffect( () => checkRemoveCompletion(), [ isRemoveFollowerSuccess ] );
+
+	function checkCurrentSubscriber() {
+		// eslint-disable-next-line
+		const _subscriber = find( followersQuery.data?.followers, ( s ) => s.ID == subscriberId );
+
+		// eslint-disable-next-line
+		subscriber?.ID != _subscriber?.ID && setSubscriber( _subscriber );
+	}
+
+	function checkSubscriberType() {
+		if ( ! subscriber ) {
+			return;
+		}
+		const type = subscriber.login ? 'wpcom' : 'email';
+
+		setSubscriberType( type );
+	}
+
+	function checkTemplateState() {
+		const { isLoading } = followersQuery;
+
+		if ( isLoading ) {
+			setTemplateState( 'loading' );
+		} else if ( ! subscriber ) {
+			setTemplateState( 'not-found' );
+		} else {
+			setTemplateState( 'default' );
+		}
+	}
+
+	function checkRemoveCompletion() {
+		if ( isRemoveFollowerSuccess ) {
+			goBack();
+		}
+	}
+
+	function onRemove() {
+		subscriber && removeSubscriber( subscriber );
+	}
+
+	function onBackClick() {
+		dispatch( recordGoogleEvent( 'People', 'Clicked Back Button on Subscriber Details' ) );
+		goBack();
+	}
+
+	function goBack() {
+		const fallback = site?.slug ? '/people/subscribers/' + site.slug : '/people/subscribers/';
+
+		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+		// @ts-ignore: There are no type definitions for page.back.
+		page.back( fallback );
+	}
+
+	function removeSubscriber( subscriber: Follower ) {
+		const listType = 'email' === subscriberType ? 'Email Follower' : 'Follower';
+		dispatch(
+			recordGoogleEvent( 'People', 'Clicked Remove Follower Button On' + listType + ' list' )
+		);
+
+		accept(
+			<div>
+				<p>
+					{ subscriberType === 'wpcom' &&
+						_(
+							'Removing followers makes them stop receiving updates from your site. ' +
+								'If they choose to, they can still visit your site, and follow it again.'
+						) }
+					{ subscriberType === 'email' &&
+						_( 'Removing email subscribers makes them stop receiving updates from your site.' ) }
+				</p>
+			</div>,
+			( accepted: boolean ) => {
+				if ( accepted ) {
+					dispatch(
+						recordGoogleEvent(
+							'People',
+							'Clicked Remove Button In Remove ' + listType + ' Confirmation'
+						)
+					);
+					removeFollower( site?.ID, subscriberType, subscriber.ID );
+				} else {
+					dispatch(
+						recordGoogleEvent(
+							'People',
+							'Clicked Cancel Button In Remove ' + listType + ' Confirmation'
+						)
+					);
+				}
+			},
+			_( 'Remove', { context: 'Confirm Remove follower button text.' } )
+		);
+	}
+
+	return (
+		<Main className="people-subscriber-details">
+			<PageViewTracker path="/people/subscribers/:site/:id" title="People > User Details" />
+
+			<FormattedHeader
+				brandFont
+				className="people__page-heading"
+				headerText={ _( 'Users' ) }
+				subHeaderText={ _( 'People who have subscribed to your site and team members.' ) }
+				align="left"
+				hasScreenOptions
+			/>
+
+			<HeaderCake isCompact onClick={ onBackClick }>
+				{ _( 'User Details' ) }
+			</HeaderCake>
+
+			{ templateState === 'loading' && (
+				<Card>
+					<PeopleListItem key="people-list-item-placeholder" />
+				</Card>
+			) }
+
+			{ templateState === 'not-found' && (
+				<EmptyContent title={ _( 'The requested subscriber does not exist.' ) } />
+			) }
+
+			{ templateState === 'default' && (
+				<Card className="subscriber-details">
+					<PeopleListItem
+						key={ `subscriber-details-${ subscriberId }` }
+						site={ site }
+						user={ subscriber }
+						onRemove={ onRemove }
+					/>
+					<div className="people-subscriber-details__meta">
+						{ subscriber?.date_subscribed && (
+							<div className="people-subscriber-details__meta-item">
+								<strong>{ _( 'Status' ) }</strong>
+								<div>
+									<span className="people-subscriber-details__meta-status-active">
+										{ _( 'Active' ) }
+									</span>
+								</div>
+							</div>
+						) }
+
+						{ subscriber?.date_subscribed && (
+							<div className="people-subscriber-details__meta-item">
+								<strong>{ _( 'Subscriber since' ) }</strong>
+								<div>
+									<span>{ moment( subscriber?.date_subscribed ).format( 'LLL' ) }</span>
+								</div>
+							</div>
+						) }
+
+						{ subscriber?.url && (
+							<div className="people-subscriber-details__meta-item">
+								<strong>{ _( 'Source' ) }</strong>
+								<div>
+									<span>{ subscriber.url }</span>
+								</div>
+							</div>
+						) }
+					</div>
+				</Card>
+			) }
+		</Main>
+	);
+}

--- a/client/my-sites/people/subscriber-details/style.scss
+++ b/client/my-sites/people/subscriber-details/style.scss
@@ -1,0 +1,32 @@
+.subscriber-details {
+	.people-list-item.card.is-compact {
+		padding: 0;
+	}
+
+	.people-subscriber-details__meta {
+		border-top: 1px solid var(--color-border-subtle);
+		padding-top: 24px;
+		margin-top: 24px;
+	}
+
+	.people-subscriber-details__meta-item {
+		margin-bottom: 1rem;
+		overflow: hidden;
+		white-space: nowrap;
+		text-overflow: ellipsis;
+
+		strong {
+			color: var(--studio-gray-70);
+		}
+
+		.people-subscriber-details__meta-status {
+			&-pending {
+				color: var(--color-warning);
+			}
+
+			&-active {
+				color: var(--color-success);
+			}
+		}
+	}
+}

--- a/client/my-sites/people/subscribers-team/index.tsx
+++ b/client/my-sites/people/subscribers-team/index.tsx
@@ -9,6 +9,7 @@ import { getSelectedSite } from 'calypso/state/ui/selectors';
 import PeopleSectionNavCompact from '../people-section-nav-compact';
 import Subscribers from '../subscribers';
 import TeamInvites from '../team-invites';
+import TeamInvitesAccepted from '../team-invites-accepted';
 import TeamMembers from '../team-members';
 import type { FollowersQuery } from '../subscribers/types';
 import type { UsersQuery } from '../team-members/types';
@@ -78,6 +79,7 @@ function SubscribersTeam( props: Props ) {
 								<>
 									<TeamMembers search={ search } usersQuery={ usersQuery } />
 									<TeamInvites />
+									<TeamInvitesAccepted />
 								</>
 							);
 					}

--- a/client/my-sites/people/subscribers/index.tsx
+++ b/client/my-sites/people/subscribers/index.tsx
@@ -42,7 +42,14 @@ function Subscribers( props: Props ) {
 	}
 
 	function renderFollower( follower: Follower ) {
-		return <PeopleListItem key={ follower?.ID } user={ follower } site={ site } type="email" />;
+		return (
+			<PeopleListItem
+				key={ follower?.ID }
+				user={ follower }
+				site={ site }
+				type="subscriber-details"
+			/>
+		);
 	}
 
 	function renderPlaceholders() {

--- a/client/my-sites/people/team-invites-accepted/index.tsx
+++ b/client/my-sites/people/team-invites-accepted/index.tsx
@@ -1,0 +1,91 @@
+import { Card, Button } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import { useDispatch, useSelector } from 'react-redux';
+import QuerySiteInvites from 'calypso/components/data/query-site-invites';
+import accept from 'calypso/lib/accept';
+import PeopleListItem from 'calypso/my-sites/people/people-list-item';
+import { deleteInvites } from 'calypso/state/invites/actions';
+import { getAcceptedInvitesForSite, isDeletingAnyInvite } from 'calypso/state/invites/selectors';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
+import PeopleListSectionHeader from '../people-list-section-header';
+import type { Invite } from '../team-invites/types';
+
+import './style.scss';
+
+function TeamInvitesAccepted() {
+	const _ = useTranslate();
+	const dispatch = useDispatch();
+
+	const site = useSelector( ( state ) => getSelectedSite( state ) );
+	const siteId = site?.ID as number;
+	const isDeleting = useSelector( ( state ) => isDeletingAnyInvite( state, siteId ) );
+	const acceptedInvites = useSelector( ( state ) => getAcceptedInvitesForSite( state, siteId ) );
+
+	function onClearAll() {
+		showPrompt();
+	}
+
+	function showPrompt() {
+		accept(
+			<div>
+				<h1>{ _( 'Clear All Accepted' ) }</h1>
+				<p>{ _( 'Are you sure you wish to clear all accepted invites?' ) }</p>
+			</div>,
+			( accepted: boolean ) => {
+				if ( ! accepted ) {
+					return;
+				}
+
+				const ids = acceptedInvites ? acceptedInvites?.map( ( x ) => x.key ) : [];
+				dispatch( deleteInvites( siteId, ids ) );
+			},
+			_( 'Clear all' )
+		);
+	}
+
+	function renderInvite( invite: Invite ) {
+		const user = invite.user;
+
+		return (
+			<PeopleListItem
+				key={ invite.key }
+				invite={ invite }
+				user={ user }
+				site={ site }
+				type="invite"
+				isSelectable={ false }
+			/>
+		);
+	}
+
+	return (
+		<>
+			<QuerySiteInvites siteId={ siteId } />
+			{ !! acceptedInvites?.length && (
+				<>
+					<PeopleListSectionHeader
+						label={ _(
+							'%(numberPeople)d user has accepted your invite',
+							'%(numberPeople)d users have accepted your invites',
+							{
+								args: {
+									numberPeople: acceptedInvites?.length,
+								},
+								count: acceptedInvites ? acceptedInvites?.length : 0,
+							}
+						) }
+					>
+						<Button compact busy={ isDeleting } onClick={ onClearAll }>
+							{ _( 'Clear all invites' ) }
+						</Button>
+					</PeopleListSectionHeader>
+					<Card className="people-team-invites-accepted-list">
+						{ acceptedInvites?.map( renderInvite ) }
+					</Card>
+				</>
+			) }
+		</>
+	);
+}
+
+export default TeamInvitesAccepted;

--- a/client/my-sites/people/team-invites-accepted/style.scss
+++ b/client/my-sites/people/team-invites-accepted/style.scss
@@ -1,0 +1,3 @@
+.people-team-invites-accepted-list {
+	padding: 0;
+}

--- a/client/my-sites/people/team-invites/index.tsx
+++ b/client/my-sites/people/team-invites/index.tsx
@@ -34,17 +34,21 @@ function TeamInvites() {
 	return (
 		<>
 			<QuerySiteInvites siteId={ siteId } />
-			<PeopleListSectionHeader
-				label={ _(
-					'You have a pending invite for %(number)d user',
-					'You have a pending invite for %(number)d users',
-					{
-						args: { number: pendingInvites?.length },
-						count: pendingInvites?.length as number,
-					}
-				) }
-			/>
-			<Card className="people-team-invites-list">{ pendingInvites?.map( renderInvite ) }</Card>
+			{ !! pendingInvites?.length && (
+				<>
+					<PeopleListSectionHeader
+						label={ _(
+							'You have a pending invite for %(number)d user',
+							'You have a pending invite for %(number)d users',
+							{
+								args: { number: pendingInvites?.length },
+								count: pendingInvites?.length as number,
+							}
+						) }
+					/>
+					<Card className="people-team-invites-list">{ pendingInvites?.map( renderInvite ) }</Card>
+				</>
+			) }
 		</>
 	);
 }


### PR DESCRIPTION
#### Proposed Changes

* User details screens adjustments
  * Added formatted header above the user details screens
  * Added CTA buttons (moved from list item)
  * Adjusted team member details page (replace radio buttons with dropdown)
  * Created subscriber user details screen with a new dedicated route `/people/subscribers/{site_slug}/{id}`
* List item adjustments
  * Adjusted badge background colors
  * Got rid of the CTA button from list the list item component
* Team tab content adjustments
  * Created accepted invites block and placed it below the pending
  * Hide pending and accepted invites if there are no invites

Design proposal: pbAok1-3rs-p2

Some stuff is hidden behind the feature flag; if you want to test it with the direct link, provide the flag with query param: `?flags=user-management-revamp`

#### Testing Instructions

Subscribers tab:
* Go to `/people/subscribers/{site_slug}`
* Check the design of the list item components
* Check if there are label distinctions between the `Follower` and `Email subscriber`
* Select on the item
* Check the User details screen (it's the new component)

Team tab:
* Click on the `Team` tab
* Add team members
* Check pending invites block
* Accept the invite you made
* Check the accepted invites block

#### Screenshots

<table>
<tr>
<td width="50%"><strong>Before:</strong></td>
<td width="50%"><strong>After:</strong></td>
</tr>
<tr>
<td width="50%">
<img src="https://user-images.githubusercontent.com/1241413/209696514-80f874d6-8b90-4369-9bac-e742122a4b2d.png" />
</td>
<td width="50%">
<img src="https://user-images.githubusercontent.com/1241413/209696554-f5180944-ea85-4ea3-8791-48d6bb8ed6ce.png" />
</td>
</tr>

<tr>
<td width="50%">
<img src="https://user-images.githubusercontent.com/1241413/209697022-08f71888-6252-49d4-8b22-028e3e7639ff.png" />
</td>
<td width="50%">
<img src="https://user-images.githubusercontent.com/1241413/209697115-e7a18189-ec90-4955-9460-95a9b8e63ea3.png" />
</td>
</tr>

<tr>
<td width="50%">
<img src="https://user-images.githubusercontent.com/1241413/209725453-84964801-932c-4481-abcc-1cf44e43ef6d.png" />

</td>
<td width="50%">
<img src="https://user-images.githubusercontent.com/1241413/209725465-63ce8169-e84c-4018-a69b-e1b90af50be0.png" />
</td>
</tr>

<tr><td colspan="2">
<img width="745" alt="Screenshot 2022-12-30 at 10 46 11" src="https://user-images.githubusercontent.com/1241413/210072681-27c231b8-9452-4d1f-b2e3-aefeb2b7dc82.png">
</td></tr>


<tr>
<td width="50%"></td>
<td width="50%"></td>
</tr>

</table>

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #70698