### PR TITLE
Update feature flag usage for Pattern Assembler in Theme Showcase

### DIFF
--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -1,4 +1,4 @@
-import { isEnabled } from '@automattic/calypso-config';
+import config from '@automattic/calypso-config';
 import { get, includes, reject } from 'lodash';
 import detectHistoryNavigation from 'calypso/lib/detect-history-navigation';
 import { getQueryArgs } from 'calypso/lib/query-args';
@@ -110,7 +110,7 @@ function getThankYouNoSiteDestination() {
 function getChecklistThemeDestination( { siteSlug, themeParameter } ) {
 	if (
 		themeParameter === 'blank-canvas-3' &&
-		isEnabled( 'pattern-assembler/logged-out-showcase' )
+		config.isEnabled( 'pattern-assembler/logged-out-showcase' )
 	) {
 		return `/setup/site-setup/patternAssembler?siteSlug=${ siteSlug }`;
 	}

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { get, includes, reject } from 'lodash';
 import detectHistoryNavigation from 'calypso/lib/detect-history-navigation';
 import { getQueryArgs } from 'calypso/lib/query-args';
@@ -107,7 +108,10 @@ function getThankYouNoSiteDestination() {
 }
 
 function getChecklistThemeDestination( { siteSlug, themeParameter } ) {
-	if ( themeParameter === 'blank-canvas-3' ) {
+	if (
+		themeParameter === 'blank-canvas-3' &&
+		isEnabled( 'pattern-assembler/logged-out-showcase' )
+	) {
 		return `/setup/site-setup/patternAssembler?siteSlug=${ siteSlug }`;
 	}
 	return `/home/${ siteSlug }`;


### PR DESCRIPTION
#### Proposed Changes

* We are going to enable blank-canvas-3 theme on all theme showcases, so this PR to make sure the logged-out flow will only show the PA step once the #71706 is completed

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Patch this D97579-code
* Confirm that upon selecting blank-cavas-3, user won't land on PA step 

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/71706