### PR TITLE
Block Renderer: Support rendering customized site info

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -2,7 +2,7 @@ import { isEnabled } from '@automattic/calypso-config';
 import { StepContainer } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
-import { useState, useRef, useEffect } from 'react';
+import { useState, useRef, useEffect, useMemo } from 'react';
 import { useDispatch as useReduxDispatch } from 'react-redux';
 import AsyncLoad from 'calypso/components/async-load';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -14,6 +14,7 @@ import { useSiteSlugParam } from '../../../../hooks/use-site-slug-param';
 import { useThemeDetails } from '../../../../hooks/use-theme-details';
 import { SITE_STORE, ONBOARD_STORE } from '../../../../stores';
 import { recordSelectedDesign } from '../../analytics/record-design';
+import { SITE_TAGLINE } from './constants';
 import PatternLayout from './pattern-layout';
 import PatternSelectorLoader from './pattern-selector-loader';
 import { useAllPatterns } from './patterns-data';
@@ -54,6 +55,14 @@ const PatternAssembler: Step = ( { navigation, flow } ) => {
 		footer,
 		activePosition,
 	};
+
+	const siteInfo = useMemo(
+		() => ( {
+			title: site?.title,
+			tagline: site?.description || SITE_TAGLINE,
+		} ),
+		[ site?.title, site?.description ]
+	);
 
 	useEffect( () => {
 		// Require to start the flow from the first step
@@ -383,6 +392,7 @@ const PatternAssembler: Step = ( { navigation, flow } ) => {
 							siteId={ themeDemoSiteSlug }
 							stylesheet={ selectedDesign?.recipe?.stylesheet }
 							patternIds={ allPatterns.map( ( pattern ) => encodePatternId( pattern.id ) ) }
+							siteInfo={ siteInfo }
 						>
 							{ stepContent }
 						</AsyncLoad>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -2,7 +2,7 @@ import { isEnabled } from '@automattic/calypso-config';
 import { StepContainer } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
-import { useState, useRef, useEffect, useMemo } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import { useDispatch as useReduxDispatch } from 'react-redux';
 import AsyncLoad from 'calypso/components/async-load';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -56,13 +56,10 @@ const PatternAssembler: Step = ( { navigation, flow } ) => {
 		activePosition,
 	};
 
-	const siteInfo = useMemo(
-		() => ( {
-			title: site?.title,
-			tagline: site?.description || SITE_TAGLINE,
-		} ),
-		[ site?.title, site?.description ]
-	);
+	const siteInfo = {
+		title: site?.name,
+		tagline: site?.description || SITE_TAGLINE,
+	};
 
 	useEffect( () => {
 		// Require to start the flow from the first step

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-assembler-container.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-assembler-container.tsx
@@ -1,13 +1,21 @@
 import { BlockRendererProvider, PatternsRendererProvider } from '@automattic/block-renderer';
+import type { SiteInfo } from '@automattic/block-renderer';
 
 interface Props {
 	siteId: number | string;
 	stylesheet: string;
 	patternIds: string[];
 	children: JSX.Element;
+	siteInfo: SiteInfo;
 }
 
-const PatternAssemblerContainer = ( { siteId, stylesheet, patternIds, children }: Props ) => (
+const PatternAssemblerContainer = ( {
+	siteId,
+	stylesheet,
+	patternIds,
+	children,
+	siteInfo,
+}: Props ) => (
 	<BlockRendererProvider siteId={ siteId } stylesheet={ stylesheet }>
 		<PatternsRendererProvider
 			// Use theme demo site to render the site-related blocks for now.
@@ -15,6 +23,7 @@ const PatternAssemblerContainer = ( { siteId, stylesheet, patternIds, children }
 			siteId={ siteId }
 			stylesheet={ stylesheet }
 			patternIds={ patternIds }
+			siteInfo={ siteInfo }
 		>
 			{ children }
 		</PatternsRendererProvider>

--- a/packages/block-renderer/src/components/patterns-renderer-provider.tsx
+++ b/packages/block-renderer/src/components/patterns-renderer-provider.tsx
@@ -1,19 +1,28 @@
 import React, { useEffect, useMemo } from 'react';
 import useRenderedPatterns from '../hooks/use-rendered-patterns';
 import PatternsRendererContext from './patterns-renderer-context';
+import type { SiteInfo } from '../types';
 
 interface Props {
 	siteId: number | string;
 	stylesheet?: string;
 	patternIds: string[];
 	children: JSX.Element;
+	siteInfo: SiteInfo;
 }
 
-const PatternsRendererProvider = ( { siteId, stylesheet = '', patternIds, children }: Props ) => {
+const PatternsRendererProvider = ( {
+	siteId,
+	stylesheet = '',
+	patternIds,
+	children,
+	siteInfo = {},
+}: Props ) => {
 	const { data, isLoading, hasNextPage, fetchNextPage } = useRenderedPatterns(
 		siteId,
 		stylesheet,
-		patternIds
+		patternIds,
+		siteInfo
 	);
 
 	const renderedPatterns = useMemo(

--- a/packages/block-renderer/src/hooks/use-rendered-patterns.ts
+++ b/packages/block-renderer/src/hooks/use-rendered-patterns.ts
@@ -1,6 +1,6 @@
 import { useInfiniteQuery, UseQueryOptions } from 'react-query';
 import wpcomRequest from 'wpcom-proxy-request';
-import type { RenderedPatterns } from '../types';
+import type { RenderedPatterns, SiteInfo } from '../types';
 
 const PAGE_SIZE = 20;
 
@@ -10,13 +10,23 @@ const fetchRenderedPatterns = (
 	siteId: number | string,
 	stylesheet: string,
 	patternIds: string[],
+	siteInfo: SiteInfo,
 	page: number
 ): Promise< RenderedPatterns > => {
 	const pattern_ids = patternIds.slice( ( page - 1 ) * PAGE_SIZE, page * PAGE_SIZE ).join( ',' );
+	const { title, tagline } = siteInfo;
 	const params = new URLSearchParams( {
 		stylesheet,
 		pattern_ids,
 	} );
+
+	if ( title ) {
+		params.set( 'site_title', title );
+	}
+
+	if ( tagline ) {
+		params.set( 'site_tagline', tagline );
+	}
 
 	return wpcomRequest( {
 		apiNamespace: 'wpcom/v2',
@@ -29,13 +39,15 @@ const useRenderedPatterns = (
 	siteId: number | string,
 	stylesheet: string,
 	patternIds: string[],
+	siteInfo: SiteInfo = {},
 	{ staleTime = HOUR_IN_MS, refetchOnMount = true }: UseQueryOptions = {}
 ) => {
 	// If we query too many patterns at once, the endpoint will be very slow.
 	// Hence, do local pagination to ensure the performance.
 	return useInfiniteQuery(
-		[ siteId, stylesheet, 'block-renderer/patterns/render', patternIds ],
-		( { pageParam = 1 } ) => fetchRenderedPatterns( siteId, stylesheet, patternIds, pageParam ),
+		[ siteId, stylesheet, 'block-renderer/patterns/render', patternIds, siteInfo ],
+		( { pageParam = 1 } ) =>
+			fetchRenderedPatterns( siteId, stylesheet, patternIds, siteInfo, pageParam ),
 		{
 			getNextPageParam: ( lastPage, allPages ) => {
 				if ( allPages.length * PAGE_SIZE >= patternIds.length ) {

--- a/packages/block-renderer/src/index.tsx
+++ b/packages/block-renderer/src/index.tsx
@@ -1,1 +1,2 @@
 export * from './components';
+export * from './types';

--- a/packages/block-renderer/src/types.ts
+++ b/packages/block-renderer/src/types.ts
@@ -14,3 +14,8 @@ export type RenderedPattern = {
 export type RenderedPatterns = {
 	[ key: string ]: RenderedPattern;
 };
+
+export type SiteInfo = {
+	title?: string;
+	tagline?: string;
+};


### PR DESCRIPTION
#### Proposed Changes

* Referring to pbxlJb-39t-p2, we want to support the customized site info for the preview of the patterns. So, this PR proposes to send the customized site title and tagline to the `/block-renderer/patterns/render` endpoint to control the site title and tagline in the preview of patterns

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply D97204-code to your sandbox
* Go to `/setup?siteSlug=<your_site>&flags=pattern-assembler/client-side-render`
* Click the "Continue" button until you land on the Design Picker step
* Scroll to the bottom and select the Blank Canvas CTA
* When you're in the Pattern Assembler step, verify the rendered site title and tagline are correct.
  * The default site title for the newly created site is "Site Title"
  * The default site tagline is "Site Tagline"

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to pbxlJb-39t-p2