### PR TITLE
Fix: don't remove the page list when fetching the next page.

### DIFF
--- a/client/my-sites/pages/page-list.jsx
+++ b/client/my-sites/pages/page-list.jsx
@@ -392,9 +392,11 @@ class Pages extends Component {
 	render() {
 		const { hasSites, loading, areBlockEditorSettingsLoading, isFSEActiveLoading } = this.props;
 		const { pages } = this.state;
-		const isLoading = loading || areBlockEditorSettingsLoading || isFSEActiveLoading;
+		const hasPage = pages.length > 0;
+		const isInitialLoad =
+			( loading || areBlockEditorSettingsLoading || isFSEActiveLoading ) && ! hasPage;
 
-		if ( ! isLoading && hasSites ) {
+		if ( ! isInitialLoad && hasSites ) {
 			return pages.length > 0 || this.showVirtualHomepage()
 				? this.renderPagesList( { pages } )
 				: this.renderNoContent();


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/69559

#### Proposed Changes

* When fetching the next page of pages, keep the existing list in place

How it looks now after this PR:

Screencast: 2e9ce-pb/#plain



#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Follow the "Steps to reproduce" [here](https://github.com/Automattic/wp-calypso/issues/69559) on prod and then on the Calypso Live link to verify the problem is fixed. 

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #