### PR TITLE
Stats: Refactor navigation arrows into a shared component.

### DIFF
--- a/client/my-sites/stats/annual-highlights-section/style.scss
+++ b/client/my-sites/stats/annual-highlights-section/style.scss
@@ -1,7 +1,7 @@
 @import "@automattic/typography/styles/variables";
 
 .highlight-year-navigation {
-	.arrow-navigation {
+	.stats-navigation-arrows {
 		margin: 0 0 16px;
 	}
 }

--- a/client/my-sites/stats/annual-highlights-section/style.scss
+++ b/client/my-sites/stats/annual-highlights-section/style.scss
@@ -1,10 +1,11 @@
 @import "@automattic/typography/styles/variables";
+@import "@automattic/components/src/highlight-cards/variables.scss";
 
 .highlight-year-navigation {
 	.stats-navigation-arrows {
 		margin: 0 0 16px;
 
-		@media ( max-width: 661px ) {
+		@media ( max-width: $custom-mobile-breakpoint ) {
 			margin-right: 16px;
 		}
 	}

--- a/client/my-sites/stats/annual-highlights-section/style.scss
+++ b/client/my-sites/stats/annual-highlights-section/style.scss
@@ -13,3 +13,9 @@
 		padding-right: 0;
 	}
 }
+
+.highlight-year-navigation {
+	.arrow-navigation {
+		margin: 0 0 16px;
+	}
+}

--- a/client/my-sites/stats/annual-highlights-section/style.scss
+++ b/client/my-sites/stats/annual-highlights-section/style.scss
@@ -3,5 +3,9 @@
 .highlight-year-navigation {
 	.stats-navigation-arrows {
 		margin: 0 0 16px;
+
+		@media ( max-width: 661px ) {
+			margin-right: 16px;
+		}
 	}
 }

--- a/client/my-sites/stats/annual-highlights-section/style.scss
+++ b/client/my-sites/stats/annual-highlights-section/style.scss
@@ -1,19 +1,5 @@
 @import "@automattic/typography/styles/variables";
 
-.stats-period-navigation.stats-year-navigation {
-	.stats-period-navigation__previous,
-	.stats-period-navigation__next {
-		&:focus,
-		&:active {
-			outline: thin dotted;
-		}
-	}
-
-	@media ( min-width: 661px ) {
-		padding-right: 0;
-	}
-}
-
 .highlight-year-navigation {
 	.arrow-navigation {
 		margin: 0 0 16px;

--- a/client/my-sites/stats/annual-highlights-section/year-navigation.tsx
+++ b/client/my-sites/stats/annual-highlights-section/year-navigation.tsx
@@ -15,20 +15,14 @@ const YearNavigation = ( {
 	disableNextArrow,
 }: YearNavigationProps ) => {
 	const handleArrowEvent = ( next: boolean ) => {
-		// eslint-disable-next-line no-console
-		// console.log( 'handleArrowEvent' );
 		const arrow = next ? 'next' : 'previous';
 		recordGoogleEvent( 'Stats Period Navigation', `Clicked ${ arrow } year` );
 		onYearChange( next );
 	};
 	const handleArrowNext = () => {
-		// eslint-disable-next-line no-console
-		// console.log( 'handleArrowNext' );
 		handleArrowEvent( true );
 	};
 	const handleArrowPrevious = () => {
-		// eslint-disable-next-line no-console
-		// console.log( 'handleArrowPrevious' );
 		handleArrowEvent( false );
 	};
 

--- a/client/my-sites/stats/annual-highlights-section/year-navigation.tsx
+++ b/client/my-sites/stats/annual-highlights-section/year-navigation.tsx
@@ -23,20 +23,11 @@ const YearNavigation = ( {
 		onYearChange( next );
 	};
 
-	const onKeyDown = ( event: React.KeyboardEvent< HTMLButtonElement >, next?: boolean ) => {
-		// eslint-disable-next-line no-console
-		// console.log( 'onKeyDown' );
-		if ( event.key === 'Enter' || event.key === 'Space' ) {
-			handleClickArrow( next );
-		}
-	};
-
 	return (
 		<NavigationArrows
 			disableNextArrow={ disableNextArrow }
 			disablePreviousArrow={ disablePreviousArrow }
 			handleClickArrow={ handleClickArrow }
-			onKeyDown={ onKeyDown }
 		/>
 	);
 };

--- a/client/my-sites/stats/annual-highlights-section/year-navigation.tsx
+++ b/client/my-sites/stats/annual-highlights-section/year-navigation.tsx
@@ -30,8 +30,8 @@ const YearNavigation = ( {
 		<NavigationArrows
 			disableNextArrow={ disableNextArrow }
 			disablePreviousArrow={ disablePreviousArrow }
-			onArrowNext={ handleArrowNext }
-			onArrowPrevious={ handleArrowPrevious }
+			onClickNext={ handleArrowNext }
+			onClickPrevious={ handleArrowPrevious }
 		/>
 	);
 };

--- a/client/my-sites/stats/annual-highlights-section/year-navigation.tsx
+++ b/client/my-sites/stats/annual-highlights-section/year-navigation.tsx
@@ -1,6 +1,5 @@
-import { Icon, arrowLeft, arrowRight } from '@wordpress/icons';
-import classNames from 'classnames';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
+import NavigationArrows from '../navigation-arrows';
 
 import './style.scss';
 
@@ -29,30 +28,12 @@ const YearNavigation = ( {
 	};
 
 	return (
-		<div className={ classNames( 'stats-period-navigation', 'stats-year-navigation' ) }>
-			<button
-				className={ classNames(
-					'stats-period-navigation__previous',
-					disablePreviousArrow && 'is-disabled'
-				) }
-				onClick={ disablePreviousArrow ? undefined : () => handleClickArrow() }
-				onKeyDown={ disablePreviousArrow ? undefined : ( e ) => onKeyDown( e ) }
-				tabIndex={ ! disablePreviousArrow ? 0 : -1 }
-			>
-				<Icon className="gridicon" icon={ arrowLeft } />
-			</button>
-			<button
-				className={ classNames(
-					'stats-period-navigation__next',
-					disableNextArrow && 'is-disabled'
-				) }
-				onClick={ disableNextArrow ? undefined : () => handleClickArrow( true ) }
-				onKeyDown={ disableNextArrow ? undefined : ( e ) => onKeyDown( e, true ) }
-				tabIndex={ ! disableNextArrow ? 0 : -1 }
-			>
-				<Icon className="gridicon" icon={ arrowRight } />
-			</button>
-		</div>
+		<NavigationArrows
+			disableNextArrow={ disableNextArrow }
+			disablePreviousArrow={ disablePreviousArrow }
+			handleClickArrow={ handleClickArrow }
+			onKeyDown={ onKeyDown }
+		/>
 	);
 };
 

--- a/client/my-sites/stats/annual-highlights-section/year-navigation.tsx
+++ b/client/my-sites/stats/annual-highlights-section/year-navigation.tsx
@@ -15,6 +15,8 @@ const YearNavigation = ( {
 	disableNextArrow,
 }: YearNavigationProps ) => {
 	const handleClickArrow = ( next?: boolean ) => {
+		// eslint-disable-next-line no-console
+		// console.log( 'handleClickArrow' );
 		const arrow = next ? 'next' : 'previous';
 		recordGoogleEvent( 'Stats Period Navigation', `Clicked ${ arrow } year` );
 
@@ -22,6 +24,8 @@ const YearNavigation = ( {
 	};
 
 	const onKeyDown = ( event: React.KeyboardEvent< HTMLButtonElement >, next?: boolean ) => {
+		// eslint-disable-next-line no-console
+		// console.log( 'onKeyDown' );
 		if ( event.key === 'Enter' || event.key === 'Space' ) {
 			handleClickArrow( next );
 		}

--- a/client/my-sites/stats/annual-highlights-section/year-navigation.tsx
+++ b/client/my-sites/stats/annual-highlights-section/year-navigation.tsx
@@ -14,20 +14,30 @@ const YearNavigation = ( {
 	disablePreviousArrow,
 	disableNextArrow,
 }: YearNavigationProps ) => {
-	const handleClickArrow = ( next?: boolean ) => {
+	const handleArrowEvent = ( next: boolean ) => {
 		// eslint-disable-next-line no-console
-		// console.log( 'handleClickArrow' );
+		// console.log( 'handleArrowEvent' );
 		const arrow = next ? 'next' : 'previous';
 		recordGoogleEvent( 'Stats Period Navigation', `Clicked ${ arrow } year` );
-
 		onYearChange( next );
+	};
+	const handleArrowNext = () => {
+		// eslint-disable-next-line no-console
+		// console.log( 'handleArrowNext' );
+		handleArrowEvent( true );
+	};
+	const handleArrowPrevious = () => {
+		// eslint-disable-next-line no-console
+		// console.log( 'handleArrowPrevious' );
+		handleArrowEvent( false );
 	};
 
 	return (
 		<NavigationArrows
 			disableNextArrow={ disableNextArrow }
 			disablePreviousArrow={ disablePreviousArrow }
-			handleClickArrow={ handleClickArrow }
+			onArrowNext={ handleArrowNext }
+			onArrowPrevious={ handleArrowPrevious }
 		/>
 	);
 };

--- a/client/my-sites/stats/navigation-arrows/index.jsx
+++ b/client/my-sites/stats/navigation-arrows/index.jsx
@@ -7,6 +7,26 @@ function NavigationArrows( {
 	handleClickArrow,
 	onKeyDown,
 } ) {
+	const handleClickNext = () => {
+		// eslint-disable-next-line no-console
+		console.log( 'click next' );
+		handleClickArrow( true );
+	};
+	const handleClickPrevious = () => {
+		// eslint-disable-next-line no-console
+		console.log( 'click previous' );
+		handleClickArrow();
+	};
+	const handleKeyNext = ( e ) => {
+		// eslint-disable-next-line no-console
+		console.log( 'key next' );
+		onKeyDown( e, true );
+	};
+	const handleKeyPrevious = ( e ) => {
+		// eslint-disable-next-line no-console
+		console.log( 'key previous' );
+		onKeyDown( e );
+	};
 	return (
 		<div className={ classNames( 'stats-period-navigation', 'stats-year-navigation' ) }>
 			<button
@@ -14,8 +34,8 @@ function NavigationArrows( {
 					'stats-period-navigation__previous',
 					disablePreviousArrow && 'is-disabled'
 				) }
-				onClick={ disablePreviousArrow ? undefined : () => handleClickArrow() }
-				onKeyDown={ disablePreviousArrow ? undefined : ( e ) => onKeyDown( e ) }
+				onClick={ disablePreviousArrow ? undefined : () => handleClickPrevious() }
+				onKeyDown={ disablePreviousArrow ? undefined : ( e ) => handleKeyPrevious( e ) }
 				tabIndex={ ! disablePreviousArrow ? 0 : -1 }
 			>
 				<Icon className="gridicon" icon={ arrowLeft } />
@@ -25,8 +45,8 @@ function NavigationArrows( {
 					'stats-period-navigation__next',
 					disableNextArrow && 'is-disabled'
 				) }
-				onClick={ disableNextArrow ? undefined : () => handleClickArrow( true ) }
-				onKeyDown={ disableNextArrow ? undefined : ( e ) => onKeyDown( e, true ) }
+				onClick={ disableNextArrow ? undefined : () => handleClickNext() }
+				onKeyDown={ disableNextArrow ? undefined : ( e ) => handleKeyNext( e ) }
 				tabIndex={ ! disableNextArrow ? 0 : -1 }
 			>
 				<Icon className="gridicon" icon={ arrowRight } />

--- a/client/my-sites/stats/navigation-arrows/index.jsx
+++ b/client/my-sites/stats/navigation-arrows/index.jsx
@@ -1,0 +1,38 @@
+import { Icon, arrowLeft, arrowRight } from '@wordpress/icons';
+import classNames from 'classnames';
+
+function NavigationArrows( {
+	disableNextArrow,
+	disablePreviousArrow,
+	handleClickArrow,
+	onKeyDown,
+} ) {
+	return (
+		<div className={ classNames( 'stats-period-navigation', 'stats-year-navigation' ) }>
+			<button
+				className={ classNames(
+					'stats-period-navigation__previous',
+					disablePreviousArrow && 'is-disabled'
+				) }
+				onClick={ disablePreviousArrow ? undefined : () => handleClickArrow() }
+				onKeyDown={ disablePreviousArrow ? undefined : ( e ) => onKeyDown( e ) }
+				tabIndex={ ! disablePreviousArrow ? 0 : -1 }
+			>
+				<Icon className="gridicon" icon={ arrowLeft } />
+			</button>
+			<button
+				className={ classNames(
+					'stats-period-navigation__next',
+					disableNextArrow && 'is-disabled'
+				) }
+				onClick={ disableNextArrow ? undefined : () => handleClickArrow( true ) }
+				onKeyDown={ disableNextArrow ? undefined : ( e ) => onKeyDown( e, true ) }
+				tabIndex={ ! disableNextArrow ? 0 : -1 }
+			>
+				<Icon className="gridicon" icon={ arrowRight } />
+			</button>
+		</div>
+	);
+}
+
+export default NavigationArrows;

--- a/client/my-sites/stats/navigation-arrows/index.jsx
+++ b/client/my-sites/stats/navigation-arrows/index.jsx
@@ -20,20 +20,18 @@ function NavigationArrows( {
 	return (
 		<div className={ classNames( 'stats-period-navigation', 'stats-year-navigation' ) }>
 			<button
-				className={ classNames(
-					'stats-period-navigation__previous',
-					disablePreviousArrow && 'is-disabled'
-				) }
+				className={ classNames( 'stats-period-navigation__previous', {
+					'is-disabled': disablePreviousArrow,
+				} ) }
 				onClick={ disablePreviousArrow ? undefined : () => handleClickPrevious() }
 				tabIndex={ ! disablePreviousArrow ? 0 : -1 }
 			>
 				<Icon className="gridicon" icon={ arrowLeft } />
 			</button>
 			<button
-				className={ classNames(
-					'stats-period-navigation__next',
-					disableNextArrow && 'is-disabled'
-				) }
+				className={ classNames( 'stats-period-navigation__next', {
+					'is-disabled': disableNextArrow,
+				} ) }
 				onClick={ disableNextArrow ? undefined : () => handleClickNext() }
 				tabIndex={ ! disableNextArrow ? 0 : -1 }
 			>

--- a/client/my-sites/stats/navigation-arrows/index.jsx
+++ b/client/my-sites/stats/navigation-arrows/index.jsx
@@ -1,6 +1,8 @@
 import { Icon, arrowLeft, arrowRight } from '@wordpress/icons';
 import classNames from 'classnames';
 
+import './style.scss';
+
 function NavigationArrows( {
 	disableNextArrow,
 	disablePreviousArrow,
@@ -18,9 +20,9 @@ function NavigationArrows( {
 		onArrowPrevious();
 	};
 	return (
-		<div className={ classNames( 'stats-period-navigation', 'stats-year-navigation' ) }>
+		<div className={ classNames( 'arrow-navigation', '' ) }>
 			<button
-				className={ classNames( 'stats-period-navigation__previous', {
+				className={ classNames( 'arrow-navigation__previous', {
 					'is-disabled': disablePreviousArrow,
 				} ) }
 				onClick={ disablePreviousArrow ? undefined : () => handleClickPrevious() }
@@ -29,7 +31,7 @@ function NavigationArrows( {
 				<Icon className="gridicon" icon={ arrowLeft } />
 			</button>
 			<button
-				className={ classNames( 'stats-period-navigation__next', {
+				className={ classNames( 'arrow-navigation__next', {
 					'is-disabled': disableNextArrow,
 				} ) }
 				onClick={ disableNextArrow ? undefined : () => handleClickNext() }

--- a/client/my-sites/stats/navigation-arrows/index.jsx
+++ b/client/my-sites/stats/navigation-arrows/index.jsx
@@ -1,16 +1,21 @@
 import { Icon, arrowLeft, arrowRight } from '@wordpress/icons';
 import classNames from 'classnames';
 
-function NavigationArrows( { disableNextArrow, disablePreviousArrow, handleClickArrow } ) {
+function NavigationArrows( {
+	disableNextArrow,
+	disablePreviousArrow,
+	onArrowNext,
+	onArrowPrevious,
+} ) {
 	const handleClickNext = () => {
 		// eslint-disable-next-line no-console
 		console.log( 'click next' );
-		handleClickArrow( true );
+		onArrowNext();
 	};
 	const handleClickPrevious = () => {
 		// eslint-disable-next-line no-console
 		console.log( 'click previous' );
-		handleClickArrow();
+		onArrowPrevious();
 	};
 	return (
 		<div className={ classNames( 'stats-period-navigation', 'stats-year-navigation' ) }>

--- a/client/my-sites/stats/navigation-arrows/index.jsx
+++ b/client/my-sites/stats/navigation-arrows/index.jsx
@@ -1,12 +1,7 @@
 import { Icon, arrowLeft, arrowRight } from '@wordpress/icons';
 import classNames from 'classnames';
 
-function NavigationArrows( {
-	disableNextArrow,
-	disablePreviousArrow,
-	handleClickArrow,
-	onKeyDown,
-} ) {
+function NavigationArrows( { disableNextArrow, disablePreviousArrow, handleClickArrow } ) {
 	const handleClickNext = () => {
 		// eslint-disable-next-line no-console
 		console.log( 'click next' );
@@ -17,16 +12,6 @@ function NavigationArrows( {
 		console.log( 'click previous' );
 		handleClickArrow();
 	};
-	const handleKeyNext = ( e ) => {
-		// eslint-disable-next-line no-console
-		console.log( 'key next' );
-		onKeyDown( e, true );
-	};
-	const handleKeyPrevious = ( e ) => {
-		// eslint-disable-next-line no-console
-		console.log( 'key previous' );
-		onKeyDown( e );
-	};
 	return (
 		<div className={ classNames( 'stats-period-navigation', 'stats-year-navigation' ) }>
 			<button
@@ -35,7 +20,6 @@ function NavigationArrows( {
 					disablePreviousArrow && 'is-disabled'
 				) }
 				onClick={ disablePreviousArrow ? undefined : () => handleClickPrevious() }
-				onKeyDown={ disablePreviousArrow ? undefined : ( e ) => handleKeyPrevious( e ) }
 				tabIndex={ ! disablePreviousArrow ? 0 : -1 }
 			>
 				<Icon className="gridicon" icon={ arrowLeft } />
@@ -46,7 +30,6 @@ function NavigationArrows( {
 					disableNextArrow && 'is-disabled'
 				) }
 				onClick={ disableNextArrow ? undefined : () => handleClickNext() }
-				onKeyDown={ disableNextArrow ? undefined : ( e ) => handleKeyNext( e ) }
 				tabIndex={ ! disableNextArrow ? 0 : -1 }
 			>
 				<Icon className="gridicon" icon={ arrowRight } />

--- a/client/my-sites/stats/navigation-arrows/index.jsx
+++ b/client/my-sites/stats/navigation-arrows/index.jsx
@@ -16,9 +16,9 @@ function NavigationArrows( {
 		onArrowPrevious();
 	};
 	return (
-		<div className="arrow-navigation">
+		<div className="stats-navigation-arrows">
 			<button
-				className={ classNames( 'arrow-navigation__previous', {
+				className={ classNames( 'stats-navigation-arrows__previous', {
 					'is-disabled': disablePreviousArrow,
 				} ) }
 				onClick={ disablePreviousArrow ? undefined : () => handleClickPrevious() }
@@ -27,7 +27,7 @@ function NavigationArrows( {
 				<Icon className="gridicon" icon={ arrowLeft } />
 			</button>
 			<button
-				className={ classNames( 'arrow-navigation__next', {
+				className={ classNames( 'stats-navigation-arrows__next', {
 					'is-disabled': disableNextArrow,
 				} ) }
 				onClick={ disableNextArrow ? undefined : () => handleClickNext() }

--- a/client/my-sites/stats/navigation-arrows/index.jsx
+++ b/client/my-sites/stats/navigation-arrows/index.jsx
@@ -20,7 +20,7 @@ function NavigationArrows( {
 		onArrowPrevious();
 	};
 	return (
-		<div className={ classNames( 'arrow-navigation', '' ) }>
+		<div className="arrow-navigation">
 			<button
 				className={ classNames( 'arrow-navigation__previous', {
 					'is-disabled': disablePreviousArrow,

--- a/client/my-sites/stats/navigation-arrows/index.jsx
+++ b/client/my-sites/stats/navigation-arrows/index.jsx
@@ -6,22 +6,16 @@ import './style.scss';
 function NavigationArrows( {
 	disableNextArrow,
 	disablePreviousArrow,
-	onArrowNext,
-	onArrowPrevious,
+	onClickNext,
+	onClickPrevious,
 } ) {
-	const handleClickNext = () => {
-		onArrowNext();
-	};
-	const handleClickPrevious = () => {
-		onArrowPrevious();
-	};
 	return (
 		<div className="stats-navigation-arrows">
 			<button
 				className={ classNames( 'stats-navigation-arrows__previous', {
 					'is-disabled': disablePreviousArrow,
 				} ) }
-				onClick={ disablePreviousArrow ? undefined : () => handleClickPrevious() }
+				onClick={ disablePreviousArrow ? undefined : onClickPrevious }
 				tabIndex={ ! disablePreviousArrow ? 0 : -1 }
 			>
 				<Icon className="gridicon" icon={ arrowLeft } />
@@ -30,7 +24,7 @@ function NavigationArrows( {
 				className={ classNames( 'stats-navigation-arrows__next', {
 					'is-disabled': disableNextArrow,
 				} ) }
-				onClick={ disableNextArrow ? undefined : () => handleClickNext() }
+				onClick={ disableNextArrow ? undefined : onClickNext }
 				tabIndex={ ! disableNextArrow ? 0 : -1 }
 			>
 				<Icon className="gridicon" icon={ arrowRight } />

--- a/client/my-sites/stats/navigation-arrows/index.jsx
+++ b/client/my-sites/stats/navigation-arrows/index.jsx
@@ -10,13 +10,9 @@ function NavigationArrows( {
 	onArrowPrevious,
 } ) {
 	const handleClickNext = () => {
-		// eslint-disable-next-line no-console
-		console.log( 'click next' );
 		onArrowNext();
 	};
 	const handleClickPrevious = () => {
-		// eslint-disable-next-line no-console
-		console.log( 'click previous' );
 		onArrowPrevious();
 	};
 	return (

--- a/client/my-sites/stats/navigation-arrows/style.scss
+++ b/client/my-sites/stats/navigation-arrows/style.scss
@@ -25,8 +25,4 @@
 	.stats-navigation-arrows__next {
 		margin-left: 4px;
 	}
-
-	@media ( min-width: 661px ) {
-		padding-right: 0;
-	}
 }

--- a/client/my-sites/stats/navigation-arrows/style.scss
+++ b/client/my-sites/stats/navigation-arrows/style.scss
@@ -5,8 +5,6 @@
 	align-items: center;
 	justify-content: space-between;
 
-	margin: 0 0 16px;
-
 	.arrow-navigation__previous,
 	.arrow-navigation__next {
 		width: 24px;

--- a/client/my-sites/stats/navigation-arrows/style.scss
+++ b/client/my-sites/stats/navigation-arrows/style.scss
@@ -1,0 +1,34 @@
+@import "@automattic/typography/styles/variables";
+
+.arrow-navigation {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+
+	margin: 0 0 16px;
+
+	.arrow-navigation__previous,
+	.arrow-navigation__next {
+		width: 24px;
+		height: 24px;
+		color: var(--color-neutral-90);
+		cursor: pointer;
+
+		&:focus,
+		&:active {
+			outline: thin dotted;
+		}
+		&.is-disabled {
+			visibility: visible;
+			opacity: 0.2;
+			pointer-events: none;
+		}
+	}
+	.arrow-navigation__next {
+		margin-left: 4px;
+	}
+
+	@media ( min-width: 661px ) {
+		padding-right: 0;
+	}
+}

--- a/client/my-sites/stats/navigation-arrows/style.scss
+++ b/client/my-sites/stats/navigation-arrows/style.scss
@@ -1,12 +1,12 @@
 @import "@automattic/typography/styles/variables";
 
-.arrow-navigation {
+.stats-navigation-arrows {
 	display: flex;
 	align-items: center;
 	justify-content: space-between;
 
-	.arrow-navigation__previous,
-	.arrow-navigation__next {
+	.stats-navigation-arrows__previous,
+	.stats-navigation-arrows__next {
 		width: 24px;
 		height: 24px;
 		color: var(--color-neutral-90);
@@ -22,7 +22,7 @@
 			pointer-events: none;
 		}
 	}
-	.arrow-navigation__next {
+	.stats-navigation-arrows__next {
 		margin-left: 4px;
 	}
 

--- a/client/my-sites/stats/stats-period-navigation/index.jsx
+++ b/client/my-sites/stats/stats-period-navigation/index.jsx
@@ -33,7 +33,7 @@ class StatsPeriodNavigation extends PureComponent {
 		endDate: false,
 	};
 
-	handleClickArrow = ( arrow, href ) => {
+	handleArrowEvent = ( arrow, href ) => {
 		const { date, onPeriodChange, period, recordGoogleEvent } = this.props;
 		recordGoogleEvent( 'Stats Period Navigation', `Clicked ${ arrow } ${ period }` );
 
@@ -57,7 +57,7 @@ class StatsPeriodNavigation extends PureComponent {
 			addQueryPrefix: true,
 		} );
 		const href = `${ url }${ nextDayQuery }`;
-		this.handleClickArrow( 'next', href );
+		this.handleArrowEvent( 'next', href );
 	};
 
 	handleArrowPrevious = () => {
@@ -68,7 +68,7 @@ class StatsPeriodNavigation extends PureComponent {
 			{ addQueryPrefix: true }
 		);
 		const href = `${ url }${ previousDayQuery }`;
-		this.handleClickArrow( 'previous', href );
+		this.handleArrowEvent( 'previous', href );
 	};
 
 	render() {

--- a/client/my-sites/stats/stats-period-navigation/index.jsx
+++ b/client/my-sites/stats/stats-period-navigation/index.jsx
@@ -1,5 +1,3 @@
-import { Icon, arrowLeft, arrowRight } from '@wordpress/icons';
-import classNames from 'classnames';
 import { localize, withRtl } from 'i18n-calypso';
 import { flowRight } from 'lodash';
 import page from 'page';
@@ -33,14 +31,6 @@ class StatsPeriodNavigation extends PureComponent {
 		queryParams: {},
 		startDate: false,
 		endDate: false,
-	};
-
-	handleClickNext = () => {
-		this.handleClickArrow( 'next' );
-	};
-
-	handleClickPrevious = () => {
-		this.handleClickArrow( 'previous' );
 	};
 
 	handleClickArrow = ( arrow, href ) => {
@@ -82,28 +72,10 @@ class StatsPeriodNavigation extends PureComponent {
 	};
 
 	render() {
-		const {
-			children,
-			date,
-			moment,
-			period,
-			url,
-			showArrows,
-			disablePreviousArrow,
-			disableNextArrow,
-			queryParams,
-		} = this.props;
+		const { children, date, moment, period, showArrows, disablePreviousArrow, disableNextArrow } =
+			this.props;
 
 		const isToday = moment( date ).isSame( moment(), period );
-		const previousDay = moment( date ).subtract( 1, period ).format( 'YYYY-MM-DD' );
-		const previousDayQuery = qs.stringify(
-			Object.assign( {}, queryParams, { startDate: previousDay } ),
-			{ addQueryPrefix: true }
-		);
-		const nextDay = moment( date ).add( 1, period ).format( 'YYYY-MM-DD' );
-		const nextDayQuery = qs.stringify( Object.assign( {}, queryParams, { startDate: nextDay } ), {
-			addQueryPrefix: true,
-		} );
 
 		return (
 			<div className="stats-period-navigation">
@@ -115,28 +87,6 @@ class StatsPeriodNavigation extends PureComponent {
 						onArrowNext={ this.handleArrowNext }
 						onArrowPrevious={ this.handleArrowPrevious }
 					/>
-				) }
-				{ showArrows && false && (
-					<>
-						<a
-							className={ classNames( 'stats-period-navigation__previous', {
-								'is-disabled': disablePreviousArrow,
-							} ) }
-							href={ `${ url }${ previousDayQuery }` }
-							onClick={ this.handleClickPrevious }
-						>
-							<Icon className="gridicon" icon={ arrowLeft } />
-						</a>
-						<a
-							className={ classNames( 'stats-period-navigation__next', {
-								'is-disabled': disableNextArrow || isToday,
-							} ) }
-							href={ `${ url }${ nextDayQuery }` }
-							onClick={ this.handleClickNext }
-						>
-							<Icon className="gridicon" icon={ arrowRight } />
-						</a>
-					</>
 				) }
 			</div>
 		);

--- a/client/my-sites/stats/stats-period-navigation/index.jsx
+++ b/client/my-sites/stats/stats-period-navigation/index.jsx
@@ -2,12 +2,14 @@ import { Icon, arrowLeft, arrowRight } from '@wordpress/icons';
 import classNames from 'classnames';
 import { localize, withRtl } from 'i18n-calypso';
 import { flowRight } from 'lodash';
+import page from 'page';
 import PropTypes from 'prop-types';
 import qs from 'qs';
 import { PureComponent } from 'react';
 import { connect } from 'react-redux';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import { recordGoogleEvent as recordGoogleEventAction } from 'calypso/state/analytics/actions';
+import NavigationArrows from '../navigation-arrows';
 
 import './style.scss';
 
@@ -41,7 +43,7 @@ class StatsPeriodNavigation extends PureComponent {
 		this.handleClickArrow( 'previous' );
 	};
 
-	handleClickArrow = ( arrow ) => {
+	handleClickArrow = ( arrow, href ) => {
 		const { date, onPeriodChange, period, recordGoogleEvent } = this.props;
 		recordGoogleEvent( 'Stats Period Navigation', `Clicked ${ arrow } ${ period }` );
 
@@ -52,6 +54,31 @@ class StatsPeriodNavigation extends PureComponent {
 				period,
 			} );
 		}
+
+		if ( href ) {
+			page( href );
+		}
+	};
+
+	handleArrowNext = () => {
+		const { date, moment, period, url, queryParams } = this.props;
+		const nextDay = moment( date ).add( 1, period ).format( 'YYYY-MM-DD' );
+		const nextDayQuery = qs.stringify( Object.assign( {}, queryParams, { startDate: nextDay } ), {
+			addQueryPrefix: true,
+		} );
+		const href = `${ url }${ nextDayQuery }`;
+		this.handleClickArrow( 'next', href );
+	};
+
+	handleArrowPrevious = () => {
+		const { date, moment, period, url, queryParams } = this.props;
+		const previousDay = moment( date ).subtract( 1, period ).format( 'YYYY-MM-DD' );
+		const previousDayQuery = qs.stringify(
+			Object.assign( {}, queryParams, { startDate: previousDay } ),
+			{ addQueryPrefix: true }
+		);
+		const href = `${ url }${ previousDayQuery }`;
+		this.handleClickArrow( 'previous', href );
 	};
 
 	render() {
@@ -81,7 +108,13 @@ class StatsPeriodNavigation extends PureComponent {
 		return (
 			<div className="stats-period-navigation">
 				<div className="stats-period-navigation__children">{ children }</div>
-				{ showArrows && (
+				<NavigationArrows
+					disableNextArrow={ disableNextArrow || isToday }
+					disablePreviousArrow={ disablePreviousArrow }
+					onArrowNext={ this.handleArrowNext }
+					onArrowPrevious={ this.handleArrowPrevious }
+				/>
+				{ showArrows && false && (
 					<>
 						<a
 							className={ classNames( 'stats-period-navigation__previous', {

--- a/client/my-sites/stats/stats-period-navigation/index.jsx
+++ b/client/my-sites/stats/stats-period-navigation/index.jsx
@@ -84,8 +84,8 @@ class StatsPeriodNavigation extends PureComponent {
 					<NavigationArrows
 						disableNextArrow={ disableNextArrow || isToday }
 						disablePreviousArrow={ disablePreviousArrow }
-						onArrowNext={ this.handleArrowNext }
-						onArrowPrevious={ this.handleArrowPrevious }
+						onClickNext={ this.handleArrowNext }
+						onClickPrevious={ this.handleArrowPrevious }
 					/>
 				) }
 			</div>

--- a/client/my-sites/stats/stats-period-navigation/index.jsx
+++ b/client/my-sites/stats/stats-period-navigation/index.jsx
@@ -108,12 +108,14 @@ class StatsPeriodNavigation extends PureComponent {
 		return (
 			<div className="stats-period-navigation">
 				<div className="stats-period-navigation__children">{ children }</div>
-				<NavigationArrows
-					disableNextArrow={ disableNextArrow || isToday }
-					disablePreviousArrow={ disablePreviousArrow }
-					onArrowNext={ this.handleArrowNext }
-					onArrowPrevious={ this.handleArrowPrevious }
-				/>
+				{ showArrows && (
+					<NavigationArrows
+						disableNextArrow={ disableNextArrow || isToday }
+						disablePreviousArrow={ disablePreviousArrow }
+						onArrowNext={ this.handleArrowNext }
+						onArrowPrevious={ this.handleArrowPrevious }
+					/>
+				) }
 				{ showArrows && false && (
 					<>
 						<a

--- a/client/my-sites/stats/stats-period-navigation/style.scss
+++ b/client/my-sites/stats/stats-period-navigation/style.scss
@@ -17,24 +17,6 @@
 		text-align: left;
 	}
 
-	.stats-period-navigation__previous,
-	.stats-period-navigation__next {
-		width: 24px;
-		height: 24px;
-		color: var(--color-neutral-90);
-		cursor: pointer;
-
-		&.is-disabled {
-			visibility: visible;
-			opacity: 0.2;
-			pointer-events: none;
-		}
-	}
-
-	.stats-period-navigation__next {
-		margin-left: 4px;
-	}
-
 	.stats-date-picker__refresh-status {
 		font-size: $font-body-small;
 		line-height: 16px;


### PR DESCRIPTION
#### Proposed Changes

Extracts the navigation arrows into a new component.

- Consolidates styles
- Fixes bug in annual insights nav that triggered multiple GA events in response to keyboard events
- Fixes bug in stats chart nav that allowed you to page into the future via keyboard

Looks that same as it did prior to refactor. The navigation in question…

**Traffic → Chart nav:**

![NavChart](https://user-images.githubusercontent.com/40267301/211002250-7c5ff7d2-92c8-4218-b93f-f324d745f944.png)

**Insights → Year in review nav:**

![InsightsNav](https://user-images.githubusercontent.com/40267301/211002338-2331712a-42ce-4daa-a048-f2b1cd0aa3cf.png)

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up the live branch.
* Visit the Traffic page and confirm the arrows look and behave as they did previously. You can compare by viewing the same page in wordpress.com
* Visit the Insights page and confirm the arrows look and behave correctly there too.
* In both cases, it should be possible to tab to the arrows and trigger them via the keyboard (in Chrome, Firefox and Safari require special setup first).
* On the Traffic page, it should not be possible to arrow past the current time period (into the future).
* On the Insights page, it should not be possible to arrow into 2024.

**Note:** This component hasn't been moved into Storybook. If we want to do that, we can tackle it in a follow-up PR.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #71677.
