### PR TITLE
ETK: Put back deleted PHP file

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-wp-rest-help-center-has-seen-promotion.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-wp-rest-help-center-has-seen-promotion.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * WP_REST_Help_Center_Has_Seen_Promotion file.
+ *
+ * @package A8C\FSE
+ */
+
+namespace A8C\FSE;
+
+use Automattic\Jetpack\Connection\Client;
+
+/**
+ * Class WP_REST_Help_Center_Has_Seen_Promotion.
+ */
+class WP_REST_Help_Center_Has_Seen_Promotion extends \WP_REST_Controller {
+	/**
+	 * WP_REST_Help_Center_Has_Seen_Promotion constructor.
+	 */
+	public function __construct() {
+		$this->namespace = 'help-center';
+		$this->rest_base = 'has-seen-promotion';
+	}
+
+	/**
+	 * Register available routes.
+	 */
+	public function register_rest_route() {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			array(
+				array(
+					'methods'             => \WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_me_preferences' ),
+					'permission_callback' => array( $this, 'permission_callback' ),
+				),
+				array(
+					'methods'             => \WP_REST_Server::EDITABLE,
+					'callback'            => array( $this, 'set_me_preferences' ),
+					'permission_callback' => array( $this, 'permission_callback' ),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Get the calypso prefernce.
+	 *
+	 * @return WP_REST_Response
+	 */
+	public function get_me_preferences() {
+		$response = Client::wpcom_json_api_request_as_user( '/me/preferences?preference_key=seen_help_center_promotion' );
+
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		$body = json_decode( wp_remote_retrieve_body( $response ) );
+
+		return rest_ensure_response( $body );
+	}
+
+	/**
+	 * Set the calypso prefernce.
+	 *
+	 * @return WP_REST_Response
+	 */
+	public function set_me_preferences() {
+		$response = Client::wpcom_json_api_request_as_user(
+			'/me/preferences',
+			'2',
+			array(
+				'method' => 'POST',
+			),
+			array(
+				'calypso_preferences' => array( 'seen_help_center_promotion' => true ),
+			)
+		);
+
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		$body = json_decode( wp_remote_retrieve_body( $response ) );
+
+		return rest_ensure_response( $body );
+	}
+
+	/**
+	 * Callback to determine whether the request can proceed.
+	 *
+	 * @return boolean
+	 */
+	public function permission_callback() {
+		return is_user_logged_in();
+	}
+}


### PR DESCRIPTION
#### Proposed Changes

* Deploying ETK after merging https://github.com/Automattic/wp-calypso/pull/71493 failed because it deletes a referenced file. The referenced file shouldn't be unreferenced and deleted in the same commit (distributed systems stuff), it should be unreferenced in a deployment, then deleted in a follow up. This PR puts the file back, and a follow-up that deletes it will follow.

Follow up: https://github.com/Automattic/wp-calypso/pull/71519

The error
```sh
This push was rejected by custom hook script 'pre-receive':


File (class-wp-rest-help-center-has-seen-promotion.php.php) removal is not safe to be deployed with require_once() removal in ref e3c71edda54be517f93318bec2994fac1a18ba32:
 	-		require_once __DIR__ . '/class-wp-rest-help-center-has-seen-promotion.php';
 
Please split them in different commits, by doing the modifications, before the removal. Be sure to DEPLOY each change after it is committed. If you need an exception, please contact systems or add 'skip-unsupported-commits-check' to your commit message.
```


