### PR TITLE
eCommerce flow: Added geolocation to storeProfiler step

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/store-profiler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/store-profiler/index.tsx
@@ -9,6 +9,7 @@ import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormSelect from 'calypso/components/forms/form-select';
 import FormInput from 'calypso/components/forms/form-text-input';
+import { useGeoLocationQuery } from 'calypso/data/geo/use-geolocation-query';
 import useSiteVerticalsFeatured from 'calypso/data/site-verticals/use-site-verticals-featured';
 import { useCountriesAndStates } from 'calypso/jetpack-cloud/sections/partner-portal/company-details-form/hooks/use-countries-and-states';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -20,7 +21,6 @@ const StoreProfiler: Step = function StoreProfiler( { navigation, flow } ) {
 	const { goBack, goNext, submit } = navigation;
 	const [ siteTitle, setSiteTitle ] = React.useState( '' );
 	const [ verticalId, setVerticalId ] = React.useState( '' );
-	const [ storeCountryCode, setStoreCountryCode ] = React.useState( '' );
 	const translate = useTranslate();
 	const currentUser = useSelect( ( select ) => select( USER_STORE ).getCurrentUser() );
 	const newUser = useSelect( ( select ) => select( USER_STORE ).getNewUser() );
@@ -58,6 +58,10 @@ const StoreProfiler: Step = function StoreProfiler( { navigation, flow } ) {
 			</option>
 		) );
 	}, [ countriesAndStates ] );
+
+	const region = useGeoLocationQuery()?.data;
+	const [ storeCountryCode, setStoreCountryCode ] = React.useState( region?.country_short );
+
 	const isLoading = verticals.isLoading || ! countriesAndStates;
 
 	const handleSubmit = async ( event: React.FormEvent ) => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/store-profiler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/store-profiler/index.tsx
@@ -3,7 +3,7 @@ import { Button, FormInputValidation } from '@automattic/components';
 import { StepContainer, ECOMMERCE_FLOW } from '@automattic/onboarding';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
-import React from 'react';
+import React, { useEffect } from 'react';
 import FormattedHeader from 'calypso/components/formatted-header';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
@@ -21,6 +21,7 @@ const StoreProfiler: Step = function StoreProfiler( { navigation, flow } ) {
 	const { goBack, goNext, submit } = navigation;
 	const [ siteTitle, setSiteTitle ] = React.useState( '' );
 	const [ verticalId, setVerticalId ] = React.useState( '' );
+	const [ storeCountryCode, setStoreCountryCode ] = React.useState( '' );
 	const translate = useTranslate();
 	const currentUser = useSelect( ( select ) => select( USER_STORE ).getCurrentUser() );
 	const newUser = useSelect( ( select ) => select( USER_STORE ).getNewUser() );
@@ -60,7 +61,12 @@ const StoreProfiler: Step = function StoreProfiler( { navigation, flow } ) {
 	}, [ countriesAndStates ] );
 
 	const region = useGeoLocationQuery()?.data;
-	const [ storeCountryCode, setStoreCountryCode ] = React.useState( region?.country_short );
+
+	useEffect( () => {
+		if ( ! storeCountryCode && region ) {
+			setStoreCountryCode( region?.country_short );
+		}
+	}, [ region ] );
 
 	const isLoading = verticals.isLoading || ! countriesAndStates;
 


### PR DESCRIPTION
#### Proposed Changes

#### Testing Instructions

* Use the eCommerce flow (`/setup/ecommerce`)
* Check that the `storeProfiler` step populates with you current location:
![image](https://user-images.githubusercontent.com/3801502/209714961-91b6bf12-617d-48ab-bf4d-13229cac704b.png)




Closes https://github.com/Automattic/wp-calypso/issues/71458
