### PR TITLE
Hide Advertising menu on atomic sites for non english users

### DIFF
--- a/client/my-sites/sidebar/menu.jsx
+++ b/client/my-sites/sidebar/menu.jsx
@@ -79,7 +79,7 @@ export const MySitesSidebarUnifiedMenu = ( {
 				{ ...props }
 			>
 				{ children.map( ( item ) => {
-					if ( ! shouldShowAdvertisingOption && item?.url?.includes( 'advertising' ) ) {
+					if ( ! shouldShowAdvertisingOption && item?.url?.includes( '/advertising/' ) ) {
 						return;
 					}
 					const isSelected = selectedMenuItem?.url === item.url;

--- a/client/my-sites/sidebar/menu.jsx
+++ b/client/my-sites/sidebar/menu.jsx
@@ -79,7 +79,7 @@ export const MySitesSidebarUnifiedMenu = ( {
 				{ ...props }
 			>
 				{ children.map( ( item ) => {
-					if ( ! shouldShowAdvertisingOption && item.title === 'Advertising' ) {
+					if ( ! shouldShowAdvertisingOption && item?.url?.includes( 'advertising' ) ) {
 						return;
 					}
 					const isSelected = selectedMenuItem?.url === item.url;


### PR DESCRIPTION
#### Proposed Changes

This PR changes the checking that was performed for displaying the "Advertising" menu. Prior to this PR the checking was being done directly by checking the "Advertising" string in the menu object. Now I'm checking if the url contains the `advertising` path. This will be remove after we enable this feature for all users.

#### Testing Instructions
Set your interface to English
Advertising menu should display in "Tools" menu
Set your interface to Spanish
Advertising menu should not display in "tools" menu

#### Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?


Related to #
