### PR TITLE
E2E: Update page template selector

### DIFF
--- a/packages/calypso-e2e/src/lib/components/page-template-modal-component.ts
+++ b/packages/calypso-e2e/src/lib/components/page-template-modal-component.ts
@@ -43,7 +43,7 @@ export class PageTemplateModalComponent {
 	 * @param {string} label Label for the template (the string underneath the preview).
 	 */
 	async selectTemplate( label: string ): Promise< void > {
-		await this.editorFrame.getByRole( 'button', { name: label, exact: true } ).click();
+		await this.editorFrame.getByRole( 'option', { name: label, exact: true } ).click();
 	}
 
 	/**


### PR DESCRIPTION
#### Proposed Changes

Fix the following test by updating the page template selector:

```
specs/editor/editor__page-basic-flow.ts: Editor: Basic Post Flow:
Select page template
```

#### Testing Instructions

The `editor__page-basic-flow.ts` suite should be passing in the CI.