### PR TITLE
Subscriber-Team screen: Turn on the ScreenOptionsTab component

### DIFF
--- a/client/my-sites/people/subscribers-team/index.tsx
+++ b/client/my-sites/people/subscribers-team/index.tsx
@@ -2,6 +2,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import FormattedHeader from 'calypso/components/formatted-header';
 import Main from 'calypso/components/main';
+import ScreenOptionsTab from 'calypso/components/screen-options-tab';
 import SectionNav from 'calypso/components/section-nav';
 import useFollowersQuery from 'calypso/data/followers/use-followers-query';
 import useUsersQuery from 'calypso/data/users/use-users-query';
@@ -41,6 +42,7 @@ function SubscribersTeam( props: Props ) {
 
 	return (
 		<Main>
+			<ScreenOptionsTab wpAdminPath="users.php" />
 			<FormattedHeader
 				brandFont
 				className="people__page-heading"


### PR DESCRIPTION
#### Proposed Changes

* Turn on the ScreenOptionsTab component with the classic view leading to the users.php page

#### Testing Instructions

* Go to `/people/subscirbers/{SITE_SLUG}`
* Check if there is a ScreenOptionsTab component

<img width="516" alt="Screenshot 2023-01-10 at 14 32 43" src="https://user-images.githubusercontent.com/1241413/211564946-5293b8c8-a600-4c9d-97c1-f064a4daa71e.png">

**Out of scope from this PR:**
* Returning to the default calypso view will lead to the old `/people/team/{site_slug}` screen. The solution could be to replace the content of the `team` route with `team-members` content based on the feature flag.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #71843
