### PR TITLE
Theme Showcase: Enable theme card's more button

### DIFF
--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -613,18 +613,8 @@ export class Theme extends Component {
 								  ! active && (
 										<span className="theme__info-upsell-description">{ translate( 'Free' ) }</span>
 								  ) ) }
-						{ isNewDetailsAndPreview ? (
-							<div
-								className={ classNames( 'theme__info-options', {
-									'has-style-variations': theme.style_variations?.length > 0,
-								} ) }
-							>
-								{ ! active && this.renderStyleVariations() }
-								{ this.renderMoreButton() }
-							</div>
-						) : (
-							this.renderMoreButton()
-						) }
+						{ isNewDetailsAndPreview && ! active && this.renderStyleVariations() }
+						{ this.renderMoreButton() }
 					</div>
 				</div>
 			</Card>

--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -471,6 +471,24 @@ export class Theme extends Component {
 		);
 	};
 
+	renderMoreButton = () => {
+		const { active, buttonContents, index, theme, onMoreButtonClick } = this.props;
+		if ( isEmpty( buttonContents ) ) {
+			return null;
+		}
+
+		return (
+			<ThemeMoreButton
+				index={ index }
+				themeId={ theme.id }
+				themeName={ theme.name }
+				active={ active }
+				onMoreButtonClick={ onMoreButtonClick }
+				options={ buttonContents }
+			/>
+		);
+	};
+
 	softLaunchedBanner = () => {
 		const { translate } = this.props;
 
@@ -572,7 +590,11 @@ export class Theme extends Component {
 
 					{ this.softLaunchedBanner() }
 
-					<div className="theme__info">
+					<div
+						className={ classNames( 'theme__info', {
+							'has-pricing': !! upsellUrl,
+						} ) }
+					>
 						<h2 className="theme__info-title">{ name }</h2>
 						{ active && (
 							<span className="theme__badge-active">
@@ -598,28 +620,10 @@ export class Theme extends Component {
 								} ) }
 							>
 								{ ! active && this.renderStyleVariations() }
-								{ ! isEmpty( this.props.buttonContents ) && (
-									<ThemeMoreButton
-										index={ this.props.index }
-										themeId={ this.props.theme.id }
-										themeName={ this.props.theme.name }
-										active={ this.props.active }
-										onMoreButtonClick={ this.props.onMoreButtonClick }
-										options={ this.props.buttonContents }
-									/>
-								) }
+								{ this.renderMoreButton() }
 							</div>
 						) : (
-							! isEmpty( this.props.buttonContents ) && (
-								<ThemeMoreButton
-									index={ this.props.index }
-									themeId={ this.props.theme.id }
-									themeName={ this.props.theme.name }
-									active={ this.props.active }
-									onMoreButtonClick={ this.props.onMoreButtonClick }
-									options={ this.props.buttonContents }
-								/>
-							)
+							this.renderMoreButton()
 						) }
 					</div>
 				</div>

--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -591,17 +591,36 @@ export class Theme extends Component {
 								  ! active && (
 										<span className="theme__info-upsell-description">{ translate( 'Free' ) }</span>
 								  ) ) }
-						{ isNewDetailsAndPreview && ! active && this.renderStyleVariations() }
-						{ ! isNewDetailsAndPreview && ! isEmpty( this.props.buttonContents ) ? (
-							<ThemeMoreButton
-								index={ this.props.index }
-								themeId={ this.props.theme.id }
-								themeName={ this.props.theme.name }
-								active={ this.props.active }
-								onMoreButtonClick={ this.props.onMoreButtonClick }
-								options={ this.props.buttonContents }
-							/>
-						) : null }
+						{ isNewDetailsAndPreview ? (
+							<div
+								className={ classNames( 'theme__info-options', {
+									'has-style-variations': theme.style_variations?.length > 0,
+								} ) }
+							>
+								{ ! active && this.renderStyleVariations() }
+								{ ! isEmpty( this.props.buttonContents ) && (
+									<ThemeMoreButton
+										index={ this.props.index }
+										themeId={ this.props.theme.id }
+										themeName={ this.props.theme.name }
+										active={ this.props.active }
+										onMoreButtonClick={ this.props.onMoreButtonClick }
+										options={ this.props.buttonContents }
+									/>
+								) }
+							</div>
+						) : (
+							! isEmpty( this.props.buttonContents ) && (
+								<ThemeMoreButton
+									index={ this.props.index }
+									themeId={ this.props.theme.id }
+									themeName={ this.props.theme.name }
+									active={ this.props.active }
+									onMoreButtonClick={ this.props.onMoreButtonClick }
+									options={ this.props.buttonContents }
+								/>
+							)
+						) }
 					</div>
 				</div>
 			</Card>

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -11,7 +11,6 @@ body.is-section-themes {
 	.layout:not(.has-no-sidebar) .layout__content {
 		padding-top: var(--masterbar-height);
 	}
-
 }
 
 .theme-showcase {
@@ -103,6 +102,15 @@ body.is-section-themes {
 }
 
 body.is-section-themes-i4-2 {
+	.layout.has-no-sidebar .layout__content {
+		.themes__selection .themes-list .theme {
+			.theme__info-options:not(.has-style-variations) {
+				align-self: flex-start;
+				flex: 0 0 auto;
+			}
+		}
+	}
+
 	.themes__selection .themes-list .theme {
 		background: none;
 		border-radius: 2px;
@@ -118,12 +126,17 @@ body.is-section-themes-i4-2 {
 				border-bottom-right-radius: 2px;
 				box-sizing: content-box;
 				flex-direction: row;
-				gap: 0;
+				gap: 16px;
 				padding: 4px 24px;
 			}
 
 			.theme__info-title {
 				color: var(--color-text-inverted);
+			}
+
+			.theme__info-options {
+				display: inline-flex;
+				flex: 0 0 auto;
 			}
 		}
 
@@ -183,8 +196,28 @@ body.is-section-themes-i4-2 {
 			line-height: 24px;
 		}
 
-		.theme__info-style-variations {
+		.theme__badge-active {
+			background-color: var(--color-primary-0);
+			border-radius: 20px; /* stylelint-disable-line scales/radii */
+			color: var(--color-neutral-100);
+			font-size: 0.75rem;
+			line-height: 20px;
+			padding: 0 10px;
+			text-transform: none;
+		}
+
+		.theme__info-options {
 			align-self: center;
+			display: flex;
+			flex-basis: 100%;
+
+			.theme__more-button:only-child {
+				margin-inline-start: auto;
+			}
+		}
+
+		.theme__info-style-variations {
+			align-content: center;
 			display: flex;
 			flex-basis: 100%;
 			font-size: 0;
@@ -195,14 +228,18 @@ body.is-section-themes-i4-2 {
 			}
 		}
 
-		.theme__badge-active {
-			background-color: var(--color-primary-0);
-			border-radius: 20px; /* stylelint-disable-line scales/radii */
-			color: var(--color-neutral-100);
-			font-size: 0.75rem;
-			line-height: 20px;
-			padding: 0 10px;
-			text-transform: none;
+		.theme__more-button {
+			border: 0;
+			height: 20px;
+
+			&:hover {
+				background-color: transparent;
+			}
+
+			button {
+				font-size: 0;
+				padding: 0;
+			}
 		}
 	}
 

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -118,6 +118,7 @@ body.is-section-themes-i4-2 {
 				box-sizing: content-box;
 				flex-direction: row;
 				gap: 16px;
+				margin-top: 0;
 				padding: 4px 24px;
 			}
 
@@ -125,9 +126,8 @@ body.is-section-themes-i4-2 {
 				color: var(--color-text-inverted);
 			}
 
-			.theme__info-options {
-				display: inline-flex;
-				flex: 0 0 auto;
+			.theme__more-button {
+				position: relative;
 			}
 		}
 
@@ -157,13 +157,12 @@ body.is-section-themes-i4-2 {
 			flex-wrap: wrap;
 			height: 48px;
 			gap: 4px;
-			padding-top: 16px;
+			margin-top: 16px;
 			position: relative;
 
 			&:not(.has-pricing) {
-				.theme__info-options:not(.has-style-variations) {
-					align-self: flex-start;
-					flex: 0 0 auto;
+				.theme__more-button {
+					top: 0;
 				}
 			}
 		}
@@ -204,16 +203,6 @@ body.is-section-themes-i4-2 {
 			text-transform: none;
 		}
 
-		.theme__info-options {
-			align-self: center;
-			display: flex;
-			flex-basis: 100%;
-
-			.theme__more-button:only-child {
-				margin-inline-start: auto;
-			}
-		}
-
 		.theme__info-style-variations {
 			align-content: center;
 			display: flex;
@@ -227,8 +216,11 @@ body.is-section-themes-i4-2 {
 		}
 
 		.theme__more-button {
+			bottom: 0;
 			border: 0;
 			height: 20px;
+			position: absolute;
+			right: 0;
 
 			&:hover {
 				background-color: transparent;

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -102,15 +102,6 @@ body.is-section-themes {
 }
 
 body.is-section-themes-i4-2 {
-	.layout.has-no-sidebar .layout__content {
-		.themes__selection .themes-list .theme {
-			.theme__info-options:not(.has-style-variations) {
-				align-self: flex-start;
-				flex: 0 0 auto;
-			}
-		}
-	}
-
 	.themes__selection .themes-list .theme {
 		background: none;
 		border-radius: 2px;
@@ -168,6 +159,13 @@ body.is-section-themes-i4-2 {
 			gap: 4px;
 			padding-top: 16px;
 			position: relative;
+
+			&:not(.has-pricing) {
+				.theme__info-options:not(.has-style-variations) {
+					align-self: flex-start;
+					flex: 0 0 auto;
+				}
+			}
 		}
 
 		.theme__info-title {


### PR DESCRIPTION
#### Proposed Changes

This PR brings back the more button as per the discussion in pbxlJb-39D-p2#comment-2188. The main reasoning is that (1) The option to delete an installed theme is not provided elsewhere in the Theme Showcase, and (2) we currently do not have data to measure how often the more button is being used.

| Before | After |
| --- | --- | 
| ![Screen Shot 2023-01-09 at 12 02 17 PM](https://user-images.githubusercontent.com/797888/211239243-114faf01-c8d9-4c40-82cc-61027df7ff25.png) | ![Screen Shot 2023-01-09 at 12 02 44 PM](https://user-images.githubusercontent.com/797888/211239279-8b685e38-533a-4e33-a9d7-e3a7fbd77d80.png) |

And the logged-out Theme Showcase:
![Screen Shot 2023-01-09 at 12 03 33 PM](https://user-images.githubusercontent.com/797888/211239362-8dd1c7fb-de69-4973-b171-3506b29752b4.png)

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the logged-in Theme Showcase `/themes/${site_slug}`. If using calypso.live, the flag `themes/showcase-i4/details-and-preview` is required.
* Ensure that the more button is displayed as shown above.
* Ensure that the options in the more button menu works as intended.
* Also test the logged-out Theme Showcase.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
