### PR TITLE
Users management: Optimize calling updateUser function

### DIFF
--- a/client/my-sites/people/edit-team-member-form/edit-user-form.jsx
+++ b/client/my-sites/people/edit-team-member-form/edit-user-form.jsx
@@ -1,7 +1,7 @@
 import { createHigherOrderComponent } from '@wordpress/compose';
 import debugModule from 'debug';
 import { localize } from 'i18n-calypso';
-import { defer } from 'lodash';
+import { defer, omit } from 'lodash';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import FormButton from 'calypso/components/forms/form-button';
@@ -163,8 +163,12 @@ class EditUserForm extends Component {
 		const changedAttributes = changedSettings.roles
 			? Object.assign( changedSettings, { roles: [ changedSettings.roles ] } )
 			: changedSettings;
+		// User object doesn't support isExternalContributor field
+		const changedUserAttributes = omit( changedAttributes, 'isExternalContributor' );
 
-		this.props.updateUser( user.ID, changedAttributes );
+		if ( Object.keys( changedUserAttributes ).length ) {
+			this.props.updateUser( user.ID, changedUserAttributes );
+		}
 
 		if ( true === changedSettings.isExternalContributor ) {
 			this.props.addExternalContributor(


### PR DESCRIPTION
Got rid of `isExternalContributor` property since the user object doesn't support that field.

#### Proposed Changes

* Fixed issue with showing error notification when user updates his own profile by toggling `This user is a contractor, freelancer, consultant, or agency.` checkbox button

#### Testing Instructions

- Go to `/people/team/{SITE_SLUG}`
- Select `superadmin` member profile
- Check if toggling `This user is a contractor, freelancer, consultant, or agency.` checkbox cause error warning.

<img width="1113" alt="Screenshot 2023-01-10 at 00 51 33" src="https://user-images.githubusercontent.com/1241413/211431078-bf20332c-4662-453d-b7bf-dc26b143a224.png">


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
