### PR TITLE
E2E: Fix artifacts overwriting

### DIFF
--- a/packages/calypso-e2e/src/jest-playwright-config/environment.ts
+++ b/packages/calypso-e2e/src/jest-playwright-config/environment.ts
@@ -148,16 +148,17 @@ class JestEnvironmentPlaywright extends NodeEnvironment {
 		}
 		const contexts = this.global.browser.contexts();
 		if ( this.failure ) {
-			let contextIndex = 0;
-			let pageIndex = 0;
+			let contextIndex = 1;
 
 			const artifactFilename = `${ this.testFilename }__${ sanitizeString( this.failure.name ) }`;
 
 			for await ( const context of contexts ) {
+				let pageIndex = 1;
 				const traceFilePath = path.join(
 					this.testArtifactsPath,
 					`${ artifactFilename }__${ contextIndex }.zip`
 				);
+
 				// Traces are saved per context.
 				await context.tracing.stop( { path: traceFilePath } );
 

--- a/packages/calypso-e2e/src/jest-playwright-config/environment.ts
+++ b/packages/calypso-e2e/src/jest-playwright-config/environment.ts
@@ -151,27 +151,29 @@ class JestEnvironmentPlaywright extends NodeEnvironment {
 			let contextIndex = 0;
 			let pageIndex = 0;
 
-			// Define artifact filename templates.
 			const artifactFilename = `${ this.testFilename }__${ sanitizeString( this.failure.name ) }`;
-			const traceFilePath = path.join(
-				this.testArtifactsPath,
-				`${ artifactFilename }__${ contextIndex }.zip`
-			);
-			const mediaFilePath = path.join(
-				this.testArtifactsPath,
-				`${ artifactFilename }__${ contextIndex }-${ pageIndex }`
-			);
 
 			for await ( const context of contexts ) {
+				const traceFilePath = path.join(
+					this.testArtifactsPath,
+					`${ artifactFilename }__${ contextIndex }.zip`
+				);
 				// Traces are saved per context.
 				await context.tracing.stop( { path: traceFilePath } );
+
 				for await ( const page of context.pages() ) {
+					// Define artifact filename.
+					const mediaFilePath = path.join(
+						this.testArtifactsPath,
+						`${ artifactFilename }__${ contextIndex }-${ pageIndex }`
+					);
+
 					// Screenshots and video are saved per page, where numerous
 					// pages may exist within a context.
 					await page.screenshot( { path: `${ mediaFilePath }.png`, timeout: env.TIMEOUT } );
 
-					// Close the now unnecessary page which also
-					// triggers saving of video to the disk.
+					// Close the now unnecessary page which also triggers saving
+					// of video to the disk.
 					await page.close();
 					await page.video()?.saveAs( `${ mediaFilePath }.webm` );
 					pageIndex++;


### PR DESCRIPTION
#### Proposed Changes

- Fix our E2E env setup teardown where artifacts are not being indexed correctly, ending up overriding each other,
- Change the indexing from 0- to 1-based for convenience (easier to tell how many contexts/pages were captured).

#### Testing Instructions

1. Create `test/e2e/specs/teardown-test.ts` with the following content:
   
   ```
   import { Browser } from 'playwright';
   
   declare const browser: Browser;
   
   describe( 'Teardown', () => {
   	it( 'creates artifacts for all contexts and', async () => {
   		const c1 = await browser.newContext();
   
   		await c1.newPage();
   		await c1.newPage();
   		await c1.newPage();
   
   		const c2 = await browser.newContext();
   
   		await c2.newPage();
   		await c2.newPage();
   		await c2.newPage();
   
   		expect( false ).toBe( true );
   	} );
   } );
   ```
2. `cd test/e2e`
3. `yarn jest specs/teardown-test.ts`
4. Open `test/e2e/results` folder and ensure that the created `teardown-test-*` folder contains artifacts for both contexts and their pages.
5. `git checkout trunk`
6. `yarn jest specs/teardown-test.ts`
7. Again, go to `test/e2e/results` and confirm that the last created `teardown-test-*` folder contains artifacts for only 1 context and 1 page.