### PR TITLE
Launchpad: Use share code to bypass sites atomic sites "Coming Soon"

### DIFF
--- a/client/components/site-preview-link/index.tsx
+++ b/client/components/site-preview-link/index.tsx
@@ -60,6 +60,7 @@ export default function SitePreviewLink( {
 			const validLinksLength = linksResponse?.filter( ( link ) => ! link.isRemoving ).length || 0;
 			setChecked( validLinksLength > 0 );
 		},
+		isEnabled: true,
 	} );
 
 	const { createLink, isLoading: isCreating } = useCreateSitePreviewLink( {

--- a/client/components/site-preview-link/use-site-preview-links.ts
+++ b/client/components/site-preview-link/use-site-preview-links.ts
@@ -14,12 +14,13 @@ export type PreviewLinksResponse = PreviewLink[];
 interface UseSitePreviewLinksOptions {
 	siteId: SiteId;
 	onSuccess?: ( previewLinks: PreviewLink[] | undefined ) => void;
+	isEnabled: boolean;
 }
 
 export const SITE_PREVIEW_LINKS_QUERY_KEY = 'site-preview-links';
 
 export function useSitePreviewLinks( options: UseSitePreviewLinksOptions ) {
-	const { siteId, onSuccess } = options;
+	const { siteId, onSuccess, isEnabled = false } = options;
 	return useQuery< PreviewLinksResponse, unknown, PreviewLink[] >(
 		[ SITE_PREVIEW_LINKS_QUERY_KEY, siteId ],
 		() =>
@@ -28,7 +29,7 @@ export function useSitePreviewLinks( options: UseSitePreviewLinksOptions ) {
 				apiNamespace: 'wpcom/v2',
 			} ),
 		{
-			enabled: !! siteId,
+			enabled: isEnabled && !! siteId,
 			meta: { persist: false },
 			onSuccess,
 		}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/launchpad-site-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/launchpad-site-preview.tsx
@@ -1,16 +1,9 @@
-import { isWpComBusinessPlan, isWpComEcommercePlan } from '@automattic/calypso-products';
 import { DEVICE_TYPES } from '@automattic/components';
 import { NEWSLETTER_FLOW, VIDEOPRESS_FLOW } from '@automattic/onboarding';
 import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
-import { useEffect } from 'react';
-import { useCreateSitePreviewLink } from 'calypso/components/site-preview-link/use-create-site-preview-link';
-import {
-	PreviewLink,
-	useSitePreviewLinks,
-} from 'calypso/components/site-preview-link/use-site-preview-links';
 import WebPreview from 'calypso/components/web-preview/component';
-import { useSite } from 'calypso/landing/stepper/hooks/use-site';
+import { useSitePreviewShareCode } from 'calypso/landing/stepper/hooks/use-site-preview-share-code';
 import { usePremiumGlobalStyles } from 'calypso/state/sites/hooks/use-premium-global-styles';
 import PreviewToolbar from '../design-setup/preview-toolbar';
 import type { Device } from '@automattic/components';
@@ -22,7 +15,6 @@ const LaunchpadSitePreview = ( {
 	siteSlug: string | null;
 	flow: string | null;
 } ) => {
-	const site = useSite();
 	const translate = useTranslate();
 	const { globalStylesInUse, shouldLimitGlobalStyles } = usePremiumGlobalStyles();
 
@@ -30,49 +22,14 @@ const LaunchpadSitePreview = ( {
 	const devicesToShow: Device[] = [ DEVICE_TYPES.COMPUTER, DEVICE_TYPES.PHONE ];
 	let defaultDevice = flow === NEWSLETTER_FLOW ? DEVICE_TYPES.COMPUTER : DEVICE_TYPES.PHONE;
 	const isVideoPressFlow = VIDEOPRESS_FLOW === flow;
-	const isBusinessPlan = site?.plan?.product_slug
-		? isWpComBusinessPlan( site?.plan?.product_slug )
-		: false;
-	const isEcommercePlan = site?.plan?.product_slug
-		? isWpComEcommercePlan( site?.plan?.product_slug )
-		: false;
 
 	if ( isVideoPressFlow ) {
 		const windowWidth = window.innerWidth;
 		defaultDevice = windowWidth >= 1000 ? DEVICE_TYPES.COMPUTER : DEVICE_TYPES.PHONE;
 	}
 
-	const usePreviewSiteLinksQueryEnabled =
-		site?.is_coming_soon && ( isBusinessPlan || isEcommercePlan ) && site?.is_wpcom_atomic;
-
-	const { data: previewLinks, isLoading: isPreviewLinksLoading } = useSitePreviewLinks( {
-		siteId: Number( site?.ID ),
-		isEnabled: usePreviewSiteLinksQueryEnabled ?? false,
-	} );
-
-	const { createLink, isLoading: isCreatingSitePreviewLinks } = useCreateSitePreviewLink( {
-		siteId: Number( site?.ID ),
-	} );
-
-	// Generate preview link for site on business or ecommerce plan
-	// Preview links are only available on these two plans
-	useEffect( () => {
-		if ( previewLinks && Array.isArray( previewLinks ) && previewLinks.length === 0 ) {
-			if ( isBusinessPlan || isEcommercePlan ) {
-				createLink();
-			}
-		}
-	}, [ previewLinks, createLink, isBusinessPlan, isEcommercePlan ] );
-
-	const shareCode = getPreviewCode( previewLinks );
-
-	function getPreviewCode( links: PreviewLink[] | undefined ) {
-		if ( typeof links === 'undefined' ) {
-			return false;
-		}
-		const link = links[ 0 ];
-		return link?.code ?? false;
-	}
+	const { shareCode, isPreviewLinksLoading, isCreatingSitePreviewLinks } =
+		useSitePreviewShareCode();
 
 	function formatPreviewUrl() {
 		if ( ! previewUrl || isPreviewLinksLoading || isCreatingSitePreviewLinks ) {

--- a/client/landing/stepper/hooks/use-site-preview-share-code.ts
+++ b/client/landing/stepper/hooks/use-site-preview-share-code.ts
@@ -1,0 +1,48 @@
+import { isWpComBusinessPlan, isWpComEcommercePlan } from '@automattic/calypso-products';
+import { useEffect } from 'react';
+import { useCreateSitePreviewLink } from 'calypso/components/site-preview-link/use-create-site-preview-link';
+import { useSitePreviewLinks } from 'calypso/components/site-preview-link/use-site-preview-links';
+import { useSite } from './use-site';
+
+export function useSitePreviewShareCode() {
+	const site = useSite();
+
+	const isBusinessPlan = site?.plan?.product_slug
+		? isWpComBusinessPlan( site?.plan?.product_slug )
+		: false;
+	const isEcommercePlan = site?.plan?.product_slug
+		? isWpComEcommercePlan( site?.plan?.product_slug )
+		: false;
+
+	const usePreviewSiteLinksQueryEnabled =
+		site?.is_coming_soon && ( isBusinessPlan || isEcommercePlan ) && site?.is_wpcom_atomic;
+
+	// Retrieves site preview share code if it exists
+	const { data: previewLinks, isLoading: isPreviewLinksLoading } = useSitePreviewLinks( {
+		siteId: Number( site?.ID ),
+		isEnabled: usePreviewSiteLinksQueryEnabled ?? false,
+	} );
+
+	// Provides createLink() function used to generate a new site preview share code
+	const { createLink, isLoading: isCreatingSitePreviewLinks } = useCreateSitePreviewLink( {
+		siteId: Number( site?.ID ),
+	} );
+
+	// Generate preview link for site on business or ecommerce plan
+	// Preview links are only available on these two plans
+	useEffect( () => {
+		if ( previewLinks && Array.isArray( previewLinks ) && previewLinks.length === 0 ) {
+			if ( isBusinessPlan || isEcommercePlan ) {
+				createLink();
+			}
+		}
+	}, [ previewLinks, createLink, isBusinessPlan, isEcommercePlan ] );
+
+	const shareCode = previewLinks?.[ 0 ]?.code;
+
+	return {
+		shareCode,
+		isPreviewLinksLoading,
+		isCreatingSitePreviewLinks,
+	};
+}


### PR DESCRIPTION
#### Proposed Changes

* Use site preview link codes to bypass coming soon in Launchpad preview on Atomic

This PR is based on: https://github.com/Automattic/wp-calypso/pull/71349

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this branch
* Create a new link-in-bio site (`/setup/link-in-bio` -  I used Firefox Developer Edition browser ) 
* Transfer this new link-in-bio site to Atomic.
* Navigate to the launchpad on production wordpress.com (https://wordpress.com/setup/link-in-bio/launchpad?siteSlug={SITE_SLUG}). The launchpad site preview should display "Coming Soon"
<img width="1511" alt="image" src="https://user-images.githubusercontent.com/10482592/210429005-a875a4d9-8a59-43ce-bf24-a402f582176b.png">

* Navigate to the launchpad screen on calypso localhost. You should be able to see the site preview.

<img width="1507" alt="image" src="https://user-images.githubusercontent.com/10482592/210429704-3f7879ea-3271-4fb2-b766-188ca9979a43.png">


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/70965
