### PR TITLE
Stats Page Redesign: Adds mobile app promo banner to Annual Insights

### DIFF
--- a/client/my-sites/stats/annual-site-stats/index.js
+++ b/client/my-sites/stats/annual-site-stats/index.js
@@ -143,7 +143,8 @@ class AnnualSiteStats extends Component {
 	}
 
 	render() {
-		const { years, translate, moment, isWidget, siteId, siteSlug } = this.props;
+		const { years, translate, moment, isWidget, siteId, siteSlug, isJetpack, isOdysseyStats } =
+			this.props;
 		const strings = this.getStrings();
 		const now = moment();
 		const currentYear = now.format( 'YYYY' );
@@ -191,6 +192,12 @@ class AnnualSiteStats extends Component {
 						</div>
 					) }
 				</Card>
+				<PromoCards
+					isJetpack={ isJetpack }
+					isOdysseyStats={ isOdysseyStats }
+					pageSlug="annual-insights"
+					slug={ siteSlug }
+				/>
 			</div>
 		);
 		/* eslint-enable wpcalypso/jsx-classname-namespace */
@@ -203,9 +210,14 @@ export default connect( ( state ) => {
 	const siteSlug = getSiteSlug( state, siteId );
 	const insights = getSiteStatsNormalizedData( state, siteId, statType, {} );
 
+	const isJetpack = isJetpackSite( state, siteId );
+	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
+
 	return {
-		years: insights.years,
+		isJetpack,
+		isOdysseyStats,
 		siteId,
 		siteSlug,
+		years: insights.years,
 	};
 } )( localize( withLocalizedMoment( AnnualSiteStats ) ) );

--- a/client/my-sites/stats/annual-site-stats/index.js
+++ b/client/my-sites/stats/annual-site-stats/index.js
@@ -8,13 +8,12 @@ import { connect } from 'react-redux';
 import QuerySiteStats from 'calypso/components/data/query-site-stats';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import SectionHeader from 'calypso/components/section-header';
+import PromoCards from 'calypso/my-sites/stats/promo-cards';
 import ErrorPanel from 'calypso/my-sites/stats/stats-error';
 import StatsModulePlaceholder from 'calypso/my-sites/stats/stats-module/placeholder';
 import { getSiteSlug, isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSiteStatsNormalizedData } from 'calypso/state/stats/lists/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import PromoCards from '../promo-cards';
-
 import './style.scss';
 
 class AnnualSiteStats extends Component {
@@ -143,7 +142,7 @@ class AnnualSiteStats extends Component {
 	}
 
 	render() {
-		const { years, translate, moment, isWidget, siteId, siteSlug, isJetpack, isOdysseyStats } =
+		const { isJetpack, isOdysseyStats, isWidget, moment, siteId, siteSlug, translate, years } =
 			this.props;
 		const strings = this.getStrings();
 		const now = moment();
@@ -207,17 +206,13 @@ class AnnualSiteStats extends Component {
 export default connect( ( state ) => {
 	const statType = 'statsInsights';
 	const siteId = getSelectedSiteId( state );
-	const siteSlug = getSiteSlug( state, siteId );
 	const insights = getSiteStatsNormalizedData( state, siteId, statType, {} );
 
-	const isJetpack = isJetpackSite( state, siteId );
-	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
-
 	return {
-		isJetpack,
-		isOdysseyStats,
+		isJetpack: isJetpackSite( state, siteId ),
+		isOdysseyStats: config.isEnabled( 'is_running_in_jetpack_site' ),
 		siteId,
-		siteSlug,
+		siteSlug: getSiteSlug( state, siteId ),
 		years: insights.years,
 	};
 } )( localize( withLocalizedMoment( AnnualSiteStats ) ) );

--- a/client/my-sites/stats/annual-site-stats/index.js
+++ b/client/my-sites/stats/annual-site-stats/index.js
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { Card } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import { find, includes } from 'lodash';
@@ -9,9 +10,10 @@ import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import SectionHeader from 'calypso/components/section-header';
 import ErrorPanel from 'calypso/my-sites/stats/stats-error';
 import StatsModulePlaceholder from 'calypso/my-sites/stats/stats-module/placeholder';
-import { getSiteSlug } from 'calypso/state/sites/selectors';
+import { getSiteSlug, isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSiteStatsNormalizedData } from 'calypso/state/stats/lists/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import PromoCards from '../promo-cards';
 
 import './style.scss';
 

--- a/client/my-sites/stats/promo-cards/index.jsx
+++ b/client/my-sites/stats/promo-cards/index.jsx
@@ -51,8 +51,10 @@ export default function PromoCards( { isOdysseyStats, slug, pageSlug } ) {
 
 	// Handle view events upon initial mount and upon paging DotPager.
 	useEffect( () => {
-		// Prevent out of bounds index when switching sites.
-		if ( dotPagerIndex >= viewEvents.length ) {
+		if ( viewEvents.length === 0 ) {
+			return;
+		} else if ( dotPagerIndex >= viewEvents.length ) {
+			// Prevent out of bounds index when switching sites.
 			recordTracksEvent( viewEvents[ viewEvents.length - 1 ], { site_id: selectedSiteId } );
 		} else {
 			recordTracksEvent( viewEvents[ dotPagerIndex ], { site_id: selectedSiteId } );

--- a/client/my-sites/stats/promo-cards/index.jsx
+++ b/client/my-sites/stats/promo-cards/index.jsx
@@ -20,8 +20,6 @@ const EVENT_TRAFFIC_YOAST_PROMO_VIEW = 'calypso_stats_wordpress_seo_premium_bann
 // TODO: Register the following events with Tracks to ensure they're properly tracked.
 const EVENT_ANNUAL_BLAZE_PROMO_VIEW = 'calypso_stats_annual_insights_blaze_banner_view';
 const EVENT_ANNUAL_MOBILE_PROMO_VIEW = 'calypso_stats_annual_insights_mobile_cta_jetpack_view';
-const EVENT_ANNUAL_YOAST_PROMO_VIEW =
-	'calypso_stats_annual_insights_wordpress_seo_premium_banner_view';
 
 export default function PromoCards( { isOdysseyStats, slug, pageSlug } ) {
 	// Keep a replica of the pager index state.
@@ -36,7 +34,7 @@ export default function PromoCards( { isOdysseyStats, slug, pageSlug } ) {
 	// Blaze promo is disabled for Odyssey.
 	const showBlazePromo = ! isOdysseyStats;
 	// Yoast promo is disabled for Odyssey & self-hosted & non-traffic pages.
-	const showYoastPromo = ! isOdysseyStats && ! jetpackNonAtomic && pageSlug !== 'traffic';
+	const showYoastPromo = ! isOdysseyStats && ! jetpackNonAtomic && pageSlug === 'traffic';
 
 	const viewEvents = useMemo( () => {
 		const events = [];
@@ -46,8 +44,7 @@ export default function PromoCards( { isOdysseyStats, slug, pageSlug } ) {
 			events.push( EVENT_TRAFFIC_MOBILE_PROMO_VIEW );
 		} else if ( pageSlug === 'annual-insights' ) {
 			showBlazePromo && events.push( EVENT_ANNUAL_BLAZE_PROMO_VIEW );
-			showYoastPromo && events.push( EVENT_ANNUAL_MOBILE_PROMO_VIEW );
-			events.push( EVENT_ANNUAL_YOAST_PROMO_VIEW );
+			events.push( EVENT_ANNUAL_MOBILE_PROMO_VIEW );
 		}
 		return events;
 	}, [ pageSlug, showBlazePromo, showYoastPromo ] );

--- a/client/my-sites/stats/promo-cards/index.jsx
+++ b/client/my-sites/stats/promo-cards/index.jsx
@@ -13,11 +13,17 @@ import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 import './style.scss';
 
-const EVENT_BLAZE_PROMO_VIEW = 'calypso_stats_traffic_blaze_banner_view';
-const EVENT_MOBILE_PROMO_VIEW = 'calypso_stats_traffic_mobile_cta_jetpack_view';
-const EVENT_YOAST_PROMO_VIEW = 'calypso_stats_wordpress_seo_premium_banner_view';
+const EVENT_TRAFFIC_BLAZE_PROMO_VIEW = 'calypso_stats_traffic_blaze_banner_view';
+const EVENT_TRAFFIC_MOBILE_PROMO_VIEW = 'calypso_stats_traffic_mobile_cta_jetpack_view';
+const EVENT_TRAFFIC_YOAST_PROMO_VIEW = 'calypso_stats_wordpress_seo_premium_banner_view';
 
-export default function PromoCards( { isOdysseyStats, slug } ) {
+// TODO: Register the following events with Tracks to ensure they're properly tracked.
+const EVENT_ANNUAL_BLAZE_PROMO_VIEW = 'calypso_stats_annual_insights_blaze_banner_view';
+const EVENT_ANNUAL_MOBILE_PROMO_VIEW = 'calypso_stats_annual_insights_mobile_cta_jetpack_view';
+const EVENT_ANNUAL_YOAST_PROMO_VIEW =
+	'calypso_stats_annual_insights_wordpress_seo_premium_banner_view';
+
+export default function PromoCards( { isOdysseyStats, slug, pageSlug } ) {
 	// Keep a replica of the pager index state.
 	// TODO: Figure out an approach that doesn't require replicating state value from DotPager.
 	const [ dotPagerIndex, setDotPagerIndex ] = useState( 0 );
@@ -29,16 +35,22 @@ export default function PromoCards( { isOdysseyStats, slug } ) {
 
 	// Blaze promo is disabled for Odyssey.
 	const showBlazePromo = ! isOdysseyStats;
-	// Yoast promo is disabled for Odyssey & self-hosted.
-	const showYoastPromo = ! isOdysseyStats && ! jetpackNonAtomic;
+	// Yoast promo is disabled for Odyssey & self-hosted & non-traffic pages.
+	const showYoastPromo = ! isOdysseyStats && ! jetpackNonAtomic && pageSlug !== 'traffic';
 
 	const viewEvents = useMemo( () => {
 		const events = [];
-		showBlazePromo && events.push( EVENT_BLAZE_PROMO_VIEW );
-		showYoastPromo && events.push( EVENT_YOAST_PROMO_VIEW );
-		events.push( EVENT_MOBILE_PROMO_VIEW );
+		if ( pageSlug === 'traffic' ) {
+			showBlazePromo && events.push( EVENT_TRAFFIC_BLAZE_PROMO_VIEW );
+			showYoastPromo && events.push( EVENT_TRAFFIC_YOAST_PROMO_VIEW );
+			events.push( EVENT_TRAFFIC_MOBILE_PROMO_VIEW );
+		} else if ( pageSlug === 'annual-insights' ) {
+			showBlazePromo && events.push( EVENT_ANNUAL_BLAZE_PROMO_VIEW );
+			showYoastPromo && events.push( EVENT_ANNUAL_MOBILE_PROMO_VIEW );
+			events.push( EVENT_ANNUAL_YOAST_PROMO_VIEW );
+		}
 		return events;
-	}, [ showBlazePromo, showYoastPromo ] );
+	}, [ pageSlug, showBlazePromo, showYoastPromo ] );
 
 	// Handle view events upon initial mount and upon paging DotPager.
 	useEffect( () => {

--- a/client/my-sites/stats/promo-cards/index.jsx
+++ b/client/my-sites/stats/promo-cards/index.jsx
@@ -10,12 +10,11 @@ import DotPager from 'calypso/components/dot-pager';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-
 import './style.scss';
 
 const EVENT_TRAFFIC_BLAZE_PROMO_VIEW = 'calypso_stats_traffic_blaze_banner_view';
 const EVENT_TRAFFIC_MOBILE_PROMO_VIEW = 'calypso_stats_traffic_mobile_cta_jetpack_view';
-const EVENT_TRAFFIC_YOAST_PROMO_VIEW = 'calypso_stats_wordpress_seo_premium_banner_view';
+const EVENT_YOAST_PROMO_VIEW = 'calypso_stats_wordpress_seo_premium_banner_view';
 
 // TODO: Register the following events with Tracks to ensure they're properly tracked.
 const EVENT_ANNUAL_BLAZE_PROMO_VIEW = 'calypso_stats_annual_insights_blaze_banner_view';
@@ -40,7 +39,7 @@ export default function PromoCards( { isOdysseyStats, slug, pageSlug } ) {
 		const events = [];
 		if ( pageSlug === 'traffic' ) {
 			showBlazePromo && events.push( EVENT_TRAFFIC_BLAZE_PROMO_VIEW );
-			showYoastPromo && events.push( EVENT_TRAFFIC_YOAST_PROMO_VIEW );
+			showYoastPromo && events.push( EVENT_YOAST_PROMO_VIEW );
 			events.push( EVENT_TRAFFIC_MOBILE_PROMO_VIEW );
 		} else if ( pageSlug === 'annual-insights' ) {
 			showBlazePromo && events.push( EVENT_ANNUAL_BLAZE_PROMO_VIEW );

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -378,7 +378,12 @@ class StatsSite extends Component {
 						}
 					</div>
 				</div>
-				<PromoCards isJetpack={ isJetpack } isOdysseyStats={ isOdysseyStats } slug={ slug } />
+				<PromoCards
+					isJetpack={ isJetpack }
+					isOdysseyStats={ isOdysseyStats }
+					pageSlug="traffic"
+					slug={ slug }
+				/>
 				<JetpackColophon />
 			</div>
 		);


### PR DESCRIPTION
#### Proposed Changes

* Adds a mobile app promo banner to the Annual Insights page

#### Testing Instructions

* Visit the Calypso Live branch.
* Select a site and visit Stats → Insights → View all annual insights.
* Confirm the new mobile app promo banner is visible
* Confirm the promo banner looks okay at different screen sizes.

| Before | After |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/30754158/209991924-b798d477-541c-46a0-9273-5f52755f68ae.png)  | ![image](https://user-images.githubusercontent.com/30754158/209991315-bc9b8413-4fef-4ba7-8c4e-bdfe7beb05c2.png)  |

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #70608
