### PR TITLE
Make multiple calls to email stats endpoint for response time

### DIFF
--- a/packages/wpcom.js/src/lib/site.js
+++ b/packages/wpcom.js/src/lib/site.js
@@ -394,8 +394,16 @@ class Site {
 	 */
 	statsEmailOpens( postId, query, fn ) {
 		const path = `${ this.path }/stats/opens/emails/${ postId }`;
-		query.stats_fields = 'timeline,country'; // Possible values: timeline,client,country,device
-		return this.wpcom.req.get( path, query, fn );
+		const statFields = [ 'timeline', 'country' ];
+		return Promise.all(
+			statFields.map( ( field ) =>
+				this.wpcom.req.get( path, { ...query, stats_fields: field }, fn )
+			)
+		).then( ( statsArray ) =>
+			statsArray.reduce( ( result, item ) => {
+				return { ...result, ...item };
+			}, {} )
+		);
 	}
 
 	/**


### PR DESCRIPTION
### Proposed Changes

#### The problem
The endpoint to retrieve email stats data have the `stats_fields` parameter, which tells the endpoint which section of the data we want: info about the timeline, about the countries, etc... The more values we ask in the call, the longest is the endpoint taking to return the data.

#### The proposed solution
Instead of one call to the endpoint asking multiple `stats_fields`, we are going to make one call per value in `stats_fields`. Once all of the calls respond their specific data, we merge the results in the same shape the endpoint would have returned them all together.

### Testing Instructions

1. Apply this branch to your local Calypso repository and start the application.
2. Insert manually in the browser address bar an URL with this format: http://calypso.localhost:3000/stats/day/[blog-domain]?flags=newsletter/stats
3. In the network tab of the browser, you should see 2 calls with these shapes:
```
https://public-api.wordpress.com/rest/v1.1/sites/[blog-id]/stats/opens/emails/[post-id]?http_envelope=1&period=day&quantity=30&date=2023-01-04&stats_fields=timeline

https://public-api.wordpress.com/rest/v1.1/sites/[blog-id]/stats/opens/emails/[post-id]?http_envelope=1&period=day&quantity=30&date=2023-01-04&stats_fields=country
```

