### PR TITLE
add: Add plan params to copy site url

### DIFF
--- a/client/sites-dashboard/components/sites-ellipsis-menu.tsx
+++ b/client/sites-dashboard/components/sites-ellipsis-menu.tsx
@@ -184,13 +184,19 @@ const CopySiteItem = ( { recordTracks, site }: SitesMenuItemProps ) => {
 	const { __ } = useI18n();
 	const hasAtomicFeature = useSafeSiteHasFeature( site.ID, WPCOM_FEATURES_ATOMIC );
 	const userId = useSelector( ( state ) => getCurrentUserId( state ) );
+	const plan = site.plan;
 	const isSiteOwner = site.site_owner === userId;
 
-	if ( ! hasAtomicFeature || ! isSiteOwner ) {
+	if ( ! hasAtomicFeature || ! isSiteOwner || ! plan ) {
 		return null;
 	}
 
+	const planId = plan.product_id;
+	const billingPeriod = plan.billing_period || 'ANNUALLY';
+
 	const copySiteHref = addQueryArgs( `/setup/copy-site`, {
+		billingPeriod,
+		planId,
 		sourceSite: site.ID,
 		sourceUrl: site.URL,
 	} );


### PR DESCRIPTION
#### Proposed Changes

Add plan info in copy site URL. More specifically, `planId` and `billingPeriod`, are now added in the copy sites url

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Go to /sites and click on Create a copy of this site.
2. Observe the source URL is present

![copy_site_plan_info](https://user-images.githubusercontent.com/497103/211827190-7ea9f400-fccd-4a14-b007-07d4b7291c11.png)


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to to #https://github.com/Automattic/dotcom-forge/issues/1468
