### PR TITLE
Jetpack Cloud | Fix login redirect on /features/comparison page

### DIFF
--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -159,15 +159,19 @@ function authorizePath() {
 	return authUri.toString();
 }
 
+const JP_CLOUD_PUBLIC_ROUTES = [ '/pricing', '/plans', '/features/comparison' ];
+
 const oauthTokenMiddleware = () => {
 	if ( config.isEnabled( 'oauth' ) ) {
 		const loggedOutRoutes = [ '/start', '/api/oauth/token', '/connect' ];
 
-		if ( isJetpackCloud() && config.isEnabled( 'jetpack/pricing-page' ) ) {
-			loggedOutRoutes.push( '/pricing', '/plans' );
-			getLanguageSlugs().forEach( ( slug ) =>
-				loggedOutRoutes.push( `/${ slug }/pricing`, `/${ slug }/plans` )
-			);
+		if ( isJetpackCloud() ) {
+			loggedOutRoutes.push( ...JP_CLOUD_PUBLIC_ROUTES );
+			getLanguageSlugs().forEach( ( slug ) => {
+				loggedOutRoutes.push(
+					...JP_CLOUD_PUBLIC_ROUTES.map( ( route ) => `/${ slug }${ route }` )
+				);
+			} );
 		}
 
 		// Forces OAuth users to the /login page if no token is present

--- a/client/jetpack-cloud/sections/comparison/index.tsx
+++ b/client/jetpack-cloud/sections/comparison/index.tsx
@@ -1,5 +1,5 @@
 import page from 'page';
-import { makeLayout, render as clientRender } from 'calypso/controller';
+import { makeLayout, render as clientRender } from 'calypso/controller/index.web';
 import { setLocaleMiddleware } from 'calypso/controller/shared';
 import { loggedInSiteSelection } from 'calypso/my-sites/controller';
 import { jetpackComparisonContext } from './controller';


### PR DESCRIPTION
If you open https://cloud.jetpack.com/features/comparison in incognito, it asks you to login, which is not the intended behavior for this public page added in #71490

#### Proposed Changes

* Disable login redirect for `/features/comparison` page on Jetpack Cloud

#### Testing Instructions

- Do any one of these
    - Click on Jetpack Cloud live link below and wait for the redirect to complete, then open `/features/comparison` in an incognito window
    - or boot up this PR 
        - Run `git fetch && git checkout fix/jp-comparison-login-redirect`
        - Run `yarn start-jetpack-cloud`
        - Open [http://jetpack.cloud.localhost:3000/features/comparison](http://jetpack.cloud.localhost:3000/features/comparison) in an incognito window
- Confirm that the page doesn't redirect to login anymore
- Confirm the same behavior for `/pricing` page.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

See p1672292745122279/1671635067.918229-slack-C03V4PXKUGP