### PR TITLE
Site Editor: Remove unused back to dashboard override logic

### DIFF
--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -1,15 +1,11 @@
 /* global calypsoifyGutenberg, Image, requestAnimationFrame */
 
 import { parse } from '@wordpress/blocks';
-import {
-	Button,
-	__experimentalNavigationBackButton as NavigationBackButton,
-} from '@wordpress/components';
+import { Button } from '@wordpress/components';
 import { dispatch, select, subscribe, use } from '@wordpress/data';
 import domReady from '@wordpress/dom-ready';
 import { __experimentalMainDashboardButton as MainDashboardButton } from '@wordpress/edit-post';
 import { addAction, addFilter, doAction, removeAction } from '@wordpress/hooks';
-import { __ } from '@wordpress/i18n';
 import { wordpress } from '@wordpress/icons';
 import { registerPlugin } from '@wordpress/plugins';
 import { addQueryArgs, getQueryArg } from '@wordpress/url';
@@ -25,12 +21,6 @@ import {
 	isEditorReadyWithBlocks,
 	sendMessage,
 } from '../../utils';
-/**
- * Conditional dependency.  We cannot use the standard 'import' since this package is
- * not available in the post editor and causes WSOD in that case.  Instead, we can
- * define it from 'require' and conditionally check if it is available for use.
- */
-const editSitePackage = require( '@wordpress/edit-site' );
 
 const debug = debugFactory( 'wpcom-block-editor:iframe-bridge-server' );
 
@@ -456,46 +446,6 @@ function handleCloseEditor( calypsoPort ) {
 	};
 
 	handleCloseInLegacyEditors( dispatchAction );
-
-	// Add back to dashboard fill for Site Editor when edit-site package is available.
-	if ( editSitePackage ) {
-		registerPlugin( 'a8c-wpcom-block-editor-site-editor-back-to-dashboard-override', {
-			render: function SiteEditorCloseFill() {
-				const [ closeUrl, setCloseUrl ] = useState( calypsoifyGutenberg.closeUrl );
-
-				useEffect( () => {
-					addAction(
-						'updateCloseButtonOverrides',
-						'a8c/wpcom-block-editor/SiteEditorCloseFill',
-						( data ) => {
-							setCloseUrl( data.closeUrl );
-						}
-					);
-					return () =>
-						removeAction(
-							'updateCloseButtonOverrides',
-							'a8c/wpcom-block-editor/SiteEditorCloseFill'
-						);
-				} );
-				const SiteEditorDashboardFill = editSitePackage?.__experimentalMainDashboardButton;
-				if ( ! SiteEditorDashboardFill || ! NavigationBackButton ) {
-					return null;
-				}
-
-				return (
-					<SiteEditorDashboardFill>
-						<NavigationBackButton
-							backButtonLabel={ __( 'Dashboard' ) }
-							// eslint-disable-next-line wpcalypso/jsx-classname-namespace
-							className="edit-site-navigation-panel__back-to-dashboard"
-							href={ closeUrl }
-							onClick={ dispatchAction }
-						/>
-					</SiteEditorDashboardFill>
-				);
-			},
-		} );
-	}
 
 	if ( ! MainDashboardButton ) {
 		return;


### PR DESCRIPTION
#### Estimated Time to Test / Review:
- Test -> Short
- Review -> Short/Med

#### Proposed Changes

New override logic was implemented in https://github.com/Automattic/jetpack/pull/27601 and https://github.com/Automattic/wp-calypso/pull/71464. 

Because of this, the `__experimentalMainDashboardButton` is no longer being exported from the editSite package, which leads to unused logic https://github.com/Automattic/wp-calypso/pull/71900/files#diff-3cd9fa865f1d9d2531b85d0a08341a655b497a3304dfbb78ff787e34ff80556bL480-L483. We remove the unnecessary code in this PR.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this branch
* ssh into wpcom sandbox
* Sandbox `widgets.wp.com` in hosts file
* Navigate to `apps/wpcom-block-editor` and run `yarn dev --sync`
* Navigate to the site editor
* Click on the back to dashboard button and confirm that the environment is redirected properly

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
