### PR TITLE
VideoPress Onboarding: updated failing onboarding e2e test after step move

### DIFF
--- a/test/e2e/specs/onboarding/setup__videopress.ts
+++ b/test/e2e/specs/onboarding/setup__videopress.ts
@@ -42,6 +42,11 @@ describe( DataHelper.createSuiteTitle( 'VideoPress Tailored Onboarding' ), () =>
 			await Promise.all( [ page.waitForNavigation(), page.click( 'text=Get started' ) ] );
 		} );
 
+		it( 'Navigate VideoMaker Setup', async function () {
+			await page.waitForURL( /.*videomakerSetup.*/ );
+			await page.click( 'button.videomaker-setup__dark-button' );
+		} );
+
 		it( 'Enter account details', async function () {
 			await page.waitForURL( /.*videopress-account.*/ );
 			const userSignupPage = new UserSignupPage( page );
@@ -61,11 +66,6 @@ describe( DataHelper.createSuiteTitle( 'VideoPress Tailored Onboarding' ), () =>
 			await page.fill( 'input[name="siteTitle"]', `Video site ${ testUser.username }` );
 			await page.fill( 'textarea[name="tagline"]', `The place of ${ testUser.username }` );
 			await page.click( 'button.site-options__submit-button' );
-		} );
-
-		it( 'Navigate VideoMaker Setup', async function () {
-			await page.waitForURL( /.*videomakerSetup.*/ );
-			await page.click( 'button.videomaker-setup__dark-button' );
 		} );
 
 		it( 'Navigate choose a domain', async function () {


### PR DESCRIPTION
#### Proposed Changes

* move the Videomaker test step up before account creation to match the new flow (should have been done in https://github.com/Automattic/wp-calypso/pull/71648)

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* team city PreRelease tests should pass

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
