### PR TITLE
VideoPress Onboarding: Fix 'busy' button style on mobile

### DIFF
--- a/client/signup/videopress-step-wrapper/style.scss
+++ b/client/signup/videopress-step-wrapper/style.scss
@@ -12,7 +12,7 @@
 	--videopress-color-white: #fff;
 
 	--videopress-color-link: #ffe61c;
-	--videopress-color-link-dark: #004cbf;
+	--videopress-color-link-dark: #ffc700;
 
 	--videopress-color-border-light: #e7e9ea;
 	--videopress-color-border: #d8dbdd;
@@ -324,6 +324,14 @@
 	&:hover {
 		color: #070707 !important;
 	}
+
+	&.is-busy {
+		background-image: linear-gradient(-45deg, var(--videopress-color-link) 28%, var(--videopress-color-link-dark) 28%, var(--videopress-color-link-dark) 72%, var(--videopress-color-link) 72%);
+	}
+}
+
+.videopress-step-wrapper__header {
+	padding: 0 20px;
 }
 
 .videopress-step-wrapper__subheader-text {


### PR DESCRIPTION
#### Proposed Changes

* Fixes the pink 'busy' state of the button to a more VideoPress-y yellow one:

<img width="330" alt="Screenshot 2023-01-04 at 3 25 14 PM" src="https://user-images.githubusercontent.com/789137/210664229-f0238b5d-c93b-43ac-a47f-3441fa774809.png">

#### Testing Instructions

* Visit `/setup/videopress` in the iOS simulator or other mobile device of your choice.
* Proceed to the user creation view. Enter an already used WP email address, and click `Create your account`. You should briefly see the busy state of the button before getting an error message back. It should be using two yellow colors instead of pink.
* I also snuck in a text padding fix, resize the window and the `Let's get you signed up` and `First, you'll need a WordPress.com account. Already have one? [Log in]` text should never bump up against the edge of the screen.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
