### PR TITLE
eCommerce flow: Removed back button from storeProfiler step

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/store-profiler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/store-profiler/index.tsx
@@ -151,6 +151,7 @@ const StoreProfiler: Step = function StoreProfiler( { navigation, flow } ) {
 		<StepContainer
 			stepName="store-profiler"
 			skipButtonAlign="top"
+			shouldHideNavButtons={ flow === ECOMMERCE_FLOW }
 			goBack={ goBack }
 			goNext={ goNext }
 			formattedHeader={


### PR DESCRIPTION
#### Proposed Changes

* This PR removes the Back button from the `storeProfiler` step when in the eCommerce flow.

#### Testing Instructions

* Use the eCommerce flow (`/setup/ecommerce`)
* Check that the `storeProfiler` step doesn't have the Back button
![arJxcb.png](https://user-images.githubusercontent.com/3801502/209582526-61f1d187-2145-4548-9b09-d4b5b3ab47f8.png)

Closes https://github.com/Automattic/wp-calypso/issues/71459