### PR TITLE
Fix display price if no intro offer is found

### DIFF
--- a/client/my-sites/plans/jetpack-plans/use-item-price.ts
+++ b/client/my-sites/plans/jetpack-plans/use-item-price.ts
@@ -176,7 +176,10 @@ const useItemPrice = (
 				)
 			) {
 				discountedPrice = introductoryOfferPrices.introOfferCost || undefined;
-				discountedPriceDuration = 1;
+
+				if ( discountedPrice ) {
+					discountedPriceDuration = 1;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
#### Proposed Changes

* Fix displaying subtle text when no intro offer applied

#### Testing Instructions

* Ensure that you use the production store
* Run calypso green env `yarn start-jetpack-cloud`
* Enter the pricing page `http://jetpack.cloud.localhost:3000/pricing`
* VaultPress Backup should have "/month, billed yearly" subtle text, instead "for the first month, billed yearly":
<img width="624" alt="CleanShot 2023-01-11 at 16 57 30@2x" src="https://user-images.githubusercontent.com/8419292/211854169-1a59a677-e41c-4f3a-9829-a26f4843aa76.png">

* Jetpack Social should be without a change:
<img width="618" alt="CleanShot 2023-01-11 at 17 04 40@2x" src="https://user-images.githubusercontent.com/8419292/211855802-56c7a415-e615-4301-9e1c-7f2486bc3cde.png">



Related to #68631
