### PR TITLE
Design Picker: use high-res mShots image for non-mobile devices

### DIFF
--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -58,7 +58,7 @@ const DesignPreviewImage: React.FC< DesignPreviewImageProps > = ( {
 			} ) }
 			aria-labelledby={ makeOptionId( design ) }
 			alt=""
-			options={ getMShotOptions( { scrollable: false, highRes: false, isMobile } ) }
+			options={ getMShotOptions( { scrollable: false, highRes: ! isMobile, isMobile } ) }
 			scrollable={ false }
 		/>
 	);


### PR DESCRIPTION
#### Proposed Changes

This enables high mShots image resolution for the theme thumbnails in the Design Picker grid. 

Background: see discussion in: https://github.com/Automattic/wp-calypso/issues/69610#issuecomment-1377256871

I enable the hi-res option only if the device is not mobile. I think for mobile devices, the current resolution is enough. I've tested on real Android and Retina iPhone devices and they still look good. Furthermore, I think enabling high-res on mobile will make the mobile users suffer from higher download sizes.

#### Testing Instructions

* Go to `/setup?siteSlug={siteSlug}`
* Select a goal and vertical
* View the Design Picker
* Verify that the images are sharper than the ones in production
   * You can also inspect the image URL, and verify that the mShots parameter uses `w=1199`

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:

- https://github.com/Automattic/wp-calypso/issues/69610
