### PR TITLE
Theme Showcase: Theme preview limit global styles

### DIFF
--- a/client/components/premium-global-styles-upgrade-modal/index.tsx
+++ b/client/components/premium-global-styles-upgrade-modal/index.tsx
@@ -1,10 +1,12 @@
+import { PLAN_PREMIUM } from '@automattic/calypso-products';
 import { Button, Gridicon, Dialog, ScreenReaderText } from '@automattic/components';
-import { useSelect } from '@wordpress/data';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
+import { useSelector } from 'react-redux';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
-import { PRODUCTS_LIST_STORE } from 'calypso/landing/stepper/stores';
-import './upgrade-modal.scss';
+import { getProductBySlug } from 'calypso/state/products-list/selectors';
+
+import './style.scss';
 
 interface PremiumGlobalStylesUpgradeModalProps {
 	checkout: () => void;
@@ -20,14 +22,8 @@ export default function PremiumGlobalStylesUpgradeModal( {
 	tryStyle,
 }: PremiumGlobalStylesUpgradeModalProps ) {
 	const translate = useTranslate();
-	const premiumPlanProduct = useSelect( ( select ) =>
-		select( PRODUCTS_LIST_STORE ).getProductBySlug( 'value_bundle' )
-	);
-
-	//Wait until we have product data to show content
+	const premiumPlanProduct = useSelector( ( state ) => getProductBySlug( state, PLAN_PREMIUM ) );
 	const isLoading = ! premiumPlanProduct;
-
-	const planName = premiumPlanProduct?.product_name;
 
 	return (
 		<Dialog
@@ -48,7 +44,7 @@ export default function PremiumGlobalStylesUpgradeModal( {
 									components: {
 										strong: <strong />,
 									},
-									args: planName,
+									args: premiumPlanProduct?.product_name,
 									comment:
 										'The variable is the plan name: "...by upgrading to WordPress.com Premium."',
 								}

--- a/client/components/premium-global-styles-upgrade-modal/style.scss
+++ b/client/components/premium-global-styles-upgrade-modal/style.scss
@@ -1,0 +1,133 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
+.upgrade-modal {
+	display: flex;
+	flex-direction: column;
+
+	&.dialog__content {
+		padding: 0;
+	}
+
+	&.loading {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		max-width: 775px;
+	}
+
+	@include break-medium() {
+		flex-direction: row;
+		max-width: 775px;
+
+		&.loading {
+			display: flex;
+			align-items: center;
+			justify-content: center;
+			width: 775px;
+			height: 430px;
+		}
+	}
+
+	&__col {
+		position: relative;
+		padding: 45px;
+		@include break-medium {
+			&:nth-of-type(1) {
+				width: 58%;
+			}
+
+			&:nth-of-type(2) {
+				width: 42%;
+			}
+		}
+
+		&:nth-of-type(2) {
+			background-color: var(--studio-gray-0);
+			padding-left: 25px;
+			padding-right: 25px;
+		}
+	}
+
+	h1.upgrade-modal__heading {
+		@extend .wp-brand-font;
+		font-size: $font-headline-small;
+		line-height: 1.1;
+		margin-bottom: 15px;
+		&.bundle {
+			margin-top: 15px;
+		}
+	}
+
+	p {
+		margin-bottom: 20px;
+	}
+
+	&__close {
+		color: var(--color-text-subtle);
+		position: absolute;
+		top: 0;
+		right: 8px;
+
+		.gridicon {
+			fill: var(--color-text-subtle);
+		}
+	}
+
+	&__actions.bundle {
+		display: grid;
+		grid-template-columns: 50% 50%;
+		column-gap: 20px;
+
+		.button {
+			padding: 9px 25px;
+			border-radius: 4px;
+			font-weight: 500;
+			margin-bottom: 0;
+			box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05) !important;
+
+			&.is-primary {
+				background: var(--color-accent);
+				border-color: var(--color-accent);
+				width: 100%;
+
+				&:hover,
+				&:focus {
+					background: var(--color-accent-60);
+					border-color: var(--color-accent-60);
+				}
+			}
+		}
+	}
+
+	&__included {
+		ul,
+		li {
+			font-size: $font-body-small;
+			line-height: 1.7;
+			list-style: none;
+			margin-left: 0;
+			padding-left: 0;
+			margin-top: 0;
+			margin-bottom: 0;
+		}
+
+		li {
+			display: flex;
+			align-items: flex-start;
+		}
+
+		.gridicon {
+			fill: var(--studio-green-50);
+			flex-shrink: 0;
+			margin-right: 10px;
+			margin-top: 4px;
+		}
+	}
+
+	h2 {
+		font-size: $font-body-small;
+		font-weight: 500;
+		margin-bottom: 5px;
+	}
+}

--- a/client/components/theme-preview-modal/index.tsx
+++ b/client/components/theme-preview-modal/index.tsx
@@ -4,7 +4,6 @@ import { useEffect, useMemo, useState } from '@wordpress/element';
 import classnames from 'classnames';
 import { useSelector } from 'react-redux';
 import AsyncLoad from 'calypso/components/async-load';
-import { useSiteGlobalStylesStatus } from 'calypso/state/sites/hooks/use-site-global-styles-status';
 import {
 	doesThemeBundleSoftwareSet as getDoesThemeBundleSoftwareSet,
 	isExternallyManagedTheme as getIsExternallyManagedTheme,
@@ -26,6 +25,7 @@ interface ThemePreviewModalProps {
 	theme: ThemeWithStyleVariations;
 	previewUrl: string;
 	actionButtons: React.ReactNode;
+	shouldLimitGlobalStyles: boolean;
 	selectedVariation?: StyleVariation;
 	onSelectVariation: ( variation: StyleVariation ) => void;
 	onClickCategory: ( category: Category ) => void;
@@ -36,6 +36,7 @@ const ThemePreviewModal: React.FC< ThemePreviewModalProps > = ( {
 	theme,
 	previewUrl,
 	actionButtons,
+	shouldLimitGlobalStyles,
 	selectedVariation,
 	onSelectVariation,
 	onClickCategory,
@@ -52,7 +53,6 @@ const ThemePreviewModal: React.FC< ThemePreviewModalProps > = ( {
 	const doesThemeBundleSoftwareSet = useSelector( ( state ) =>
 		getDoesThemeBundleSoftwareSet( state, theme.id )
 	);
-	const { shouldLimitGlobalStyles } = useSiteGlobalStylesStatus( siteId );
 	const [ selectedStyleVariation, setSelectedStyleVariation ] = useState< StyleVariation | null >(
 		selectedVariation || null
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -18,6 +18,7 @@ import { useDispatch as useReduxDispatch, useSelector } from 'react-redux';
 import AsyncLoad from 'calypso/components/async-load';
 import { useQuerySitePurchases } from 'calypso/components/data/query-site-purchases';
 import FormattedHeader from 'calypso/components/formatted-header';
+import PremiumGlobalStylesUpgradeModal from 'calypso/components/premium-global-styles-upgrade-modal';
 import WebPreview from 'calypso/components/web-preview/content';
 import { useSiteVerticalQueryById } from 'calypso/data/site-verticals';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -41,7 +42,6 @@ import {
 import { getCategorizationOptions } from './categories';
 import { DEFAULT_VARIATION_SLUG, RETIRING_DESIGN_SLUGS, STEP_NAME } from './constants';
 import DesignPickerDesignTitle from './design-picker-design-title';
-import PremiumGlobalStylesUpgradeModal from './premium-global-styles-upgrade-modal';
 import PreviewToolbar from './preview-toolbar';
 import UpgradeModal from './upgrade-modal';
 import getThemeIdFromDesign from './utils/get-theme-id-from-design';

--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -295,9 +295,9 @@ const connectOptionsHoc = connect(
 			mapHideForTheme = ( hideForTheme ) => ( t, s ) => hideForTheme( state, t, s, origin );
 		}
 
-		return mapValues( getAllThemeOptions( props ), ( option ) =>
+		return mapValues( getAllThemeOptions( props ), ( option, key ) =>
 			Object.assign(
-				{},
+				{ key },
 				option,
 				option.getUrl ? { getUrl: mapGetUrl( option.getUrl ) } : {},
 				option.hideForTheme ? { hideForTheme: mapHideForTheme( option.hideForTheme ) } : {}

--- a/client/my-sites/themes/theme-preview.jsx
+++ b/client/my-sites/themes/theme-preview.jsx
@@ -1,16 +1,20 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { Button } from '@automattic/components';
 import { getDesignPreviewUrl } from '@automattic/design-picker';
+import { createHigherOrderComponent } from '@wordpress/compose';
 import { localize } from 'i18n-calypso';
+import page from 'page';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import QueryCanonicalTheme from 'calypso/components/data/query-canonical-theme';
+import PremiumGlobalStylesUpgradeModal from 'calypso/components/premium-global-styles-upgrade-modal';
 import PulsingDot from 'calypso/components/pulsing-dot';
 import ThemePreviewModal from 'calypso/components/theme-preview-modal';
 import WebPreview from 'calypso/components/web-preview';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
+import { useSiteGlobalStylesStatus } from 'calypso/state/sites/hooks/use-site-global-styles-status';
 import { getSiteSlug, isJetpackSite } from 'calypso/state/sites/selectors';
 import { hideThemePreview, setThemePreviewOptions } from 'calypso/state/themes/actions';
 import {
@@ -26,6 +30,8 @@ import {
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { getSubjectsFromTermTable, localizeThemesPath } from './helpers';
 import { connectOptions } from './theme-options';
+
+const isDefaultVariationSlug = ( slug ) => ! slug || slug === 'default';
 
 class ThemePreview extends Component {
 	static displayName = 'ThemePreview';
@@ -44,6 +50,7 @@ class ThemePreview extends Component {
 
 	state = {
 		showActionIndicator: false,
+		showUnlockStyleUpgradeModal: false,
 	};
 
 	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
@@ -57,6 +64,43 @@ class ThemePreview extends Component {
 		}
 	}
 
+	getPrimaryOption = () => {
+		return this.props.themeOptions.primary;
+	};
+
+	getSecondaryOption = () => {
+		const { isActive } = this.props;
+		return isActive ? null : this.props.themeOptions.secondary;
+	};
+
+	getStyleVariationOption = () => {
+		return this.props.themeOptions?.styleVariation;
+	};
+
+	getPreviewUrl = () => {
+		const { demoUrl, locale, theme } = this.props;
+		if ( isEnabled( 'themes/showcase-i4/details-and-preview' ) ) {
+			return getDesignPreviewUrl( { slug: theme.id, recipe: theme }, { language: locale } );
+		}
+
+		return demoUrl + '?demo=true&iframe=true&theme_preview=true';
+	};
+
+	shouldShowUnlockStyleButton = () => {
+		const { options, shouldLimitGlobalStyles, themeOptions } = this.props;
+		if ( ! themeOptions ) {
+			return false;
+		}
+
+		const primaryOption = this.getPrimaryOption();
+		const styleVariationOption = this.getStyleVariationOption();
+		return (
+			shouldLimitGlobalStyles &&
+			primaryOption?.key === options.activate.key &&
+			! isDefaultVariationSlug( styleVariationOption?.slug )
+		);
+	};
+
 	onPrimaryButtonClick = () => {
 		const option = this.getPrimaryOption();
 		option.action && option.action( this.props.themeId );
@@ -69,17 +113,27 @@ class ThemePreview extends Component {
 		! this.props.isJetpack && this.props.hideThemePreview();
 	};
 
-	getPrimaryOption = () => {
-		return this.props.themeOptions.primary;
+	onUnlockStyleButtonClick = () => {
+		this.setState( { showUnlockStyleUpgradeModal: true } );
 	};
 
-	getSecondaryOption = () => {
-		const { isActive } = this.props;
-		return isActive ? null : this.props.themeOptions.secondary;
+	onSelectVariation = ( variation ) => {
+		const { themeId, primary, secondary } = this.props.themeOptions;
+		this.props.setThemePreviewOptions( themeId, primary, secondary, variation );
 	};
 
-	getStyleVariationOption = () => {
-		return this.props.themeOptions.styleVariation;
+	onPremiumGlobalStylesUpgradeModalCheckout = () => {
+		this.setState( { showUnlockStyleUpgradeModal: false } );
+		page( `/checkout/${ this.props.siteSlug || '' }/premium` );
+	};
+
+	onPremiumGlobalStylesUpgradeModalTryStyle = () => {
+		this.setState( { showUnlockStyleUpgradeModal: false } );
+		this.onPrimaryButtonClick();
+	};
+
+	onPremiumGlobalStylesUpgradeModalClose = () => {
+		this.setState( { showUnlockStyleUpgradeModal: false } );
 	};
 
 	appendStyleVariationOptionToUrl = ( url ) => {
@@ -126,6 +180,14 @@ class ThemePreview extends Component {
 		);
 	};
 
+	renderUnlockStyleButton = () => {
+		return (
+			<Button primary onClick={ this.onUnlockStyleButtonClick }>
+				{ this.props.translate( 'Unlock this style' ) }
+			</Button>
+		);
+	};
+
 	getPreviewUrl = () => {
 		const { demoUrl, locale, theme } = this.props;
 		if ( isEnabled( 'themes/showcase-i4/details-and-preview' ) && theme.stylesheet ) {
@@ -152,8 +214,11 @@ class ThemePreview extends Component {
 	};
 
 	render() {
-		const { theme, themeId, siteId, demoUrl, children, isWPForTeamsSite } = this.props;
-		const { showActionIndicator } = this.state;
+		const { theme, themeId, siteId, demoUrl, children, isWPForTeamsSite, shouldLimitGlobalStyles } =
+			this.props;
+		const { showActionIndicator, showUnlockStyleUpgradeModal } = this.state;
+		const selectedVariation = this.getStyleVariationOption();
+		const showUnlockStyleButton = this.shouldShowUnlockStyleButton();
 		const isNewDetailsAndPreview = isEnabled( 'themes/showcase-i4/details-and-preview' );
 
 		if ( ! themeId || isWPForTeamsSite ) {
@@ -169,8 +234,11 @@ class ThemePreview extends Component {
 						<ThemePreviewModal
 							theme={ theme }
 							previewUrl={ this.getPreviewUrl() }
-							selectedVariation={ this.getStyleVariationOption() }
-							actionButtons={ this.renderPrimaryButton() }
+							selectedVariation={ selectedVariation }
+							actionButtons={
+								showUnlockStyleButton ? this.renderUnlockStyleButton() : this.renderPrimaryButton()
+							}
+							shouldLimitGlobalStyles={ shouldLimitGlobalStyles }
 							onSelectVariation={ this.onSelectVariation }
 							onClickCategory={ this.onClickCategory }
 							onClose={ this.props.hideThemePreview }
@@ -190,10 +258,25 @@ class ThemePreview extends Component {
 							{ ! showActionIndicator && this.renderPrimaryButton() }
 						</WebPreview>
 					) ) }
+				<PremiumGlobalStylesUpgradeModal
+					checkout={ this.onPremiumGlobalStylesUpgradeModalCheckout }
+					tryStyle={ this.onPremiumGlobalStylesUpgradeModalTryStyle }
+					closeModal={ this.onPremiumGlobalStylesUpgradeModalClose }
+					isOpen={ showUnlockStyleUpgradeModal }
+				/>
 			</div>
 		);
 	}
 }
+
+const withSiteGlobalStylesStatus = createHigherOrderComponent(
+	( Wrapped ) => ( props ) => {
+		const { siteId } = props;
+		const { shouldLimitGlobalStyles } = useSiteGlobalStylesStatus( siteId || -1 );
+		return <Wrapped { ...props } shouldLimitGlobalStyles={ shouldLimitGlobalStyles } />;
+	},
+	'withSiteGlobalStylesStatus'
+);
 
 // make all actions available to preview.
 const ConnectedThemePreview = connectOptions( ThemePreview );
@@ -238,4 +321,4 @@ export default connect(
 		};
 	},
 	{ hideThemePreview, setThemePreviewOptions }
-)( localize( ConnectedThemePreview ) );
+)( withSiteGlobalStylesStatus( localize( ConnectedThemePreview ) ) );

--- a/client/my-sites/themes/theme-preview.jsx
+++ b/client/my-sites/themes/theme-preview.jsx
@@ -77,15 +77,6 @@ class ThemePreview extends Component {
 		return this.props.themeOptions?.styleVariation;
 	};
 
-	getPreviewUrl = () => {
-		const { demoUrl, locale, theme } = this.props;
-		if ( isEnabled( 'themes/showcase-i4/details-and-preview' ) ) {
-			return getDesignPreviewUrl( { slug: theme.id, recipe: theme }, { language: locale } );
-		}
-
-		return demoUrl + '?demo=true&iframe=true&theme_preview=true';
-	};
-
 	shouldShowUnlockStyleButton = () => {
 		const { options, shouldLimitGlobalStyles, themeOptions } = this.props;
 		if ( ! themeOptions ) {
@@ -195,11 +186,6 @@ class ThemePreview extends Component {
 		}
 
 		return demoUrl + '?demo=true&iframe=true&theme_preview=true';
-	};
-
-	onSelectVariation = ( variation ) => {
-		const { themeId, primary, secondary } = this.props.themeOptions;
-		this.props.setThemePreviewOptions( themeId, primary, secondary, variation );
 	};
 
 	onClickCategory = ( category ) => {


### PR DESCRIPTION
#### Proposed Changes

This PR implements the limitation of global styles. New sites will have global styles limited to Premium plans (see p7DVsv-fY6-p2 for more context). As a result, whenever a user selects a style variation in the theme preview, the primary button will change to "Unlock this style". Clicking the button will open an overlay, where users can select to try the style or head to checkout. See screenshots below for reference:

**Selecting a style variation will change the primary button to "Unlock this style"**
![Screen Shot 2023-01-10 at 9 38 01 PM](https://user-images.githubusercontent.com/797888/211566061-9e8bda24-40be-4dd5-b04e-89726c4b6a73.png)

**Clicking the "Unlock this style" button will open the upgrade modal**
![Screen Shot 2023-01-10 at 9 38 09 PM](https://user-images.githubusercontent.com/797888/211566290-39ec8894-4192-4348-9388-2c632375ed8b.png)


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the logged-in Theme Showcase `/themes/${site_slug}`. If using calypso.live, the flag `themes/showcase-i4/details-and-preview` is required.
* Open the preview of any theme with global style selection.
* Ensure that selecting any style other than the default will change the primary button to "Unlock this button".
* Ensure that clicking the "Unlock this button" will open the upgrade modal.
* Ensure that clicking the "Try it out first" button will open the theme switch modal.
* Ensure that clicking the "Upgrade plan" button will take users to the checkout page.
* Since this PR modifies the onboarding design picker, ensure that the design preview flow for limiting global styles works as before. 

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
