### PR TITLE
Jetpack Cloud Cart Integration - Fix mobile cart alignment

### DIFF
--- a/client/components/jetpack/intro-pricing-banner/hooks/use-bounding-client-rect.ts
+++ b/client/components/jetpack/intro-pricing-banner/hooks/use-bounding-client-rect.ts
@@ -1,0 +1,32 @@
+import { useState, useLayoutEffect } from 'react';
+
+const useBoundingClientRect = ( eleQuery: string ) => {
+	const [ boundingClientRect, setBoundingClientRect ] = useState( {
+		bottom: 0,
+		height: 0,
+		left: 0,
+		right: 0,
+		top: 0,
+		width: 0,
+		x: 0,
+		y: 0,
+	} );
+
+	useLayoutEffect( () => {
+		const resizeListener = () => {
+			document.querySelectorAll( eleQuery ).forEach( ( node ) => {
+				const style = window.getComputedStyle( node, undefined );
+				if ( style[ 'display' ] !== 'none' ) {
+					setBoundingClientRect( node.getBoundingClientRect() );
+				}
+			} );
+		};
+
+		resizeListener();
+		window.addEventListener( 'resize', resizeListener );
+	}, [ eleQuery ] );
+
+	return boundingClientRect;
+};
+
+export default useBoundingClientRect;

--- a/client/components/jetpack/intro-pricing-banner/index.tsx
+++ b/client/components/jetpack/intro-pricing-banner/index.tsx
@@ -1,7 +1,7 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { useBreakpoint } from '@automattic/viewport-react';
 import { useTranslate } from 'i18n-calypso';
-import { useLayoutEffect, useMemo, useState } from 'react';
+import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import CloudCart from 'calypso/jetpack-cloud/sections/pricing/jpcom-masterbar/cloud-cart';
 import useDetectWindowBoundary from 'calypso/lib/detect-window-boundary';
@@ -12,39 +12,11 @@ import { isConnectStore } from 'calypso/my-sites/plans/jetpack-plans/product-gri
 import './style.scss';
 import { isJetpackCloudCartEnabled } from 'calypso/state/sites/selectors';
 import guaranteeBadge from './14-day-badge.svg';
+import useBoundingClientRect from './hooks/use-bounding-client-rect';
 import people from './people.svg';
 
 const CALYPSO_MASTERBAR_HEIGHT = 47;
 const CLOUD_MASTERBAR_HEIGHT = 0;
-
-const useBoundingClientRect = ( eleQuery: string ) => {
-	const [ boundingClientRect, setBoundingClientRect ] = useState( {
-		bottom: 0,
-		height: 0,
-		left: 0,
-		right: 0,
-		top: 0,
-		width: 0,
-		x: 0,
-		y: 0,
-	} );
-
-	useLayoutEffect( () => {
-		const resizeListener = () => {
-			document.querySelectorAll( eleQuery ).forEach( ( node ) => {
-				const style = window.getComputedStyle( node, undefined );
-				if ( style[ 'display' ] !== 'none' ) {
-					setBoundingClientRect( node.getBoundingClientRect() );
-				}
-			} );
-		};
-
-		resizeListener();
-		window.addEventListener( 'resize', resizeListener );
-	}, [ eleQuery ] );
-
-	return boundingClientRect;
-};
 
 const IntroPricingBanner: React.FC = () => {
 	const translate = useTranslate();

--- a/client/components/jetpack/intro-pricing-banner/index.tsx
+++ b/client/components/jetpack/intro-pricing-banner/index.tsx
@@ -1,6 +1,7 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { useBreakpoint } from '@automattic/viewport-react';
 import { useTranslate } from 'i18n-calypso';
-import { useMemo } from 'react';
+import { useLayoutEffect, useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
 import CloudCart from 'calypso/jetpack-cloud/sections/pricing/jpcom-masterbar/cloud-cart';
 import useDetectWindowBoundary from 'calypso/lib/detect-window-boundary';
@@ -16,9 +17,40 @@ import people from './people.svg';
 const CALYPSO_MASTERBAR_HEIGHT = 47;
 const CLOUD_MASTERBAR_HEIGHT = 0;
 
+const useBoundingClientRect = ( eleQuery: string ) => {
+	const [ boundingClientRect, setBoundingClientRect ] = useState( {
+		bottom: 0,
+		height: 0,
+		left: 0,
+		right: 0,
+		top: 0,
+		width: 0,
+		x: 0,
+		y: 0,
+	} );
+
+	useLayoutEffect( () => {
+		const resizeListener = () => {
+			document.querySelectorAll( eleQuery ).forEach( ( node ) => {
+				const style = window.getComputedStyle( node, undefined );
+				if ( style[ 'display' ] !== 'none' ) {
+					setBoundingClientRect( node.getBoundingClientRect() );
+				}
+			} );
+		};
+
+		resizeListener();
+		window.addEventListener( 'resize', resizeListener );
+	}, [ eleQuery ] );
+
+	return boundingClientRect;
+};
+
 const IntroPricingBanner: React.FC = () => {
 	const translate = useTranslate();
 	const shouldShowCart = useSelector( isJetpackCloudCartEnabled );
+	const clientRect = useBoundingClientRect( '.header__content .header__jetpack-masterbar-cart' );
+	const isSmallScreen = useBreakpoint( '<660px' );
 
 	const windowBoundaryOffset = useMemo( () => {
 		if ( isJetpackCloud() || isConnectStore() ) {
@@ -66,7 +98,9 @@ const IntroPricingBanner: React.FC = () => {
 							{ preventWidows( translate( 'Explore Jetpack for Agencies' ) ) }
 						</a>
 					</div>
-					{ shouldShowCart && hasCrossed && <CloudCart /> }
+					{ shouldShowCart && hasCrossed && (
+						<CloudCart cartStyle={ isSmallScreen ? {} : { left: clientRect.left } } />
+					) }
 				</div>
 			</div>
 		</>

--- a/client/components/jetpack/intro-pricing-banner/style.scss
+++ b/client/components/jetpack/intro-pricing-banner/style.scss
@@ -20,6 +20,12 @@
 		@include break-large {
 			height: 52px;
 		}
+
+
+		@media (max-width: $break-mobile) {
+			justify-content: flex-start;
+			padding-left: 15px;
+		}
 	}
 }
 
@@ -89,6 +95,11 @@
 	position: absolute;
 	right: 10%;
 	display: inline-flex;
+
+	@media (max-width: 960px) {
+		top: 14px;
+	}
+
 }
 
 

--- a/client/components/jetpack/intro-pricing-banner/style.scss
+++ b/client/components/jetpack/intro-pricing-banner/style.scss
@@ -93,8 +93,11 @@
 .is-section-jetpack-connect .intro-pricing-banner.is-sticky,
 .is-group-jetpack-cloud.is-section-jetpack-cloud-pricing .intro-pricing-banner.is-sticky .header__jetpack-masterbar-cart {
 	position: absolute;
-	right: 10%;
 	display: inline-flex;
+
+	@media (max-width: 660px) {
+		right: 11%;
+	}
 
 	@media (max-width: 960px) {
 		top: 14px;

--- a/client/jetpack-cloud/sections/pricing/jpcom-masterbar/cloud-cart/index.tsx
+++ b/client/jetpack-cloud/sections/pricing/jpcom-masterbar/cloud-cart/index.tsx
@@ -9,7 +9,7 @@ import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import CloudCartIcon from './cloud-cart-icon';
 import EmptyCart from './empty-cart';
 
-const CloudCart = () => {
+const CloudCart = ( { cartStyle }: { cartStyle?: React.CSSProperties } ) => {
 	const translate = useTranslate();
 	const shoppingCartTracker = useShoppingCartTracker();
 	const siteId = useSelector( getSelectedSiteId );
@@ -37,7 +37,7 @@ const CloudCart = () => {
 	};
 
 	return (
-		<div className="header__jetpack-masterbar-cart">
+		<div className="header__jetpack-masterbar-cart" style={ cartStyle }>
 			<MasterbarCartWrapper
 				goToCheckout={ goToCheckout }
 				onRemoveProduct={ onRemoveProductFromCart }

--- a/client/jetpack-cloud/sections/pricing/jpcom-masterbar/style.scss
+++ b/client/jetpack-cloud/sections/pricing/jpcom-masterbar/style.scss
@@ -207,19 +207,25 @@
 			width: 90%;
 		}
 		.header__content-wrapper {
-			height: 520px;
+			height: 445px;
 		}
 	}
 
 	@media ( max-width: 600px ) {
 		.header__content-wrapper {
-			height: 445px;
+			height: 520px;
 		}
 	}
 
 	@media ( max-width: 480px ) {
 		.header__content-wrapper {
 			height: 570px;
+		}
+	}
+
+	@media ( max-width: 336px ) {
+		.header__content-wrapper {
+			height: 690px;
 		}
 	}
 
@@ -1219,7 +1225,7 @@
 			& > .header__jetpack-masterbar-cart {
 				justify-content: flex-end;
 				flex: unset;
-				margin-right: 32px;
+				margin-right: 16px;
 			}
 			.header__home-link {
 				flex: 1;

--- a/client/jetpack-cloud/sections/pricing/style.scss
+++ b/client/jetpack-cloud/sections/pricing/style.scss
@@ -18,7 +18,7 @@
 
 	.layout__content {
 		overflow: clip;
-  }
+	}
 	.global-notices {
 		z-index: 100201;
 	}

--- a/client/layout/masterbar/masterbar-cart/masterbar-cart-count.scss
+++ b/client/layout/masterbar/masterbar-cart/masterbar-cart-count.scss
@@ -12,7 +12,7 @@
 	position: relative;
 
 	&.masterbar-cart-count__hidden {
-		display: none;
+		visibility: hidden;
 	}
 }
 

--- a/client/my-sites/plans/jetpack-plans/product-store/hooks/use-store-item-info.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/hooks/use-store-item-info.tsx
@@ -213,7 +213,9 @@ export const useStoreItemInfo = ( {
 				} );
 
 				const addedToCartText = translate( 'added to cart' );
-				dispatch( successNotice( `${ item.displayName } ${ addedToCartText }` ) );
+				const productName = reactNodeToString( item.displayName );
+				dispatch( successNotice( `${ productName } ${ addedToCartText }` ) );
+
 				return addProductsToCart( [ { product_slug: item.productSlug } ] );
 			}
 


### PR DESCRIPTION
#### Proposed Changes

 - Fix mobile banner cart alignment
 - Convert displayName from component to plain string to be shown in JITM
 - Calculate the position of the cart in the main banner and use the same for the banner transition (on desktop)
 - When no item is in the cart hide the count instead of not displaying it

#### Testing Instructions

* Make sure you are logged-in to WordPress.com 
* click on Jetpack Cloud live link below
* or boot up this PR 
    * Run `git fetch && git checkout fix/cloud-cart-lightbox-cta`
    * Run `yarn start-jetpack-cloud`
    * Goto http://jetpack.cloud.localhost:3000
* you will be presented with a landing page, asking you to select a site, choose any site from the list
* Once selected, you will be redirected to `/backup/:site-slug` page by default, replace `backup` with `pricing` and you should land in pricing page
* Now append this query string (`?flags=jetpack/pricing-page-cart`) to the end of URL to enable the cart and reload the page
* Make sure the cart shows up in the header
* Click on Add to Cart on Akismet Anti-Spam and make sure JITM says **Akismet Anti-Spam added to cart**
* Now switch to mobile view and confirm the cart is displayed just before the menu 
* Now slowly scroll down to *14 days money back guarantee* banner and confirm that the banner becomes sticky and cart is shown in the banner and Jetpack logo masterbar banner hides (*checkout the screencast*)
* Also validate that cart is positioned in the same location when moving between banners in different screen size (***refer screencast 2 for different scenarios to be tested. The cart will transition to the same location between banners only for view >660px***)

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
#### Screencast


https://user-images.githubusercontent.com/2027003/210622743-a3420978-4594-444e-acd6-d02ca78b6388.mov


##### Cart transition between banners for different screen sizes



https://user-images.githubusercontent.com/2027003/210809639-5fa49f5b-d668-417a-b131-d09f42dabb78.mov



#### Screenshot

| Before | After |
|--------|------|
| <img width="500" alt="Screen Shot 2022-12-06 at 4 33 54 PM" src="https://user-images.githubusercontent.com/2027003/210623393-7bf499a6-fa08-4243-bad9-ecd7e6e0441a.png"> | <img width="500" alt="Screen Shot 2022-12-06 at 3 26 40 PM" src="https://user-images.githubusercontent.com/2027003/210623366-f8639935-d4be-458d-b62c-4fe825ea20ee.png"> |


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
