### PR TITLE
format-currency: Fix the number of decimal places used by the HUF currency

### DIFF
--- a/packages/format-currency/src/currencies.ts
+++ b/packages/format-currency/src/currencies.ts
@@ -359,7 +359,7 @@ export const CURRENCIES: CurrenciesDictionary = {
 		symbol: 'Ft',
 		grouping: '.',
 		decimal: ',',
-		precision: 0,
+		precision: 2,
 	},
 	IDR: {
 		symbol: 'Rp',


### PR DESCRIPTION
#### Proposed Changes

The HUF currency uses 2 decimal places, but our hard-coded config has it listed as using 0. The result of this is that numbers formatted by the frontend in that currency will be wrong.

This went unnoticed until https://github.com/Automattic/wp-calypso/pull/71722 began using the calypso formatting for more prices.

Here's how you can see the appropriate number of decimal places used by the currency:

```
(new Intl.NumberFormat( 'en', { style: 'currency', currency: 'HUF'} )).resolvedOptions().maximumFractionDigits // outputs '2'
```

Reported in pNPgK-6iv-p2

Before this PR:

<img width="567" alt="Screenshot 2023-01-09 at 11 57 22 AM" src="https://user-images.githubusercontent.com/2036909/211364144-a8f36fdb-af6c-4c98-b0ff-5acef72782b1.png">

After this PR:

<img width="564" alt="Screenshot 2023-01-09 at 11 59 44 AM" src="https://user-images.githubusercontent.com/2036909/211364646-71e36eea-1c88-470c-aaf5-e7c11b2d0bbe.png">


#### Testing Instructions

- Change your currency to HUF.
- Add a product to your cart and visit checkout.
- Verify that the price is expected.