### PR TITLE
Migrate PurchaseMetaOwner component  from the Purchases page to TypeScript

### DIFF
--- a/client/components/user/index.jsx
+++ b/client/components/user/index.jsx
@@ -1,24 +1,20 @@
 import PropTypes from 'prop-types';
-import { Component } from 'react';
 import Gravatar from 'calypso/components/gravatar';
 
 import './style.scss';
 
-export default class User extends Component {
-	static displayName = 'User';
+const User = ( { user } ) => {
+	const name = user ? user.display_name || user.name : '';
+	return (
+		<div className="user" title={ name }>
+			<Gravatar size={ 26 } user={ user } />
+			<span className="user__name">{ name }</span>
+		</div>
+	);
+};
 
-	static propTypes = {
-		user: PropTypes.object,
-	};
+User.propTypes = {
+	user: PropTypes.object,
+};
 
-	render() {
-		const user = this.props.user || null;
-		const name = user ? user.display_name || user.name : '';
-		return (
-			<div className="user" title={ name }>
-				<Gravatar size={ 26 } user={ user } />
-				<span className="user__name">{ name }</span>
-			</div>
-		);
-	}
-}
+export default User;

--- a/client/lib/purchases/types.ts
+++ b/client/lib/purchases/types.ts
@@ -271,3 +271,8 @@ export interface MembershipSubscriptionsSite {
 }
 
 export type GetChangePaymentMethodUrlFor = ( siteSlug: string, purchase: Purchase ) => string;
+
+export interface Owner {
+	ID: string;
+	display_name: string;
+}

--- a/client/me/purchases/manage-purchase/purchase-meta-owner.tsx
+++ b/client/me/purchases/manage-purchase/purchase-meta-owner.tsx
@@ -1,7 +1,8 @@
 import { useTranslate } from 'i18n-calypso';
 import UserItem from 'calypso/components/user';
+import type { Owner } from 'calypso/lib/purchases/types';
 
-function PurchaseMetaOwner( { owner } ) {
+function PurchaseMetaOwner( { owner }: { owner: Owner } ) {
 	const translate = useTranslate();
 	if ( ! owner ) {
 		return null;

--- a/client/me/purchases/manage-purchase/purchase-meta-owner.tsx
+++ b/client/me/purchases/manage-purchase/purchase-meta-owner.tsx
@@ -1,0 +1,20 @@
+import { useTranslate } from 'i18n-calypso';
+import UserItem from 'calypso/components/user';
+
+function PurchaseMetaOwner( { owner } ) {
+	const translate = useTranslate();
+	if ( ! owner ) {
+		return null;
+	}
+
+	return (
+		<li>
+			<em className="manage-purchase__detail-label">{ translate( 'Owner' ) }</em>
+			<span className="manage-purchase__detail">
+				<UserItem user={ { ...owner, name: owner.display_name } } />
+			</span>
+		</li>
+	);
+}
+
+export default PurchaseMetaOwner;

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -18,7 +18,6 @@ import { useSelector } from 'react-redux';
 import ClipboardButton from 'calypso/components/forms/clipboard-button';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
-import UserItem from 'calypso/components/user';
 import useUserLicenseBySubscriptionQuery from 'calypso/data/jetpack-licensing/use-user-license-by-subscription-query';
 import {
 	getName,
@@ -41,6 +40,7 @@ import { managePurchase } from '../paths';
 import { isJetpackTemporarySitePurchase } from '../utils';
 import AutoRenewToggle from './auto-renew-toggle';
 import PurchaseMetaIntroductoryOfferDetail from './purchase-meta-introductory-offer-detail';
+import PurchaseMetaOwner from './purchase-meta-owner';
 import PurchaseMetaPaymentDetails from './purchase-meta-payment-details';
 import PurchaseMetaPrice from './purchase-meta-price';
 
@@ -195,22 +195,6 @@ function PurchaseMetaPlaceholder() {
 				</li>
 			) ) }
 		</ul>
-	);
-}
-
-function PurchaseMetaOwner( { owner } ) {
-	const translate = useTranslate();
-	if ( ! owner ) {
-		return null;
-	}
-
-	return (
-		<li>
-			<em className="manage-purchase__detail-label">{ translate( 'Owner' ) }</em>
-			<span className="manage-purchase__detail">
-				<UserItem user={ { ...owner, name: owner.display_name } } />
-			</span>
-		</li>
 	);
 }
 


### PR DESCRIPTION
### Testing Instructions:

* As it is a TypeScript migration, it should not change anything so ensure that the usual functionality described below on the purchases page just works as expected.
* Goto this page `/purchases/subscriptions/:site/:purchaseID` ,  for any purchase you should see the `owner` component as usual without any changes [with gravatar and name].   
![isCZtO.png](https://user-images.githubusercontent.com/552016/210277956-0be24ddd-cfed-4bfd-b03b-d64a19c97403.png)

Fixes https://github.com/Automattic/payments-shilling/issues/1307

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
