### PR TITLE
Site settings: Add Track events to upsell

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -797,6 +797,9 @@ export class SiteSettingsFormGeneral extends Component {
 									'Upgrade to remove the footer credit, use advanced SEO tools and more'
 								) }
 								showIcon={ true }
+								event="settings_remove_footer"
+								tracksImpressionName="calypso_upgrade_nudge_impression"
+								tracksClickName="calypso_upgrade_nudge_cta_click"
 							/>
 						) }
 					</div>


### PR DESCRIPTION
Small PR to add a missing Tracks event to the Remove footer upsell in Site settings.

#### Proposed Changes
* Adds event `settings_remove_footer` to the <UpsellNudge> component for removing the footer credit.
* Uses already validated Tracks events `calypso_upgrade_nudge_impression` and `calypso_upgrade_cta_click`


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix. "Before / After" screenshots can also be very helpful when the change is visual. -->

* Spin up this change with the Calypso Live link.
* Navigate to `Settings` > `General` for a site (/settings/general/:site)
* Check there's a Tracks event fired for `calypso_upgrade_nudge_impression` with the attribute `event=settings_remove_footer`
* Click the `Remove the footer credit entirely` upsell in the Footer credit section.
* Check there's a Tracks event fired for `calypso_upgrade_nudge_cta_click` with the attribute `event=settings_remove_footer`

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to pebzTe-Al-p2
