### PR TITLE
Stats: fix the empty state of the Countries section

### DIFF
--- a/client/my-sites/stats/stats-countries/style.scss
+++ b/client/my-sites/stats/stats-countries/style.scss
@@ -6,12 +6,16 @@ $break-large-stats-countries: 1280px;
 .stats__module-list--traffic {
 	.stats__module-wrapper--countryviews .stats-module,
 	.list-countryviews {
-		display: grid;
 		gap: 0 24px;
 		grid-template-columns: 7fr 5fr;
 		grid-template-areas:
 			"map list"
 			"more more";
+
+		// only applies this statement if there's data to show
+		&:has(.stats-card--hero .stats-geochart:not(.has-no-data)) {
+			display: grid;
+		}
 
 		@media ( max-width: $break-large-stats-countries ) {
 			grid-template-columns: 100%;

--- a/client/my-sites/stats/stats-countries/style.scss
+++ b/client/my-sites/stats/stats-countries/style.scss
@@ -14,7 +14,6 @@ $break-large-stats-countries: 1280px;
 
 		.list-countryviews {
 			.stats-card--hero {
-				grid-area: map;
 				padding-bottom: 0;
 
 				.stats-geochart.stats-module__placeholder {

--- a/client/my-sites/stats/stats-countries/style.scss
+++ b/client/my-sites/stats/stats-countries/style.scss
@@ -4,38 +4,29 @@ $break-large-stats-countries: 1280px;
 
 // Countries
 .stats__module-list--traffic {
-	.stats__module-wrapper--countryviews .stats-module,
-	.list-countryviews {
-		gap: 0 24px;
-		grid-template-columns: 7fr 5fr;
-		grid-template-areas:
-			"map list"
-			"more more";
-
-		// only applies this statement if there's data to show
-		&:has(.stats-card--hero .stats-geochart:not(.has-no-data)) {
-			display: grid;
+	@media ( min-width: $break-large-stats-countries ) {
+		.stats__module-wrapper--countryviews .stats-module,
+		.list-countryviews {
+			display: flex;
+			flex-direction: row;
+			flex-wrap: wrap;
 		}
 
-		@media ( max-width: $break-large-stats-countries ) {
-			grid-template-columns: 100%;
-			grid-template-areas:
-				"map"
-				"list"
-				"more";
-		}
-	}
+		.list-countryviews {
+			.stats-card--hero {
+				grid-area: map;
+				padding-bottom: 0;
 
-	.list-countryviews {
-		.stats-card--hero {
-			grid-area: map;
-			padding-bottom: 0;
-		}
-		.stats-card--header-and-body {
-			grid-area: list;
-		}
-		.stats-card--footer {
-			grid-area: more;
+				.stats-geochart.stats-module__placeholder {
+					min-width: 550px;
+				}
+			}
+			.stats-card--header-and-body {
+				flex: 1;
+			}
+			.stats-card--footer {
+				flex-basis: 100%;
+			}
 		}
 	}
 

--- a/client/my-sites/stats/stats-countries/style.scss
+++ b/client/my-sites/stats/stats-countries/style.scss
@@ -4,7 +4,22 @@ $break-large-stats-countries: 1280px;
 
 // Countries
 .stats__module-list--traffic {
-	@media ( min-width: $break-large-stats-countries ) {
+	.list-countryviews {
+		.stats-card--hero {
+			padding-bottom: 0;
+
+			.stats-geochart {
+				margin-bottom: 32px;
+
+				&.has-no-data {
+					margin-bottom: 0;
+				}
+			}
+		}
+	}
+
+	@media (min-width: $break-large-stats-countries ) {
+
 		.stats__module-wrapper--countryviews .stats-module,
 		.list-countryviews {
 			display: flex;
@@ -14,15 +29,19 @@ $break-large-stats-countries: 1280px;
 
 		.list-countryviews {
 			.stats-card--hero {
-				padding-bottom: 0;
+				.stats-geochart {
+					margin-bottom: 0;
+				}
 
 				.stats-geochart.stats-module__placeholder {
 					min-width: 550px;
 				}
 			}
+
 			.stats-card--header-and-body {
 				flex: 1;
 			}
+
 			.stats-card--footer {
 				flex-basis: 100%;
 			}
@@ -34,15 +53,19 @@ $break-large-stats-countries: 1280px;
 			grid-column: map-start / list-end;
 			margin-bottom: 24px;
 		}
+
 		.stats-geochart {
 			grid-area: map;
 		}
+
 		.stats__list-wrapper {
 			grid-area: list;
 		}
+
 		.stats-module__expand {
 			grid-area: more;
 		}
+
 		.module-content-list:last-child {
 			padding-bottom: 0;
 		}


### PR DESCRIPTION
Fixes #71817 

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the Calypso live link
* Go to the Traffic page
* Select a period of time with no data to show in the Countries section. Ensure the `empty state` message looks the same as the other components
* Change for a period of time with data to show and ensure the section looks exactly like it was before.

#### Screenshots
Before
![image](https://user-images.githubusercontent.com/6406071/211698526-bb8a9140-3fdb-426f-bba3-feee24734685.png)

After
![image](https://user-images.githubusercontent.com/6406071/211698555-ed5ef418-3016-4212-8ccc-e5e3cbdb2290.png)


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #71817
