### PR TITLE
Add hours to Email Stats chart

### DIFF
--- a/client/blocks/stats-navigation/constants.js
+++ b/client/blocks/stats-navigation/constants.js
@@ -3,12 +3,14 @@ import { translate } from 'i18n-calypso';
 /**
  * Intervals
  */
+const hour = { value: 'hour', label: translate( 'Hours' ) };
 const day = { value: 'day', label: translate( 'Days' ) };
 const week = { value: 'week', label: translate( 'Weeks' ) };
 const month = { value: 'month', label: translate( 'Months' ) };
 const year = { value: 'year', label: translate( 'Years' ) };
 
 export const intervals = [ day, week, month, year ];
+export const emailIntervals = [ hour, day, week, month, year ];
 
 /**
  * Nav items
@@ -50,6 +52,7 @@ export const navItems = {
 /**
  * Define properties with translatable strings getters
  */
+Object.defineProperty( hour, 'label', { get: () => translate( 'Hours' ) } );
 Object.defineProperty( day, 'label', { get: () => translate( 'Days' ) } );
 Object.defineProperty( week, 'label', { get: () => translate( 'Weeks' ) } );
 Object.defineProperty( month, 'label', { get: () => translate( 'Months' ) } );

--- a/client/blocks/stats-navigation/intervals.js
+++ b/client/blocks/stats-navigation/intervals.js
@@ -7,13 +7,21 @@ import { intervals } from './constants';
 import './intervals.scss';
 
 const Intervals = ( props ) => {
-	const { selected, pathTemplate, className, standalone, compact = true } = props;
+	const {
+		selected,
+		pathTemplate,
+		className,
+		standalone,
+		compact = true,
+		intervalValues = intervals,
+	} = props;
 	const classes = classnames( 'stats-navigation__intervals', className, {
 		'is-standalone': standalone,
 	} );
+
 	return (
 		<SegmentedControl primary className={ classes } compact={ compact }>
-			{ intervals.map( ( i ) => {
+			{ intervalValues.map( ( i ) => {
 				const path = pathTemplate.replace( /{{ interval }}/g, i.value );
 				return (
 					<SegmentedControl.Item key={ i.value } path={ path } selected={ i.value === selected }>
@@ -30,6 +38,7 @@ Intervals.propTypes = {
 	pathTemplate: PropTypes.string.isRequired,
 	selected: PropTypes.string.isRequired,
 	standalone: PropTypes.bool,
+	intervalValues: PropTypes.array,
 };
 
 Intervals.defaultProps = {

--- a/client/my-sites/stats/controller.jsx
+++ b/client/my-sites/stats/controller.jsx
@@ -71,6 +71,12 @@ function getSiteFilters( siteId ) {
 			id: 'stats-insights',
 		},
 		{
+			title: i18n.translate( 'Hours' ),
+			path: '/stats/hour/' + siteId,
+			id: 'stats-hour',
+			period: 'hour',
+		},
+		{
 			title: i18n.translate( 'Days' ),
 			path: '/stats/day/' + siteId,
 			id: 'stats-day',
@@ -93,6 +99,12 @@ function getSiteFilters( siteId ) {
 			path: '/stats/year/' + siteId,
 			id: 'stats-year',
 			period: 'year',
+		},
+		{
+			title: i18n.translate( 'Hours' ),
+			path: '/stats/email/open/' + siteId + '/hour',
+			id: 'stats-email-opens-hour',
+			period: 'hour',
 		},
 		{
 			title: i18n.translate( 'Days' ),

--- a/client/my-sites/stats/index.js
+++ b/client/my-sites/stats/index.js
@@ -26,6 +26,7 @@ const statsPage = ( url, controller ) => {
 
 export default function () {
 	const validPeriods = [ 'day', 'week', 'month', 'year' ].join( '|' );
+	const validEmailPeriods = [ 'hour', 'day', 'week', 'month', 'year' ].join( '|' );
 
 	const validModules = [
 		'posts',
@@ -80,7 +81,7 @@ export default function () {
 
 	// Email stats Pages
 	if ( config.isEnabled( 'newsletter/stats' ) ) {
-		statsPage( `/stats/email/open/:site/:period(${ validPeriods })/:email_id`, emailOpen );
+		statsPage( `/stats/email/open/:site/:period(${ validEmailPeriods })/:email_id`, emailOpen );
 	}
 
 	// Anything else should redirect to default stats page

--- a/client/my-sites/stats/stats-email-chart-tabs/index.jsx
+++ b/client/my-sites/stats/stats-email-chart-tabs/index.jsx
@@ -115,7 +115,8 @@ const connectComponent = connect(
 			return NO_SITE_STATE;
 		}
 
-		const quantity = 'year' === period ? 10 : 30;
+		let quantity = 'year' === period ? 10 : 30;
+		quantity = 'hour' === period ? 24 : quantity;
 		const counts = getCountRecords( state, siteId, postId, period, statType );
 		const chartData = buildChartData( activeLegend, chartTab, counts, period, queryDate );
 		const isActiveTabLoading = isLoadingTabs( state, siteId, postId, period, statType );

--- a/client/my-sites/stats/stats-email-open-detail/index.jsx
+++ b/client/my-sites/stats/stats-email-open-detail/index.jsx
@@ -8,6 +8,7 @@ import { parse as parseQs, stringify as stringifyQs } from 'qs';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import titlecase from 'to-title-case';
+import { emailIntervals } from 'calypso/blocks/stats-navigation/constants';
 import Intervals from 'calypso/blocks/stats-navigation/intervals';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryEmailStats from 'calypso/components/data/query-email-stats';
@@ -37,7 +38,6 @@ import ChartTabs from '../stats-email-chart-tabs';
 import { StatsNoContentBanner } from '../stats-no-content-banner';
 import StatsPeriodHeader from '../stats-period-header';
 import StatsPeriodNavigation from '../stats-period-navigation';
-
 import './style.scss';
 
 function getPageUrl() {
@@ -260,7 +260,12 @@ class StatsEmailOpenDetail extends Component {
 									showQueryDate
 								/>
 							</StatsPeriodNavigation>
-							<Intervals selected={ period } pathTemplate={ pathTemplate } compact={ false } />
+							<Intervals
+								selected={ period }
+								pathTemplate={ pathTemplate }
+								intervalValues={ emailIntervals }
+								compact={ false }
+							/>
 						</StatsPeriodHeader>
 
 						<ChartTabs

--- a/client/state/stats/emails/actions.js
+++ b/client/state/stats/emails/actions.js
@@ -56,6 +56,9 @@ export function requestEmailStats( siteId, postId, period, date, statType, quant
 			statType,
 		} );
 
+		quantity = 'year' === period ? 10 : quantity;
+		quantity = 'hour' === period ? 24 : quantity;
+
 		return wpcom
 			.site( siteId )
 			.statsEmailOpens( postId, { period, quantity, date } )
@@ -64,7 +67,8 @@ export function requestEmailStats( siteId, postId, period, date, statType, quant
 
 				// create an object from emailStats with period as the key
 				const emailStatsObject = emailChartData.reduce( ( obj, item ) => {
-					obj[ item.period ] = {
+					const filter = 'hour' === period ? item.labelHour : item.period;
+					obj[ filter ] = {
 						chart: item,
 						countries: parseEmailCountriesData(
 							stats.countries[ item.period ],

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -175,6 +175,10 @@ export function getChartLabels( unit, date, localizedDate ) {
 		const isWeekend = 'day' === unit && ( 6 === dayOfWeek || 0 === dayOfWeek );
 		const labelName = `label${ unit.charAt( 0 ).toUpperCase() + unit.slice( 1 ) }`;
 		const formats = {
+			hour: translate( 'MMM D HH:mm', {
+				context: 'momentjs format string (hour)',
+				comment: 'This specifies an hour for the stats x-axis label.',
+			} ),
 			day: translate( 'MMM D', {
 				context: 'momentjs format string (day)',
 				comment: 'This specifies a day for the stats x-axis label.',
@@ -1006,6 +1010,9 @@ export function parseEmailChartData( payload, nullAttributes = [] ) {
 			const date = moment( dataRecord.period, 'YYYY-MM-DD' ).locale( 'en' );
 			const localeSlug = getLocaleSlug();
 			const localizedDate = moment( dataRecord.period, 'YYYY-MM-DD' ).locale( localeSlug );
+			if ( dataRecord.hour ) {
+				localizedDate.add( dataRecord.hour, 'hours' );
+			}
 			Object.assign( dataRecord, getChartLabels( payload.unit, date, localizedDate ) );
 		}
 		return dataRecord;


### PR DESCRIPTION
#### Proposed Changes

This PR adds the `hours` interval to the chart in the Email Open Stats page, like this:
<img width="1098" alt="Screenshot 2023-01-10 at 13 39 08" src="https://user-images.githubusercontent.com/3832570/211553815-627ef299-f9ea-4caf-8988-b68850b65e28.png">

#### Testing Instructions

1. Apply this branch to your local Calypso repository and start the application.
2. Insert manually in the browser address bar an URL with this format: https://calypso.localhost:3000/stats/email/open/[the-doomain-of-your-blog]/day/[post-id]?flags=newsletter/stats. Note that you can change day for week and month.
3. Check that the `hours` interval is there. If you click it, you should see the result after the endpoint brings back the response. The endpoint triggered by clicking the `hours` interval should have this shape: `https://public-api.wordpress.com/rest/v1.1/sites/[site-id]/stats/opens/emails/[post-id]?period=hour&quantity=24&date=2023-01-01&stats_fields=timeline`.

#### Known problems

There is a problem with the `previous` and `next` arrows that is being investigated at the moment, and will be addressed in a future PR. The stuff developed in this PR is behind the `newsletter/stats` feature flag, so we are safe.