### PR TITLE
Add more unit tests to cover `getSiteFragment`

### DIFF
--- a/client/lib/route/test/index.js
+++ b/client/lib/route/test/index.js
@@ -140,6 +140,38 @@ describe( 'route', function () {
 				).toEqual( 2916284 );
 			} );
 		} );
+		describe( 'for checkout paths', function () {
+			test( 'should return false for gift checkouts', function () {
+				expect(
+					route.getSiteFragment( '/checkout/value_bundle/gift/18726247?cancel_to=/home' )
+				).toEqual( false );
+			} );
+			test( 'should return false for domain checkouts', function () {
+				expect( route.getSiteFragment( '/checkout/thank-you/no-site/75806534' ) ).toEqual( false );
+			} );
+			test( 'should return the correct site fragment when checking out', function () {
+				expect(
+					route.getSiteFragment( '/checkout/thank-you/example.wordpress.com/75806534' )
+				).toEqual( 'example.wordpress.com' );
+			} );
+		} );
+		describe( 'for jetpack paths', function () {
+			test( 'should return correct site fragment when site_url is trailing slashed', function () {
+				expect( route.getSiteFragment( '/jetpack/connect/plans/subdomain.example.com::' ) ).toEqual(
+					'subdomain.example.com'
+				);
+			} );
+		} );
+		describe( 'for plugins paths', function () {
+			test( 'should return correct site fragment', function () {
+				expect( route.getSiteFragment( '/plugins/404-to-301/example.wpcomstaging.com' ) ).toEqual(
+					'example.wpcomstaging.com'
+				);
+			} );
+			test( 'should return false when plugin name ends a number', function () {
+				expect( route.getSiteFragment( '/plugins/404-to-301' ) ).toEqual( false );
+			} );
+		} );
 	} );
 
 	describe( 'addSiteFragment', function () {


### PR DESCRIPTION
#### Proposed Changes

* Add more unit tests to cover `getSiteFragment`

Context: To address this issue https://github.com/Automattic/wp-calypso/issues/71669 I'd like to update `getSiteFragment`. Before I do that I wanted to add some missing unit tests.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Unit tests still pass.
* You can run these tests locally using the command: `yarn run test-client client/lib/route/test/` in Terminal.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #71669
