### PR TITLE
Removed 'view details' link from email opens card in stats

### DIFF
--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -291,7 +291,7 @@ class StatsSite extends Component {
 								period={ this.props.period }
 								query={ query }
 								statType="statsEmailsOpen"
-								showSummaryLink
+								hideSummaryLink
 								showNewModules
 							/>
 						) }


### PR DESCRIPTION
#### Proposed Changes

This super short PR removes the 'View details' link from the bottom of the email opens card in the stats dashboard:
<img width="1073" alt="Screenshot 2023-01-03 at 16 57 46" src="https://user-images.githubusercontent.com/3832570/210397077-e9ca7fec-7877-4af9-9320-b292a061d507.png">

This is not required there as we don't show any details until an email from that list is clicked.

#### Testing Instructions

1. Apply this branch to your local Calypso repository and start the application.
2. Insert manually in the browser address bar an URL with this format: `http://calypso.localhost:3000/stats/day/[blog-domain]?flags=newsletter/stats`
3. Check that no "View details" link is shown at the bottom of that screen you can click on Opens and Unique Opens tabs and the data changes accordingly.
Note: the endpoint retrieves data a bit slowly for now, as the fine tuning is still pending. Be patient, please 
