### PR TITLE
Stats: Fix the Recent weeks' table styles on the post detail page

### DIFF
--- a/client/my-sites/stats/post-detail-table-section/style.scss
+++ b/client/my-sites/stats/post-detail-table-section/style.scss
@@ -23,6 +23,14 @@ $common-border-radius: 4px;
 					&:nth-child(2) {
 						border-top-left-radius: 0;
 					}
+
+					&:nth-last-child(2) {
+						border-top-right-radius: 0;
+					}
+
+					&:nth-last-child(3) {
+						border-top-right-radius: $common-border-radius;
+					}
 				}
 			}
 
@@ -35,7 +43,27 @@ $common-border-radius: 4px;
 					&:nth-child(2) {
 						border-bottom-left-radius: 0;
 					}
+
+					&:nth-last-child(2) {
+						border-bottom-right-radius: 0;
+					}
+
+					&:nth-last-child(3) {
+						border-bottom-right-radius: $common-border-radius;
+					}
 				}
+			}
+
+			th:nth-last-child(2) {
+				text-align: right;
+				width: 100px;
+			}
+
+			td:nth-last-child(2) {
+				background-color: var(--studio-white);
+				font-weight: 600;
+				text-align: right;
+				vertical-align: top;
 			}
 		}
 	}
@@ -58,12 +86,12 @@ $common-border-radius: 4px;
 			}
 
 			&:last-child {
-				background: none;
 				font-weight: 600;
 				text-align: right;
 			}
 
-			&.has-no-data {
+			&.has-no-data,
+			&:last-child {
 				background-color: var(--studio-white);
 			}
 

--- a/client/my-sites/stats/post-detail-table-section/style.scss
+++ b/client/my-sites/stats/post-detail-table-section/style.scss
@@ -13,7 +13,7 @@ $common-border-radius: 4px;
 			display: none;
 		}
 
-		.is-post-weeks {
+		.is-detail-weeks {
 			tr:first-child {
 				td {
 					&:first-child {

--- a/client/my-sites/stats/stats-detail-weeks/index.jsx
+++ b/client/my-sites/stats/stats-detail-weeks/index.jsx
@@ -157,7 +157,7 @@ const StatsPostDetailWeeks = ( props ) => {
 	} );
 
 	return (
-		<Card className={ classNames( 'stats-module', 'is-expanded', 'is-post-weeks', classes ) }>
+		<Card className={ classNames( 'stats-module', 'is-expanded', 'is-detail-weeks', classes ) }>
 			<QueryPostStats siteId={ siteId } postId={ postId } />
 			<QueryPosts siteId={ siteId } postId={ postId } />
 			<div className="module-header">

--- a/client/my-sites/stats/stats-detail-weeks/index.jsx
+++ b/client/my-sites/stats/stats-detail-weeks/index.jsx
@@ -103,7 +103,7 @@ const StatsPostDetailWeeks = ( props ) => {
 			// If there are fewer than 7 days in the last week, append blank days
 			if ( week.days.length < 7 && 0 !== index ) {
 				for ( let j = 0; j < 7 - week.days.length; j++ ) {
-					cells.push( <td key={ 'w' + index + 'e' + j } /> );
+					cells.push( <td className="has-no-data" key={ 'w' + index + 'e' + j } /> );
 				}
 			}
 


### PR DESCRIPTION
#### Proposed Changes

* Use the existing class name `has-no-data` for empty cell styles.
* Modify `Total` cell styles without coloring.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

> For a11n, if you have no idea about the testing data on the tables, please refer to `p1671729060450249/1671728562.298969-slack-C0438NHCLSY`.

* Spin up this change with the Calypso Live link.
* Navigate to the Stats `Post Detail` page (`/stats/post/${post-id}/${site-id}`).
* Append the feature flag `?flags=stats/enhance-post-detail` to the URL.
* Ensure the `Recent weeks`' table styles are fixed, as shown in the screenshot below.

| Before | After |
| --- | --- |
| <img width="1095" alt="截圖 2022-12-28 下午10 25 13" src="https://user-images.githubusercontent.com/6869813/209829757-a5ab01d5-e84e-449f-9eb9-3399acbd9239.png"> | <img width="1111" alt="截圖 2022-12-28 下午10 24 54" src="https://user-images.githubusercontent.com/6869813/209829807-b83d3fbb-8520-4fb2-aa95-eeb0338d483b.png"> |



#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/70671#issuecomment-1365994680
