### PR TITLE
Fix/mobile pricing placeholder alignment

### DIFF
--- a/client/my-sites/plans/jetpack-plans/product-store/item-price/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/item-price/style.scss
@@ -87,7 +87,7 @@
 
 	.display-price__billing-time-frame {
 		max-height: 40px;
-		margin-top: 0px;
+		margin-top: 0;
 	}
 }
 

--- a/client/my-sites/plans/jetpack-plans/product-store/item-price/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/item-price/style.scss
@@ -77,6 +77,8 @@
 }
 
 .item-price .display-price.is-placeholder {
+	display: inline-flex;
+	align-items: center;
 	max-height: 24px;
 
 	.plan-price {
@@ -84,7 +86,8 @@
 	}
 
 	.display-price__billing-time-frame {
-		line-height: 20px;
+		max-height: 40px;
+		margin-top: 0px;
 	}
 }
 


### PR DESCRIPTION
#### Proposed Changes

* per a bug report in Asana 1202858161751496-as-1203614628458891/f the little grey boxes that show up before the pricing displays are misaligned on the comparison page in mobile.  They also look a little off on desktop:

![mobile bug](https://user-images.githubusercontent.com/12895386/211631989-3eb9d5b8-17b5-466c-821f-60d16417b91a.png)

![full width bug](https://user-images.githubusercontent.com/12895386/211632063-db13eccf-49ef-4ca7-a6a9-18b1016f7a41.png)

This PR adjusts the CSS so the results are better aligned:

![mobile fixed](https://user-images.githubusercontent.com/12895386/211632145-78165056-6c49-49ee-9cda-baa97ab8c71d.png)

![full width fixed](https://user-images.githubusercontent.com/12895386/211632191-e907ab31-52fe-4c77-9541-eed48c14c8df.png)


#### Testing Instructions

* Visit the Jetpack Cloud version of the live link below.  Head over to /features/comparison and watch it load, you should see the "loading" boxes align properly before the real pricing displays on both the regular and mobile views.
* There was a similar but not quite as pronounced issue on /pricing that is also fixed with these changes.  Check that that page also looks right now.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #