### PR TITLE
Checkout: hide discount percentage in variant picker if purchase is jetpack

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/item-variation-picker/variant-dropdown-price.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/item-variation-picker/variant-dropdown-price.tsx
@@ -1,3 +1,4 @@
+import { isJetpackPlan, isJetpackProduct } from '@automattic/calypso-products';
 import formatCurrency from '@automattic/format-currency';
 import { useMobileBreakpoint } from '@automattic/viewport-react';
 import { styled } from '@automattic/wpcom-checkout';
@@ -105,6 +106,7 @@ export const ItemVariantDropDownPrice: FunctionComponent< {
 	compareTo?: WPCOMProductVariant;
 } > = ( { variant, compareTo } ) => {
 	const isMobile = useMobileBreakpoint();
+	const isJetpack = isJetpackPlan( variant ) || isJetpackProduct( variant );
 	const compareToPriceForVariantTerm = getItemVariantCompareToPrice( variant, compareTo );
 	const discountPercentage = getItemVariantDiscountPercentage( variant, compareTo );
 	const formattedCurrentPrice = formatCurrency( variant.priceInteger, variant.currency, {
@@ -224,15 +226,15 @@ export const ItemVariantDropDownPrice: FunctionComponent< {
 		<Variant>
 			<Label>
 				{ variant.variantLabel }
-				{ discountPercentage > 0 && isMobile && (
+				{ discountPercentage > 0 && ! isJetpack && isMobile && (
 					<DiscountPercentage percent={ discountPercentage } />
 				) }
 			</Label>
 			<PriceTextContainer>
-				{ discountPercentage > 0 && ! isMobile && ! isIntroductoryOffer && (
+				{ discountPercentage > 0 && ! isJetpack && ! isMobile && ! isIntroductoryOffer && (
 					<DiscountPercentage percent={ discountPercentage } />
 				) }
-				{ discountPercentage > 0 && ! isIntroductoryOffer && (
+				{ discountPercentage > 0 && ! isJetpack && ! isIntroductoryOffer && (
 					<DoNotPayThis>{ formattedCompareToPriceForVariantTerm }</DoNotPayThis>
 				) }
 				<Price aria-hidden={ isIntroductoryOffer }>{ formattedCurrentPrice }</Price>


### PR DESCRIPTION
#### Proposed Changes

* per 1199980337313591-as-1203595785054343/f and p1671636858945399-slack-C03RCHNVC0H jetpack products should NOT show the price before discount on the variation dropdowns.  This PR hides those sections if the product or plan is Jetpack (WP.com may still wish to display that)
* The code checks the product variant against the isJetpackPlan and isJetpackProduct functions and if true the "original" price and discount percent are not displayed.

Before:

![before](https://user-images.githubusercontent.com/12895386/212057185-0a1a92f2-94c8-4069-ad5f-728b9dbb39c1.png)

After:

![after](https://user-images.githubusercontent.com/12895386/212057223-da3a4934-121d-48e2-a9d7-ee562a92bb39.png)

#### Testing Instructions

* using a jetpack site, add a product with a discount (like videopress) to your cart.  Head over to the Calyspo live link and append /checkout/:site to the URL
* Click the variation dropdown, confirm there's no discount percent pricing showing.  Then, select the other variation.
* Click the drop down again to verify there's still no discount showing.
* Verify wp.com still shows the extra info by adding a wordpress.com plan to a wp.com site's cart.  Repeat the same steps above, but make sure there is a discount displaying

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - 0-as-1203595785054343