### PR TITLE
WP Login: use account-only flow for account creation and persist redirect_to param

### DIFF
--- a/client/login/wp-login/login-links.jsx
+++ b/client/login/wp-login/login-links.jsx
@@ -104,6 +104,7 @@ export class LoginLinks extends Component {
 			twoFactorAuthType: 'link',
 			signupUrl: this.props.query?.signup_url,
 			oauth2ClientId: this.props.oauth2ClientId,
+			redirect_to: this.props.query?.redirect_to,
 		};
 
 		if ( this.props.currentRoute === '/log-in/jetpack' ) {
@@ -342,6 +343,7 @@ export class LoginLinks extends Component {
 			<a
 				href={ addQueryArgs(
 					{
+						redirect_to: this.props.query?.redirect_to,
 						user_email: usernameOrEmail,
 					},
 					signupUrl


### PR DESCRIPTION
When visiting the login page with a `redirect_to` query parameter, some of the possible login and signup links don't maintain the redirection, leaving the user on default destination links instead of returning the user to where the app most likely intends.

A particular example (seen in #70354) would be visiting the login page with a `redirect_to` parameter that redirects the user to Checkout after logging-in. This works correctly for the main action of the page (logging in with an existing account), but if the user clicks "Create a new account" they'll finish the Signup flow at Customer Home.

This PR attempts to persist the `redirect_to` param for actions that support it.

Fixes: https://github.com/Automattic/wp-calypso/issues/71027

**To test:**
- as a logged out user, visit the login page with a valid redirect_to param (http://calypso.localhost:3000/log-in?redirect_to=%2Fstats%2F)
- 