### PR TITLE
Theme Showcase: Support param style in theme signup url

### DIFF
--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -225,7 +225,7 @@ export function createSiteWithCart( callback, dependencies, stepData, reduxStore
 		isPurchasingItem: isPurchasingDomainItem,
 		siteUrl,
 		themeSlugWithRepo,
-		themeStyle,
+		themeStyleVariation,
 		themeItem,
 		siteAccentColor,
 	} = stepData;
@@ -298,7 +298,7 @@ export function createSiteWithCart( callback, dependencies, stepData, reduxStore
 				themeItem,
 			};
 
-			processItemCart(
+			processItemCart( {
 				providedDependencies,
 				newCartItems,
 				callback,
@@ -306,14 +306,13 @@ export function createSiteWithCart( callback, dependencies, stepData, reduxStore
 				siteSlug,
 				isFreeThemePreselected,
 				themeSlugWithRepo,
-				themeStyle,
-				null
-			);
+				themeStyleVariation,
+			} );
 		}
 	);
 }
 
-export function setThemeOnSite( callback, { siteSlug, themeSlugWithRepo, themeStyle } ) {
+export function setThemeOnSite( callback, { siteSlug, themeSlugWithRepo, themeStyleVariation } ) {
 	if ( isEmpty( themeSlugWithRepo ) ) {
 		defer( callback );
 		return;
@@ -324,7 +323,7 @@ export function setThemeOnSite( callback, { siteSlug, themeSlugWithRepo, themeSt
 	wpcom.req
 		.post( `/sites/${ siteSlug }/themes/mine`, {
 			theme,
-			...( themeStyle && { style_variation_slug: themeStyle } ),
+			...( themeStyleVariation && { style_variation_slug: themeStyleVariation } ),
 		} )
 		.then( () => callback() )
 		.catch( ( error ) => callback( [ error ] ) );
@@ -351,17 +350,13 @@ function addDIFMLiteProductToCart( callback, dependencies, step, reduxStore ) {
 		cartItem,
 	};
 	const newCartItems = [ cartItem ];
-	processItemCart(
+	processItemCart( {
 		providedDependencies,
 		newCartItems,
 		callback,
 		reduxStore,
 		siteSlug,
-		null,
-		null,
-		null,
-		null
-	);
+	} );
 }
 
 /**
@@ -516,17 +511,14 @@ export function addPlanToCart( callback, dependencies, stepProvidedItems, reduxS
 	const providedDependencies = { cartItem };
 	const newCartItems = [ cartItem, emailItem ].filter( ( item ) => item );
 
-	processItemCart(
+	processItemCart( {
 		providedDependencies,
 		newCartItems,
 		callback,
 		reduxStore,
 		siteSlug,
-		null,
-		null,
-		null,
-		lastKnownFlow
-	);
+		lastKnownFlow,
+	} );
 }
 export function addAddOnsToCart(
 	callback,
@@ -548,17 +540,13 @@ export function addAddOnsToCart(
 	}
 
 	const newCartItems = cartItem.filter( ( item ) => item );
-	processItemCart(
+	processItemCart( {
 		providedDependencies,
 		newCartItems,
 		callback,
 		reduxStore,
 		slug,
-		null,
-		null,
-		null,
-		null
-	);
+	} );
 }
 
 export function addDomainToCart(
@@ -575,20 +563,16 @@ export function addDomainToCart(
 
 	const newCartItems = [ domainItem, googleAppsCartItem ].filter( ( item ) => item );
 
-	processItemCart(
+	processItemCart( {
 		providedDependencies,
 		newCartItems,
 		callback,
 		reduxStore,
 		slug,
-		null,
-		null,
-		null,
-		null
-	);
+	} );
 }
 
-function processItemCart(
+function processItemCart( {
 	providedDependencies,
 	newCartItems,
 	callback,
@@ -596,9 +580,9 @@ function processItemCart(
 	siteSlug,
 	isFreeThemePreselected,
 	themeSlugWithRepo,
-	themeStyle,
-	lastKnownFlow
-) {
+	themeStyleVariation,
+	lastKnownFlow,
+} ) {
 	const addToCartAndProceed = async () => {
 		debug( 'preparing to add cart items (if any) from', newCartItems );
 		const reduxState = reduxStore.getState();
@@ -630,11 +614,15 @@ function processItemCart(
 	const userLoggedIn = isUserLoggedIn( reduxStore.getState() );
 
 	if ( ! userLoggedIn && isFreeThemePreselected ) {
-		setThemeOnSite( addToCartAndProceed, { siteSlug, themeSlugWithRepo, themeStyle } );
+		setThemeOnSite( addToCartAndProceed, { siteSlug, themeSlugWithRepo, themeStyleVariation } );
 	} else if ( userLoggedIn && isFreeThemePreselected ) {
 		fetchSitesAndUser(
 			siteSlug,
-			setThemeOnSite.bind( null, addToCartAndProceed, { siteSlug, themeSlugWithRepo, themeStyle } ),
+			setThemeOnSite.bind( null, addToCartAndProceed, {
+				siteSlug,
+				themeSlugWithRepo,
+				themeStyleVariation,
+			} ),
 			reduxStore
 		);
 	} else if ( userLoggedIn && siteSlug ) {

--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -225,6 +225,7 @@ export function createSiteWithCart( callback, dependencies, stepData, reduxStore
 		isPurchasingItem: isPurchasingDomainItem,
 		siteUrl,
 		themeSlugWithRepo,
+		themeStyle,
 		themeItem,
 		siteAccentColor,
 	} = stepData;
@@ -304,13 +305,15 @@ export function createSiteWithCart( callback, dependencies, stepData, reduxStore
 				reduxStore,
 				siteSlug,
 				isFreeThemePreselected,
-				themeSlugWithRepo
+				themeSlugWithRepo,
+				themeStyle,
+				null
 			);
 		}
 	);
 }
 
-export function setThemeOnSite( callback, { siteSlug, themeSlugWithRepo } ) {
+export function setThemeOnSite( callback, { siteSlug, themeSlugWithRepo, themeStyle } ) {
 	if ( isEmpty( themeSlugWithRepo ) ) {
 		defer( callback );
 		return;
@@ -319,7 +322,10 @@ export function setThemeOnSite( callback, { siteSlug, themeSlugWithRepo } ) {
 	const theme = themeSlugWithRepo.split( '/' )[ 1 ];
 
 	wpcom.req
-		.post( `/sites/${ siteSlug }/themes/mine`, { theme } )
+		.post( `/sites/${ siteSlug }/themes/mine`, {
+			theme,
+			...( themeStyle && { style_variation_slug: themeStyle } ),
+		} )
 		.then( () => callback() )
 		.catch( ( error ) => callback( [ error ] ) );
 }
@@ -345,7 +351,17 @@ function addDIFMLiteProductToCart( callback, dependencies, step, reduxStore ) {
 		cartItem,
 	};
 	const newCartItems = [ cartItem ];
-	processItemCart( providedDependencies, newCartItems, callback, reduxStore, siteSlug, null, null );
+	processItemCart(
+		providedDependencies,
+		newCartItems,
+		callback,
+		reduxStore,
+		siteSlug,
+		null,
+		null,
+		null,
+		null
+	);
 }
 
 /**
@@ -508,6 +524,7 @@ export function addPlanToCart( callback, dependencies, stepProvidedItems, reduxS
 		siteSlug,
 		null,
 		null,
+		null,
 		lastKnownFlow
 	);
 }
@@ -539,6 +556,7 @@ export function addAddOnsToCart(
 		slug,
 		null,
 		null,
+		null,
 		null
 	);
 }
@@ -565,6 +583,7 @@ export function addDomainToCart(
 		slug,
 		null,
 		null,
+		null,
 		null
 	);
 }
@@ -577,6 +596,7 @@ function processItemCart(
 	siteSlug,
 	isFreeThemePreselected,
 	themeSlugWithRepo,
+	themeStyle,
 	lastKnownFlow
 ) {
 	const addToCartAndProceed = async () => {
@@ -610,11 +630,11 @@ function processItemCart(
 	const userLoggedIn = isUserLoggedIn( reduxStore.getState() );
 
 	if ( ! userLoggedIn && isFreeThemePreselected ) {
-		setThemeOnSite( addToCartAndProceed, { siteSlug, themeSlugWithRepo } );
+		setThemeOnSite( addToCartAndProceed, { siteSlug, themeSlugWithRepo, themeStyle } );
 	} else if ( userLoggedIn && isFreeThemePreselected ) {
 		fetchSitesAndUser(
 			siteSlug,
-			setThemeOnSite.bind( null, addToCartAndProceed, { siteSlug, themeSlugWithRepo } ),
+			setThemeOnSite.bind( null, addToCartAndProceed, { siteSlug, themeSlugWithRepo, themeStyle } ),
 			reduxStore
 		);
 	} else if ( userLoggedIn && siteSlug ) {

--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -298,12 +298,7 @@ export function createSiteWithCart( callback, dependencies, stepData, reduxStore
 				themeItem,
 			};
 
-			processItemCart( {
-				providedDependencies,
-				newCartItems,
-				callback,
-				reduxStore,
-				siteSlug,
+			processItemCart( providedDependencies, newCartItems, callback, reduxStore, siteSlug, {
 				isFreeThemePreselected,
 				themeSlugWithRepo,
 				themeStyleVariation,
@@ -350,13 +345,7 @@ function addDIFMLiteProductToCart( callback, dependencies, step, reduxStore ) {
 		cartItem,
 	};
 	const newCartItems = [ cartItem ];
-	processItemCart( {
-		providedDependencies,
-		newCartItems,
-		callback,
-		reduxStore,
-		siteSlug,
-	} );
+	processItemCart( providedDependencies, newCartItems, callback, reduxStore, siteSlug );
 }
 
 /**
@@ -511,12 +500,7 @@ export function addPlanToCart( callback, dependencies, stepProvidedItems, reduxS
 	const providedDependencies = { cartItem };
 	const newCartItems = [ cartItem, emailItem ].filter( ( item ) => item );
 
-	processItemCart( {
-		providedDependencies,
-		newCartItems,
-		callback,
-		reduxStore,
-		siteSlug,
+	processItemCart( providedDependencies, newCartItems, callback, reduxStore, siteSlug, {
 		lastKnownFlow,
 	} );
 }
@@ -540,13 +524,7 @@ export function addAddOnsToCart(
 	}
 
 	const newCartItems = cartItem.filter( ( item ) => item );
-	processItemCart( {
-		providedDependencies,
-		newCartItems,
-		callback,
-		reduxStore,
-		slug,
-	} );
+	processItemCart( providedDependencies, newCartItems, callback, reduxStore, slug );
 }
 
 export function addDomainToCart(
@@ -563,26 +541,17 @@ export function addDomainToCart(
 
 	const newCartItems = [ domainItem, googleAppsCartItem ].filter( ( item ) => item );
 
-	processItemCart( {
-		providedDependencies,
-		newCartItems,
-		callback,
-		reduxStore,
-		slug,
-	} );
+	processItemCart( providedDependencies, newCartItems, callback, reduxStore, slug );
 }
 
-function processItemCart( {
+function processItemCart(
 	providedDependencies,
 	newCartItems,
 	callback,
 	reduxStore,
 	siteSlug,
-	isFreeThemePreselected,
-	themeSlugWithRepo,
-	themeStyleVariation,
-	lastKnownFlow,
-} ) {
+	{ isFreeThemePreselected, themeSlugWithRepo, themeStyleVariation, lastKnownFlow }
+) {
 	const addToCartAndProceed = async () => {
 		debug( 'preparing to add cart items (if any) from', newCartItems );
 		const reduxState = reduxStore.getState();

--- a/client/my-sites/themes/theme-preview.jsx
+++ b/client/my-sites/themes/theme-preview.jsx
@@ -81,7 +81,10 @@ class ThemePreview extends Component {
 
 	renderPrimaryButton = () => {
 		const primaryOption = this.getPrimaryOption();
-		const buttonHref = primaryOption.getUrl ? primaryOption.getUrl( this.props.themeId ) : null;
+		const styleVariationOption = this.getStyleVariationOption();
+		const buttonHref = primaryOption.getUrl
+			? primaryOption.getUrl( this.props.themeId, styleVariationOption )
+			: null;
 
 		return (
 			<Button primary onClick={ this.onPrimaryButtonClick } href={ buttonHref }>
@@ -92,10 +95,15 @@ class ThemePreview extends Component {
 
 	renderSecondaryButton = () => {
 		const secondaryButton = this.getSecondaryOption();
+		const styleVariationOption = this.getStyleVariationOption();
 		if ( ! secondaryButton ) {
 			return;
 		}
-		const buttonHref = secondaryButton.getUrl ? secondaryButton.getUrl( this.props.themeId ) : null;
+
+		const buttonHref = secondaryButton.getUrl
+			? secondaryButton.getUrl( this.props.themeId, styleVariationOption )
+			: null;
+
 		return (
 			<Button onClick={ this.onSecondaryButtonClick } href={ buttonHref }>
 				{ secondaryButton.label }

--- a/client/my-sites/themes/theme-preview.jsx
+++ b/client/my-sites/themes/theme-preview.jsx
@@ -82,9 +82,10 @@ class ThemePreview extends Component {
 	renderPrimaryButton = () => {
 		const primaryOption = this.getPrimaryOption();
 		const styleVariationOption = this.getStyleVariationOption();
-		const buttonHref = primaryOption.getUrl
-			? primaryOption.getUrl( this.props.themeId, styleVariationOption )
-			: null;
+		let buttonHref = primaryOption.getUrl ? primaryOption.getUrl( this.props.themeId ) : null;
+		if ( buttonHref && styleVariationOption ) {
+			buttonHref += `&style=${ styleVariationOption.slug }`;
+		}
 
 		return (
 			<Button primary onClick={ this.onPrimaryButtonClick } href={ buttonHref }>
@@ -95,14 +96,15 @@ class ThemePreview extends Component {
 
 	renderSecondaryButton = () => {
 		const secondaryButton = this.getSecondaryOption();
-		const styleVariationOption = this.getStyleVariationOption();
 		if ( ! secondaryButton ) {
 			return;
 		}
 
-		const buttonHref = secondaryButton.getUrl
-			? secondaryButton.getUrl( this.props.themeId, styleVariationOption )
-			: null;
+		const styleVariationOption = this.getStyleVariationOption();
+		let buttonHref = secondaryButton.getUrl ? secondaryButton.getUrl( this.props.themeId ) : null;
+		if ( buttonHref && styleVariationOption ) {
+			buttonHref += `&style=${ styleVariationOption.slug }`;
+		}
 
 		return (
 			<Button onClick={ this.onSecondaryButtonClick } href={ buttonHref }>

--- a/client/my-sites/themes/theme-preview.jsx
+++ b/client/my-sites/themes/theme-preview.jsx
@@ -79,12 +79,23 @@ class ThemePreview extends Component {
 		return this.props.themeOptions.styleVariation;
 	};
 
+	appendStyleVariationOptionToUrl = ( url ) => {
+		const styleVariationOption = this.getStyleVariationOption();
+		if ( ! styleVariationOption ) {
+			return url;
+		}
+
+		const [ base, query ] = url.split( '?' );
+		const params = new URLSearchParams( query );
+		params.set( 'style_variation', styleVariationOption.slug );
+		return `${ base }?${ params.toString() }`;
+	};
+
 	renderPrimaryButton = () => {
 		const primaryOption = this.getPrimaryOption();
-		const styleVariationOption = this.getStyleVariationOption();
 		let buttonHref = primaryOption.getUrl ? primaryOption.getUrl( this.props.themeId ) : null;
-		if ( buttonHref && styleVariationOption ) {
-			buttonHref += `&style=${ styleVariationOption.slug }`;
+		if ( buttonHref ) {
+			buttonHref = this.appendStyleVariationOptionToUrl( buttonHref );
 		}
 
 		return (
@@ -100,10 +111,9 @@ class ThemePreview extends Component {
 			return;
 		}
 
-		const styleVariationOption = this.getStyleVariationOption();
 		let buttonHref = secondaryButton.getUrl ? secondaryButton.getUrl( this.props.themeId ) : null;
-		if ( buttonHref && styleVariationOption ) {
-			buttonHref += `&style=${ styleVariationOption.slug }`;
+		if ( buttonHref ) {
+			buttonHref = this.appendStyleVariationOptionToUrl( buttonHref );
 		}
 
 		return (

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -182,14 +182,19 @@ class DomainsStep extends Component {
 		return this.props.queryObject ? this.props.queryObject.theme : undefined;
 	};
 
+	getThemeStyle = () => {
+		return this.props.queryObject ? this.props.queryObject.style : undefined;
+	};
+
 	getThemeArgs = () => {
 		const themeSlug = this.getThemeSlug();
+		const themeStyle = this.getThemeStyle();
 		const themeSlugWithRepo = this.getThemeSlugWithRepo( themeSlug );
 		const theme = this.isPurchasingTheme()
 			? themeItem( themeSlug, 'signup-with-theme' )
 			: undefined;
 
-		return { themeSlug, themeSlugWithRepo, themeItem: theme };
+		return { themeSlug, themeSlugWithRepo, themeStyle, themeItem: theme };
 	};
 
 	getThemeSlugWithRepo = ( themeSlug ) => {

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -182,19 +182,19 @@ class DomainsStep extends Component {
 		return this.props.queryObject ? this.props.queryObject.theme : undefined;
 	};
 
-	getThemeStyle = () => {
-		return this.props.queryObject ? this.props.queryObject.style : undefined;
+	getThemeStyleVariation = () => {
+		return this.props.queryObject ? this.props.queryObject.style_variation : undefined;
 	};
 
 	getThemeArgs = () => {
 		const themeSlug = this.getThemeSlug();
-		const themeStyle = this.getThemeStyle();
+		const themeStyleVariation = this.getThemeStyleVariation();
 		const themeSlugWithRepo = this.getThemeSlugWithRepo( themeSlug );
 		const theme = this.isPurchasingTheme()
 			? themeItem( themeSlug, 'signup-with-theme' )
 			: undefined;
 
-		return { themeSlug, themeSlugWithRepo, themeStyle, themeItem: theme };
+		return { themeSlug, themeSlugWithRepo, themeStyleVariation, themeItem: theme };
 	};
 
 	getThemeSlugWithRepo = ( themeSlug ) => {

--- a/client/state/themes/selectors/get-theme-signup-url.js
+++ b/client/state/themes/selectors/get-theme-signup-url.js
@@ -5,16 +5,20 @@ import 'calypso/state/themes/init';
 /**
  * Returns the URL for signing up for a new WordPress.com account with the given theme pre-selected.
  *
- * @param  {object}  state   Global state tree
- * @param  {string}  themeId Theme ID
+ * @param  {object}  state      Global state tree
+ * @param  {string}  themeId    Theme ID
+ * @param  {string}  themeStyle Theme style
  * @returns {?string}         Signup URL
  */
-export function getThemeSignupUrl( state, themeId ) {
+export function getThemeSignupUrl( state, themeId, themeStyle ) {
 	if ( ! themeId ) {
 		return null;
 	}
 
 	let url = '/start/with-theme?ref=calypshowcase&theme=' + themeId;
+	if ( themeStyle ) {
+		url += `&style=${ themeStyle.slug }`;
+	}
 
 	if ( isThemePremium( state, themeId ) ) {
 		url += '&premium=true';

--- a/client/state/themes/selectors/get-theme-signup-url.js
+++ b/client/state/themes/selectors/get-theme-signup-url.js
@@ -5,20 +5,16 @@ import 'calypso/state/themes/init';
 /**
  * Returns the URL for signing up for a new WordPress.com account with the given theme pre-selected.
  *
- * @param  {object}  state      Global state tree
- * @param  {string}  themeId    Theme ID
- * @param  {string}  themeStyle Theme style
+ * @param  {object}  state   Global state tree
+ * @param  {string}  themeId Theme ID
  * @returns {?string}         Signup URL
  */
-export function getThemeSignupUrl( state, themeId, themeStyle ) {
+export function getThemeSignupUrl( state, themeId ) {
 	if ( ! themeId ) {
 		return null;
 	}
 
 	let url = '/start/with-theme?ref=calypshowcase&theme=' + themeId;
-	if ( themeStyle ) {
-		url += `&style=${ themeStyle.slug }`;
-	}
 
 	if ( isThemePremium( state, themeId ) ) {
 		url += '&premium=true';


### PR DESCRIPTION
#### Proposed Changes

This PR adds support for a new URL parameter `style` that is passed down the theme signup URL all the way to the domain selection, and ultimately applied to the site creation.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use Firefox for testing, since the `with-theme` flow is partially broken in Chrome (see related discussion here p1669733829929689-slack-CJS75TX3R)
* Head to the logged-out Theme Showcase `/themes`. If using calypso.live, the flag `themes/showcase-i4/details-and-preview` is required.
* Pick any theme with style variation, such as "Pixl".
* Open the theme preview and select one of the styles, then click on the button "Pick this design".
* Ensure that you are redirected to the signup screen, and check that the `style` parameter is there (e.g.: `/start/with-theme/user?ref=calypshowcase&theme=pixl&style=magenta`). Click on Log in link and enter your account.

![Screen Shot 2023-01-13 at 9 36 48 AM](https://user-images.githubusercontent.com/797888/212217086-6742cf45-6580-42ca-af4b-b82f2af6d3e9.png)

* Ensure that you are redirected to the domain selection screen, and check that the `style` parameter is there (e.g: `/start/with-theme/domains-theme-preselected?ref=calypshowcase&theme=pixl&style=magenta`). This part is broken in Chrome, since it will redirect you back to the log in screen (cc: @ianstewart)
* Select a domain, and the site will be created, leading you to the homepage.
* Go to the site editor, and ensure that the theme with the selected variation is applied.

Note: The selected variation is only visible in the site editor, since it's gated. This means that clicking on the site preview won't show the theme with the variation applied.

![Screen Shot 2023-01-13 at 9 33 52 AM](https://user-images.githubusercontent.com/797888/212216798-b89defa7-cb5b-4ce9-a3b4-7faf46115ff8.png)


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

