### PR TITLE
PlanPrice: Add additional tests

### DIFF
--- a/client/my-sites/plan-price/test/index.js
+++ b/client/my-sites/plan-price/test/index.js
@@ -204,4 +204,28 @@ describe( 'PlanPrice', () => {
 		expect( document.body ).toHaveTextContent( 'Rp44,700.50' );
 		expect( screen.queryByText( '(+25 tax)' ) ).not.toBeInTheDocument();
 	} );
+
+	it( 'renders a price with a heading tag if omitHeading is false', () => {
+		render( <PlanPrice rawPrice={ 44700.5 } currencyCode="IDR" /> );
+		expect( document.body ).toHaveTextContent( 'Rp44,700.50' );
+		expect( document.querySelector( 'h4' ) ).toBeTruthy();
+	} );
+
+	it( 'renders a price with a non-heading tag if omitHeading is true', () => {
+		render( <PlanPrice rawPrice={ 44700.5 } currencyCode="IDR" omitHeading /> );
+		expect( document.body ).toHaveTextContent( 'Rp44,700.50' );
+		expect( document.querySelector( 'h4' ) ).toBeFalsy();
+	} );
+
+	it( 'renders a price with a heading tag if productDisplayPrice is set and omitHeading is false', () => {
+		render( <PlanPrice productDisplayPrice="Rp44,700.50" currencyCode="IDR" /> );
+		expect( document.body ).toHaveTextContent( 'Rp44,700.50' );
+		expect( document.querySelector( 'h4' ) ).toBeTruthy();
+	} );
+
+	it( 'renders a price with a non-heading tag if productDisplayPrice is set and omitHeading is true', () => {
+		render( <PlanPrice productDisplayPrice="Rp44,700.50" currencyCode="IDR" omitHeading /> );
+		expect( document.body ).toHaveTextContent( 'Rp44,700.50' );
+		expect( document.querySelector( 'h4' ) ).toBeFalsy();
+	} );
 } );

--- a/client/my-sites/plan-price/test/index.js
+++ b/client/my-sites/plan-price/test/index.js
@@ -228,4 +228,35 @@ describe( 'PlanPrice', () => {
 		expect( document.body ).toHaveTextContent( 'Rp44,700.50' );
 		expect( document.querySelector( 'h4' ) ).toBeFalsy();
 	} );
+
+	it( 'renders a price without an outer div if is2023OnboardingPricingGrid is not set', () => {
+		render( <PlanPrice rawPrice={ 44700.5 } currencyCode="IDR" /> );
+		expect( document.body ).toHaveTextContent( 'Rp44,700.50' );
+		expect( document.querySelector( 'div.plan-price__integer-fraction' ) ).toBeFalsy();
+	} );
+
+	it( 'renders a price with an outer div if is2023OnboardingPricingGrid is set', () => {
+		render( <PlanPrice rawPrice={ 44700.5 } currencyCode="IDR" is2023OnboardingPricingGrid /> );
+		expect( document.body ).toHaveTextContent( 'Rp44,700.50' );
+		expect( document.querySelector( 'div.plan-price__integer-fraction' ) ).toBeTruthy();
+	} );
+
+	it( 'renders a price without an outer div if productDisplayPrice is set and is2023OnboardingPricingGrid is set', () => {
+		render( <PlanPrice productDisplayPrice="$45" is2023OnboardingPricingGrid /> );
+		expect( document.body ).toHaveTextContent( '$45' );
+		expect( document.querySelector( 'div.plan-price__integer-fraction' ) ).toBeFalsy();
+	} );
+
+	it( 'renders a price without an outer div if displayFlatPrice is set and is2023OnboardingPricingGrid is set', () => {
+		render(
+			<PlanPrice
+				rawPrice={ 44700.5 }
+				currencyCode="IDR"
+				displayFlatPrice
+				is2023OnboardingPricingGrid
+			/>
+		);
+		expect( document.body ).toHaveTextContent( 'Rp44,700.50' );
+		expect( document.querySelector( 'div.plan-price__integer-fraction' ) ).toBeFalsy();
+	} );
 } );

--- a/client/my-sites/plan-price/test/index.js
+++ b/client/my-sites/plan-price/test/index.js
@@ -1,7 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import PlanPrice from '../index';
 
 describe( 'PlanPrice', () => {
@@ -9,27 +9,44 @@ describe( 'PlanPrice', () => {
 		render( <PlanPrice rawPrice={ 0 } /> );
 		expect( document.body ).toHaveTextContent( '$0' );
 	} );
+
 	it( 'renders a rawPrice of $50', () => {
 		render( <PlanPrice rawPrice={ 50 } /> );
 		expect( document.body ).toHaveTextContent( '$50' );
 	} );
+
 	it( 'renders a rawPrice with a decimal', () => {
 		render( <PlanPrice rawPrice={ 50.01 } /> );
 		expect( document.body ).toHaveTextContent( '$50.01' );
+		expect( screen.queryByText( '50.01' ) ).not.toBeInTheDocument();
+		expect( screen.getByText( '50' ) ).toBeInTheDocument();
+		expect( screen.getByText( '.01' ) ).toBeInTheDocument();
 	} );
+
 	it( 'renders a range of prices', () => {
 		render( <PlanPrice rawPrice={ [ 10, 50 ] } /> );
 		expect( document.body ).toHaveTextContent( '$10-50' );
+		expect( screen.queryByText( '$10-50' ) ).not.toBeInTheDocument();
+		expect( screen.getByText( '10' ) ).toBeInTheDocument();
+		expect( screen.getByText( '50' ) ).toBeInTheDocument();
 	} );
+
 	it( 'renders a range of prices with decimals', () => {
 		render( <PlanPrice rawPrice={ [ 10, 50.01 ] } /> );
 		expect( document.body ).toHaveTextContent( '$10-50.01' );
+		expect( screen.queryByText( '$10-50.01' ) ).not.toBeInTheDocument();
+		expect( screen.getByText( '10' ) ).toBeInTheDocument();
+		expect( screen.getByText( '50' ) ).toBeInTheDocument();
+		expect( screen.getByText( '.01' ) ).toBeInTheDocument();
 	} );
+
 	it( 'will not render a range of prices with a 0', () => {
 		render( <PlanPrice rawPrice={ [ 10, 0 ] } /> );
 		expect( document.body ).not.toHaveTextContent( '$10-0' );
+		expect( screen.queryByText( '$10-0' ) ).not.toBeInTheDocument();
 	} );
-	it( 'will use productDisplayPrice when rawPrice is an integer', () => {
+
+	it( 'will use productDisplayPrice when rawPrice is a number', () => {
 		render(
 			<PlanPrice
 				rawPrice={ 10 }
@@ -38,7 +55,11 @@ describe( 'PlanPrice', () => {
 		);
 		expect( document.body ).toHaveTextContent( '$96.00' );
 		expect( document.body ).not.toHaveTextContent( '$10' );
+		expect( screen.queryByText( '$96.00' ) ).not.toBeInTheDocument();
+		expect( screen.getByText( '96.00' ) ).toBeInTheDocument();
+		expect( screen.getByTitle( 'United States Dollars' ) ).toBeInTheDocument();
 	} );
+
 	it( 'will use productDisplayPrice when rawPrice is an array with length of 1', () => {
 		render(
 			<PlanPrice
@@ -48,8 +69,12 @@ describe( 'PlanPrice', () => {
 		);
 		expect( document.body ).toHaveTextContent( '$96.00' );
 		expect( document.body ).not.toHaveTextContent( '$10' );
+		expect( screen.queryByText( '$96.00' ) ).not.toBeInTheDocument();
+		expect( screen.getByText( '96.00' ) ).toBeInTheDocument();
+		expect( screen.getByTitle( 'United States Dollars' ) ).toBeInTheDocument();
 	} );
-	it( 'will use rawPrice when rawPrice is passed an array with length > 1', () => {
+
+	it( 'will use rawPrice over productDisplayPrice when rawPrice is passed an array with length > 1', () => {
 		render(
 			<PlanPrice
 				rawPrice={ [ 5, 10 ] }
@@ -58,16 +83,25 @@ describe( 'PlanPrice', () => {
 		);
 		expect( document.body ).toHaveTextContent( '$5-10' );
 		expect( document.body ).not.toHaveTextContent( '$96.00' );
+		expect( screen.getByText( '5' ) ).toBeInTheDocument();
+		expect( screen.getByText( '10' ) ).toBeInTheDocument();
+		expect( screen.queryByTitle( 'United States Dollars' ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'renders a currency when set', () => {
 		render( <PlanPrice rawPrice={ 5.05 } currencyCode="EUR" /> );
 		expect( document.body ).toHaveTextContent( '€5.05' );
+		expect( screen.queryByText( '€5.05' ) ).not.toBeInTheDocument();
+		expect( screen.getByText( '5' ) ).toBeInTheDocument();
+		expect( screen.getByText( '.05' ) ).toBeInTheDocument();
 	} );
 
 	it( 'renders USD currency when currency is undefined', () => {
 		render( <PlanPrice rawPrice={ 5.05 } currencyCode={ undefined } /> );
 		expect( document.body ).toHaveTextContent( '$5.05' );
+		expect( screen.queryByText( '$5.05' ) ).not.toBeInTheDocument();
+		expect( screen.getByText( '5' ) ).toBeInTheDocument();
+		expect( screen.getByText( '.05' ) ).toBeInTheDocument();
 	} );
 
 	it( 'renders nothing when currency is null', () => {
@@ -79,10 +113,15 @@ describe( 'PlanPrice', () => {
 		render( <PlanPrice rawPrice={ 44700 } currencyCode="IDR" /> );
 		expect( document.body ).toHaveTextContent( 'Rp44,700' );
 		expect( document.body ).not.toHaveTextContent( 'Rp44,700.00' );
+		expect( screen.queryByText( 'Rp44,700' ) ).not.toBeInTheDocument();
+		expect( screen.getByText( '44,700' ) ).toBeInTheDocument();
 	} );
 
 	it( 'renders a decimal section when price is not integer', () => {
 		render( <PlanPrice rawPrice={ 44700.5 } currencyCode="IDR" /> );
 		expect( document.body ).toHaveTextContent( 'Rp44,700.50' );
+		expect( screen.queryByText( 'Rp44,700' ) ).not.toBeInTheDocument();
+		expect( screen.getByText( '44,700' ) ).toBeInTheDocument();
+		expect( screen.getByText( '.50' ) ).toBeInTheDocument();
 	} );
 } );

--- a/client/my-sites/plan-price/test/index.js
+++ b/client/my-sites/plan-price/test/index.js
@@ -259,4 +259,40 @@ describe( 'PlanPrice', () => {
 		expect( document.body ).toHaveTextContent( 'Rp44,700.50' );
 		expect( document.querySelector( 'div.plan-price__integer-fraction' ) ).toBeFalsy();
 	} );
+
+	it( 'renders a price without the "is-discounted" tag if discounted is not set', () => {
+		render( <PlanPrice rawPrice={ 44700.5 } currencyCode="IDR" /> );
+		expect( document.body ).toHaveTextContent( 'Rp44,700.50' );
+		expect( document.querySelector( '.is-discounted' ) ).toBeFalsy();
+	} );
+
+	it( 'renders a price with the "is-discounted" tag if discounted is set', () => {
+		render( <PlanPrice rawPrice={ 44700.5 } currencyCode="IDR" discounted /> );
+		expect( document.body ).toHaveTextContent( 'Rp44,700.50' );
+		expect( document.querySelector( '.is-discounted' ) ).toBeTruthy();
+	} );
+
+	it( 'renders a price with the "is-discounted" tag if using productDisplayPrice and discounted is set', () => {
+		render( <PlanPrice productDisplayPrice="$45" discounted /> );
+		expect( document.body ).toHaveTextContent( '$45' );
+		expect( document.querySelector( '.is-discounted' ) ).toBeTruthy();
+	} );
+
+	it( 'renders a price without the "is-original" tag if original is not set', () => {
+		render( <PlanPrice rawPrice={ 44700.5 } currencyCode="IDR" /> );
+		expect( document.body ).toHaveTextContent( 'Rp44,700.50' );
+		expect( document.querySelector( '.is-discounted' ) ).toBeFalsy();
+	} );
+
+	it( 'renders a price with the "is-original" tag if original is set', () => {
+		render( <PlanPrice rawPrice={ 44700.5 } currencyCode="IDR" original /> );
+		expect( document.body ).toHaveTextContent( 'Rp44,700.50' );
+		expect( document.querySelector( '.is-original' ) ).toBeTruthy();
+	} );
+
+	it( 'renders a price with the "is-original" tag if using productDisplayPrice and original is set', () => {
+		render( <PlanPrice productDisplayPrice="$45" original /> );
+		expect( document.body ).toHaveTextContent( '$45' );
+		expect( document.querySelector( '.is-original' ) ).toBeTruthy();
+	} );
 } );

--- a/client/my-sites/plan-price/test/index.js
+++ b/client/my-sites/plan-price/test/index.js
@@ -88,6 +88,17 @@ describe( 'PlanPrice', () => {
 		expect( screen.queryByTitle( 'United States Dollars' ) ).not.toBeInTheDocument();
 	} );
 
+	it( 'ignores currencyCode when productDisplayPrice is set', () => {
+		render(
+			<PlanPrice
+				productDisplayPrice={ '<abbr title="United States Dollars">$</abbr>96.00' }
+				currencyCode="IDR"
+			/>
+		);
+		expect( document.body ).toHaveTextContent( '$96.00' );
+		expect( screen.getByTitle( 'United States Dollars' ) ).toBeInTheDocument();
+	} );
+
 	it( 'renders a currency when set', () => {
 		render( <PlanPrice rawPrice={ 5.05 } currencyCode="EUR" /> );
 		expect( document.body ).toHaveTextContent( '€5.05' );
@@ -120,8 +131,77 @@ describe( 'PlanPrice', () => {
 	it( 'renders a decimal section when price is not integer', () => {
 		render( <PlanPrice rawPrice={ 44700.5 } currencyCode="IDR" /> );
 		expect( document.body ).toHaveTextContent( 'Rp44,700.50' );
-		expect( screen.queryByText( 'Rp44,700' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Rp 44,700' ) ).not.toBeInTheDocument();
 		expect( screen.getByText( '44,700' ) ).toBeInTheDocument();
 		expect( screen.getByText( '.50' ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders a price without html when displayFlatPrice is set', () => {
+		render( <PlanPrice rawPrice={ 44700.5 } currencyCode="IDR" displayFlatPrice /> );
+		expect( document.body ).toHaveTextContent( 'Rp44,700.50' );
+		expect( screen.getByText( 'Rp44,700.50' ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders a price without sale text when displayFlatPrice is set', () => {
+		render( <PlanPrice rawPrice={ 44700.5 } currencyCode="IDR" displayFlatPrice isOnSale /> );
+		expect( document.body ).toHaveTextContent( 'Rp44,700.50' );
+		expect( screen.getByText( 'Rp44,700.50' ) ).toBeInTheDocument();
+		expect( screen.queryByText( 'Sale' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'renders a price without sale text when productDisplayPrice is set', () => {
+		render(
+			<PlanPrice
+				productDisplayPrice={ '<abbr title="United States Dollars">$</abbr>96.00' }
+				isOnSale
+			/>
+		);
+		expect( document.body ).toHaveTextContent( '$96.00' );
+		expect( screen.queryByText( 'Sale' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'renders a price with sale text when using rawPrice and isOnSale', () => {
+		render( <PlanPrice rawPrice={ 44700.5 } currencyCode="IDR" isOnSale /> );
+		expect( document.body ).toHaveTextContent( 'Rp44,700.50' );
+		expect( screen.getByText( 'Sale' ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders a price with monthly text when using rawPrice and displayPerMonthNotation', () => {
+		render( <PlanPrice rawPrice={ 44700.5 } currencyCode="IDR" displayPerMonthNotation /> );
+		expect( document.body ).toHaveTextContent( 'Rp44,700.50' );
+		// Note: there is a newline between "per" and "month" but testing-library cannot detect those.
+		expect( screen.getByText( 'permonth' ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders a price without monthly text when using productDisplayPrice and displayPerMonthNotation', () => {
+		render( <PlanPrice productDisplayPrice="$96.00" currencyCode="IDR" displayPerMonthNotation /> );
+		expect( document.body ).toHaveTextContent( '$96.00' );
+		expect( screen.queryByText( /per/ ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'renders a price without monthly text when using displayFlatPrice and displayPerMonthNotation', () => {
+		render(
+			<PlanPrice rawPrice={ 96.05 } currencyCode="USD" displayFlatPrice displayPerMonthNotation />
+		);
+		expect( document.body ).toHaveTextContent( '$96.05' );
+		expect( screen.queryByText( /per/ ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'renders a price with tax text when using rawPrice and taxText', () => {
+		render( <PlanPrice rawPrice={ 44700.5 } currencyCode="IDR" taxText="25" /> );
+		expect( document.body ).toHaveTextContent( 'Rp44,700.50(+25 tax)' );
+		expect( screen.getByText( '(+25 tax)' ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders a price without tax text when using productDisplayPrice and taxText', () => {
+		render( <PlanPrice productDisplayPrice="$96.00" currencyCode="IDR" taxText="25" /> );
+		expect( document.body ).toHaveTextContent( '$96.00' );
+		expect( screen.queryByText( '(+25 tax)' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'renders a price without tax text when using displayFlatPrice and taxText', () => {
+		render( <PlanPrice rawPrice={ 44700.5 } currencyCode="IDR" displayFlatPrice taxText="25" /> );
+		expect( document.body ).toHaveTextContent( 'Rp44,700.50' );
+		expect( screen.queryByText( '(+25 tax)' ) ).not.toBeInTheDocument();
 	} );
 } );


### PR DESCRIPTION
#### Proposed Changes

This is a follow-up to https://github.com/Automattic/wp-calypso/pull/71737 which improved the documentation and test coverage for the `PlanPrice` component. Here we add tests for all the special options of the component: `displayFlatPrice`, `taxText`, `displayPerMonthNotation`, `omitHeading`, and `isOnSale`. Also tested are the CSS options: `discounted`, `original`, and `is2023OnboardingPricingGrid`.

#### Testing Instructions

This is just tests, so nothing needs to be done if the tests pass.