### PR TITLE
WooExpress Trial: Add the ecommerce-trial-bundle-monthly plan to a new trial site

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/assign-trial-plan/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/assign-trial-plan/index.tsx
@@ -22,6 +22,10 @@ const AssignTrialPlanStep: Step = function AssignTrialPlanStep( { navigation, da
 		if ( submit ) {
 			const assignTrialPlan = async () => {
 				try {
+					if ( ! data?.siteSlug ) {
+						throw new Error( 'Invalid site slug' );
+					}
+
 					await wpcom.req.post(
 						`/sites/${ data?.siteSlug }/ecommerce-trial/add/ecommerce-trial-bundle-monthly`,
 						{

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/assign-trial-plan/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/assign-trial-plan/index.tsx
@@ -1,4 +1,9 @@
+import { StepContainer } from '@automattic/onboarding';
+import { useI18n } from '@wordpress/react-i18n';
 import { useEffect } from 'react';
+import DocumentHead from 'calypso/components/data/document-head';
+import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import wpcom from 'calypso/lib/wp';
 import type { Step } from '../../types';
 
@@ -11,6 +16,7 @@ export enum AssignTrialResult {
 
 const AssignTrialPlanStep: Step = function AssignTrialPlanStep( { navigation, data } ) {
 	const { submit } = navigation;
+	const { __ } = useI18n();
 
 	useEffect( () => {
 		if ( submit ) {
@@ -34,7 +40,29 @@ const AssignTrialPlanStep: Step = function AssignTrialPlanStep( { navigation, da
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [] );
 
-	return null;
+	const getCurrentMessage = () => {
+		return __( 'Setting up your trial' );
+	};
+
+	return (
+		<>
+			<DocumentHead title={ getCurrentMessage() } />
+			<StepContainer
+				shouldHideNavButtons={ true }
+				hideFormattedHeader={ true }
+				stepName="assign-trial-step"
+				isHorizontalLayout={ true }
+				recordTracksEvent={ recordTracksEvent }
+				stepContent={
+					<>
+						<h1>{ getCurrentMessage() }</h1>
+						<LoadingEllipsis />
+					</>
+				}
+				showFooterWooCommercePowered={ false }
+			/>
+		</>
+	);
 };
 
 export default AssignTrialPlanStep;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/assign-trial-plan/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/assign-trial-plan/index.tsx
@@ -1,0 +1,40 @@
+import { useEffect } from 'react';
+import wpcom from 'calypso/lib/wp';
+import type { Step } from '../../types';
+
+import './styles.scss';
+
+export enum AssignTrialResult {
+	SUCCESS = 'success',
+	FAILURE = 'failure',
+}
+
+const AssignTrialPlanStep: Step = function AssignTrialPlanStep( { navigation, data } ) {
+	const { submit } = navigation;
+
+	useEffect( () => {
+		if ( submit ) {
+			const assignTrialPlan = async () => {
+				try {
+					await wpcom.req.post(
+						`/sites/${ data?.siteSlug }/ecommerce-trial/add/ecommerce-trial-bundle-monthly`,
+						{
+							apiVersion: '1.1',
+						}
+					);
+
+					submit?.( { siteSlug: data?.siteSlug }, AssignTrialResult.SUCCESS );
+				} catch ( err: any ) {
+					submit?.( { siteSlug: data?.siteSlug }, AssignTrialResult.FAILURE );
+				}
+			};
+
+			assignTrialPlan();
+		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [] );
+
+	return null;
+};
+
+export default AssignTrialPlanStep;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/assign-trial-plan/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/assign-trial-plan/styles.scss
@@ -1,0 +1,25 @@
+@import "../style";
+
+$font-family: "SF Pro Text", $sans;
+
+.link-in-bio-setup,
+.free-setup {
+	.step-container__content {
+		display: flex;
+		justify-content: center;
+		margin-bottom: 30px;
+		min-height: unset;
+	}
+
+	.link-in-bio-setup .step-container__header {
+		margin-bottom: 32px;
+
+		h1.formatted-header__title {
+			font-size: $font-title-medium;
+
+			@include break-medium {
+				font-size: $font-headline-medium;
+			}
+		}
+	}
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/assign-trial-plan/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/assign-trial-plan/styles.scss
@@ -1,25 +1,22 @@
-@import "../style";
+@import "@automattic/typography/styles/variables";
+@import "@automattic/onboarding/styles/mixins";
 
-$font-family: "SF Pro Text", $sans;
 
-.link-in-bio-setup,
-.free-setup {
-	.step-container__content {
+.wooexpress.assign-trial-plan {
+	padding: 1em;
+	max-width: 540px;
+	text-align: center;
+	margin: 16vh auto 0;
+
+	.step-container {
 		display: flex;
-		justify-content: center;
-		margin-bottom: 30px;
-		min-height: unset;
 	}
 
-	.link-in-bio-setup .step-container__header {
-		margin-bottom: 32px;
+	.step-container__content {
+		width: 100%;
 
-		h1.formatted-header__title {
-			font-size: $font-title-medium;
-
-			@include break-medium {
-				font-size: $font-headline-medium;
-			}
+		h1 {
+			@include onboarding-font-recoleta;
 		}
 	}
 }

--- a/client/landing/stepper/declarative-flow/trial-wooexpress-flow.ts
+++ b/client/landing/stepper/declarative-flow/trial-wooexpress-flow.ts
@@ -4,6 +4,9 @@ import { useSiteSetupFlowProgress } from '../hooks/use-site-setup-flow-progress'
 import { useSiteSlugParam } from '../hooks/use-site-slug-param';
 import { USER_STORE, ONBOARD_STORE } from '../stores';
 import { recordSubmitStep } from './internals/analytics/record-submit-step';
+import AssignTrialPlanStep, {
+	AssignTrialResult,
+} from './internals/steps-repository/assign-trial-plan';
 import ErrorStep from './internals/steps-repository/error-step';
 import ProcessingStep, { ProcessingResult } from './internals/steps-repository/processing-step';
 import SiteCreationStep from './internals/steps-repository/site-creation-step';
@@ -17,6 +20,7 @@ const wooexpress: Flow = {
 		return [
 			{ slug: 'siteCreationStep', component: SiteCreationStep },
 			{ slug: 'processing', component: ProcessingStep },
+			{ slug: 'assignTrialPlan', component: AssignTrialPlanStep },
 			{ slug: 'error', component: ErrorStep },
 		];
 	},
@@ -94,6 +98,16 @@ const wooexpress: Flow = {
 					const processingResult = params[ 0 ] as ProcessingResult;
 
 					if ( processingResult === ProcessingResult.FAILURE ) {
+						return navigate( 'error' );
+					}
+
+					return navigate( 'assignTrialPlan', { siteSlug } );
+				}
+
+				case 'assignTrialPlan': {
+					const assignTrialResult = params[ 0 ] as AssignTrialResult;
+
+					if ( assignTrialResult === AssignTrialResult.FAILURE ) {
 						return navigate( 'error' );
 					}
 


### PR DESCRIPTION
#### Proposed Changes

When a new WooExpress trial site is added, ensure the site is created with the new ecommerce-trial-bundle-monthly plan.

![image](https://user-images.githubusercontent.com/917632/211572350-74efa202-b955-49c6-afcf-0c5286e94b07.png)


#### Testing Instructions

* Patch your sandbox with D97045-code and sandbox the public-api.
* Visit http://calypso.localhost:3000/setup/wooexpress/.
* You should go through the `siteCreationStep`, `processing`, and `assignTrial` steps.
* You should finish on the dashboard for the new site.
* Click Upgrades -> Purchases and verify that there the "Active Upgrade" is "WordPress.com eCommerce Trial".

**Note: The admin sidebar will still say "Upgrades: Free" at this point. This will be addressed in future PRs.**.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [NA] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [NA] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [NA] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [NA] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [NA] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #71764