### PR TITLE
Remove obsolete code from Upgrade nudge

### DIFF
--- a/client/blocks/post-share/nudges.jsx
+++ b/client/blocks/post-share/nudges.jsx
@@ -1,9 +1,4 @@
-import {
-	findFirstSimilarPlanKey,
-	TYPE_PREMIUM,
-	TERM_ANNUALLY,
-	TYPE_SECURITY_T1,
-} from '@automattic/calypso-products';
+import { findFirstSimilarPlanKey, TYPE_PREMIUM } from '@automattic/calypso-products';
 import formatCurrency from '@automattic/format-currency';
 import { connect } from 'react-redux';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
@@ -51,12 +46,9 @@ const getDiscountedOrRegularPrice = ( state, siteId, plan ) =>
 	getSitePlanRawPrice( state, siteId, plan, { isMonthly: true } );
 
 export const UpgradeToPremiumNudge = connect( ( state, ownProps ) => {
-	const { isJetpack, siteId } = ownProps;
+	const { siteId } = ownProps;
 	const currentPlanSlug = ( getSitePlan( state, getSelectedSiteId( state ) ) || {} ).product_slug;
-	const proposedPlan = findFirstSimilarPlanKey( currentPlanSlug, {
-		type: isJetpack ? TYPE_SECURITY_T1 : TYPE_PREMIUM,
-		...( isJetpack ? { term: TERM_ANNUALLY } : {} ),
-	} );
+	const proposedPlan = findFirstSimilarPlanKey( currentPlanSlug, { type: TYPE_PREMIUM } );
 
 	return {
 		planSlug: proposedPlan,

--- a/client/blocks/post-share/nudges.jsx
+++ b/client/blocks/post-share/nudges.jsx
@@ -1,4 +1,3 @@
-import { recordTracksEvent } from '@automattic/calypso-analytics';
 import {
 	findFirstSimilarPlanKey,
 	TYPE_PREMIUM,
@@ -8,8 +7,6 @@ import {
 import formatCurrency from '@automattic/format-currency';
 import { connect } from 'react-redux';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
-import ExternalLink from 'calypso/components/external-link';
-import { preventWidows } from 'calypso/lib/formatting';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import {
 	getSitePlanRawPrice,
@@ -19,28 +16,15 @@ import { getSitePlan } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 export const UpgradeToPremiumNudgePure = ( props ) => {
-	const { price, planSlug, siteSlug, translate, userCurrency, canUserUpgrade, isJetpack } = props;
+	const { price, planSlug, translate, userCurrency, canUserUpgrade } = props;
 
-	let featureList;
-	if ( isJetpack ) {
-		featureList = [
-			translate( 'Share posts that have already been published.' ),
-			translate( 'Schedule your social messages in advance.' ),
-			preventWidows(
-				translate(
-					'Enjoy all other Jetpack Security features, including real-time cloud backups, real-time malware scanning, comment and form spam protection, and more.'
-				)
-			),
-		];
-	} else {
-		featureList = [
-			translate( 'Share posts that have already been published.' ),
-			translate( 'Schedule your social messages in advance.' ),
-			translate( 'Remove all advertising from your site.' ),
-			translate( 'Enjoy live chat support.' ),
-			translate( 'Easy monetization options' ),
-		];
-	}
+	const featureList = [
+		translate( 'Share posts that have already been published.' ),
+		translate( 'Schedule your social messages in advance.' ),
+		translate( 'Remove all advertising from your site.' ),
+		translate( 'Enjoy live chat support.' ),
+		translate( 'Easy monetization options' ),
+	];
 
 	if ( ! canUserUpgrade ) {
 		return null;
@@ -57,30 +41,7 @@ export const UpgradeToPremiumNudgePure = ( props ) => {
 			list={ featureList }
 			plan={ planSlug }
 			showIcon
-			title={
-				isJetpack
-					? translate( 'Upgrade to Jetpack Security to unlock additional features.' )
-					: translate( 'Upgrade to a Premium Plan!' )
-			}
-			{ ...( isJetpack && {
-				description: translate(
-					'Jetpack Social makes it easy to share your new posts on your social media networks automatically. With a Jetpack Security or Complete plan, you can share content that has already been published and can also schedule posts to be shared at a specific time. {{ExternalLink}}Learn more{{/ExternalLink}}',
-					{
-						components: {
-							ExternalLink: (
-								<ExternalLink
-									href="https://jetpack.com/support/jetpack-social/#re-sharing-your-content"
-									icon={ true }
-									onClick={ () =>
-										recordTracksEvent( 'calypso_publicize_post_share_learn_more_click' )
-									}
-								/>
-							),
-						},
-					}
-				),
-				href: `/checkout/${ siteSlug }/jetpack_security_t1_yearly`,
-			} ) }
+			title={ translate( 'Upgrade to a Premium Plan!' ) }
 		/>
 	);
 };

--- a/client/blocks/post-share/test/nudges.jsx
+++ b/client/blocks/post-share/test/nudges.jsx
@@ -77,7 +77,7 @@ describe( 'UpgradeToPremiumNudgePure.render()', () => {
 		PLAN_ECOMMERCE_2_YEARS,
 	].forEach( ( plan ) => {
 		test( `Should pass 2-years wp.com premium plan for 2-years plans ${ plan }`, () => {
-			render( <UpgradeToPremiumNudgePure { ...props } isJetpack={ false } planSlug={ plan } /> );
+			render( <UpgradeToPremiumNudgePure { ...props } planSlug={ plan } /> );
 			expect( screen.getByTestId( 'upsell-nudge-plan' ) ).toHaveTextContent( plan );
 		} );
 	} );


### PR DESCRIPTION
#### Proposed Changes

Re-publicize is now free for all Jetpack sites, so the code that would ask for Jetpack sites to upgrade to Security is not needed anymore. This change removes that.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use a free simple site, go into Posts in wp-admin, than try to reshare a post. It should still ask you to upgrade to a Premium Plan
* Using a Jetpack site there should be not prompt at all - not touched in this change

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
