### PR TITLE
Clarify Social and VideoPress on Comparison Page

### DIFF
--- a/client/jetpack-cloud/sections/comparison/table/useComparisonData.tsx
+++ b/client/jetpack-cloud/sections/comparison/table/useComparisonData.tsx
@@ -212,16 +212,17 @@ export const useComparisonData = () => {
 						url: links.videopress,
 						info: {
 							FREE: {
-								content: translate( '1 video' ),
+								content: translate( '1 video (Up to 1GB)' ),
 							},
 							BACKUP: {
-								content: translate( '1 video' ),
+								content: translate( '1 video (Up to 1GB)' ),
 							},
 							SECURITY: {
-								content: translate( '1 video' ),
+								content: translate( '1 video (Up to 1GB)' ),
 							},
 							COMPLETE: {
-								content: <CheckIcon />,
+								highlight: true,
+								content: translate( 'Unlimited Videos (Up to 1TB)' ),
 							},
 						},
 					},
@@ -287,11 +288,11 @@ export const useComparisonData = () => {
 							},
 							SECURITY: {
 								highlight: true,
-								content: translate( 'Scheduled posting' ),
+								content: translate( 'Automated and Scheduled posting' ),
 							},
 							COMPLETE: {
 								highlight: true,
-								content: translate( 'Scheduled posting' ),
+								content: translate( 'Automated and Scheduled posting' ),
 							},
 						},
 					},


### PR DESCRIPTION
#### Proposed Changes

This diff updates the copy on the comparison page to be more clear when differentiating features

Context: p1672414183961959-slack-C01264051NE

#### Testing Instructions

1. Checkout this branch via `git switch fix/social-videopress-copy-comparison--page`
( The -- was unintentional )
2. Start up Calypso via `yarn start-jetpack-cloud`
3. Go to http://jetpack.cloud.localhost:3000/features/comparison
4. Make sure the changes match what was suggested in the context link
![Screenshot 2023-01-02 at 3 58 36 PM](https://user-images.githubusercontent.com/65001528/210283454-17c9c894-5a99-482e-907e-39fb30b6d030.jpg)

#### Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?