### PR TITLE
Jetpack Connection: deprecate the 'blacklisted' error code

### DIFF
--- a/client/jetpack-connect/jetpack-connection.jsx
+++ b/client/jetpack-connect/jetpack-connection.jsx
@@ -233,7 +233,7 @@ const jetpackConnection = ( WrappedComponent ) => {
 				return IS_DOT_COM;
 			}
 
-			if ( this.isError( 'site_blacklisted' ) ) {
+			if ( this.isError( 'site_blacklisted' ) || this.isError( 'connection_disabled' ) ) {
 				return SITE_BLOCKED;
 			}
 

--- a/client/state/jetpack-connect/selectors/is-site-blocked-error.js
+++ b/client/state/jetpack-connect/selectors/is-site-blocked-error.js
@@ -12,5 +12,7 @@ import 'calypso/state/jetpack-connect/init';
 export const isSiteBlockedError = function ( state ) {
 	const authorizeData = getAuthorizationData( state );
 
-	return get( authorizeData, [ 'authorizeError', 'error' ] ) === 'site_blacklisted';
+	return [ 'site_blacklisted', 'connection_disabled' ].includes(
+		get( authorizeData, [ 'authorizeError', 'error' ] )
+	);
 };

--- a/client/state/jetpack-connect/test/selectors.js
+++ b/client/state/jetpack-connect/test/selectors.js
@@ -405,7 +405,7 @@ describe( 'selectors', () => {
 				jetpackConnect: {
 					jetpackConnectAuthorize: {
 						authorizeError: {
-							error: 'site_blacklisted',
+							error: 'connection_disabled',
 						},
 					},
 				},


### PR DESCRIPTION
#### Proposed Changes
* Accept error code `connection_disabled` as an alternative to `site_blacklisted` to allow for removal of the latter.

#### Testing Instructions

##### Jetpack Connect tool
1. Create a new Jetpack site, connect it, then disconnect.
2. Go to the blog RC and use the "Graylist" tool to set the "black" flag.
3. Load `/jetpack/connect` in Calypso and enter the URL of the site you blocked.
4. Click "Continue", confirm that you see the error:
<img width="360" alt="Screen Shot 2023-01-12 at 15 15 02" src="https://user-images.githubusercontent.com/1341249/212171403-ae6e4642-3d68-4598-bf8b-27988c7f5217.png">

##### Regular Jetpack connection flow
1. Go to the blog RC and set the "Graylist" to "no flag".
3. Go to "Jetpack -> Jetpack" and click "Set up Jetpack".
4. When you see the "Approve" page in Calypso, go to the blog RC and set the "black" flag again.
5. Replace the URL of the "Approve" page to the "calypso.live" one.
6. Click "Approve", confirm that you see the same error:
<img width="360" alt="Screen Shot 2023-01-12 at 15 15 02" src="https://user-images.githubusercontent.com/1341249/212173101-7dcf4dc9-7417-495e-83e2-0be639eafdff.png">

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Project thread: p9dueE-6oT-p2
Related to #43998
