### PR TITLE
Implement the revamped Logged out Plugins header

### DIFF
--- a/client/components/main/index.jsx
+++ b/client/components/main/index.jsx
@@ -8,10 +8,12 @@ export default function Main( {
 	children,
 	wideLayout = false,
 	fullWidthLayout = false,
+	isRedesign = false,
 } ) {
 	const classes = classNames( className, 'main', {
 		'is-wide-layout': wideLayout,
 		'is-full-width-layout': fullWidthLayout,
+		'is-redesign': isRedesign,
 	} );
 
 	return (

--- a/client/components/main/index.jsx
+++ b/client/components/main/index.jsx
@@ -8,12 +8,12 @@ export default function Main( {
 	children,
 	wideLayout = false,
 	fullWidthLayout = false,
-	isRedesign = false,
+	isLoggedOut = false,
 } ) {
 	const classes = classNames( className, 'main', {
 		'is-wide-layout': wideLayout,
 		'is-full-width-layout': fullWidthLayout,
-		'is-redesign': isRedesign,
+		'is-logged-out': isLoggedOut,
 	} );
 
 	return (

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -125,9 +125,8 @@ const PluginsBrowser = ( { trackPageViews = true, category, search, hideHeader }
 	if ( ! isRequestingSitesData && noPermissionsError ) {
 		return <NoPermissionsError title={ __( 'Plugins' ) } />;
 	}
-	const isRedesign = ! isLoggedIn;
 	return (
-		<MainComponent wideLayout isRedesign={ isRedesign }>
+		<MainComponent wideLayout isLoggedOut={ ! isLoggedIn }>
 			<QueryProductsList persist />
 			<QueryPlugins siteId={ selectedSite?.ID } />
 			<QuerySitePurchases siteId={ selectedSite?.ID } />
@@ -161,7 +160,7 @@ const PluginsBrowser = ( { trackPageViews = true, category, search, hideHeader }
 						: __( 'Plugins you need to get your projects done' )
 				}
 				subtitle={
-					isRedesign &&
+					! isLoggedIn &&
 					( 'en' === locale ||
 						hasTranslation(
 							'Add new functionality and integrations to your site with thousands of plugins.'

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -34,10 +34,9 @@ import PluginsSearchResultPage from '../plugins-search-results-page';
 
 import './style.scss';
 
-const PageViewTrackerWrapper = ( { category, selectedSiteId, trackPageViews } ) => {
+const PageViewTrackerWrapper = ( { category, selectedSiteId, trackPageViews, isLoggedIn } ) => {
 	const analyticsPageTitle = 'Plugin Browser' + category ? ` > ${ category }` : '';
 	let analyticsPath = category ? `/plugins/browse/${ category }` : '/plugins';
-	const isLoggedIn = useSelector( isUserLoggedIn );
 
 	if ( selectedSiteId ) {
 		analyticsPath += '/:site';
@@ -83,14 +82,13 @@ const PluginsBrowser = ( { trackPageViews = true, category, search, hideHeader }
 	const siteSlug = useSelector( getSelectedSiteSlug );
 	const siteId = useSelector( getSelectedSiteId );
 	const sites = useSelector( getSelectedOrAllSitesJetpackCanManage );
+	const isLoggedIn = useSelector( isUserLoggedIn );
 
 	const { __, hasTranslation } = useI18n();
 	const locale = useLocale();
 
 	const categories = useCategories();
 	const categoryName = categories[ category ]?.menu || __( 'Plugins' );
-
-	const isRedesign = true;
 
 	// this is a temporary hack until we merge Phase 4 of the refactor
 	const renderList = () => {
@@ -127,9 +125,9 @@ const PluginsBrowser = ( { trackPageViews = true, category, search, hideHeader }
 	if ( ! isRequestingSitesData && noPermissionsError ) {
 		return <NoPermissionsError title={ __( 'Plugins' ) } />;
 	}
-
+	const isRedesign = ! isLoggedIn;
 	return (
-		<MainComponent wideLayout isRedesign>
+		<MainComponent wideLayout isRedesign={ isRedesign }>
 			<QueryProductsList persist />
 			<QueryPlugins siteId={ selectedSite?.ID } />
 			<QuerySitePurchases siteId={ selectedSite?.ID } />
@@ -137,11 +135,12 @@ const PluginsBrowser = ( { trackPageViews = true, category, search, hideHeader }
 				category={ category }
 				selectedSiteId={ selectedSite?.ID }
 				trackPageViews={ trackPageViews }
+				isLoggedIn={ isLoggedIn }
 			/>
 			<DocumentHead title={ __( 'Plugins' ) } />
 
 			<PluginsAnnouncementModal />
-			{ ! hideHeader && ! isRedesign && (
+			{ ! hideHeader && (
 				<PluginsNavigationHeader
 					navigationHeaderRef={ navigationHeaderRef }
 					categoryName={ categoryName }
@@ -153,13 +152,21 @@ const PluginsBrowser = ( { trackPageViews = true, category, search, hideHeader }
 			<SearchBoxHeader
 				searchRef={ searchRef }
 				stickySearchBoxRef={ searchHeaderRef }
-				isSticky={ ! isRedesign && isAboveElement }
+				isSticky={ isAboveElement }
 				searchTerm={ search }
 				isSearching={ isFetchingPluginsBySearchTerm }
 				title={
 					'en' === locale || hasTranslation( 'Flex your site’s features with plugins' )
 						? __( 'Flex your site’s features with plugins' )
 						: __( 'Plugins you need to get your projects done' )
+				}
+				subtitle={
+					isRedesign &&
+					( 'en' === locale ||
+						hasTranslation(
+							'Add new functionality and integrations to your site with thousands of plugins.'
+						) ) &&
+					__( 'Add new functionality and integrations to your site with thousands of plugins.' )
 				}
 				searchTerms={ [ 'seo', 'pay', 'booking', 'ecommerce', 'newsletter' ] }
 				renderTitleInH1={ ! category }

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -90,6 +90,8 @@ const PluginsBrowser = ( { trackPageViews = true, category, search, hideHeader }
 	const categories = useCategories();
 	const categoryName = categories[ category ]?.menu || __( 'Plugins' );
 
+	const isRedesign = true;
+
 	// this is a temporary hack until we merge Phase 4 of the refactor
 	const renderList = () => {
 		if ( search ) {
@@ -127,7 +129,7 @@ const PluginsBrowser = ( { trackPageViews = true, category, search, hideHeader }
 	}
 
 	return (
-		<MainComponent wideLayout>
+		<MainComponent wideLayout isRedesign>
 			<QueryProductsList persist />
 			<QueryPlugins siteId={ selectedSite?.ID } />
 			<QuerySitePurchases siteId={ selectedSite?.ID } />
@@ -139,7 +141,7 @@ const PluginsBrowser = ( { trackPageViews = true, category, search, hideHeader }
 			<DocumentHead title={ __( 'Plugins' ) } />
 
 			<PluginsAnnouncementModal />
-			{ ! hideHeader && (
+			{ ! hideHeader && ! isRedesign && (
 				<PluginsNavigationHeader
 					navigationHeaderRef={ navigationHeaderRef }
 					categoryName={ categoryName }
@@ -151,7 +153,7 @@ const PluginsBrowser = ( { trackPageViews = true, category, search, hideHeader }
 			<SearchBoxHeader
 				searchRef={ searchRef }
 				stickySearchBoxRef={ searchHeaderRef }
-				isSticky={ isAboveElement }
+				isSticky={ ! isRedesign && isAboveElement }
 				searchTerm={ search }
 				isSearching={ isFetchingPluginsBySearchTerm }
 				title={

--- a/client/my-sites/plugins/plugins-browser/style.scss
+++ b/client/my-sites/plugins/plugins-browser/style.scss
@@ -71,8 +71,35 @@
 	}
 }
 
-.is-redesign .layout__content {
+body.is-section-plugins #primary .main.is-redesign {
 	padding-top: 0;
+
+	.fixed-navigation-header__header {
+		visibility: hidden;
+	}
+
+	.responsive-toolbar-group__swipe-list {
+		background: none;
+		margin-bottom: 22px;
+	}
+
+	.responsive-toolbar-group__dropdown {
+		margin-bottom: 20px;
+		padding: 0 8px;
+
+		.responsive-toolbar-group__button-item {
+			padding: 0 16px;
+		}
+		.responsive-toolbar-group__button-item:not([class*="is-pressed"]):hover::before {
+			background: none;
+		}
+	}
+
+	.components-button.is-pressed::before {
+		background: #0675c4;
+		left: 4px;
+		right: 4px;
+	}
 }
 // Jetpack injects a banner on the /plugins page for jetpack sites
 .is-section-plugins .layout__content > .banner {

--- a/client/my-sites/plugins/plugins-browser/style.scss
+++ b/client/my-sites/plugins/plugins-browser/style.scss
@@ -71,7 +71,7 @@
 	}
 }
 
-body.is-section-plugins #primary .main.is-redesign {
+body.is-section-plugins #primary .main.is-logged-out {
 	padding-top: 0;
 
 	.fixed-navigation-header__header {
@@ -91,12 +91,12 @@ body.is-section-plugins #primary .main.is-redesign {
 			padding: 0 16px;
 		}
 		.responsive-toolbar-group__button-item:not([class*="is-pressed"]):hover::before {
-			background: none;
+			background: rgba(6, 117, 196, 0.1);
 		}
 	}
 
 	.components-button.is-pressed::before {
-		background: #0675c4;
+		background: var(--studio-blue-50);
 		left: 4px;
 		right: 4px;
 	}

--- a/client/my-sites/plugins/plugins-browser/style.scss
+++ b/client/my-sites/plugins/plugins-browser/style.scss
@@ -71,6 +71,9 @@
 	}
 }
 
+.is-redesign .layout__content {
+	padding-top: 0;
+}
 // Jetpack injects a banner on the /plugins page for jetpack sites
 .is-section-plugins .layout__content > .banner {
 	// This moves it down out from under our sticky header

--- a/client/my-sites/plugins/search-box-header/index.jsx
+++ b/client/my-sites/plugins/search-box-header/index.jsx
@@ -41,6 +41,7 @@ const SearchBoxHeader = ( props ) => {
 	const {
 		searchTerm,
 		title,
+		subtitle,
 		isSticky,
 		stickySearchBoxRef,
 		isSearching,
@@ -68,6 +69,7 @@ const SearchBoxHeader = ( props ) => {
 		<div className={ classNames.join( ' ' ) }>
 			{ renderTitleInH1 && <h1 className="search-box-header__header">{ title }</h1> }
 			{ ! renderTitleInH1 && <div className="search-box-header__header">{ title }</div> }
+			{ subtitle && <p className="search-box-header__subtitle">{ subtitle }</p> }
 			<div className="search-box-header__search">
 				<SearchBox
 					searchTerm={ searchTerm }

--- a/client/my-sites/plugins/search-box-header/index.jsx
+++ b/client/my-sites/plugins/search-box-header/index.jsx
@@ -58,8 +58,14 @@ const SearchBoxHeader = ( props ) => {
 		}
 	}, [ searchRef, searchTerm ] );
 
+	const classNames = [ 'search-box-header' ];
+
+	if ( isSticky ) {
+		classNames.push( 'fixed-top' );
+	}
+
 	return (
-		<div className={ isSticky ? 'search-box-header fixed-top' : 'search-box-header' }>
+		<div className={ classNames.join( ' ' ) }>
 			{ renderTitleInH1 && <h1 className="search-box-header__header">{ title }</h1> }
 			{ ! renderTitleInH1 && <div className="search-box-header__header">{ title }</div> }
 			<div className="search-box-header__search">

--- a/client/my-sites/plugins/search-box-header/style.scss
+++ b/client/my-sites/plugins/search-box-header/style.scss
@@ -157,27 +157,36 @@
 	}
 }
 
-.is-redesign .search-box-header {
+main.is-redesign .search-box-header {
 	align-items: flex-start;
-	margin-bottom: 34px;
+	margin-bottom: 7px;
+	margin-top: -15px;
+
+	&.fixed-top .search-box-header__search {
+		justify-content: center;
+		background: #e5f4ff;
+	}
 
 	.search-box-header__header {
-		font-size: $font-title-large;
+		font-size: rem(44px);
 		color: #0675c4;
 		padding-top: 0;
-		max-width: 500px;
 		line-height: 1.15;
 		text-align: left;
+		margin-bottom: 16px;
+	}
+	.search-box-header__subtitle {
+		margin-bottom: 0;
 	}
 
 	.search-box-header__search {
 		justify-content: flex-start;
-		margin-top: 21px;
-
+		margin-top: 17px;
 
 		.search-box-header__searchbox .search-component {
 			margin-left: 0;
-			max-width: 447px;
+			height: 55px;
+			max-width: 450px;
 			box-shadow:
 				0 0 0 0 rgba(38, 19, 19, 0.03),
 				0 1px 2px 0 rgba(38, 19, 19, 0.03),
@@ -189,10 +198,11 @@
 			.search-component__open-icon {
 				color: var(--studio-gray-30);
 				transform: scaleX(-1);
+				height: 33px;
 			}
 			input.search-component__input[type="search"],
 			input.search-component__input[type="search"]::placeholder {
-				color: var(--studio-blue-90);
+				color: var(--studio-gray-50);
 			}
 		}
 	}

--- a/client/my-sites/plugins/search-box-header/style.scss
+++ b/client/my-sites/plugins/search-box-header/style.scss
@@ -156,3 +156,44 @@
 		}
 	}
 }
+
+.is-redesign .search-box-header {
+	align-items: flex-start;
+	margin-bottom: 34px;
+
+	.search-box-header__header {
+		font-size: $font-title-large;
+		color: #0675c4;
+		padding-top: 0;
+		max-width: 500px;
+		line-height: 1.15;
+		text-align: left;
+	}
+
+	.search-box-header__search {
+		justify-content: flex-start;
+		margin-top: 21px;
+
+
+		.search-box-header__searchbox .search-component {
+			margin-left: 0;
+			max-width: 447px;
+			box-shadow:
+				0 0 0 0 rgba(38, 19, 19, 0.03),
+				0 1px 2px 0 rgba(38, 19, 19, 0.03),
+				0 4px 4px 0 rgba(38, 19, 19, 0.03),
+				0 9px 5px 0 rgba(38, 19, 19, 0.02),
+				0 16px 6px 0 rgba(38, 19, 19, 0),
+				0 25px 7px 0 rgba(38, 19, 19, 0);
+
+			.search-component__open-icon {
+				color: var(--studio-gray-30);
+				transform: scaleX(-1);
+			}
+			input.search-component__input[type="search"],
+			input.search-component__input[type="search"]::placeholder {
+				color: var(--studio-blue-90);
+			}
+		}
+	}
+}

--- a/client/my-sites/plugins/search-box-header/style.scss
+++ b/client/my-sites/plugins/search-box-header/style.scss
@@ -157,7 +157,7 @@
 	}
 }
 
-main.is-redesign .search-box-header {
+main.is-logged-out .search-box-header {
 	align-items: flex-start;
 	margin-bottom: 7px;
 	margin-top: -15px;
@@ -169,7 +169,7 @@ main.is-redesign .search-box-header {
 
 	.search-box-header__header {
 		font-size: rem(44px);
-		color: #0675c4;
+		color: var(--studio-blue-50);
 		padding-top: 0;
 		line-height: 1.15;
 		text-align: left;

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -310,7 +310,7 @@ body.is-section-plugins #primary {
 		z-index: -1;
 	}
 
-	.is-redesign .search-box-header::before {
+	.is-logged-out .search-box-header::before {
 		background: #e5f4ff;
 		top: 0;
 	}

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -310,6 +310,11 @@ body.is-section-plugins #primary {
 		z-index: -1;
 	}
 
+	.is-redesign .search-box-header::before {
+		background: #e5f4ff;
+		top: 0;
+	}
+
 	.categories__menu {
 		.components-button {
 			&:not(.is-pressed):not(.is-selected) {


### PR DESCRIPTION
#### Proposed Changes
More info: pdgAPm-yE#comment-638-p2
Figma file: 2ea28-pb
This implements the new design for the Logged Out Plugins header. This is visible on:
* Plugins Landing page `/plugins`
* Category pages ex. `/plugins/browse/seo`
* Search result pages ex. `/plugins?s=ecommerce`

![Home (1)](https://user-images.githubusercontent.com/2749938/210070264-bfcc1a0a-2ab3-4bcc-a23a-9226bfa6fc44.png)

Note: adjustments to the navbar will be included in a separate PR

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Log out
* Go to /plugins
* The revamped header should be visible
<img width="420" alt="Screenshot 2022-12-30 at 14 30 37" src="https://user-images.githubusercontent.com/2749938/210070383-5169b7c4-30f8-4050-a600-f201cd76efc4.png">


* The new header **should** also be visible on **Category pages and a Search**
* The new header **should not** be visible on the **Plugin Details** page (ex. /plugins/wordpress-seo-premium)
<img width="420" alt="Screenshot 2022-12-30 at 14 32 15" src="https://user-images.githubusercontent.com/2749938/210070560-18d35d46-521b-49e9-b07f-1a2f6fb9b806.png">

* The subtitle **should not** be visible on non-English locales (until translations arrive)
<img width="420" alt="Screenshot 2022-12-30 at 14 36 05" src="https://user-images.githubusercontent.com/2749938/210070834-f6f7adaa-8e4b-46a3-a1a8-83c679fdf192.png">


* The new header **should not** be visible on any **Logged In Plugin** page
<img width="420" alt="Screenshot 2022-12-30 at 14 32 37" src="https://user-images.githubusercontent.com/2749938/210070548-439536e6-cda6-4f0e-b796-446c432d1f5d.png">



#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
