### PR TITLE
Update expected title for YouTube block test

### DIFF
--- a/test/e2e/specs/blocks/blocks__core.ts
+++ b/test/e2e/specs/blocks/blocks__core.ts
@@ -13,7 +13,7 @@ import { createBlockTests } from './shared/block-smoke-testing';
 const blockFlows: BlockFlow[] = [
 	new YouTubeBlockFlow( {
 		embedUrl: 'https://www.youtube.com/watch?v=twGLN4lug-I',
-		expectedVideoTitle: 'Getting Started on @WordPress.com',
+		expectedVideoTitle: 'Getting Started on @WordPressdotcom',
 	} ),
 	new LayoutGridBlockFlow( {
 		leftColumnText: DataHelper.getRandomPhrase(),


### PR DESCRIPTION
#### Proposed Changes

For the Gutenberg 14.8.2 update, we're getting a test failure related to the YouTube block.

It looks like the Youtube title has changed from "WordPress.com" to "WordPressdotcom." (See https://www.youtube.com/watch?v=twGLN4lug-I) As a result, we need to update our test code to match that.

#### Testing Instructions
Run the gutenberg edge tests using this PR, and this particular YouTube test should pass. (See https://teamcity.a8c.com/buildConfiguration/calypso_WPComTests_gutenberg_simple_edge_desktop/9223402) This will resolve it for all four builds which are failing.

**This works!**
