### PR TITLE
Add setting for writing prompt email notification

### DIFF
--- a/client/me/notification-settings/settings-form/constants.js
+++ b/client/me/notification-settings/settings-form/constants.js
@@ -1,3 +1,3 @@
 export const NOTIFICATIONS_EXCEPTIONS = {
-	email: [ 'achievement', 'scheduled_publicize', 'store_order', 'blogging_prompt' ],
+	email: [ 'achievement', 'scheduled_publicize', 'store_order' ],
 };

--- a/client/me/notification-settings/settings-form/stream-options.jsx
+++ b/client/me/notification-settings/settings-form/stream-options.jsx
@@ -2,6 +2,7 @@ import { get } from 'lodash';
 import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 import FormCheckbox from 'calypso/components/forms/form-checkbox';
+import { NOTIFICATIONS_EXCEPTIONS } from './constants';
 
 export default class extends PureComponent {
 	static displayName = 'NotificationSettingsFormStreamOptions';
@@ -23,7 +24,10 @@ export default class extends PureComponent {
 		return (
 			<ul className="notification-settings-form-stream-options">
 				{ this.props.settingKeys.map( ( setting, index ) => {
-					const isException = setting === 'blogging_prompt' && this.isDeviceStream();
+					const isException =
+						( this.props.stream in NOTIFICATIONS_EXCEPTIONS &&
+							NOTIFICATIONS_EXCEPTIONS[ this.props.stream ].indexOf( setting ) >= 0 ) ||
+						( setting === 'blogging_prompt' && this.isDeviceStream() );
 					return (
 						<li className="notification-settings-form-stream-options__item" key={ index }>
 							{ isException ? null : (

--- a/client/me/notification-settings/settings-form/stream-options.jsx
+++ b/client/me/notification-settings/settings-form/stream-options.jsx
@@ -2,7 +2,6 @@ import { get } from 'lodash';
 import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 import FormCheckbox from 'calypso/components/forms/form-checkbox';
-import { NOTIFICATIONS_EXCEPTIONS } from './constants';
 
 export default class extends PureComponent {
 	static displayName = 'NotificationSettingsFormStreamOptions';
@@ -24,10 +23,7 @@ export default class extends PureComponent {
 		return (
 			<ul className="notification-settings-form-stream-options">
 				{ this.props.settingKeys.map( ( setting, index ) => {
-					const isException =
-						( this.props.stream in NOTIFICATIONS_EXCEPTIONS &&
-							NOTIFICATIONS_EXCEPTIONS[ this.props.stream ].indexOf( setting ) >= 0 ) ||
-						( setting === 'blogging_prompt' && this.isDeviceStream() );
+					const isException = setting === 'blogging_prompt' && this.isDeviceStream();
 					return (
 						<li className="notification-settings-form-stream-options__item" key={ index }>
 							{ isException ? null : (


### PR DESCRIPTION
#### Proposed Changes

* This adds a new setting for the writing prompts email notification.

The setting was not added in the V1 and was filtered out. This PR removes that filter and allows the setting to render.

<img width="685" alt="Screenshot 2023-01-12 at 08 59 33" src="https://user-images.githubusercontent.com/5560595/212031676-468fb888-a242-48a3-b601-d251fc3df91a.png">

#### Testing Instructions
* Go to `/me/notifications` and check that the setting is visible
* The settings should be disabled by default
* Update 0-sandbox.php to include the following;
```
function sandbox_jobs( $sandboxed, $type ) {
	return in_array( $type, [ 'notification_settings_persistance' ] ); ;
}

add_filter( 'sandbox_async_job', 'sandbox_jobs', 10, 2 );
```
* Run the watcher `php /home/wpcom/public_html/async-jobs/watcher.php`
* Check the new setting and save
* Refresh page and that setting should be saved


