### PR TITLE
Stats: adds styling to ads earning history table

### DIFF
--- a/client/my-sites/stats/wordads/style.scss
+++ b/client/my-sites/stats/wordads/style.scss
@@ -4,7 +4,7 @@
 	}
 
 	.earnings_history td:hover,
-	tbody tr:hover td,
+	.earnings_history tbody tr:hover td,
 	.earnings_history tbody tr:hover th:first-child {
 		background: var(--color-primary-0);
 	}

--- a/client/my-sites/stats/wordads/style.scss
+++ b/client/my-sites/stats/wordads/style.scss
@@ -2,6 +2,13 @@
 	.wordads .stats-tabs .stats-tab {
 		width: 33.33%;
 	}
+
+	.earnings_history td:hover,
+	tbody tr:hover td,
+	.earnings_history tbody tr:hover th:first-child {
+		background: var(--color-primary-0);
+	}
+
 	.earnings_history tbody tr:nth-child(odd) {
 		background-color: var(--studio-gray-0);
 	}

--- a/client/my-sites/stats/wordads/style.scss
+++ b/client/my-sites/stats/wordads/style.scss
@@ -2,4 +2,8 @@
 	.wordads .stats-tabs .stats-tab {
 		width: 33.33%;
 	}
+	.earnings_history tbody tr:nth-child(odd) {
+		background-color: var(--studio-gray-0);
+	}
+
 }


### PR DESCRIPTION
#### Proposed Changes

* This small PR adds zebra striping (alternative row colors) to the earning history table on the ads stats page
* It also adds row hover coloring
* The intention of this PR is to get the styling right and see if we like it. Refactoring this styles into one unified stats table styling class will come in a follow-up PR. 

#### Testing Instructions

* With a calypso local env running, go to our MC /tools/support-user/ to SU into a user account which has an active WordAds history
* Use the dropdown on the SU MC page to select your local Calypso instance
* Navigate to `Stats` -> `Ads (tab)`
* Check that the `Earnings History` tab has alternating (zebra stripe) row colors
* Check that the row highlights with the faintest version of the primary color when hovered
* Check against the table on the Annual Insights page for consistency (`Stats` -> `Insights` -> `View All Annual Insights`)

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
