### PR TITLE
Make sure user lands on PatternAssembler after select blank-canvas

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/constants.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/constants.ts
@@ -2,3 +2,12 @@ export const PATTERN_SOURCE_SITE_ID = 174455321; // dotcompatterns
 export const PUBLIC_API_URL = 'https://public-api.wordpress.com';
 export const PREVIEW_PATTERN_URL = PUBLIC_API_URL + '/wpcom/v2/block-previews/pattern';
 export const SITE_TAGLINE = 'Site Tagline';
+
+export const BLANK_CANVAS_DESIGN = {
+	slug: 'blank-canvas-3',
+	title: 'Blank Canvas',
+	recipe: {
+		stylesheet: 'pub/blank-canvas-3',
+	},
+	design_type: 'assembler',
+};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -7,6 +7,7 @@ import { useDispatch as useReduxDispatch } from 'react-redux';
 import AsyncLoad from 'calypso/components/async-load';
 import DocumentHead from 'calypso/components/data/document-head';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { getSignupSelectedThemeSlug } from 'calypso/signup/storageUtils';
 import { requestActiveTheme } from 'calypso/state/themes/actions';
 import { useSite } from '../../../../hooks/use-site';
 import { useSiteIdParam } from '../../../../hooks/use-site-id-param';
@@ -24,24 +25,16 @@ import type { DesignRecipe, Design } from '@automattic/design-picker/src/types';
 import './style.scss';
 
 const PatternAssembler: Step = ( { navigation, flow } ) => {
-	const hardcodeDesign = {
+	const blankCanvasDesign = {
 		slug: 'blank-canvas-3',
 		title: 'Blank Canvas',
-		description:
-			'Blank Canvas is a barebones starter theme, stripped off of content templates but only a footer and a header.',
 		recipe: {
 			stylesheet: 'pub/blank-canvas-3',
 		},
 		verticalizable: false,
-		categories: [],
 		is_premium: false,
 		is_bundled_with_woo_commerce: false,
-		software_sets: [],
 		design_type: 'assembler',
-		style_variations: [],
-		features: [],
-		template: '',
-		theme: '',
 	};
 
 	const translate = useTranslate();
@@ -52,11 +45,12 @@ const PatternAssembler: Step = ( { navigation, flow } ) => {
 	const [ sectionPosition, setSectionPosition ] = useState< number | null >( null );
 	const incrementIndexRef = useRef( 0 );
 	const [ activePosition, setActivePosition ] = useState( -1 );
-	const { goBack, goNext, submit } = navigation;
+	const { goBack, goNext, goToStep, submit } = navigation;
 	const { setThemeOnSite, runThemeSetupOnSite, createCustomTemplate } = useDispatch( SITE_STORE );
 	const reduxDispatch = useReduxDispatch();
 	const { setPendingAction } = useDispatch( ONBOARD_STORE );
 	const selectedDesign = useSelect( ( select ) => select( ONBOARD_STORE ).getSelectedDesign() );
+	const signupSelectedThemeSlug = getSignupSelectedThemeSlug();
 	const { setSelectedDesign } = useDispatch( ONBOARD_STORE );
 	const intent = useSelect( ( select ) => select( ONBOARD_STORE ).getIntent() );
 	const site = useSite();
@@ -81,9 +75,11 @@ const PatternAssembler: Step = ( { navigation, flow } ) => {
 	useEffect( () => {
 		// Require to start the flow from the first step
 		if ( ! selectedDesign ) {
-			// Should get the persisted theme param from signup
-			setSelectedDesign( hardcodeDesign as Design );
-			// goToStep?.( 'goals' );
+			if ( signupSelectedThemeSlug !== 'blank-canvas-3' ) {
+				goToStep?.( 'goals' );
+			}
+			// User has selected blank-canvas-3 theme from theme showcase
+			setSelectedDesign( blankCanvasDesign as Design );
 		}
 	}, [] );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -52,12 +52,12 @@ const PatternAssembler: Step = ( { navigation, flow } ) => {
 	const [ sectionPosition, setSectionPosition ] = useState< number | null >( null );
 	const incrementIndexRef = useRef( 0 );
 	const [ activePosition, setActivePosition ] = useState( -1 );
-	const { goBack, goNext, submit, goToStep } = navigation;
+	const { goBack, goNext, submit } = navigation;
 	const { setThemeOnSite, runThemeSetupOnSite, createCustomTemplate } = useDispatch( SITE_STORE );
 	const reduxDispatch = useReduxDispatch();
 	const { setPendingAction } = useDispatch( ONBOARD_STORE );
-	const selectedDesign =
-		useSelect( ( select ) => select( ONBOARD_STORE ).getSelectedDesign() ) || hardcodeDesign;
+	const selectedDesign = useSelect( ( select ) => select( ONBOARD_STORE ).getSelectedDesign() );
+	const { setSelectedDesign } = useDispatch( ONBOARD_STORE );
 	const intent = useSelect( ( select ) => select( ONBOARD_STORE ).getIntent() );
 	const site = useSite();
 	const siteSlug = useSiteSlugParam();
@@ -81,7 +81,9 @@ const PatternAssembler: Step = ( { navigation, flow } ) => {
 	useEffect( () => {
 		// Require to start the flow from the first step
 		if ( ! selectedDesign ) {
-			goToStep?.( 'goals' );
+			// Should get the persisted theme param from signup
+			setSelectedDesign( hardcodeDesign as Design );
+			// goToStep?.( 'goals' );
 		}
 	}, [] );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -24,6 +24,26 @@ import type { DesignRecipe, Design } from '@automattic/design-picker/src/types';
 import './style.scss';
 
 const PatternAssembler: Step = ( { navigation, flow } ) => {
+	const hardcodeDesign = {
+		slug: 'blank-canvas-3',
+		title: 'Blank Canvas',
+		description:
+			'Blank Canvas is a barebones starter theme, stripped off of content templates but only a footer and a header.',
+		recipe: {
+			stylesheet: 'pub/blank-canvas-3',
+		},
+		verticalizable: false,
+		categories: [],
+		is_premium: false,
+		is_bundled_with_woo_commerce: false,
+		software_sets: [],
+		design_type: 'assembler',
+		style_variations: [],
+		features: [],
+		template: '',
+		theme: '',
+	};
+
 	const translate = useTranslate();
 	const [ showPatternSelectorType, setShowPatternSelectorType ] = useState< string | null >( null );
 	const [ header, setHeader ] = useState< Pattern | null >( null );
@@ -36,7 +56,8 @@ const PatternAssembler: Step = ( { navigation, flow } ) => {
 	const { setThemeOnSite, runThemeSetupOnSite, createCustomTemplate } = useDispatch( SITE_STORE );
 	const reduxDispatch = useReduxDispatch();
 	const { setPendingAction } = useDispatch( ONBOARD_STORE );
-	const selectedDesign = useSelect( ( select ) => select( ONBOARD_STORE ).getSelectedDesign() );
+	const selectedDesign =
+		useSelect( ( select ) => select( ONBOARD_STORE ).getSelectedDesign() ) || hardcodeDesign;
 	const intent = useSelect( ( select ) => select( ONBOARD_STORE ).getIntent() );
 	const site = useSite();
 	const siteSlug = useSiteSlugParam();

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -14,7 +14,7 @@ import { useSiteIdParam } from '../../../../hooks/use-site-id-param';
 import { useSiteSlugParam } from '../../../../hooks/use-site-slug-param';
 import { SITE_STORE, ONBOARD_STORE } from '../../../../stores';
 import { recordSelectedDesign } from '../../analytics/record-design';
-import { SITE_TAGLINE } from './constants';
+import { SITE_TAGLINE, BLANK_CANVAS_DESIGN } from './constants';
 import PatternLayout from './pattern-layout';
 import PatternSelectorLoader from './pattern-selector-loader';
 import { useAllPatterns } from './patterns-data';
@@ -25,18 +25,6 @@ import type { DesignRecipe, Design } from '@automattic/design-picker/src/types';
 import './style.scss';
 
 const PatternAssembler: Step = ( { navigation, flow } ) => {
-	const blankCanvasDesign = {
-		slug: 'blank-canvas-3',
-		title: 'Blank Canvas',
-		recipe: {
-			stylesheet: 'pub/blank-canvas-3',
-		},
-		verticalizable: false,
-		is_premium: false,
-		is_bundled_with_woo_commerce: false,
-		design_type: 'assembler',
-	};
-
 	const translate = useTranslate();
 	const [ showPatternSelectorType, setShowPatternSelectorType ] = useState< string | null >( null );
 	const [ header, setHeader ] = useState< Pattern | null >( null );
@@ -77,9 +65,10 @@ const PatternAssembler: Step = ( { navigation, flow } ) => {
 		if ( ! selectedDesign ) {
 			if ( signupSelectedThemeSlug !== 'blank-canvas-3' ) {
 				goToStep?.( 'goals' );
+			} else {
+				// User has selected blank-canvas-3 theme from theme showcase
+				setSelectedDesign( BLANK_CANVAS_DESIGN as Design );
 			}
-			// User has selected blank-canvas-3 theme from theme showcase
-			setSelectedDesign( blankCanvasDesign as Design );
 		}
 	}, [] );
 

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -26,6 +26,7 @@ import {
 	clearSignupDestinationCookie,
 	getSignupCompleteFlowName,
 	wasSignupCheckoutPageUnloaded,
+	setSignupSelectedThemeSlug,
 } from './storageUtils';
 import {
 	getStepUrl,
@@ -294,6 +295,11 @@ export default {
 		};
 		if ( ! isEmpty( additionalDependencies ) ) {
 			context.store.dispatch( updateDependencies( additionalDependencies ) );
+		}
+		if ( themeParameter ) {
+			setSignupSelectedThemeSlug( query.theme );
+		} else {
+			setSignupSelectedThemeSlug( null );
 		}
 
 		context.primary = createElement( SignupComponent, {

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -296,11 +296,7 @@ export default {
 		if ( ! isEmpty( additionalDependencies ) ) {
 			context.store.dispatch( updateDependencies( additionalDependencies ) );
 		}
-		if ( themeParameter ) {
-			setSignupSelectedThemeSlug( query.theme );
-		} else {
-			setSignupSelectedThemeSlug( null );
-		}
+		setSignupSelectedThemeSlug( themeParameter || '' );
 
 		context.primary = createElement( SignupComponent, {
 			store: context.store,

--- a/client/signup/storageUtils.js
+++ b/client/signup/storageUtils.js
@@ -20,6 +20,10 @@ export const clearSignupDestinationCookie = () => {
 	document.cookie = cookie.serialize( 'wpcom_signup_complete_destination', '', options );
 };
 
+export const getSignupSelectedThemeSlug = () =>
+	sessionStorage.getItem( 'wpcom_signup_selected_theme_slug' );
+export const setSignupSelectedThemeSlug = ( value ) =>
+	sessionStorage.setItem( 'wpcom_signup_selected_theme_slug', value );
 export const getSignupCompleteSlug = () =>
 	sessionStorage.getItem( 'wpcom_signup_complete_site_slug' );
 export const setSignupCompleteSlug = ( value ) =>


### PR DESCRIPTION

#### Proposed Changes

* This PR will address the solution to pre-select blank-canvas design for users that come from the logged-out theme showcase ( after they selected blank-canvas-3 theme )
* Also make sure user will be landed on /site-editor after PA step completed

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this branch, if you are using calypso live link, open the browser console and run this to make sure the feature flag is enabled `document.cookie = 'flags=pattern-assembler/logged-out-showcase;max-age=1209600;path=/'`
* Log out from your wp account
* Access theme showcase via /themes
* Select blank-canvas-3 theme and confirm that /patternAssembler step is shown after finishing site creation
* Select other theme and confirm that the end of flow is /home
* Recording
<video src="https://user-images.githubusercontent.com/10071857/212860158-f8c88972-438a-472a-8d08-b1cfb933fa50.mp4"></video>

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #71706