### PR TITLE
Stats: Add arrow navigation to the Posting Activity section

### DIFF
--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -353,14 +353,6 @@ body.is-focus-sites {
 		.main.customize.is-iframe {
 			right: 272px;
 		}
-
-		// adjust when scroll arrows show up in stats insights when chat panel is open
-		&.is-section-stats {
-			.post-trends__scroll-left,
-			.post-trends__scroll-right {
-				display: block;
-			}
-		}
 	}
 }
 

--- a/client/my-sites/stats/post-trends/day.jsx
+++ b/client/my-sites/stats/post-trends/day.jsx
@@ -1,5 +1,7 @@
+import { Icon, postContent } from '@wordpress/icons';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
+import moment from 'moment';
 import PropTypes from 'prop-types';
 import { createRef, PureComponent, Fragment } from 'react';
 import Tooltip from 'calypso/components/tooltip';
@@ -29,18 +31,32 @@ class PostTrendsDay extends PureComponent {
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	buildTooltipData = () => {
 		const { label, postCount } = this.props;
-		const content = this.props.translate( '%(posts)d post', '%(posts)d posts', {
-			count: postCount,
-			args: {
-				posts: postCount,
-			},
-			comment: 'How many posts published on a certain date.',
-		} );
+		const date = moment( label );
+		const weekDay = date.format( 'dddd' );
+		const formattedDate = date.format( 'MMMM DD, YYYY' );
+
+		const postPublished = this.props.translate(
+			'%(posts)d post published',
+			'%(posts)d posts published',
+			{
+				count: postCount,
+				args: {
+					posts: postCount,
+				},
+				comment: 'How many posts published on a certain date.',
+			}
+		);
 
 		return (
-			<span>
-				<span className="post-count">{ content } </span>
-				<span className="date">{ label }</span>
+			<span className="post-trends__tooltip-content">
+				<div className="post-date">
+					{ formattedDate } ({ weekDay })
+				</div>
+
+				<div className="post-count">
+					<Icon icon={ postContent } className="post-count-icon" />
+					{ postPublished }
+				</div>
 			</span>
 		);
 	};
@@ -61,8 +77,8 @@ class PostTrendsDay extends PureComponent {
 				/>
 				{ postCount > 0 && (
 					<Tooltip
-						className="chart__tooltip is-streak"
-						id="popover__chart-bar"
+						className="post-trends-day__tooltip is-streak"
+						id="post-trends__tooltip"
 						context={ this.dayRef.current }
 						isVisible={ this.state.showPopover }
 						position="top"

--- a/client/my-sites/stats/post-trends/day.jsx
+++ b/client/my-sites/stats/post-trends/day.jsx
@@ -1,7 +1,6 @@
 import { Icon, postContent } from '@wordpress/icons';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
-import moment from 'moment';
 import PropTypes from 'prop-types';
 import { createRef, PureComponent, Fragment } from 'react';
 import Tooltip from 'calypso/components/tooltip';
@@ -31,9 +30,13 @@ class PostTrendsDay extends PureComponent {
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	buildTooltipData = () => {
 		const { label, postCount } = this.props;
-		const date = moment( label );
-		const weekDay = date.format( 'dddd' );
-		const formattedDate = date.format( 'MMMM DD, YYYY' );
+		const date = new Date( label );
+		const weekDay = date.toLocaleDateString( undefined, { weekday: 'long' } );
+		const formattedDate = date.toLocaleDateString( undefined, {
+			month: 'long',
+			day: 'numeric',
+			year: 'numeric',
+		} );
 
 		const postPublished = this.props.translate(
 			'%(posts)d post published',

--- a/client/my-sites/stats/post-trends/index.jsx
+++ b/client/my-sites/stats/post-trends/index.jsx
@@ -1,35 +1,54 @@
-import { localize } from 'i18n-calypso';
-import { values } from 'lodash';
+import { Spinner } from '@automattic/components';
+import classNames from 'classnames';
+import { useTranslate } from 'i18n-calypso';
+import { values, isEmpty } from 'lodash';
 import moment from 'moment';
-import PropTypes from 'prop-types';
-import { Component } from 'react';
-import { connect } from 'react-redux';
+import { useMemo, useState } from 'react';
+import { useSelector } from 'react-redux';
 import QuerySiteStats from 'calypso/components/data/query-site-stats';
-import { withLocalizedMoment } from 'calypso/components/localized-moment';
-import compareProps from 'calypso/lib/compare-props';
 import { getSiteOption } from 'calypso/state/sites/selectors';
 import { getSiteStatsPostStreakData } from 'calypso/state/stats/lists/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import Month from './month';
+import YearNavigation from './year-navigation';
 
 import './style.scss';
 
-class PostTrends extends Component {
-	static displayName = 'PostTrends';
+const buildQuery = ( previousYear, gmtOffset ) => ( {
+	startDate: moment()
+		.locale( 'en' )
+		.subtract( previousYear, 'year' )
+		.startOf( 'month' )
+		.format( 'YYYY-MM-DD' ),
+	endDate: moment()
+		.locale( 'en' )
+		.subtract( previousYear - 1, 'year' )
+		.endOf( 'month' )
+		.format( 'YYYY-MM-DD' ),
+	gmtOffset,
+	max: 3000,
+} );
 
-	static propTypes = {
-		siteId: PropTypes.number,
-		query: PropTypes.object,
-	};
+export default function PostTrends() {
+	const translate = useTranslate();
+	const siteId = useSelector( getSelectedSiteId );
+	const gmtOffset = useSelector( ( state ) => getSiteOption( state, siteId, 'gmt_offset' ) );
+	const [ counter, setCounter ] = useState( 1 );
+	const query = useMemo( () => buildQuery( counter, gmtOffset ), [ counter, gmtOffset ] );
+	const streakData = useSelector( ( state ) => getSiteStatsPostStreakData( state, siteId, query ) );
+	const isLoading = useMemo( () => isEmpty( streakData ), [ streakData ] );
 
-	getMonthComponents = () => {
-		const { streakData } = this.props;
+	const getMonthComponents = () => {
 		// Compute maximum per-day post count from the streakData. It's used to scale the chart.
+
 		const maxPosts = Math.max( ...values( streakData ) );
 		const months = [];
 
 		for ( let i = 11; i >= 0; i-- ) {
-			const startDate = this.props.moment().subtract( i, 'months' ).startOf( 'month' );
+			const startDate = moment()
+				.subtract( counter - 1, 'year' )
+				.subtract( i, 'months' )
+				.startOf( 'month' );
 			months.push(
 				<Month key={ i } startDate={ startDate } streakData={ streakData } max={ maxPosts } />
 			);
@@ -38,66 +57,62 @@ class PostTrends extends Component {
 		return months;
 	};
 
-	render() {
-		const { siteId, query, translate } = this.props;
+	const onYearChange = ( moveToNext ) => {
+		if ( moveToNext ) {
+			if ( counter > 1 ) {
+				setCounter( counter - 1 );
+			}
+		} else {
+			setCounter( counter + 1 );
+		}
+	};
 
-		/* eslint-disable jsx-a11y/click-events-have-key-events, wpcalypso/jsx-classname-namespace */
-		return (
-			<div className="post-trends">
-				{ siteId && <QuerySiteStats siteId={ siteId } statType="statsStreak" query={ query } /> }
+	return (
+		<div className="post-trends">
+			{ siteId && <QuerySiteStats siteId={ siteId } statType="statsStreak" query={ query } /> }
 
-				<div className="post-trends__heading">
-					<h1 className="post-trends__title">{ translate( 'Posting activity' ) }</h1>
+			<div className="post-trends__heading">
+				<h1 className="post-trends__title">{ translate( 'Posting activity' ) }</h1>
+
+				<YearNavigation
+					disablePreviousArrow={ false }
+					disableNextArrow={ counter === 1 }
+					onYearChange={ onYearChange }
+				/>
+			</div>
+			{ isLoading && (
+				<div className="post-trends__spinner-container">
+					<Spinner />
 				</div>
-				<div ref={ this.wrapperRef } className="post-trends__wrapper">
-					<div ref={ this.yearRef } className="post-trends__year">
-						{ this.getMonthComponents() }
-					</div>
-					<div className="post-trends__key-container">
-						<span className="post-trends__key-label">
-							{ translate( 'Fewer Posts', {
-								context: 'Legend label in stats post trends visualization',
-							} ) }
-						</span>
-						<ul className="post-trends__key">
-							<li className="post-trends__key-day is-today" />
-							<li className="post-trends__key-day is-level-1" />
-							<li className="post-trends__key-day is-level-2" />
-							<li className="post-trends__key-day is-level-3" />
-							<li className="post-trends__key-day is-level-4" />
-						</ul>
-						<span className="post-trends__key-label">
-							{ translate( 'More Posts', {
-								context: 'Legend label in stats post trends visualization',
-							} ) }
-						</span>
-					</div>
+			) }
+			<div className="post-trends__wrapper">
+				<div
+					className={ classNames( 'post-trends__year', {
+						'post-trends__year-loading': isLoading,
+					} ) }
+				>
+					{ getMonthComponents() }
+				</div>
+				<div className="post-trends__key-container">
+					<span className="post-trends__key-label">
+						{ translate( 'Fewer Posts', {
+							context: 'Legend label in stats post trends visualization',
+						} ) }
+					</span>
+					<ul className="post-trends__key">
+						<li className="post-trends__key-day is-today" />
+						<li className="post-trends__key-day is-level-1" />
+						<li className="post-trends__key-day is-level-2" />
+						<li className="post-trends__key-day is-level-3" />
+						<li className="post-trends__key-day is-level-4" />
+					</ul>
+					<span className="post-trends__key-label">
+						{ translate( 'More Posts', {
+							context: 'Legend label in stats post trends visualization',
+						} ) }
+					</span>
 				</div>
 			</div>
-		);
-	}
+		</div>
+	);
 }
-
-const mapStateToProps = ( state ) => {
-	const siteId = getSelectedSiteId( state );
-	const query = {
-		startDate: moment()
-			.locale( 'en' )
-			.subtract( 1, 'year' )
-			.startOf( 'month' )
-			.format( 'YYYY-MM-DD' ),
-		endDate: moment().locale( 'en' ).endOf( 'month' ).format( 'YYYY-MM-DD' ),
-		gmtOffset: getSiteOption( state, siteId, 'gmt_offset' ),
-		max: 3000,
-	};
-
-	return {
-		streakData: getSiteStatsPostStreakData( state, siteId, query ),
-		query,
-		siteId,
-	};
-};
-
-export default connect( mapStateToProps, null, null, {
-	areStatePropsEqual: compareProps( { deep: [ 'query' ] } ),
-} )( localize( withLocalizedMoment( PostTrends ) ) );

--- a/client/my-sites/stats/post-trends/index.jsx
+++ b/client/my-sites/stats/post-trends/index.jsx
@@ -1,5 +1,4 @@
-import { Card } from '@automattic/components';
-import classNames from 'classnames';
+// import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import { throttle, values } from 'lodash';
 import moment from 'moment';
@@ -13,6 +12,7 @@ import { getSiteOption } from 'calypso/state/sites/selectors';
 import { getSiteStatsPostStreakData } from 'calypso/state/stats/lists/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import Month from './month';
+// import YearNavigation from './year-navigation';
 
 import './style.scss';
 
@@ -129,28 +129,38 @@ class PostTrends extends Component {
 	render() {
 		const { siteId, query, translate } = this.props;
 
-		const leftClass = classNames( 'post-trends__scroll-left', {
-			'is-active': this.state.canScrollLeft,
-		} );
+		// const leftClass = classNames( 'post-trends__scroll-left', {
+		// 	'is-active': this.state.canScrollLeft,
+		// } );
 
-		const rightClass = classNames( 'post-trends__scroll-right', {
-			'is-active': this.state.canScrollRight,
-		} );
+		// const rightClass = classNames( 'post-trends__scroll-right', {
+		// 	'is-active': this.state.canScrollRight,
+		// } );
 
 		/* eslint-disable jsx-a11y/click-events-have-key-events, wpcalypso/jsx-classname-namespace */
 		return (
 			<div className="post-trends">
 				{ siteId && <QuerySiteStats siteId={ siteId } statType="statsStreak" query={ query } /> }
 
-				<Card>
-					<h1 className="post-trends__title">{ translate( 'Posting activity' ) }</h1>
+				<div>
+					<div className="post-trends__heading">
+						<h1 className="post-trends__title">{ translate( 'Posting activity' ) }</h1>
 
+						{ /* This will be finished later */ }
+						{ /* <YearNavigation
+							disablePreviousArrow={ false }
+							disableNextArrow={ false }
+							onYearChange={ () => {} }
+						/> */ }
+					</div>
+
+					{ /* 
 					<div className={ leftClass } onClick={ this.scrollLeft } role="button" tabIndex="0">
 						<span className="left-arrow" />
 					</div>
 					<div className={ rightClass } onClick={ this.scrollRight } role="button" tabIndex="0">
 						<span className="right-arrow" />
-					</div>
+					</div> */ }
 					<div ref={ this.wrapperRef } className="post-trends__wrapper">
 						<div ref={ this.yearRef } className="post-trends__year">
 							{ this.getMonthComponents() }
@@ -175,7 +185,7 @@ class PostTrends extends Component {
 							</span>
 						</div>
 					</div>
-				</Card>
+				</div>
 			</div>
 		);
 	}

--- a/client/my-sites/stats/post-trends/index.jsx
+++ b/client/my-sites/stats/post-trends/index.jsx
@@ -46,33 +46,31 @@ class PostTrends extends Component {
 			<div className="post-trends">
 				{ siteId && <QuerySiteStats siteId={ siteId } statType="statsStreak" query={ query } /> }
 
-				<div>
-					<div className="post-trends__heading">
-						<h1 className="post-trends__title">{ translate( 'Posting activity' ) }</h1>
+				<div className="post-trends__heading">
+					<h1 className="post-trends__title">{ translate( 'Posting activity' ) }</h1>
+				</div>
+				<div ref={ this.wrapperRef } className="post-trends__wrapper">
+					<div ref={ this.yearRef } className="post-trends__year">
+						{ this.getMonthComponents() }
 					</div>
-					<div ref={ this.wrapperRef } className="post-trends__wrapper">
-						<div ref={ this.yearRef } className="post-trends__year">
-							{ this.getMonthComponents() }
-						</div>
-						<div className="post-trends__key-container">
-							<span className="post-trends__key-label">
-								{ translate( 'Fewer Posts', {
-									context: 'Legend label in stats post trends visualization',
-								} ) }
-							</span>
-							<ul className="post-trends__key">
-								<li className="post-trends__key-day is-today" />
-								<li className="post-trends__key-day is-level-1" />
-								<li className="post-trends__key-day is-level-2" />
-								<li className="post-trends__key-day is-level-3" />
-								<li className="post-trends__key-day is-level-4" />
-							</ul>
-							<span className="post-trends__key-label">
-								{ translate( 'More Posts', {
-									context: 'Legend label in stats post trends visualization',
-								} ) }
-							</span>
-						</div>
+					<div className="post-trends__key-container">
+						<span className="post-trends__key-label">
+							{ translate( 'Fewer Posts', {
+								context: 'Legend label in stats post trends visualization',
+							} ) }
+						</span>
+						<ul className="post-trends__key">
+							<li className="post-trends__key-day is-today" />
+							<li className="post-trends__key-day is-level-1" />
+							<li className="post-trends__key-day is-level-2" />
+							<li className="post-trends__key-day is-level-3" />
+							<li className="post-trends__key-day is-level-4" />
+						</ul>
+						<span className="post-trends__key-label">
+							{ translate( 'More Posts', {
+								context: 'Legend label in stats post trends visualization',
+							} ) }
+						</span>
 					</div>
 				</div>
 			</div>

--- a/client/my-sites/stats/post-trends/index.jsx
+++ b/client/my-sites/stats/post-trends/index.jsx
@@ -1,9 +1,8 @@
-// import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
-import { throttle, values } from 'lodash';
+import { values } from 'lodash';
 import moment from 'moment';
 import PropTypes from 'prop-types';
-import { createRef, Component } from 'react';
+import { Component } from 'react';
 import { connect } from 'react-redux';
 import QuerySiteStats from 'calypso/components/data/query-site-stats';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
@@ -12,7 +11,6 @@ import { getSiteOption } from 'calypso/state/sites/selectors';
 import { getSiteStatsPostStreakData } from 'calypso/state/stats/lists/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import Month from './month';
-// import YearNavigation from './year-navigation';
 
 import './style.scss';
 
@@ -22,92 +20,6 @@ class PostTrends extends Component {
 	static propTypes = {
 		siteId: PropTypes.number,
 		query: PropTypes.object,
-	};
-
-	state = {
-		canScrollLeft: false,
-		canScrollRight: false,
-	};
-
-	wrapperRef = createRef();
-	yearRef = createRef();
-
-	componentDidMount() {
-		const node = this.wrapperRef.current;
-		const yearNode = this.yearRef.current;
-		const computedStyle = window.getComputedStyle( yearNode );
-		const margin =
-			parseInt( computedStyle.getPropertyValue( 'margin-left' ), 10 ) +
-			parseInt( computedStyle.getPropertyValue( 'margin-right' ), 10 );
-
-		// Initially scroll all the way to the left
-		yearNode.style.left = 0 - yearNode.scrollWidth + node.clientWidth - margin + 'px';
-
-		// Add resize listener
-		this.resize = throttle( this.resize, 400 );
-		window.addEventListener( 'resize', this.resize );
-		this.resize();
-	}
-
-	// Remove listener
-	componentWillUnmount() {
-		window.removeEventListener( 'resize', this.resize );
-	}
-
-	resize = () => {
-		const scrollProps = {};
-		const node = this.wrapperRef.current;
-		const yearNode = this.yearRef.current;
-		const computedStyle = window.getComputedStyle( yearNode );
-		const margin =
-			parseInt( computedStyle.getPropertyValue( 'margin-left' ), 10 ) +
-			parseInt( computedStyle.getPropertyValue( 'margin-right' ), 10 );
-		const left = parseInt( yearNode.style.left, 10 );
-
-		scrollProps.canScrollLeft = left < 0;
-		scrollProps.canScrollRight = left > 0 - yearNode.scrollWidth + node.clientWidth - margin;
-
-		if ( this.state.canScrollLeft && node.clientWidth >= yearNode.scrollWidth - margin ) {
-			yearNode.style.left = '0px';
-		}
-
-		this.setState( scrollProps );
-	};
-
-	scroll = ( direction ) => {
-		const node = this.wrapperRef.current;
-		const yearNode = this.yearRef.current;
-		const computedStyle = window.getComputedStyle( yearNode );
-		const margin =
-			parseInt( computedStyle.getPropertyValue( 'margin-left' ), 10 ) +
-			parseInt( computedStyle.getPropertyValue( 'margin-right' ), 10 );
-		let left = parseInt( computedStyle.getPropertyValue( 'left' ), 10 );
-
-		if ( 1 !== direction ) {
-			direction = -1;
-		}
-
-		// scroll left 80% of the clientWidth
-		left -= Math.ceil( direction * node.clientWidth * 0.8 );
-
-		// enforce bounds
-		if ( left > 0 ) {
-			left = 0;
-		} else if ( left < 0 - yearNode.scrollWidth + node.clientWidth - margin ) {
-			left = 0 - yearNode.scrollWidth + node.clientWidth - margin;
-		}
-
-		yearNode.style.left = left + 'px';
-
-		this.resize();
-	};
-
-	scrollLeft = () => {
-		this.scroll( -1 );
-	};
-
-	scrollRight = () => {
-		this.scroll( 1 );
 	};
 
 	getMonthComponents = () => {
@@ -129,14 +41,6 @@ class PostTrends extends Component {
 	render() {
 		const { siteId, query, translate } = this.props;
 
-		// const leftClass = classNames( 'post-trends__scroll-left', {
-		// 	'is-active': this.state.canScrollLeft,
-		// } );
-
-		// const rightClass = classNames( 'post-trends__scroll-right', {
-		// 	'is-active': this.state.canScrollRight,
-		// } );
-
 		/* eslint-disable jsx-a11y/click-events-have-key-events, wpcalypso/jsx-classname-namespace */
 		return (
 			<div className="post-trends">
@@ -145,22 +49,7 @@ class PostTrends extends Component {
 				<div>
 					<div className="post-trends__heading">
 						<h1 className="post-trends__title">{ translate( 'Posting activity' ) }</h1>
-
-						{ /* This will be finished later */ }
-						{ /* <YearNavigation
-							disablePreviousArrow={ false }
-							disableNextArrow={ false }
-							onYearChange={ () => {} }
-						/> */ }
 					</div>
-
-					{ /* 
-					<div className={ leftClass } onClick={ this.scrollLeft } role="button" tabIndex="0">
-						<span className="left-arrow" />
-					</div>
-					<div className={ rightClass } onClick={ this.scrollRight } role="button" tabIndex="0">
-						<span className="right-arrow" />
-					</div> */ }
 					<div ref={ this.wrapperRef } className="post-trends__wrapper">
 						<div ref={ this.yearRef } className="post-trends__year">
 							{ this.getMonthComponents() }

--- a/client/my-sites/stats/post-trends/index.jsx
+++ b/client/my-sites/stats/post-trends/index.jsx
@@ -8,7 +8,6 @@ import { createRef, Component } from 'react';
 import { connect } from 'react-redux';
 import QuerySiteStats from 'calypso/components/data/query-site-stats';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
-import SectionHeader from 'calypso/components/section-header';
 import compareProps from 'calypso/lib/compare-props';
 import { getSiteOption } from 'calypso/state/sites/selectors';
 import { getSiteStatsPostStreakData } from 'calypso/state/stats/lists/selectors';
@@ -128,7 +127,7 @@ class PostTrends extends Component {
 	};
 
 	render() {
-		const { siteId, query } = this.props;
+		const { siteId, query, translate } = this.props;
 
 		const leftClass = classNames( 'post-trends__scroll-left', {
 			'is-active': this.state.canScrollLeft,
@@ -142,8 +141,10 @@ class PostTrends extends Component {
 		return (
 			<div className="post-trends">
 				{ siteId && <QuerySiteStats siteId={ siteId } statType="statsStreak" query={ query } /> }
-				<SectionHeader label={ this.props.translate( 'Posting activity' ) } />
+
 				<Card>
+					<h1 className="post-trends__title">{ translate( 'Posting activity' ) }</h1>
+
 					<div className={ leftClass } onClick={ this.scrollLeft } role="button" tabIndex="0">
 						<span className="left-arrow" />
 					</div>
@@ -156,7 +157,7 @@ class PostTrends extends Component {
 						</div>
 						<div className="post-trends__key-container">
 							<span className="post-trends__key-label">
-								{ this.props.translate( 'Fewer Posts', {
+								{ translate( 'Fewer Posts', {
 									context: 'Legend label in stats post trends visualization',
 								} ) }
 							</span>
@@ -168,7 +169,7 @@ class PostTrends extends Component {
 								<li className="post-trends__key-day is-level-4" />
 							</ul>
 							<span className="post-trends__key-label">
-								{ this.props.translate( 'More Posts', {
+								{ translate( 'More Posts', {
 									context: 'Legend label in stats post trends visualization',
 								} ) }
 							</span>

--- a/client/my-sites/stats/post-trends/style.scss
+++ b/client/my-sites/stats/post-trends/style.scss
@@ -1,20 +1,28 @@
+@import "@automattic/typography/styles/variables";
+@import "@wordpress/base-styles/breakpoints";
+@import "@automattic/components/src/highlight-cards/variables.scss";
+
+$font-recoleta: Recoleta, $sans;
+$font-label: "SF Pro Text", $sans;
+$mobile-layout-breakpoint: $break-small;
+$common-border-radius: 4px;
+
 .post-trends {
 	display: inline-block;
 	user-select: none;
 	position: relative;
 	width: 100%;
-	@include breakpoint-deprecated( "<480px" ) {
+
+	@include breakpoint-deprecated("<480px") {
 		display: none;
 	}
-}
 
-.post-trends__title {
-	color: var(--color-neutral-40);
-	margin-left: 11px;
-	height: 40px;
-	font-weight: 600;
-	position: relative;
-	z-index: z-index("root", ".post-trends__title");
+	.post-trends__title {
+		font-size: 32px; // stylelint-disable-line declaration-property-unit-allowed-list
+		font-weight: 400;
+		line-height: 40px;
+		font-family: $font-recoleta;
+	}
 }
 
 .post-trends__value {
@@ -25,18 +33,17 @@
 }
 
 .post-trends__year {
-	position: relative;
-	top: 0;
-	left: 0;
-	display: block;
-	white-space: nowrap;
+	margin-top: 16px;
+	padding: 16px 0;
+	display: flex;
+	justify-content: space-between;
 	transition: left, 1s, ease-in-out;
 }
 
 .post-trends__wrapper {
 	position: relative;
-	height: 130px;
-	max-width: 660px; // necessary for fluid width mode
+	// height: 130px;
+	// max-width: 660px; // necessary for fluid width mode
 	margin: 0 auto;
 	overflow: hidden;
 }
@@ -47,11 +54,15 @@
 	top: 0;
 	width: 30px;
 	height: 130px;
-	background: linear-gradient(to right, var(--color-surface), rgba(var(--color-surface-rgb), 0.92), rgba(var(--color-surface-rgb), 0));
+	background:
+		linear-gradient(to right,
+			var(--color-surface),
+			rgba(var(--color-surface-rgb), 0.92),
+			rgba(var(--color-surface-rgb), 0));
 	text-align: left;
 	z-index: z-index("root", ".post-trends__scroll");
 
-	@include breakpoint-deprecated( "<960px" ) {
+	@include breakpoint-deprecated("<960px") {
 		.focus-sidebar & {
 			z-index: 0;
 		}
@@ -62,17 +73,18 @@
 		width: 30px;
 		height: 100px;
 		display: block;
-		background: url(calypso/assets/images/stats/left-arrow.svg) no-repeat 4px 48px;
+		background: url(calypso/assets/images/stats/left-arrow.svg ) no-repeat 4px 48px;
 		background-size: 18px 18px;
 		opacity: 0.15;
 	}
 
 	.right-arrow {
-		background: url(calypso/assets/images/stats/right-arrow.svg) no-repeat 4px 48px;
+		background: url(calypso/assets/images/stats/right-arrow.svg ) no-repeat 4px 48px;
 		background-size: 18px 18px;
 	}
 
 	&.is-active {
+
 		.right-arrow,
 		.left-arrow {
 			opacity: 0.8;
@@ -85,7 +97,10 @@
 }
 
 .post-trends__scroll-right {
-	background: linear-gradient(to left, var(--color-surface), rgba(var(--color-surface-rgb), 0.92), rgba(var(--color-surface-rgb), 0));
+	background: linear-gradient(to left,
+			var(--color-surface),
+			rgba(var(--color-surface-rgb), 0.92),
+			rgba(var(--color-surface-rgb), 0));
 	text-align: right;
 	right: 0;
 }
@@ -99,23 +114,35 @@
 
 .post-trends__month {
 	font-size: 0;
-	display: inline-block;
-	white-space: normal;
-	margin: 0 4px;
+	display: flex;
+	flex-direction: column;
+	justify-content: space-between;
+
+	&:not( :first-child) {
+		margin-left: 28px;
+	}
+}
+
+.post-trends__weeks {
+	display: flex;
+	flex-direction: column;
 }
 
 .post-trends__week {
-	display: inline-block;
-	width: 9px;
+	display: flex;
 }
 
 .post-trends__label {
+	margin-top: 32px;
+	font-family: $font-label;
+	color: var(--color-neutral-80);
+	// --studio-gray-80
+	font-weight: 400;
+	font-size: 0.875rem;
+	line-height: 20px;
+	text-transform: none;
 	text-align: center;
-	font-size: $font-body-extra-small;
-	color: var(--color-neutral-40);
-	margin-top: 10px;
-	text-transform: uppercase;
-	letter-spacing: 0.1em;
+	letter-spacing: -0.15px;
 
 	.is-loading & {
 		display: none;
@@ -124,11 +151,12 @@
 
 .post-trends__day {
 	display: inline-block;
-	width: 7px;
-	height: 7px;
+	width: 12px;
+	height: 12px;
 	border: 1px solid var(--color-border-inverted);
+	border-radius: 2px;
 	background-color: var(--color-neutral-5);
-	margin: 0;
+	margin: 2px;
 }
 
 .post-trends__day,
@@ -171,7 +199,8 @@
 	}
 }
 
-@include breakpoint-deprecated( ">1040px" ) {
+@include breakpoint-deprecated(">1040px") {
+
 	.post-trends__scroll-left,
 	.post-trends__scroll-right {
 		display: none;
@@ -179,39 +208,37 @@
 }
 
 .post-trends__key-container {
-	@include clear-fix;
-	padding-top: 10px;
-	float: right;
+	padding: 16px;
+	float: none;
+	display: flex;
+	align-items: center;
+	justify-content: center;
 
-	@include breakpoint-deprecated( "<960px" ) {
-		float: none;
-		margin: 0 auto;
-		margin-bottom: 25px;
-		text-align: center;
+	@media (max-width: $break-large ) {
+		margin-bottom: 0;
 	}
 }
 
-.post-trends__key-label,
-.post-trends__key {
-	display: inline-block;
-}
-
 .post-trends__key-label {
-	font-size: $font-body-extra-small;
-	color: var(--color-neutral);
-	letter-spacing: 0.1em;
-	text-transform: uppercase;
+	font-weight: 400;
+	font-size: $font-body-small;
+	line-height: 18px;
+	color: #000;
+	text-transform: none;
+	letter-spacing: normal;
 }
 
 .post-trends__key {
-	margin: 0;
+	border-radius: $common-border-radius;
+	overflow: hidden;
+	padding: 0;
+	margin: 0 16px;
 	list-style-type: none;
-	padding: 2px 9px 0 5px;
+	display: flex;
 
 	.post-trends__key-day {
-		width: 10px;
-		height: 10px;
-		float: left;
-		margin-left: 3px;
+		width: 25px;
+		height: 25px;
+		margin: 0;
 	}
 }

--- a/client/my-sites/stats/post-trends/style.scss
+++ b/client/my-sites/stats/post-trends/style.scss
@@ -13,8 +13,9 @@ $common-border-radius: 4px;
 	position: relative;
 	width: 100%;
 
-	@include breakpoint-deprecated("<480px") {
-		display: none;
+	@media (max-width: 660px) {
+		margin-left: 0.875rem;
+		margin-right: 0.875rem;
 	}
 
 }
@@ -45,12 +46,11 @@ $common-border-radius: 4px;
 	display: flex;
 	justify-content: space-between;
 	transition: left, 1s, ease-in-out;
+	overflow-x: scroll;
 }
 
 .post-trends__wrapper {
 	position: relative;
-	// height: 130px;
-	// max-width: 660px; // necessary for fluid width mode
 	margin: 0 auto;
 	overflow: hidden;
 }

--- a/client/my-sites/stats/post-trends/style.scss
+++ b/client/my-sites/stats/post-trends/style.scss
@@ -41,7 +41,7 @@ $common-border-radius: 4px;
 
 .post-trends__year {
 	margin-top: 16px;
-	padding: 16px 0;
+	padding: 16px 2px;
 	display: flex;
 	justify-content: space-between;
 	transition: left, 1s, ease-in-out;
@@ -157,7 +157,6 @@ $common-border-radius: 4px;
 	display: inline-block;
 	width: 12px;
 	height: 12px;
-	border: 1px solid var(--color-border-inverted);
 	border-radius: 2px;
 	background-color: var(--color-neutral-5);
 
@@ -169,7 +168,7 @@ $common-border-radius: 4px;
 .post-trends__day,
 .post-trends__key-day {
 	&.is-outside-month {
-		background-color: transparent;
+		visibility: hidden;
 		border-color: var(--color-border-inverted);
 	}
 
@@ -198,7 +197,7 @@ $common-border-radius: 4px;
 	}
 
 	&.is-hovered {
-		border-color: var(--color-primary);
+		transform: scale(1.2);
 	}
 
 	.is-loading & {
@@ -267,5 +266,48 @@ $common-border-radius: 4px;
 
 	@media (min-width: 661px) {
 		padding-right: 0;
+	}
+}
+
+
+.tooltip.popover.post-trends-day__tooltip {
+	&.is-top .popover__arrow {
+		border-top-color: var(--color-neutral-100);
+		box-shadow: 0 1px 2px #0000000d;
+	}
+
+	.popover__inner {
+		background-color: var(--color-neutral-100);
+		box-shadow: 0 1px 2px #0000000d;
+		border-radius: 4px;
+		padding: 16px 24px;
+
+		.post-trends__tooltip-content {
+			.post-date,
+			.post-count {
+				font-family: var(--p2-font-inter);
+				font-size: 14px; // stylelint-disable-line declaration-property-unit-allowed-list
+				line-height: 20px;
+				letter-spacing: -0.24px;
+				color: var(--studio-white);
+			}
+
+			.post-date {
+				font-weight: 600;
+			}
+
+
+			.post-count {
+				margin-top: 14px;
+				display: flex;
+				align-items: center;
+				font-weight: 500;
+				fill: var(--studio-white);
+
+				.post-count-icon {
+					margin-right: 12px;
+				}
+			}
+		}
 	}
 }

--- a/client/my-sites/stats/post-trends/style.scss
+++ b/client/my-sites/stats/post-trends/style.scss
@@ -17,12 +17,19 @@ $common-border-radius: 4px;
 		display: none;
 	}
 
-	.post-trends__title {
-		font-size: 32px; // stylelint-disable-line declaration-property-unit-allowed-list
-		font-weight: 400;
-		line-height: 40px;
-		font-family: $font-recoleta;
-	}
+}
+
+.post-trends__heading {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+}
+
+.post-trends__title {
+	font-size: 32px; // stylelint-disable-line declaration-property-unit-allowed-list
+	font-weight: 400;
+	line-height: 40px;
+	font-family: $font-recoleta;
 }
 
 .post-trends__value {
@@ -54,11 +61,7 @@ $common-border-radius: 4px;
 	top: 0;
 	width: 30px;
 	height: 130px;
-	background:
-		linear-gradient(to right,
-			var(--color-surface),
-			rgba(var(--color-surface-rgb), 0.92),
-			rgba(var(--color-surface-rgb), 0));
+	background: linear-gradient(to right, var(--color-surface), rgba(var(--color-surface-rgb), 0.92), rgba(var(--color-surface-rgb), 0));
 	text-align: left;
 	z-index: z-index("root", ".post-trends__scroll");
 
@@ -73,13 +76,13 @@ $common-border-radius: 4px;
 		width: 30px;
 		height: 100px;
 		display: block;
-		background: url(calypso/assets/images/stats/left-arrow.svg ) no-repeat 4px 48px;
+		background: url(calypso/assets/images/stats/left-arrow.svg) no-repeat 4px 48px;
 		background-size: 18px 18px;
 		opacity: 0.15;
 	}
 
 	.right-arrow {
-		background: url(calypso/assets/images/stats/right-arrow.svg ) no-repeat 4px 48px;
+		background: url(calypso/assets/images/stats/right-arrow.svg) no-repeat 4px 48px;
 		background-size: 18px 18px;
 	}
 
@@ -97,10 +100,7 @@ $common-border-radius: 4px;
 }
 
 .post-trends__scroll-right {
-	background: linear-gradient(to left,
-			var(--color-surface),
-			rgba(var(--color-surface-rgb), 0.92),
-			rgba(var(--color-surface-rgb), 0));
+	background: linear-gradient(to left, var(--color-surface), rgba(var(--color-surface-rgb), 0.92), rgba(var(--color-surface-rgb), 0));
 	text-align: right;
 	right: 0;
 }
@@ -118,7 +118,7 @@ $common-border-radius: 4px;
 	flex-direction: column;
 	justify-content: space-between;
 
-	&:not( :first-child) {
+	&:not(:first-child) {
 		margin-left: 28px;
 	}
 }
@@ -130,6 +130,10 @@ $common-border-radius: 4px;
 
 .post-trends__week {
 	display: flex;
+
+	&:not(:first-child) {
+		margin-top: 4px;
+	}
 }
 
 .post-trends__label {
@@ -156,7 +160,10 @@ $common-border-radius: 4px;
 	border: 1px solid var(--color-border-inverted);
 	border-radius: 2px;
 	background-color: var(--color-neutral-5);
-	margin: 2px;
+
+	&:not(:first-child) {
+		margin-left: 4px;
+	}
 }
 
 .post-trends__day,
@@ -208,7 +215,7 @@ $common-border-radius: 4px;
 }
 
 .post-trends__key-container {
-	padding: 16px;
+	margin-top: 16px;
 	float: none;
 	display: flex;
 	align-items: center;
@@ -240,5 +247,25 @@ $common-border-radius: 4px;
 		width: 25px;
 		height: 25px;
 		margin: 0;
+	}
+}
+
+.post-trends-year-navigation {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+
+	.post-trends-year-navigation__previous,
+	.post-trends-year-navigation__next {
+		height: 24px;
+
+		&:focus,
+		&:active {
+			outline: thin dotted;
+		}
+	}
+
+	@media (min-width: 661px) {
+		padding-right: 0;
 	}
 }

--- a/client/my-sites/stats/post-trends/style.scss
+++ b/client/my-sites/stats/post-trends/style.scss
@@ -47,6 +47,10 @@ $common-border-radius: 4px;
 	justify-content: space-between;
 	transition: left, 1s, ease-in-out;
 	overflow-x: scroll;
+
+	&.post-trends__year-loading {
+		opacity: 0.2;
+	}
 }
 
 .post-trends__wrapper {
@@ -189,11 +193,23 @@ $common-border-radius: 4px;
 		&:active {
 			outline: thin dotted;
 		}
+
+		&.is-disabled {
+			opacity: 0.2;
+			pointer-events: none;
+		}
 	}
 
 	@media (min-width: 661px) {
 		padding-right: 0;
 	}
+}
+
+.post-trends__spinner-container {
+	position: absolute;
+	top: 50%;
+	left: 50%;
+	transform: translate(-50%, -50%);
 }
 
 

--- a/client/my-sites/stats/post-trends/style.scss
+++ b/client/my-sites/stats/post-trends/style.scss
@@ -21,6 +21,7 @@ $common-border-radius: 4px;
 }
 
 .post-trends__heading {
+	margin-top: 48px;
 	display: flex;
 	justify-content: space-between;
 	align-items: center;
@@ -215,6 +216,7 @@ $common-border-radius: 4px;
 
 .post-trends__key-container {
 	margin-top: 16px;
+	margin-bottom: 48px;
 	float: none;
 	display: flex;
 	align-items: center;

--- a/client/my-sites/stats/post-trends/style.scss
+++ b/client/my-sites/stats/post-trends/style.scss
@@ -12,12 +12,11 @@ $common-border-radius: 4px;
 	user-select: none;
 	position: relative;
 	width: 100%;
+	margin: 0 0.875rem;
 
-	@media (max-width: 660px) {
-		margin-left: 0.875rem;
-		margin-right: 0.875rem;
+	@media (min-width: 660px) {
+		margin: 0;
 	}
-
 }
 
 .post-trends__heading {
@@ -56,63 +55,6 @@ $common-border-radius: 4px;
 	overflow: hidden;
 }
 
-.post-trends__scroll-left,
-.post-trends__scroll-right {
-	position: absolute;
-	top: 0;
-	width: 30px;
-	height: 130px;
-	background: linear-gradient(to right, var(--color-surface), rgba(var(--color-surface-rgb), 0.92), rgba(var(--color-surface-rgb), 0));
-	text-align: left;
-	z-index: z-index("root", ".post-trends__scroll");
-
-	@include breakpoint-deprecated("<960px") {
-		.focus-sidebar & {
-			z-index: 0;
-		}
-	}
-
-	.left-arrow,
-	.right-arrow {
-		width: 30px;
-		height: 100px;
-		display: block;
-		background: url(calypso/assets/images/stats/left-arrow.svg) no-repeat 4px 48px;
-		background-size: 18px 18px;
-		opacity: 0.15;
-	}
-
-	.right-arrow {
-		background: url(calypso/assets/images/stats/right-arrow.svg) no-repeat 4px 48px;
-		background-size: 18px 18px;
-	}
-
-	&.is-active {
-
-		.right-arrow,
-		.left-arrow {
-			opacity: 0.8;
-		}
-	}
-
-	&.is-active:hover {
-		cursor: pointer;
-	}
-}
-
-.post-trends__scroll-right {
-	background: linear-gradient(to left, var(--color-surface), rgba(var(--color-surface-rgb), 0.92), rgba(var(--color-surface-rgb), 0));
-	text-align: right;
-	right: 0;
-}
-
-/*rtl:begin:ignore*/
-.post-trends__scroll-left {
-	left: 0;
-}
-
-/*rtl:end:ignore*/
-
 .post-trends__month {
 	font-size: 0;
 	display: flex;
@@ -141,17 +83,12 @@ $common-border-radius: 4px;
 	margin-top: 32px;
 	font-family: $font-label;
 	color: var(--color-neutral-80);
-	// --studio-gray-80
 	font-weight: 400;
 	font-size: 0.875rem;
 	line-height: 20px;
 	text-transform: none;
 	text-align: center;
 	letter-spacing: -0.15px;
-
-	.is-loading & {
-		display: none;
-	}
 }
 
 .post-trends__day {
@@ -206,14 +143,6 @@ $common-border-radius: 4px;
 	}
 }
 
-@include breakpoint-deprecated(">1040px") {
-
-	.post-trends__scroll-left,
-	.post-trends__scroll-right {
-		display: none;
-	}
-}
-
 .post-trends__key-container {
 	margin-top: 16px;
 	margin-bottom: 48px;
@@ -221,10 +150,6 @@ $common-border-radius: 4px;
 	display: flex;
 	align-items: center;
 	justify-content: center;
-
-	@media (max-width: $break-large ) {
-		margin-bottom: 0;
-	}
 }
 
 .post-trends__key-label {

--- a/client/my-sites/stats/post-trends/year-navigation.jsx
+++ b/client/my-sites/stats/post-trends/year-navigation.jsx
@@ -1,0 +1,43 @@
+import { Icon, arrowLeft, arrowRight } from '@wordpress/icons';
+import classNames from 'classnames';
+
+const YearNavigation = ( { onYearChange, disablePreviousArrow, disableNextArrow } ) => {
+	const handleClickArrow = ( next ) => {
+		onYearChange( next );
+	};
+
+	const onKeyDown = ( event, next ) => {
+		if ( event.key === 'Enter' || event.key === 'Space' ) {
+			handleClickArrow( next );
+		}
+	};
+
+	return (
+		<div className={ classNames( 'post-trends-year-navigation' ) }>
+			<button
+				className={ classNames(
+					'post-trends-year-navigation__previous',
+					disablePreviousArrow && 'is-disabled'
+				) }
+				onClick={ disablePreviousArrow ? undefined : () => handleClickArrow() }
+				onKeyDown={ disablePreviousArrow ? undefined : ( e ) => onKeyDown( e ) }
+				tabIndex={ ! disablePreviousArrow ? 0 : -1 }
+			>
+				<Icon className="gridicon" icon={ arrowLeft } />
+			</button>
+			<button
+				className={ classNames(
+					'post-trends-year-navigation__next',
+					disableNextArrow && 'is-disabled'
+				) }
+				onClick={ disableNextArrow ? undefined : () => handleClickArrow( true ) }
+				onKeyDown={ disableNextArrow ? undefined : ( e ) => onKeyDown( e, true ) }
+				tabIndex={ ! disableNextArrow ? 0 : -1 }
+			>
+				<Icon className="gridicon" icon={ arrowRight } />
+			</button>
+		</div>
+	);
+};
+
+export default YearNavigation;

--- a/client/my-sites/stats/stats-insights/index.jsx
+++ b/client/my-sites/stats/stats-insights/index.jsx
@@ -60,10 +60,8 @@ const StatsInsights = ( props ) => {
 				</div>
 				{ ! isNewAllTimeViews && (
 					<div className="stats__module--insights-unified">
-						<>
-							<SectionHeader label={ translate( 'All-time views' ) } />
-							<StatsViews />
-						</>
+						<SectionHeader label={ translate( 'All-time views' ) } />
+						<StatsViews />
 					</div>
 				) }
 				{ siteId && (

--- a/client/my-sites/stats/stats-insights/index.jsx
+++ b/client/my-sites/stats/stats-insights/index.jsx
@@ -55,15 +55,17 @@ const StatsInsights = ( props ) => {
 				<AnnualHighlightsSection siteId={ siteId } />
 				<AllTimelHighlightsSection siteId={ siteId } />
 				{ isNewAllTimeViews && <AllTimelViewsSection siteId={ siteId } slug={ siteSlug } /> }
-				<div className="stats__module--insights-unified">
+				<div className="stats__module--insights-posting-activity">
 					<PostingActivity />
-					{ ! isNewAllTimeViews && (
+				</div>
+				{ ! isNewAllTimeViews && (
+					<div className="stats__module--insights-unified">
 						<>
 							<SectionHeader label={ translate( 'All-time views' ) } />
 							<StatsViews />
 						</>
-					) }
-				</div>
+					</div>
+				) }
 				{ siteId && (
 					<DomainTip
 						siteId={ siteId }

--- a/client/my-sites/stats/stats-module/style.scss
+++ b/client/my-sites/stats/stats-module/style.scss
@@ -612,8 +612,6 @@ ul.module-header-actions {
 }
 
 .stats__module--insights-posting-activity {
-	padding-top: 48px;
-	padding-bottom: 48px;
 	border-top: 1px solid var(--studio-gray-5);
 	border-bottom: 1px solid var(--studio-gray-5);
 	margin-bottom: 32px;

--- a/client/my-sites/stats/stats-module/style.scss
+++ b/client/my-sites/stats/stats-module/style.scss
@@ -611,6 +611,14 @@ ul.module-header-actions {
 	}
 }
 
+.stats__module--insights-posting-activity {
+	padding-top: 48px;
+	padding-bottom: 48px;
+	border-top: 1px solid var(--studio-gray-5);
+	border-bottom: 1px solid var(--studio-gray-5);
+	margin-bottom: 32px;
+}
+
 .stats__module--unified {
 	.card {
 		&:first-child {


### PR DESCRIPTION
#### Proposed Changes

* Add arrow navigation so users can scan the data from previous years
* Remove the `moment.js` usage from the `PostTrends` component
* Turn the `PostTrends` component from a Class component to a Function component

#### Testing Instructions

* Go to the Calypso live link
* Navigate to the Insights tab
* Ensure the current site has data available for the Posting Activity section
* On the top right of the Posting Activity section should appear two arrow buttons that you can use to see the data from different years

#### Screenshots

![image](https://user-images.githubusercontent.com/6406071/210114279-2ff4360a-7816-4012-84eb-7a7d37b70bba.png)
![image](https://user-images.githubusercontent.com/6406071/210114294-9b6d3cb9-bd24-48fe-88a8-427f9642d5ed.png)



#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #70609
