### PR TITLE
Plugin Details: Add a track event when the premium version available USP link is clicked

### DIFF
--- a/client/my-sites/plugins/plugin-details-sidebar-usp/index.jsx
+++ b/client/my-sites/plugins/plugin-details-sidebar-usp/index.jsx
@@ -99,7 +99,7 @@ const PluginDetailsSidebarUSP = ( {
 				links.map( ( link, idx ) => {
 					return (
 						<Fragment key={ idx }>
-							<Link icon href={ link.href }>
+							<Link icon href={ link.href } onClick={ link.onClick }>
 								{ link.label }
 							</Link>
 							<br />

--- a/client/my-sites/plugins/plugin-details-sidebar/index.jsx
+++ b/client/my-sites/plugins/plugin-details-sidebar/index.jsx
@@ -4,8 +4,10 @@ import {
 	WPCOM_FEATURES_INSTALL_PURCHASED_PLUGINS,
 } from '@automattic/calypso-products';
 import { useTranslate } from 'i18n-calypso';
+import { useCallback } from 'react';
 import { useSelector } from 'react-redux';
 import './style.scss';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { formatNumberMetric } from 'calypso/lib/format-number-compact';
 import { PlanUSPS, USPS } from 'calypso/my-sites/plugins/plugin-details-CTA/usps';
 import PluginDetailsSidebarUSP from 'calypso/my-sites/plugins/plugin-details-sidebar-usp';
@@ -64,6 +66,14 @@ const PluginDetailsSidebar = ( {
 
 	const isPremiumVersionAvailable = !! premium_slug;
 	const premiumVersionLink = `/plugins/${ premium_slug }/${ selectedSite?.slug || '' }`;
+	const premiumVersionLinkOnClik = useCallback( () => {
+		recordTracksEvent( 'calypso_plugin_details_premium_plugin_link_click', {
+			current_plugin_slug: slug,
+			premium_plugin_slug: premium_slug,
+			premium_plugin_link: premiumVersionLink,
+			site: selectedSite?.ID,
+		} );
+	}, [ premiumVersionLink, premium_slug, selectedSite?.ID, slug ] );
 
 	return (
 		<div className="plugin-details-sidebar__plugin-details-content">
@@ -75,7 +85,11 @@ const PluginDetailsSidebar = ( {
 						'This plugin has a premium version that might suit your needs better.'
 					) }
 					links={ [
-						{ href: premiumVersionLink, label: translate( 'Check out the premium version' ) },
+						{
+							href: premiumVersionLink,
+							label: translate( 'Check out the premium version' ),
+							onClick: premiumVersionLinkOnClik,
+						},
 					] }
 					first
 				/>

--- a/client/my-sites/plugins/plugin-details-sidebar/index.jsx
+++ b/client/my-sites/plugins/plugin-details-sidebar/index.jsx
@@ -70,10 +70,9 @@ const PluginDetailsSidebar = ( {
 		recordTracksEvent( 'calypso_plugin_details_premium_plugin_link_click', {
 			current_plugin_slug: slug,
 			premium_plugin_slug: premium_slug,
-			premium_plugin_link: premiumVersionLink,
 			site: selectedSite?.ID,
 		} );
-	}, [ premiumVersionLink, premium_slug, selectedSite?.ID, slug ] );
+	}, [ premium_slug, selectedSite?.ID, slug ] );
 
 	return (
 		<div className="plugin-details-sidebar__plugin-details-content">


### PR DESCRIPTION
#### Proposed Changes

Add a track event when a premium version available USP link is clicked

#### Testing Instructions

*On the browser console terminal enter localStorage.setItem( 'debug', 'calypso:analytics*' )
* Go to a plugin page associated with a premium plugin. Ex: `/plugins/wordpress-seo` or `/plugins/mailpoet`
* Click on the `Premium version available` USP link
* Check if the event `calypso_plugin_details_premium_plugin_link_click` was logged


<img width="1138" alt="Screen Shot 2022-12-21 at 12 03 12" src="https://user-images.githubusercontent.com/5039531/210244717-9e9a1e1b-bca6-4cbd-b79a-c45a48fc5283.png">

