### PR TITLE
Fix the email opens summary + make it clickable

### DIFF
--- a/client/state/stats/lists/actions.js
+++ b/client/state/stats/lists/actions.js
@@ -33,7 +33,7 @@ const wpcomV1Endpoints = {
 	statsInsights: 'stats/insights',
 	statsFileDownloads: 'stats/file-downloads',
 	statsAds: 'wordads/stats',
-	statsEmailsOpen: 'stats/opens/emails',
+	statsEmailsOpen: 'stats/opens/emails/summary',
 };
 
 const wpcomV2Endpoints = {

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -952,16 +952,19 @@ export const normalizers = {
 	 *
 	 * @param   {object} data   Stats data
 	 * @param   {object} query  Stats query
+	 * @param   {number} siteId  Site ID
+	 * @param   {object} site    Site object
 	 * @returns {Array}       Normalized stats data
 	 */
-	statsEmailsOpen( data, query = {} ) {
+	statsEmailsOpen( data, query = {}, siteId, site ) {
 		if ( ! data || ! query.period || ! query.date ) {
 			return [];
 		}
-		const { startOf } = rangeOfPeriod( query.period, query.date );
-		const emailsData = get( data, [ 'days', startOf, 'email_opens' ], [] );
+
+		const emailsData = get( data, [ 'posts' ], [] );
 
 		return emailsData.map( ( { id, href, date, title, type, opens } ) => {
+			const detailPage = site ? `/stats/email/open/${ site.slug }/${ query.period }/${ id }` : null;
 			return {
 				id,
 				href,
@@ -969,6 +972,13 @@ export const normalizers = {
 				label: title,
 				type,
 				value: opens || '0',
+				page: detailPage,
+				actions: [
+					{
+						type: 'link',
+						data: href,
+					},
+				],
 			};
 		} );
 	},


### PR DESCRIPTION
#### Proposed Changes

* This PR brings back the email opens summary. The endpoint changed, so changes in Calypso are necessary.

![CleanShot 2023-01-03 at 16 30 18@2x](https://user-images.githubusercontent.com/528287/210388727-d4c56896-2f78-43f0-99d6-9ceb173a8116.png)


#### Testing Instructions

* Apply this PR
* Visit your Stats `/stats/day/<site>?flags=newsletter/stats` . Make sure to add the newsletter/stats flag.
* Click around to a day/week/month when you have newsletter opens. You should see them.
* Clicking on a row should bring you to the (incomplete) detail view
* Clicking on the open icon (<img width="42" alt="CleanShot 2023-01-03 at 16 33 20@2x" src="https://user-images.githubusercontent.com/528287/210389265-a9619bd0-5122-44cb-bd1b-293ad2474ba3.png">) should bring you to your post.


#### Pre-merge Checklist


- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
