### PR TITLE
Launchpad: correctly detect VideoPress flow for preview interactivity

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/launchpad-site-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/launchpad-site-preview.tsx
@@ -21,6 +21,7 @@ const LaunchpadSitePreview = ( {
 	const translate = useTranslate();
 	const { globalStylesInUse, shouldLimitGlobalStyles } = usePremiumGlobalStyles();
 	const site = useSite();
+	const isInVideoPressFlow = isVideoPressFlow( flow );
 
 	let previewUrl = siteSlug ? 'https://' + siteSlug : null;
 	const devicesToShow: Device[] = [ DEVICE_TYPES.COMPUTER, DEVICE_TYPES.PHONE ];
@@ -29,7 +30,7 @@ const LaunchpadSitePreview = ( {
 		components: { strong: <strong /> },
 	} );
 
-	if ( isVideoPressFlow( flow ) ) {
+	if ( isInVideoPressFlow ) {
 		const windowWidth = window.innerWidth;
 		defaultDevice = windowWidth >= 1000 ? DEVICE_TYPES.COMPUTER : DEVICE_TYPES.PHONE;
 		const productSlug = site?.plan?.product_slug;
@@ -65,7 +66,7 @@ const LaunchpadSitePreview = ( {
 			hide_banners: true,
 			// hide cookies popup
 			preview: true,
-			do_preview_no_interactions: ! isVideoPressFlow,
+			do_preview_no_interactions: ! isInVideoPressFlow,
 			...( globalStylesInUse && shouldLimitGlobalStyles && { 'preview-global-styles': true } ),
 		} );
 	}


### PR DESCRIPTION
#### Proposed Changes

* ensure no preview interactivity for non-VideoPress flows

Fixes #72029

#### Testing Instructions

With an existing (non-VideoPress) Launchpad-enabled site, visit Launchpad. Or create one ([Free](https://horizon.wordpress.com/setup/free/intro), [LIB](https://horizon.wordpress.com/setup/link-in-bio/intro), [Newsletter](https://horizon.wordpress.com/setup/newsletter/intro))

Ensure that you can't click inside the preview:
<img width="1451" alt="Screenshot 2023-01-12 at 16 24 01" src="https://user-images.githubusercontent.com/195089/212193945-76d618aa-dc44-4418-a736-5603bfb2fc2c.png">


#### Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?

