### PR TITLE
format-currency: Update getCurrencyObject to never return null

### DIFF
--- a/packages/format-currency/README.md
+++ b/packages/format-currency/README.md
@@ -13,7 +13,7 @@ import formatCurrency from '@automattic/format-currency';`
 
 ## formatCurrency()
 
-`formatCurrency( number: number, code: string, options: FormatCurrencyOptions = {} ): string | null`
+`formatCurrency( number: number, code: string, options: FormatCurrencyOptions = {} ): string`
 
 Formats money with a given currency code.
 
@@ -23,11 +23,9 @@ For currencies that include decimals, this will always return the amount with de
 
 Since rounding errors are common in floating point math, sometimes a price is provided as an integer in the smallest unit of a currency (eg: cents in USD or yen in JPY). Set the `isSmallestUnit` to change the function to operate on integer numbers instead. If this option is not set or false, the function will format the amount `1025` in `USD` as `$1,025.00`, but when the option is true, it will return `$10.25` instead.
 
-Will return null if the currency code is unknown or if the number is not a number. Will also return null if `isSmallestUnit` is set and the number is not an integer.
-
 ## getCurrencyObject()
 
-`getCurrencyObject( number: number, code: string, options: FormatCurrencyOptions = {} ): CurrencyObject | null`
+`getCurrencyObject( number: number, code: string, options: FormatCurrencyOptions = {} ): CurrencyObject`
 
 Returns a formatted price object.
 
@@ -36,8 +34,6 @@ The currency will define the properties to use for this formatting, but those pr
 For currencies that include decimals, this will always return the amount with decimals included, even if those decimals are zeros. To exclude the zeros, use the `stripZeros` option. For example, the function will normally format `10.00` in `USD` as `$10.00` but when this option is true, it will return `$10` instead.
 
 Since rounding errors are common in floating point math, sometimes a price is provided as an integer in the smallest unit of a currency (eg: cents in USD or yen in JPY). Set the `isSmallestUnit` to change the function to operate on integer numbers instead. If this option is not set or false, the function will format the amount `1025` in `USD` as `$1,025.00`, but when the option is true, it will return `$10.25` instead.
-
-Will return null if the currency code is unknown or if the number is not a number. Will also return null if `isSmallestUnit` is set and the number is not an integer.
 
 ## FormatCurrencyOptions
 

--- a/packages/format-currency/src/index.ts
+++ b/packages/format-currency/src/index.ts
@@ -1,6 +1,6 @@
 import { doesCurrencyExist, getCurrencyDefaults } from './currencies';
 import numberFormat from './number-format';
-import { FormatCurrencyOptions, CurrencyObject } from './types';
+import type { FormatCurrencyOptions, CurrencyObject } from './types';
 
 export { getCurrencyDefaults };
 
@@ -45,7 +45,7 @@ export function formatCurrency(
 	number: number,
 	code: string,
 	options: FormatCurrencyOptions = {}
-): string | null {
+): string {
 	if ( ! doesCurrencyExist( code ) ) {
 		// eslint-disable-next-line no-console
 		console.warn( `formatCurrency was called with an unknown currency "${ code }"` );
@@ -101,7 +101,12 @@ export function formatCurrency(
  * function will format the amount `1025` in `USD` as `$1,025.00`, but when the
  * option is true, it will return `$10.25` instead.
  *
- * If the number is NaN, this will return null.
+ * Note that the `integer` return value of this function is not a number, but a
+ * locale-formatted string which may include symbols like spaces, commas, or
+ * periods as group separators. Similarly, the `fraction` property is a string
+ * that contains the decimal separator.
+ *
+ * If the number is NaN, it will be treated as 0.
  *
  * If the currency code is not known, this will assume a default currency
  * similar to USD.
@@ -112,13 +117,13 @@ export function formatCurrency(
  * @param      {number}                   number     number to format; assumed to be a float unless isSmallestUnit is set.
  * @param      {string}                   code       currency code e.g. 'USD'
  * @param      {FormatCurrencyOptions}    options    options object
- * @returns    {?CurrencyObject}          A formatted string e.g. { symbol:'$', integer: '$99', fraction: '.99', sign: '-' }
+ * @returns    {CurrencyObject}          A formatted string e.g. { symbol:'$', integer: '$99', fraction: '.99', sign: '-' }
  */
 export function getCurrencyObject(
 	number: number,
 	code: string,
 	options: FormatCurrencyOptions = {}
-): CurrencyObject | null {
+): CurrencyObject {
 	if ( ! doesCurrencyExist( code ) ) {
 		// eslint-disable-next-line no-console
 		console.warn( `getCurrencyObject was called with an unknown currency "${ code }"` );
@@ -127,7 +132,7 @@ export function getCurrencyObject(
 	if ( isNaN( number ) ) {
 		// eslint-disable-next-line no-console
 		console.warn( 'getCurrencyObject was called with NaN' );
-		return null;
+		number = 0;
 	}
 	const { decimal, grouping, precision, symbol, isSmallestUnit } = {
 		...currencyDefaults,


### PR DESCRIPTION
#### Proposed Changes

In https://github.com/Automattic/wp-calypso/pull/71497, `formatCurrency()` was modified so that it never returns null, instead using default values for invalid input (invalid number or currency).

In this PR, we do the same for its sister-function `getCurrencyObject()`.

In addition, this PR updates the TypeScript types and documentation to clarify that the functions cannot return null. 

This was extracted from https://github.com/Automattic/wp-calypso/pull/71387

#### Testing Instructions

The existing automated tests should cover every use-case.
