### PR TITLE
Show domain information to user if migrate the site using plugin

### DIFF
--- a/client/blocks/importer/components/domain-info/index.tsx
+++ b/client/blocks/importer/components/domain-info/index.tsx
@@ -1,0 +1,24 @@
+/* eslint-disable wpcalypso/jsx-classname-namespace */
+
+import { __ } from '@wordpress/i18n';
+import Badge from 'calypso/components/badge';
+import './style.scss';
+
+interface Props {
+	domain: string;
+}
+
+const DomainInfo: React.FunctionComponent< Props > = ( { domain } ) => {
+	return (
+		<div className="temp-domain-item">
+			<div className="temp-domain-item__label">{ __( 'Your temporary site is:' ) }</div>
+			<div className="temp-domain-item__description">
+				<span>{ domain }</span>
+				<Badge className="temp-domain-item__primary-badge" type="info-green">
+					{ __( 'New' ) }
+				</Badge>
+			</div>
+		</div>
+	);
+};
+export default DomainInfo;

--- a/client/blocks/importer/components/domain-info/style.scss
+++ b/client/blocks/importer/components/domain-info/style.scss
@@ -8,13 +8,13 @@
 	align-items: flex-start;
 	justify-content: space-between;
 	padding: 16px;
+	margin: 24px auto;
 	background-color: var(--studio-gray-0);
 	font-size: $font-body-small;
 	color: var(--studio-gray-80);
 	max-width: 486px;
 
 	@include break-mobile {
-		margin: 24px auto;
 		align-items: start;
 		padding: 24px;
 	}

--- a/client/blocks/importer/components/domain-info/style.scss
+++ b/client/blocks/importer/components/domain-info/style.scss
@@ -1,0 +1,51 @@
+@import "@automattic/typography/styles/variables";
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
+.temp-domain-item {
+	display: flex;
+	flex-direction: column;
+	align-items: flex-start;
+	justify-content: space-between;
+	padding: 16px;
+	background-color: var(--studio-gray-0);
+    font-size: $font-body-small;
+	color: var(--studio-gray-80);
+    max-width: 486px;
+
+	@include break-mobile {
+		margin: 24px auto;
+		align-items: start;
+		padding: 24px;
+	}
+
+	& &__primary-badge {
+		font-size: $font-body-extra-small;
+		border-radius: 4px;
+		font-weight: 500;
+
+		@include break-mobile {
+			margin-top: 0;
+			margin-left: 12px;
+		}
+	}
+
+	&__manage-button {
+		background: none;
+	}
+
+	.temp-domain-item__description {
+        box-sizing: border-box;
+        display: flex;
+        width: 100%;
+        justify-content: space-between;
+		font-size: $font-body-small;
+		color: var(--studio-gray-80);
+		background: var( --studio-white );
+        padding: 8px 16px;
+	}
+
+    .temp-domain-item__label {
+		margin-bottom: 16px;
+	}
+}

--- a/client/blocks/importer/components/domain-info/style.scss
+++ b/client/blocks/importer/components/domain-info/style.scss
@@ -9,9 +9,9 @@
 	justify-content: space-between;
 	padding: 16px;
 	background-color: var(--studio-gray-0);
-    font-size: $font-body-small;
+	font-size: $font-body-small;
 	color: var(--studio-gray-80);
-    max-width: 486px;
+	max-width: 486px;
 
 	@include break-mobile {
 		margin: 24px auto;
@@ -35,17 +35,17 @@
 	}
 
 	.temp-domain-item__description {
-        box-sizing: border-box;
-        display: flex;
-        width: 100%;
-        justify-content: space-between;
+		box-sizing: border-box;
+		display: flex;
+		width: 100%;
+		justify-content: space-between;
 		font-size: $font-body-small;
 		color: var(--studio-gray-80);
-		background: var( --studio-white );
-        padding: 8px 16px;
+		background: var(--studio-white);
+		padding: 8px 16px;
 	}
 
-    .temp-domain-item__label {
+	.temp-domain-item__label {
 		margin-bottom: 16px;
 	}
 }

--- a/client/blocks/importer/components/domain-info/style.scss
+++ b/client/blocks/importer/components/domain-info/style.scss
@@ -30,10 +30,6 @@
 		}
 	}
 
-	&__manage-button {
-		background: none;
-	}
-
 	.temp-domain-item__description {
 		box-sizing: border-box;
 		display: flex;

--- a/client/blocks/importer/components/done-button/index.tsx
+++ b/client/blocks/importer/components/done-button/index.tsx
@@ -10,6 +10,8 @@ interface Props {
 	label?: string;
 	resetImport?: ( siteId: number, importerId: string ) => void;
 	onSiteViewClick?: () => void;
+	className?: string;
+	isPrimary?: boolean;
 }
 const DoneButton: React.FunctionComponent< Props > = ( props ) => {
 	const { __ } = useI18n();
@@ -21,14 +23,27 @@ const DoneButton: React.FunctionComponent< Props > = ( props ) => {
 			: __( 'View site' ),
 		resetImport,
 		onSiteViewClick,
+		className,
+		isPrimary = true,
 	} = props;
+
+	const isSecondary = isPrimary ? false : true;
 
 	function onButtonClick() {
 		onSiteViewClick?.();
 		job && siteId && resetImport && resetImport( siteId, job?.importerId );
 	}
 
-	return <NextButton onClick={ onButtonClick }>{ label }</NextButton>;
+	return (
+		<NextButton
+			isPrimary={ isPrimary }
+			isSecondary={ isSecondary }
+			className={ className }
+			onClick={ onButtonClick }
+		>
+			{ label }
+		</NextButton>
+	);
 };
 
 export default DoneButton;

--- a/client/blocks/importer/types.ts
+++ b/client/blocks/importer/types.ts
@@ -16,6 +16,7 @@ export type StepNavigator = {
 	goToWpAdminImportPage?: () => void;
 	goToWpAdminWordPressPluginPage?: () => void;
 	navigate?: ( path: string ) => void;
+	goToAddDomainPage?: () => void;
 };
 
 export interface ImportError {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/importer/hooks/use-step-navigator.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/importer/hooks/use-step-navigator.ts
@@ -81,6 +81,13 @@ export function useStepNavigator(
 		return addQueryArgs( queryParams, path );
 	}
 
+	function goToAddDomainPage() {
+		navigation.submit?.( {
+			type: 'redirect',
+			url: `/domains/add/${ siteSlug }`,
+		} );
+	}
+
 	return {
 		supportLinkModal: false,
 		goToIntentPage,
@@ -89,6 +96,7 @@ export function useStepNavigator(
 		goToCheckoutPage,
 		goToWpAdminImportPage,
 		goToWpAdminWordPressPluginPage,
+		goToAddDomainPage,
 		navigate: ( path ) => navigator( path ),
 	};
 }

--- a/packages/onboarding/src/hooray/style.scss
+++ b/packages/onboarding/src/hooray/style.scss
@@ -17,9 +17,15 @@
 		margin-bottom: 1.5em;
 	}
 
-	.components-button.action-buttons__next.is-primary {
+	.components-button.action_buttons__button.action-buttons__next.is-primary {
 		min-width: 100px;
-		padding: 0;
+		padding: 10px 24px;
+	}
+
+	.components-button.action-buttons__next.is-secondary {
+		min-width: 100px;
+		margin-left: 24px;
+		padding: 10px 24px;
 	}
 }
 

--- a/packages/onboarding/src/hooray/style.scss
+++ b/packages/onboarding/src/hooray/style.scss
@@ -1,3 +1,6 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
 .onboarding-hooray {
 	text-align: center;
 
@@ -17,15 +20,19 @@
 		margin-bottom: 1.5em;
 	}
 
-	.components-button.action_buttons__button.action-buttons__next.is-primary {
+	.components-button.is-normal-width.action-buttons__next.is-primary {
 		min-width: 100px;
 		padding: 10px 24px;
 	}
 
 	.components-button.action-buttons__next.is-secondary {
 		min-width: 100px;
-		margin-left: 24px;
+		margin-left: 8px;
 		padding: 10px 24px;
+
+		@include break-mobile {
+			margin-left: 24px;
+		}
 	}
 }
 


### PR DESCRIPTION
#### Proposed Changes

* If a user comes from the migration plugin and starts from the `siteCreationStep`, we'll offer them to add domain at the end of the migration progress. 

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Launch a [JN site with migration plugin](https://jurassic.ninja/create/?jetpack-beta&branches.jetpack-migration=add/migration-plugin&wp-debug-log) and click `Set up Jetpack` to connect the site to your target site user account, or use any self-hosted site you've already connected to your target user account. 
* Once it's done, navigate to `http://calypso.localhost:3000/setup/import-focused/siteCreationStep?from=${TARGET_SITE_SLUG}`. The `TARGET_SITE_SLUG` here should be the site you want to migrate. For example, a testing Jurassic Ninja site.
* Going through and finishing the migration process.
* Once it's finished, see if you get a screenshot with your domain information.
![Screen Shot 2023-01-12 at 1 20 38 AM](https://user-images.githubusercontent.com/4074459/211873786-bd558f7d-1bf7-4bdf-ba00-c8967c149c62.png)
* Click `Update domain name` button and see if it brings you to the `domains/add/${SITE_SLUG}` page.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
