### PR TITLE
WooExpress Trial: Initial flow framework

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -67,6 +67,7 @@ button {
 .anchor-fm,
 .subscribers,
 .ecommerce,
+.wooexpress-trial,
 .intro,
 .free-setup,
 .free-post-setup,
@@ -300,6 +301,7 @@ button {
 	}
 }
 
+.wooexpress-trial,
 .ecommerce {
 	.step-container.processing-step {
 		display: flex;

--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -67,7 +67,7 @@ button {
 .anchor-fm,
 .subscribers,
 .ecommerce,
-.wooexpress-trial,
+.wooexpress,
 .intro,
 .free-setup,
 .free-post-setup,
@@ -301,7 +301,7 @@ button {
 	}
 }
 
-.wooexpress-trial,
+.wooexpress,
 .ecommerce {
 	.step-container.processing-step {
 		display: flex;

--- a/client/landing/stepper/declarative-flow/registered-flows.ts
+++ b/client/landing/stepper/declarative-flow/registered-flows.ts
@@ -40,7 +40,7 @@ const availableFlows: Record< string, () => Promise< { default: Flow } > > = {
 			/* webpackChunkName: "tailored-ecommerce-flow" */ '../declarative-flow/tailored-ecommerce-flow'
 		),
 
-	wooExpressTrial: () =>
+	wooexpress: () =>
 		import(
 			/* webpackChunkName: "trial-wooexpress-flow" */ '../declarative-flow/trial-wooexpress-flow'
 		),

--- a/client/landing/stepper/declarative-flow/registered-flows.ts
+++ b/client/landing/stepper/declarative-flow/registered-flows.ts
@@ -40,9 +40,9 @@ const availableFlows: Record< string, () => Promise< { default: Flow } > > = {
 			/* webpackChunkName: "tailored-ecommerce-flow" */ '../declarative-flow/tailored-ecommerce-flow'
 		),
 
-	ecommerceTrial: () =>
+	wooExpressTrial: () =>
 		import(
-			/* webpackChunkName: "trial-ecommerce-flow" */ '../declarative-flow/trial-ecommerce-flow'
+			/* webpackChunkName: "trial-wooexpress-flow" */ '../declarative-flow/trial-wooexpress-flow'
 		),
 
 	free: () => import( /* webpackChunkName: "free-flow" */ '../declarative-flow/free' ),

--- a/client/landing/stepper/declarative-flow/registered-flows.ts
+++ b/client/landing/stepper/declarative-flow/registered-flows.ts
@@ -40,6 +40,11 @@ const availableFlows: Record< string, () => Promise< { default: Flow } > > = {
 			/* webpackChunkName: "tailored-ecommerce-flow" */ '../declarative-flow/tailored-ecommerce-flow'
 		),
 
+	ecommerceTrial: () =>
+		import(
+			/* webpackChunkName: "trial-ecommerce-flow" */ '../declarative-flow/trial-ecommerce-flow'
+		),
+
 	free: () => import( /* webpackChunkName: "free-flow" */ '../declarative-flow/free' ),
 
 	'free-post-setup': () =>
@@ -50,4 +55,5 @@ if ( config.isEnabled( 'themes/plugin-bundling' ) ) {
 	availableFlows[ 'plugin-bundle' ] = () =>
 		import( /* webpackChunkName: "plugin-bundle-flow" */ '../declarative-flow/plugin-bundle-flow' );
 }
+
 export default availableFlows;

--- a/client/landing/stepper/declarative-flow/trial-ecommerce-flow.ts
+++ b/client/landing/stepper/declarative-flow/trial-ecommerce-flow.ts
@@ -1,0 +1,62 @@
+import { useSelect, useDispatch } from '@wordpress/data';
+import { useSiteSetupFlowProgress } from '../hooks/use-site-setup-flow-progress';
+import { useSiteSlugParam } from '../hooks/use-site-slug-param';
+import { ONBOARD_STORE } from '../stores';
+import { recordSubmitStep } from './internals/analytics/record-submit-step';
+import ProcessingStep, { ProcessingResult } from './internals/steps-repository/processing-step';
+import SiteCreationStep from './internals/steps-repository/site-creation-step';
+import { Flow, ProvidedDependencies } from './internals/types';
+
+const ecommerceTrialFlow: Flow = {
+	name: 'ecommerce-trial',
+
+	useSteps() {
+		return [
+			{ slug: 'siteCreationStep', component: SiteCreationStep },
+			{ slug: 'processing', component: ProcessingStep },
+		];
+	},
+	useStepNavigation( currentStep, navigate ) {
+		const flowName = this.name;
+		const intent = useSelect( ( select ) => select( ONBOARD_STORE ).getIntent() );
+		const siteSlugParam = useSiteSlugParam();
+
+		const { setStepProgress } = useDispatch( ONBOARD_STORE );
+		const storeType = useSelect( ( select ) => select( ONBOARD_STORE ).getStoreType() );
+
+		const flowProgress = useSiteSetupFlowProgress( currentStep, intent, storeType );
+
+		if ( flowProgress ) {
+			setStepProgress( flowProgress );
+		}
+
+		const exitFlow = ( to: string ) => {
+			window.location.assign( to );
+		};
+
+		function submit( providedDependencies: ProvidedDependencies = {}, ...params: string[] ) {
+			recordSubmitStep( providedDependencies, intent, flowName, currentStep );
+			const siteSlug = ( providedDependencies?.siteSlug as string ) || siteSlugParam || '';
+
+			switch ( currentStep ) {
+				case 'siteCreationStep': {
+					return navigate( 'processing' );
+				}
+
+				case 'processing': {
+					const processingResult = params[ 0 ] as ProcessingResult;
+
+					if ( processingResult === ProcessingResult.FAILURE ) {
+						return navigate( 'error' );
+					}
+
+					return exitFlow( `/home/${ siteSlug }` );
+				}
+			}
+		}
+
+		return { submit, exitFlow };
+	},
+};
+
+export default ecommerceTrialFlow;

--- a/client/landing/stepper/declarative-flow/trial-wooexpress-flow.ts
+++ b/client/landing/stepper/declarative-flow/trial-wooexpress-flow.ts
@@ -10,8 +10,8 @@ import SiteCreationStep from './internals/steps-repository/site-creation-step';
 import { AssertConditionState } from './internals/types';
 import type { AssertConditionResult, Flow, ProvidedDependencies } from './internals/types';
 
-const wooExpressTrialFlow: Flow = {
-	name: 'wooexpress-trial',
+const wooexpress: Flow = {
+	name: 'wooexpress',
 
 	useSteps() {
 		return [
@@ -37,7 +37,7 @@ const wooExpressTrialFlow: Flow = {
 			}
 
 			const redirectTarget =
-				`/setup/wooExpressTrial` +
+				`/setup/wooexpress` +
 				( hasFlowParams ? encodeURIComponent( '?' + flowParams.toString() ) : '' );
 			const url =
 				locale && locale !== 'en'
@@ -101,4 +101,4 @@ const wooExpressTrialFlow: Flow = {
 	},
 };
 
-export default wooExpressTrialFlow;
+export default wooexpress;

--- a/client/landing/stepper/declarative-flow/trial-wooexpress-flow.ts
+++ b/client/landing/stepper/declarative-flow/trial-wooexpress-flow.ts
@@ -6,12 +6,8 @@ import { USER_STORE, ONBOARD_STORE } from '../stores';
 import { recordSubmitStep } from './internals/analytics/record-submit-step';
 import ProcessingStep, { ProcessingResult } from './internals/steps-repository/processing-step';
 import SiteCreationStep from './internals/steps-repository/site-creation-step';
-import {
-	AssertConditionResult,
-	AssertConditionState,
-	Flow,
-	ProvidedDependencies,
-} from './internals/types';
+import { AssertConditionState } from './internals/types';
+import type { AssertConditionResult, Flow, ProvidedDependencies } from './internals/types';
 
 const wooExpressTrialFlow: Flow = {
 	name: 'wooexpress-trial',

--- a/client/landing/stepper/declarative-flow/trial-wooexpress-flow.ts
+++ b/client/landing/stepper/declarative-flow/trial-wooexpress-flow.ts
@@ -4,6 +4,7 @@ import { useSiteSetupFlowProgress } from '../hooks/use-site-setup-flow-progress'
 import { useSiteSlugParam } from '../hooks/use-site-slug-param';
 import { USER_STORE, ONBOARD_STORE } from '../stores';
 import { recordSubmitStep } from './internals/analytics/record-submit-step';
+import ErrorStep from './internals/steps-repository/error-step';
 import ProcessingStep, { ProcessingResult } from './internals/steps-repository/processing-step';
 import SiteCreationStep from './internals/steps-repository/site-creation-step';
 import { AssertConditionState } from './internals/types';
@@ -16,6 +17,7 @@ const wooExpressTrialFlow: Flow = {
 		return [
 			{ slug: 'siteCreationStep', component: SiteCreationStep },
 			{ slug: 'processing', component: ProcessingStep },
+			{ slug: 'error', component: ErrorStep },
 		];
 	},
 	useAssertConditions(): AssertConditionResult {

--- a/client/landing/stepper/declarative-flow/trial-wooexpress-flow.ts
+++ b/client/landing/stepper/declarative-flow/trial-wooexpress-flow.ts
@@ -39,12 +39,17 @@ const wooexpress: Flow = {
 			const redirectTarget =
 				`/setup/wooexpress` +
 				( hasFlowParams ? encodeURIComponent( '?' + flowParams.toString() ) : '' );
-			const url =
-				locale && locale !== 'en'
-					? `/start/account/user/${ locale }?variationName=${ flowName }&redirect_to=${ redirectTarget }`
-					: `/start/account/user?variationName=${ flowName }&redirect_to=${ redirectTarget }`;
+			// Early return approach
+			if ( locale || locale === 'en' ) {
+				return `/start/account/user/${ locale }?variationName=${ flowName }&redirect_to=${ redirectTarget }`;
+			}
+			
+			return `/start/account/user?variationName=${ flowName }&redirect_to=${ redirectTarget }`;
 
-			return url;
+			// Initial URL approach
+			const baseUrl = '/start/account/user' + ( locale && locale !== 'en' ? `/${ locale }` : '' );
+
+			return baseUrl + `?variationName=${ flowName }&redirect_to=${ redirectTarget }`;
 		};
 
 		if ( ! userIsLoggedIn ) {

--- a/client/landing/stepper/declarative-flow/trial-wooexpress-flow.ts
+++ b/client/landing/stepper/declarative-flow/trial-wooexpress-flow.ts
@@ -22,7 +22,6 @@ const wooExpressTrialFlow: Flow = {
 		const userIsLoggedIn = useSelect( ( select ) => select( USER_STORE ).isCurrentUserLoggedIn() );
 		let result: AssertConditionResult = { state: AssertConditionState.SUCCESS };
 
-		const flags = new URLSearchParams( window.location.search ).get( 'flags' );
 		const flowName = this.name;
 		const locale = useLocale();
 
@@ -36,14 +35,14 @@ const wooExpressTrialFlow: Flow = {
 			}
 
 			const redirectTarget =
-				`/setup/wooexpress-trial/processing` +
+				`/setup/wooExpressTrial` +
 				( hasFlowParams ? encodeURIComponent( '?' + flowParams.toString() ) : '' );
 			const url =
 				locale && locale !== 'en'
 					? `/start/account/user/${ locale }?variationName=${ flowName }&redirect_to=${ redirectTarget }`
 					: `/start/account/user?variationName=${ flowName }&redirect_to=${ redirectTarget }`;
 
-			return url + ( flags ? `&flags=${ flags }` : '' );
+			return url;
 		};
 
 		if ( ! userIsLoggedIn ) {
@@ -51,7 +50,7 @@ const wooExpressTrialFlow: Flow = {
 			window.location.assign( logInUrl );
 			result = {
 				state: AssertConditionState.FAILURE,
-				message: 'store-setup requires a logged in user',
+				message: 'wooexpress-trial requires a logged in user',
 			};
 		}
 

--- a/client/landing/stepper/declarative-flow/trial-wooexpress-flow.ts
+++ b/client/landing/stepper/declarative-flow/trial-wooexpress-flow.ts
@@ -7,8 +7,8 @@ import ProcessingStep, { ProcessingResult } from './internals/steps-repository/p
 import SiteCreationStep from './internals/steps-repository/site-creation-step';
 import { Flow, ProvidedDependencies } from './internals/types';
 
-const ecommerceTrialFlow: Flow = {
-	name: 'ecommerce-trial',
+const wooExpressTrialFlow: Flow = {
+	name: 'wooexpress-trial',
 
 	useSteps() {
 		return [
@@ -59,4 +59,4 @@ const ecommerceTrialFlow: Flow = {
 	},
 };
 
-export default ecommerceTrialFlow;
+export default wooExpressTrialFlow;

--- a/client/landing/stepper/declarative-flow/trial-wooexpress-flow.ts
+++ b/client/landing/stepper/declarative-flow/trial-wooexpress-flow.ts
@@ -43,7 +43,7 @@ const wooexpress: Flow = {
 			if ( locale || locale === 'en' ) {
 				return `/start/account/user/${ locale }?variationName=${ flowName }&redirect_to=${ redirectTarget }`;
 			}
-			
+
 			return `/start/account/user?variationName=${ flowName }&redirect_to=${ redirectTarget }`;
 
 			// Initial URL approach

--- a/packages/calypso-products/src/constants/wpcom.ts
+++ b/packages/calypso-products/src/constants/wpcom.ts
@@ -26,6 +26,7 @@ export const PLAN_BLOGGER_2_YEARS = 'blogger-bundle-2y';
 export const PLAN_ECOMMERCE_MONTHLY = 'ecommerce-bundle-monthly';
 export const PLAN_ECOMMERCE = 'ecommerce-bundle';
 export const PLAN_ECOMMERCE_2_YEARS = 'ecommerce-bundle-2y';
+export const PLAN_ECOMMERCE_TRIAL_MONTHLY = 'wp-bundle-ecommerce-trial';
 export const PLAN_FREE = 'free_plan';
 export const PLAN_HOST_BUNDLE = 'host-bundle';
 export const PLAN_WPCOM_ENTERPRISE = 'wpcom-enterprise';
@@ -53,6 +54,7 @@ export const WPCOM_PLANS = <const>[
 	PLAN_ECOMMERCE_MONTHLY,
 	PLAN_ECOMMERCE,
 	PLAN_ECOMMERCE_2_YEARS,
+	PLAN_ECOMMERCE_TRIAL_MONTHLY,
 	PLAN_FREE,
 	PLAN_HOST_BUNDLE,
 	PLAN_WPCOM_ENTERPRISE,
@@ -71,6 +73,7 @@ export const WPCOM_MONTHLY_PLANS = <const>[
 	PLAN_PREMIUM_MONTHLY,
 	PLAN_PERSONAL_MONTHLY,
 	PLAN_ECOMMERCE_MONTHLY,
+	PLAN_ECOMMERCE_TRIAL_MONTHLY,
 	PLAN_WPCOM_PRO_MONTHLY,
 ];
 

--- a/packages/calypso-products/src/constants/wpcom.ts
+++ b/packages/calypso-products/src/constants/wpcom.ts
@@ -26,7 +26,7 @@ export const PLAN_BLOGGER_2_YEARS = 'blogger-bundle-2y';
 export const PLAN_ECOMMERCE_MONTHLY = 'ecommerce-bundle-monthly';
 export const PLAN_ECOMMERCE = 'ecommerce-bundle';
 export const PLAN_ECOMMERCE_2_YEARS = 'ecommerce-bundle-2y';
-export const PLAN_ECOMMERCE_TRIAL_MONTHLY = 'wp-bundle-ecommerce-trial';
+export const PLAN_WOOEXPRESS_TRIAL_MONTHLY = 'ecommerce-trial-bundle-monthly';
 export const PLAN_FREE = 'free_plan';
 export const PLAN_HOST_BUNDLE = 'host-bundle';
 export const PLAN_WPCOM_ENTERPRISE = 'wpcom-enterprise';
@@ -54,7 +54,7 @@ export const WPCOM_PLANS = <const>[
 	PLAN_ECOMMERCE_MONTHLY,
 	PLAN_ECOMMERCE,
 	PLAN_ECOMMERCE_2_YEARS,
-	PLAN_ECOMMERCE_TRIAL_MONTHLY,
+	PLAN_WOOEXPRESS_TRIAL_MONTHLY,
 	PLAN_FREE,
 	PLAN_HOST_BUNDLE,
 	PLAN_WPCOM_ENTERPRISE,
@@ -73,7 +73,7 @@ export const WPCOM_MONTHLY_PLANS = <const>[
 	PLAN_PREMIUM_MONTHLY,
 	PLAN_PERSONAL_MONTHLY,
 	PLAN_ECOMMERCE_MONTHLY,
-	PLAN_ECOMMERCE_TRIAL_MONTHLY,
+	PLAN_WOOEXPRESS_TRIAL_MONTHLY,
 	PLAN_WPCOM_PRO_MONTHLY,
 ];
 

--- a/packages/calypso-products/src/constants/wpcom.ts
+++ b/packages/calypso-products/src/constants/wpcom.ts
@@ -26,7 +26,7 @@ export const PLAN_BLOGGER_2_YEARS = 'blogger-bundle-2y';
 export const PLAN_ECOMMERCE_MONTHLY = 'ecommerce-bundle-monthly';
 export const PLAN_ECOMMERCE = 'ecommerce-bundle';
 export const PLAN_ECOMMERCE_2_YEARS = 'ecommerce-bundle-2y';
-export const PLAN_WOOEXPRESS_TRIAL_MONTHLY = 'ecommerce-trial-bundle-monthly';
+export const PLAN_ECOMMERCE_TRIAL_MONTHLY = 'ecommerce-trial-bundle-monthly';
 export const PLAN_FREE = 'free_plan';
 export const PLAN_HOST_BUNDLE = 'host-bundle';
 export const PLAN_WPCOM_ENTERPRISE = 'wpcom-enterprise';
@@ -54,7 +54,7 @@ export const WPCOM_PLANS = <const>[
 	PLAN_ECOMMERCE_MONTHLY,
 	PLAN_ECOMMERCE,
 	PLAN_ECOMMERCE_2_YEARS,
-	PLAN_WOOEXPRESS_TRIAL_MONTHLY,
+	PLAN_ECOMMERCE_TRIAL_MONTHLY,
 	PLAN_FREE,
 	PLAN_HOST_BUNDLE,
 	PLAN_WPCOM_ENTERPRISE,
@@ -73,7 +73,7 @@ export const WPCOM_MONTHLY_PLANS = <const>[
 	PLAN_PREMIUM_MONTHLY,
 	PLAN_PERSONAL_MONTHLY,
 	PLAN_ECOMMERCE_MONTHLY,
-	PLAN_WOOEXPRESS_TRIAL_MONTHLY,
+	PLAN_ECOMMERCE_TRIAL_MONTHLY,
 	PLAN_WPCOM_PRO_MONTHLY,
 ];
 

--- a/packages/data-stores/src/plans/constants.ts
+++ b/packages/data-stores/src/plans/constants.ts
@@ -33,7 +33,7 @@ export const PLAN_PERSONAL_MONTHLY = 'personal-bundle-monthly';
 export const PLAN_PREMIUM_MONTHLY = 'value_bundle_monthly';
 export const PLAN_BUSINESS_MONTHLY = 'business-bundle-monthly';
 export const PLAN_ECOMMERCE_MONTHLY = 'ecommerce-bundle-monthly';
-export const PLAN_WOOEXPRESS_TRIAL_MONTHLY = 'ecommerce-trial-bundle-monthly';
+export const PLAN_ECOMMERCE_TRIAL_MONTHLY = 'ecommerce-trial-bundle-monthly';
 
 export const annualSlugs = [ PLAN_PERSONAL, PLAN_PREMIUM, PLAN_BUSINESS, PLAN_ECOMMERCE ] as const;
 
@@ -42,7 +42,7 @@ export const monthlySlugs = [
 	PLAN_PREMIUM_MONTHLY,
 	PLAN_BUSINESS_MONTHLY,
 	PLAN_ECOMMERCE_MONTHLY,
-	PLAN_WOOEXPRESS_TRIAL_MONTHLY,
+	PLAN_ECOMMERCE_TRIAL_MONTHLY,
 ] as const;
 
 export const plansProductSlugs = [ PLAN_FREE, ...annualSlugs, ...monthlySlugs ] as const;

--- a/packages/data-stores/src/plans/constants.ts
+++ b/packages/data-stores/src/plans/constants.ts
@@ -33,6 +33,7 @@ export const PLAN_PERSONAL_MONTHLY = 'personal-bundle-monthly';
 export const PLAN_PREMIUM_MONTHLY = 'value_bundle_monthly';
 export const PLAN_BUSINESS_MONTHLY = 'business-bundle-monthly';
 export const PLAN_ECOMMERCE_MONTHLY = 'ecommerce-bundle-monthly';
+export const PLAN_ECOMMERCE_TRIAL_MONTHLY = 'wp-bundle-ecommerce-trial';
 
 export const annualSlugs = [ PLAN_PERSONAL, PLAN_PREMIUM, PLAN_BUSINESS, PLAN_ECOMMERCE ] as const;
 
@@ -41,6 +42,7 @@ export const monthlySlugs = [
 	PLAN_PREMIUM_MONTHLY,
 	PLAN_BUSINESS_MONTHLY,
 	PLAN_ECOMMERCE_MONTHLY,
+	PLAN_ECOMMERCE_TRIAL_MONTHLY,
 ] as const;
 
 export const plansProductSlugs = [ PLAN_FREE, ...annualSlugs, ...monthlySlugs ] as const;

--- a/packages/data-stores/src/plans/constants.ts
+++ b/packages/data-stores/src/plans/constants.ts
@@ -33,7 +33,7 @@ export const PLAN_PERSONAL_MONTHLY = 'personal-bundle-monthly';
 export const PLAN_PREMIUM_MONTHLY = 'value_bundle_monthly';
 export const PLAN_BUSINESS_MONTHLY = 'business-bundle-monthly';
 export const PLAN_ECOMMERCE_MONTHLY = 'ecommerce-bundle-monthly';
-export const PLAN_ECOMMERCE_TRIAL_MONTHLY = 'wp-bundle-ecommerce-trial';
+export const PLAN_WOOEXPRESS_TRIAL_MONTHLY = 'ecommerce-trial-bundle-monthly';
 
 export const annualSlugs = [ PLAN_PERSONAL, PLAN_PREMIUM, PLAN_BUSINESS, PLAN_ECOMMERCE ] as const;
 
@@ -42,7 +42,7 @@ export const monthlySlugs = [
 	PLAN_PREMIUM_MONTHLY,
 	PLAN_BUSINESS_MONTHLY,
 	PLAN_ECOMMERCE_MONTHLY,
-	PLAN_ECOMMERCE_TRIAL_MONTHLY,
+	PLAN_WOOEXPRESS_TRIAL_MONTHLY,
 ] as const;
 
 export const plansProductSlugs = [ PLAN_FREE, ...annualSlugs, ...monthlySlugs ] as const;

--- a/packages/onboarding/src/utils/flows.ts
+++ b/packages/onboarding/src/utils/flows.ts
@@ -6,6 +6,7 @@ export const LINK_IN_BIO_POST_SETUP_FLOW = 'link-in-bio-post-setup';
 export const VIDEOPRESS_FLOW = 'videopress';
 export const IMPORT_FOCUSED_FLOW = 'import-focused';
 export const ECOMMERCE_FLOW = 'ecommerce';
+export const ECOMMERCE_TRIAL_FLOW = 'ecommerce-trial';
 export const FREE_FLOW = 'free';
 export const FREE_POST_SETUP_FLOW = 'free-post-setup';
 

--- a/packages/onboarding/src/utils/flows.ts
+++ b/packages/onboarding/src/utils/flows.ts
@@ -6,7 +6,7 @@ export const LINK_IN_BIO_POST_SETUP_FLOW = 'link-in-bio-post-setup';
 export const VIDEOPRESS_FLOW = 'videopress';
 export const IMPORT_FOCUSED_FLOW = 'import-focused';
 export const ECOMMERCE_FLOW = 'ecommerce';
-export const WOOEXPRESS_TRIAL_FLOW = 'wooexpress-trial';
+export const WOOEXPRESS_FLOW = 'wooexpress';
 export const FREE_FLOW = 'free';
 export const FREE_POST_SETUP_FLOW = 'free-post-setup';
 

--- a/packages/onboarding/src/utils/flows.ts
+++ b/packages/onboarding/src/utils/flows.ts
@@ -6,7 +6,7 @@ export const LINK_IN_BIO_POST_SETUP_FLOW = 'link-in-bio-post-setup';
 export const VIDEOPRESS_FLOW = 'videopress';
 export const IMPORT_FOCUSED_FLOW = 'import-focused';
 export const ECOMMERCE_FLOW = 'ecommerce';
-export const ECOMMERCE_TRIAL_FLOW = 'ecommerce-trial';
+export const WOOEXPRESS_TRIAL_FLOW = 'wooexpress-trial';
 export const FREE_FLOW = 'free';
 export const FREE_POST_SETUP_FLOW = 'free-post-setup';
 


### PR DESCRIPTION
#### Proposed Changes

This adds the basic WooExpress trial flow framework. We also added product constants for use in future PRs.

Accessing the flow creates a new site with a default domain name and free plan and redirects the user to the dashboard.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Logged-in user**
1. Go to http://calypso.localhost:3000/setup/wooexpress/
2. You should see the `processing` step.
3. After the `processing` step, you should be redirected to the dashboard.

**Logged-out user**
1. Go to http://calypso.localhost:3000/setup/wooexpress/
2. You should be redirected to the account creation page.

The new site should have a domain name like `[wpcom username][NN].wordpress.com` (eg `markbiek94.wordpress.com`) and be on the Free plan.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [NA] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [NA] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [NA] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [NA] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [NA] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
