### PR TITLE
Add pricing to comparison page

### DIFF
--- a/client/jetpack-cloud/sections/comparison/table/index.tsx
+++ b/client/jetpack-cloud/sections/comparison/table/index.tsx
@@ -59,7 +59,7 @@ export const Table: React.FC = () => {
 								{ isFree ? translate( 'Get started' ) : getCtaLabel( item, '' ) }
 							</Button>
 
-							{ ! isFree && <ItemPrice item={ item } /> }
+							{ ! isFree && <ItemPrice item={ item } siteId={ null } /> }
 
 							{ isFree ? (
 								<span className="more-info-link">{ translate( 'Get started for free' ) }</span>

--- a/client/jetpack-cloud/sections/comparison/table/index.tsx
+++ b/client/jetpack-cloud/sections/comparison/table/index.tsx
@@ -2,7 +2,7 @@ import { TERM_ANNUALLY, PLAN_JETPACK_FREE } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { Fragment, useCallback, useMemo } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch } from 'react-redux';
 import ProductLightbox from 'calypso/my-sites/plans/jetpack-plans/product-lightbox';
 import StoreItemInfoContext, {
 	useStoreItemInfoContext,
@@ -13,7 +13,6 @@ import { ItemPrice } from 'calypso/my-sites/plans/jetpack-plans/product-store/it
 import { MoreInfoLink } from 'calypso/my-sites/plans/jetpack-plans/product-store/more-info-link';
 import slugToSelectorProduct from 'calypso/my-sites/plans/jetpack-plans/slug-to-selector-product';
 import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { getPurchaseURLCallback } from '../../../../my-sites/plans/jetpack-plans/get-purchase-url-callback';
 import { TableWithStoreContextProps } from '../types';
 import { links } from './links';
@@ -24,23 +23,14 @@ import './style.scss';
 
 export const Table: React.FC = () => {
 	const translate = useTranslate();
-	const siteId = useSelector( getSelectedSiteId );
 
 	const productsToCompare = useProductsToCompare();
 
 	const data = useComparisonData();
 
 	const { currentProduct, setCurrentProduct, onClickMoreInfoFactory } = useProductLightbox();
-	const {
-		getCheckoutURL,
-		getCtaLabel,
-		getIsExternal,
-		getOnClickPurchase,
-		getIsOwned,
-		getIsIncludedInPlan,
-		getIsMultisiteCompatible,
-		isMultisite,
-	} = useStoreItemInfoContext();
+	const { getCheckoutURL, getCtaLabel, getIsExternal, getOnClickPurchase } =
+		useStoreItemInfoContext();
 
 	const sectionHeadingColSpan = productsToCompare.length + 1;
 
@@ -53,10 +43,6 @@ export const Table: React.FC = () => {
 				const item = (
 					isFree ? { productSlug: PLAN_JETPACK_FREE } : slugToSelectorProduct( productSlug )
 				 ) as SelectorProduct;
-
-				const isOwned = getIsOwned( item );
-				const isIncludedInPlan = getIsIncludedInPlan( item );
-				const isMultiSiteIncompatible = isMultisite && ! getIsMultisiteCompatible( item );
 
 				return (
 					<th key={ id } scope="col" className={ `product product-jetpack-${ id.toLowerCase() }` }>
@@ -73,15 +59,7 @@ export const Table: React.FC = () => {
 								{ isFree ? translate( 'Get started' ) : getCtaLabel( item, '' ) }
 							</Button>
 
-							{ ! isFree && (
-								<ItemPrice
-									isMultiSiteIncompatible={ isMultiSiteIncompatible }
-									isIncludedInPlan={ isIncludedInPlan }
-									isOwned={ isOwned }
-									item={ item }
-									siteId={ siteId }
-								/>
-							) }
+							{ ! isFree && <ItemPrice item={ item } /> }
 
 							{ isFree ? (
 								<span className="more-info-link">{ translate( 'Get started for free' ) }</span>

--- a/client/jetpack-cloud/sections/comparison/table/style.scss
+++ b/client/jetpack-cloud/sections/comparison/table/style.scss
@@ -247,13 +247,14 @@
 		}
 	}
 
-
+	// Products with price need to be slightly wider so the placeholder size doesn't get warped
 	col.product {
-		width: 200px;
+		width: 230px;
 	}
 
 	col.product-jetpack-free {
 		background-color: rgba(157, 217, 119, 0.05);
+		width: 200px;
 	}
 
 	col.product-jetpack-backup {


### PR DESCRIPTION
#### Proposed Changes

This PR adds the pricing directly to the comparison page so that it is visible immediately for users. The "More info" links below the CTA's show pricing, but it is not immediately apparent that clicking on those will show you the price of the product.

This uses the existing price component used on the `/pricing` page and inserts it under the CTA but above the "More info" link

Context: p1621670951025100-slack-C01264051NE

#### Testing Instructions

1. Switch to this branch via `git switch add/pricing-to-comparison-page`
2. Start your local environment via `yarn start-jetpack-cloud`
3. Go to http://jetpack.cloud.localhost:3000/features/comparison
4. Confirm the prices are showing underneath the product CTA and ensure it looks alright on desktop and mobile
![image](https://user-images.githubusercontent.com/65001528/210013590-17874afd-c276-4307-a54d-bc1cc4ba619e.png)
5. Check the placeholders, when the column widths were slightly smaller, the placeholder was being squished and became much taller than it should've. Just make sure that is not happening 😄 

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?