### PR TITLE
Users managements: Fix the issue of highlighting Users -> Add a new submenu item

### DIFF
--- a/client/my-sites/sidebar/utils.js
+++ b/client/my-sites/sidebar/utils.js
@@ -26,6 +26,16 @@ export const itemLinkMatches = ( path, currentPath ) => {
 		return fragmentIsEqual( path, currentPath, 3 );
 	}
 
+	if ( pathIncludes( currentPath, 'people', 1 ) ) {
+		if ( pathIncludes( currentPath, 'new', 2 ) ) {
+			return fragmentIsEqual( path, currentPath, 2 );
+		}
+
+		if ( pathIncludes( currentPath, 'team-members', 2 ) ) {
+			return fragmentIsEqual( path, currentPath, 2 );
+		}
+	}
+
 	if ( pathIncludes( currentPath, 'settings', 1 ) ) {
 		// Jetpack Cloud uses a simpler /settings/:site pattern for the settings page.
 		if ( isJetpackCloud() ) {


### PR DESCRIPTION
#### Proposed Changes

Fixed the issue of highlighting `Users -> Add new` submenu item and supporting future `Team`.

#### Testing Instructions

* Go to `/people/team/{SITE_SLUG}`
* Select the submenu `Add new` item
* Check if the selected item is highlighted

<table>
<tr>
<td>
<img width="280" alt="Screenshot 2023-01-10 at 18 20 38" src="https://user-images.githubusercontent.com/1241413/211619999-97405008-bc91-4c56-a07c-2b94d982fa40.png">
</td>
<td>
<img width="281" alt="Screenshot 2023-01-10 at 18 23 48" src="https://user-images.githubusercontent.com/1241413/211620045-86dc39b2-7ce9-44a9-82ed-74d3647cb9f1.png">
</td>
</tr>
</table>

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
