### PR TITLE
BBE: Update the page picker step for the store flow

### DIFF
--- a/client/signup/difm/components/BrowserView.tsx
+++ b/client/signup/difm/components/BrowserView.tsx
@@ -8,6 +8,7 @@ import {
 	PHOTO_GALLERY_PAGE,
 	PRICING_PAGE,
 	SERVICE_SHOWCASE_PAGE,
+	SHOP_PAGE,
 	SITEMAP_PAGE,
 	TEAM_PAGE,
 	TESTIMONIALS_PAGE,
@@ -60,7 +61,8 @@ const Container = styled.div< { isSelected?: boolean; isClickDisabled?: boolean 
 	width: 222px;
 	height: 170px;
 	position: relative;
-	cursor: ${ ( { isClickDisabled } ) => ( isClickDisabled ? 'default' : 'pointer' ) }; ;
+	cursor: ${ ( { isClickDisabled } ) => ( isClickDisabled ? 'default' : 'pointer' ) };
+	pointer-events: ${ ( { isClickDisabled } ) => ( isClickDisabled ? 'none' : 'default' ) }; ;
 `;
 
 const HeaderContainer = styled.div< { isSelected?: boolean; isClickDisabled?: boolean } >`
@@ -141,6 +143,7 @@ export function BrowserView( {
 			case HOME_PAGE:
 				return homePage;
 			case PHOTO_GALLERY_PAGE:
+			case SHOP_PAGE:
 				return photoGallery;
 			case SERVICE_SHOWCASE_PAGE:
 				return serviceShowcase;

--- a/client/signup/difm/constants.tsx
+++ b/client/signup/difm/constants.tsx
@@ -16,6 +16,7 @@ export const SERVICES_PAGE = 'SERVICES_PAGE';
 export const TESTIMONIALS_PAGE = 'TESTIMONIALS_PAGE';
 export const PRICING_PAGE = 'PRICING_PAGE';
 export const TEAM_PAGE = 'TEAM_PAGE';
+export const SHOP_PAGE = 'SHOP_PAGE';
 
 export type PageId =
 	| typeof HOME_PAGE
@@ -29,7 +30,8 @@ export type PageId =
 	| typeof SERVICES_PAGE
 	| typeof TESTIMONIALS_PAGE
 	| typeof PRICING_PAGE
-	| typeof TEAM_PAGE;
+	| typeof TEAM_PAGE
+	| typeof SHOP_PAGE;
 
 export type DeprecatedPageIds =
 	| typeof SERVICE_SHOWCASE_PAGE

--- a/client/signup/difm/translation-hooks.tsx
+++ b/client/signup/difm/translation-hooks.tsx
@@ -12,6 +12,7 @@ import {
 	TESTIMONIALS_PAGE,
 	PRICING_PAGE,
 	TEAM_PAGE,
+	SHOP_PAGE,
 } from 'calypso/signup/difm/constants';
 import type { PageId } from 'calypso/signup/difm/constants';
 import type { TranslateResult } from 'i18n-calypso';
@@ -36,20 +37,25 @@ export function useTranslatedPageTitles() {
 		[ TESTIMONIALS_PAGE ]: translate( 'Testimonials' ),
 		[ PRICING_PAGE ]: translate( 'Pricing' ),
 		[ TEAM_PAGE ]: translate( 'Team' ),
+		[ SHOP_PAGE ]: translate( 'Shop' ),
 	};
 	return pages;
 }
 
 // Requesting Contexts
 export const BBE_ONBOARDING_PAGE_PICKER_STEP = 'BBE_ONBOARDING_PAGE_PICKER_STEP';
+export const BBE_STORE_ONBOARDING_PAGE_PICKER_STEP = 'BBE_STORE_ONBOARDING_PAGE_PICKER_STEP';
 export const BBE_WEBSITE_CONTENT_FILLING_STEP = 'BBE_WEBSITE_CONTENT_FILLING_STEP';
-type TranslationContext =
+export const BBE_STORE_WEBSITE_CONTENT_FILLING_STEP = 'BBE_STORE_WEBSITE_CONTENT_FILLING_STEP';
+export type BBETranslationContext =
 	| typeof BBE_ONBOARDING_PAGE_PICKER_STEP
-	| typeof BBE_WEBSITE_CONTENT_FILLING_STEP;
+	| typeof BBE_STORE_ONBOARDING_PAGE_PICKER_STEP
+	| typeof BBE_WEBSITE_CONTENT_FILLING_STEP
+	| typeof BBE_STORE_WEBSITE_CONTENT_FILLING_STEP;
 
 export function useTranslatedPageDescriptions(
 	pageId: PageId,
-	context?: TranslationContext
+	context?: BBETranslationContext
 ): TranslateResult {
 	const translate = useTranslate();
 	const defaultDescriptions: Record< PageId, TranslateResult > = {
@@ -90,9 +96,12 @@ export function useTranslatedPageDescriptions(
 		[ TEAM_PAGE ]: translate(
 			'Showcase a mini profile of each member of your business, with an image, name, and role description.'
 		),
+		[ SHOP_PAGE ]: translate(
+			'Your shop page will display all the products you have for sale. We will set up the shop page and explain how you can add products to your new site.'
+		),
 	};
 
-	const contextualDescriptions: Record< TranslationContext, typeof defaultDescriptions > = {
+	const contextualDescriptions: Record< BBETranslationContext, typeof defaultDescriptions > = {
 		[ BBE_ONBOARDING_PAGE_PICKER_STEP ]: {
 			...defaultDescriptions,
 		},
@@ -103,6 +112,21 @@ export function useTranslatedPageDescriptions(
 			),
 			[ CONTACT_PAGE ]: translate(
 				'This page will include a contact form. Optionally provide text to appear above the form to let visitors know other ways they can reach you.'
+			),
+			[ SHOP_PAGE ]: translate(
+				'Add a short description to explain what type of products will appear on your site. We will set up the page so this description appears above your products; you can add the products later with the editor.'
+			),
+		},
+		[ BBE_STORE_ONBOARDING_PAGE_PICKER_STEP ]: {
+			...defaultDescriptions,
+			[ HOME_PAGE ]: translate(
+				'An overview of you, your shop, or your business. What phrases would someone search on Google to find you? What can visitors purchase on this site?'
+			),
+		},
+		[ BBE_STORE_WEBSITE_CONTENT_FILLING_STEP ]: {
+			...defaultDescriptions,
+			[ HOME_PAGE ]: translate(
+				'An overview of you, your shop, or your business. What phrases would someone search on Google to find you? What can visitors purchase on this site?'
 			),
 		},
 	};

--- a/client/signup/steps/page-picker/shopping-cart-for-difm.tsx
+++ b/client/signup/steps/page-picker/shopping-cart-for-difm.tsx
@@ -159,10 +159,18 @@ function DummyLineItem( {
 	);
 }
 
-export default function ShoppingCartForDIFM( { selectedPages }: { selectedPages: string[] } ) {
+export default function ShoppingCartForDIFM( {
+	selectedPages,
+	isStoreFlow,
+}: {
+	selectedPages: string[];
+	isStoreFlow: boolean;
+} ) {
 	const translate = useTranslate();
-	const { items, total, effectiveCurrencyCode, isFormattedCurrencyLoading } =
-		useCartForDIFM( selectedPages );
+	const { items, total, effectiveCurrencyCode, isFormattedCurrencyLoading } = useCartForDIFM(
+		selectedPages,
+		isStoreFlow
+	);
 	return isFormattedCurrencyLoading || effectiveCurrencyCode === null ? (
 		<LoadingContainer>
 			<LoadingLine key="plan-placeholder" />

--- a/client/signup/steps/page-picker/use-cart-for-difm.tsx
+++ b/client/signup/steps/page-picker/use-cart-for-difm.tsx
@@ -2,6 +2,7 @@ import {
 	PLAN_PREMIUM,
 	WPCOM_DIFM_LITE,
 	getDIFMTieredPriceDetails,
+	PLAN_BUSINESS,
 } from '@automattic/calypso-products';
 import formatCurrency from '@automattic/format-currency';
 import { MinimalRequestCartProduct, useShoppingCart } from '@automattic/shopping-cart';
@@ -163,6 +164,7 @@ function getSiteCartProducts( {
 	const cartItems: Array< CartItem | null > = responseCart.products.map( ( product ) => {
 		switch ( product.product_slug ) {
 			case PLAN_PREMIUM:
+			case PLAN_BUSINESS:
 				return {
 					productSlug: product.product_slug,
 					productOriginalName: product.product_name,
@@ -218,7 +220,9 @@ function getSiteCartProducts( {
 	// Enforce order of display, so that the DIFM product is visible first
 	const difmRelatedCartItems = cartItems.filter( ( e ) => e !== null );
 	const difmProduct = difmRelatedCartItems.find( ( e ) => e?.productSlug === WPCOM_DIFM_LITE );
-	const planProduct = difmRelatedCartItems.find( ( e ) => e?.productSlug === PLAN_PREMIUM );
+	const planProduct = difmRelatedCartItems.find( ( e ) =>
+		[ PLAN_PREMIUM, PLAN_BUSINESS ].includes( e?.productSlug || '' )
+	);
 
 	//Enforce order
 	const finalCartItems: CartItem[] = [];
@@ -232,7 +236,10 @@ function getSiteCartProducts( {
 	return finalCartItems;
 }
 
-export function useCartForDIFM( selectedPages: string[] ): {
+export function useCartForDIFM(
+	selectedPages: string[],
+	isStoreFlow: boolean
+): {
 	items: CartItem[];
 	total: string | null;
 	isCartLoading: boolean;
@@ -248,7 +255,9 @@ export function useCartForDIFM( selectedPages: string[] ): {
 	const signupDependencies = useSelector( getSignupDependencyStore );
 	const translate = useTranslate();
 	const dispatch = useDispatch();
-	const premiumPlan = useSelector( ( state ) => getProductBySlug( state, PLAN_PREMIUM ) );
+	const activePlanScheme = useSelector( ( state ) =>
+		getProductBySlug( state, isStoreFlow ? PLAN_BUSINESS : PLAN_PREMIUM )
+	);
 	const { newOrExistingSiteChoice, siteId, siteSlug } = signupDependencies;
 	const isExistingSite = newOrExistingSiteChoice === 'existing-site';
 	const isProductsLoading = useSelector( isProductsListFetching );
@@ -274,12 +283,13 @@ export function useCartForDIFM( selectedPages: string[] ): {
 				extra: buildDIFMCartExtrasObject( {
 					...signupDependencies,
 					selectedPageTitles: selectedPages,
+					isStoreFlow,
 				} ),
 				quantity: selectedPages.length,
 			};
 		}
 		return null;
-	}, [ signupDependencies, selectedPages, difmLiteProduct ] );
+	}, [ difmLiteProduct, signupDependencies, selectedPages, isStoreFlow ] );
 
 	// [Effect] Loads required initial data
 	useEffect( () => {
@@ -318,7 +328,7 @@ export function useCartForDIFM( selectedPages: string[] ): {
 	const effectiveCurrencyCode = getEffectiveCurrencyCode();
 	let displayedCartItems: CartItem[] = [];
 	let totalCostFormatted = null;
-	if ( difmLiteProduct && premiumPlan && effectiveCurrencyCode ) {
+	if ( difmLiteProduct && activePlanScheme && effectiveCurrencyCode ) {
 		if ( isExistingSite ) {
 			displayedCartItems = getSiteCartProducts( {
 				responseCart,
@@ -330,7 +340,7 @@ export function useCartForDIFM( selectedPages: string[] ): {
 				selectedPages,
 				currencyCode: effectiveCurrencyCode,
 				translate,
-				activePlanScheme: premiumPlan,
+				activePlanScheme: activePlanScheme,
 				difmLiteProduct,
 			} );
 		}


### PR DESCRIPTION
#### Proposed Changes

PT: pdh1Xd-1Cz-p2

Parent PR: https://github.com/Automattic/wp-calypso/pull/71626

This PR introduces a few changes to the page picker step for the store flow:
* Adds a new page "Shop". This page is available only in the store flow and will be required by default. It cannot be unselected.
* Introduces a new translation context for the page picker step. This allows us to show different descriptions for pages depending on the flow.
* Swaps the order of the "Services" & "FAQ" pages.
* Hides the "Pricing" page.
* Adds the Popular badge to the "Testimonials" page.
* Changes the copy of the subheader.
* Modifies the DIFM cart to accommodate the Business plan, which is required for BBE with the store flow. (The backend changes have already been shipped)

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/do-it-for-me-store`.
* Select "New Site" and go through the flow steps till you reach the page picker step.
* Confirm that the "Shop" page is visible and cannot be unselected.
<img width="560" alt="image" src="https://user-images.githubusercontent.com/5436027/210505667-157e6f8f-5d38-4574-806b-926f78d0b554.png">

* Confirm that the description for the Shop page matches the screenshot.
<img width="297" alt="image" src="https://user-images.githubusercontent.com/5436027/210505730-bba09f8d-9331-4174-aaed-4281ea9212c3.png">

* Confirm that the description for the Home page matches the screenshot.
<img width="326" alt="image" src="https://user-images.githubusercontent.com/5436027/210505893-a68d5296-be59-4dcb-a30e-45871791c0dc.png">

* Confirm that the subheader copy matches the screenshot.
<img width="484" alt="image" src="https://user-images.githubusercontent.com/5436027/210505964-73588e3a-0f84-41c0-8dfe-dd75fb5417e3.png">

* Confirm that the FAQ page is in the third row and that there is a Popular badge on the "Testimonials" page.
<img width="921" alt="image" src="https://user-images.githubusercontent.com/5436027/210506224-4d8ac805-0add-4fff-b9cd-58e568fa58d0.png">

* Confirm that the Business plan is visible in the mini-cart and that the totals add up.
<img width="559" alt="image" src="https://user-images.githubusercontent.com/5436027/210506461-592de5f8-a53a-4429-8213-adaae4a732cb.png">

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes Automattic/martech#1375