### PR TITLE
Reading Settings: Add 'Your homepage displays' site setting

### DIFF
--- a/client/data/dropdown-pages/use-dropdown-pages.ts
+++ b/client/data/dropdown-pages/use-dropdown-pages.ts
@@ -1,4 +1,4 @@
-import { useQuery, UseQueryOptions } from 'react-query';
+import { useQuery } from 'react-query';
 import wpcom from 'calypso/lib/wp';
 
 type Response = PageNode[];
@@ -9,12 +9,7 @@ export type PageNode = {
 	children?: PageNode[];
 };
 
-type QueryOptions = Omit<
-	UseQueryOptions< Response, unknown, Response, ( string | number | undefined )[] >,
-	'queryKey' | 'queryFn'
->;
-
-const useDropdownPagesQuery = ( siteId?: number, queryOptions: QueryOptions = {} ) => {
+const useDropdownPagesQuery = ( siteId?: number, queryOptions = {} ) => {
 	return useQuery(
 		[ 'sites', siteId, 'dropdown-pages' ],
 		(): Promise< Response > => wpcom.req.get( `/sites/${ siteId }/dropdown-pages` ),

--- a/client/data/dropdown-pages/use-dropdown-pages.ts
+++ b/client/data/dropdown-pages/use-dropdown-pages.ts
@@ -1,0 +1,28 @@
+import { useQuery, UseQueryOptions } from 'react-query';
+import wpcom from 'calypso/lib/wp';
+
+type Response = PageNode[];
+
+export type PageNode = {
+	ID: number;
+	title: string;
+	children?: PageNode[];
+};
+
+type QueryOptions = Omit<
+	UseQueryOptions< Response, unknown, Response, ( string | number | undefined )[] >,
+	'queryKey' | 'queryFn'
+>;
+
+const useDropdownPagesQuery = ( siteId?: number, queryOptions: QueryOptions = {} ) => {
+	return useQuery(
+		[ 'sites', siteId, 'dropdown-pages' ],
+		(): Promise< Response > => wpcom.req.get( `/sites/${ siteId }/dropdown-pages` ),
+		{
+			enabled: !! siteId,
+			...queryOptions,
+		}
+	);
+};
+
+export default useDropdownPagesQuery;

--- a/client/my-sites/site-settings/reading-site-settings/YourHomepageDisplaysSetting.tsx
+++ b/client/my-sites/site-settings/reading-site-settings/YourHomepageDisplaysSetting.tsx
@@ -1,0 +1,15 @@
+type YourHomepageDisplaysOptions = {
+	show_on_front?: 'posts' | 'page';
+	page_on_front?: string;
+};
+
+type YourHomepageDisplaysSettingProps = {
+	value: YourHomepageDisplaysOptions;
+	onChange?: ( value: YourHomepageDisplaysOptions ) => void;
+	disabled?: boolean;
+};
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export const YourHomepageDisplaysSetting = ( { value }: YourHomepageDisplaysSettingProps ) => {
+	return null;
+};

--- a/client/my-sites/site-settings/reading-site-settings/YourHomepageDisplaysSetting.tsx
+++ b/client/my-sites/site-settings/reading-site-settings/YourHomepageDisplaysSetting.tsx
@@ -1,14 +1,48 @@
 import { localizeUrl } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
-import { ChangeEvent } from 'react';
 import { connect } from 'react-redux';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
-import FormRadio from 'calypso/components/forms/form-radio';
 import FormSelect from 'calypso/components/forms/form-select';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
-import usePostsQuery from 'calypso/data/posts/use-posts-query';
-import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import useDropdownPagesQuery, { PageNode } from 'calypso/data/dropdown-pages/use-dropdown-pages';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+
+const PAGE_TITLE_DEPTH_PADDING = '—'; // em dash
+
+const toDropdownPageTitle = ( pageTitle: string, depth = 0 ) => {
+	const padding = `${ PAGE_TITLE_DEPTH_PADDING.repeat( depth ) }`;
+	padding !== '' && padding.concat( ' ' );
+	return `${ padding }${ pageTitle }`;
+};
+
+type DropdownPage = {
+	ID: number;
+	title: string;
+};
+
+const insertPageNodeToDropdownPages = (
+	{ ID, title, children }: PageNode,
+	dropdownPages: DropdownPage[],
+	depth = 0
+) => {
+	const dropdownPage = {
+		ID,
+		title: toDropdownPageTitle( title, depth ),
+	};
+	dropdownPages.push( dropdownPage );
+	children?.forEach( ( childPageNode ) => {
+		insertPageNodeToDropdownPages( childPageNode, dropdownPages, depth + 1 );
+	} );
+};
+
+const toFlatDropdownPages = ( pageNodes: PageNode[] ): DropdownPage[] => {
+	const dropdownPages: DropdownPage[] = [];
+	pageNodes.forEach( ( pageNode ) => {
+		insertPageNodeToDropdownPages( pageNode, dropdownPages );
+	} );
+	return dropdownPages;
+};
 
 type YourHomepageDisplaysValue = {
 	show_on_front?: 'posts' | 'page';
@@ -22,79 +56,56 @@ type YourHomepageDisplaysSettingProps = {
 	disabled?: boolean;
 	updateFields?: ( fields: Partial< YourHomepageDisplaysValue > ) => void;
 	siteId?: number;
-	siteSlug?: string;
 };
 
 const YourHomepageDisplaysSetting = ( {
-	value: { show_on_front, page_for_posts, page_on_front } = {},
+	value: { page_for_posts, page_on_front } = {},
 	onChange,
 	disabled,
 	siteId,
-	siteSlug,
 }: YourHomepageDisplaysSettingProps ) => {
 	const translate = useTranslate();
-	const { data: pages, isLoading } = usePostsQuery(
-		siteId,
-		{ type: 'page' },
-		{ select: ( { posts } ) => posts }
-	);
+
+	const { data: pages, isLoading } = useDropdownPagesQuery( siteId, {
+		select: toFlatDropdownPages,
+	} );
+
+	const handlePageOnFrontChange: React.FormEventHandler = ( { target } ) => {
+		const selectedPageId: string = ( target as HTMLSelectElement ).value;
+		if ( selectedPageId === '' ) {
+			// Default was selected, so we need to set show_on_front to 'posts'
+			onChange?.( { show_on_front: 'posts', page_on_front: '' } );
+		} else {
+			onChange?.( { show_on_front: 'page', page_on_front: selectedPageId } );
+		}
+	};
+
+	const handlePageForPosts: React.FormEventHandler = ( { target } ) => {
+		const selectedPageId: string = ( target as HTMLSelectElement ).value;
+		onChange?.( { page_for_posts: selectedPageId } );
+	};
+
 	return (
 		<FormFieldset>
 			<FormLabel>{ translate( 'Your homepage displays' ) }</FormLabel>
 
-			<FormLabel>
-				<FormRadio
-					value="posts"
-					checked={ ! show_on_front || show_on_front === 'posts' }
-					onChange={ ( { target: { value } }: ChangeEvent< HTMLInputElement > ) =>
-						value === 'posts' && onChange?.( { show_on_front: 'posts' } )
-					}
-					disabled={ disabled || isLoading }
-					label={ translate( 'Your latest posts' ) }
-					className={ undefined }
-				/>
-			</FormLabel>
-
-			<FormLabel>
-				<FormRadio
-					name="show_on_front"
-					value="page"
-					checked={ show_on_front === 'page' }
-					onChange={ ( { target: { value } }: ChangeEvent< HTMLInputElement > ) =>
-						value === 'page' && onChange?.( { show_on_front: 'page' } )
-					}
-					disabled={ disabled || isLoading }
-					label={ translate( 'A {{toSitePagesLink}}page{{/toSitePagesLink}} (select below)', {
-						components: {
-							toSitePagesLink: (
-								<a href={ `/pages/${ siteSlug }` } target="_blank" rel="noreferrer" />
-							),
-						},
-					} ) }
-					className={ undefined }
-				/>
-			</FormLabel>
-
 			<FormLabel htmlFor="homepage-page-select">
-				{ translate( 'Homepage' ) }
-
 				<FormSelect
 					id="homepage-page-select"
+					className="select-homepage-setting"
 					name="page_on_front"
-					disabled={ disabled || isLoading || show_on_front !== 'page' || ! pages?.length }
+					disabled={ disabled || isLoading || ! pages?.length }
 					value={ page_on_front }
-					onChange={ ( { target } ) =>
-						onChange?.( { page_on_front: ( target as HTMLSelectElement ).value } )
-					}
+					onChange={ handlePageOnFrontChange }
 				>
-					<option value="">{ translate( '-- Select --' ) }</option>
+					<option value="">{ translate( '—— Default ——' ) }</option>
 					{ pages?.map( ( page ) => {
-						if ( page_for_posts && page_for_posts === String( page.ID ) ) {
-							return null;
-						}
-
 						return (
-							<option key={ page.ID } value={ page.ID }>
+							<option
+								key={ page.ID }
+								value={ page.ID }
+								disabled={ page.ID === Number( page_for_posts ) }
+							>
 								{ page.title }
 							</option>
 						);
@@ -102,23 +113,24 @@ const YourHomepageDisplaysSetting = ( {
 				</FormSelect>
 			</FormLabel>
 
-			<FormLabel htmlFor="posts-page-select">
-				{ translate( 'Posts page' ) }
+			<FormLabel htmlFor="posts-page-select" className="default-posts-page-setting">
+				{ translate( 'Default posts page' ) }
 
 				<FormSelect
 					id="posts-page-select"
 					name="page_for_posts"
-					disabled={ disabled || isLoading || show_on_front !== 'page' || ! pages?.length }
+					disabled={ disabled || isLoading || ! pages?.length }
 					value={ page_for_posts }
+					onChange={ handlePageForPosts }
 				>
-					<option value="">{ translate( '-- Select --' ) }</option>
+					<option value="">{ translate( '—— Select ——' ) }</option>
 					{ pages?.map( ( page ) => {
-						if ( page_on_front && page_on_front === String( page.ID ) ) {
-							return null;
-						}
-
 						return (
-							<option key={ page.ID } value={ page.ID }>
+							<option
+								key={ page.ID }
+								value={ page.ID }
+								disabled={ page.ID === Number( page_on_front ) }
+							>
 								{ page.title }
 							</option>
 						);
@@ -128,26 +140,13 @@ const YourHomepageDisplaysSetting = ( {
 
 			<FormSettingExplanation>
 				{ translate(
-					'If you choose to assign a {{aboutFrontPageLink}}static homepage{{/aboutFrontPageLink}}, you can also choose to assign a default posts page. Your default posts page will be controlled by a dedicated template as determined by your theme. In Classic themes, this posts page cannot be customized, {{aboutPostsPageLink}}Learn More{{/aboutPostsPageLink}}. In Block themes, you can customize the posts page template, {{aboutTemplatesLink}}Learn More{{/aboutTemplatesLink}}.',
+					'Default homepage and posts page content and layout are determined by your active theme. {{aboutTemplatesLink}}Learn More{{/aboutTemplatesLink}}.',
 					{
 						components: {
-							aboutFrontPageLink: (
-								<a
-									href={ localizeUrl( 'https://wordpress.com/support/pages/front-page/' ) }
-									target="_blank"
-									rel="noreferrer"
-								/>
-							),
-							aboutPostsPageLink: (
-								<a
-									href={ localizeUrl( 'https://wordpress.com/support/posts-page/' ) }
-									target="_blank"
-									rel="noreferrer"
-								/>
-							),
 							aboutTemplatesLink: (
 								<a
-									href={ localizeUrl( 'https://wordpress.com/support/templates/' ) }
+									className="learn-more-link"
+									href={ localizeUrl( 'https://wordpress.com/support/templates/' ) } // todo: update link to doc from https://github.com/Automattic/en.support-docs-content/issues/1805 once complete
 									target="_blank"
 									rel="noreferrer"
 								/>
@@ -162,10 +161,5 @@ const YourHomepageDisplaysSetting = ( {
 
 export default connect( ( state ) => {
 	const siteId = getSelectedSiteId( state );
-	const siteSlug = getSelectedSiteSlug( state );
-
-	return {
-		...( siteId && { siteId } ),
-		...( siteSlug && { siteSlug } ),
-	};
+	return { ...( siteId && { siteId } ) };
 } )( YourHomepageDisplaysSetting );

--- a/client/my-sites/site-settings/reading-site-settings/YourHomepageDisplaysSetting.tsx
+++ b/client/my-sites/site-settings/reading-site-settings/YourHomepageDisplaysSetting.tsx
@@ -140,13 +140,13 @@ const YourHomepageDisplaysSetting = ( {
 
 			<FormSettingExplanation>
 				{ translate(
-					'Default homepage and posts page content and layout are determined by your active theme. {{aboutTemplatesLink}}Learn More{{/aboutTemplatesLink}}.',
+					'Default homepage and posts page content and layout are determined by your active theme. {{aboutTemplatesLink}}Learn more{{/aboutTemplatesLink}}.',
 					{
 						components: {
 							aboutTemplatesLink: (
 								<a
 									className="learn-more-link"
-									href={ localizeUrl( 'https://wordpress.com/support/templates/' ) } // todo: update link to doc from https://github.com/Automattic/en.support-docs-content/issues/1805 once complete
+									href={ localizeUrl( 'https://wordpress.com/support/pages/front-page/' ) }
 									target="_blank"
 									rel="noreferrer"
 								/>

--- a/client/my-sites/site-settings/reading-site-settings/YourHomepageDisplaysSetting.tsx
+++ b/client/my-sites/site-settings/reading-site-settings/YourHomepageDisplaysSetting.tsx
@@ -9,11 +9,11 @@ import useDropdownPagesQuery, { PageNode } from 'calypso/data/dropdown-pages/use
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 const PAGE_TITLE_DEPTH_PADDING = '—'; // em dash
+const SPACE = ' ';
 
 const toDropdownPageTitle = ( pageTitle: string, depth = 0 ) => {
 	const padding = `${ PAGE_TITLE_DEPTH_PADDING.repeat( depth ) }`;
-	padding !== '' && padding.concat( ' ' );
-	return `${ padding }${ pageTitle }`;
+	return `${ padding }${ padding ? SPACE : '' }${ pageTitle }`;
 };
 
 type DropdownPage = {

--- a/client/my-sites/site-settings/reading-site-settings/YourHomepageDisplaysSetting.tsx
+++ b/client/my-sites/site-settings/reading-site-settings/YourHomepageDisplaysSetting.tsx
@@ -80,7 +80,7 @@ const YourHomepageDisplaysSetting = ( {
 		}
 	};
 
-	const handlePageForPosts: React.FormEventHandler = ( { target } ) => {
+	const handlePageForPostsChange: React.FormEventHandler = ( { target } ) => {
 		const selectedPageId: string = ( target as HTMLSelectElement ).value;
 		onChange?.( { page_for_posts: selectedPageId } );
 	};
@@ -121,7 +121,7 @@ const YourHomepageDisplaysSetting = ( {
 					name="page_for_posts"
 					disabled={ disabled || isLoading || ! pages?.length }
 					value={ page_for_posts }
-					onChange={ handlePageForPosts }
+					onChange={ handlePageForPostsChange }
 				>
 					<option value="">{ translate( '—— Select ——' ) }</option>
 					{ pages?.map( ( page ) => {

--- a/client/my-sites/site-settings/reading-site-settings/YourHomepageDisplaysSetting.tsx
+++ b/client/my-sites/site-settings/reading-site-settings/YourHomepageDisplaysSetting.tsx
@@ -1,15 +1,171 @@
-type YourHomepageDisplaysOptions = {
+import { localizeUrl } from '@automattic/i18n-utils';
+import { useTranslate } from 'i18n-calypso';
+import { ChangeEvent } from 'react';
+import { connect } from 'react-redux';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+import FormLabel from 'calypso/components/forms/form-label';
+import FormRadio from 'calypso/components/forms/form-radio';
+import FormSelect from 'calypso/components/forms/form-select';
+import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
+import usePostsQuery from 'calypso/data/posts/use-posts-query';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+
+type YourHomepageDisplaysValue = {
 	show_on_front?: 'posts' | 'page';
 	page_on_front?: string;
+	page_for_posts?: string;
 };
 
 type YourHomepageDisplaysSettingProps = {
-	value: YourHomepageDisplaysOptions;
-	onChange?: ( value: YourHomepageDisplaysOptions ) => void;
+	value: YourHomepageDisplaysValue;
+	onChange?: ( value: Partial< YourHomepageDisplaysValue > ) => void;
 	disabled?: boolean;
+	updateFields?: ( fields: Partial< YourHomepageDisplaysValue > ) => void;
+	siteId?: number;
+	siteSlug?: string;
 };
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-export const YourHomepageDisplaysSetting = ( { value }: YourHomepageDisplaysSettingProps ) => {
-	return null;
+export const YourHomepageDisplaysSetting = ( {
+	value: { show_on_front, page_for_posts, page_on_front } = {},
+	onChange,
+	disabled,
+	siteId,
+	siteSlug,
+}: YourHomepageDisplaysSettingProps ) => {
+	const translate = useTranslate();
+	const { data: pages, isLoading } = usePostsQuery( siteId, { type: 'page' } );
+	return (
+		<FormFieldset>
+			<FormLabel>{ translate( 'Your homepage displays' ) }</FormLabel>
+
+			<FormLabel>
+				<FormRadio
+					value="posts"
+					checked={ ! show_on_front || show_on_front === 'posts' }
+					onChange={ ( { target: { value } }: ChangeEvent< HTMLInputElement > ) =>
+						value === 'posts' && onChange?.( { show_on_front: 'posts' } )
+					}
+					disabled={ disabled || isLoading }
+					label={ translate( 'Your latest posts' ) }
+					className={ undefined }
+				/>
+			</FormLabel>
+
+			<FormLabel>
+				<FormRadio
+					name="show_on_front"
+					value="page"
+					checked={ show_on_front === 'page' }
+					onChange={ ( { target: { value } }: ChangeEvent< HTMLInputElement > ) =>
+						value === 'page' && onChange?.( { show_on_front: 'page' } )
+					}
+					disabled={ disabled || isLoading }
+					label={ translate( 'A {{toSitePagesLink}}page{{/toSitePagesLink}} (select below)', {
+						components: {
+							toSitePagesLink: (
+								<a href={ `/pages/${ siteSlug }` } target="_blank" rel="noreferrer" />
+							),
+						},
+					} ) }
+					className={ undefined }
+				/>
+			</FormLabel>
+
+			{ pages?.length ? (
+				<FormLabel htmlFor="homepage-page-select">
+					{ translate( 'Homepage' ) }
+
+					<FormSelect
+						id="homepage-page-select"
+						name="page_on_front"
+						disabled={ show_on_front !== 'page' || disabled || isLoading }
+						value={ page_on_front }
+						onChange={ ( { target } ) =>
+							onChange?.( { page_on_front: ( target as HTMLSelectElement ).value } )
+						}
+					>
+						<option value="">{ translate( '-- Select --' ) }</option>
+						{ pages.map( ( page ) => {
+							if ( page_for_posts && page_for_posts === String( page.ID ) ) {
+								return null;
+							}
+
+							return (
+								<option key={ page.ID } value={ page.ID }>
+									{ page.title }
+								</option>
+							);
+						} ) }
+					</FormSelect>
+				</FormLabel>
+			) : null }
+
+			{ pages?.length ? (
+				<FormLabel htmlFor="posts-page-select">
+					{ translate( 'Posts page' ) }
+
+					<FormSelect
+						id="posts-page-select"
+						name="page_for_posts"
+						disabled={ show_on_front !== 'page' || disabled || isLoading }
+						value={ page_for_posts }
+					>
+						<option value="">{ translate( '-- Select --' ) }</option>
+						{ pages.map( ( page ) => {
+							if ( page_on_front && page_on_front === String( page.ID ) ) {
+								return null;
+							}
+
+							return (
+								<option key={ page.ID } value={ page.ID }>
+									{ page.title }
+								</option>
+							);
+						} ) }
+					</FormSelect>
+				</FormLabel>
+			) : null }
+
+			<FormSettingExplanation>
+				{ translate(
+					'If you choose to assign a {{aboutFrontPageLink}}static homepage{{/aboutFrontPageLink}}, you can also choose to assign a default posts page. Your default posts page will be controlled by a dedicated template as determined by your theme. In Classic themes, this posts page cannot be customized, {{aboutPostsPageLink}}Learn More{{/aboutPostsPageLink}}. In Block themes, you can customize the posts page template, {{aboutTemplatesLink}}Learn More{{/aboutTemplatesLink}}.',
+					{
+						components: {
+							aboutFrontPageLink: (
+								<a
+									href={ localizeUrl( 'https://wordpress.com/support/pages/front-page/' ) }
+									target="_blank"
+									rel="noreferrer"
+								/>
+							),
+							aboutPostsPageLink: (
+								<a
+									href={ localizeUrl( 'https://wordpress.com/support/posts-page/' ) }
+									target="_blank"
+									rel="noreferrer"
+								/>
+							),
+							aboutTemplatesLink: (
+								<a
+									href={ localizeUrl( 'https://wordpress.com/support/templates/' ) }
+									target="_blank"
+									rel="noreferrer"
+								/>
+							),
+						},
+					}
+				) }
+			</FormSettingExplanation>
+		</FormFieldset>
+	);
 };
+
+export default connect( ( state ) => {
+	const siteId = getSelectedSiteId( state );
+	const siteSlug = getSelectedSiteSlug( state );
+
+	return {
+		...( siteId && { siteId } ),
+		...( siteSlug && { siteSlug } ),
+	};
+} )( YourHomepageDisplaysSetting );

--- a/client/my-sites/site-settings/reading-site-settings/YourHomepageDisplaysSetting.tsx
+++ b/client/my-sites/site-settings/reading-site-settings/YourHomepageDisplaysSetting.tsx
@@ -25,7 +25,7 @@ type YourHomepageDisplaysSettingProps = {
 	siteSlug?: string;
 };
 
-export const YourHomepageDisplaysSetting = ( {
+const YourHomepageDisplaysSetting = ( {
 	value: { show_on_front, page_for_posts, page_on_front } = {},
 	onChange,
 	disabled,
@@ -33,7 +33,11 @@ export const YourHomepageDisplaysSetting = ( {
 	siteSlug,
 }: YourHomepageDisplaysSettingProps ) => {
 	const translate = useTranslate();
-	const { data: pages, isLoading } = usePostsQuery( siteId, { type: 'page' } );
+	const { data: pages, isLoading } = usePostsQuery(
+		siteId,
+		{ type: 'page' },
+		{ select: ( { posts } ) => posts }
+	);
 	return (
 		<FormFieldset>
 			<FormLabel>{ translate( 'Your homepage displays' ) }</FormLabel>
@@ -71,60 +75,56 @@ export const YourHomepageDisplaysSetting = ( {
 				/>
 			</FormLabel>
 
-			{ pages?.length ? (
-				<FormLabel htmlFor="homepage-page-select">
-					{ translate( 'Homepage' ) }
+			<FormLabel htmlFor="homepage-page-select">
+				{ translate( 'Homepage' ) }
 
-					<FormSelect
-						id="homepage-page-select"
-						name="page_on_front"
-						disabled={ show_on_front !== 'page' || disabled || isLoading }
-						value={ page_on_front }
-						onChange={ ( { target } ) =>
-							onChange?.( { page_on_front: ( target as HTMLSelectElement ).value } )
+				<FormSelect
+					id="homepage-page-select"
+					name="page_on_front"
+					disabled={ disabled || isLoading || show_on_front !== 'page' || ! pages?.length }
+					value={ page_on_front }
+					onChange={ ( { target } ) =>
+						onChange?.( { page_on_front: ( target as HTMLSelectElement ).value } )
+					}
+				>
+					<option value="">{ translate( '-- Select --' ) }</option>
+					{ pages?.map( ( page ) => {
+						if ( page_for_posts && page_for_posts === String( page.ID ) ) {
+							return null;
 						}
-					>
-						<option value="">{ translate( '-- Select --' ) }</option>
-						{ pages.map( ( page ) => {
-							if ( page_for_posts && page_for_posts === String( page.ID ) ) {
-								return null;
-							}
 
-							return (
-								<option key={ page.ID } value={ page.ID }>
-									{ page.title }
-								</option>
-							);
-						} ) }
-					</FormSelect>
-				</FormLabel>
-			) : null }
+						return (
+							<option key={ page.ID } value={ page.ID }>
+								{ page.title }
+							</option>
+						);
+					} ) }
+				</FormSelect>
+			</FormLabel>
 
-			{ pages?.length ? (
-				<FormLabel htmlFor="posts-page-select">
-					{ translate( 'Posts page' ) }
+			<FormLabel htmlFor="posts-page-select">
+				{ translate( 'Posts page' ) }
 
-					<FormSelect
-						id="posts-page-select"
-						name="page_for_posts"
-						disabled={ show_on_front !== 'page' || disabled || isLoading }
-						value={ page_for_posts }
-					>
-						<option value="">{ translate( '-- Select --' ) }</option>
-						{ pages.map( ( page ) => {
-							if ( page_on_front && page_on_front === String( page.ID ) ) {
-								return null;
-							}
+				<FormSelect
+					id="posts-page-select"
+					name="page_for_posts"
+					disabled={ disabled || isLoading || show_on_front !== 'page' || ! pages?.length }
+					value={ page_for_posts }
+				>
+					<option value="">{ translate( '-- Select --' ) }</option>
+					{ pages?.map( ( page ) => {
+						if ( page_on_front && page_on_front === String( page.ID ) ) {
+							return null;
+						}
 
-							return (
-								<option key={ page.ID } value={ page.ID }>
-									{ page.title }
-								</option>
-							);
-						} ) }
-					</FormSelect>
-				</FormLabel>
-			) : null }
+						return (
+							<option key={ page.ID } value={ page.ID }>
+								{ page.title }
+							</option>
+						);
+					} ) }
+				</FormSelect>
+			</FormLabel>
 
 			<FormSettingExplanation>
 				{ translate(

--- a/client/my-sites/site-settings/reading-site-settings/index.tsx
+++ b/client/my-sites/site-settings/reading-site-settings/index.tsx
@@ -3,7 +3,7 @@ import { useTranslate } from 'i18n-calypso';
 import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
 import { BlogPagesSetting, BLOG_PAGES_OPTION } from './BlogPagesSetting';
 import { RelatedPostsSetting } from './RelatedPostsSetting';
-import { YourHomepageDisplaysSetting } from './YourHomepageDisplaysSetting';
+import YourHomepageDisplaysSetting from './YourHomepageDisplaysSetting';
 
 type Fields = {
 	jetpack_relatedposts_enabled?: boolean;

--- a/client/my-sites/site-settings/reading-site-settings/index.tsx
+++ b/client/my-sites/site-settings/reading-site-settings/index.tsx
@@ -9,6 +9,7 @@ type Fields = {
 	jetpack_relatedposts_enabled?: boolean;
 	jetpack_relatedposts_show_headline?: boolean;
 	jetpack_relatedposts_show_thumbnails?: boolean;
+	page_for_posts?: string;
 	page_on_front?: string;
 	posts_per_page?: number;
 	show_on_front?: 'posts' | 'page';
@@ -22,6 +23,7 @@ type SiteSettingsSectionProps = {
 	disabled?: boolean;
 	isRequestingSettings?: boolean;
 	isSavingSettings?: boolean;
+	updateFields: ( fields: Fields ) => void;
 };
 
 export const SiteSettingsSection = ( {
@@ -32,9 +34,10 @@ export const SiteSettingsSection = ( {
 	disabled,
 	isRequestingSettings,
 	isSavingSettings,
+	updateFields,
 }: SiteSettingsSectionProps ) => {
 	const translate = useTranslate();
-	const { posts_per_page, show_on_front, page_on_front } = fields;
+	const { page_for_posts, page_on_front, posts_per_page, show_on_front } = fields;
 
 	return (
 		<>
@@ -47,15 +50,18 @@ export const SiteSettingsSection = ( {
 				isSaving={ isSavingSettings }
 			/>
 			<Card className="site-settings__card">
+				<YourHomepageDisplaysSetting
+					value={ { page_for_posts, page_on_front, show_on_front } }
+					onChange={ ( value ) => {
+						updateFields( value );
+					} }
+					disabled={ disabled }
+				/>
+			</Card>
+			<Card className="site-settings__card">
 				<BlogPagesSetting
 					value={ posts_per_page }
 					onChange={ onChangeField( BLOG_PAGES_OPTION ) }
-					disabled={ disabled }
-				/>
-				<YourHomepageDisplaysSetting
-					value={ { show_on_front, page_on_front } }
-					// eslint-disable-next-line @typescript-eslint/no-empty-function
-					onChange={ () => {} }
 					disabled={ disabled }
 				/>
 			</Card>

--- a/client/my-sites/site-settings/reading-site-settings/index.tsx
+++ b/client/my-sites/site-settings/reading-site-settings/index.tsx
@@ -3,12 +3,15 @@ import { useTranslate } from 'i18n-calypso';
 import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
 import { BlogPagesSetting, BLOG_PAGES_OPTION } from './BlogPagesSetting';
 import { RelatedPostsSetting } from './RelatedPostsSetting';
+import { YourHomepageDisplaysSetting } from './YourHomepageDisplaysSetting';
 
 type Fields = {
-	posts_per_page?: number;
 	jetpack_relatedposts_enabled?: boolean;
 	jetpack_relatedposts_show_headline?: boolean;
 	jetpack_relatedposts_show_thumbnails?: boolean;
+	page_on_front?: string;
+	posts_per_page?: number;
+	show_on_front?: 'posts' | 'page';
 };
 
 type SiteSettingsSectionProps = {
@@ -31,7 +34,7 @@ export const SiteSettingsSection = ( {
 	isSavingSettings,
 }: SiteSettingsSectionProps ) => {
 	const translate = useTranslate();
-	const { posts_per_page } = fields;
+	const { posts_per_page, show_on_front, page_on_front } = fields;
 
 	return (
 		<>
@@ -47,6 +50,12 @@ export const SiteSettingsSection = ( {
 				<BlogPagesSetting
 					value={ posts_per_page }
 					onChange={ onChangeField( BLOG_PAGES_OPTION ) }
+					disabled={ disabled }
+				/>
+				<YourHomepageDisplaysSetting
+					value={ { show_on_front, page_on_front } }
+					// eslint-disable-next-line @typescript-eslint/no-empty-function
+					onChange={ () => {} }
 					disabled={ disabled }
 				/>
 			</Card>

--- a/client/my-sites/site-settings/settings-reading/main.tsx
+++ b/client/my-sites/site-settings/settings-reading/main.tsx
@@ -13,7 +13,7 @@ import wrapSettingsForm from '../wrap-settings-form';
 
 const isEnabled = config.isEnabled( 'settings/modernize-reading-settings' );
 
-type Settings = {
+type Fields = {
 	jetpack_relatedposts_enabled?: boolean;
 	jetpack_relatedposts_show_headline?: boolean;
 	jetpack_relatedposts_show_thumbnails?: boolean;
@@ -31,7 +31,7 @@ type Settings = {
 	wpcom_subscription_emails_use_excerpt?: boolean;
 };
 
-const getFormSettings = ( settings: Settings ) => {
+const getFormSettings = ( settings: unknown & Fields ) => {
 	if ( ! settings ) {
 		return {};
 	}
@@ -74,18 +74,6 @@ const connectComponent = connect( ( state ) => {
 		...( siteUrl && { siteUrl } ),
 	};
 } );
-
-type Fields = {
-	posts_per_page?: number;
-	posts_per_rss?: number;
-	rss_use_excerpt?: boolean;
-	subscription_options?: {
-		invitation: string;
-		comment_follow: string;
-	};
-	wpcom_featured_image_in_email?: boolean;
-	wpcom_subscription_emails_use_excerpt?: boolean;
-};
 
 type ReadingSettingsFormProps = {
 	fields: Fields;

--- a/client/my-sites/site-settings/settings-reading/main.tsx
+++ b/client/my-sites/site-settings/settings-reading/main.tsx
@@ -17,15 +17,17 @@ type Settings = {
 	jetpack_relatedposts_enabled?: boolean;
 	jetpack_relatedposts_show_headline?: boolean;
 	jetpack_relatedposts_show_thumbnails?: boolean;
-	posts_per_page?: boolean;
-	posts_per_rss?: boolean;
+	page_on_front?: string;
+	posts_per_page?: number;
+	posts_per_rss?: number;
 	rss_use_excerpt?: boolean;
-	wpcom_featured_image_in_email?: boolean;
-	wpcom_subscription_emails_use_excerpt?: boolean;
+	show_on_front?: 'posts' | 'page';
 	subscription_options?: {
 		invitation: string;
 		comment_follow: string;
 	};
+	wpcom_featured_image_in_email?: boolean;
+	wpcom_subscription_emails_use_excerpt?: boolean;
 };
 
 const getFormSettings = ( settings: Settings ) => {
@@ -37,24 +39,28 @@ const getFormSettings = ( settings: Settings ) => {
 		jetpack_relatedposts_enabled,
 		jetpack_relatedposts_show_headline,
 		jetpack_relatedposts_show_thumbnails,
+		page_on_front,
 		posts_per_page,
 		posts_per_rss,
 		rss_use_excerpt,
+		show_on_front,
+		subscription_options,
 		wpcom_featured_image_in_email,
 		wpcom_subscription_emails_use_excerpt,
-		subscription_options,
 	} = settings;
 
 	return {
 		...( jetpack_relatedposts_enabled && { jetpack_relatedposts_enabled } ),
 		...( jetpack_relatedposts_show_headline && { jetpack_relatedposts_show_headline } ),
 		...( jetpack_relatedposts_show_thumbnails && { jetpack_relatedposts_show_thumbnails } ),
+		...( page_on_front && { page_on_front } ),
 		...( posts_per_page && { posts_per_page } ),
 		...( posts_per_rss && { posts_per_rss } ),
 		...( rss_use_excerpt && { rss_use_excerpt } ),
+		...( show_on_front && { show_on_front } ),
+		...( subscription_options && { subscription_options } ),
 		...( wpcom_featured_image_in_email && { wpcom_featured_image_in_email } ),
 		...( wpcom_subscription_emails_use_excerpt && { wpcom_subscription_emails_use_excerpt } ),
-		...( subscription_options && { subscription_options } ),
 	};
 };
 

--- a/client/my-sites/site-settings/settings-reading/main.tsx
+++ b/client/my-sites/site-settings/settings-reading/main.tsx
@@ -154,7 +154,7 @@ const ReadingSettings = () => {
 	}
 
 	return (
-		<Main className="site-settings">
+		<Main className="site-settings site-settings__reading-settings">
 			<DocumentHead title={ translate( 'Reading Settings' ) } />
 			<FormattedHeader brandFont headerText={ translate( 'Reading Settings' ) } align="left" />
 			<ReadingSettingsForm />

--- a/client/my-sites/site-settings/settings-reading/main.tsx
+++ b/client/my-sites/site-settings/settings-reading/main.tsx
@@ -17,6 +17,7 @@ type Settings = {
 	jetpack_relatedposts_enabled?: boolean;
 	jetpack_relatedposts_show_headline?: boolean;
 	jetpack_relatedposts_show_thumbnails?: boolean;
+	page_for_posts?: string;
 	page_on_front?: string;
 	posts_per_page?: number;
 	posts_per_rss?: number;
@@ -39,6 +40,7 @@ const getFormSettings = ( settings: Settings ) => {
 		jetpack_relatedposts_enabled,
 		jetpack_relatedposts_show_headline,
 		jetpack_relatedposts_show_thumbnails,
+		page_for_posts,
 		page_on_front,
 		posts_per_page,
 		posts_per_rss,
@@ -53,6 +55,7 @@ const getFormSettings = ( settings: Settings ) => {
 		...( jetpack_relatedposts_enabled && { jetpack_relatedposts_enabled } ),
 		...( jetpack_relatedposts_show_headline && { jetpack_relatedposts_show_headline } ),
 		...( jetpack_relatedposts_show_thumbnails && { jetpack_relatedposts_show_thumbnails } ),
+		...( page_for_posts && { page_for_posts } ),
 		...( page_on_front && { page_on_front } ),
 		...( posts_per_page && { posts_per_page } ),
 		...( posts_per_rss && { posts_per_rss } ),
@@ -76,12 +79,12 @@ type Fields = {
 	posts_per_page?: number;
 	posts_per_rss?: number;
 	rss_use_excerpt?: boolean;
-	wpcom_featured_image_in_email?: boolean;
-	wpcom_subscription_emails_use_excerpt?: boolean;
 	subscription_options?: {
 		invitation: string;
 		comment_follow: string;
 	};
+	wpcom_featured_image_in_email?: boolean;
+	wpcom_subscription_emails_use_excerpt?: boolean;
 };
 
 type ReadingSettingsFormProps = {
@@ -118,6 +121,7 @@ const ReadingSettingsForm = wrapSettingsForm( getFormSettings )(
 						disabled={ disabled }
 						isRequestingSettings={ isRequestingSettings }
 						isSavingSettings={ isSavingSettings }
+						updateFields={ updateFields }
 					/>
 					<RssFeedSettingsSection
 						fields={ fields }

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -689,3 +689,17 @@ button.site-settings__general-settings-set-guessed-timezone.button.is-borderless
 		margin-top: 24px;
 	}
 }
+
+.site-settings__reading-settings {
+	.select-homepage-setting {
+		margin-bottom: 12px;
+	}
+
+	.default-posts-page-setting {
+		margin-bottom: 12px;
+	}
+
+	.learn-more-link {
+		white-space: nowrap;
+	}
+}


### PR DESCRIPTION
![Screen Shot 2023-01-14 at 11 48 30](https://user-images.githubusercontent.com/2019970/212471549-aec76976-6f1e-4c47-957e-8632a201ecaa.png)

#### Proposed Changes

* Add **Your homepage displays** setting to the new **Reading Settings** page
  * Display it at the top of the **Site settings** section
  * Use the `GET /sites/$site/dropdown-pages/` endpoint to populate the setting's dropdown options
  * A page selected in one of the dropdowns should be disabled in another dropdown. E.g.: I have selected **About** page for **Your homepage displays** dropdown. Then once I open up the **Default posts page** dropdown the **About** page should be disabled.
  * Display an explanation note as:
    > Default homepage and posts page content and layout are determined by your active theme. [Learn More](https://wordpress.com/support/templates/).
   
     For now the "Learn more." link leads to https://wordpress.com/support/templates but there is a new support doc being written up that will replace it when the feature goes out to prod. The following ticket tracks the doc work: https://github.com/Automattic/en.support-docs-content/issues/1805

#### Testing Instructions

<!--
Add as many details as pos can also be very helpful when the change is visual.
-->

‼️ Be aware that unsetting the **Default posts page** does not work properly with the component for now due to the following backend issue: https://github.com/Automattic/wp-calypso/issues/72119

* Apply jetpack's `trunk` to your sandbox
* Sandbox `public-api.wordpress.com`
* Go to `http://calypso.localhost:3000/settings/reading/$site`, e.g.: `http://calypso.localhost:3000/settings/reading/simple-site.blog`

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #70409
