### PR TITLE
Launchpad: Enable Site Editor redirect from Launchpad iframe

### DIFF
--- a/client/components/web-preview/component.jsx
+++ b/client/components/web-preview/component.jsx
@@ -63,6 +63,8 @@ export class WebPreviewModal extends Component {
 		fixedViewportWidth: PropTypes.number,
 		// Prevents tabbing into the iframe.
 		disableTabbing: PropTypes.bool,
+		// Allow specific functionality for Launchpad
+		isLaunchpad: PropTypes.bool,
 	};
 
 	static defaultProps = {

--- a/client/components/web-preview/component.jsx
+++ b/client/components/web-preview/component.jsx
@@ -63,8 +63,8 @@ export class WebPreviewModal extends Component {
 		fixedViewportWidth: PropTypes.number,
 		// Prevents tabbing into the iframe.
 		disableTabbing: PropTypes.bool,
-		// Allow specific functionality for Launchpad
-		isLaunchpad: PropTypes.bool,
+		// Edit overlay that redirects to the Site Editor
+		enableEditOverlay: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -83,7 +83,7 @@ export class WebPreviewModal extends Component {
 		hasSidebar: false,
 		overridePost: null,
 		autoHeight: false,
-		isLaunchpad: false,
+		enableEditOverlay: false,
 	};
 
 	constructor( props ) {

--- a/client/components/web-preview/component.jsx
+++ b/client/components/web-preview/component.jsx
@@ -83,6 +83,7 @@ export class WebPreviewModal extends Component {
 		hasSidebar: false,
 		overridePost: null,
 		autoHeight: false,
+		isLaunchpad: false,
 	};
 
 	constructor( props ) {

--- a/client/components/web-preview/content.jsx
+++ b/client/components/web-preview/content.jsx
@@ -31,6 +31,7 @@ export default class WebPreviewContent extends Component {
 		loaded: false,
 		isLoadingSubpage: false,
 		isMobile: isWithinBreakpoint( '<660px' ),
+		showIFrameOverlay: false,
 	};
 
 	setIframeInstance = ( ref ) => {
@@ -410,6 +411,7 @@ export default class WebPreviewContent extends Component {
 								'is-resizable': ! this.props.isModalWindow,
 							} ) }
 						>
+							{ /* eslint-disable jsx-a11y/mouse-events-have-key-events */ }
 							<iframe
 								ref={ this.setIframeInstance }
 								className="web-preview__frame"
@@ -420,7 +422,23 @@ export default class WebPreviewContent extends Component {
 								fetchpriority={ fetchpriority ? fetchpriority : undefined }
 								scrolling={ autoHeight ? 'no' : undefined }
 								tabIndex={ disableTabbing ? -1 : 0 }
+								onMouseOver={ () => this.setState( { showIFrameOverlay: true } ) }
+								onMouseOut={ () =>
+									setTimeout( () => this.setState( { showIFrameOverlay: false } ), 150 )
+								}
 							/>
+							{ this.state.showIFrameOverlay && (
+								<div className="web-preview__frame-edit-overlay">
+									<button
+										className="web-preview__frame-edit-button"
+										onClick={ () => {
+											window.location.assign( `/site-editor/${ this.props.externalUrl }` );
+										} }
+									>
+										Edit
+									</button>
+								</div>
+							) }
 						</div>
 					) }
 					{ 'seo' === this.state.device && (

--- a/client/components/web-preview/content.jsx
+++ b/client/components/web-preview/content.jsx
@@ -427,7 +427,7 @@ export default class WebPreviewContent extends Component {
 								style={ {
 									...this.state.iframeStyle,
 									height: this.state.viewport?.height,
-									pointerEvents: this.props.isLaunchpad ? 'none' : 'all',
+									pointerEvents: this.props.isLaunchpad ? 'auto' : 'all',
 								} }
 								src="about:blank"
 								onLoad={ () => this.setLoaded( 'iframe-onload' ) }
@@ -436,32 +436,34 @@ export default class WebPreviewContent extends Component {
 								scrolling={ autoHeight ? 'no' : undefined }
 								tabIndex={ disableTabbing ? -1 : 0 }
 							/>
-							<div
-								className="web-preview__frame-edit-overlay"
-								style={ {
-									opacity: this.state.showIFrameOverlay ? '1' : '0',
-									background: this.state.showIFrameOverlay
-										? `rgba(16, 21, 23, 0.5)`
-										: 'rgba(16, 21, 23, 0)',
-									transition: 'background 0.2s ease',
-								} }
-							>
-								<button
+							{ this.props.isLaunchpad && (
+								<div
+									className="web-preview__frame-edit-overlay"
 									style={ {
-										position: 'relative',
-										top: this.state.showIFrameOverlay ? '0' : '15px',
-										transition: 'all 0.2s ease',
+										opacity: this.state.showIFrameOverlay ? '1' : '0',
+										background: this.state.showIFrameOverlay
+											? `rgba(16, 21, 23, 0.5)`
+											: 'rgba(16, 21, 23, 0)',
+										transition: 'background 0.2s ease',
 									} }
-									className="web-preview__frame-edit-button"
-									onClick={ () => {
-										window.location.assign( `/site-editor/${ this.props.externalUrl }` );
-									} }
-									onFocus={ () => this.setState( { showIFrameOverlay: true } ) }
-									onBlur={ () => this.setState( { showIFrameOverlay: false } ) }
 								>
-									Edit
-								</button>
-							</div>
+									<button
+										style={ {
+											position: 'relative',
+											top: this.state.showIFrameOverlay ? '0' : '15px',
+											transition: 'all 0.2s ease',
+										} }
+										className="web-preview__frame-edit-button"
+										onClick={ () => {
+											window.location.assign( `/site-editor/${ this.props.externalUrl }` );
+										} }
+										onFocus={ () => this.setState( { showIFrameOverlay: true } ) }
+										onBlur={ () => this.setState( { showIFrameOverlay: false } ) }
+									>
+										{ translate( 'Edit' ) }
+									</button>
+								</div>
+							) }
 						</div>
 					) }
 					{ 'seo' === this.state.device && (
@@ -550,8 +552,6 @@ WebPreviewContent.propTypes = {
 	scrollToSelector: PropTypes.string,
 	// Allow specific functionality for Launchpad
 	isLaunchpad: PropTypes.bool,
-	// Show Edit button on hover
-	showIFrameOverlay: PropTypes.bool,
 };
 
 WebPreviewContent.defaultProps = {
@@ -577,4 +577,5 @@ WebPreviewContent.defaultProps = {
 	autoHeight: false,
 	inlineCss: null,
 	scrollToSelector: null,
+	isLaunchpad: false,
 };

--- a/client/components/web-preview/content.jsx
+++ b/client/components/web-preview/content.jsx
@@ -408,12 +408,12 @@ export default class WebPreviewContent extends Component {
 					{ 'seo' !== this.state.device && (
 						<div
 							onMouseEnter={ () => {
-								if ( this.props.isLaunchpad ) {
+								if ( this.props.enableEditOverlay ) {
 									this.setState( { showIFrameOverlay: true } );
 								}
 							} }
 							onMouseLeave={ () => {
-								if ( this.props.isLaunchpad ) {
+								if ( this.props.enableEditOverlay ) {
 									this.setState( { showIFrameOverlay: false } );
 								}
 							} }
@@ -427,7 +427,7 @@ export default class WebPreviewContent extends Component {
 								style={ {
 									...this.state.iframeStyle,
 									height: this.state.viewport?.height,
-									pointerEvents: this.props.isLaunchpad ? 'auto' : 'all',
+									pointerEvents: this.props.enableEditOverlay ? 'auto' : 'all',
 								} }
 								src="about:blank"
 								onLoad={ () => this.setLoaded( 'iframe-onload' ) }
@@ -436,7 +436,7 @@ export default class WebPreviewContent extends Component {
 								scrolling={ autoHeight ? 'no' : undefined }
 								tabIndex={ disableTabbing ? -1 : 0 }
 							/>
-							{ this.props.isLaunchpad && (
+							{ this.props.enableEditOverlay && (
 								<div
 									className="web-preview__frame-edit-overlay"
 									style={ {
@@ -453,6 +453,7 @@ export default class WebPreviewContent extends Component {
 											top: this.state.showIFrameOverlay ? '0' : '15px',
 											transition: 'all 0.2s ease',
 										} }
+										aria-label="Edit your new site"
 										className="web-preview__frame-edit-button"
 										onClick={ () => {
 											window.location.assign( `/site-editor/${ this.props.externalUrl }` );
@@ -550,8 +551,8 @@ WebPreviewContent.propTypes = {
 	inlineCss: PropTypes.string,
 	// Uses the CSS selector to scroll to it
 	scrollToSelector: PropTypes.string,
-	// Allow specific functionality for Launchpad
-	isLaunchpad: PropTypes.bool,
+	// Edit overlay that redirects to the Site Editor
+	enableEditOverlay: PropTypes.bool,
 };
 
 WebPreviewContent.defaultProps = {
@@ -577,5 +578,5 @@ WebPreviewContent.defaultProps = {
 	autoHeight: false,
 	inlineCss: null,
 	scrollToSelector: null,
-	isLaunchpad: false,
+	enableEditOverlay: false,
 };

--- a/client/components/web-preview/content.jsx
+++ b/client/components/web-preview/content.jsx
@@ -407,20 +407,27 @@ export default class WebPreviewContent extends Component {
 					) }
 					{ 'seo' !== this.state.device && (
 						<div
-							onMouseEnter={ () => this.setState( { showIFrameOverlay: true } ) }
-							onMouseLeave={ () => this.setState( { showIFrameOverlay: false } ) }
+							onMouseEnter={ () => {
+								if ( this.props.isLaunchpad ) {
+									this.setState( { showIFrameOverlay: true } );
+								}
+							} }
+							onMouseLeave={ () => {
+								if ( this.props.isLaunchpad ) {
+									this.setState( { showIFrameOverlay: false } );
+								}
+							} }
 							className={ classNames( 'web-preview__frame-wrapper', {
 								'is-resizable': ! this.props.isModalWindow,
 							} ) }
 						>
-							{ /* eslint-disable jsx-a11y/mouse-events-have-key-events */ }
 							<iframe
 								ref={ this.setIframeInstance }
 								className="web-preview__frame"
 								style={ {
 									...this.state.iframeStyle,
 									height: this.state.viewport?.height,
-									pointerEvents: 'none',
+									pointerEvents: this.props.isLaunchpad ? 'none' : 'all',
 								} }
 								src="about:blank"
 								onLoad={ () => this.setLoaded( 'iframe-onload' ) }
@@ -527,6 +534,10 @@ WebPreviewContent.propTypes = {
 	inlineCss: PropTypes.string,
 	// Uses the CSS selector to scroll to it
 	scrollToSelector: PropTypes.string,
+	// Allow specific functionality for Launchpad
+	isLaunchpad: PropTypes.bool,
+	// Show Edit button on hover
+	showIFrameOverlay: PropTypes.bool,
 };
 
 WebPreviewContent.defaultProps = {

--- a/client/components/web-preview/content.jsx
+++ b/client/components/web-preview/content.jsx
@@ -436,18 +436,21 @@ export default class WebPreviewContent extends Component {
 								scrolling={ autoHeight ? 'no' : undefined }
 								tabIndex={ disableTabbing ? -1 : 0 }
 							/>
-							{ this.state.showIFrameOverlay && (
-								<div className="web-preview__frame-edit-overlay">
-									<button
-										className="web-preview__frame-edit-button"
-										onClick={ () => {
-											window.location.assign( `/site-editor/${ this.props.externalUrl }` );
-										} }
-									>
-										Edit
-									</button>
-								</div>
-							) }
+							<div
+								className="web-preview__frame-edit-overlay"
+								style={ { opacity: this.state.showIFrameOverlay ? '1' : '0' } }
+							>
+								<button
+									className="web-preview__frame-edit-button"
+									onClick={ () => {
+										window.location.assign( `/site-editor/${ this.props.externalUrl }` );
+									} }
+									onFocus={ () => this.setState( { showIFrameOverlay: true } ) }
+									onBlur={ () => this.setState( { showIFrameOverlay: false } ) }
+								>
+									Edit
+								</button>
+							</div>
 						</div>
 					) }
 					{ 'seo' === this.state.device && (

--- a/client/components/web-preview/content.jsx
+++ b/client/components/web-preview/content.jsx
@@ -438,9 +438,21 @@ export default class WebPreviewContent extends Component {
 							/>
 							<div
 								className="web-preview__frame-edit-overlay"
-								style={ { opacity: this.state.showIFrameOverlay ? '1' : '0' } }
+								style={ {
+									opacity: this.state.showIFrameOverlay ? '1' : '0',
+									background: this.state.showIFrameOverlay
+										? `rgba(16, 21, 23, 0.5)`
+										: 'rgba(16, 21, 23, 0)',
+									transition: 'background 0.2s ease',
+								} }
 							>
 								<button
+									style={ {
+										position: 'relative',
+										top: this.state.showIFrameOverlay ? '0' : '15px',
+										// top: '200px',
+										transition: 'all 0.2s ease',
+									} }
 									className="web-preview__frame-edit-button"
 									onClick={ () => {
 										window.location.assign( `/site-editor/${ this.props.externalUrl }` );

--- a/client/components/web-preview/content.jsx
+++ b/client/components/web-preview/content.jsx
@@ -450,7 +450,6 @@ export default class WebPreviewContent extends Component {
 									style={ {
 										position: 'relative',
 										top: this.state.showIFrameOverlay ? '0' : '15px',
-										// top: '200px',
 										transition: 'all 0.2s ease',
 									} }
 									className="web-preview__frame-edit-button"

--- a/client/components/web-preview/content.jsx
+++ b/client/components/web-preview/content.jsx
@@ -407,6 +407,8 @@ export default class WebPreviewContent extends Component {
 					) }
 					{ 'seo' !== this.state.device && (
 						<div
+							onMouseEnter={ () => this.setState( { showIFrameOverlay: true } ) }
+							onMouseLeave={ () => this.setState( { showIFrameOverlay: false } ) }
 							className={ classNames( 'web-preview__frame-wrapper', {
 								'is-resizable': ! this.props.isModalWindow,
 							} ) }
@@ -415,17 +417,17 @@ export default class WebPreviewContent extends Component {
 							<iframe
 								ref={ this.setIframeInstance }
 								className="web-preview__frame"
-								style={ { ...this.state.iframeStyle, height: this.state.viewport?.height } }
+								style={ {
+									...this.state.iframeStyle,
+									height: this.state.viewport?.height,
+									pointerEvents: 'none',
+								} }
 								src="about:blank"
 								onLoad={ () => this.setLoaded( 'iframe-onload' ) }
 								title={ this.props.iframeTitle || translate( 'Preview' ) }
 								fetchpriority={ fetchpriority ? fetchpriority : undefined }
 								scrolling={ autoHeight ? 'no' : undefined }
 								tabIndex={ disableTabbing ? -1 : 0 }
-								onMouseOver={ () => this.setState( { showIFrameOverlay: true } ) }
-								onMouseOut={ () =>
-									setTimeout( () => this.setState( { showIFrameOverlay: false } ), 150 )
-								}
 							/>
 							{ this.state.showIFrameOverlay && (
 								<div className="web-preview__frame-edit-overlay">

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/launchpad-site-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/launchpad-site-preview.tsx
@@ -102,6 +102,7 @@ const LaunchpadSitePreview = ( {
 				defaultViewportDevice={ defaultDevice }
 				devicesToShow={ devicesToShow }
 				showSiteAddressBar={ false }
+				isLaunchpad
 			/>
 		</div>
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/launchpad-site-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/launchpad-site-preview.tsx
@@ -102,7 +102,7 @@ const LaunchpadSitePreview = ( {
 				defaultViewportDevice={ defaultDevice }
 				devicesToShow={ devicesToShow }
 				showSiteAddressBar={ false }
-				isLaunchpad
+				enableEditOverlay
 			/>
 		</div>
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
@@ -458,11 +458,27 @@
 
 	.web-preview__placeholder {
 		overflow-y: visible;
-		min-height: 720px;
+	}
+
+	.is-phone .web-preview__placeholder {
+		display: flex;
+		justify-content: center;
+		align-items: start;
 	}
 
 	.preview-toolbar__devices {
 		margin-bottom: 28px;
+	}
+
+	.is-phone .web-preview__frame-wrapper.is-resizable {
+		height: 100%;
+		max-width: 95%;
+
+		@include break-large {
+			// width: auto;
+			max-width: 340px;
+			height: 680px;
+		}
 	}
 
 	.web-preview__frame-wrapper.is-resizable {
@@ -472,12 +488,11 @@
 		position: relative;
 
 		.web-preview__frame-edit-overlay {
-			width: 320px;
-			height: 660px;
 			position: absolute;
-			top: 10px; // TODO: change this
-			left: 50%;
-			transform: translateX(-50%);
+			top: 0;
+			left: 0;
+			right: 0;
+			bottom: 0;
 			background: rgba(16, 21, 23, 0.5);
 			border-radius: 30px;  /* stylelint-disable-line scales/radii */
 
@@ -519,7 +534,8 @@
 	}
 
 	.is-phone .web-preview__frame-wrapper.is-resizable .web-preview__frame {
-		max-width: 95%;
+		max-width: 100%;
+		min-height: 720px;
 
 		@include break-large {
 			box-shadow:
@@ -529,9 +545,8 @@
 				0 15px 13px rgba(0 0 0 / 2%),
 				0 6px 5px rgba(0 0 0 / 2%),
 				0 2px 3px rgba(0 0 0 / 1%);
-			max-width: 340px;
 			border-radius: 40px; /* stylelint-disable-line scales/radii */
-			height: 680px;
+			min-height: 680px;
 		}
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
@@ -501,7 +501,6 @@
 			left: 0;
 			right: 0;
 			bottom: 0;
-			background: rgba(16, 21, 23, 0.5);
 			border-radius: 40px;  /* stylelint-disable-line scales/radii */
 
 			display: flex;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
@@ -469,6 +469,34 @@
 		margin: 0;
 		padding: 0;
 		background-color: transparent;
+		position: relative;
+
+		.web-preview__frame-edit-overlay {
+			width: 320px;
+			height: 660px;
+			position: absolute;
+			top: 10px; // TODO: change this
+			left: 50%;
+			transform: translateX(-50%);
+			background: rgba(16, 21, 23, 0.5);
+			border-radius: 30px;  /* stylelint-disable-line scales/radii */
+
+			display: flex;
+			justify-content: center;
+			align-items: center;
+
+			.web-preview__frame-edit-button {
+				font-size: 14px;  /* stylelint-disable-line declaration-property-unit-allowed-list */
+				line-height: 20px;
+				padding: 10px 24px;
+				color: #000;
+				background: #fff;
+				border-radius: 4px;
+				border-color: #c3c4c7;
+				border-width: 2px;
+				cursor: pointer;
+			}
+		}
 	}
 
 	.web-preview__frame {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
@@ -491,8 +491,7 @@
 		max-width: 95%;
 
 		@include break-large {
-			min-height: 585px;
-			height: calc(100% - 120px);
+			height: 880px;
 		}
 
 		.web-preview__frame-edit-overlay {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
@@ -458,9 +458,6 @@
 
 	.web-preview__placeholder {
 		overflow-y: visible;
-	}
-
-	.is-phone .web-preview__placeholder {
 		display: flex;
 		justify-content: center;
 		align-items: start;
@@ -472,13 +469,18 @@
 
 	.is-phone .web-preview__frame-wrapper.is-resizable {
 		height: 100%;
-		max-width: 95%;
 
 		@include break-large {
-			// width: auto;
 			max-width: 340px;
 			height: 680px;
 		}
+
+		.web-preview__frame-edit-overlay {
+			@include break-large {
+				border-radius: 40px; /* stylelint-disable-line scales/radii */
+			}
+		}
+
 	}
 
 	.web-preview__frame-wrapper.is-resizable {
@@ -486,6 +488,12 @@
 		padding: 0;
 		background-color: transparent;
 		position: relative;
+		max-width: 95%;
+
+		@include break-large {
+			min-height: 585px;
+			height: calc(100% - 120px);
+		}
 
 		.web-preview__frame-edit-overlay {
 			position: absolute;
@@ -494,11 +502,15 @@
 			right: 0;
 			bottom: 0;
 			background: rgba(16, 21, 23, 0.5);
-			border-radius: 30px;  /* stylelint-disable-line scales/radii */
+			border-radius: 40px;  /* stylelint-disable-line scales/radii */
 
 			display: flex;
 			justify-content: center;
 			align-items: center;
+
+			@include break-large {
+				border-radius: 20px; /* stylelint-disable-line scales/radii */
+			}
 
 			.web-preview__frame-edit-button {
 				font-size: 14px;  /* stylelint-disable-line declaration-property-unit-allowed-list */
@@ -518,8 +530,8 @@
 		border: 10px solid var(--color-print);
 		border-radius: 40px; /* stylelint-disable-line scales/radii */
 		box-sizing: border-box;
-		max-width: 95%;
 		box-shadow: 0 5px 15px rgba(0 0 0 / 7%), 0 3px 10px rgba(0 0 0 / 4%);
+		min-height: 720px;
 
 		@include break-large {
 			margin-top: 0;
@@ -528,14 +540,11 @@
 				0 13px 10px rgb(0 0 0 / 3%),
 				0 6px 6px rgb(0 0 0 / 2%);
 			border-radius: 20px; /* stylelint-disable-line scales/radii */
-			min-height: 585px;
-			height: calc(100% - 120px);
 		}
 	}
 
 	.is-phone .web-preview__frame-wrapper.is-resizable .web-preview__frame {
 		max-width: 100%;
-		min-height: 720px;
 
 		@include break-large {
 			box-shadow:


### PR DESCRIPTION
#### Proposed Changes
This PR adds an overlay with a button over the Launchpad's web preview which is displayed on hover to allow going directly to the Site Editor.

#### Testing Instructions
1. Checkout this branch or use Calypso Live
2. Go to Launchpad
3. Verify that once you hover over the web preview, the overlay is displayed and clicking the "Edit" button takes you to the Site Editor and you can go back to Launchpad. Verify you can interact with the overlay using the keyboard
4. Verify that the styling looks good. The CSS changes in this PR are significant so I'd appreciate a thorough test:
• Verify that everything looks good when switching between the phone and the desktop preview using the buttons above the web preview
• Verify that shrinking the browser to mobile size looks good both when using the desktop and phone previews
• In general pay attention to the styling
5. We should also test another instance of the WebPreview component to make sure these changes won't affect it. You can go through the Free Flow and test at the design picker step.

https://user-images.githubusercontent.com/20927667/212164158-baf7de7d-5fbb-4077-a18d-b0f8cc34bd66.mov

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #71329 
