### PR TITLE
Stats: Avoid redirecting back to the views tab

### DIFF
--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -181,7 +181,7 @@ class StatsSite extends Component {
 	}
 
 	renderStats() {
-		const { date, siteId, slug, isJetpack, isSitePrivate, isOdysseyStats } = this.props;
+		const { date, siteId, slug, isJetpack, isSitePrivate, isOdysseyStats, context } = this.props;
 
 		const queryDate = date.format( 'YYYY-MM-DD' );
 		const { period, endOf } = this.props.period;
@@ -248,6 +248,7 @@ class StatsSite extends Component {
 								date={ date }
 								period={ period }
 								url={ `/stats/${ period }/${ slug }` }
+								queryParams={ context.query }
 							>
 								<DatePicker
 									period={ period }

--- a/client/my-sites/stats/stats-period-navigation/index.jsx
+++ b/client/my-sites/stats/stats-period-navigation/index.jsx
@@ -52,8 +52,7 @@ class StatsPeriodNavigation extends PureComponent {
 
 	handleArrowNext = () => {
 		const { date, moment, period, url, queryParams } = this.props;
-		const getQueryParams = new URLSearchParams( window.location.search );
-		const tabValue = getQueryParams.get( 'tab' );
+		const tabValue = queryParams.tab;
 		const nextDay = moment( date ).add( 1, period ).format( 'YYYY-MM-DD' );
 		const nextDayQuery = qs.stringify(
 			Object.assign(

--- a/client/my-sites/stats/stats-period-navigation/index.jsx
+++ b/client/my-sites/stats/stats-period-navigation/index.jsx
@@ -71,9 +71,8 @@ class StatsPeriodNavigation extends PureComponent {
 
 	handleArrowPrevious = () => {
 		const { date, moment, period, url, queryParams } = this.props;
+		const tabValue = queryParams.tab;
 		const previousDay = moment( date ).subtract( 1, period ).format( 'YYYY-MM-DD' );
-		const getQueryParams = new URLSearchParams( window.location.search );
-		const tabValue = getQueryParams.get( 'tab' );
 		const previousDayQuery = qs.stringify(
 			Object.assign(
 				{},

--- a/client/my-sites/stats/stats-period-navigation/index.jsx
+++ b/client/my-sites/stats/stats-period-navigation/index.jsx
@@ -52,8 +52,9 @@ class StatsPeriodNavigation extends PureComponent {
 
 	handleArrowNext = () => {
 		const { date, moment, period, url, queryParams } = this.props;
+		const usedPeriod = 'hour' === period ? 'day' : period;
 		const tabValue = queryParams.tab;
-		const nextDay = moment( date ).add( 1, period ).format( 'YYYY-MM-DD' );
+		const nextDay = moment( date ).add( 1, usedPeriod ).format( 'YYYY-MM-DD' );
 		const nextDayQuery = qs.stringify(
 			Object.assign( {}, queryParams, { startDate: nextDay }, tabValue && { tab: tabValue } ),
 			{
@@ -66,8 +67,9 @@ class StatsPeriodNavigation extends PureComponent {
 
 	handleArrowPrevious = () => {
 		const { date, moment, period, url, queryParams } = this.props;
+		const usedPeriod = 'hour' === period ? 'day' : period;
 		const tabValue = queryParams.tab;
-		const previousDay = moment( date ).subtract( 1, period ).format( 'YYYY-MM-DD' );
+		const previousDay = moment( date ).subtract( 1, usedPeriod ).format( 'YYYY-MM-DD' );
 		const previousDayQuery = qs.stringify(
 			Object.assign( {}, queryParams, { startDate: previousDay }, tabValue && { tab: tabValue } ),
 			{ addQueryPrefix: true }

--- a/client/my-sites/stats/stats-period-navigation/index.jsx
+++ b/client/my-sites/stats/stats-period-navigation/index.jsx
@@ -53,14 +53,10 @@ class StatsPeriodNavigation extends PureComponent {
 	handleArrowNext = () => {
 		const { date, moment, period, url, queryParams } = this.props;
 		const usedPeriod = 'hour' === period ? 'day' : period;
-		const tabValue = queryParams.tab;
 		const nextDay = moment( date ).add( 1, usedPeriod ).format( 'YYYY-MM-DD' );
-		const nextDayQuery = qs.stringify(
-			Object.assign( {}, queryParams, { startDate: nextDay }, tabValue && { tab: tabValue } ),
-			{
-				addQueryPrefix: true,
-			}
-		);
+		const nextDayQuery = qs.stringify( Object.assign( {}, queryParams, { startDate: nextDay } ), {
+			addQueryPrefix: true,
+		} );
 		const href = `${ url }${ nextDayQuery }`;
 		this.handleArrowEvent( 'next', href );
 	};
@@ -68,10 +64,9 @@ class StatsPeriodNavigation extends PureComponent {
 	handleArrowPrevious = () => {
 		const { date, moment, period, url, queryParams } = this.props;
 		const usedPeriod = 'hour' === period ? 'day' : period;
-		const tabValue = queryParams.tab;
 		const previousDay = moment( date ).subtract( 1, usedPeriod ).format( 'YYYY-MM-DD' );
 		const previousDayQuery = qs.stringify(
-			Object.assign( {}, queryParams, { startDate: previousDay }, tabValue && { tab: tabValue } ),
+			Object.assign( {}, queryParams, { startDate: previousDay } ),
 			{ addQueryPrefix: true }
 		);
 		const href = `${ url }${ previousDayQuery }`;

--- a/client/my-sites/stats/stats-period-navigation/index.jsx
+++ b/client/my-sites/stats/stats-period-navigation/index.jsx
@@ -55,12 +55,7 @@ class StatsPeriodNavigation extends PureComponent {
 		const tabValue = queryParams.tab;
 		const nextDay = moment( date ).add( 1, period ).format( 'YYYY-MM-DD' );
 		const nextDayQuery = qs.stringify(
-			Object.assign(
-				{},
-				queryParams,
-				{ startDate: nextDay },
-				{ tab: tabValue ? tabValue : 'views' }
-			),
+			Object.assign( {}, queryParams, { startDate: nextDay }, tabValue && { tab: tabValue } ),
 			{
 				addQueryPrefix: true,
 			}
@@ -74,12 +69,7 @@ class StatsPeriodNavigation extends PureComponent {
 		const tabValue = queryParams.tab;
 		const previousDay = moment( date ).subtract( 1, period ).format( 'YYYY-MM-DD' );
 		const previousDayQuery = qs.stringify(
-			Object.assign(
-				{},
-				queryParams,
-				{ startDate: previousDay },
-				{ tab: tabValue ? tabValue : 'views' }
-			),
+			Object.assign( {}, queryParams, { startDate: previousDay }, tabValue && { tab: tabValue } ),
 			{ addQueryPrefix: true }
 		);
 		const href = `${ url }${ previousDayQuery }`;

--- a/client/my-sites/stats/stats-period-navigation/index.jsx
+++ b/client/my-sites/stats/stats-period-navigation/index.jsx
@@ -52,12 +52,20 @@ class StatsPeriodNavigation extends PureComponent {
 
 	handleArrowNext = () => {
 		const { date, moment, period, url, queryParams } = this.props;
-
-		const usedPeriod = 'hour' === period ? 'day' : period;
-		const nextDay = moment( date ).add( 1, usedPeriod ).format( 'YYYY-MM-DD' );
-		const nextDayQuery = qs.stringify( Object.assign( {}, queryParams, { startDate: nextDay } ), {
-			addQueryPrefix: true,
-		} );
+		const getQueryParams = new URLSearchParams( window.location.search );
+		const tabValue = getQueryParams.get( 'tab' );
+		const nextDay = moment( date ).add( 1, period ).format( 'YYYY-MM-DD' );
+		const nextDayQuery = qs.stringify(
+			Object.assign(
+				{},
+				queryParams,
+				{ startDate: nextDay },
+				{ tab: tabValue ? tabValue : 'views' }
+			),
+			{
+				addQueryPrefix: true,
+			}
+		);
 		const href = `${ url }${ nextDayQuery }`;
 		this.handleArrowEvent( 'next', href );
 	};
@@ -65,8 +73,15 @@ class StatsPeriodNavigation extends PureComponent {
 	handleArrowPrevious = () => {
 		const { date, moment, period, url, queryParams } = this.props;
 		const previousDay = moment( date ).subtract( 1, period ).format( 'YYYY-MM-DD' );
+		const getQueryParams = new URLSearchParams( window.location.search );
+		const tabValue = getQueryParams.get( 'tab' );
 		const previousDayQuery = qs.stringify(
-			Object.assign( {}, queryParams, { startDate: previousDay } ),
+			Object.assign(
+				{},
+				queryParams,
+				{ startDate: previousDay },
+				{ tab: tabValue ? tabValue : 'views' }
+			),
 			{ addQueryPrefix: true }
 		);
 		const href = `${ url }${ previousDayQuery }`;


### PR DESCRIPTION
#### Proposed Changes

This PR fixes #71788

This adds the `tab` query string onto the URL to persist the current tab instead of redirecting it back to views. This implementation fixes the issue. However, I feel like there is a better/cleaner way to implement this. So, I'm looking for some feedback/suggestions on a better approach

#### Testing Instructions

* Open the Calypso live branch
* Navigate to the Stats page
* Switch to one of the tabs aside from `views` (eg. to `visitors`, `likes`, or `comments`)
* Use the left and right arrows to navigate between different dates
* Confirm that while switching through date ranges, that the active tab remains the same

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
