### PR TITLE
Jetpack cloud cart integration - fix license activation banner link

### DIFF
--- a/client/jetpack-cloud/sections/pricing/jpcom-masterbar/index.tsx
+++ b/client/jetpack-cloud/sections/pricing/jpcom-masterbar/index.tsx
@@ -10,7 +10,10 @@ import Gravatar from 'calypso/components/gravatar';
 import JetpackLogo from 'calypso/components/jetpack-logo';
 import JetpackSaleBanner from 'calypso/jetpack-cloud/sections/pricing/sale-banner';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import useDetectWindowBoundary from 'calypso/lib/detect-window-boundary';
+import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { trailingslashit } from 'calypso/lib/route';
+import { isConnectStore } from 'calypso/my-sites/plans/jetpack-plans/product-grid/utils';
 import { isUserLoggedIn, getCurrentUser } from 'calypso/state/current-user/selectors';
 import { getJetpackSaleCoupon } from 'calypso/state/marketing/selectors';
 import { isJetpackCloudCartEnabled } from 'calypso/state/sites/selectors';
@@ -133,6 +136,22 @@ const JetpackComMasterbar: React.FC< Props > = ( { pathname } ) => {
 
 	const shouldShowCart = useSelector( isJetpackCloudCartEnabled );
 
+	const windowBoundaryOffset = useMemo( () => {
+		if ( isJetpackCloud() || isConnectStore() ) {
+			return 0;
+		}
+
+		return 47;
+	}, [] );
+
+	const [ barRef, hasCrossed ] = useDetectWindowBoundary( windowBoundaryOffset );
+
+	const outerDivProps = barRef ? { ref: barRef as React.RefObject< HTMLDivElement > } : {};
+
+	const classes = classNames( 'header__content-background-wrapper', {
+		'header__content-background-wrapper--sticky': shouldShowCart && hasCrossed,
+	} );
+
 	const onLinkClick = useCallback( ( e ) => {
 		recordTracksEvent( 'calypso_jetpack_nav_item_click', {
 			nav_item: e.currentTarget
@@ -155,7 +174,8 @@ const JetpackComMasterbar: React.FC< Props > = ( { pathname } ) => {
 			<div className="jpcom-masterbar">
 				<header className="header js-header force-opaque">
 					<div className="header__content-wrapper">
-						<div className="header__content-background-wrapper">
+						<div className="header__content-background-wrapper-sentinal" { ...outerDivProps }></div>
+						<div className={ classes }>
 							<nav className="header__content is-sticky">
 								<a className="header__skip" href={ `#${ MAIN_CONTENT_ID }` }>
 									{ translate( 'Skip to main content' ) }

--- a/client/jetpack-cloud/sections/pricing/jpcom-masterbar/style.scss
+++ b/client/jetpack-cloud/sections/pricing/jpcom-masterbar/style.scss
@@ -133,8 +133,6 @@
 	@media ( max-width: 900px ) {
 		.header {
 			position: relative;
-			display: flex;
-			align-items: center;
 			padding: 0;
 			height: 80px;
 			background-color: var(--studio-white);
@@ -159,7 +157,6 @@
 	.header__content-wrapper {
 		position: absolute;
 		width: 100%;
-		height: 195px;
 	}
 
 	.header__content-background-wrapper {
@@ -167,7 +164,10 @@
 		background-color: #fff;
 		top: 0;
 		max-width: 100%;
-		position: sticky;
+		&--sticky {
+			position: fixed;
+		}
+
 	}
 
 	.header__content {
@@ -181,16 +181,10 @@
 		.header__content {
 			width: 90%;
 		}
-		.header__content-wrapper {
-			height: 225px;
-		}
 	}
 	@media ( max-width: 1100px ) {
 		.header__content {
 			width: 95%;
-		}
-		.header__content-wrapper {
-			height: 195px;
 		}
 	}
 	@media ( max-width: 900px ) {
@@ -198,36 +192,13 @@
 			justify-content: space-between;
 		}
 
-		.header__content-wrapper {
-			height: 400px;
-		}
 	}
 	@media ( max-width: 782px ) {
 		.header__content {
 			width: 90%;
 		}
-		.header__content-wrapper {
-			height: 445px;
-		}
 	}
 
-	@media ( max-width: 600px ) {
-		.header__content-wrapper {
-			height: 520px;
-		}
-	}
-
-	@media ( max-width: 480px ) {
-		.header__content-wrapper {
-			height: 570px;
-		}
-	}
-
-	@media ( max-width: 336px ) {
-		.header__content-wrapper {
-			height: 690px;
-		}
-	}
 
 	@media ( max-width: 900px ) {
 		.header__nav-wrapper {
@@ -241,6 +212,11 @@
 			padding: 1rem 0 2rem;
 			background-color: var(--studio-white);
 			box-shadow: 0 12px 12px 0 rgba(0, 0, 0, 0.15);
+		}
+		.header__content-background-wrapper--sticky {
+			.header__nav-wrapper {
+				top: 48px;
+			}
 		}
 		.header__nav-wrapper.is-expanded,
 		.header__nav-wrapper:target {


### PR DESCRIPTION
#### Proposed Changes
- Make the header sticky using IntersectionObserver instead of CSS
- This makes sure the link below (like the license activation banner is clickable)

#### Testing Instructions
**Prerequisites:** 
- You'll need a un-activated product license key.
- If you don't have one:
    - Go to https://jetpack.com/
    - Scroll down the page a bit until you see the 3 product cards (Backup, Security, Complete). Click on "**Get Backup**" and purchase it on the checkout page.
    - On the 'Thank you' page, it's asking you to select a site you want to apply the license to. Do Not select a site. Rather select the dropdown and choose, "**I don't see my site, let me configure it manually**".
    - You now should have an unattached product license key.

----
**Test**
- Do any one of these
    * Click on Jetpack Cloud live link below and wait for the redirect to complete, then goto `/pricing/:site` (`:site` is the site-slug of a jetpack site you own, or a Jurassic Ninja site you created **and connected**.) (This is probably the quickest and easiest way to test this PR).
    * or run this PR 
        * Run `git fetch && git checkout fix/cloud-sticky-header`
        * Run `yarn start-jetpack-cloud` (it takes a little while to build the application)
        * Goto http://jetpack.cloud.localhost:3000/pricing/:site  (where `:site` is the site-slug of a jetpack site you own, or a Jurassic Ninja site you created **and connected**.)
- You may be prompted with a dialog/modal notifying you that you have an available license key. Close (X) the dialog/modal. Then Notice/verify you see a black horizontal banner, notifying you the same, that you have an available license key. It will have an underlined link that says, "**Activate it now**".
- Hover over the **"Activate it now**" link and verify you cursor turns into a pointer. Verify you can click the link and it works! 
![Markup 2023-01-11 at 23 43 14](https://user-images.githubusercontent.com/11078128/211978171-7bfe2a7a-eb46-400a-bbaa-2ad33a10596e.png)

- At various other viewport widths, all the way to mobile, verify that the 2 sticky banners are working correctly as before and verify that the **"Activate it now**" link is working properly and the cursor turns into a pointer when hovering the link
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # 1203495437860512-as-1203698368270970/f