### PR TITLE
Reading Settings: Add logic that decides whether the Newsletter settings section will be displayed

### DIFF
--- a/client/my-sites/site-settings/settings-reading/main.tsx
+++ b/client/my-sites/site-settings/settings-reading/main.tsx
@@ -6,7 +6,7 @@ import FormattedHeader from 'calypso/components/formatted-header';
 import Main from 'calypso/components/main';
 import { isModuleActive } from 'calypso/lib/site/utils';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
-import { getSiteUrl, getSite, isJetpackSite } from 'calypso/state/sites/selectors';
+import { getSiteUrl, getSite, isSimpleSite, isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { NewsletterSettingsSection } from '../reading-newsletter-settings';
 import { RssFeedSettingsSection } from '../reading-rss-feed-settings';
@@ -58,14 +58,16 @@ const connectComponent = connect( ( state ) => {
 	const siteId = getSelectedSiteId( state );
 	const siteUrl = siteId && getSiteUrl( state, siteId );
 	const site = siteId && getSite( state, siteId );
-	const isJetpack = isJetpackSite( state, siteId );
+	const isSimple = isSimpleSite( state );
 	const isAtomic = isSiteAutomatedTransfer( state, siteId );
+	const isJetpack = isJetpackSite( state, siteId );
 
 	return {
 		...( siteUrl && { siteUrl } ),
 		...( site && { site } ),
-		...( isJetpack && { isJetpack } ),
+		...( isSimple && { isSimple } ),
 		...( isAtomic && { isAtomic } ),
+		...( isJetpack && { isJetpack } ),
 	};
 } );
 
@@ -86,8 +88,9 @@ type ReadingSettingsFormProps = {
 	isSavingSettings: boolean;
 	siteUrl?: string;
 	site?: object;
-	isJetpack?: boolean;
+	isSimple?: boolean;
 	isAtomic?: boolean;
+	isJetpack?: boolean;
 	updateFields: ( fields: Fields ) => void;
 };
 
@@ -102,14 +105,14 @@ const ReadingSettingsForm = wrapSettingsForm( getFormSettings )(
 			isSavingSettings,
 			siteUrl,
 			site,
-			isJetpack,
+			isSimple,
 			isAtomic,
+			isJetpack,
 			updateFields,
 		}: ReadingSettingsFormProps ) => {
 			const disabled = isRequestingSettings || isSavingSettings;
 			const newsletterSectionEnabled =
-				( ! isJetpack && ! isAtomic ) ||
-				( ( isJetpack || isAtomic ) && site && isModuleActive( site, 'subscriptions' ) )
+				isSimple || ( ( isJetpack || isAtomic ) && site && isModuleActive( site, 'subscriptions' ) )
 					? true
 					: false;
 			return (


### PR DESCRIPTION
🚧  Work in progress. Not ready for review yet. Will need design input.

Fixes https://github.com/Automattic/wp-calypso/issues/71714

#### Proposed Changes

The proposed changes add condition based on which the `NewsletterSettingsSection` component will or will not render on the new Reading settings page:

![Image](https://user-images.githubusercontent.com/25105483/210815948-7662af3f-67ee-4468-bb64-b0ae00c77ab9.png)

The section should be displayed only in one of these two cases:

- the site is Simple (where the `subscriptions` module cannot be deactivated)
- the site is Atomic or Jetpack and the `subscriptions` module is active

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check put the PR and build it locally.
2. Navigate to the new Reading page (`http://calypso.localhost:3000/settings/reading/`).
3. Test with Simple, Atomic and Jetpack (e.g. via Jurassic Ninja) sites.
4. If the site is Simple, the Newsletter settings section should render. **If the site is Atomic or Jetpack, the section should render only if the `subscriptions` module is enabled.** This module can be enabled through `wp-admin/admin.php?page=jetpack#/discussion`:

![Markup on 2023-01-09 at 14:23:33](https://user-images.githubusercontent.com/25105483/211318083-af77a0cf-ac1a-4fe9-9c3d-646fac349afe.png)

(or through the Blog RC).

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #71714
