### PR TITLE
Stats: Update Charts Empty State

### DIFF
--- a/client/my-sites/stats/stats-chart-tabs/index.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/index.jsx
@@ -15,6 +15,7 @@ import { requestChartCounts } from 'calypso/state/stats/chart-tabs/actions';
 import { QUERY_FIELDS } from 'calypso/state/stats/chart-tabs/constants';
 import { getCountRecords, getLoadingTabs } from 'calypso/state/stats/chart-tabs/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import StatsEmptyState from '../stats-empty-state';
 import StatsModulePlaceholder from '../stats-module/placeholder';
 import StatTabs from '../stats-tabs';
 import { buildChartData, getQueryDate } from './utility';
@@ -111,7 +112,9 @@ class StatModuleChartTabs extends Component {
 				/>
 				{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace */ }
 				<StatsModulePlaceholder className="is-chart" isLoading={ isActiveTabLoading } />
-				<Chart barClick={ this.props.barClick } data={ this.props.chartData } minBarWidth={ 35 } />
+				<Chart barClick={ this.props.barClick } data={ this.props.chartData } minBarWidth={ 35 }>
+					<StatsEmptyState stateType={ this.props.activeTab && this.props.activeTab.label } />
+				</Chart>
 				<StatTabs
 					data={ this.props.counts }
 					tabs={ this.props.charts }

--- a/client/my-sites/stats/stats-empty-state/index.tsx
+++ b/client/my-sites/stats/stats-empty-state/index.tsx
@@ -1,0 +1,33 @@
+import { Card } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+
+import './style.scss';
+
+interface Props {
+	stateType: string;
+}
+
+export default function StatsEmptyState( { stateType }: Props ) {
+	const _stateType = String( stateType ).toLowerCase().trim();
+	const translate = useTranslate();
+
+	return (
+		<div className="stats__empty-state">
+			<Card className="empty-state-card">
+				<div className="empty-state-card-heading">
+					{ translate( 'No %(_stateType)s in this period', {
+						args: { _stateType },
+					} ) }
+				</div>
+				<p className="empty-state-card-info">
+					{ translate(
+						'There were no %(_stateType)s recorded during the selected time period. Try selecting a different time range.',
+						{
+							args: { _stateType },
+						}
+					) }
+				</p>
+			</Card>
+		</div>
+	);
+}

--- a/client/my-sites/stats/stats-empty-state/style.scss
+++ b/client/my-sites/stats/stats-empty-state/style.scss
@@ -1,0 +1,30 @@
+@import "@automattic/typography/styles/variables";
+
+$font-sf-pro-display: "SF Pro Display", $sans;
+$font-sf-pro-text: "SF Pro Text", $sans;
+
+.stats__empty-state {
+	.empty-state-card {
+		padding: 24px;
+		min-width: 320px;
+		margin: 0;
+		background-color: rgba(255, 255, 255, 0.85);
+	}
+
+	.empty-state-card-heading {
+		font-family: $font-sf-pro-display;
+		font-size: $font-title-small;
+		line-height: 26px;
+		font-weight: 500;
+		color: var(--color-neutral-100);
+	}
+
+	.empty-state-card-info {
+		margin-top: 16px;
+		font-family: $font-sf-pro-text;
+		font-size: $font-body-small;
+		line-height: 20px;
+		letter-spacing: -0.24px;
+		color: var(--color-neutral-80);
+	}
+}

--- a/client/my-sites/stats/stats-summary/index.jsx
+++ b/client/my-sites/stats/stats-summary/index.jsx
@@ -9,6 +9,7 @@ import { Component } from 'react';
 import { connect } from 'react-redux';
 import ElementChart from 'calypso/components/chart';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
+import StatsEmptyState from '../stats-empty-state';
 import StatsModulePlaceholder from '../stats-module/placeholder';
 import StatsTabs from '../stats-tabs';
 import StatsTab from '../stats-tabs/tab';
@@ -65,6 +66,10 @@ class StatsSummaryChart extends Component {
 		return icon;
 	}
 
+	renderEmptyState() {
+		return <StatsEmptyState stateType={ this.props.tabLabel } />;
+	}
+
 	buildChartData() {
 		const { data, chartType, numberFormat, sectionClass, selected, tabLabel } = this.props;
 
@@ -117,14 +122,18 @@ class StatsSummaryChart extends Component {
 				className={ classNames( 'stats-module', 'is-summary-chart', { 'is-loading': isLoading } ) }
 			>
 				<StatsModulePlaceholder className="is-chart" isLoading={ isLoading } />
-				<ElementChart data={ this.buildChartData() } barClick={ this.barClick } />
+				<ElementChart data={ this.buildChartData() } barClick={ this.barClick }>
+					{ this.renderEmptyState() }
+				</ElementChart>
 			</div>
 		) : (
 			<Card
 				className={ classNames( 'stats-module', 'is-summary-chart', { 'is-loading': isLoading } ) }
 			>
 				<StatsModulePlaceholder className="is-chart" isLoading={ isLoading } />
-				<ElementChart data={ this.buildChartData() } barClick={ this.barClick } />
+				<ElementChart data={ this.buildChartData() } barClick={ this.barClick }>
+					{ this.renderEmptyState() }
+				</ElementChart>
 				<StatsTabs>
 					<StatsTab { ...tabOptions } />
 				</StatsTabs>

--- a/client/my-sites/stats/wordads-chart-tabs/index.jsx
+++ b/client/my-sites/stats/wordads-chart-tabs/index.jsx
@@ -16,6 +16,7 @@ import {
 } from 'calypso/state/stats/lists/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { formatDate, getQueryDate } from '../stats-chart-tabs/utility';
+import StatsEmptyState from '../stats-empty-state';
 import StatsModulePlaceholder from '../stats-module/placeholder';
 import StatTabs from '../stats-tabs';
 
@@ -131,7 +132,7 @@ class WordAdsChartTabs extends Component {
 	}
 
 	render() {
-		const { siteId, query, isDataLoading } = this.props;
+		const { siteId, query, isDataLoading, activeTab } = this.props;
 		const classes = [
 			'is-chart-tabs',
 			{
@@ -146,11 +147,9 @@ class WordAdsChartTabs extends Component {
 				<div className={ classNames( ...classes ) }>
 					{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace */ }
 					<StatsModulePlaceholder className="is-chart" isLoading={ isDataLoading } />
-					<Chart
-						barClick={ this.props.barClick }
-						data={ this.buildChartData() }
-						minBarWidth={ 35 }
-					/>
+					<Chart barClick={ this.props.barClick } data={ this.buildChartData() } minBarWidth={ 35 }>
+						<StatsEmptyState stateType={ activeTab && activeTab.label } />
+					</Chart>
 					<StatTabs
 						data={ this.props.data }
 						tabs={ this.props.charts }

--- a/client/my-sites/store/app/store-stats/store-stats-chart/index.js
+++ b/client/my-sites/store/app/store-stats/store-stats-chart/index.js
@@ -7,6 +7,7 @@ import { Component } from 'react';
 import ElementChart from 'calypso/components/chart';
 import Legend from 'calypso/components/chart/legend';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
+import StatsEmptyState from '../../../../stats/stats-empty-state';
 import { recordTrack } from '../../../lib/analytics';
 import { UNITS } from '../constants';
 import { getWidgetPath, formatValue } from '../utils';
@@ -165,7 +166,9 @@ class StoreStatsChart extends Component {
 					data={ chartData }
 					barClick={ this.barClick }
 					minBarWidth={ 35 }
-				/>
+				>
+					<StatsEmptyState stateType={ selectedTab.label } />
+				</ElementChart>
 				{ ! isLoading &&
 					renderTabs( {
 						chartData,


### PR DESCRIPTION
#### Proposed Changes

- Create a new component called StatsEmptyState
- Replace the StatsChartTabs default empty state with the new component
- Replace the StatsSummary default empty state with the new component
- Update the Store page's Chart to use the new empty state UI
- Update the Ads page's Chart to use the new empty state UI

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure you have a site with no data to be shown on Stats
* Ensure the empty state on the chart on the **Traffic** tab looks as described on #71021 
* Try it on different screen sizes
* Navigate between the charts tabs (view, visitors, likes, and comments) and check if the text with the empty state changes
* Enable the Store tab and do the same test as described above for it 
* Enable the Ads tab and do the same test as described above for it

#### Screenshot

Traffic page
![image](https://user-images.githubusercontent.com/6406071/210914521-9cb2802e-9799-42a6-aafc-8a77586bdb3f.png)

Post detail
![image](https://user-images.githubusercontent.com/6406071/211121856-d2d97e14-b30b-4886-ad53-289d6639926d.png)

Store page
![image](https://user-images.githubusercontent.com/6406071/211406341-476fa3b3-06cc-48a8-94e1-aaf6842f2713.png)

Ads page
<img width="1265" alt="image" src="https://user-images.githubusercontent.com/6406071/211406251-628a309d-fa64-4038-82a9-827598718ca7.png">

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #71021 
