### PR TITLE
Happyblocks: Remove now unnecessary feature flag

### DIFF
--- a/apps/happy-blocks/index.php
+++ b/apps/happy-blocks/index.php
@@ -127,9 +127,7 @@ function a8c_happyblocks_pricing_plans_is_author() {
 function a8c_happyblocks_get_config() {
 
 	return array(
-		'features' => array(
-			'planTabs' => apply_filters( 'support_forums_use_upsell_block_tabs', false ),
-		),
+		'features' => array(),
 		'locale'   => get_user_locale(),
 	);
 }

--- a/apps/happy-blocks/src/pricing-plans/components/block-settings.tsx
+++ b/apps/happy-blocks/src/pricing-plans/components/block-settings.tsx
@@ -6,14 +6,12 @@ import {
 	PanelBody,
 	RadioControl,
 	CheckboxControl,
-	SelectControl,
 	TextControl,
 } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import classNames from 'classnames';
 import { FunctionComponent } from 'react';
-import config from '../config';
 import usePlanOptions from '../hooks/plan-options';
 import { BlockPlan } from '../hooks/pricing-plans';
 import { BlockAttributes } from '../types';
@@ -58,10 +56,6 @@ const BlockSettings: FunctionComponent<
 		}
 	};
 
-	const onPlanTypeChange = ( newPlanType: string ) => {
-		setPlan( newPlanType, currentPlan?.term ?? plans[ 0 ].term );
-	};
-
 	const isDisabled = ( value: string ) =>
 		planTypeOptions.includes( value ) && planTypeOptions.length === 1;
 
@@ -89,27 +83,18 @@ const BlockSettings: FunctionComponent<
 				initialOpen={ true }
 			>
 				<PanelRow>
-					{ ! config.features.planTabs && (
-						<SelectControl
-							label={ __( 'Plan', 'happy-blocks' ) }
-							value={ currentPlan?.type }
-							options={ planOptions }
-							onChange={ onPlanTypeChange }
+					{ planOptions.map( ( option ) => (
+						<CheckboxControl
+							className={ classNames( {
+								'hb-pricing-plans-embed__settings-checkbox--disabled': isDisabled( option.value ),
+							} ) }
+							key={ option.value }
+							label={ option.label }
+							checked={ isChecked( option.value ) }
+							disabled={ isDisabled( option.value ) }
+							onChange={ ( checked ) => onPlanTypeToggle( option.value, checked ) }
 						/>
-					) }
-					{ config.features.planTabs &&
-						planOptions.map( ( option ) => (
-							<CheckboxControl
-								className={ classNames( {
-									'hb-pricing-plans-embed__settings-checkbox--disabled': isDisabled( option.value ),
-								} ) }
-								key={ option.value }
-								label={ option.label }
-								checked={ isChecked( option.value ) }
-								disabled={ isDisabled( option.value ) }
-								onChange={ ( checked ) => onPlanTypeToggle( option.value, checked ) }
-							/>
-						) ) }
+					) ) }
 					<TextControl
 						className="hb-pricing-plans-embed__settings-domain"
 						label={ __( 'Domain', 'happy-blocks' ) }

--- a/apps/happy-blocks/src/pricing-plans/components/pricing-plans.tsx
+++ b/apps/happy-blocks/src/pricing-plans/components/pricing-plans.tsx
@@ -1,7 +1,6 @@
 import { BlockEditProps } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
 import { FunctionComponent } from 'react';
-import config from '../config';
 import { BlockPlan } from '../hooks/pricing-plans';
 import { BlockAttributes } from '../types';
 import PricingPlanDetail from './pricing-plan-detail';
@@ -25,7 +24,7 @@ const PricingPlans: FunctionComponent<
 
 	return (
 		<div className="hb-pricing-plans-embed">
-			{ config.features.planTabs && attributes.planTypeOptions.length > 1 && (
+			{ attributes.planTypeOptions.length > 1 && (
 				<PricingPlansTabs
 					attributes={ attributes }
 					plans={ plans }

--- a/apps/happy-blocks/src/pricing-plans/types.d.ts
+++ b/apps/happy-blocks/src/pricing-plans/types.d.ts
@@ -20,9 +20,7 @@ declare global {
 	interface Window {
 		A8C_HAPPY_BLOCKS_CONFIG: {
 			locale: string;
-			features: {
-				planTabs: boolean;
-			};
+			features: Record< string, boolean >;
 		};
 	}
 }


### PR DESCRIPTION
#### Proposed Changes

This pull request removes a now unnecessary feature flag (the feature has been already enabled for everyone)

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run `yarn dev --sync` in `apps/happy-blocks` to sync code to your sandbox
* Create a new topic, in the editor press `/` and search for "Upgrade" block. Submit the post.
* Visit the publication as a logged in user, ensure the block renders correctly
* Visit the publication in an incognito browser window, ensure the block renders correctly.


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
