### PR TITLE
BBE: Checkout improvements

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
@@ -1,4 +1,4 @@
-import { isJetpackPurchasableItem, isPremium } from '@automattic/calypso-products';
+import { isJetpackPurchasableItem } from '@automattic/calypso-products';
 import { FormStatus, useFormStatus } from '@automattic/composite-checkout';
 import {
 	canItemBeRemovedFromCart,
@@ -13,7 +13,6 @@ import {
 } from '@automattic/wpcom-checkout';
 import styled from '@emotion/styled';
 import { useState } from 'react';
-import { hasDIFMProduct } from 'calypso/lib/cart-values/cart-items';
 import { useExperiment } from 'calypso/lib/explat';
 import { isWcMobileApp } from 'calypso/lib/mobile-app';
 import { useGetProductVariants } from 'calypso/my-sites/checkout/composite-checkout/hooks/product-variants';
@@ -181,11 +180,7 @@ function LineItemWrapper( {
 	const isDeletable = canItemBeRemovedFromCart( product, responseCart ) && ! isWooMobile;
 
 	const shouldShowVariantSelector =
-		onChangePlanLength &&
-		! isWooMobile &&
-		! isRenewal &&
-		! isPremiumPlanWithDIFMInTheCart( product, responseCart ) &&
-		! hasPartnerCoupon;
+		onChangePlanLength && ! isWooMobile && ! isRenewal && ! hasPartnerCoupon;
 	const isJetpack = responseCart.products.some( ( product ) =>
 		isJetpackPurchasableItem( product.product_slug )
 	);
@@ -242,11 +237,4 @@ function LineItemWrapper( {
 			</LineItem>
 		</WPOrderReviewListItem>
 	);
-}
-
-/**
- * Checks if the given item is the premium plan product and the DIFM product exists in the provided shopping cart object
- */
-function isPremiumPlanWithDIFMInTheCart( item: ResponseCartProduct, responseCart: ResponseCart ) {
-	return isPremium( item ) && hasDIFMProduct( responseCart );
 }

--- a/packages/wpcom-checkout/src/can-item-be-removed-from-cart.ts
+++ b/packages/wpcom-checkout/src/can-item-be-removed-from-cart.ts
@@ -1,4 +1,4 @@
-import { isPremium, isDIFMProduct } from '@automattic/calypso-products';
+import { isDIFMProduct, isPlan } from '@automattic/calypso-products';
 import type { ResponseCart, ResponseCartProduct } from '@automattic/shopping-cart';
 
 /**
@@ -9,10 +9,10 @@ function hasDIFMProduct( cart: ResponseCart ): boolean {
 }
 
 /**
- * Check if the given item is the premium plan product and the DIFM product exists in the provided shopping cart object
+ * Check if the given item is a plan product and the DIFM product exists in the provided shopping cart object
  */
-function isPremiumPlanWithDIFMInTheCart( item: ResponseCartProduct, responseCart: ResponseCart ) {
-	return isPremium( item ) && hasDIFMProduct( responseCart );
+function isPlanWithDIFMInTheCart( item: ResponseCartProduct, responseCart: ResponseCart ) {
+	return isPlan( item ) && hasDIFMProduct( responseCart );
 }
 
 /**
@@ -36,8 +36,8 @@ export function canItemBeRemovedFromCart(
 		return false;
 	}
 
-	// The Premium plan cannot be removed from the cart when in combination with the DIFM lite product
-	if ( isPremiumPlanWithDIFMInTheCart( item, responseCart ) ) {
+	// The plan cannot be removed from the cart when in combination with the DIFM lite product
+	if ( isPlanWithDIFMInTheCart( item, responseCart ) ) {
 		return false;
 	}
 


### PR DESCRIPTION
#### Proposed Changes

This PR contains 2 changes:

1. Enables the variant selector for plan products on the checkout page when the BBE product is in the cart. The relevant backend change is D96443-code.
2. Hides the "Remove from cart" button for plan products when a BBE product is in the cart. Earlier, this check was for the Premium plan only, but since newer flows have different plans, this check now covers all plan products.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/do-it-for-me` and proceed through the flow steps.
* On the checkout page, confirm that the variant selector is visible for the plan product.
* Confirm that the "Remove from cart" button is hidden for the plan product.
<img width="699" alt="image" src="https://user-images.githubusercontent.com/5436027/210547793-61d9092e-0b45-45d4-bb9d-f9bdc2cb4c5c.png">


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #