### PR TITLE
i18n: Fix adding preloaded translations batch throttling

### DIFF
--- a/client/lib/i18n-utils/switch-locale.js
+++ b/client/lib/i18n-utils/switch-locale.js
@@ -366,15 +366,11 @@ export default async function switchLocale( localeSlug ) {
 			);
 
 			// Add preloaded translation chunks
-			Promise.all(
-				preloadedTranslatedInstalledChunks.map( ( chunkId ) =>
-					getTranslationChunkFile( chunkId, localeSlug )
-				)
-			).then( ( allTranslations ) =>
-				addTranslations(
-					allTranslations.reduce( ( acc, translations ) => Object.assign( acc, translations ), {} )
-				)
+			const preloadedTranslations = preloadedTranslatedInstalledChunks.reduce(
+				( acc, chunkId ) => Object.assign( acc, window.i18nTranslationChunks?.[ chunkId ] ),
+				{}
 			);
+			addTranslations( preloadedTranslations );
 
 			// Load individual translation chunks
 			translatedInstalledChunksToBeLoaded.forEach( ( chunkId ) =>


### PR DESCRIPTION
Currently, the preloaded translation chunks are [being added asynchronously](https://github.com/Automattic/wp-calypso/blob/trunk/client/lib/i18n-utils/switch-locale.js#L368), which creates a racing condition between preloaded translations and the [require translation chunks handler](https://github.com/Automattic/wp-calypso/blob/trunk/client/lib/i18n-utils/switch-locale.js#L282), causing the former to be [throttled by 50ms](https://github.com/Automattic/wp-calypso/blob/trunk/client/lib/i18n-utils/switch-locale.js#L587-L592) in some cases.

This PR drops the use of `Promise.all()` for the preloaded chunks in order to make sure the translations are being added in the `i18n-calypso` instance all at once with no delay.

#### Proposed Changes

* Drop the use of promises for adding preloaded translations 

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout branch and run locally with `BUILD_TRANSLATION_CHUNKS=true ENABLE_FEATURES=use-translation-chunks yarn start`
* Change UI language to a Mag-16
* Navigate through different screens in Calypso and check for regression with missing preloaded translations.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1673435602868809-slack-C74C3THK7
