### PR TITLE
Users management: Update user details screen

### DIFF
--- a/client/my-sites/people/edit-team-member-form/index.jsx
+++ b/client/my-sites/people/edit-team-member-form/index.jsx
@@ -70,7 +70,9 @@ export const EditTeamMemberForm = ( {
 					hasScreenOptions
 				/>
 			) }
-			<HeaderCake onClick={ goBack } isCompact />
+			<HeaderCake onClick={ goBack } isCompact>
+				{ translate( 'User Details' ) }
+			</HeaderCake>
 			<Card className="edit-team-member-form__user-profile">
 				<PeopleProfile siteId={ siteId } user={ user } />
 				{ user && (

--- a/client/my-sites/people/edit-team-member-form/index.jsx
+++ b/client/my-sites/people/edit-team-member-form/index.jsx
@@ -78,6 +78,7 @@ export const EditTeamMemberForm = ( {
 						user={ user }
 						disabled={ false } // @TODO added when added mutation to remove user
 						siteId={ siteId }
+						autoSave={ isEnabled( 'user-management-revamp' ) }
 						isJetpack={ isJetpack }
 						markChanged={ markChanged }
 						markSaved={ markSaved }

--- a/client/my-sites/people/people-invite-details/index.jsx
+++ b/client/my-sites/people/people-invite-details/index.jsx
@@ -131,7 +131,7 @@ export class PeopleInviteDetails extends PureComponent {
 					</div>
 				</div>
 				<div className="people-invite-details__meta-item">
-					<strong>{ translate( 'Invited By' ) }</strong>
+					<strong>{ translate( 'Added By' ) }</strong>
 					<div>
 						<span>
 							{ showName && <>{ invite.invitedBy.name }</> } { '@' + invite.invitedBy.login }


### PR DESCRIPTION
#### Proposed Changes

* Update copy
* Team member edit form: Added title to match the User Details design
* Introduced autosave functionality on team member edit form

#### Testing Instructions

- Go to `/people/team-members/{SITE_SLUG}`
- Click on the team member item
- Try to edit the role or toggle the `contractor` checkbox
- Check if autosave works

Known issues:
- Updating the admin profile shows "There was an error updating..." but the change is saved (the same behavior is on production so it is not introduced with this PR)

#### Screenshots

<img width="749" alt="Screenshot 2023-01-06 at 12 03 54" src="https://user-images.githubusercontent.com/1241413/211000217-ce00e61a-1319-48f5-9aa1-660f7118e4f2.png">

![Screen Capture on 2023-01-06 at 11-59-07](https://user-images.githubusercontent.com/1241413/211000002-388aa7ea-052f-4b74-941f-40b6e760b0f5.gif)

#### Pre-merge Checklist


- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #71718
