### PR TITLE
Add privacy-toolset/block-renderer packages to tsconfig

### DIFF
--- a/packages/tsconfig.json
+++ b/packages/tsconfig.json
@@ -7,6 +7,7 @@
 	// Reference all TS packages
 	"references": [
 		{ "path": "./accessible-focus" },
+		{ "path": "./block-renderer" },
 		{ "path": "./browser-data-collector" },
 		{ "path": "./calypso-analytics" },
 		{ "path": "./calypso-config" },
@@ -37,6 +38,7 @@
 		{ "path": "./pattern-picker" },
 		{ "path": "./photon" },
 		{ "path": "./plans-grid" },
+		{ "path": "./privacy-toolset" },
 		{ "path": "./search" },
 		{ "path": "./sites" },
 		{ "path": "./shopping-cart" },


### PR DESCRIPTION
#### Proposed Changes

Currently when running the TypeScript compiler on calypso's `client` directory, you get a lot of errors like:

```
client/blocks/do-not-sell-dialog/index.tsx:1:33 - error TS2307: Cannot find module '@automattic/privacy-toolset' or its corresponding type declarations.
client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-list-renderer.tsx:1:33 - error TS2307: Cannot find module '@automattic/block-renderer' or its
corresponding type declarations.
```

These errors are also visible if you use a TypeScript-aware editor when editing the mentioned files. However, the missing packages do exist, they just had not been listed as dependencies or added to the TS config file. 

This PR adds both packages, `@automattic/privacy-toolkit` (added by https://github.com/Automattic/wp-calypso/pull/70833) and `@automattic/block-renderer` (added by https://github.com/Automattic/wp-calypso/pull/71417) to the TS config file.

I tried also adding them to the dependencies list, but that causes errors. See https://github.com/Automattic/wp-calypso/pull/71772

#### Testing Instructions

Before this PR, running `yarn tsc -p client/tsconfig.json --noEmit` would result in 8 errors.

After this PR, the command will result in no errors.