### PR TITLE
Theme Showcase: Theme preview modal update

### DIFF
--- a/client/assets/stylesheets/shared/functions/_z-index.scss
+++ b/client/assets/stylesheets/shared/functions/_z-index.scss
@@ -157,6 +157,7 @@ $z-layers: (
 		".popover.ellipsis-menu__menu": 100201,
 		".popover.plugin-action__disabled-info": 100202,
 		".design-picker__premium-badge-tooltip": 100300,
+		".design-preview__sidebar-action-buttons": 100300,
 		".plan-storage__tooltip": 100300,
 		".popover.gallery__order-popover": 100300,
 		"popover.is-dialog-visible": 100300,

--- a/client/components/theme-preview-modal/index.tsx
+++ b/client/components/theme-preview-modal/index.tsx
@@ -13,7 +13,7 @@ import {
 } from 'calypso/state/themes/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import ThemePreviewModalNavigation from './navigation';
-import type { StyleVariation } from '@automattic/design-picker/src/types';
+import type { Category, StyleVariation } from '@automattic/design-picker/src/types';
 import type { Theme } from 'calypso/types';
 
 import './style.scss';
@@ -28,6 +28,7 @@ interface ThemePreviewModalProps {
 	actionButtons: React.ReactNode;
 	selectedVariation?: StyleVariation;
 	onSelectVariation: ( variation: StyleVariation ) => void;
+	onClickCategory: ( category: Category ) => void;
 	onClose: () => void;
 }
 
@@ -37,6 +38,7 @@ const ThemePreviewModal: React.FC< ThemePreviewModalProps > = ( {
 	actionButtons,
 	selectedVariation,
 	onSelectVariation,
+	onClickCategory,
 	onClose,
 } ) => {
 	const siteId = useSelector( getSelectedSiteId ) || -1;
@@ -123,13 +125,17 @@ const ThemePreviewModal: React.FC< ThemePreviewModalProps > = ( {
 						title={
 							<div className="theme-preview-modal__content-title design-picker-design-title__container">
 								{ theme.name }
-								{ badge }
 							</div>
 						}
-						description={ shortDescription }
+						author={ theme.author }
+						categories={ theme.taxonomies?.theme_subject }
+						description={ theme.description }
+						shortDescription={ shortDescription }
+						pricingBadge={ badge }
 						variations={ theme.style_variations }
 						selectedVariation={ selectedStyleVariation }
 						onSelectVariation={ previewDesignVariation }
+						onClickCategory={ onClickCategory }
 						actionButtons={ actionButtons }
 						showGlobalStylesPremiumBadge={ shouldLimitGlobalStyles }
 					/>

--- a/client/components/theme-preview-modal/style.scss
+++ b/client/components/theme-preview-modal/style.scss
@@ -119,7 +119,8 @@ $break-design-preview: 1024px;
 		max-height: none;
 
 		.design-preview__sidebar {
-			margin-top: 72px;
+			margin: 72px -16px 0 -8px;
+			padding: 0 16px 96px 8px;
 		}
 	}
 
@@ -142,6 +143,7 @@ $break-design-preview: 1024px;
 		.premium-badge,
 		.woocommerce-bundled-badge {
 			font-family: $default-font;
+			margin: 0;
 		}
 	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
@@ -638,7 +638,9 @@ $break-design-preview: 1024px;
 		.step-container__content {
 			// 156px = .design-preview__sidebar + step-container__navigation.action-buttons
 			height: calc(100vh - 156px);
-			margin-top: 36px;
+			margin: 36px -8px 0;
+			overflow: hidden;
+			padding: 0 8px;
 			position: relative;
 			z-index: 1;
 		}
@@ -659,7 +661,8 @@ $break-design-preview: 1024px;
 			}
 
 			.design-preview__sidebar {
-				margin-top: 72px;
+				margin: 72px -16px 0 -8px;
+				padding: 0 16px 96px 8px;
 			}
 		}
 	}

--- a/client/my-sites/themes/helpers.js
+++ b/client/my-sites/themes/helpers.js
@@ -78,3 +78,12 @@ export function localizeThemesPath( path, locale, isLoggedOut = true ) {
 export function marketplaceThemeBillingProductSlug( themeId ) {
 	return `wp-mp-theme-${ themeId }`;
 }
+
+export function getSubjectsFromTermTable( filterToTermTable ) {
+	return Object.keys( filterToTermTable )
+		.filter( ( key ) => key.indexOf( 'subject:' ) !== -1 )
+		.reduce( ( obj, key ) => {
+			obj[ key ] = filterToTermTable[ key ];
+			return obj;
+		}, {} );
+}

--- a/client/my-sites/themes/theme-preview.jsx
+++ b/client/my-sites/themes/theme-preview.jsx
@@ -9,12 +9,14 @@ import QueryCanonicalTheme from 'calypso/components/data/query-canonical-theme';
 import PulsingDot from 'calypso/components/pulsing-dot';
 import ThemePreviewModal from 'calypso/components/theme-preview-modal';
 import WebPreview from 'calypso/components/web-preview';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
-import { isJetpackSite } from 'calypso/state/sites/selectors';
+import { getSiteSlug, isJetpackSite } from 'calypso/state/sites/selectors';
 import { hideThemePreview, setThemePreviewOptions } from 'calypso/state/themes/actions';
 import {
 	getCanonicalTheme,
 	getThemeDemoUrl,
+	getThemeFilterToTermTable,
 	getThemePreviewThemeOptions,
 	themePreviewVisibility,
 	isThemeActive,
@@ -22,6 +24,7 @@ import {
 	isActivatingTheme,
 } from 'calypso/state/themes/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { getSubjectsFromTermTable, localizeThemesPath } from './helpers';
 import { connectOptions } from './theme-options';
 
 class ThemePreview extends Component {
@@ -117,6 +120,17 @@ class ThemePreview extends Component {
 		this.props.setThemePreviewOptions( themeId, primary, secondary, variation );
 	};
 
+	onClickCategory = ( category ) => {
+		const { filterToTermTable, isLoggedIn, locale, siteSlug } = this.props;
+		const subjectTermTable = getSubjectsFromTermTable( filterToTermTable );
+		const subject = subjectTermTable[ `subject:${ category.slug }` ];
+
+		if ( subject ) {
+			const path = `/themes/filter/${ subject }/${ siteSlug ?? '' }`;
+			window.location.href = localizeThemesPath( path, locale, ! isLoggedIn );
+		}
+	};
+
 	render() {
 		const { theme, themeId, siteId, demoUrl, children, isWPForTeamsSite } = this.props;
 		const { showActionIndicator } = this.state;
@@ -138,6 +152,7 @@ class ThemePreview extends Component {
 							selectedVariation={ this.getStyleVariationOption() }
 							actionButtons={ this.renderPrimaryButton() }
 							onSelectVariation={ this.onSelectVariation }
+							onClickCategory={ this.onClickCategory }
 							onClose={ this.props.hideThemePreview }
 						/>
 					) : (
@@ -177,13 +192,16 @@ export default connect(
 			theme: getCanonicalTheme( state, siteId, themeId ),
 			themeId,
 			siteId,
+			siteSlug: getSiteSlug( state, siteId ),
 			isJetpack,
 			themeOptions,
+			filterToTermTable: getThemeFilterToTermTable( state ),
 			isInstalling: isInstallingTheme( state, themeId, siteId ),
 			isActive: isThemeActive( state, themeId, siteId ),
 			isActivating: isActivatingTheme( state, siteId ),
 			demoUrl: getThemeDemoUrl( state, themeId, siteId ),
 			isWPForTeamsSite: isSiteWPForTeams( state, siteId ),
+			isLoggedIn: isUserLoggedIn( state ),
 			options: [
 				'activate',
 				'preview',

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -36,7 +36,7 @@ import {
 	isUpsellCardDisplayed as isUpsellCardDisplayedSelector,
 } from 'calypso/state/themes/selectors';
 import { getThemesBookmark } from 'calypso/state/themes/themes-ui/selectors';
-import { addTracking, trackClick, localizeThemesPath } from './helpers';
+import { addTracking, getSubjectsFromTermTable, trackClick, localizeThemesPath } from './helpers';
 import InstallThemeButton from './install-theme-button';
 import ThemePreview from './theme-preview';
 import ThemesHeader from './themes-header';
@@ -74,7 +74,7 @@ class ThemeShowcase extends Component {
 		};
 
 		this.subjectFilters = this.getSubjectFilters( props );
-		this.subjectTermTable = this.getSubjectTermTable( props );
+		this.subjectTermTable = getSubjectsFromTermTable( props.filterToTermTable );
 
 		this.tiers = [
 			{ value: 'all', label: props.translate( 'All' ) },
@@ -166,15 +166,6 @@ class ThemeShowcase extends Component {
 			ALL: this.staticFilters.ALL,
 			...this.subjectFilters,
 		};
-	};
-
-	getSubjectTermTable = ( { filterToTermTable } ) => {
-		return Object.keys( filterToTermTable )
-			.filter( ( key ) => key.indexOf( 'subject:' ) !== -1 )
-			.reduce( ( obj, key ) => {
-				obj[ key ] = filterToTermTable[ key ];
-				return obj;
-			}, {} );
 	};
 
 	findTabFilter = ( tabFilters, filterKey ) =>

--- a/client/types.ts
+++ b/client/types.ts
@@ -46,6 +46,7 @@ export interface Theme {
 	taxonomies?: {
 		theme_feature?: ThemeFeature[];
 		theme_software_set?: ThemeSoftwareSet[];
+		theme_subject?: ThemeSubject[];
 	};
 	template: string;
 	theme_uri: string;
@@ -66,6 +67,12 @@ interface ThemeFeature {
 }
 
 interface ThemeSoftwareSet {
+	name: string;
+	slug: string;
+	term_id: string;
+}
+
+interface ThemeSubject {
 	name: string;
 	slug: string;
 	term_id: string;

--- a/packages/design-preview/src/components/index.tsx
+++ b/packages/design-preview/src/components/index.tsx
@@ -1,16 +1,21 @@
 import { useMemo } from '@wordpress/element';
 import Sidebar from './sidebar';
 import SitePreview from './site-preview';
-import type { StyleVariation } from '@automattic/design-picker/src/types';
+import type { Category, StyleVariation } from '@automattic/design-picker/src/types';
 import './style.scss';
 
 interface PreviewProps {
 	previewUrl: string;
 	title?: string;
+	author?: string;
+	categories?: Category[];
 	description?: string;
+	shortDescription?: string;
+	pricingBadge?: React.ReactNode;
 	variations?: StyleVariation[];
 	selectedVariation?: StyleVariation;
 	onSelectVariation: ( variation: StyleVariation ) => void;
+	onClickCategory?: ( category: Category ) => void;
 	actionButtons: React.ReactNode;
 	recordDeviceClick: ( device: string ) => void;
 	showGlobalStylesPremiumBadge: boolean;
@@ -24,10 +29,15 @@ const getVariationBySlug = ( variations: StyleVariation[], slug: string ) =>
 const Preview: React.FC< PreviewProps > = ( {
 	previewUrl,
 	title,
+	author,
+	categories = [],
 	description,
+	shortDescription,
+	pricingBadge,
 	variations = [],
 	selectedVariation,
 	onSelectVariation,
+	onClickCategory,
 	actionButtons,
 	recordDeviceClick,
 	showGlobalStylesPremiumBadge,
@@ -48,10 +58,15 @@ const Preview: React.FC< PreviewProps > = ( {
 		<div className="design-preview">
 			<Sidebar
 				title={ title }
+				author={ author }
+				categories={ categories }
 				description={ description }
+				shortDescription={ shortDescription }
+				pricingBadge={ pricingBadge }
 				variations={ variations }
 				selectedVariation={ selectedVariation }
 				onSelectVariation={ onSelectVariation }
+				onClickCategory={ onClickCategory }
 				actionButtons={ actionButtons }
 				showGlobalStylesPremiumBadge={ showGlobalStylesPremiumBadge }
 			/>

--- a/packages/design-preview/src/components/sidebar.tsx
+++ b/packages/design-preview/src/components/sidebar.tsx
@@ -1,39 +1,103 @@
+import { Button } from '@automattic/components';
+import { useState } from '@wordpress/element';
 import { translate } from 'i18n-calypso';
 import StyleVariationPreviews from './style-variation';
-import type { StyleVariation } from '@automattic/design-picker/src/types';
+import type { Category, StyleVariation } from '@automattic/design-picker/src/types';
+
+interface CategoryBadgeProps {
+	category: Category;
+	onClick?: ( category: Category ) => void;
+}
+
+const CategoryBadge: React.FC< CategoryBadgeProps > = ( { category, onClick } ) => {
+	if ( ! onClick ) {
+		return <div className="design-preview__sidebar-badge-category">{ category.name }</div>;
+	}
+
+	return (
+		<button
+			className="design-preview__sidebar-badge-category"
+			onClick={ () => onClick( category ) }
+		>
+			{ category.name }
+		</button>
+	);
+};
 
 interface SidebarProps {
 	title?: string;
+	author?: string;
+	categories?: Category[];
 	description?: string;
+	shortDescription?: string;
+	pricingBadge?: React.ReactNode;
 	variations: StyleVariation[];
 	selectedVariation?: StyleVariation;
 	onSelectVariation: ( variation: StyleVariation ) => void;
+	onClickCategory?: ( category: Category ) => void;
 	actionButtons: React.ReactNode;
 	showGlobalStylesPremiumBadge: boolean;
 }
 
 const Sidebar: React.FC< SidebarProps > = ( {
 	title,
+	author,
+	categories = [],
+	pricingBadge,
 	description,
+	shortDescription,
 	variations = [],
 	selectedVariation,
 	onSelectVariation,
+	onClickCategory,
 	actionButtons,
 	showGlobalStylesPremiumBadge,
 } ) => {
+	const [ isShowFullDescription, setIsShowFullDescription ] = useState( false );
+	const isShowDescriptionToggle = shortDescription && description !== shortDescription;
+
 	return (
 		<div className="design-preview__sidebar">
 			<div className="design-preview__sidebar-content">
 				<div className="design-preview__sidebar-title">
 					<h1>{ title }</h1>
 				</div>
-
-				{ description && (
-					<div className="design-preview__sidebar-description">
-						<p>{ description }</p>
+				{ author && (
+					<div className="design-preview__sidebar-author">
+						{ translate( 'By %(author)s', { args: { author } } ) }
 					</div>
 				) }
-
+				{ ( pricingBadge || categories.length > 0 ) && (
+					<div className="design-preview__sidebar-badges">
+						{ pricingBadge }
+						{ categories.map( ( category ) => (
+							<CategoryBadge
+								key={ category.slug }
+								category={ category }
+								onClick={ onClickCategory }
+							/>
+						) ) }
+					</div>
+				) }
+				{ ( description || shortDescription ) && (
+					<div className="design-preview__sidebar-description">
+						<p>
+							{ isShowDescriptionToggle ? (
+								<>
+									{ isShowFullDescription ? description : shortDescription }
+									<Button
+										borderless
+										onClick={ () => setIsShowFullDescription( ! isShowFullDescription ) }
+									>
+										{ isShowFullDescription ? translate( 'Read less' ) : translate( 'Read more' ) }
+									</Button>
+								</>
+							) : (
+								description ?? shortDescription
+							) }
+						</p>
+					</div>
+				) }
 				{ variations.length > 0 && (
 					<div className="design-preview__sidebar-variations">
 						<h2>{ translate( 'Choose your style' ) }</h2>
@@ -49,7 +113,6 @@ const Sidebar: React.FC< SidebarProps > = ( {
 					</div>
 				) }
 			</div>
-
 			{ actionButtons && (
 				<div className="design-preview__sidebar-action-buttons">{ actionButtons }</div>
 			) }

--- a/packages/design-preview/src/components/style.scss
+++ b/packages/design-preview/src/components/style.scss
@@ -40,9 +40,10 @@ $break-design-preview: 1024px;
 
 	.design-preview__sidebar-action-buttons {
 		display: none;
-		position: absolute;
+		position: sticky;
 		bottom: 0;
 		width: 100%;
+		z-index: z-index("root", ".design-preview__sidebar-action-buttons");
 
 		a,
 		button {
@@ -52,8 +53,9 @@ $break-design-preview: 1024px;
 		}
 
 		@include break-design-preview {
-			bottom: 32px;
+			bottom: 8px;
 			display: block;
+			margin: 2rem 0 0;
 		}
 	}
 
@@ -66,11 +68,11 @@ $break-design-preview: 1024px;
 		border: 0;
 		box-shadow: none;
 		display: block;
-		height: auto;
-		overflow: visible;
+		height: 100%;
+		overflow: scroll;
 		padding: 0;
 		position: relative;
-		width: 280px;
+		width: 311px;
 	}
 }
 
@@ -114,6 +116,47 @@ $break-design-preview: 1024px;
 		}
 	}
 
+	.design-preview__sidebar-author {
+		display: none;
+		font-size: $font-body-small;
+
+		@include break-design-preview {
+			display: block;
+			margin-top: 0.25rem;
+		}
+	}
+
+	.design-preview__sidebar-badges {
+		display: none;
+
+		.premium-badge,
+		.woocommerce-bundled-badge {
+			letter-spacing: 0.2px;
+			margin: 0;
+		}
+
+		.design-preview__sidebar-badge-category {
+			background-color: rgba(0, 0, 0, 0.05);
+			color: var(--studio-gray-100);
+			border-radius: 4px;
+			font-size: $font-body-extra-small;
+			height: 20px;
+			line-height: 20px;
+			padding: 0 10px;
+
+			&:is(button) {
+				cursor: pointer;
+			}
+		}
+
+		@include break-design-preview {
+			display: flex;
+			flex-wrap: wrap;
+			gap: 8px 4px;
+			margin-top: 0.75rem;
+		}
+	}
+
 	.design-preview__sidebar-description {
 		display: none;
 
@@ -121,20 +164,28 @@ $break-design-preview: 1024px;
 			color: var(--studio-gray-80);
 			font-size: 1rem;
 			line-height: 24px;
+
+			button {
+				color: var(--color-link);
+				display: block;
+				font-size: 1rem;
+				line-height: 24px;
+				padding: 0;
+
+				&:active,
+				&:focus {
+					color: var(--color-link);
+				}
+			}
 		}
 
 		@include break-design-preview {
 			display: block;
-			margin-top: 1rem;
+			margin-top: 2rem;
 		}
 	}
 
 	@include break-design-preview {
-		margin: 0 -8px;
-		max-height: 100%;
-		overflow-y: scroll;
-		padding: 0 8px;
-
 		h2 {
 			display: block;
 		}
@@ -168,7 +219,6 @@ $break-design-preview: 1024px;
 
 	@include break-design-preview {
 		margin: 2rem 0 0;
-		padding-bottom: 96px;
 
 		> p {
 			display: block;


### PR DESCRIPTION
#### Proposed Changes

This PR updates the theme preview UI as per spec in 0EogtxvlmxMGcnEEaMVECv-fi-1759%3A54399&t=WeysR6crwKBHinUN-0. See screenshot for reference:

![Screen Shot 2023-01-12 at 5 13 49 PM](https://user-images.githubusercontent.com/797888/212026398-91342729-c55d-427e-9c01-7af534448f75.png)

Changes are as follows:
* Added theme author.
* Added theme categories (taxonomy subjects).
* Toggle theme description.
* Update the action button positioning to sticky.

| Before | After |
| --- | --- |
| ![Screen Shot 2023-01-12 at 5 20 33 PM](https://user-images.githubusercontent.com/797888/212027667-a69228ac-5486-4b6c-827b-d2d8722973f2.png) | ![Screen Shot 2023-01-12 at 5 20 55 PM](https://user-images.githubusercontent.com/797888/212027761-97f85da1-a247-4853-a93b-9e31ae958547.png)

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the logged-in Theme Showcase `/themes/${site_slug}`. If using calypso.live, the flag `themes/showcase-i4/details-and-preview` is required.
* Open any theme preview and ensure that it's working as described above.
* Ensure that the changes also work in the logged-out Theme Showcase.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->