### PR TITLE
Stats Page Redesign: Update table row hover colors

### DIFF
--- a/client/my-sites/stats/stats-module/style.scss
+++ b/client/my-sites/stats/stats-module/style.scss
@@ -449,7 +449,7 @@ ul.module-header-actions {
 	@include breakpoint-deprecated( ">480px" ) {
 		.stats-module & td.has-no-data:hover, // 1
 		tbody tr:hover td,
-		.stats-module & tbody tr:hover th {
+		.stats-module & tbody tr:hover th:first-child {
 			background: var(--color-primary-0);
 		}
 

--- a/client/my-sites/stats/stats-module/style.scss
+++ b/client/my-sites/stats/stats-module/style.scss
@@ -450,12 +450,12 @@ ul.module-header-actions {
 		.stats-module & td.has-no-data:hover, // 1
 		tbody tr:hover td,
 		tbody tr:hover th {
-			background: var(--color-neutral-0);
+			background: var(--color-primary-0);
 		}
 
 		.stats-module & td.highest-count:hover,
 		tbody tr td:hover {
-			background: var(--color-neutral-0);
+			background: var(--color-primary-0);
 			color: var(--color-neutral-70);
 		}
 	}

--- a/client/my-sites/stats/stats-module/style.scss
+++ b/client/my-sites/stats/stats-module/style.scss
@@ -449,7 +449,7 @@ ul.module-header-actions {
 	@include breakpoint-deprecated( ">480px" ) {
 		.stats-module & td.has-no-data:hover, // 1
 		tbody tr:hover td,
-		tbody tr:hover th {
+		.stats-module & tbody tr:hover th {
 			background: var(--color-primary-0);
 		}
 


### PR DESCRIPTION
#### Proposed Changes

* This PR updates the stats module tables row hover color to the primary color set in its lightest tint

#### Testing Instructions


* Visit the Calypso Live branch.
* Navigate to the Annual Insights page at `/stats/day/annualstats/[SiteURL]`
* Confirm that the table rows highlight 

![Screen Capture on 2023-01-04 at 16-32-02](https://user-images.githubusercontent.com/30754158/210662829-d0cc9db7-d6dc-406f-9021-0603231fc782.gif)

**Question:** Do we want the hover/highlight to extend to include the `year` row?  Up until now it hasn't, but I think maybe it could look better if we did. 


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #70608
