### PR TITLE
Enable themes/third-party-premium in horizon and wpcalypso

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -119,7 +119,7 @@
 		"themes/showcase-i4/details-and-preview": false,
 		"themes/subscription-purchases": false,
 		"themes/theme-switch-persist-template": true,
-		"themes/third-party-premium": false,
+		"themes/third-party-premium": true,
 		"unified-pages/virtual-home-page": true,
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -144,7 +144,7 @@
 		"themes/showcase-i4/details-and-preview": false,
 		"themes/subscription-purchases": false,
 		"themes/theme-switch-persist-template": false,
-		"themes/third-party-premium": false,
+		"themes/third-party-premium": true,
 		"unified-pages/virtual-home-page": true,
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,


### PR DESCRIPTION
#### Proposed Changes

* This PR enables the `themes/third-party-premium` feature flag in the Horizon and WPCalypso environments to allow for broader testing of the feature outside of developer environments, as we have now addressed #71732

#### Testing Instructions

* While logged in using an Automattic user account, open the Calypso Live branch
* Navigate to _Appearance_ -> _Themes_
* Verify that the Makoney theme is listed
* Search for `makoney` in the search field
* Verify that Makoney is listed in the response

Optionally, you can also purchase the theme to verify that we correctly display the theme after visiting checkout (where I think we lose the feature flag), but that is really testing previous functionality rather than whether the feature flag is enabled.

#### Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [N/A] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [N/A] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [N/A] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [N/A] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [N/A] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?