### PR TITLE
Virtual page: Hide description and popover when the template is not able to resolve

### DIFF
--- a/client/my-sites/pages/virtual-page/index.tsx
+++ b/client/my-sites/pages/virtual-page/index.tsx
@@ -64,11 +64,11 @@ const HomepagePopover = ( { isAdmin, template }: HomepagePopoverProps ) => {
 	} else if (
 		isEnglishLocale ||
 		hasTranslation(
-			'You can change the content of this page by editing the template using the Site Editor. {{learnMoreLink}}Learn more{{/learnMoreLink}}.'
+			'You can change the content of this page using the Site Editor. {{learnMoreLink}}Learn more{{/learnMoreLink}}.'
 		)
 	) {
 		msg = translate(
-			'You can change the content of this page by editing the template using the Site Editor. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+			'You can change the content of this page using the Site Editor. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
 			{
 				components: {
 					learnMoreLink,

--- a/client/my-sites/pages/virtual-page/index.tsx
+++ b/client/my-sites/pages/virtual-page/index.tsx
@@ -1,9 +1,10 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { CompactCard, Gridicon } from '@automattic/components';
 import { useTemplate } from '@automattic/data-stores';
-import { localizeUrl } from '@automattic/i18n-utils';
+import { localizeUrl, useIsEnglishLocale } from '@automattic/i18n-utils';
 import { ExternalLink } from '@wordpress/components';
 import { decodeEntities } from '@wordpress/html-entities';
+import { hasTranslation } from '@wordpress/i18n';
 import { useTranslate } from 'i18n-calypso';
 import pageRouter from 'page';
 import { connect } from 'react-redux';
@@ -19,8 +20,67 @@ import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import { setLayoutFocus } from 'calypso/state/ui/layout-focus/actions';
 import { setPreviewUrl } from 'calypso/state/ui/preview/actions';
 import Placeholder from '../placeholder';
-import type { SiteDetails } from '@automattic/data-stores';
+import type { SiteDetails, Template } from '@automattic/data-stores';
 import './style.scss';
+
+interface HomepagePopoverProps {
+	isAdmin: boolean;
+	template?: Template;
+}
+
+const HomepagePopover = ( { isAdmin, template }: HomepagePopoverProps ) => {
+	const translate = useTranslate();
+	const isEnglishLocale = useIsEnglishLocale();
+	const learnMoreLink = (
+		<ExternalLink
+			href={ localizeUrl( 'https://wordpress.com/support/templates/#template-hierarchy' ) }
+			target="_blank"
+			rel="noopener noreferrer"
+		/>
+	);
+
+	let msg = null;
+	if ( ! isAdmin ) {
+		msg = translate(
+			'Administrators can change the content of this page using the Site Editor. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+			{
+				components: {
+					learnMoreLink,
+				},
+			}
+		);
+	} else if ( template ) {
+		msg = translate(
+			'You can change the content of this page by editing the %(templateTitle)s template using the Site Editor. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+			{
+				components: {
+					learnMoreLink,
+				},
+				args: {
+					templateTitle: decodeEntities( template.title.rendered || template.slug ),
+				},
+			}
+		);
+	} else if (
+		isEnglishLocale ||
+		hasTranslation(
+			'You can change the content of this page by editing the template using the Site Editor. {{learnMoreLink}}Learn more{{/learnMoreLink}}.'
+		)
+	) {
+		msg = translate(
+			'You can change the content of this page by editing the template using the Site Editor. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+			{
+				components: {
+					learnMoreLink,
+				},
+			}
+		);
+	} else {
+		return null;
+	}
+
+	return <InfoPopover position="right">{ msg }</InfoPopover>;
+};
 
 interface Props {
 	site: SiteDetails;
@@ -54,7 +114,7 @@ const VirtualPage = ( {
 		? addQueryArgs( { templateId: id, templateType: type }, defaultEditorUrl )
 		: defaultEditorUrl;
 
-	const { data: template } = useTemplate( site.ID, id, { enabled: isAdmin } );
+	const { data: template, isLoading } = useTemplate( site.ID, id, { enabled: isAdmin && !! id } );
 
 	const recordGoogleEvent = ( action: string ) => {
 		props.recordGoogleEvent( 'Pages', action );
@@ -118,17 +178,9 @@ const VirtualPage = ( {
 		props.recordGoogleEvent( 'Pages', 'Clicked Copy Page Link' );
 	};
 
-	if ( isAdmin && ! template ) {
+	if ( isAdmin && isLoading ) {
 		return <Placeholder.Page key={ id } multisite={ ! site } />;
 	}
-
-	const homepageLearnMoreLink = (
-		<ExternalLink
-			href={ localizeUrl( 'https://wordpress.com/support/templates/#template-hierarchy' ) }
-			target="_blank"
-			rel="noopener noreferrer"
-		/>
-	);
 
 	return (
 		<CompactCard key={ id } className="page is-virtual">
@@ -145,30 +197,7 @@ const VirtualPage = ( {
 					onClick={ clickPageTitle }
 				>
 					<span>{ title }</span>
-					{ isHomepage && (
-						<InfoPopover position="right">
-							{ isAdmin && template
-								? translate(
-										'You can change the content of this page by editing the %(templateTitle)s template using the Site Editor. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
-										{
-											components: {
-												learnMoreLink: homepageLearnMoreLink,
-											},
-											args: {
-												templateTitle: decodeEntities( template.title.rendered || template.slug ),
-											},
-										}
-								  )
-								: translate(
-										'Administrators can change the content of this page using the Site Editor. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
-										{
-											components: {
-												learnMoreLink: homepageLearnMoreLink,
-											},
-										}
-								  ) }
-						</InfoPopover>
-					) }
+					{ isHomepage && <HomepagePopover isAdmin={ isAdmin } template={ template } /> }
 				</a>
 				{ isHomepage && template && (
 					<div className="page-card-info">


### PR DESCRIPTION
#### Proposed Changes

* Now we're able to resolve the homepage template if the atomic site is private. So, this PR proposes to hide the description of the virtual homepage and change the copy of the popover.

| Before | After |
| - | - |
| ![image](https://user-images.githubusercontent.com/13596067/210746582-13cf80df-c14c-46d0-83e3-8e0cba7613c5.png) | ![image](https://user-images.githubusercontent.com/13596067/210746684-9cd46edb-e181-4f2c-ac42-cb90cce50199.png) |

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/home/<your_atomic_site>`
* Go to Settings, and configure the Privacy to "private"
* Go to Themes, and activate the themes whose "Your homepage displays" is configured to "Your latest posts", e.g.: TT3
* Go to `/pages`

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/71375, https://github.com/Automattic/wp-calypso/pull/71541, https://github.com/Automattic/jetpack/pull/28158
