### PR TITLE
Created blaze track event on post/page listing

### DIFF
--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/promote.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/promote.jsx
@@ -3,6 +3,7 @@ import { localize, useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { connect, useSelector } from 'react-redux';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import {
 	recordDSPEntryPoint,
 	usePromoteWidget,
@@ -62,6 +63,7 @@ function PostActionsEllipsisMenuPromote( {
 
 	const showDSPWidget = () => {
 		dispatch( recordDSPEntryPoint( bumpStatKey ) );
+		recordTracksEvent( 'calypso_post_type_list_blaze' );
 		openModal();
 	};
 


### PR DESCRIPTION
task-related: https://github.com/Automattic/wp-calypso/issues/71610
Extra-context: p1672257326587239-slack-C04DZ725FEK

#### Proposed Changes
Added blaze event on clicking at posts/page listing `Promote Post`


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- On a Simple/Atomic site, open page/post and click on `Promote Post` (inside of three dots page/post listing)
- You should see a new event `calypso_post_type_list_blaze` being fired