### PR TITLE
CopySite: add parameters into the flow and show url in intro step

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/intro/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/intro/index.tsx
@@ -9,6 +9,7 @@ import {
 import { createInterpolateElement, useMemo } from '@wordpress/element';
 import { useI18n } from '@wordpress/react-i18n';
 import { StepContainer } from 'calypso/../packages/onboarding/src';
+import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import IntroStep, { IntroContent } from './intro';
 import type { Step } from '../../types';
@@ -17,13 +18,19 @@ import './styles.scss';
 
 const useIntroContent = ( flowName: string | null ): IntroContent => {
 	const { __ } = useI18n();
-
+	const urlQueryParams = useQuery();
 	return useMemo( () => {
 		if ( isCopySiteFlow( flowName ) ) {
 			return {
-				title: createInterpolateElement(
-					__( 'You’re 5 minutes away from<br />creating a new copy site.<br />Ready? ' ),
-					{ br: <br /> }
+				title: __( 'Copy Site' ),
+				text: createInterpolateElement(
+					__(
+						'You’re 5 minutes away from<br />creating a new copy site from <SourceUrl/>.<br />Ready?'
+					),
+					{
+						br: <br />,
+						SourceUrl: <span>{ urlQueryParams.get( 'sourceUrl' ) }</span>,
+					}
 				),
 				buttonText: __( 'Start copying' ),
 			};
@@ -85,7 +92,7 @@ const useIntroContent = ( flowName: string | null ): IntroContent => {
 			),
 			buttonText: __( 'Get started' ),
 		};
-	}, [ flowName, __ ] );
+	}, [ flowName, __, urlQueryParams ] );
 };
 
 const Intro: Step = function Intro( { navigation, flow } ) {

--- a/client/sites-dashboard/components/sites-ellipsis-menu.tsx
+++ b/client/sites-dashboard/components/sites-ellipsis-menu.tsx
@@ -9,6 +9,7 @@ import { css } from '@emotion/css';
 import styled from '@emotion/styled';
 import { DropdownMenu, MenuGroup, MenuItem as CoreMenuItem, Modal } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
+import { addQueryArgs } from '@wordpress/url';
 import { ComponentType, useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import SitePreviewLink from 'calypso/components/site-preview-link';
@@ -189,7 +190,10 @@ const CopySiteItem = ( { recordTracks, site }: SitesMenuItemProps ) => {
 		return null;
 	}
 
-	const copySiteHref = `/setup/copy-site`;
+	const copySiteHref = addQueryArgs( `/setup/copy-site`, {
+		sourceSite: site.ID,
+		sourceUrl: site.URL,
+	} );
 	return (
 		<MenuItemLink
 			href={ copySiteHref }


### PR DESCRIPTION
#### Proposed Changes

* Add source url in intro step and add first parameters needed to the flow.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /sites click on `Create a copy of this site`.
* Observe the source url is present

<img width="1728" alt="Screenshot 2023-01-11 at 10 32 37" src="https://user-images.githubusercontent.com/779993/211783904-867fac3d-bfaf-4589-8386-1711415fd863.png">


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/1468
