### PR TITLE
WooExpress: Add WaitForAtomic step

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -311,3 +311,9 @@ button {
 		margin-top: 25vh;
 	}
 }
+
+.wooexpress {
+	.flow-progress.progress-bar {
+		display: none;
+	}
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/assign-trial-plan/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/assign-trial-plan/index.tsx
@@ -1,8 +1,10 @@
 import { StepContainer } from '@automattic/onboarding';
+import { useSelect } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
 import { useEffect } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
+import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import wpcom from 'calypso/lib/wp';
 import type { Step } from '../../types';
@@ -17,6 +19,7 @@ export enum AssignTrialResult {
 const AssignTrialPlanStep: Step = function AssignTrialPlanStep( { navigation, data } ) {
 	const { submit } = navigation;
 	const { __ } = useI18n();
+	const stepProgress = useSelect( ( select ) => select( ONBOARD_STORE ).getStepProgress() );
 
 	useEffect( () => {
 		if ( submit ) {
@@ -63,6 +66,7 @@ const AssignTrialPlanStep: Step = function AssignTrialPlanStep( { navigation, da
 						<LoadingEllipsis />
 					</>
 				}
+				stepProgress={ stepProgress }
 				showFooterWooCommercePowered={ false }
 			/>
 		</>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/wait-for-atomic/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/wait-for-atomic/index.tsx
@@ -32,13 +32,17 @@ export const transferStates = {
 
 const wait = ( ms: number ) => new Promise( ( res ) => setTimeout( res, ms ) );
 
-const WaitForAtomic: Step = function WaitForAtomic( { navigation } ) {
+const WaitForAtomic: Step = function WaitForAtomic( { navigation, data } ) {
 	const { submit } = navigation;
 	const { setPendingAction, setProgress } = useDispatch( ONBOARD_STORE );
 	const { requestLatestAtomicTransfer } = useDispatch( SITE_STORE );
 	const site = useSite();
 
-	const siteId = site?.ID;
+	let siteId = site?.ID as number;
+	// In some cases, we get the siteId from the navigation extra data rather than the SITE_STORE.
+	if ( data?.siteId ) {
+		siteId = data?.siteId as number;
+	}
 
 	const { getSiteLatestAtomicTransfer, getSiteLatestAtomicTransferError } = useSelect( ( select ) =>
 		select( SITE_STORE )
@@ -130,7 +134,7 @@ const WaitForAtomic: Step = function WaitForAtomic( { navigation } ) {
 
 			setProgress( 1 );
 
-			return { finishedWaitingForAtomic: true };
+			return { finishedWaitingForAtomic: true, siteSlug: data?.siteSlug };
 		} );
 
 		submit?.();


### PR DESCRIPTION
#### Proposed Changes

Similar to how we handle the tailored ecommerce flow, this adds the `WaitForAtomic` step to the WooExpress flow to ensure that we don't redirect to the dashboard until the Atomic transfer is complete.

#### Testing Instructions

1. Apply this branch and visit http://calypso.localhost:3000/setup/wooexpress/.
2. You should go through the following steps
  a. `siteCreationStep`
  b. `processing`
  c. `assignTrialPlan`
  d. `waitForAtomic`
  e. `processing`
3. Once that's done, you should be redirected to the dashboard and the site should be fully transferred to Atomic.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [NA] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [NA] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [NA] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [NA] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [NA] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #71868
