### PR TITLE
Add ability to render custom list items in Banner component

### DIFF
--- a/client/components/banner/README.md
+++ b/client/components/banner/README.md
@@ -57,6 +57,7 @@ function render() {
 | `jetpack`                    | `bool`   | false   | When true, a Jetpack logo will be rendered and the border color will be set to Jetpack green.                                |
 | `icon`                       | `string` | null    | The component icon.                                                                                                          |
 | `list`                       | `string` | null    | A list of the upgrade features.                                                                                              |
+| `body`                       | `node`   | null    | A custom component to render as the main content.                                                                            |
 | `onClick`                    | `string` | null    | A function associated to the click on the whole banner or just the CTA or dismiss button.                                    |
 | `plan`                       | `string` | null    | PlanSlug of the plan that upgrade leads to.                                                                                  |
 | `price`                      | `string` | null    | One or two (original/discounted) upgrade prices.                                                                             |

--- a/client/components/banner/README.md
+++ b/client/components/banner/README.md
@@ -57,7 +57,7 @@ function render() {
 | `jetpack`                    | `bool`   | false   | When true, a Jetpack logo will be rendered and the border color will be set to Jetpack green.                                |
 | `icon`                       | `string` | null    | The component icon.                                                                                                          |
 | `list`                       | `string` | null    | A list of the upgrade features.                                                                                              |
-| `body`                       | `node`   | null    | A custom component to render as the main content.                                                                            |
+| `renderListItem`             | `string` | null    | A function that allows rendering of custom list items.                                                                       |
 | `onClick`                    | `string` | null    | A function associated to the click on the whole banner or just the CTA or dismiss button.                                    |
 | `plan`                       | `string` | null    | PlanSlug of the plan that upgrade leads to.                                                                                  |
 | `price`                      | `string` | null    | One or two (original/discounted) upgrade prices.                                                                             |

--- a/client/components/banner/README.md
+++ b/client/components/banner/README.md
@@ -41,34 +41,34 @@ function render() {
 
 ### Props
 
-| Name                         | Type     | Default | Description                                                                                                                  |
-| ---------------------------- | -------- | ------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| `callToAction`               | `string` | null    | Shows a CTA text.                                                                                                            |
-| `className`                  | `string` | null    | Any additional CSS classes.                                                                                                  |
-| `compact`                    | `bool`   | false   | Display a compact version of the banner.                                                                                     |
-| `description`                | `string` | null    | The banner description.                                                                                                      |
-| `disableHref`                | `bool`   | false   | When true, prevent the Banner to be linked either via the `href` props or as a side effect of the `siteSlug` connected prop. |
-| `dismissPreferenceName`      | `string` | null    | The user preference name that we store a boolean against, prefixed with `dismissible-card-` to avoid namespace collisions.   |
-| `dismissTemporary`           | `bool`   | false   | When true, clicking on the cross will dismiss the card for the current page load.                                            |
-| `event`                      | `string` | null    | Event to distinguish the nudge in tracks. Used as <code>cta_name</code> event property.                                      |
-| `feature`                    | `string` | null    | Slug of the feature to highlight in the plans compare card.                                                                  |
-| `horizontal`                 | `bool`   | false   | When true, the banner content will be laid out in a single row (similar to `compact` but normal size).                       |
-| `href`                       | `string` | null    | The component target URL.                                                                                                    |
-| `jetpack`                    | `bool`   | false   | When true, a Jetpack logo will be rendered and the border color will be set to Jetpack green.                                |
-| `icon`                       | `string` | null    | The component icon.                                                                                                          |
-| `list`                       | `string` | null    | A list of the upgrade features.                                                                                              |
-| `renderListItem`             | `string` | null    | A function that allows rendering of custom list items.                                                                       |
-| `onClick`                    | `string` | null    | A function associated to the click on the whole banner or just the CTA or dismiss button.                                    |
-| `plan`                       | `string` | null    | PlanSlug of the plan that upgrade leads to.                                                                                  |
-| `price`                      | `string` | null    | One or two (original/discounted) upgrade prices.                                                                             |
-| `showIcon`                   | `bool`   | `true`  | Show the icon specified in `icon`                                                                                            |
-| `title`                      | `string` | null    | (required) The banner title.                                                                                                 |
-| `tracksImpressionName`       | `string` |         | Unique event name to track when the nudge is viewed                                                                          |
-| `tracksClickName`            | `string` |         | Unique event name to track when the nudge is clicked                                                                         |
-| `tracksDismissName`          | `string` |         | Unique event name to track when the nudge is dismissed                                                                       |
-| `tracksImpressionProperties` | `object` |         | Additional props to track when the nudge is viewed                                                                           |
-| `tracksClickProperties`      | `object` |         | Additional props to track when the nudge is clicked                                                                          |
-| `tracksDismissProperties`    | `object` |         | Additional props to track when the nudge is dismissed                                                                        |
+| Name                         | Type                   | Default | Description                                                                                                                                          |
+| ---------------------------- | ---------------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `callToAction`               | `string`               | null    | Shows a CTA text.                                                                                                                                    |
+| `className`                  | `string`               | null    | Any additional CSS classes.                                                                                                                          |
+| `compact`                    | `bool`                 | false   | Display a compact version of the banner.                                                                                                             |
+| `description`                | `string`               | null    | The banner description.                                                                                                                              |
+| `disableHref`                | `bool`                 | false   | When true, prevent the Banner to be linked either via the `href` props or as a side effect of the `siteSlug` connected prop.                         |
+| `dismissPreferenceName`      | `string`               | null    | The user preference name that we store a boolean against, prefixed with `dismissible-card-` to avoid namespace collisions.                           |
+| `dismissTemporary`           | `bool`                 | false   | When true, clicking on the cross will dismiss the card for the current page load.                                                                    |
+| `event`                      | `string`               | null    | Event to distinguish the nudge in tracks. Used as <code>cta_name</code> event property.                                                              |
+| `feature`                    | `string`               | null    | Slug of the feature to highlight in the plans compare card.                                                                                          |
+| `horizontal`                 | `bool`                 | false   | When true, the banner content will be laid out in a single row (similar to `compact` but normal size).                                               |
+| `href`                       | `string`               | null    | The component target URL.                                                                                                                            |
+| `jetpack`                    | `bool`                 | false   | When true, a Jetpack logo will be rendered and the border color will be set to Jetpack green.                                                        |
+| `icon`                       | `string`               | null    | The component icon.                                                                                                                                  |
+| `list`                       | `string[] \| object[]` | null    | A list of the upgrade features. Use a `object[]` if you want to pass arbitrary arguments to `renderListItem`.                                        |
+| `renderListItem`             | `func`                 |         | A [render prop](https://reactjs.org/docs/render-props.html) for rendering custom list UI. The elements of the `list` prop are passed as an argument. |
+| `onClick`                    | `string`               | null    | A function associated to the click on the whole banner or just the CTA or dismiss button.                                                            |
+| `plan`                       | `string`               | null    | PlanSlug of the plan that upgrade leads to.                                                                                                          |
+| `price`                      | `string`               | null    | One or two (original/discounted) upgrade prices.                                                                                                     |
+| `showIcon`                   | `bool`                 | `true`  | Show the icon specified in `icon`                                                                                                                    |
+| `title`                      | `string`               | null    | (required) The banner title.                                                                                                                         |
+| `tracksImpressionName`       | `string`               |         | Unique event name to track when the nudge is viewed                                                                                                  |
+| `tracksClickName`            | `string`               |         | Unique event name to track when the nudge is clicked                                                                                                 |
+| `tracksDismissName`          | `string`               |         | Unique event name to track when the nudge is dismissed                                                                                               |
+| `tracksImpressionProperties` | `object`               |         | Additional props to track when the nudge is viewed                                                                                                   |
+| `tracksClickProperties`      | `object`               |         | Additional props to track when the nudge is clicked                                                                                                  |
+| `tracksDismissProperties`    | `object`               |         | Additional props to track when the nudge is dismissed                                                                                                |
 
 ### General guidelines
 

--- a/client/components/banner/docs/example.jsx
+++ b/client/components/banner/docs/example.jsx
@@ -16,7 +16,7 @@ const BannerExample = () => (
 			callToAction="Update"
 			disableHref
 			showIcon={ false }
-			title="Simple banner with description with custom body"
+			title="Simple banner with custom body"
 			body={
 				<div style={ { display: 'flex', flexWrap: 'wrap', justifyContent: 'flex-start' } }>
 					{ icons.map( ( icon, idx ) => (

--- a/client/components/banner/docs/example.jsx
+++ b/client/components/banner/docs/example.jsx
@@ -16,42 +16,45 @@ const BannerExample = () => (
 			callToAction="Update"
 			disableHref
 			showIcon={ false }
-			title="Simple banner with custom body"
-			body={
-				<div style={ { display: 'flex', flexWrap: 'wrap', justifyContent: 'flex-start' } }>
-					{ icons.map( ( icon, idx ) => (
-						<div key={ idx } style={ { marginRight: '12px', marginTop: '12px' } }>
-							<ListTile
-								title={ <h5>Feature name</h5> }
-								leading={
-									<div
-										style={ {
-											display: 'flex',
-											marginRight: '10px',
-											alignItems: 'center',
-											borderRadius: '50%',
-											justifyContent: 'center',
-											flexShrink: 0,
-											width: '24px',
-											height: '24px',
-											padding: '3px 4px 4px 3px',
-											backgroundColor: 'var(--color-accent)',
-											color: 'var(--color-text-inverted)',
-										} }
-									>
-										<Gridicon icon={ icon } size={ 18 } />
-									</div>
-								}
-								trailing={
-									<div style={ { marginLeft: '8px', marginTop: '5px' } }>
-										<Gridicon color="#C6C6C6" icon="info-outline" size={ 18 } />
-									</div>
-								}
+			title="Simple banner with custom list items"
+			list={ icons }
+			renderListItem={ ( icon ) => (
+				<ListTile
+					title={ <h5>Feature name</h5> }
+					leading={
+						<div
+							style={ {
+								display: 'flex',
+								marginRight: '10px',
+								alignItems: 'center',
+								borderRadius: '50%',
+								justifyContent: 'center',
+								flexShrink: 0,
+								width: '24px',
+								height: '24px',
+								padding: '3px 4px 4px 3px',
+								backgroundColor: 'var(--color-accent)',
+							} }
+						>
+							<Gridicon
+								icon={ icon }
+								size={ 18 }
+								style={ { marginRight: '0px', color: 'var(--color-text-inverted)' } }
 							/>
 						</div>
-					) ) }
-				</div>
-			}
+					}
+					trailing={
+						<div style={ { marginLeft: '8px' } }>
+							<Gridicon
+								color="#C6C6C6"
+								icon="info-outline"
+								size={ 18 }
+								style={ { verticalAlign: 'unset' } }
+							/>
+						</div>
+					}
+				/>
+			) }
 		/>
 		<Banner showIcon={ false } title="Banner with showIcon set to false" />
 		<Banner

--- a/client/components/banner/docs/example.jsx
+++ b/client/components/banner/docs/example.jsx
@@ -1,4 +1,6 @@
+import { ListTile, Gridicon } from '@automattic/components';
 import Banner from 'calypso/components/banner';
+const icons = [ 'custom-post-type', 'cloud', 'layout' ];
 
 const BannerExample = () => (
 	<div>
@@ -9,6 +11,47 @@ const BannerExample = () => (
 			disableHref
 			showIcon
 			title="Simple banner with description and call to action"
+		/>
+		<Banner
+			callToAction="Update"
+			disableHref
+			showIcon={ false }
+			title="Simple banner with description with custom body"
+			body={
+				<div style={ { display: 'flex', flexWrap: 'wrap', justifyContent: 'flex-start' } }>
+					{ icons.map( ( icon, idx ) => (
+						<div key={ idx } style={ { marginRight: '12px', marginTop: '12px' } }>
+							<ListTile
+								title={ <h5>Feature name</h5> }
+								leading={
+									<div
+										style={ {
+											display: 'flex',
+											marginRight: '10px',
+											alignItems: 'center',
+											borderRadius: '50%',
+											justifyContent: 'center',
+											flexShrink: 0,
+											width: '24px',
+											height: '24px',
+											padding: '3px 4px 4px 3px',
+											backgroundColor: 'var(--color-accent)',
+											color: 'var(--color-text-inverted)',
+										} }
+									>
+										<Gridicon icon={ icon } size={ 18 } />
+									</div>
+								}
+								trailing={
+									<div style={ { marginLeft: '8px', marginTop: '5px' } }>
+										<Gridicon color="#C6C6C6" icon="info-outline" size={ 18 } />
+									</div>
+								}
+							/>
+						</div>
+					) ) }
+				</div>
+			}
 		/>
 		<Banner showIcon={ false } title="Banner with showIcon set to false" />
 		<Banner

--- a/client/components/banner/index.jsx
+++ b/client/components/banner/index.jsx
@@ -51,6 +51,7 @@ export class Banner extends Component {
 		isAtomic: PropTypes.bool,
 		compact: PropTypes.bool,
 		list: PropTypes.arrayOf( PropTypes.string ),
+		body: PropTypes.node,
 		onClick: PropTypes.func,
 		onDismiss: PropTypes.func,
 		plan: PropTypes.string,
@@ -183,6 +184,7 @@ export class Banner extends Component {
 			feature,
 			compact,
 			list,
+			body,
 			price,
 			primaryButton,
 			title,
@@ -209,6 +211,7 @@ export class Banner extends Component {
 				<div className="banner__info">
 					<div className="banner__title">{ title }</div>
 					{ description && <div className="banner__description">{ description }</div> }
+					{ body }
 					{ size( list ) > 0 && (
 						<ul className="banner__list">
 							{ list.map( ( item, key ) => (

--- a/client/components/banner/index.jsx
+++ b/client/components/banner/index.jsx
@@ -214,7 +214,6 @@ export class Banner extends Component {
 				<div className="banner__info">
 					<div className="banner__title">{ title }</div>
 					{ description && <div className="banner__description">{ description }</div> }
-					{ renderListItem }
 					{ size( list ) > 0 && (
 						<ul className="banner__list">
 							{ list.map( ( item, key ) => (

--- a/client/components/banner/index.jsx
+++ b/client/components/banner/index.jsx
@@ -50,8 +50,11 @@ export class Banner extends Component {
 		jetpack: PropTypes.bool,
 		isAtomic: PropTypes.bool,
 		compact: PropTypes.bool,
-		list: PropTypes.arrayOf( PropTypes.string ),
-		body: PropTypes.node,
+		list: PropTypes.oneOfType( [
+			PropTypes.arrayOf( PropTypes.string ),
+			PropTypes.arrayOf( PropTypes.object ),
+		] ),
+		renderListItem: PropTypes.func,
 		onClick: PropTypes.func,
 		onDismiss: PropTypes.func,
 		plan: PropTypes.string,
@@ -184,7 +187,7 @@ export class Banner extends Component {
 			feature,
 			compact,
 			list,
-			body,
+			renderListItem,
 			price,
 			primaryButton,
 			title,
@@ -211,13 +214,17 @@ export class Banner extends Component {
 				<div className="banner__info">
 					<div className="banner__title">{ title }</div>
 					{ description && <div className="banner__description">{ description }</div> }
-					{ body }
+					{ renderListItem }
 					{ size( list ) > 0 && (
 						<ul className="banner__list">
 							{ list.map( ( item, key ) => (
 								<li key={ key }>
-									<Gridicon icon="checkmark" size={ 18 } />
-									{ item }
+									{ renderListItem?.( item ) ?? (
+										<>
+											<Gridicon icon="checkmark" size={ 18 } />
+											{ item }
+										</>
+									) }
 								</li>
 							) ) }
 						</ul>


### PR DESCRIPTION
#### Proposed Changes

*Add function to allow rendering of custom list items

#### Testing Instructions

1. Go to `/devdocs/design`
2. Find the banner component and verify banner with custom body
![image](https://user-images.githubusercontent.com/47489215/210111280-8ae72df5-5cc9-40ae-bdaf-2382ec18d8fc.png)

3. Verify the other banners in the devdocs is not affected and renders correctly
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #71597
