### PR TITLE
Bugomattic: unify the bug reporting template.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -12,7 +12,7 @@ body:
         Please **do not** link to image hosting services such as Cloudup, Droplr, Imgur, etc…
         Instead, directly embed screenshot(s) or recording(s) in any of the text areas below: click, then drag and drop.
 
-        If you have any questions, please ask in: `slack-bug-herders`.
+        If you have any questions, please ask in: `#dotcom-pa-triage`.
   - type: markdown
     attributes:
       value: |

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -18,7 +18,7 @@ body:
     attributes:
       value: |
         ---
-        ## Required Information
+        ## Core Information
   - type: textarea
     id: summary
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -66,7 +66,7 @@ body:
         
         ## Optional Information
 
-        The following section is optional. If you're an Automattician, you should be able to fill it in. If not, please scroll to the bottom and submit the issue.
+        The following section is optional. 
   - type: dropdown
     id: site-type
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -96,4 +96,4 @@ body:
     attributes:
       label: Logs or notes
       placeholder: |
-        e.g. Logs, CLI or console errors, notes, observations, etc.
+        e.g. Logs, CLI or console errors, notes, browser, platform, etc.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -96,8 +96,6 @@ body:
       label: Logs or notes
       placeholder: |
         Add any information that may be relevant, such as:
-          - browser
-          - platform
-          - theme
-          - logs
-          - cli/console errors
+          - Browser/Platform
+          - Theme
+          - Logs/Errors

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -95,4 +95,4 @@ body:
     attributes:
       label: Logs or notes
       placeholder: |
-        e.g. Logs, CLI or console errors, notes, browser, platform, etc.
+        e.g. Any relevant information - logs, CLI/console errors, notes, browser, platform, themes, etc.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -62,8 +62,8 @@ body:
   - type: markdown
     attributes:
       value: |
-        ---
         <br>
+        ---
         ## Optional Information
 
         The following section is optional. If you're an Automattician, you should be able to fill it in. If not, please scroll to the bottom and submit the issue.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -52,7 +52,7 @@ body:
   - type: dropdown
     id: users-affected
     attributes:
-      label: Severity
+      label: Impact
       description: Approximately how many users are impacted?
       options:
         - One

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -50,13 +50,15 @@ body:
     validations:
       required: true
   - type: dropdown
-    id: impact_level
+    id: users-affected
     attributes:
-      label: Impact
+      label: Severity
+      description: Approximately how many users are impacted?
       options:
-        - Low
-        - Normal
-        - High
+        - One
+        - Some (< 50%)
+        - Most (> 50%)
+        - All
     validations:
       required: true
   - type: dropdown

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,7 +1,6 @@
 name: Bug Report
 description: Helps us improve our product!
 labels: "Needs triage, [Type] Bug, User Report"
-title: ""
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,17 +1,25 @@
 name: Bug Report
 description: Helps us improve our product!
-labels: "Needs triage, [Type] Bug"
-title: "[Bug]: "
+labels: "Needs triage, [Type] Bug, User Report"
+title: ""
 body:
   - type: markdown
     attributes:
       value: |
         ### Thanks for contributing!
 
-        Please write a clear title, then fill in as much details as possible.
+        Please write a clear title, then fill in the fields below and submit.
+        There are only ***3 required fields***, but please provide as much additional information and context as you are able to.
 
-        __Avoid using image hosting services such as Cloudup, Droplr, Imgur, etc., to link to media.__
-        Instead, attach screenshot(s) or recording(s) directly in any of the text areas below: click, then drag and drop.
+        Please **do not** link to image hosting services such as Cloudup, Droplr, Imgur, etc…
+        Instead, directly embed screenshot(s) or recording(s) in any of the text areas below: click, then drag and drop.
+
+        If you have any questions, please ask in: `slack-bug-herders`.
+  - type: markdown
+    attributes:
+      value: |
+        ---
+        ## Required Information
   - type: textarea
     id: summary
     attributes:
@@ -25,8 +33,6 @@ body:
         2. Click on any blog post.
         3. Click on the 'Like' button.
         4. ...
-
-        Attach any media by drag and dropping or selecting upload.
     validations:
       required: true
   - type: textarea
@@ -46,29 +52,20 @@ body:
     validations:
       required: true
   - type: dropdown
-    id: browser
+    id: internal_severity
     attributes:
-      label: Browser
-      description: (You may select more than one)
+      label: Severity
       options:
-        - Google Chrome/Chromium
-        - Mozilla Firefox
-        - Microsoft Edge
-        - Apple Safari
-        - iOS Safari
-        - Android Chrome
-      multiple: true
-  - type: input
-    id: issue_context
-    attributes:
-      label: Context
-      placeholder: |
-        e.g. Customer report, details of your exploratory testing, etc.
+        - Low
+        - Normal
+        - High
+      
   - type: markdown
     attributes:
       value: |
         ---
-        ## Additional context
+        <br>
+        ## Optional Information
 
         The following section is optional. If you're an Automattician, you should be able to fill it in. If not, please scroll to the bottom and submit the issue.
   - type: dropdown
@@ -82,52 +79,8 @@ body:
         - Self-hosted
       multiple: true
   - type: textarea
-    id: other_notes
+    id: logs
     attributes:
-      label: Other notes
+      label: Logs or notes
       placeholder: |
         e.g. Logs, CLI or console errors, notes, observations, etc.
-  - type: markdown
-    attributes:
-      value: |
-        ---
-        ## Issue severity
-
-        Please provide details around how often the issue is reproducible & how many users are affected.
-  - type: dropdown
-    id: reproducibility
-    attributes:
-      label: Reproducibility
-      options:
-        - Consistent
-        - Intermittent
-        - Once
-    validations:
-      required: true
-  - type: dropdown
-    id: users-affected
-    attributes:
-      label: Severity
-      description: How many users are impacted? A guess is fine.
-      options:
-        - One
-        - Some (< 50%)
-        - Most (> 50%)
-        - All
-  - type: dropdown
-    id: workarounds
-    attributes:
-      label: Available workarounds?
-      options:
-        - No and the platform is unusable
-        - No but the platform is still usable
-        - Yes, difficult to implement
-        - Yes, easy to implement
-        - There is no user impact
-  - type: textarea
-    id: workarounds-detail
-    attributes:
-      label: Workaround details
-      description: If you are aware of a workaround, please describe it below.
-      placeholder: |
-        e.g. There is an alternative way to access this setting in the sidebar, but it's not readily apparent.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -8,7 +8,6 @@ body:
         ### Thanks for contributing!
 
         Please write a clear title, then fill in the fields below and submit.
-        There are only ***3 required fields***, but please provide as much additional information and context as you are able to.
 
         Please **do not** link to image hosting services such as Cloudup, Droplr, Imgur, etc…
         Instead, directly embed screenshot(s) or recording(s) in any of the text areas below: click, then drag and drop.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -63,7 +63,7 @@ body:
     attributes:
       value: |
         <br>
-        ---
+        
         ## Optional Information
 
         The following section is optional. If you're an Automattician, you should be able to fill it in. If not, please scroll to the bottom and submit the issue.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -70,7 +70,7 @@ body:
   - type: dropdown
     id: site-type
     attributes:
-      label: Platform (Simple, Atomic, or both?)
+      label: Platform (Simple and/or Atomic)
       description: (You may select more than one)
       options:
         - Simple

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -51,14 +51,28 @@ body:
     validations:
       required: true
   - type: dropdown
-    id: internal_severity
+    id: impact_level
     attributes:
-      label: Severity
+      label: Impact
       options:
         - Low
         - Normal
         - High
-      
+    validations:
+      required: true
+  - type: dropdown
+    id: workarounds
+    attributes:
+      label: Available workarounds?
+      options:
+        - No and the platform is unusable
+        - No but the platform is still usable
+        - Yes, difficult to implement
+        - Yes, easy to implement
+        - There is no user impact
+    validations:
+      required: true
+
   - type: markdown
     attributes:
       value: |

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -95,4 +95,9 @@ body:
     attributes:
       label: Logs or notes
       placeholder: |
-        e.g. Any relevant information - logs, CLI/console errors, notes, browser, platform, themes, etc.
+        Add any information that may be relevant, such as:
+          - browser
+          - platform
+          - theme
+          - logs
+          - cli/console errors


### PR DESCRIPTION
#### Proposed Changes

To support Bugomattic Ragnarok, `wp-calypso`'s bug report templates should be re-unified into one.

Context: pciE2j-1Hh-p2

#### Testing Instructions

Preview the template by navigating to `.github/ISSUE_TEMPLATE/bug_report.yml` in this feature branch.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #