### PR TITLE
Jetpack Pro Dashboard: Implement email validation for monitor notification settings

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
@@ -1,5 +1,6 @@
 import { Button } from '@automattic/components';
 import { Modal, ToggleControl } from '@wordpress/components';
+import emailValidator from 'email-validator';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
 import clockIcon from 'calypso/assets/images/jetpack/clock-icon.svg';
@@ -70,6 +71,11 @@ export default function NotificationSettings( { onClose, site, settings }: Props
 	function handleAddEmail( recipients: Array< string > ) {
 		if ( recipients.length ) {
 			setValidationError( '' );
+			recipients.forEach( ( recipient ) => {
+				if ( ! emailValidator.validate( recipient ) ) {
+					setValidationError( translate( 'Please enter a valid email address.' ) );
+				}
+			} );
 		}
 		setAddedEmailAddresses( recipients );
 	}


### PR DESCRIPTION
#### Proposed Changes

This PR implements email validation for the notification settings form in the Jetpack Pro Dashboard.

#### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

> **_NOTE:_** Changing the monitor status will not update the status immediately; we will have to debug this - 1203448324265423-as-1203576555374768. API integration to save the notification settings will be done in a separate PR.

**Instructions**

1. Run `git checkout add/email-validation-for-monitor-notification-settings` and `yarn start-jetpack-cloud`
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Click the clock icon(which also shows the current notification schedule) or Enable the monitor for any site by clicking the toggle on the monitor column if you don't have monitor enabled on any of your sites.
4. Please note the monitor will not be enabled immediately; you might have to wait for some time until it is enabled. 
5. Once clicked on the clock icon, the notification settings popup will be opened.
6. Set toggle on for `Email` and enter an invalid email id(xyz) -> Click `Save` -> Verify that an error message is shown as below and the `Save` button is disabled. Adding a valid email id should remove the error message and enable the `Save` button.

<img width="493" alt="Screenshot 2023-01-04 at 1 35 14 PM" src="https://user-images.githubusercontent.com/10586875/210510297-a2203ac5-96b1-4811-8674-26f06228445d.png">

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1203448324265423-as-1203634022020882