### PR TITLE
Chart Component: Fix bug in empty state test.

### DIFF
--- a/client/components/chart/index.jsx
+++ b/client/components/chart/index.jsx
@@ -110,7 +110,7 @@ function Chart( {
 	// Memoize data calculations to avoid performing them too often.
 	const { chartData, isEmptyChart, yMax } = useMemo( () => {
 		const nextData = data.length <= maxBars ? data : data.slice( 0 - maxBars );
-		const nextVals = data.map( ( { value } ) => value );
+		const nextVals = nextData.map( ( { value } ) => value );
 
 		return {
 			chartData: nextData,


### PR DESCRIPTION
The previous test was using the full data set instead of the newly computed visible data set. As a result, narrower views and mobile weren’t showing empty states correctly.

#### Proposed Changes

Fixes the empty state test to use the computed subset of visible data.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

This is a bit specific to test but the steps are:

1. Find a site that doesn't have any views over the past seven days but does have views within the past 30 days. 
2. Navigate to the Stats → Traffic page.
3. View the site at full width (so the full 30 days of data is visible in the chart). Confirm the empty state is not shown.
4. Change to responsive mode and reduce the screen width as needed to remove days with recorded views. Confirm the empty state is shown.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #71746
