### PR TITLE
Stats: Fix post detail thumbnail displaying

### DIFF
--- a/client/my-sites/stats/post-detail-highlights-section/style.scss
+++ b/client/my-sites/stats/post-detail-highlights-section/style.scss
@@ -18,6 +18,10 @@
 		.post-stats-card {
 			margin: 0;
 			max-height: unset;
+
+			&::after {
+				display: none;
+			}
 		}
 
 		.highlight-card {

--- a/client/my-sites/stats/post-detail-highlights-section/style.scss
+++ b/client/my-sites/stats/post-detail-highlights-section/style.scss
@@ -24,6 +24,11 @@
 			}
 		}
 
+		.post-stats-card__thumbnail {
+			max-height: 300px;
+			width: 300px;
+		}
+
 		.highlight-card {
 			padding: 24px;
 			height: 300px;


### PR DESCRIPTION
#### Proposed Changes

* Remove redundant card gap on `PostStatsCard`.
* Add thumbnail size limitation for the cover of all size images.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up this change with the Calypso Live link.
* Navigate to the Stats `Post Detail` page (`/stats/post/${post-id}/${site-id}`).
* Append the feature flag `?flags=stats/enhance-post-detail` to the URL.
* Ensure all size images for the `All-time stats` thumbnail are cropped appropriately as covers.

##### Square

| Original | Displayed |
| --- | --- |
| ![square](https://user-images.githubusercontent.com/6869813/209842399-8766f846-722a-4f0c-82ac-415196a7be2a.png) | <img width="641" alt="截圖 2022-12-29 上午12 13 12" src="https://user-images.githubusercontent.com/6869813/209842431-f56c1a2e-29f4-4c67-8d44-ac97ab45c0d4.png"> |

##### Landscape

| Original | Displayed |
| --- | --- |
| ![landscape](https://user-images.githubusercontent.com/6869813/209842521-3cff60fc-8f8c-4143-abf5-27ad027c532e.png) | <img width="641" alt="截圖 2022-12-29 上午12 13 37" src="https://user-images.githubusercontent.com/6869813/209842609-0db6ed60-8371-44b9-b570-4b0163bb6287.png"> |

##### Portrait

| Original | Displayed |
| --- | --- |
| ![portrait](https://user-images.githubusercontent.com/6869813/209842656-35df36e6-1391-4882-9fad-430fdbd7d89e.png) | <img width="639" alt="截圖 2022-12-29 上午12 14 04" src="https://user-images.githubusercontent.com/6869813/209842698-fd05289f-2b9e-453b-8ee5-4f3922495e54.png"> |

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/70671#issuecomment-1365980396, https://github.com/Automattic/wp-calypso/issues/70671#issuecomment-1363531011
