### PR TITLE
Add correct page title to Email Stats Detail page

### DIFF
--- a/client/my-sites/stats/stats-email-open-detail/index.jsx
+++ b/client/my-sites/stats/stats-email-open-detail/index.jsx
@@ -9,6 +9,7 @@ import { Component } from 'react';
 import { connect } from 'react-redux';
 import titlecase from 'to-title-case';
 import Intervals from 'calypso/blocks/stats-navigation/intervals';
+import DocumentHead from 'calypso/components/data/document-head';
 import QueryEmailStats from 'calypso/components/data/query-email-stats';
 import EmptyContent from 'calypso/components/empty-content';
 import FixedNavigationHeader from 'calypso/components/fixed-navigation-header';
@@ -215,6 +216,7 @@ class StatsEmailOpenDetail extends Component {
 
 		return (
 			<Main className="has-fixed-nav stats__email-opens" wideLayout>
+				<DocumentHead title={ translate( 'Jetpack Stats' ) } />
 				<QueryEmailStats
 					siteId={ siteId }
 					postId={ postId }


### PR DESCRIPTION
#### Proposed Changes

This PR adds the correct title to the Email Stats Details page, fixing [this issue](https://github.com/Automattic/wp-calypso/issues/71694).

#### Testing Instructions
1. Apply this branch to your local Calypso repository and start the application.
2. Insert manually in the browser address bar an URL with this format: https://calypso.localhost:3000/stats/email/open/[the-doomain-of-your-blog]/day/[post-id]?flags=newsletter/stats. Note that you can change day for week and month.
3. You should see a title like `Jetpack Stats < [the-title-of-the-site] -- Wordpress.com`.

---

Fixes https://github.com/Automattic/wp-calypso/issues/71694
