### PR TITLE
Revert "CI: streamline the `WPComPlugin` build configuration to reduce queue sizes."

### DIFF
--- a/.teamcity/_self/lib/wpcom/WPComPluginBuild.kt
+++ b/.teamcity/_self/lib/wpcom/WPComPluginBuild.kt
@@ -49,11 +49,6 @@ open class WPComPluginBuild(
 		}
 
 		params.buildParams()
-		maxRunningBuildsPerBranch = """
-			<default>: 0
-			revert*: 0
-			*: 1
-		""".trimIndent()
 
 		artifactRules = "$pluginSlug.zip"
 		buildNumberPattern = "%build.prefix%.%build.counter%"


### PR DESCRIPTION
Reverts Automattic/wp-calypso#71351

Unfortunately, there's an issue with the setting, and it causes _all_ plugin builds to get stuck in the queue. See p1672786252694769-slack-C02DQP0FP
