### PR TITLE
Stats: Refactor "stats-views__key" to Heat Map Legend

### DIFF
--- a/client/my-sites/stats/all-time-views-section/index.tsx
+++ b/client/my-sites/stats/all-time-views-section/index.tsx
@@ -5,7 +5,7 @@ import { useSelector } from 'react-redux';
 import QuerySiteStats from 'calypso/components/data/query-site-stats';
 import SimplifiedSegmentedControl from 'calypso/components/segmented-control/simplified';
 import { getSiteStatsViewSummary } from 'calypso/state/stats/lists/selectors';
-import StatsHeatMapTableLegends from '../stats-heap-map/legends';
+import StatsHeatMapLegend from '../stats-heap-map/legend';
 import StatsModulePlaceholder from '../stats-module/placeholder';
 import Months from '../stats-views/months';
 
@@ -54,7 +54,7 @@ export default function AllTimeViewsSection( { siteId, slug }: { siteId: number;
 							<Months dataKey={ chartOption } data={ viewData } siteSlug={ slug } showYearTotal />
 						</div>
 
-						<StatsHeatMapTableLegends />
+						<StatsHeatMapLegend />
 					</Card>
 				</div>
 			</div>

--- a/client/my-sites/stats/all-time-views-section/index.tsx
+++ b/client/my-sites/stats/all-time-views-section/index.tsx
@@ -5,6 +5,7 @@ import { useSelector } from 'react-redux';
 import QuerySiteStats from 'calypso/components/data/query-site-stats';
 import SimplifiedSegmentedControl from 'calypso/components/segmented-control/simplified';
 import { getSiteStatsViewSummary } from 'calypso/state/stats/lists/selectors';
+import StatsHeatMapTableLegends from '../stats-heap-map/legends';
 import StatsModulePlaceholder from '../stats-module/placeholder';
 import Months from '../stats-views/months';
 
@@ -53,25 +54,7 @@ export default function AllTimeViewsSection( { siteId, slug }: { siteId: number;
 							<Months dataKey={ chartOption } data={ viewData } siteSlug={ slug } showYearTotal />
 						</div>
 
-						<div className="stats-views__key-container">
-							<span className="stats-views__key-label">
-								{ translate( 'Fewer Views', {
-									context: 'Legend label in stats all-time views table',
-								} ) }
-							</span>
-							<ul className="stats-views__key">
-								<li className="stats-views__key-item level-1" />
-								<li className="stats-views__key-item level-2" />
-								<li className="stats-views__key-item level-3" />
-								<li className="stats-views__key-item level-4" />
-								<li className="stats-views__key-item level-5" />
-							</ul>
-							<span className="stats-views__key-label">
-								{ translate( 'More Views', {
-									context: 'Legend label in stats all-time views table',
-								} ) }
-							</span>
-						</div>
+						<StatsHeatMapTableLegends />
 					</Card>
 				</div>
 			</div>

--- a/client/my-sites/stats/modernized-stats-table-styles.scss
+++ b/client/my-sites/stats/modernized-stats-table-styles.scss
@@ -157,38 +157,4 @@ $common-border-radius: 4px;
 			}
 		}
 	}
-
-	.stats-views__key-container {
-		padding-top: 16px;
-		float: none;
-		display: flex;
-		align-items: center;
-		justify-content: center;
-
-		@media ( max-width: $break-large ) {
-			margin-bottom: 0;
-		}
-	}
-
-	.stats-views__key-label {
-		font-weight: 400;
-		font-size: $font-body-small;
-		line-height: 18px;
-		color: #000;
-		text-transform: none;
-		letter-spacing: normal;
-	}
-
-	.stats-views__key {
-		border-radius: $common-border-radius;
-		overflow: hidden;
-		padding: 0;
-		margin: 0 16px;
-
-		.stats-views__key-item {
-			width: 25px;
-			height: 25px;
-			margin: 0;
-		}
-	}
 }

--- a/client/my-sites/stats/post-detail-table-section/index.tsx
+++ b/client/my-sites/stats/post-detail-table-section/index.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 import SimplifiedSegmentedControl from 'calypso/components/segmented-control/simplified';
 import PostMonths from '../stats-detail-months';
 import PostWeeks from '../stats-detail-weeks';
-import StatsHeatMapTableLegends from '../stats-heap-map/legends';
+import StatsHeatMapLegend from '../stats-heap-map/legend';
 
 import './style.scss';
 
@@ -59,7 +59,7 @@ export default function PostDetailTableSection( {
 							) }
 						</div>
 
-						<StatsHeatMapTableLegends levels={ 2 } />
+						<StatsHeatMapLegend levels={ 2 } />
 					</Card>
 				</div>
 			</div>

--- a/client/my-sites/stats/post-detail-table-section/index.tsx
+++ b/client/my-sites/stats/post-detail-table-section/index.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import SimplifiedSegmentedControl from 'calypso/components/segmented-control/simplified';
 import PostMonths from '../stats-detail-months';
 import PostWeeks from '../stats-detail-weeks';
+import StatsHeatMapTableLegends from '../stats-heap-map/legends';
 
 import './style.scss';
 
@@ -58,22 +59,7 @@ export default function PostDetailTableSection( {
 							) }
 						</div>
 
-						<div className="stats-views__key-container">
-							<span className="stats-views__key-label">
-								{ translate( 'Fewer Views', {
-									context: 'Legend label in stats all-time views table',
-								} ) }
-							</span>
-							<ul className="stats-views__key">
-								<li className="stats-views__key-item level-1" />
-								<li className="stats-views__key-item level-2" />
-							</ul>
-							<span className="stats-views__key-label">
-								{ translate( 'More Views', {
-									context: 'Legend label in stats all-time views table',
-								} ) }
-							</span>
-						</div>
+						<StatsHeatMapTableLegends levels={ 2 } />
 					</Card>
 				</div>
 			</div>

--- a/client/my-sites/stats/stats-heap-map/legend.tsx
+++ b/client/my-sites/stats/stats-heap-map/legend.tsx
@@ -6,25 +6,25 @@ interface Props {
 	levels?: number;
 }
 
-export default function StatsHeatMapLegends( { levels = 5 }: Props ) {
+export default function StatsHeatMapLegend( { levels = 5 }: Props ) {
 	const translate = useTranslate();
 
 	const items = [ ...Array( levels ).keys() ].map( ( index ) => {
 		const idx = index + 1;
 		return (
-			<li key={ `level-${ idx }` } className={ `stats-heat-map__legends-item level-${ idx }` } />
+			<li key={ `level-${ idx }` } className={ `stats-heat-map__legend-item level-${ idx }` } />
 		);
 	} );
 
 	return (
-		<div className="stats-heat-map__legends">
-			<span className="stats-heat-map__legends-label">
+		<div className="stats-heat-map__legend">
+			<span className="stats-heat-map__legend-label">
 				{ translate( 'Fewer Views', {
 					context: 'Legend label in stats all-time views table',
 				} ) }
 			</span>
-			<ul className="stats-heat-map__legends-item-list">{ items }</ul>
-			<span className="stats-heat-map__legends-label">
+			<ul className="stats-heat-map__legend-item-list">{ items }</ul>
+			<span className="stats-heat-map__legend-label">
 				{ translate( 'More Views', {
 					context: 'Legend label in stats all-time views table',
 				} ) }

--- a/client/my-sites/stats/stats-heap-map/legends.tsx
+++ b/client/my-sites/stats/stats-heap-map/legends.tsx
@@ -1,0 +1,34 @@
+import { useTranslate } from 'i18n-calypso';
+
+import './style.scss';
+
+interface Props {
+	levels?: number;
+}
+
+export default function StatsHeatMapLegends( { levels = 5 }: Props ) {
+	const translate = useTranslate();
+
+	const items = [ ...Array( levels ).keys() ].map( ( index ) => {
+		const idx = index + 1;
+		return (
+			<li key={ `level-${ idx }` } className={ `stats-heat-map__legends-item level-${ idx }` } />
+		);
+	} );
+
+	return (
+		<div className="stats-heat-map__legends">
+			<span className="stats-heat-map__legends-label">
+				{ translate( 'Fewer Views', {
+					context: 'Legend label in stats all-time views table',
+				} ) }
+			</span>
+			<ul className="stats-heat-map__legends-item-list">{ items }</ul>
+			<span className="stats-heat-map__legends-label">
+				{ translate( 'More Views', {
+					context: 'Legend label in stats all-time views table',
+				} ) }
+			</span>
+		</div>
+	);
+}

--- a/client/my-sites/stats/stats-heap-map/style.scss
+++ b/client/my-sites/stats/stats-heap-map/style.scss
@@ -1,0 +1,52 @@
+@import "@automattic/typography/styles/variables";
+
+.stats-heat-map__legends {
+	margin-top: 16px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+}
+
+.stats-heat-map__legends-label {
+	font-weight: 400;
+	font-size: $font-body-small;
+	line-height: 18px;
+	color: #000;
+}
+
+.stats-heat-map__legends-item-list {
+	list-style-type: none;
+	border-radius: 4px;
+	overflow: hidden;
+	margin: 0 16px;
+}
+
+.stats-heat-map__legends-item {
+	float: left;
+	width: 25px;
+	height: 25px;
+
+	&.level-0 {
+		background-color: var(--color-neutral-0);
+	}
+
+	&.level-1 {
+		background-color: var(--color-primary-5);
+	}
+
+	&.level-2 {
+		background-color: var(--color-primary-10);
+	}
+
+	&.level-3 {
+		background-color: var(--color-primary-light);
+	}
+
+	&.level-4 {
+		background-color: var(--color-primary);
+	}
+
+	&.level-5 {
+		background-color: var(--color-primary-dark);
+	}
+}

--- a/client/my-sites/stats/stats-heap-map/style.scss
+++ b/client/my-sites/stats/stats-heap-map/style.scss
@@ -1,27 +1,27 @@
 @import "@automattic/typography/styles/variables";
 
-.stats-heat-map__legends {
+.stats-heat-map__legend {
 	margin-top: 16px;
 	display: flex;
 	align-items: center;
 	justify-content: center;
 }
 
-.stats-heat-map__legends-label {
+.stats-heat-map__legend-label {
 	font-weight: 400;
 	font-size: $font-body-small;
 	line-height: 18px;
 	color: #000;
 }
 
-.stats-heat-map__legends-item-list {
+.stats-heat-map__legend-item-list {
 	list-style-type: none;
 	border-radius: 4px;
 	overflow: hidden;
 	margin: 0 16px;
 }
 
-.stats-heat-map__legends-item {
+.stats-heat-map__legend-item {
 	float: left;
 	width: 25px;
 	height: 25px;

--- a/client/my-sites/stats/stats-views/style.scss
+++ b/client/my-sites/stats/stats-views/style.scss
@@ -24,8 +24,7 @@
 	}
 }
 
-.stats-views__month,
-.stats-views__key-item {
+.stats-views__month {
 	background-color: none;
 
 	&.is-total {
@@ -71,42 +70,4 @@
 .segmented-control.stats-views__month-control {
 	max-width: 280px;
 	margin: 0 auto 10px;
-}
-
-.stats-views__key-container {
-	@include clear-fix;
-	padding-top: 10px;
-	float: right;
-
-	@include breakpoint-deprecated( "<960px" ) {
-		float: none;
-		margin: 0 auto;
-		margin-bottom: 25px;
-		text-align: center;
-	}
-}
-
-.stats-views__key-label,
-.stats-views__key {
-	display: inline-block;
-}
-
-.stats-views__key-label {
-	font-size: $font-body-extra-small;
-	color: var(--color-neutral);
-	letter-spacing: 0.1em;
-	text-transform: uppercase;
-}
-
-.stats-views__key {
-	margin: 0;
-	list-style-type: none;
-	padding: 2px 9px 0 5px;
-
-	.stats-views__key-item {
-		width: 10px;
-		height: 10px;
-		float: left;
-		margin-left: 3px;
-	}
 }


### PR DESCRIPTION
#### Proposed Changes

* Introduce the component `HeatMapLegends`.
* Deprecate legacy `.stats-views__key` related styles.
* Alter basic usage of legends inside the `Insights` and `PostDetail` pages.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up this change with the Calypso Live link.
* Navigate to the Stats `Insights` page.
* Ensure the All-time insights table legends work as previously.
* Navigate to the Stats `Post Detail` page with the feature flag `/stats/post/${post-id}/${site-id}?flags=stats/enhance-post-detail`.
* Ensure the All-time Insights table legends work as previously.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #71762 
