### PR TITLE
Hosting Config: Update upsell message to be less specific about plan name

### DIFF
--- a/client/my-sites/hosting/main.js
+++ b/client/my-sites/hosting/main.js
@@ -1,6 +1,10 @@
+<<<<<<< HEAD
 import { PLAN_BUSINESS, FEATURE_SFTP } from '@automattic/calypso-products';
 import { englishLocales } from '@automattic/i18n-utils';
 import { Spinner } from '@wordpress/components';
+=======
+import { FEATURE_SFTP } from '@automattic/calypso-products';
+>>>>>>> ea1876e34c (Update Hosting Config upsell message to be less specific about plan name)
 import { localize } from 'i18n-calypso';
 import { Component, Fragment } from 'react';
 import wrapWithClickOutside from 'react-click-outside';
@@ -80,24 +84,33 @@ class Hosting extends Component {
 		} = this.props;
 
 		const getUpgradeBanner = () => (
-			<Experiment
-				name="calypso_hosting_configuration_upsell_list_features"
-				defaultExperience={
-					<UpsellNudge
-						title={ translate( 'Upgrade to the Business plan to access all hosting features' ) }
-						event="calypso_hosting_configuration_upgrade_click"
-						href={ `/checkout/${ siteId }/business` }
-						plan={ PLAN_BUSINESS }
-						feature={ FEATURE_SFTP }
-						showIcon={ true }
-					/>
-				}
-				treatmentExperience={ <HostingUpsellNudge siteId={ siteId } /> }
-				loadingExperience={ <Spinner className="hosting__upsell-experiment-spinner" /> }
-				options={ {
-					isEligible: englishLocales.includes( locale ),
-				} }
-			/>
+			<>
+				<Experiment
+					name="calypso_hosting_configuration_upsell_list_features"
+					defaultExperience={
+						<UpsellNudge
+							title={ translate( 'Upgrade to the Business plan to access all hosting features' ) }
+							event="calypso_hosting_configuration_upgrade_click"
+							href={ `/checkout/${ siteId }/business` }
+							plan={ PLAN_BUSINESS }
+							feature={ FEATURE_SFTP }
+							showIcon={ true }
+						/>
+					}
+					treatmentExperience={ <HostingUpsellNudge siteId={ siteId } /> }
+					loadingExperience={ <Spinner className="hosting__upsell-experiment-spinner" /> }
+					options={ {
+						isEligible: englishLocales.includes( locale ),
+					} }
+				/>
+				<UpsellNudge
+					title={ translate( 'Upgrade your plan to access hosting features' ) }
+					event="calypso_hosting_configuration_upgrade_click"
+					href={ `/plans/${ siteSlug }/` }
+					feature={ FEATURE_SFTP }
+					showIcon={ true }
+				/>
+			</>
 		);
 
 		const getAtomicActivationNotice = () => {

--- a/client/my-sites/hosting/main.js
+++ b/client/my-sites/hosting/main.js
@@ -1,10 +1,14 @@
 <<<<<<< HEAD
+<<<<<<< HEAD
 import { PLAN_BUSINESS, FEATURE_SFTP } from '@automattic/calypso-products';
 import { englishLocales } from '@automattic/i18n-utils';
 import { Spinner } from '@wordpress/components';
 =======
 import { FEATURE_SFTP } from '@automattic/calypso-products';
 >>>>>>> ea1876e34c (Update Hosting Config upsell message to be less specific about plan name)
+=======
+import { FEATURE_SFTP, FEATURE_SFTP_DATABASE } from '@automattic/calypso-products';
+>>>>>>> a874b7a809 (Update feature constant; add as query param for highlighting)
 import { localize } from 'i18n-calypso';
 import { Component, Fragment } from 'react';
 import wrapWithClickOutside from 'react-click-outside';

--- a/client/my-sites/hosting/main.js
+++ b/client/my-sites/hosting/main.js
@@ -87,7 +87,7 @@ class Hosting extends Component {
 					<UpsellNudge
 						title={ translate( 'Upgrade your plan to access all hosting features' ) }
 						event="calypso_hosting_configuration_upgrade_click"
-						href={ `/plans/${ siteSlug }/` }
+						href={ `/plans/${ siteSlug }?feature=${ encodeURIComponent( FEATURE_SFTP_DATABASE ) }` }
 						feature={ FEATURE_SFTP_DATABASE }
 						showIcon={ true }
 					/>

--- a/client/my-sites/hosting/main.js
+++ b/client/my-sites/hosting/main.js
@@ -104,7 +104,7 @@ class Hosting extends Component {
 					} }
 				/>
 				<UpsellNudge
-					title={ translate( 'Upgrade your plan to access hosting features' ) }
+					title={ translate( 'Upgrade your plan to access all hosting features' ) }
 					event="calypso_hosting_configuration_upgrade_click"
 					href={ `/plans/${ siteSlug }/` }
 					feature={ FEATURE_SFTP }

--- a/client/my-sites/hosting/main.js
+++ b/client/my-sites/hosting/main.js
@@ -82,7 +82,7 @@ class Hosting extends Component {
 		} = this.props;
 
 		const getUpgradeBanner = () => {
-			//Adding a comment to fix some weirdness with this diff
+			//eCommerce Trial should not see the experiment
 			if ( isECommerceTrial ) {
 				return (
 					<UpsellNudge

--- a/client/my-sites/hosting/main.js
+++ b/client/my-sites/hosting/main.js
@@ -1,14 +1,6 @@
-<<<<<<< HEAD
-<<<<<<< HEAD
-import { PLAN_BUSINESS, FEATURE_SFTP } from '@automattic/calypso-products';
+import { PLAN_BUSINESS, FEATURE_SFTP, FEATURE_SFTP_DATABASE } from '@automattic/calypso-products';
 import { englishLocales } from '@automattic/i18n-utils';
 import { Spinner } from '@wordpress/components';
-=======
-import { FEATURE_SFTP } from '@automattic/calypso-products';
->>>>>>> ea1876e34c (Update Hosting Config upsell message to be less specific about plan name)
-=======
-import { FEATURE_SFTP, FEATURE_SFTP_DATABASE } from '@automattic/calypso-products';
->>>>>>> a874b7a809 (Update feature constant; add as query param for highlighting)
 import { localize } from 'i18n-calypso';
 import { Component, Fragment } from 'react';
 import wrapWithClickOutside from 'react-click-outside';
@@ -35,6 +27,7 @@ import {
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { requestSite } from 'calypso/state/sites/actions';
+import { isSiteOnECommerceTrial } from 'calypso/state/sites/plans/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import { HostingUpsellNudge } from './hosting-upsell-nudge';
 import MiscellaneousCard from './miscellaneous-card';
@@ -78,6 +71,7 @@ class Hosting extends Component {
 			clickActivate,
 			hasSftpFeature,
 			isDisabled,
+			isECommerceTrial,
 			isTransferring,
 			locale,
 			requestSiteById,
@@ -87,8 +81,20 @@ class Hosting extends Component {
 			transferState,
 		} = this.props;
 
-		const getUpgradeBanner = () => (
-			<>
+		const getUpgradeBanner = () => {
+			if ( isECommerceTrial ) {
+				return (
+					<UpsellNudge
+						title={ translate( 'Upgrade your plan to access all hosting features' ) }
+						event="calypso_hosting_configuration_upgrade_click"
+						href={ `/plans/${ siteSlug }/` }
+						feature={ FEATURE_SFTP_DATABASE }
+						showIcon={ true }
+					/>
+				);
+			}
+
+			return (
 				<Experiment
 					name="calypso_hosting_configuration_upsell_list_features"
 					defaultExperience={
@@ -107,15 +113,8 @@ class Hosting extends Component {
 						isEligible: englishLocales.includes( locale ),
 					} }
 				/>
-				<UpsellNudge
-					title={ translate( 'Upgrade your plan to access all hosting features' ) }
-					event="calypso_hosting_configuration_upgrade_click"
-					href={ `/plans/${ siteSlug }/` }
-					feature={ FEATURE_SFTP }
-					showIcon={ true }
-				/>
-			</>
-		);
+			);
+		};
 
 		const getAtomicActivationNotice = () => {
 			const { COMPLETE, FAILURE } = transferStates;
@@ -232,6 +231,7 @@ export default connect(
 		const hasSftpFeature = siteHasFeature( state, siteId, FEATURE_SFTP );
 
 		return {
+			isECommerceTrial: isSiteOnECommerceTrial( state, siteId ),
 			transferState: getAutomatedTransferStatus( state, siteId ),
 			isTransferring: isAutomatedTransferActive( state, siteId ),
 			isDisabled: ! hasSftpFeature || ! isSiteAutomatedTransfer( state, siteId ),

--- a/client/my-sites/hosting/main.js
+++ b/client/my-sites/hosting/main.js
@@ -82,6 +82,7 @@ class Hosting extends Component {
 		} = this.props;
 
 		const getUpgradeBanner = () => {
+			//Adding a comment to fix some weirdness with this diff
 			if ( isECommerceTrial ) {
 				return (
 					<UpsellNudge


### PR DESCRIPTION
#### Proposed Changes

* Show a different upsell for users on the eCommerce Trial, bypassing the new experiment introduced in #71750 
* Update copy for upsell to *not* specify a plan name, since there are multiple upgrade paths for this feature
* Instead of linking the upsell directly to checkout with the Business plan in the cart, link to the `/plans` page

**eCommerce Trial**
<img width="1131" alt="Screen Shot 2023-01-16 at 10 11 48 AM" src="https://user-images.githubusercontent.com/2124984/212711271-6940a3e4-19b0-43c9-9d33-f6433044b530.png">

**eCommerce/Business Plan**

<img width="1108" alt="Screen Shot 2023-01-16 at 10 11 13 AM" src="https://user-images.githubusercontent.com/2124984/212711298-c7c131cc-b25b-435f-9072-bf6ec1c333b0.png">

**Experiment variation for everyone else**

(This may differ depending on which experiment id you're assigned to)

<img width="1117" alt="Screen Shot 2023-01-16 at 10 10 54 AM" src="https://user-images.githubusercontent.com/2124984/212711328-22445cbc-3f5b-4cc9-ba54-8f51a3f86799.png">


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to this PR, visit `/hosting-config/[siteSlug]`
* Confirm the upsell only shows for sites on the Free, Pro, Premium, and eCommerce Trial plans.
* Confirm the wording has changed for eCommerce Trial plans.
* Confirm the upsell links to the `/plans` page for eCommerce Trial plans.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- N/A [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- N/A Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- N/A For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #71862
