### PR TITLE
Add `getSiteFragment` unit test to cover domain renewal

### DIFF
--- a/client/lib/route/test/index.js
+++ b/client/lib/route/test/index.js
@@ -149,9 +149,16 @@ describe( 'route', function () {
 			test( 'should return false for domain checkouts', function () {
 				expect( route.getSiteFragment( '/checkout/thank-you/no-site/75806534' ) ).toEqual( false );
 			} );
-			test( 'should return the correct site fragment when checking out', function () {
+			test( 'should return the correct site fragment on the checkout thank you page', function () {
 				expect(
 					route.getSiteFragment( '/checkout/thank-you/example.wordpress.com/75806534' )
+				).toEqual( 'example.wordpress.com' );
+			} );
+			test( 'should return the correct site fragment on domain renewals', function () {
+				expect(
+					route.getSiteFragment(
+						'/checkout/dotin_domain:example.in/renew/17254842/example.wordpress.com'
+					)
 				).toEqual( 'example.wordpress.com' );
 			} );
 		} );


### PR DESCRIPTION
#### Proposed Changes

* Add domain renewal unit test test to cover `getSiteFragment`

Context: In a [recent refactor of `getSiteFragment`](https://github.com/Automattic/wp-calypso/pull/71766) an issue was discovered in domain renewals where the refactor favored returning an int when found in the 2nd to last URL position, over the site-slug found in the last URL position. The refactor has been [reverted](https://github.com/Automattic/wp-calypso/pull/71892) and this PR adds a unit test to cover this case.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Unit tests pass.
* You can run these tests locally using the command: `yarn run test-client client/lib/route/test/` in Terminal.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #71669
