### PR TITLE
Users management: Record missing track events and edit form adjustments

### DIFF
--- a/client/my-sites/people/edit-team-member-form/edit-user-form.jsx
+++ b/client/my-sites/people/edit-team-member-form/edit-user-form.jsx
@@ -202,7 +202,8 @@ class EditUserForm extends Component {
 				returnField = (
 					<RoleSelect
 						key="role-select"
-						formControlType="select"
+						formControlType={ this.props.roleSelectControlType }
+						explanation={ true }
 						id={ fieldKeys.roles }
 						name={ fieldKeys.roles }
 						siteId={ this.props.siteId }

--- a/client/my-sites/people/edit-team-member-form/index.jsx
+++ b/client/my-sites/people/edit-team-member-form/index.jsx
@@ -81,6 +81,7 @@ export const EditTeamMemberForm = ( {
 						disabled={ false } // @TODO added when added mutation to remove user
 						siteId={ siteId }
 						autoSave={ isEnabled( 'user-management-revamp' ) }
+						roleSelectControlType={ isEnabled( 'user-management-revamp' ) ? 'select' : 'radio' }
 						isJetpack={ isJetpack }
 						markChanged={ markChanged }
 						markSaved={ markSaved }

--- a/client/my-sites/people/subscriber-details/index.tsx
+++ b/client/my-sites/people/subscriber-details/index.tsx
@@ -96,7 +96,7 @@ export default function SubscriberDetails( props: Props ) {
 	function removeSubscriber( subscriber: Follower ) {
 		const listType = 'email' === subscriberType ? 'Email Follower' : 'Follower';
 		dispatch(
-			recordGoogleEvent( 'People', 'Clicked Remove Follower Button On' + listType + ' list' )
+			recordGoogleEvent( 'People', 'Clicked Remove Follower Button On ' + listType + ' list' )
 		);
 
 		accept(

--- a/client/my-sites/people/subscribers-team/index.tsx
+++ b/client/my-sites/people/subscribers-team/index.tsx
@@ -1,6 +1,8 @@
+import { localizeUrl } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import FormattedHeader from 'calypso/components/formatted-header';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 import Main from 'calypso/components/main';
 import SectionNav from 'calypso/components/section-nav';
 import useFollowersQuery from 'calypso/data/followers/use-followers-query';
@@ -47,7 +49,17 @@ function SubscribersTeam( props: Props ) {
 				className="people__page-heading"
 				headerText={ _( 'Users' ) }
 				subHeaderText={ _(
-					'Invite subscribers and team members to your site and manage their access settings.'
+					'Invite subscribers and team members to your site and manage their access settings. {{learnMore}}Learn more{{/learnMore}}.',
+					{
+						components: {
+							learnMore: (
+								<InlineSupportLink
+									showIcon={ false }
+									supportLink={ localizeUrl( 'https://wordpress.com/support/invite-people/' ) }
+								/>
+							),
+						},
+					}
 				) }
 				align="left"
 				hasScreenOptions

--- a/client/my-sites/people/subscribers-team/index.tsx
+++ b/client/my-sites/people/subscribers-team/index.tsx
@@ -5,6 +5,7 @@ import Main from 'calypso/components/main';
 import SectionNav from 'calypso/components/section-nav';
 import useFollowersQuery from 'calypso/data/followers/use-followers-query';
 import useUsersQuery from 'calypso/data/users/use-users-query';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import PeopleSectionNavCompact from '../people-section-nav-compact';
 import Subscribers from '../subscribers';
@@ -67,16 +68,25 @@ function SubscribersTeam( props: Props ) {
 					switch ( filter ) {
 						case 'subscribers':
 							return (
-								<Subscribers
-									filter={ filter }
-									search={ search }
-									followersQuery={ followersQuery }
-								/>
+								<>
+									<PageViewTracker path="/people/subscribers/:site" title="People > Subscribers" />
+
+									<Subscribers
+										filter={ filter }
+										search={ search }
+										followersQuery={ followersQuery }
+									/>
+								</>
 							);
 
 						case 'team-members':
 							return (
 								<>
+									<PageViewTracker
+										path="/people/team-members/:site"
+										title="People > Team Members / Invites"
+									/>
+
 									<TeamMembers search={ search } usersQuery={ usersQuery } />
 									<TeamInvites />
 									<TeamInvitesAccepted />

--- a/client/my-sites/people/subscribers/index.tsx
+++ b/client/my-sites/people/subscribers/index.tsx
@@ -1,13 +1,14 @@
 import { Card, Button } from '@automattic/components';
 import { AddSubscriberForm } from '@automattic/subscriber';
 import { useTranslate } from 'i18n-calypso';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import EllipsisMenu from 'calypso/components/ellipsis-menu';
 import InfiniteList from 'calypso/components/infinite-list';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import { addQueryArgs } from 'calypso/lib/url';
 import NoResults from 'calypso/my-sites/no-results';
 import PeopleListItem from 'calypso/my-sites/people/people-list-item';
+import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import PeopleListSectionHeader from '../people-list-section-header';
 import type { Follower, FollowersQuery } from './types';
@@ -21,6 +22,7 @@ interface Props {
 }
 function Subscribers( props: Props ) {
 	const _ = useTranslate();
+	const dispatch = useDispatch();
 	const { search, followersQuery } = props;
 	const site = useSelector( ( state ) => getSelectedSite( state ) );
 
@@ -36,6 +38,15 @@ function Subscribers( props: Props ) {
 		{ page: 'stats', blog: site?.ID, blog_subscribers: 'csv', type: 'email' },
 		'https://dashboard.wordpress.com/wp-admin/index.php'
 	);
+
+	function onDownloadCsvClick() {
+		dispatch(
+			recordGoogleEvent(
+				'People',
+				'Clicked Download email subscribers as CSV menu item on Subscribers'
+			)
+		);
+	}
 
 	function getFollowerRef( follower: Follower ) {
 		return 'follower-' + follower.ID;
@@ -83,7 +94,7 @@ function Subscribers( props: Props ) {
 							{ _( 'Add subscribers' ) }
 						</Button>
 						<EllipsisMenu compact position="bottom">
-							<PopoverMenuItem href={ downloadCsvLink }>
+							<PopoverMenuItem href={ downloadCsvLink } onClick={ onDownloadCsvClick }>
 								{ _( 'Download email subscribers as CSV' ) }
 							</PopoverMenuItem>
 						</EllipsisMenu>


### PR DESCRIPTION
#### Proposed Changes

* Record missing track events
* Added missing learn more link
* Updated edit user form: decide RoleSelect control type based on feature flag. Switch between `dropdown` and `radio` buttons.

---

#### Testing Instructions

**Events**

How to See Calypso Tracks Events Fire in Real Time: PCYsg-cae-p2

**Learn more link**

- Go to `/people/subscribers/{SITE_SLUG}`
- Check if there is learn more link

**RoleSelect component type**

- Go to `/people/team-members/{SITE_SLUG}`
- Select a non-super-admin member
- Check the type of role select component based on feature flag
- **NOTE:** you can toggle feature flag by providing `?flags=` query param with `user-management-revamp` or `-user-management-revamp`. (leading minus will turn off)

---

#### Screenshots
**Learn more link**
<img width="762" alt="Screenshot 2023-01-05 at 18 36 201" src="https://user-images.githubusercontent.com/1241413/211421972-074f0c81-b5b4-48cc-8572-8a17a7a91eb2.png">

**Switch between radio and dropdown**
<table>
<tr>
<td>
<img width="740" alt="Screenshot 2023-01-09 at 23 51 59" src="https://user-images.githubusercontent.com/1241413/211426038-0a3bea52-5eef-4459-92f9-2e54bfd0375a.png">

</td><td>
<img width="734" alt="Screenshot 2023-01-09 at 23 52 11" src="https://user-images.githubusercontent.com/1241413/211426053-c37bf4e0-e05b-4a91-bdd4-b64801fa6838.png">
</td>
</tr>
</table>

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #71005 | #71129