### PR TITLE
Stats: Deprecate the feature flag "stats/all-time-views"

### DIFF
--- a/client/my-sites/stats/all-time-views-section/style.scss
+++ b/client/my-sites/stats/all-time-views-section/style.scss
@@ -1,1 +1,2 @@
 @import "calypso/my-sites/stats/modernized-stats-table-styles.scss";
+@import "calypso/my-sites/stats/stats-views/style.scss";

--- a/client/my-sites/stats/post-detail-table-section/style.scss
+++ b/client/my-sites/stats/post-detail-table-section/style.scss
@@ -1,4 +1,5 @@
 @import "calypso/my-sites/stats/modernized-stats-table-styles.scss";
+@import "calypso/my-sites/stats/stats-views/style.scss";
 
 $common-border-radius: 4px;
 

--- a/client/my-sites/stats/stats-insights/index.jsx
+++ b/client/my-sites/stats/stats-insights/index.jsx
@@ -9,7 +9,6 @@ import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
 import JetpackColophon from 'calypso/components/jetpack-colophon';
 import Main from 'calypso/components/main';
-import SectionHeader from 'calypso/components/section-header';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { getSuggestionsVendor } from 'calypso/lib/domains/suggestions';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
@@ -24,14 +23,12 @@ import StatsModule from '../stats-module';
 import Reach from '../stats-reach';
 import StatShares from '../stats-shares';
 import statsStrings from '../stats-strings';
-import StatsViews from '../stats-views';
 
 const StatsInsights = ( props ) => {
 	const { siteId, siteSlug, translate, isOdysseyStats } = props;
 	const moduleStrings = statsStrings();
 
 	const isNewMainChart = config.isEnabled( 'stats/new-main-chart' );
-	const isNewAllTimeViews = config.isEnabled( 'stats/all-time-views' );
 
 	// Track the last viewed tab.
 	// Necessary to properly configure the fixed navigation headers.
@@ -54,16 +51,10 @@ const StatsInsights = ( props ) => {
 				<StatsNavigation selectedItem="insights" siteId={ siteId } slug={ siteSlug } />
 				<AnnualHighlightsSection siteId={ siteId } />
 				<AllTimelHighlightsSection siteId={ siteId } />
-				{ isNewAllTimeViews && <AllTimelViewsSection siteId={ siteId } slug={ siteSlug } /> }
+				<AllTimelViewsSection siteId={ siteId } slug={ siteSlug } />
 				<div className="stats__module--insights-posting-activity">
 					<PostingActivity />
 				</div>
-				{ ! isNewAllTimeViews && (
-					<div className="stats__module--insights-unified">
-						<SectionHeader label={ translate( 'All-time views' ) } />
-						<StatsViews />
-					</div>
-				) }
 				{ siteId && (
 					<DomainTip
 						siteId={ siteId }

--- a/config/client.json
+++ b/config/client.json
@@ -25,7 +25,6 @@
 	"readerFollowingSource",
 	"siftscience_key",
 	"signup_url",
-	"stats/all-time-views",
 	"stats/new-main-chart",
 	"wpcom_concierge_schedule_id",
 	"wpcom_signup_id",

--- a/config/development.json
+++ b/config/development.json
@@ -161,7 +161,6 @@
 		"signup/woo-verify-email": false,
 		"site-indicator": true,
 		"ssr/prefetch-timebox": false,
-		"stats/all-time-views": true,
 		"stats/new-main-chart": true,
 		"stepper-woocommerce-poc": true,
 		"subscriber-csv-upload": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -106,7 +106,6 @@
 		"signup/woo-verify-email": false,
 		"site-indicator": true,
 		"ssr/prefetch-timebox": true,
-		"stats/all-time-views": true,
 		"stats/new-main-chart": true,
 		"stepper-woocommerce-poc": true,
 		"subscriber-csv-upload": true,

--- a/config/production.json
+++ b/config/production.json
@@ -126,7 +126,6 @@
 		"ssr/log-prefetch-errors": true,
 		"ssr/prefetch-timebox": true,
 		"ssr/sample-log-cache-misses": true,
-		"stats/all-time-views": true,
 		"stats/new-main-chart": true,
 		"stepper-woocommerce-poc": true,
 		"subscriber-csv-upload": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -122,7 +122,6 @@
 		"signup/woo-verify-email": false,
 		"site-indicator": true,
 		"ssr/prefetch-timebox": true,
-		"stats/all-time-views": true,
 		"stats/new-main-chart": true,
 		"stepper-woocommerce-poc": true,
 		"subscriber-csv-upload": true,

--- a/config/test.json
+++ b/config/test.json
@@ -89,7 +89,6 @@
 		"signup/social": true,
 		"site-indicator": true,
 		"ssr/prefetch-timebox": true,
-		"stats/all-time-views": true,
 		"stats/new-main-chart": true,
 		"stepper-woocommerce-poc": true,
 		"themes/premium": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -131,7 +131,6 @@
 		"signup/woo-verify-email": false,
 		"site-indicator": true,
 		"ssr/prefetch-timebox": true,
-		"stats/all-time-views": true,
 		"stats/new-main-chart": true,
 		"stepper-woocommerce-poc": true,
 		"subscriber-csv-upload": true,


### PR DESCRIPTION
#### Proposed Changes

* Remove all flags usage of `stats/all-time-views`.
* Patch `StatsViews` styles accompanying the modernized table for `.stats-views__key-container` content.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up this change with the Calypso Live link.
* Navigate to the `Insights` page.
* Ensure the `All-time insights` section works as previously.

<img width="1268" alt="截圖 2023-01-05 下午11 21 17" src="https://user-images.githubusercontent.com/6869813/210815844-493c6ada-0ec7-44dc-b62c-bc947f8f6b4b.png">

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #71660 
