### PR TITLE
Jetpack Pro Dashboard: disable toggle monitor when a site is down

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/toggle-activate-monitoring/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/toggle-activate-monitoring/index.tsx
@@ -1,5 +1,6 @@
 import { Button } from '@automattic/components';
 import { ToggleControl as OriginalToggleControl } from '@wordpress/components';
+import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import clockIcon from 'calypso/assets/images/jetpack/clock-icon.svg';
@@ -14,9 +15,10 @@ interface Props {
 	site: { blog_id: number; url: string };
 	status: AllowedStatusTypes | string;
 	settings: MonitorSettings | undefined;
+	siteError: boolean;
 }
 
-export default function ToggleActivateMonitoring( { site, status, settings }: Props ) {
+export default function ToggleActivateMonitoring( { site, status, settings, siteError }: Props ) {
 	const moment = useLocalizedMoment();
 	const translate = useTranslate();
 	const [ toggleActivateMonitor, isLoading ] = useToggleActivateMonitor( site );
@@ -104,11 +106,15 @@ export default function ToggleActivateMonitoring( { site, status, settings }: Pr
 
 	return (
 		<>
-			<span className="toggle-activate-monitoring__toggle-button">
+			<span
+				className={ classNames( 'toggle-activate-monitoring__toggle-button', {
+					[ 'sites-overview__disabled' ]: siteError,
+				} ) }
+			>
 				<ToggleControl
 					onChange={ handleToggleActivateMonitoring }
 					checked={ isChecked }
-					disabled={ isLoading }
+					disabled={ isLoading || siteError }
 					label={ isChecked && currentSettings() }
 				/>
 			</span>

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/toggle-activate-monitoring/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/toggle-activate-monitoring/style.scss
@@ -26,6 +26,13 @@
 			}
 		}
 	}
+
+	&.sites-overview__disabled {
+		.components-form-toggle__input {
+			cursor: not-allowed;
+		}
+	}
+
 }
 
 .toggle-activate-monitoring__duration {

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content.tsx
@@ -157,6 +157,7 @@ export default function SiteStatusContent( {
 				site={ rows.site.value }
 				settings={ rows.monitor.settings }
 				status={ status }
+				siteError={ siteError }
 			/>
 		);
 	}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content.tsx
@@ -150,7 +150,8 @@ export default function SiteStatusContent( {
 		'jetpack/partner-portal-downtime-monitoring-updates'
 	);
 
-	if ( isDownTimeMonitorEnabled && type === 'monitor' ) {
+	// We will show "Site Down" when the site is down which is handled differently.
+	if ( isDownTimeMonitorEnabled && type === 'monitor' && ! siteDown ) {
 		return (
 			<ToggleActivateMonitoring
 				site={ rows.site.value }


### PR DESCRIPTION
#### Proposed Changes

This PR makes the below changes 
- To the monitor toggle by disabling it when a site has an error.
- To monitor column by showing `Site Down` when a site is down.

#### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

> **_NOTE:_** Changing the monitor status will not update the status immediately; this will be fixed in a [different PR](https://github.com/Automattic/wp-calypso/pull/71752).

**Instructions**

1. Run `git checkout add/disable-monitor-when-site-down` and `yarn start-jetpack-cloud`
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Verify that the monitor is disabled for a site with a site error.

<img width="1358" alt="Screenshot 2023-01-10 at 5 11 41 PM" src="https://user-images.githubusercontent.com/10586875/211559753-27ab03c1-109c-4632-ac85-4bd9bb0c2e64.png">

4. Verify that "Site Down" is shown when a site is down(Monitor status is failed)

<img width="1295" alt="Screenshot 2023-01-10 at 5 17 19 PM" src="https://user-images.githubusercontent.com/10586875/211559789-b793132e-72ac-4517-88d2-f0dbadc50aa8.png">

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1203448324265423-as-1203661745205572