### PR TITLE
Migrate PurchaseMetaExpiration component to TypeScript

### DIFF
--- a/client/lib/purchases/types.ts
+++ b/client/lib/purchases/types.ts
@@ -46,13 +46,7 @@ export interface Purchase {
 	productDisplayPrice: string;
 	productId: number;
 	productName: string;
-	productSlug:
-		| 'jetpack_personal'
-		| 'jetpack_personal_monthly'
-		| 'jetpack_business'
-		| 'jetpack_business_monthly'
-		| 'jetpack_premium'
-		| 'jetpack_premium_monthly';
+	productSlug: string;
 	productType: string;
 	purchaseRenewalQuantity: number | null;
 	refundAmount: number;
@@ -296,84 +290,3 @@ export type RenderRenewsOrExpiresOnLabel = ( args: {
 	purchase: Purchase;
 	translate: ReturnType< typeof useTranslate >;
 } ) => string;
-
-export interface Site {
-	ID?: number;
-	name?: string;
-	description?: string;
-	URL?: string;
-	capabilities?: { [ key: string ]: boolean };
-	jetpack?: boolean;
-	is_multisite?: boolean;
-	site_owner?: number;
-	lang?: string;
-	visible?: boolean;
-	is_private?: boolean;
-	is_coming_soon?: boolean;
-	single_user_site?: boolean;
-	is_vip?: boolean;
-	options?: Options;
-	plan?: Plan;
-
-	jetpack_modules?: null;
-	launch_status?: string;
-	site_migration?: null;
-	is_core_site_editor_enabled?: boolean;
-	is_wpcom_atomic?: boolean;
-	user_interactions?: Date[];
-	domain?: string;
-	slug?: string;
-	title?: string;
-}
-
-export interface Options {
-	timezone?: string;
-	gmt_offset?: number;
-	videopress_enabled?: boolean;
-	upgraded_filetypes_enabled?: boolean;
-	admin_url?: string;
-	is_mapped_domain?: boolean;
-	is_redirect?: boolean;
-	unmapped_url?: string;
-	default_post_format?: string;
-	allowed_file_types?: string[];
-	show_on_front?: string;
-	default_comment_status?: boolean;
-	default_ping_status?: boolean;
-	software_version?: string;
-	created_at?: Date;
-	updated_at?: Date;
-	wordads?: boolean;
-	publicize_permanently_disabled?: boolean;
-	frame_nonce?: string;
-	jetpack_frame_nonce?: string;
-	page_on_front?: number;
-	page_for_posts?: number;
-	advanced_seo_front_page_description?: string;
-	verification_services_codes?: null;
-	podcasting_archive?: null;
-	is_domain_only?: boolean;
-	is_automated_transfer?: boolean;
-	is_wpcom_atomic?: boolean;
-	is_wpcom_store?: boolean;
-	woocommerce_is_active?: boolean;
-	editing_toolkit_is_active?: boolean;
-	design_type?: null;
-	site_segment?: null;
-	is_wpforteams_site?: boolean;
-	p2_hub_blog_id?: null;
-	is_cloud_eligible?: boolean;
-	anchor_podcast?: boolean;
-	is_difm_lite_in_progress?: boolean;
-	site_intent?: string;
-	launchpad_screen?: boolean;
-}
-
-export interface Plan {
-	product_id?: number;
-	product_slug?: string;
-	product_name_short?: string;
-	expired?: boolean;
-	user_is_owner?: boolean;
-	is_free?: boolean;
-}

--- a/client/lib/purchases/types.ts
+++ b/client/lib/purchases/types.ts
@@ -1,5 +1,6 @@
 import { PriceTierEntry } from '@automattic/calypso-products';
-
+import { useTranslate } from 'i18n-calypso';
+import { useLocalizedMoment } from 'calypso/components/localized-moment';
 export interface Purchase {
 	active?: boolean;
 	amount: number;
@@ -270,9 +271,22 @@ export interface MembershipSubscriptionsSite {
 	subscriptions: MembershipSubscription[];
 }
 
-export type GetChangePaymentMethodUrlFor = ( siteSlug: string, purchase: Purchase ) => string;
-
 export interface Owner {
 	ID: string;
 	display_name: string;
 }
+export type GetChangePaymentMethodUrlFor = ( siteSlug: string, purchase: Purchase ) => string;
+export type GetManagePurchaseUrlFor = ( siteSlug: string, attachedToPurchaseId: string ) => string;
+
+export type RenderRenewsOrExpiresOn = (
+	moment: ReturnType< typeof useLocalizedMoment >,
+	purchase: Purchase,
+	siteSlug: string,
+	translate: ReturnType< typeof useTranslate >,
+	getManagePurchaseUrlFor: GetManagePurchaseUrlFor
+) => string;
+
+export type RenderRenewsOrExpiresOnLabel = (
+	purchase: Purchase,
+	translate: ReturnType< typeof useTranslate >
+) => string;

--- a/client/lib/purchases/types.ts
+++ b/client/lib/purchases/types.ts
@@ -46,7 +46,13 @@ export interface Purchase {
 	productDisplayPrice: string;
 	productId: number;
 	productName: string;
-	productSlug: string;
+	productSlug:
+		| 'jetpack_personal'
+		| 'jetpack_personal_monthly'
+		| 'jetpack_business'
+		| 'jetpack_business_monthly'
+		| 'jetpack_premium'
+		| 'jetpack_premium_monthly';
 	productType: string;
 	purchaseRenewalQuantity: number | null;
 	refundAmount: number;
@@ -281,7 +287,7 @@ export type GetManagePurchaseUrlFor = ( siteSlug: string, attachedToPurchaseId: 
 export type RenderRenewsOrExpiresOn = (
 	moment: ReturnType< typeof useLocalizedMoment >,
 	purchase: Purchase,
-	siteSlug: string,
+	siteSlug: string | undefined,
 	translate: ReturnType< typeof useTranslate >,
 	getManagePurchaseUrlFor: GetManagePurchaseUrlFor
 ) => string;
@@ -290,3 +296,84 @@ export type RenderRenewsOrExpiresOnLabel = (
 	purchase: Purchase,
 	translate: ReturnType< typeof useTranslate >
 ) => string;
+
+export interface Site {
+	ID?: number;
+	name?: string;
+	description?: string;
+	URL?: string;
+	capabilities?: { [ key: string ]: boolean };
+	jetpack?: boolean;
+	is_multisite?: boolean;
+	site_owner?: number;
+	lang?: string;
+	visible?: boolean;
+	is_private?: boolean;
+	is_coming_soon?: boolean;
+	single_user_site?: boolean;
+	is_vip?: boolean;
+	options?: Options;
+	plan?: Plan;
+
+	jetpack_modules?: null;
+	launch_status?: string;
+	site_migration?: null;
+	is_core_site_editor_enabled?: boolean;
+	is_wpcom_atomic?: boolean;
+	user_interactions?: Date[];
+	domain?: string;
+	slug?: string;
+	title?: string;
+}
+
+export interface Options {
+	timezone?: string;
+	gmt_offset?: number;
+	videopress_enabled?: boolean;
+	upgraded_filetypes_enabled?: boolean;
+	admin_url?: string;
+	is_mapped_domain?: boolean;
+	is_redirect?: boolean;
+	unmapped_url?: string;
+	default_post_format?: string;
+	allowed_file_types?: string[];
+	show_on_front?: string;
+	default_comment_status?: boolean;
+	default_ping_status?: boolean;
+	software_version?: string;
+	created_at?: Date;
+	updated_at?: Date;
+	wordads?: boolean;
+	publicize_permanently_disabled?: boolean;
+	frame_nonce?: string;
+	jetpack_frame_nonce?: string;
+	page_on_front?: number;
+	page_for_posts?: number;
+	advanced_seo_front_page_description?: string;
+	verification_services_codes?: null;
+	podcasting_archive?: null;
+	is_domain_only?: boolean;
+	is_automated_transfer?: boolean;
+	is_wpcom_atomic?: boolean;
+	is_wpcom_store?: boolean;
+	woocommerce_is_active?: boolean;
+	editing_toolkit_is_active?: boolean;
+	design_type?: null;
+	site_segment?: null;
+	is_wpforteams_site?: boolean;
+	p2_hub_blog_id?: null;
+	is_cloud_eligible?: boolean;
+	anchor_podcast?: boolean;
+	is_difm_lite_in_progress?: boolean;
+	site_intent?: string;
+	launchpad_screen?: boolean;
+}
+
+export interface Plan {
+	product_id?: number;
+	product_slug?: string;
+	product_name_short?: string;
+	expired?: boolean;
+	user_is_owner?: boolean;
+	is_free?: boolean;
+}

--- a/client/lib/purchases/types.ts
+++ b/client/lib/purchases/types.ts
@@ -284,18 +284,18 @@ export interface Owner {
 export type GetChangePaymentMethodUrlFor = ( siteSlug: string, purchase: Purchase ) => string;
 export type GetManagePurchaseUrlFor = ( siteSlug: string, attachedToPurchaseId: string ) => string;
 
-export type RenderRenewsOrExpiresOn = (
-	moment: ReturnType< typeof useLocalizedMoment >,
-	purchase: Purchase,
-	siteSlug: string | undefined,
-	translate: ReturnType< typeof useTranslate >,
-	getManagePurchaseUrlFor: GetManagePurchaseUrlFor
-) => string;
+export type RenderRenewsOrExpiresOn = ( args: {
+	moment: ReturnType< typeof useLocalizedMoment >;
+	purchase: Purchase;
+	siteSlug: string | undefined;
+	translate: ReturnType< typeof useTranslate >;
+	getManagePurchaseUrlFor: GetManagePurchaseUrlFor;
+} ) => string;
 
-export type RenderRenewsOrExpiresOnLabel = (
-	purchase: Purchase,
-	translate: ReturnType< typeof useTranslate >
-) => string;
+export type RenderRenewsOrExpiresOnLabel = ( args: {
+	purchase: Purchase;
+	translate: ReturnType< typeof useTranslate >;
+} ) => string;
 
 export interface Site {
 	ID?: number;

--- a/client/me/purchases/manage-purchase/purchase-meta-expiration.tsx
+++ b/client/me/purchases/manage-purchase/purchase-meta-expiration.tsx
@@ -11,91 +11,13 @@ import { useSelector } from 'react-redux';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import {
 	hasPaymentMethod,
-	isExpired,
 	isRechargeable,
 	isCloseToExpiration,
 	isRenewable,
+	isExpired,
 } from 'calypso/lib/purchases';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import AutoRenewToggle from './auto-renew-toggle';
-
-function renderRenewsOrExpiresOnLabel( { purchase, translate } ) {
-	if ( isExpiring( purchase ) ) {
-		if ( isDomainRegistration( purchase ) ) {
-			return translate( 'Domain expires on' );
-		}
-
-		if ( isSubscription( purchase ) ) {
-			return translate( 'Subscription expires on' );
-		}
-
-		if ( isOneTimePurchase( purchase ) ) {
-			return translate( 'Expires on' );
-		}
-	}
-
-	if ( isExpired( purchase ) ) {
-		if ( isDomainRegistration( purchase ) ) {
-			return translate( 'Domain expired on' );
-		}
-
-		if ( isConciergeSession( purchase ) ) {
-			return translate( 'Session used on' );
-		}
-
-		if ( isSubscription( purchase ) ) {
-			return translate( 'Subscription expired on' );
-		}
-
-		if ( isOneTimePurchase( purchase ) ) {
-			return translate( 'Expired on' );
-		}
-	}
-
-	if ( isDomainRegistration( purchase ) ) {
-		return translate( 'Domain renews on' );
-	}
-
-	if ( isSubscription( purchase ) ) {
-		return translate( 'Subscription renews on' );
-	}
-
-	if ( isOneTimePurchase( purchase ) ) {
-		return translate( 'Renews on' );
-	}
-
-	return null;
-}
-
-function renderRenewsOrExpiresOn( {
-	moment,
-	purchase,
-	siteSlug,
-	translate,
-	getManagePurchaseUrlFor,
-} ) {
-	if ( isIncludedWithPlan( purchase ) ) {
-		const attachedPlanUrl = getManagePurchaseUrlFor( siteSlug, purchase.attachedToPurchaseId );
-
-		return (
-			<span>
-				<a href={ attachedPlanUrl }>{ translate( 'Renews with Plan' ) }</a>
-			</span>
-		);
-	}
-
-	if ( isExpiring( purchase ) || isExpired( purchase ) ) {
-		return moment( purchase.expiryDate ).format( 'LL' );
-	}
-
-	if ( isRenewing( purchase ) ) {
-		return moment( purchase.renewDate ).format( 'LL' );
-	}
-
-	if ( isOneTimePurchase( purchase ) ) {
-		return translate( 'Never Expires' );
-	}
-}
 
 function PurchaseMetaExpiration( {
 	purchase,
@@ -103,6 +25,8 @@ function PurchaseMetaExpiration( {
 	siteSlug,
 	getChangePaymentMethodUrlFor,
 	getManagePurchaseUrlFor,
+	renderRenewsOrExpiresOn,
+	renderRenewsOrExpiresOnLabel,
 } ) {
 	const translate = useTranslate();
 	const moment = useLocalizedMoment();

--- a/client/me/purchases/manage-purchase/purchase-meta-expiration.tsx
+++ b/client/me/purchases/manage-purchase/purchase-meta-expiration.tsx
@@ -18,6 +18,23 @@ import {
 } from 'calypso/lib/purchases';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import AutoRenewToggle from './auto-renew-toggle';
+import type {
+	Purchase,
+	GetChangePaymentMethodUrlFor,
+	RenderRenewsOrExpiresOn,
+	RenderRenewsOrExpiresOnLabel,
+	GetManagePurchaseUrlFor,
+} from 'calypso/lib/purchases/types';
+
+interface ExpirationProps {
+	purchase: Purchase;
+	site?: string;
+	siteSlug?: string;
+	getChangePaymentMethodUrlFor: GetChangePaymentMethodUrlFor;
+	getManagePurchaseUrlFor: GetManagePurchaseUrlFor;
+	renderRenewsOrExpiresOn: RenderRenewsOrExpiresOn;
+	renderRenewsOrExpiresOnLabel: RenderRenewsOrExpiresOnLabel;
+}
 
 function PurchaseMetaExpiration( {
 	purchase,
@@ -27,9 +44,10 @@ function PurchaseMetaExpiration( {
 	getManagePurchaseUrlFor,
 	renderRenewsOrExpiresOn,
 	renderRenewsOrExpiresOnLabel,
-} ) {
+}: ExpirationProps ) {
 	const translate = useTranslate();
 	const moment = useLocalizedMoment();
+
 	const isProductOwner = purchase?.userId === useSelector( getCurrentUserId );
 	const isJetpackPurchase = isJetpackPlan( purchase ) || isJetpackProduct( purchase );
 	const isAutorenewalEnabled = purchase?.isAutoRenewEnabled ?? false;
@@ -140,16 +158,16 @@ function PurchaseMetaExpiration( {
 	return (
 		<li>
 			<em className="manage-purchase__detail-label">
-				{ renderRenewsOrExpiresOnLabel( { purchase, translate } ) }
+				{ renderRenewsOrExpiresOnLabel( purchase, translate ) }
 			</em>
 			<span className="manage-purchase__detail">
-				{ renderRenewsOrExpiresOn( {
+				{ renderRenewsOrExpiresOn(
 					moment,
 					purchase,
 					siteSlug,
 					translate,
-					getManagePurchaseUrlFor,
-				} ) }
+					getManagePurchaseUrlFor
+				) }
 			</span>
 		</li>
 	);

--- a/client/me/purchases/manage-purchase/purchase-meta-expiration.tsx
+++ b/client/me/purchases/manage-purchase/purchase-meta-expiration.tsx
@@ -18,9 +18,9 @@ import {
 } from 'calypso/lib/purchases';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import AutoRenewToggle from './auto-renew-toggle';
+import type { SiteDetails } from '@automattic/data-stores/src/site/types';
 import type {
 	Purchase,
-	Site,
 	GetChangePaymentMethodUrlFor,
 	RenderRenewsOrExpiresOn,
 	RenderRenewsOrExpiresOnLabel,
@@ -29,7 +29,7 @@ import type {
 
 interface ExpirationProps {
 	purchase: Purchase;
-	site?: Site;
+	site?: SiteDetails;
 	siteSlug?: string;
 	getChangePaymentMethodUrlFor: GetChangePaymentMethodUrlFor;
 	getManagePurchaseUrlFor: GetManagePurchaseUrlFor;
@@ -55,7 +55,9 @@ function PurchaseMetaExpiration( {
 	const isJetpackPurchaseUsingPrimaryCancellationFlow =
 		isJetpackPurchase && config.isEnabled( 'jetpack/cancel-through-main-flow' );
 	const hideAutoRenew =
-		purchase && JETPACK_LEGACY_PLANS.includes( purchase.productSlug ) && ! isRenewable( purchase );
+		purchase &&
+		JETPACK_LEGACY_PLANS.some( ( plan ) => plan === purchase.productSlug ) &&
+		! isRenewable( purchase );
 
 	if ( ! purchase || isDomainTransfer( purchase ) || purchase?.isInAppPurchase ) {
 		return null;

--- a/client/me/purchases/manage-purchase/purchase-meta-expiration.tsx
+++ b/client/me/purchases/manage-purchase/purchase-meta-expiration.tsx
@@ -160,16 +160,16 @@ function PurchaseMetaExpiration( {
 	return (
 		<li>
 			<em className="manage-purchase__detail-label">
-				{ renderRenewsOrExpiresOnLabel( purchase, translate ) }
+				{ renderRenewsOrExpiresOnLabel( { purchase, translate } ) }
 			</em>
 			<span className="manage-purchase__detail">
-				{ renderRenewsOrExpiresOn(
+				{ renderRenewsOrExpiresOn( {
 					moment,
 					purchase,
 					siteSlug,
 					translate,
-					getManagePurchaseUrlFor
-				) }
+					getManagePurchaseUrlFor,
+				} ) }
 			</span>
 		</li>
 	);

--- a/client/me/purchases/manage-purchase/purchase-meta-expiration.tsx
+++ b/client/me/purchases/manage-purchase/purchase-meta-expiration.tsx
@@ -1,0 +1,234 @@
+import config from '@automattic/calypso-config';
+import {
+	isDomainTransfer,
+	isJetpackPlan,
+	isJetpackProduct,
+	JETPACK_LEGACY_PLANS,
+} from '@automattic/calypso-products';
+import classNames from 'classnames';
+import { useTranslate } from 'i18n-calypso';
+import { useSelector } from 'react-redux';
+import { useLocalizedMoment } from 'calypso/components/localized-moment';
+import {
+	hasPaymentMethod,
+	isExpired,
+	isRechargeable,
+	isCloseToExpiration,
+	isRenewable,
+} from 'calypso/lib/purchases';
+import { getCurrentUserId } from 'calypso/state/current-user/selectors';
+import AutoRenewToggle from './auto-renew-toggle';
+
+function renderRenewsOrExpiresOnLabel( { purchase, translate } ) {
+	if ( isExpiring( purchase ) ) {
+		if ( isDomainRegistration( purchase ) ) {
+			return translate( 'Domain expires on' );
+		}
+
+		if ( isSubscription( purchase ) ) {
+			return translate( 'Subscription expires on' );
+		}
+
+		if ( isOneTimePurchase( purchase ) ) {
+			return translate( 'Expires on' );
+		}
+	}
+
+	if ( isExpired( purchase ) ) {
+		if ( isDomainRegistration( purchase ) ) {
+			return translate( 'Domain expired on' );
+		}
+
+		if ( isConciergeSession( purchase ) ) {
+			return translate( 'Session used on' );
+		}
+
+		if ( isSubscription( purchase ) ) {
+			return translate( 'Subscription expired on' );
+		}
+
+		if ( isOneTimePurchase( purchase ) ) {
+			return translate( 'Expired on' );
+		}
+	}
+
+	if ( isDomainRegistration( purchase ) ) {
+		return translate( 'Domain renews on' );
+	}
+
+	if ( isSubscription( purchase ) ) {
+		return translate( 'Subscription renews on' );
+	}
+
+	if ( isOneTimePurchase( purchase ) ) {
+		return translate( 'Renews on' );
+	}
+
+	return null;
+}
+
+function renderRenewsOrExpiresOn( {
+	moment,
+	purchase,
+	siteSlug,
+	translate,
+	getManagePurchaseUrlFor,
+} ) {
+	if ( isIncludedWithPlan( purchase ) ) {
+		const attachedPlanUrl = getManagePurchaseUrlFor( siteSlug, purchase.attachedToPurchaseId );
+
+		return (
+			<span>
+				<a href={ attachedPlanUrl }>{ translate( 'Renews with Plan' ) }</a>
+			</span>
+		);
+	}
+
+	if ( isExpiring( purchase ) || isExpired( purchase ) ) {
+		return moment( purchase.expiryDate ).format( 'LL' );
+	}
+
+	if ( isRenewing( purchase ) ) {
+		return moment( purchase.renewDate ).format( 'LL' );
+	}
+
+	if ( isOneTimePurchase( purchase ) ) {
+		return translate( 'Never Expires' );
+	}
+}
+
+function PurchaseMetaExpiration( {
+	purchase,
+	site,
+	siteSlug,
+	getChangePaymentMethodUrlFor,
+	getManagePurchaseUrlFor,
+} ) {
+	const translate = useTranslate();
+	const moment = useLocalizedMoment();
+	const isProductOwner = purchase?.userId === useSelector( getCurrentUserId );
+	const isJetpackPurchase = isJetpackPlan( purchase ) || isJetpackProduct( purchase );
+	const isAutorenewalEnabled = purchase?.isAutoRenewEnabled ?? false;
+	const isJetpackPurchaseUsingPrimaryCancellationFlow =
+		isJetpackPurchase && config.isEnabled( 'jetpack/cancel-through-main-flow' );
+	const hideAutoRenew =
+		purchase && JETPACK_LEGACY_PLANS.includes( purchase.productSlug ) && ! isRenewable( purchase );
+
+	if ( ! purchase || isDomainTransfer( purchase ) || purchase?.isInAppPurchase ) {
+		return null;
+	}
+
+	if ( isRenewable( purchase ) && ! isExpired( purchase ) ) {
+		const dateSpan = <span className="manage-purchase__detail-date-span" />;
+		// If a jetpack site has been disconnected, the "site" prop will be null here.
+		const shouldRenderToggle = site && isProductOwner;
+		const autoRenewToggle = shouldRenderToggle ? (
+			<AutoRenewToggle
+				planName={ site.plan.product_name_short }
+				siteDomain={ site.domain }
+				siteSlug={ site.slug }
+				purchase={ purchase }
+				toggleSource="manage-purchase"
+				showLink={ true }
+				getChangePaymentMethodUrlFor={ getChangePaymentMethodUrlFor }
+			/>
+		) : (
+			<span />
+		);
+		const subsRenewText = isAutorenewalEnabled
+			? translate( 'Auto-renew is {{autoRenewToggle}}ON{{/autoRenewToggle}}', {
+					components: {
+						autoRenewToggle,
+					},
+			  } )
+			: translate( 'Auto-renew is {{autoRenewToggle}}OFF{{/autoRenewToggle}}', {
+					components: {
+						autoRenewToggle,
+					},
+			  } );
+
+		const subsReEnableText = translate(
+			'{{autoRenewToggle}}Re-activate subscription{{/autoRenewToggle}}',
+			{
+				components: {
+					autoRenewToggle,
+				},
+			}
+		);
+
+		let subsBillingText;
+		if (
+			isAutorenewalEnabled &&
+			! hideAutoRenew &&
+			hasPaymentMethod( purchase ) &&
+			isRechargeable( purchase )
+		) {
+			subsBillingText = translate( 'You will be billed on {{dateSpan}}%(renewDate)s{{/dateSpan}}', {
+				args: {
+					renewDate: purchase.renewDate && moment( purchase.renewDate ).format( 'LL' ),
+				},
+				components: {
+					dateSpan,
+				},
+			} );
+		} else {
+			subsBillingText = translate( 'Expires on {{dateSpan}}%(expireDate)s{{/dateSpan}}', {
+				args: {
+					expireDate: moment( purchase.expiryDate ).format( 'LL' ),
+				},
+				components: {
+					dateSpan,
+				},
+			} );
+		}
+
+		return (
+			<li className="manage-purchase__meta-expiration">
+				<em className="manage-purchase__detail-label">{ translate( 'Subscription Renewal' ) }</em>
+				{ ! hideAutoRenew && ! isJetpackPurchaseUsingPrimaryCancellationFlow && (
+					<div className="manage-purchase__auto-renew">
+						<span className="manage-purchase__detail manage-purchase__auto-renew-text">
+							{ subsRenewText }
+						</span>
+					</div>
+				) }
+				<span
+					className={ classNames( 'manage-purchase__detail', {
+						'is-expiring': isCloseToExpiration( purchase ),
+					} ) }
+				>
+					{ subsBillingText }
+				</span>
+				{ ! isAutorenewalEnabled &&
+					! hideAutoRenew &&
+					shouldRenderToggle &&
+					isJetpackPurchaseUsingPrimaryCancellationFlow && (
+						<div className="manage-purchase__auto-renew">
+							<span className="manage-purchase__detail manage-purchase__auto-renew-text">
+								{ subsReEnableText }
+							</span>
+						</div>
+					) }
+			</li>
+		);
+	}
+
+	return (
+		<li>
+			<em className="manage-purchase__detail-label">
+				{ renderRenewsOrExpiresOnLabel( { purchase, translate } ) }
+			</em>
+			<span className="manage-purchase__detail">
+				{ renderRenewsOrExpiresOn( {
+					moment,
+					purchase,
+					siteSlug,
+					translate,
+					getManagePurchaseUrlFor,
+				} ) }
+			</span>
+		</li>
+	);
+}
+
+export default PurchaseMetaExpiration;

--- a/client/me/purchases/manage-purchase/purchase-meta-expiration.tsx
+++ b/client/me/purchases/manage-purchase/purchase-meta-expiration.tsx
@@ -18,7 +18,7 @@ import {
 } from 'calypso/lib/purchases';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import AutoRenewToggle from './auto-renew-toggle';
-import type { SiteDetails } from '@automattic/data-stores/src/site/types';
+import type { SiteDetails } from '@automattic/data-stores';
 import type {
 	Purchase,
 	GetChangePaymentMethodUrlFor,

--- a/client/me/purchases/manage-purchase/purchase-meta-expiration.tsx
+++ b/client/me/purchases/manage-purchase/purchase-meta-expiration.tsx
@@ -20,6 +20,7 @@ import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import AutoRenewToggle from './auto-renew-toggle';
 import type {
 	Purchase,
+	Site,
 	GetChangePaymentMethodUrlFor,
 	RenderRenewsOrExpiresOn,
 	RenderRenewsOrExpiresOnLabel,
@@ -28,7 +29,7 @@ import type {
 
 interface ExpirationProps {
 	purchase: Purchase;
-	site?: string;
+	site?: Site;
 	siteSlug?: string;
 	getChangePaymentMethodUrlFor: GetChangePaymentMethodUrlFor;
 	getManagePurchaseUrlFor: GetManagePurchaseUrlFor;
@@ -64,9 +65,10 @@ function PurchaseMetaExpiration( {
 		const dateSpan = <span className="manage-purchase__detail-date-span" />;
 		// If a jetpack site has been disconnected, the "site" prop will be null here.
 		const shouldRenderToggle = site && isProductOwner;
+
 		const autoRenewToggle = shouldRenderToggle ? (
 			<AutoRenewToggle
-				planName={ site.plan.product_name_short }
+				planName={ site.plan?.product_name_short }
 				siteDomain={ site.domain }
 				siteSlug={ site.slug }
 				purchase={ purchase }

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -76,6 +76,8 @@ export default function PurchaseMeta( {
 					siteSlug={ siteSlug }
 					getChangePaymentMethodUrlFor={ getChangePaymentMethodUrlFor }
 					getManagePurchaseUrlFor={ getManagePurchaseUrlFor }
+					renderRenewsOrExpiresOn={ renderRenewsOrExpiresOn }
+					renderRenewsOrExpiresOnLabel={ renderRenewsOrExpiresOnLabel }
 				/>
 				<PurchaseMetaPaymentDetails
 					purchase={ purchase }
@@ -97,6 +99,84 @@ PurchaseMeta.propTypes = {
 	getManagePurchaseUrlFor: PropTypes.func,
 	getChangePaymentMethodUrlFor: PropTypes.func,
 };
+
+function renderRenewsOrExpiresOn( {
+	moment,
+	purchase,
+	siteSlug,
+	translate,
+	getManagePurchaseUrlFor,
+} ) {
+	if ( isIncludedWithPlan( purchase ) ) {
+		const attachedPlanUrl = getManagePurchaseUrlFor( siteSlug, purchase.attachedToPurchaseId );
+
+		return (
+			<span>
+				<a href={ attachedPlanUrl }>{ translate( 'Renews with Plan' ) }</a>
+			</span>
+		);
+	}
+
+	if ( isExpiring( purchase ) || isExpired( purchase ) ) {
+		return moment( purchase.expiryDate ).format( 'LL' );
+	}
+
+	if ( isRenewing( purchase ) ) {
+		return moment( purchase.renewDate ).format( 'LL' );
+	}
+
+	if ( isOneTimePurchase( purchase ) ) {
+		return translate( 'Never Expires' );
+	}
+}
+
+function renderRenewsOrExpiresOnLabel( { purchase, translate } ) {
+	if ( isExpiring( purchase ) ) {
+		if ( isDomainRegistration( purchase ) ) {
+			return translate( 'Domain expires on' );
+		}
+
+		if ( isSubscription( purchase ) ) {
+			return translate( 'Subscription expires on' );
+		}
+
+		if ( isOneTimePurchase( purchase ) ) {
+			return translate( 'Expires on' );
+		}
+	}
+
+	if ( isExpired( purchase ) ) {
+		if ( isDomainRegistration( purchase ) ) {
+			return translate( 'Domain expired on' );
+		}
+
+		if ( isConciergeSession( purchase ) ) {
+			return translate( 'Session used on' );
+		}
+
+		if ( isSubscription( purchase ) ) {
+			return translate( 'Subscription expired on' );
+		}
+
+		if ( isOneTimePurchase( purchase ) ) {
+			return translate( 'Expired on' );
+		}
+	}
+
+	if ( isDomainRegistration( purchase ) ) {
+		return translate( 'Domain renews on' );
+	}
+
+	if ( isSubscription( purchase ) ) {
+		return translate( 'Subscription renews on' );
+	}
+
+	if ( isOneTimePurchase( purchase ) ) {
+		return translate( 'Renews on' );
+	}
+
+	return null;
+}
 
 function PurchaseMetaPlaceholder() {
 	return (

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -100,36 +100,6 @@ PurchaseMeta.propTypes = {
 	getChangePaymentMethodUrlFor: PropTypes.func,
 };
 
-function renderRenewsOrExpiresOn( {
-	moment,
-	purchase,
-	siteSlug,
-	translate,
-	getManagePurchaseUrlFor,
-} ) {
-	if ( isIncludedWithPlan( purchase ) ) {
-		const attachedPlanUrl = getManagePurchaseUrlFor( siteSlug, purchase.attachedToPurchaseId );
-
-		return (
-			<span>
-				<a href={ attachedPlanUrl }>{ translate( 'Renews with Plan' ) }</a>
-			</span>
-		);
-	}
-
-	if ( isExpiring( purchase ) || isExpired( purchase ) ) {
-		return moment( purchase.expiryDate ).format( 'LL' );
-	}
-
-	if ( isRenewing( purchase ) ) {
-		return moment( purchase.renewDate ).format( 'LL' );
-	}
-
-	if ( isOneTimePurchase( purchase ) ) {
-		return translate( 'Never Expires' );
-	}
-}
-
 function renderRenewsOrExpiresOnLabel( { purchase, translate } ) {
 	if ( isExpiring( purchase ) ) {
 		if ( isDomainRegistration( purchase ) ) {
@@ -176,6 +146,36 @@ function renderRenewsOrExpiresOnLabel( { purchase, translate } ) {
 	}
 
 	return null;
+}
+
+function renderRenewsOrExpiresOn( {
+	moment,
+	purchase,
+	siteSlug,
+	translate,
+	getManagePurchaseUrlFor,
+} ) {
+	if ( isIncludedWithPlan( purchase ) ) {
+		const attachedPlanUrl = getManagePurchaseUrlFor( siteSlug, purchase.attachedToPurchaseId );
+
+		return (
+			<span>
+				<a href={ attachedPlanUrl }>{ translate( 'Renews with Plan' ) }</a>
+			</span>
+		);
+	}
+
+	if ( isExpiring( purchase ) || isExpired( purchase ) ) {
+		return moment( purchase.expiryDate ).format( 'LL' );
+	}
+
+	if ( isRenewing( purchase ) ) {
+		return moment( purchase.renewDate ).format( 'LL' );
+	}
+
+	if ( isOneTimePurchase( purchase ) ) {
+		return translate( 'Never Expires' );
+	}
 }
 
 function PurchaseMetaPlaceholder() {

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -1,15 +1,11 @@
-import config from '@automattic/calypso-config';
 import {
 	isConciergeSession,
 	isDomainRegistration,
-	isDomainTransfer,
 	isJetpackPlan,
 	isJetpackProduct,
-	JETPACK_LEGACY_PLANS,
 } from '@automattic/calypso-products';
 import { Card } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
-import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { times } from 'lodash';
 import PropTypes from 'prop-types';
@@ -17,28 +13,23 @@ import { useState, useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import ClipboardButton from 'calypso/components/forms/clipboard-button';
 import FormTextInput from 'calypso/components/forms/form-text-input';
-import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import useUserLicenseBySubscriptionQuery from 'calypso/data/jetpack-licensing/use-user-license-by-subscription-query';
 import {
 	getName,
-	hasPaymentMethod,
 	isExpired,
 	isExpiring,
 	isIncludedWithPlan,
 	isOneTimePurchase,
-	isRechargeable,
 	isRenewing,
 	isSubscription,
-	isCloseToExpiration,
-	isRenewable,
 } from 'calypso/lib/purchases';
 import { CALYPSO_CONTACT, JETPACK_SUPPORT } from 'calypso/lib/url/support';
-import { getCurrentUser, getCurrentUserId } from 'calypso/state/current-user/selectors';
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { getByPurchaseId } from 'calypso/state/purchases/selectors';
 import { getSite, isRequestingSites } from 'calypso/state/sites/selectors';
 import { managePurchase } from '../paths';
 import { isJetpackTemporarySitePurchase } from '../utils';
-import AutoRenewToggle from './auto-renew-toggle';
+import PurchaseMetaExpiration from './purchase-meta-expiration';
 import PurchaseMetaIntroductoryOfferDetail from './purchase-meta-introductory-offer-detail';
 import PurchaseMetaOwner from './purchase-meta-owner';
 import PurchaseMetaPaymentDetails from './purchase-meta-payment-details';
@@ -106,84 +97,6 @@ PurchaseMeta.propTypes = {
 	getManagePurchaseUrlFor: PropTypes.func,
 	getChangePaymentMethodUrlFor: PropTypes.func,
 };
-
-function renderRenewsOrExpiresOnLabel( { purchase, translate } ) {
-	if ( isExpiring( purchase ) ) {
-		if ( isDomainRegistration( purchase ) ) {
-			return translate( 'Domain expires on' );
-		}
-
-		if ( isSubscription( purchase ) ) {
-			return translate( 'Subscription expires on' );
-		}
-
-		if ( isOneTimePurchase( purchase ) ) {
-			return translate( 'Expires on' );
-		}
-	}
-
-	if ( isExpired( purchase ) ) {
-		if ( isDomainRegistration( purchase ) ) {
-			return translate( 'Domain expired on' );
-		}
-
-		if ( isConciergeSession( purchase ) ) {
-			return translate( 'Session used on' );
-		}
-
-		if ( isSubscription( purchase ) ) {
-			return translate( 'Subscription expired on' );
-		}
-
-		if ( isOneTimePurchase( purchase ) ) {
-			return translate( 'Expired on' );
-		}
-	}
-
-	if ( isDomainRegistration( purchase ) ) {
-		return translate( 'Domain renews on' );
-	}
-
-	if ( isSubscription( purchase ) ) {
-		return translate( 'Subscription renews on' );
-	}
-
-	if ( isOneTimePurchase( purchase ) ) {
-		return translate( 'Renews on' );
-	}
-
-	return null;
-}
-
-function renderRenewsOrExpiresOn( {
-	moment,
-	purchase,
-	siteSlug,
-	translate,
-	getManagePurchaseUrlFor,
-} ) {
-	if ( isIncludedWithPlan( purchase ) ) {
-		const attachedPlanUrl = getManagePurchaseUrlFor( siteSlug, purchase.attachedToPurchaseId );
-
-		return (
-			<span>
-				<a href={ attachedPlanUrl }>{ translate( 'Renews with Plan' ) }</a>
-			</span>
-		);
-	}
-
-	if ( isExpiring( purchase ) || isExpired( purchase ) ) {
-		return moment( purchase.expiryDate ).format( 'LL' );
-	}
-
-	if ( isRenewing( purchase ) ) {
-		return moment( purchase.renewDate ).format( 'LL' );
-	}
-
-	if ( isOneTimePurchase( purchase ) ) {
-		return translate( 'Never Expires' );
-	}
-}
 
 function PurchaseMetaPlaceholder() {
 	return (
@@ -268,140 +181,6 @@ function RenewErrorMessage( { purchase, translate, site } ) {
 				}
 			) }
 		</div>
-	);
-}
-
-function PurchaseMetaExpiration( {
-	purchase,
-	site,
-	siteSlug,
-	getChangePaymentMethodUrlFor,
-	getManagePurchaseUrlFor,
-} ) {
-	const translate = useTranslate();
-	const moment = useLocalizedMoment();
-	const isProductOwner = purchase?.userId === useSelector( getCurrentUserId );
-	const isJetpackPurchase = isJetpackPlan( purchase ) || isJetpackProduct( purchase );
-	const isAutorenewalEnabled = purchase?.isAutoRenewEnabled ?? false;
-	const isJetpackPurchaseUsingPrimaryCancellationFlow =
-		isJetpackPurchase && config.isEnabled( 'jetpack/cancel-through-main-flow' );
-	const hideAutoRenew =
-		purchase && JETPACK_LEGACY_PLANS.includes( purchase.productSlug ) && ! isRenewable( purchase );
-
-	if ( ! purchase || isDomainTransfer( purchase ) || purchase?.isInAppPurchase ) {
-		return null;
-	}
-
-	if ( isRenewable( purchase ) && ! isExpired( purchase ) ) {
-		const dateSpan = <span className="manage-purchase__detail-date-span" />;
-		// If a jetpack site has been disconnected, the "site" prop will be null here.
-		const shouldRenderToggle = site && isProductOwner;
-		const autoRenewToggle = shouldRenderToggle ? (
-			<AutoRenewToggle
-				planName={ site.plan?.product_name_short ?? '' }
-				siteDomain={ site.domain }
-				siteSlug={ site.slug }
-				purchase={ purchase }
-				toggleSource="manage-purchase"
-				showLink={ true }
-				getChangePaymentMethodUrlFor={ getChangePaymentMethodUrlFor }
-			/>
-		) : (
-			<span />
-		);
-		const subsRenewText = isAutorenewalEnabled
-			? translate( 'Auto-renew is {{autoRenewToggle}}ON{{/autoRenewToggle}}', {
-					components: {
-						autoRenewToggle,
-					},
-			  } )
-			: translate( 'Auto-renew is {{autoRenewToggle}}OFF{{/autoRenewToggle}}', {
-					components: {
-						autoRenewToggle,
-					},
-			  } );
-
-		const subsReEnableText = translate(
-			'{{autoRenewToggle}}Re-activate subscription{{/autoRenewToggle}}',
-			{
-				components: {
-					autoRenewToggle,
-				},
-			}
-		);
-
-		let subsBillingText;
-		if (
-			isAutorenewalEnabled &&
-			! hideAutoRenew &&
-			hasPaymentMethod( purchase ) &&
-			isRechargeable( purchase )
-		) {
-			subsBillingText = translate( 'You will be billed on {{dateSpan}}%(renewDate)s{{/dateSpan}}', {
-				args: {
-					renewDate: purchase.renewDate && moment( purchase.renewDate ).format( 'LL' ),
-				},
-				components: {
-					dateSpan,
-				},
-			} );
-		} else {
-			subsBillingText = translate( 'Expires on {{dateSpan}}%(expireDate)s{{/dateSpan}}', {
-				args: {
-					expireDate: moment( purchase.expiryDate ).format( 'LL' ),
-				},
-				components: {
-					dateSpan,
-				},
-			} );
-		}
-
-		return (
-			<li className="manage-purchase__meta-expiration">
-				<em className="manage-purchase__detail-label">{ translate( 'Subscription Renewal' ) }</em>
-				{ ! hideAutoRenew && ! isJetpackPurchaseUsingPrimaryCancellationFlow && (
-					<div className="manage-purchase__auto-renew">
-						<span className="manage-purchase__detail manage-purchase__auto-renew-text">
-							{ subsRenewText }
-						</span>
-					</div>
-				) }
-				<span
-					className={ classNames( 'manage-purchase__detail', {
-						'is-expiring': isCloseToExpiration( purchase ),
-					} ) }
-				>
-					{ subsBillingText }
-				</span>
-				{ ! isAutorenewalEnabled &&
-					! hideAutoRenew &&
-					shouldRenderToggle &&
-					isJetpackPurchaseUsingPrimaryCancellationFlow && (
-						<div className="manage-purchase__auto-renew">
-							<span className="manage-purchase__detail manage-purchase__auto-renew-text">
-								{ subsReEnableText }
-							</span>
-						</div>
-					) }
-			</li>
-		);
-	}
-
-	return (
-		<li>
-			<em className="manage-purchase__detail-label">
-				{ renderRenewsOrExpiresOnLabel( { purchase, translate } ) }
-			</em>
-			<span className="manage-purchase__detail">
-				{ renderRenewsOrExpiresOn( {
-					moment,
-					purchase,
-					siteSlug,
-					translate,
-					getManagePurchaseUrlFor,
-				} ) }
-			</span>
-		</li>
 	);
 }
 


### PR DESCRIPTION
### Testing Instructions:

* As it is a TypeScript migration, it should not change anything so ensure that the usual functionality described below on the purchases page just works as expected.
* Goto this page `/purchases/subscriptions/:site/:purchaseID` ,  for any purchase you should see the `Subscription renewal` component as usual without any changes.   
![oekGTR.png](https://user-images.githubusercontent.com/552016/210436618-9f8ded2e-0c0f-4e56-9660-b86f196b924b.png)

Fixes https://github.com/Automattic/payments-shilling/issues/1306

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
