### PR TITLE
chore: remove CoBlocks build configuration from TeamCity config.

### DIFF
--- a/.teamcity/_self/projects/WPComTests.kt
+++ b/.teamcity/_self/projects/WPComTests.kt
@@ -49,9 +49,6 @@ object WPComTests : Project({
 	// Editor Tracking Edge
 	buildType(editorTrackingBuildType("desktop", "c752ca9a-e77d-11ec-8fea-0242ac120002", atomic=false, edge=true));
 
-	buildType(coblocksPlaywrightBuildType("desktop", "08f88b93-993e-4de8-8d80-4a94981d9af4"));
-	buildType(coblocksPlaywrightBuildType("mobile", "cbcd44d5-4d31-4adc-b1b5-97f1225c6a7c"));
-
 	buildType(jetpackPlaywrightBuildType("desktop", "68fe6336-5869-4244-b236-cca23ba03487"));
 	buildType(jetpackPlaywrightBuildType("mobile", "a80b5c10-1fef-4c7f-9e2c-5c5c30d637c8"));
 
@@ -172,51 +169,6 @@ fun editorTrackingBuildType( targetDevice: String, buildUuid: String, atomic: Bo
 				buildFinishedSuccessfully = true
 			}
 		}
-	)
-}
-
-fun coblocksPlaywrightBuildType( targetDevice: String, buildUuid: String ): E2EBuildType {
-    return E2EBuildType (
-		buildId = "WPComTests_coblocks_Playwright_$targetDevice",
-		buildUuid = buildUuid,
-		buildName = "CoBlocks E2E Tests ($targetDevice)",
-		buildDescription = "Runs CoBlocks E2E tests as $targetDevice",
-		testGroup = "coblocks",
-		buildParams = {
-			text(
-				name = "env.CALYPSO_BASE_URL",
-				value = "https://wordpress.com",
-				label = "Test URL",
-				description = "URL to test against",
-				allowEmpty = false
-			)
-			checkbox(
-				name = "env.COBLOCKS_EDGE",
-				value = "false",
-				label = "Use coblocks-edge",
-				description = "Use a blog with coblocks-edge sticker",
-				checked = "true",
-				unchecked = "false"
-			)
-			param("env.AUTHENTICATE_ACCOUNTS", "gutenbergSimpleSiteEdgeUser,gutenbergSimpleSiteUser,coBlocksSimpleSiteEdgeUser")
-			param("env.VIEWPORT_NAME", "$targetDevice")
-		},
-		buildFeatures = {
-			notifications {
-				notifierSettings = slackNotifier {
-					connection = "PROJECT_EXT_11"
-					sendTo = "#gutenberg-e2e"
-					messageFormat = verboseMessageFormat {
-						addBranch = true
-						addStatusText = true
-						maximumNumberOfChanges = 10
-					}
-				}
-				branchFilter = "+:<default>"
-				buildFailed = true
-				buildFinishedSuccessfully = true
-			}
-		},
 	)
 }
 

--- a/test/e2e/specs/blocks/blocks__coblocks__blocks.ts
+++ b/test/e2e/specs/blocks/blocks__coblocks__blocks.ts
@@ -1,6 +1,5 @@
 /**
  * @group gutenberg
- * @group coblocks
  */
 import {
 	envVariables,

--- a/test/e2e/specs/blocks/blocks__coblocks__extensions__cover-styles.ts
+++ b/test/e2e/specs/blocks/blocks__coblocks__extensions__cover-styles.ts
@@ -1,6 +1,5 @@
 /**
  * @group gutenberg
- * @group coblocks
  */
 import {
 	envVariables,

--- a/test/e2e/specs/blocks/blocks__coblocks__extensions__gutter-control.ts
+++ b/test/e2e/specs/blocks/blocks__coblocks__extensions__gutter-control.ts
@@ -1,6 +1,5 @@
 /**
  * @group gutenberg
- * @group coblocks
  */
 import {
 	envVariables,

--- a/test/e2e/specs/blocks/blocks__coblocks__extensions__replace-image.ts
+++ b/test/e2e/specs/blocks/blocks__coblocks__extensions__replace-image.ts
@@ -1,6 +1,5 @@
 /**
  * @group gutenberg
- * @group coblocks
  */
 import {
 	envVariables,


### PR DESCRIPTION
#### Proposed Changes

This PR removes the CoBlocks build configuration from TeamCity.

Context: p1673572424667869/1673571770.547419-slack-C1A1EKDGQ

#### Testing Instructions


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #