### PR TITLE
[PoC][WIP][experiment] Try to select/extract the new inner editor iframe introduced by Gutenberg 14.9.1

### DIFF
--- a/packages/calypso-e2e/src/lib/components/editor-gutenberg-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-gutenberg-component.ts
@@ -58,7 +58,7 @@ export class EditorGutenbergComponent {
 	async enterTitle( title: string ): Promise< void > {
 		const sanitizedTitle = title.trim();
 		const locator = this.editor.locator( selectors.title );
-		await locator.fill( sanitizedTitle, { timeout: 20 * 1000 } );
+		await locator.fill( sanitizedTitle, { timeout: 20 * 100000 } );
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/pages/editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/editor-page.ts
@@ -27,6 +27,7 @@ import type {
 const selectors = {
 	// iframe and editor
 	editorFrame: 'iframe.is-loaded',
+	editorInnerFrame: '[name="editor-canvas"]',
 	editor: 'body.block-editor-page',
 	editorTitle: '.editor-post-title__input',
 
@@ -67,14 +68,22 @@ export class EditorPage {
 	 * @param param0.target Target editor type. Defaults to 'simple'.
 	 */
 	constructor( page: Page, { target = 'simple' }: { target?: SiteType } = {} ) {
+		// There's a difference between simple and AT in that in AT, the editor is not
+		// contained within an iframe (aka Gutenframe) in test sites. However, starting in
+		// Gutenberg 14.9, the editor does have an inner iframe is a block-based theme is
+		// used (which should be the case for all test sites). This is common across AT and
+		// simple, so in both scenarios extract it.
 		if ( target === 'atomic' ) {
-			// For Atomic editors, there is no iFrame - the editor is
+			// For Atomic editors, there is iFrame wrapping the editor - the editor is
 			// part of the page DOM and is thus accessible directly.
-			this.editor = page.locator( selectors.editor );
+			this.editor = page.frameLocator( selectors.editorInnerFrame ).locator( selectors.editor );
 		} else {
 			// For Simple editors, the editor is located within an iFrame
 			// and thus it must first be extracted.
-			this.editor = page.frameLocator( selectors.editorFrame ).locator( selectors.editor );
+			this.editor = page
+				.frameLocator( selectors.editorFrame )
+				.frameLocator( selectors.editorInnerFrame )
+				.locator( selectors.editor );
 		}
 
 		this.page = page;


### PR DESCRIPTION
#### Proposed Changes

*

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
