### PR TITLE
Plugin Details: Update the query time to stale of the elastic search query to 1 day

### DIFF
--- a/client/data/marketplace/use-es-query.ts
+++ b/client/data/marketplace/use-es-query.ts
@@ -96,10 +96,11 @@ export const getESPluginQueryParams = (
 	return [ cacheKey, fetchFn ];
 };
 
+const ONE_DAY_IN_MS = 1000 * 60 * 60 * 24;
 export const useESPlugin = (
 	slug: string,
 	fields?: Array< string >,
-	{ enabled = true, staleTime = 10000, refetchOnMount = true }: UseQueryOptions = {}
+	{ enabled = true, staleTime = ONE_DAY_IN_MS, refetchOnMount = true }: UseQueryOptions = {}
 ): UseQueryResult => {
 	const locale = useSelector( getCurrentUserLocale );
 


### PR DESCRIPTION
#### Proposed Changes

Update the time to consider the ES plugin query result stale from 1 second to 1 day.

---

> Query instances via useQuery or useInfiniteQuery by default consider cached data as stale.
To change this behavior, you can configure your queries both globally and per-query using the staleTime option. Specifying a longer staleTime means queries will not refetch their data as often.  [source](https://tanstack.com/query/v4/docs/react/guides/important-defaults)

Currently, this query is only used to show the **Premium plugin available** USP, which is not expected to change often, therefore it is safe to use a bigger stale time. 

Also, this is the default value for this query but it can be changed *per case* by passing the `staleTime` property.

For a better understanding of the `staleTime` property and how it differs from `cacheTime`, [check this guide](https://medium.com/doctolib/react-query-cachetime-vs-staletime-ec74defc483e).

#### Testing Instructions

1. Go to a plugin details page. Ex: `/plugins/wordpress-seo-premium`
2. Check if the ES API request is only done once.
3. Additionally, you can enable the React query dev tools and verify the request don't get stale often. 
4. In the current version in production, the assumptions `2` and `3` are not true.

