### PR TITLE
Email stats: make devices, countries and clients all time stats

### DIFF
--- a/client/my-sites/stats/stats-email-open-detail/index.jsx
+++ b/client/my-sites/stats/stats-email-open-detail/index.jsx
@@ -24,7 +24,7 @@ import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 import { getSitePost } from 'calypso/state/posts/selectors';
 import isPrivateSite from 'calypso/state/selectors/is-private-site';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
-import { getEmailStat, isRequestingPeriodEmailStats } from 'calypso/state/stats/emails/selectors';
+import { getEmailStat, isRequestingEmailStats } from 'calypso/state/stats/emails/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import DatePicker from '../stats-date-picker';
 import ChartTabs from '../stats-email-chart-tabs';
@@ -282,7 +282,7 @@ class StatsEmailOpenDetail extends Component {
 									statType="opens"
 									postId={ postId }
 									siteId={ siteId }
-									period={ period }
+									period="alltime"
 									date={ queryDate }
 								/>
 
@@ -291,7 +291,7 @@ class StatsEmailOpenDetail extends Component {
 									statType="opens"
 									postId={ postId }
 									siteId={ siteId }
-									period={ period }
+									period="alltime"
 									date={ queryDate }
 								/>
 
@@ -300,7 +300,7 @@ class StatsEmailOpenDetail extends Component {
 									statType="opens"
 									postId={ postId }
 									siteId={ siteId }
-									period={ period }
+									period="alltime"
 									date={ queryDate }
 								/>
 							</div>
@@ -320,7 +320,7 @@ const connectComponent = connect(
 
 		return {
 			countViews: getEmailStat( state, siteId, postId, period, statType ),
-			isRequestingStats: isRequestingPeriodEmailStats(
+			isRequestingStats: isRequestingEmailStats(
 				state,
 				siteId,
 				postId,

--- a/client/my-sites/stats/stats-email-open-detail/index.jsx
+++ b/client/my-sites/stats/stats-email-open-detail/index.jsx
@@ -24,6 +24,7 @@ import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 import { getSitePost } from 'calypso/state/posts/selectors';
 import isPrivateSite from 'calypso/state/selectors/is-private-site';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
+import { PERIOD_ALL_TIME } from 'calypso/state/stats/emails/constants';
 import { getEmailStat, isRequestingEmailStats } from 'calypso/state/stats/emails/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import DatePicker from '../stats-date-picker';
@@ -71,6 +72,7 @@ const CHART_UNIQUE_OPENS = {
 	label: translate( 'Unique opens', { context: 'noun' } ),
 };
 const CHARTS = [ CHART_OPENS, CHART_UNIQUE_OPENS ];
+
 Object.defineProperty( CHART_OPENS, 'label', {
 	get: () => translate( 'Opens', { context: 'noun' } ),
 } );
@@ -282,7 +284,7 @@ class StatsEmailOpenDetail extends Component {
 									statType="opens"
 									postId={ postId }
 									siteId={ siteId }
-									period="alltime"
+									period={ PERIOD_ALL_TIME }
 									date={ queryDate }
 								/>
 
@@ -291,7 +293,7 @@ class StatsEmailOpenDetail extends Component {
 									statType="opens"
 									postId={ postId }
 									siteId={ siteId }
-									period="alltime"
+									period={ PERIOD_ALL_TIME }
 									date={ queryDate }
 								/>
 
@@ -300,7 +302,7 @@ class StatsEmailOpenDetail extends Component {
 									statType="opens"
 									postId={ postId }
 									siteId={ siteId }
-									period="alltime"
+									period={ PERIOD_ALL_TIME }
 									date={ queryDate }
 								/>
 							</div>

--- a/client/my-sites/stats/stats-email-open-top-row/index.jsx
+++ b/client/my-sites/stats/stats-email-open-top-row/index.jsx
@@ -3,6 +3,7 @@ import { Icon } from '@wordpress/icons';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
+import { PERIOD_ALL_TIME } from 'calypso/state/stats/emails/constants';
 import {
 	getEmailStatsNormalizedData,
 	isRequestingEmailStats,
@@ -15,10 +16,10 @@ export default function StatsEmailOpenTopRow( { siteId, postId, className } ) {
 	const translate = useTranslate();
 
 	const counts = useSelector( ( state ) =>
-		getEmailStatsNormalizedData( state, siteId, postId, 'alltime', 'opens', null, 'rate' )
+		getEmailStatsNormalizedData( state, siteId, postId, PERIOD_ALL_TIME, 'opens', null, 'rate' )
 	);
 	const isRequesting = useSelector( ( state ) =>
-		isRequestingEmailStats( state, siteId, postId, 'alltime', 'opens' )
+		isRequestingEmailStats( state, siteId, postId, PERIOD_ALL_TIME, 'opens' )
 	);
 
 	return (

--- a/client/my-sites/stats/stats-email-open-top-row/index.jsx
+++ b/client/my-sites/stats/stats-email-open-top-row/index.jsx
@@ -15,7 +15,7 @@ export default function StatsEmailOpenTopRow( { siteId, postId, className } ) {
 	const translate = useTranslate();
 
 	const counts = useSelector( ( state ) =>
-		getEmailStatsNormalizedData( state, siteId, postId, 'alltime', 'opens', null, 'open_rate' )
+		getEmailStatsNormalizedData( state, siteId, postId, 'alltime', 'opens', null, 'rate' )
 	);
 	const isRequesting = useSelector( ( state ) =>
 		isRequestingEmailStats( state, siteId, postId, 'alltime', 'opens' )

--- a/client/my-sites/stats/stats-email-open-top-row/index.jsx
+++ b/client/my-sites/stats/stats-email-open-top-row/index.jsx
@@ -4,8 +4,8 @@ import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import {
-	getAlltimeStats,
-	isRequestingAlltimeEmailStats,
+	getEmailStatsNormalizedData,
+	isRequestingEmailStats,
 } from 'calypso/state/stats/emails/selectors';
 import { eye } from './icons';
 import TopCard from './top-card';
@@ -14,9 +14,11 @@ import './style.scss';
 export default function StatsEmailOpenTopRow( { siteId, postId, className } ) {
 	const translate = useTranslate();
 
-	const counts = useSelector( ( state ) => getAlltimeStats( state, siteId, postId, 'opens' ) );
+	const counts = useSelector( ( state ) =>
+		getEmailStatsNormalizedData( state, siteId, postId, 'alltime', 'opens', null, 'open_rate' )
+	);
 	const isRequesting = useSelector( ( state ) =>
-		isRequestingAlltimeEmailStats( state, siteId, postId, 'opens' )
+		isRequestingEmailStats( state, siteId, postId, 'alltime', 'opens' )
 	);
 
 	return (

--- a/client/state/stats/emails/actions.js
+++ b/client/state/stats/emails/actions.js
@@ -5,6 +5,7 @@ import {
 	EMAIL_STATS_REQUEST_FAILURE,
 	EMAIL_STATS_REQUEST_SUCCESS,
 } from 'calypso/state/action-types';
+import { PERIOD_ALL_TIME } from 'calypso/state/stats/emails/constants';
 import {
 	parseEmailChartData,
 	parseEmailCountriesData,
@@ -109,11 +110,11 @@ function requestEmailOpensStats( siteId, postId, period, date, quantity ) {
 			return quantity;
 		} )();
 
-		const query = period === 'alltime' ? {} : { period, quantity: queryQuantity, date };
+		const query = period === PERIOD_ALL_TIME ? {} : { period, quantity: queryQuantity, date };
 
 		const site = wpcom.site( siteId );
 		const statsPromise =
-			period === 'alltime'
+			period === PERIOD_ALL_TIME
 				? site.statsEmailOpensAlltime( postId )
 				: site.statsEmailOpensForPeriod( postId, query );
 
@@ -121,7 +122,7 @@ function requestEmailOpensStats( siteId, postId, period, date, quantity ) {
 			.then( ( stats ) => {
 				// create an object from emailStats with period as the key
 				const emailStatsObject =
-					period === 'alltime'
+					period === PERIOD_ALL_TIME
 						? emailOpenStatsAlltimeTransform( stats )
 						: emailOpenStatsPeriodTransform( stats, period );
 
@@ -184,6 +185,6 @@ export function requestEmailAlltimeStats( siteId, postId, statType, quantity = 3
 	switch ( statType ) {
 		case 'opens':
 			// request stats bound by period ( chart, countries, devices & clients )
-			return requestEmailOpensStats( siteId, postId, 'alltime', null, quantity );
+			return requestEmailOpensStats( siteId, postId, PERIOD_ALL_TIME, null, quantity );
 	}
 }

--- a/client/state/stats/emails/actions.js
+++ b/client/state/stats/emails/actions.js
@@ -69,6 +69,11 @@ function emailOpenStatsAlltimeTransform( stats ) {
 		countries: parseEmailCountriesData( stats.countries?.data, stats[ 'countries-info' ] ),
 		devices: parseEmailListData( stats.devices?.data ),
 		clients: parseEmailListData( stats.clients?.data ),
+		rate: {
+			opens_rate: stats.opens_rate,
+			total_opens: stats.total_opens,
+			total_sends: stats.total_sends,
+		},
 	};
 }
 

--- a/client/state/stats/emails/constants.js
+++ b/client/state/stats/emails/constants.js
@@ -1,0 +1,1 @@
+export const PERIOD_ALL_TIME = 'alltime';

--- a/client/state/stats/emails/reducer.js
+++ b/client/state/stats/emails/reducer.js
@@ -4,6 +4,7 @@ import {
 	EMAIL_STATS_REQUEST,
 	EMAIL_STATS_REQUEST_FAILURE,
 } from 'calypso/state/action-types';
+import { PERIOD_ALL_TIME } from 'calypso/state/stats/emails/constants';
 import { combineReducers, withSchemaValidation } from 'calypso/state/utils';
 import { items as itemSchemas } from './schema';
 
@@ -35,7 +36,7 @@ export const requests = ( state = {}, action ) => {
 			} )();
 
 			// don't set data key when period is alltime
-			if ( period === 'alltime' ) {
+			if ( period === PERIOD_ALL_TIME ) {
 				return merge( {}, state, {
 					[ siteId ]: {
 						[ postId ]: {

--- a/client/state/stats/emails/selectors.js
+++ b/client/state/stats/emails/selectors.js
@@ -2,6 +2,13 @@ import { createSelector } from '@automattic/state-utils';
 import { get } from 'lodash';
 import 'calypso/state/stats/init';
 
+function getDataPath( siteId, postId, period, statType, date ) {
+	if ( period === 'alltime' ) {
+		return [ siteId, postId, period, statType ];
+	}
+	return [ siteId, postId, period, statType, date ];
+}
+
 /**
  * Returns true if current requesting email stat for the specified site ID,
  * email ID, period and stat key, or * false otherwise.
@@ -11,14 +18,14 @@ import 'calypso/state/stats/init';
  * @param  {number}  postId Post Id
  * @param  {number}  period The period (eg day, week, month, year)
  * @param  {string}  statType The type of stat we are working with. For example: 'opens' for Email Open stats
- * @param  {string}  date The date of the stat
+ * @param  {string?}  date The date of the stat
  * @returns {boolean}        Whether email stat is being requested
  */
-export function isRequestingPeriodEmailStats( state, siteId, postId, period, statType, date ) {
+export function isRequestingEmailStats( state, siteId, postId, period, statType, date ) {
 	return state.stats.emails
 		? get(
 				state.stats.emails.requests,
-				[ siteId, postId, period, statType, date, 'requesting' ],
+				[ ...getDataPath( siteId, postId, period, statType, date ), 'requesting' ],
 				false
 		  )
 		: false;
@@ -38,7 +45,7 @@ export function isRequestingAlltimeEmailStats( state, siteId, postId, statType )
 	return state.stats.emails
 		? get(
 				state.stats.emails.requests,
-				[ siteId, postId, 'alltime', statType, 'requesting' ],
+				[ ...getDataPath( siteId, postId, 'alltime', statType, null ), 'requesting' ],
 				false
 		  )
 		: false;
@@ -60,14 +67,14 @@ export function isRequestingAlltimeEmailStats( state, siteId, postId, statType )
 export function shouldShowLoadingIndicator( state, siteId, postId, period, statType, date, path ) {
 	const stats = get(
 		state.stats.emails.items,
-		[ siteId, postId, period, statType, date, path ],
+		getDataPath( siteId, postId, period, statType, date, path ),
 		null
 	);
 	// if we have redux stats ready return false
 	if ( stats ) {
 		return false;
 	}
-	return isRequestingPeriodEmailStats( state, siteId, postId, period, statType, date );
+	return isRequestingEmailStats( state, siteId, postId, period, statType, date );
 }
 
 /**
@@ -165,7 +172,11 @@ export function getEmailStat( state, siteId, postId, period, statType ) {
  */
 export function getEmailStatsNormalizedData( state, siteId, postId, period, statType, date, path ) {
 	return state.stats.emails.items
-		? get( state.stats.emails.items, [ siteId, postId, period, statType, date, path ], null )
+		? get(
+				state.stats.emails.items,
+				[ ...getDataPath( siteId, postId, period, statType ), path ],
+				null
+		  )
 		: null;
 }
 

--- a/client/state/stats/emails/selectors.js
+++ b/client/state/stats/emails/selectors.js
@@ -1,9 +1,10 @@
 import { createSelector } from '@automattic/state-utils';
 import { get } from 'lodash';
+import { PERIOD_ALL_TIME } from 'calypso/state/stats/emails/constants';
 import 'calypso/state/stats/init';
 
 function getDataPath( siteId, postId, period, statType, date ) {
-	if ( period === 'alltime' ) {
+	if ( period === PERIOD_ALL_TIME ) {
 		return [ siteId, postId, period, statType ];
 	}
 	return [ siteId, postId, period, statType, date ];
@@ -45,7 +46,7 @@ export function isRequestingAlltimeEmailStats( state, siteId, postId, statType )
 	return state.stats.emails
 		? get(
 				state.stats.emails.requests,
-				[ ...getDataPath( siteId, postId, 'alltime', statType, null ), 'requesting' ],
+				[ ...getDataPath( siteId, postId, PERIOD_ALL_TIME, statType, null ), 'requesting' ],
 				false
 		  )
 		: false;
@@ -191,6 +192,6 @@ export function getEmailStatsNormalizedData( state, siteId, postId, period, stat
  */
 export function getAlltimeStats( state, siteId, postId, statType ) {
 	return state.stats.emails.items
-		? get( state.stats.emails.items, [ siteId, postId, 'alltime', statType ], null )
+		? get( state.stats.emails.items, [ siteId, postId, PERIOD_ALL_TIME, statType ], null )
 		: {};
 }

--- a/packages/wpcom.js/src/lib/site.js
+++ b/packages/wpcom.js/src/lib/site.js
@@ -417,8 +417,7 @@ class Site {
 	 */
 	statsEmailOpensAlltime( postId, fn ) {
 		const basePath = `${ this.path }/stats/opens/emails/${ postId }`;
-		// add opens_rate when endpoint becomes available
-		const statFields = [ 'client', 'device', 'country' ];
+		const statFields = [ 'client', 'device', 'country', 'rate' ];
 		return Promise.all(
 			statFields.map( ( field ) => this.wpcom.req.get( `${ basePath }/${ field }`, fn ) )
 		).then( ( statsArray ) =>

--- a/packages/wpcom.js/src/lib/site.js
+++ b/packages/wpcom.js/src/lib/site.js
@@ -385,22 +385,42 @@ class Site {
 	}
 
 	/**
-	 * Get detailed stats about a specific email
+	 * Get detailed stats about a specific email and period
+	 * This fetches the timeline, according to the query passed
 	 *
 	 * @param {string} postId - id of the post which email we are querying
 	 * @param {object} [query] - query object parameter
 	 * @param {Function?} fn - callback function
 	 * @returns {Function} request handler
 	 */
-	statsEmailOpens( postId, query, fn ) {
+	statsEmailOpensForPeriod( postId, query, fn ) {
 		const path = `${ this.path }/stats/opens/emails/${ postId }`;
-		const statFields = query.period
-			? [ 'timeline', 'country', 'device', 'client' ]
-			: [ 'opens_rate' ];
+		const statFields = [ 'timeline' ];
 		return Promise.all(
 			statFields.map( ( field ) =>
 				this.wpcom.req.get( path, { ...query, stats_fields: field }, fn )
 			)
+		).then( ( statsArray ) =>
+			statsArray.reduce( ( result, item ) => {
+				return { ...result, ...item };
+			}, {} )
+		);
+	}
+
+	/**
+	 * Get detailed all time stats about a specific email and period
+	 * This fetchesthe clients, devices & countries
+	 *
+	 * @param {string} postId - id of the post which email we are querying
+	 * @param {Function?} fn - callback function
+	 * @returns {Function} request handler
+	 */
+	statsEmailOpensAlltime( postId, fn ) {
+		const basePath = `${ this.path }/stats/opens/emails/${ postId }`;
+		// add opens_rate when endpoint becomes available
+		const statFields = [ 'client', 'device', 'country' ];
+		return Promise.all(
+			statFields.map( ( field ) => this.wpcom.req.get( `${ basePath }/${ field }`, fn ) )
 		).then( ( statsArray ) =>
 			statsArray.reduce( ( result, item ) => {
 				return { ...result, ...item };


### PR DESCRIPTION
#### Proposed Changes

This PR makes `devices`, `countries` and `clients` all time stats.

#### Testing Instructions

* Apply this PR

When visiting the email open stats, you'll see that `open rate`, `devices`, `countries` and `clients` are all-time stats now.

<img width="1144" alt="CleanShot 2023-01-12 at 17 31 11@2x" src="https://user-images.githubusercontent.com/528287/212125128-d85fb571-248b-4a23-943a-13eebcccee41.png">


#### Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->