### PR TITLE
Site Assembler: Add scroll behavior to pattern large preview

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-assembler-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-assembler-preview.tsx
@@ -22,17 +22,18 @@ interface Props {
 	header: Pattern | null;
 	sections: Pattern[];
 	footer: Pattern | null;
-	scrollToSelector: string | null;
+	activePosition: number;
 }
 
-const PatternAssemblerPreview = ( { header, sections = [], footer, scrollToSelector }: Props ) => {
+const PatternAssemblerPreview = ( { header, sections = [], footer, activePosition }: Props ) => {
 	const locale = useLocale();
 	const translate = useTranslate();
 	const site = useSite();
 	const [ webPreviewFrameContainer, setWebPreviewFrameContainer ] = useState< Element | null >(
 		null
 	);
-	const hasSelectedPatterns = header || sections.length > 0 || footer;
+	const totalPatterns = [ header, ...sections, footer ].filter( Boolean );
+	const hasSelectedPatterns = totalPatterns.length > 1;
 	const selectedDesign = useSelect( ( select ) => select( ONBOARD_STORE ).getSelectedDesign() );
 
 	const mergedDesign = {
@@ -46,6 +47,9 @@ const PatternAssemblerPreview = ( { header, sections = [], footer, scrollToSelec
 				.map( ( pattern ) => encodePatternId( pattern!.id ) ),
 		},
 	} as Design;
+
+	const targetPosition = Math.min( activePosition + 1, totalPatterns.length );
+	const scrollToSelector = `.wp-site-blocks > .wp-block-group > :nth-child( ${ targetPosition } )`;
 
 	useEffect( () => {
 		setWebPreviewFrameContainer( document.querySelector( '.web-preview__frame-wrapper' ) );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
@@ -42,10 +42,9 @@ const PatternLargePreview = ( { header, sections, footer, activePosition }: Prop
 			// Use the height to determine whether the newly added pattern is loaded.
 			// If it's not loaded, try to delay the behavior of scrolling into view.
 			if ( height && height > PATTERN_RENDERER_MIN_HEIGHT ) {
-				element.scrollIntoView( {
-					block: 'start',
-					behavior: 'smooth',
-				} );
+				// Note that Firefox has an issue related to "smooth" behavior, so we leave it as default
+				// See https://github.com/Automattic/wp-calypso/pull/71527#issuecomment-1370522634
+				element.scrollIntoView();
 			} else {
 				timerId = window.setTimeout( () => scrollIntoView(), 100 );
 			}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
@@ -2,6 +2,7 @@ import { PatternRenderer } from '@automattic/block-renderer';
 import { DeviceSwitcher } from '@automattic/components';
 import { Icon, layout } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
+import { useRef, useEffect } from 'react';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { encodePatternId } from './utils';
 import type { Pattern } from './types';
@@ -11,11 +12,53 @@ interface Props {
 	header: Pattern | null;
 	sections: Pattern[];
 	footer: Pattern | null;
+	activePosition: number;
 }
 
-const PatternLargePreview = ( { header, sections, footer }: Props ) => {
+// The pattern renderer element has 1px min height before the pattern is loaded
+const PATTERN_RENDERER_MIN_HEIGHT = 1;
+
+const PatternLargePreview = ( { header, sections, footer, activePosition }: Props ) => {
 	const translate = useTranslate();
 	const hasSelectedPattern = header || sections.length || footer;
+	const containerRef = useRef< HTMLUListElement | null >( null );
+
+	const renderPattern = ( key: string, pattern: Pattern ) => (
+		<li key={ key }>
+			<PatternRenderer patternId={ encodePatternId( pattern.id ) } />
+		</li>
+	);
+
+	useEffect( () => {
+		let timerId: number;
+		const scrollIntoView = () => {
+			const element = containerRef.current?.children[ activePosition ];
+			if ( ! element ) {
+				return;
+			}
+
+			const { height } = element.getBoundingClientRect();
+
+			// Use the height to determine whether the newly added pattern is loaded.
+			// If it's not loaded, try to delay the behavior of scrolling into view.
+			if ( height && height > PATTERN_RENDERER_MIN_HEIGHT ) {
+				element.scrollIntoView( {
+					block: 'start',
+					behavior: 'smooth',
+				} );
+			} else {
+				timerId = window.setTimeout( () => scrollIntoView(), 100 );
+			}
+		};
+
+		scrollIntoView();
+
+		return () => {
+			if ( timerId ) {
+				window.clearTimeout( timerId );
+			}
+		};
+	}, [ activePosition, header, sections, footer ] );
 
 	return (
 		<DeviceSwitcher
@@ -27,22 +70,10 @@ const PatternLargePreview = ( { header, sections, footer }: Props ) => {
 			}
 		>
 			{ hasSelectedPattern ? (
-				<ul className="pattern-large-preview__patterns">
-					{ header && (
-						<li key="header">
-							<PatternRenderer patternId={ encodePatternId( header.id ) } />
-						</li>
-					) }
-					{ sections.map( ( pattern ) => (
-						<li key={ pattern.key }>
-							<PatternRenderer patternId={ encodePatternId( pattern.id ) } />
-						</li>
-					) ) }
-					{ footer && (
-						<li key="footer">
-							<PatternRenderer patternId={ encodePatternId( footer.id ) } />
-						</li>
-					) }
+				<ul className="pattern-large-preview__patterns" ref={ containerRef }>
+					{ header && renderPattern( 'header', header ) }
+					{ sections.map( ( pattern ) => renderPattern( pattern.key!, pattern ) ) }
+					{ footer && renderPattern( 'footer', footer ) }
 				</ul>
 			) : (
 				<div className="pattern-large-preview__placeholder">


### PR DESCRIPTION
#### Proposed Changes

* Add the scroll behavior after replacing the mechanism of the site assembler preview with the fast preview component

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply D95663-code to your sandbox
* Go to `/setup?siteSlug=<your_site>&flags=pattern-assembler/client-side-render`
* Click the "Continue" button until you land on the Design Picker step
* Scroll to the bottom and select the Blank Canvas CTA
* When you're in the Pattern Assembler step, verify the scroll behavior is correct when you add/replace/delete/reorder any header, sections
  * When you add/replace/delete a header, the preview will scroll to the top
  * When you add/replace/delete a footer, the preview will scroll to the bottom
  * When you add a new section, the preview will scroll to the bottom
  * When you replace/delete a section, the preview will scroll to that section
  * When you reorder a section, the preview will scroll to that section at the new position

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/67076