### PR TITLE
Don't load hosting upsell experiment if we know user is ineligible

### DIFF
--- a/client/my-sites/hosting/main.js
+++ b/client/my-sites/hosting/main.js
@@ -1,4 +1,5 @@
 import { PLAN_BUSINESS, FEATURE_SFTP } from '@automattic/calypso-products';
+import { englishLocales } from '@automattic/i18n-utils';
 import { Spinner } from '@wordpress/components';
 import { localize } from 'i18n-calypso';
 import { Component, Fragment } from 'react';
@@ -70,6 +71,7 @@ class Hosting extends Component {
 			hasSftpFeature,
 			isDisabled,
 			isTransferring,
+			locale,
 			requestSiteById,
 			siteId,
 			siteSlug,
@@ -92,6 +94,9 @@ class Hosting extends Component {
 				}
 				treatmentExperience={ <HostingUpsellNudge siteId={ siteId } /> }
 				loadingExperience={ <Spinner className="hosting__upsell-experiment-spinner" /> }
+				options={ {
+					isEligible: englishLocales.includes( locale ),
+				} }
 			/>
 		);
 


### PR DESCRIPTION
#### Proposed Changes

Following this suggestion here pbxNRc-2f8-p2#comment-4022 to disable the hosting upsell experiment on the client-side when we _know_ the user isn't eligible to be included.

We can exclude all English locales because even though Abacus interface uses the `en` slug 20995-explat-experiment, which would usually only refer to US English, we know under the hood it checks against the locale prefix so we know it includes both `en` and `en-gb` fbhepr%2Skers%2Sjcpbz%2Sjc%2Qpbagrag%2Syvo%2Sjcpbz%2Qnogrfg%2Scnegvpvcnag%2Qnffvtazrag%2Spynff%2Qerdhrfg%2Qpbagrkg.cuc%3Se%3Qpn8o051s%23162-og

This means we don't subject non-`en` users to the loading state.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to experiment page 20995-explat-experiment
* Add the `treatment` bookmarklet to your bookmark bar
* Click bookmarklet and add your user to the `treatment` cohort (tutorial video p1673249013170409/1673241333.083479-slack-C04H4NY6STW)
* Switch Calypso to English
* `calypso.localhost:3000/hosting-config` in a site with a free plan
* You should see the new nudge
* Switch Calypso to non-English
* Test `calypso.localhost:3000/hosting-config` again and see the old nudge
* Clear your cached cohort assignment by deleting `explat-experiment--calypso_hosting_configuration_upsell_list_features` from `localStorage`
* Refresh the page and see that it doesn't even attempt to load the cohort info

