### PR TITLE
Plans 2023 : Add basic feature resolution and display

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
@@ -20,6 +20,7 @@ import { getPlanSlug } from 'calypso/state/plans/selectors';
 import { ONBOARD_STORE } from '../../../../stores';
 import './style.scss';
 
+type IntervalType = 'yearly' | 'monthly';
 interface Props {
 	flowName: string | null;
 	onSubmit: () => void;
@@ -83,16 +84,16 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 		);
 	};
 
-	const getIntervalType = () => {
+	const getIntervalType: () => IntervalType = () => {
 		const urlParts = getUrlParts( typeof window !== 'undefined' ? window.location?.href : '' );
-		const intervalType = urlParts?.searchParams.get( 'intervalType' ) as string;
-
-		if ( [ 'yearly', 'monthly' ].includes( intervalType ) ) {
-			return intervalType;
+		const intervalType = urlParts?.searchParams.get( 'intervalType' );
+		switch ( intervalType ) {
+			case 'monthly':
+			case 'yearly':
+				return intervalType as IntervalType;
+			default:
+				return 'yearly';
 		}
-
-		// Default value
-		return 'yearly';
 	};
 
 	const plansFeaturesList = () => {

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -54,7 +54,7 @@ import PlanFeatures2023GridBillingTimeframe from './billing-timeframe';
 import PlanFeatures2023GridFeatures from './features';
 import PlanFeatures2023GridHeaderPrice from './header-price';
 import { PlanFeaturesItem } from './item';
-import { PlanComparison2023Grid } from './plan-comparison-grid';
+import { PlanComparisonGrid } from './plan-comparison-grid';
 import { PlanProperties, TransformedFeatureObject } from './types';
 import { getStorageStringFromFeature } from './util';
 
@@ -92,6 +92,7 @@ type PlanFeatures2023GridProps = {
 	domainName: string;
 	placeholder?: string;
 	isLandingPage?: boolean;
+	intervalType: string;
 };
 
 type PlanFeatures2023GridConnectedProps = {
@@ -135,7 +136,10 @@ export class PlanFeatures2023Grid extends Component< PlanFeatures2023GridType > 
 						</div>
 					</div>
 				</div>
-				<PlanComparison2023Grid planProperties={ this.props.planProperties } />
+				<PlanComparisonGrid
+					planProperties={ this.props.planProperties }
+					intervalType={ this.props.intervalType }
+				/>
 			</div>
 		);
 	}

--- a/client/my-sites/plan-features-2023-grid/plan-comparison-grid.tsx
+++ b/client/my-sites/plan-features-2023-grid/plan-comparison-grid.tsx
@@ -8,9 +8,7 @@ import { Gridicon } from '@automattic/components';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
-import { BrowserRouter } from 'react-router-dom';
 import { getPlanFeaturesObject } from 'calypso/lib/plans/features-list';
-import { IntervalTypeToggle } from 'calypso/my-sites/plans-features-main/plan-type-selector';
 import { PlanProperties } from './types';
 
 const PlanComparisonHeader = styled.h1`
@@ -33,13 +31,15 @@ const Row = styled.div`
 	justify-content: space-between;
 	padding: 14px 0px;
 	border-bottom: 1px solid #eee;
-	.plan-comparison-grid__feature-feature-name {
-		width: 250px;
-	}
 `;
 
 const Cell = styled.div< { textAlign?: string } >`
 	text-align: ${ ( props ) => props.textAlign ?? 'left' };
+	width: 150px;
+`;
+
+const RowHead = styled.div`
+	width: 300px;
 `;
 
 type FeatureAvailabilityForPlansProps = {
@@ -55,19 +55,16 @@ const FeatureAvailabilityForPlans: React.FC< FeatureAvailabilityForPlansProps > 
 } ) => {
 	return (
 		<>
-			{ ( displayedPlans ?? [] ).map( ( { planName } ) => {
-				if ( planFeatureMap[ planName ].has( featureSlug ) ) {
-					return (
-						<Cell
-							key={ planName }
-							className={ `plan-comparison-grid__plan ${ planName }` }
-							textAlign="center"
-						>
-							<Gridicon icon="checkmark" color="#0675C4" />
-						</Cell>
-					);
-				}
-				return (
+			{ ( displayedPlans ?? [] ).map( ( { planName } ) =>
+				planFeatureMap[ planName ].has( featureSlug ) ? (
+					<Cell
+						key={ planName }
+						className={ `plan-comparison-grid__plan ${ planName }` }
+						textAlign="center"
+					>
+						<Gridicon icon="checkmark" color="#0675C4" />
+					</Cell>
+				) : (
 					<Cell
 						key={ planName }
 						className={ `plan-comparison-grid__plan ${ planName }` }
@@ -75,8 +72,8 @@ const FeatureAvailabilityForPlans: React.FC< FeatureAvailabilityForPlansProps > 
 					>
 						<Gridicon icon="minus-small" />
 					</Cell>
-				);
-			} ) }
+				)
+			) }
 		</>
 	);
 };
@@ -135,7 +132,9 @@ export const PlanComparisonGrid: React.FC< PlanComparisonGridProps > = ( {
 			</PlanComparisonHeader>
 			<Grid>
 				<Row key="feature-group-title" className="plan-comparison-grid__plan-row">
-					<Cell key="feature-name" className="plan-comparison-grid__interval-toggle">
+					<RowHead key="feature-name" className="plan-comparison-grid__interval-toggle">
+						{ /* 
+						// This component was breaking scroll and the click was not working to be picked up later
 						<BrowserRouter>
 							<IntervalTypeToggle
 								eligibleForWpcomMonthlyPlans={ true }
@@ -144,8 +143,8 @@ export const PlanComparisonGrid: React.FC< PlanComparisonGridProps > = ( {
 								isInSignup={ true }
 								isPlansInsideStepper={ true }
 							/>
-						</BrowserRouter>
-					</Cell>
+						</BrowserRouter> */ }
+					</RowHead>
 					{ displayedPlansProperties.map( ( { planName, planConstantObj } ) => (
 						<Cell key={ planName } className="plan-comparison-grid__plan-title" textAlign="center">
 							{ planConstantObj.getTitle() }
@@ -170,12 +169,12 @@ export const PlanComparisonGrid: React.FC< PlanComparisonGridProps > = ( {
 										key={ featureSlug }
 										className={ `plan-comparison-grid__feature-row ${ feature.getTitle() }` }
 									>
-										<Cell
+										<RowHead
 											key="feature-name"
 											className={ `plan-comparison-grid__feature-feature-name ${ feature.getTitle() }` }
 										>
 											{ feature.getTitle() }
-										</Cell>
+										</RowHead>
 										<FeatureAvailabilityForPlans
 											displayedPlans={ displayedPlansProperties }
 											featureSlug={ featureSlug }

--- a/client/my-sites/plan-features-2023-grid/plan-comparison-grid.tsx
+++ b/client/my-sites/plan-features-2023-grid/plan-comparison-grid.tsx
@@ -1,21 +1,193 @@
+import {
+	applyTestFiltersToPlansList,
+	FeatureGroup,
+	getPlanFeaturesGrouped,
+	PLAN_ENTERPRISE_GRID_WPCOM,
+} from '@automattic/calypso-products';
+import { Gridicon } from '@automattic/components';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
+import { useMemo } from 'react';
+import { BrowserRouter } from 'react-router-dom';
+import { getPlanFeaturesObject } from 'calypso/lib/plans/features-list';
+import { IntervalTypeToggle } from 'calypso/my-sites/plans-features-main/plan-type-selector';
 import { PlanProperties } from './types';
+
 const PlanComparisonHeader = styled.h1`
 	font-size: 2rem;
 	text-align: center;
 	margin: 48px 0;
 `;
 
-type PlanComparison2023GridProps = { planProperties?: Array< PlanProperties > };
+const Title = styled.div`
+	font-weight: 500;
+	font-size: 20px;
+	margin-bottom: 15px;
+`;
 
-export const PlanComparison2023Grid: React.FC< PlanComparison2023GridProps > = () => {
+const Grid = styled.div`
+	display: grid;
+`;
+const Row = styled.div`
+	display: flex;
+	justify-content: space-between;
+	padding: 14px 0px;
+	border-bottom: 1px solid #eee;
+	.plan-comparison-grid__feature-feature-name {
+		width: 250px;
+	}
+`;
+
+const Cell = styled.div< { textAlign?: string } >`
+	text-align: ${ ( props ) => props.textAlign ?? 'left' };
+`;
+
+type FeatureAvailabilityForPlansProps = {
+	displayedPlans?: Array< PlanProperties >;
+	featureSlug: string;
+	planFeatureMap: Record< string, Set< string > >;
+};
+
+const FeatureAvailabilityForPlans: React.FC< FeatureAvailabilityForPlansProps > = ( {
+	displayedPlans,
+	featureSlug,
+	planFeatureMap,
+} ) => {
+	return (
+		<>
+			{ ( displayedPlans ?? [] ).map( ( { planName } ) => {
+				if ( planFeatureMap[ planName ].has( featureSlug ) ) {
+					return (
+						<Cell
+							key={ planName }
+							className={ `plan-comparison-grid__plan ${ planName }` }
+							textAlign="center"
+						>
+							<Gridicon icon="checkmark" color="#0675C4" />
+						</Cell>
+					);
+				}
+				return (
+					<Cell
+						key={ planName }
+						className={ `plan-comparison-grid__plan ${ planName }` }
+						textAlign="center"
+					>
+						<Gridicon icon="minus-small" />
+					</Cell>
+				);
+			} ) }
+		</>
+	);
+};
+
+type PlanComparisonGridProps = {
+	planProperties?: Array< PlanProperties >;
+	intervalType: string;
+};
+
+export const PlanComparisonGrid: React.FC< PlanComparisonGridProps > = ( {
+	planProperties,
+	intervalType,
+} ) => {
 	const translate = useTranslate();
+	const planGroups = getPlanFeaturesGrouped();
+	const displayedPlansProperties = ( planProperties ?? [] ).filter(
+		( { planName } ) => ! ( planName === PLAN_ENTERPRISE_GRID_WPCOM )
+	);
+	const isMonthly = intervalType === 'monthly';
+	const planFeatureMap = useMemo( () => {
+		let previousPlan = null;
+		const featureMap: Record< string, Set< string > > = {};
+
+		for ( const plan of planProperties ?? [] ) {
+			const { planName } = plan;
+			const planObject = applyTestFiltersToPlansList( planName, undefined );
+			const wpcomFeatures = planObject.get2023PricingGridSignupWpcomFeatures?.() ?? [];
+			const jetpackFeatures = planObject.get2023PricingGridSignupJetpackFeatures?.() ?? [];
+			const annualOnlyFeatures = planObject.getAnnualPlansOnlyFeatures?.() ?? [];
+
+			let featuresAvailable = [ ...wpcomFeatures, ...jetpackFeatures ];
+			if ( isMonthly ) {
+				// Filter out features only available annually
+				featuresAvailable = featuresAvailable.filter(
+					( feature ) => ! annualOnlyFeatures.includes( feature )
+				);
+			}
+			featureMap[ planName ] = new Set( featuresAvailable );
+
+			// Add previous plan feature
+			if ( previousPlan !== null ) {
+				featureMap[ planName ] = new Set( [
+					...featureMap[ planName ],
+					...featureMap[ previousPlan ],
+				] );
+			}
+			previousPlan = planName;
+		}
+		return featureMap;
+	}, [ planProperties, isMonthly ] );
+
 	return (
 		<div className="plan-comparison-grid">
 			<PlanComparisonHeader className="wp-brand-font">
 				{ translate( 'Compare our plans and find yours' ) }
 			</PlanComparisonHeader>
+			<Grid>
+				<Row key="feature-group-title" className="plan-comparison-grid__plan-row">
+					<Cell key="feature-name" className="plan-comparison-grid__interval-toggle">
+						<BrowserRouter>
+							<IntervalTypeToggle
+								eligibleForWpcomMonthlyPlans={ true }
+								intervalType={ intervalType }
+								plans={ [] }
+								isInSignup={ true }
+								isPlansInsideStepper={ true }
+							/>
+						</BrowserRouter>
+					</Cell>
+					{ displayedPlansProperties.map( ( { planName, planConstantObj } ) => (
+						<Cell key={ planName } className="plan-comparison-grid__plan-title" textAlign="center">
+							{ planConstantObj.getTitle() }
+						</Cell>
+					) ) }
+				</Row>
+
+				{ Object.values( planGroups ).map( ( featureGroup: FeatureGroup ) => {
+					const features = featureGroup.get2023PricingGridSignupWpcomFeatures();
+					const featureObjects = getPlanFeaturesObject( features );
+					return (
+						<>
+							<Row key="feature-group-title" className="plan-comparison-grid__group-title-row">
+								<Title className={ `plan-comparison-grid__group-${ featureGroup.slug }` }>
+									{ featureGroup.getTitle() }
+								</Title>
+							</Row>
+							{ featureObjects.map( ( feature ) => {
+								const featureSlug = feature.getSlug();
+								return (
+									<Row
+										key={ featureSlug }
+										className={ `plan-comparison-grid__feature-row ${ feature.getTitle() }` }
+									>
+										<Cell
+											key="feature-name"
+											className={ `plan-comparison-grid__feature-feature-name ${ feature.getTitle() }` }
+										>
+											{ feature.getTitle() }
+										</Cell>
+										<FeatureAvailabilityForPlans
+											displayedPlans={ displayedPlansProperties }
+											featureSlug={ featureSlug }
+											planFeatureMap={ planFeatureMap }
+										/>
+									</Row>
+								);
+							} ) }
+						</>
+					);
+				} ) }
+			</Grid>
 		</div>
 	);
 };

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -123,6 +123,7 @@ export class PlansFeaturesMain extends Component {
 			isFAQCondensedExperiment,
 			isPlansInsideStepper,
 			is2023OnboardingPricingGrid,
+			intervalType,
 		} = this.props;
 
 		const plans = this.getPlansForPlanFeatures();
@@ -154,6 +155,7 @@ export class PlansFeaturesMain extends Component {
 				siteId,
 				isReskinned,
 				isPlansInsideStepper,
+				intervalType,
 			};
 			const asyncPlanFeatures2023Grid = (
 				<AsyncLoad require="calypso/my-sites/plan-features-2023-grid" { ...asyncProps } />

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -627,7 +627,7 @@ PlansFeaturesMain.propTypes = {
 	hidePremiumPlan: PropTypes.bool,
 	customerType: PropTypes.string,
 	flowName: PropTypes.string,
-	intervalType: PropTypes.string,
+	intervalType: PropTypes.oneOf( [ 'monthly', 'yearly' ] ),
 	isChatAvailable: PropTypes.bool,
 	isInSignup: PropTypes.bool,
 	isLandingPage: PropTypes.bool,

--- a/packages/calypso-products/src/constants/feature-group.ts
+++ b/packages/calypso-products/src/constants/feature-group.ts
@@ -1,0 +1,9 @@
+export const FEATURE_GROUP_GENERAL_FEATURES = 'feature-group-general-features';
+export const FEATURE_GROUP_PERFORMANCE_BOOSTERS = 'feature-group-performance-boosters';
+export const FEATURE_GROUP_HIGH_AVAILABILITY = 'feature-group-high-availability';
+export const FEATURE_GROUP_DEVELOPER_TOOLS = 'feature-group-developer-tools';
+export const FEATURE_GROUP_SECURITY_AND_SAFETY = 'feature-group-security-and-safety';
+export const FEATURE_GROUP_INNOVATIVE_TECHNOLOGIES = 'feature-group-innovative-technologies';
+export const FEATURE_GROUP_THEMES_AND_CUSTOMIZATION = 'feature-group-themes-and-customization';
+export const FEATURE_GROUP_MARKETING_GROWTH_AND_MONETIZATION_TOOLS =
+	'feature-group-marketing-growth-and-monetization-tools';

--- a/packages/calypso-products/src/constants/index.ts
+++ b/packages/calypso-products/src/constants/index.ts
@@ -7,3 +7,4 @@ export * from './terms';
 export * from './titan';
 export * from './types';
 export * from './wpcom';
+export * from './feature-group';

--- a/packages/calypso-products/src/feature-group-plan-map.ts
+++ b/packages/calypso-products/src/feature-group-plan-map.ts
@@ -1,0 +1,30 @@
+import i18n from 'i18n-calypso';
+import {
+	FEATURE_LIVE_CHAT_SUPPORT,
+	FEATURE_PAGES,
+	FEATURE_USERS,
+	FEATURE_POST_EDITS_HISTORY,
+	FEATURE_ALWAYS_ONLINE,
+	FEATURE_STATS_JP,
+	FEATURE_CONTACT_FORM_JP,
+	FEATURE_GROUP_GENERAL_FEATURES,
+	FEATURE_CUSTOM_DOMAIN,
+} from './constants';
+import { FeatureGroupMap } from './types';
+
+export const featureGroups: Partial< FeatureGroupMap > = {
+	[ FEATURE_GROUP_GENERAL_FEATURES ]: {
+		slug: FEATURE_GROUP_GENERAL_FEATURES,
+		getTitle: () => i18n.translate( 'General Features' ),
+		get2023PricingGridSignupWpcomFeatures: () => [
+			FEATURE_PAGES,
+			FEATURE_USERS,
+			FEATURE_POST_EDITS_HISTORY,
+			FEATURE_ALWAYS_ONLINE,
+			FEATURE_CONTACT_FORM_JP,
+			FEATURE_STATS_JP,
+			FEATURE_CUSTOM_DOMAIN,
+			FEATURE_LIVE_CHAT_SUPPORT,
+		],
+	},
+};

--- a/packages/calypso-products/src/main.ts
+++ b/packages/calypso-products/src/main.ts
@@ -25,6 +25,7 @@ import {
 	TYPE_P2_PLUS,
 	TYPE_ENTERPRISE_GRID_WPCOM,
 } from './constants';
+import { featureGroups } from './feature-group-plan-map';
 import { PLANS_LIST } from './plans-list';
 import {
 	isJetpackBusiness,
@@ -44,11 +45,16 @@ import type {
 	PlanSlug,
 	WithCamelCaseSlug,
 	WithSnakeCaseSlug,
+	FeatureGroupMap,
 } from './types';
 import type { TranslateResult } from 'i18n-calypso';
 
 export function getPlans(): Record< string, Plan > {
 	return PLANS_LIST;
+}
+
+export function getPlanFeaturesGrouped(): Partial< FeatureGroupMap > {
+	return featureGroups;
 }
 
 export function getPlansSlugs(): string[] {

--- a/packages/calypso-products/src/types.ts
+++ b/packages/calypso-products/src/types.ts
@@ -11,6 +11,14 @@ import type {
 	TERMS_LIST,
 	PERIOD_LIST,
 	JETPACK_PRODUCT_CATEGORIES,
+	FEATURE_GROUP_GENERAL_FEATURES,
+	FEATURE_GROUP_PERFORMANCE_BOOSTERS,
+	FEATURE_GROUP_HIGH_AVAILABILITY,
+	FEATURE_GROUP_DEVELOPER_TOOLS,
+	FEATURE_GROUP_SECURITY_AND_SAFETY,
+	FEATURE_GROUP_INNOVATIVE_TECHNOLOGIES,
+	FEATURE_GROUP_THEMES_AND_CUSTOMIZATION,
+	FEATURE_GROUP_MARKETING_GROWTH_AND_MONETIZATION_TOOLS,
 } from './constants';
 import type { TranslateResult } from 'i18n-calypso';
 import type { ReactElement } from 'react';
@@ -45,6 +53,7 @@ export interface WPComPlan extends Plan {
 	getPromotedFeatures?: () => Feature[];
 	getPathSlug: () => string;
 	getAnnualPlansOnlyFeatures?: () => string[];
+	get2023PricingGridSignupWpcomFeatures?: () => Feature[];
 }
 
 export type IncompleteWPcomPlan = Partial< WPComPlan > &
@@ -118,6 +127,23 @@ export interface BillingTerm {
 	term: typeof TERMS_LIST[ number ];
 	getBillingTimeFrame: () => TranslateResult;
 }
+
+export type FeatureGroupSlug =
+	| typeof FEATURE_GROUP_GENERAL_FEATURES
+	| typeof FEATURE_GROUP_PERFORMANCE_BOOSTERS
+	| typeof FEATURE_GROUP_HIGH_AVAILABILITY
+	| typeof FEATURE_GROUP_DEVELOPER_TOOLS
+	| typeof FEATURE_GROUP_SECURITY_AND_SAFETY
+	| typeof FEATURE_GROUP_INNOVATIVE_TECHNOLOGIES
+	| typeof FEATURE_GROUP_THEMES_AND_CUSTOMIZATION
+	| typeof FEATURE_GROUP_MARKETING_GROWTH_AND_MONETIZATION_TOOLS;
+
+export type FeatureGroup = {
+	slug: FeatureGroupSlug;
+	getTitle: () => string;
+	get2023PricingGridSignupWpcomFeatures: () => Feature[];
+};
+export type FeatureGroupMap = Record< FeatureGroupSlug, FeatureGroup >;
 
 export type Plan = BillingTerm & {
 	group: typeof GROUP_WPCOM | typeof GROUP_JETPACK;


### PR DESCRIPTION
#### Proposed Changes

* This change adds the basic scaffolding required to implement the plans comparison grid
* The styling changes are not implemented at this stage.
* All the features are also not added here so that focus of this review can be of the implementation
* The toggle was removed due to a bug

![image](https://user-images.githubusercontent.com/3422709/213354432-05be95ca-ec94-4fe9-8174-1a367eefc548.png)

#### Testing Instructions
- Go to 
    - `/start/onboarding-2023-pricing-grid/plans?intervalType=yearly`
    - `/start/onboarding-2023-pricing-grid/plans?intervalType=monthly`
- Make sure the above grid s are visible on the respective URL

### What is not implemented?
- Please note the buttons at the comparison grid are not working right now
- Please note that the designs have not been implemented completely
-  All the plan features are also not added here in the grid so that focus of this review can be purely on the implementation

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
