### PR TITLE
Jetpack Search: do not mark as conflicting with Jetpack Complete

### DIFF
--- a/client/blocks/product-plan-overlap-notices/index.jsx
+++ b/client/blocks/product-plan-overlap-notices/index.jsx
@@ -2,6 +2,7 @@ import {
 	isJetpackProduct,
 	planHasFeature,
 	planHasSuperiorFeature,
+	JETPACK_SEARCH_PRODUCTS,
 } from '@automattic/calypso-products';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -58,8 +59,10 @@ class ProductPlanOverlapNotices extends Component {
 		// Does the current plan include the current product as a feature, or have a superior version of it?
 		return currentProductSlugs.filter(
 			( productSlug ) =>
-				planHasFeature( currentPlanSlug, productSlug ) ||
-				planHasSuperiorFeature( currentPlanSlug, productSlug )
+				// Skip the check for search products, they are included only partially (up to 100k records/requests)
+				! JETPACK_SEARCH_PRODUCTS.includes( productSlug ) &&
+				( planHasFeature( currentPlanSlug, productSlug ) ||
+					planHasSuperiorFeature( currentPlanSlug, productSlug ) )
 		);
 	}
 


### PR DESCRIPTION
#### Proposed Changes

Removes this warning about Jetpack Complete and Jetpack Search conflicting:

![image](https://user-images.githubusercontent.com/6437642/210030313-e559f1b3-3296-4c5b-9ea0-bba582f12f0e.png)

Jetpack Complete includes Jetpack Search up to 100k records and/or requests per month.
We will start suggesting purchasing additional Jetpack Search subscription to users who are over this limit.
We should not mark it as conflicting at the same time.

See panfyZ-1wq-p2#comment-3755

#### Testing Instructions

* Have a blog with both Jetpack Complete and Jetpack Search
* Go to <cloud.jetpack.com dev domain>/purchases/subscriptions/<your-blog-domain>
* Verify that the conflict is not shown.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #