### PR TITLE
Plans 2023 Grid: Improve TypeScript types

### DIFF
--- a/client/lib/plans/features-list.js
+++ b/client/lib/plans/features-list.js
@@ -1820,6 +1820,10 @@ export const FEATURES_LIST = {
 	/* END: 2023 Pricing Grid Features */
 };
 
+/**
+ * @param {string[]} planFeaturesList
+ * @returns {import('calypso/my-sites/plan-features-2023-grid/types').PlanFeature} PlanFeature
+ */
 export const getPlanFeaturesObject = ( planFeaturesList ) => {
 	return planFeaturesList.map( ( featuresConst ) => FEATURES_LIST[ featuresConst ] );
 };

--- a/client/lib/plans/features-list.js
+++ b/client/lib/plans/features-list.js
@@ -1822,7 +1822,7 @@ export const FEATURES_LIST = {
 
 /**
  * @param {string[]} planFeaturesList
- * @returns {import('calypso/my-sites/plan-features-2023-grid/types').PlanFeature} PlanFeature
+ * @returns {import('calypso/my-sites/plan-features-2023-grid/types').PlanFeature[]} PlanFeature
  */
 export const getPlanFeaturesObject = ( planFeaturesList ) => {
 	return planFeaturesList.map( ( featuresConst ) => FEATURES_LIST[ featuresConst ] );

--- a/client/my-sites/checkout/composite-checkout/lib/get-flow-plan-features.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/get-flow-plan-features.ts
@@ -6,16 +6,10 @@ import {
 	getPlanFeatureAccessor,
 } from 'calypso/my-sites/plan-features-comparison/util';
 
-interface Feature {
-	getSlug: () => string;
-	getTitle: () => string;
-	isHighlightedFeature: boolean;
-}
-
 export default function getFlowPlanFeatures(
 	flowName: string,
 	plan: ResponseCartProduct | undefined
-): Feature[] {
+) {
 	const productSlug = plan?.product_slug;
 
 	if ( ! productSlug ) {
@@ -39,7 +33,7 @@ export default function getFlowPlanFeatures(
 	}
 
 	const highlightedFeatures = getHighlightedFeatures( flowName, planConstantObj );
-	return getPlanFeaturesObject( featureAccessor() ).map( ( feature: Feature ) => {
+	return getPlanFeaturesObject( featureAccessor() ).map( ( feature ) => {
 		return {
 			...feature,
 			isHighlightedFeature: highlightedFeatures.includes( feature.getSlug() ),

--- a/client/my-sites/plan-features-2023-grid/features.tsx
+++ b/client/my-sites/plan-features-2023-grid/features.tsx
@@ -2,14 +2,15 @@ import { getPlanClass, FEATURE_CUSTOM_DOMAIN } from '@automattic/calypso-product
 import classNames from 'classnames';
 import { localize, useTranslate } from 'i18n-calypso';
 import { PlanFeaturesItem } from './item';
+import type { PlanFeature } from './types';
 
 const PlanFeatures2023GridFeatures: React.FC< {
-	features: Array< any >;
+	features: Array< PlanFeature >;
 	planName: string;
 	domainName: string;
 } > = ( { features, planName, domainName } ) => {
 	const translate = useTranslate();
-	const annualPlansFeatureNotice = ( feature: any ) => {
+	const annualPlansFeatureNotice = ( feature: PlanFeature ) => {
 		if ( ! feature.availableOnlyForAnnualPlans || feature.availableForCurrentPlan ) {
 			return '';
 		}

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -65,7 +65,12 @@ type PlanRowOptions = {
 	previousProductNameShort?: string;
 };
 
-const Container = ( props: any ): any => {
+const Container = (
+	props: (
+		| React.HTMLAttributes< HTMLDivElement >
+		| React.HTMLAttributes< HTMLTableCellElement >
+	 ) & { isMobile?: boolean; scope?: string }
+) => {
 	const { children, isMobile, ...otherProps } = props;
 	return isMobile ? (
 		<div { ...otherProps }>{ children }</div>

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -79,12 +79,12 @@ type PlanFeatures2023GridProps = {
 	isLaunchPage?: boolean;
 	isReskinned?: boolean;
 	is2023OnboardingPricingGrid?: boolean;
-	onUpgradeClick: ( cartItem: MinimalRequestCartProduct ) => void;
+	onUpgradeClick: ( cartItem: MinimalRequestCartProduct | null ) => void;
 	plans: Array< string >;
 	visiblePlans: Array< string >;
 	flowName: string;
 	domainName: string;
-	placeholder?: boolean;
+	placeholder?: string;
 	isLandingPage?: boolean;
 };
 
@@ -92,6 +92,8 @@ type PlanFeatures2023GridConnectedProps = {
 	translate: LocalizeProps[ 'translate' ];
 	recordTracksEvent: ( slug: string ) => void;
 	planProperties: Array< PlanProperties >;
+	planName: string;
+	tagline: string;
 };
 
 type PlanFeatures2023GridType = PlanFeatures2023GridProps &
@@ -186,7 +188,7 @@ export class PlanFeatures2023Grid extends Component< PlanFeatures2023GridType > 
 
 	renderMobileView() {
 		const { planProperties, translate } = this.props;
-		const CardContainer = ( props: PlanFeatures2023GridType ) => {
+		const CardContainer = ( props: React.ComponentProps< typeof FoldableCard > ) => {
 			const { children, planName, ...otherProps } = props;
 			return isWpcomEnterpriseGridPlan( planName ) ? (
 				<div { ...otherProps }>{ children }</div>
@@ -584,10 +586,10 @@ export default connect(
 			}
 
 			let planFeatures = getPlanFeaturesObject(
-				planConstantObj?.get2023PricingGridSignupWpcomFeatures?.()
+				planConstantObj?.get2023PricingGridSignupWpcomFeatures?.() ?? []
 			);
 			let jetpackFeatures = getPlanFeaturesObject(
-				planConstantObj.get2023PricingGridSignupJetpackFeatures?.()
+				planConstantObj.get2023PricingGridSignupJetpackFeatures?.() ?? []
 			);
 
 			const rawPrice = getPlanRawPrice( state, planProductId, showMonthlyPrice );
@@ -651,18 +653,18 @@ export default connect(
 					? discountPrice * 12
 					: getPlanRawPrice( state, planProductId, false );
 
-			const tagline = planConstantObj.getPlanTagline?.();
+			const tagline = planConstantObj.getPlanTagline?.() ?? '';
 			const product_name_short =
 				isWpcomEnterpriseGridPlan( plan ) && planConstantObj.getPathSlug
 					? planConstantObj.getPathSlug()
-					: planObject.product_name_short;
+					: planObject?.product_name_short ?? '';
 			const storageOptions =
 				( planConstantObj.get2023PricingGridSignupStorageOptions &&
 					planConstantObj.get2023PricingGridSignupStorageOptions() ) ||
 				[];
 
 			return {
-				cartItemForPlan: getCartItemForPlan( getPlanSlug( state, planProductId ) ),
+				cartItemForPlan: getCartItemForPlan( getPlanSlug( state, planProductId ) ?? '' ),
 				currencyCode: getCurrentUserCurrencyCode( state ),
 				discountPrice,
 				features: planFeatures,

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -92,8 +92,6 @@ type PlanFeatures2023GridConnectedProps = {
 	translate: LocalizeProps[ 'translate' ];
 	recordTracksEvent: ( slug: string ) => void;
 	planProperties: Array< PlanProperties >;
-	planName: string;
-	tagline: string;
 };
 
 type PlanFeatures2023GridType = PlanFeatures2023GridProps &

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -191,7 +191,9 @@ export class PlanFeatures2023Grid extends Component< PlanFeatures2023GridType > 
 
 	renderMobileView() {
 		const { planProperties, translate } = this.props;
-		const CardContainer = ( props: React.ComponentProps< typeof FoldableCard > ) => {
+		const CardContainer = (
+			props: React.ComponentProps< typeof FoldableCard > & { planName: string }
+		) => {
 			const { children, planName, ...otherProps } = props;
 			return isWpcomEnterpriseGridPlan( planName ) ? (
 				<div { ...otherProps }>{ children }</div>

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -56,6 +56,7 @@ import { PlanFeaturesItem } from './item';
 import { PlanComparison2023Grid } from './plan-comparison-grid';
 import { PlanProperties } from './types';
 import { getStorageStringFromFeature } from './util';
+import type { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 
 import './style.scss';
 
@@ -73,21 +74,29 @@ const Container = ( props: any ): any => {
 	);
 };
 
-type PlanFeatures2023GridType = {
-	isInSignup: boolean;
-	isLaunchPage: boolean;
-	isReskinned: boolean;
-	is2023OnboardingPricingGrid: boolean;
-	translate: LocalizeProps[ 'translate' ];
-	recordTracksEvent: ( slug: string ) => void;
-	onUpgradeClick: ( cartItem: any ) => void;
-	// either you specify the plans prop or isPlaceholder prop
+type PlanFeatures2023GridProps = {
+	isInSignup?: boolean;
+	isLaunchPage?: boolean;
+	isReskinned?: boolean;
+	is2023OnboardingPricingGrid?: boolean;
+	onUpgradeClick: ( cartItem: MinimalRequestCartProduct ) => void;
 	plans: Array< string >;
 	visiblePlans: Array< string >;
-	planProperties: Array< PlanProperties >;
 	flowName: string;
 	domainName: string;
+	placeholder?: boolean;
+	isLandingPage?: boolean;
 };
+
+type PlanFeatures2023GridConnectedProps = {
+	translate: LocalizeProps[ 'translate' ];
+	recordTracksEvent: ( slug: string ) => void;
+	planProperties: Array< PlanProperties >;
+};
+
+type PlanFeatures2023GridType = PlanFeatures2023GridProps &
+	PlanFeatures2023GridConnectedProps & { children?: React.ReactNode };
+
 export class PlanFeatures2023Grid extends Component< PlanFeatures2023GridType > {
 	componentDidMount() {
 		this.props.recordTracksEvent( 'calypso_wp_plans_test_view' );
@@ -177,7 +186,7 @@ export class PlanFeatures2023Grid extends Component< PlanFeatures2023GridType > 
 
 	renderMobileView() {
 		const { planProperties, translate } = this.props;
-		const CardContainer = ( props: any ) => {
+		const CardContainer = ( props: PlanFeatures2023GridType ) => {
 			const { children, planName, ...otherProps } = props;
 			return isWpcomEnterpriseGridPlan( planName ) ? (
 				<div { ...otherProps }>{ children }</div>
@@ -449,7 +458,7 @@ export class PlanFeatures2023Grid extends Component< PlanFeatures2023GridType > 
 		options?: PlanRowOptions
 	) {
 		const { translate } = this.props;
-		let previousPlanShortNameFromProperties: any;
+		let previousPlanShortNameFromProperties: string;
 
 		return planPropertiesObj.map( ( properties: PlanProperties ) => {
 			const { planName, product_name_short } = properties;
@@ -554,12 +563,12 @@ export class PlanFeatures2023Grid extends Component< PlanFeatures2023GridType > 
 
 /* eslint-disable wpcalypso/redux-no-bound-selectors */
 export default connect(
-	( state, ownProps: any ) => {
+	( state, ownProps: PlanFeatures2023GridProps ) => {
 		const { placeholder, plans, isLandingPage, visiblePlans } = ownProps;
 
 		let planProperties: PlanProperties[] = plans.map( ( plan: string ) => {
 			let isPlaceholder = false;
-			const planConstantObj: any = applyTestFiltersToPlansList( plan, undefined );
+			const planConstantObj = applyTestFiltersToPlansList( plan, undefined );
 			const planProductId = planConstantObj.getProductId();
 			const planObject = getPlan( state, planProductId );
 			const isMonthlyPlan = isMonthly( plan );
@@ -609,7 +618,7 @@ export default connect(
 			const rawPriceForMonthlyPlan = getPlanRawPrice( state, monthlyPlanProductId ?? 0, true );
 			const annualPlansOnlyFeatures = planConstantObj.getAnnualPlansOnlyFeatures?.() || [];
 			if ( annualPlansOnlyFeatures.length > 0 ) {
-				planFeatures = planFeatures.map( ( feature: any ) => {
+				planFeatures = planFeatures.map( ( feature ) => {
 					const availableOnlyForAnnualPlans = annualPlansOnlyFeatures.includes( feature.getSlug() );
 
 					return {
@@ -620,7 +629,7 @@ export default connect(
 				} );
 			}
 
-			jetpackFeatures = jetpackFeatures.map( ( feature: any ) => {
+			jetpackFeatures = jetpackFeatures.map( ( feature ) => {
 				const availableOnlyForAnnualPlans = annualPlansOnlyFeatures.includes( feature.getSlug() );
 
 				return {

--- a/client/my-sites/plan-features-2023-grid/types.ts
+++ b/client/my-sites/plan-features-2023-grid/types.ts
@@ -22,3 +22,11 @@ export type PlanProperties = {
 	tagline: any;
 	storageOptions: any;
 };
+
+export interface PlanFeature {
+	availableForCurrentPlan?: boolean;
+	availableOnlyForAnnualPlans?: boolean;
+	getSlug: () => React.ReactNode;
+	getTitle: ( name?: string ) => React.ReactNode;
+	getDescription: () => React.ReactNode;
+}

--- a/client/my-sites/plan-features-2023-grid/types.ts
+++ b/client/my-sites/plan-features-2023-grid/types.ts
@@ -6,27 +6,27 @@ export type PlanProperties = {
 	discountPrice: number | null;
 	features: any;
 	jpFeatures: any;
-	isLandingPage: boolean;
-	isPlaceholder: boolean;
+	isLandingPage?: boolean;
+	isPlaceholder?: boolean;
 	planConstantObj: any;
-	planName: any;
+	planName: string;
 	planObject: any;
-	product_name_short: any;
-	hideMonthly: any;
+	product_name_short: string;
+	hideMonthly?: boolean;
 	rawPrice: number | null;
 	rawPriceAnnual: number | null;
 	rawPriceForMonthlyPlan: number | null;
 	relatedMonthlyPlan: any;
 	annualPricePerMonth: number | null;
 	isMonthlyPlan: boolean;
-	tagline: any;
+	tagline: string;
 	storageOptions: any;
 };
 
 export interface PlanFeature {
 	availableForCurrentPlan?: boolean;
 	availableOnlyForAnnualPlans?: boolean;
-	getSlug: () => React.ReactNode;
+	getSlug: () => string;
 	getTitle: ( name?: string ) => React.ReactNode;
 	getDescription: () => React.ReactNode;
 }

--- a/client/my-sites/plan-features-2023-grid/types.ts
+++ b/client/my-sites/plan-features-2023-grid/types.ts
@@ -1,26 +1,29 @@
+import { applyTestFiltersToPlansList } from '@automattic/calypso-products';
+import type { PricedAPIPlan } from '@automattic/data-stores';
+
 export type PlanProperties = {
 	cartItemForPlan: {
 		product_slug: string;
 	} | null;
 	currencyCode: string | null;
 	discountPrice: number | null;
-	features: any;
-	jpFeatures: any;
+	features: PlanFeature[];
+	jpFeatures: PlanFeature[];
 	isLandingPage?: boolean;
 	isPlaceholder?: boolean;
-	planConstantObj: any;
+	planConstantObj: ReturnType< typeof applyTestFiltersToPlansList >;
 	planName: string;
-	planObject: any;
+	planObject: PricedAPIPlan | undefined;
 	product_name_short: string;
 	hideMonthly?: boolean;
 	rawPrice: number | null;
 	rawPriceAnnual: number | null;
 	rawPriceForMonthlyPlan: number | null;
-	relatedMonthlyPlan: any;
+	relatedMonthlyPlan: null | PricedAPIPlan | undefined;
 	annualPricePerMonth: number | null;
 	isMonthlyPlan: boolean;
 	tagline: string;
-	storageOptions: any;
+	storageOptions: string[];
 };
 
 export interface PlanFeature {

--- a/client/my-sites/plans-features-main/plan-type-selector.tsx
+++ b/client/my-sites/plans-features-main/plan-type-selector.tsx
@@ -236,7 +236,8 @@ function useMaxDiscount( plans: string[] ): number {
 				return 0;
 			}
 
-			const monthlyPlanAnnualCost = ( getPlanRawPrice( state, monthlyPlan.product_id ) ?? 0 ) * 12;
+			const monthlyPlanAnnualCost =
+				( getPlanRawPrice( state, monthlyPlan?.product_id ?? 0 ) ?? 0 ) * 12;
 			const rawPrice = getPlanRawPrice( state, yearlyPlan.product_id );
 			const discountPrice = getDiscountedRawPrice( state, yearlyPlan.product_id );
 			const yearlyPlanCost = discountPrice || rawPrice || 0;

--- a/client/state/plans/selectors/get-plan-raw-price.ts
+++ b/client/state/plans/selectors/get-plan-raw-price.ts
@@ -23,7 +23,7 @@ export function getPlanRawPrice(
 	if ( rawPrice < 0 ) {
 		return null;
 	}
-	const price = origCost || plan.raw_price;
+	const price = origCost || plan?.raw_price;
 
-	return isMonthly ? calculateMonthlyPriceForPlan( plan.product_slug, price ) : price;
+	return isMonthly ? calculateMonthlyPriceForPlan( plan?.product_slug ?? '', price ) : price;
 }

--- a/client/state/plans/selectors/get-plan-raw-price.ts
+++ b/client/state/plans/selectors/get-plan-raw-price.ts
@@ -25,5 +25,7 @@ export function getPlanRawPrice(
 	}
 	const price = origCost || plan?.raw_price;
 
-	return isMonthly ? calculateMonthlyPriceForPlan( plan?.product_slug ?? '', price ) : price;
+	return isMonthly
+		? calculateMonthlyPriceForPlan( plan?.product_slug ?? '', price ?? 0 )
+		: price ?? null;
 }

--- a/client/state/plans/selectors/plan.ts
+++ b/client/state/plans/selectors/plan.ts
@@ -1,38 +1,31 @@
 import { createSelector } from '@automattic/state-utils';
 import { get, find } from 'lodash';
+import type { PricedAPIPlan } from '@automattic/data-stores';
+import type { AppState } from 'calypso/types';
 
 import 'calypso/state/plans/init';
 
 /**
  * Return WordPress plans getting from state object
- *
- * @param {object} state - current state object
- * @returns {Array} WordPress plans
  */
-export const getPlans = ( state: any ) => {
+export const getPlans = ( state: AppState ): PricedAPIPlan[] => {
 	return state.plans.items;
 };
 
 /**
  * Return requesting state
- *
- * @param {object} state - current state object
- * @returns {boolean} is plans requesting?
  */
-export const isRequestingPlans = ( state: any ) => {
+export const isRequestingPlans = ( state: AppState ): boolean => {
 	return state.plans.requesting;
 };
 
 /**
  * Returns a plan
- *
- * @param  {object} state      global state
- * @param  {number} productId  the plan productId
- * @returns {object} the matching plan
  */
 export const getPlan = createSelector(
-	( state, productId ) => find( getPlans( state ), { product_id: productId } ),
-	( state ) => getPlans( state )
+	( state: AppState, productId: string | number ): PricedAPIPlan | undefined =>
+		getPlans( state ).find( ( plan ) => plan.product_id === productId ),
+	( state: AppState ) => getPlans( state )
 );
 
 /**
@@ -54,7 +47,7 @@ export const getPlanBySlug = createSelector(
  * @param  {number}  productId the plan productId
  * @returns {string}  plan product_slug
  */
-export function getPlanSlug( state: any, productId: any ) {
+export function getPlanSlug( state: AppState, productId: string | number ): string | null {
 	const plan = getPlan( state, productId );
 
 	return get( plan, 'product_slug', null );

--- a/packages/calypso-products/src/main.ts
+++ b/packages/calypso-products/src/main.ts
@@ -563,7 +563,7 @@ export function applyTestFiltersToPlansList(
 	planName: string | Plan,
 	abtest: string | undefined,
 	extraArgs: Record< string, string | boolean[] > = {}
-): Plan & Pick< WPComPlan, 'getPlanCompareFeatures' > {
+): Plan & Pick< WPComPlan, 'getPlanCompareFeatures' | 'getAnnualPlansOnlyFeatures' > {
 	const plan = getPlan( planName );
 	if ( ! plan ) {
 		throw new Error( `Unknown plan: ${ planName }` );

--- a/packages/calypso-products/src/main.ts
+++ b/packages/calypso-products/src/main.ts
@@ -563,7 +563,8 @@ export function applyTestFiltersToPlansList(
 	planName: string | Plan,
 	abtest: string | undefined,
 	extraArgs: Record< string, string | boolean[] > = {}
-): Plan & Pick< WPComPlan, 'getPlanCompareFeatures' | 'getAnnualPlansOnlyFeatures' > {
+): Plan &
+	Pick< WPComPlan, 'getPlanCompareFeatures' | 'getAnnualPlansOnlyFeatures' | 'getPlanTagline' > {
 	const plan = getPlan( planName );
 	if ( ! plan ) {
 		throw new Error( `Unknown plan: ${ planName }` );

--- a/packages/data-stores/src/index.ts
+++ b/packages/data-stores/src/index.ts
@@ -30,6 +30,7 @@ export * from './site/types';
 export * from './templates';
 export * from './onboard/types';
 export * from './domain-suggestions/types';
+export * from './plans/types';
 
 export {
 	Analyzer,

--- a/packages/data-stores/src/plans/types.ts
+++ b/packages/data-stores/src/plans/types.ts
@@ -59,6 +59,7 @@ export interface PricedAPIPlan {
 	product_name_short: string;
 	bill_period: -1 | 31 | 365;
 	raw_price: number;
+	orig_cost?: number | null;
 	currency_code: string;
 }
 export interface PricedAPIPlanFree extends PricedAPIPlan {

--- a/packages/data-stores/src/plans/types.ts
+++ b/packages/data-stores/src/plans/types.ts
@@ -39,10 +39,11 @@ export interface PlanProduct {
 	annualDiscount?: number;
 	periodAgnosticSlug: PlanSlug;
 	pathSlug?: PlanPath;
-	/** Useful for two cases:
+	/**
+	 * Useful for two cases:
 	 * 1) to show how much we bill the users for annual plans ($8/mo billed $96)
 	 * 2) to show how much a monthly plan would cost in a year (billed 12$/mo costs $144/yr)
-	 *  */
+	 */
 	annualPrice: string;
 }
 
@@ -55,6 +56,7 @@ export interface PricedAPIPlan {
 	product_name: string;
 	path_slug?: PlanPath;
 	product_slug: StorePlanSlug;
+	product_name_short: string;
 	bill_period: -1 | 31 | 365;
 	raw_price: number;
 	currency_code: string;


### PR DESCRIPTION
#### Proposed Changes

Some suggested improvements to the typings in https://github.com/Automattic/wp-calypso/pull/71912 to replace all uses of `any` with more specific types.

If this touches too many things, we can extract some of its more general fixes (mostly adding types to `getPlans` and adding some additional properties to other types) into their own PR.

#### Testing Instructions

These are pretty much just type changes (with a few default strings thrown in) so if the tests pass, they should be good to go.