### PR TITLE
Append text to Calypso's Zendesk ticket creation to flag WCCOM NUX

### DIFF
--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -1,5 +1,6 @@
 import { get, includes, reject } from 'lodash';
 import detectHistoryNavigation from 'calypso/lib/detect-history-navigation';
+import { getQueryArgs } from 'calypso/lib/query-args';
 import { addQueryArgs } from 'calypso/lib/url';
 import { generateFlows } from 'calypso/signup/config/flows-pure';
 import stepConfig from './steps';
@@ -15,6 +16,7 @@ function getCheckoutUrl( dependencies, localeSlug, flowName ) {
 	return addQueryArgs(
 		{
 			signup: 1,
+			ref: getQueryArgs()?.ref,
 			...( [ 'domain', 'add-domain' ].includes( flowName ) && { isDomainOnly: 1 } ),
 		},
 		checkoutURL

--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -292,7 +292,9 @@ export const HelpCenterContactForm = () => {
 
 					if ( getQueryArgs()?.ref === 'woocommerce-com' ) {
 						ticketMeta.push(
-							`Created during store setup on ${ isWcMobileApp() ? 'Woo mobile app' : 'Woo browser' }`
+							`Created during store setup on ${
+								isWcMobileApp() ? 'Woo mobile app' : 'Woo browser'
+							}`
 						);
 					}
 

--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -27,6 +27,8 @@ import { useQueryClient } from 'react-query';
 import { useSelector } from 'react-redux';
 import { useHistory, useLocation } from 'react-router-dom';
 import { useDebounce } from 'use-debounce';
+import { isWcMobileApp } from 'calypso/lib/mobile-app';
+import { getQueryArgs } from 'calypso/lib/query-args';
 import { getCurrentUserEmail, getCurrentUserId } from 'calypso/state/current-user/selectors';
 import { getSectionName } from 'calypso/state/ui/selectors';
 /**
@@ -244,7 +246,6 @@ export const HelpCenterContactForm = () => {
 	);
 
 	const showingSibylResults = params.get( 'show-results' ) === 'true';
-
 	function handleCTA() {
 		if ( ! showingSibylResults && sibylArticles && sibylArticles.length > 0 ) {
 			params.set( 'show-results', 'true' );
@@ -288,6 +289,14 @@ export const HelpCenterContactForm = () => {
 						'Site I need help with: ' + supportSite.URL,
 						`Plan: ${ productId } - ${ productName } (${ productTerm })`,
 					];
+
+					if ( getQueryArgs()?.ref === 'woocommerce-com' ) {
+						ticketMeta.push(
+							isWcMobileApp()
+								? 'Created during store setup on Woo mobile app'
+								: ' Created during store setup on Woo browser'
+						);
+					}
 
 					const kayakoMessage = [ ...ticketMeta, '\n', message ].join( '\n' );
 

--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -292,9 +292,7 @@ export const HelpCenterContactForm = () => {
 
 					if ( getQueryArgs()?.ref === 'woocommerce-com' ) {
 						ticketMeta.push(
-							isWcMobileApp()
-								? 'Created during store setup on Woo mobile app'
-								: ' Created during store setup on Woo browser'
+							`Created: during store setup on ${ isWcMobileApp() ? 'Woo mobile app' : 'browser' }`
 						);
 					}
 

--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -292,7 +292,7 @@ export const HelpCenterContactForm = () => {
 
 					if ( getQueryArgs()?.ref === 'woocommerce-com' ) {
 						ticketMeta.push(
-							`Created: during store setup on ${ isWcMobileApp() ? 'Woo mobile app' : 'browser' }`
+							`Created during store setup on ${ isWcMobileApp() ? 'Woo mobile app' : 'Woo browser' }`
 						);
 					}
 


### PR DESCRIPTION
#### Proposed Changes

pe5sF9-Nq-p2#comment-1289

Append additional context to Zendesk ticket creation:

1. When requested from mobile app, append `Created during store setup on Woo mobile app`
2. When requested via browser (applies to all browsers including desktop or mobile), append `Created during store setup on Woo browser`

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Browsers**

* Make sure you're logged in to wpcom
* Go to http://calypso.localhost:3000/start/ecommerce-monthly/domains?ref=woocommerce-com
* Select a domain
* Observe that you're redirected to the checkout page with a query param `ref=woocommerce-com`.
* Open dev console
* Click "Ask a Happiness Engineer"
* Click "Still need help?"
* Select "Email"
* Fill out "subject" and "How can we help you today?"
* Submit the ticket
* Go to dev console > network tab
* Filter `ticket/new`
* Observe that message contains `Created during store setup on Woo mobile app` text.

**Test WC mobile app**

* Add `wc-ios` to your browser's user agent string(use [User-Agent Switcher](https://addons.mozilla.org/en-US/firefox/addon/uaswitcher/) in Firefox or follow the steps in https://www.searchenginejournal.com/change-user-agent/368448)
* repeat the Browsers steps above
* Observe that message contains `Created during store setup on Woo browser` text.

Optionally, go to zendesk and find the tickets you just submitted (hint: use `requester:me` filter). 

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


![Screen Shot 2023-01-05 at 14 43 37](https://user-images.githubusercontent.com/4344253/210721622-26955670-12f0-4ffa-a802-ce2cdccdb82a.png)

![Screen Shot 2023-01-05 at 14 48 00](https://user-images.githubusercontent.com/4344253/210722210-c39b8579-0595-4dc9-8732-2c0846e85b52.png)


Related to https://github.com/woocommerce/team-ghidorah/issues/138
