### PR TITLE
Theme Showcase: Hide preview option for non-wpcom themes

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -248,8 +248,10 @@ class ThemeSheet extends Component {
 	};
 
 	shouldRenderPreviewButton() {
-		const { isWPForTeamsSite } = this.props;
-		return this.isThemeAvailable() && ! this.isThemeCurrentOne() && ! isWPForTeamsSite;
+		const { isWpcomTheme, isWPForTeamsSite } = this.props;
+		return (
+			this.isThemeAvailable() && ! this.isThemeCurrentOne() && ! isWPForTeamsSite && isWpcomTheme
+		);
 	}
 
 	isThemeCurrentOne() {
@@ -302,7 +304,7 @@ class ThemeSheet extends Component {
 					className="theme__sheet-screenshot is-active"
 					href={ demoUrl }
 					onClick={ ( e ) => {
-						this.previewAction( e, 'screenshot' );
+						isWpcomTheme && this.previewAction( e, 'screenshot' );
 					} }
 					rel="noopener noreferrer"
 				>

--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -224,11 +224,8 @@ function getAllThemeOptions( { translate, isFSEActive } ) {
 			comment: 'label for previewing the theme demo website',
 		} ),
 		action: themePreview,
-		hideForTheme: ( state, themeId, siteId ) => {
-			const demoUrl = getThemeDemoUrl( state, themeId, siteId );
-
-			return ! demoUrl;
-		},
+		hideForTheme: ( state, themeId, siteId ) =>
+			! getThemeDemoUrl( state, themeId, siteId ) || ! isWpcomTheme( state, themeId ),
 	};
 
 	const signupLabel = translate( 'Pick this design', {


### PR DESCRIPTION
#### Proposed Changes

Currently, opening the preview for non-wpcom themes such as Astra (https://wordpress.com/themes?s=astra) results in the theme preview opening, but the iframe fails to render. Instead, the demo URL (https://wp-themes.com/astra/?demo=true&iframe=true&theme_preview=true) opens up in a new tab. This is a confusing experience, since the demo URL isn't loaded in the preview UI, but as a separate browser tab.

As a solution, we can hide the preview option for non-wpcom themes, or update #71785 to load the demo URL in the preview iframe instead. The caveat of this latter approach is that users will be able to navigate the embedded site, which can cause unforseeable effects.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the logged-in Theme Showcase `/themes/${site_slug}`. If using calypso.live, the flag `themes/showcase-i4/details-and-preview` is required.
* Search for a non-wpcom theme, such as Astra.
* Ensure that the option "Live demo" isn't available for non-wpcom themes.
* Ensure that the option "Live demo" is available for wpcom themes.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

