### PR TITLE
Onboarding bug crash patch - Error protection when getting the slug from a missing product object

### DIFF
--- a/packages/calypso-products/src/is-free-plan.ts
+++ b/packages/calypso-products/src/is-free-plan.ts
@@ -3,5 +3,5 @@ import { PLAN_FREE } from './constants';
 import type { WithSnakeCaseSlug, WithCamelCaseSlug } from './types';
 
 export function isFreePlanProduct( product: WithSnakeCaseSlug | WithCamelCaseSlug ): boolean {
-	return camelOrSnakeSlug( product ) === PLAN_FREE;
+	return product && camelOrSnakeSlug( product ) === PLAN_FREE;
 }


### PR DESCRIPTION
#### Proposed Changes
To fix a production bug that breaks the onboarding in the `/start/domain` step when creating a new site from `Dashboard > My sites > Switch site > Add new site`

* Check if the product object exists before getting the slug in `isFreePlanProduct`


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* From WordPress admin, go to My Sites
* Click on `Add new site` at the bottom of the list
<img width="269" alt="Screenshot 2566-01-13 at 12 17 22" src="https://user-images.githubusercontent.com/1881481/212243143-38969f18-9e20-4ad0-92dd-20eabeb871a9.png">
* Confirm that you land on the domains step and it loads as expected. It should NOT be a blank page.


| Before | After |
|------|-----|
|<img width="895" alt="Screenshot 2566-01-13 at 12 22 03" src="https://user-images.githubusercontent.com/1881481/212243543-33070605-8c86-41b0-9258-86e0d857ef36.png">|<img width="1193" alt="Screenshot 2566-01-13 at 12 19 52" src="https://user-images.githubusercontent.com/1881481/212243329-c133d708-2991-489f-aff3-260f5f2bdba6.png">|


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [X] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [X] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [X] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [X] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [X] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related https://github.com/Automattic/wp-calypso/pull/68766
Maybe related to https://github.com/Automattic/wp-calypso/issues/69899