### PR TITLE
BBE: Add initial store flow

### DIFF
--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -326,6 +326,9 @@ export function setThemeOnSite( callback, { siteSlug, themeSlugWithRepo } ) {
 
 function addDIFMLiteProductToCart( callback, dependencies, step, reduxStore ) {
 	const { selectedDesign, selectedSiteCategory, isLetUsChooseSelected, siteSlug } = dependencies;
+	if ( step.lastKnownFlow === 'do-it-for-me-store' ) {
+		dependencies.isStoreFlow = true;
+	}
 	const extra = buildDIFMCartExtrasObject( dependencies );
 	const cartItem = {
 		product_slug: WPCOM_DIFM_LITE,

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -480,6 +480,23 @@ export function generateFlows( {
 			enableBranchSteps: true,
 		},
 		{
+			name: 'do-it-for-me-store',
+			steps: [
+				'user',
+				'new-or-existing-site',
+				'difm-site-picker',
+				'difm-store-options',
+				'social-profiles',
+				'difm-design-setup-site',
+				'difm-page-picker',
+			],
+			destination: getDIFMSignupDestination,
+			description: 'The BBE store flow',
+			excludeFromManageSiteFlows: true,
+			lastModified: '2023-03-01',
+			enableBranchSteps: true,
+		},
+		{
 			name: 'website-design-services',
 			steps: [ 'difm-options', 'social-profiles', 'difm-design-setup-site', 'difm-page-picker' ],
 			destination: getDIFMSignupDestination,

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -78,6 +78,7 @@ const stepNameToModuleName = {
 	'difm-site-picker': 'difm-site-picker',
 	'difm-design-setup-site': 'design-picker',
 	'difm-options': 'site-options',
+	'difm-store-options': 'site-options',
 	'difm-page-picker': 'page-picker',
 	'website-content': 'website-content',
 	intent: 'intent',

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -838,6 +838,17 @@ export function generateSteps( {
 				hideSkip: true,
 			},
 		},
+		'difm-store-options': {
+			stepName: 'site-options',
+			providesDependencies: [ 'siteTitle', 'tagline', 'newOrExistingSiteChoice' ],
+			optionalDependencies: [ 'newOrExistingSiteChoice' ],
+			defaultDependencies: {
+				newOrExistingSiteChoice: 'existing-site',
+			},
+			props: {
+				hideSkip: true,
+			},
+		},
 		'difm-page-picker': {
 			stepName: 'difm-page-picker',
 			providesDependencies: [ 'selectedPageTitles' ],

--- a/client/signup/reskinned-processing-screen/index.jsx
+++ b/client/signup/reskinned-processing-screen/index.jsx
@@ -10,7 +10,7 @@ import './style.scss';
 // Default estimated time to perform "loading"
 const DURATION_IN_MS = 6000;
 
-const flowsWithDesignPicker = [ 'setup-site', 'do-it-for-me' ];
+const flowsWithDesignPicker = [ 'setup-site', 'do-it-for-me', 'do-it-for-me-store' ];
 
 const useSteps = ( { flowName, hasPaidDomain, isDestinationSetupSiteFlow } ) => {
 	const { __ } = useI18n();

--- a/client/signup/steps/new-or-existing-site/index.tsx
+++ b/client/signup/steps/new-or-existing-site/index.tsx
@@ -1,8 +1,7 @@
-import { isEnabled } from '@automattic/calypso-config';
 import {
 	getPlan,
+	PLAN_BUSINESS,
 	PLAN_PREMIUM,
-	PLAN_WPCOM_PRO,
 	WPCOM_DIFM_LITE,
 } from '@automattic/calypso-products';
 import { IntentScreen } from '@automattic/onboarding';
@@ -31,6 +30,7 @@ interface Props {
 	goToNextStep: () => void;
 	submitSignupStep: ( { stepName, wasSkipped }: { stepName: string; wasSkipped: boolean } ) => void;
 	goToStep: ( stepName: string ) => void;
+	flowName: string;
 	stepName: string;
 }
 
@@ -56,9 +56,10 @@ export default function NewOrExistingSiteStep( props: Props ) {
 			args: {
 				displayCost,
 				fulfillmentDays: 4,
-				plan: isEnabled( 'plans/pro-plan' )
-					? getPlan( PLAN_WPCOM_PRO )?.getTitle()
-					: getPlan( PLAN_PREMIUM )?.getTitle(),
+				plan:
+					props.flowName === 'do-it-for-me-store'
+						? getPlan( PLAN_BUSINESS )?.getTitle()
+						: getPlan( PLAN_PREMIUM )?.getTitle(),
 			},
 			components: {
 				PriceWrapper: isLoading ? <Placeholder /> : <strong />,

--- a/client/signup/steps/site-options/index.scss
+++ b/client/signup/steps/site-options/index.scss
@@ -2,6 +2,7 @@
 @import "@wordpress/base-styles/mixins";
 
 .signup__step .is-site-options,
+.signup__step .is-difm-store-options
 .signup__step .is-difm-options {
 	.step-wrapper__header {
 		@include break-small {

--- a/client/signup/steps/site-options/index.tsx
+++ b/client/signup/steps/site-options/index.tsx
@@ -33,6 +33,17 @@ export default function SiteOptionsStep( props: Props ) {
 					siteTitleLabel: translate( 'Store name' ),
 					taglineExplanation: translate( 'In a few words, explain what your store is about.' ),
 				};
+			case 'difm-store-options':
+				return {
+					headerText: translate( "First, let's give your store a name" ),
+					headerImage: storeImageUrl,
+					siteTitleLabel: translate( 'Store name' ),
+					siteTitleExplanation: translate(
+						'Enter the name of your business or store as it should appear on your site.'
+					),
+					taglineExplanation: translate( 'In a few words, explain what your store is about.' ),
+					isSiteTitleRequired: true,
+				};
 			case 'difm-options':
 				return {
 					headerText: translate( "First, let's give your site a name" ),

--- a/client/state/difm/assemblers.ts
+++ b/client/state/difm/assemblers.ts
@@ -16,6 +16,7 @@ interface Dependencies {
 	displayPhone: string;
 	displayAddress: string;
 	selectedPageTitles: string[];
+	isStoreFlow: boolean;
 }
 
 export function buildDIFMCartExtrasObject( dependencies: Partial< Dependencies > ) {
@@ -35,6 +36,7 @@ export function buildDIFMCartExtrasObject( dependencies: Partial< Dependencies >
 		displayPhone,
 		displayAddress,
 		selectedPageTitles,
+		isStoreFlow,
 	} = dependencies;
 
 	return {
@@ -52,5 +54,6 @@ export function buildDIFMCartExtrasObject( dependencies: Partial< Dependencies >
 		display_phone: displayPhone,
 		display_address: displayAddress,
 		selected_page_titles: selectedPageTitles,
+		is_store_flow: isStoreFlow,
 	};
 }

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -186,6 +186,7 @@
 		"setup-site",
 		"account",
 		"do-it-for-me",
+		"do-it-for-me-store",
 		"website-design-services",
 		"desktop",
 		"developer",


### PR DESCRIPTION
#### Proposed Changes

PT: pdh1Xd-1Cz-p2

This PR adds a new flow `do-it-for-me-store`, which can be used to purchase BBE for store/eCommerce sites.
This is the first part of several changes that will follow soon and adds the barebones flow. Since this is a new flow, it's safe to merge.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/do-it-for-me-store`.
* Confirm that the subheader copy mentions that the Business plan would be required.
<img width="1364" alt="image" src="https://user-images.githubusercontent.com/5436027/210381450-c5ba42aa-d9b3-424e-9354-b055cb1f1d1b.png">

* Select "New Site". Confirm that the next screen look like this:
<img width="1917" alt="image" src="https://user-images.githubusercontent.com/5436027/210381566-08d0a8c6-a115-40f7-9e4a-ed0816a8412c.png">

- Go through the flow steps till you reach the page picker step.
- Confirm that the cart contains the BBE product and the Business plan.
- Go to checkout and confirm that the cart contains the BBE product and the Business plan.
- Complete the purchase. You'll be taken to the website content form.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes Automattic/martech#1373