### PR TITLE
Stats: Reorder sections on the insights page

### DIFF
--- a/client/my-sites/stats/post-trends/index.jsx
+++ b/client/my-sites/stats/post-trends/index.jsx
@@ -9,7 +9,6 @@ import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import compareProps from 'calypso/lib/compare-props';
 import { getSiteOption } from 'calypso/state/sites/selectors';
 import { getSiteStatsPostStreakData } from 'calypso/state/stats/lists/selectors';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import Month from './month';
 
 import './style.scss';
@@ -43,34 +42,36 @@ class PostTrends extends Component {
 
 		/* eslint-disable jsx-a11y/click-events-have-key-events, wpcalypso/jsx-classname-namespace */
 		return (
-			<div className="post-trends">
-				{ siteId && <QuerySiteStats siteId={ siteId } statType="statsStreak" query={ query } /> }
+			<div className="post-trends-section">
+				<div className="post-trends">
+					{ siteId && <QuerySiteStats siteId={ siteId } statType="statsStreak" query={ query } /> }
 
-				<div className="post-trends__heading">
-					<h1 className="post-trends__title">{ translate( 'Posting activity' ) }</h1>
-				</div>
-				<div ref={ this.wrapperRef } className="post-trends__wrapper">
-					<div ref={ this.yearRef } className="post-trends__year">
-						{ this.getMonthComponents() }
+					<div className="post-trends__heading">
+						<h1 className="post-trends__title">{ translate( 'Posting activity' ) }</h1>
 					</div>
-					<div className="post-trends__key-container">
-						<span className="post-trends__key-label">
-							{ translate( 'Fewer Posts', {
-								context: 'Legend label in stats post trends visualization',
-							} ) }
-						</span>
-						<ul className="post-trends__key">
-							<li className="post-trends__key-day is-today" />
-							<li className="post-trends__key-day is-level-1" />
-							<li className="post-trends__key-day is-level-2" />
-							<li className="post-trends__key-day is-level-3" />
-							<li className="post-trends__key-day is-level-4" />
-						</ul>
-						<span className="post-trends__key-label">
-							{ translate( 'More Posts', {
-								context: 'Legend label in stats post trends visualization',
-							} ) }
-						</span>
+					<div ref={ this.wrapperRef } className="post-trends__wrapper">
+						<div ref={ this.yearRef } className="post-trends__year">
+							{ this.getMonthComponents() }
+						</div>
+						<div className="post-trends__key-container">
+							<span className="post-trends__key-label">
+								{ translate( 'Fewer Posts', {
+									context: 'Legend label in stats post trends visualization',
+								} ) }
+							</span>
+							<ul className="post-trends__key">
+								<li className="post-trends__key-day is-today" />
+								<li className="post-trends__key-day is-level-1" />
+								<li className="post-trends__key-day is-level-2" />
+								<li className="post-trends__key-day is-level-3" />
+								<li className="post-trends__key-day is-level-4" />
+							</ul>
+							<span className="post-trends__key-label">
+								{ translate( 'More Posts', {
+									context: 'Legend label in stats post trends visualization',
+								} ) }
+							</span>
+						</div>
 					</div>
 				</div>
 			</div>
@@ -78,8 +79,7 @@ class PostTrends extends Component {
 	}
 }
 
-const mapStateToProps = ( state ) => {
-	const siteId = getSelectedSiteId( state );
+const mapStateToProps = ( state, { siteId } ) => {
 	const query = {
 		startDate: moment()
 			.locale( 'en' )
@@ -94,7 +94,6 @@ const mapStateToProps = ( state ) => {
 	return {
 		streakData: getSiteStatsPostStreakData( state, siteId, query ),
 		query,
-		siteId,
 	};
 };
 

--- a/client/my-sites/stats/post-trends/index.jsx
+++ b/client/my-sites/stats/post-trends/index.jsx
@@ -42,36 +42,34 @@ class PostTrends extends Component {
 
 		/* eslint-disable jsx-a11y/click-events-have-key-events, wpcalypso/jsx-classname-namespace */
 		return (
-			<div className="post-trends-section">
-				<div className="post-trends">
-					{ siteId && <QuerySiteStats siteId={ siteId } statType="statsStreak" query={ query } /> }
+			<div className="post-trends">
+				{ siteId && <QuerySiteStats siteId={ siteId } statType="statsStreak" query={ query } /> }
 
-					<div className="post-trends__heading">
-						<h1 className="post-trends__title">{ translate( 'Posting activity' ) }</h1>
+				<div className="post-trends__heading">
+					<h1 className="post-trends__title">{ translate( 'Posting activity' ) }</h1>
+				</div>
+				<div ref={ this.wrapperRef } className="post-trends__wrapper">
+					<div ref={ this.yearRef } className="post-trends__year">
+						{ this.getMonthComponents() }
 					</div>
-					<div ref={ this.wrapperRef } className="post-trends__wrapper">
-						<div ref={ this.yearRef } className="post-trends__year">
-							{ this.getMonthComponents() }
-						</div>
-						<div className="post-trends__key-container">
-							<span className="post-trends__key-label">
-								{ translate( 'Fewer Posts', {
-									context: 'Legend label in stats post trends visualization',
-								} ) }
-							</span>
-							<ul className="post-trends__key">
-								<li className="post-trends__key-day is-today" />
-								<li className="post-trends__key-day is-level-1" />
-								<li className="post-trends__key-day is-level-2" />
-								<li className="post-trends__key-day is-level-3" />
-								<li className="post-trends__key-day is-level-4" />
-							</ul>
-							<span className="post-trends__key-label">
-								{ translate( 'More Posts', {
-									context: 'Legend label in stats post trends visualization',
-								} ) }
-							</span>
-						</div>
+					<div className="post-trends__key-container">
+						<span className="post-trends__key-label">
+							{ translate( 'Fewer Posts', {
+								context: 'Legend label in stats post trends visualization',
+							} ) }
+						</span>
+						<ul className="post-trends__key">
+							<li className="post-trends__key-day is-today" />
+							<li className="post-trends__key-day is-level-1" />
+							<li className="post-trends__key-day is-level-2" />
+							<li className="post-trends__key-day is-level-3" />
+							<li className="post-trends__key-day is-level-4" />
+						</ul>
+						<span className="post-trends__key-label">
+							{ translate( 'More Posts', {
+								context: 'Legend label in stats post trends visualization',
+							} ) }
+						</span>
 					</div>
 				</div>
 			</div>

--- a/client/my-sites/stats/post-trends/style.scss
+++ b/client/my-sites/stats/post-trends/style.scss
@@ -8,17 +8,9 @@ $mobile-layout-breakpoint: $break-small;
 $common-border-radius: 4px;
 $mobile-container-margin: 16px;
 
-.post-trends-section {
-	border-top: 1px solid var(--studio-gray-5);
-	border-bottom: 1px solid var(--studio-gray-5);
-}
-
 .post-trends {
-	display: inline-block;
-	user-select: none;
-	position: relative;
-	width: 100%;
-
+	border-bottom: 1px solid var(--studio-gray-5);
+	border-top: 1px solid var(--studio-gray-5);
 }
 
 .post-trends__heading,

--- a/client/my-sites/stats/post-trends/style.scss
+++ b/client/my-sites/stats/post-trends/style.scss
@@ -8,6 +8,11 @@ $mobile-layout-breakpoint: $break-small;
 $common-border-radius: 4px;
 $mobile-container-margin: 16px;
 
+.post-trends-section {
+	border-top: 1px solid var(--studio-gray-5);
+	border-bottom: 1px solid var(--studio-gray-5);
+}
+
 .post-trends {
 	display: inline-block;
 	user-select: none;

--- a/client/my-sites/stats/stats-insights/index.jsx
+++ b/client/my-sites/stats/stats-insights/index.jsx
@@ -13,7 +13,7 @@ import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { getSuggestionsVendor } from 'calypso/lib/domains/suggestions';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import AllTimelHighlightsSection from '../all-time-highlights-section';
-import AllTimelViewsSection from '../all-time-views-section';
+import AllTimeViewsSection from '../all-time-views-section';
 import AnnualHighlightsSection from '../annual-highlights-section';
 import LatestPostSummary from '../post-performance';
 import PostingActivity from '../post-trends';
@@ -49,10 +49,8 @@ const StatsInsights = ( props ) => {
 				<StatsNavigation selectedItem="insights" siteId={ siteId } slug={ siteSlug } />
 				<AnnualHighlightsSection siteId={ siteId } />
 				<AllTimelHighlightsSection siteId={ siteId } />
-				<AllTimelViewsSection siteId={ siteId } slug={ siteSlug } />
-				<div className="stats__module--insights-posting-activity">
-					<PostingActivity />
-				</div>
+				<PostingActivity siteId={ siteId } />
+				<AllTimeViewsSection siteId={ siteId } slug={ siteSlug } />
 				{ siteId && (
 					<DomainTip
 						siteId={ siteId }

--- a/client/my-sites/stats/stats-module/style.scss
+++ b/client/my-sites/stats/stats-module/style.scss
@@ -611,12 +611,6 @@ ul.module-header-actions {
 	}
 }
 
-.stats__module--insights-posting-activity {
-	border-top: 1px solid var(--studio-gray-5);
-	border-bottom: 1px solid var(--studio-gray-5);
-	margin-bottom: 32px;
-}
-
 .stats__module--unified {
 	.card {
 		&:first-child {


### PR DESCRIPTION
#### Proposed Changes

|Before|After|
|-|-|
|<img width="1521" alt="image" src="https://user-images.githubusercontent.com/4044428/211661230-fc7f40d4-4582-4869-968f-a578182f8d83.png">|<img width="1522" alt="image" src="https://user-images.githubusercontent.com/4044428/211661106-7022d048-0339-48c5-a0d5-0eb908dcc82e.png">|

* Moves the posting activity section above the all-time insights heatmap section.
* Polishes posting activity styling.

#### Testing Instructions

* Open this PR in a live branch.
* Navigate to the stats insights page.
* Ensure that the "Posting Activity" and "All-time insights" sections render as expected, in this order.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
