### PR TITLE
Jetpack Pricing Page Cart Integration - Fix lightbox styles

### DIFF
--- a/client/my-sites/plans/jetpack-plans/product-lightbox/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-lightbox/index.tsx
@@ -1,4 +1,8 @@
-import { JetpackTag, JETPACK_RELATED_PRODUCTS_MAP } from '@automattic/calypso-products';
+import {
+	isJetpackPlanSlug,
+	JetpackTag,
+	JETPACK_RELATED_PRODUCTS_MAP,
+} from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
 import { useBreakpoint } from '@automattic/viewport-react';
 import { useTranslate } from 'i18n-calypso';
@@ -67,8 +71,14 @@ const ProductLightbox: React.FC< Props > = ( {
 		[ onChangeProduct, dispatch, siteId ]
 	);
 
-	const { getCheckoutURL, getIsMultisiteCompatible, isMultisite, getOnClickPurchase } =
-		useStoreItemInfoContext();
+	const {
+		getCheckoutURL,
+		getIsMultisiteCompatible,
+		isMultisite,
+		getOnClickPurchase,
+		getLightBoxCtaLabel,
+		getIsProductInCart,
+	} = useStoreItemInfoContext();
 
 	const onCheckoutClick = useCallback( () => {
 		getOnClickPurchase( product )();
@@ -107,6 +117,9 @@ const ProductLightbox: React.FC< Props > = ( {
 	const isLargeScreen = useBreakpoint( '>782px' );
 
 	const showPricingBreakdown = includedProductSlugs?.length;
+
+	const isProductInCart =
+		! isJetpackPlanSlug( product.productSlug ) && getIsProductInCart( product );
 
 	return (
 		<Modal
@@ -180,13 +193,13 @@ const ProductLightbox: React.FC< Props > = ( {
 								product={ product }
 							/>
 							<Button
-								primary
+								primary={ ! isProductInCart }
 								onClick={ onCheckoutClick }
 								className="jetpack-product-card__button product-lightbox__checkout-button"
 								href={ isMultiSiteIncompatible ? '#' : getCheckoutURL( product ) }
 								disabled={ isMultiSiteIncompatible }
 							>
-								{ translate( 'Proceed to checkout' ) }
+								{ getLightBoxCtaLabel( product ) }
 							</Button>
 						</div>
 					</div>

--- a/client/my-sites/plans/jetpack-plans/product-lightbox/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-lightbox/style.scss
@@ -475,6 +475,9 @@
 .product-lightbox__checkout-button {
 	margin-block-start: 1rem;
 	margin-block-end: 0;
+	display: flex;
+	align-items: center;
+	justify-content: center;
 }
 
 .ReactModal__Html--open.lightbox-mode .layout__content {
@@ -529,4 +532,16 @@ p.product-lightbox__included-product-list-item-description span {
 .product-lightbox__included-product-list-item-icon img {
 	width: 45%;
 	height: auto;
+}
+
+.product-lightbox__checkout-button .gridicon.gridicons-checkmark {
+	transform: rotate(-8.37deg);
+	margin-right: 11.46px;
+	margin-bottom: 4px;
+	color: #008710;
+}
+
+.product-lightbox__checkout-button.button:not([disabled], :disabled, .is-primary) {
+	color: var(--color-neutral-100);
+	border: 1px solid var(--color-neutral-100);
 }

--- a/client/my-sites/plans/jetpack-plans/product-store/hooks/use-store-item-info.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/hooks/use-store-item-info.tsx
@@ -7,12 +7,12 @@ import {
 	TERM_ANNUALLY,
 	TERM_MONTHLY,
 } from '@automattic/calypso-products';
+import { Gridicon } from '@automattic/components';
 import { useShoppingCart } from '@automattic/shopping-cart';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import isSupersedingJetpackItem from 'calypso/../packages/calypso-products/src/is-superseding-jetpack-item';
-import { Gridicon } from 'calypso/devdocs/design/playground-scope';
 import { getPurchaseByProductSlug } from 'calypso/lib/purchases/utils';
 import reactNodeToString from 'calypso/lib/react-node-to-string';
 import OwnerInfo from 'calypso/me/purchases/purchase-item/owner-info';

--- a/client/my-sites/plans/jetpack-plans/product-store/hooks/use-store-item-info.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/hooks/use-store-item-info.tsx
@@ -12,6 +12,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useCallback, useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import isSupersedingJetpackItem from 'calypso/../packages/calypso-products/src/is-superseding-jetpack-item';
+import { Gridicon } from 'calypso/devdocs/design/playground-scope';
 import { getPurchaseByProductSlug } from 'calypso/lib/purchases/utils';
 import reactNodeToString from 'calypso/lib/react-node-to-string';
 import OwnerInfo from 'calypso/me/purchases/purchase-item/owner-info';
@@ -233,6 +234,29 @@ export const useStoreItemInfo = ( {
 		[ getPurchase, isCurrentUserPurchaseOwner ]
 	);
 
+	const getLightBoxCtaLabel = useCallback(
+		( item: SelectorProduct ) => {
+			const shouldShowCart = getShouldShowCart( item );
+			const isProductInCart = getIsProductInCart( item );
+
+			if ( ! shouldShowCart ) {
+				return <>{ translate( 'Proceed to checkout' ) }</>;
+			}
+
+			if ( isProductInCart ) {
+				return (
+					<>
+						<Gridicon icon="checkmark" />
+						{ translate( 'View Cart' ) }
+					</>
+				);
+			}
+
+			return <>{ translate( 'Add to cart' ) }</>;
+		},
+		[ getIsProductInCart, getShouldShowCart, translate ]
+	);
+
 	const getCtaLabel = useCallback(
 		( item: SelectorProduct, fallbackLabel = translate( 'Get' ) ) => {
 			const ctaLabel = productButtonLabel( {
@@ -305,6 +329,7 @@ export const useStoreItemInfo = ( {
 			getIsSuperseded,
 			getIsUpgradeableToYearly,
 			getIsUserPurchaseOwner,
+			getLightBoxCtaLabel,
 			getOnClickPurchase,
 			getIsProductInCart,
 			getPurchase,
@@ -321,6 +346,7 @@ export const useStoreItemInfo = ( {
 			getIsSuperseded,
 			getIsUpgradeableToYearly,
 			getIsUserPurchaseOwner,
+			getLightBoxCtaLabel,
 			getOnClickPurchase,
 			getIsProductInCart,
 			getPurchase,


### PR DESCRIPTION
#### Proposed Changes
* Make the CTA in the lightbox cart compatible
* Make CTA read "Add to cart" for products but not bundles
* Make CTA read "View Cart" once the product has been added to the cart

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Make sure you are logged-in to WordPress.com 
* click on Jetpack Cloud live link below
* or boot up this PR 
    * Run `git fetch && git checkout fix/cloud-cart-lightbox-cta`
    * Run `yarn start-jetpack-cloud`
    * Goto http://jetpack.cloud.localhost:3000
* you will be presented with a landing page, asking you to select a site, choose any site from the list
* Once selected, you will be redirected to `/backup/:site-slug` page by default, replace `backup` with `pricing` and you should land in pricing page
* Now append this query string (`?flags=jetpack/pricing-page-cart`) to the end of URL to enable the cart and reload the page
* Make sure the cart shows up in the header
* Click on **More about** link in any of the product cards (except bundles)
* Confirm that the CTA reads **Add to cart** instead of **Procced to checkout** 
* Click to add an item to cart and confirm the button text changes to **View Cart**
* Click on **View Cart** and confirm it navigates to checkout page
* Also make sure bundles are unaffected by this change i.e Click on **More about** in any of the bundles and confirm it still reads **Proceed to Checkout** and clicking on it takes you directly to checkout page instead of adding it to the cart


#### Screencast
*Note: For some reason, the screencast below doesn't show the cursor at the correct location. It shows a few pixels below the actual location of the cursor. So, please ignore it*

[lightbox-cta-fix.webm](https://user-images.githubusercontent.com/2027003/209984746-f9707d6c-e387-4892-9fa2-f98f0b210310.webm)

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
