### PR TITLE
Update the Plugins Post-Purchase page layout

### DIFF
--- a/client/components/thank-you/index.tsx
+++ b/client/components/thank-you/index.tsx
@@ -159,7 +159,7 @@ export const ThankYou = ( props: ThankYouProps ) => {
 		showSupportSection = true,
 		thankYouTitle,
 		thankYouSubtitle,
-		thankYouImage,
+		thankYouImage = null,
 		thankYouNotice,
 		thankYouHeaderBody = null,
 	} = props;
@@ -181,8 +181,8 @@ export const ThankYou = ( props: ThankYouProps ) => {
 		background-color: ${ headerBackgroundColor };
 		min-height: 352px;
 		img {
-			width: ${ thankYouImage.width ? null : 'auto' };
-			height: ${ thankYouImage.height ? null : '200px' };
+			width: ${ thankYouImage?.width ? null : 'auto' };
+			height: ${ thankYouImage?.height ? null : '200px' };
 			margin-bottom: 14px;
 		}
 	`;
@@ -210,7 +210,7 @@ export const ThankYou = ( props: ThankYouProps ) => {
 	return (
 		<ThankYouContainer className={ classNames( 'thank-you__container', containerClassName ) }>
 			<ThankYouHeader className={ classNames( 'thank-you__container-header', headerClassName ) }>
-				<img { ...{ ...thankYouImage, alt: String( thankYouImage.alt ) } } />
+				{ thankYouImage && <img { ...{ ...thankYouImage, alt: String( thankYouImage.alt ) } } /> }
 				{ thankYouTitle && (
 					<ThankYouTitleContainer>
 						<h1 className="thank-you__header-title wp-brand-font">{ thankYouTitle }</h1>

--- a/client/components/thank-you/index.tsx
+++ b/client/components/thank-you/index.tsx
@@ -88,15 +88,18 @@ const ThankYouNotice = ( props: ThankYouNoticeProps ) => {
 };
 
 const ThankYouNextStep = ( props: ThankYouNextStepProps ) => {
-	const { stepIcon, stepCta, stepDescription, stepKey, stepTitle } = props;
+	const { stepIcon, stepCta, stepDescription, stepSection, stepKey, stepTitle } = props;
 
 	return (
 		<div className="thank-you__step" key={ stepKey }>
 			{ stepIcon && <div className="thank-you__step-icon">{ stepIcon }</div> }
-			<div>
-				<h3>{ stepTitle }</h3>
-				<p>{ stepDescription }</p>
-			</div>
+			{ ( stepTitle || stepDescription ) && (
+				<div>
+					<h3>{ stepTitle }</h3>
+					<p>{ stepDescription }</p>
+				</div>
+			) }
+			{ stepSection && <div className="thank-you__step-section">{ stepSection }</div> }
 			{ stepCta && <div className="thank-you__step-cta">{ stepCta }</div> }
 		</div>
 	);

--- a/client/components/thank-you/index.tsx
+++ b/client/components/thank-you/index.tsx
@@ -88,21 +88,22 @@ const ThankYouNotice = ( props: ThankYouNoticeProps ) => {
 };
 
 const ThankYouNextStep = ( props: ThankYouNextStepProps ) => {
-	const { stepCta, stepDescription, stepKey, stepTitle } = props;
+	const { stepIcon, stepCta, stepDescription, stepKey, stepTitle } = props;
 
 	return (
 		<div className="thank-you__step" key={ stepKey }>
+			{ stepIcon && <div className="thank-you__step-icon">{ stepIcon }</div> }
 			<div>
 				<h3>{ stepTitle }</h3>
 				<p>{ stepDescription }</p>
 			</div>
-			<div className="thank-you__step-cta">{ stepCta }</div>
+			{ stepCta && <div className="thank-you__step-cta">{ stepCta }</div> }
 		</div>
 	);
 };
 
 const ThankYouSection = ( props: ThankYouSectionProps ) => {
-	const { nextSteps, sectionTitle } = props;
+	const { nextSteps, sectionTitle, nextStepsClassName } = props;
 
 	const nextStepComponents = nextSteps.map( ( nextStepProps, index ) => (
 		<ThankYouNextStep key={ index } { ...nextStepProps } />
@@ -110,11 +111,13 @@ const ThankYouSection = ( props: ThankYouSectionProps ) => {
 
 	return (
 		<ThankYouSectionContainer>
-			<ThankYouSectionTitle className="thank-you__body-header wp-brand-font">
-				{ sectionTitle }
-			</ThankYouSectionTitle>
+			{ sectionTitle && (
+				<ThankYouSectionTitle className="thank-you__body-header wp-brand-font">
+					{ sectionTitle }
+				</ThankYouSectionTitle>
+			) }
 
-			<ThankYouNextSteps>{ nextStepComponents }</ThankYouNextSteps>
+			<ThankYouNextSteps className={ nextStepsClassName }>{ nextStepComponents }</ThankYouNextSteps>
 		</ThankYouSectionContainer>
 	);
 };

--- a/client/components/thank-you/types.ts
+++ b/client/components/thank-you/types.ts
@@ -2,10 +2,11 @@ import { TranslateResult } from 'i18n-calypso';
 import * as React from 'react';
 
 export type ThankYouNextStepProps = {
-	stepCta: React.ReactNode | React.ReactFragment;
-	stepDescription: TranslateResult;
+	stepCta?: React.ReactNode | React.ReactFragment;
+	stepDescription: TranslateResult | React.ReactElement;
 	stepKey: string;
-	stepTitle: TranslateResult;
+	stepTitle?: TranslateResult;
+	stepIcon?: React.ReactNode;
 };
 
 export type ThankYouNoticeProps = {
@@ -17,7 +18,8 @@ export type ThankYouNoticeProps = {
 export type ThankYouSectionProps = {
 	nextSteps: ThankYouNextStepProps[];
 	sectionKey: string;
-	sectionTitle: TranslateResult;
+	sectionTitle?: TranslateResult;
+	nextStepsClassName?: string;
 };
 
 export type ThankYouSupportLink = {

--- a/client/components/thank-you/types.ts
+++ b/client/components/thank-you/types.ts
@@ -39,7 +39,7 @@ export type ThankYouProps = {
 	sections: ThankYouSectionProps[];
 	showSupportSection?: boolean;
 	customSupportSection?: ThankYouSupportSectionProps;
-	thankYouImage: {
+	thankYouImage?: {
 		alt: string | TranslateResult;
 		src: string;
 		width?: string;

--- a/client/components/thank-you/types.ts
+++ b/client/components/thank-you/types.ts
@@ -3,7 +3,8 @@ import * as React from 'react';
 
 export type ThankYouNextStepProps = {
 	stepCta?: React.ReactNode | React.ReactFragment;
-	stepDescription: TranslateResult | React.ReactElement;
+	stepSection?: TranslateResult | React.ReactElement;
+	stepDescription?: TranslateResult | React.ReactElement;
 	stepKey: string;
 	stepTitle?: TranslateResult;
 	stepIcon?: React.ReactNode;

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you-plugin-section.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you-plugin-section.tsx
@@ -24,8 +24,22 @@ const PluginSectionContainer = styled.div`
 
 const PluginSectionContent = styled.div`
 	display: flex;
+	flex-direction: column;
 	flex-grow: 1;
 	margin: 0 16px;
+`;
+
+const PluginSectionName = styled.div`
+	font-size: 16px;
+	font-weight: 500;
+	line-height: 24px;
+	color: var( --studio-gray-100 );
+`;
+
+const PluginSectionExpirationDate = styled.div`
+	font-size: 14px;
+	line-height: 22px;
+	color: var( --studio-gray-60 );
 `;
 
 const PluginSectionButtons = styled.div`
@@ -65,7 +79,13 @@ export const ThankYouPluginSection = ( { plugin }: { plugin: any } ) => {
 					} ) as string
 				}
 			/>
-			<PluginSectionContent>{ plugin.name }</PluginSectionContent>
+			<PluginSectionContent>
+				<PluginSectionName>{ plugin.name }</PluginSectionName>
+				{ /* TODO: Implement expiration date logic, the prop expiration date doesn't exists */ }
+				{ plugin.expirationDate && (
+					<PluginSectionExpirationDate>{ plugin.expirationDate }</PluginSectionExpirationDate>
+				) }
+			</PluginSectionContent>
 			<PluginSectionButtons>
 				{ documentationURL && (
 					<Button isSecondary href={ documentationURL }>

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you-plugin-section.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you-plugin-section.tsx
@@ -87,14 +87,14 @@ export const ThankYouPluginSection = ( { plugin }: { plugin: any } ) => {
 				) }
 			</PluginSectionContent>
 			<PluginSectionButtons>
+				<Button isPrimary href={ setupURL }>
+					{ translate( 'Manage plugin' ) }
+				</Button>
 				{ documentationURL && (
 					<Button isSecondary href={ documentationURL }>
 						{ translate( 'Plugin guide' ) }
 					</Button>
 				) }
-				<Button isPrimary href={ setupURL }>
-					{ translate( 'Manage plugin' ) }
-				</Button>
 			</PluginSectionButtons>
 		</PluginSectionContainer>
 	);

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you-plugin-section.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you-plugin-section.tsx
@@ -10,6 +10,7 @@ import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selecto
 const PluginSectionContainer = styled.div`
 	display: flex;
 	flex-direction: row;
+	flex-wrap: wrap;
 	width: 720px;
 	padding: 24px;
 	box-sizing: border-box;
@@ -20,6 +21,15 @@ const PluginSectionContainer = styled.div`
 	div {
 		min-width: auto;
 	}
+
+	@media ( max-width: 740px ) {
+		width: 500px;
+		gap: 16px;
+	}
+
+	@media ( max-width: 520px ) {
+		width: 280px;
+	}
 `;
 
 const PluginSectionContent = styled.div`
@@ -27,6 +37,10 @@ const PluginSectionContent = styled.div`
 	flex-direction: column;
 	flex-grow: 1;
 	margin: 0 16px;
+
+	@media ( max-width: 740px ) {
+		margin: 0;
+	}
 `;
 
 const PluginSectionName = styled.div`

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you-plugin-section.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you-plugin-section.tsx
@@ -1,0 +1,81 @@
+import { WPCOM_FEATURES_MANAGE_PLUGINS } from '@automattic/calypso-products';
+import styled from '@emotion/styled';
+import { Button } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import { useSelector } from 'react-redux';
+import siteHasFeature from 'calypso/state/selectors/site-has-feature';
+import { getSiteAdminUrl } from 'calypso/state/sites/selectors';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+
+const PluginSectionContainer = styled.div`
+	display: flex;
+	flex-direction: row;
+	width: 720px;
+	padding: 24px;
+	box-sizing: border-box;
+	border: 1px solid var( --studio-gray-5 );
+	border-radius: 4px;
+	align-items: center;
+
+	div {
+		min-width: auto;
+	}
+`;
+
+const PluginSectionContent = styled.div`
+	display: flex;
+	flex-grow: 1;
+	margin: 0 16px;
+`;
+
+const PluginSectionButtons = styled.div`
+	display: flex;
+	gap: 16px;
+	min-width: auto;
+`;
+
+export const ThankYouPluginSection = ( { plugin }: { plugin: any } ) => {
+	const translate = useTranslate();
+	const siteId = useSelector( getSelectedSiteId );
+	const siteSlug = useSelector( getSelectedSiteSlug );
+	const siteAdminUrl = useSelector( ( state ) => getSiteAdminUrl( state, siteId ) );
+	const hasManagePluginsFeature = useSelector( ( state ) =>
+		siteHasFeature( state, siteId, WPCOM_FEATURES_MANAGE_PLUGINS )
+	);
+	const managePluginsUrl = hasManagePluginsFeature
+		? `${ siteAdminUrl }plugins.php`
+		: `/plugins/${ plugin.slug }/${ siteSlug } `;
+	const fallbackSetupUrl =
+		plugin?.setup_url && siteAdminUrl ? siteAdminUrl + plugin.setup_url : null;
+	const setupURL = plugin?.action_links?.Settings || fallbackSetupUrl || managePluginsUrl;
+
+	const documentationURL = plugin?.documentation_url;
+
+	return (
+		<PluginSectionContainer>
+			<img
+				width={ 50 }
+				height={ 50 }
+				src={ plugin.icon }
+				alt={
+					translate( "%(plugin)s's icon", {
+						args: {
+							plugin: plugin.name,
+						},
+					} ) as string
+				}
+			/>
+			<PluginSectionContent>{ plugin.name }</PluginSectionContent>
+			<PluginSectionButtons>
+				{ documentationURL && (
+					<Button isSecondary href={ documentationURL }>
+						{ translate( 'Plugin guide' ) }
+					</Button>
+				) }
+				<Button isPrimary href={ setupURL }>
+					{ translate( 'Manage plugin' ) }
+				</Button>
+			</PluginSectionButtons>
+		</PluginSectionContainer>
+	);
+};

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
@@ -2,6 +2,7 @@ import { ConfettiAnimation } from '@automattic/components';
 import { ThemeProvider, Global, css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { Button } from '@wordpress/components';
+import { Icon, table } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
 import { useEffect, useState, useMemo } from 'react';
@@ -41,7 +42,8 @@ const ThankYouContainer = styled.div`
 	.thank-you__container-header {
 		min-height: auto;
 		padding: 0px;
-		padding-top: 15px;
+		/* padding-top: 15px; */
+		padding-top: 60px;
 	}
 
 	.thank-you__body {
@@ -52,6 +54,10 @@ const ThankYouContainer = styled.div`
 			display: flex;
 			flex-direction: column;
 			align-items: center;
+		}
+
+		div {
+			min-width: auto;
 		}
 	}
 
@@ -75,15 +81,38 @@ const ThankYouContainer = styled.div`
 
 	.thank-you__footer {
 		width: 1072px;
+		padding: 40px;
 		display: flex;
+		justify-content: space-between;
 
 		.thank-you__step {
 			display: flex;
 			flex-direction: column;
+			flex-wrap: wrap;
+			width: 270px;
+			justify-content: space-between;
+
+			h3 {
+				line-height: 24px;
+				font-weight: 500;
+				font-size: 16px;
+				color: var( --studio-gray-100 );
+			}
+
+			p {
+				line-height: 20px;
+				font-size: 14px;
+				color: var( --studio-gray-60 );
+			}
 		}
 
 		.thank-you__step-cta {
 			margin: 0;
+		}
+
+		.thank-you__step-icon {
+			width: 50px;
+			flex-basis: 100%;
 		}
 	}
 `;
@@ -266,6 +295,7 @@ const MarketplaceThankYou = ( { productSlug }: { productSlug: string } ) => {
 		nextStepsClassName: 'thank-you__footer',
 		nextSteps: [
 			{
+				stepIcon: <Icon icon={ table } size={ 20 } />,
 				stepKey: 'thank_you_footer_support_guides',
 				stepTitle: translate( 'Support guides' ),
 				stepDescription: translate(
@@ -278,6 +308,7 @@ const MarketplaceThankYou = ( { productSlug }: { productSlug: string } ) => {
 				),
 			},
 			{
+				stepIcon: <Icon icon={ table } size={ 20 } />,
 				stepKey: 'thank_you_footer_explore',
 				stepTitle: translate( 'Keep growing' ),
 				stepDescription: translate(
@@ -290,6 +321,7 @@ const MarketplaceThankYou = ( { productSlug }: { productSlug: string } ) => {
 				),
 			},
 			{
+				stepIcon: <Icon icon={ table } size={ 20 } />,
 				stepKey: 'thank_you_footer_support',
 				stepTitle: translate( 'How can we support?' ),
 				stepDescription: translate(

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
@@ -62,6 +62,7 @@ const ThankYouContainer = styled.div`
 	}
 
 	.thank-you__step div > p {
+		padding: 0;
 		margin-bottom: 16px;
 	}
 
@@ -72,7 +73,7 @@ const ThankYouContainer = styled.div`
 	}
 
 	.thank-you__header-subtitle {
-		margin-top: 16px;
+		margin: 16px auto;
 		width: 500px;
 		line-height: 24px;
 		font-size: 16px;

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
@@ -203,7 +203,7 @@ const MarketplaceThankYou = ( { productSlug }: { productSlug: string } ) => {
 		sectionKey: 'plugin_information',
 		nextSteps: pluginInformationList.map( ( plugin: any ) => ( {
 			stepKey: `plugin_information_${ plugin.slug }`,
-			stepDescription: <ThankYouPluginSection plugin={ plugin } />,
+			stepSection: <ThankYouPluginSection plugin={ plugin } />,
 		} ) ),
 	};
 

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
@@ -1,6 +1,5 @@
 import { ConfettiAnimation } from '@automattic/components';
 import { ThemeProvider, Global, css } from '@emotion/react';
-import styled from '@emotion/styled';
 import { Button } from '@wordpress/components';
 import { Icon, table } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
@@ -33,90 +32,7 @@ import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-t
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import { ThankYouPluginSection } from './marketplace-thank-you-plugin-section';
-
-const ThankYouContainer = styled.div`
-	.thank-you__container {
-		padding-top: var( --masterbar-height );
-	}
-
-	.thank-you__container-header {
-		min-height: auto;
-		padding: 0px;
-		/* padding-top: 15px; */
-		padding-top: 60px;
-	}
-
-	.thank-you__body {
-		margin: 40px 0;
-
-		> div {
-			width: auto;
-			display: flex;
-			flex-direction: column;
-			align-items: center;
-		}
-
-		div {
-			min-width: auto;
-		}
-	}
-
-	.thank-you__step div > p {
-		padding: 0;
-		margin-bottom: 16px;
-	}
-
-	.thank-you__header-title {
-		font-family: Recoleta;
-		font-size: 48px;
-		line-height: 24px;
-	}
-
-	.thank-you__header-subtitle {
-		margin: 16px auto;
-		width: 500px;
-		line-height: 24px;
-		font-size: 16px;
-		color: var( --studio-gray-60 );
-	}
-
-	.thank-you__footer {
-		width: 1072px;
-		padding: 40px;
-		display: flex;
-		justify-content: space-between;
-
-		.thank-you__step {
-			display: flex;
-			flex-direction: column;
-			flex-wrap: wrap;
-			width: 270px;
-			justify-content: space-between;
-
-			h3 {
-				line-height: 24px;
-				font-weight: 500;
-				font-size: 16px;
-				color: var( --studio-gray-100 );
-			}
-
-			p {
-				line-height: 20px;
-				font-size: 14px;
-				color: var( --studio-gray-60 );
-			}
-		}
-
-		.thank-you__step-cta {
-			margin: 0;
-		}
-
-		.thank-you__step-icon {
-			width: 50px;
-			flex-basis: 100%;
-		}
-	}
-`;
+import './style.scss';
 
 type Plugin = {
 	slug: string;
@@ -363,7 +279,7 @@ const MarketplaceThankYou = ( { productSlug }: { productSlug: string } ) => {
 				</div>
 			) }
 			{ ! showProgressBar && (
-				<ThankYouContainer>
+				<div className="marketplace-thank-you__container">
 					<ConfettiAnimation />
 					<ThankYou
 						containerClassName="marketplace-thank-you"
@@ -380,7 +296,7 @@ const MarketplaceThankYou = ( { productSlug }: { productSlug: string } ) => {
 						headerBackgroundColor="#fff"
 						headerTextColor="#000"
 					/>
-				</ThankYouContainer>
+				</div>
 			) }
 		</ThemeProvider>
 	);

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
@@ -93,17 +93,18 @@ const MarketplaceThankYou = ( { productSlug }: { productSlug: string } ) => {
 
 	// Consolidate the plugin information from the .org and .com sources in a single list
 	const pluginInformationList = useMemo( () => {
-		return pluginsOnSite.reduce( ( pluginsList: Array< any >, pluginOnSite: Plugin ) => {
-			if ( typeof pluginOnSite?.slug === 'string' ) {
+		return pluginsOnSite.reduce(
+			( pluginsList: Array< any >, pluginOnSite: Plugin, index: number ) => {
 				pluginsList.push( {
-					...wpComPluginsData.find( ( wpComPlugin ) => wpComPlugin?.slug === pluginOnSite.slug ),
-					...wporgPlugins.find( ( wpOrgPlugin ) => wpOrgPlugin?.slug === pluginOnSite.slug ),
+					...wpComPluginsData[ index ],
+					...wporgPlugins[ index ],
 					...pluginOnSite,
 				} );
-			}
 
-			return pluginsList;
-		}, [] );
+				return pluginsList;
+			},
+			[]
+		);
 	}, [ pluginsOnSite, wpComPluginsData, wporgPlugins ] );
 
 	// Site is transferring to Atomic.

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/style.scss
@@ -1,0 +1,81 @@
+.marketplace-thank-you__container {
+	.thank-you__container {
+		padding-top: var(--masterbar-height);
+	}
+
+	.thank-you__container-header {
+		min-height: auto;
+		padding: 0;
+		padding-top: 60px;
+	}
+
+	.thank-you__body {
+		margin: 40px 0;
+
+		> div {
+			width: auto;
+			display: flex;
+			flex-direction: column;
+			align-items: center;
+		}
+
+		div {
+			min-width: auto;
+		}
+	}
+
+	.thank-you__step div > p {
+		padding: 0;
+		margin-bottom: 16px;
+	}
+
+	.thank-you__header-title {
+		font-size: $font-headline-medium;
+		line-height: 40px;
+	}
+
+	.thank-you__header-subtitle {
+		margin: 16px auto;
+		width: 500px;
+		line-height: 24px;
+		font-size: $font-body;
+		color: var(--studio-gray-60);
+	}
+
+	.thank-you__footer {
+		width: 1072px;
+		padding: 40px;
+		display: flex;
+		justify-content: space-between;
+
+		.thank-you__step {
+			display: flex;
+			flex-direction: column;
+			flex-wrap: wrap;
+			width: 270px;
+			justify-content: space-between;
+
+			h3 {
+				line-height: 24px;
+				font-weight: 500;
+				font-size: $font-body;
+				color: var(--studio-gray-100);
+			}
+
+			p {
+				line-height: 20px;
+				font-size: $font-body-small;
+				color: var(--studio-gray-60);
+			}
+		}
+
+		.thank-you__step-cta {
+			margin: 0;
+		}
+
+		.thank-you__step-icon {
+			width: 50px;
+			flex-basis: 100%;
+		}
+	}
+}

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/style.scss
@@ -36,24 +36,25 @@
 
 	.thank-you__header-subtitle {
 		margin: 16px auto;
-		width: 500px;
+		max-width: 500px;
 		line-height: 24px;
 		font-size: $font-body;
 		color: var(--studio-gray-60);
 	}
 
 	.thank-you__footer {
-		width: 1072px;
+		max-width: 1072px;
 		padding: 40px;
 		display: flex;
-		justify-content: space-between;
+		flex-wrap: wrap;
+		gap: 75px;
+		justify-content: center;
 
 		.thank-you__step {
 			display: flex;
 			flex-direction: column;
 			flex-wrap: wrap;
-			width: 270px;
-			justify-content: space-between;
+			min-width: 280px;
 
 			h3 {
 				line-height: 24px;
@@ -76,6 +77,10 @@
 		.thank-you__step-icon {
 			width: 50px;
 			flex-basis: 100%;
+		}
+
+		div {
+			max-width: 240px;
 		}
 	}
 }

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/style.scss
@@ -32,10 +32,12 @@
 	.thank-you__header-title {
 		font-size: $font-headline-medium;
 		line-height: 40px;
+		padding: 0 16px;
 	}
 
 	.thank-you__header-subtitle {
 		margin: 16px auto;
+		padding: 0 16px;
 		max-width: 500px;
 		line-height: 24px;
 		font-size: $font-body;

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/style.scss
@@ -24,7 +24,7 @@
 		}
 	}
 
-	.thank-you__step div > p {
+	.thank-you__step-section {
 		padding: 0;
 		margin-bottom: 16px;
 	}


### PR DESCRIPTION
#### Proposed Changes
* Update the layout of the Post-Purchase page, following HOg65lHD0QOfaq0QtzKQbC-fi?t=cqreC05FWZnyDJRu-1
* Turn some ThankYou page properties into optional 
* Add icons to the ThankYou page steps

<img width="1507" alt="Screen Shot 2023-01-10 at 18 29 31" src="https://user-images.githubusercontent.com/5039531/211676166-0731b893-565a-4963-b340-7113bfff5c58.png">

Some items from the figma were not covered in this PR:
* The expiration date below the name - after we solve #71675 its likely we'll have this information on the page, ready to be used
* The proper icons on the footer
* The vertical centralization

#### Testing Instructions
**Bussiness or Ecommerce plan** 
* Go to a free plugin page and click to install
* After the installing page, you should see the Post-purchase page showing the selected plugin (as in production)
* Go to a paid plugin page and click to purchase and install
* After the checkout you should see the Post-purchase page behaving as in production

**Below Bussiness plan** 
* Go to a paid plugin and click to `Purchase and activate`, accepting the dialog to upgrade
* Close the cart page clicking on the `X` on the top left of the screen and selecting to `Leave items`
* Select another paid plugin and click to `Purchase and activate`
* After the progress bar page you should see the Post-Purchase page as usual 
**Post-Purchase page with multiple plugins**
* Using plugins already installed on the previous step, go to the Post-purchase page via URL (`/marketplace/thank-you/{paid_plugin_slug},{free_plugin_slug}/{site}`). Ex: /marketplace/thank-you/woocommerce-subscriptions,woocommerce/site.wpcomstaging.com

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #70891
Fixes #70894