### PR TITLE
Removed weeks, months and years from the chart in Email Stats page

### DIFF
--- a/client/blocks/stats-navigation/constants.js
+++ b/client/blocks/stats-navigation/constants.js
@@ -10,7 +10,7 @@ const month = { value: 'month', label: translate( 'Months' ) };
 const year = { value: 'year', label: translate( 'Years' ) };
 
 export const intervals = [ day, week, month, year ];
-export const emailIntervals = [ hour, day, week, month, year ];
+export const emailIntervals = [ hour, day ];
 
 /**
  * Nav items

--- a/client/my-sites/stats/index.js
+++ b/client/my-sites/stats/index.js
@@ -26,7 +26,7 @@ const statsPage = ( url, controller ) => {
 
 export default function () {
 	const validPeriods = [ 'day', 'week', 'month', 'year' ].join( '|' );
-	const validEmailPeriods = [ 'hour', 'day', 'week', 'month', 'year' ].join( '|' );
+	const validEmailPeriods = [ 'hour', 'day' ].join( '|' );
 
 	const validModules = [
 		'posts',

--- a/client/my-sites/stats/stats-email-chart-tabs/index.jsx
+++ b/client/my-sites/stats/stats-email-chart-tabs/index.jsx
@@ -115,8 +115,7 @@ const connectComponent = connect(
 			return NO_SITE_STATE;
 		}
 
-		let quantity = 'year' === period ? 10 : 30;
-		quantity = 'hour' === period ? 24 : quantity;
+		const quantity = 'hour' === period ? 24 : 30;
 		const counts = getCountRecords( state, siteId, postId, period, statType );
 		const chartData = buildChartData( activeLegend, chartTab, counts, period, queryDate );
 		const isActiveTabLoading = isLoadingTabs( state, siteId, postId, period, statType );

--- a/client/my-sites/stats/stats-email-chart-tabs/utility.js
+++ b/client/my-sites/stats/stats-email-chart-tabs/utility.js
@@ -7,17 +7,13 @@ import memoizeLast from 'calypso/lib/memoize-last';
 import { rangeOfPeriod } from 'calypso/state/stats/lists/utils';
 
 export function formatDate( date, period ) {
-	// NOTE: Consider localizing the dates, especially for the 'week' case.
+	// NOTE: Consider localizing the dates.
 	const momentizedDate = moment( date );
 	switch ( period ) {
+		case 'hour':
+			return momentizedDate.format( 'HH:mm' );
 		case 'day':
 			return momentizedDate.format( 'LL' );
-		case 'week':
-			return momentizedDate.format( 'L' ) + ' - ' + momentizedDate.add( 6, 'days' ).format( 'L' );
-		case 'month':
-			return momentizedDate.format( 'MMMM YYYY' );
-		case 'year':
-			return momentizedDate.format( 'YYYY' );
 		default:
 			return null;
 	}

--- a/client/state/stats/emails/actions.js
+++ b/client/state/stats/emails/actions.js
@@ -19,7 +19,7 @@ import 'calypso/state/stats/init';
  *
  * @param  {number} siteId Site ID
  * @param  {number} postId Email Id
- * @param  {string} period Unit for each element of the returned array (ie: 'year', 'month', ...)
+ * @param  {string} period Unit for each element of the returned array (ie: 'hour' or 'day')
  * @param  {string} statType The type of stat we are working with. For example: 'opens' for Email Open stats
  * @param  {object}  stats  The received stats
  * @returns {object}        Action object
@@ -78,7 +78,7 @@ function emailOpenStatsAlltimeTransform( stats ) {
  *
  * @param  {number} siteId Site ID
  * @param  {number} postId Email Id
- * @param  {string} period Unit for each element of the returned array (ie: 'year', 'month', ...)
+ * @param  {string} period Unit for each element of the returned array (ie: 'hour' or 'day')
  * @param  {string?} date A date in YYYY-MM-DD or YYYY-MM-DDTHH:mm:ss format
  * @param  {number} quantity The number of elements retrieved in the array
  */
@@ -92,11 +92,8 @@ function requestEmailOpensStats( siteId, postId, period, date, quantity ) {
 			statType: 'opens',
 		} );
 
-		// set defaults for year and hour
+		// set defaults for hour
 		const queryQuantity = ( () => {
-			if ( period === 'year' ) {
-				return 10;
-			}
 			if ( period === 'hour' ) {
 				return 24;
 			}
@@ -144,7 +141,7 @@ function requestEmailOpensStats( siteId, postId, period, date, quantity ) {
  *
  * @param  {number} siteId Site ID
  * @param  {number} postId Email Id
- * @param  {string} period Unit for each element of the returned array (ie: 'year', 'month', ...)
+ * @param  {string} period Unit for each element of the returned array (ie: 'hour' or 'day')
  * @param  {string} date A date in YYYY-MM-DD or YYYY-MM-DDTHH:mm:ss format
  * @param  {string} statType The type of stat we are working with. For example: 'opens' for Email Open stats
  * @param  {number} quantity The number of elements retrieved in the array


### PR DESCRIPTION
#### Proposed Changes

This PR removes the unneeded periods from the chart in the Email Stats Page. These periods are `weeks`, `months` and `years`:

<img width="1082" alt="Screenshot 2023-01-11 at 17 14 59" src="https://user-images.githubusercontent.com/3832570/211863398-2273a081-87db-4e25-9461-a01394317887.png">

#### Why do we want to do that?

Unlike posts, emails are not something that the user would revisit with time. Normally, the email will be open, read, and then archived or deleted. In very rare cases the email is left there to open it later. That makes `weeks`, `months` and `years` periods very well fitted for posts, but not very useful for emails.

#### Testing Instructions

1. Apply this branch to your local Calypso repository and start the application.
2. Insert manually in the browser address bar an URL with this format: https://calypso.localhost:3000/stats/email/open/[the-doomain-of-your-blog]/day/[post-id]?flags=newsletter/stats. Note that you can change day for week and month.
3. Check that the graph has only two periods, `hours` and `days`, like this:
<img width="1103" alt="Screenshot 2023-01-11 at 17 40 15" src="https://user-images.githubusercontent.com/3832570/211864422-93b11b53-3efd-4013-8ec7-33881c7959e3.png">

Fixes https://github.com/Automattic/wp-calypso/issues/71940
