### PR TITLE
PlanPrice: Refactor to simplify output

### DIFF
--- a/client/my-sites/plan-price/index.tsx
+++ b/client/my-sites/plan-price/index.tsx
@@ -3,11 +3,10 @@ import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { Component, createElement } from 'react';
 import Badge from 'calypso/components/badge';
-import type { LocalizeProps } from 'i18n-calypso';
 
 import './style.scss';
 
-export class PlanPrice extends Component< PlanPriceProps & LocalizeProps > {
+export class PlanPrice extends Component< PlanPriceProps > {
 	render() {
 		const {
 			currencyCode = 'USD',

--- a/client/my-sites/plan-price/index.tsx
+++ b/client/my-sites/plan-price/index.tsx
@@ -1,9 +1,8 @@
 import { getCurrencyObject } from '@automattic/format-currency';
 import classNames from 'classnames';
-import { localize, useTranslate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import { Component, createElement } from 'react';
 import Badge from 'calypso/components/badge';
-import type { CurrencyObject } from '@automattic/format-currency';
 import type { LocalizeProps } from 'i18n-calypso';
 
 import './style.scss';
@@ -21,7 +20,6 @@ export class PlanPrice extends Component< PlanPriceProps & LocalizeProps > {
 			productDisplayPrice,
 			isOnSale,
 			taxText,
-			translate,
 			omitHeading,
 			is2023OnboardingPricingGrid,
 		} = this.props;
@@ -59,20 +57,6 @@ export class PlanPrice extends Component< PlanPriceProps & LocalizeProps > {
 			return null;
 		}
 
-		const priceRange: PriceRangeData[] = rawPriceRange.map( ( item ) => {
-			return {
-				price: getCurrencyObject( item, currencyCode ),
-				raw: item,
-			};
-		} );
-
-		const renderPrice = ( priceObj: PriceRangeData ) => {
-			if ( ! Number.isInteger( priceObj.raw ) ) {
-				return `${ priceObj.price.integer }${ priceObj.price.fraction }`;
-			}
-			return priceObj.price.integer;
-		};
-
 		if ( displayFlatPrice ) {
 			return (
 				<FlatPriceDisplay
@@ -84,65 +68,23 @@ export class PlanPrice extends Component< PlanPriceProps & LocalizeProps > {
 			);
 		}
 
-		const renderPriceHtml = ( priceObj: PriceRangeData ) => {
-			const hasFraction = ! Number.isInteger( priceObj.raw );
-
-			if ( is2023OnboardingPricingGrid ) {
-				return (
-					<div className="plan-price__integer-fraction">
-						<span className="plan-price__integer">{ priceObj.price.integer }</span>
-						<sup className="plan-price__fraction">{ hasFraction && priceObj.price.fraction }</sup>
-					</div>
-				);
-			}
-
-			return (
-				<>
-					<span className="plan-price__integer">{ priceObj.price.integer }</span>
-					<sup className="plan-price__fraction">{ hasFraction && priceObj.price.fraction }</sup>
-				</>
-			);
-		};
-
-		const saleBadgeText = translate( 'Sale', {
-			comment: 'Shown next to a domain that has a special discounted sale price',
-		} );
-
-		const smallerPriceHtml = renderPriceHtml( priceRange[ 0 ] );
-		const higherPriceHtml = priceRange[ 1 ] && renderPriceHtml( priceRange[ 1 ] );
-
-		return createElement(
-			tagName,
-			{ className: classes },
-			<>
-				<sup className="plan-price__currency-symbol">{ priceRange[ 0 ].price.symbol }</sup>
-				{ ! higherPriceHtml && renderPriceHtml( priceRange[ 0 ] ) }
-				{ higherPriceHtml &&
-					translate( '{{smallerPrice/}}-{{higherPrice/}}', {
-						components: { smallerPrice: smallerPriceHtml, higherPrice: higherPriceHtml },
-						comment: 'The price range for a particular product',
-					} ) }
-				{ taxText && (
-					<sup className="plan-price__tax-amount">
-						{ translate( '(+%(taxText)s tax)', { args: { taxText } } ) }
-					</sup>
-				) }
-				{ displayPerMonthNotation && (
-					<span className="plan-price__term">
-						{ translate( 'per{{newline/}}month', {
-							components: { newline: <br /> },
-							comment:
-								'Displays next to the price. You can remove the "{{newline/}}" if it is not proper for your language.',
-						} ) }
-					</span>
-				) }
-				{ isOnSale && <Badge>{ saleBadgeText }</Badge> }
-			</>
+		return (
+			<MultiPriceDisplay
+				className={ classes }
+				tagName={ tagName }
+				smallerPrice={ rawPriceRange[ 0 ] }
+				higherPrice={ rawPriceRange[ 1 ] }
+				currencyCode={ currencyCode }
+				taxText={ taxText }
+				displayPerMonthNotation={ displayPerMonthNotation }
+				isOnSale={ isOnSale }
+				is2023OnboardingPricingGrid={ is2023OnboardingPricingGrid }
+			/>
 		);
 	}
 }
 
-export default localize( PlanPrice );
+export default PlanPrice;
 
 export interface PlanPriceProps {
 	/**
@@ -243,11 +185,6 @@ export interface PlanPriceProps {
 	is2023OnboardingPricingGrid?: boolean;
 }
 
-interface PriceRangeData {
-	price: CurrencyObject;
-	raw: number;
-}
-
 function renderBasicPrice( price: number, currencyCode: string ): string {
 	const priceObj = getCurrencyObject( price, currencyCode );
 	if ( ! Number.isInteger( price ) ) {
@@ -292,5 +229,117 @@ function FlatPriceDisplay( {
 				comment: 'The price range for a particular product',
 			} ) }
 		</span>
+	);
+}
+
+function MultiPriceDisplay( {
+	tagName,
+	className,
+	smallerPrice,
+	higherPrice,
+	currencyCode,
+	taxText,
+	displayPerMonthNotation,
+	isOnSale,
+	is2023OnboardingPricingGrid,
+}: {
+	tagName: 'h4' | 'span';
+	className?: string;
+	smallerPrice: number;
+	higherPrice?: number;
+	currencyCode: string;
+	taxText?: string;
+	displayPerMonthNotation?: boolean;
+	isOnSale?: boolean;
+	is2023OnboardingPricingGrid?: boolean;
+} ) {
+	const { symbol: currencySymbol } = getCurrencyObject( smallerPrice, currencyCode );
+	const translate = useTranslate();
+
+	// TODO: render currencySymbol on the localized side (before or after) of
+	// the price. We can use `symbolPosition` from `getCurrencyObject`.
+	return createElement(
+		tagName,
+		{ className },
+		<>
+			<sup className="plan-price__currency-symbol">{ currencySymbol }</sup>
+			{ ! higherPrice && (
+				<HtmlPriceDisplay
+					price={ smallerPrice }
+					currencyCode={ currencyCode }
+					is2023OnboardingPricingGrid={ is2023OnboardingPricingGrid }
+				/>
+			) }
+			{ higherPrice &&
+				translate( '{{smallerPrice/}}-{{higherPrice/}}', {
+					components: {
+						smallerPrice: (
+							<HtmlPriceDisplay
+								price={ smallerPrice }
+								currencyCode={ currencyCode }
+								is2023OnboardingPricingGrid={ is2023OnboardingPricingGrid }
+							/>
+						),
+						higherPrice: (
+							<HtmlPriceDisplay
+								price={ higherPrice }
+								currencyCode={ currencyCode }
+								is2023OnboardingPricingGrid={ is2023OnboardingPricingGrid }
+							/>
+						),
+					},
+					comment: 'The price range for a particular product',
+				} ) }
+			{ taxText && (
+				<sup className="plan-price__tax-amount">
+					{ translate( '(+%(taxText)s tax)', { args: { taxText } } ) }
+				</sup>
+			) }
+			{ displayPerMonthNotation && (
+				<span className="plan-price__term">
+					{ translate( 'per{{newline/}}month', {
+						components: { newline: <br /> },
+						comment:
+							'Displays next to the price. You can remove the "{{newline/}}" if it is not proper for your language.',
+					} ) }
+				</span>
+			) }
+			{ isOnSale && (
+				<Badge>
+					{ translate( 'Sale', {
+						comment: 'Shown next to a domain that has a special discounted sale price',
+					} ) }
+				</Badge>
+			) }
+		</>
+	);
+}
+
+function HtmlPriceDisplay( {
+	price,
+	currencyCode,
+	is2023OnboardingPricingGrid,
+}: {
+	price: number;
+	currencyCode: string;
+	is2023OnboardingPricingGrid?: boolean;
+} ) {
+	const hasFraction = ! Number.isInteger( price );
+	const priceObj = getCurrencyObject( price, currencyCode );
+
+	if ( is2023OnboardingPricingGrid ) {
+		return (
+			<div className="plan-price__integer-fraction">
+				<span className="plan-price__integer">{ priceObj.integer }</span>
+				<sup className="plan-price__fraction">{ hasFraction && priceObj.fraction }</sup>
+			</div>
+		);
+	}
+
+	return (
+		<>
+			<span className="plan-price__integer">{ priceObj.integer }</span>
+			<sup className="plan-price__fraction">{ hasFraction && priceObj.fraction }</sup>
+		</>
 	);
 }


### PR DESCRIPTION
#### Proposed Changes

A follow-up to https://github.com/Automattic/wp-calypso/pull/71737 which converted the `PlanPrice` component to TypeScript and https://github.com/Automattic/wp-calypso/pull/71959 which improved its test coverage, this PR refactors the rendering parts of the component to simplify their output and make the flow easier to read. This hopefully will make some of the more complex prop interactions easier to understand (eg: how `displayFlatPrice` ignores most options and `productDisplayPrice` ignores many options). This should also make it easier and safer to add new options or behavior in the future without risking disruption to existing behavior.

#### Testing Instructions

The tests added by the https://github.com/Automattic/wp-calypso/pull/71737 and https://github.com/Automattic/wp-calypso/pull/71959 should cover this, but you can also review typical output manually by viewing the prices displayed on `/plans` page and the prices displayed on purchase pages (visit `/me/purchases` and click on any purchase).

<img width="345" alt="Screenshot 2023-01-11 at 7 41 04 PM" src="https://user-images.githubusercontent.com/2036909/211953303-b9c50af1-d86e-4c67-80c1-bab4ce2f3d9b.png">

<img width="268" alt="Screenshot 2023-01-11 at 8 25 33 PM" src="https://user-images.githubusercontent.com/2036909/211953932-3ecceb74-4f68-4d6e-94e7-0e3a68118c22.png">
