### PR TITLE
Stats: Force improved contrast on default theme

### DIFF
--- a/client/my-sites/customer-home/cards/features/stats/style.scss
+++ b/client/my-sites/customer-home/cards/features/stats/style.scss
@@ -1,3 +1,5 @@
+@import "calypso/my-sites/stats/theme-override-mixin.scss";
+
 .stats .customer-home__card.stats__with-chart {
 	box-shadow: none;
 	border-bottom: none;
@@ -15,6 +17,10 @@
 
 	@include breakpoint-deprecated( ">480px" ) {
 		margin: 0 -24px;
+	}
+
+	.color-scheme.is-classic-dark.is-section-home & {
+		@include apply-improved-classic-dark-colors();
 	}
 
 	.chart__bar:hover {

--- a/client/my-sites/stats/style.scss
+++ b/client/my-sites/stats/style.scss
@@ -2,6 +2,7 @@
 @import "calypso/my-sites/stats/modernized-tooltip-styles.scss";
 @import "calypso/my-sites/stats/modernized-chart-tabs-styles.scss";
 @import "calypso/my-sites/stats/modernized-layout-styles.scss";
+@import "calypso/my-sites/stats/theme-override-mixin.scss";
 
 // Module container
 @include breakpoint-deprecated( ">960px" ) {
@@ -228,6 +229,10 @@
 // Stats section scoped styles
 .is-section-stats {
 	background: var(--studio-white);
+
+	&.color-scheme.is-classic-dark {
+		@include apply-improved-classic-dark-colors();
+	}
 }
 
 @import "calypso/my-sites/stats/grid-layout.scss";

--- a/client/my-sites/stats/theme-override-mixin.scss
+++ b/client/my-sites/stats/theme-override-mixin.scss
@@ -1,0 +1,10 @@
+@mixin apply-improved-classic-dark-colors() {
+	// Ensure you apply these styles only if .color-scheme.is-classic-dark has been set on the body.
+	// Override classic-dark's primary-dark color, which lacks sufficient contrast.
+	--color-primary: var(--studio-gray-50);
+	--color-primary-rgb: var(--studio-gray-50-rgb);
+	--color-primary-dark: var(--studio-gray-100);
+	--color-primary-dark-rgb: var(--studio-gray-100-rgb);
+	--color-primary-light: var(--studio-gray-20);
+	--color-primary-light-rgb: var(--studio-gray-20-rgb);
+}


### PR DESCRIPTION
#### Proposed Changes

|Before|After|
|-|-|
|<img width="1251" alt="image" src="https://user-images.githubusercontent.com/4044428/212185519-c08538fc-2a5e-4b7f-8be7-ccc059f628fe.png">|<img width="1268" alt="image" src="https://user-images.githubusercontent.com/4044428/212185548-cdba215f-2087-4e4c-bacf-06256d2b65fb.png">|
|<img width="714" alt="image" src="https://user-images.githubusercontent.com/4044428/212185617-23cb9334-1362-427e-be45-46865d993f9c.png">|<img width="721" alt="image" src="https://user-images.githubusercontent.com/4044428/212185589-a2cb2f1a-f636-4232-9ef9-f96fd703a29c.png">|
|<img width="1478" alt="image" src="https://user-images.githubusercontent.com/4044428/212187210-3c430229-e4cf-4c8e-b327-cb307ed77cbe.png">|<img width="1251" alt="image" src="https://user-images.githubusercontent.com/4044428/212187173-82fe1e72-8e8f-494c-b0d7-bf05cd61f56e.png">|
|Primary: gray-90|Primary: gray-50|
|Dark: gray-70|Dark: gray-100|
|Light: gray-30|Light: gray-20|

(See [color-studio](https://color-studio.blog/) for exact hex values.)

* Forces the default theme to use improved `primary`, `primary-dark`, and `primary-light` colors on Calypso Stats and on the chart on the "My Home" page. Specifically:
    * Dark variant is now darker instead of lighter.
    * Contrast between the primary and the dark variant has been improved.

#### Testing Instructions

* Open the live branch for this PR with the "Default" theme applied via `/me/account`.
* Ensure that the traffic chart in Calypso Stats has sufficient contrast.
* Ensure that the heatmap tables now use correct gradation. 

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #72026.
