### PR TITLE
Refactor getSiteFragment to add new exception for plan upsell path

### DIFF
--- a/client/lib/route/path.ts
+++ b/client/lib/route/path.ts
@@ -1,4 +1,4 @@
-import { URL as URLString, SiteSlug, SiteId } from 'calypso/types';
+import { SiteId, SiteSlug, URL as URLString } from 'calypso/types';
 import { trailingslashit, untrailingslashit } from './index';
 
 /**
@@ -17,46 +17,47 @@ export function getSiteFragment( path: URLString ): SiteSlug | SiteId | false {
 	const basePath = path.split( '?' )[ 0 ];
 	const pieces = basePath.split( '/' );
 
-	// There are 2 URL positions where we should look for the site fragment:
-	// last (most sections) and second-to-last (post ID is last in editor)
-
-	// Avoid confusing the receipt ID for the site ID in domain-only checkouts.
-	if ( 0 === basePath.indexOf( '/checkout/thank-you/no-site/' ) ) {
+	// Some paths include a receipt or subscription ID that can be mistaken for a site ID.
+	// Always return false for these specific paths.
+	if (
+		// Avoid confusing the receipt ID for the site ID in domain-only checkouts.
+		0 === basePath.indexOf( '/checkout/thank-you/no-site/' ) ||
+		// Avoid confusing the subscription ID for the site ID in gifting checkouts.
+		( basePath.includes( '/gift/' ) && basePath.startsWith( '/checkout/' ) )
+	) {
 		return false;
 	}
 
-	// Avoid confusing the subscription ID for the site ID in gifting checkouts.
-	if ( basePath.includes( '/gift/' ) && basePath.startsWith( '/checkout/' ) ) {
-		return false;
-	}
+	// By default there are 2 URL positions where we should look for the site fragment:
+	// last (most sections) and second-to-last (post ID is last in editor).
+	// Define the second-to-last and last index positions to search. Order matters.
+	let searchPositions = [ pieces.length - 2, pieces.length - 1 ];
 
-	// In some paths, the site fragment could also be in third position.
+	// There are exceptions. In some paths, the site fragment is in third position.
 	// e.g. /me/purchases/example.wordpress.com/foo/bar
 	if (
 		0 === basePath.indexOf( '/me/purchases/' ) ||
 		0 === basePath.indexOf( '/checkout/thank-you/' )
 	) {
-		const piece = pieces[ 3 ]; // 0 is the empty string before the first `/`
-		if ( piece && -1 !== piece.indexOf( '.' ) ) {
-			return piece;
-		}
-		const numericPiece = parseInt( piece, 10 );
-		if ( Number.isSafeInteger( numericPiece ) ) {
-			return numericPiece;
-		}
+		searchPositions = [ 3 ];
+	}
+	// In other paths, the site fragment is in second position.
+	// e.g. /checkout/example.wordpress.com/offer-plan-upgrade/business-monthly/75806534
+	else if ( basePath.includes( '/offer-plan-upgrade/' ) && basePath.startsWith( '/checkout/' ) ) {
+		searchPositions = [ 2 ];
 	}
 
-	// Check last and second-to-last piece for site slug
-	for ( let i = 2; i > 0; i-- ) {
-		const piece = pieces[ pieces.length - i ];
+	// Search for site slug or ID in the positions defined above.
+	for ( let i = 0; i < searchPositions.length; i++ ) {
+		const piece = pieces[ searchPositions[ i ] ];
+
+		// Check for site slug.
 		if ( piece && -1 !== piece.indexOf( '.' ) ) {
+			// There is a special Jetpack case for site slugs that end with '::'.
 			return piece.endsWith( '::' ) ? piece.replace( /::$/, '' ) : piece;
 		}
-	}
 
-	// Check last and second-to-last piece for numeric site ID
-	for ( let i = 2; i > 0; i-- ) {
-		const piece = pieces[ pieces.length - i ];
+		// Check for site ID.
 		// We can't just do parseInt because some strings look like numbers, eg: '404-hello'
 		const isNumber = /^\d+$/.test( piece );
 		const intPiece = parseInt( piece, 10 );
@@ -65,7 +66,7 @@ export function getSiteFragment( path: URLString ): SiteSlug | SiteId | false {
 		}
 	}
 
-	// No site fragment here
+	// No site fragment found.
 	return false;
 }
 

--- a/client/lib/route/path.ts
+++ b/client/lib/route/path.ts
@@ -28,12 +28,12 @@ export function getSiteFragment( path: URLString ): SiteSlug | SiteId | false {
 		return false;
 	}
 
-	// By default there are 2 URL positions where we should look for the site fragment:
+	// By default there are two URL positions where we should look for the site fragment:
 	// last (most sections) and second-to-last (post ID is last in editor).
-	// Define the second-to-last and last index positions to search. Order matters.
+	// searchPositions defines the second-to-last and last index positions to search. Order matters.
 	let searchPositions = [ pieces.length - 2, pieces.length - 1 ];
 
-	// There are exceptions. In some paths, the site fragment is in third position.
+	// There are exceptions. In some paths the site fragment is in the third position.
 	// e.g. /me/purchases/example.wordpress.com/foo/bar
 	if (
 		0 === basePath.indexOf( '/me/purchases/' ) ||
@@ -41,13 +41,13 @@ export function getSiteFragment( path: URLString ): SiteSlug | SiteId | false {
 	) {
 		searchPositions = [ 3 ];
 	}
-	// In other paths, the site fragment is in second position.
+	// In other paths the site fragment is in the second position.
 	// e.g. /checkout/example.wordpress.com/offer-plan-upgrade/business-monthly/75806534
 	else if ( basePath.includes( '/offer-plan-upgrade/' ) && basePath.startsWith( '/checkout/' ) ) {
 		searchPositions = [ 2 ];
 	}
 
-	// Search for site slug or ID in the positions defined above.
+	// Search for site slug or ID in the URL positions defined above in searchPositions.
 	for ( let i = 0; i < searchPositions.length; i++ ) {
 		const piece = pieces[ searchPositions[ i ] ];
 

--- a/client/lib/route/test/index.js
+++ b/client/lib/route/test/index.js
@@ -154,6 +154,13 @@ describe( 'route', function () {
 					route.getSiteFragment( '/checkout/thank-you/example.wordpress.com/75806534' )
 				).toEqual( 'example.wordpress.com' );
 			} );
+			test( 'should return the correct site fragment during upsell', function () {
+				expect(
+					route.getSiteFragment(
+						'/checkout/example.wordpress.com/offer-plan-upgrade/business-monthly/75806534'
+					)
+				).toEqual( 'example.wordpress.com' );
+			} );
 		} );
 		describe( 'for jetpack paths', function () {
 			test( 'should return correct site fragment when site_url is trailing slashed', function () {
@@ -168,7 +175,7 @@ describe( 'route', function () {
 					'example.wpcomstaging.com'
 				);
 			} );
-			test( 'should return false when plugin name ends a number', function () {
+			test( 'should return false when plugin name starts with a number', function () {
 				expect( route.getSiteFragment( '/plugins/404-to-301' ) ).toEqual( false );
 			} );
 		} );


### PR DESCRIPTION
Context: The `calypso_page_view event` Tracks event is not running on the Premium-Business upsell page. e.g. `/checkout/example.wordpress.com/offer-plan-upgrade/business-monthly/65846531` This is because `getSiteFragment` is returning `:order_id` instead of `:site` for the the upsell page.

Issue here: https://github.com/Automattic/wp-calypso/issues/71669

#### Proposed Changes

* By default `getSiteFragment` looks for site slug or site ID in the last 2 URL positions. However, there are exceptions to that generality.
* This PR refactors `getSiteFragment` so it can better wrangle those exceptions by reducing and discouraging code duplication.
* This PR adds a new exception for the Premium to Business upsell page path. e.g. `/checkout/example.wordpress.com/offer-plan-upgrade/business-monthly/65846531`
  * Before this PR `getSiteFragment` incorrectly returned 65846531 for this path. Now it correctly returns `example.wordpress.com`.
* This PR also adds a unit test for the above exception.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Code:
* Before this PR I added more unit tests to cover `getSiteFragment` here: https://github.com/Automattic/wp-calypso/pull/71736 These should continue to pass as well as the new unit test included in this PR.
* Review the PR diff to be double check nothing was missed in the refactor.

Functionality:
* Follow this guide so you can view Tracks events fire in real-time: PCYsg-cae-p2
* In production load this page http://wordpress.com/checkout/example.wordpress.com/offer-plan-upgrade/business-monthly/65846531 and notice that the `calypso_page_view` event is NOT called.
* Load this PR and go to the same page locally: http://calypso.localhost:3000/checkout/example.wordpress.com/offer-plan-upgrade/business-monthly/65846531. Notice that the `calypso_page_view` event IS called and the `path` property is correct.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/71669