### PR TITLE
Fix warning when running e2e decrypt

### DIFF
--- a/packages/calypso-e2e/package.json
+++ b/packages/calypso-e2e/package.json
@@ -43,6 +43,6 @@
 		"clean": "yarn build --clean && rm -rf dist",
 		"build": "tsc --build ./tsconfig.json",
 		"encrypt-secrets": "openssl enc -md sha1 -aes-256-cbc -pass env:E2E_SECRETS_KEY -out ./src/secrets/encrypted.enc -in ./src/secrets/decrypted-secrets.json",
-		"decrypt-secrets": "rm ./src/secrets/decrypted-secrets.json; openssl enc -md sha1 -aes-256-cbc -d -pass env:E2E_SECRETS_KEY -in ./src/secrets/encrypted.enc -out ./src/secrets/decrypted-secrets.json"
+		"decrypt-secrets": "rm -f ./src/secrets/decrypted-secrets.json; openssl enc -md sha1 -aes-256-cbc -d -pass env:E2E_SECRETS_KEY -in ./src/secrets/encrypted.enc -out ./src/secrets/decrypted-secrets.json"
 	}
 }


### PR DESCRIPTION
#### Proposed Changes

When running the e2e decrypt command, a message is printed when the secrets file doesn't exist. (Just from `rm $file` saying there's an issue when $file doesn't exist.) It doesn't impact functionality, but it made me second guess whether the command worked! An easy fix is `rm -f $file`, which doesn't show an error if the file doesn't exist.

#### Testing Instructions
1. If it exists already, delete `./src/secrets/decrypted-secrets.json`
2. Run `yarn workspace wp-e2e-tests decrypt-secrets`.
3. There shouldn't be an error about the secrets file missing. (Though if you don't have the secret set up, the next command might fail. That's unimportant for this PR) On trunk, an error is printed. (Which you could quickly check by checking on trunk and running the command again.)
