### PR TITLE
Stats: add styling for annual insights table

### DIFF
--- a/client/my-sites/stats/summary/style.scss
+++ b/client/my-sites/stats/summary/style.scss
@@ -10,6 +10,6 @@
 
 	tbody tr:nth-child( odd ),
 	.module-content-table-scroll tbody > tr:nth-child( odd ) > th {
-		background: $studio-gray-0;
+		background-color: var(--studio-gray-0);
 	}
 }

--- a/client/my-sites/stats/summary/style.scss
+++ b/client/my-sites/stats/summary/style.scss
@@ -1,5 +1,3 @@
-@import '~@automattic/color-studio/dist/color-variables';
-
 .stats-summary-view {
 	.highlight-cards-heading {
 		@media ( min-width: 661px ) and ( max-width: 1380px ) {
@@ -8,8 +6,8 @@
 		}
 	}
 
-	tbody tr:nth-child( odd ),
-	.module-content-table-scroll tbody > tr:nth-child( odd ) > th {
-		background-color: var(--studio-gray-0);
+	tbody tr:nth-child(odd),
+	.is-fixed-row-header tbody > tr:nth-child(odd) > th {
+		background-color: var( --studio-gray-0 );
 	}
 }

--- a/client/my-sites/stats/summary/style.scss
+++ b/client/my-sites/stats/summary/style.scss
@@ -1,8 +1,15 @@
+@import '~@automattic/color-studio/dist/color-variables';
+
 .stats-summary-view {
 	.highlight-cards-heading {
 		@media ( min-width: 661px ) and ( max-width: 1380px ) {
 			margin-left: 32px;
 			margin-right: 32px;
 		}
+	}
+
+	tbody tr:nth-child( odd ),
+	.module-content-table-scroll tbody > tr:nth-child( odd ) > th {
+		background: $studio-gray-0;
 	}
 }

--- a/client/my-sites/stats/summary/style.scss
+++ b/client/my-sites/stats/summary/style.scss
@@ -8,6 +8,6 @@
 
 	tbody tr:nth-child(odd),
 	.is-fixed-row-header tbody > tr:nth-child(odd) > th {
-		background-color: var( --studio-gray-0 );
+		background-color: var(--studio-gray-0);
 	}
 }


### PR DESCRIPTION
#### Proposed Changes

* Adds zebra stripes (alternating row color) styling to annual insights table to make it easier to parse. 

#### Testing Instructions

| First Header  | Second Header |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/30754158/210283212-aff3cce5-b007-4cbb-b2a7-2a0287339487.png)  | ![image](https://user-images.githubusercontent.com/30754158/210283220-b1407383-4d5a-4891-af44-0b4002bf63d9.png)  |

* Visit the Calypso Live branch.
* Navigate to the Annual Insights page at `/stats/day/annualstats/[SiteURL]`
* Confirm that the table has alternating row colors

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #70608 