### PR TITLE
Copy Site: Prototype flow to copy an existing site

### DIFF
--- a/client/landing/stepper/declarative-flow/copy-site.ts
+++ b/client/landing/stepper/declarative-flow/copy-site.ts
@@ -1,0 +1,97 @@
+import { useFlowProgress, COPY_SITE_FLOW } from '@automattic/onboarding';
+import { useDispatch } from '@wordpress/data';
+import { translate } from 'i18n-calypso';
+import { useEffect } from 'react';
+import { recordFullStoryEvent } from 'calypso/lib/analytics/fullstory';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { useSiteSlug } from '../hooks/use-site-slug';
+import { ONBOARD_STORE } from '../stores';
+import { recordSubmitStep } from './internals/analytics/record-submit-step';
+import Intro from './internals/steps-repository/intro';
+import LaunchPad from './internals/steps-repository/launchpad';
+import ProcessingStep, { ProcessingResult } from './internals/steps-repository/processing-step';
+import SiteCreationStep from './internals/steps-repository/site-creation-step';
+import type { Flow, ProvidedDependencies } from './internals/types';
+
+const copySite: Flow = {
+	name: COPY_SITE_FLOW,
+	get title() {
+		return translate( 'Copy Site' );
+	},
+	useSteps() {
+		useEffect( () => {
+			recordTracksEvent( 'calypso_signup_start', { flow: this.name } );
+			recordFullStoryEvent( 'calypso_signup_start_copy_site', { flow: this.name } );
+		}, [] );
+
+		return [
+			{ slug: 'intro', component: Intro },
+			// { slug: 'chooseAPlan', component: ChooseAPlan }, // We can replicate the chooseAPlan.onPlanSelect
+			{ slug: 'siteCreationStep', component: SiteCreationStep },
+			{ slug: 'processing', component: ProcessingStep },
+			{ slug: 'launchpad', component: LaunchPad },
+		];
+	},
+
+	useStepNavigation( _currentStepSlug, navigate ) {
+		const flowName = this.name;
+		const { setStepProgress } = useDispatch( ONBOARD_STORE );
+		const flowProgress = useFlowProgress( { stepName: _currentStepSlug, flowName } );
+		const siteSlug = useSiteSlug();
+
+		setStepProgress( flowProgress );
+
+		const submit = ( providedDependencies: ProvidedDependencies = {}, ...params: string[] ) => {
+			recordSubmitStep( providedDependencies, '', flowName, _currentStepSlug );
+
+			switch ( _currentStepSlug ) {
+				case 'intro': {
+					return navigate( 'siteCreationStep' );
+				}
+
+				case 'siteCreationStep': {
+					return navigate( 'processing' );
+				}
+
+				case 'processing': {
+					const processingResult = params[ 0 ] as ProcessingResult;
+
+					if ( processingResult === ProcessingResult.FAILURE ) {
+						return navigate( 'error' );
+					}
+
+					const returnUrl = '/home/' + providedDependencies?.siteSlug;
+
+					return window.location.assign(
+						`/checkout/${ encodeURIComponent(
+							( providedDependencies?.siteSlug as string ) ?? ''
+						) }?redirect_to=${ returnUrl }&signup=1`
+					);
+				}
+			}
+			return providedDependencies;
+		};
+
+		const goBack = () => {
+			return;
+		};
+
+		const goNext = () => {
+			switch ( _currentStepSlug ) {
+				case 'launchpad':
+					return window.location.assign( `/view/${ siteSlug }` );
+
+				default:
+					return navigate( 'intro' );
+			}
+		};
+
+		const goToStep = ( step: string ) => {
+			navigate( step );
+		};
+
+		return { goNext, goBack, goToStep, submit };
+	},
+};
+
+export default copySite;

--- a/client/landing/stepper/declarative-flow/copy-site.tsx
+++ b/client/landing/stepper/declarative-flow/copy-site.tsx
@@ -33,12 +33,19 @@ const copySite: Flow = {
 			recordFullStoryEvent( 'calypso_signup_start_copy_site', { flow: this.name } );
 		}, [] );
 
+		const urlQueryParams = useQuery();
+		const sourceSlug = urlQueryParams.get( 'sourceSlug' );
+		if ( ! sourceSlug ) {
+			window.location.assign( `/sites` );
+			return [];
+		}
+
 		return [
 			{ slug: 'intro', component: Intro },
-			{ slug: 'siteCreationStep', component: SiteCreationStep },
+			{ slug: 'site-creation-step', component: SiteCreationStep },
 			{ slug: 'processing', component: ProcessingStep },
-			{ slug: 'automatedCopy', component: AutomatedCopySite },
-			{ slug: 'processingCopy', component: ProcessingStep },
+			{ slug: 'automated-copy', component: AutomatedCopySite },
+			{ slug: 'processing-copy', component: ProcessingStep },
 		];
 	},
 
@@ -72,15 +79,15 @@ const copySite: Flow = {
 			switch ( _currentStepSlug ) {
 				case 'intro': {
 					clearSignupDestinationCookie();
-					return navigate( 'siteCreationStep' );
+					return navigate( 'site-creation-step' );
 				}
 
-				case 'siteCreationStep': {
+				case 'site-creation-step': {
 					return navigate( 'processing' );
 				}
 
 				case 'processing': {
-					const destination = addQueryArgs( `/setup/${ this.name }/automatedCopy`, {
+					const destination = addQueryArgs( `/setup/${ this.name }/automated-copy`, {
 						sourceSlug: urlQueryParams.get( 'sourceSlug' ),
 						siteSlug: providedDependencies?.siteSlug,
 					} );
@@ -95,11 +102,11 @@ const copySite: Flow = {
 					);
 				}
 
-				case 'automatedCopy': {
-					return navigate( 'processingCopy' );
+				case 'automated-copy': {
+					return navigate( 'processing-copy' );
 				}
 
-				case 'processingCopy': {
+				case 'processing-copy': {
 					const processingResult = params[ 0 ] as ProcessingResult;
 
 					if ( processingResult === ProcessingResult.FAILURE ) {

--- a/client/landing/stepper/declarative-flow/copy-site.tsx
+++ b/client/landing/stepper/declarative-flow/copy-site.tsx
@@ -1,5 +1,5 @@
 import { useFlowProgress, COPY_SITE_FLOW } from '@automattic/onboarding';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useDispatch } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
 import { translate } from 'i18n-calypso';
 import { useEffect } from 'react';
@@ -55,25 +55,12 @@ const copySite: Flow = {
 		const flowProgress = useFlowProgress( { stepName: _currentStepSlug, flowName } );
 		const urlQueryParams = useQuery();
 
-		const { setPlanCartItem } = useDispatch( ONBOARD_STORE );
-		const { getPlanCartItem } = useSelect( ( select ) => select( ONBOARD_STORE ) );
-
 		setStepProgress( flowProgress );
 
 		const submit = async (
 			providedDependencies: ProvidedDependencies = {},
 			...params: string[]
 		) => {
-			// We need to do this here to avoid any race conditions
-			// due to dispatch and window.assign
-			const productSlug = urlQueryParams.get( 'productSlug' );
-			if ( productSlug && ! getPlanCartItem() ) {
-				const productToAdd = {
-					product_slug: productSlug,
-				};
-				setPlanCartItem( productToAdd );
-			}
-
 			recordSubmitStep( providedDependencies, '', flowName, _currentStepSlug );
 
 			switch ( _currentStepSlug ) {

--- a/client/landing/stepper/declarative-flow/copy-site.tsx
+++ b/client/landing/stepper/declarative-flow/copy-site.tsx
@@ -97,7 +97,7 @@ const copySite: Flow = {
 					const processingResult = params[ 0 ] as ProcessingResult;
 
 					if ( processingResult === ProcessingResult.FAILURE ) {
-						// Create a retry step here.
+						// @TODO:Create a retry step
 						return navigate( 'retry' );
 					}
 					clearSignupDestinationCookie();

--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -68,6 +68,7 @@ button {
 .subscribers,
 .ecommerce,
 .wooexpress,
+.copy-site,
 .intro,
 .free-setup,
 .free-post-setup,
@@ -158,10 +159,12 @@ button {
 	}
 
 	.step-container {
+
 		.step-container__content h1,
 		.step-container__header h1.formatted-header__title {
 			font-size: $font-title-medium;
-			line-height: 1.2em; /* stylelint-disable-line declaration-property-unit-allowed-list */
+			line-height: 1.2em;
+			/* stylelint-disable-line declaration-property-unit-allowed-list */
 
 			@include break-medium {
 				font-size: $font-headline-medium;
@@ -219,12 +222,15 @@ button {
 						}
 					}
 				}
+
 				&:focus {
 					background-color: var(--studio-blue-50);
 					box-shadow: none;
+
 					svg {
 						fill: #fff;
 					}
+
 					span {
 						color: var(--studio-blue-50);
 					}
@@ -294,7 +300,7 @@ button {
 }
 
 
-@media ( max-width: 660px ) {
+@media (max-width: 660px) {
 	body.is-section-stepper .wpcom-site {
 		.inline-help {
 			bottom: 74px;
@@ -303,6 +309,7 @@ button {
 }
 
 .wooexpress,
+.copy-site,
 .ecommerce {
 	.step-container.processing-step {
 		display: flex;

--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -159,12 +159,10 @@ button {
 	}
 
 	.step-container {
-
 		.step-container__content h1,
 		.step-container__header h1.formatted-header__title {
 			font-size: $font-title-medium;
-			line-height: 1.2em;
-			/* stylelint-disable-line declaration-property-unit-allowed-list */
+			line-height: 1.2em; /* stylelint-disable-line declaration-property-unit-allowed-list */
 
 			@include break-medium {
 				font-size: $font-headline-medium;
@@ -222,15 +220,12 @@ button {
 						}
 					}
 				}
-
 				&:focus {
 					background-color: var(--studio-blue-50);
 					box-shadow: none;
-
 					svg {
 						fill: #fff;
 					}
-
 					span {
 						color: var(--studio-blue-50);
 					}
@@ -300,7 +295,7 @@ button {
 }
 
 
-@media (max-width: 660px) {
+@media ( max-width: 660px ) {
 	body.is-section-stepper .wpcom-site {
 		.inline-help {
 			bottom: 74px;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/automated-copy-site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/automated-copy-site/index.tsx
@@ -1,57 +1,35 @@
-import { StepContainer } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
-import { useCallback, useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
-import { SITE_STORE } from 'calypso/landing/stepper/stores';
-import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { ONBOARD_STORE, SITE_STORE } from 'calypso/landing/stepper/stores';
 import wpcom from 'calypso/lib/wp';
 import type { Step } from '../../types';
 
 const TIME_CHECK_TRANSFER_STATUS = 3000;
 
-function useCopyingStatus() {
-	const [ status, setStatus ] = useState< {
-		status: 'init' | 'copying' | 'success' | 'error';
-		error: string | null;
-	} >( {
-		status: 'init',
-		error: null,
-	} );
+export const transferStates = {
+	PENDING: 'pending',
+	ACTIVE: 'active',
+	PROVISIONED: 'provisioned',
+	COMPLETED: 'completed',
+	ERROR: 'error',
+	REVERTED: 'reverted',
+	RELOCATING_REVERT: 'relocating_revert',
+	RELOCATING_SWITCHEROO: 'relocating_switcheroo',
+	REVERTING: 'reverting',
+	RENAMING: 'renaming',
+	EXPORTING: 'exporting',
+	IMPORTING: 'importing',
+	CLEANUP: 'cleanup',
+} as const;
 
-	const setIsCopying = useCallback( () => setStatus( { status: 'copying', error: null } ), [] );
-	const setIsSuccess = useCallback( () => setStatus( { status: 'success', error: null } ), [] );
-	const setIsError = useCallback(
-		( error: string ) => setStatus( { status: 'error', error } ),
-		[]
-	);
-
-	return {
-		isLoading: [ 'copying', 'init' ].includes( status.status ),
-		isCopying: status.status === 'copying',
-		isSuccess: status.status === 'success',
-		isError: status.status === 'error',
-		error: status.error,
-		setIsCopying,
-		setIsSuccess,
-		setIsError,
-	};
-}
+const wait = ( ms: number ) => new Promise( ( res ) => setTimeout( res, ms ) );
 
 const AutomatedCopySite: Step = function AutomatedCopySite( { navigation } ) {
 	const { submit } = navigation;
 	const { __ } = useI18n();
-	const {
-		isCopying,
-		isLoading,
-		setIsCopying,
-		setIsSuccess,
-		setIsError,
-		isSuccess,
-		isError,
-		error,
-	} = useCopyingStatus();
 	const site = useSite();
 	const urlQueryParams = useQuery();
 	const siteSlug = urlQueryParams.get( 'siteSlug' );
@@ -60,111 +38,87 @@ const AutomatedCopySite: Step = function AutomatedCopySite( { navigation } ) {
 		( select ) => sourceSlug && select( SITE_STORE ).getSite( sourceSlug )
 	);
 	const sourceSiteId = sourceSite?.ID;
+	const { setPendingAction, setProgress, setProgressTitle } = useDispatch( ONBOARD_STORE );
 	const { requestLatestAtomicTransfer } = useDispatch( SITE_STORE );
 	const { getSiteLatestAtomicTransfer, getSiteLatestAtomicTransferError } = useSelect( ( select ) =>
 		select( SITE_STORE )
 	);
 
+	const progressTitle = __( 'Copying site' );
+
 	useEffect( () => {
-		if ( isCopying && site ) {
-			const timer = setInterval( async () => {
-				await requestLatestAtomicTransfer( site.ID );
-				const transfer = getSiteLatestAtomicTransfer( site.ID );
-				const transferError = getSiteLatestAtomicTransferError( site.ID );
-				const transferStatus = transfer?.status;
-				const isTransferringStatusFailed = transferError && transferError?.status >= 500;
-
-				if ( isTransferringStatusFailed ) {
-					setIsError( 'Error Copying' );
-				} else if ( transferStatus === 'completed' ) {
-					setIsSuccess();
-				}
-			}, TIME_CHECK_TRANSFER_STATUS );
-			return () => clearTimeout( timer );
+		if ( ! site?.ID || ! sourceSiteId ) {
+			return;
 		}
-	}, [
-		getSiteLatestAtomicTransfer,
-		getSiteLatestAtomicTransferError,
-		isCopying,
-		requestLatestAtomicTransfer,
-		setIsError,
-		setIsSuccess,
-		site,
-	] );
-
-	const startCopying = useCallback(
-		function startCopying() {
-			if ( ! site?.ID || ! sourceSiteId ) {
-				return;
-			}
-			return wpcom.req
-				.post( {
-					path: `/sites/${ site.ID }/copy-from-site`,
+		setProgressTitle( progressTitle );
+		setPendingAction( async () => {
+			const siteId = site.ID;
+			setProgress( 0 );
+			try {
+				await wpcom.req.post( {
+					path: `/sites/${ siteId }/copy-from-site`,
 					apiNamespace: 'wpcom/v2',
 					body: {
 						source_blog_id: sourceSiteId,
 					},
-				} )
-				.then( () => {
-					setIsCopying();
-				} )
-				.catch( ( e: { message: string; code: string; data: { status: number } } ) => {
-					// eslint-disable-next-line no-console
-					console.error( e );
-					setIsError( e.message || 'Error Starting the Copy' );
 				} );
-		},
-		[ setIsCopying, setIsError, site?.ID, sourceSiteId ]
-	);
-
-	useEffect( () => {
-		startCopying();
-	}, [ startCopying ] );
-
-	if ( ! sourceSlug || ! siteSlug ) {
-		// TODO: show a better error or redirect to the start /sites
-		return <h1>{ __( 'Missing required parameters' ) }</h1>;
-	}
-
-	if ( ! sourceSiteId || ! site ) {
-		// eslint-disable-next-line no-console
-		console.info( { sourceSlug, siteSlug, sourceSiteId, site } );
-		// Wait for stores to populate
-		return null;
-	}
-
-	return (
-		<StepContainer
-			stepName="AutomatedcopySite"
-			hideBack
-			recordTracksEvent={ recordTracksEvent }
-			stepContent={
-				<div>
-					{ isLoading && <h1>{ __( 'Copying Site…' ) }</h1> }
-					{ isError && (
-						<>
-							<h1>{ __( 'Error copying site. Contact support' ) }</h1>
-							<p>{ error }</p>
-							<button onClick={ startCopying }>{ __( 'Retry?' ) }</button>
-						</>
-					) }
-					{ isSuccess && (
-						<>
-							<h1>{ __( 'Site copied successfully 🥳' ) }</h1>
-							<p>
-								{ __(
-									'Congrats all your content has been migrated and your new site is ready to enjoy.'
-								) }
-							</p>
-							<button onClick={ () => submit?.( { siteSlug } ) }>
-								{ __( 'Visit my new site' ) }
-							</button>
-						</>
-					) }
-				</div>
+			} catch ( _error ) {
+				throw new Error( 'Error copying site' );
 			}
-		></StepContainer>
-	);
+
+			let stopPollingTransfer = false;
+
+			while ( ! stopPollingTransfer ) {
+				await wait( TIME_CHECK_TRANSFER_STATUS );
+				await requestLatestAtomicTransfer( siteId );
+				const transfer = getSiteLatestAtomicTransfer( siteId );
+				const transferError = getSiteLatestAtomicTransferError( siteId );
+				const transferStatus = transfer?.status;
+				const isTransferringStatusFailed = transferError && transferError?.status >= 500;
+
+				switch ( transferStatus ) {
+					case transferStates.PENDING:
+						setProgress( 0.2 );
+						break;
+					case transferStates.ACTIVE:
+						setProgress( 0.4 );
+						break;
+					case transferStates.PROVISIONED:
+						setProgress( 0.5 );
+						break;
+					case transferStates.COMPLETED:
+						setProgress( 0.7 );
+						break;
+				}
+
+				if ( isTransferringStatusFailed || transferStatus === transferStates.ERROR ) {
+					throw new Error( 'Error copying site' );
+				}
+
+				stopPollingTransfer = transferStatus === transferStates.COMPLETED;
+			}
+
+			setProgress( 1 );
+
+			return { finishedWaitingForCopy: true, siteSlug };
+		} );
+
+		submit?.();
+	}, [
+		progressTitle,
+		sourceSiteId,
+		siteSlug,
+		setProgressTitle,
+		getSiteLatestAtomicTransfer,
+		getSiteLatestAtomicTransferError,
+		requestLatestAtomicTransfer,
+		setPendingAction,
+		setProgress,
+		site,
+		submit,
+	] );
+
+	return null;
 };
 
 export default AutomatedCopySite;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/automated-copy-site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/automated-copy-site/index.tsx
@@ -34,8 +34,8 @@ const AutomatedCopySite: Step = function AutomatedCopySite( { navigation } ) {
 	const urlQueryParams = useQuery();
 	const siteSlug = urlQueryParams.get( 'siteSlug' );
 	const sourceSlug = urlQueryParams.get( 'sourceSlug' );
-	const sourceSite = useSelect(
-		( select ) => sourceSlug && select( SITE_STORE ).getSite( sourceSlug )
+	const sourceSite = useSelect( ( select ) =>
+		sourceSlug ? select( SITE_STORE ).getSite( sourceSlug ) : undefined
 	);
 	const sourceSiteId = sourceSite?.ID;
 	const { setPendingAction, setProgress, setProgressTitle } = useDispatch( ONBOARD_STORE );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/automated-copy-site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/automated-copy-site/index.tsx
@@ -56,9 +56,10 @@ const AutomatedCopySite: Step = function AutomatedCopySite( { navigation } ) {
 	const urlQueryParams = useQuery();
 	const siteSlug = urlQueryParams.get( 'siteSlug' );
 	const sourceSlug = urlQueryParams.get( 'sourceSlug' );
-	const sourceSiteId = useSelect(
-		( select ) => sourceSlug && select( SITE_STORE ).getSiteIdBySlug( sourceSlug )
+	const sourceSite = useSelect(
+		( select ) => sourceSlug && select( SITE_STORE ).getSite( sourceSlug )
 	);
+	const sourceSiteId = sourceSite?.ID;
 	const { requestLatestAtomicTransfer } = useDispatch( SITE_STORE );
 	const { getSiteLatestAtomicTransfer, getSiteLatestAtomicTransferError } = useSelect( ( select ) =>
 		select( SITE_STORE )

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/automated-copy-site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/automated-copy-site/index.tsx
@@ -1,0 +1,169 @@
+import { StepContainer } from '@automattic/onboarding';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { useI18n } from '@wordpress/react-i18n';
+import { useCallback, useEffect, useState } from 'react';
+import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
+import { useSite } from 'calypso/landing/stepper/hooks/use-site';
+import { SITE_STORE } from 'calypso/landing/stepper/stores';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import wpcom from 'calypso/lib/wp';
+import type { Step } from '../../types';
+
+const TIME_CHECK_TRANSFER_STATUS = 3000;
+
+function useCopyingStatus() {
+	const [ status, setStatus ] = useState< {
+		status: 'init' | 'copying' | 'success' | 'error';
+		error: string | null;
+	} >( {
+		status: 'init',
+		error: null,
+	} );
+
+	const setIsCopying = useCallback( () => setStatus( { status: 'copying', error: null } ), [] );
+	const setIsSuccess = useCallback( () => setStatus( { status: 'success', error: null } ), [] );
+	const setIsError = useCallback(
+		( error: string ) => setStatus( { status: 'error', error } ),
+		[]
+	);
+
+	return {
+		isLoading: [ 'copying', 'init' ].includes( status.status ),
+		isCopying: status.status === 'copying',
+		isSuccess: status.status === 'success',
+		isError: status.status === 'error',
+		error: status.error,
+		setIsCopying,
+		setIsSuccess,
+		setIsError,
+	};
+}
+
+const AutomatedCopySite: Step = function AutomatedCopySite( { navigation } ) {
+	const { submit } = navigation;
+	const { __ } = useI18n();
+	const {
+		isCopying,
+		isLoading,
+		setIsCopying,
+		setIsSuccess,
+		setIsError,
+		isSuccess,
+		isError,
+		error,
+	} = useCopyingStatus();
+	const site = useSite();
+	const urlQueryParams = useQuery();
+	const siteSlug = urlQueryParams.get( 'siteSlug' );
+	const sourceSlug = urlQueryParams.get( 'sourceSlug' );
+	const sourceSiteId = useSelect(
+		( select ) => sourceSlug && select( SITE_STORE ).getSiteIdBySlug( sourceSlug )
+	);
+	const { requestLatestAtomicTransfer } = useDispatch( SITE_STORE );
+	const { getSiteLatestAtomicTransfer, getSiteLatestAtomicTransferError } = useSelect( ( select ) =>
+		select( SITE_STORE )
+	);
+
+	useEffect( () => {
+		if ( isCopying && site ) {
+			const timer = setInterval( async () => {
+				await requestLatestAtomicTransfer( site.ID );
+				const transfer = getSiteLatestAtomicTransfer( site.ID );
+				const transferError = getSiteLatestAtomicTransferError( site.ID );
+				const transferStatus = transfer?.status;
+				const isTransferringStatusFailed = transferError && transferError?.status >= 500;
+
+				if ( isTransferringStatusFailed ) {
+					setIsError( 'Error Copying' );
+				} else if ( transferStatus === 'completed' ) {
+					setIsSuccess();
+				}
+			}, TIME_CHECK_TRANSFER_STATUS );
+			return () => clearTimeout( timer );
+		}
+	}, [
+		getSiteLatestAtomicTransfer,
+		getSiteLatestAtomicTransferError,
+		isCopying,
+		requestLatestAtomicTransfer,
+		setIsError,
+		setIsSuccess,
+		site,
+	] );
+
+	const startCopying = useCallback(
+		function startCopying() {
+			if ( ! site?.ID || ! sourceSiteId ) {
+				return;
+			}
+			return wpcom.req
+				.post( {
+					path: `/sites/${ site.ID }/copy-from-site`,
+					apiNamespace: 'wpcom/v2',
+					body: {
+						source_blog_id: sourceSiteId,
+					},
+				} )
+				.then( () => {
+					setIsCopying();
+				} )
+				.catch( ( e: { message: string; code: string; data: { status: number } } ) => {
+					// eslint-disable-next-line no-console
+					console.error( e );
+					setIsError( e.message || 'Error Starting the Copy' );
+				} );
+		},
+		[ setIsCopying, setIsError, site?.ID, sourceSiteId ]
+	);
+
+	useEffect( () => {
+		startCopying();
+	}, [ startCopying ] );
+
+	if ( ! sourceSlug || ! siteSlug ) {
+		// TODO: show a better error or redirect to the start /sites
+		return <h1>{ __( 'Missing required parameters' ) }</h1>;
+	}
+
+	if ( ! sourceSiteId || ! site ) {
+		// eslint-disable-next-line no-console
+		console.info( { sourceSlug, siteSlug, sourceSiteId, site } );
+		// Wait for stores to populate
+		return null;
+	}
+
+	return (
+		<StepContainer
+			stepName="AutomatedcopySite"
+			hideBack
+			recordTracksEvent={ recordTracksEvent }
+			stepContent={
+				<div>
+					{ isLoading && <h1>{ __( 'Copying Site…' ) }</h1> }
+					{ isError && (
+						<>
+							<h1>{ __( 'Error copying site. Contact support' ) }</h1>
+							<p>{ error }</p>
+							<button onClick={ startCopying }>{ __( 'Retry?' ) }</button>
+						</>
+					) }
+					{ isSuccess && (
+						<>
+							<h1>{ __( 'Site copied successfully 🥳' ) }</h1>
+							<p>
+								{ __(
+									'Congrats all your content has been migrated and your new site is ready to enjoy.'
+								) }
+							</p>
+							<button onClick={ () => submit?.( { siteSlug } ) }>
+								{ __( 'Visit my new site' ) }
+							</button>
+						</>
+					) }
+				</div>
+			}
+		></StepContainer>
+	);
+};
+
+export default AutomatedCopySite;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/intro/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/intro/index.tsx
@@ -25,11 +25,11 @@ const useIntroContent = ( flowName: string | null ): IntroContent => {
 				title: __( 'Copy Site' ),
 				text: createInterpolateElement(
 					__(
-						'You’re 5 minutes away from<br />creating a new copy site from <SourceUrl/>.<br />Ready?'
+						'You’re 5 minutes away from<br />creating a new copy site from <SourceSlug/>.<br />Ready?'
 					),
 					{
 						br: <br />,
-						SourceUrl: <span>{ urlQueryParams.get( 'sourceUrl' ) }</span>,
+						SourceSlug: <span>{ urlQueryParams.get( 'sourceSlug' ) }</span>,
 					}
 				),
 				buttonText: __( 'Start copying' ),

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/intro/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/intro/index.tsx
@@ -9,6 +9,7 @@ import {
 import { createInterpolateElement, useMemo } from '@wordpress/element';
 import { useI18n } from '@wordpress/react-i18n';
 import { StepContainer } from 'calypso/../packages/onboarding/src';
+import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import IntroStep, { IntroContent } from './intro';
 import type { Step } from '../../types';
@@ -17,13 +18,19 @@ import './styles.scss';
 
 const useIntroContent = ( flowName: string | null ): IntroContent => {
 	const { __ } = useI18n();
-
+	const urlQueryParams = useQuery();
 	return useMemo( () => {
 		if ( isCopySiteFlow( flowName ) ) {
 			return {
-				title: createInterpolateElement(
-					__( 'You’re 5 minutes away from<br />creating a new copy site.<br />Ready? ' ),
-					{ br: <br /> }
+				title: __( 'Copy Site' ),
+				text: createInterpolateElement(
+					__(
+						'You’re 5 minutes away from<br />creating a new copy site from <SourceUrl/>.<br />Ready?'
+					),
+					{
+						br: <br />,
+						SourceUrl: <span>{ urlQueryParams.get( 'sourceUrl' ) }</span>,
+					}
 				),
 				buttonText: __( 'Start copying' ),
 			};
@@ -85,7 +92,7 @@ const useIntroContent = ( flowName: string | null ): IntroContent => {
 			),
 			buttonText: __( 'Get started' ),
 		};
-	}, [ flowName, __ ] );
+	}, [ flowName, __, urlQueryParams ] );
 };
 
 const Intro: Step = function Intro( { navigation, flow } ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/intro/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/intro/index.tsx
@@ -4,6 +4,7 @@ import {
 	VIDEOPRESS_FLOW,
 	FREE_FLOW,
 	isLinkInBioFlow,
+	isCopySiteFlow,
 } from '@automattic/onboarding';
 import { createInterpolateElement, useMemo } from '@wordpress/element';
 import { useI18n } from '@wordpress/react-i18n';
@@ -18,6 +19,16 @@ const useIntroContent = ( flowName: string | null ): IntroContent => {
 	const { __ } = useI18n();
 
 	return useMemo( () => {
+		if ( isCopySiteFlow( flowName ) ) {
+			return {
+				title: createInterpolateElement(
+					__( 'You’re 5 minutes away from<br />creating a new copy site.<br />Ready? ' ),
+					{ br: <br /> }
+				),
+				buttonText: __( 'Start copying' ),
+			};
+		}
+
 		if ( isLinkInBioFlow( flowName ) ) {
 			return {
 				title: createInterpolateElement(

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
@@ -7,6 +7,7 @@ import {
 	createSiteWithCart,
 	isFreeFlow,
 	isMigrationFlow,
+	isCopySiteFlow,
 } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect } from 'react';
@@ -22,6 +23,8 @@ import { getCurrentUserName } from 'calypso/state/current-user/selectors';
 import type { Step } from '../../types';
 
 import './styles.scss';
+
+const DEFAULT_WP_SITE_THEME = 'pub/zoologist';
 
 const SiteCreationStep: Step = function SiteCreationStep( { navigation, flow } ) {
 	const { submit } = navigation;
@@ -40,8 +43,8 @@ const SiteCreationStep: Step = function SiteCreationStep( { navigation, flow } )
 	const { setPendingAction, setIsMigrateFromWp } = useDispatch( ONBOARD_STORE );
 
 	let theme: string;
-	if ( isMigrationFlow( flow ) ) {
-		theme = 'pub/zoologist';
+	if ( isMigrationFlow( flow ) || isCopySiteFlow( flow ) ) {
+		theme = DEFAULT_WP_SITE_THEME;
 	} else {
 		theme = isLinkInBioFlow( flow ) ? 'pub/lynx' : 'pub/lettre';
 	}

--- a/client/landing/stepper/declarative-flow/registered-flows.ts
+++ b/client/landing/stepper/declarative-flow/registered-flows.ts
@@ -45,8 +45,6 @@ const availableFlows: Record< string, () => Promise< { default: Flow } > > = {
 			/* webpackChunkName: "trial-wooexpress-flow" */ '../declarative-flow/trial-wooexpress-flow'
 		),
 
-	'copy-site': () => import( /* webpackChunkName: "copy-site" */ '../declarative-flow/copy-site' ),
-
 	free: () => import( /* webpackChunkName: "free-flow" */ '../declarative-flow/free' ),
 
 	'free-post-setup': () =>
@@ -56,6 +54,11 @@ const availableFlows: Record< string, () => Promise< { default: Flow } > > = {
 if ( config.isEnabled( 'themes/plugin-bundling' ) ) {
 	availableFlows[ 'plugin-bundle' ] = () =>
 		import( /* webpackChunkName: "plugin-bundle-flow" */ '../declarative-flow/plugin-bundle-flow' );
+}
+
+if ( config.isEnabled( 'sites/copy-site' ) ) {
+	availableFlows[ 'copy-site' ] = () =>
+		import( /* webpackChunkName: "copy-site" */ '../declarative-flow/copy-site' );
 }
 
 export default availableFlows;

--- a/client/landing/stepper/declarative-flow/registered-flows.ts
+++ b/client/landing/stepper/declarative-flow/registered-flows.ts
@@ -45,6 +45,8 @@ const availableFlows: Record< string, () => Promise< { default: Flow } > > = {
 			/* webpackChunkName: "trial-wooexpress-flow" */ '../declarative-flow/trial-wooexpress-flow'
 		),
 
+	'copy-site': () => import( /* webpackChunkName: "copy-site" */ '../declarative-flow/copy-site' ),
+
 	free: () => import( /* webpackChunkName: "free-flow" */ '../declarative-flow/free' ),
 
 	'free-post-setup': () =>

--- a/client/sites-dashboard/components/sites-ellipsis-menu.tsx
+++ b/client/sites-dashboard/components/sites-ellipsis-menu.tsx
@@ -201,7 +201,7 @@ const CopySiteItem = ( { recordTracks, site }: SitesMenuItemProps ) => {
 			href={ copySiteHref }
 			onClick={ () => recordTracks( 'calypso_sites_dashboard_site_action_copy_site' ) }
 		>
-			{ __( 'Create a copy of this site' ) }
+			{ __( 'Copy site' ) }
 		</MenuItemLink>
 	);
 };

--- a/client/sites-dashboard/components/sites-ellipsis-menu.tsx
+++ b/client/sites-dashboard/components/sites-ellipsis-menu.tsx
@@ -191,13 +191,9 @@ const CopySiteItem = ( { recordTracks, site }: SitesMenuItemProps ) => {
 		return null;
 	}
 
-	const planId = plan.product_id;
-	const billingPeriod = plan.billing_period || 'ANNUALLY';
-
 	const copySiteHref = addQueryArgs( `/setup/copy-site`, {
-		billingPeriod,
-		planId,
-		sourceSite: site.ID,
+		productSlug: plan.product_slug,
+		sourceSlug: site.slug,
 		sourceUrl: site.URL,
 	} );
 	return (

--- a/client/sites-dashboard/components/sites-ellipsis-menu.tsx
+++ b/client/sites-dashboard/components/sites-ellipsis-menu.tsx
@@ -1,4 +1,6 @@
+import { isEnabled } from '@automattic/calypso-config';
 import {
+	WPCOM_FEATURES_ATOMIC,
 	WPCOM_FEATURES_MANAGE_PLUGINS,
 	WPCOM_FEATURES_SITE_PREVIEW_LINKS,
 } from '@automattic/calypso-products';
@@ -11,6 +13,7 @@ import { ComponentType, useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import SitePreviewLink from 'calypso/components/site-preview-link';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { fetchSiteFeatures } from 'calypso/state/sites/features/actions';
 import { launchSiteOrRedirectToLaunchSignupFlow } from 'calypso/state/sites/launch/actions';
@@ -176,6 +179,27 @@ const PreviewSiteModalItem = ( { recordTracks, site }: SitesMenuItemProps ) => {
 	);
 };
 
+const CopySiteItem = ( { recordTracks, site }: SitesMenuItemProps ) => {
+	const { __ } = useI18n();
+	const hasAtomicFeature = useSafeSiteHasFeature( site.ID, WPCOM_FEATURES_ATOMIC );
+	const userId = useSelector( ( state ) => getCurrentUserId( state ) );
+	const isSiteOwner = site.site_owner === userId;
+
+	if ( ! hasAtomicFeature || ! isSiteOwner ) {
+		return null;
+	}
+
+	const copySiteHref = `/setup/wooexpress`; // TODO: Update this to the correct URL
+	return (
+		<MenuItemLink
+			href={ copySiteHref }
+			onClick={ () => recordTracks( 'calypso_sites_dashboard_site_action_copy_site' ) }
+		>
+			{ __( 'Create a copy of this site' ) }
+		</MenuItemLink>
+	);
+};
+
 const ExternalGridIcon = styled( Gridicon )( {
 	insetBlockStart: '-1px',
 	marginInlineStart: '4px',
@@ -246,6 +270,7 @@ export const SitesEllipsisMenu = ( {
 					<ManagePluginsItem { ...props } />
 					{ showHosting && <HostingConfigItem { ...props } /> }
 					{ site.is_coming_soon && <PreviewSiteModalItem { ...props } /> }
+					{ isEnabled( 'sites/copy-site' ) && <CopySiteItem { ...props } /> }
 					<WpAdminItem { ...props } />
 				</SiteMenuGroup>
 			) }

--- a/client/sites-dashboard/components/sites-ellipsis-menu.tsx
+++ b/client/sites-dashboard/components/sites-ellipsis-menu.tsx
@@ -184,13 +184,19 @@ const CopySiteItem = ( { recordTracks, site }: SitesMenuItemProps ) => {
 	const { __ } = useI18n();
 	const hasAtomicFeature = useSafeSiteHasFeature( site.ID, WPCOM_FEATURES_ATOMIC );
 	const userId = useSelector( ( state ) => getCurrentUserId( state ) );
+	const plan = site.plan;
 	const isSiteOwner = site.site_owner === userId;
 
-	if ( ! hasAtomicFeature || ! isSiteOwner ) {
+	if ( ! hasAtomicFeature || ! isSiteOwner || ! plan ) {
 		return null;
 	}
 
+	const planId = plan.product_id;
+	const billingPeriod = plan.billing_period || 'ANNUALLY';
+
 	const copySiteHref = addQueryArgs( `/setup/copy-site`, {
+		billingPeriod,
+		planId,
 		sourceSite: site.ID,
 		sourceUrl: site.URL,
 	} );

--- a/client/sites-dashboard/components/sites-ellipsis-menu.tsx
+++ b/client/sites-dashboard/components/sites-ellipsis-menu.tsx
@@ -9,6 +9,7 @@ import { css } from '@emotion/css';
 import styled from '@emotion/styled';
 import { DropdownMenu, MenuGroup, MenuItem as CoreMenuItem, Modal } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
+import { addQueryArgs } from '@wordpress/url';
 import { ComponentType, useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import SitePreviewLink from 'calypso/components/site-preview-link';
@@ -189,7 +190,10 @@ const CopySiteItem = ( { recordTracks, site }: SitesMenuItemProps ) => {
 		return null;
 	}
 
-	const copySiteHref = `/setup/copy-site`;
+	const copySiteHref = addQueryArgs( `/setup/copy-site`, {
+		sourceSite: site.ID,
+		sourceUrl: site.URL,
+	} );
 	return (
 		<MenuItemLink
 			href={ copySiteHref }

--- a/client/sites-dashboard/components/sites-ellipsis-menu.tsx
+++ b/client/sites-dashboard/components/sites-ellipsis-menu.tsx
@@ -8,11 +8,13 @@ import { Gridicon } from '@automattic/components';
 import { css } from '@emotion/css';
 import styled from '@emotion/styled';
 import { DropdownMenu, MenuGroup, MenuItem as CoreMenuItem, Modal } from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
 import { addQueryArgs } from '@wordpress/url';
 import { ComponentType, useEffect, useState } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch as useReduxDispatch, useSelector } from 'react-redux';
 import SitePreviewLink from 'calypso/components/site-preview-link';
+import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
@@ -51,7 +53,7 @@ const MenuItemLink = MenuItem as ComponentType< MenuItemLinkProps >;
 
 const LaunchItem = ( { site, recordTracks }: SitesMenuItemProps ) => {
 	const { __ } = useI18n();
-	const dispatch = useDispatch();
+	const dispatch = useReduxDispatch();
 
 	return (
 		<MenuItem
@@ -132,7 +134,7 @@ const modalOverlayClassName = css( {
 } );
 
 function useSafeSiteHasFeature( siteId: number, feature: string ) {
-	const dispatch = useDispatch();
+	const dispatch = useReduxDispatch();
 	useEffect( () => {
 		dispatch( fetchSiteFeatures( siteId ) );
 	}, [ dispatch, siteId ] );
@@ -186,13 +188,14 @@ const CopySiteItem = ( { recordTracks, site }: SitesMenuItemProps ) => {
 	const userId = useSelector( ( state ) => getCurrentUserId( state ) );
 	const plan = site.plan;
 	const isSiteOwner = site.site_owner === userId;
+	const { setPlanCartItem } = useDispatch( ONBOARD_STORE );
 
 	if ( ! hasAtomicFeature || ! isSiteOwner || ! plan ) {
 		return null;
 	}
+	setPlanCartItem( { product_slug: plan.product_slug } );
 
 	const copySiteHref = addQueryArgs( `/setup/copy-site`, {
-		productSlug: plan.product_slug,
 		sourceSlug: site.slug,
 		sourceUrl: site.URL,
 	} );
@@ -252,7 +255,7 @@ export const SitesEllipsisMenu = ( {
 	className?: string;
 	site: SiteExcerptData;
 } ) => {
-	const dispatch = useDispatch();
+	const dispatch = useReduxDispatch();
 	const { __ } = useI18n();
 	const props: SitesMenuItemProps = {
 		site,

--- a/client/sites-dashboard/components/sites-ellipsis-menu.tsx
+++ b/client/sites-dashboard/components/sites-ellipsis-menu.tsx
@@ -189,7 +189,7 @@ const CopySiteItem = ( { recordTracks, site }: SitesMenuItemProps ) => {
 		return null;
 	}
 
-	const copySiteHref = `/setup/wooexpress`; // TODO: Update this to the correct URL
+	const copySiteHref = `/setup/copy-site`;
 	return (
 		<MenuItemLink
 			href={ copySiteHref }

--- a/client/sites-dashboard/components/sites-ellipsis-menu.tsx
+++ b/client/sites-dashboard/components/sites-ellipsis-menu.tsx
@@ -197,7 +197,6 @@ const CopySiteItem = ( { recordTracks, site }: SitesMenuItemProps ) => {
 
 	const copySiteHref = addQueryArgs( `/setup/copy-site`, {
 		sourceSlug: site.slug,
-		sourceUrl: site.URL,
 	} );
 	return (
 		<MenuItemLink

--- a/config/development.json
+++ b/config/development.json
@@ -162,6 +162,7 @@
 		"signup/social": true,
 		"signup/woo-verify-email": false,
 		"site-indicator": true,
+		"sites/copy-site": true,
 		"ssr/prefetch-timebox": false,
 		"stats/horizontal-bars-everywhere": true,
 		"stepper-woocommerce-poc": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -132,6 +132,7 @@
 		"signup/social": true,
 		"signup/woo-verify-email": false,
 		"site-indicator": true,
+		"sites/copy-site": true,
 		"ssr/prefetch-timebox": true,
 		"stats/horizontal-bars-everywhere": false,
 		"stepper-woocommerce-poc": true,

--- a/packages/onboarding/src/flow-progress/use-flow-progress.ts
+++ b/packages/onboarding/src/flow-progress/use-flow-progress.ts
@@ -69,10 +69,10 @@ const flows: Record< string, { [ step: string ]: number } > = {
 	},
 	[ COPY_SITE_FLOW ]: {
 		intro: 0,
-		siteCreationStep: 1,
+		'site-creation-step': 1,
 		processing: 1,
-		automatedCopy: 3,
-		processingCopy: 3,
+		'automated-copy': 3,
+		'processing-copy': 3,
 	},
 };
 

--- a/packages/onboarding/src/flow-progress/use-flow-progress.ts
+++ b/packages/onboarding/src/flow-progress/use-flow-progress.ts
@@ -1,4 +1,10 @@
-import { ECOMMERCE_FLOW, LINK_IN_BIO_FLOW, LINK_IN_BIO_TLD_FLOW, FREE_FLOW } from '../utils/flows';
+import {
+	ECOMMERCE_FLOW,
+	LINK_IN_BIO_FLOW,
+	LINK_IN_BIO_TLD_FLOW,
+	FREE_FLOW,
+	COPY_SITE_FLOW,
+} from '../utils/flows';
 
 /* eslint-disable no-restricted-imports */
 interface FlowProgress {
@@ -60,6 +66,12 @@ const flows: Record< string, { [ step: string ]: number } > = {
 		waitForAtomic: 4,
 		checkPlan: 4,
 		storeAddress: 5,
+	},
+	[ COPY_SITE_FLOW ]: {
+		intro: 0,
+		siteCreationStep: 1,
+		processing: 1,
+		automatedCopy: 3,
 	},
 };
 

--- a/packages/onboarding/src/flow-progress/use-flow-progress.ts
+++ b/packages/onboarding/src/flow-progress/use-flow-progress.ts
@@ -72,6 +72,7 @@ const flows: Record< string, { [ step: string ]: number } > = {
 		siteCreationStep: 1,
 		processing: 1,
 		automatedCopy: 3,
+		processingCopy: 3,
 	},
 };
 

--- a/packages/onboarding/src/utils/flows.ts
+++ b/packages/onboarding/src/utils/flows.ts
@@ -10,6 +10,7 @@ export const WOOEXPRESS_FLOW = 'wooexpress';
 export const FREE_FLOW = 'free';
 export const FREE_POST_SETUP_FLOW = 'free-post-setup';
 export const MIGRATION_FLOW = 'import-focused';
+export const COPY_SITE_FLOW = 'copy-site';
 
 export const isLinkInBioFlow = ( flowName: string | null ) => {
 	return Boolean(
@@ -47,6 +48,10 @@ export const isTailoredSignupFlow = ( flowName: string | null ) => {
 
 export const isMigrationFlow = ( flowName: string | null ) => {
 	return Boolean( flowName && [ MIGRATION_FLOW ].includes( flowName ) );
+};
+
+export const isCopySiteFlow = ( flowName: string | null ) => {
+	return Boolean( flowName && [ COPY_SITE_FLOW ].includes( flowName ) );
 };
 
 export const ecommerceFlowRecurTypes = {


### PR DESCRIPTION
- Closes https://github.com/Automattic/dotcom-forge/issues/1468

#### Proposed Changes

* Add a new `Copy Site` item on SMP site actions for atomic sites that you own.
* Create a new rough `Copy Site` flow to create a new site, buy a plan and migrate it to Atomic.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
* If It's not yet deployed, Apply and sandbox D97450-code.
* Go to `/sites`.
* On an atomic site you own, Click on the ellipsis action menu.
* Click on `Create a copy of this site`.
* Observe a new flow is open.
* Follow the steps, pay the plan, and observe a Success message after copying your site.

<!--
### Screencast

https://user-images.githubusercontent.com/779993/211998222-7916d146-011b-4185-9c96-4a0c10e1e4ad.mp4

!-->


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->