### PR TITLE
Add unit test covering checkout when 3rd position is not site fragment

### DIFF
--- a/client/lib/route/test/index.js
+++ b/client/lib/route/test/index.js
@@ -161,6 +161,13 @@ describe( 'route', function () {
 					)
 				).toEqual( 'example.wordpress.com' );
 			} );
+			test( 'should return the correct site fragment when site fragment is not found in 3rd position', function () {
+				expect(
+					route.getSiteFragment(
+						'/checkout/thank-you/features/all-free-features/example.wordpress.com/12345678'
+					)
+				).toEqual( 'example.wordpress.com' );
+			} );
 		} );
 		describe( 'for jetpack paths', function () {
 			test( 'should return correct site fragment when site_url is trailing slashed', function () {

--- a/client/lib/route/test/index.js
+++ b/client/lib/route/test/index.js
@@ -161,7 +161,7 @@ describe( 'route', function () {
 					)
 				).toEqual( 'example.wordpress.com' );
 			} );
-			test( 'should return the correct site fragment when site fragment is not found in 3rd position', function () {
+			test( 'should return the correct site fragment when it is found outside the 3rd position', function () {
 				expect(
 					route.getSiteFragment(
 						'/checkout/thank-you/features/all-free-features/example.wordpress.com/12345678'


### PR DESCRIPTION
#### Proposed Changes

* Add unit test for `getSiteFragment` covering checkout when 3rd position is not a site fragment e.g. /checkout/thank-you/features/all-free-features/example.wordpress.com/12345

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Unit tests pass

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
