### PR TITLE
Fix missing TypeScript dependencies for privacy-toolkit and block-renderer

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -50,6 +50,7 @@
 		"@automattic/onboarding": "workspace:^",
 		"@automattic/pattern-picker": "workspace:^",
 		"@automattic/plans-grid": "workspace:^",
+		"@automattic/privacy-toolset": "workspace:^",
 		"@automattic/react-virtualized": "^9.22.3",
 		"@automattic/request-external-access": "workspace:^",
 		"@automattic/search": "workspace:^",

--- a/package.json
+++ b/package.json
@@ -134,6 +134,7 @@
 		"whybundled:server": "NODE_ENV=production CALYPSO_ENV=production EMIT_STATS=withreasons CONCATENATE_MODULES=false yarn run build-server && whybundled client/stats-server.json"
 	},
 	"dependencies": {
+		"@automattic/block-renderer": "workspace:^",
 		"@automattic/calypso-babel-config": "workspace:^",
 		"@automattic/calypso-build": "workspace:^",
 		"@automattic/calypso-color-schemes": "workspace:^",

--- a/packages/tsconfig.json
+++ b/packages/tsconfig.json
@@ -7,6 +7,7 @@
 	// Reference all TS packages
 	"references": [
 		{ "path": "./accessible-focus" },
+		{ "path": "./block-renderer" },
 		{ "path": "./browser-data-collector" },
 		{ "path": "./calypso-analytics" },
 		{ "path": "./calypso-config" },

--- a/packages/tsconfig.json
+++ b/packages/tsconfig.json
@@ -37,6 +37,7 @@
 		{ "path": "./pattern-picker" },
 		{ "path": "./photon" },
 		{ "path": "./plans-grid" },
+		{ "path": "./privacy-toolset" },
 		{ "path": "./search" },
 		{ "path": "./sites" },
 		{ "path": "./shopping-cart" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -12599,6 +12599,7 @@ __metadata:
     "@automattic/onboarding": "workspace:^"
     "@automattic/pattern-picker": "workspace:^"
     "@automattic/plans-grid": "workspace:^"
+    "@automattic/privacy-toolset": "workspace:^"
     "@automattic/react-virtualized": ^9.22.3
     "@automattic/request-external-access": "workspace:^"
     "@automattic/search": "workspace:^"
@@ -35586,6 +35587,7 @@ swiper@4.5.1:
   version: 0.0.0-use.local
   resolution: "wp-calypso@workspace:."
   dependencies:
+    "@automattic/block-renderer": "workspace:^"
     "@automattic/calypso-babel-config": "workspace:^"
     "@automattic/calypso-build": "workspace:^"
     "@automattic/calypso-color-schemes": "workspace:^"


### PR DESCRIPTION
#### Proposed Changes

Currently when running the TypeScript compiler on calypso's `client` directory, you get a lot of errors like:

```
client/blocks/do-not-sell-dialog/index.tsx:1:33 - error TS2307: Cannot find module '@automattic/privacy-toolset' or its corresponding type declarations.
client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-list-renderer.tsx:1:33 - error TS2307: Cannot find module '@automattic/block-renderer' or its
corresponding type declarations.
```

These errors are also visible if you use a TypeScript-aware editor when editing the mentioned files. However, the missing packages do exist, they just had not been listed as dependencies or added to the TS config file. 

This PR adds both packages, `@automattic/privacy-toolkit` (added by https://github.com/Automattic/wp-calypso/pull/70833) and `@automattic/block-renderer` (added by https://github.com/Automattic/wp-calypso/pull/71417) as dependencies to the `client` package and also to the TS config file.

**Note:** Yarn's build process now reports the following error, but I'm not sure how to fix it.

```
➤ YN0060: │ wp-calypso@workspace:. provides react (p4692f) with version 17.0.2, which doesn't satisfy what @automattic/block-renderer and some of its descendants request
➤ YN0060: │ wp-calypso@workspace:. provides react-dom (p0b524) with version 17.0.2, which doesn't satisfy what @automattic/block-renderer and some of its descendants request
...
➤ YN0000: wp-calypso@workspace:. provides react@npm:17.0.2 with version 17.0.2, which doesn't satisfy the following requirements:
➤ YN0000: react-autosize-textarea@npm:7.1.0 [f63de]                            → ^0.14.0 || ^15.0.0 || ^16.0.0 ✘
```

So the problem is that `@automattic/block-renderer` depends on `@wordpress/block-editor`, which does not support React 17 because of its dependency on `react-autosize-textarea`. The issue would be resolved by this PR but I think the repo might be abandoned: https://github.com/buildo/react-autosize-textarea/pull/148 


#### Testing Instructions

Before this PR, running `yarn tsc -p client/tsconfig.json --noEmit` would result in 8 errors.

After this PR, the command will result in no errors.