### PR TITLE
localizeUrl: Improve support for Go blog URLs

### DIFF
--- a/packages/i18n-utils/src/locales.ts
+++ b/packages/i18n-utils/src/locales.ts
@@ -7,6 +7,7 @@
 export type Locale = string;
 export const i18nDefaultLocaleSlug: Locale = 'en';
 export const localesWithBlog: Locale[] = [ 'en', 'ja', 'es', 'pt', 'fr', 'pt-br' ];
+export const localesWithGoBlog: Locale[] = [ 'en', 'pt-br', 'de', 'es', 'fr', 'it' ];
 export const localesWithPrivacyPolicy: Locale[] = [ 'en', 'fr', 'de', 'es' ];
 export const localesWithCookiePolicy: Locale[] = [ 'en', 'fr', 'de', 'es' ];
 

--- a/packages/i18n-utils/src/localize-url.tsx
+++ b/packages/i18n-utils/src/localize-url.tsx
@@ -4,6 +4,7 @@ import { useCallback, ComponentType } from 'react';
 import { useLocale } from './locale-context';
 import {
 	localesWithBlog,
+	localesWithGoBlog,
 	localesWithPrivacyPolicy,
 	localesWithCookiePolicy,
 	localesToSubdomains,
@@ -114,6 +115,7 @@ export const urlLocalizationMapping: UrlLocalizationMapping = {
 	'wordpress.com/support/': prefixLocalizedUrlPath( supportSiteLocales ),
 	'wordpress.com/forums/': prefixLocalizedUrlPath( forumLocales ),
 	'wordpress.com/blog/': prefixLocalizedUrlPath( localesWithBlog, /^\/blog\/?$/ ),
+	'wordpress.com/go/': prefixLocalizedUrlPath( localesWithGoBlog, /^\/go\/?$/ ),
 	'wordpress.com/tos/': prefixLocalizedUrlPath( magnificentNonEnLocales ),
 	'wordpress.com/wp-admin/': setLocalizedUrlHost( 'wordpress.com', magnificentNonEnLocales ),
 	'wordpress.com/wp-login.php': setLocalizedUrlHost( 'wordpress.com', magnificentNonEnLocales ),

--- a/packages/i18n-utils/src/test/localize-url.js
+++ b/packages/i18n-utils/src/test/localize-url.js
@@ -179,6 +179,30 @@ describe( '#localizeUrl', () => {
 		);
 	} );
 
+	test( 'go blog url', () => {
+		expect( localizeUrl( 'https://wordpress.com/go/', 'en' ) ).toEqual(
+			'https://wordpress.com/go/'
+		);
+		// Locales without a Go blog.
+		expect( localizeUrl( 'https://wordpress.com/go/', 'sv' ) ).toEqual(
+			'https://wordpress.com/go/'
+		);
+		expect( localizeUrl( 'https://wordpress.com/go/', 'pl' ) ).toEqual(
+			'https://wordpress.com/go/'
+		);
+		// Locales with a Go blog.
+		expect( localizeUrl( 'https://wordpress.com/go/', 'pt-br' ) ).toEqual(
+			'https://wordpress.com/pt-br/go/'
+		);
+		expect( localizeUrl( 'https://wordpress.com/go/', 'es' ) ).toEqual(
+			'https://wordpress.com/es/go/'
+		);
+		// Don't rewrite specific posts.
+		expect( localizeUrl( 'https://wordpress.com/go/category/test/', 'pt-br' ) ).toEqual(
+			'https://wordpress.com/go/category/test/'
+		);
+	} );
+
 	test( 'support url', () => {
 		expect( localizeUrl( 'https://en.support.wordpress.com/', 'en' ) ).toEqual(
 			'https://wordpress.com/support/'


### PR DESCRIPTION
#### Proposed Changes

This PR makes sure that `localizeUrl` only returns localized Go blog URLs for locales that actually have a Go blog.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Code review
* Verify that the tests for `localizeUrl` pass by running `yarn test-packages -- packages/i18n-utils/src/test/localize-url.js`.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/71734.
