### PR TITLE
Fix response for home template in /pages for Coming Soon sites

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/coming-soon.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/coming-soon.php
@@ -221,15 +221,17 @@ function add_option_to_new_site( $blog_id, $user_id, $domain, $path, $network_id
 add_action( 'wpmu_new_blog', __NAMESPACE__ . '\add_option_to_new_site', 10, 6 );
 
 /**
- * Decides whether to redirect to the site's coming soon page and performs
- * the redirect.
+ * Decides whether to render to the site's coming soon page and performs
+ * the render.
+ *
+ * @param string $template The template to render.
  */
-function coming_soon_page() {
+function coming_soon_page( $template ) {
 	if ( ! should_show_coming_soon_page() ) {
-		return;
+		return $template;
 	}
 
 	render_fallback_coming_soon_page();
 	die();
 }
-add_action( 'template_redirect', __NAMESPACE__ . '\coming_soon_page' );
+add_filter( 'template_include', __NAMESPACE__ . '\coming_soon_page' );


### PR DESCRIPTION
#### Proposed Changes

* `template_redirect` returns a HTML response instead of a JSON response expected [here](fbhepr%2Skers%2Sjcpbz%2Sjc%2Qpbagrag%2Serfg%2Qncv%2Qcyhtvaf%2Sraqcbvagf%2Sfvgrf%2Qoybpx%2Qrqvgbe.cuc%3Se%3Qr05pqr84%2390-og) 
* This results in `null` response for `https://public-api.wordpress.com/wpcom/v2/sites/:blog_id/block-editor?_envelope=1`
(notice the `null` values in `home_template`), which then prevents the Homepage template from being rendered (screenshots below) 
```
{
	"body": {
		"is_fse_eligible": true,
		"is_fse_active": false,
		"home_template": {
			"postType": null,
			"postId": null
		}
	},
	"status": 200,
	"headers": {
		"Allow": "GET"
	}
}
```


| Before  | After |
| :-------------: | :-------------: |
| <img src="https://user-images.githubusercontent.com/6586048/209795256-a62fe883-b0b6-4c6d-90da-1470ef919163.png">  | <img src="https://user-images.githubusercontent.com/6586048/209795261-a9a9a79a-5450-4880-8745-a1eaf324dff2.png">|


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

This is a fix for **atomic** sites in "Coming Soon" mode.

* Checkout to this branch
* Follow the steps here (PCYsg-ly5-p2) for testing editing-toolkit changes on atomic sites
* Go to /pages/:site to see if it renders the homepage
* Alternatively: check the API response for `https://public-api.wordpress.com/wpcom/v2/sites/:blog_id/block-editor?_envelope=1`
```
{
	"body": {
		"is_fse_eligible": true,
		"is_fse_active": false,
		"home_template": {
			"postType": "wp_template",
			"postId": "quadrat-white\/\/index" // the fse-supported theme you chose
		}
	},
	"status": 200,
	"headers": {
		"Allow": "GET"
	}
}
```

Feel free to test around the issue to see if private atomic/simple sites are functioning correctly.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] ~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~
- [ ] ~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~
- [ ] ~For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #71375