### PR TITLE
format-currency: When stripping zeros, also set minimumFractionDigits

### DIFF
--- a/packages/format-currency/src/index.ts
+++ b/packages/format-currency/src/index.ts
@@ -70,7 +70,7 @@ function getCachedFormatter( {
 		currency,
 		// There's an option called `trailingZeroDisplay` but it does not yet work
 		// in FF so we have to strip zeros manually.
-		...( noDecimals ? { maximumFractionDigits: 0 } : {} ),
+		...( noDecimals ? { maximumFractionDigits: 0, minimumFractionDigits: 0 } : {} ),
 	} );
 
 	formatterCache.set( cacheKey, formatter );


### PR DESCRIPTION
#### Proposed Changes

JavaScript's `Intl.NumberFormat` class [has the ability to strip decimal zeros](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#trailingzerodisplay) from a formatted currency, which is needed by the `formatCurrency()` function (implemented in https://github.com/Automattic/wp-calypso/pull/71387 which switched `formatCurrency` to use `NumberFormat`). However, that option is not yet supported by some browsers. As a result, we manually implement the functionality by setting `maximumFractionDigits` to 0.

Apparently this causes issues in some browsers (Safari in particular), triggering a `"maximumFractionDigits is out of range"` error. This appears to be because `maximumFractionDigits` is now less than `minimumFractionDigits`.

In this PR we set both properties to avoid the error.

See https://stackoverflow.com/a/41045289/2615868 which suggested this solution.

#### Testing Instructions

Automated tests should prove that this causes no regressions. At worst, it should not cause more problems. If this does not resolve the issue for browsers in question, then we'll see more errors.