### PR TITLE
Stats: remove "Unknown Search Terms" from the Search Terms stats module

### DIFF
--- a/client/state/stats/lists/test/utils.js
+++ b/client/state/stats/lists/test/utils.js
@@ -1090,7 +1090,7 @@ describe( 'utils', () => {
 				expect( normalizers.statsVideo() ).toBeNull();
 			} );
 
-			test( 'should return an a properly parsed data array', () => {
+			test( 'should return a properly parsed data array', () => {
 				expect(
 					normalizers.statsVideo( {
 						data: [
@@ -1146,7 +1146,7 @@ describe( 'utils', () => {
 				expect( normalizers.statsTopAuthors( {}, { period: 'day' } ) ).toEqual( [] );
 			} );
 
-			test( 'should return an a properly parsed data array', () => {
+			test( 'should return a properly parsed data array', () => {
 				expect(
 					normalizers.statsTopAuthors(
 						{
@@ -1234,7 +1234,7 @@ describe( 'utils', () => {
 				expect( normalizers.statsTags( { bad: [] } ) ).toEqual( [] );
 			} );
 
-			test( 'should return an a properly parsed data array', () => {
+			test( 'should return a properly parsed data array', () => {
 				expect(
 					normalizers.statsTags( {
 						date: '2014-10-01',
@@ -1328,7 +1328,7 @@ describe( 'utils', () => {
 				expect( normalizers.statsClicks( {}, { period: 'day' } ) ).toEqual( [] );
 			} );
 
-			test( 'should return an a properly parsed data array', () => {
+			test( 'should return a properly parsed data array', () => {
 				expect(
 					normalizers.statsClicks(
 						{
@@ -1556,7 +1556,7 @@ describe( 'utils', () => {
 				] );
 			} );
 
-			test( 'should return an a properly parsed data array', () => {
+			test( 'should return a properly parsed data array', () => {
 				expect(
 					normalizers.statsReferrers(
 						{
@@ -1660,7 +1660,7 @@ describe( 'utils', () => {
 				expect( normalizers.statsSearchTerms( {}, { period: 'day' } ) ).toEqual( [] );
 			} );
 
-			test( 'should return an a properly parsed data array', () => {
+			test( 'should return a properly parsed data array', () => {
 				expect(
 					normalizers.statsSearchTerms(
 						{
@@ -1762,7 +1762,7 @@ describe( 'utils', () => {
 				expect( normalizers.statsVisits( { bad: [] } ) ).toEqual( [] );
 			} );
 
-			test( 'should return an a properly parsed data array', () => {
+			test( 'should return a properly parsed data array', () => {
 				expect(
 					normalizers.statsVisits( {
 						fields: [ 'period', 'views', 'visitors' ],

--- a/client/state/stats/lists/test/utils.js
+++ b/client/state/stats/lists/test/utils.js
@@ -1000,7 +1000,7 @@ describe( 'utils', () => {
 				expect( normalizers.statsPublicize( { bad: [] } ) ).toEqual( [] );
 			} );
 
-			test( 'should return an a properly parsed services array', () => {
+			test( 'should return a properly parsed services array', () => {
 				expect(
 					normalizers.statsPublicize( {
 						services: [
@@ -1393,7 +1393,7 @@ describe( 'utils', () => {
 				] );
 			} );
 
-			test( 'should return an a properly parsed summary data array', () => {
+			test( 'should return a properly parsed summary data array', () => {
 				expect(
 					normalizers.statsClicks(
 						{
@@ -1471,7 +1471,7 @@ describe( 'utils', () => {
 				expect( normalizers.statsReferrers( {}, { period: 'day' } ) ).toEqual( [] );
 			} );
 
-			test( 'should return an a properly parsed summary data array', () => {
+			test( 'should return a properly parsed summary data array', () => {
 				expect(
 					normalizers.statsReferrers(
 						{
@@ -1706,7 +1706,7 @@ describe( 'utils', () => {
 				] );
 			} );
 
-			test( 'should return an a properly parsed summarized data array', () => {
+			test( 'should return a properly parsed summarized data array', () => {
 				expect(
 					normalizers.statsSearchTerms(
 						{

--- a/client/state/stats/lists/test/utils.js
+++ b/client/state/stats/lists/test/utils.js
@@ -1648,7 +1648,7 @@ describe( 'utils', () => {
 		} );
 
 		describe( 'statsSearchTerms()', () => {
-			test( 'should return an empty array if not data is passed', () => {
+			test( 'should return an empty array if no data is passed', () => {
 				expect( normalizers.statsSearchTerms() ).toEqual( [] );
 			} );
 
@@ -1697,12 +1697,6 @@ describe( 'utils', () => {
 						label: 'ribs',
 						value: 10,
 					},
-					{
-						label: 'Unknown Search Terms',
-						labelIcon: 'external',
-						link: 'https://wordpress.com/support/stats/#search-engine-terms',
-						value: 221,
-					},
 				] );
 			} );
 
@@ -1712,7 +1706,6 @@ describe( 'utils', () => {
 						{
 							date: '2017-01-12',
 							summary: {
-								encrypted_search_terms: 400,
 								search_terms: [
 									{
 										term: 'chicken',
@@ -1742,12 +1735,6 @@ describe( 'utils', () => {
 						className: 'user-selectable',
 						label: 'ribs',
 						value: 100,
-					},
-					{
-						label: 'Unknown Search Terms',
-						labelIcon: 'external',
-						link: 'https://wordpress.com/support/stats/#search-engine-terms',
-						value: 400,
 					},
 				] );
 			} );

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -893,11 +893,6 @@ export const normalizers = {
 		const { startOf } = rangeOfPeriod( query.period, query.date );
 		const dataPath = query.summarize ? [ 'summary' ] : [ 'days', startOf ];
 		const searchTerms = get( data, dataPath.concat( [ 'search_terms' ] ), [] );
-		const encryptedSearchTerms = get(
-			data,
-			dataPath.concat( [ 'encrypted_search_terms' ] ),
-			false
-		);
 
 		const result = searchTerms.map( ( day ) => {
 			return {
@@ -906,15 +901,6 @@ export const normalizers = {
 				value: day.views,
 			};
 		} );
-
-		if ( encryptedSearchTerms ) {
-			result.push( {
-				label: translate( 'Unknown Search Terms' ),
-				value: encryptedSearchTerms,
-				link: 'https://wordpress.com/support/stats/#search-engine-terms',
-				labelIcon: 'external',
-			} );
-		}
 
 		return result;
 	},


### PR DESCRIPTION
#### Proposed Changes

fixes #70963 

This PR removes `encrypted_search_terms` handling so that we no longer display `Unknown Search Terms` in the Search Terms stats module

#### Testing Instructions

* Before using live branches, open stats for a website that has some recent search terms displaying (including unknown ones) and verify that you can see `unknown search terms` 
* Visit the Calypso Live branch.
* Verify that `unknown search terms` is no longer displayed. 


| Before  | After |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/30754158/209736838-3b14c28c-8f8d-40a1-a8d8-100ff1317988.png)  | ![image](https://user-images.githubusercontent.com/30754158/209736818-77547d3e-b975-45e2-a5a9-9b39dab67094.png)  |


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->