### PR TITLE
SSH: show old keys instead of spinner when the tab focuses on Hosting Configuration

### DIFF
--- a/client/my-sites/hosting/sftp-card/ssh-key-card.tsx
+++ b/client/my-sites/hosting/sftp-card/ssh-key-card.tsx
@@ -13,6 +13,7 @@ interface SshKeyCardProps {
 	deleteText: string;
 	siteId: number;
 	sshKey: AtomicKey;
+	disabled?: boolean;
 }
 
 const noticeOptions = {
@@ -33,10 +34,10 @@ const SSHKeyCardRoot = styled( SSHKeyCard.Root )( {
 
 const sshKeyDetachFailureNoticeId = 'ssh-key-detach-failure';
 
-function SshKeyCard( { deleteText, siteId, sshKey }: SshKeyCardProps ) {
+function SshKeyCard( { deleteText, siteId, sshKey, disabled = false }: SshKeyCardProps ) {
 	const { __ } = useI18n();
 	const dispatch = useDispatch();
-	const { detachSshKey, isLoading } = useDetachSshKeyMutation(
+	const { detachSshKey, isLoading: isDetaching } = useDetachSshKeyMutation(
 		{ siteId },
 		{
 			onMutate: () => {
@@ -88,8 +89,8 @@ function SshKeyCard( { deleteText, siteId, sshKey }: SshKeyCardProps ) {
 			</SSHKeyCard.Details>
 			<SSHKeyCard.Button
 				onClick={ () => detachSshKey( { user_login, name } ) }
-				busy={ isLoading }
-				disabled={ isLoading }
+				busy={ isDetaching }
+				disabled={ isDetaching || disabled }
 			>
 				{ deleteText }
 			</SSHKeyCard.Button>

--- a/client/my-sites/hosting/sftp-card/ssh-keys.tsx
+++ b/client/my-sites/hosting/sftp-card/ssh-keys.tsx
@@ -33,7 +33,11 @@ const sshKeyAttachFailureNoticeId = 'ssh-key-attach-failure';
 function SshKeys( { siteId, siteSlug, username, disabled }: SshKeysProps ) {
 	const { __ } = useI18n();
 	const dispatch = useDispatch();
-	const { data: keys, isLoading: isLoadingKeys } = useAtomicSshKeys( siteId, {
+	const {
+		data: keys,
+		isLoading: isLoadingKeys,
+		isFetching: isFetchingKeys,
+	} = useAtomicSshKeys( siteId, {
 		enabled: ! disabled,
 	} );
 	const { data: userKeys, isLoading: isLoadingUserKeys } = useSSHKeyQuery();
@@ -96,6 +100,7 @@ function SshKeys( { siteId, siteSlug, username, disabled }: SshKeysProps ) {
 					sshKey={ sshKey }
 					deleteText={ __( 'Detach' ) }
 					siteId={ siteId }
+					disabled={ isFetchingKeys }
 				/>
 			) ) }
 

--- a/client/my-sites/hosting/sftp-card/ssh-keys.tsx
+++ b/client/my-sites/hosting/sftp-card/ssh-keys.tsx
@@ -33,11 +33,7 @@ const sshKeyAttachFailureNoticeId = 'ssh-key-attach-failure';
 function SshKeys( { siteId, siteSlug, username, disabled }: SshKeysProps ) {
 	const { __ } = useI18n();
 	const dispatch = useDispatch();
-	const {
-		data: keys,
-		isLoading: isLoadingKeys,
-		isFetching: isFetchingKeys,
-	} = useAtomicSshKeys( siteId, {
+	const { data: keys, isLoading: isLoadingKeys } = useAtomicSshKeys( siteId, {
 		enabled: ! disabled,
 	} );
 	const { data: userKeys, isLoading: isLoadingUserKeys } = useSSHKeyQuery();
@@ -80,15 +76,7 @@ function SshKeys( { siteId, siteSlug, username, disabled }: SshKeysProps ) {
 		return !! keys.find( ( { user_login } ) => user_login === username );
 	}, [ keys, username ] );
 
-	/*
-	 * isFetching keys is needed here, because when we update a key from me/security/ssh-key page,
-	 * and return to this page, the keys, although the query reruns, are not cleared.
-	 * isFetching returns true when refetching in the background. Happens when there is stale cache to display as a placeholder.
-	 * So we rely on that to display the loader.
-	 * Same goes with the map of the keys in the view below. We don't want to show the old keys
-	 * until the refetching is completed.
-	 * */
-	const isLoading = isLoadingKeys || isLoadingUserKeys || isFetchingKeys;
+	const isLoading = isLoadingKeys || isLoadingUserKeys;
 	const showKeysSelect = ! isLoading && ! userKeyIsAttached && userKeys && userKeys.length > 0;
 	const showLinkToAddUserKey = ! isLoading && ! userKeyIsAttached && userKeys?.length === 0;
 	const SSH_ADD_URL = addQueryArgs( '/me/security/ssh-key', {
@@ -102,15 +90,14 @@ function SshKeys( { siteId, siteSlug, username, disabled }: SshKeysProps ) {
 				{ __( 'SSH Keys' ) }
 			</label>
 
-			{ ! isFetchingKeys &&
-				keys?.map( ( sshKey ) => (
-					<SshKeyCard
-						key={ sshKey.sha256 }
-						sshKey={ sshKey }
-						deleteText={ __( 'Detach' ) }
-						siteId={ siteId }
-					/>
-				) ) }
+			{ keys?.map( ( sshKey ) => (
+				<SshKeyCard
+					key={ sshKey.sha256 }
+					sshKey={ sshKey }
+					deleteText={ __( 'Detach' ) }
+					siteId={ siteId }
+				/>
+			) ) }
 
 			{ isLoading && <Spinner /> }
 


### PR DESCRIPTION
#### Proposed Changes

* Avoid showing the spinner when the tab focuses on Hosting configuration SSH Keys
* Disable `Detach` button on fetching/refreshing the SSH keys, to avoid a user clicking when the fingerprint is showing an incorrect/old one for a few seconds.

- The spinner was added on purpose on https://github.com/Automattic/wp-calypso/pull/69826 . Check the comment I'm removing in this PR for more context. In my opinion, it's better to show the old ssh keys for a few seconds than to show the spinner each time. The chances of a user updating the ssh keys are very low compared to a user changing de tab/window.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* On an atomic site, go to `Settings` > `Hosting Configuration`
* Scroll until `SSH Keys`
* Observe your SSH keys, if you don't have any Add a SSH Keys in `/me/security/ssh-key`
* Click in a different tab or window, and go back to the `Hosting Configuration`
* Observe the SSH key is still there and doesn't show any spinner.


### Screenshots

Attached SSH Key

| **Before** | **After** |
|---|---|
| ![SSH-keys-attached-before](https://user-images.githubusercontent.com/779993/210677723-91e0cc15-8a8f-4f58-9683-8cd7b04ff563.gif) | ![SSH-keys-attached-after](https://user-images.githubusercontent.com/779993/210677802-bf73aaa6-1c00-4af5-a4b3-a51466150a84.gif) |



Non Attached SSH Key
| **Before** | **After** |
|---|---|
| ![SSH-keys-non-attached-before](https://user-images.githubusercontent.com/779993/210676502-a4fb9cd5-062d-443a-b7a7-07d46100fcc2.gif) | ![SSH-keys-non-attached-after](https://user-images.githubusercontent.com/779993/210676507-de21b2bd-d1c3-4df2-bc4f-5f26b0e92028.gif) |


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

- Closes https://github.com/Automattic/wp-calypso/issues/71449
