### PR TITLE
Jetpack cloud cart integration - add cart provider to feature comparison page controller

### DIFF
--- a/client/jetpack-cloud/sections/comparison/content.tsx
+++ b/client/jetpack-cloud/sections/comparison/content.tsx
@@ -1,8 +1,7 @@
 import QueryIntroOffers from 'calypso/components/data/query-intro-offers';
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import Main from 'calypso/components/main';
-import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
-import { TableWithStoreContext } from './table';
+import { TableWithStoreAccess } from './table';
 import { ContentProps } from './types';
 
 export const Content: React.FC< ContentProps > = ( {
@@ -21,13 +20,7 @@ export const Content: React.FC< ContentProps > = ( {
 			<QueryIntroOffers />
 			<Main>
 				{ header }
-				<CalypsoShoppingCartProvider>
-					<TableWithStoreContext
-						locale={ locale }
-						rootUrl={ rootUrl }
-						urlQueryArgs={ urlQueryArgs }
-					/>
-				</CalypsoShoppingCartProvider>
+				<TableWithStoreAccess locale={ locale } rootUrl={ rootUrl } urlQueryArgs={ urlQueryArgs } />
 			</Main>
 			{ footer }
 		</>

--- a/client/jetpack-cloud/sections/comparison/content.tsx
+++ b/client/jetpack-cloud/sections/comparison/content.tsx
@@ -1,6 +1,7 @@
 import QueryIntroOffers from 'calypso/components/data/query-intro-offers';
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import Main from 'calypso/components/main';
+import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 import { TableWithStoreContext } from './table';
 import { ContentProps } from './types';
 
@@ -20,11 +21,13 @@ export const Content: React.FC< ContentProps > = ( {
 			<QueryIntroOffers />
 			<Main>
 				{ header }
-				<TableWithStoreContext
-					locale={ locale }
-					rootUrl={ rootUrl }
-					urlQueryArgs={ urlQueryArgs }
-				/>
+				<CalypsoShoppingCartProvider>
+					<TableWithStoreContext
+						locale={ locale }
+						rootUrl={ rootUrl }
+						urlQueryArgs={ urlQueryArgs }
+					/>
+				</CalypsoShoppingCartProvider>
 			</Main>
 			{ footer }
 		</>

--- a/client/jetpack-cloud/sections/comparison/controller.tsx
+++ b/client/jetpack-cloud/sections/comparison/controller.tsx
@@ -1,6 +1,5 @@
 import page from 'page';
 import { addQueryArgs } from 'calypso/lib/route';
-import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 import { hideMasterbar } from 'calypso/state/ui/actions';
 import JetpackComFooter from '../pricing/jpcom-footer';
 import JetpackComMasterbar from '../pricing/jpcom-masterbar';
@@ -23,16 +22,14 @@ export function jetpackComparisonContext( context: PageJS.Context, next: () => v
 	context.footer = <JetpackComFooter />;
 
 	context.primary = (
-		<CalypsoShoppingCartProvider>
-			<Content
-				footer={ context.footer }
-				header={ context.header }
-				locale={ lang }
-				nav={ context.nav }
-				urlQueryArgs={ urlQueryArgs }
-				rootUrl={ context.pathname }
-			/>
-		</CalypsoShoppingCartProvider>
+		<Content
+			footer={ context.footer }
+			header={ context.header }
+			locale={ lang }
+			nav={ context.nav }
+			urlQueryArgs={ urlQueryArgs }
+			rootUrl={ context.pathname }
+		/>
 	);
 	next();
 }

--- a/client/jetpack-cloud/sections/comparison/controller.tsx
+++ b/client/jetpack-cloud/sections/comparison/controller.tsx
@@ -1,5 +1,6 @@
 import page from 'page';
 import { addQueryArgs } from 'calypso/lib/route';
+import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 import { hideMasterbar } from 'calypso/state/ui/actions';
 import JetpackComFooter from '../pricing/jpcom-footer';
 import JetpackComMasterbar from '../pricing/jpcom-masterbar';
@@ -22,14 +23,16 @@ export function jetpackComparisonContext( context: PageJS.Context, next: () => v
 	context.footer = <JetpackComFooter />;
 
 	context.primary = (
-		<Content
-			footer={ context.footer }
-			header={ context.header }
-			locale={ lang }
-			nav={ context.nav }
-			urlQueryArgs={ urlQueryArgs }
-			rootUrl={ context.pathname }
-		/>
+		<CalypsoShoppingCartProvider>
+			<Content
+				footer={ context.footer }
+				header={ context.header }
+				locale={ lang }
+				nav={ context.nav }
+				urlQueryArgs={ urlQueryArgs }
+				rootUrl={ context.pathname }
+			/>
+		</CalypsoShoppingCartProvider>
 	);
 	next();
 }

--- a/client/jetpack-cloud/sections/comparison/table/index.tsx
+++ b/client/jetpack-cloud/sections/comparison/table/index.tsx
@@ -3,6 +3,7 @@ import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { Fragment, useCallback, useMemo } from 'react';
 import { useDispatch } from 'react-redux';
+import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 import ProductLightbox from 'calypso/my-sites/plans/jetpack-plans/product-lightbox';
 import StoreItemInfoContext, {
 	useStoreItemInfoContext,
@@ -19,6 +20,7 @@ import { links } from './links';
 import { useComparisonData } from './useComparisonData';
 import { useProductsToCompare } from './useProductsToCompare';
 import type { SelectorProduct, PurchaseCallback } from 'calypso/my-sites/plans/jetpack-plans/types';
+
 import './style.scss';
 
 export const Table: React.FC = () => {
@@ -155,7 +157,7 @@ export const Table: React.FC = () => {
 	);
 };
 
-export const TableWithStoreContext: React.FC< TableWithStoreContextProps > = ( {
+const TableWithStoreContext: React.FC< TableWithStoreContextProps > = ( {
 	locale,
 	rootUrl,
 	urlQueryArgs,
@@ -190,5 +192,17 @@ export const TableWithStoreContext: React.FC< TableWithStoreContextProps > = ( {
 		<StoreItemInfoContext.Provider value={ storeItemInfo }>
 			<Table />
 		</StoreItemInfoContext.Provider>
+	);
+};
+
+export const TableWithStoreAccess: React.FC< TableWithStoreContextProps > = ( {
+	locale,
+	rootUrl,
+	urlQueryArgs,
+} ) => {
+	return (
+		<CalypsoShoppingCartProvider>
+			<TableWithStoreContext locale={ locale } rootUrl={ rootUrl } urlQueryArgs={ urlQueryArgs } />
+		</CalypsoShoppingCartProvider>
 	);
 };


### PR DESCRIPTION
#### Proposed Changes

* Add Cart provider to feature comparison page in jetpack cloud so that we can use `useStoreItemInfo` hook

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to `/features/comparison?retry=1` from the URL generated below and confirm that page is loaded and also the table
* Click on `More about..` link in any column and confirm it opens the lightbox 

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
