### PR TITLE
WooExpress Trial: Ensure that wooexpress trial sites are created as Private

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
@@ -1,6 +1,7 @@
 import { Site } from '@automattic/data-stores';
 import {
 	ECOMMERCE_FLOW,
+	WOOEXPRESS_FLOW,
 	isLinkInBioFlow,
 	addPlanToCart,
 	createSiteWithCart,
@@ -48,8 +49,9 @@ const SiteCreationStep: Step = function SiteCreationStep( { navigation, flow } )
 		siteVisibility = Site.Visibility.PublicNotIndexed;
 	}
 
-	// Ecommerce flow defaults to Private
-	if ( flow === ECOMMERCE_FLOW ) {
+	// Certain flows should default to private.
+	const privateFlows = [ ECOMMERCE_FLOW, WOOEXPRESS_FLOW ];
+	if ( privateFlows.includes( flow ) ) {
 		siteVisibility = Site.Visibility.Private;
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
@@ -51,7 +51,7 @@ const SiteCreationStep: Step = function SiteCreationStep( { navigation, flow } )
 
 	// Certain flows should default to private.
 	const privateFlows = [ ECOMMERCE_FLOW, WOOEXPRESS_FLOW ];
-	if ( privateFlows.includes( flow ) ) {
+	if ( privateFlows.includes( flow || '' ) ) {
 		siteVisibility = Site.Visibility.Private;
 	}
 


### PR DESCRIPTION
#### Proposed Changes

Previously, newly created WooExpress trial sites were created as public. This change makes it so the newly created sites a private instead.

#### Testing Instructions

1. Apply this branch.
2. Visit http://calypso.localhost:3000/setup/wooexpress/
3. After the `processing` step, you'll be redirected to the dashboard.
4. Verify that the site is private (eg. not launched yet)

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [NA] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [NA] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [NA] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [NA] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [NA] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #71730
