### PR TITLE
[ETK][StarterPageTemplates] Do not close the Starter Pages Templates modal on blur

### DIFF
--- a/packages/page-pattern-modal/src/components/page-pattern-modal.tsx
+++ b/packages/page-pattern-modal/src/components/page-pattern-modal.tsx
@@ -173,20 +173,16 @@ class PagePatternModal extends Component< PagePatternModalProps, PagePatternModa
 		// automatically. See: https://github.com/WordPress/gutenberg/pull/40195.
 		// This ends up triggering a `blur` event on the Modal that causes it
 		// to close just after the editor loads. To circumvent this, we check if
-		// the `blur` event is related to the title auto-focus and if so,
-		// we ignore it so that the Modal stays open. It's important to note
-		// that this callback handles more than the  event, though. See the
-		// `CloseModalEvent` type for more info.
-
-		// Let's narrow-down the types to be able to safely handle the `blur` scenario
-		// `KeyboardEvent` doesn't have a `relatedTarget` property, and the `MouseEvent`'s
-		// `relatedTarget` type doesn't have a `className` property, though for those events
-		// the Modal can just close and we don't need the piece of logic below:
-		if ( 'relatedTarget' in event && event.relatedTarget && 'className' in event.relatedTarget ) {
-			if ( event.relatedTarget?.className?.match( /wp-block-post-title/ ) ) {
-				event.stopPropagation();
-				return;
-			}
+		// the event is a `blur`, and if that's the case, we return before the
+		// function is able to close the modal. Originally, you can't click outside
+		// the modal to close it, meaning it doesn't respond to the `blur` event
+		// anyways, so it's safe to use this simpler approach instead of trying to
+		// check what element triggered the `blur` (which doesn't work when the
+		// theme is block-based, as the title block DOM element is not directly
+		// accessible as it's inside the `editor-canvas` iframe).
+		if ( event.type === 'blur' ) {
+			event.stopPropagation();
+			return;
 		}
 
 		trackDismiss();


### PR DESCRIPTION
#### Proposed Changes

Follow up to: https://github.com/Automattic/wp-calypso/pull/63160.

Gutenberg auto-focus the post-title by default, upon editor load. This causes a `blur` event in the Starter Page Templates modal that ends up closing it, as the `Modal` component ends up calling `onRequestClose` to handle it.

The previous PR used to fix this issue by checking if the blur event was originated from the post-tile block DOM element. This worked fine until Gutenberg 14.9.x introduced the `editor-canvas` iframe that now wraps the editor elements when a block theme is used. In that case, we can't access the post title DOM element directly from JS anymore as it's sandboxed by the iframe, so the `relatedTarget` property we relied on before to test if the element that caused the `blur` was the post tile DOM element, ends up returning `null` and the modal then proceeds to close. Not good.

I further tested the modal original UX, and it appears that it's not supposed to close on blur, at least from the user's perspective. You can test that by adding a breakpoint in `page-pattern-modal.tsx`, line 183 (just below `if ( event.type === 'blur' ) {`) and trying to close it by clicking outside it. You'll see the breakpoint never triggers. The only way for the user to close it is by clicking the `X` button at the top right corner or choosing a template (or going with none, by choosing a blank canvas). This means we can further simplify the code and prevent the modal from closing if there's a blur event, which also works if the editor is within the `editor-canvas` iframe.

#### Testing Instructions

* In your sandboxed WPCOM simple site running Gutenberg 14.9.1, start a new Page and notice how the starter page templates modal appears and quickly closes (because of the post title auto-focus); ❌ 
* Checkout this branch in Calypso and build and sync ETK to your sandbox with `yarn dev --sync` (in `wp-calypso/apps/editing-toolkit`);
* Start a new page and notice how the modal doesn't close automatically ✅ 

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
