### PR TITLE
Jetpack cloud - fix expired products CTA text

### DIFF
--- a/client/my-sites/plans/jetpack-plans/product-store/hooks/use-store-item-info.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/hooks/use-store-item-info.tsx
@@ -91,10 +91,20 @@ export const useStoreItemInfo = ( {
 			if ( sitePlan && sitePlan.product_slug === item.productSlug ) {
 				return true;
 			} else if ( siteProducts ) {
-				return siteProducts
-					.filter( ( product ) => ! product.expired )
-					.map( ( product ) => product.productSlug )
-					.includes( item.productSlug );
+				return siteProducts.map( ( product ) => product.productSlug ).includes( item.productSlug );
+			}
+			return false;
+		},
+		[ sitePlan, siteProducts ]
+	);
+
+	const getIsExpired = useCallback(
+		( item: SelectorProduct ) => {
+			if ( sitePlan && sitePlan.product_slug === item.productSlug ) {
+				return !! sitePlan.expired;
+			} else if ( siteProducts ) {
+				return !! siteProducts.find( ( product ) => product.productSlug === item.productSlug )
+					?.expired;
 			}
 			return false;
 		},
@@ -333,6 +343,7 @@ export const useStoreItemInfo = ( {
 			getIsIncludedInPlanOrSuperseded,
 			getIsMultisiteCompatible,
 			getIsOwned,
+			getIsExpired,
 			getIsPlanFeature,
 			getIsSuperseded,
 			getIsUpgradeableToYearly,
@@ -350,6 +361,7 @@ export const useStoreItemInfo = ( {
 			getIsIncludedInPlan,
 			getIsIncludedInPlanOrSuperseded,
 			getIsOwned,
+			getIsExpired,
 			getIsPlanFeature,
 			getIsSuperseded,
 			getIsUpgradeableToYearly,

--- a/client/my-sites/plans/jetpack-plans/product-store/item-price/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/item-price/index.tsx
@@ -12,6 +12,7 @@ import './style.scss';
 export const ItemPrice: React.FC< ItemPriceProps > = ( {
 	isIncludedInPlan,
 	isOwned,
+	isExpired,
 	item,
 	siteId,
 	isMultiSiteIncompatible,
@@ -30,7 +31,8 @@ export const ItemPrice: React.FC< ItemPriceProps > = ( {
 			<ItemPriceMessage message={ translate( 'Not available for multisite WordPress installs' ) } />
 		);
 	} else if ( isOwned ) {
-		return <ItemPriceMessage message={ translate( 'Active on your site' ) } />;
+		const message = isExpired ? translate( 'Expired' ) : translate( 'Active on your site' );
+		return <ItemPriceMessage expired={ isExpired } message={ message } />;
 	} else if ( isIncludedInPlan ) {
 		return <ItemPriceMessage message={ translate( 'Part of the current plan' ) } />;
 	}

--- a/client/my-sites/plans/jetpack-plans/product-store/item-price/item-price-message.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/item-price/item-price-message.tsx
@@ -1,8 +1,20 @@
-const ItemPriceMessage: React.FC< { message: React.ReactNode } > = ( { message } ) => (
-	<div className="item-price__message">
-		<span className="item-price__message--dot"></span>
-		<span className="item-price__message--text">{ message }</span>
-	</div>
-);
+import classNames from 'classnames';
+
+const ItemPriceMessage: React.FC< { message: React.ReactNode; expired?: boolean } > = ( {
+	message,
+	expired = false,
+} ) => {
+	const messageClass = classNames( 'item-price__message', {
+		'item-price__message--expired': expired,
+		'item-price__message--active': ! expired,
+	} );
+
+	return (
+		<div className={ messageClass }>
+			<span className="item-price__message--dot"></span>
+			<span className="item-price__message--text">{ message }</span>
+		</div>
+	);
+};
 
 export default ItemPriceMessage;

--- a/client/my-sites/plans/jetpack-plans/product-store/item-price/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/item-price/style.scss
@@ -112,13 +112,28 @@ Hack to fix line-through not showing in the middle of the text in firefox browse
 	font-weight: 600;
 	display: flex;
 	align-items: center;
+
+	.item-price__message--dot {
+		display: inline-block;
+		width: 8px;
+		height: 8px;
+		border-radius: 50%;
+		margin-inline-end: 4px;
+	}
+
+	&--active {
+		color: var(--studio-jetpack-green-50);
+		.item-price__message--dot {
+			background: var(--studio-jetpack-green-50);
+		}
+
+	}
+	&--expired {
+		color: var(--color-error-50);
+		.item-price__message--dot {
+			background: var(--color-error-50);
+		}
+
+	}
 }
 
-.item-price__message--dot {
-	display: inline-block;
-	width: 8px;
-	height: 8px;
-	background: var(--studio-jetpack-green-50);
-	border-radius: 50%;
-	margin-inline-end: 4px;
-}

--- a/client/my-sites/plans/jetpack-plans/product-store/items-list/all-items.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/items-list/all-items.tsx
@@ -26,6 +26,7 @@ export const AllItems: React.FC< AllItemsProps > = ( {
 		getIsIncludedInPlanOrSuperseded,
 		getIsMultisiteCompatible,
 		getIsOwned,
+		getIsExpired,
 		getIsPlanFeature,
 		getIsSuperseded,
 		getIsUserPurchaseOwner,
@@ -43,6 +44,7 @@ export const AllItems: React.FC< AllItemsProps > = ( {
 			<ul className="jetpack-product-store__all-items--grid">
 				{ items.map( ( item ) => {
 					const isOwned = getIsOwned( item );
+					const isExpired = getIsExpired( item );
 					const isProductInCart =
 						! isJetpackPlanSlug( item.productSlug ) && getIsProductInCart( item );
 					const isSuperseded = getIsSuperseded( item );
@@ -66,6 +68,7 @@ export const AllItems: React.FC< AllItemsProps > = ( {
 							isMultiSiteIncompatible={ isMultiSiteIncompatible }
 							isIncludedInPlan={ isIncludedInPlan }
 							isOwned={ isOwned }
+							isExpired={ isExpired }
 							item={ item }
 							siteId={ siteId }
 						/>

--- a/client/my-sites/plans/jetpack-plans/product-store/items-list/most-popular.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/items-list/most-popular.tsx
@@ -35,6 +35,7 @@ export const MostPopular: React.FC< MostPopularProps > = ( {
 		getIsUserPurchaseOwner,
 		getOnClickPurchase,
 		isMultisite,
+		getIsExpired,
 	} = useStoreItemInfoContext();
 
 	return (
@@ -43,6 +44,7 @@ export const MostPopular: React.FC< MostPopularProps > = ( {
 			<ul className="jetpack-product-store__most-popular--items">
 				{ items.map( ( item ) => {
 					const isOwned = getIsOwned( item );
+					const isExpired = getIsExpired( item );
 					const isSuperseded = getIsSuperseded( item );
 					const isProductInCart =
 						! isJetpackPlanSlug( item.productSlug ) && getIsProductInCart( item );
@@ -66,6 +68,7 @@ export const MostPopular: React.FC< MostPopularProps > = ( {
 							isMultiSiteIncompatible={ isMultiSiteIncompatible }
 							isIncludedInPlan={ isIncludedInPlan }
 							isOwned={ isOwned }
+							isExpired={ isExpired }
 							item={ item }
 							siteId={ siteId }
 						/>

--- a/client/my-sites/plans/jetpack-plans/product-store/types.ts
+++ b/client/my-sites/plans/jetpack-plans/product-store/types.ts
@@ -79,6 +79,7 @@ export type StoreItemInfo = ReturnType< typeof useStoreItemInfo >;
 export type ItemPriceProps = ProductStoreBaseProps &
 	HeroImageProps & {
 		isOwned?: boolean;
+		isExpired?: boolean;
 		isIncludedInPlan?: boolean;
 		isMultiSiteIncompatible?: boolean;
 	};


### PR DESCRIPTION
#### Proposed Changes

- CTA for expired products in the pricing page item shows "Get", this change replace it with "Manage Subscription" CTA
- This also changes the text shown below the Expired item


#### Testing Instructions

* Click on Jetpack Cloud live link below and wait for the redirect to complete, then goto /pricing/:site (:site is the site-slug of a jetpack site you own, or a Jurassic Ninja site you created and connected.) (This is probably the quickest and easiest way to test this PR).
* or run this PR
     * Run git fetch && git checkout fix/cloud-expired-items
     * Run yarn start-jetpack-cloud (it takes a little while to build the application)
     * Goto http://jetpack.cloud.localhost:3000/pricing/:site (where :site is the site-slug of a jetpack site you own, or a Jurassic Ninja site you created and connected.)
* Purchase any product
* After purchase change the expiry of the product to past date in store admin here https://wordpress.com/wp-admin/network/admin.php?page=store-admin&action=search&username=<your_wpcom_username>
  * find the site in the list and find the product purchased for the site
  * in **Purchase/Expires* column change the second date to past date, after changing a U button will be shown, click on it to update the expiry
* Now go back to the same pricing page (as specified in the first step)
* Confirm that the expired product CTA is **Manage Subscription** and below the product name it shows *Expired* in red font


#### Screenshot

<img width="1140" alt="Screenshot 2023-01-13 at 12 20 06 AM" src="https://user-images.githubusercontent.com/2027003/212153491-29e80b2d-de57-4a48-ad7a-4fdf2dc58b71.png">


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # 1203495437860512-as-1203698486186502/f