### PR TITLE
PlanPrice: convert to TypeScript and improve strip-zeros behavior

### DIFF
--- a/client/blocks/importer/wordpress/import-everything/confirm-upgrade-plan.tsx
+++ b/client/blocks/importer/wordpress/import-everything/confirm-upgrade-plan.tsx
@@ -83,7 +83,7 @@ export const ConfirmUpgradePlan: FunctionComponent< Props > = ( props ) => {
 			<div className={ classnames( 'import__upgrade-plan-container' ) }>
 				<div className={ classnames( 'import__upgrade-plan-price' ) }>
 					<h3 className={ classnames( 'plan-title' ) }>{ plan?.getTitle() }</h3>
-					<PlanPrice rawPrice={ rawPrice } currencyCode={ currencyCode } />
+					<PlanPrice rawPrice={ rawPrice ?? undefined } currencyCode={ currencyCode } />
 					<span className={ classnames( 'plan-time-frame' ) }>{ plan?.getBillingTimeFrame() }</span>
 				</div>
 				<div className={ classnames( 'import__upgrade-plan-details' ) }>

--- a/client/my-sites/plan-price/index.tsx
+++ b/client/my-sites/plan-price/index.tsx
@@ -33,20 +33,9 @@ export class PlanPrice extends Component< PlanPriceProps & LocalizeProps > {
 
 		const tagName = omitHeading ? 'span' : 'h4';
 
-		// productDisplayPrice is returned from Store Price and provides a geo-IDed currency format
-		const shouldUseDisplayPrice = () => {
-			if ( ! productDisplayPrice ) {
-				return false;
-			}
-			if ( rawPrice ) {
-				if ( Array.isArray( rawPrice ) && rawPrice.length > 1 ) {
-					return false;
-				}
-			}
-			return true;
-		};
+		const areThereMultipleRawPrices = rawPrice && Array.isArray( rawPrice ) && rawPrice.length > 1;
 
-		if ( shouldUseDisplayPrice() && productDisplayPrice ) {
+		if ( productDisplayPrice && ! areThereMultipleRawPrices ) {
 			return createElement(
 				tagName,
 				{ className: classes },

--- a/client/my-sites/plan-price/index.tsx
+++ b/client/my-sites/plan-price/index.tsx
@@ -153,16 +153,91 @@ export class PlanPrice extends Component< PlanPriceProps & LocalizeProps > {
 export default localize( PlanPrice );
 
 export interface PlanPriceProps {
+	/**
+	 * Can be either a floating point price to display, or a pair of floating
+	 * point prices.
+	 *
+	 * If there are a pair of prices, they will be displayed as a range (eg:
+	 * '$5-$10').
+	 *
+	 * If either of the numbers is a 0, nothing will be rendered at all.
+	 *
+	 * If specified along with `productDisplayPrice`, this will be ignored unless
+	 * it is an array, in which case `productDisplayPrice` will be ignored.
+	 */
 	rawPrice?: number | [ number, number ];
+
+	/**
+	 * Adds the `is-original` CSS class.
+	 */
 	original?: boolean;
+
+	/**
+	 * Adds the `is-discounted` CSS class.
+	 */
 	discounted?: boolean;
+
+	/**
+	 * The currency code for the price.
+	 *
+	 * Ignored if `productDisplayPrice` is set and `rawPrice` is not an array.
+	 *
+	 * Defaults to `USD` if not set or if undefined, but if it is `null`, the
+	 * component will render nothing at all (if using `rawPrice`).
+	 */
 	currencyCode?: string | null;
+
+	/**
+	 * A string to add to the className of the component's output.
+	 */
 	className?: string;
+
+	/**
+	 * Displays a "Sale" banner over the price if set.
+	 *
+	 * Ignored if `productDisplayPrice` is set and `rawPrice` is not an array.
+	 * Also ignored if `displayFlatPrice` is set.
+	 */
 	isOnSale?: boolean;
+
+	/**
+	 * Text to display adjacent to the price referring to taxes.
+	 *
+	 * It is rendered inside the string '(+X tax)' where `X` is this prop.
+	 *
+	 * Ignored if `productDisplayPrice` is set and `rawPrice` is not an array.
+	 * Also ignored if `displayFlatPrice` is set.
+	 */
 	taxText?: string;
+
+	/**
+	 * Whether to display a "per month" label adjacent to the price.
+	 *
+	 * Ignored if `productDisplayPrice` is set and `rawPrice` is not an array.
+	 * Also ignored if `displayFlatPrice` is set.
+	 */
 	displayPerMonthNotation?: boolean;
+
+	/**
+	 * A pre-formatted price to display.
+	 *
+	 * Ignored if `rawPrice` is set and is an array.
+	 */
 	productDisplayPrice?: string;
+
+	/**
+	 * If set, the component will render a `span` instead of an `h4`.
+	 */
 	omitHeading?: boolean;
+
+	/**
+	 * If set, the component will render without separating the integer part of
+	 * the price from the decimal part of the price.
+	 *
+	 * If set, many of the other formatting options will be ignored.
+	 *
+	 * Ignored if `productDisplayPrice` is set and `rawPrice` is not an array.
+	 */
 	displayFlatPrice?: boolean;
 }
 

--- a/client/my-sites/plan-price/index.tsx
+++ b/client/my-sites/plan-price/index.tsx
@@ -1,16 +1,17 @@
 import { getCurrencyObject } from '@automattic/format-currency';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
-import PropTypes from 'prop-types';
 import { Component, createElement } from 'react';
 import Badge from 'calypso/components/badge';
+import type { CurrencyObject } from '@automattic/format-currency';
+import type { LocalizeProps } from 'i18n-calypso';
 
 import './style.scss';
 
-export class PlanPrice extends Component {
+export class PlanPrice extends Component< PlanPriceProps & LocalizeProps > {
 	render() {
 		const {
-			currencyCode,
+			currencyCode = 'USD',
 			rawPrice,
 			original,
 			discounted,
@@ -45,7 +46,7 @@ export class PlanPrice extends Component {
 			return true;
 		};
 
-		if ( shouldUseDisplayPrice() ) {
+		if ( shouldUseDisplayPrice() && productDisplayPrice ) {
 			return createElement(
 				tagName,
 				{ className: classes },
@@ -69,17 +70,16 @@ export class PlanPrice extends Component {
 			return null;
 		}
 
-		const priceRange = rawPriceRange.map( ( item ) => {
+		const priceRange: PriceRangeData[] = rawPriceRange.map( ( item ) => {
 			return {
 				price: getCurrencyObject( item, currencyCode ),
 				raw: item,
 			};
 		} );
 
-		const renderPrice = ( priceObj ) => {
-			const fraction = priceObj.raw - priceObj.price.integer > 0 && priceObj.price.fraction;
-			if ( fraction ) {
-				return `${ priceObj.price.integer }${ fraction }`;
+		const renderPrice = ( priceObj: PriceRangeData ) => {
+			if ( ! Number.isInteger( priceObj.raw ) ) {
+				return `${ priceObj.price.integer }${ priceObj.price.fraction }`;
 			}
 			return priceObj.price.integer;
 		};
@@ -101,11 +101,8 @@ export class PlanPrice extends Component {
 			);
 		}
 
-		const renderPriceHtml = ( priceObj ) => {
-			let priceInteger = priceObj.price.integer;
-			// In some currencies like IDR, a dot is used to separate group of threes.
-			// Remove it so that it's not confused to be a decimal point by the subtraction operator.
-			priceInteger = priceInteger.replace( /[,.]/g, '' );
+		const renderPriceHtml = ( priceObj: PriceRangeData ) => {
+			const hasFraction = ! Number.isInteger( priceObj.raw );
 
 			if ( is2023OnboardingPricingGrid ) {
 				return (
@@ -121,9 +118,7 @@ export class PlanPrice extends Component {
 			return (
 				<>
 					<span className="plan-price__integer">{ priceObj.price.integer }</span>
-					<sup className="plan-price__fraction">
-						{ priceObj.raw - priceInteger > 0 && priceObj.price.fraction }
-					</sup>
+					<sup className="plan-price__fraction">{ hasFraction && priceObj.price.fraction }</sup>
 				</>
 			);
 		};
@@ -168,26 +163,21 @@ export class PlanPrice extends Component {
 
 export default localize( PlanPrice );
 
-PlanPrice.propTypes = {
-	rawPrice: PropTypes.oneOfType( [ PropTypes.number, PropTypes.arrayOf( PropTypes.number ) ] ),
-	original: PropTypes.bool,
-	discounted: PropTypes.bool,
-	currencyCode: PropTypes.string,
-	className: PropTypes.string,
-	isOnSale: PropTypes.bool,
-	taxText: PropTypes.string,
-	translate: PropTypes.func.isRequired,
-	displayPerMonthNotation: PropTypes.bool,
-	currencyFormatOptions: PropTypes.object,
-	productDisplayPrice: PropTypes.string,
-	omitHeading: PropTypes.bool,
-};
+export interface PlanPriceProps {
+	rawPrice?: number | [ number, number ];
+	original?: boolean;
+	discounted?: boolean;
+	currencyCode?: string | null;
+	className?: string;
+	isOnSale?: boolean;
+	taxText?: string;
+	displayPerMonthNotation?: boolean;
+	productDisplayPrice?: string;
+	omitHeading?: boolean;
+	displayFlatPrice?: boolean;
+}
 
-PlanPrice.defaultProps = {
-	currencyCode: 'USD',
-	original: false,
-	discounted: false,
-	className: '',
-	isOnSale: false,
-	displayPerMonthNotation: false,
-};
+interface PriceRangeData {
+	price: CurrencyObject;
+	raw: number;
+}

--- a/client/my-sites/plan-price/index.tsx
+++ b/client/my-sites/plan-price/index.tsx
@@ -97,9 +97,7 @@ export class PlanPrice extends Component< PlanPriceProps & LocalizeProps > {
 				return (
 					<div className="plan-price__integer-fraction">
 						<span className="plan-price__integer">{ priceObj.price.integer }</span>
-						<sup className="plan-price__fraction">
-							{ priceObj.raw - priceInteger > 0 && priceObj.price.fraction }
-						</sup>
+						<sup className="plan-price__fraction">{ hasFraction && priceObj.price.fraction }</sup>
 					</div>
 				);
 			}
@@ -239,6 +237,16 @@ export interface PlanPriceProps {
 	 * Ignored if `productDisplayPrice` is set and `rawPrice` is not an array.
 	 */
 	displayFlatPrice?: boolean;
+
+	/**
+	 * If true, this renders each price inside a `div` with the class
+	 * `plan-price__integer-fraction` but is otherwise identical to the output normally used by `rawPrice`.
+	 *
+	 * Ignored if `displayFlatPrice` is set.
+	 *
+	 * Ignored if `productDisplayPrice` is set and `rawPrice` is not an array.
+	 */
+	is2023OnboardingPricingGrid?: boolean;
 }
 
 interface PriceRangeData {

--- a/client/my-sites/plan-price/test/index.js
+++ b/client/my-sites/plan-price/test/index.js
@@ -76,12 +76,13 @@ describe( 'PlanPrice', () => {
 	} );
 
 	it( 'renders no decimal section when price is integer', () => {
-		render( <PlanPrice rawPrice={ 5.0 } currencyCode="IDR" /> );
-		expect( document.body ).toHaveTextContent( 'Rp5' );
+		render( <PlanPrice rawPrice={ 44700 } currencyCode="IDR" /> );
+		expect( document.body ).toHaveTextContent( 'Rp44.700' );
+		expect( document.body ).not.toHaveTextContent( 'Rp44.700,00' );
 	} );
 
 	it( 'renders a decimal section when price is not integer', () => {
-		render( <PlanPrice rawPrice={ 5.5 } currencyCode="IDR" /> );
-		expect( document.body ).toHaveTextContent( 'Rp5,50' );
+		render( <PlanPrice rawPrice={ 44700.5 } currencyCode="IDR" /> );
+		expect( document.body ).toHaveTextContent( 'Rp44.700,50' );
 	} );
 } );

--- a/client/my-sites/plan-price/test/index.js
+++ b/client/my-sites/plan-price/test/index.js
@@ -59,4 +59,29 @@ describe( 'PlanPrice', () => {
 		expect( document.body ).toHaveTextContent( '$5-10' );
 		expect( document.body ).not.toHaveTextContent( '$96.00' );
 	} );
+
+	it( 'renders a currency when set', () => {
+		render( <PlanPrice rawPrice={ 5.05 } currencyCode="EUR" /> );
+		expect( document.body ).toHaveTextContent( '€5,05' );
+	} );
+
+	it( 'renders USD currency when currency is undefined', () => {
+		render( <PlanPrice rawPrice={ 5.05 } currencyCode={ undefined } /> );
+		expect( document.body ).toHaveTextContent( '$5.05' );
+	} );
+
+	it( 'renders nothing when currency is null', () => {
+		render( <PlanPrice rawPrice={ 5.05 } currencyCode={ null } /> );
+		expect( document.body ).not.toHaveTextContent( '$5.05' );
+	} );
+
+	it( 'renders no decimal section when price is integer', () => {
+		render( <PlanPrice rawPrice={ 5.0 } currencyCode="IDR" /> );
+		expect( document.body ).toHaveTextContent( 'Rp5' );
+	} );
+
+	it( 'renders a decimal section when price is not integer', () => {
+		render( <PlanPrice rawPrice={ 5.5 } currencyCode="IDR" /> );
+		expect( document.body ).toHaveTextContent( 'Rp5,50' );
+	} );
 } );

--- a/client/my-sites/plans-comparison/plans-comparison-col-cta.tsx
+++ b/client/my-sites/plans-comparison/plans-comparison-col-cta.tsx
@@ -1,7 +1,6 @@
 import styled from '@emotion/styled';
 import PlanPrice from 'calypso/my-sites/plan-price';
 import type { Plan } from '@automattic/calypso-products';
-import type { translate } from 'i18n-calypso';
 
 interface Props {
 	currencyCode: string;
@@ -9,7 +8,6 @@ interface Props {
 	price?: number;
 	originalPrice?: number;
 	onClick?: ( productSlug: string ) => void;
-	translate: typeof translate;
 }
 
 const PriceContainer = styled.div`
@@ -37,7 +35,6 @@ export const PlansComparisonColCTA: React.FunctionComponent< Props > = ( {
 	price,
 	originalPrice,
 	children,
-	translate,
 } ) => {
 	const isDiscounted = typeof originalPrice === 'number';
 
@@ -50,25 +47,18 @@ export const PlansComparisonColCTA: React.FunctionComponent< Props > = ( {
 							currencyCode={ currencyCode }
 							rawPrice={ originalPrice }
 							displayFlatPrice={ true }
-							translate={ translate }
 							original
 						/>
 						<PlanPrice
 							currencyCode={ currencyCode }
 							displayFlatPrice={ true }
 							rawPrice={ price }
-							translate={ translate }
 							discounted
 						/>
 					</>
 				) }
 				{ ! isDiscounted && (
-					<PlanPrice
-						currencyCode={ currencyCode }
-						displayFlatPrice={ true }
-						rawPrice={ price }
-						translate={ translate }
-					/>
+					<PlanPrice currencyCode={ currencyCode } displayFlatPrice={ true } rawPrice={ price } />
 				) }
 			</PriceContainer>
 			<BillingTimeFrame>{ plan.getBillingTimeFrame() }</BillingTimeFrame>

--- a/client/my-sites/plans-comparison/plans-comparison.tsx
+++ b/client/my-sites/plans-comparison/plans-comparison.tsx
@@ -528,7 +528,6 @@ export const PlansComparison: React.FunctionComponent< Props > = ( {
 									currencyCode={ currencyCode }
 									price={ prices[ index ].price }
 									originalPrice={ prices[ index ].originalPrice }
-									translate={ translate }
 								>
 									{ selectedDomainConnection && <PlansDomainConnectionInfo plan={ plan } /> }
 									<PlansComparisonAction

--- a/client/my-sites/plans/jetpack-plans/product-store/pricing-breakdown/render-price.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/pricing-breakdown/render-price.tsx
@@ -2,7 +2,7 @@ import { useSelector } from 'react-redux';
 import PlanPrice from 'calypso/my-sites/plan-price';
 import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
 
-export const RenderPrice = ( { price }: { price: number | string } ) => {
+export const RenderPrice = ( { price }: { price: number } ) => {
 	const currencyCode = useSelector( getCurrentUserCurrencyCode ) || 'USD';
 
 	return price ? (

--- a/client/my-sites/plans/jetpack-plans/upsell/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/upsell/index.tsx
@@ -234,7 +234,7 @@ const JetpackUpsellPage: React.FC< Props > = ( {
 										<PlanPrice
 											className="jetpack-upsell__price"
 											rawPrice={ priceDelta }
-											currency={ currencyCode }
+											currencyCode={ currencyCode }
 										/>
 										<span className="jetpack-upsell__price-timeframe">
 											{ translate( '/month, paid yearly' ) }


### PR DESCRIPTION
#### Proposed Changes

This PR converts the `PlanPrice` component to TypeScript. It also improves one significant behavior of the component: displaying numbers in "strip-zeros" style.

PlanPrice renders most of its prices using the "strip-zeros" approach: if a price is an integer number, the number will be rendered without its decimal section. However, the way it does this is by trying to perform math on the _formatted_ version of the non-decimal section of a price (eg: `10.000,50` for 10,000.50 EUR); this version is a formatted string including spaces, grouping separators, etc. and will therefore often be challenging to use for math.

This change modifies the code to examine the _number_ version of the price instead to see if it contains non-zero decimal places, which should always be accurate regardless of currency or locale.

**Note:** Due to the added types, the TS conversion surfaced a subtle bug in `JetpackUpsellPage` (added in https://github.com/Automattic/wp-calypso/pull/63828) where the currency was always ignored. The bug is fixed by this PR.

#### Testing Instructions

Automated tests already cover this code and the component's output should be unchanged. To be sure, this PR adds additional tests that work with or without this PR (you can check yourself by reverting the changes to the file before running them).

Also, because there was previously no test for it (though this PR adds one), make sure that this doesn't break the fix to IDR applied in https://github.com/Automattic/wp-calypso/pull/71478, ie: that the Plans page does not display zeros for integer prices in currencies with a period (`.`) as the grouping separator:

<img width="489" alt="Screenshot 2023-01-05 at 6 23 34 PM" src="https://user-images.githubusercontent.com/2036909/210899095-41b9a280-4fbe-4a59-b0de-aded698349b0.png">
