### PR TITLE
Fix the period buttons on the Email Stats graph

### DIFF
--- a/client/components/data/query-email-stats/index.jsx
+++ b/client/components/data/query-email-stats/index.jsx
@@ -15,7 +15,7 @@ function QueryEmailStats( { siteId, postId, period, date, quantity } ) {
 		if ( siteId && postId > -1 ) {
 			dispatch( request( siteId, postId, period, date, statType, quantity ) );
 		}
-	}, [ dispatch, siteId, postId ] );
+	}, [ dispatch, siteId, postId, period ] );
 
 	return null;
 }


### PR DESCRIPTION
#### Proposed Changes

This short PR fixes the period buttons in the top of the Email Stats chart. The problem was the hook for retrieving the data wasn't reacting to the period prop, which was the one changing with those buttons.

#### Testing Instructions

1. Checkout this branch and start the application.
2. Insert manually in the browser address bar an URL with this format: https://calypso.localhost:3000/stats/email/open/[the-doomain-of-your-blog]/day/[post-id]?flags=newsletter/stats. Note that you can change day for week and month.
3. Click on the period buttons. You should see how the url changes accordingly in the browser, and how the chart fetches the proper info. You could check the endpoint too in the network tab of the browser. It should include the proper `period` query parameter.


