### PR TITLE
Site Editor: Catch exceptions for site editor back to dashboard button

### DIFF
--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -1093,11 +1093,14 @@ function handleSiteEditorBackButton( calypsoPort ) {
 			clickedElement.attributes?.href?.value === dashboardLink;
 
 		// Since the clicked element may not have an href (as noted by internal SVG and path woes above).
-		const returnHref = clickedElement.href || dashboardLink;
+		let postUrl = clickedElement.href || dashboardLink;
 
-		// The URL constructor cannot handle relative paths, so, if returnHref becomes a relative path in
-		// thefuture, fall back to returnHref
-		const postUrl = new URL( returnHref )?.pathname || returnHref;
+		// Use relative path instead of absolute path when possible
+		try {
+			postUrl = new URL( postUrl )?.pathname;
+		} catch ( e ) {
+			// Do nothing
+		}
 
 		if ( isOldDashboardButton || isNewDashboardButton ) {
 			event.preventDefault();


### PR DESCRIPTION
#### Proposed Changes

Converting absolute to relative URLs threw type errors because truthy values that aren't URLs were being passed to the `new URL` constructor. We add a try catch to handle the exceptions.

#### Before
![2023-01-10 16 17 19](https://user-images.githubusercontent.com/5414230/211689710-d46de9c9-7818-4f22-9ba8-74a55d6bf0ac.gif)

#### After
![2023-01-10 16 22 30](https://user-images.githubusercontent.com/5414230/211689654-0d223be8-a917-4941-9046-49cdae4745e5.gif)

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this branch
* ssh into wpcom sandbox
* Sandbox `widgets.wp.com` in hosts file
* Navigate to `apps/wpcom-block-editor` and run `yarn dev --sync`
* Visit http://calypso.localhost:3000/setup/link-in-bio/intro
* Walk through the tailored onboarding flow until at the Launchpad
* Click on the "Add Links" task
* Click on the back to dashboard button and confirm that the environment is redirected to Launchpad with a http://calypso.localhost:3000 origin
* Test that exceptions are caught correctly by changing the value of `postUrl` on Line 1096 to an invalid URL like 'asdf1234' and removing the try catch. Clicking anywhere in the _navigation sidebar_ of the site editor should throw errors in the dev console. `TypeError: Failed to construct 'URL'`
* Uncomment the try catch and continue clicking in the navigation sidebar. There should be no more errors thrown.

![2023-01-10 12 21 44](https://user-images.githubusercontent.com/5414230/211654102-aa45a155-d5c3-44aa-8510-856fb0e6d3f1.gif)

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/71760
