### PR TITLE
Stats: Fix the toggleable mobile menu for list items

### DIFF
--- a/client/my-sites/stats/stats-list/stats-list-actions.jsx
+++ b/client/my-sites/stats/stats-list/stats-list-actions.jsx
@@ -2,30 +2,13 @@ import { Icon, moreHorizontalMobile } from '@wordpress/icons';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useMemo } from 'react';
 import titlecase from 'to-title-case';
 import Follow from './action-follow';
 import OpenLink from './action-link';
 import Page from './action-page';
 import Promote from './action-promote';
 import Spam from './action-spam';
-
-function useStatefulMobileMenu() {
-	const [ isMobileMenuVisible, setIsMobileMenuVisible ] = useState( false );
-	const toggleMobileMenu = useCallback(
-		( event ) => {
-			event.stopPropagation();
-			event.preventDefault();
-			setIsMobileMenuVisible( ! isMobileMenuVisible );
-		},
-		[ isMobileMenuVisible, setIsMobileMenuVisible ]
-	);
-	return {
-		isMobileMenuVisible,
-		setIsMobileMenuVisible,
-		toggleMobileMenu,
-	};
-}
 
 function useActionItems( { data, moduleName } ) {
 	return useMemo( () => {
@@ -96,15 +79,14 @@ function useActionItems( { data, moduleName } ) {
  * Render a list of `action` icons based on action array from a list item.
  * Possible types: External Link redirect, Specific page statistics redirect, Spam, Promote, Follow.
  */
-const StatsListActions = ( { data, moduleName, children } ) => {
+const StatsListActions = ( { data, moduleName, children, isMobileMenuVisible, onClick } ) => {
 	const translate = useTranslate();
 	const actionItems = useActionItems( { data, moduleName } );
-	const { isMobileMenuVisible, toggleMobileMenu } = useStatefulMobileMenu();
 
 	return actionItems?.length || children ? (
 		<>
 			<button
-				onClick={ toggleMobileMenu }
+				onClick={ onClick }
 				className={ classNames( 'stats-list-actions__mobile-toggle', {
 					'stats-list-actions__mobile-toggle--expanded': isMobileMenuVisible,
 				} ) }

--- a/client/my-sites/stats/stats-list/stats-list-actions.jsx
+++ b/client/my-sites/stats/stats-list/stats-list-actions.jsx
@@ -79,14 +79,20 @@ function useActionItems( { data, moduleName } ) {
  * Render a list of `action` icons based on action array from a list item.
  * Possible types: External Link redirect, Specific page statistics redirect, Spam, Promote, Follow.
  */
-const StatsListActions = ( { data, moduleName, children, isMobileMenuVisible, onClick } ) => {
+const StatsListActions = ( {
+	data,
+	moduleName,
+	children,
+	isMobileMenuVisible,
+	onMobileMenuClick,
+} ) => {
 	const translate = useTranslate();
 	const actionItems = useActionItems( { data, moduleName } );
 
 	return actionItems?.length || children ? (
 		<>
 			<button
-				onClick={ onClick }
+				onClick={ onMobileMenuClick }
 				className={ classNames( 'stats-list-actions__mobile-toggle', {
 					'stats-list-actions__mobile-toggle--expanded': isMobileMenuVisible,
 				} ) }

--- a/client/my-sites/stats/stats-list/stats-list-card.jsx
+++ b/client/my-sites/stats/stats-list/stats-list-card.jsx
@@ -65,7 +65,7 @@ const StatsListCard = ( {
 				moduleName={ moduleType }
 				isMobileMenuVisible={ isVisible }
 				inStatsListCard
-				onClick={ ( event ) => toggleMobileMenu( event, isVisible, key ) }
+				onMobileMenuClick={ ( event ) => toggleMobileMenu( event, isVisible, key ) }
 			>
 				{ item?.link && (
 					<OpenLink href={ item.link } key={ `link-${ key }` } moduleName={ moduleType } />

--- a/client/my-sites/stats/stats-list/stats-list-card.jsx
+++ b/client/my-sites/stats/stats-list/stats-list-card.jsx
@@ -8,7 +8,7 @@ import {
 import debugFactory from 'debug';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
-import React from 'react';
+import React, { useState, useCallback } from 'react';
 import titlecase from 'to-title-case';
 import { gaRecordEvent } from 'calypso/lib/analytics/ga';
 import OpenLink from './action-link';
@@ -29,6 +29,7 @@ const StatsListCard = ( {
 	const translate = useTranslate();
 	const moduleNameTitle = titlecase( moduleType );
 	const debug = debugFactory( `calypso:stats:list:${ moduleType }` );
+	const [ visibleRightItemKey, setVisibleRightItemKey ] = useState( undefined );
 
 	const localClickHandler = ( event, listItemData ) => {
 		debug( 'clickHandler' );
@@ -44,11 +45,30 @@ const StatsListCard = ( {
 		}
 	};
 
-	const outputRightItem = ( item, index ) => {
+	const toggleMobileMenu = useCallback( ( event, isVisible, key ) => {
+		event.stopPropagation();
+		event.preventDefault();
+
+		if ( isVisible ) {
+			setVisibleRightItemKey( undefined );
+		} else {
+			setVisibleRightItemKey( key );
+		}
+	}, [] );
+
+	const outputRightItem = ( item, key ) => {
+		const isVisible = key === visibleRightItemKey;
+
 		return (
-			<StatsListActions data={ item } moduleName={ moduleType } inStatsListCard>
+			<StatsListActions
+				data={ item }
+				moduleName={ moduleType }
+				isMobileMenuVisible={ isVisible }
+				inStatsListCard
+				onClick={ ( event ) => toggleMobileMenu( event, isVisible, key ) }
+			>
 				{ item?.link && (
-					<OpenLink href={ item.link } key={ `link-${ index }` } moduleName={ moduleType } />
+					<OpenLink href={ item.link } key={ `link-${ key }` } moduleName={ moduleType } />
 				) }
 			</StatsListActions>
 		);
@@ -89,6 +109,7 @@ const StatsListCard = ( {
 				{ sortedData?.map( ( item, index ) => {
 					let leftSideItem;
 					const isInteractive = item?.link || item?.page || item?.children;
+					const key = item?.id || index; // not every item has an id
 
 					// left icon visible only for Author avatars and Contry flags.
 					if ( item?.countryCode ) {
@@ -99,13 +120,13 @@ const StatsListCard = ( {
 
 					return (
 						<HorizontalBarListItem
-							key={ item?.id || index } // not every item has an id
+							key={ key }
 							data={ item }
 							maxValue={ barMaxValue }
 							hasIndicator={ item?.className?.includes( 'published' ) }
 							onClick={ localClickHandler }
 							leftSideItem={ leftSideItem }
-							renderRightSideItem={ ( incomingItem ) => outputRightItem( incomingItem, index ) }
+							renderRightSideItem={ ( incomingItem ) => outputRightItem( incomingItem, key ) }
 							useShortLabel={ useShortLabel }
 							isStatic={ ! isInteractive }
 							barMaxValue={ barMaxValue }


### PR DESCRIPTION
#### Proposed Changes

* Enable only one toggleable mobile menu for list items to be open on the page. Currently, having more than one menu open makes it difficult to close them.

<img src="https://user-images.githubusercontent.com/6406071/210447270-7388bf7b-c7a0-4a33-a957-fa89b55a9c48.png" width="400"/>

#### Testing Instructions

* Go to the Calypso live link
* Navigate to Calypso Stats in a mobile-sized viewport (at window width of <480px).
* Go to the `Posts & pages` section
* Ensure that you see an ellipsis button that spawns a mobile dropdown menu when pressed.
* Ensure that when you try to open another menu, the previous one gets closed.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #70152 
