### PR TITLE
VideoPress Onboarding: Move theme chooser up before account creation

### DIFF
--- a/client/landing/stepper/declarative-flow/videopress.ts
+++ b/client/landing/stepper/declarative-flow/videopress.ts
@@ -28,8 +28,8 @@ const videopress: Flow = {
 
 		return [
 			{ slug: 'intro', component: Intro },
-			{ slug: 'options', component: SiteOptions },
 			{ slug: 'videomakerSetup', component: VideomakerSetup },
+			{ slug: 'options', component: SiteOptions },
 			{ slug: 'chooseADomain', component: ChooseADomain },
 			{ slug: 'chooseAPlan', component: ChooseAPlan },
 			{ slug: 'processing', component: ProcessingStep },
@@ -110,6 +110,9 @@ const videopress: Flow = {
 		async function submit( providedDependencies: ProvidedDependencies = {} ) {
 			switch ( _currentStep ) {
 				case 'intro':
+					return navigate( 'videomakerSetup' );
+
+				case 'videomakerSetup':
 					if ( userIsLoggedIn ) {
 						return navigate( 'options' );
 					}
@@ -122,10 +125,6 @@ const videopress: Flow = {
 					const { siteTitle, tagline } = providedDependencies;
 					setSiteTitle( siteTitle as string );
 					setSiteDescription( tagline as string );
-					return navigate( 'videomakerSetup' );
-				}
-
-				case 'videomakerSetup': {
 					return navigate( 'chooseADomain' );
 				}
 


### PR DESCRIPTION


#### Proposed Changes

* move theme chooser before account creation, to provide an example of what the customer will get before asking them to go through the work of creating an account

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* In a logged out browser visit `/setup/videopress`
* go through the entire flow. The theme chooser should be the first step after the Intro page
* You shouldn't be asked to create an account until after you've chosen the theme
* go through the rest of the flow, the site should be created as expected
* Re-test in a logged in session: Theme chooser should still be first and you shouldn't be asked to create an account

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/greenhouse/issues/1478
