### PR TITLE
Hosting Configuration: Revamped upsell nudge doesn't disappear on sites with personal/premium plans

### DIFF
--- a/client/my-sites/hosting/hosting-upsell-nudge/index.tsx
+++ b/client/my-sites/hosting/hosting-upsell-nudge/index.tsx
@@ -1,3 +1,4 @@
+import { FEATURE_SFTP, PLAN_BUSINESS } from '@automattic/calypso-products';
 import { useTranslate } from 'i18n-calypso';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
 import { preventWidows } from 'calypso/lib/formatting';
@@ -28,6 +29,8 @@ export function HostingUpsellNudge( { siteId }: { siteId: number | null } ) {
 			event="calypso_hosting_configuration_upgrade_click"
 			href={ `/checkout/${ siteId }/business` }
 			callToAction={ translate( 'Upgrade to Business Plan' ) }
+			plan={ PLAN_BUSINESS }
+			feature={ FEATURE_SFTP }
 			showIcon={ true }
 			list={ features }
 			renderListItem={ ( { icon, title, description }: FeatureListItem ) => (


### PR DESCRIPTION
#### Proposed Changes

The code inside the standard `<UpsellNudge>` knows when to hide itself based on things like whether the current site is a Jetpack site or the site's plan already includes the feature being sold.

The upsell revamp introduced in https://github.com/Automattic/wp-calypso/pull/71750 didn't include the `plan` and `feature` props which meant that when the user visited `/hosting-config` (and they were assigned to the cohort seeing the revamped upsell) then the upsell would be hidden.

<img width="1155" alt="CleanShot 2023-01-12 at 14 14 49@2x" src="https://user-images.githubusercontent.com/1500769/211952447-0acfd88d-86dc-4a8f-9d9f-85b04e1f442a.png">

This doesn't happen with the free plan which is why it was missed.

The fix is to tell the `<UpsellNudge>` what plan and feature we're upselling so that it doesn't get hidden.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to experiment page 20995-explat-experiment
* Add the `treatment` bookmarklet to your bookmark bar
* Click bookmarklet and add your user to the `treatment` cohort (tutorial video p1673249013170409/1673241333.083479-slack-C04H4NY6STW)
* `calypso.localhost:3000/hosting-config` in a site with **a free plan**
* You should see the new nudge
* `calypso.localhost:3000/hosting-config` in a site with **a premium or personal plan**
* You should see the new nudge (previously you saw nothing but the faded out controls)

