### PR TITLE
Stats: fix the padding at the top of the Traffic page

### DIFF
--- a/client/my-sites/stats/modernized-layout-styles.scss
+++ b/client/my-sites/stats/modernized-layout-styles.scss
@@ -35,8 +35,9 @@ $sidebar-appearance-break-point: 783px;
 		}
 	}
 
-	> .stats-banner-wrapper {
-		padding-bottom: 1em;
+	> .stats-banner-wrapper .jetpack-backup-creds-banner {
+		// .jetpack-backup-creds-banner has a bottom margin of 16px. This overrides it since we want it to be 32px
+		margin-bottom: 32px;
 	}
 
 	&.has-fixed-nav {


### PR DESCRIPTION
#### Proposed Changes

* Remove the padding-bottom of `.stats-banner-wrapper` when there is no displayed `JetpackBackupCredsBanner`.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit the Traffic page on a site with no Jetpack installed. The `JetpackBackupCredsBanner` won't be shown.
* Ensure the `.stats-banner-wrapper` has no `padding-bottom` set
* Visit the Traffic page on a site with Jetpack installed. The `JetpackBackupCredsBanner` will appear.
* Ensure the `JetpackBackupCredsBanner` has a `margin-bottom` of 32px.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #71783 
