### PR TITLE
BBE: Update theme filters for the store flow

### DIFF
--- a/client/signup/steps/design-picker/index.jsx
+++ b/client/signup/steps/design-picker/index.jsx
@@ -59,9 +59,11 @@ export default function DesignPickerStep( props ) {
 	const [ selectedDesign, setSelectedDesign ] = useState( null );
 	const scrollTop = useRef( 0 );
 
+	const isDIFMStoreFlow = 'do-it-for-me-store' === props.flowName;
+
 	const getThemeFilters = () => {
 		if ( props.useDIFMThemes ) {
-			return 'do-it-for-me';
+			return isDIFMStoreFlow ? 'do-it-for-me-store' : 'do-it-for-me';
 		}
 
 		return 'auto-loading-homepage,full-site-editing';
@@ -134,13 +136,6 @@ export default function DesignPickerStep( props ) {
 				result.defaultSelection = null;
 				result.sort = sortBlogToTop;
 				break;
-		}
-
-		// This is a temporary change until DIFM Lite switches to the full WPCOM theme catalog.
-		// We'll then use the 'difm' intent here.
-		if ( props.useDIFMThemes ) {
-			result.defaultSelection = null;
-			result.sort = sortLocalServicesToTop;
 		}
 
 		return result;
@@ -390,7 +385,7 @@ export default function DesignPickerStep( props ) {
 			{ ...props }
 			className={ classnames( {
 				'design-picker__has-categories': showDesignPickerCategories,
-				'design-picker__sell-intent': 'sell' === intent,
+				'design-picker__sell-intent': 'sell' === intent || isDIFMStoreFlow,
 			} ) }
 			{ ...headerProps }
 			stepContent={ renderDesignPicker() }
@@ -427,17 +422,6 @@ function sortStoreToTop( a, b ) {
 	} else if ( a.slug === 'store' ) {
 		return -1;
 	} else if ( b.slug === 'store' ) {
-		return 1;
-	}
-	return 0;
-}
-
-function sortLocalServicesToTop( a, b ) {
-	if ( a.slug === b.slug ) {
-		return 0;
-	} else if ( a.slug === 'local-services' ) {
-		return -1;
-	} else if ( b.slug === 'local-services' ) {
 		return 1;
 	}
 	return 0;

--- a/client/signup/steps/design-picker/let-us-choose.tsx
+++ b/client/signup/steps/design-picker/let-us-choose.tsx
@@ -28,10 +28,9 @@ const LetUsChooseButton = styled( Button )`
 	text-align: center;
 `;
 
-const LET_US_CHOOSE_THEME_SLUG = 'russell';
-
 const LetUsChoose = ( { flowName, designs, onSelect }: Props ) => {
 	const translate = useTranslate();
+	const LET_US_CHOOSE_THEME_SLUG = flowName === 'do-it-for-me-store' ? 'tazza' : 'russell';
 
 	const defaultDesign = designs.find( ( design ) => LET_US_CHOOSE_THEME_SLUG === design.slug );
 


### PR DESCRIPTION
#### Proposed Changes

PT: pdh1Xd-1Cz-p2

Parent PR: #71625

* This PR modifies the theme filters used to fetch themes for the design picker step in the BBE store flow. 
* Also changes the "Let Us Choose" theme to `Tazza` for the store flow.

<img width="1915" alt="image" src="https://user-images.githubusercontent.com/5436027/210384850-9b6cbdbb-64b5-4499-ab57-3bdf93989461.png">


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/do-it-for-me-store`.
* Go through the flow steps till you reach the design picker step.
* Confirm that themes tagged with the `do-it-for-me-store` feature are shown.
* Confirm that the category sidebar is hidden.
* Click on the "Let Us Choose" button.
* Complete the purchase.
* Further instructions here: 2ea73-pb

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes Automattic/martech#1374
