### PR TITLE
Adding isMigrateFromWp flag and site creation step to importer flow

### DIFF
--- a/client/blocks/importer/wordpress/utils.js
+++ b/client/blocks/importer/wordpress/utils.js
@@ -1,0 +1,13 @@
+export const SESSION_STORAGE_IS_MIGRATE_FROM_WP = 'is_migrate_from_wp';
+
+export const storeMigrateSource = () => {
+	window.sessionStorage.setItem( SESSION_STORAGE_IS_MIGRATE_FROM_WP, 'true' );
+};
+
+export const clearMigrateSource = () => {
+	window.sessionStorage.removeItem( SESSION_STORAGE_IS_MIGRATE_FROM_WP );
+};
+
+export const retrieveMigrateSource = () => {
+	return window.sessionStorage.getItem( SESSION_STORAGE_IS_MIGRATE_FROM_WP );
+};

--- a/client/landing/stepper/declarative-flow/import-flow.ts
+++ b/client/landing/stepper/declarative-flow/import-flow.ts
@@ -158,7 +158,7 @@ const importFlow: Flow = {
 				case 'importerSquarespace':
 				case 'importerWordpress':
 				case 'designSetup':
-					return navigate( `import?siteSlug=${ siteSlugParam }` );
+					return navigate( 'import' );
 			}
 		};
 

--- a/client/landing/stepper/declarative-flow/import-flow.ts
+++ b/client/landing/stepper/declarative-flow/import-flow.ts
@@ -20,6 +20,7 @@ import ImporterWix from './internals/steps-repository/importer-wix';
 import ImporterWordpress from './internals/steps-repository/importer-wordpress';
 import PatternAssembler from './internals/steps-repository/pattern-assembler';
 import ProcessingStep from './internals/steps-repository/processing-step';
+import SiteCreationStep from './internals/steps-repository/site-creation-step';
 import { Flow, ProvidedDependencies } from './internals/types';
 
 const importFlow: Flow = {
@@ -41,6 +42,7 @@ const importFlow: Flow = {
 			{ slug: 'designSetup', component: DesignSetup },
 			{ slug: 'patternAssembler', component: PatternAssembler },
 			{ slug: 'processing', component: ProcessingStep },
+			{ slug: 'siteCreationStep', component: SiteCreationStep },
 		];
 	},
 
@@ -114,7 +116,14 @@ const importFlow: Flow = {
 				case 'patternAssembler':
 					return navigate( 'processing' );
 
+				case 'siteCreationStep':
+					return navigate( 'processing' );
+
 				case 'processing': {
+					if ( providedDependencies?.siteSlug ) {
+						const from = urlQueryParams.get( 'from' );
+						return navigate( `import?siteSlug=${ providedDependencies?.siteSlug }&from=${ from }` );
+					}
 					// End of Pattern Assembler flow
 					if ( selectedDesign?.design_type === 'assembler' ) {
 						return exitFlow( `/site-editor/${ siteSlugParam }` );
@@ -149,7 +158,7 @@ const importFlow: Flow = {
 				case 'importerSquarespace':
 				case 'importerWordpress':
 				case 'designSetup':
-					return navigate( 'import' );
+					return navigate( `import?siteSlug=${ siteSlugParam }` );
 			}
 		};
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
@@ -6,6 +6,7 @@ import {
 	addPlanToCart,
 	createSiteWithCart,
 	isFreeFlow,
+	isMigrationFlow,
 } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect } from 'react';
@@ -36,16 +37,22 @@ const SiteCreationStep: Step = function SiteCreationStep( { navigation, flow } )
 
 	const username = useSelector( ( state ) => getCurrentUserName( state ) );
 
-	const { setPendingAction } = useDispatch( ONBOARD_STORE );
+	const { setPendingAction, setIsMigrateFromWp } = useDispatch( ONBOARD_STORE );
 
-	const theme = isLinkInBioFlow( flow ) ? 'pub/lynx' : 'pub/lettre';
+	let theme: string;
+	if ( isMigrationFlow( flow ) ) {
+		theme = 'pub/zoologist';
+	} else {
+		theme = isLinkInBioFlow( flow ) ? 'pub/lynx' : 'pub/lettre';
+	}
 	const isPaidDomainItem = Boolean( domainCartItem?.product_slug );
 
 	// Default visibility is public
 	let siteVisibility = Site.Visibility.PublicIndexed;
 
 	// Link-in-bio flow defaults to "Coming Soon"
-	if ( isLinkInBioFlow( flow ) || isFreeFlow( flow ) ) {
+
+	if ( isLinkInBioFlow( flow ) || isFreeFlow( flow ) || isMigrationFlow( flow ) ) {
 		siteVisibility = Site.Visibility.PublicNotIndexed;
 	}
 
@@ -96,6 +103,10 @@ const SiteCreationStep: Step = function SiteCreationStep( { navigation, flow } )
 	}
 
 	useEffect( () => {
+		if ( isMigrationFlow( flow ) ) {
+			setIsMigrateFromWp( true );
+		}
+
 		if ( submit ) {
 			setPendingAction( createSite );
 			submit();

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
@@ -51,7 +51,6 @@ const SiteCreationStep: Step = function SiteCreationStep( { navigation, flow } )
 	let siteVisibility = Site.Visibility.PublicIndexed;
 
 	// Link-in-bio flow defaults to "Coming Soon"
-
 	if ( isLinkInBioFlow( flow ) || isFreeFlow( flow ) || isMigrationFlow( flow ) ) {
 		siteVisibility = Site.Visibility.PublicNotIndexed;
 	}

--- a/packages/data-stores/src/onboard/actions.ts
+++ b/packages/data-stores/src/onboard/actions.ts
@@ -408,6 +408,11 @@ export const setHideFreePlan = ( hideFreePlan: boolean ) => ( {
 	hideFreePlan,
 } );
 
+export const setIsMigrateFromWp = ( isMigrateFromWp: boolean ) => ( {
+	type: 'SET_IS_MIGRATE_FROM_WP' as const,
+	isMigrateFromWp,
+} );
+
 export type OnboardAction = ReturnType<
 	| typeof addFeature
 	| typeof removeFeature
@@ -459,4 +464,5 @@ export type OnboardAction = ReturnType<
 	| typeof setEcommerceFlowRecurType
 	| typeof setHideFreePlan
 	| typeof setPlanCartItem
+	| typeof setIsMigrateFromWp
 >;

--- a/packages/data-stores/src/onboard/reducer.ts
+++ b/packages/data-stores/src/onboard/reducer.ts
@@ -460,6 +460,16 @@ const domainCartItem: Reducer< MinimalRequestCartProduct | undefined, OnboardAct
 	return state;
 };
 
+const isMigrateFromWp: Reducer< boolean, OnboardAction > = ( state = false, action ) => {
+	if ( action.type === 'SET_IS_MIGRATE_FROM_WP' ) {
+		return action.isMigrateFromWp;
+	}
+	if ( action.type === 'RESET_ONBOARD_STORE' ) {
+		return false;
+	}
+	return state;
+};
+
 const reducer = combineReducers( {
 	anchorPodcastId,
 	anchorEpisodeId,
@@ -501,6 +511,7 @@ const reducer = combineReducers( {
 	storeLocationCountryCode,
 	ecommerceFlowRecurType,
 	planCartItem,
+	isMigrateFromWp,
 } );
 
 export type State = ReturnType< typeof reducer >;

--- a/packages/data-stores/src/onboard/selectors.ts
+++ b/packages/data-stores/src/onboard/selectors.ts
@@ -61,3 +61,4 @@ export const getEditEmail = ( state: State ) => state.editEmail;
 export const getDomainForm = ( state: State ) => state.domainForm;
 export const getDomainCartItem = ( state: State ) => state.domainCartItem;
 export const getHideFreePlan = ( state: State ) => state.hideFreePlan;
+export const getIsMigrateFromWp = ( state: State ) => state.isMigrateFromWp;

--- a/packages/onboarding/src/utils/flows.ts
+++ b/packages/onboarding/src/utils/flows.ts
@@ -9,6 +9,7 @@ export const ECOMMERCE_FLOW = 'ecommerce';
 export const WOOEXPRESS_FLOW = 'wooexpress';
 export const FREE_FLOW = 'free';
 export const FREE_POST_SETUP_FLOW = 'free-post-setup';
+export const MIGRATION_FLOW = 'import-focused';
 
 export const isLinkInBioFlow = ( flowName: string | null ) => {
 	return Boolean(
@@ -42,6 +43,10 @@ export const isTailoredSignupFlow = ( flowName: string | null ) => {
 				ECOMMERCE_FLOW === flowName ||
 				FREE_FLOW === flowName )
 	);
+};
+
+export const isMigrationFlow = ( flowName: string | null ) => {
+	return Boolean( flowName && [ MIGRATION_FLOW ].includes( flowName ) );
 };
 
 export const ecommerceFlowRecurTypes = {


### PR DESCRIPTION
#### Proposed Changes
To allow us to use the current importer flow and integrate with the Migration plugin later, we will need to modify the current importer flow. In this PR, we are trying to add:

* Introduce `isMigrateFromWp` flag into the onboarding store to detect if a user came from the migration plugin.
* Introduce `siteCreationStep` into the `import-focused` flow so it creates a blog for users automatically.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* go to `http://calypso.localhost:3000/setup/import-focused/siteCreationStep?from=${TARGET_SITE_SLUG}`. The `TARGET_SITE_SLUG` here should be the site you want to migrate. For example, a testing Jurassic Ninja site.
* A new blog should be created automatically under the hood based on your username and redirect you to the import page.
* The URL should look like `http://calypso.localhost:3000/setup/import-focused/import?siteSlug=${THE_NEW_BLOG_JUST_CREATED}&from=${TARGET_SITE_SLUG}`. The `THE_NEW_BLOG_JUST_CREATED` should looks like something similar to your username.
* Fill in the site URL on the page and click continue.
* Going through the progress until you see the screen that asks you to import everything or content only.
<img width="1342" alt="Screen Shot 2023-01-11 at 7 04 27 PM" src="https://user-images.githubusercontent.com/4074459/211790567-3dccdc6f-1b8e-45de-8b33-380b06c091df.png">
* Use the inspect tool and see if there's a session storage with key call `is_migrate_from_wp` with value `true`. Once you confirm the session storage exists, you can delete it.

#### What's out of scope
* The position of the process step is a known issue and will not be handle in this PR.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
