### PR TITLE
BBE: Update the website content step for the store flow

### DIFF
--- a/client/signup/accordion-form/accordion-form.tsx
+++ b/client/signup/accordion-form/accordion-form.tsx
@@ -1,5 +1,4 @@
-import { useTranslate } from 'i18n-calypso';
-import { ChangeEvent, useState } from 'react';
+import { useState } from 'react';
 import AccordionFormSection from './accordion-form-section';
 import {
 	AccordionSectionProps,
@@ -16,7 +15,7 @@ interface AccordionFormProps< T > {
 	currentIndex: number;
 	updateCurrentIndex: ( index: number ) => void;
 	onSubmit: ( formValues: T ) => void;
-	formValuesInitialState: T;
+	formValues: T;
 	updateFormValues?: ( formValues: T ) => void;
 	onErrorUpdates?: ( errors: ValidationErrors ) => void;
 	blockNavigation?: boolean;
@@ -26,23 +25,12 @@ export default function AccordionForm< T >( {
 	currentIndex,
 	updateCurrentIndex,
 	updateFormValues,
-	formValuesInitialState,
-	sectionGenerator,
+	formValues,
 	onSubmit,
 	generatedSections,
 	onErrorUpdates,
 	blockNavigation,
 }: AccordionFormProps< T > ) {
-	const translate = useTranslate();
-	// Initialize local state with the values from the redux store
-	const [ formValues, setFormValues ] = useState< T >( formValuesInitialState );
-	const onChangeField = ( { target: { name, value } }: ChangeEvent< HTMLInputElement > ) => {
-		setFormValues( {
-			...formValues,
-			[ name ]: value,
-		} );
-	};
-
 	const [ formErrors, setFormErrors ] = useState< ValidationErrors >( {} );
 
 	const isSectionAtIndexTouchedInitialState: Record< string, boolean > = {};
@@ -54,14 +42,7 @@ export default function AccordionForm< T >( {
 		Record< string, boolean >
 	>( isSectionAtIndexTouchedInitialState );
 
-	const sections = sectionGenerator
-		? sectionGenerator()( {
-				translate,
-				formValues,
-				formErrors,
-				onChangeField,
-		  } )
-		: generatedSections ?? [];
+	const sections = generatedSections ?? [];
 
 	const runValidatorAndSetFormErrors = ( validator: ValidatorFunction< T > ) => {
 		const validationResult = validator( formValues );

--- a/client/signup/accordion-form/types.ts
+++ b/client/signup/accordion-form/types.ts
@@ -1,5 +1,6 @@
 import { TranslateResult, useTranslate } from 'i18n-calypso';
 import { ChangeEvent, ReactNode } from 'react';
+import { BBETranslationContext } from '../difm/translation-hooks';
 
 export type ValidationErrors = Record< string, TranslateResult | null >;
 
@@ -22,5 +23,6 @@ export interface SectionGeneratorReturnType< T > {
 	translate: ReturnType< typeof useTranslate >;
 	formValues: T;
 	formErrors: ValidationErrors;
+	context: BBETranslationContext;
 	onChangeField: ( { target: { name, value } }: ChangeEvent< HTMLInputElement > ) => void;
 }

--- a/client/signup/steps/website-content/section-generator.tsx
+++ b/client/signup/steps/website-content/section-generator.tsx
@@ -1,4 +1,4 @@
-import { BLOG_PAGE, CONTACT_PAGE } from 'calypso/signup/difm/constants';
+import { BLOG_PAGE, CONTACT_PAGE, SHOP_PAGE } from 'calypso/signup/difm/constants';
 import {
 	ContactPageDetails,
 	FeedbackSection,
@@ -68,11 +68,12 @@ const generateWebsiteContentSections = (
 	params: SectionGeneratorReturnType< WebsiteContent >,
 	elapsedSections = 0
 ): SectionProcessedResult => {
-	const { translate, formValues, formErrors, onChangeField } = params;
+	const { translate, formValues, formErrors, context, onChangeField } = params;
 
 	const OPTIONAL_PAGES: Partial< Record< PageId, boolean > > = {
 		[ CONTACT_PAGE ]: true,
 		[ BLOG_PAGE ]: true,
+		[ SHOP_PAGE ]: true,
 	};
 
 	const websiteContentSections = formValues.pages.map( ( page, index ) => {
@@ -101,6 +102,7 @@ const generateWebsiteContentSections = (
 					page={ page }
 					formErrors={ formErrors }
 					onChangeField={ onChangeField }
+					context={ context }
 				/>
 			),
 			showSkip: !! OPTIONAL_PAGES[ page.id ],

--- a/client/signup/steps/website-content/section-types/contact-page-details.tsx
+++ b/client/signup/steps/website-content/section-types/contact-page-details.tsx
@@ -7,10 +7,7 @@ import {
 	ContactInformation,
 	LabelBlock,
 } from 'calypso/signup/accordion-form/form-components';
-import {
-	BBE_WEBSITE_CONTENT_FILLING_STEP,
-	useTranslatedPageDescriptions,
-} from 'calypso/signup/difm/translation-hooks';
+import { useTranslatedPageDescriptions } from 'calypso/signup/difm/translation-hooks';
 import {
 	MediaUploadData,
 	WordpressMediaUpload,
@@ -32,6 +29,7 @@ export const IMAGE_PREFIX = 'Image';
 export function ContactPageDetails( {
 	page,
 	formErrors,
+	context,
 	onChangeField,
 }: PageDetailsParams< ContactPageData > ) {
 	const translate = useTranslate();
@@ -39,7 +37,7 @@ export function ContactPageDetails( {
 	const site = useSelector( getSelectedSite );
 	const pageTitle = page.title;
 	const pageID = page.id;
-	const description = useTranslatedPageDescriptions( pageID, BBE_WEBSITE_CONTENT_FILLING_STEP );
+	const description = useTranslatedPageDescriptions( pageID, context );
 
 	const onMediaUploadFailed = ( { mediaIndex }: MediaUploadData ) => {
 		dispatch(

--- a/client/signup/steps/website-content/section-types/default-page-details.tsx
+++ b/client/signup/steps/website-content/section-types/default-page-details.tsx
@@ -7,10 +7,7 @@ import {
 	LabelBlock,
 } from 'calypso/signup/accordion-form/form-components';
 import { ValidationErrors } from 'calypso/signup/accordion-form/types';
-import {
-	BBE_WEBSITE_CONTENT_FILLING_STEP,
-	useTranslatedPageDescriptions,
-} from 'calypso/signup/difm/translation-hooks';
+import { useTranslatedPageDescriptions } from 'calypso/signup/difm/translation-hooks';
 import {
 	mediaRemoved,
 	mediaUploaded,
@@ -20,6 +17,7 @@ import {
 } from 'calypso/state/signup/steps/website-content/actions';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import { MediaUploadData, WordpressMediaUpload } from '../wordpress-media-upload';
+import type { BBETranslationContext } from 'calypso/signup/difm/translation-hooks';
 import type { PageData } from 'calypso/state/signup/steps/website-content/schema';
 
 export const CONTENT_SUFFIX = 'Content';
@@ -27,11 +25,13 @@ export const IMAGE_PREFIX = 'Image';
 export interface PageDetailsParams< T > {
 	page: T;
 	formErrors: ValidationErrors;
+	context: BBETranslationContext;
 	onChangeField?: ( { target: { name, value } }: ChangeEvent< HTMLInputElement > ) => void;
 }
 export function DefaultPageDetails( {
 	page,
 	formErrors,
+	context,
 	onChangeField,
 }: PageDetailsParams< PageData > ) {
 	const translate = useTranslate();
@@ -39,7 +39,7 @@ export function DefaultPageDetails( {
 	const site = useSelector( getSelectedSite );
 	const pageTitle = page.title;
 	const pageID = page.id;
-	const description = useTranslatedPageDescriptions( pageID, BBE_WEBSITE_CONTENT_FILLING_STEP );
+	const description = useTranslatedPageDescriptions( pageID, context );
 
 	const onMediaUploadFailed = ( { mediaIndex }: MediaUploadData ) => {
 		dispatch(


### PR DESCRIPTION
#### Proposed Changes

PT: pdh1Xd-1Cz-p2

Parent PR: https://github.com/Automattic/wp-calypso/pull/71627
#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/do-it-for-me-store`.
* Proceed through the flow steps and complete the purchase.
* After purchase, you'll be taken to the website content form.
* Confirm that the subheader copy matches the screenshot.
<img width="675" alt="image" src="https://user-images.githubusercontent.com/5436027/210509803-f15803bc-df86-4353-9496-00690a53b9ad.png">

* Confirm that the description for the Home page matches the screenshot.
<img width="841" alt="image" src="https://user-images.githubusercontent.com/5436027/210509922-cb9173bf-e3c5-4e7a-a1e6-71101bb6f547.png">

* Confirm that entering content in the Shop page section is optional, and you can proceed to the next section without entering any text.
* Confirm that you can enter text in the form, and that you can submit the form without any errors.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #