### PR TITLE
Fix unified design picker mShot config

### DIFF
--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -58,8 +58,8 @@ const DesignPreviewImage: React.FC< DesignPreviewImageProps > = ( {
 			} ) }
 			aria-labelledby={ makeOptionId( design ) }
 			alt=""
-			options={ getMShotOptions( { scrollable: true, highRes: false, isMobile } ) }
-			scrollable={ true }
+			options={ getMShotOptions( { scrollable: false, highRes: false, isMobile } ) }
+			scrollable={ false }
 		/>
 	);
 };

--- a/packages/design-picker/src/utils/available-designs.ts
+++ b/packages/design-picker/src/utils/available-designs.ts
@@ -57,7 +57,9 @@ export const getMShotOptions = ( {
 	// Take care changing these values, as the design-picker CSS animations are written for these values (see the *__landscape and *__portrait classes)
 	return {
 		vpw: isMobile ? MOBILE_VIEWPORT_WIDTH : DEFAULT_VIEWPORT_WIDTH,
-		// 901 renders well with all the current designs
+		// 901 renders well with all the current designs, more details in the links below
+		// https://github.com/Automattic/wp-calypso/issues/71439#issuecomment-1367335609
+		// https://github.com/Automattic/wp-calypso/issues/71439#issuecomment-1369694397
 		vph: scrollable ? 1600 : 901,
 		// When `w` was 1200 it created a visual glitch on one thumbnail. #57261
 		w: highRes ? 1199 : 600,

--- a/packages/design-picker/src/utils/available-designs.ts
+++ b/packages/design-picker/src/utils/available-designs.ts
@@ -57,7 +57,8 @@ export const getMShotOptions = ( {
 	// Take care changing these values, as the design-picker CSS animations are written for these values (see the *__landscape and *__portrait classes)
 	return {
 		vpw: isMobile ? MOBILE_VIEWPORT_WIDTH : DEFAULT_VIEWPORT_WIDTH,
-		vph: scrollable ? 1600 : 1040,
+		// 901 renders well with all the current designs
+		vph: scrollable ? 1600 : 901,
 		// When `w` was 1200 it created a visual glitch on one thumbnail. #57261
 		w: highRes ? 1199 : 600,
 		screen_height: 3600,


### PR DESCRIPTION
#### Proposed Changes

* Make scrollable false (p1672387691133409/1672385901.465829-slack-CRWCHQGUB)
Note: scrollable is not working even when set to true (was testing in Chrome).
* Adjust the mShot config according to [this comment](https://github.com/Automattic/wp-calypso/issues/71439#issuecomment-1367335609)

| Before  | After |
| :-------------: | :-------------: |
| <img src="https://user-images.githubusercontent.com/6586048/210066401-77651d50-eecb-404a-8bf5-01b456156e73.png">  | <img src="https://user-images.githubusercontent.com/6586048/210066407-d48049a8-446f-44c8-87b4-993bea38a08e.png">|


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout to this branch
* Go to `/setup/site-setup/designSetup?siteSlug=:site`
* Check if screenshots for all designs look normal on desktop and mobile

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] ~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~
- [ ] ~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~
- [ ] ~For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #71439 