### PR TITLE
Fix redirect URL on edit page/post for Jetpack + WPCore custom path

### DIFF
--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -13,10 +13,10 @@ import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import shouldLoadGutenframe from 'calypso/state/selectors/should-load-gutenframe';
 import { requestSite } from 'calypso/state/sites/actions';
 import {
-	getSiteUrl,
 	getSiteOption,
 	isJetpackSite,
 	isSSOEnabled,
+	getSiteAdminUrl,
 } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import CalypsoifyIframe from './calypsoify-iframe';
@@ -158,8 +158,11 @@ export const authenticate = ( context, next ) => {
 		`${ origin }${ context.path }`
 	);
 
-	const siteUrl = getSiteUrl( state, siteId );
-	const wpAdminLoginUrl = addQueryArgs( { redirect_to: returnUrl }, `${ siteUrl }/wp-login.php` );
+	const siteAdminUrl = getSiteAdminUrl( state, siteId );
+	const wpAdminLoginUrl = addQueryArgs(
+		{ redirect_to: returnUrl },
+		`${ siteAdminUrl }../wp-login.php`
+	);
 
 	window.location.replace( wpAdminLoginUrl );
 };
@@ -198,7 +201,6 @@ export const redirect = async ( context, next ) => {
 		// pass along parameters, for example press-this
 		return window.location.replace( addQueryArgs( context.query, url ) );
 	}
-
 	return next();
 };
 


### PR DESCRIPTION
#### Proposed Changes

Fix redirect URL on edit page/post for Jetpack + WPCore custom path by replacing `getSiteUrl` with `getSiteAdminUrl`

#### Testing Instructions

1. Install Wordpress Bedrock to change the folder structure - Wordpress core should be under *`example.com`*`/wp`.
2. Jetpack plugin installation.
3. Connecting Jetpack to your Wordpress.com account.
4. Trying to edit a post or page on https://wordpress.com/posts or https://wordpress.com/pages or through the desktop application.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] ~~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~~
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~~
- [ ] ~~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~~
- [ ] ~~For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~~
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #71767 
