### PR TITLE
Reading Settings: Add 'For each new post, include...' RSS feed setting

### DIFF
--- a/client/my-sites/site-settings/reading-rss-feed-settings/ExcerptSetting.tsx
+++ b/client/my-sites/site-settings/reading-rss-feed-settings/ExcerptSetting.tsx
@@ -1,0 +1,59 @@
+import { localizeUrl } from '@automattic/i18n-utils';
+import { useTranslate } from 'i18n-calypso';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+import FormLabel from 'calypso/components/forms/form-label';
+import FormRadio from 'calypso/components/forms/form-radio';
+import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
+
+type ExcerptSettingProps = {
+	value?: boolean;
+	disabled?: boolean;
+	updateFields?: ( fields: { [ key: string ]: unknown } ) => void;
+};
+
+export const ExcerptSetting = ( {
+	value = false,
+	disabled,
+	updateFields,
+}: ExcerptSettingProps ) => {
+	const translate = useTranslate();
+	return (
+		<FormFieldset>
+			<FormLabel>For each post in a feed, include</FormLabel>
+			<FormLabel>
+				{ /* @ts-expect-error FormRadio is not typed and is causing errors */ }
+				<FormRadio
+					checked={ ! value }
+					onChange={ () => updateFields?.( { rss_use_excerpt: false } ) }
+					disabled={ disabled }
+					label={ translate( 'Full text' ) }
+				/>
+			</FormLabel>
+			<FormLabel>
+				{ /* @ts-expect-error FormRadio is not typed and is causing errors */ }
+				<FormRadio
+					checked={ value }
+					onChange={ () => updateFields?.( { rss_use_excerpt: true } ) }
+					disabled={ disabled }
+					label={ translate( 'Excerpt' ) }
+				/>
+			</FormLabel>
+			<FormSettingExplanation>
+				{ translate(
+					'Sets whether RSS subscribers can read full posts in their RSS reader, or just an excerpt and link to the full version on your site. {{link}}Learn more about feeds{{/link}}.',
+					{
+						components: {
+							link: (
+								<a
+									href={ localizeUrl( 'https://wordpress.com/support/feeds/' ) }
+									target="_blank"
+									rel="noreferrer"
+								/>
+							),
+						},
+					}
+				) }
+			</FormSettingExplanation>
+		</FormFieldset>
+	);
+};

--- a/client/my-sites/site-settings/reading-rss-feed-settings/index.tsx
+++ b/client/my-sites/site-settings/reading-rss-feed-settings/index.tsx
@@ -1,16 +1,19 @@
 import { Card } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
+import { ExcerptSetting } from './ExcerptSetting';
 import { SyndicationFeedsSetting, SYNDICATION_FEEDS_OPTION } from './SyndicationFeedsSetting';
 
 type Fields = {
 	posts_per_rss?: number;
+	rss_use_excerpt?: boolean;
 };
 
 type RssFeedSettingsSectionProps = {
 	fields: Fields;
 	onChangeField: ( field: string ) => ( event: React.ChangeEvent< HTMLInputElement > ) => void;
 	handleSubmitForm: ( event: React.FormEvent< HTMLFormElement > ) => void;
+	updateFields: ( fields: Fields ) => void;
 	disabled?: boolean;
 	siteUrl?: string;
 	isSavingSettings?: boolean;
@@ -20,12 +23,13 @@ export const RssFeedSettingsSection = ( {
 	fields,
 	onChangeField,
 	handleSubmitForm,
+	updateFields,
 	disabled,
 	siteUrl,
 	isSavingSettings,
 }: RssFeedSettingsSectionProps ) => {
 	const translate = useTranslate();
-	const { posts_per_rss } = fields;
+	const { posts_per_rss, rss_use_excerpt } = fields;
 
 	return (
 		<>
@@ -37,12 +41,19 @@ export const RssFeedSettingsSection = ( {
 				disabled={ disabled }
 				isSaving={ isSavingSettings }
 			/>
-			<Card>
+			<Card className="site-settings__card">
 				<SyndicationFeedsSetting
 					value={ posts_per_rss }
 					onChange={ onChangeField( SYNDICATION_FEEDS_OPTION ) }
 					disabled={ disabled }
 					siteUrl={ siteUrl }
+				/>
+			</Card>
+			<Card className="site-settings__card">
+				<ExcerptSetting
+					value={ rss_use_excerpt }
+					updateFields={ updateFields }
+					disabled={ disabled }
 				/>
 			</Card>
 		</>

--- a/client/my-sites/site-settings/settings-reading/main.tsx
+++ b/client/my-sites/site-settings/settings-reading/main.tsx
@@ -16,6 +16,7 @@ const isEnabled = config.isEnabled( 'settings/modernize-reading-settings' );
 type Settings = {
 	posts_per_page?: boolean;
 	posts_per_rss?: boolean;
+	rss_use_excerpt?: boolean;
 	wpcom_featured_image_in_email?: boolean;
 	wpcom_subscription_emails_use_excerpt?: boolean;
 };
@@ -28,6 +29,7 @@ const getFormSettings = ( settings: Settings ) => {
 	const {
 		posts_per_page,
 		posts_per_rss,
+		rss_use_excerpt,
 		wpcom_featured_image_in_email,
 		wpcom_subscription_emails_use_excerpt,
 	} = settings;
@@ -35,6 +37,7 @@ const getFormSettings = ( settings: Settings ) => {
 	return {
 		...( posts_per_page && { posts_per_page } ),
 		...( posts_per_rss && { posts_per_rss } ),
+		...( rss_use_excerpt && { rss_use_excerpt } ),
 		...( wpcom_featured_image_in_email && { wpcom_featured_image_in_email } ),
 		...( wpcom_subscription_emails_use_excerpt && { wpcom_subscription_emails_use_excerpt } ),
 	};
@@ -51,6 +54,7 @@ const connectComponent = connect( ( state ) => {
 type Fields = {
 	posts_per_page?: number;
 	posts_per_rss?: number;
+	rss_use_excerpt?: boolean;
 	wpcom_featured_image_in_email?: boolean;
 	wpcom_subscription_emails_use_excerpt?: boolean;
 };
@@ -92,6 +96,7 @@ const ReadingSettingsForm = wrapSettingsForm( getFormSettings )(
 						fields={ fields }
 						onChangeField={ onChangeField }
 						handleSubmitForm={ handleSubmitForm }
+						updateFields={ updateFields }
 						disabled={ disabled }
 						isSavingSettings={ isSavingSettings }
 						siteUrl={ siteUrl }


### PR DESCRIPTION
#### Proposed Changes

* Add "For each new post, include..." RSS feed setting to the new Reading Settings page
* The setting is persisted as boolean value under the `rss_use_excerpt` option on the backend
* Change in the setting is only persisted on "Save" button click

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `http://calypso.localhost:3000/settings/reading/${siteSlug}`

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/70423

![Screen Capture on 2022-12-30 at 10-57-27](https://user-images.githubusercontent.com/2019970/210058162-d909e7a0-efba-461d-877f-3ee214b85407.gif)

