### PR TITLE
Pricing Grid: Launch to en

### DIFF
--- a/client/my-sites/plan-features-2023-grid/header-price.jsx
+++ b/client/my-sites/plan-features-2023-grid/header-price.jsx
@@ -8,7 +8,7 @@ const PlanFeatures2023GridHeaderPrice = ( {
 	discountPrice,
 	currencyCode,
 	rawPrice,
-	is2023OnboardingPricingGrid,
+	isOnboarding2023PricingGrid,
 } ) => {
 	if ( isWpcomEnterpriseGridPlan( planName ) ) {
 		return null;
@@ -23,14 +23,14 @@ const PlanFeatures2023GridHeaderPrice = ( {
 							currencyCode={ currencyCode }
 							rawPrice={ rawPrice }
 							displayPerMonthNotation={ false }
-							is2023OnboardingPricingGrid={ is2023OnboardingPricingGrid }
+							isOnboarding2023PricingGrid={ isOnboarding2023PricingGrid }
 							original
 						/>
 						<PlanPrice
 							currencyCode={ currencyCode }
 							rawPrice={ discountPrice }
 							displayPerMonthNotation={ false }
-							is2023OnboardingPricingGrid={ is2023OnboardingPricingGrid }
+							isOnboarding2023PricingGrid={ isOnboarding2023PricingGrid }
 							discounted
 						/>
 					</div>
@@ -41,7 +41,7 @@ const PlanFeatures2023GridHeaderPrice = ( {
 					currencyCode={ currencyCode }
 					rawPrice={ rawPrice }
 					displayPerMonthNotation={ false }
-					is2023OnboardingPricingGrid={ is2023OnboardingPricingGrid }
+					isOnboarding2023PricingGrid={ isOnboarding2023PricingGrid }
 				/>
 			) }
 		</div>
@@ -53,7 +53,7 @@ PlanFeatures2023GridHeaderPrice.propTypes = {
 	discountPrice: PropTypes.number,
 	currencyCode: PropTypes.string,
 	rawPrice: PropTypes.number,
-	is2023OnboardingPricingGrid: PropTypes.bool,
+	isOnboarding2023PricingGrid: PropTypes.bool,
 };
 
 export default localize( PlanFeatures2023GridHeaderPrice );

--- a/client/my-sites/plan-features-2023-grid/index.jsx
+++ b/client/my-sites/plan-features-2023-grid/index.jsx
@@ -229,7 +229,7 @@ export class PlanFeatures2023Grid extends Component {
 	}
 
 	renderPlanPrice( planPropertiesObj, { isMobile } = {} ) {
-		const { isReskinned, is2023OnboardingPricingGrid } = this.props;
+		const { isReskinned, isOnboarding2023PricingGrid } = this.props;
 
 		return planPropertiesObj.map( ( properties ) => {
 			const { currencyCode, discountPrice, planName, rawPrice } = properties;
@@ -244,7 +244,7 @@ export class PlanFeatures2023Grid extends Component {
 						discountPrice={ discountPrice }
 						rawPrice={ rawPrice }
 						planName={ planName }
-						is2023OnboardingPricingGrid={ is2023OnboardingPricingGrid }
+						isOnboarding2023PricingGrid={ isOnboarding2023PricingGrid }
 					/>
 				</Container>
 			);

--- a/client/my-sites/plan-features-2023-grid/index.jsx
+++ b/client/my-sites/plan-features-2023-grid/index.jsx
@@ -546,7 +546,7 @@ PlanFeatures2023Grid.defaultProps = {
 /* eslint-disable wpcalypso/redux-no-bound-selectors */
 export default connect(
 	( state, ownProps ) => {
-		const { placeholder, plans, isLandingPage, visiblePlans } = ownProps;
+		const { placeholder, plans, visiblePlans } = ownProps;
 
 		let planProperties = plans.map( ( plan ) => {
 			let isPlaceholder = false;
@@ -645,7 +645,6 @@ export default connect(
 				discountPrice,
 				features: planFeatures,
 				jpFeatures: jetpackFeatures,
-				isLandingPage,
 				isPlaceholder,
 				planConstantObj,
 				planName: plan,

--- a/client/my-sites/plan-price/index.jsx
+++ b/client/my-sites/plan-price/index.jsx
@@ -22,7 +22,7 @@ export class PlanPrice extends Component {
 			taxText,
 			translate,
 			omitHeading,
-			is2023OnboardingPricingGrid,
+			isOnboarding2023PricingGrid,
 		} = this.props;
 
 		const classes = classNames( 'plan-price', className, {
@@ -107,7 +107,7 @@ export class PlanPrice extends Component {
 			// Remove it so that it's not confused to be a decimal point by the subtraction operator.
 			priceInteger = priceInteger.replace( /[,.]/g, '' );
 
-			if ( is2023OnboardingPricingGrid ) {
+			if ( isOnboarding2023PricingGrid ) {
 				return (
 					<div className="plan-price__integer-fraction">
 						<span className="plan-price__integer">{ priceObj.price.integer }</span>

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -38,7 +38,6 @@ import { get } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
-import AsyncLoad from 'calypso/components/async-load';
 import QueryPlans from 'calypso/components/data/query-plans';
 import QuerySitePlans from 'calypso/components/data/query-site-plans';
 import QuerySites from 'calypso/components/data/query-sites';
@@ -48,6 +47,7 @@ import Notice from 'calypso/components/notice';
 import { getTld } from 'calypso/lib/domains';
 import { isValidFeatureKey } from 'calypso/lib/plans/features-list';
 import PlanFeatures from 'calypso/my-sites/plan-features';
+import PlanFeatures2023Grid from 'calypso/my-sites/plan-features-2023-grid';
 import PlanFeaturesComparison from 'calypso/my-sites/plan-features-comparison';
 import isHappychatAvailable from 'calypso/state/happychat/selectors/is-happychat-available';
 import { selectSiteId as selectHappychatSiteId } from 'calypso/state/help/actions';
@@ -100,6 +100,48 @@ export class PlansFeaturesMain extends Component {
 		}
 	}
 
+	render2023PricingGrid() {
+		const {
+			customerType,
+			domainName,
+			isInSignup,
+			isLaunchPage,
+			onUpgradeClick,
+			flowName,
+			isReskinned,
+			isOnboarding2023PricingGrid,
+		} = this.props;
+
+		const plans = this.getPlansForPlanFeatures();
+		const visiblePlans = this.getVisiblePlansForPlanFeatures( plans );
+
+		const componentProps = {
+			domainName,
+			isInSignup,
+			isLaunchPage,
+			onUpgradeClick,
+			plans,
+			visiblePlans,
+			flowName,
+			isReskinned,
+			isOnboarding2023PricingGrid,
+		};
+
+		return (
+			<div
+				className={ classNames(
+					'plans-features-main__group',
+					'is-wpcom',
+					`is-customer-${ customerType }`,
+					'is-2023-pricing-grid'
+				) }
+				data-e2e-plans="wpcom"
+			>
+				<PlanFeatures2023Grid { ...componentProps } />
+			</div>
+		);
+	}
+
 	showFeatureComparison() {
 		const {
 			basePlansPath,
@@ -121,60 +163,10 @@ export class PlansFeaturesMain extends Component {
 			isReskinned,
 			isFAQCondensedExperiment,
 			isPlansInsideStepper,
-			isOnboarding2023PricingGrid,
 		} = this.props;
 
 		const plans = this.getPlansForPlanFeatures();
 		const visiblePlans = this.getVisiblePlansForPlanFeatures( plans );
-
-		if ( isOnboarding2023PricingGrid ) {
-			const asyncProps = {
-				basePlansPath,
-				domainName,
-				isInSignup,
-				isLandingPage,
-				isLaunchPage,
-				onUpgradeClick,
-				plans,
-				flowName,
-				redirectTo,
-				visiblePlans,
-				selectedFeature,
-				selectedPlan,
-				withDiscount,
-				discountEndDate,
-				withScroll: plansWithScroll,
-				popularPlanSpec: getPopularPlanSpec( {
-					flowName,
-					customerType,
-					isJetpack,
-					availablePlans: visiblePlans,
-				} ),
-				siteId,
-				isReskinned,
-				isPlansInsideStepper,
-				isOnboarding2023PricingGrid,
-			};
-			const asyncPlanFeatures2023Grid = (
-				<AsyncLoad require="calypso/my-sites/plan-features-2023-grid" { ...asyncProps } />
-			);
-			return (
-				<div
-					className={ classNames(
-						'plans-features-main__group',
-						'is-wpcom',
-						`is-customer-${ customerType }`,
-						'is-2023-pricing-grid',
-						{
-							'is-scrollable': plansWithScroll,
-						}
-					) }
-					data-e2e-plans="wpcom"
-				>
-					{ asyncPlanFeatures2023Grid }
-				</div>
-			);
-		}
 
 		return (
 			<div
@@ -554,13 +546,10 @@ export class PlansFeaturesMain extends Component {
 	}
 
 	renderPlansGrid() {
-		const { shouldShowPlansFeatureComparison, flowName } = this.props;
+		const { isOnboarding2023PricingGrid, shouldShowPlansFeatureComparison } = this.props;
 
-		if (
-			isEnabled( 'onboarding/2023-pricing-grid' ) &&
-			flowName === 'onboarding-2023-pricing-grid'
-		) {
-			return this.showFeatureComparison();
+		if ( isOnboarding2023PricingGrid ) {
+			return this.render2023PricingGrid();
 		}
 
 		return shouldShowPlansFeatureComparison ? this.showFeatureComparison() : this.getPlanFeatures();

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -121,15 +121,13 @@ export class PlansFeaturesMain extends Component {
 			isReskinned,
 			isFAQCondensedExperiment,
 			isPlansInsideStepper,
+			isOnboarding2023PricingGrid,
 		} = this.props;
 
 		const plans = this.getPlansForPlanFeatures();
 		const visiblePlans = this.getVisiblePlansForPlanFeatures( plans );
 
-		if (
-			isEnabled( 'onboarding/2023-pricing-grid' ) &&
-			flowName === 'onboarding-2023-pricing-grid'
-		) {
+		if ( isOnboarding2023PricingGrid ) {
 			const asyncProps = {
 				basePlansPath,
 				domainName,
@@ -155,9 +153,7 @@ export class PlansFeaturesMain extends Component {
 				siteId,
 				isReskinned,
 				isPlansInsideStepper,
-				is2023OnboardingPricingGrid:
-					isEnabled( 'onboarding/2023-pricing-grid' ) &&
-					flowName === 'onboarding-2023-pricing-grid',
+				isOnboarding2023PricingGrid,
 			};
 			const asyncPlanFeatures2023Grid = (
 				<AsyncLoad require="calypso/my-sites/plan-features-2023-grid" { ...asyncProps } />
@@ -349,7 +345,7 @@ export class PlansFeaturesMain extends Component {
 			sitePlanSlug,
 			showTreatmentPlansReorderTest,
 			flowName,
-			isInSignup,
+			isOnboarding2023PricingGrid,
 		} = this.props;
 
 		const hideBloggerPlan = ! isBloggerPlan( selectedPlan ) && ! isBloggerPlan( sitePlanSlug );
@@ -369,9 +365,7 @@ export class PlansFeaturesMain extends Component {
 				findPlansKeys( { group: GROUP_WPCOM, term, type: TYPE_PREMIUM } )[ 0 ],
 				findPlansKeys( { group: GROUP_WPCOM, term, type: TYPE_BUSINESS } )[ 0 ],
 				findPlansKeys( { group: GROUP_WPCOM, term, type: TYPE_ECOMMERCE } )[ 0 ],
-				isEnabled( 'onboarding/2023-pricing-grid' ) &&
-				isInSignup &&
-				flowName === 'onboarding-2023-pricing-grid'
+				isOnboarding2023PricingGrid
 					? findPlansKeys( { group: GROUP_WPCOM, type: TYPE_ENTERPRISE_GRID_WPCOM } )[ 0 ]
 					: null,
 			].filter( ( el ) => el !== null );
@@ -435,7 +429,7 @@ export class PlansFeaturesMain extends Component {
 			isAllPaidPlansShown,
 			isInMarketplace,
 			sitePlanSlug,
-			flowName,
+			isOnboarding2023PricingGrid,
 		} = this.props;
 
 		const isPlanOneOfType = ( plan, types ) =>
@@ -455,10 +449,7 @@ export class PlansFeaturesMain extends Component {
 			  } )
 			: availablePlans;
 
-		if (
-			isEnabled( 'onboarding/2023-pricing-grid' ) &&
-			flowName === 'onboarding-2023-pricing-grid'
-		) {
+		if ( isOnboarding2023PricingGrid ) {
 			return plans.filter( ( plan ) =>
 				isPlanOneOfType( plan, [
 					TYPE_FREE,

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -114,16 +114,6 @@ export function generateFlows( {
 			showRecaptcha: true,
 		},
 		{
-			name: 'onboarding-2023-pricing-grid',
-			steps: isEnabled( 'signup/professional-email-step' )
-				? [ 'user', 'domains', 'emails', 'plans' ]
-				: [ 'user', 'domains', 'plans' ],
-			destination: getSignupDestination,
-			description: 'Abridged version of the onboarding flow. Read more in https://wp.me/pau2Xa-Vs.',
-			lastModified: '2020-12-10',
-			showRecaptcha: true,
-		},
-		{
 			name: 'newsletter',
 			steps: [ 'domains', 'plans-newsletter' ],
 			destination: ( dependencies ) =>

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -6,6 +6,7 @@ import {
 } from '@automattic/calypso-products';
 import { isBlankCanvasDesign } from '@automattic/design-picker';
 import { isNewsletterOrLinkInBioFlow, LINK_IN_BIO_TLD_FLOW } from '@automattic/onboarding';
+import classNames from 'classnames';
 import debugModule from 'debug';
 import {
 	clone,
@@ -875,10 +876,16 @@ class Signup extends Component {
 		}
 
 		const isReskinned = isReskinnedFlow( this.props.flowName );
+		const isOnboarding2023PricingGrid = config( 'english_locales' ).includes(
+			this.props.localeSlug
+		);
+		const classes = classNames( 'signup', `is-${ kebabCase( this.props.flowName ) }`, {
+			'is-onboarding-2023-pricing-grid': isOnboarding2023PricingGrid,
+		} );
 
 		return (
 			<>
-				<div className={ `signup is-${ kebabCase( this.props.flowName ) }` }>
+				<div className={ classes }>
 					<DocumentHead title={ this.props.pageTitle } />
 					{ ! isP2Flow( this.props.flowName ) && (
 						<SignupHeader

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -774,12 +774,13 @@ class Signup extends Component {
 
 		// Hide the free option in the signup flow
 		const selectedHideFreePlan = get( this.props, 'signupDependencies.shouldHideFreePlan', false );
+		const isOnboarding2023PricingGrid = config( 'english_locales' ).includes(
+			this.props.localeSlug
+		);
 
-		const hideFreePlan =
-			config.isEnabled( 'onboarding/2023-pricing-grid' ) &&
-			this.props.flowName === 'onboarding-2023-pricing-grid'
-				? false
-				: planWithDomain || this.props.isDomainOnlySite || selectedHideFreePlan;
+		const hideFreePlan = isOnboarding2023PricingGrid
+			? false
+			: planWithDomain || this.props.isDomainOnlySite || selectedHideFreePlan;
 		const shouldRenderLocaleSuggestions = 0 === this.getPositionInFlow() && ! this.props.isLoggedIn;
 
 		let propsForCurrentStep = propsFromConfig;
@@ -818,6 +819,7 @@ class Signup extends Component {
 							hideFreePlan={ hideFreePlan }
 							isReskinned={ isReskinned }
 							queryParams={ this.getCurrentFlowSupportedQueryParams() }
+							isOnboarding2023PricingGrid={ isOnboarding2023PricingGrid }
 							{ ...propsForCurrentStep }
 						/>
 					) }

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import {
 	planHasFeature,
 	FEATURE_UPLOAD_THEMES_PLUGINS,
@@ -194,6 +193,7 @@ export class PlansStep extends Component {
 			isInVerticalScrollingPlansExperiment,
 			isReskinned,
 			eligibleForProPlan,
+			isOnboarding2023PricingGrid,
 		} = this.props;
 
 		let errorDisplay;
@@ -257,6 +257,7 @@ export class PlansStep extends Component {
 					isInVerticalScrollingPlansExperiment={ isInVerticalScrollingPlansExperiment }
 					shouldShowPlansFeatureComparison={ this.state.isDesktop } // Show feature comparison layout in signup flow and desktop resolutions
 					isReskinned={ isReskinned }
+					isOnboarding2023PricingGrid={ isOnboarding2023PricingGrid }
 				/>
 			</div>
 		);
@@ -475,7 +476,7 @@ export const isDotBlogDomainRegistration = ( domainItem ) => {
 export default connect(
 	(
 		state,
-		{ path, flowName, signupDependencies: { siteSlug, domainItem, plans_reorder_abtest_variation } }
+		{ path, signupDependencies: { siteSlug, domainItem, plans_reorder_abtest_variation } }
 	) => ( {
 		// Blogger plan is only available if user chose either a free domain or a .blog domain registration
 		disableBloggerPlanWithNonBlogDomain:
@@ -496,8 +497,6 @@ export default connect(
 		isInVerticalScrollingPlansExperiment: true,
 		plansLoaded: Boolean( getPlanSlug( state, getPlan( PLAN_FREE )?.getProductId() || 0 ) ),
 		eligibleForProPlan: isEligibleForProPlan( state, getSiteBySlug( state, siteSlug )?.ID ),
-		isOnboarding2023PricingGrid:
-			isEnabled( 'onboarding/2023-pricing-grid' ) && flowName === 'onboarding-2023-pricing-grid',
 	} ),
 	{ recordTracksEvent, saveSignupStep, submitSignupStep, errorNotice }
 )( localize( PlansStep ) );


### PR DESCRIPTION
#### Proposed Changes

* This PR launches the new pricing grid to `en` and in all signup flows that have a plans step such as `onboarding` flow and `/launch-site` flow.
* The existing pricing grid is shown to non-EN.
* The new pricing grid will be seen in all signup flow

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go through the signup flow `/start`:
    *   In `en`, you should see the new pricing grid.
    * In non-EN, you should see the existing pricing grid.
* Go through the site launch flow:
    *   In `en`, you should see the new pricing grid.
    * In non-EN, you should see the existing pricing grid.
* Add a new site. Verify you see the new pricing grid in `en`, and old pricing grid in non-EN.
* Confirm that Calypso `/plans` page is unaffected in both `en` and non-EN.
* Verify that the free plan is always visible, whether or not you select a custom domain in the plans step.
* Verify that site creation works with any plan selection (except Enterprise which will open the VIP landing page).
* Verify you can see the new pricing grid in the plans step of the domain-only flow signup flow, when you select the option to create a site after selecting a domain.

