### PR TITLE
Site Editor: Use relative path for site editor back button ( Attempt 2 )

### DIFF
--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -1092,15 +1092,9 @@ function handleSiteEditorBackButton( calypsoPort ) {
 			clickedElement.attributes?.href?.value &&
 			clickedElement.attributes?.href?.value === dashboardLink;
 
-		// Since the clicked element may not have an href (as noted by internal SVG and path woes above).
-		const returnHref = clickedElement.href || dashboardLink;
-
 		if ( isOldDashboardButton || isNewDashboardButton ) {
 			event.preventDefault();
-			calypsoPort.postMessage( {
-				action: 'openLinkInParentFrame',
-				payload: { postUrl: returnHref },
-			} );
+			calypsoPort.postMessage( { action: 'navigateToHome' } );
 		}
 	} );
 }

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -125,6 +125,7 @@ enum EditorActions {
 	GetCalypsoUrlInfo = 'getCalypsoUrlInfo',
 	TrackPerformance = 'trackPerformance',
 	GetIsAppBannerVisible = 'getIsAppBannerVisible',
+	NavigateToHome = 'navigateToHome',
 }
 
 type ComponentProps = Props &
@@ -488,6 +489,10 @@ class CalypsoifyIframe extends Component< ComponentProps, State > {
 			if ( isAppBannerVisible ) {
 				this.appBannerPort = ports[ 0 ];
 			}
+		}
+
+		if ( EditorActions.NavigateToHome === action ) {
+			window.open( `/home/${ this.props.siteSlug }`, '_top' );
 		}
 	};
 

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -492,7 +492,7 @@ class CalypsoifyIframe extends Component< ComponentProps, State > {
 		}
 
 		if ( EditorActions.NavigateToHome === action ) {
-			window.open( `/home/${ this.props.siteSlug }`, '_top' );
+			page( `/home/${ this.props.siteSlug }` );
 		}
 	};
 


### PR DESCRIPTION
## Estimated Time to Test / Review:
- Test -> Short
- Review -> Short / Med

#### Proposed Changes

**Note:** We had a first iteration of this PR that was reverted because of runtime errors.

The site editor back to dashboard button currently redirects to an absolute url with wordpress.com. This is inconvenient when we're working in horizon or the calypso.localhost environment and can lead to misleading testing results. This PR forces the redirect to use a relative URL when possible.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this branch
* ssh into wpcom sandbox
* Sandbox `widgets.wp.com` in hosts file
* Navigate to `apps/wpcom-block-editor` and run `yarn dev --sync`
* Visit http://calypso.localhost:3000/setup/link-in-bio/intro
* Walk through the tailored onboarding flow until at the Launchpad
* Click on the "Add Links" task
* Click on the back to dashboard button and confirm that the environment is redirected to Launchpad with a http://calypso.localhost:3000 origin
* Do the same for the free onboarding flow and the "Edit site design" button

![2023-01-10 12 21 44](https://user-images.githubusercontent.com/5414230/211654102-aa45a155-d5c3-44aa-8510-856fb0e6d3f1.gif)

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

- Related to https://github.com/Automattic/wp-calypso/issues/71760
- First attempt https://github.com/Automattic/wp-calypso/pull/71890 which was reverted because of runtime type errors p1673392490656679-slack-C7YPUHBB2