### PR TITLE
Jetpack Cloud Cart integration - split changes in layout and mini-cart folder 

### DIFF
--- a/client/layout/masterbar/masterbar-cart/masterbar-cart-button.tsx
+++ b/client/layout/masterbar/masterbar-cart/masterbar-cart-button.tsx
@@ -2,7 +2,6 @@ import { Popover } from '@automattic/components';
 import { CheckoutErrorBoundary } from '@automattic/composite-checkout';
 import { MiniCart } from '@automattic/mini-cart';
 import { useShoppingCart } from '@automattic/shopping-cart';
-import { useMobileBreakpoint } from '@automattic/viewport-react';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useRef, useState } from 'react';
 import { useDispatch } from 'react-redux';
@@ -44,7 +43,6 @@ export function MasterbarCartButton( {
 	const cartButtonRef = useRef( null );
 	const [ isActive, setIsActive ] = useState( false );
 	const translate = useTranslate();
-	const isMobile = useMobileBreakpoint();
 
 	const reduxDispatch = useDispatch();
 	const shouldShowCart =
@@ -59,15 +57,12 @@ export function MasterbarCartButton( {
 	}, [ shouldShowCart, reduxDispatch ] );
 
 	useEffect( () => {
-		const isPricingPage = document.body.classList.contains( 'is-section-jetpack-cloud-pricing' );
-
-		//add the className for body, only if the page is in mobile view and in pricing page
-		if ( isActive && isMobile && isPricingPage ) {
-			document.body.classList.add( 'is-mobile-cart' );
+		if ( isActive ) {
+			document.body.classList.add( 'body--masterbar-cart-visible' );
 		} else {
-			document.body.classList.remove( 'is-mobile-cart' );
+			document.body.classList.remove( 'body--masterbar-cart-visible' );
 		}
-	}, [ isActive, isMobile ] );
+	}, [ isActive ] );
 
 	if ( ! shouldShowCart ) {
 		return null;

--- a/client/layout/masterbar/masterbar-cart/masterbar-cart-count.scss
+++ b/client/layout/masterbar/masterbar-cart/masterbar-cart-count.scss
@@ -1,4 +1,4 @@
-masterbar-cart-count {
+.masterbar-cart-count {
 	height: 18px;
 	font-size: 0.75rem;
 	color: #fff;

--- a/client/layout/masterbar/masterbar-cart/masterbar-cart-count.scss
+++ b/client/layout/masterbar/masterbar-cart/masterbar-cart-count.scss
@@ -1,0 +1,17 @@
+masterbar-cart-count {
+	height: 18px;
+	font-size: 0.75rem;
+	color: #fff;
+	padding: 0 5px;
+	vertical-align: top;
+	text-align: center;
+	min-width: 0.5rem;
+	border-radius: 50%;
+	background-color: #c9356e;
+	top: 5px;
+	position: relative;
+
+	&.masterbar-cart-count__hidden {
+		visibility: hidden;
+	}
+}

--- a/client/layout/masterbar/masterbar-cart/masterbar-cart-count.tsx
+++ b/client/layout/masterbar/masterbar-cart/masterbar-cart-count.tsx
@@ -1,0 +1,13 @@
+import classNames from 'classnames';
+import './masterbar-cart-count.scss';
+
+type MasterbarCartCountProps = {
+	cartCount: number;
+};
+
+export function MasterBarCartCount( { cartCount }: MasterbarCartCountProps ) {
+	const classes = classNames( 'masterbar-cart-count', {
+		'masterbar-cart-count__hidden': cartCount <= 0,
+	} );
+	return <span className={ classes }>{ cartCount }</span>;
+}

--- a/packages/mini-cart/src/mini-cart.tsx
+++ b/packages/mini-cart/src/mini-cart.tsx
@@ -110,6 +110,8 @@ export function MiniCart( {
 	closeCart,
 	onRemoveProduct,
 	onRemoveCoupon,
+	checkoutLabel,
+	emptyCart,
 }: {
 	selectedSiteSlug: string;
 	cartKey: number | undefined;
@@ -117,10 +119,14 @@ export function MiniCart( {
 	closeCart: () => void;
 	onRemoveProduct?: ( uuid: string ) => void;
 	onRemoveCoupon?: () => void;
+	checkoutLabel?: string;
+	emptyCart?: React.ReactNode;
 } ) {
 	const { responseCart, removeCoupon, removeProductFromCart, isLoading, isPendingUpdate } =
 		useShoppingCart( cartKey ? cartKey : undefined );
 	const { __ } = useI18n();
+
+	const shouldRenderEmptyCart = emptyCart && responseCart.products.length <= 0;
 	const isDisabled = isLoading || isPendingUpdate;
 
 	const handleRemoveCoupon = () => {
@@ -162,18 +168,21 @@ export function MiniCart( {
 					removeProductFromCart={ handleRemoveProduct }
 					responseCart={ responseCart }
 				/>
-				<MiniCartTotal responseCart={ responseCart } />
+				{ shouldRenderEmptyCart && emptyCart }
+				{ ! shouldRenderEmptyCart && <MiniCartTotal responseCart={ responseCart } /> }
 				<MiniCartFooter className="mini-cart__footer">
-					<Button
-						className="mini-cart__checkout"
-						buttonType="primary"
-						fullWidth
-						disabled={ isDisabled }
-						isBusy={ isDisabled }
-						onClick={ () => goToCheckout( selectedSiteSlug ) }
-					>
-						{ __( 'Checkout' ) }
-					</Button>
+					{ ! shouldRenderEmptyCart && (
+						<Button
+							className="mini-cart__checkout"
+							buttonType="primary"
+							fullWidth
+							disabled={ isDisabled }
+							isBusy={ isDisabled }
+							onClick={ () => goToCheckout( selectedSiteSlug ) }
+						>
+							{ checkoutLabel || __( 'Checkout' ) }
+						</Button>
+					) }
 				</MiniCartFooter>
 			</MiniCartWrapper>
 		</CheckoutProvider>


### PR DESCRIPTION
#### Proposed Changes

* This PR includes the common changes made to client/layout/ and packages/mini-cart in PR #70588 
* This adds the following props to `masterbar-cart-button.tsx`
  * `forceShow` : by default the cart icon shows up only if one or more items are added. This props make sure to show the cart all the time
  * `showCount`: by default count is not shown next to the cart icon. This enables it
  * `cartIcon`: Used to override the default cart icon
* This also adds following props to `mini-cart.tsx`:
  * `checkoutLabel`: Overrides the default checkout button label inside cart 
  * `emptyCart`: By default when cart is empty nothing is shown, this property allows us to show any custom component on empty cart 

#### Testing Instructions

* Merge this branch with the branch in PR #70588 and follow the testing instructions there.

#### Screenshot

##### Cart with count

![Screenshot 2023-01-09 at 11 58 49 PM](https://user-images.githubusercontent.com/2027003/211385495-7962aeb7-b908-40ba-a4fa-4724ae9bbd91.png)


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
