### PR TITLE
Allow users to pass typing site address in the import page

### DIFF
--- a/client/blocks/import/capture/capture-input.tsx
+++ b/client/blocks/import/capture/capture-input.tsx
@@ -6,7 +6,8 @@ import { sprintf } from '@wordpress/i18n';
 import { Icon, info } from '@wordpress/icons';
 import classnames from 'classnames';
 import { localize, translate } from 'i18n-calypso';
-import React, { ChangeEvent, FormEvent, useState } from 'react';
+import React, { ChangeEvent, FormEvent, useState, useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
 import { CAPTURE_URL_RGX } from 'calypso/blocks/import/util';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
@@ -31,6 +32,20 @@ const CaptureInput: FunctionComponent< Props > = ( props ) => {
 	const [ submitted, setSubmitted ] = useState( false );
 	const exampleInputWebsite = 'www.artfulbaker.blog';
 	const showValidationMsg = hasError || ( submitted && ! isValid );
+	const { search } = useLocation();
+
+	useEffect( () => {
+		const urlValue = new URLSearchParams( search ).get( 'from' );
+		if ( urlValue ) {
+			const isValid = CAPTURE_URL_RGX.test( urlValue );
+			if ( isValid ) {
+				onInputEnter( urlValue );
+				setSubmitted( true );
+			} else {
+				setUrlValue( urlValue );
+			}
+		}
+	}, [] );
 
 	function validateUrl( url: string ) {
 		const isValid = CAPTURE_URL_RGX.test( url );

--- a/client/blocks/import/capture/capture-input.tsx
+++ b/client/blocks/import/capture/capture-input.tsx
@@ -34,7 +34,9 @@ const CaptureInput: FunctionComponent< Props > = ( props ) => {
 	const showValidationMsg = hasError || ( submitted && ! isValid );
 	const { search } = useLocation();
 
-	useEffect( () => {
+	useEffect( () => checkInitSubmissionState(), [] );
+
+	function checkInitSubmissionState() {
 		const urlValue = new URLSearchParams( search ).get( 'from' ) || '';
 		if ( urlValue ) {
 			const isValid = CAPTURE_URL_RGX.test( urlValue );
@@ -45,7 +47,7 @@ const CaptureInput: FunctionComponent< Props > = ( props ) => {
 				setUrlValue( urlValue );
 			}
 		}
-	}, [] );
+	}
 
 	function validateUrl( url: string ) {
 		const isValid = CAPTURE_URL_RGX.test( url );

--- a/client/blocks/import/capture/capture-input.tsx
+++ b/client/blocks/import/capture/capture-input.tsx
@@ -35,7 +35,7 @@ const CaptureInput: FunctionComponent< Props > = ( props ) => {
 	const { search } = useLocation();
 
 	useEffect( () => {
-		const urlValue = new URLSearchParams( search ).get( 'from' );
+		const urlValue = new URLSearchParams( search ).get( 'from' ) || '';
 		if ( urlValue ) {
 			const isValid = CAPTURE_URL_RGX.test( urlValue );
 			if ( isValid ) {

--- a/client/landing/stepper/declarative-flow/import-flow.ts
+++ b/client/landing/stepper/declarative-flow/import-flow.ts
@@ -149,7 +149,7 @@ const importFlow: Flow = {
 				case 'importerSquarespace':
 				case 'importerWordpress':
 				case 'designSetup':
-					return navigate( 'import' );
+					return navigate( `import?siteSlug=${ siteSlugParam }` );
 			}
 		};
 
@@ -166,6 +166,8 @@ const importFlow: Flow = {
 			switch ( step ) {
 				case 'goals':
 					return exitFlow( `/setup/site-setup/goals?siteSlug=${ siteSlugParam }` );
+				case 'import':
+					return navigate( `import?siteSlug=${ siteSlugParam }` );
 				default:
 					return navigate( step );
 			}


### PR DESCRIPTION
#### Proposed Changes

* To reduce the steps for users from the migration plugin, if users come to the import step with `from` query string, we can skip the page where they type in their site address and proceed to the next step.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to `http://calypso.localhost:3000/setup/import-focused/import?siteSlug=${YOUR_TARGET_SITE}&from=${YOUR_SOURCE_SITE}`
* See if you skip the step to type in the site address and get the loading screen and go straight to the next step. (`importReadyPreview` or `importReadyNot` screen)

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
