### PR TITLE
E2E: refactor methods in `RestAPIClient` used to delete a site.

### DIFF
--- a/packages/calypso-e2e/src/rest-api-client.ts
+++ b/packages/calypso-e2e/src/rest-api-client.ts
@@ -13,7 +13,6 @@ import {
 import type { Roles } from './lib';
 import type {
 	AccountDetails,
-	SiteDetails,
 	BearerTokenResponse,
 	MyAccountInformationResponse,
 	AccountClosureResponse,
@@ -262,7 +261,7 @@ export class RestAPIClient {
 	 * Otherwise the active subscription must be first cancelled
 	 * or else the REST API will throw a HTTP 403 status.
 	 *
-	 * @param {SiteDetails} expectedSiteDetails Expected details for the site to be deleted.
+	 * @param { {id: number, domain: string}} targetSite Details for the target site to be deleted.
 	 * @returns {SiteDeletionResponse | null} Null if deletion was unsuccessful or not performed. SiteDeletionResponse otherwise.
 	 */
 	async deleteSite( targetSite: {

--- a/packages/calypso-e2e/src/rest-api-client.ts
+++ b/packages/calypso-e2e/src/rest-api-client.ts
@@ -180,21 +180,18 @@ export class RestAPIClient {
 	/* Sites */
 
 	/**
-	 * Gets the list of users's sites.
+	 * Gets the list of domains belonging to the user.
 	 *
-	 * This method returns an array of Site objects, where
-	 * each Site object exposes a few key pieces of data from
+	 * This method returns an array of DomainData objects, where
+	 * each object exposes a few key pieces of data from
 	 * the response JSON:
-	 * 	- ID
-	 * 	- name
-	 * 	- site description
-	 * 	- URL
-	 * 	- site owner
+	 * 	- domain
+	 * 	- blog id
 	 *
 	 * @returns {Promise<AllDomainsResponse>} JSON array of sites.
 	 * @throws {Error} If API responded with an error.
 	 */
-	async getAllSites(): Promise< AllDomainsResponse > {
+	async getAllDomains(): Promise< AllDomainsResponse > {
 		const params: RequestParams = {
 			method: 'get',
 			headers: {
@@ -281,7 +278,7 @@ export class RestAPIClient {
 			? targetSite.domain.replace( 'https://', '' )
 			: targetSite.domain;
 
-		const mySites: AllDomainsResponse = await this.getAllSites();
+		const mySites: AllDomainsResponse = await this.getAllDomains();
 
 		const match = mySites.domains.filter( ( site: DomainsMetadata ) => {
 			site.blog_id === targetSite.id && site.domain === targetDomain;

--- a/packages/calypso-e2e/src/rest-api-client.ts
+++ b/packages/calypso-e2e/src/rest-api-client.ts
@@ -273,8 +273,9 @@ export class RestAPIClient {
 			return null;
 		}
 
-		const targetDomain = targetSite.domain.startsWith( 'http' )
-			? targetSite.domain.replace( 'https://', '' )
+		const scheme = 'http://';
+		const targetDomain = targetSite.domain.startsWith( scheme )
+			? targetSite.domain.replace( scheme, '' )
 			: targetSite.domain;
 
 		const mySites: AllDomainsResponse = await this.getAllDomains();

--- a/packages/calypso-e2e/src/rest-api-client.ts
+++ b/packages/calypso-e2e/src/rest-api-client.ts
@@ -8,7 +8,7 @@ import {
 	SettingsParams,
 	PluginParams,
 	AllDomainsResponse,
-	DomainsMetadata,
+	DomainData,
 } from './types';
 import type { Roles } from './lib';
 import type {
@@ -279,7 +279,7 @@ export class RestAPIClient {
 
 		const mySites: AllDomainsResponse = await this.getAllDomains();
 
-		const match = mySites.domains.filter( ( site: DomainsMetadata ) => {
+		const match = mySites.domains.filter( ( site: DomainData ) => {
 			site.blog_id === targetSite.id && site.domain === targetDomain;
 		} );
 

--- a/packages/calypso-e2e/src/test/rest-api-client.test.ts
+++ b/packages/calypso-e2e/src/test/rest-api-client.test.ts
@@ -81,7 +81,7 @@ describe( 'RestAPIClient: getMyAccountInformation', function () {
 	} );
 } );
 
-describe( 'RestAPIClient: getAllSites', function () {
+describe( 'RestAPIClient: getAllDomains', function () {
 	const restAPIClient = new RestAPIClient( {
 		username: 'fake_user',
 		password: 'fake_password',
@@ -104,7 +104,7 @@ describe( 'RestAPIClient: getAllSites', function () {
 
 		nock( requestURL.origin ).get( requestURL.pathname ).reply( 200, testData );
 
-		const response = await restAPIClient.getAllSites();
+		const response = await restAPIClient.getAllDomains();
 		expect( response.domains.length ).toBe( 2 );
 		expect( response.domains[ 0 ].blog_id ).toBe( 5420 );
 		expect( response.domains[ 1 ].blog_id ).toBe( 8799 );
@@ -120,7 +120,7 @@ describe( 'RestAPIClient: getAllSites', function () {
 			.get( requestURL.pathname )
 			.reply( 400, { error: code, message: message } );
 
-		await expect( restAPIClient.getAllSites() ).rejects.toThrowError( `${ code }: ${ message }` );
+		await expect( restAPIClient.getAllDomains() ).rejects.toThrowError( `${ code }: ${ message }` );
 	} );
 } );
 

--- a/packages/calypso-e2e/src/test/rest-api-client.test.ts
+++ b/packages/calypso-e2e/src/test/rest-api-client.test.ts
@@ -86,24 +86,18 @@ describe( 'RestAPIClient: getAllSites', function () {
 		username: 'fake_user',
 		password: 'fake_password',
 	} );
-	const requestURL = restAPIClient.getRequestURL( '1.1', '/me/sites' );
+	const requestURL = restAPIClient.getRequestURL( '1.1', '/all-domains/' );
 
 	test( 'Sites are returned on successful request', async function () {
 		const testData = {
-			sites: [
+			domains: [
 				{
-					ID: 5420,
-					name: 'Site One',
-					description: 'My amazing site',
-					URL: 'https://myamazinsite.test.com',
-					site_owner: 420,
+					blog_id: 5420,
+					domain: 'myamazinsite.test.com',
 				},
 				{
-					ID: 8799,
-					name: 'Site Two',
-					description: 'My amazing site, redux',
-					URL: 'https://myamazinsiteredux.test.com',
-					site_owner: 420,
+					blog_id: 8799,
+					domain: 'myamazinsiteredux.test.com',
 				},
 			],
 		};
@@ -111,9 +105,9 @@ describe( 'RestAPIClient: getAllSites', function () {
 		nock( requestURL.origin ).get( requestURL.pathname ).reply( 200, testData );
 
 		const response = await restAPIClient.getAllSites();
-		expect( response.sites.length ).toBe( 2 );
-		expect( response.sites[ 0 ].ID ).toBe( 5420 );
-		expect( response.sites[ 1 ].ID ).toBe( 8799 );
+		expect( response.domains.length ).toBe( 2 );
+		expect( response.domains[ 0 ].blog_id ).toBe( 5420 );
+		expect( response.domains[ 1 ].blog_id ).toBe( 8799 );
 	} );
 
 	test.each( [

--- a/packages/calypso-e2e/src/types/rest-api-client.types.ts
+++ b/packages/calypso-e2e/src/types/rest-api-client.types.ts
@@ -43,13 +43,13 @@ export interface BearerTokenResponse {
 	};
 }
 
-export interface DomainsMetadata {
+export interface DomainData {
 	blog_id: number;
 	domain: string;
 }
 
 export interface AllDomainsResponse {
-	domains: Array< DomainsMetadata >;
+	domains: Array< DomainData >;
 }
 
 export interface CalypsoPreferencesResponse {

--- a/packages/calypso-e2e/src/types/rest-api-client.types.ts
+++ b/packages/calypso-e2e/src/types/rest-api-client.types.ts
@@ -43,16 +43,13 @@ export interface BearerTokenResponse {
 	};
 }
 
-interface SiteMetadata {
-	ID: number;
-	name: string;
-	description: string;
-	URL: string;
-	site_owner: number;
+export interface DomainsMetadata {
+	blog_id: number;
+	domain: string;
 }
 
-export interface AllSitesResponse {
-	sites: Array< SiteMetadata >;
+export interface AllDomainsResponse {
+	domains: Array< DomainsMetadata >;
 }
 
 export interface CalypsoPreferencesResponse {

--- a/test/e2e/specs/shared/api-delete-site.ts
+++ b/test/e2e/specs/shared/api-delete-site.ts
@@ -5,7 +5,7 @@ import type { SiteDetails } from '@automattic/calypso-e2e';
  * Makes an API request to delete a site.
  *
  * @param {RestAPIClient} client Client to interact with the WP REST API.
- * @param { SiteDetails} siteDetails Details of the site to be closed.
+ * @param {SiteDetails} siteDetails Details of the site to be closed.
  */
 export async function apiDeleteSite(
 	client: RestAPIClient,
@@ -13,7 +13,7 @@ export async function apiDeleteSite(
 ): Promise< void > {
 	console.info( `Deleting siteID ${ siteDetails.id }` );
 
-	const response = await client.deleteSite( siteDetails );
+	const response = await client.deleteSite( { id: siteDetails.id, domain: siteDetails.url } );
 
 	// If the response is `null` then no action has been
 	// performed.


### PR DESCRIPTION
#### Proposed Changes

This PR is a performance refactor of the `RestAPIClient` methods `getAllSites` and `deleteSite` in light of the experience detailed in p1672955277744179/1672953171.452809-slack-C04J1601X97.

Key changes:
- use the less expensive call to `/all-domains/` which returns the list of domains registered to the user's account, to obtain a list of sites the user owns.
- simplify the parameters to `deleteSite` to require just the `siteID` and `siteURL`.
- use `filter` instead of a reverse `for` loop to search for a match of site to be deleted against the list of sites the account owns.

#### Testing Instructions

Ensure the following build configurations are passing:
  - [x] Calypso E2E (desktop)
  - [ ] Pre-Release Tests

Additional verification if required:
1. pull the branch.
2. edit a spec with the `calypso-release` tag with `throw new Error()` somewhere in the steps.
3. run the spec and verify that sites are deleted as expected.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #