### PR TITLE
i18n: Wrap "Join thousands of others" Earn paragraph for translation

### DIFF
--- a/client/my-sites/earn/memberships/index.jsx
+++ b/client/my-sites/earn/memberships/index.jsx
@@ -589,7 +589,9 @@ class MembershipsSection extends Component {
 					<div>
 						<h3>{ translate( 'Join thousands of others' ) }</h3>
 						{ preventWidows(
-							'Sites that actively promoted their businesses and causes on social media, email, and other platforms have collected tens of thousands of dollars through these blocks.'
+							translate(
+								'Sites that actively promoted their businesses and causes on social media, email, and other platforms have collected tens of thousands of dollars through these blocks.'
+							)
 						) }
 					</div>
 				</div>


### PR DESCRIPTION
#### Proposed Changes
This PR wraps the paragraph below the "Join thousands of others" heading for translation on the Earn -> Payments page (`/earn/payments/`).

![image](https://user-images.githubusercontent.com/75777864/210440901-385747cd-4dff-4ff4-bf5a-6e9fe8610931.png)


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Code review
* Visit http://calypso.localhost:3000/earn/payments/ (or on Calypso.live), choose a site, and verify that the English text is still shown normally (there aren't any translations yet).

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 542-gh-Automattic/i18n-issues.

