### PR TITLE
Odyssey Stats: Fix the WordPress banners style

### DIFF
--- a/apps/odyssey-stats/src/styles/wp-admin.scss
+++ b/apps/odyssey-stats/src/styles/wp-admin.scss
@@ -6,6 +6,37 @@
 	}
 }
 
+// Override notice styles
+#wpbody-content > .notice {
+	display: block;
+	width: auto;
+	background: var(--studio-white);
+	color: var(--color-text);
+	font-size: 13px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+	margin-bottom: 2px;
+
+	h2,
+	h3 {
+		color: var(--studio-gray-90);
+		font-size: 1.3em; /* stylelint-disable-line declaration-property-unit-allowed-list */
+		margin: 1em 0;
+		font-weight: 600;
+	}
+
+	p {
+		font-size: 13px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+		line-height: 1.5;
+		margin: 0.5em 0;
+		padding: 2px;
+		color: var(--studio-gray-70);
+	}
+
+	code {
+		padding: 3px 5px 2px;
+		margin: 0 1px;
+	}
+}
+
 // Overrides layout for WP Admin.
 .wp-admin {
 	& .layout__content,


### PR DESCRIPTION
Fixes #71830 

#### Proposed Changes

* Overrides the `notice` styles

#### Testing Instructions

* Spin up a Jurassic Ninja site
* Follow the second option described here: PejTkB-3E-p2
* Ensure the banner look as usual

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

| Screenshots |
| :-----: |
| Before |
| ![image](https://user-images.githubusercontent.com/6406071/211918717-e91663a3-7e24-4d71-bd98-730d914fa3c7.png) |
| After |
| ![image](https://user-images.githubusercontent.com/6406071/211919989-c21b3024-6fcf-44c1-8ac5-b0af9816c118.png) |

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #71830 