### PR TITLE
Add user came through info to happy chat

### DIFF
--- a/apps/happychat/src/getUserInfo.ts
+++ b/apps/happychat/src/getUserInfo.ts
@@ -1,3 +1,6 @@
+import { isWcMobileApp } from 'calypso/lib/mobile-app';
+import { getQueryArgs } from 'calypso/lib/query-args';
+
 type UserInfo = {
 	siteUrl: string;
 	siteId: number;
@@ -17,7 +20,21 @@ type UserInfo = {
 		region: string;
 		city: string;
 	};
+	cameThrough: string | null;
 };
+
+/**
+ * Returns the source where the user came from.
+ */
+function getUserCameThrough() {
+	const queryArgs = getQueryArgs();
+	const isWCCOM = queryArgs?.ref === 'woocommerce-com';
+
+	if ( isWCCOM ) {
+		return isWcMobileApp() ? 'Store setup on Woo mobile app' : 'Store setup on Woo browser';
+	}
+	return null;
+}
 
 export function getUserInfo(
 	message: string,
@@ -42,6 +59,7 @@ export function getUserInfo(
 		// add user agent
 		userAgent: window.navigator.userAgent,
 		geoLocation,
+		cameThrough: getUserCameThrough(),
 	};
 	return info;
 }

--- a/apps/happychat/src/getUserInfo.ts
+++ b/apps/happychat/src/getUserInfo.ts
@@ -31,7 +31,7 @@ function getUserCameThrough() {
 	const isWCCOM = queryArgs?.ref === 'woocommerce-com';
 
 	if ( isWCCOM ) {
-		return isWcMobileApp() ? 'Store setup on Woo mobile app' : 'Store setup on Woo browser';
+		return isWcMobileApp() ? 'store setup on Woo mobile app' : 'store setup on Woo browser';
 	}
 	return null;
 }

--- a/packages/help-center/src/components/help-center-inline-chat.tsx
+++ b/packages/help-center/src/components/help-center-inline-chat.tsx
@@ -91,9 +91,12 @@ const InlineChat: React.FC = () => {
 	const { search } = useLocation();
 	const params = new URLSearchParams( search );
 	const session = params.get( 'session' ) === 'continued' ? 'continued' : 'new';
+	const ref = new URLSearchParams( window.location.search ).get( 'ref' ) || '';
 
 	return (
-		<PersistentIframe src={ `https://widgets.wp.com/calypso-happychat/?session=${ session }` } />
+		<PersistentIframe
+			src={ `https://widgets.wp.com/calypso-happychat/?session=${ session }&ref=${ ref }` }
+		/>
 	);
 };
 

--- a/packages/help-center/src/components/help-center-inline-chat.tsx
+++ b/packages/help-center/src/components/help-center-inline-chat.tsx
@@ -91,6 +91,8 @@ const InlineChat: React.FC = () => {
 	const { search } = useLocation();
 	const params = new URLSearchParams( search );
 	const session = params.get( 'session' ) === 'continued' ? 'continued' : 'new';
+	// "ref" is used to track where the user came from so we can show the right message
+	// See happychat/getUserInfo for more info.
 	const ref = new URLSearchParams( window.location.search ).get( 'ref' ) || '';
 
 	return (


### PR DESCRIPTION
#### Proposed Changes

* Add `cameThrough` field to happychat `getUserInfo`

We want to add WooCommerce.com context to Happychat.

1. When requested from mobile app, `Customer came through store setup on Woo mobile app`
2. When requested via browser (applies to all browsers including desktop or mobile), `Customer came through store setup on Woo browser`


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Make sure you're logged in with your WP account
* Follow step 1 - step 4  instructions in pebzTe-sj-p2  & enable proxy
* Set up `happychat-hud` local env (Follow the instructions in **Getting started** section of happychat-hud's README.md)
* Check out `happychat-hud` project to `add/user-came-through-info` branch https://github.com/Automattic/happychat-hud/pull/1257
* Start a local HUB server
* Log in to local HUD
* Make sure to check the "skills" (WordPress.com+Support) in HUD and set your status to "All Chat"
* Go to http://calypso.localhost:3000/checkout/fwfw8dotblog.wordpress.com?signup=1&ref=woocommerce-com
* Click `Ask a Happiness Engineer`
* Click `Still need help?`
* Observe that `Using HappyChat staging` text is displayed under the Live Chat option 
* Start a chat
* You should see a new chat in HUD
* Observe that message contains `Came through store setup on Woo browser`

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

![Screen Shot 2023-01-06 at 16 06 43](https://user-images.githubusercontent.com/4344253/210958772-5a54fd97-d173-48b3-9deb-c8f70c3684a6.png)

![Screen Shot 2023-01-06 at 18 02 33](https://user-images.githubusercontent.com/4344253/210977988-eda181c8-078f-499c-8375-3bad095fc4c7.png)

Related to  https://github.com/woocommerce/team-ghidorah/issues/139

