### PR TITLE
E2E: Fix tracking specs against GB v14.8.x

### DIFF
--- a/packages/calypso-e2e/src/lib/components/editor-dimensions-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-dimensions-component.ts
@@ -63,8 +63,6 @@ export class EditorDimensionsComponent {
 	 * @param {number} padding Padding dimension to select.
 	 */
 	private async setPadding( padding: number ): Promise< void > {
-		const locator = this.editor.locator( selectors.paddingInput );
-		await locator.fill( padding.toString() );
-		await locator.press( 'Enter' ); // Confirm rounding.
+		await this.editor.getByLabel( 'All sides padding' ).fill( padding.toString() );
 	}
 }

--- a/packages/calypso-e2e/src/lib/components/editor-inline-block-inserter-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-inline-block-inserter-component.ts
@@ -3,10 +3,6 @@ import { Page, Locator } from 'playwright';
 const popoverParentSelector = '.block-editor-inserter__quick-inserter';
 const selectors = {
 	searchInput: `${ popoverParentSelector } input[type=search]`,
-	blockResultItem: ( blockName: string ) =>
-		`${ popoverParentSelector } [aria-label=Blocks] button:has-text("${ blockName }")`,
-	patternResultItem: ( patternName: string ) =>
-		`${ popoverParentSelector } [aria-label="Block Patterns"] [aria-label="${ patternName }"]`,
 };
 
 /**
@@ -40,24 +36,10 @@ export class EditorInlineBlockInserterComponent {
 	/**
 	 * Selects the maching result from the block inserter.
 	 *
-	 * By default, this method considers only the Block-type results
-	 * (including Resuable blocks).
-	 * In order to select from Pattern-type results, set the `type`
-	 * optional flag in the parameter to `'pattern'`.
-	 *
-	 * Where mulltiple matches exist (eg. due to partial matching), the first result will be chosen.
+	 * Where mulltiple matches exist (eg. due to partial matching), the first
+	 * result will be chosen.
 	 */
-	async selectBlockInserterResult(
-		name: string,
-		{ type = 'block' }: { type?: 'block' | 'pattern' } = {}
-	): Promise< void > {
-		let locator;
-
-		if ( type === 'pattern' ) {
-			locator = this.editor.locator( selectors.patternResultItem( name ) );
-		} else {
-			locator = this.editor.locator( selectors.blockResultItem( name ) );
-		}
-		await locator.first().click();
+	async selectBlockInserterResult( name: string ): Promise< void > {
+		await this.editor.getByRole( 'option', { name, exact: true } ).first().click();
 	}
 }

--- a/packages/calypso-e2e/src/lib/components/editor-site-styles-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-site-styles-component.ts
@@ -12,7 +12,7 @@ const parentSelector = '.edit-site-global-styles-sidebar';
 const selectors = {
 	menuButton: ( buttonName: string ) =>
 		`${ parentSelector } button.components-navigator-button:has-text("${ buttonName }")`,
-	closeSidebarButton: 'button[aria-label="Close global styles sidebar"]:visible',
+	closeSidebarButton: 'button[aria-expanded="true"][aria-label="Styles"]',
 	backButton: `${ parentSelector } button[aria-label="Navigate to the previous view"]`,
 	moreActionsMenuButton: `${ parentSelector } button[aria-label="More Global Styles Actions"]`,
 };

--- a/packages/calypso-e2e/src/lib/components/editor-site-styles-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-site-styles-component.ts
@@ -14,7 +14,7 @@ const selectors = {
 		`${ parentSelector } button.components-navigator-button:has-text("${ buttonName }")`,
 	closeSidebarButton: 'button[aria-expanded="true"][aria-label="Styles"]',
 	backButton: `${ parentSelector } button[aria-label="Navigate to the previous view"]`,
-	moreActionsMenuButton: `${ parentSelector } button[aria-label="More Global Styles Actions"]`,
+	moreActionsMenuButton: `${ parentSelector } button[aria-label="More Styles actions"]`,
 };
 
 export type ColorLocation = 'Background' | 'Text' | 'Links';

--- a/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
@@ -3,7 +3,7 @@ import envVariables from '../../env-variables';
 import { translateFromPage } from '../utils';
 import type { EditorPreviewOptions } from './types';
 
-const panel = 'div.interface-interface-skeleton__header';
+const panel = '.interface-navigable-region[class*="header"]';
 const settingsButtonLabel = 'Settings';
 const moreOptionsLabel = 'Options';
 const selectors = {

--- a/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
@@ -337,25 +337,6 @@ export class EditorToolbarComponent {
 		await locator.click();
 	}
 
-	/* Details popover */
-
-	/**
-	 * Opens the post details popover (i.e. number of character, words, etc.).
-	 */
-	async openDetailsPopover(): Promise< void > {
-		if ( envVariables.VIEWPORT_NAME === 'mobile' ) {
-			// Details are not available on mobile!
-			return;
-		}
-
-		if ( await this.targetIsOpen( selectors.detailsButton ) ) {
-			return;
-		}
-
-		const locator = this.editor.locator( selectors.detailsButton );
-		await locator.click();
-	}
-
 	/**
 	 * Click the editor undo button. Throws an error if the button is not enabled.
 	 *

--- a/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
@@ -27,8 +27,8 @@ const selectors = {
 		return `${ panel } button.editor-post-publish-button__button[aria-disabled="${ buttonState }"]`;
 	},
 
-	// List view
-	listViewButton: `${ panel } button[aria-label="List View"]`,
+	// Document overview
+	documentOverviewButton: `${ panel } button[aria-label="Document Overview"]`,
 
 	// Details popover
 	detailsButton: `${ panel } button[aria-label="Details"]`,
@@ -312,11 +312,11 @@ export class EditorToolbarComponent {
 			return;
 		}
 
-		if ( await this.targetIsOpen( selectors.listViewButton ) ) {
+		if ( await this.targetIsOpen( selectors.documentOverviewButton ) ) {
 			return;
 		}
 
-		const locator = this.editor.locator( selectors.listViewButton );
+		const locator = this.editor.locator( selectors.documentOverviewButton );
 		await locator.click();
 	}
 
@@ -329,11 +329,11 @@ export class EditorToolbarComponent {
 			return;
 		}
 
-		if ( ! ( await this.targetIsOpen( selectors.listViewButton ) ) ) {
+		if ( ! ( await this.targetIsOpen( selectors.documentOverviewButton ) ) ) {
 			return;
 		}
 
-		const locator = this.editor.locator( selectors.listViewButton );
+		const locator = this.editor.locator( selectors.documentOverviewButton );
 		await locator.click();
 	}
 

--- a/packages/calypso-e2e/src/lib/components/editor-typography-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-typography-component.ts
@@ -1,12 +1,5 @@
 import { Locator, Page } from 'playwright';
 
-const parentSelector = '[class*="typography"]'; // Support block and site.
-const selectors = {
-	appearanceDropdownButton: `${ parentSelector } button[aria-label="Appearance"]`,
-	appearanceSelection: ( appearance: FontAppearance ) =>
-		`${ parentSelector } .components-font-appearance-control [role=option]:text-is("${ appearance }")`,
-};
-
 type FontSize = 'Small' | 'Medium' | 'Large' | 'Extra Large'; // expand as needed.
 type FontAppearance = 'Default' | 'Thin' | 'Regular' | 'Medium'; // expand as needed.
 
@@ -72,11 +65,16 @@ export class EditorTypographyComponent {
 	private async setAppearance( fontAppearance: FontAppearance ): Promise< void > {
 		// In the future, if we're in the block context, we'll have to add this field first.
 
-		// It's not a real select input. It's a button and a custom control.
-		const dropdownButtonLocator = this.editor.locator( selectors.appearanceDropdownButton );
+		const dropdownButtonLocator = this.editor.getByRole( 'button', {
+			name: 'Appearance',
+			exact: true,
+		} );
 		await dropdownButtonLocator.click();
 
-		const selectionLocator = this.editor.locator( selectors.appearanceSelection( fontAppearance ) );
+		const selectionLocator = this.editor.getByRole( 'option', {
+			name: fontAppearance,
+			exact: true,
+		} );
 		await selectionLocator.click();
 	}
 }

--- a/packages/calypso-e2e/src/lib/components/full-side-editor-nav-sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/full-side-editor-nav-sidebar-component.ts
@@ -1,9 +1,9 @@
 import { Page, Locator } from 'playwright';
 
-const panel = '.edit-site-navigation-panel';
 const selectors = {
-	exitLink: `${ panel } a.edit-site-navigation-panel__back-to-dashboard`,
-	templatePartsLink: `${ panel } a:has-text("Template Parts")`,
+	exitButton: `a[aria-label="Go back to the dashboard"]`,
+	templatePartsItem: 'button[id="/template-parts"]',
+	manageAllTemplatePartsItem: 'button:text("Manage all template parts")',
 };
 
 /**
@@ -26,15 +26,15 @@ export class FullSiteEditorNavSidebarComponent {
 	 * Clicks the Dashboard menu link to exit the editor.
 	 */
 	async exit(): Promise< void > {
-		const exitLinkLocator = this.editor.locator( selectors.exitLink );
-		await exitLinkLocator.click();
+		const exitButtonLocator = this.editor.locator( selectors.exitButton );
+		await exitButtonLocator.click();
 	}
 
 	/**
 	 * Clicks sidebar link to open the template parts list.
 	 */
-	async navigateToTemplateParts(): Promise< void > {
-		const locator = this.editor.locator( selectors.templatePartsLink );
-		await locator.click();
+	async navigateToTemplatePartsManager(): Promise< void > {
+		await this.editor.locator( selectors.templatePartsItem ).click();
+		await this.editor.locator( selectors.manageAllTemplatePartsItem ).click();
 	}
 }

--- a/packages/calypso-e2e/src/lib/components/template-part-list-component.ts
+++ b/packages/calypso-e2e/src/lib/components/template-part-list-component.ts
@@ -3,9 +3,9 @@ import { Locator, Page } from 'playwright';
 const parentSelector = '[aria-label="Template parts list - Content"]';
 
 const selectors = {
-	deleteButton: `${ parentSelector } button:has-text("Delete")`,
+	deleteButton: '[aria-label="Actions"] button :text("Delete")',
 	actionsButtonForPart: ( partName: string ) =>
-		`${ parentSelector } .edit-site-list-table-row:has-text("${ partName }") button[aria-label="Actions"]`,
+		`.edit-site-list-table-row:has-text("${ partName }") button[aria-label="Actions"]`,
 };
 
 /**

--- a/packages/calypso-e2e/src/lib/pages/editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/editor-page.ts
@@ -366,11 +366,6 @@ export class EditorPage {
 	): Promise< void > {
 		await inserter.searchBlockInserter( patternName );
 		await inserter.selectBlockInserterResult( patternName, { type: 'pattern' } );
-
-		const insertConfirmationToastLocator = this.editor.locator(
-			`.components-snackbar__content:text('Block pattern "${ patternName }" inserted.')`
-		);
-		await insertConfirmationToastLocator.waitFor();
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/pages/editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/editor-page.ts
@@ -798,13 +798,6 @@ export class EditorPage {
 	}
 
 	/**
-	 * Opens the post details popover (i.e. number of character, words, etc.).
-	 */
-	async openDetailsPopover(): Promise< void > {
-		await this.editorToolbarComponent.openDetailsPopover();
-	}
-
-	/**
 	 * Checks whether the editor has any block warnings/errors displaying.
 	 *
 	 * @returns {Promise<boolean>} True if there are block warnings/errors.

--- a/packages/calypso-e2e/src/lib/pages/full-site-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/full-site-editor-page.ts
@@ -549,13 +549,15 @@ export class FullSiteEditorPage {
 	/**
 	 * Delete a template part in the site editor.
 	 *
-	 * @param {string} name Name of the template part.
+	 * @param {string[]} names Name of the template part.
 	 */
-	async deleteTemplatePart( name: string ): Promise< void > {
+	async deleteTemplateParts( names: string[] ): Promise< void > {
 		await this.openNavSidebar();
 		await this.fullSiteEditorNavSidebarComponent.navigateToTemplatePartsManager();
-		await this.templatePartListComponent.deleteTemplatePart( name );
-		await this.waitForConfirmationToast( `"${ name }" deleted.` );
+		for ( const name of names ) {
+			await this.templatePartListComponent.deleteTemplatePart( name );
+			await this.waitForConfirmationToast( `"${ name }" deleted.` );
+		}
 	}
 
 	//#endregion

--- a/packages/calypso-e2e/src/lib/pages/full-site-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/full-site-editor-page.ts
@@ -118,7 +118,9 @@ export class FullSiteEditorPage {
 	 * @param {string} siteHostName Host name of the site, without scheme. (e.g. testsite.wordpress.com)
 	 */
 	async visit( siteHostName: string ): Promise< void > {
-		await this.page.goto( getCalypsoURL( `site-editor/${ siteHostName }` ) );
+		await this.page.goto( getCalypsoURL( `site-editor/${ siteHostName }` ), {
+			timeout: 60 * 1000,
+		} );
 	}
 
 	/**
@@ -362,6 +364,26 @@ export class FullSiteEditorPage {
 	}
 
 	/**
+	 * Open the navigation sidebar.
+	 */
+	async openNavSidebar(): Promise< void > {
+		const openButton = this.editor.locator( 'button[aria-label="Open Navigation Sidebar"]' );
+		const closeButton = this.editor.locator( 'button[aria-label="Open the editor"]' );
+
+		await Promise.race( [ closeButton.waitFor(), openButton.click() ] );
+	}
+
+	/**
+	 * Close the navigation sidebar.
+	 */
+	async closeNavSidebar(): Promise< void > {
+		const openButton = this.editor.locator( 'button[aria-label="Open Navigation Sidebar"]' );
+		const closeButton = this.editor.locator( 'button[aria-label="Open the editor"]' );
+
+		await Promise.race( [ openButton.waitFor(), closeButton.click() ] );
+	}
+
+	/**
 	 * Click the editor document actions icon.
 	 */
 	async openDocumentActionsDropdown(): Promise< void > {
@@ -530,10 +552,8 @@ export class FullSiteEditorPage {
 	 * @param {string} name Name of the template part.
 	 */
 	async deleteTemplatePart( name: string ): Promise< void > {
-		if ( ! ( await this.templatePartListComponent.isOpen() ) ) {
-			await this.editorToolbarComponent.openNavSidebar();
-			await this.fullSiteEditorNavSidebarComponent.navigateToTemplateParts();
-		}
+		await this.openNavSidebar();
+		await this.fullSiteEditorNavSidebarComponent.navigateToTemplatePartsManager();
 		await this.templatePartListComponent.deleteTemplatePart( name );
 		await this.waitForConfirmationToast( `"${ name }" deleted.` );
 	}

--- a/test/e2e/specs/editor-tracking/editor-tracking__block-inserted-event.ts
+++ b/test/e2e/specs/editor-tracking/editor-tracking__block-inserted-event.ts
@@ -43,6 +43,10 @@ describe(
 				editorPage = new EditorPage( page, { target: features.siteType } );
 			} );
 
+			afterAll( async () => {
+				await page.close();
+			} );
+
 			it( 'Start a new post', async function () {
 				await editorPage.visit( 'post' );
 				await editorPage.waitUntilLoaded();
@@ -146,6 +150,10 @@ describe(
 				editorPage = new EditorPage( page, { target: features.siteType } );
 			} );
 
+			afterAll( async () => {
+				await page.close();
+			} );
+
 			it( 'Start a new page', async function () {
 				await editorPage.visit( 'page' );
 				await editorPage.waitUntilLoaded();
@@ -202,9 +210,22 @@ describe(
 				fullSiteEditorPage = new FullSiteEditorPage( page, { target: features.siteType } );
 			} );
 
+			afterAll( async () => {
+				// Always try to delete the created template part.
+				if ( templatePartName ) {
+					await fullSiteEditorPage.deleteTemplatePart( templatePartName );
+				}
+
+				await page.close();
+			} );
+
 			it( 'Visit the site editor', async function () {
 				await fullSiteEditorPage.visit( testAccount.getSiteURL( { protocol: false } ) );
 				await fullSiteEditorPage.prepareForInteraction( { leaveWithoutSaving: true } );
+			} );
+
+			it( 'Close the navigation sidebar', async function () {
+				await fullSiteEditorPage.closeNavSidebar();
 			} );
 
 			// A lot of block insertions sometimes happen on load
@@ -299,13 +320,6 @@ describe(
 					);
 					expect( eventDidFire ).toBe( false );
 				} );
-			} );
-
-			// Always try to delete the created template part.
-			afterAll( async function () {
-				if ( templatePartName ) {
-					await fullSiteEditorPage.deleteTemplatePart( templatePartName );
-				}
 			} );
 		} );
 	}

--- a/test/e2e/specs/editor-tracking/editor-tracking__block-inserted-event.ts
+++ b/test/e2e/specs/editor-tracking/editor-tracking__block-inserted-event.ts
@@ -280,7 +280,7 @@ describe(
 							matchingProperties: {
 								block_name: 'core/page-list',
 								entity_context: 'core/template-part',
-								template_part_id: `pub/blockbase//${ templatePartName.toLowerCase() }`,
+								template_part_id: `pub/twentytwentytwo//${ templatePartName.toLowerCase() }`,
 							},
 						}
 					);

--- a/test/e2e/specs/editor-tracking/editor-tracking__block-inserted-event.ts
+++ b/test/e2e/specs/editor-tracking/editor-tracking__block-inserted-event.ts
@@ -288,7 +288,7 @@ describe(
 				} );
 			} );
 
-			describe( 'Adding blocks from existing template parts', function () {
+			describe.skip( 'Adding blocks from existing template parts', function () {
 				it( 'Add a Header block', async function () {
 					const block = await fullSiteEditorPage.addBlockFromSidebar(
 						HeaderBlock.blockName,
@@ -312,16 +312,12 @@ describe(
 				// arguably a reasonable outcome. We need to decide whether
 				// to adjust the test to match the tracking behavior or adjust
 				// the underlyting tracking behavior.
-				it.skip( '"wpcom_block_instered" event does NOT fire', async function () {
+				it( '"wpcom_block_instered" event does NOT fire', async function () {
 					const eventDidFire = await editorTracksEventManager.didEventFire(
 						'wpcom_block_inserted'
 					);
 					expect( eventDidFire ).toBe( false );
 				} );
-			} );
-
-			it( 'Close the page', async function () {
-				await page.close();
 			} );
 		} );
 	}

--- a/test/e2e/specs/editor-tracking/editor-tracking__block-inserted-event.ts
+++ b/test/e2e/specs/editor-tracking/editor-tracking__block-inserted-event.ts
@@ -43,10 +43,6 @@ describe(
 				editorPage = new EditorPage( page, { target: features.siteType } );
 			} );
 
-			afterAll( async () => {
-				await page.close();
-			} );
-
 			it( 'Start a new post', async function () {
 				await editorPage.visit( 'post' );
 				await editorPage.waitUntilLoaded();
@@ -132,6 +128,10 @@ describe(
 					} );
 				} );
 			} );
+
+			it( 'Close the page', async function () {
+				await page.close();
+			} );
 		} );
 
 		describe( 'In the page editor', function () {
@@ -148,10 +148,6 @@ describe(
 
 				editorTracksEventManager = new EditorTracksEventManager( page );
 				editorPage = new EditorPage( page, { target: features.siteType } );
-			} );
-
-			afterAll( async () => {
-				await page.close();
 			} );
 
 			it( 'Start a new page', async function () {
@@ -187,6 +183,10 @@ describe(
 					expect( eventDidFire ).toBe( true );
 				} );
 			} );
+
+			it( 'Close the page', async function () {
+				await page.close();
+			} );
 		} );
 
 		describe( 'In the site editor', function () {
@@ -215,8 +215,6 @@ describe(
 				if ( templatePartName ) {
 					await fullSiteEditorPage.deleteTemplateParts( [ templatePartName ] );
 				}
-
-				await page.close();
 			} );
 
 			it( 'Visit the site editor', async function () {
@@ -320,6 +318,10 @@ describe(
 					);
 					expect( eventDidFire ).toBe( false );
 				} );
+			} );
+
+			it( 'Close the page', async function () {
+				await page.close();
 			} );
 		} );
 	}

--- a/test/e2e/specs/editor-tracking/editor-tracking__block-inserted-event.ts
+++ b/test/e2e/specs/editor-tracking/editor-tracking__block-inserted-event.ts
@@ -213,7 +213,7 @@ describe(
 			afterAll( async () => {
 				// Always try to delete the created template part.
 				if ( templatePartName ) {
-					await fullSiteEditorPage.deleteTemplatePart( templatePartName );
+					await fullSiteEditorPage.deleteTemplateParts( [ templatePartName ] );
 				}
 
 				await page.close();

--- a/test/e2e/specs/editor-tracking/editor-tracking__document-actions-events.ts
+++ b/test/e2e/specs/editor-tracking/editor-tracking__document-actions-events.ts
@@ -37,9 +37,17 @@ describe(
 				fullSiteEditorPage = new FullSiteEditorPage( page, { target: features.siteType } );
 			} );
 
+			afterAll( async () => {
+				await page.close();
+			} );
+
 			it( 'Visit the site editor', async function () {
 				await fullSiteEditorPage.visit( testAccount.getSiteURL( { protocol: false } ) );
 				await fullSiteEditorPage.prepareForInteraction( { leaveWithoutSaving: true } );
+			} );
+
+			it( 'Close the navigation sidebar', async function () {
+				await fullSiteEditorPage.closeNavSidebar();
 			} );
 
 			it( 'Open the document actions dropdown', async function () {
@@ -69,9 +77,17 @@ describe(
 				fullSiteEditorPage = new FullSiteEditorPage( page, { target: features.siteType } );
 			} );
 
+			afterAll( async () => {
+				await page.close();
+			} );
+
 			it( 'Visit the site editor', async function () {
 				await fullSiteEditorPage.visit( testAccount.getSiteURL( { protocol: false } ) );
 				await fullSiteEditorPage.prepareForInteraction( { leaveWithoutSaving: true } );
+			} );
+
+			it( 'Close the navigation sidebar', async function () {
+				await fullSiteEditorPage.closeNavSidebar();
 			} );
 
 			it( 'Open the document actions dropdown', async function () {
@@ -112,9 +128,17 @@ describe(
 				fullSiteEditorPage = new FullSiteEditorPage( page, { target: features.siteType } );
 			} );
 
+			afterAll( async () => {
+				await page.close();
+			} );
+
 			it( 'Visit the site editor', async function () {
 				await fullSiteEditorPage.visit( testAccount.getSiteURL( { protocol: false } ) );
 				await fullSiteEditorPage.prepareForInteraction( { leaveWithoutSaving: true } );
+			} );
+
+			it( 'Close the navigation sidebar', async function () {
+				await fullSiteEditorPage.closeNavSidebar();
 			} );
 
 			it( 'Customize the current template', async function () {
@@ -161,9 +185,17 @@ describe(
 				fullSiteEditorPage = new FullSiteEditorPage( page, { target: features.siteType } );
 			} );
 
+			afterAll( async () => {
+				await page.close();
+			} );
+
 			it( 'Visit the site editor', async function () {
 				await fullSiteEditorPage.visit( testAccount.getSiteURL( { protocol: false } ) );
 				await fullSiteEditorPage.prepareForInteraction( { leaveWithoutSaving: true } );
+			} );
+
+			it( 'Close the navigation sidebar', async function () {
+				await fullSiteEditorPage.closeNavSidebar();
 			} );
 
 			it( 'Open the document actions dropdown', async function () {

--- a/test/e2e/specs/editor-tracking/editor-tracking__document-actions-events.ts
+++ b/test/e2e/specs/editor-tracking/editor-tracking__document-actions-events.ts
@@ -37,10 +37,6 @@ describe(
 				fullSiteEditorPage = new FullSiteEditorPage( page, { target: features.siteType } );
 			} );
 
-			afterAll( async () => {
-				await page.close();
-			} );
-
 			it( 'Visit the site editor', async function () {
 				await fullSiteEditorPage.visit( testAccount.getSiteURL( { protocol: false } ) );
 				await fullSiteEditorPage.prepareForInteraction( { leaveWithoutSaving: true } );
@@ -60,6 +56,10 @@ describe(
 				);
 				expect( eventDidFire ).toBe( true );
 			} );
+
+			it( 'Close the page', async function () {
+				await page.close();
+			} );
 		} );
 
 		describe( 'wpcom_site_editor_document_actions_template_area_click header', function () {
@@ -75,10 +75,6 @@ describe(
 				await testAccount.authenticate( page );
 				editorTracksEventManager = new EditorTracksEventManager( page );
 				fullSiteEditorPage = new FullSiteEditorPage( page, { target: features.siteType } );
-			} );
-
-			afterAll( async () => {
-				await page.close();
 			} );
 
 			it( 'Visit the site editor', async function () {
@@ -111,6 +107,10 @@ describe(
 				);
 				expect( eventDidFire ).toBe( true );
 			} );
+
+			it( 'Close the page', async function () {
+				await page.close();
+			} );
 		} );
 
 		describe( 'wpcom_site_editor_document_actions_revert_click', function () {
@@ -126,10 +126,6 @@ describe(
 				await testAccount.authenticate( page );
 				editorTracksEventManager = new EditorTracksEventManager( page );
 				fullSiteEditorPage = new FullSiteEditorPage( page, { target: features.siteType } );
-			} );
-
-			afterAll( async () => {
-				await page.close();
 			} );
 
 			it( 'Visit the site editor', async function () {
@@ -168,6 +164,10 @@ describe(
 				);
 				expect( eventDidFire ).toBe( true );
 			} );
+
+			it( 'Close the page', async function () {
+				await page.close();
+			} );
 		} );
 
 		describe( 'wpcom_site_editor_document_actions_show_all_click', function () {
@@ -183,10 +183,6 @@ describe(
 				await testAccount.authenticate( page );
 				editorTracksEventManager = new EditorTracksEventManager( page );
 				fullSiteEditorPage = new FullSiteEditorPage( page, { target: features.siteType } );
-			} );
-
-			afterAll( async () => {
-				await page.close();
 			} );
 
 			it( 'Visit the site editor', async function () {
@@ -213,6 +209,10 @@ describe(
 					'wpcom_site_editor_document_actions_show_all_click'
 				);
 				expect( eventDidFire ).toBe( true );
+			} );
+
+			it( 'Close the page', async function () {
+				await page.close();
 			} );
 		} );
 	}

--- a/test/e2e/specs/editor-tracking/editor-tracking__fse-template-events.ts
+++ b/test/e2e/specs/editor-tracking/editor-tracking__fse-template-events.ts
@@ -245,7 +245,7 @@ describe(
 					'wpcom_block_editor_convert_to_template_part',
 					{
 						matchingProperties: {
-							block_names: 'core/page-list',
+							block_names: 'core/page-list,core/page-list-item',
 						},
 					}
 				);
@@ -262,7 +262,7 @@ describe(
 					'wpcom_block_editor_template_part_detach_blocks',
 					{
 						matchingProperties: {
-							block_names: 'core/page-list',
+							block_names: 'core/page-list,core/page-list-item',
 							// Event property values are always lower case.
 							template_part_id: `pub/blockbase//${ templatePartName.toLowerCase() }`,
 						},

--- a/test/e2e/specs/editor-tracking/editor-tracking__fse-template-events.ts
+++ b/test/e2e/specs/editor-tracking/editor-tracking__fse-template-events.ts
@@ -29,6 +29,25 @@ describe(
 
 		const createdTemplateParts: string[] = [];
 
+		afterAll( async function () {
+			if ( createdTemplateParts.length > 0 ) {
+				// Template part data cleanup
+				const page = await browser.newPage();
+
+				const testAccount = new TestAccount( accountName );
+				await testAccount.authenticate( page );
+
+				const fullSiteEditorPage = new FullSiteEditorPage( page, { target: features.siteType } );
+				await fullSiteEditorPage.visit( testAccount.getSiteURL( { protocol: false } ) );
+				await fullSiteEditorPage.prepareForInteraction( { leaveWithoutSaving: true } );
+
+				console.info( `Deleting created template parts: ${ createdTemplateParts.join( ', ' ) }` );
+				for ( const templatePart of createdTemplateParts ) {
+					await fullSiteEditorPage.deleteTemplatePart( templatePart );
+				}
+			}
+		} );
+
 		describe( 'wpcom_block_editor_create_template_part', function () {
 			let page: Page;
 			let testAccount: TestAccount;
@@ -50,9 +69,17 @@ describe(
 				templatePartName = createTemplatePartName();
 			} );
 
+			afterAll( async () => {
+				await page.close();
+			} );
+
 			it( 'Visit the site editor', async function () {
 				await fullSiteEditorPage.visit( testAccount.getSiteURL( { protocol: false } ) );
 				await fullSiteEditorPage.prepareForInteraction( { leaveWithoutSaving: true } );
+			} );
+
+			it( 'Close the navigation sidebar', async function () {
+				await fullSiteEditorPage.closeNavSidebar();
 			} );
 
 			it( 'Add a Template Part block', async function () {
@@ -94,9 +121,17 @@ describe(
 				fullSiteEditorPage = new FullSiteEditorPage( page, { target: features.siteType } );
 			} );
 
+			afterAll( async () => {
+				await page.close();
+			} );
+
 			it( 'Visit the site editor', async function () {
 				await fullSiteEditorPage.visit( testAccount.getSiteURL( { protocol: false } ) );
 				await fullSiteEditorPage.prepareForInteraction( { leaveWithoutSaving: true } );
+			} );
+
+			it( 'Close the navigation sidebar', async function () {
+				await fullSiteEditorPage.closeNavSidebar();
 			} );
 
 			it( 'Add a Header block', async function () {
@@ -176,9 +211,17 @@ describe(
 				templatePartName = createTemplatePartName();
 			} );
 
+			afterAll( async () => {
+				await page.close();
+			} );
+
 			it( 'Visit the site editor', async function () {
 				await fullSiteEditorPage.visit( testAccount.getSiteURL( { protocol: false } ) );
 				await fullSiteEditorPage.prepareForInteraction( { leaveWithoutSaving: true } );
+			} );
+
+			it( 'Close the navigation sidebar', async function () {
+				await fullSiteEditorPage.closeNavSidebar();
 			} );
 
 			it( 'Add a Page List block', async function () {
@@ -227,25 +270,6 @@ describe(
 				);
 				expect( eventDidFire ).toBe( true );
 			} );
-		} );
-
-		afterAll( async function () {
-			if ( createdTemplateParts.length > 0 ) {
-				// Template part data cleanup
-				const page = await browser.newPage();
-
-				const testAccount = new TestAccount( accountName );
-				await testAccount.authenticate( page );
-
-				const fullSiteEditorPage = new FullSiteEditorPage( page, { target: features.siteType } );
-				await fullSiteEditorPage.visit( testAccount.getSiteURL( { protocol: false } ) );
-				await fullSiteEditorPage.prepareForInteraction( { leaveWithoutSaving: true } );
-
-				console.info( `Deleting created template parts: ${ createdTemplateParts.join( ', ' ) }` );
-				for ( const templatePart of createdTemplateParts ) {
-					await fullSiteEditorPage.deleteTemplatePart( templatePart );
-				}
-			}
 		} );
 	}
 );

--- a/test/e2e/specs/editor-tracking/editor-tracking__fse-template-events.ts
+++ b/test/e2e/specs/editor-tracking/editor-tracking__fse-template-events.ts
@@ -67,10 +67,6 @@ describe(
 				templatePartName = createTemplatePartName();
 			} );
 
-			afterAll( async () => {
-				await page.close();
-			} );
-
 			it( 'Visit the site editor', async function () {
 				await fullSiteEditorPage.visit( testAccount.getSiteURL( { protocol: false } ) );
 				await fullSiteEditorPage.prepareForInteraction( { leaveWithoutSaving: true } );
@@ -100,6 +96,10 @@ describe(
 				);
 				expect( eventDidFire ).toBe( true );
 			} );
+
+			it( 'Close the page', async function () {
+				await page.close();
+			} );
 		} );
 
 		describe( 'wpcom_block_editor_template_part_choose_existing/replace', function () {
@@ -117,10 +117,6 @@ describe(
 
 				editorTracksEventManager = new EditorTracksEventManager( page );
 				fullSiteEditorPage = new FullSiteEditorPage( page, { target: features.siteType } );
-			} );
-
-			afterAll( async () => {
-				await page.close();
 			} );
 
 			it( 'Visit the site editor', async function () {
@@ -187,6 +183,10 @@ describe(
 				);
 				expect( eventDidFire ).toBe( false );
 			} );
+
+			it( 'Close the page', async function () {
+				await page.close();
+			} );
 		} );
 
 		describe( 'wpcom_block_editor_convert_to_template_part / wpcom_block_editor_template_part_detach_blocks', function () {
@@ -207,10 +207,6 @@ describe(
 				fullSiteEditorPage = new FullSiteEditorPage( page, { target: features.siteType } );
 
 				templatePartName = createTemplatePartName();
-			} );
-
-			afterAll( async () => {
-				await page.close();
 			} );
 
 			it( 'Visit the site editor', async function () {
@@ -267,6 +263,10 @@ describe(
 					}
 				);
 				expect( eventDidFire ).toBe( true );
+			} );
+
+			it( 'Close the page', async function () {
+				await page.close();
 			} );
 		} );
 	}

--- a/test/e2e/specs/editor-tracking/editor-tracking__fse-template-events.ts
+++ b/test/e2e/specs/editor-tracking/editor-tracking__fse-template-events.ts
@@ -137,9 +137,9 @@ describe(
 				headerBlock = new HeaderBlock( page, block );
 			} );
 
-			it( 'Choose an existing template ("header-minimal")', async function () {
+			it( 'Choose an existing template ("Header (Dark, small)")', async function () {
 				await headerBlock.clickChoose();
-				await fullSiteEditorPage.selectExistingTemplatePartFromModal( 'header-minimal' );
+				await fullSiteEditorPage.selectExistingTemplatePartFromModal( 'Header (Dark, small)' );
 			} );
 
 			it( '"wpcom_block_editor_template_part_choose_existing" event fires', async function () {
@@ -160,14 +160,14 @@ describe(
 				await editorTracksEventManager.clearEvents();
 			} );
 
-			it( 'Replace template with a different template ("header-linear")', async function () {
+			it( 'Replace template with a different template ("Header (Dark, large)")', async function () {
 				// First, let's make sure we have the right block focused!
 				const blockId = await ElementHelper.getIdFromBlock( headerBlock.block );
 				await fullSiteEditorPage.focusBlock( `#${ blockId }` );
 
 				// Then we can take block toolbar actions.
-				await fullSiteEditorPage.clickBlockToolbarOption( 'Replace header-minimal' );
-				await fullSiteEditorPage.selectExistingTemplatePartFromModal( 'header-linear' );
+				await fullSiteEditorPage.clickBlockToolbarOption( 'Replace Header (Dark, small)' );
+				await fullSiteEditorPage.selectExistingTemplatePartFromModal( 'Header (Dark, large)' );
 			} );
 
 			it( '"wpcom_block_editor_template_part_replace" event fires', async function () {
@@ -239,7 +239,7 @@ describe(
 					'wpcom_block_editor_convert_to_template_part',
 					{
 						matchingProperties: {
-							block_names: 'core/page-list,core/page-list-item',
+							block_names: 'core/page-list',
 						},
 					}
 				);
@@ -256,9 +256,9 @@ describe(
 					'wpcom_block_editor_template_part_detach_blocks',
 					{
 						matchingProperties: {
-							block_names: 'core/page-list,core/page-list-item',
+							block_names: 'core/page-list',
 							// Event property values are always lower case.
-							template_part_id: `pub/blockbase//${ templatePartName.toLowerCase() }`,
+							template_part_id: `pub/twentytwentytwo//${ templatePartName.toLowerCase() }`,
 						},
 					}
 				);

--- a/test/e2e/specs/editor-tracking/editor-tracking__fse-template-events.ts
+++ b/test/e2e/specs/editor-tracking/editor-tracking__fse-template-events.ts
@@ -42,9 +42,7 @@ describe(
 				await fullSiteEditorPage.prepareForInteraction( { leaveWithoutSaving: true } );
 
 				console.info( `Deleting created template parts: ${ createdTemplateParts.join( ', ' ) }` );
-				for ( const templatePart of createdTemplateParts ) {
-					await fullSiteEditorPage.deleteTemplatePart( templatePart );
-				}
+				await fullSiteEditorPage.deleteTemplateParts( createdTemplateParts );
 			}
 		} );
 

--- a/test/e2e/specs/editor-tracking/editor-tracking__global-styles-events.ts
+++ b/test/e2e/specs/editor-tracking/editor-tracking__global-styles-events.ts
@@ -82,7 +82,7 @@ describe( DataHelper.createSuiteTitle( 'Editor tracking: Global styles events' )
 		} );
 	} );
 
-	describe.skip( 'wpcom_block_editor_global_styles_menu_selected', function () {
+	describe( 'wpcom_block_editor_global_styles_menu_selected', function () {
 		let page: Page;
 		let testAccount: TestAccount;
 		let fullSiteEditorPage: FullSiteEditorPage;

--- a/test/e2e/specs/editor-tracking/editor-tracking__global-styles-events.ts
+++ b/test/e2e/specs/editor-tracking/editor-tracking__global-styles-events.ts
@@ -288,8 +288,13 @@ describe( DataHelper.createSuiteTitle( 'Editor tracking: Global styles events' )
 			fullSiteEditorPage = new FullSiteEditorPage( page, { target: features.siteType } );
 		} );
 
-		afterAll( async () => {
-			await page.close();
+		afterAll( async function () {
+			// Reset the layout back to empty to protect future runs.
+			// You can reset an already empty layout, so this is safe to do even if saving didn't go through.
+			await fullSiteEditorPage.openSiteStyles();
+			await fullSiteEditorPage.resetGlobalLayoutStyle();
+			await fullSiteEditorPage.closeSiteStyles();
+			await fullSiteEditorPage.save();
 		} );
 
 		it( 'Visit the site editor', async function () {
@@ -328,15 +333,6 @@ describe( DataHelper.createSuiteTitle( 'Editor tracking: Global styles events' )
 				}
 			);
 			expect( eventDidFire ).toBe( true );
-		} );
-
-		afterAll( async function () {
-			// Reset the layout back to empty to protect future runs.
-			// You can reset an already empty layout, so this is safe to do even if saving didn't go through.
-			await fullSiteEditorPage.openSiteStyles();
-			await fullSiteEditorPage.resetGlobalLayoutStyle();
-			await fullSiteEditorPage.closeSiteStyles();
-			await fullSiteEditorPage.save();
 		} );
 	} );
 } );

--- a/test/e2e/specs/editor-tracking/editor-tracking__global-styles-events.ts
+++ b/test/e2e/specs/editor-tracking/editor-tracking__global-styles-events.ts
@@ -36,10 +36,6 @@ describe( DataHelper.createSuiteTitle( 'Editor tracking: Global styles events' )
 			fullSiteEditorPage = new FullSiteEditorPage( page, { target: features.siteType } );
 		} );
 
-		afterAll( async () => {
-			await page.close();
-		} );
-
 		it( 'Visit the site editor', async function () {
 			await fullSiteEditorPage.visit( testAccount.getSiteURL( { protocol: false } ) );
 			await fullSiteEditorPage.prepareForInteraction( { leaveWithoutSaving: true } );
@@ -80,6 +76,10 @@ describe( DataHelper.createSuiteTitle( 'Editor tracking: Global styles events' )
 			);
 			expect( eventDidFire ).toBe( true );
 		} );
+
+		it( 'Close the page', async function () {
+			await page.close();
+		} );
 	} );
 
 	describe( 'wpcom_block_editor_global_styles_menu_selected', function () {
@@ -96,10 +96,6 @@ describe( DataHelper.createSuiteTitle( 'Editor tracking: Global styles events' )
 
 			editorTracksEventManager = new EditorTracksEventManager( page );
 			fullSiteEditorPage = new FullSiteEditorPage( page, { target: features.siteType } );
-		} );
-
-		afterAll( async () => {
-			await page.close();
 		} );
 
 		it( 'Visit the site editor', async function () {
@@ -150,6 +146,10 @@ describe( DataHelper.createSuiteTitle( 'Editor tracking: Global styles events' )
 			);
 			expect( eventDidFire ).toBe( true );
 		} );
+
+		it( 'Close the page', async function () {
+			await page.close();
+		} );
 	} );
 
 	describe( 'wpcom_block_editor_global_styles_update', function () {
@@ -166,10 +166,6 @@ describe( DataHelper.createSuiteTitle( 'Editor tracking: Global styles events' )
 
 			editorTracksEventManager = new EditorTracksEventManager( page );
 			fullSiteEditorPage = new FullSiteEditorPage( page, { target: features.siteType } );
-		} );
-
-		afterAll( async () => {
-			await page.close();
 		} );
 
 		it( 'Visit the site editor', async function () {
@@ -264,6 +260,10 @@ describe( DataHelper.createSuiteTitle( 'Editor tracking: Global styles events' )
 				} );
 			}
 		);
+
+		it( 'Close the page', async function () {
+			await page.close();
+		} );
 	} );
 
 	describe( 'wpcom_block_editor_global_styles_save', function () {
@@ -333,6 +333,10 @@ describe( DataHelper.createSuiteTitle( 'Editor tracking: Global styles events' )
 				}
 			);
 			expect( eventDidFire ).toBe( true );
+		} );
+
+		it( 'Close the page', async function () {
+			await page.close();
 		} );
 	} );
 } );

--- a/test/e2e/specs/editor-tracking/editor-tracking__global-styles-events.ts
+++ b/test/e2e/specs/editor-tracking/editor-tracking__global-styles-events.ts
@@ -36,9 +36,17 @@ describe( DataHelper.createSuiteTitle( 'Editor tracking: Global styles events' )
 			fullSiteEditorPage = new FullSiteEditorPage( page, { target: features.siteType } );
 		} );
 
+		afterAll( async () => {
+			await page.close();
+		} );
+
 		it( 'Visit the site editor', async function () {
 			await fullSiteEditorPage.visit( testAccount.getSiteURL( { protocol: false } ) );
 			await fullSiteEditorPage.prepareForInteraction( { leaveWithoutSaving: true } );
+		} );
+
+		it( 'Close the navigation sidebar', async function () {
+			await fullSiteEditorPage.closeNavSidebar();
 		} );
 
 		it( 'Open site styles', async function () {
@@ -74,7 +82,7 @@ describe( DataHelper.createSuiteTitle( 'Editor tracking: Global styles events' )
 		} );
 	} );
 
-	describe( 'wpcom_block_editor_global_styles_menu_selected', function () {
+	describe.skip( 'wpcom_block_editor_global_styles_menu_selected', function () {
 		let page: Page;
 		let testAccount: TestAccount;
 		let fullSiteEditorPage: FullSiteEditorPage;
@@ -90,9 +98,17 @@ describe( DataHelper.createSuiteTitle( 'Editor tracking: Global styles events' )
 			fullSiteEditorPage = new FullSiteEditorPage( page, { target: features.siteType } );
 		} );
 
+		afterAll( async () => {
+			await page.close();
+		} );
+
 		it( 'Visit the site editor', async function () {
 			await fullSiteEditorPage.visit( testAccount.getSiteURL( { protocol: false } ) );
 			await fullSiteEditorPage.prepareForInteraction( { leaveWithoutSaving: true } );
+		} );
+
+		it( 'Close the navigation sidebar', async function () {
+			await fullSiteEditorPage.closeNavSidebar();
 		} );
 
 		it( 'Open site styles', async function () {
@@ -152,9 +168,17 @@ describe( DataHelper.createSuiteTitle( 'Editor tracking: Global styles events' )
 			fullSiteEditorPage = new FullSiteEditorPage( page, { target: features.siteType } );
 		} );
 
+		afterAll( async () => {
+			await page.close();
+		} );
+
 		it( 'Visit the site editor', async function () {
 			await fullSiteEditorPage.visit( testAccount.getSiteURL( { protocol: false } ) );
 			await fullSiteEditorPage.prepareForInteraction( { leaveWithoutSaving: true } );
+		} );
+
+		it( 'Close the navigation sidebar', async function () {
+			await fullSiteEditorPage.closeNavSidebar();
 		} );
 
 		it( 'Open site styles', async function () {
@@ -264,9 +288,17 @@ describe( DataHelper.createSuiteTitle( 'Editor tracking: Global styles events' )
 			fullSiteEditorPage = new FullSiteEditorPage( page, { target: features.siteType } );
 		} );
 
+		afterAll( async () => {
+			await page.close();
+		} );
+
 		it( 'Visit the site editor', async function () {
 			await fullSiteEditorPage.visit( testAccount.getSiteURL( { protocol: false } ) );
 			await fullSiteEditorPage.prepareForInteraction( { leaveWithoutSaving: true } );
+		} );
+
+		it( 'Close the navigation sidebar', async function () {
+			await fullSiteEditorPage.closeNavSidebar();
 		} );
 
 		it( 'Open site styles', async function () {

--- a/test/e2e/specs/editor-tracking/editor-tracking__other-block-events.ts
+++ b/test/e2e/specs/editor-tracking/editor-tracking__other-block-events.ts
@@ -37,10 +37,6 @@ describe(
 				editorPage = new EditorPage( page, { target: features.siteType } );
 			} );
 
-			afterAll( async () => {
-				await page.close();
-			} );
-
 			it( 'Start a new post', async function () {
 				await editorPage.visit( 'post' );
 				await editorPage.waitUntilLoaded();
@@ -74,6 +70,10 @@ describe(
 				);
 				expect( eventDidFire ).toBe( true );
 			} );
+
+			it( 'Close the page', async function () {
+				await page.close();
+			} );
 		} );
 
 		describe( '"wpcom_block_deleted"', function () {
@@ -92,10 +92,6 @@ describe(
 
 				editorTracksEventManager = new EditorTracksEventManager( page );
 				fullSiteEditorPage = new FullSiteEditorPage( page, { target: features.siteType } );
-			} );
-
-			afterAll( async () => {
-				await page.close();
 			} );
 
 			it( 'Go to the site editor', async function () {
@@ -122,6 +118,10 @@ describe(
 			it( '"wpcom_block_deleted" event fires', async function () {
 				const eventDidFire = await editorTracksEventManager.didEventFire( 'wpcom_block_deleted' );
 				expect( eventDidFire ).toBe( true );
+			} );
+
+			it( 'Close the page', async function () {
+				await page.close();
 			} );
 		} );
 	}

--- a/test/e2e/specs/editor-tracking/editor-tracking__other-block-events.ts
+++ b/test/e2e/specs/editor-tracking/editor-tracking__other-block-events.ts
@@ -37,6 +37,10 @@ describe(
 				editorPage = new EditorPage( page, { target: features.siteType } );
 			} );
 
+			afterAll( async () => {
+				await page.close();
+			} );
+
 			it( 'Start a new post', async function () {
 				await editorPage.visit( 'post' );
 				await editorPage.waitUntilLoaded();
@@ -90,9 +94,17 @@ describe(
 				fullSiteEditorPage = new FullSiteEditorPage( page, { target: features.siteType } );
 			} );
 
+			afterAll( async () => {
+				await page.close();
+			} );
+
 			it( 'Go to the site editor', async function () {
 				await fullSiteEditorPage.visit( testAccount.getSiteURL( { protocol: false } ) );
 				await fullSiteEditorPage.prepareForInteraction( { leaveWithoutSaving: true } );
+			} );
+
+			it( 'Close the navigation sidebar', async function () {
+				await fullSiteEditorPage.closeNavSidebar();
 			} );
 
 			it( 'Add a Pullquote block', async function () {

--- a/test/e2e/specs/editor-tracking/editor-tracking__pattern-events.ts
+++ b/test/e2e/specs/editor-tracking/editor-tracking__pattern-events.ts
@@ -53,8 +53,8 @@ describe( DataHelper.createSuiteTitle( 'Editor tracking: Pattern-related events'
 		} );
 
 		describe( 'From the sidebar inserter', function () {
-			const patternName = 'Two columns of text and title'; // This is distinct and returns one result.
-			const patternNameInEventProperty = 'core/two-columns-of-text-and-title';
+			const patternName = 'Simple Two Column Layout'; // This is distinct and returns one result.
+			const patternNameInEventProperty = 'a8c/simple-two-column-layout';
 
 			it( 'Add pattern from sidebar inserter', async function () {
 				await editorPage.addPatternFromSidebar( patternName );
@@ -73,8 +73,8 @@ describe( DataHelper.createSuiteTitle( 'Editor tracking: Pattern-related events'
 		describe( 'From the inline inserter', function () {
 			// We use a different pattern here for distinction.
 			// This especially helps distinguish the toast popups that confirm patter insertion.
-			const patternName = 'Pricing table'; // This returns one result.
-			const patternNameInEventProperty = 'pricing-table';
+			const patternName = 'Two column food menu'; // This returns one result.
+			const patternNameInEventProperty = 'a8c/two-column-food-menu';
 
 			it( 'Clear event stack for clean slate', async function () {
 				await eventManager.clearEvents();

--- a/test/e2e/specs/editor-tracking/editor-tracking__toolbar-events.ts
+++ b/test/e2e/specs/editor-tracking/editor-tracking__toolbar-events.ts
@@ -40,10 +40,6 @@ skipDescribeIf( envVariables.VIEWPORT_NAME === 'mobile' )(
 				editorPage = new EditorPage( page, { target: features.siteType } );
 			} );
 
-			afterAll( async () => {
-				await page.close();
-			} );
-
 			it( 'Start a new post', async function () {
 				await editorPage.visit( 'post' );
 				await editorPage.waitUntilLoaded();
@@ -100,6 +96,10 @@ skipDescribeIf( envVariables.VIEWPORT_NAME === 'mobile' )(
 				);
 				expect( eventDidFire ).toBe( true );
 			} );
+
+			it( 'Close the page', async function () {
+				await page.close();
+			} );
 		} );
 
 		describe( 'wpcom_block_editor_undo/redo_performed', function () {
@@ -117,10 +117,6 @@ skipDescribeIf( envVariables.VIEWPORT_NAME === 'mobile' )(
 
 				editorTracksEventManager = new EditorTracksEventManager( page );
 				fullSiteEditorPage = new FullSiteEditorPage( page, { target: features.siteType } );
-			} );
-
-			afterAll( async () => {
-				await page.close();
 			} );
 
 			it( 'Go to site editor', async function () {
@@ -159,6 +155,10 @@ skipDescribeIf( envVariables.VIEWPORT_NAME === 'mobile' )(
 					'wpcom_block_editor_redo_performed'
 				);
 				expect( eventDidFire ).toBe( true );
+			} );
+
+			it( 'Close the page', async function () {
+				await page.close();
 			} );
 		} );
 	}

--- a/test/e2e/specs/editor-tracking/editor-tracking__toolbar-events.ts
+++ b/test/e2e/specs/editor-tracking/editor-tracking__toolbar-events.ts
@@ -97,43 +97,6 @@ skipDescribeIf( envVariables.VIEWPORT_NAME === 'mobile' )(
 			} );
 		} );
 
-		describe( 'wpcom_block_editor_details_open', function () {
-			let page: Page;
-			let editorPage: EditorPage;
-			let editorTracksEventManager: EditorTracksEventManager;
-			beforeAll( async () => {
-				page = await browser.newPage();
-
-				const accountName = getTestAccountByFeature( features );
-				const testAccount = new TestAccount( accountName );
-				await testAccount.authenticate( page );
-
-				editorTracksEventManager = new EditorTracksEventManager( page );
-				editorPage = new EditorPage( page, { target: features.siteType } );
-			} );
-
-			it( 'Start a new post', async function () {
-				await editorPage.visit( 'post' );
-				await editorPage.waitUntilLoaded();
-			} );
-
-			// Needed to enable the details button.
-			it( 'Enter some text', async function () {
-				await editorPage.enterText( 'The actual text does not matter for this test either.' );
-			} );
-
-			it( 'Click details button', async function () {
-				await editorPage.openDetailsPopover();
-			} );
-
-			it( '"wpcom_block_editor_details_open" event fires', async function () {
-				const eventDidFire = await editorTracksEventManager.didEventFire(
-					'wpcom_block_editor_details_open'
-				);
-				expect( eventDidFire ).toBe( true );
-			} );
-		} );
-
 		describe( 'wpcom_block_editor_undo/redo_performed', function () {
 			let page: Page;
 			let fullSiteEditorPage: FullSiteEditorPage;

--- a/test/e2e/specs/editor-tracking/editor-tracking__toolbar-events.ts
+++ b/test/e2e/specs/editor-tracking/editor-tracking__toolbar-events.ts
@@ -28,6 +28,7 @@ skipDescribeIf( envVariables.VIEWPORT_NAME === 'mobile' )(
 			let page: Page;
 			let editorPage: EditorPage;
 			let editorTracksEventManager: EditorTracksEventManager;
+
 			beforeAll( async () => {
 				page = await browser.newPage();
 
@@ -37,6 +38,10 @@ skipDescribeIf( envVariables.VIEWPORT_NAME === 'mobile' )(
 
 				editorTracksEventManager = new EditorTracksEventManager( page );
 				editorPage = new EditorPage( page, { target: features.siteType } );
+			} );
+
+			afterAll( async () => {
+				await page.close();
 			} );
 
 			it( 'Start a new post', async function () {
@@ -102,6 +107,7 @@ skipDescribeIf( envVariables.VIEWPORT_NAME === 'mobile' )(
 			let fullSiteEditorPage: FullSiteEditorPage;
 			let editorTracksEventManager: EditorTracksEventManager;
 			let testAccount: TestAccount;
+
 			beforeAll( async () => {
 				page = await browser.newPage();
 
@@ -113,9 +119,17 @@ skipDescribeIf( envVariables.VIEWPORT_NAME === 'mobile' )(
 				fullSiteEditorPage = new FullSiteEditorPage( page, { target: features.siteType } );
 			} );
 
+			afterAll( async () => {
+				await page.close();
+			} );
+
 			it( 'Go to site editor', async function () {
 				await fullSiteEditorPage.visit( testAccount.getSiteURL( { protocol: false } ) );
 				await fullSiteEditorPage.prepareForInteraction( { leaveWithoutSaving: true } );
+			} );
+
+			it( 'Close the navigation sidebar', async function () {
+				await fullSiteEditorPage.closeNavSidebar();
 			} );
 
 			it( 'Add a Header block', async function () {


### PR DESCRIPTION
> **Warning**
> Do not merge before Gutenberg v14.8 is in production.

Context:
- p4TIVU-am0-p2
- p4TIVU-amj-p2

#### Proposed Changes

Fix tracking specs against the [GB v14.8.x upgrade](https://github.com/Automattic/wp-calypso/issues/71272):
- specs/editor-tracking/editor-tracking__block-inserted-event.ts
- specs/editor-tracking/editor-tracking__other-block-events.ts
- specs/editor-tracking/editor-tracking__toolbar-events.ts
- specs/editor-tracking/editor-tracking__global-styles-events.ts
- specs/editor-tracking/editor-tracking__fse-template-events.ts
- specs/editor-tracking/editor-tracking__document-actions-events.ts
- specs/editor-tracking/editor-tracking__pattern-events.ts

#### Testing Instructions

The above suites should be passing [against edge sites in the CI](https://teamcity.a8c.com/buildConfiguration/calypso_WPComTests_editor_tracking_simple_edge_desktop?branch=fix%2Fe2e-tracking-specs&mode=builds).