### PR TITLE
Revert 71583 update/pricing grid launch to en

### DIFF
--- a/client/my-sites/plan-features-2023-grid/header-price.jsx
+++ b/client/my-sites/plan-features-2023-grid/header-price.jsx
@@ -8,7 +8,7 @@ const PlanFeatures2023GridHeaderPrice = ( {
 	discountPrice,
 	currencyCode,
 	rawPrice,
-	isOnboarding2023PricingGrid,
+	is2023OnboardingPricingGrid,
 } ) => {
 	if ( isWpcomEnterpriseGridPlan( planName ) ) {
 		return null;
@@ -23,14 +23,14 @@ const PlanFeatures2023GridHeaderPrice = ( {
 							currencyCode={ currencyCode }
 							rawPrice={ rawPrice }
 							displayPerMonthNotation={ false }
-							isOnboarding2023PricingGrid={ isOnboarding2023PricingGrid }
+							is2023OnboardingPricingGrid={ is2023OnboardingPricingGrid }
 							original
 						/>
 						<PlanPrice
 							currencyCode={ currencyCode }
 							rawPrice={ discountPrice }
 							displayPerMonthNotation={ false }
-							isOnboarding2023PricingGrid={ isOnboarding2023PricingGrid }
+							is2023OnboardingPricingGrid={ is2023OnboardingPricingGrid }
 							discounted
 						/>
 					</div>
@@ -41,7 +41,7 @@ const PlanFeatures2023GridHeaderPrice = ( {
 					currencyCode={ currencyCode }
 					rawPrice={ rawPrice }
 					displayPerMonthNotation={ false }
-					isOnboarding2023PricingGrid={ isOnboarding2023PricingGrid }
+					is2023OnboardingPricingGrid={ is2023OnboardingPricingGrid }
 				/>
 			) }
 		</div>
@@ -53,7 +53,7 @@ PlanFeatures2023GridHeaderPrice.propTypes = {
 	discountPrice: PropTypes.number,
 	currencyCode: PropTypes.string,
 	rawPrice: PropTypes.number,
-	isOnboarding2023PricingGrid: PropTypes.bool,
+	is2023OnboardingPricingGrid: PropTypes.bool,
 };
 
 export default localize( PlanFeatures2023GridHeaderPrice );

--- a/client/my-sites/plan-features-2023-grid/index.jsx
+++ b/client/my-sites/plan-features-2023-grid/index.jsx
@@ -227,7 +227,7 @@ export class PlanFeatures2023Grid extends Component {
 	}
 
 	renderPlanPrice( planPropertiesObj, { isMobile } = {} ) {
-		const { isReskinned, isOnboarding2023PricingGrid } = this.props;
+		const { isReskinned, is2023OnboardingPricingGrid } = this.props;
 
 		return planPropertiesObj.map( ( properties ) => {
 			const { currencyCode, discountPrice, planName, rawPrice } = properties;
@@ -242,7 +242,7 @@ export class PlanFeatures2023Grid extends Component {
 						discountPrice={ discountPrice }
 						rawPrice={ rawPrice }
 						planName={ planName }
-						isOnboarding2023PricingGrid={ isOnboarding2023PricingGrid }
+						is2023OnboardingPricingGrid={ is2023OnboardingPricingGrid }
 					/>
 				</Container>
 			);
@@ -544,7 +544,7 @@ PlanFeatures2023Grid.defaultProps = {
 /* eslint-disable wpcalypso/redux-no-bound-selectors */
 export default connect(
 	( state, ownProps ) => {
-		const { placeholder, plans, visiblePlans } = ownProps;
+		const { placeholder, plans, isLandingPage, visiblePlans } = ownProps;
 
 		let planProperties = plans.map( ( plan ) => {
 			let isPlaceholder = false;
@@ -643,6 +643,7 @@ export default connect(
 				discountPrice,
 				features: planFeatures,
 				jpFeatures: jetpackFeatures,
+				isLandingPage,
 				isPlaceholder,
 				planConstantObj,
 				planName: plan,

--- a/client/my-sites/plan-price/index.jsx
+++ b/client/my-sites/plan-price/index.jsx
@@ -22,7 +22,7 @@ export class PlanPrice extends Component {
 			taxText,
 			translate,
 			omitHeading,
-			isOnboarding2023PricingGrid,
+			is2023OnboardingPricingGrid,
 		} = this.props;
 
 		const classes = classNames( 'plan-price', className, {
@@ -107,7 +107,7 @@ export class PlanPrice extends Component {
 			// Remove it so that it's not confused to be a decimal point by the subtraction operator.
 			priceInteger = priceInteger.replace( /[,.]/g, '' );
 
-			if ( isOnboarding2023PricingGrid ) {
+			if ( is2023OnboardingPricingGrid ) {
 				return (
 					<div className="plan-price__integer-fraction">
 						<span className="plan-price__integer">{ priceObj.price.integer }</span>

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -114,6 +114,16 @@ export function generateFlows( {
 			showRecaptcha: true,
 		},
 		{
+			name: 'onboarding-2023-pricing-grid',
+			steps: isEnabled( 'signup/professional-email-step' )
+				? [ 'user', 'domains', 'emails', 'plans' ]
+				: [ 'user', 'domains', 'plans' ],
+			destination: getSignupDestination,
+			description: 'Abridged version of the onboarding flow. Read more in https://wp.me/pau2Xa-Vs.',
+			lastModified: '2020-12-10',
+			showRecaptcha: true,
+		},
+		{
 			name: 'newsletter',
 			steps: [ 'domains', 'plans-newsletter' ],
 			destination: ( dependencies ) =>

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -6,7 +6,6 @@ import {
 } from '@automattic/calypso-products';
 import { isBlankCanvasDesign } from '@automattic/design-picker';
 import { isNewsletterOrLinkInBioFlow, LINK_IN_BIO_TLD_FLOW } from '@automattic/onboarding';
-import classNames from 'classnames';
 import debugModule from 'debug';
 import {
 	clone,
@@ -775,13 +774,12 @@ class Signup extends Component {
 
 		// Hide the free option in the signup flow
 		const selectedHideFreePlan = get( this.props, 'signupDependencies.shouldHideFreePlan', false );
-		const isOnboarding2023PricingGrid = config( 'english_locales' ).includes(
-			this.props.localeSlug
-		);
 
-		const hideFreePlan = isOnboarding2023PricingGrid
-			? false
-			: planWithDomain || this.props.isDomainOnlySite || selectedHideFreePlan;
+		const hideFreePlan =
+			config.isEnabled( 'onboarding/2023-pricing-grid' ) &&
+			this.props.flowName === 'onboarding-2023-pricing-grid'
+				? false
+				: planWithDomain || this.props.isDomainOnlySite || selectedHideFreePlan;
 		const shouldRenderLocaleSuggestions = 0 === this.getPositionInFlow() && ! this.props.isLoggedIn;
 
 		let propsForCurrentStep = propsFromConfig;
@@ -820,7 +818,6 @@ class Signup extends Component {
 							hideFreePlan={ hideFreePlan }
 							isReskinned={ isReskinned }
 							queryParams={ this.getCurrentFlowSupportedQueryParams() }
-							isOnboarding2023PricingGrid={ isOnboarding2023PricingGrid }
 							{ ...propsForCurrentStep }
 						/>
 					) }
@@ -876,16 +873,10 @@ class Signup extends Component {
 		}
 
 		const isReskinned = isReskinnedFlow( this.props.flowName );
-		const isOnboarding2023PricingGrid = config( 'english_locales' ).includes(
-			this.props.localeSlug
-		);
-		const classes = classNames( 'signup', `is-${ kebabCase( this.props.flowName ) }`, {
-			'is-onboarding-2023-pricing-grid': isOnboarding2023PricingGrid,
-		} );
 
 		return (
 			<>
-				<div className={ classes }>
+				<div className={ `signup is-${ kebabCase( this.props.flowName ) }` }>
 					<DocumentHead title={ this.props.pageTitle } />
 					{ ! isP2Flow( this.props.flowName ) && (
 						<SignupHeader

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import {
 	planHasFeature,
 	FEATURE_UPLOAD_THEMES_PLUGINS,
@@ -193,7 +194,6 @@ export class PlansStep extends Component {
 			isInVerticalScrollingPlansExperiment,
 			isReskinned,
 			eligibleForProPlan,
-			isOnboarding2023PricingGrid,
 		} = this.props;
 
 		let errorDisplay;
@@ -257,7 +257,6 @@ export class PlansStep extends Component {
 					isInVerticalScrollingPlansExperiment={ isInVerticalScrollingPlansExperiment }
 					shouldShowPlansFeatureComparison={ this.state.isDesktop } // Show feature comparison layout in signup flow and desktop resolutions
 					isReskinned={ isReskinned }
-					isOnboarding2023PricingGrid={ isOnboarding2023PricingGrid }
 				/>
 			</div>
 		);
@@ -476,7 +475,7 @@ export const isDotBlogDomainRegistration = ( domainItem ) => {
 export default connect(
 	(
 		state,
-		{ path, signupDependencies: { siteSlug, domainItem, plans_reorder_abtest_variation } }
+		{ path, flowName, signupDependencies: { siteSlug, domainItem, plans_reorder_abtest_variation } }
 	) => ( {
 		// Blogger plan is only available if user chose either a free domain or a .blog domain registration
 		disableBloggerPlanWithNonBlogDomain:
@@ -497,6 +496,8 @@ export default connect(
 		isInVerticalScrollingPlansExperiment: true,
 		plansLoaded: Boolean( getPlanSlug( state, getPlan( PLAN_FREE )?.getProductId() || 0 ) ),
 		eligibleForProPlan: isEligibleForProPlan( state, getSiteBySlug( state, siteSlug )?.ID ),
+		isOnboarding2023PricingGrid:
+			isEnabled( 'onboarding/2023-pricing-grid' ) && flowName === 'onboarding-2023-pricing-grid',
 	} ),
 	{ recordTracksEvent, saveSignupStep, submitSignupStep, errorNotice }
 )( localize( PlansStep ) );


### PR DESCRIPTION
#### Proposed Changes

This PR is a direct revert of https://github.com/Automattic/wp-calypso/pull/71583, in attempt to let us merge https://github.com/Automattic/wp-calypso/pull/71378 safely without exposing the new pricing grid to the users. 

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

It's just a direct revert, so it should be good to go once all the CI tests pass.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
