### PR TITLE
Stats: Release the All-time insights section on the Insights page

### DIFF
--- a/client/my-sites/stats/all-time-views-section/index.tsx
+++ b/client/my-sites/stats/all-time-views-section/index.tsx
@@ -37,7 +37,7 @@ export default function AllTimeViewsSection( { siteId, slug }: { siteId: number;
 			{ siteId && <QuerySiteStats statType="statsVisits" siteId={ siteId } query={ query } /> }
 
 			<div className="highlight-cards">
-				<h1 className="highlight-cards-heading">{ translate( 'All-time Insights' ) }</h1>
+				<h1 className="highlight-cards-heading">{ translate( 'All-time insights' ) }</h1>
 
 				<div className="highlight-cards-list">
 					<Card className="highlight-card">

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -106,7 +106,7 @@
 		"signup/woo-verify-email": false,
 		"site-indicator": true,
 		"ssr/prefetch-timebox": true,
-		"stats/all-time-views": false,
+		"stats/all-time-views": true,
 		"stats/new-main-chart": true,
 		"stepper-woocommerce-poc": true,
 		"subscriber-csv-upload": true,

--- a/config/production.json
+++ b/config/production.json
@@ -126,7 +126,7 @@
 		"ssr/log-prefetch-errors": true,
 		"ssr/prefetch-timebox": true,
 		"ssr/sample-log-cache-misses": true,
-		"stats/all-time-views": false,
+		"stats/all-time-views": true,
 		"stats/new-main-chart": true,
 		"stepper-woocommerce-poc": true,
 		"subscriber-csv-upload": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -122,7 +122,7 @@
 		"signup/woo-verify-email": false,
 		"site-indicator": true,
 		"ssr/prefetch-timebox": true,
-		"stats/all-time-views": false,
+		"stats/all-time-views": true,
 		"stats/new-main-chart": true,
 		"stepper-woocommerce-poc": true,
 		"subscriber-csv-upload": true,

--- a/config/test.json
+++ b/config/test.json
@@ -89,7 +89,7 @@
 		"signup/social": true,
 		"site-indicator": true,
 		"ssr/prefetch-timebox": true,
-		"stats/all-time-views": false,
+		"stats/all-time-views": true,
 		"stats/new-main-chart": true,
 		"stepper-woocommerce-poc": true,
 		"themes/premium": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -131,7 +131,7 @@
 		"signup/woo-verify-email": false,
 		"site-indicator": true,
 		"ssr/prefetch-timebox": true,
-		"stats/all-time-views": false,
+		"stats/all-time-views": true,
 		"stats/new-main-chart": true,
 		"stepper-woocommerce-poc": true,
 		"subscriber-csv-upload": true,


### PR DESCRIPTION
#### Proposed Changes

* Fix capitalization of the title `All-time insights`.
* Enable the feature flag `stats/all-time-views` on all environments.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up this change with the Calypso Live link.
* Navigate to the Stats `Insights` page.
* Ensure the `All-time insights` section is displayed in line with the design.

<img width="1275" alt="截圖 2023-01-03 下午10 46 32" src="https://user-images.githubusercontent.com/6869813/210380370-107eef58-ec4f-4f38-ae04-c095b320f1f7.png">

<img width="572" alt="截圖 2023-01-03 下午10 55 33" src="https://user-images.githubusercontent.com/6869813/210383609-c093b273-e192-4347-ba80-cf2846b7cd71.png">

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #70610
