### PR TITLE
i18n: Localize the nav URLs on the logged-out themes and plugins pages

### DIFF
--- a/client/layout/universal-navbar-footer/index.tsx
+++ b/client/layout/universal-navbar-footer/index.tsx
@@ -13,7 +13,7 @@ import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 const UniversalNavbarFooter = () => {
 	const translate = useTranslate();
 	const localizeUrl = useLocalizeUrl();
-	const locale = getLocaleSlug();
+	const locale = getLocaleSlug() ?? undefined;
 	const { shouldSeeDoNotSell, isDoNotSell, onSetDoNotSell } = useDoNotSell();
 	const [ isDialogOpen, setIsDialogOpen ] = useState( false );
 	const isLoggedIn = useSelector( isUserLoggedIn );

--- a/client/layout/universal-navbar-footer/index.tsx
+++ b/client/layout/universal-navbar-footer/index.tsx
@@ -1,5 +1,6 @@
 import './style.scss';
-import { useTranslate } from 'i18n-calypso';
+import { useLocalizeUrl } from '@automattic/i18n-utils';
+import { useTranslate, getLocaleSlug } from 'i18n-calypso';
 import { useCallback, useState } from 'react';
 import DoNotSellDialogContainer from 'calypso/blocks/do-not-sell-dialog';
 import SocialLogo from 'calypso/components/social-logo';
@@ -9,6 +10,8 @@ import { navigate } from 'calypso/lib/navigate';
 
 const UniversalNavbarFooter = () => {
 	const translate = useTranslate();
+	const localizeUrl = useLocalizeUrl();
+	const locale = getLocaleSlug();
 	const { shouldSeeDoNotSell, isDoNotSell, onSetDoNotSell } = useDoNotSell();
 	const [ isDialogOpen, setIsDialogOpen ] = useState( false );
 
@@ -34,32 +37,41 @@ const UniversalNavbarFooter = () => {
 							<h3>{ translate( 'Products' ) }</h3>
 							<ul>
 								<li>
-									<a href="https://wordpress.com/hosting/" target="_self">
+									<a href={ localizeUrl( 'https://wordpress.com/hosting/' ) } target="_self">
 										{ translate( 'WordPress Hosting' ) }
 									</a>
 								</li>
 								<li>
-									<a href="https://wordpress.com/domains/" target="_self">
+									<a href={ localizeUrl( 'https://wordpress.com/domains/' ) } target="_self">
 										{ translate( 'Domain Names' ) }
 									</a>
 								</li>
 								<li>
-									<a href="https://wordpress.com/website-builder/" target="_self">
+									<a
+										href={ localizeUrl( 'https://wordpress.com/website-builder/' ) }
+										target="_self"
+									>
 										{ translate( 'Website Builder' ) }
 									</a>
 								</li>
 								<li>
-									<a href="https://wordpress.com/create-blog/" target="_self">
+									<a href={ localizeUrl( 'https://wordpress.com/create-blog/' ) } target="_self">
 										{ translate( 'Create a Blog' ) }
 									</a>
 								</li>
 								<li>
-									<a href="https://wordpress.com/professional-email/" target="_self">
+									<a
+										href={ localizeUrl( 'https://wordpress.com/professional-email/' ) }
+										target="_self"
+									>
 										{ translate( 'Professional Email' ) }
 									</a>
 								</li>
 								<li>
-									<a href="https://wordpress.com/p2/?ref=wpcom-product-menu" target="_self">
+									<a
+										href={ localizeUrl( 'https://wordpress.com/p2/?ref=wpcom-product-menu' ) }
+										target="_self"
+									>
 										{ translate( 'P2: WordPress for Teams' ) }
 									</a>
 								</li>
@@ -71,7 +83,7 @@ const UniversalNavbarFooter = () => {
 								</li>
 								<li>
 									<a
-										href="https://wordpress.com/do-it-for-me/?ref=footer_pricing"
+										href={ localizeUrl( 'https://wordpress.com/do-it-for-me/?ref=footer_pricing' ) }
 										title="WordPress Website Building Service"
 										target="_self"
 									>
@@ -85,7 +97,7 @@ const UniversalNavbarFooter = () => {
 							<ul>
 								<li>
 									<a
-										href="https://wordpress.com/features/"
+										href={ localizeUrl( 'https://wordpress.com/features/' ) }
 										title="WordPress.com Features"
 										target="_self"
 									>
@@ -93,17 +105,23 @@ const UniversalNavbarFooter = () => {
 									</a>
 								</li>
 								<li>
-									<a href="https://wordpress.com/themes" target="_self">
+									<a
+										href={ localizeUrl( 'https://wordpress.com/themes', locale, false ) }
+										target="_self"
+									>
 										{ translate( 'WordPress Themes' ) }
 									</a>
 								</li>
 								<li>
-									<a href="https://wordpress.com/install-plugins/" target="_self">
+									<a
+										href={ localizeUrl( 'https://wordpress.com/plugins/', locale, false ) }
+										target="_self"
+									>
 										{ translate( 'WordPress Plugins' ) }
 									</a>
 								</li>
 								<li>
-									<a href="https://wordpress.com/google/" target="_self">
+									<a href={ localizeUrl( 'https://wordpress.com/google/' ) } target="_self">
 										{ translate( 'Google Apps' ) }
 									</a>
 								</li>
@@ -113,47 +131,53 @@ const UniversalNavbarFooter = () => {
 							<h3>{ translate( 'Resources' ) }</h3>
 							<ul>
 								<li>
-									<a href="https://wordpress.com/support/" target="_self">
+									<a href={ localizeUrl( 'https://wordpress.com/support/' ) } target="_self">
 										{ translate( 'WordPress.com Support' ) }
 									</a>
 								</li>
 								<li>
-									<a href="https://wordpress.com/forums/" target="_self">
+									<a href={ localizeUrl( 'https://wordpress.com/forums/' ) } target="_self">
 										{ translate( 'WordPress Forums' ) }
 									</a>
 								</li>
 								<li>
-									<a href="https://wordpress.com/blog/" target="_self">
+									<a href={ localizeUrl( 'https://wordpress.com/blog/' ) } target="_self">
 										{ translate( 'WordPress News' ) }
 									</a>
 								</li>
 								<li>
-									<a href="https://wordpress.com/go/" target="_self">
+									<a href={ localizeUrl( 'https://wordpress.com/go/' ) } target="_self">
 										{ translate( 'Website Building Tips' ) }
 									</a>
 								</li>
 								<li>
-									<a href="https://wordpress.com/business-name-generator/" target="_self">
+									<a
+										href={ localizeUrl( 'https://wordpress.com/business-name-generator/' ) }
+										target="_self"
+									>
 										{ translate( 'Business Name Generator' ) }
 									</a>
 								</li>
 								<li>
-									<a href="https://wordpress.com/logo-maker/" target="_self">
+									<a href={ localizeUrl( 'https://wordpress.com/logo-maker/' ) } target="_self">
 										{ translate( 'Logo Maker' ) }
 									</a>
 								</li>
 								<li>
-									<a href="https://wordpress.com/webinars/" target="_self">
+									<a href={ localizeUrl( 'https://wordpress.com/webinars/' ) } target="_self">
 										{ translate( 'Daily Webinars' ) }
 									</a>
 								</li>
 								<li>
-									<a href="https://wordpress.com/courses/" target="_self">
+									<a href={ localizeUrl( 'https://wordpress.com/courses/' ) } target="_self">
 										{ translate( 'WordPress Courses' ) }
 									</a>
 								</li>
 								<li>
-									<a href="https://developer.wordpress.com/" data-is_external="1">
+									<a
+										href={ localizeUrl( 'https://developer.wordpress.com/' ) }
+										data-is_external="1"
+									>
 										{ translate( 'Developer' ) }{ ' ' }
 										<span className="lp-link-chevron-external">{ translate( 'Resources' ) }</span>
 									</a>
@@ -164,12 +188,12 @@ const UniversalNavbarFooter = () => {
 							<h3>{ translate( 'Company' ) }</h3>
 							<ul>
 								<li>
-									<a href="https://wordpress.com/about/" target="_self">
+									<a href={ localizeUrl( 'https://wordpress.com/about/' ) } target="_self">
 										{ translate( 'About' ) }
 									</a>
 								</li>
 								<li>
-									<a href="https://wordpress.com/partners/" target="_self">
+									<a href={ localizeUrl( 'https://wordpress.com/partners/' ) } target="_self">
 										{ translate( 'Partners' ) }
 									</a>
 								</li>
@@ -179,7 +203,7 @@ const UniversalNavbarFooter = () => {
 									</a>
 								</li>
 								<li>
-									<a href="https://wordpress.com/tos/" target="_self">
+									<a href={ localizeUrl( 'https://wordpress.com/tos/' ) } target="_self">
 										{ translate( 'Terms of Service' ) }
 									</a>
 								</li>

--- a/client/layout/universal-navbar-footer/index.tsx
+++ b/client/layout/universal-navbar-footer/index.tsx
@@ -2,11 +2,13 @@ import './style.scss';
 import { useLocalizeUrl } from '@automattic/i18n-utils';
 import { useTranslate, getLocaleSlug } from 'i18n-calypso';
 import { useCallback, useState } from 'react';
+import { useSelector } from 'react-redux';
 import DoNotSellDialogContainer from 'calypso/blocks/do-not-sell-dialog';
 import SocialLogo from 'calypso/components/social-logo';
 import { useDoNotSell } from 'calypso/lib/analytics/utils';
 import { preventWidows } from 'calypso/lib/formatting';
 import { navigate } from 'calypso/lib/navigate';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 
 const UniversalNavbarFooter = () => {
 	const translate = useTranslate();
@@ -14,6 +16,7 @@ const UniversalNavbarFooter = () => {
 	const locale = getLocaleSlug();
 	const { shouldSeeDoNotSell, isDoNotSell, onSetDoNotSell } = useDoNotSell();
 	const [ isDialogOpen, setIsDialogOpen ] = useState( false );
+	const isLoggedIn = useSelector( isUserLoggedIn );
 
 	const openDialog = useCallback( () => {
 		setIsDialogOpen( true );
@@ -106,7 +109,7 @@ const UniversalNavbarFooter = () => {
 								</li>
 								<li>
 									<a
-										href={ localizeUrl( 'https://wordpress.com/themes', locale, false ) }
+										href={ localizeUrl( 'https://wordpress.com/themes', locale, isLoggedIn ) }
 										target="_self"
 									>
 										{ translate( 'WordPress Themes' ) }
@@ -114,7 +117,7 @@ const UniversalNavbarFooter = () => {
 								</li>
 								<li>
 									<a
-										href={ localizeUrl( 'https://wordpress.com/plugins/', locale, false ) }
+										href={ localizeUrl( 'https://wordpress.com/plugins/', locale, isLoggedIn ) }
 										target="_self"
 									>
 										{ translate( 'WordPress Plugins' ) }

--- a/client/layout/universal-navbar-header/index.jsx
+++ b/client/layout/universal-navbar-header/index.jsx
@@ -7,6 +7,7 @@ import WordPressWordmark from 'calypso/components/wordpress-wordmark';
 import UniversalNavbarBtnMenuItem from 'calypso/layout/universal-navbar-header/btn-menu-item.jsx';
 import UniversalNavbarLiMenuItem from 'calypso/layout/universal-navbar-header/li-menu-item.jsx';
 import { addQueryArgs } from 'calypso/lib/route';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { getSectionName } from 'calypso/state/ui/selectors';
 
 const UniversalNavbarHeader = () => {
@@ -15,14 +16,15 @@ const UniversalNavbarHeader = () => {
 	const locale = getLocaleSlug();
 	const [ isMobileMenuOpen, setMobileMenuOpen ] = useState( false );
 	const sectionName = useSelector( getSectionName );
+	const isLoggedIn = useSelector( isUserLoggedIn );
 
 	const startUrl = addQueryArgs(
 		{
 			ref: sectionName + '-lp',
 		},
 		sectionName === 'plugins'
-			? localizeUrl( '//wordpress.com/start/business', locale, false )
-			: localizeUrl( '//wordpress.com/start', locale, false )
+			? localizeUrl( '//wordpress.com/start/business', locale, isLoggedIn )
+			: localizeUrl( '//wordpress.com/start', locale, isLoggedIn )
 	);
 
 	return (
@@ -131,13 +133,13 @@ const UniversalNavbarHeader = () => {
 												<UniversalNavbarLiMenuItem
 													titleValue={ translate( 'WordPress Themes' ) }
 													elementContent={ translate( 'WordPress Themes' ) }
-													urlValue={ localizeUrl( '//wordpress.com/themes', locale, false ) }
+													urlValue={ localizeUrl( '//wordpress.com/themes', locale, isLoggedIn ) }
 													type="dropdown"
 												/>
 												<UniversalNavbarLiMenuItem
 													titleValue={ translate( 'WordPress Plugins' ) }
 													elementContent={ translate( 'WordPress Plugins' ) }
-													urlValue={ localizeUrl( '//wordpress.com/plugins', locale, false ) }
+													urlValue={ localizeUrl( '//wordpress.com/plugins', locale, isLoggedIn ) }
 													type="dropdown"
 												/>
 												<UniversalNavbarLiMenuItem
@@ -228,7 +230,7 @@ const UniversalNavbarHeader = () => {
 										className="x-nav-item x-nav-item__wide"
 										titleValue={ translate( 'Log In' ) }
 										elementContent={ translate( 'Log In' ) }
-										urlValue={ localizeUrl( '//wordpress.com/log-in', locale, false ) }
+										urlValue={ localizeUrl( '//wordpress.com/log-in', locale, isLoggedIn ) }
 										type="nav"
 									/>
 									<UniversalNavbarLiMenuItem
@@ -293,7 +295,7 @@ const UniversalNavbarHeader = () => {
 									<UniversalNavbarLiMenuItem
 										titleValue={ translate( 'Log In' ) }
 										elementContent={ translate( 'Log In' ) }
-										urlValue={ localizeUrl( '/log-in', locale, false ) }
+										urlValue={ localizeUrl( '/log-in', locale, isLoggedIn ) }
 										type="menu"
 									/>
 								</ul>
@@ -364,13 +366,13 @@ const UniversalNavbarHeader = () => {
 									<UniversalNavbarLiMenuItem
 										titleValue={ translate( 'WordPress Themes' ) }
 										elementContent={ translate( 'WordPress Themes' ) }
-										urlValue={ localizeUrl( '//wordpress.com/themes', locale, false ) }
+										urlValue={ localizeUrl( '//wordpress.com/themes', locale, isLoggedIn ) }
 										type="menu"
 									/>
 									<UniversalNavbarLiMenuItem
 										titleValue={ translate( 'WordPress Plugins' ) }
 										elementContent={ translate( 'WordPress Plugins' ) }
-										urlValue={ localizeUrl( '//wordpress.com/plugins', locale, false ) }
+										urlValue={ localizeUrl( '//wordpress.com/plugins', locale, isLoggedIn ) }
 										type="menu"
 									/>
 									<UniversalNavbarLiMenuItem

--- a/client/layout/universal-navbar-header/index.jsx
+++ b/client/layout/universal-navbar-header/index.jsx
@@ -1,5 +1,6 @@
 import './nav-style.scss';
-import { useTranslate } from 'i18n-calypso';
+import { useLocalizeUrl } from '@automattic/i18n-utils';
+import { useTranslate, getLocaleSlug } from 'i18n-calypso';
 import { useState } from 'react';
 import { useSelector } from 'react-redux';
 import WordPressWordmark from 'calypso/components/wordpress-wordmark';
@@ -10,6 +11,8 @@ import { getSectionName } from 'calypso/state/ui/selectors';
 
 const UniversalNavbarHeader = () => {
 	const translate = useTranslate();
+	const localizeUrl = useLocalizeUrl();
+	const locale = getLocaleSlug();
 	const [ isMobileMenuOpen, setMobileMenuOpen ] = useState( false );
 	const sectionName = useSelector( getSectionName );
 
@@ -17,7 +20,9 @@ const UniversalNavbarHeader = () => {
 		{
 			ref: sectionName + '-lp',
 		},
-		sectionName === 'plugins' ? '/start/business' : '/start'
+		sectionName === 'plugins'
+			? localizeUrl( '//wordpress.com/start/business', locale, false )
+			: localizeUrl( '//wordpress.com/start', locale, false )
 	);
 
 	return (
@@ -56,35 +61,35 @@ const UniversalNavbarHeader = () => {
 												<UniversalNavbarLiMenuItem
 													titleValue={ translate( 'WordPress Hosting' ) }
 													elementContent={ translate( 'WordPress Hosting' ) }
-													urlValue="//wordpress.com/hosting/"
+													urlValue={ localizeUrl( '//wordpress.com/hosting/' ) }
 													type="dropdown"
 													target="_self"
 												/>
 												<UniversalNavbarLiMenuItem
 													titleValue={ translate( 'Domain Names' ) }
 													elementContent={ translate( 'Domain Names' ) }
-													urlValue="//wordpress.com/domains/"
+													urlValue={ localizeUrl( '//wordpress.com/domains/' ) }
 													type="dropdown"
 													target="_self"
 												/>
 												<UniversalNavbarLiMenuItem
 													titleValue={ translate( 'Website Builder' ) }
 													elementContent={ translate( 'Website Builder' ) }
-													urlValue="//wordpress.com/website-builder/"
+													urlValue={ localizeUrl( '//wordpress.com/website-builder/' ) }
 													type="dropdown"
 													target="_self"
 												/>
 												<UniversalNavbarLiMenuItem
 													titleValue={ translate( 'Create a Blog' ) }
 													elementContent={ translate( 'Create a Blog' ) }
-													urlValue="//wordpress.com/create-blog/"
+													urlValue={ localizeUrl( '//wordpress.com/create-blog/' ) }
 													type="dropdown"
 													target="_self"
 												/>
 												<UniversalNavbarLiMenuItem
 													titleValue={ translate( 'Professional Email' ) }
 													elementContent={ translate( 'Professional Email' ) }
-													urlValue="//wordpress.com/professional-email/"
+													urlValue={ localizeUrl( '//wordpress.com/professional-email/' ) }
 													type="dropdown"
 													target="_self"
 												/>
@@ -116,7 +121,7 @@ const UniversalNavbarHeader = () => {
 												<UniversalNavbarLiMenuItem
 													titleValue={ translate( 'Features' ) }
 													elementContent={ translate( 'Overview' ) }
-													urlValue="//wordpress.com/features/"
+													urlValue={ localizeUrl( '//wordpress.com/features/' ) }
 													type="dropdown"
 													target="_self"
 												/>
@@ -126,19 +131,19 @@ const UniversalNavbarHeader = () => {
 												<UniversalNavbarLiMenuItem
 													titleValue={ translate( 'WordPress Themes' ) }
 													elementContent={ translate( 'WordPress Themes' ) }
-													urlValue="//wordpress.com/themes"
+													urlValue={ localizeUrl( '//wordpress.com/themes', locale, false ) }
 													type="dropdown"
 												/>
 												<UniversalNavbarLiMenuItem
 													titleValue={ translate( 'WordPress Plugins' ) }
 													elementContent={ translate( 'WordPress Plugins' ) }
-													urlValue="//wordpress.com/plugins"
+													urlValue={ localizeUrl( '//wordpress.com/plugins', locale, false ) }
 													type="dropdown"
 												/>
 												<UniversalNavbarLiMenuItem
 													titleValue={ translate( 'Google Apps' ) }
 													elementContent={ translate( 'Google Apps' ) }
-													urlValue="//wordpress.com/google/"
+													urlValue={ localizeUrl( '//wordpress.com/google/' ) }
 													type="dropdown"
 													target="_self"
 												/>
@@ -161,48 +166,48 @@ const UniversalNavbarHeader = () => {
 												<UniversalNavbarLiMenuItem
 													titleValue={ translate( 'Support' ) }
 													elementContent={ translate( 'WordPress.com Support' ) }
-													urlValue="//en.support.wordpress.com/"
+													urlValue={ localizeUrl( '//wordpress.com/support/' ) }
 													type="dropdown"
 												/>
 												<UniversalNavbarLiMenuItem
 													titleValue={ translate( 'News' ) }
 													elementContent={ translate( 'News' ) }
-													urlValue="//wordpress.com/blog/"
+													urlValue={ localizeUrl( '//wordpress.com/blog/' ) }
 													type="dropdown"
 													target="_self"
 												/>
 												<UniversalNavbarLiMenuItem
 													titleValue={ translate( 'Website Building Tips' ) }
 													elementContent={ translate( 'Website Building Tips' ) }
-													urlValue="//wordpress.com/go/"
+													urlValue={ localizeUrl( '//wordpress.com/go/' ) }
 													type="dropdown"
 													target="_self"
 												/>
 												<UniversalNavbarLiMenuItem
 													titleValue={ translate( 'Business Name Generator' ) }
 													elementContent={ translate( 'Business Name Generator' ) }
-													urlValue="//wordpress.com/business-name-generator/"
+													urlValue={ localizeUrl( '//wordpress.com/business-name-generator/' ) }
 													type="dropdown"
 													target="_self"
 												/>
 												<UniversalNavbarLiMenuItem
 													titleValue={ translate( 'Logo Maker' ) }
 													elementContent={ translate( 'Logo Maker' ) }
-													urlValue="//wordpress.com/logo-maker/"
+													urlValue={ localizeUrl( '//wordpress.com/logo-maker/' ) }
 													type="dropdown"
 													target="_self"
 												/>
 												<UniversalNavbarLiMenuItem
 													titleValue={ translate( 'Daily Webinars' ) }
 													elementContent={ translate( 'Daily Webinars' ) }
-													urlValue="//wordpress.com/webinars/"
+													urlValue={ localizeUrl( '//wordpress.com/webinars/' ) }
 													type="dropdown"
 													target="_self"
 												/>
 												<UniversalNavbarLiMenuItem
 													titleValue={ translate( 'WordPress Courses' ) }
 													elementContent={ translate( 'WordPress Courses' ) }
-													urlValue="//wordpress.com/courses/"
+													urlValue={ localizeUrl( '//wordpress.com/courses/' ) }
 													type="dropdown"
 													target="_self"
 												/>
@@ -213,7 +218,7 @@ const UniversalNavbarHeader = () => {
 										className="x-nav-item x-nav-item__wide"
 										titleValue={ translate( 'Plans & Pricing' ) }
 										elementContent={ translate( 'Plans & Pricing' ) }
-										urlValue="//wordpress.com/pricing/"
+										urlValue={ localizeUrl( '//wordpress.com/pricing/' ) }
 										type="nav"
 										target="_self"
 									/>
@@ -223,7 +228,7 @@ const UniversalNavbarHeader = () => {
 										className="x-nav-item x-nav-item__wide"
 										titleValue={ translate( 'Log In' ) }
 										elementContent={ translate( 'Log In' ) }
-										urlValue="/log-in"
+										urlValue={ localizeUrl( '//wordpress.com/log-in', locale, false ) }
 										type="nav"
 									/>
 									<UniversalNavbarLiMenuItem
@@ -288,7 +293,7 @@ const UniversalNavbarHeader = () => {
 									<UniversalNavbarLiMenuItem
 										titleValue={ translate( 'Log In' ) }
 										elementContent={ translate( 'Log In' ) }
-										urlValue="/log-in"
+										urlValue={ localizeUrl( '/log-in', locale, false ) }
 										type="menu"
 									/>
 								</ul>
@@ -299,7 +304,7 @@ const UniversalNavbarHeader = () => {
 									<UniversalNavbarLiMenuItem
 										titleValue={ translate( 'Plans & Pricing' ) }
 										elementContent={ translate( 'Plans & Pricing' ) }
-										urlValue="//wordpress.com/pricing/"
+										urlValue={ localizeUrl( '//wordpress.com/pricing/' ) }
 										type="menu"
 									/>
 								</ul>
@@ -310,31 +315,31 @@ const UniversalNavbarHeader = () => {
 									<UniversalNavbarLiMenuItem
 										titleValue={ translate( 'WordPress Hosting' ) }
 										elementContent={ translate( 'WordPress Hosting' ) }
-										urlValue="//wordpress.com/hosting/"
+										urlValue={ localizeUrl( '//wordpress.com/hosting/' ) }
 										type="menu"
 									/>
 									<UniversalNavbarLiMenuItem
 										titleValue={ translate( 'Domain Names' ) }
 										elementContent={ translate( 'Domain Names' ) }
-										urlValue="//wordpress.com/domains/"
+										urlValue={ localizeUrl( '//wordpress.com/domains/' ) }
 										type="menu"
 									/>
 									<UniversalNavbarLiMenuItem
 										titleValue={ translate( 'Website Builder' ) }
 										elementContent={ translate( 'Website Builder' ) }
-										urlValue="//wordpress.com/website-builder/"
+										urlValue={ localizeUrl( '//wordpress.com/website-builder/' ) }
 										type="menu"
 									/>
 									<UniversalNavbarLiMenuItem
 										titleValue={ translate( 'Create a Blog' ) }
 										elementContent={ translate( 'Create a Blog' ) }
-										urlValue="//wordpress.com/create-blog/"
+										urlValue={ localizeUrl( '//wordpress.com/create-blog/' ) }
 										type="menu"
 									/>
 									<UniversalNavbarLiMenuItem
 										titleValue={ translate( 'Professional Email' ) }
 										elementContent={ translate( 'Professional Email' ) }
-										urlValue="//wordpress.com/professional-email/"
+										urlValue={ localizeUrl( '//wordpress.com/professional-email/' ) }
 										type="menu"
 									/>
 									<UniversalNavbarLiMenuItem
@@ -351,7 +356,7 @@ const UniversalNavbarHeader = () => {
 									<UniversalNavbarLiMenuItem
 										titleValue={ translate( 'Features' ) }
 										elementContent={ translate( 'Overview' ) }
-										urlValue="//wordpress.com/features/"
+										urlValue={ localizeUrl( '//wordpress.com/features/' ) }
 										type="menu"
 									/>
 								</ul>
@@ -359,19 +364,19 @@ const UniversalNavbarHeader = () => {
 									<UniversalNavbarLiMenuItem
 										titleValue={ translate( 'WordPress Themes' ) }
 										elementContent={ translate( 'WordPress Themes' ) }
-										urlValue="//wordpress.com/themes"
+										urlValue={ localizeUrl( '//wordpress.com/themes', locale, false ) }
 										type="menu"
 									/>
 									<UniversalNavbarLiMenuItem
 										titleValue={ translate( 'WordPress Plugins' ) }
 										elementContent={ translate( 'WordPress Plugins' ) }
-										urlValue="//wordpress.com/plugins"
+										urlValue={ localizeUrl( '//wordpress.com/plugins', locale, false ) }
 										type="menu"
 									/>
 									<UniversalNavbarLiMenuItem
 										titleValue={ translate( 'Google Apps' ) }
 										elementContent={ translate( 'Google Apps' ) }
-										urlValue="//wordpress.com/google/"
+										urlValue={ localizeUrl( '//wordpress.com/google/' ) }
 										type="menu"
 									/>
 								</ul>
@@ -382,43 +387,43 @@ const UniversalNavbarHeader = () => {
 									<UniversalNavbarLiMenuItem
 										titleValue={ translate( 'Support' ) }
 										elementContent={ translate( 'WordPress.com Support' ) }
-										urlValue="//en.support.wordpress.com/"
+										urlValue={ localizeUrl( '//wordpress.com/support/' ) }
 										type="menu"
 									/>
 									<UniversalNavbarLiMenuItem
 										titleValue={ translate( 'News' ) }
 										elementContent={ translate( 'News' ) }
-										urlValue="//wordpress.com/blog/"
+										urlValue={ localizeUrl( '//wordpress.com/blog/' ) }
 										type="menu"
 									/>
 									<UniversalNavbarLiMenuItem
 										titleValue={ translate( 'Website Building Tips' ) }
 										elementContent={ translate( 'Website Building Tips' ) }
-										urlValue="//wordpress.com/go/"
+										urlValue={ localizeUrl( '//wordpress.com/go/' ) }
 										type="menu"
 									/>
 									<UniversalNavbarLiMenuItem
 										titleValue={ translate( 'Business Name Generator' ) }
 										elementContent={ translate( 'Business Name Generator' ) }
-										urlValue="//wordpress.com/business-name-generator/"
+										urlValue={ localizeUrl( '//wordpress.com/business-name-generator/' ) }
 										type="menu"
 									/>
 									<UniversalNavbarLiMenuItem
 										titleValue={ translate( 'Logo Maker' ) }
 										elementContent={ translate( 'Logo Maker' ) }
-										urlValue="//wordpress.com/logo-maker/"
+										urlValue={ localizeUrl( '//wordpress.com/logo-maker/' ) }
 										type="menu"
 									/>
 									<UniversalNavbarLiMenuItem
 										titleValue={ translate( 'Daily Webinars' ) }
 										elementContent={ translate( 'Daily Webinars' ) }
-										urlValue="//wordpress.com/webinars/"
+										urlValue={ localizeUrl( '//wordpress.com/webinars/' ) }
 										type="menu"
 									/>
 									<UniversalNavbarLiMenuItem
 										titleValue={ translate( 'WordPress Courses' ) }
 										elementContent={ translate( 'WordPress Courses' ) }
-										urlValue="//wordpress.com/courses/"
+										urlValue={ localizeUrl( '//wordpress.com/courses/' ) }
 										type="menu"
 									/>
 								</ul>

--- a/client/layout/universal-navbar-header/index.jsx
+++ b/client/layout/universal-navbar-header/index.jsx
@@ -38,7 +38,7 @@ const UniversalNavbarHeader = () => {
 										<a
 											role="menuitem"
 											className="x-nav-link x-nav-link__logo x-link"
-											href="/"
+											href={ localizeUrl( '//wordpress.com' ) }
 											target="_self"
 										>
 											<WordPressWordmark className="x-icon x-icon__logo" />

--- a/client/layout/universal-navbar-header/index.jsx
+++ b/client/layout/universal-navbar-header/index.jsx
@@ -13,7 +13,7 @@ import { getSectionName } from 'calypso/state/ui/selectors';
 const UniversalNavbarHeader = () => {
 	const translate = useTranslate();
 	const localizeUrl = useLocalizeUrl();
-	const locale = getLocaleSlug();
+	const locale = getLocaleSlug() ?? undefined;
 	const [ isMobileMenuOpen, setMobileMenuOpen ] = useState( false );
 	const sectionName = useSelector( getSectionName );
 	const isLoggedIn = useSelector( isUserLoggedIn );

--- a/client/layout/universal-navbar-header/index.jsx
+++ b/client/layout/universal-navbar-header/index.jsx
@@ -295,7 +295,7 @@ const UniversalNavbarHeader = () => {
 									<UniversalNavbarLiMenuItem
 										titleValue={ translate( 'Log In' ) }
 										elementContent={ translate( 'Log In' ) }
-										urlValue={ localizeUrl( '/log-in', locale, isLoggedIn ) }
+										urlValue={ localizeUrl( '//wordpress.com/log-in', locale, isLoggedIn ) }
 										type="menu"
 									/>
 								</ul>

--- a/packages/i18n-utils/src/locales.ts
+++ b/packages/i18n-utils/src/locales.ts
@@ -7,6 +7,7 @@
 export type Locale = string;
 export const i18nDefaultLocaleSlug: Locale = 'en';
 export const localesWithBlog: Locale[] = [ 'en', 'ja', 'es', 'pt', 'fr', 'pt-br' ];
+export const localesWithGoBlog: Locale[] = [ 'en', 'pt-br', 'de', 'es', 'fr', 'it' ];
 export const localesWithPrivacyPolicy: Locale[] = [ 'en', 'fr', 'de', 'es' ];
 export const localesWithCookiePolicy: Locale[] = [ 'en', 'fr', 'de', 'es' ];
 

--- a/packages/i18n-utils/src/locales.ts
+++ b/packages/i18n-utils/src/locales.ts
@@ -7,7 +7,6 @@
 export type Locale = string;
 export const i18nDefaultLocaleSlug: Locale = 'en';
 export const localesWithBlog: Locale[] = [ 'en', 'ja', 'es', 'pt', 'fr', 'pt-br' ];
-export const localesWithGoBlog: Locale[] = [ 'en', 'pt-br', 'de', 'es', 'fr', 'it' ];
 export const localesWithPrivacyPolicy: Locale[] = [ 'en', 'fr', 'de', 'es' ];
 export const localesWithCookiePolicy: Locale[] = [ 'en', 'fr', 'de', 'es' ];
 

--- a/packages/i18n-utils/src/localize-url.tsx
+++ b/packages/i18n-utils/src/localize-url.tsx
@@ -154,6 +154,9 @@ export const urlLocalizationMapping: UrlLocalizationMapping = {
 	'wordpress.com/log-in/': ( url: URL, localeSlug: Locale, isLoggedIn: boolean ) => {
 		return isLoggedIn ? url : suffixLocalizedUrlPath( magnificentNonEnLocales )( url, localeSlug );
 	},
+	'wordpress.com/start/': ( url: URL, localeSlug: Locale, isLoggedIn: boolean ) => {
+		return isLoggedIn ? url : suffixLocalizedUrlPath( magnificentNonEnLocales )( url, localeSlug );
+	},
 };
 
 export function localizeUrl(

--- a/packages/i18n-utils/src/localize-url.tsx
+++ b/packages/i18n-utils/src/localize-url.tsx
@@ -4,7 +4,6 @@ import { useCallback, ComponentType } from 'react';
 import { useLocale } from './locale-context';
 import {
 	localesWithBlog,
-	localesWithGoBlog,
 	localesWithPrivacyPolicy,
 	localesWithCookiePolicy,
 	localesToSubdomains,
@@ -115,7 +114,6 @@ export const urlLocalizationMapping: UrlLocalizationMapping = {
 	'wordpress.com/support/': prefixLocalizedUrlPath( supportSiteLocales ),
 	'wordpress.com/forums/': prefixLocalizedUrlPath( forumLocales ),
 	'wordpress.com/blog/': prefixLocalizedUrlPath( localesWithBlog, /^\/blog\/?$/ ),
-	'wordpress.com/go/': prefixLocalizedUrlPath( localesWithGoBlog, /^\/go\/?$/ ),
 	'wordpress.com/tos/': prefixLocalizedUrlPath( magnificentNonEnLocales ),
 	'wordpress.com/wp-admin/': setLocalizedUrlHost( 'wordpress.com', magnificentNonEnLocales ),
 	'wordpress.com/wp-login.php': setLocalizedUrlHost( 'wordpress.com', magnificentNonEnLocales ),

--- a/packages/i18n-utils/src/localize-url.tsx
+++ b/packages/i18n-utils/src/localize-url.tsx
@@ -4,6 +4,7 @@ import { useCallback, ComponentType } from 'react';
 import { useLocale } from './locale-context';
 import {
 	localesWithBlog,
+	localesWithGoBlog,
 	localesWithPrivacyPolicy,
 	localesWithCookiePolicy,
 	localesToSubdomains,
@@ -114,6 +115,7 @@ export const urlLocalizationMapping: UrlLocalizationMapping = {
 	'wordpress.com/support/': prefixLocalizedUrlPath( supportSiteLocales ),
 	'wordpress.com/forums/': prefixLocalizedUrlPath( forumLocales ),
 	'wordpress.com/blog/': prefixLocalizedUrlPath( localesWithBlog, /^\/blog\/?$/ ),
+	'wordpress.com/go/': prefixLocalizedUrlPath( localesWithGoBlog, /^\/go\/?$/ ),
 	'wordpress.com/tos/': prefixLocalizedUrlPath( magnificentNonEnLocales ),
 	'wordpress.com/wp-admin/': setLocalizedUrlHost( 'wordpress.com', magnificentNonEnLocales ),
 	'wordpress.com/wp-login.php': setLocalizedUrlHost( 'wordpress.com', magnificentNonEnLocales ),

--- a/packages/i18n-utils/src/test/localize-url.js
+++ b/packages/i18n-utils/src/test/localize-url.js
@@ -351,6 +351,36 @@ describe( '#localizeUrl', () => {
 		).toEqual( 'https://wordpress.com/de/themes/free/filter/example-filter/' );
 	} );
 
+	test( 'start', () => {
+		expect( localizeUrl( 'https://wordpress.com/start/', 'en', true ) ).toEqual(
+			'https://wordpress.com/start/'
+		);
+		expect( localizeUrl( 'https://wordpress.com/start/', 'de', true ) ).toEqual(
+			'https://wordpress.com/start/'
+		);
+		expect( localizeUrl( 'https://wordpress.com/start/', 'pl', true ) ).toEqual(
+			'https://wordpress.com/start/'
+		);
+		expect( localizeUrl( 'https://wordpress.com/start/', 'en', false ) ).toEqual(
+			'https://wordpress.com/start/'
+		);
+		expect( localizeUrl( 'https://wordpress.com/start/', 'de', false ) ).toEqual(
+			'https://wordpress.com/start/de/'
+		);
+		expect( localizeUrl( 'https://wordpress.com/start/', 'pl', false ) ).toEqual(
+			'https://wordpress.com/start/'
+		);
+		expect( localizeUrl( 'https://wordpress.com/start/user/', 'de', true ) ).toEqual(
+			'https://wordpress.com/start/user/'
+		);
+		expect( localizeUrl( 'https://wordpress.com/start/user/', 'de', false ) ).toEqual(
+			'https://wordpress.com/start/user/de/'
+		);
+		expect( localizeUrl( 'https://wordpress.com/start/user/', 'pl', false ) ).toEqual(
+			'https://wordpress.com/start/user/'
+		);
+	} );
+
 	test( 'tos', () => {
 		expect( localizeUrl( 'https://wordpress.com/tos/', 'en' ) ).toEqual(
 			'https://wordpress.com/tos/'


### PR DESCRIPTION
#### Proposed Changes

* Localizes the URLs in the `UniversalNavbarHeader` and `UniversalNavbarFooter`, which are currently used on the logged-out themes and plugins pages.
* Adds support for `/start` to `localizeUrl`.

Some localized URLs distinguish between logged-in and not-logged-in states (`/themes`, `/plugins`, `/log-in`). Even though `UniversalNavbarHeader` and `UniversalNavbarFooter` are currently only used on logged-out pages, I've decided to check for the logged-in state anyway: if these components were to be used anywhere else, the localized URLs would remain correct.

Note: not all locales have a Go blog, but `localizeUrl` does not take this into account yet. I have added this in a separate PR: https://github.com/Automattic/wp-calypso/pull/71763.

Non-mobile header | Mobile header | Footer
----- | ----- | -----
<img width="862" alt="image" src="https://user-images.githubusercontent.com/75777864/210878237-951b9516-632d-425d-b903-f257babeadba.png">|<img width="446" alt="image" src="https://user-images.githubusercontent.com/75777864/210878364-dfb03e48-75c8-4da8-bf6e-489339628cbc.png">|<img width="794" alt="image" src="https://user-images.githubusercontent.com/75777864/210878291-021b950d-123e-49ce-acf2-c9eb7637de8c.png">


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit the logged-out themes and plugins pages in a non-English locale (e.g. `/sv/plugins`)
* Verify that the wordpress.com-links in the header (including the logo and Log In and Get Started buttons), mobile header, and footer are localized.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1360-gh-Automattic/martech
