### PR TITLE
Stats: Fixing hover colour for small screens for horizontal bars

### DIFF
--- a/packages/components/src/horizontal-bar-list/style.scss
+++ b/packages/components/src/horizontal-bar-list/style.scss
@@ -31,8 +31,15 @@
 			background-color: var(--theme-highlight-color);
 			color: var(--studio-white);
 
-			svg {
-				fill: var(--studio-white);
+			@media (min-width: 481px) {
+				svg {
+					fill: var(--studio-white);
+				}
+
+				a,
+				button {
+					color: var(--studio-white);
+				}
 			}
 
 			.horizontal-bar-list--hover-action {
@@ -43,6 +50,19 @@
 				color: var(--studio-white);
 			}
 
+			.stats-list-actions__mobile-toggle {
+				.stats-icon {
+					fill: var(--studio-white);
+				}
+			}
+		}
+
+		.stats-list-actions__mobile-toggle {
+			&:focus {
+				.stats-icon {
+					outline: dotted 1px var(--studio-white);
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
#### Proposed Changes

* Fixing hover colour for hover actions after replacing the previous background colour (for components with horizontal bars)
* Adding CSS overlay (dotted lines) for mobile `...` menu when it's focused with keyboard navigation

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the live branch and go to Stats and `Traffic`
* Look at the modules with horizontal bars and make sure that action icons and labels are visible and have good contrast across different breakpoints. For the large (regular desktop) screen sizes, when only the icons are visible, the icons should be white when hovering and the dark background is visible. Same should apply for small and medium screen sizes but also for the labels
* When using keyboard navigation, a dotted overlay should be visible when the `...` mobile menu is focused (previously only row's label on the left)

Before:
* labels
![Screenshot 2023-01-05 at 8 43 48 AM](https://user-images.githubusercontent.com/112354940/210637613-086ffac9-17b6-4d4f-bc22-3a9264f0f55b.png)

* active `...` element
![Screenshot 2023-01-05 at 8 44 11 AM](https://user-images.githubusercontent.com/112354940/210637700-e34d7649-604b-4f93-90e3-ab914bfbd3f7.png)

After:
* labels
![Screenshot 2023-01-05 at 8 44 59 AM](https://user-images.githubusercontent.com/112354940/210637727-6ad85c7e-ef75-434c-ba39-409a8f9bca12.png)

* active `...` element
![Screenshot 2023-01-05 at 8 45 20 AM](https://user-images.githubusercontent.com/112354940/210637777-a9df25c0-4924-442f-ad1d-71b449591153.png)


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #71650 
