### PR TITLE
Fixed Unique Opens Count in Email Stats

### DIFF
--- a/client/my-sites/stats/controller.jsx
+++ b/client/my-sites/stats/controller.jsx
@@ -488,7 +488,7 @@ export function emailOpen( context, next ) {
 		return next();
 	}
 
-	const validTabs = [ 'opens_count', 'unique_opens' ];
+	const validTabs = [ 'opens_count', 'unique_opens_count' ];
 	const chartTab = validTabs.includes( queryOptions.tab ) ? queryOptions.tab : 'opens_count';
 
 	context.primary = (

--- a/client/my-sites/stats/stats-email-chart-tabs/utility.js
+++ b/client/my-sites/stats/stats-email-chart-tabs/utility.js
@@ -81,7 +81,7 @@ function addTooltipData( chartTab, item, period ) {
 				icon: <Icon className="gridicon" icon={ starEmpty } />,
 			} );
 			break;
-		case 'unique_opens':
+		case 'unique_opens_count':
 			tooltipData.push( {
 				label: translate( 'Unique opens' ),
 				value: numberFormat( item.value ),

--- a/client/my-sites/stats/stats-email-open-detail/index.jsx
+++ b/client/my-sites/stats/stats-email-open-detail/index.jsx
@@ -69,7 +69,7 @@ const CHART_OPENS = {
 	label: translate( 'Opens', { context: 'noun' } ),
 };
 const CHART_UNIQUE_OPENS = {
-	attr: 'unique_opens',
+	attr: 'unique_opens_count',
 	icon: <Icon className="gridicon" icon={ people } />,
 	label: translate( 'Unique opens', { context: 'noun' } ),
 };


### PR DESCRIPTION
#### Proposed Changes

The changes proposed in this PR fix the Unique Opens count in the Email stats, like this:
<img width="1083" alt="Screenshot 2023-01-03 at 11 17 36" src="https://user-images.githubusercontent.com/3832570/210339146-70cd1794-2964-443b-af12-fdfc51c17480.png">

Before, it was always disabled, like this:
<img width="1080" alt="Screenshot 2023-01-03 at 10 39 45" src="https://user-images.githubusercontent.com/3832570/210339203-daa6ae4d-4b84-45b4-8d0f-8588d3aa5f44.png">


#### Testing Instructions

1. Apply this branch to your local Calypso repository and start the application.
2. As the endpoint we use returns real data, it's quite possible you need to simulate having data by going to `client/state/stats/lists/utils.js`, line 1013, and add mocked data like this:
```js
		if ( dataRecord.period ) {
			const date = moment( dataRecord.period, 'YYYY-MM-DD' ).locale( 'en' );
			const localeSlug = getLocaleSlug();
			const localizedDate = moment( dataRecord.period, 'YYYY-MM-DD' ).locale( localeSlug );
			Object.assign( dataRecord, getChartLabels( payload.unit, date, localizedDate ) );
			dataRecord.opens_count = Math.random() * 100;
			dataRecord.unique_opens_count = Math.random() * 100;
		}
```
3. Insert manually in the browser address bar an URL with this format: `https://calypso.localhost:3000/stats/email/open/[the-doomain-of-your-blog]/day/[post-id]?flags=newsletter/stats`. Note that you can change day for week and month.
4. Check that you can click on `Opens` and `Unique Opens` tabs and the data changes accordingly.
Note: the endpoint retrieves data a bit slowly for now, as the fine tuning is still pending. Be patient, please 😄 

Thanks for the review! 🏅 