### PR TITLE
Themes: Hide Business plan upsell if there are results

### DIFF
--- a/client/components/themes-list/index.jsx
+++ b/client/components/themes-list/index.jsx
@@ -171,16 +171,18 @@ function Empty( props ) {
 					{ ...props }
 				/>
 			) : (
-				<div className="themes-list__not-found-text">
-					{ translate( 'No themes match your search' ) }
-				</div>
+				<>
+					<div className="themes-list__not-found-text">
+						{ translate( 'No themes match your search' ) }
+					</div>
+					<PlanUpgradeCTA
+						selectedSite={ selectedSite }
+						searchTerm={ searchTerm }
+						translate={ translate }
+						recordTracksEvent={ props.recordTracksEvent }
+					/>
+				</>
 			) }
-			<PlanUpgradeCTA
-				selectedSite={ selectedSite }
-				searchTerm={ searchTerm }
-				translate={ translate }
-				recordTracksEvent={ props.recordTracksEvent }
-			/>
 		</div>
 	) : (
 		<>


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/1400

#### Proposed Changes

Hides the Business plan upsell from the themes search if we're displaying results.

This upsell was intended to show on searches for Astra as an experiment when we were not displaying WP.org themes in the results.

Now that WP.org themes are listed in the search, we shouldn’t show the upsell if there are matching themes.

Before | After
--- | ---
<img width="1280" alt="Screenshot 2023-01-12 at 13 55 36" src="https://user-images.githubusercontent.com/1233880/212073245-e8830a7f-71b4-448c-9198-6fb4695421ce.png"> | <img width="1276" alt="Screenshot 2023-01-12 at 13 57 15" src="https://user-images.githubusercontent.com/1233880/212073265-fd37b941-25b2-4fec-8c4a-f2403377e90a.png">

#### Testing Instructions

- Use the Calypso live link below
- Go to Appearance > Themes
- Search for "Astra" or "Hotel"
- Make sure the upsell doesn't show up
- Search for something that doesn't produce any result
- Make sure the upsell shows up
