### PR TITLE
Chore/refactoring copy site

### DIFF
--- a/client/landing/stepper/declarative-flow/copy-site.tsx
+++ b/client/landing/stepper/declarative-flow/copy-site.tsx
@@ -51,6 +51,16 @@ const copySite: Flow = {
 
 		const { setPlanCartItem } = useDispatch( ONBOARD_STORE );
 
+		// We need to do this here to avoid any race conditions
+		// due to dispatch adn window.assign
+		const productSlug = urlQueryParams.get( 'productSlug' );
+		if ( productSlug ) {
+			const productToAdd = {
+				product_slug: productSlug,
+			};
+			setPlanCartItem( productToAdd );
+		}
+
 		setStepProgress( flowProgress );
 
 		const submit = async (
@@ -78,16 +88,6 @@ const copySite: Flow = {
 					if ( processingResult === ProcessingResult.FAILURE ) {
 						return navigate( 'error' );
 					}
-
-					const productSlug = urlQueryParams.get( 'productSlug' );
-					if ( ! productSlug ) {
-						throw new Error( 'Plan product not found' );
-					}
-					const productToAdd = {
-						product_slug: productSlug,
-					};
-
-					setPlanCartItem( productToAdd );
 
 					const destination = addQueryArgs( `/setup/${ this.name }/automatedCopy`, {
 						sourceSlug: urlQueryParams.get( 'sourceSlug' ),

--- a/client/landing/stepper/declarative-flow/copy-site.tsx
+++ b/client/landing/stepper/declarative-flow/copy-site.tsx
@@ -1,5 +1,5 @@
 import { useFlowProgress, COPY_SITE_FLOW } from '@automattic/onboarding';
-import { useDispatch } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
 import { translate } from 'i18n-calypso';
 import { useEffect } from 'react';
@@ -50,16 +50,7 @@ const copySite: Flow = {
 		const urlQueryParams = useQuery();
 
 		const { setPlanCartItem } = useDispatch( ONBOARD_STORE );
-
-		// We need to do this here to avoid any race conditions
-		// due to dispatch adn window.assign
-		const productSlug = urlQueryParams.get( 'productSlug' );
-		if ( productSlug ) {
-			const productToAdd = {
-				product_slug: productSlug,
-			};
-			setPlanCartItem( productToAdd );
-		}
+		const { getPlanCartItem } = useSelect( ( select ) => select( ONBOARD_STORE ) );
 
 		setStepProgress( flowProgress );
 
@@ -67,6 +58,16 @@ const copySite: Flow = {
 			providedDependencies: ProvidedDependencies = {},
 			...params: string[]
 		) => {
+			// We need to do this here to avoid any race conditions
+			// due to dispatch and window.assign
+			const productSlug = urlQueryParams.get( 'productSlug' );
+			if ( productSlug && ! getPlanCartItem() ) {
+				const productToAdd = {
+					product_slug: productSlug,
+				};
+				setPlanCartItem( productToAdd );
+			}
+
 			recordSubmitStep( providedDependencies, '', flowName, _currentStepSlug );
 
 			switch ( _currentStepSlug ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/automated-copy-site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/automated-copy-site/index.tsx
@@ -1,57 +1,35 @@
-import { StepContainer } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
-import { useCallback, useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
-import { SITE_STORE } from 'calypso/landing/stepper/stores';
-import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { ONBOARD_STORE, SITE_STORE } from 'calypso/landing/stepper/stores';
 import wpcom from 'calypso/lib/wp';
 import type { Step } from '../../types';
 
 const TIME_CHECK_TRANSFER_STATUS = 3000;
 
-function useCopyingStatus() {
-	const [ status, setStatus ] = useState< {
-		status: 'init' | 'copying' | 'success' | 'error';
-		error: string | null;
-	} >( {
-		status: 'init',
-		error: null,
-	} );
+export const transferStates = {
+	PENDING: 'pending',
+	ACTIVE: 'active',
+	PROVISIONED: 'provisioned',
+	COMPLETED: 'completed',
+	ERROR: 'error',
+	REVERTED: 'reverted',
+	RELOCATING_REVERT: 'relocating_revert',
+	RELOCATING_SWITCHEROO: 'relocating_switcheroo',
+	REVERTING: 'reverting',
+	RENAMING: 'renaming',
+	EXPORTING: 'exporting',
+	IMPORTING: 'importing',
+	CLEANUP: 'cleanup',
+} as const;
 
-	const setIsCopying = useCallback( () => setStatus( { status: 'copying', error: null } ), [] );
-	const setIsSuccess = useCallback( () => setStatus( { status: 'success', error: null } ), [] );
-	const setIsError = useCallback(
-		( error: string ) => setStatus( { status: 'error', error } ),
-		[]
-	);
-
-	return {
-		isLoading: [ 'copying', 'init' ].includes( status.status ),
-		isCopying: status.status === 'copying',
-		isSuccess: status.status === 'success',
-		isError: status.status === 'error',
-		error: status.error,
-		setIsCopying,
-		setIsSuccess,
-		setIsError,
-	};
-}
+const wait = ( ms: number ) => new Promise( ( res ) => setTimeout( res, ms ) );
 
 const AutomatedCopySite: Step = function AutomatedCopySite( { navigation } ) {
 	const { submit } = navigation;
 	const { __ } = useI18n();
-	const {
-		isCopying,
-		isLoading,
-		setIsCopying,
-		setIsSuccess,
-		setIsError,
-		isSuccess,
-		isError,
-		error,
-	} = useCopyingStatus();
 	const site = useSite();
 	const urlQueryParams = useQuery();
 	const siteSlug = urlQueryParams.get( 'siteSlug' );
@@ -60,111 +38,87 @@ const AutomatedCopySite: Step = function AutomatedCopySite( { navigation } ) {
 		( select ) => sourceSlug && select( SITE_STORE ).getSite( sourceSlug )
 	);
 	const sourceSiteId = sourceSite?.ID;
+	const { setPendingAction, setProgress, setProgressTitle } = useDispatch( ONBOARD_STORE );
 	const { requestLatestAtomicTransfer } = useDispatch( SITE_STORE );
 	const { getSiteLatestAtomicTransfer, getSiteLatestAtomicTransferError } = useSelect( ( select ) =>
 		select( SITE_STORE )
 	);
 
+	const progressTitle = __( 'Copying site' );
+
 	useEffect( () => {
-		if ( isCopying && site ) {
-			const timer = setInterval( async () => {
-				await requestLatestAtomicTransfer( site.ID );
-				const transfer = getSiteLatestAtomicTransfer( site.ID );
-				const transferError = getSiteLatestAtomicTransferError( site.ID );
-				const transferStatus = transfer?.status;
-				const isTransferringStatusFailed = transferError && transferError?.status >= 500;
-
-				if ( isTransferringStatusFailed ) {
-					setIsError( 'Error Copying' );
-				} else if ( transferStatus === 'completed' ) {
-					setIsSuccess();
-				}
-			}, TIME_CHECK_TRANSFER_STATUS );
-			return () => clearTimeout( timer );
+		if ( ! site?.ID || ! sourceSiteId ) {
+			return;
 		}
-	}, [
-		getSiteLatestAtomicTransfer,
-		getSiteLatestAtomicTransferError,
-		isCopying,
-		requestLatestAtomicTransfer,
-		setIsError,
-		setIsSuccess,
-		site,
-	] );
-
-	const startCopying = useCallback(
-		function startCopying() {
-			if ( ! site?.ID || ! sourceSiteId ) {
-				return;
-			}
-			return wpcom.req
-				.post( {
-					path: `/sites/${ site.ID }/copy-from-site`,
+		setProgressTitle( progressTitle );
+		setPendingAction( async () => {
+			const siteId = site.ID;
+			setProgress( 0 );
+			try {
+				await wpcom.req.post( {
+					path: `/sites/${ siteId }/copy-from-site`,
 					apiNamespace: 'wpcom/v2',
 					body: {
 						source_blog_id: sourceSiteId,
 					},
-				} )
-				.then( () => {
-					setIsCopying();
-				} )
-				.catch( ( e: { message: string; code: string; data: { status: number } } ) => {
-					// eslint-disable-next-line no-console
-					console.error( e );
-					setIsError( e.message || 'Error Starting the Copy' );
 				} );
-		},
-		[ setIsCopying, setIsError, site?.ID, sourceSiteId ]
-	);
-
-	useEffect( () => {
-		startCopying();
-	}, [ startCopying ] );
-
-	if ( ! sourceSlug || ! siteSlug ) {
-		// TODO: show a better error or redirect to the start /sites
-		return <h1>{ __( 'Missing required parameters' ) }</h1>;
-	}
-
-	if ( ! sourceSiteId || ! site ) {
-		// eslint-disable-next-line no-console
-		console.info( { sourceSlug, siteSlug, sourceSiteId, site } );
-		// Wait for stores to populate
-		return null;
-	}
-
-	return (
-		<StepContainer
-			stepName="AutomatedcopySite"
-			hideBack
-			recordTracksEvent={ recordTracksEvent }
-			stepContent={
-				<div>
-					{ isLoading && <h1>{ __( 'Copying Site…' ) }</h1> }
-					{ isError && (
-						<>
-							<h1>{ __( 'Error copying site. Contact support' ) }</h1>
-							<p>{ error }</p>
-							<button onClick={ startCopying }>{ __( 'Retry?' ) }</button>
-						</>
-					) }
-					{ isSuccess && (
-						<>
-							<h1>{ __( 'Site copied successfully 🥳' ) }</h1>
-							<p>
-								{ __(
-									'Congrats all your content has been migrated and your new site is ready to enjoy.'
-								) }
-							</p>
-							<button onClick={ () => submit?.( { siteSlug } ) }>
-								{ __( 'Visit my new site' ) }
-							</button>
-						</>
-					) }
-				</div>
+			} catch ( _error ) {
+				throw new Error( 'Error copying site' );
 			}
-		></StepContainer>
-	);
+
+			let stopPollingTransfer = false;
+
+			while ( ! stopPollingTransfer ) {
+				await wait( TIME_CHECK_TRANSFER_STATUS );
+				await requestLatestAtomicTransfer( siteId );
+				const transfer = getSiteLatestAtomicTransfer( siteId );
+				const transferError = getSiteLatestAtomicTransferError( siteId );
+				const transferStatus = transfer?.status;
+				const isTransferringStatusFailed = transferError && transferError?.status >= 500;
+
+				switch ( transferStatus ) {
+					case transferStates.PENDING:
+						setProgress( 0.2 );
+						break;
+					case transferStates.ACTIVE:
+						setProgress( 0.4 );
+						break;
+					case transferStates.PROVISIONED:
+						setProgress( 0.5 );
+						break;
+					case transferStates.COMPLETED:
+						setProgress( 0.7 );
+						break;
+				}
+
+				if ( isTransferringStatusFailed || transferStatus === transferStates.ERROR ) {
+					throw new Error( 'Error copying site' );
+				}
+
+				stopPollingTransfer = transferStatus === transferStates.COMPLETED;
+			}
+
+			setProgress( 1 );
+
+			return { finishedWaitingForCopy: true, siteSlug };
+		} );
+
+		submit?.();
+	}, [
+		progressTitle,
+		sourceSiteId,
+		siteSlug,
+		setProgressTitle,
+		getSiteLatestAtomicTransfer,
+		getSiteLatestAtomicTransferError,
+		requestLatestAtomicTransfer,
+		setPendingAction,
+		setProgress,
+		site,
+		submit,
+	] );
+
+	return null;
 };
 
 export default AutomatedCopySite;

--- a/packages/onboarding/src/flow-progress/use-flow-progress.ts
+++ b/packages/onboarding/src/flow-progress/use-flow-progress.ts
@@ -72,6 +72,7 @@ const flows: Record< string, { [ step: string ]: number } > = {
 		siteCreationStep: 1,
 		processing: 1,
 		automatedCopy: 3,
+		processingCopy: 3,
 	},
 };
 


### PR DESCRIPTION
#### Proposed Changes

- Fix a bug where on copy site, if you start fresh you ended up not having the cart setup correctly.
- Switch copy site to use a progress bar just like `trial-wooexpress-flow`

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new copy of your sites using the flow in `/sites`
* Notice that there is a new progress bar when the copy is started.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/1468
