### PR TITLE
Adding new Twitter tracking pixel conversion events

### DIFF
--- a/client/lib/analytics/ad-tracking/ad-track-registration.js
+++ b/client/lib/analytics/ad-tracking/ad-track-registration.js
@@ -61,5 +61,13 @@ export async function adTrackRegistration() {
 		window.pintrk( ...params );
 	}
 
+	// Twitter
+
+	if ( mayWeTrackByTracker( 'pinterest' ) ) {
+		const params = [ 'event', 'tw-nvzbs-odfz8' ];
+		debug( 'adTrackRegistration: [Twitter]', params );
+		window.twq( ...params );
+	}
+
 	debug( 'adTrackRegistration: dataLayer:', JSON.stringify( window.dataLayer, null, 2 ) );
 }

--- a/client/lib/analytics/ad-tracking/ad-track-registration.js
+++ b/client/lib/analytics/ad-tracking/ad-track-registration.js
@@ -63,7 +63,7 @@ export async function adTrackRegistration() {
 
 	// Twitter
 
-	if ( mayWeTrackByTracker( 'pinterest' ) ) {
+	if ( mayWeTrackByTracker( 'twitter' ) ) {
 		const params = [ 'event', 'tw-nvzbs-odfz8' ];
 		debug( 'adTrackRegistration: [Twitter]', params );
 		window.twq( ...params );

--- a/client/lib/analytics/ad-tracking/ad-track-signup-complete.js
+++ b/client/lib/analytics/ad-tracking/ad-track-signup-complete.js
@@ -159,15 +159,7 @@ export async function adTrackSignupComplete( { isNewUserSite } ) {
 	// Twitter
 
 	if ( mayWeTrackByTracker( 'twitter' ) ) {
-		const params = [
-			'event',
-			'tw-nvzbs-ode0f',
-			{
-				value: syntheticCart.total_cost,
-				currency: syntheticCart.currency,
-				conversion_id: syntheticOrderId,
-			},
-		];
+		const params = [ 'event', 'tw-nvzbs-ode0f' ];
 		debug( 'recordSignup: [Twitter]', params );
 		window.twq( ...params );
 	}

--- a/client/lib/analytics/ad-tracking/ad-track-signup-complete.js
+++ b/client/lib/analytics/ad-tracking/ad-track-signup-complete.js
@@ -159,7 +159,15 @@ export async function adTrackSignupComplete( { isNewUserSite } ) {
 	// Twitter
 
 	if ( mayWeTrackByTracker( 'twitter' ) ) {
-		const params = [ 'track', 'Signup', {} ];
+		const params = [
+			'event',
+			'tw-nvzbs-ode0f',
+			{
+				value: syntheticCart.total_cost,
+				currency: syntheticCart.currency,
+				conversion_id: syntheticOrderId,
+			},
+		];
 		debug( 'recordSignup: [Twitter]', params );
 		window.twq( ...params );
 	}

--- a/client/lib/analytics/ad-tracking/record-order.js
+++ b/client/lib/analytics/ad-tracking/record-order.js
@@ -96,15 +96,7 @@ export async function recordOrder( cart, orderId ) {
 
 	// Twitter
 	if ( mayWeTrackByTracker( 'twitter' ) ) {
-		const params = [
-			'event',
-			'tw-nvzbs-ode0u',
-			{
-				value: cart.total_cost.toString(),
-				currency: cart.currency,
-				order_id: orderId,
-			},
-		];
+		const params = [ 'event', 'tw-nvzbs-ode0u', { value: usdTotalCost } ];
 		debug( 'recordOrder: [Twitter]', params );
 		window.twq( ...params );
 	}

--- a/client/lib/analytics/ad-tracking/record-order.js
+++ b/client/lib/analytics/ad-tracking/record-order.js
@@ -97,15 +97,11 @@ export async function recordOrder( cart, orderId ) {
 	// Twitter
 	if ( mayWeTrackByTracker( 'twitter' ) ) {
 		const params = [
-			'track',
-			'Purchase',
+			'event',
+			'tw-nvzbs-ode0u',
 			{
 				value: cart.total_cost.toString(),
 				currency: cart.currency,
-				content_name: cart.products.map( ( product ) => product.product_name ).join( ',' ),
-				content_type: 'product',
-				content_ids: cart.products.map( ( product ) => product.product_slug ),
-				num_items: cart.products.length,
 				order_id: orderId,
 			},
 		];

--- a/client/lib/analytics/ad-tracking/retarget.js
+++ b/client/lib/analytics/ad-tracking/retarget.js
@@ -101,7 +101,7 @@ export async function retarget( urlPath ) {
 
 		// Twitter
 		if ( mayWeTrackByTracker( 'twitter' ) ) {
-			const params = [ 'track', 'PageView' ];
+			const params = [ 'event', 'tw-nvzbs-odfz9' ];
 			debug( 'retarget: [Twitter] [rate limited]', params );
 			window.twq( ...params );
 		}


### PR DESCRIPTION
#### Proposed Changes

This PR adds support for two new Twitter Ads conversion events (`New Signup Complete` (ID: tw-nvzbs-ode0f) and `New Purchase` (ID: tw-nvzbs-ode0u)). P2 discussion at pau2Xa-4Im-2.

Here's the generated tracking code for one of the events:

```
<!-- Twitter conversion tracking event code -->
<script type="text/javascript">
  // Insert Twitter Event ID
  twq('event', 'tw-nvzbs-ode0f', {
    value: null, // use this to pass the value of the conversion (e.g. 5.00)
    currency: null, // use this to pass the currency of the conversion with an ISO 4217 code (e.g. ‘USD’)
    conversion_id: null // use this to pass a unique ID for the conversion event for deduplication (e.g. order id '1a2b3c')
  });
</script>
<!-- End Twitter conversion tracking event code -->
```

I created new tracking events for:
- Page views (event id: `tw-nvzbs-odfz9`)
- Registration complete (user step) (event id: `tw-nvzbs-odfz8`)
- Signup complete (event id: `tw-nvzbs-ode0f`)
- Purchase (event id: `tw-nvzbs-ode0u`)

I changed the retargeting event to use this new event so that everything is consistently using the new events.

#### Testing Instructions
* Check out this PR and set `ad-tracking` to true in your development.json config file
* Sandbox store so that you can place a credit card order
* Download the Twitter Pixel Helper Chrome extension
* Start Calypso locally
* Navigate through signup and confirm that the events are firing as expected as you progress through the signup flow.
* Confirm in the Twitter admin that the conversion events were captured.




Related to #
