### PR TITLE
Remove Hosting Config link from /sites ellipsis menu for P2 sites

### DIFF
--- a/client/sites-dashboard/components/sites-ellipsis-menu.tsx
+++ b/client/sites-dashboard/components/sites-ellipsis-menu.tsx
@@ -231,6 +231,8 @@ export const SitesEllipsisMenu = ( {
 		},
 	};
 
+	const showHosting = ! isNotAtomicJetpack( site ) && ! site.options?.is_wpforteams_site;
+
 	return (
 		<SiteDropdownMenu
 			icon={ <Gridicon icon="ellipsis" /> }
@@ -242,7 +244,7 @@ export const SitesEllipsisMenu = ( {
 					{ site.launch_status === 'unlaunched' && <LaunchItem { ...props } /> }
 					<SettingsItem { ...props } />
 					<ManagePluginsItem { ...props } />
-					{ ! isNotAtomicJetpack( site ) && <HostingConfigItem { ...props } /> }
+					{ showHosting && <HostingConfigItem { ...props } /> }
 					{ site.is_coming_soon && <PreviewSiteModalItem { ...props } /> }
 					<WpAdminItem { ...props } />
 				</SiteMenuGroup>


### PR DESCRIPTION
#### Proposed Changes

P2s don't display the Hosting Configuration link in the Calypso sidebar

<img width="286" alt="CleanShot 2023-01-13 at 10 58 08@2x" src="https://user-images.githubusercontent.com/1500769/212190442-2ea188dc-c3ca-46bf-8e2d-81f7acbdde99.png">

But it's there for P2 sites on `/sites`

<img src="https://user-images.githubusercontent.com/1500769/212190662-03f86db3-76fd-46e3-b310-212eb8cbfd7e.png" alt="CleanShot 2023-01-13 at 11 01 19@2x" style="max-width: 100%;" width="50%">

P2s don't go atomic so we shouldn't show the link.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test ellipsis menus on `/sites`
* Hosting configuration link should
   * now be hidden P2s
   * still be hidden for self-hosted Jetpack sites
   * be available for other simple and atomic sites

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] ~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] ~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~
- [ ] ~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~
- [ ] ~For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

