### PR TITLE
Stats: Refactor posting activity legend with StatsHeatMapLegend

### DIFF
--- a/client/my-sites/stats/post-trends/index.jsx
+++ b/client/my-sites/stats/post-trends/index.jsx
@@ -9,6 +9,7 @@ import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import compareProps from 'calypso/lib/compare-props';
 import { getSiteOption } from 'calypso/state/sites/selectors';
 import { getSiteStatsPostStreakData } from 'calypso/state/stats/lists/selectors';
+import StatsHeatMapLegend from '../stats-heap-map/legend';
 import Month from './month';
 
 import './style.scss';
@@ -52,25 +53,15 @@ class PostTrends extends Component {
 					<div ref={ this.yearRef } className="post-trends__year">
 						{ this.getMonthComponents() }
 					</div>
-					<div className="post-trends__key-container">
-						<span className="post-trends__key-label">
-							{ translate( 'Fewer Posts', {
-								context: 'Legend label in stats post trends visualization',
-							} ) }
-						</span>
-						<ul className="post-trends__key">
-							<li className="post-trends__key-day is-today" />
-							<li className="post-trends__key-day is-level-1" />
-							<li className="post-trends__key-day is-level-2" />
-							<li className="post-trends__key-day is-level-3" />
-							<li className="post-trends__key-day is-level-4" />
-						</ul>
-						<span className="post-trends__key-label">
-							{ translate( 'More Posts', {
-								context: 'Legend label in stats post trends visualization',
-							} ) }
-						</span>
-					</div>
+
+					<StatsHeatMapLegend
+						labelFewer={ translate( 'Fewer Posts', {
+							context: 'Legend label in stats post trends visualization',
+						} ) }
+						labelMore={ translate( 'More Posts', {
+							context: 'Legend label in stats post trends visualization',
+						} ) }
+					/>
 				</div>
 			</div>
 		);

--- a/client/my-sites/stats/post-trends/style.scss
+++ b/client/my-sites/stats/post-trends/style.scss
@@ -12,6 +12,16 @@ $lowestLevelColor: var(--color-neutral-5);
 .post-trends {
 	border-bottom: 1px solid var(--studio-gray-5);
 	border-top: 1px solid var(--studio-gray-5);
+
+	.stats-heat-map__legend {
+		margin-bottom: 48px;
+	}
+
+	.stats-heat-map__legend-item {
+		&.level-1 {
+			background-color: $lowestLevelColor;
+		}
+	}
 }
 
 .post-trends__heading,
@@ -187,15 +197,5 @@ $lowestLevelColor: var(--color-neutral-5);
 		.post-count-icon {
 			margin-right: 12px;
 		}
-	}
-}
-
-.stats-heat-map__legend {
-	margin-bottom: 48px;
-}
-
-.stats-heat-map__legend-item {
-	&.level-1 {
-		background-color: $lowestLevelColor;
 	}
 }

--- a/client/my-sites/stats/post-trends/style.scss
+++ b/client/my-sites/stats/post-trends/style.scss
@@ -7,6 +7,7 @@ $font-label: "SF Pro Text", $sans;
 $mobile-layout-breakpoint: $break-small;
 $common-border-radius: 4px;
 $mobile-container-margin: 16px;
+$lowestLevelColor: var(--color-neutral-5);
 
 .post-trends {
 	border-bottom: 1px solid var(--studio-gray-5);
@@ -98,22 +99,19 @@ $mobile-container-margin: 16px;
 	width: 10px;
 	height: 10px;
 	border-radius: 2px;
-	background-color: var(--color-neutral-5);
+	background-color: $lowestLevelColor;
 
 	&:not(:first-child) {
 		margin-left: 2px;
 	}
-}
 
-.post-trends__day,
-.post-trends__key-day {
 	&.is-outside-month {
 		visibility: hidden;
 		border-color: var(--color-border-inverted);
 	}
 
 	&.is-today {
-		background-color: var(--color-neutral-5);
+		background-color: $lowestLevelColor;
 	}
 
 	&.is-after-today {
@@ -142,39 +140,6 @@ $mobile-container-margin: 16px;
 
 	.is-loading & {
 		animation: loading-fade 1.6s ease-in-out infinite;
-	}
-}
-
-.post-trends__key-container {
-	margin-top: 16px;
-	margin-bottom: 48px;
-	float: none;
-	display: flex;
-	align-items: center;
-	justify-content: center;
-}
-
-.post-trends__key-label {
-	font-weight: 400;
-	font-size: $font-body-small;
-	line-height: 18px;
-	color: var(--color-text);
-	text-transform: none;
-	letter-spacing: normal;
-}
-
-.post-trends__key {
-	border-radius: $common-border-radius;
-	overflow: hidden;
-	padding: 0;
-	margin: 0 16px;
-	list-style-type: none;
-	display: flex;
-
-	.post-trends__key-day {
-		width: 25px;
-		height: 25px;
-		margin: 0;
 	}
 }
 
@@ -222,5 +187,15 @@ $mobile-container-margin: 16px;
 		.post-count-icon {
 			margin-right: 12px;
 		}
+	}
+}
+
+.stats-heat-map__legend {
+	margin-bottom: 48px;
+}
+
+.stats-heat-map__legend-item {
+	&.level-1 {
+		background-color: $lowestLevelColor;
 	}
 }

--- a/client/my-sites/stats/stats-heap-map/legend.tsx
+++ b/client/my-sites/stats/stats-heap-map/legend.tsx
@@ -4,9 +4,11 @@ import './style.scss';
 
 interface Props {
 	levels?: number;
+	labelFewer?: string;
+	labelMore?: string;
 }
 
-export default function StatsHeatMapLegend( { levels = 5 }: Props ) {
+export default function StatsHeatMapLegend( { levels = 5, labelFewer, labelMore }: Props ) {
 	const translate = useTranslate();
 
 	const items = [ ...Array( levels ).keys() ].map( ( index ) => {
@@ -19,15 +21,19 @@ export default function StatsHeatMapLegend( { levels = 5 }: Props ) {
 	return (
 		<div className="stats-heat-map__legend">
 			<span className="stats-heat-map__legend-label">
-				{ translate( 'Fewer Views', {
-					context: 'Legend label in stats all-time views table',
-				} ) }
+				{ labelFewer
+					? labelFewer
+					: translate( 'Fewer Views', {
+							context: 'Legend label in stats all-time views table',
+					  } ) }
 			</span>
 			<ul className="stats-heat-map__legend-item-list">{ items }</ul>
 			<span className="stats-heat-map__legend-label">
-				{ translate( 'More Views', {
-					context: 'Legend label in stats all-time views table',
-				} ) }
+				{ labelMore
+					? labelMore
+					: translate( 'More Views', {
+							context: 'Legend label in stats all-time views table',
+					  } ) }
 			</span>
 		</div>
 	);

--- a/client/my-sites/stats/stats-heap-map/style.scss
+++ b/client/my-sites/stats/stats-heap-map/style.scss
@@ -11,10 +11,12 @@
 	font-weight: 400;
 	font-size: $font-body-small;
 	line-height: 18px;
-	color: #000;
+	color: var(--studio-black);
+	text-align: center;
 }
 
 .stats-heat-map__legend-item-list {
+	display: flex;
 	list-style-type: none;
 	border-radius: 4px;
 	overflow: hidden;
@@ -22,7 +24,6 @@
 }
 
 .stats-heat-map__legend-item {
-	float: left;
 	width: 25px;
 	height: 25px;
 


### PR DESCRIPTION
#### Proposed Changes

* Extend the `StatsHeatMapLegend` component for more props.
* Refactor the `Posting activity` section legend with `StatsHeatMapLegend` on the `Insights` page.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up this change with the Calypso Live link.
* Navigate to the Stats `Insights` page.
* Ensure the legend of the `Posting activity` section works as previously.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #71762 
