### PR TITLE
Allow 3-year to monthly downgrades in the cancel flow

### DIFF
--- a/client/components/marketing-survey/cancel-purchase-form/get-upsell-type.ts
+++ b/client/components/marketing-survey/cancel-purchase-form/get-upsell-type.ts
@@ -5,6 +5,7 @@ import {
 	isWpComPremiumPlan,
 	isWpComAnnualPlan,
 	isWpComBiennialPlan,
+	isWpComTriennialPlan,
 	isWpComEcommercePlan,
 } from '@automattic/calypso-products';
 
@@ -59,7 +60,9 @@ export function getUpsellType( reason: string, opts: UpsellOptions ): UpsellType
 
 			if (
 				canRefund &&
-				( isWpComAnnualPlan( productSlug ) || isWpComBiennialPlan( productSlug ) )
+				( isWpComAnnualPlan( productSlug ) ||
+					isWpComBiennialPlan( productSlug ) ||
+					isWpComTriennialPlan( productSlug ) )
 			) {
 				return 'downgrade-monthly';
 			}


### PR DESCRIPTION
#### Proposed Changes

Three year plans should also be downgrade-able from the reason/solutions in the cancel flow

#### Testing Instructions

1. Purchase 3-year Personal, for example
2. Proceed to /me/purchases and cancel
3. In the survey, select that the plan was too expensive and you want a cheaper plan. You should see a proposal for a partial refund and switching to monthly payments
4. Downgrade
5. Make sure you're on a monthly plan and you got a partial refund

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
