### PR TITLE
Update/email stats graph with spinning

### DIFF
--- a/client/components/data/query-email-stats/index.jsx
+++ b/client/components/data/query-email-stats/index.jsx
@@ -15,7 +15,7 @@ function QueryEmailStats( { siteId, postId, period, date, quantity } ) {
 		if ( siteId && postId > -1 ) {
 			dispatch( request( siteId, postId, period, date, statType, quantity ) );
 		}
-	}, [ dispatch, siteId, postId ] );
+	}, [ dispatch, siteId, postId, period ] );
 
 	return null;
 }

--- a/client/my-sites/stats/stats-email-chart-tabs/index.jsx
+++ b/client/my-sites/stats/stats-email-chart-tabs/index.jsx
@@ -10,7 +10,7 @@ import Legend from 'calypso/components/chart/legend';
 import { withPerformanceTrackerStop } from 'calypso/lib/performance-tracking';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 import { getSiteOption } from 'calypso/state/sites/selectors';
-import { getLoadingTabs, getCountRecords } from 'calypso/state/stats/email-chart-tabs/selectors';
+import { isLoadingTabs, getCountRecords } from 'calypso/state/stats/email-chart-tabs/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import StatsModulePlaceholder from '../stats-module/placeholder';
 import StatTabs from '../stats-tabs';
@@ -123,8 +123,7 @@ const connectComponent = connect(
 		const quantity = 'year' === period ? 10 : 30;
 		const counts = getCountRecords( state, siteId, postId, period, statType );
 		const chartData = buildChartData( activeLegend, chartTab, counts, period, queryDate );
-		const loadingTabs = getLoadingTabs( state, siteId, postId, period );
-		const isActiveTabLoading = loadingTabs.includes( chartTab ) || chartData.length !== quantity;
+		const isActiveTabLoading = isLoadingTabs( state, siteId, postId, period, statType );
 		const timezoneOffset = getSiteOption( state, siteId, 'gmt_offset' ) || 0;
 		const date = getQueryDate( queryDate, timezoneOffset, period, quantity );
 		const queryKey = `${ date }-${ period }-${ quantity }-${ siteId }`;

--- a/client/my-sites/stats/stats-email-open-detail/index.jsx
+++ b/client/my-sites/stats/stats-email-open-detail/index.jsx
@@ -33,7 +33,6 @@ import {
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import DatePicker from '../stats-date-picker';
 import ChartTabs from '../stats-email-chart-tabs';
-import StatsPlaceholder from '../stats-module/placeholder';
 import { StatsNoContentBanner } from '../stats-no-content-banner';
 import StatsPeriodHeader from '../stats-period-header';
 import StatsPeriodNavigation from '../stats-period-navigation';
@@ -220,7 +219,6 @@ class StatsEmailOpenDetail extends Component {
 			slug,
 			isSitePrivate,
 		} = this.props;
-		const isLoading = isRequestingStats && ! countViews;
 
 		const queryDate = date.format( 'YYYY-MM-DD' );
 		const actionLabel = translate( 'View Email' );
@@ -258,9 +256,7 @@ class StatsEmailOpenDetail extends Component {
 					) }
 				</FixedNavigationHeader>
 
-				<StatsPlaceholder isLoading={ isLoading } />
-
-				{ ! isLoading && ! countViews && (
+				{ ! isRequestingStats && ! countViews && (
 					<EmptyContent
 						title={ noViewsLabel }
 						line={ translate( 'Learn some tips to attract more visitors' ) }
@@ -272,46 +268,44 @@ class StatsEmailOpenDetail extends Component {
 					/>
 				) }
 
-				{ ! isLoading && countViews && (
-					<div>
-						<>
-							<StatsPeriodHeader>
-								<StatsPeriodNavigation
-									date={ date }
+				<div>
+					<>
+						<StatsPeriodHeader>
+							<StatsPeriodNavigation
+								date={ date }
+								period={ period }
+								url={ `/stats/email/open/${ slug }/${ period }/${ postId }` }
+							>
+								<DatePicker
 									period={ period }
-									url={ `/stats/email/open/${ slug }/${ period }/${ postId }` }
-								>
-									<DatePicker
-										period={ period }
-										date={ date }
-										query={ query }
-										statsType="statsTopPosts"
-										showQueryDate
-									/>
-								</StatsPeriodNavigation>
-								<Intervals selected={ period } pathTemplate={ pathTemplate } compact={ false } />
-							</StatsPeriodHeader>
+									date={ date }
+									query={ query }
+									statsType="statsTopPosts"
+									showQueryDate
+								/>
+							</StatsPeriodNavigation>
+							<Intervals selected={ period } pathTemplate={ pathTemplate } compact={ false } />
+						</StatsPeriodHeader>
 
-							<ChartTabs
-								activeTab={ getActiveTab( this.props.chartTab ) }
-								activeLegend={ this.state.activeLegend }
-								availableLegend={ this.getAvailableLegend() }
-								onChangeLegend={ this.onChangeLegend }
-								barClick={ this.barClick }
-								switchTab={ this.switchChart }
-								charts={ CHARTS }
-								queryDate={ queryDate }
-								period={ this.props.period }
-								chartTab={ this.props.chartTab }
-								postId={ postId }
-								statType={ statType }
-							/>
+						<ChartTabs
+							activeTab={ getActiveTab( this.props.chartTab ) }
+							activeLegend={ this.state.activeLegend }
+							availableLegend={ this.getAvailableLegend() }
+							onChangeLegend={ this.onChangeLegend }
+							barClick={ this.barClick }
+							switchTab={ this.switchChart }
+							charts={ CHARTS }
+							queryDate={ queryDate }
+							period={ this.props.period }
+							chartTab={ this.props.chartTab }
+							postId={ postId }
+							statType={ statType }
+						/>
 
-							{ isSitePrivate ? this.renderPrivateSiteBanner( siteId, slug ) : null }
-							{ ! isSitePrivate && <StatsNoContentBanner siteId={ siteId } siteSlug={ slug } /> }
-						</>
-					</div>
-				) }
+						{ isSitePrivate ? this.renderPrivateSiteBanner( siteId, slug ) : null }
+						{ ! isSitePrivate && <StatsNoContentBanner siteId={ siteId } siteSlug={ slug } /> }
+					</>
+				</div>
 			</Main>
 		);
 	}
@@ -330,12 +324,10 @@ const connectComponent = connect(
 			emailFallback: getEmailStat( state, siteId, postId, 'email' ),
 			isLatestEmailsHomepage,
 			countViews: getEmailStat( state, siteId, postId, period, statType ),
-			// countViews: [1],
-			isRequestingStats: isRequestingEmailStats( state, siteId, postId ),
+			isRequestingStats: isRequestingEmailStats( state, siteId, postId, period, statType ),
 			siteSlug: getSiteSlug( state, siteId ),
 			showViewLink: ! isJetpack && ! isLatestEmailsHomepage && isPreviewable,
 			slug: getSelectedSiteSlug( state ),
-			// previewUrl: getEmailPreviewUrl( state, siteId, postId ),
 			isSitePrivate: isPrivateSite( state, siteId ),
 			siteId,
 		};

--- a/client/state/stats/email-chart-tabs/selectors.js
+++ b/client/state/stats/email-chart-tabs/selectors.js
@@ -1,5 +1,4 @@
 import { get } from 'lodash';
-import { QUERY_FIELDS } from 'calypso/state/stats/chart-tabs/constants';
 
 import 'calypso/state/stats/init';
 
@@ -16,11 +15,9 @@ const EMPTY_RESULT = [];
  * @returns {Array}            Array of count objects
  */
 export function getCountRecords( state, siteId, postId, period, statType ) {
-	return (
-		Object.keys( state.stats.emails.items[ siteId ][ postId ][ period ][ statType ] ).map(
-			( key ) => state.stats.emails.items[ siteId ][ postId ][ period ][ statType ][ key ]
-		) || EMPTY_RESULT
-	);
+	const stats = get( state.stats.emails.items, [ siteId, postId, period, statType ], null );
+
+	return stats ? Object.keys( stats ).map( ( key ) => stats[ key ] ) || EMPTY_RESULT : EMPTY_RESULT;
 }
 
 /**
@@ -32,8 +29,8 @@ export function getCountRecords( state, siteId, postId, period, statType ) {
  * @param   {string}  period   Type of duration to include in the query (such as daily)
  * @returns {Array}          	 Array of stat types as strings
  */
-export function getLoadingTabs( state, siteId, postId, period ) {
-	return QUERY_FIELDS.filter( () =>
-		get( state, [ 'stats', 'emails', 'requesting', siteId, postId, period ] )
-	);
+export function isLoadingTabs( state, siteId, postId, period, statType ) {
+	return state.stats.emails
+		? get( state.stats.emails.requests, [ siteId, postId, period, statType, 'requesting' ], false )
+		: false;
 }

--- a/client/state/stats/emails/selectors.js
+++ b/client/state/stats/emails/selectors.js
@@ -12,9 +12,9 @@ import 'calypso/state/stats/init';
  * @param  {number}  postId Email Id
  * @returns {boolean}        Whether email stat is being requested
  */
-export function isRequestingEmailStats( state, siteId, postId ) {
+export function isRequestingEmailStats( state, siteId, postId, period, statType ) {
 	return state.stats.emails
-		? get( state.stats.emails.requesting, [ siteId, postId ], false )
+		? get( state.stats.emails.requests, [ siteId, postId, period, statType, 'requesting' ], false )
 		: false;
 }
 


### PR DESCRIPTION
#### Proposed Changes

This PR adds a spinning circle of loading while the email stats endpoint is retrieving the data:
<img width="1111" alt="Screenshot 2022-12-29 at 16 15 12" src="https://user-images.githubusercontent.com/3832570/209973591-1690f29b-db5c-42d8-984a-61a8ec44c98d.png">



#### Testing Instructions
1. Checkout this branch and start the application.
2. Insert manually in the browser address bar an URL with this format: [https://calypso.localhost:3000/stats/email/open/[the-doomain-of-your-blog]/day/[post-id]?flags=newsletter/stats](https://calypso.localhost:3000/stats/email/open/%5Bthe-doomain-of-your-blog%5D/day/%5Bpost-id%5D?flags=newsletter/stats). Note that you can change day for week and month.
3. You should see the spinning while the endpoint loads. Click on the period buttons (year, month, etc) in order to see it again while the new info is loading.
