### PR TITLE
Marketplace: Use dynamic plugins endpoint

### DIFF
--- a/client/data/marketplace/use-wpcom-plugins-query.ts
+++ b/client/data/marketplace/use-wpcom-plugins-query.ts
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import {
 	useQuery,
 	UseQueryResult,
@@ -16,7 +17,8 @@ import { BASE_STALE_TIME } from 'calypso/state/initial-state';
 
 type Type = 'all' | 'featured';
 
-const plugisApiBase = '/marketplace/products';
+const pluginsApiBase = '/marketplace/products';
+const dynamicPluginsApiBase = '/marketplace/products-dynamic';
 const featuredPluginsApiBase = '/plugins/featured';
 const pluginsApiNamespace = 'wpcom/v2';
 
@@ -32,7 +34,7 @@ const fetchWPCOMPlugins = ( type: Type, searchTerm?: string, tag?: string ) => {
 
 	return wpcom.req.get(
 		{
-			path: plugisApiBase,
+			path: pluginsApiBase,
 			apiNamespace: pluginsApiNamespace,
 		},
 		{
@@ -80,8 +82,13 @@ export const useWPCOMPluginsList = (
 };
 
 const fetchWPCOMPlugin = ( slug: string ) => {
+	// eslint-disable-next-line no-constant-condition
+	const pluginBase = config.isEnabled( 'marketplace-fetch-dynamic-plugin-details' )
+		? dynamicPluginsApiBase
+		: pluginsApiBase;
+
 	return wpcom.req.get( {
-		path: `${ plugisApiBase }/${ slug }`,
+		path: `${ pluginBase }/${ slug }`,
 		apiNamespace: pluginsApiNamespace,
 	} );
 };

--- a/client/lib/plugins/utils.js
+++ b/client/lib/plugins/utils.js
@@ -240,7 +240,8 @@ export function normalizePluginData( plugin, pluginData ) {
 						item[ '2x' ] ||
 						item[ '1x' ] ||
 						item.svg ||
-						item.default;
+						item.default ||
+						item;
 				}
 				break;
 			case 'homepage':

--- a/config/development.json
+++ b/config/development.json
@@ -103,6 +103,7 @@
 		"mailchimp": true,
 		"manage/import/site-importer-endpoints": true,
 		"marketplace-domain-bundle": true,
+		"marketplace-fetch-dynamic-plugin-details": true,
 		"marketplace-jetpack-plugin-search": true,
 		"marketplace-personal-premium": false,
 		"marketplace-test": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -66,12 +66,8 @@
 		"livechat_solution": true,
 		"mailchimp": false,
 		"marketplace-domain-bundle": false,
-<<<<<<< HEAD
-		"marketplace-jetpack-plugin-search": false,
-=======
 		"marketplace-fetch-dynamic-plugin-details": false,
 		"marketplace-jetpack-plugin-search": true,
->>>>>>> f062e34f4e (Add new feature flag)
 		"marketplace-personal-premium": false,
 		"marketplace-test": false,
 		"me/account/color-scheme-picker": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -66,7 +66,12 @@
 		"livechat_solution": true,
 		"mailchimp": false,
 		"marketplace-domain-bundle": false,
+<<<<<<< HEAD
 		"marketplace-jetpack-plugin-search": false,
+=======
+		"marketplace-fetch-dynamic-plugin-details": false,
+		"marketplace-jetpack-plugin-search": true,
+>>>>>>> f062e34f4e (Add new feature flag)
 		"marketplace-personal-premium": false,
 		"marketplace-test": false,
 		"me/account/color-scheme-picker": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -67,7 +67,7 @@
 		"mailchimp": false,
 		"marketplace-domain-bundle": false,
 		"marketplace-fetch-dynamic-plugin-details": false,
-		"marketplace-jetpack-plugin-search": true,
+		"marketplace-jetpack-plugin-search": false,
 		"marketplace-personal-premium": false,
 		"marketplace-test": false,
 		"me/account/color-scheme-picker": true,

--- a/config/production.json
+++ b/config/production.json
@@ -73,7 +73,12 @@
 		"login/react-lost-password-screen": true,
 		"mailchimp": true,
 		"marketplace-domain-bundle": false,
+<<<<<<< HEAD
 		"marketplace-jetpack-plugin-search": false,
+=======
+		"marketplace-fetch-dynamic-plugin-details": false,
+		"marketplace-jetpack-plugin-search": true,
+>>>>>>> f062e34f4e (Add new feature flag)
 		"marketplace-personal-premium": false,
 		"marketplace-test": false,
 		"me/account-close": true,

--- a/config/production.json
+++ b/config/production.json
@@ -73,12 +73,8 @@
 		"login/react-lost-password-screen": true,
 		"mailchimp": true,
 		"marketplace-domain-bundle": false,
-<<<<<<< HEAD
-		"marketplace-jetpack-plugin-search": false,
-=======
 		"marketplace-fetch-dynamic-plugin-details": false,
 		"marketplace-jetpack-plugin-search": true,
->>>>>>> f062e34f4e (Add new feature flag)
 		"marketplace-personal-premium": false,
 		"marketplace-test": false,
 		"me/account-close": true,

--- a/config/production.json
+++ b/config/production.json
@@ -74,7 +74,7 @@
 		"mailchimp": true,
 		"marketplace-domain-bundle": false,
 		"marketplace-fetch-dynamic-plugin-details": false,
-		"marketplace-jetpack-plugin-search": true,
+		"marketplace-jetpack-plugin-search": false,
 		"marketplace-personal-premium": false,
 		"marketplace-test": false,
 		"me/account-close": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -71,7 +71,7 @@
 		"mailchimp": true,
 		"marketplace-domain-bundle": true,
 		"marketplace-fetch-dynamic-plugin-details": false,
-		"marketplace-jetpack-plugin-search": true,
+		"marketplace-jetpack-plugin-search": false,
 		"marketplace-personal-premium": false,
 		"marketplace-test": true,
 		"me/account-close": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -70,7 +70,12 @@
 		"login/react-lost-password-screen": true,
 		"mailchimp": true,
 		"marketplace-domain-bundle": true,
+<<<<<<< HEAD
 		"marketplace-jetpack-plugin-search": false,
+=======
+		"marketplace-fetch-dynamic-plugin-details": false,
+		"marketplace-jetpack-plugin-search": true,
+>>>>>>> f062e34f4e (Add new feature flag)
 		"marketplace-personal-premium": false,
 		"marketplace-test": true,
 		"me/account-close": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -70,12 +70,8 @@
 		"login/react-lost-password-screen": true,
 		"mailchimp": true,
 		"marketplace-domain-bundle": true,
-<<<<<<< HEAD
-		"marketplace-jetpack-plugin-search": false,
-=======
 		"marketplace-fetch-dynamic-plugin-details": false,
 		"marketplace-jetpack-plugin-search": true,
->>>>>>> f062e34f4e (Add new feature flag)
 		"marketplace-personal-premium": false,
 		"marketplace-test": true,
 		"me/account-close": true,

--- a/config/test.json
+++ b/config/test.json
@@ -60,7 +60,12 @@
 		"legal-updates-banner": true,
 		"limit-global-styles": true,
 		"mailchimp": true,
+<<<<<<< HEAD
 		"marketplace-jetpack-plugin-search": false,
+=======
+		"marketplace-fetch-dynamic-plugin-details": false,
+		"marketplace-jetpack-plugin-search": true,
+>>>>>>> f062e34f4e (Add new feature flag)
 		"marketplace-personal-premium": false,
 		"me/account-close": true,
 		"me/vat-details": true,

--- a/config/test.json
+++ b/config/test.json
@@ -60,12 +60,8 @@
 		"legal-updates-banner": true,
 		"limit-global-styles": true,
 		"mailchimp": true,
-<<<<<<< HEAD
-		"marketplace-jetpack-plugin-search": false,
-=======
 		"marketplace-fetch-dynamic-plugin-details": false,
 		"marketplace-jetpack-plugin-search": true,
->>>>>>> f062e34f4e (Add new feature flag)
 		"marketplace-personal-premium": false,
 		"me/account-close": true,
 		"me/vat-details": true,

--- a/config/test.json
+++ b/config/test.json
@@ -61,7 +61,7 @@
 		"limit-global-styles": true,
 		"mailchimp": true,
 		"marketplace-fetch-dynamic-plugin-details": false,
-		"marketplace-jetpack-plugin-search": true,
+		"marketplace-jetpack-plugin-search": false,
 		"marketplace-personal-premium": false,
 		"me/account-close": true,
 		"me/vat-details": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -78,12 +78,8 @@
 		"logmein": true,
 		"mailchimp": true,
 		"marketplace-domain-bundle": true,
-<<<<<<< HEAD
-		"marketplace-jetpack-plugin-search": false,
-=======
 		"marketplace-fetch-dynamic-plugin-details": false,
 		"marketplace-jetpack-plugin-search": true,
->>>>>>> f062e34f4e (Add new feature flag)
 		"marketplace-personal-premium": false,
 		"marketplace-test": true,
 		"me/account-close": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -79,7 +79,7 @@
 		"mailchimp": true,
 		"marketplace-domain-bundle": true,
 		"marketplace-fetch-dynamic-plugin-details": false,
-		"marketplace-jetpack-plugin-search": true,
+		"marketplace-jetpack-plugin-search": false,
 		"marketplace-personal-premium": false,
 		"marketplace-test": true,
 		"me/account-close": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -78,7 +78,12 @@
 		"logmein": true,
 		"mailchimp": true,
 		"marketplace-domain-bundle": true,
+<<<<<<< HEAD
 		"marketplace-jetpack-plugin-search": false,
+=======
+		"marketplace-fetch-dynamic-plugin-details": false,
+		"marketplace-jetpack-plugin-search": true,
+>>>>>>> f062e34f4e (Add new feature flag)
 		"marketplace-personal-premium": false,
 		"marketplace-test": true,
 		"me/account-close": true,


### PR DESCRIPTION
#### Proposed Changes

This PR introduces a way for switching between static and dynamic product catalogs for fetching plugin details. 

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Append `?flags=marketplace-fetch-dynamic-plugin-details` to enable the feature. 
- If required clear the indexeddb cache from the browser
- Visit the paid plugin details page - `plugins/woocommerce-bookings/:site`
- Open the network tab on the browser console and check if the plugin details page is fetching details from the newly created endpoint for getting details from the shadow database. 
- Check if plugin details are displayed correctly. 

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
