### PR TITLE
Jetpack Pricing Page Cart Integration - post checkout url fix

### DIFF
--- a/client/jetpack-cloud/sections/pricing/jpcom-masterbar/index.tsx
+++ b/client/jetpack-cloud/sections/pricing/jpcom-masterbar/index.tsx
@@ -1,5 +1,6 @@
 import { Gridicon } from '@automattic/components';
 import { useLocale, localizeUrl } from '@automattic/i18n-utils';
+import { useShoppingCart } from '@automattic/shopping-cart';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useMemo } from 'react';
@@ -47,6 +48,10 @@ const JetpackComMasterbar: React.FC< Props > = ( { pathname } ) => {
 	const isLoggedIn = useSelector( isUserLoggedIn );
 	const user = useSelector( getCurrentUser );
 
+	const siteId = useSelector( getSelectedSiteId );
+	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) );
+
+	const { responseCart } = useShoppingCart( siteId ?? undefined );
 	const shoppingCartTracker = useShoppingCartTracker();
 
 	const onRemoveProductFromCart = ( productSlug: string ) => {
@@ -60,7 +65,13 @@ const JetpackComMasterbar: React.FC< Props > = ( { pathname } ) => {
 			addProducts: true,
 		} );
 
-		window.location.href = buildCheckoutURL( siteSlug, '' );
+		window.location.href = buildCheckoutURL( siteSlug, '', {
+			...( responseCart.products.length > 1
+				? {
+						redirect_to: `https://${ siteSlug }/wp-admin/admin.php?page=jetpack#/recommendations/site-type`,
+				  }
+				: {} ),
+		} );
 	};
 
 	const sections = useMemo(
@@ -151,9 +162,6 @@ const JetpackComMasterbar: React.FC< Props > = ( { pathname } ) => {
 		],
 		[ translate ]
 	);
-
-	const siteId = useSelector( getSelectedSiteId );
-	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) );
 
 	const shouldShowCart = useSelector( isJetpackCloudCartEnabled );
 

--- a/client/jetpack-cloud/sections/pricing/jpcom-masterbar/index.tsx
+++ b/client/jetpack-cloud/sections/pricing/jpcom-masterbar/index.tsx
@@ -65,13 +65,14 @@ const JetpackComMasterbar: React.FC< Props > = ( { pathname } ) => {
 			addProducts: true,
 		} );
 
-		window.location.href = buildCheckoutURL( siteSlug, '', {
-			...( responseCart.products.length > 1
+		const buildUrlParams =
+			responseCart.products.length > 1
 				? {
 						redirect_to: `https://${ siteSlug }/wp-admin/admin.php?page=jetpack#/recommendations/site-type`,
 				  }
-				: {} ),
-		} );
+				: undefined;
+
+		window.location.href = buildCheckoutURL( siteSlug, '', buildUrlParams );
 	};
 
 	const sections = useMemo(


### PR DESCRIPTION
#### Proposed Changes
* Add redirect_to query param and redirect to wp-admin recommendation page for users purchasing more than one item


#### Testing Instructions

* Make sure you are logged-in to WordPress.com 
* click on Jetpack Cloud live link below
* or boot up this PR 
    * Run `git fetch && git checkout fix/checkout-redirect`
    * Run `yarn start-jetpack-cloud`
    * Goto http://jetpack.cloud.localhost:3000
* you will be presented with a landing page, asking you to select a site, choose any site from the list
* Once selected, you will be redirected to `/backup/:site-slug` page by default, replace `backup` with `pricing` and you should land in pricing page
* Now append this query string (`?flags=jetpack/pricing-page-cart`) to the end of URL to enable the cart and reload the page
* Make sure the cart shows up in the header
* Add more than one product to the cart and checkout
* After checkout, you should be redirected to wp-admin page of your site (`wp-admin/admin.php?page=jetpack#/recommendations/site-type`)


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
1203495437860512-as-1203534015891207/f

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203534015891207