### PR TITLE
Reading Settings: Add 'Related Posts' setting

### DIFF
--- a/client/my-sites/marketing/traffic/index.js
+++ b/client/my-sites/marketing/traffic/index.js
@@ -74,7 +74,7 @@ const SiteSettingsTraffic = ( {
 		{ isAdmin && (
 			<RelatedPosts
 				onSubmitForm={ handleSubmitForm }
-				handleAutosavingToggle={ handleAutosavingToggle }
+				handleToggle={ handleAutosavingToggle }
 				isSavingSettings={ isSavingSettings }
 				isRequestingSettings={ isRequestingSettings }
 				fields={ fields }

--- a/client/my-sites/site-settings/reading-site-settings/RelatedPostsSetting.tsx
+++ b/client/my-sites/site-settings/reading-site-settings/RelatedPostsSetting.tsx
@@ -1,0 +1,36 @@
+import { useTranslate } from 'i18n-calypso';
+import FormLabel from 'calypso/components/forms/form-label';
+import { RelatedPostsSetting as RelatedPostsFormFieldset } from 'calypso/my-sites/site-settings/related-posts';
+
+type RelatedPostsFields = {
+	jetpack_relatedposts_enabled?: boolean;
+	jetpack_relatedposts_show_headline?: boolean;
+	jetpack_relatedposts_show_thumbnails?: boolean;
+};
+
+type RelatedPostsSettingProps = {
+	fields: RelatedPostsFields;
+	handleToggle?: ( field: string ) => ( ( isChecked: boolean ) => void ) | undefined;
+	isRequestingSettings?: boolean;
+	isSavingSettings?: boolean;
+};
+
+export const RelatedPostsSetting = ( {
+	fields,
+	handleToggle,
+	isRequestingSettings,
+	isSavingSettings,
+}: RelatedPostsSettingProps ) => {
+	const translate = useTranslate();
+	return (
+		<>
+			<FormLabel>{ translate( 'Related Posts' ) }</FormLabel>
+			<RelatedPostsFormFieldset
+				fields={ fields }
+				handleToggle={ handleToggle }
+				isRequestingSettings={ isRequestingSettings }
+				isSavingSettings={ isSavingSettings }
+			/>
+		</>
+	);
+};

--- a/client/my-sites/site-settings/reading-site-settings/index.tsx
+++ b/client/my-sites/site-settings/reading-site-settings/index.tsx
@@ -2,24 +2,32 @@ import { Card } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
 import { BlogPagesSetting, BLOG_PAGES_OPTION } from './BlogPagesSetting';
+import { RelatedPostsSetting } from './RelatedPostsSetting';
 
 type Fields = {
 	posts_per_page?: number;
+	jetpack_relatedposts_enabled?: boolean;
+	jetpack_relatedposts_show_headline?: boolean;
+	jetpack_relatedposts_show_thumbnails?: boolean;
 };
 
 type SiteSettingsSectionProps = {
 	fields: Fields;
 	onChangeField: ( field: string ) => ( event: React.ChangeEvent< HTMLInputElement > ) => void;
 	handleSubmitForm: ( event: React.FormEvent< HTMLFormElement > ) => void;
+	handleToggle?: ( field: string ) => ( ( isChecked: boolean ) => void ) | undefined;
 	disabled?: boolean;
+	isRequestingSettings?: boolean;
 	isSavingSettings?: boolean;
 };
 
 export const SiteSettingsSection = ( {
 	fields,
 	onChangeField,
+	handleToggle,
 	handleSubmitForm,
 	disabled,
+	isRequestingSettings,
 	isSavingSettings,
 }: SiteSettingsSectionProps ) => {
 	const translate = useTranslate();
@@ -35,11 +43,19 @@ export const SiteSettingsSection = ( {
 				disabled={ disabled }
 				isSaving={ isSavingSettings }
 			/>
-			<Card>
+			<Card className="site-settings__card">
 				<BlogPagesSetting
 					value={ posts_per_page }
 					onChange={ onChangeField( BLOG_PAGES_OPTION ) }
 					disabled={ disabled }
+				/>
+			</Card>
+			<Card className="site-settings__card">
+				<RelatedPostsSetting
+					fields={ fields }
+					handleToggle={ handleToggle }
+					isRequestingSettings={ isRequestingSettings }
+					isSavingSettings={ isSavingSettings }
 				/>
 			</Card>
 		</>

--- a/client/my-sites/site-settings/related-posts/index.jsx
+++ b/client/my-sites/site-settings/related-posts/index.jsx
@@ -1,6 +1,6 @@
 import { Card } from '@automattic/components';
 import { ToggleControl } from '@wordpress/components';
-import { localize } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
@@ -10,92 +10,109 @@ import RelatedContentPreview from './related-content-preview';
 
 import './style.scss';
 
-const RelatedPosts = ( {
+export const RelatedPostsSetting = ( {
 	fields,
-	handleAutosavingToggle,
+	handleToggle,
 	isRequestingSettings,
 	isSavingSettings,
-	translate,
 } ) => {
+	const translate = useTranslate();
+	return (
+		<FormFieldset>
+			<SupportInfo
+				text={ translate(
+					'The feature helps visitors find more of your content by displaying related posts at the bottom of each post.'
+				) }
+				link="https://jetpack.com/support/related-posts/"
+			/>
+
+			<ToggleControl
+				checked={ !! fields.jetpack_relatedposts_enabled }
+				disabled={ isRequestingSettings || isSavingSettings }
+				onChange={ handleToggle( 'jetpack_relatedposts_enabled' ) }
+				label={ translate( 'Show related content after posts' ) }
+			/>
+
+			<div className="related-posts__module-settings site-settings__child-settings">
+				<ToggleControl
+					checked={ !! fields.jetpack_relatedposts_show_headline }
+					disabled={
+						isRequestingSettings || isSavingSettings || ! fields.jetpack_relatedposts_enabled
+					}
+					onChange={ handleToggle( 'jetpack_relatedposts_show_headline' ) }
+					label={ translate( 'Highlight related content with a heading' ) }
+				/>
+
+				<ToggleControl
+					checked={ !! fields.jetpack_relatedposts_show_thumbnails }
+					disabled={
+						isRequestingSettings || isSavingSettings || ! fields.jetpack_relatedposts_enabled
+					}
+					onChange={ handleToggle( 'jetpack_relatedposts_show_thumbnails' ) }
+					label={ translate( 'Show a thumbnail image where available' ) }
+				/>
+			</div>
+
+			<FormSettingExplanation>
+				{ translate(
+					"These settings won't apply to {{a}}related posts added using the block editor{{/a}}.",
+					{
+						components: {
+							a: (
+								<a
+									href="https://jetpack.com/support/jetpack-blocks/related-posts-block/"
+									target="_blank"
+									rel="noopener noreferrer"
+								/>
+							),
+						},
+					}
+				) }
+			</FormSettingExplanation>
+
+			<RelatedContentPreview
+				showHeadline={ fields.jetpack_relatedposts_show_headline }
+				showThumbnails={ fields.jetpack_relatedposts_show_thumbnails }
+			/>
+		</FormFieldset>
+	);
+};
+
+const RelatedPostsSection = ( {
+	fields,
+	handleToggle,
+	isRequestingSettings,
+	isSavingSettings,
+} ) => {
+	const translate = useTranslate();
 	return (
 		<div>
 			<SettingsSectionHeader title={ translate( 'Related posts' ) } />
 
 			<Card className="related-posts__card site-settings__traffic-settings">
-				<FormFieldset>
-					<SupportInfo
-						text={ translate(
-							'The feature helps visitors find more of your content by displaying related posts at the bottom of each post.'
-						) }
-						link="https://jetpack.com/support/related-posts/"
-					/>
-
-					<ToggleControl
-						checked={ !! fields.jetpack_relatedposts_enabled }
-						disabled={ isRequestingSettings || isSavingSettings }
-						onChange={ handleAutosavingToggle( 'jetpack_relatedposts_enabled' ) }
-						label={ translate( 'Show related content after posts' ) }
-					/>
-
-					<div className="related-posts__module-settings site-settings__child-settings">
-						<ToggleControl
-							checked={ !! fields.jetpack_relatedposts_show_headline }
-							disabled={
-								isRequestingSettings || isSavingSettings || ! fields.jetpack_relatedposts_enabled
-							}
-							onChange={ handleAutosavingToggle( 'jetpack_relatedposts_show_headline' ) }
-							label={ translate( 'Highlight related content with a heading' ) }
-						/>
-
-						<ToggleControl
-							checked={ !! fields.jetpack_relatedposts_show_thumbnails }
-							disabled={
-								isRequestingSettings || isSavingSettings || ! fields.jetpack_relatedposts_enabled
-							}
-							onChange={ handleAutosavingToggle( 'jetpack_relatedposts_show_thumbnails' ) }
-							label={ translate( 'Show a thumbnail image where available' ) }
-						/>
-					</div>
-
-					<FormSettingExplanation>
-						{ translate(
-							"These settings won't apply to {{a}}related posts added using the block editor{{/a}}.",
-							{
-								components: {
-									a: (
-										<a
-											href="https://jetpack.com/support/jetpack-blocks/related-posts-block/"
-											target="_blank"
-											rel="noopener noreferrer"
-										/>
-									),
-								},
-							}
-						) }
-					</FormSettingExplanation>
-
-					<RelatedContentPreview
-						showHeadline={ fields.jetpack_relatedposts_show_headline }
-						showThumbnails={ fields.jetpack_relatedposts_show_thumbnails }
-					/>
-				</FormFieldset>
+				<RelatedPostsSetting
+					fields={ fields }
+					handleToggle={ handleToggle }
+					isRequestingSettings={ isRequestingSettings }
+					isSavingSettings={ isSavingSettings }
+					translate={ translate }
+				/>
 			</Card>
 		</div>
 	);
 };
 
-RelatedPosts.defaultProps = {
+RelatedPostsSection.defaultProps = {
 	isSavingSettings: false,
 	isRequestingSettings: true,
 	fields: {},
 };
 
-RelatedPosts.propTypes = {
-	onSubmitForm: PropTypes.func.isRequired,
-	handleAutosavingToggle: PropTypes.func.isRequired,
+RelatedPostsSection.propTypes = {
+	handleToggle: PropTypes.func.isRequired,
 	isSavingSettings: PropTypes.bool,
 	isRequestingSettings: PropTypes.bool,
 	fields: PropTypes.object,
 };
 
-export default localize( RelatedPosts );
+export default RelatedPostsSection;

--- a/client/my-sites/site-settings/settings-reading/main.tsx
+++ b/client/my-sites/site-settings/settings-reading/main.tsx
@@ -14,6 +14,9 @@ import wrapSettingsForm from '../wrap-settings-form';
 const isEnabled = config.isEnabled( 'settings/modernize-reading-settings' );
 
 type Settings = {
+	jetpack_relatedposts_enabled?: boolean;
+	jetpack_relatedposts_show_headline?: boolean;
+	jetpack_relatedposts_show_thumbnails?: boolean;
 	posts_per_page?: boolean;
 	posts_per_rss?: boolean;
 	wpcom_featured_image_in_email?: boolean;
@@ -26,6 +29,9 @@ const getFormSettings = ( settings: Settings ) => {
 	}
 
 	const {
+		jetpack_relatedposts_enabled,
+		jetpack_relatedposts_show_headline,
+		jetpack_relatedposts_show_thumbnails,
 		posts_per_page,
 		posts_per_rss,
 		wpcom_featured_image_in_email,
@@ -33,6 +39,9 @@ const getFormSettings = ( settings: Settings ) => {
 	} = settings;
 
 	return {
+		...( jetpack_relatedposts_enabled && { jetpack_relatedposts_enabled } ),
+		...( jetpack_relatedposts_show_headline && { jetpack_relatedposts_show_headline } ),
+		...( jetpack_relatedposts_show_thumbnails && { jetpack_relatedposts_show_thumbnails } ),
 		...( posts_per_page && { posts_per_page } ),
 		...( posts_per_rss && { posts_per_rss } ),
 		...( wpcom_featured_image_in_email && { wpcom_featured_image_in_email } ),
@@ -84,8 +93,10 @@ const ReadingSettingsForm = wrapSettingsForm( getFormSettings )(
 					<SiteSettingsSection
 						fields={ fields }
 						onChangeField={ onChangeField }
+						handleToggle={ handleToggle }
 						handleSubmitForm={ handleSubmitForm }
 						disabled={ disabled }
+						isRequestingSettings={ isRequestingSettings }
 						isSavingSettings={ isSavingSettings }
 					/>
 					<RssFeedSettingsSection


### PR DESCRIPTION
#### Proposed Changes

* Add Related Posts site setting to the new Reading Settings page
  * Refactor the already existing `RelatedPosts` setting component so that it can be re-used on the new Reading Settings page without affecting its look and feel of the existing implementation (in **Tools -> Marketing -> Traffic**)

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
1. Test the new setting in the new Reading Settings page
* Go to `http://calypso.localhost:3000/settings/reading/${siteSlug}`
* Play around with the "Related Posts" setting and ensure it is persisted when saved, and not persisted when not saved, across page re-loads
Note: Be aware of that there is an already reported [bug](https://github.com/Automattic/wp-calypso/issues/71071), tracked in another [ticket](https://github.com/Automattic/wp-calypso/issues/71071), where there is a pop-up message "Reload site? Changes you made may not be saved." appearing when a user wants to reload a page after having saved changes made using toggles.

2. Test the "Related Posts" setting in **Tools -> Marketing -> Traffic** to ensure no regressions. Note that this one is meant to be auto saved on every toggle change which is different to how it is meant to behave on the new Reading Settings page.
* Go to `http://calypso.localhost:3000/marketing/traffic/${siteSlug}`

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #70412

![Screen Capture on 2022-12-29 at 21-41-24](https://user-images.githubusercontent.com/2019970/210010542-570b2c2e-99c5-406e-be89-bcd95c3a0d20.gif)
