### PR TITLE
i18n: Fix loading of filter translations on the logged-out themes page

### DIFF
--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -153,8 +153,6 @@ class ThemeShowcase extends Component {
 	};
 
 	getStaticFilters = () => {
-		// As the values of these filter is static and won't be changed, we use it to check a filter
-		// is a static filter directly in the `isStaticFilter` function.
 		return {
 			MYTHEMES: {
 				key: 'my-themes',

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -120,7 +120,11 @@ class ThemeShowcase extends Component {
 		}
 	}
 
-	isStaticFilter = ( tabFilter ) => Object.values( this.getStaticFilters() ).includes( tabFilter );
+	isStaticFilter = ( tabFilter ) => {
+		return Object.values( this.getStaticFilters() ).some(
+			( staticFilter ) => tabFilter.key === staticFilter.key
+		);
+	};
 
 	getSubjectFilters = ( props ) => {
 		const { subjects } = props;

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -58,29 +58,8 @@ class ThemeShowcase extends Component {
 		this.scrollRef = createRef();
 		this.bookmarkRef = createRef();
 
-		// As the values of these filter is static and won't be changed, we use it to check a filter
-		// is a static filter directly in the `isStaticFilter` function.
-		this.staticFilters = {
-			MYTHEMES: {
-				key: 'my-themes',
-				text: props.translate( 'My Themes' ),
-				order: 3,
-			},
-			ALL: {
-				key: 'all',
-				text: props.translate( 'All' ),
-				order: 4,
-			},
-		};
-
 		this.subjectFilters = this.getSubjectFilters( props );
 		this.subjectTermTable = getSubjectsFromTermTable( props.filterToTermTable );
-
-		this.tiers = [
-			{ value: 'all', label: props.translate( 'All' ) },
-			{ value: 'free', label: props.translate( 'Free' ) },
-			{ value: 'premium', label: props.translate( 'Premium' ) },
-		];
 
 		this.state = {
 			tabFilter: this.getTabFilterFromUrl( props.filter ),
@@ -141,7 +120,7 @@ class ThemeShowcase extends Component {
 		}
 	}
 
-	isStaticFilter = ( tabFilter ) => Object.values( this.staticFilters ).includes( tabFilter );
+	isStaticFilter = ( tabFilter ) => Object.values( this.getStaticFilters() ).includes( tabFilter );
 
 	getSubjectFilters = ( props ) => {
 		const { subjects } = props;
@@ -159,18 +138,44 @@ class ThemeShowcase extends Component {
 			( this.props.isJetpackSite && ! this.props.isAtomicSite ) ||
 			( this.props.isAtomicSite && this.props.siteCanInstallThemes );
 
+		const staticFilters = this.getStaticFilters();
 		return {
 			...( shouldShowMyThemesFilter && {
-				MYTHEMES: this.staticFilters.MYTHEMES,
+				MYTHEMES: staticFilters.MYTHEMES,
 			} ),
-			ALL: this.staticFilters.ALL,
+			ALL: staticFilters.ALL,
 			...this.subjectFilters,
 		};
 	};
 
+	getStaticFilters = () => {
+		// As the values of these filter is static and won't be changed, we use it to check a filter
+		// is a static filter directly in the `isStaticFilter` function.
+		return {
+			MYTHEMES: {
+				key: 'my-themes',
+				text: this.props.translate( 'My Themes' ),
+				order: 3,
+			},
+			ALL: {
+				key: 'all',
+				text: this.props.translate( 'All' ),
+				order: 4,
+			},
+		};
+	};
+
+	getTiers = () => {
+		return [
+			{ value: 'all', label: this.props.translate( 'All' ) },
+			{ value: 'free', label: this.props.translate( 'Free' ) },
+			{ value: 'premium', label: this.props.translate( 'Premium' ) },
+		];
+	};
+
 	findTabFilter = ( tabFilters, filterKey ) =>
 		Object.values( tabFilters ).find( ( filter ) => filter.key === filterKey ) ||
-		this.staticFilters.ALL;
+		this.getStaticFilters().ALL;
 
 	getTabFilterFromUrl = ( filterString = '' ) => {
 		const filterArray = filterString.split( '+' );
@@ -179,7 +184,7 @@ class ThemeShowcase extends Component {
 		);
 
 		if ( ! matches.length ) {
-			return this.findTabFilter( this.staticFilters, this.state?.tabFilter.key );
+			return this.findTabFilter( this.getStaticFilters(), this.state?.tabFilter.key );
 		}
 
 		const filterKey = matches[ matches.length - 1 ].split( ':' ).pop();
@@ -260,12 +265,13 @@ class ThemeShowcase extends Component {
 	onTierSelect = ( { value: tier } ) => {
 		// Due to the search backend limitation, static filters other than "All"
 		// can only have "All" tier.
+		const staticFilters = this.getStaticFilters();
 		if (
 			tier !== 'all' &&
 			this.isStaticFilter( this.state.tabFilter ) &&
-			this.state.tabFilter.key !== this.staticFilters.ALL.key
+			this.state.tabFilter.key !== staticFilters.ALL.key
 		) {
-			this.setState( { tabFilter: this.staticFilters.ALL } );
+			this.setState( { tabFilter: staticFilters.ALL } );
 		}
 
 		recordTracksEvent( 'calypso_themeshowcase_filter_pricing_click', { tier } );
@@ -285,7 +291,7 @@ class ThemeShowcase extends Component {
 		// can only have "All" tier.
 		if (
 			this.isStaticFilter( tabFilter ) &&
-			tabFilter.key !== this.staticFilters.ALL.key &&
+			tabFilter.key !== this.getStaticFilters().ALL.key &&
 			this.props.tier !== 'all'
 		) {
 			callback = () => {
@@ -360,8 +366,9 @@ class ThemeShowcase extends Component {
 
 		const tabKey = this.state.tabFilter.key;
 
+		const staticFilters = this.getStaticFilters();
 		if (
-			tabKey !== this.staticFilters.MYTHEMES?.key &&
+			tabKey !== staticFilters.MYTHEMES?.key &&
 			! isExpertBannerDissmissed &&
 			! loggedOutComponent
 		) {
@@ -372,7 +379,7 @@ class ThemeShowcase extends Component {
 
 			// See p2-pau2Xa-4nq#comment-12458 for the context regarding the utm campaign value.
 			switch ( tabKey ) {
-				case this.staticFilters.ALL.key:
+				case staticFilters.ALL.key:
 					location = 'all-theme-banner';
 					utmCampaign = 'theme-all';
 			}
@@ -386,7 +393,7 @@ class ThemeShowcase extends Component {
 	renderThemes = ( themeProps ) => {
 		const tabKey = this.state.tabFilter.key;
 		switch ( tabKey ) {
-			case this.staticFilters.MYTHEMES?.key:
+			case this.getStaticFilters().MYTHEMES?.key:
 				return <ThemesSelection { ...themeProps } />;
 			default:
 				return this.allThemes( { themeProps } );
@@ -461,6 +468,7 @@ class ThemeShowcase extends Component {
 		};
 
 		const tabFilters = this.getTabFilters();
+		const tiers = this.getTiers();
 
 		// FIXME: Logged-in title should only be 'Themes'
 		return (
@@ -510,7 +518,7 @@ class ThemeShowcase extends Component {
 								<SimplifiedSegmentedControl
 									key={ tier }
 									initialSelected={ tier || 'all' }
-									options={ this.tiers }
+									options={ tiers }
 									onSelect={ this.onTierSelect }
 								/>
 							) }


### PR DESCRIPTION
#### Proposed Changes
This PR fixes the loading of the translations of the tier filters (All / Free / Premium) and static filters (All / My Themes) in the logged-out theme showcase. 

The translations were loaded in the `ThemeShowcase` component's constructor, during the assignment of `this.tiers` and `this.staticFilters`. At that point, the translations weren't loaded yet. Loading them through functions (`getTiers` and `getStaticFilters`) makes sure that the translations are returned correctly and will update in case they change asynchronously.

**EDIT:** We recently pushed a PR (#71924) that makes the translations from preloaded chunks load earlier, which (accidentally) fixes the issue in this PR too. Still, it would be good to move the `translate` calls out of the constructor.

| Before #71924 | After |
| ------- | ----- |
| <img width="1064" alt="image" src="https://user-images.githubusercontent.com/75777864/211654851-d56362c5-9d87-465d-a30d-c6d99a6c9dc4.png"> | <img width="1064" alt="image" src="https://user-images.githubusercontent.com/75777864/211654987-888b83bf-fe73-48e6-8235-33de89bd2915.png"> |


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* The issue is only visible when using translation chunks, so run Calypso locally using `BUILD_TRANSLATION_CHUNKS=true ENABLE_FEATURES=use-translation-chunks yarn start`.
* Visit /themes while logged out in a non-English locale and verify that the translations are working.
* Visit /themes while logged in and verify that the translations are still working.
* Make sure the testing instructions in #71560 still work.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 544-gh-Automattic/i18n-issues.
