### PR TITLE
Improve subdomain verification steps

### DIFF
--- a/client/components/domains/connect-domain-step/connect-domain-step-login.jsx
+++ b/client/components/domains/connect-domain-step/connect-domain-step-login.jsx
@@ -90,40 +90,46 @@ export default function ConnectDomainStepLogin( {
 					text={ __( 'This domain cannot be connected.' ) }
 				></Notice>
 			) }
-			{ rootDomainProvider === 'wpcom' ? (
-				<p className={ className + '__text' }>
-					{ createInterpolateElement(
-						__(
-							"Open a new browser tab, switch to the site the domain is added to and go to <em>Upgrades → Domains</em>. Then click on the domain name to access the domain's settings page (alternatively click on the 3 vertical dots on the domain row and select <em>View Settings</em>). If the domain is under another WordPress.com account, use a different browser, log in to that account and follow the previous instructions. <a>More info here</a>."
-						),
-						{
-							em: createElement( 'em' ),
-							a: createElement( 'a', { href: supportUrl, target: '_blank' } ),
-						}
-					) }
-				</p>
-			) : (
+			{ ! isFetching && (
 				<>
-					<p className={ className + '__text' }>
-						{ createInterpolateElement(
-							__(
-								'Log into your domain provider account (like GoDaddy, NameCheap, 1&1, etc.). If you can’t remember who this is: go to <a>this link</a>, enter your domain and look at <em>Reseller Information</em> or <em>Registrar</em> to see the name of your provider.'
-							),
-							{
-								em: createElement( 'em' ),
-								a: createElement( 'a', { href: 'https://lookup.icann.org', target: '_blank' } ),
-							}
-						) }
-					</p>
-					<p className={ className + '__text' }>
-						{ sprintf(
-							/* translators: %s: the domain name that the user is connecting to WordPress.com (ex.: example.com) */
-							__(
-								'On your domain provider’s site go to the domains page. Find %s and go to its settings page.'
-							),
-							domain
-						) }
-					</p>
+					{ rootDomainProvider === 'wpcom' && (
+						<p className={ className + '__text' }>
+							{ createInterpolateElement(
+								__(
+									"Open a new browser tab, switch to the site the domain is added to and go to <em>Upgrades → Domains</em>. Then click on the domain name to access the domain's settings page (alternatively click on the 3 vertical dots on the domain row and select <em>View Settings</em>).<br/><br/> If the domain is under another WordPress.com account, use a different browser, log in to that account and follow the previous instructions. <a>More info can be found here</a>."
+								),
+								{
+									br: createElement( 'br' ),
+									em: createElement( 'em' ),
+									a: createElement( 'a', { href: supportUrl, target: '_blank' } ),
+								}
+							) }
+						</p>
+					) }
+					{ rootDomainProvider === 'unkwown' && (
+						<>
+							<p className={ className + '__text' }>
+								{ createInterpolateElement(
+									__(
+										'Log into your domain provider account (like GoDaddy, NameCheap, 1&1, etc.). If you can’t remember who this is: go to <a>this link</a>, enter your domain and look at <em>Reseller Information</em> or <em>Registrar</em> to see the name of your provider.'
+									),
+									{
+										em: createElement( 'em' ),
+										a: createElement( 'a', { href: 'https://lookup.icann.org', target: '_blank' } ),
+									}
+								) }
+							</p>
+							<p className={ className + '__text' }>
+								{ sprintf(
+									/* translators: %s: the domain name that the user is connecting to WordPress.com (ex.: example.com) */
+									__(
+										'On your domain provider’s site go to the domains page. Find %s and go to its settings page.'
+									),
+									domain
+								) }
+							</p>
+						</>
+					) }
 				</>
 			) }
 

--- a/client/components/domains/connect-domain-step/connect-domain-step-login.jsx
+++ b/client/components/domains/connect-domain-step/connect-domain-step-login.jsx
@@ -106,7 +106,7 @@ export default function ConnectDomainStepLogin( {
 							) }
 						</p>
 					) }
-					{ rootDomainProvider === 'unkwown' && (
+					{ rootDomainProvider !== 'wpcom' && (
 						<>
 							<p className={ className + '__text' }>
 								{ createInterpolateElement(

--- a/client/components/domains/connect-domain-step/connect-domain-step-login.jsx
+++ b/client/components/domains/connect-domain-step/connect-domain-step-login.jsx
@@ -26,6 +26,7 @@ export default function ConnectDomainStepLogin( {
 	const [ heading, setHeading ] = useState();
 	const [ isFetching, setIsFetching ] = useState( false );
 	const [ isConnectSupported, setIsConnectSupported ] = useState( true );
+	const [ rootDomainProvider, setRootDomainProvider ] = useState( 'unknown' );
 
 	const initialValidation = useRef( false );
 	const localizeUrl = useLocalizeUrl();
@@ -63,6 +64,7 @@ export default function ConnectDomainStepLogin( {
 				if ( domainAvailability.MAPPABLE !== availability.mappable ) {
 					setIsConnectSupported( false );
 				}
+				setRootDomainProvider( availability.root_domain_provider );
 			} catch {
 				setIsConnectSupported( false );
 			} finally {
@@ -88,43 +90,43 @@ export default function ConnectDomainStepLogin( {
 					text={ __( 'This domain cannot be connected.' ) }
 				></Notice>
 			) }
-			<h2 className={ className + '__title' }>
-				<b>{ __( 'Domain registered with an external proveder' ) }</b>
-			</h2>
-			<p className={ className + '__text' }>
-				{ createInterpolateElement(
-					__(
-						'Log into your domain provider account (like GoDaddy, NameCheap, 1&1, etc.). If you can’t remember who this is: go to <a>this link</a>, enter your domain and look at <em>Reseller Information</em> or <em>Registrar</em> to see the name of your provider.'
-					),
-					{
-						em: createElement( 'em' ),
-						a: createElement( 'a', { href: 'https://lookup.icann.org', target: '_blank' } ),
-					}
-				) }
-			</p>
-			<p className={ className + '__text' }>
-				{ sprintf(
-					/* translators: %s: the domain name that the user is connecting to WordPress.com (ex.: example.com) */
-					__(
-						'On your domain provider’s site go to the domains page. Find %s and go to its settings page.'
-					),
-					domain
-				) }
-			</p>
-			<h2 className={ className + '__title' }>
-				<b>{ __( 'Domain registered with WordPress.com' ) }</b>
-			</h2>
-			<p className={ className + '__text' }>
-				{ createInterpolateElement(
-					__(
-						"Open a new browser tab, switch to the site the domain is added to and go to <em>Upgrades → Domains</em>. Then click on the domain name to access the domain's settings page (alternatively click on the 3 vertical dots on the domain row and select <em>View Settings</em>). If the domain is under another WordPress.com account, use a different browser, log in to that account and follow the previous instructions. <a>More info here</a>."
-					),
-					{
-						em: createElement( 'em' ),
-						a: createElement( 'a', { href: supportUrl, target: '_blank' } ),
-					}
-				) }
-			</p>
+			{ rootDomainProvider === 'wpcom' ? (
+				<p className={ className + '__text' }>
+					{ createInterpolateElement(
+						__(
+							"Open a new browser tab, switch to the site the domain is added to and go to <em>Upgrades → Domains</em>. Then click on the domain name to access the domain's settings page (alternatively click on the 3 vertical dots on the domain row and select <em>View Settings</em>). If the domain is under another WordPress.com account, use a different browser, log in to that account and follow the previous instructions. <a>More info here</a>."
+						),
+						{
+							em: createElement( 'em' ),
+							a: createElement( 'a', { href: supportUrl, target: '_blank' } ),
+						}
+					) }
+				</p>
+			) : (
+				<>
+					<p className={ className + '__text' }>
+						{ createInterpolateElement(
+							__(
+								'Log into your domain provider account (like GoDaddy, NameCheap, 1&1, etc.). If you can’t remember who this is: go to <a>this link</a>, enter your domain and look at <em>Reseller Information</em> or <em>Registrar</em> to see the name of your provider.'
+							),
+							{
+								em: createElement( 'em' ),
+								a: createElement( 'a', { href: 'https://lookup.icann.org', target: '_blank' } ),
+							}
+						) }
+					</p>
+					<p className={ className + '__text' }>
+						{ sprintf(
+							/* translators: %s: the domain name that the user is connecting to WordPress.com (ex.: example.com) */
+							__(
+								'On your domain provider’s site go to the domains page. Find %s and go to its settings page.'
+							),
+							domain
+						) }
+					</p>
+				</>
+			) }
+
 			<Button
 				primary
 				onClick={ onNextStep }

--- a/client/components/domains/connect-domain-step/connect-domain-step-login.jsx
+++ b/client/components/domains/connect-domain-step/connect-domain-step-login.jsx
@@ -1,4 +1,5 @@
 import { Button } from '@automattic/components';
+import { useLocalizeUrl } from '@automattic/i18n-utils';
 import { createElement, createInterpolateElement } from '@wordpress/element';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
@@ -27,6 +28,7 @@ export default function ConnectDomainStepLogin( {
 	const [ isConnectSupported, setIsConnectSupported ] = useState( true );
 
 	const initialValidation = useRef( false );
+	const localizeUrl = useLocalizeUrl();
 
 	useEffect( () => {
 		switch ( mode ) {
@@ -70,6 +72,8 @@ export default function ConnectDomainStepLogin( {
 		} )();
 	} );
 
+	const supportUrl = localizeUrl( 'https://wordpress.com/support/domains/connect-subdomain' );
+
 	const stepContent = (
 		<div className={ className + '__login' }>
 			{ isOwnershipVerificationFlow && (
@@ -84,6 +88,9 @@ export default function ConnectDomainStepLogin( {
 					text={ __( 'This domain cannot be connected.' ) }
 				></Notice>
 			) }
+			<h2 className={ className + '__title' }>
+				<b>{ __( 'Domain registered with an external proveder' ) }</b>
+			</h2>
 			<p className={ className + '__text' }>
 				{ createInterpolateElement(
 					__(
@@ -102,6 +109,20 @@ export default function ConnectDomainStepLogin( {
 						'On your domain provider’s site go to the domains page. Find %s and go to its settings page.'
 					),
 					domain
+				) }
+			</p>
+			<h2 className={ className + '__title' }>
+				<b>{ __( 'Domain registered with WordPress.com' ) }</b>
+			</h2>
+			<p className={ className + '__text' }>
+				{ createInterpolateElement(
+					__(
+						"Open a new browser tab, switch to the site the domain is added to and go to <em>Upgrades → Domains</em>. Then click on the domain name to access the domain's settings page (alternatively click on the 3 vertical dots on the domain row and select <em>View Settings</em>). If the domain is under another WordPress.com account, use a different browser, log in to that account and follow the previous instructions. <a>More info here</a>."
+					),
+					{
+						em: createElement( 'em' ),
+						a: createElement( 'a', { href: supportUrl, target: '_blank' } ),
+					}
 				) }
 			</p>
 			<Button

--- a/client/components/domains/connect-domain-step/connect-domain-step-ownership-auth-code.jsx
+++ b/client/components/domains/connect-domain-step/connect-domain-step-ownership-auth-code.jsx
@@ -1,8 +1,9 @@
 import { createElement, createInterpolateElement } from '@wordpress/element';
 import { useI18n } from '@wordpress/react-i18n';
-import { useCallback } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { connect } from 'react-redux';
 import { connectDomainAction } from 'calypso/components/domains/use-my-domain/utilities';
+import wpcom from 'calypso/lib/wp';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { authCodeStepDefaultDescription } from './constants';
 import DomainStepAuthCode from './domain-step-auth-code';
@@ -21,6 +22,19 @@ const ConnectDomainStepOwnershipAuthCode = ( {
 		() => recordTracksEvent( 'calypso_use_your_domain_mapping_click', { domain } ),
 		[ domain ]
 	);
+	const [ rootDomainProvider, setRootDomainProvider ] = useState( 'unknown' );
+	useEffect( () => {
+		( async () => {
+			try {
+				const availability = await wpcom
+					.domain( domain )
+					.isAvailable( { apiVersion: '1.3', is_cart_pre_check: false } );
+				setRootDomainProvider( availability.root_domain_provider );
+			} catch {
+				setRootDomainProvider( 'unkwnown' );
+			}
+		} )();
+	} );
 	const authCodeDescription = (
 		<>
 			<p className="connect-domain-step__text">
@@ -30,14 +44,16 @@ const ConnectDomainStepOwnershipAuthCode = ( {
 			</p>
 			<p className="connect-domain-step__text">{ authCodeStepDefaultDescription.label }</p>
 
-			<p className="connect-domain-step__text">
-				{ createInterpolateElement(
-					__(
-						'If the domain was registered with WordPress.com, click on <em>Transfer</em> button and in the next screen click on <em>Get authorization code</em>. The code is sent to contact email address on the domain (the option <em>Transfer lock on</em> can remain toggled on).'
-					),
-					{ em: createElement( 'em' ) }
-				) }
-			</p>
+			{ rootDomainProvider === 'wpcom' && (
+				<p className="connect-domain-step__text">
+					{ createInterpolateElement(
+						__(
+							'In the domain settings page, click on <em>Transfer</em> button and, in the next screen, click on <em>Get authorization code</em>. The code will be sent to the contact email address specified for the domain (the option <em>Transfer lock on</em> can remain toggled on).'
+						),
+						{ em: createElement( 'em' ) }
+					) }
+				</p>
+			) }
 			<p className="connect-domain-step__text">
 				{ createInterpolateElement(
 					__(

--- a/client/components/domains/connect-domain-step/connect-domain-step-ownership-auth-code.jsx
+++ b/client/components/domains/connect-domain-step/connect-domain-step-ownership-auth-code.jsx
@@ -29,6 +29,15 @@ const ConnectDomainStepOwnershipAuthCode = ( {
 				) }
 			</p>
 			<p className="connect-domain-step__text">{ authCodeStepDefaultDescription.label }</p>
+
+			<p className="connect-domain-step__text">
+				{ createInterpolateElement(
+					__(
+						'If the domain was registered with WordPress.com, click on <em>Transfer</em> button and in the next screen click on <em>Get authorization code</em>. The code is sent to contact email address on the domain (the option <em>Transfer lock on</em> can remain toggled on).'
+					),
+					{ em: createElement( 'em' ) }
+				) }
+			</p>
 			<p className="connect-domain-step__text">
 				{ createInterpolateElement(
 					__(


### PR DESCRIPTION
#### Proposed Changes

This PR improves the instructions for verifying a domain during subdomain connection steps. In particularly, it provides specific info on how to get the auth code for domain registered with WordPress.com

#### Testing Instructions

- Checkout this branch locally or open the Calypso link below
- Create a new site (with a paid plan) and add a new domain connection, using a subdomain for a domain you own on WordPress.com
- Verify that the instructions in the 2 verification steps (_Log in to provider_ and `Verify ownership`) are the same as the screenshots below.
- Verify also that the instructions for aa 3rd party subdomain aren't changed.

![domain verification - step 1 - before](https://user-images.githubusercontent.com/2797601/210762994-93219bc0-bc2a-4383-b9d2-5a1ce10eca03.png)

![domain-login-after](https://user-images.githubusercontent.com/2797601/212852387-010b9024-d9a0-480d-bde7-90b1c56f2a33.png)

![domain verification - step 2 - before](https://user-images.githubusercontent.com/2797601/210763027-2cc0a4e5-de39-403d-be29-02e09cd26fe3.png)

![domain-code-after](https://user-images.githubusercontent.com/2797601/212852401-9819c69f-4468-4bc4-95de-63193baee2b0.png)

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?

Related to #
