### PR TITLE
Theme Showcase: Show theme preview modal with selected style variation 

### DIFF
--- a/client/components/theme-preview-modal/index.tsx
+++ b/client/components/theme-preview-modal/index.tsx
@@ -26,6 +26,7 @@ interface ThemePreviewModalProps {
 	theme: ThemeWithStyleVariations;
 	previewUrl: string;
 	actionButtons: React.ReactNode;
+	selectedVariation?: StyleVariation;
 	onClose: () => void;
 }
 
@@ -33,6 +34,7 @@ const ThemePreviewModal: React.FC< ThemePreviewModalProps > = ( {
 	theme,
 	previewUrl,
 	actionButtons,
+	selectedVariation,
 	onClose,
 } ) => {
 	const siteId = useSelector( getSelectedSiteId ) || -1;
@@ -48,7 +50,7 @@ const ThemePreviewModal: React.FC< ThemePreviewModalProps > = ( {
 	);
 	const { shouldLimitGlobalStyles } = useSiteGlobalStylesStatus( siteId );
 	const [ selectedStyleVariation, setSelectedStyleVariation ] = useState< StyleVariation | null >(
-		null
+		selectedVariation || null
 	);
 
 	const shortDescription = useMemo( () => {

--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -71,6 +71,8 @@ export class Theme extends Component {
 		screenshotClickUrl: PropTypes.string,
 		// Called when theme screenshot is clicked
 		onScreenshotClick: PropTypes.func,
+		// Called when theme style variation is clicked
+		onStyleVariationClick: PropTypes.func,
 		// Called when the more button is clicked
 		onMoreButtonClick: PropTypes.func,
 		// Options to populate the 'More' button popover menu with
@@ -135,6 +137,7 @@ export class Theme extends Component {
 			) ||
 			nextProps.screenshotClickUrl !== this.props.screenshotClickUrl ||
 			nextProps.onScreenshotClick !== this.props.onScreenshotClick ||
+			nextProps.onStyleVariationClick !== this.props.onStyleVariationClick ||
 			nextProps.onMoreButtonClick !== this.props.onMoreButtonClick ||
 			themeThumbnailRefUpdated
 		);
@@ -153,6 +156,10 @@ export class Theme extends Component {
 		if ( typeof onScreenshotClick === 'function' ) {
 			onScreenshotClick( this.props.theme.id, this.props.index );
 		}
+	};
+
+	onStyleVariationClick = ( variation ) => {
+		this.props.onStyleVariationClick?.( this.props.theme.id, this.props.index, variation );
 	};
 
 	isBeginnerTheme() {
@@ -454,7 +461,11 @@ export class Theme extends Component {
 		return (
 			style_variations.length > 0 && (
 				<div className="theme__info-style-variations">
-					<StyleVariationBadges variations={ style_variations } />
+					<StyleVariationBadges
+						variations={ style_variations }
+						onMoreClick={ this.onStyleVariationClick }
+						onClick={ this.onStyleVariationClick }
+					/>
 				</div>
 			)
 		);

--- a/client/components/theme/more-button.jsx
+++ b/client/components/theme/more-button.jsx
@@ -40,7 +40,7 @@ class ThemeMoreButton extends Component {
 
 	popoverAction( action, label ) {
 		return () => {
-			action( this.props.themeId );
+			action( this.props.themeId, 'more button' );
 			this.props.onMoreButtonClick( this.props.themeId, this.props.index, 'popup_' + label );
 		};
 	}

--- a/client/components/themes-list/index.jsx
+++ b/client/components/themes-list/index.jsx
@@ -66,6 +66,7 @@ ThemesList.propTypes = {
 	getButtonOptions: PropTypes.func,
 	getScreenshotUrl: PropTypes.func,
 	onScreenshotClick: PropTypes.func.isRequired,
+	onStyleVariationClick: PropTypes.func,
 	onMoreButtonClick: PropTypes.func,
 	getActionLabel: PropTypes.func,
 	isActive: PropTypes.func,
@@ -113,6 +114,7 @@ function ThemeBlock( props ) {
 			buttonContents={ props.getButtonOptions( theme.id ) }
 			screenshotClickUrl={ props.getScreenshotUrl && props.getScreenshotUrl( theme.id ) }
 			onScreenshotClick={ props.onScreenshotClick }
+			onStyleVariationClick={ props.onStyleVariationClick }
 			onMoreButtonClick={ props.onMoreButtonClick }
 			actionLabel={ props.getActionLabel( theme.id ) }
 			index={ index }

--- a/client/my-sites/themes/helpers.js
+++ b/client/my-sites/themes/helpers.js
@@ -16,9 +16,9 @@ function appendActionTracking( option, name ) {
 	const { action } = option;
 
 	return Object.assign( {}, option, {
-		action: ( t ) => {
+		action: ( t, context ) => {
 			action && action( t );
-			trackClick( 'more button', name );
+			context && trackClick( context, name );
 		},
 	} );
 }

--- a/client/my-sites/themes/theme-preview.jsx
+++ b/client/my-sites/themes/theme-preview.jsx
@@ -75,6 +75,10 @@ class ThemePreview extends Component {
 		return isActive ? null : this.props.themeOptions.secondary;
 	};
 
+	getStyleVariationOption = () => {
+		return this.props.themeOptions.styleVariation;
+	};
+
 	renderPrimaryButton = () => {
 		const primaryOption = this.getPrimaryOption();
 		const buttonHref = primaryOption.getUrl ? primaryOption.getUrl( this.props.themeId ) : null;
@@ -126,6 +130,7 @@ class ThemePreview extends Component {
 						<ThemePreviewModal
 							theme={ theme }
 							previewUrl={ this.getPreviewUrl() }
+							selectedVariation={ this.getStyleVariationOption() }
 							actionButtons={ this.renderPrimaryButton() }
 							onClose={ this.props.hideThemePreview }
 						/>

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -68,7 +68,7 @@ class ThemesSelection extends Component {
 		}
 	}
 
-	recordSearchResultsClick = ( themeId, resultsRank, action ) => {
+	recordSearchResultsClick = ( themeId, resultsRank, action, variation = '@theme' ) => {
 		const { query, filterString } = this.props;
 		const themes = this.props.customizedThemesList || this.props.themes;
 		const search_taxonomies = filterString;
@@ -78,6 +78,7 @@ class ThemesSelection extends Component {
 			search_term: search_term || null,
 			search_taxonomies,
 			theme: themeId,
+			style_variation: variation,
 			results_rank: resultsRank + 1,
 			results: themes.map( property( 'id' ) ).join(),
 			page_number: query.page,
@@ -104,6 +105,22 @@ class ThemesSelection extends Component {
 		this.props.onScreenshotClick && this.props.onScreenshotClick( themeId );
 	};
 
+	onStyleVariationClick = ( themeId, resultsRank, variation ) => {
+		if ( ! this.props.isThemeActive( themeId ) ) {
+			this.recordSearchResultsClick( themeId, resultsRank, 'style_variation', variation?.slug );
+		}
+
+		const options = this.getOptions(
+			themeId,
+			variation,
+			`style variation: ${ variation ? variation.slug : 'show more' }`
+		);
+
+		if ( options && options.preview ) {
+			options.preview.action( themeId );
+		}
+	};
+
 	fetchNextPage = ( options ) => {
 		if ( this.props.isRequesting || this.props.isLastPage ) {
 			return;
@@ -119,7 +136,7 @@ class ThemesSelection extends Component {
 	};
 
 	//intercept preview and add primary and secondary
-	getOptions = ( themeId ) => {
+	getOptions = ( themeId, styleVariation, context ) => {
 		const options = this.props.getOptions( themeId );
 		const wrappedPreviewAction = ( action ) => {
 			let defaultOption;
@@ -149,8 +166,8 @@ class ThemesSelection extends Component {
 				} else {
 					defaultOption = options.activate;
 				}
-				this.props.setThemePreviewOptions( defaultOption, secondaryOption );
-				return action( t );
+				this.props.setThemePreviewOptions( defaultOption, secondaryOption, styleVariation );
+				return action( t, context );
 			};
 		};
 
@@ -179,6 +196,7 @@ class ThemesSelection extends Component {
 					onMoreButtonClick={ this.recordSearchResultsClick }
 					getButtonOptions={ this.getOptions }
 					onScreenshotClick={ this.onScreenshotClick }
+					onStyleVariationClick={ this.onStyleVariationClick }
 					getScreenshotUrl={ this.props.getScreenshotUrl }
 					getActionLabel={ this.props.getActionLabel }
 					isActive={ this.props.isThemeActive }

--- a/client/state/themes/actions/set-theme-preview-options.js
+++ b/client/state/themes/actions/set-theme-preview-options.js
@@ -2,10 +2,11 @@ import { THEME_PREVIEW_OPTIONS } from 'calypso/state/themes/action-types';
 
 import 'calypso/state/themes/init';
 
-export function setThemePreviewOptions( primary, secondary ) {
+export function setThemePreviewOptions( primary, secondary, styleVariation ) {
 	return {
 		type: THEME_PREVIEW_OPTIONS,
 		primary,
 		secondary,
+		styleVariation,
 	};
 }

--- a/client/state/themes/reducer.js
+++ b/client/state/themes/reducer.js
@@ -410,9 +410,8 @@ export const lastQuery = ( state = {}, action ) => {
 export const themePreviewOptions = ( state = {}, action ) => {
 	switch ( action.type ) {
 		case THEME_PREVIEW_OPTIONS: {
-			const { primary, secondary } = action;
-
-			return { primary, secondary };
+			const { primary, secondary, styleVariation } = action;
+			return { primary, secondary, styleVariation };
 		}
 	}
 

--- a/packages/design-picker/src/components/style-variation-badges/index.tsx
+++ b/packages/design-picker/src/components/style-variation-badges/index.tsx
@@ -3,15 +3,19 @@ import Badge from './badge';
 import type { StyleVariation } from '../../types';
 import './style.scss';
 
+const SPACE_BAR_KEYCODE = 32;
+
 interface BadgesProps {
 	maxVariationsToShow?: number;
 	variations: StyleVariation[];
+	onMoreClick?: () => void;
 	onClick?: ( variation: StyleVariation ) => void;
 }
 
 const Badges: React.FC< BadgesProps > = ( {
 	maxVariationsToShow = 4,
 	variations = [],
+	onMoreClick,
 	onClick,
 } ) => {
 	const variationsToShow = useMemo(
@@ -25,7 +29,25 @@ const Badges: React.FC< BadgesProps > = ( {
 				<Badge key={ variation.slug } variation={ variation } onClick={ onClick } />
 			) ) }
 			{ variations.length > variationsToShow.length && (
-				<div className="style-variation__badge-more-wrapper">
+				<div
+					className="style-variation__badge-more-wrapper"
+					tabIndex={ 0 }
+					role="button"
+					onClick={ ( e ) => {
+						if ( onMoreClick ) {
+							// Prevent the event from bubbling to the the parent button.
+							e.stopPropagation();
+							onMoreClick();
+						}
+					} }
+					onKeyDown={ ( e ) => {
+						if ( onMoreClick && e.keyCode === SPACE_BAR_KEYCODE ) {
+							// Prevent the event from bubbling to the the parent button.
+							e.stopPropagation();
+							onMoreClick();
+						}
+					} }
+				>
 					<span>{ `+${ variations.length - variationsToShow.length }` }</span>
 				</div>
 			) }


### PR DESCRIPTION
#### Proposed Changes

This PR implements the behavior in which clicking one of the styles in the theme card will open the theme preview modal with the style pre-selected. This is done by passing new property `styleVariation`  to the state `THEME_PREVIEW_OPTION` ([src](https://github.com/Automattic/wp-calypso/blob/trunk/client/state/themes/actions/set-theme-preview-options.js#L5)).

![Screen Shot 2023-01-05 at 4 52 25 PM](https://user-images.githubusercontent.com/797888/210740255-6589b035-fc34-44ce-aab6-2bf8faccd773.png)

![Screen Shot 2023-01-05 at 4 55 28 PM](https://user-images.githubusercontent.com/797888/210740327-6a2d4683-9232-4636-894e-46328e450601.png)


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the logged-in Theme Showcase `/themes/${site_slug}`. If using calypso.live, the flag `themes/showcase-i4/details-and-preview` is required.
* Find a theme with style variations in the theme grid, and click on one of the styles.
* Ensure that the theme preview modal shows up with the selected style applied.
* Ensure that it also works as described in the logged-out Theme Showcase.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
