### PR TITLE
Checkout: don't display pre-sales chat if purchases are blocked

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/checkout-help-link.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-help-link.tsx
@@ -147,7 +147,7 @@ export default function CheckoutHelpLink() {
 	const cartKey = useCartKey();
 	const { responseCart } = useShoppingCart( cartKey );
 
-	const cartErrors = responseCart.messages?.errors || [];
+	const cartErrors = responseCart.messages?.persistent_errors || [];
 	const purchasesAreBlocked = cartErrors.some(
 		( error: ResponseCartMessage ) => error.code === 'blocked'
 	);

--- a/client/my-sites/checkout/composite-checkout/components/checkout-help-link.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-help-link.tsx
@@ -3,6 +3,7 @@ import { Gridicon } from '@automattic/components';
 import { HelpCenter } from '@automattic/data-stores';
 import { SUPPORT_FORUM, shouldShowHelpCenterToUser } from '@automattic/help-center';
 import { useIsEnglishLocale } from '@automattic/i18n-utils';
+import { ResponseCartMessage, useShoppingCart } from '@automattic/shopping-cart';
 import { keyframes } from '@emotion/react';
 import styled from '@emotion/styled';
 import { useDispatch as useDataStoreDispatch } from '@wordpress/data';
@@ -11,6 +12,7 @@ import { useSelector, useDispatch } from 'react-redux';
 import QuerySupportTypes from 'calypso/blocks/inline-help/inline-help-query-support-types';
 import AsyncLoad from 'calypso/components/async-load';
 import HappychatButtonUnstyled from 'calypso/components/happychat/button';
+import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import getSupportLevel from 'calypso/state/happychat/selectors/get-support-level';
@@ -142,6 +144,13 @@ export default function CheckoutHelpLink() {
 	const { setShowHelpCenter } = useDataStoreDispatch( HELP_CENTER_STORE );
 	const isEnglishLocale = useIsEnglishLocale();
 
+	const cartKey = useCartKey();
+	const { responseCart } = useShoppingCart( cartKey );
+
+	const cartErrors = responseCart.messages?.errors || [];
+	const purchasesAreBlocked =
+		cartErrors.filter( ( error: ResponseCartMessage ) => error.code === 'blocked' ).length > 0;
+
 	const {
 		presalesZendeskChatAvailable,
 		section,
@@ -176,7 +185,10 @@ export default function CheckoutHelpLink() {
 
 	const zendeskPresalesChatKey: string | false = config( 'zendesk_presales_chat_key' );
 	const isPresalesZendeskChatEligible =
-		presalesZendeskChatAvailable && isEnglishLocale && zendeskPresalesChatKey;
+		presalesZendeskChatAvailable &&
+		isEnglishLocale &&
+		zendeskPresalesChatKey &&
+		! purchasesAreBlocked;
 
 	const hasDirectSupport = supportVariation !== SUPPORT_FORUM;
 

--- a/client/my-sites/checkout/composite-checkout/components/checkout-help-link.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-help-link.tsx
@@ -148,8 +148,9 @@ export default function CheckoutHelpLink() {
 	const { responseCart } = useShoppingCart( cartKey );
 
 	const cartErrors = responseCart.messages?.errors || [];
-	const purchasesAreBlocked =
-		cartErrors.filter( ( error: ResponseCartMessage ) => error.code === 'blocked' ).length > 0;
+	const purchasesAreBlocked = cartErrors.some(
+		( error: ResponseCartMessage ) => error.code === 'blocked'
+	);
 
 	const {
 		presalesZendeskChatAvailable,


### PR DESCRIPTION
#### Proposed Changes

* This checks the cart for purchases-blocked error messages and prevents the display of pre-sales chat if purchases are blocked.

#### Testing Instructions

* To block purchase for a user on wpcom, run `update_user_attribute( $_user_id, 'block_purchases', true )` in wpsh;
* See #70118 for general testing instructions (note that by default, presales chat availability is controlled by wpcom endpoint). You can overwrite `presalesZendeskChatAvailable` to check just this new condition.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?

Fixes #71310
