### PR TITLE
Add hotfix for 1$ intro prices for jetpack_backup_tier_1 (similar to Jetpack Social)

### DIFF
--- a/client/my-sites/plans/jetpack-plans/use-item-price.ts
+++ b/client/my-sites/plans/jetpack-plans/use-item-price.ts
@@ -1,4 +1,5 @@
 import {
+	JETPACK_BACKUP_T1_PRODUCTS,
 	JETPACK_CRM_PRODUCTS,
 	JETPACK_SOCIAL_PRODUCTS,
 	TERM_MONTHLY,
@@ -166,10 +167,12 @@ const useItemPrice = (
 				? getMonthlyPrice( introductoryOfferPrices.introOfferCost )
 				: undefined;
 
-			// Override Jetpack Social price by hard-coding it for now
+			// Override Jetpack Social and Jetpack Backup Tier 1 price by hard-coding it for now
 			if (
-				JETPACK_SOCIAL_PRODUCTS.includes(
-					item?.productSlug as typeof JETPACK_SOCIAL_PRODUCTS[ number ]
+				[ ...JETPACK_SOCIAL_PRODUCTS, ...JETPACK_BACKUP_T1_PRODUCTS ].includes(
+					item?.productSlug as
+						| typeof JETPACK_SOCIAL_PRODUCTS[ number ]
+						| typeof JETPACK_BACKUP_T1_PRODUCTS[ number ]
 				)
 			) {
 				discountedPrice = introductoryOfferPrices.introOfferCost || undefined;


### PR DESCRIPTION
#### Proposed Changes

* Fix displaying 1$ intro offer for jetpack_backup_tier_1

#### Testing Instructions

* (a11n only) Enable store sandbox on your sandbox
* Run calypso green env `yarn start-jetpack-cloud`
* Enter the pricing page `http://jetpack.cloud.localhost:3000/pricing`
* The displayed price of VaultPress Backup should be 1 USD/EUR instead of a small amount (e.g., 0.08 EUR)

Related to #68631
