### PR TITLE
Refetch data when date query argument changes

### DIFF
--- a/client/components/data/query-email-stats/index.jsx
+++ b/client/components/data/query-email-stats/index.jsx
@@ -15,7 +15,7 @@ function QueryEmailStats( { siteId, postId, period, date, quantity } ) {
 		if ( siteId && postId > -1 ) {
 			dispatch( request( siteId, postId, period, date, statType, quantity ) );
 		}
-	}, [ dispatch, siteId, postId, period ] );
+	}, [ dispatch, date, siteId, postId, period ] );
 
 	return null;
 }


### PR DESCRIPTION
#### Proposed Changes

* Date was not refetched when the `date` query argument changes.

#### Testing Instructions

* Apply this PR
* Visit ``/stats/email/open/<site>/day/<postid>?flags=newsletter/stats`
* Change the current date with the arrow keys, or by clicking the bar chart.
* A new HTTP request will be made

**Todo**: we need to look into the loading states. If data is available in Redux for the selected date, this should be shown without loading state. 

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

