### PR TITLE
Theme showcase: disallow tier filtering on My Themes tab

### DIFF
--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -295,12 +295,11 @@ class ThemeShowcase extends Component {
 	};
 
 	onTierSelect = ( { value: tier } ) => {
-		// In this state: tabFilter = [ ##Recommended## | All(1) ]   tier = [ All(2) | Free | Premium ]
-		// Clicking "Free" or "Premium" forces tabFilter from "Recommended" to "All"
+		// Due to the search backend limitation, static filters other than "All"
+		// can only have "All" tier.
 		if (
-			! config.isEnabled( 'themes/showcase-i4/search-and-filter' ) &&
-			tier !== '' &&
 			tier !== 'all' &&
+			this.isStaticFilter( this.state.tabFilter ) &&
 			this.state.tabFilter.key !== this.staticFilters.ALL.key
 		) {
 			this.setState( { tabFilter: this.staticFilters.ALL } );
@@ -315,23 +314,22 @@ class ThemeShowcase extends Component {
 	};
 
 	onFilterClick = ( tabFilter ) => {
-		const scrollPos = window.pageYOffset;
 		const isNewSearchAndFilter = config.isEnabled( 'themes/showcase-i4/search-and-filter' );
 
 		recordTracksEvent( 'calypso_themeshowcase_filter_category_click', { category: tabFilter.key } );
 		trackClick( 'section nav filter', tabFilter );
 
 		let callback = () => null;
-		// In this state: tabFilter = [ Recommended | ##All(1)## ]  tier = [ All(2) | Free | ##Premium## ]
-		// Clicking "Recommended" forces tier to be "all", since Recommend themes cannot filter on tier.
+		// Due to the search backend limitation, static filters other than "All"
+		// can only have "All" tier.
 		if (
-			! isNewSearchAndFilter &&
+			this.isStaticFilter( tabFilter ) &&
 			tabFilter.key !== this.staticFilters.ALL.key &&
-			'all' !== this.props.tier
+			this.props.tier !== 'all'
 		) {
 			callback = () => {
 				this.onTierSelect( { value: 'all' } );
-				window.scrollTo( 0, scrollPos );
+				this.scrollToSearchInput();
 			};
 		}
 


### PR DESCRIPTION
#### Proposed Changes

The launch of `themes/showcase-i4/search-and-filter` feature flag has a regression where we allow tier filtering on the My Themes tab. This PR fixes the regression by disallowing such case.


#### Testing Instructions

1. Create an Atomic site.
2. Go to `/themes`.
3. Verify that you CANNOT get the `My Themes` filter and `Free` / `Premium` tier go together. In such cases, the filter/tier (or both) will just go back to `All`:
   - [x] On My Themes filter, if we click on any other tier, the filter will go to All.
   - [x] On Free/Premium tier, if we click on My Themes filter, the tier will go to All.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:

- #71382
