### PR TITLE
Update free flow site preview default device

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/launchpad-site-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/launchpad-site-preview.tsx
@@ -1,6 +1,6 @@
 import { FEATURE_VIDEO_UPLOADS, planHasFeature } from '@automattic/calypso-products';
 import { DEVICE_TYPES } from '@automattic/components';
-import { NEWSLETTER_FLOW } from '@automattic/onboarding';
+import { FREE_FLOW, NEWSLETTER_FLOW } from '@automattic/onboarding';
 import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import WebPreview from 'calypso/components/web-preview/component';
@@ -24,7 +24,7 @@ const LaunchpadSitePreview = ( {
 
 	let previewUrl = siteSlug ? 'https://' + siteSlug : null;
 	const devicesToShow: Device[] = [ DEVICE_TYPES.COMPUTER, DEVICE_TYPES.PHONE ];
-	let defaultDevice = flow === NEWSLETTER_FLOW ? DEVICE_TYPES.COMPUTER : DEVICE_TYPES.PHONE;
+	let defaultDevice = getSitePreviewDefaultDevice( flow );
 	let loadingMessage = translate( '{{strong}}One moment, please…{{/strong}} loading your site.', {
 		components: { strong: <strong /> },
 	} );
@@ -68,6 +68,17 @@ const LaunchpadSitePreview = ( {
 			do_preview_no_interactions: ! isVideoPressFlow,
 			...( globalStylesInUse && shouldLimitGlobalStyles && { 'preview-global-styles': true } ),
 		} );
+	}
+
+	function getSitePreviewDefaultDevice( flow: string | null ) {
+		switch ( flow ) {
+			case NEWSLETTER_FLOW:
+				return DEVICE_TYPES.COMPUTER;
+			case FREE_FLOW:
+				return DEVICE_TYPES.COMPUTER;
+			default:
+				return DEVICE_TYPES.PHONE;
+		}
 	}
 
 	return (


### PR DESCRIPTION
#### Proposed Changes

* Adds a function to set Launchpad site preview default device based on flow.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this branch
* Create a new link-in-bio, newsletter, free flow site, or use an existing site. You can reuse the same site slug for the tests below.
* Confirm newsletter flow launchpad site preview defaults to desktop view: `/setup/newsletter/launchpad?siteSlug={siteSlug}`
* Confirm link-in-bio flow launchpad site preview defaults to mobile view: `/setup/link-in-bio/launchpad?siteSlug={siteSlug}`
* Confirm free flow launchpad site preview defaults to desktop view: `/setup/free/launchpad?siteSlug={siteSlug}`

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
