### PR TITLE
Redirect user to importer flow with siteCreationStep if comes from migration plugin

### DIFF
--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -350,6 +350,14 @@ export class LoginForm extends Component {
 		return translate( 'Continue' );
 	};
 
+	showJetpackConnectSiteOnly = () => {
+		const { currentQuery } = this.props;
+		const isFromJetpackMigration = currentQuery?.redirect_to?.includes( 'jetpack-migration' );
+		return (
+			( currentQuery?.skip_user || currentQuery?.allow_site_connection ) && ! isFromJetpackMigration
+		);
+	};
+
 	renderWooCommerce( { showSocialLogin = true, socialToS } = {} ) {
 		const isFormDisabled = this.state.isFormDisabledWhileLoading || this.props.isFormDisabled;
 		const { requestError, socialAccountIsLinking: linkingSocialUser } = this.props;
@@ -759,7 +767,7 @@ export class LoginForm extends Component {
 					</Fragment>
 				) }
 
-				{ ( currentQuery?.skip_user || currentQuery?.allow_site_connection ) && (
+				{ this.showJetpackConnectSiteOnly() && (
 					<JetpackConnectSiteOnly
 						homeUrl={ currentQuery?.site }
 						redirectAfterAuth={ currentQuery?.redirect_after_auth }

--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -291,6 +291,8 @@ export class JetpackAuthorize extends Component {
 		} else if ( this.isFromJetpackBackupPlugin() && ! siteHasBackups ) {
 			debug( `Redirecting directly to cart with ${ PRODUCT_JETPACK_BACKUP_T1_YEARLY } in cart.` );
 			navigate( `/checkout/${ urlToSlug( homeUrl ) }/${ PRODUCT_JETPACK_BACKUP_T1_YEARLY }` );
+		} else if ( this.isFromJetpackMigration() ) {
+			navigate( `/setup/import-focused/siteCreationStep?from=${ urlToSlug( homeUrl ) }` );
 		} else {
 			const redirectionTarget = this.getRedirectionTarget();
 			debug( `Redirecting to: ${ redirectionTarget }` );
@@ -414,6 +416,11 @@ export class JetpackAuthorize extends Component {
 	isJetpackPartnerCoupon( props = this.props ) {
 		const { from } = props.authQuery;
 		return startsWith( from, 'jetpack-partner-coupon' );
+	}
+
+	isFromJetpackMigration( props = this.props ) {
+		const { from } = props.authQuery;
+		return startsWith( from, 'jetpack-migration' );
 	}
 
 	shouldRedirectJetpackStart( props = this.props ) {

--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -22,7 +22,7 @@ import {
 } from '@automattic/calypso-products';
 import { getLocaleFromPath, removeLocaleFromPath } from '@automattic/i18n-utils';
 import Debug from 'debug';
-import { get, some } from 'lodash';
+import { get, some, startsWith } from 'lodash';
 import page from 'page';
 import { recordPageView } from 'calypso/lib/analytics/page-view';
 import { navigate } from 'calypso/lib/navigate';
@@ -387,12 +387,22 @@ export function signupForm( context, next ) {
 	);
 
 	const isLoggedIn = isUserLoggedIn( context.store.getState() );
+	const { query } = context;
+	const from = query.from;
+	if ( from && startsWith( from, 'jetpack-migration' ) ) {
+		const signupUrl = config( 'signup_url' );
+		const urlQueryArgs = {
+			redirect_to: context.path,
+			from,
+		};
+		return page( addQueryArgs( urlQueryArgs, `${ signupUrl }/account` ) );
+	}
+
 	if ( retrieveMobileRedirect() && ! isLoggedIn ) {
 		// Force login for mobile app flow. App will intercept this request and prompt native login.
 		return window.location.replace( login( { redirectTo: context.path } ) );
 	}
 
-	const { query } = context;
 	const transformedQuery = parseAuthorizationQuery( query );
 
 	if ( transformedQuery ) {

--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -203,6 +203,7 @@ export function redirectJetpack( context, next ) {
 	const isUserComingFromPricingPage =
 		redirect_to?.includes( 'source=jetpack-plans' ) ||
 		redirect_to?.includes( 'source=jetpack-connect-plans' );
+	const isUserComingFromMigrationPlugin = redirect_to?.includes( 'jetpack-migration' );
 	/**
 	 * Send arrivals from the jetpack connect process or jetpack's pricing page
 	 * (when site user email matches a wpcom account) to the jetpack branded login.
@@ -212,8 +213,10 @@ export function redirectJetpack( context, next ) {
 	 * native credentials form.
 	 */
 	if (
-		isJetpack !== 'jetpack' &&
-		( redirect_to?.includes( 'jetpack/connect' ) || isUserComingFromPricingPage )
+		( isJetpack !== 'jetpack' &&
+			redirect_to?.includes( 'jetpack/connect' ) &&
+			! isUserComingFromMigrationPlugin ) ||
+		isUserComingFromPricingPage
 	) {
 		return context.redirect( context.path.replace( 'log-in', 'log-in/jetpack' ) );
 	}


### PR DESCRIPTION
#### Proposed Changes

* When user connects their site and user account from the migration plugin in their self-hosted site, we need to redirect the users to importer flow and helps them import their self-hosted site to WordPress.com

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Launch a [JN site with the migration plugin](https://jurassic.ninja/create/?jetpack-beta&branches.jetpack-migration=add/migration-plugin&wp-debug-log).
* Navigate to Jetpack > Migration page from the left menu.
* Click `Get Started` button from the page.

* Test case 1
    * If you are already logged in, you will be redirected to something like `https://wordpress.com/jetpack/connect/authorize?client_id=xxx...`, please replace `https://wordpress.com` with `http://calypso.localhost:3000` and try again, continue on the authorization process and see if you landed in the importer flow with a new blog and continue to finish the site migration.

* Test case 2
    * If you haven't logged in, but the user email you use in your testing site already has an account on WordPress.com, you will be redirected to something like `https://wordpress.com/log-in/jetpack?email_addres=.....`, please replace `https://wordpress.com/log-in/jetpack` with `http://calypso.localhost:3000/log-in` and try again, continue on the authorization process and see if you landed in the importer flow with a new blog and continue to finish the site migration.

* Test case 3
    * If you haven't logged in, and the user email you use in your testing site doesn't have any account on WordPress.com, you will be redirected to something like `https://wordpress.com/jetpack/connect/authorize?client_id=xxx....`, please replace `https://wordpress.com` with `http://calypso.localhost:3000` and try again, see if you get redirect to `/start/account/user` signup page. Create an account, continue on the authorization process and see if you landed in the importer flow with a new blog and continue to finish the site migration.

**Note**
* During the test please make sure the URL you are testing is calypso and not the live site.
* To change the user email from the testing JN site, you can go to Users > Profile page. Please make sure that you need to confirm the changes by clicking the link in email to update it.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
