### PR TITLE
[GB 14.8+] Misc Calypso GB E2E test fixes

### DIFF
--- a/packages/calypso-e2e/src/lib/components/editor-settings-sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-settings-sidebar-component.ts
@@ -31,9 +31,8 @@ const selectors = {
 
 	// Schedule
 	scheduleButton: `button.edit-post-post-schedule__toggle`,
-	scheduleInput: ( attribute: string ) => `role=spinbutton[name="${ attribute }"i]`,
+	scheduleInput: ( name: string ) => `.edit-post-post-schedule__dialog label:has-text("${ name }")`,
 	scheduleMeridianButton: ( meridian: 'am' | 'pm' ) => `role=button[name="${ meridian }"i]`,
-	scheduleMonthSelect: `role=combobox[name="month"i]`,
 
 	// Category
 	categoryCheckbox: ( categoryName: string ) =>
@@ -270,8 +269,8 @@ export class EditorSettingsSidebarComponent {
 			if ( key === 'month' ) {
 				// For month numbers less than 10, pad the digit to be
 				// 2 digits as required by the select.
-				const monthSelectLocator = this.editor.locator( selectors.scheduleMonthSelect );
-				await monthSelectLocator.selectOption( date[ key ].toString().padStart( 2, '0' ) );
+				const monthSelectLocator = this.editor.locator( selectors.scheduleInput( 'month' ) );
+				await monthSelectLocator.selectOption( ( date[ key ] + 1 ).toString().padStart( 2, '0' ) );
 				continue;
 			}
 			if ( key === 'date' ) {


### PR DESCRIPTION
#### Proposed Changes

Fix misc issues with the WPCOM (Calypso) Gutenberg E2E tests. Some issues have not been introduced by 14.9.1, some might. This is being done as part of the release process for Gutenberg 14.9.1 on WPCOM.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Calypso Gutenberg WPCOM simple site's E2E tests should pass.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/71630
