### PR TITLE
Disable promote post CTA on non english users

### DIFF
--- a/client/my-sites/marketing/traffic/index.js
+++ b/client/my-sites/marketing/traffic/index.js
@@ -21,6 +21,7 @@ import wrapSettingsForm from 'calypso/my-sites/site-settings/wrap-settings-form'
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
+import isBlazeEnabled from 'calypso/state/ui/selectors/is-blaze-enabled';
 
 import './style.scss';
 
@@ -37,6 +38,7 @@ const SiteSettingsTraffic = ( {
 	setFieldValue,
 	siteId,
 	siteSlug,
+	shouldShowAdvertisingOption,
 	translate,
 } ) => (
 	// eslint-disable-next-line wpcalypso/jsx-classname-namespace
@@ -49,7 +51,7 @@ const SiteSettingsTraffic = ( {
 			/>
 		) }
 		<JetpackDevModeNotice />
-		{ isAdmin && (
+		{ isAdmin && shouldShowAdvertisingOption && (
 			<PromoCardBlock
 				productSlug="blaze"
 				impressionEvent="calypso_marketing_traffic_blaze_banner_view"
@@ -121,6 +123,7 @@ const connectComponent = connect( ( state ) => {
 	const isAdmin = canCurrentUser( state, siteId, 'manage_options' );
 	const isJetpack = isJetpackSite( state, siteId );
 	const isJetpackAdmin = isJetpack && isAdmin;
+	const shouldShowAdvertisingOption = isBlazeEnabled( state );
 
 	return {
 		siteId,
@@ -128,6 +131,7 @@ const connectComponent = connect( ( state ) => {
 		isAdmin,
 		isJetpack,
 		isJetpackAdmin,
+		shouldShowAdvertisingOption,
 	};
 } );
 

--- a/client/my-sites/stats/promo-cards/index.jsx
+++ b/client/my-sites/stats/promo-cards/index.jsx
@@ -7,6 +7,7 @@ import blazeDropDownIllustration from 'calypso/assets/images/illustrations/blaze
 import wordpressSeoIllustration from 'calypso/assets/images/illustrations/wordpress-seo-premium.svg';
 import PromoCardBlock from 'calypso/blocks/promo-card-block';
 import DotPager from 'calypso/components/dot-pager';
+import { PromoteWidgetStatus, usePromoteWidget } from 'calypso/lib/promote-post';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
@@ -29,9 +30,10 @@ export default function PromoCards( { isOdysseyStats, slug, pageSlug } ) {
 	const jetpackNonAtomic = useSelector(
 		( state ) => isJetpackSite( state, selectedSiteId ) && ! isAtomicSite( state, selectedSiteId )
 	);
+	const shouldShowAdvertisingOption = usePromoteWidget() === PromoteWidgetStatus.ENABLED;
 
 	// Blaze promo is disabled for Odyssey.
-	const showBlazePromo = ! isOdysseyStats;
+	const showBlazePromo = ! isOdysseyStats && shouldShowAdvertisingOption;
 	// Yoast promo is disabled for Odyssey & self-hosted & non-traffic pages.
 	const showYoastPromo = ! isOdysseyStats && ! jetpackNonAtomic && pageSlug === 'traffic';
 

--- a/client/state/ui/selectors/is-blaze-enabled.js
+++ b/client/state/ui/selectors/is-blaze-enabled.js
@@ -1,0 +1,5 @@
+import 'calypso/state/ui/init';
+
+export default function isBlazeEnabled( state ) {
+	return !! state.currentUser?.user?.has_promote_widget || false;
+}


### PR DESCRIPTION
#### Proposed Changes
It seems some users without a english UI can see promoted posts CTA under marketing tab. This PR adds a check before displaying those CTAs
*

#### Testing Instructions
Change the interface language to English. Go to Tools > Marketing > Traffic. You should see this banner:
![image](https://user-images.githubusercontent.com/43957544/211601119-38c56891-71e4-42e5-b002-fbed8fb8c3ec.png)

Change the interface to any other language. You shouldn't see the Promote post CTA banner
![image](https://user-images.githubusercontent.com/43957544/211601284-f640d174-76c9-4ac1-95fb-64fb1ed79fbc.png)


*

#### Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?


Related to #
