### PR TITLE
Jetpack Pro Portal: Capitalize "Pro" on prices page

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/primary/prices/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/prices/index.tsx
@@ -120,7 +120,7 @@ export default function Prices() {
 			<div className="prices__description">
 				<p>
 					{ translate(
-						'The following products are available through the Licenses section. Prices are calculated daily and invoiced at the beginning of the next month. Please note that the Jetpack pro Dashboard prices will be displayed as a monthly cost. If you want to determine a yearly cost for the Agency/Pro pricing, you can take the daily cost x 365.'
+						'The following products are available through the Licenses section. Prices are calculated daily and invoiced at the beginning of the next month. Please note that the Jetpack Pro Dashboard prices will be displayed as a monthly cost. If you want to determine a yearly cost for the Agency/Pro pricing, you can take the daily cost x 365.'
 					) }
 				</p>
 			</div>


### PR DESCRIPTION
#### Proposed Changes

* Jetpack Pro is a proper noun, and thus must always be capitalized. This changes a single lowercase `p` to an uppercase `P`.

#### Testing Instructions

* The description copy at the top of `/partner-portal/prices` should read "Please note that the Jetpack Pro Dashboard prices will be..." and the "Pro" should be capitalized in this PR.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
