### PR TITLE
Jetpack Pricing Page Cart integration - toast message on add to cart

### DIFF
--- a/client/jetpack-cloud/sections/pricing/style.scss
+++ b/client/jetpack-cloud/sections/pricing/style.scss
@@ -15,4 +15,8 @@
 			border: solid 2px var(--studio-pink-50);
 		}
 	}
+
+	.global-notices {
+		z-index: 100201;
+	}
 }

--- a/client/my-sites/plans/jetpack-plans/product-store/hooks/use-store-item-info.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/hooks/use-store-item-info.tsx
@@ -10,12 +10,13 @@ import {
 import { useShoppingCart } from '@automattic/shopping-cart';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useMemo } from 'react';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import isSupersedingJetpackItem from 'calypso/../packages/calypso-products/src/is-superseding-jetpack-item';
 import { getPurchaseByProductSlug } from 'calypso/lib/purchases/utils';
 import reactNodeToString from 'calypso/lib/react-node-to-string';
 import OwnerInfo from 'calypso/me/purchases/purchase-item/owner-info';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
+import { successNotice } from 'calypso/state/notices/actions';
 import { getSitePurchases } from 'calypso/state/purchases/selectors';
 import { useIsUserPurchaseOwner } from 'calypso/state/purchases/utils';
 import {
@@ -31,7 +32,6 @@ import productButtonLabel from '../../product-card/product-button-label';
 import { SelectorProduct } from '../../types';
 import { UseStoreItemInfoProps } from '../types';
 import { useShoppingCartTracker } from './use-shopping-cart-tracker';
-
 const getIsDeprecated = ( item: SelectorProduct ) => Boolean( item.legacy );
 
 const getIsExternal = ( item: SelectorProduct ) =>
@@ -63,6 +63,7 @@ export const useStoreItemInfo = ( {
 		( state ) => !! ( siteId && isJetpackSiteMultiSite( state, siteId ) )
 	);
 	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) );
+	const dispatch = useDispatch();
 
 	const isCurrentUserPurchaseOwner = useIsUserPurchaseOwner();
 	const translate = useTranslate();
@@ -209,7 +210,11 @@ export const useStoreItemInfo = ( {
 				shoppingCartTracker( 'calypso_jetpack_shopping_cart_add_product', {
 					productSlug: item.productSlug,
 				} );
-				return addProductsToCart( [ { product_slug: item.productSlug } ] );
+				addProductsToCart( [ { product_slug: item.productSlug } ] );
+
+				const addedToCartText = translate( 'added to cart' );
+				dispatch( successNotice( `${ item.displayName } ${ addedToCartText }` ) );
+				return;
 			}
 
 			return onClickPurchase?.( item, getIsUpgradeableToYearly( item ), getPurchase( item ) );
@@ -220,8 +225,10 @@ export const useStoreItemInfo = ( {
 			getIsUpgradeableToYearly,
 			getPurchase,
 			getIsProductInCart,
-			addProductsToCart,
 			shoppingCartTracker,
+			addProductsToCart,
+			dispatch,
+			translate,
 		]
 	);
 

--- a/client/my-sites/plans/jetpack-plans/product-store/hooks/use-store-item-info.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/hooks/use-store-item-info.tsx
@@ -210,11 +210,10 @@ export const useStoreItemInfo = ( {
 				shoppingCartTracker( 'calypso_jetpack_shopping_cart_add_product', {
 					productSlug: item.productSlug,
 				} );
-				addProductsToCart( [ { product_slug: item.productSlug } ] );
 
 				const addedToCartText = translate( 'added to cart' );
 				dispatch( successNotice( `${ item.displayName } ${ addedToCartText }` ) );
-				return;
+				return addProductsToCart( [ { product_slug: item.productSlug } ] );
 			}
 
 			return onClickPurchase?.( item, getIsUpgradeableToYearly( item ), getPurchase( item ) );


### PR DESCRIPTION
#### Proposed Changes

* Show a toast message when the user adds an item to the cart

#### Testing Instructions

* Make sure you are logged-in to WordPress.com 
* click on Jetpack Cloud live link below
* or boot up this PR 
    * Run `git fetch && git checkout fix/toast-on-cart-add`
    * Run `yarn start-jetpack-cloud`
    * Goto http://jetpack.cloud.localhost:3000
* you will be presented with a landing page, asking you to select a site, choose any site from the list
* Once selected, you will be redirected to `/backup/:site-slug` page by default, replace `backup` with `pricing` and you should land in pricing page
* Now append this query string (`?flags=jetpack/pricing-page-cart`) to the end of URL to enable the cart and reload the page
* Make sure the cart shows up in the header
* Add any items to the cart and confirm that the toast message is shown on the top right corner. 
    


#### Screenshot

![Screenshot 2022-12-28 at 5 29 31 PM](https://user-images.githubusercontent.com/2027003/209808914-cf09303c-070e-4a40-8972-43efaddae3dc.png)

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
1203495437860512-as-1203596148132211/f

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203596148132211