### PR TITLE
Fix asset loading for anonymous users

### DIFF
--- a/apps/happy-blocks/index.php
+++ b/apps/happy-blocks/index.php
@@ -41,18 +41,6 @@
 function a8c_happyblocks_assets() {
 	$assets = require_once plugin_dir_path( __FILE__ ) . 'dist/editor.min.asset.php';
 
-	wp_register_script( 'a8c-happyblocks-pricing-plans', '', array(), '20221212', true );
-	wp_enqueue_script( 'a8c-happyblocks-pricing-plans' );
-	wp_add_inline_script(
-		'a8c-happyblocks-pricing-plans',
-		sprintf(
-			'window.A8C_HAPPY_BLOCKS_CONFIG = %s;
-			window.configData ||= {};',
-			wp_json_encode( a8c_happyblocks_get_config() )
-		),
-		'before'
-	);
-
 	wp_enqueue_script(
 		'a8c-happyblocks-edit-js',
 		plugins_url( 'dist/editor.min.js', __FILE__ ),
@@ -76,6 +64,18 @@ function a8c_happyblocks_assets() {
 function a8c_happyblocks_view_assets() {
 	$assets = require plugin_dir_path( __FILE__ ) . 'dist/view.min.asset.php';
 
+	wp_register_script( 'a8c-happyblocks-pricing-plans', '', array(), '20221212', true );
+	wp_enqueue_script( 'a8c-happyblocks-pricing-plans' );
+	wp_add_inline_script(
+		'a8c-happyblocks-pricing-plans',
+		sprintf(
+			'window.A8C_HAPPY_BLOCKS_CONFIG = %s;
+			window.configData ||= {};',
+			wp_json_encode( a8c_happyblocks_get_config() )
+		),
+		'before'
+	);
+
 	$style_file = 'dist/view' . ( is_rtl() ? '.rtl.css' : '.css' );
 	wp_enqueue_style(
 		'a8c-happyblock-view-css',
@@ -88,7 +88,7 @@ function a8c_happyblocks_view_assets() {
 	wp_enqueue_script(
 		'a8c-happyblock-view-js',
 		plugins_url( $script_file, __FILE__ ),
-		$assets['dependencies'],
+		array_merge( $assets['dependencies'], array( 'a8c-happyblocks-pricing-plans' ) ),
 		$assets['version'],
 		true
 	);


### PR DESCRIPTION
#### Proposed Changes

fixes 168-gh-Automattic/lighthouse-forums

This pull request updates the `wp_enqueue_script` dependencies array and moves the call to the view assets loading handler instead of the editor assets handler.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run `yarn dev --sync` in `apps/happy-blocks` to sync code to your sandbox
* Create a new topic, in the editor press `/` and search for "Upgrade" block. Submit the post.
* Visit the publication as a logged in user, ensure the block renders correctly
* Visit the publication in an incognito browser window, ensure the block renders correctly.


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
