### PR TITLE
Plugins: Allow the Plugins Post-Purchase (Thank you) page to support multiple plugins via URL

### DIFF
--- a/client/data/marketplace/use-wpcom-plugins-query.ts
+++ b/client/data/marketplace/use-wpcom-plugins-query.ts
@@ -1,4 +1,11 @@
-import { useQuery, UseQueryResult, UseQueryOptions, QueryKey, QueryFunction } from 'react-query';
+import {
+	useQuery,
+	UseQueryResult,
+	UseQueryOptions,
+	QueryKey,
+	QueryFunction,
+	useQueries,
+} from 'react-query';
 import {
 	extractSearchInformation,
 	normalizePluginsList,
@@ -59,7 +66,7 @@ export const getWPCOMPluginsQueryParams = (
  * @param {{enabled: boolean, staleTime: number, refetchOnMount: boolean}} {} Optional options to pass to the underlying query engine
  * @returns {{ data, error, isLoading: boolean ...}} Returns various parameters piped from `useQuery`
  */
-export const useWPCOMPlugins = (
+export const useWPCOMPluginsList = (
 	type: Type,
 	searchTerm?: string,
 	tag?: string,
@@ -105,6 +112,16 @@ export const useWPCOMPlugin = (
 		staleTime: staleTime,
 		refetchOnMount: refetchOnMount,
 	} );
+};
+
+export const useWPCOMPlugins = ( slugs: Array< string > ): Array< UseQueryResult< any > > => {
+	return useQueries(
+		slugs.map( ( slug ) => {
+			const [ cacheKey, fetchFn ] = getWPCOMPluginQueryParams( slug );
+
+			return { queryKey: cacheKey, queryFn: fetchFn };
+		} )
+	);
 };
 
 export const getWPCOMFeaturedPluginsQueryParams = (): [ QueryKey, QueryFunction< any[] > ] => {

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
@@ -94,7 +94,8 @@ const MarketplaceThankYou = ( { productSlug }: { productSlug: string } ) => {
 		! new URLSearchParams( document.location.search ).has( 'hide-progress-bar' )
 	);
 
-	const areAllPluginsOnSite = pluginsOnSite.every( ( pluginOnSite ) => !! pluginOnSite );
+	const areAllPluginsOnSite =
+		!! pluginsOnSite.length && pluginsOnSite.every( ( pluginOnSite ) => !! pluginOnSite );
 
 	// Site is transferring to Atomic.
 	// Poll the transfer status.

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
@@ -51,7 +51,7 @@ const ThankYouContainer = styled.div`
 `;
 
 const MarketplaceThankYou = ( { productSlug }: { productSlug: string } ) => {
-	const productSlugs = productSlug.split( ',' );
+	const [ productSlugs ] = useState< Array< string > >( productSlug.split( ',' ) );
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 	const siteId = useSelector( getSelectedSiteId );
@@ -70,7 +70,10 @@ const MarketplaceThankYou = ( { productSlug }: { productSlug: string } ) => {
 	const pluginsOnSite: [] = useSelector( ( state ) =>
 		getPluginsOnSite( state, siteId, softwareSlugs )
 	);
-	const wporgPlugins = useSelector( ( state ) => getPlugins( state, productSlugs ) );
+	const wporgPlugins = useSelector(
+		( state ) => getPlugins( state, productSlugs ),
+		( oldValue, newValue ) => oldValue.slug === newValue.slug
+	);
 	const areWporgPluginsFetched = useSelector( ( state ) => areFetched( state, productSlugs ) );
 	const areAllWporgPluginsFetched = areWporgPluginsFetched.every( Boolean );
 	const siteAdminUrl = useSelector( ( state ) => getSiteAdminUrl( state, siteId ) );
@@ -122,7 +125,7 @@ const MarketplaceThankYou = ( { productSlug }: { productSlug: string } ) => {
 			// wporgPlugin exists in the wporg directory.
 			setPluginIcon( wporgPlugins?.[ 0 ]?.icon || successImage );
 		}
-	}, [ areAllWporgPluginsFetched, productSlugs, setPluginIcon, dispatch, wporgPlugins ] );
+	}, [ areAllWporgPluginsFetched, productSlugs, dispatch, wporgPlugins ] );
 
 	useEffect( () => {
 		if ( wporgPlugins?.[ 0 ]?.wporg === false ) {

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
@@ -50,6 +50,13 @@ const ThankYouContainer = styled.div`
 	}
 `;
 
+type Plugin = {
+	slug: string;
+	fetched: boolean;
+	wporg: boolean;
+	icon: string;
+};
+
 const MarketplaceThankYou = ( { productSlug }: { productSlug: string } ) => {
 	const [ productSlugs ] = useState< Array< string > >( productSlug.split( ',' ) );
 	const dispatch = useDispatch();
@@ -72,7 +79,14 @@ const MarketplaceThankYou = ( { productSlug }: { productSlug: string } ) => {
 	);
 	const wporgPlugins = useSelector(
 		( state ) => getPlugins( state, productSlugs ),
-		( oldValue, newValue ) => oldValue.slug === newValue.slug
+		( newPluginsValue: Array< Plugin >, oldPluginsValue: Array< Plugin > ) =>
+			oldPluginsValue.length === newPluginsValue.length &&
+			oldPluginsValue.every( ( oldPluginValue, i ) => {
+				return (
+					oldPluginValue?.slug === newPluginsValue[ i ]?.slug &&
+					Boolean( oldPluginValue ) === Boolean( newPluginsValue[ i ] )
+				);
+			} )
 	);
 	const areWporgPluginsFetched = useSelector( ( state ) => areFetched( state, productSlugs ) );
 	const areAllWporgPluginsFetched = areWporgPluginsFetched.every( Boolean );

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
@@ -7,7 +7,7 @@ import { useEffect, useState, useMemo } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import successImage from 'calypso/assets/images/marketplace/check-circle.svg';
 import { ThankYou } from 'calypso/components/thank-you';
-import { useWPCOMPlugin } from 'calypso/data/marketplace/use-wpcom-plugins-query';
+import { useWPCOMPlugins } from 'calypso/data/marketplace/use-wpcom-plugins-query';
 import { FullWidthButton } from 'calypso/my-sites/marketplace/components';
 import MasterbarStyled from 'calypso/my-sites/marketplace/components/masterbar-styled';
 import MarketplaceProgressBar from 'calypso/my-sites/marketplace/components/progressbar';
@@ -24,9 +24,9 @@ import {
 import { pluginInstallationStateChange } from 'calypso/state/marketplace/purchase-flow/actions';
 import { MARKETPLACE_ASYNC_PROCESS_STATUS } from 'calypso/state/marketplace/types';
 import { fetchSitePlugins } from 'calypso/state/plugins/installed/actions';
-import { getPluginOnSite, isRequesting } from 'calypso/state/plugins/installed/selectors';
+import { getPluginsOnSite, isRequesting } from 'calypso/state/plugins/installed/selectors';
 import { fetchPluginData as wporgFetchPluginData } from 'calypso/state/plugins/wporg/actions';
-import { getPlugin, isFetched } from 'calypso/state/plugins/wporg/selectors';
+import { areFetched, getPlugins } from 'calypso/state/plugins/wporg/selectors';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { getSiteAdminUrl, isJetpackSite } from 'calypso/state/sites/selectors';
@@ -51,6 +51,7 @@ const ThankYouContainer = styled.div`
 `;
 
 const MarketplaceThankYou = ( { productSlug }: { productSlug: string } ) => {
+	const productSlugs = productSlug.split( ',' );
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 	const siteId = useSelector( getSelectedSiteId );
@@ -58,14 +59,20 @@ const MarketplaceThankYou = ( { productSlug }: { productSlug: string } ) => {
 	const isRequestingPlugins = useSelector( ( state ) => isRequesting( state, siteId ) );
 
 	// retrieve WPCom plugin data
-	const { data: wpComPluginData } = useWPCOMPlugin( productSlug );
-	const softwareSlug = wpComPluginData
-		? wpComPluginData.software_slug || wpComPluginData.org_slug
-		: productSlug;
+	const wpComPluginsDataResults = useWPCOMPlugins( productSlugs );
+	const wpComPluginsData = wpComPluginsDataResults.map(
+		( wpComPluginData ) => wpComPluginData.data
+	);
+	const softwareSlugs = wpComPluginsData.map( ( wpComPluginData, i ) =>
+		wpComPluginData ? wpComPluginData.software_slug || wpComPluginData.org_slug : productSlugs[ i ]
+	);
 
-	const pluginOnSite = useSelector( ( state ) => getPluginOnSite( state, siteId, softwareSlug ) );
-	const wporgPlugin = useSelector( ( state ) => getPlugin( state, productSlug ) );
-	const isWporgPluginFetched = useSelector( ( state ) => isFetched( state, productSlug ) );
+	const pluginsOnSite: [] = useSelector( ( state ) =>
+		getPluginsOnSite( state, siteId, softwareSlugs )
+	);
+	const wporgPlugins = useSelector( ( state ) => getPlugins( state, productSlugs ) );
+	const areWporgPluginsFetched = useSelector( ( state ) => areFetched( state, productSlugs ) );
+	const areAllWporgPluginsFetched = areWporgPluginsFetched.every( Boolean );
 	const siteAdminUrl = useSelector( ( state ) => getSiteAdminUrl( state, siteId ) );
 	const isFetchingTransferStatus = useSelector( ( state ) =>
 		isFetchingAutomatedTransferStatus( state, siteId )
@@ -84,7 +91,7 @@ const MarketplaceThankYou = ( { productSlug }: { productSlug: string } ) => {
 		! new URLSearchParams( document.location.search ).has( 'hide-progress-bar' )
 	);
 
-	const isPluginOnSite = !! pluginOnSite;
+	const areAllPluginsOnSite = pluginsOnSite.every( ( pluginOnSite ) => !! pluginOnSite );
 
 	// Site is transferring to Atomic.
 	// Poll the transfer status.
@@ -108,21 +115,21 @@ const MarketplaceThankYou = ( { productSlug }: { productSlug: string } ) => {
 
 	// retrieve wporg plugin data if not available
 	useEffect( () => {
-		if ( ! isWporgPluginFetched ) {
-			dispatch( wporgFetchPluginData( productSlug ) );
+		if ( ! areAllWporgPluginsFetched ) {
+			productSlugs.forEach( ( productSlug ) => dispatch( wporgFetchPluginData( productSlug ) ) );
 		}
-		if ( isWporgPluginFetched ) {
+		if ( areAllWporgPluginsFetched ) {
 			// wporgPlugin exists in the wporg directory.
-			setPluginIcon( wporgPlugin?.icon || successImage );
+			setPluginIcon( wporgPlugins?.[ 0 ]?.icon || successImage );
 		}
-	}, [ isWporgPluginFetched, productSlug, setPluginIcon, dispatch, wporgPlugin?.icon ] );
+	}, [ areAllWporgPluginsFetched, productSlugs, setPluginIcon, dispatch, wporgPlugins ] );
 
 	useEffect( () => {
-		if ( wporgPlugin?.wporg === false ) {
+		if ( wporgPlugins?.[ 0 ]?.wporg === false ) {
 			// wporgPlugin exists and plugin doesn't exist in wporg directory.
 			setPluginIcon( successImage );
 		}
-	}, [ wporgPlugin ] );
+	}, [ wporgPlugins ] );
 
 	// Site is already Atomic (or just transferred).
 	// Poll the plugin installation status.
@@ -132,7 +139,7 @@ const MarketplaceThankYou = ( { productSlug }: { productSlug: string } ) => {
 		}
 
 		// Update the menu after the plugin has been installed, since that might change some menu items.
-		if ( isPluginOnSite ) {
+		if ( areAllPluginsOnSite ) {
 			dispatch( requestAdminMenu( siteId ) );
 			return;
 		}
@@ -142,7 +149,7 @@ const MarketplaceThankYou = ( { productSlug }: { productSlug: string } ) => {
 		}
 	}, [
 		isRequestingPlugins,
-		isPluginOnSite,
+		areAllPluginsOnSite,
 		dispatch,
 		siteId,
 		transferStatus,
@@ -156,7 +163,7 @@ const MarketplaceThankYou = ( { productSlug }: { productSlug: string } ) => {
 			return;
 		}
 
-		setShowProgressBar( ! isPluginOnSite );
+		setShowProgressBar( ! areAllPluginsOnSite );
 
 		// Sites already transferred to Atomic or self-hosted Jetpack sites no longer need to change the current step.
 		if ( isJetpack ) {
@@ -172,7 +179,7 @@ const MarketplaceThankYou = ( { productSlug }: { productSlug: string } ) => {
 		} else if ( transferStatus === transferStates.COMPLETE ) {
 			setCurrentStep( 3 );
 		}
-	}, [ transferStatus, isPluginOnSite, showProgressBar, isJetpack ] );
+	}, [ transferStatus, areAllPluginsOnSite, showProgressBar, isJetpack ] );
 
 	const steps = useMemo(
 		() =>
@@ -198,18 +205,27 @@ const MarketplaceThankYou = ( { productSlug }: { productSlug: string } ) => {
 	// Cast pluginOnSite's type because the return type of getPluginOnSite is
 	// wrong and I don't know how to fix it. Remove this cast if the return type
 	// can be made correct.
-	const pluginOnSiteData = pluginOnSite as
-		| undefined
-		| { action_links?: { Settings?: string }; name?: string };
+	const pluginsOnSiteData = pluginsOnSite as Array<
+		undefined | { action_links?: { Settings?: string }; name?: string }
+	>;
 
-	const fallbackSetupUrl = wpComPluginData?.setup_url && siteAdminUrl + wpComPluginData?.setup_url;
-	const managePluginsUrl = hasManagePluginsFeature
-		? `${ siteAdminUrl }plugins.php`
-		: `/plugins/${ productSlug }/${ siteSlug } `;
+	const fallbackSetupUrls = wpComPluginsData.map(
+		( wpComPluginData ) => wpComPluginData?.setup_url && siteAdminUrl + wpComPluginData?.setup_url
+	);
+	const managePluginsUrls = productSlugs.map( ( productSlug ) =>
+		hasManagePluginsFeature
+			? `${ siteAdminUrl }plugins.php`
+			: `/plugins/${ productSlug }/${ siteSlug } `
+	);
 
-	const setupURL = pluginOnSiteData?.action_links?.Settings || fallbackSetupUrl || managePluginsUrl;
+	const setupURLs = pluginsOnSiteData.map(
+		( pluginOnSiteData, i ) =>
+			pluginOnSiteData?.action_links?.Settings || fallbackSetupUrls[ i ] || managePluginsUrls[ i ]
+	);
 
-	const documentationURL = wpComPluginData?.documentation_url;
+	const documentationURLs = wpComPluginsData.map(
+		( wpComPluginData ) => wpComPluginData?.documentation_url
+	);
 
 	const setupSection = {
 		sectionKey: 'setup_whats_next',
@@ -222,12 +238,12 @@ const MarketplaceThankYou = ( { productSlug }: { productSlug: string } ) => {
 					'Get to know your plugin and customize it, so you can hit the ground running.'
 				),
 				stepCta: (
-					<FullWidthButton href={ setupURL } primary busy={ ! isPluginOnSite }>
+					<FullWidthButton href={ setupURLs[ 0 ] } primary busy={ ! areAllPluginsOnSite }>
 						{ translate( 'Manage plugin' ) }
 					</FullWidthButton>
 				),
 			},
-			...( documentationURL
+			...( documentationURLs[ 0 ]
 				? [
 						{
 							stepKey: 'whats_next_documentation',
@@ -236,7 +252,7 @@ const MarketplaceThankYou = ( { productSlug }: { productSlug: string } ) => {
 								'Visit the step-by-step guide to learn how to use this plugin.'
 							),
 							stepCta: (
-								<FullWidthButton href={ documentationURL }>
+								<FullWidthButton href={ documentationURLs[ 0 ] }>
 									{ translate( 'Visit guide' ) }
 								</FullWidthButton>
 							),
@@ -259,7 +275,7 @@ const MarketplaceThankYou = ( { productSlug }: { productSlug: string } ) => {
 	};
 
 	const thankYouSubtitle = translate( '%(pluginName)s has been installed.', {
-		args: { pluginName: pluginOnSiteData?.name },
+		args: { pluginName: pluginsOnSiteData?.[ 0 ]?.name },
 	} );
 
 	return (
@@ -275,7 +291,7 @@ const MarketplaceThankYou = ( { productSlug }: { productSlug: string } ) => {
 			<MasterbarStyled
 				onClick={ () => page( `/plugins/${ siteSlug }` ) }
 				backText={ translate( 'Back to plugins' ) }
-				canGoBack={ isPluginOnSite }
+				canGoBack={ areAllPluginsOnSite }
 			/>
 			{ showProgressBar && (
 				// eslint-disable-next-line wpcalypso/jsx-classname-namespace
@@ -295,7 +311,7 @@ const MarketplaceThankYou = ( { productSlug }: { productSlug: string } ) => {
 						showSupportSection={ true }
 						thankYouImage={ thankYouImage }
 						thankYouTitle={ translate( 'All ready to go!' ) }
-						thankYouSubtitle={ isPluginOnSite ? thankYouSubtitle : '' }
+						thankYouSubtitle={ areAllPluginsOnSite ? thankYouSubtitle : '' }
 						headerBackgroundColor="#fff"
 						headerTextColor="#000"
 					/>

--- a/client/my-sites/marketplace/pages/marketplace-test/index.jsx
+++ b/client/my-sites/marketplace/pages/marketplace-test/index.jsx
@@ -12,7 +12,7 @@ import CardHeading from 'calypso/components/card-heading';
 import QueryJetpackPlugins from 'calypso/components/data/query-jetpack-plugins';
 import Notice from 'calypso/components/notice';
 import { useESPluginsInfinite } from 'calypso/data/marketplace/use-es-query';
-import { useWPCOMPlugins } from 'calypso/data/marketplace/use-wpcom-plugins-query';
+import { useWPCOMPluginsList } from 'calypso/data/marketplace/use-wpcom-plugins-query';
 import PluginsBrowserList from 'calypso/my-sites/plugins/plugins-browser-list';
 import { PluginsBrowserListVariant } from 'calypso/my-sites/plugins/plugins-browser-list/types';
 import {
@@ -52,7 +52,7 @@ export default function MarketplaceTest() {
 	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
 	const isAtomicSite = useSelector( ( state ) => isSiteWpcomAtomic( state, selectedSiteId ?? 0 ) );
 	const pluginDetails = useSelector( ( state ) => getPlugins( state, [ selectedSiteId ] ) );
-	const { data = [], isFetching } = useWPCOMPlugins( 'all' );
+	const { data = [], isFetching } = useWPCOMPluginsList( 'all' );
 
 	const {
 		data: dataSearch = [],

--- a/client/my-sites/plugins/plugins-browser/test/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/test/index.jsx
@@ -22,7 +22,7 @@ jest.mock( 'calypso/data/marketplace/use-wporg-plugin-query', () => ( {
 } ) );
 
 jest.mock( 'calypso/data/marketplace/use-wpcom-plugins-query', () => ( {
-	useWPCOMPlugins: () => ( { data: [] } ),
+	useWPCOMPluginsList: () => ( { data: [] } ),
 	useWPCOMFeaturedPlugins: () => ( { data: [] } ),
 } ) );
 

--- a/client/my-sites/plugins/use-plugins/index.ts
+++ b/client/my-sites/plugins/use-plugins/index.ts
@@ -5,7 +5,7 @@ import { Plugin } from 'calypso/data/marketplace/types';
 import { useESPluginsInfinite } from 'calypso/data/marketplace/use-es-query';
 import {
 	useWPCOMFeaturedPlugins,
-	useWPCOMPlugins,
+	useWPCOMPluginsList,
 } from 'calypso/data/marketplace/use-wpcom-plugins-query';
 import { useCategories } from '../categories/use-categories';
 
@@ -93,7 +93,7 @@ const usePlugins = ( {
 			!! ( search || ! WPORG_CATEGORIES_BLOCKLIST.includes( category || '' ) ) && wporgEnabled,
 	} ) as WPORGResponse;
 
-	const { data: wpcomPluginsRaw = [], isLoading: isFetchingDotCom } = useWPCOMPlugins(
+	const { data: wpcomPluginsRaw = [], isLoading: isFetchingDotCom } = useWPCOMPluginsList(
 		'all',
 		search,
 		tag,

--- a/client/state/plugins/installed/selectors.js
+++ b/client/state/plugins/installed/selectors.js
@@ -142,6 +142,10 @@ export function getPluginOnSite( state, siteId, pluginSlug ) {
 	return find( pluginList, ( plugin ) => isEqualSlugOrId( pluginSlug, plugin ) );
 }
 
+export function getPluginsOnSite( state, siteId, pluginSlugs ) {
+	return pluginSlugs.map( ( pluginSlug ) => getPluginOnSite( state, siteId, pluginSlug ) );
+}
+
 export function getSitesWithPlugin( state, siteIds, pluginSlug ) {
 	const pluginList = getPlugins( state, siteIds );
 	const plugin = find( pluginList, ( pluginItem ) => isEqualSlugOrId( pluginSlug, pluginItem ) );

--- a/client/state/plugins/wporg/selectors.js
+++ b/client/state/plugins/wporg/selectors.js
@@ -9,6 +9,10 @@ export function getPlugin( state, pluginSlug ) {
 	return plugin ? { ...plugin } : plugin;
 }
 
+export function getPlugins( state, pluginSlugs ) {
+	return pluginSlugs.map( ( pluginSlug ) => getPlugin( state, pluginSlug ) );
+}
+
 export function isFetching( state, pluginSlug ) {
 	return state?.plugins.wporg.fetchingItems[ pluginSlug ] ?? false;
 }
@@ -21,6 +25,10 @@ export function hasError( state, pluginSlug ) {
 export function isFetched( state, pluginSlug ) {
 	const plugin = getPlugin( state, pluginSlug );
 	return plugin ? !! plugin.fetched : false;
+}
+
+export function areFetched( state, pluginSlugs ) {
+	return pluginSlugs.map( ( pluginSlug ) => isFetched( state, pluginSlug ) );
 }
 
 /**


### PR DESCRIPTION
#### Proposed Changes

* Add plugins selectors to handle multiple plugins slugs
* Add WPCom plugin query to support multiple plugins slugs
* Update the Post-Purchase page to support multiple plugins

PS: Even supporting multiple plugins, currently the only plugin being shown is the first. This should be fixed by #70891.

#### Testing Instructions
**Bussiness or Ecommerce plan** 

* Go to a free plugin page and click to install
* After the installing page, you should see the Post-purchase page showing the selected plugin (as in production)
* Go to a paid plugin page and click to purchase and install
* After the checkout you should see the Post-purchase page behaving as in production

**Below Bussiness plan** 
* Go to a paid plugin and click to `Purchase and activate`, accepting the dialog to upgrade
* Close the cart page clicking on the `X` on the top left of the screen and selecting to `Leave items`
* Select another paid plugin and click to `Purchase and activate`
* After the progress bar page you should see the Post-Purchase page as usual 
Note: You should only see the last plugin as installed, to be fixed by #70891.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #70890