### PR TITLE
Jetpack Pro Dashboard: implement checkbox for dashboard sites bulk actions

### DIFF
--- a/client/components/bulk-select/index.jsx
+++ b/client/components/bulk-select/index.jsx
@@ -45,7 +45,7 @@ export class BulkSelect extends Component {
 	};
 
 	render() {
-		const { translate, ariaLabel = translate( 'Select All' ), disabled } = this.props;
+		const { translate, ariaLabel = translate( 'Select All' ), disabled = false } = this.props;
 		const isChecked = this.hasAllElementsSelected();
 		const inputClasses = classNames( 'bulk-select__box', {
 			// TODO: We might be able to remove this class in favor of the :checked pseudoselector.

--- a/client/components/bulk-select/index.jsx
+++ b/client/components/bulk-select/index.jsx
@@ -26,11 +26,17 @@ export class BulkSelect extends Component {
 	};
 
 	hasAllElementsSelected = () => {
-		return this.props.selectedElements && this.props.selectedElements === this.props.totalElements;
+		return (
+			this.props.isChecked ??
+			( this.props.selectedElements && this.props.selectedElements === this.props.totalElements )
+		);
 	};
 
 	hasSomeElementsSelected = () => {
-		return this.props.selectedElements && this.props.selectedElements < this.props.totalElements;
+		return (
+			this.props.isHalfChecked ??
+			( this.props.selectedElements && this.props.selectedElements < this.props.totalElements )
+		);
 	};
 
 	handleToggleAll = () => {
@@ -39,7 +45,7 @@ export class BulkSelect extends Component {
 	};
 
 	render() {
-		const { translate, ariaLabel = translate( 'Select All' ) } = this.props;
+		const { translate, ariaLabel = translate( 'Select All' ), disabled } = this.props;
 		const isChecked = this.hasAllElementsSelected();
 		const inputClasses = classNames( 'bulk-select__box', {
 			// TODO: We might be able to remove this class in favor of the :checked pseudoselector.
@@ -54,6 +60,7 @@ export class BulkSelect extends Component {
 						checked={ isChecked }
 						onChange={ this.handleToggleAll }
 						aria-label={ ariaLabel }
+						disabled={ disabled }
 					/>
 					<Count count={ this.props.selectedElements } />
 					{ this.getStateIcon() }

--- a/client/jetpack-cloud/sections/agency-dashboard/dashboard-bulk-actions/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/dashboard-bulk-actions/index.tsx
@@ -51,20 +51,23 @@ export default function DashboardBulkActions( { selectedSites }: Props ) {
 	];
 
 	let content = null;
+	const disabled = selectedSites.length === 0;
 
 	if ( ! isMobile ) {
 		content = (
 			<>
 				<ButtonGroup>
 					{ toggleMonitorActions.map( ( { label, action } ) => (
-						<Button key={ label } onClick={ action }>
+						<Button key={ label } disabled={ disabled } onClick={ action }>
 							{ label }
 						</Button>
 					) ) }
 				</ButtonGroup>
 				{ otherMonitorActions.map( ( { label, action } ) => (
 					<ButtonGroup key={ label }>
-						<Button onClick={ action }>{ label }</Button>
+						<Button disabled={ disabled } onClick={ action }>
+							{ label }
+						</Button>
 					</ButtonGroup>
 				) ) }
 			</>
@@ -73,7 +76,7 @@ export default function DashboardBulkActions( { selectedSites }: Props ) {
 		content = (
 			<SelectDropdown compact selectedText={ translate( 'Actions' ) }>
 				{ [ ...toggleMonitorActions, ...otherMonitorActions ].map( ( { label, action } ) => (
-					<SelectDropdown.Item key={ label } onClick={ action }>
+					<SelectDropdown.Item key={ label } disabled={ disabled } onClick={ action }>
 						{ label }
 					</SelectDropdown.Item>
 				) ) }

--- a/client/jetpack-cloud/sections/agency-dashboard/dashboard-bulk-actions/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/dashboard-bulk-actions/style.scss
@@ -24,7 +24,9 @@
 }
 
 .dashboard-bulk-actions {
+	width: 100%;
 	text-align: right;
+	display: inline-block;
 
 	.button-group {
 		margin-inline-start: 14px;

--- a/client/jetpack-cloud/sections/agency-dashboard/dashboard-overview/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/dashboard-overview/index.tsx
@@ -21,7 +21,7 @@ export default function DashboardOverview( {
 	const hasFetched = useSelector( hasFetchedPartner );
 	const isFetching = useSelector( isFetchingPartner );
 	const hasActiveKey = useSelector( hasActivePartnerKey );
-	const [ isBulkManagementActive, setIsBulkManagementActive ] = useState( true );
+	const [ isBulkManagementActive, setIsBulkManagementActive ] = useState( false );
 	const [ selectedSites, setSelectedSites ] = useState< number[] >( [] );
 
 	if ( hasFetched && ! hasActiveKey ) {

--- a/client/jetpack-cloud/sections/agency-dashboard/dashboard-overview/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/dashboard-overview/index.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { useSelector } from 'react-redux';
 import JetpackLogo from 'calypso/components/jetpack-logo';
 import SelectPartnerKey from 'calypso/jetpack-cloud/sections/partner-portal/primary/select-partner-key';
@@ -20,6 +21,7 @@ export default function DashboardOverview( {
 	const hasFetched = useSelector( hasFetchedPartner );
 	const isFetching = useSelector( isFetchingPartner );
 	const hasActiveKey = useSelector( hasActivePartnerKey );
+	const [ isBulkManagementActive, setIsBulkManagementActive ] = useState( true );
 
 	if ( hasFetched && ! hasActiveKey ) {
 		return <SelectPartnerKey />;
@@ -30,6 +32,8 @@ export default function DashboardOverview( {
 			search,
 			currentPage,
 			filter,
+			isBulkManagementActive,
+			setIsBulkManagementActive,
 		};
 		return (
 			<SitesOverviewContext.Provider value={ context }>

--- a/client/jetpack-cloud/sections/agency-dashboard/dashboard-overview/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/dashboard-overview/index.tsx
@@ -21,7 +21,7 @@ export default function DashboardOverview( {
 	const hasFetched = useSelector( hasFetchedPartner );
 	const isFetching = useSelector( isFetchingPartner );
 	const hasActiveKey = useSelector( hasActivePartnerKey );
-	const [ isBulkManagementActive, setIsBulkManagementActive ] = useState( true );
+	const [ isBulkManagementActive, setIsBulkManagementActive ] = useState( false );
 	const [ selectedSites, setSelectedSites ] = useState< Site[] >( [] );
 
 	if ( hasFetched && ! hasActiveKey ) {

--- a/client/jetpack-cloud/sections/agency-dashboard/dashboard-overview/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/dashboard-overview/index.tsx
@@ -9,7 +9,7 @@ import {
 } from 'calypso/state/partner-portal/partner/selectors';
 import SitesOverview from '../sites-overview';
 import SitesOverviewContext from '../sites-overview/context';
-import type { SitesOverviewContextInterface } from '../sites-overview/types';
+import type { DashboardOverviewContextInterface } from '../sites-overview/types';
 
 import '../style.scss';
 
@@ -17,11 +17,12 @@ export default function DashboardOverview( {
 	search,
 	currentPage,
 	filter,
-}: SitesOverviewContextInterface ) {
+}: DashboardOverviewContextInterface ) {
 	const hasFetched = useSelector( hasFetchedPartner );
 	const isFetching = useSelector( isFetchingPartner );
 	const hasActiveKey = useSelector( hasActivePartnerKey );
 	const [ isBulkManagementActive, setIsBulkManagementActive ] = useState( true );
+	const [ selectedSites, setSelectedSites ] = useState< number[] >( [] );
 
 	if ( hasFetched && ! hasActiveKey ) {
 		return <SelectPartnerKey />;
@@ -34,6 +35,8 @@ export default function DashboardOverview( {
 			filter,
 			isBulkManagementActive,
 			setIsBulkManagementActive,
+			selectedSites,
+			setSelectedSites,
 		};
 		return (
 			<SitesOverviewContext.Provider value={ context }>

--- a/client/jetpack-cloud/sections/agency-dashboard/dashboard-overview/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/dashboard-overview/index.tsx
@@ -9,7 +9,7 @@ import {
 } from 'calypso/state/partner-portal/partner/selectors';
 import SitesOverview from '../sites-overview';
 import SitesOverviewContext from '../sites-overview/context';
-import type { DashboardOverviewContextInterface } from '../sites-overview/types';
+import type { DashboardOverviewContextInterface, Site } from '../sites-overview/types';
 
 import '../style.scss';
 
@@ -21,8 +21,8 @@ export default function DashboardOverview( {
 	const hasFetched = useSelector( hasFetchedPartner );
 	const isFetching = useSelector( isFetchingPartner );
 	const hasActiveKey = useSelector( hasActivePartnerKey );
-	const [ isBulkManagementActive, setIsBulkManagementActive ] = useState( false );
-	const [ selectedSites, setSelectedSites ] = useState< number[] >( [] );
+	const [ isBulkManagementActive, setIsBulkManagementActive ] = useState( true );
+	const [ selectedSites, setSelectedSites ] = useState< Site[] >( [] );
 
 	if ( hasFetched && ! hasActiveKey ) {
 		return <SelectPartnerKey />;

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/context.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/context.ts
@@ -5,6 +5,14 @@ const SitesOverviewContext = createContext< SitesOverviewContextInterface >( {
 	currentPage: 1,
 	search: '',
 	filter: { issueTypes: [], showOnlyFavorites: false },
+	isBulkManagementActive: false,
+	setIsBulkManagementActive: () => {
+		return undefined;
+	},
+	selectedSites: [],
+	setSelectedSites: () => {
+		return undefined;
+	},
 } );
 
 export default SitesOverviewContext;

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
@@ -24,7 +24,6 @@ import {
 	getSelectedLicensesSiteId,
 } from 'calypso/state/jetpack-agency-dashboard/selectors';
 import { getIsPartnerOAuthTokenLoaded } from 'calypso/state/partner-portal/partner/selectors';
-import DashboardBulkActions from '../dashboard-bulk-actions';
 import SitesOverviewContext from './context';
 import SiteAddLicenseNotification from './site-add-license-notification';
 import SiteContent from './site-content';
@@ -51,9 +50,9 @@ export default function SitesOverview() {
 	const highlightFavoriteTab = getQueryArg( window.location.href, 'highlight' ) === 'favorite-tab';
 
 	const [ highlightTab, setHighlightTab ] = useState( false );
-	const [ selectedSites, setSelectedSites ] = useState< number[] >( [] );
 
-	const { search, currentPage, filter } = useContext( SitesOverviewContext );
+	const { search, currentPage, filter, selectedSites, setSelectedSites } =
+		useContext( SitesOverviewContext );
 
 	const { data, isError, isLoading, refetch } = useFetchDashboardSites(
 		isPartnerOAuthTokenLoaded,
@@ -275,12 +274,6 @@ export default function SitesOverview() {
 								isLoading={ isLoading }
 							/>
 						) }
-
-						<DashboardBulkActions
-							selectedSites={ data?.sites.filter( ( site: { blog_id: number } ) =>
-								selectedSites.includes( site.blog_id )
-							) }
-						/>
 
 						{ showEmptyState ? (
 							<div className="sites-overview__no-sites">{ emptyStateMessage }</div>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
@@ -30,6 +30,7 @@ import SiteContent from './site-content';
 import SiteSearchFilterContainer from './site-search-filter-container/SiteSearchFilterContainer';
 import SiteWelcomeBanner from './site-welcome-banner';
 import { getProductSlugFromProductType } from './utils';
+import type { Site } from '../sites-overview/types';
 
 import './style.scss';
 
@@ -61,11 +62,13 @@ export default function SitesOverview() {
 		filter
 	);
 
-	function handleSetSelectedSites( id: number ) {
-		if ( selectedSites.includes( id ) ) {
-			setSelectedSites( selectedSites.filter( ( siteId ) => siteId !== id ) );
+	const selectedSiteIds = selectedSites.map( ( site ) => site.blog_id );
+
+	function handleSetSelectedSites( selectedSite: Site ) {
+		if ( selectedSiteIds.includes( selectedSite.blog_id ) ) {
+			setSelectedSites( selectedSites.filter( ( site ) => site.blog_id !== selectedSite.blog_id ) );
 		} else {
-			setSelectedSites( [ ...selectedSites, id ] );
+			setSelectedSites( [ ...selectedSites, selectedSite ] );
 		}
 	}
 
@@ -73,8 +76,8 @@ export default function SitesOverview() {
 		data.sites = data.sites.map( ( site: any ) => {
 			return {
 				...site,
-				isSelected: selectedSites.includes( site.blog_id ),
-				onSelect: () => handleSetSelectedSites( site.blog_id ),
+				isSelected: selectedSiteIds.includes( site.blog_id ),
+				onSelect: () => handleSetSelectedSites( site ),
 			};
 		} );
 	}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
@@ -73,7 +73,7 @@ export default function SitesOverview() {
 	}
 
 	if ( data?.sites ) {
-		data.sites = data.sites.map( ( site: any ) => {
+		data.sites = data.sites.map( ( site: Site ) => {
 			return {
 				...site,
 				isSelected: selectedSiteIds.includes( site.blog_id ),

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
@@ -24,6 +24,7 @@ import {
 	getSelectedLicensesSiteId,
 } from 'calypso/state/jetpack-agency-dashboard/selectors';
 import { getIsPartnerOAuthTokenLoaded } from 'calypso/state/partner-portal/partner/selectors';
+import DashboardBulkActions from '../dashboard-bulk-actions';
 import SitesOverviewContext from './context';
 import SiteAddLicenseNotification from './site-add-license-notification';
 import SiteContent from './site-content';
@@ -50,6 +51,7 @@ export default function SitesOverview() {
 	const highlightFavoriteTab = getQueryArg( window.location.href, 'highlight' ) === 'favorite-tab';
 
 	const [ highlightTab, setHighlightTab ] = useState( false );
+	const [ selectedSites, setSelectedSites ] = useState< number[] >( [] );
 
 	const { search, currentPage, filter } = useContext( SitesOverviewContext );
 
@@ -59,6 +61,24 @@ export default function SitesOverview() {
 		currentPage,
 		filter
 	);
+
+	function handleSetSelectedSites( id: number ) {
+		if ( selectedSites.includes( id ) ) {
+			setSelectedSites( selectedSites.filter( ( siteId ) => siteId !== id ) );
+		} else {
+			setSelectedSites( [ ...selectedSites, id ] );
+		}
+	}
+
+	if ( data?.sites ) {
+		data.sites = data.sites.map( ( site: any ) => {
+			return {
+				...site,
+				isSelected: selectedSites.includes( site.blog_id ),
+				onSelect: () => handleSetSelectedSites( site.blog_id ),
+			};
+		} );
+	}
 
 	useEffect( () => {
 		dispatch( recordTracksEvent( 'calypso_jetpack_agency_dashboard_visit' ) );
@@ -255,6 +275,13 @@ export default function SitesOverview() {
 								isLoading={ isLoading }
 							/>
 						) }
+
+						<DashboardBulkActions
+							selectedSites={ data?.sites.filter( ( site: { blog_id: number } ) =>
+								selectedSites.includes( site.blog_id )
+							) }
+						/>
+
 						{ showEmptyState ? (
 							<div className="sites-overview__no-sites">{ emptyStateMessage }</div>
 						) : (

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-bulk-select/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-bulk-select/index.tsx
@@ -9,23 +9,56 @@ import './style.scss';
 
 interface Props {
 	sites: Array< SiteData >;
+	isLoading: boolean;
 }
 
-export default function SiteBulkSelect( { sites }: Props ) {
+export default function SiteBulkSelect( { sites, isLoading }: Props ) {
 	const translate = useTranslate();
 
 	const { selectedSites, setSelectedSites } = useContext( SitesOverviewContext );
 
+	const selectedSiteIds = selectedSites.map( ( site ) => site.blog_id );
+
+	const isAllChecked = ( sites: Array< SiteData > ) => {
+		return (
+			selectedSites.length > 0 &&
+			sites
+				.map( ( site ) => site.site.value.blog_id )
+				.every( ( item ) => selectedSiteIds.includes( item ) )
+		);
+	};
+
 	const handleToggleSelect = () => {
 		// Filter sites with site error as they are not selectable.
 		const filteredSites = sites.filter( ( site ) => ! site.site.error );
+		const isChecked = isAllChecked( filteredSites );
 
-		if ( selectedSites.length === filteredSites.length ) {
-			setSelectedSites( [] );
+		if ( isChecked ) {
+			setSelectedSites(
+				selectedSites.filter(
+					( selectedSite ) =>
+						! filteredSites.find( ( site ) => site.site.value.blog_id === selectedSite.blog_id )
+				)
+			);
 		} else {
-			setSelectedSites( filteredSites.map( ( site ) => site.site.value.blog_id ) );
+			setSelectedSites(
+				[ ...selectedSites, ...filteredSites.map( ( site ) => site.site.value ) ].filter(
+					( element, index, array ) =>
+						array.map( ( selectedSite ) => selectedSite.blog_id ).indexOf( element.blog_id ) ===
+						index
+				)
+			);
 		}
 	};
+
+	const isChecked = isAllChecked( sites );
+
+	const isHalfChecked =
+		! isChecked &&
+		selectedSites.length > 0 &&
+		sites
+			.map( ( site ) => site.site.value.blog_id )
+			.some( ( item ) => selectedSiteIds.includes( item ) );
 
 	return (
 		<div className="site-bulk-select">
@@ -35,6 +68,9 @@ export default function SiteBulkSelect( { sites }: Props ) {
 					totalElements={ sites.length }
 					selectedElements={ selectedSites.length }
 					onToggle={ handleToggleSelect }
+					isChecked={ isChecked }
+					isHalfChecked={ isHalfChecked }
+					disabled={ isLoading }
 				/>
 
 				<div className="site-bulk-select__bulk-select-label">
@@ -48,11 +84,7 @@ export default function SiteBulkSelect( { sites }: Props ) {
 					} ) }
 				</div>
 			</div>
-			<DashboardBulkActions
-				selectedSites={ sites
-					.map( ( item ) => item.site.value )
-					.filter( ( site ) => selectedSites.includes( site.blog_id ) ) }
-			/>
+			<DashboardBulkActions selectedSites={ selectedSites } />
 		</div>
 	);
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-bulk-select/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-bulk-select/index.tsx
@@ -17,6 +17,7 @@ export default function SiteBulkSelect( { sites }: Props ) {
 	const { selectedSites, setSelectedSites } = useContext( SitesOverviewContext );
 
 	const handleToggleSelect = () => {
+		// Filter sites with site error as they are not selectable.
 		const filteredSites = sites.filter( ( site ) => ! site.site.error );
 
 		if ( selectedSites.length === filteredSites.length ) {

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-bulk-select/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-bulk-select/index.tsx
@@ -1,0 +1,57 @@
+import { useTranslate } from 'i18n-calypso';
+import { useContext } from 'react';
+import BulkSelect from 'calypso/components/bulk-select';
+import DashboardBulkActions from '../../dashboard-bulk-actions';
+import SitesOverviewContext from '../context';
+import type { SiteData } from '../types';
+
+import './style.scss';
+
+interface Props {
+	sites: Array< SiteData >;
+}
+
+export default function SiteBulkSelect( { sites }: Props ) {
+	const translate = useTranslate();
+
+	const { selectedSites, setSelectedSites } = useContext( SitesOverviewContext );
+
+	const handleToggleSelect = () => {
+		const filteredSites = sites.filter( ( site ) => ! site.site.error );
+
+		if ( selectedSites.length === filteredSites.length ) {
+			setSelectedSites( [] );
+		} else {
+			setSelectedSites( filteredSites.map( ( site ) => site.site.value.blog_id ) );
+		}
+	};
+
+	return (
+		<div className="site-bulk-select">
+			<div className="site-bulk-select__checkbox">
+				<BulkSelect
+					key="site-bulk-select"
+					totalElements={ sites.length }
+					selectedElements={ selectedSites.length }
+					onToggle={ handleToggleSelect }
+				/>
+
+				<div className="site-bulk-select__bulk-select-label">
+					{ translate( '%(number)d {{span}}Selected{{/span}}', {
+						args: {
+							number: selectedSites.length,
+						},
+						components: {
+							span: <span />,
+						},
+					} ) }
+				</div>
+			</div>
+			<DashboardBulkActions
+				selectedSites={ sites
+					.map( ( item ) => item.site.value )
+					.filter( ( site ) => selectedSites.includes( site.blog_id ) ) }
+			/>
+		</div>
+	);
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-bulk-select/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-bulk-select/index.tsx
@@ -22,9 +22,7 @@ export default function SiteBulkSelect( { sites, isLoading }: Props ) {
 	const isAllChecked = ( sites: Array< SiteData > ) => {
 		return (
 			selectedSites.length > 0 &&
-			sites
-				.map( ( site ) => site.site.value.blog_id )
-				.every( ( item ) => selectedSiteIds.includes( item ) )
+			sites.every( ( item ) => selectedSiteIds.includes( item.site.value.blog_id ) )
 		);
 	};
 
@@ -56,9 +54,7 @@ export default function SiteBulkSelect( { sites, isLoading }: Props ) {
 	const isHalfChecked =
 		! isChecked &&
 		selectedSites.length > 0 &&
-		sites
-			.map( ( site ) => site.site.value.blog_id )
-			.some( ( item ) => selectedSiteIds.includes( item ) );
+		sites.some( ( item ) => selectedSiteIds.includes( item.site.value.blog_id ) );
 
 	return (
 		<div className="site-bulk-select">

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-bulk-select/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-bulk-select/style.scss
@@ -1,0 +1,39 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
+.bulk-select {
+	display: inline-block;
+	.count {
+		display: none;
+	}
+}
+
+.site-bulk-select {
+	position: relative;
+}
+
+.site-bulk-select__checkbox {
+	display: inline-flex;
+	align-items: center;
+	position: absolute;
+	inset-block-start: 50%;
+	transform: translateY(-50%);
+}
+
+.site-bulk-select__bulk-select-label {
+	display: inline-block;
+	margin-inline-end: 16px;
+	font-size: 0.75rem;
+	font-weight: bold;
+	margin-inline-start: 38px;
+	position: relative;
+
+	span {
+		display: none;
+
+		@include breakpoint-deprecated( ">960px" ) {
+			display: inline;
+		}
+	}
+}
+

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-card/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-card/index.tsx
@@ -35,7 +35,7 @@ export default function SiteCard( { rows, columns }: Props ) {
 
 	const toggleIsExpanded = useCallback(
 		( event: MouseEvent< HTMLSpanElement > | KeyboardEvent< HTMLSpanElement > ) => {
-			// Don't toogle the card when clicked on set/remove favorite
+			// Don't toogle the card when clicked on actions like set/remove favorite or select site.
 			if ( ( event?.target as HTMLElement )?.closest( '.disable-card-expand' ) ) {
 				return;
 			}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-card/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-card/index.tsx
@@ -36,7 +36,7 @@ export default function SiteCard( { rows, columns }: Props ) {
 	const toggleIsExpanded = useCallback(
 		( event: MouseEvent< HTMLSpanElement > | KeyboardEvent< HTMLSpanElement > ) => {
 			// Don't toogle the card when clicked on set/remove favorite
-			if ( ( event?.target as HTMLElement )?.closest( '.site-set-favorite__favorite-icon' ) ) {
+			if ( ( event?.target as HTMLElement )?.closest( '.disable-card-expand' ) ) {
 				return;
 			}
 			setIsExpanded( ( expanded ) => {

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/index.tsx
@@ -1,12 +1,16 @@
 import { Card } from '@automattic/components';
 import { useDesktopBreakpoint, useMobileBreakpoint } from '@automattic/viewport-react';
 import page from 'page';
+import { useContext } from 'react';
 import Pagination from 'calypso/components/pagination';
 import TextPlaceholder from 'calypso/jetpack-cloud/sections/partner-portal/text-placeholder';
 import { addQueryArgs } from 'calypso/lib/route';
+import SitesOverviewContext from '../context';
+import SiteBulkSelect from '../site-bulk-select';
 import SiteCard from '../site-card';
 import SiteTable from '../site-table';
 import { formatSites, siteColumns } from '../utils';
+
 import './style.scss';
 
 const addPageArgs = ( pageNumber: number ) => {
@@ -25,6 +29,7 @@ interface Props {
 export default function SiteContent( { data, isLoading, currentPage, isFavoritesTab }: Props ) {
 	const isMobile = useMobileBreakpoint();
 	const isDesktop = useDesktopBreakpoint();
+	const { isBulkManagementActive } = useContext( SitesOverviewContext );
 
 	const sites = formatSites( data?.sites );
 
@@ -37,22 +42,29 @@ export default function SiteContent( { data, isLoading, currentPage, isFavorites
 			{ isDesktop ? (
 				<SiteTable isLoading={ isLoading } columns={ siteColumns } items={ sites } />
 			) : (
-				<div className="site-content__mobile-view">
-					<>
-						{ isLoading ? (
-							<Card>
-								<TextPlaceholder />
-							</Card>
-						) : (
-							<>
-								{ sites.length > 0 &&
-									sites.map( ( rows, index ) => (
-										<SiteCard key={ index } columns={ siteColumns } rows={ rows } />
-									) ) }
-							</>
-						) }
-					</>
-				</div>
+				<>
+					<div className="site-content__mobile-view">
+						<>
+							{ isBulkManagementActive && (
+								<Card className="site-content__bulk-select">
+									<SiteBulkSelect sites={ sites } />
+								</Card>
+							) }
+							{ isLoading ? (
+								<Card>
+									<TextPlaceholder />
+								</Card>
+							) : (
+								<>
+									{ sites.length > 0 &&
+										sites.map( ( rows, index ) => (
+											<SiteCard key={ index } columns={ siteColumns } rows={ rows } />
+										) ) }
+								</>
+							) }
+						</>
+					</div>
+				</>
 			) }
 			{ data && data?.total > 0 && (
 				<Pagination

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/index.tsx
@@ -29,11 +29,13 @@ interface Props {
 export default function SiteContent( { data, isLoading, currentPage, isFavoritesTab }: Props ) {
 	const isMobile = useMobileBreakpoint();
 	const isDesktop = useDesktopBreakpoint();
-	const { isBulkManagementActive } = useContext( SitesOverviewContext );
+	const { isBulkManagementActive, setSelectedSites } = useContext( SitesOverviewContext );
 
 	const sites = formatSites( data?.sites );
 
 	const handlePageClick = ( pageNumber: number ) => {
+		// Reset selected sites when there is a page change
+		setSelectedSites( [] );
 		addPageArgs( pageNumber );
 	};
 

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/index.tsx
@@ -29,13 +29,11 @@ interface Props {
 export default function SiteContent( { data, isLoading, currentPage, isFavoritesTab }: Props ) {
 	const isMobile = useMobileBreakpoint();
 	const isDesktop = useDesktopBreakpoint();
-	const { isBulkManagementActive, setSelectedSites } = useContext( SitesOverviewContext );
+	const { isBulkManagementActive } = useContext( SitesOverviewContext );
 
 	const sites = formatSites( data?.sites );
 
 	const handlePageClick = ( pageNumber: number ) => {
-		// Reset selected sites when there is a page change
-		setSelectedSites( [] );
 		addPageArgs( pageNumber );
 	};
 
@@ -49,7 +47,7 @@ export default function SiteContent( { data, isLoading, currentPage, isFavorites
 						<>
 							{ isBulkManagementActive && (
 								<Card className="site-content__bulk-select">
-									<SiteBulkSelect sites={ sites } />
+									<SiteBulkSelect sites={ sites } isLoading={ isLoading } />
 								</Card>
 							) }
 							{ isLoading ? (

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/style.scss
@@ -1,3 +1,16 @@
 .site-content__mobile-view {
 	margin-bottom: 1.5rem;
 }
+
+.site-content__bulk-select {
+	.dashboard-bulk-actions {
+		display: flex;
+		justify-content: end;
+		.select-dropdown.is-compact {
+			width: 70%;
+		}
+	}
+	.site-bulk-select__bulk-select-label {
+		margin-inline-start: 12px;
+	}
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-select-checkbox/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-select-checkbox/index.tsx
@@ -1,0 +1,22 @@
+import FormInputCheckbox from 'calypso/components/forms/form-checkbox';
+import type { SiteData } from '../types';
+
+import './style.scss';
+
+interface Props {
+	item: SiteData;
+	siteError: boolean;
+}
+
+export default function SiteSelectCheckbox( { item, siteError }: Props ) {
+	return (
+		<FormInputCheckbox
+			className="site-select-checkbox disable-card-expand"
+			id={ item.blog_id }
+			onClick={ item.onSelect }
+			checked={ item.isSelected }
+			readOnly={ true }
+			disabled={ siteError }
+		/>
+	);
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-select-checkbox/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-select-checkbox/index.tsx
@@ -10,13 +10,15 @@ interface Props {
 
 export default function SiteSelectCheckbox( { item, siteError }: Props ) {
 	return (
-		<FormInputCheckbox
-			className="site-select-checkbox disable-card-expand"
-			id={ item.blog_id }
-			onClick={ item.onSelect }
-			checked={ item.isSelected }
-			readOnly={ true }
-			disabled={ siteError }
-		/>
+		<span className="site-select-checkbox">
+			<FormInputCheckbox
+				className="disable-card-expand"
+				id={ item.blog_id }
+				onClick={ item.onSelect }
+				checked={ item.isSelected }
+				readOnly={ true }
+				disabled={ siteError }
+			/>
+		</span>
 	);
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-select-checkbox/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-select-checkbox/style.scss
@@ -3,9 +3,10 @@
 
 input.site-select-checkbox {
 	position: absolute;
-	inset-block-start: 15px;
+	margin: 0;
+	inset-block-start: 50%;
+	transform: translateY(-50%);
 	inset-inline-start: 14px;
-	color: var(--studio-gray-20) !important;
 
 	&:checked::before {
 		content: url(/calypso/images/checkbox-icons/checkmark-jetpack.svg);
@@ -15,24 +16,12 @@ input.site-select-checkbox {
 		// Making tap area larger
 		content: "";
 		position: absolute;
-		inset-block-start: -1px;
-		inset-inline-start: -1px;
-		width: 50px;
+		inset-block-start: -18px;
+		inset-inline-start: -15px;
+		width: 40px;
 		height: 50px;
 	}
 	+ span {
 		margin-inline-start: 8px;
-	}
-
-	@include break-large() {
-		position: static;
-		margin-block-start: 6px;
-		color: var(--color-primary) !important;
-
-		&::after {
-			inset-block-start: -18px;
-			inset-inline-start: -15px;
-			width: 40px;
-		}
 	}
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-select-checkbox/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-select-checkbox/style.scss
@@ -1,27 +1,12 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 
-input.site-select-checkbox {
-	position: absolute;
-	margin: 0;
-	inset-block-start: 50%;
-	transform: translateY(-50%);
-	inset-inline-start: 14px;
-
-	&:checked::before {
-		content: url(/calypso/images/checkbox-icons/checkmark-jetpack.svg);
-	}
-
-	&::after {
-		// Making tap area larger
-		content: "";
+.site-select-checkbox {
+	input[type="checkbox"] {
 		position: absolute;
-		inset-block-start: -18px;
-		inset-inline-start: -15px;
-		width: 40px;
-		height: 50px;
-	}
-	+ span {
-		margin-inline-start: 8px;
+		margin: 0;
+		inset-block-start: 50%;
+		transform: translateY(-50%);
+		inset-inline-start: 16px;
 	}
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-select-checkbox/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-select-checkbox/style.scss
@@ -1,0 +1,38 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
+input.site-select-checkbox {
+	position: absolute;
+	inset-block-start: 15px;
+	inset-inline-start: 14px;
+	color: var(--studio-gray-20) !important;
+
+	&:checked::before {
+		content: url(/calypso/images/checkbox-icons/checkmark-jetpack.svg);
+	}
+
+	&::after {
+		// Making tap area larger
+		content: "";
+		position: absolute;
+		inset-block-start: -1px;
+		inset-inline-start: -1px;
+		width: 50px;
+		height: 50px;
+	}
+	+ span {
+		margin-inline-start: 8px;
+	}
+
+	@include break-large() {
+		position: static;
+		margin-block-start: 6px;
+		color: var(--color-primary) !important;
+
+		&::after {
+			inset-block-start: -18px;
+			inset-inline-start: -15px;
+			width: 40px;
+		}
+	}
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-set-favorite/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-set-favorite/index.tsx
@@ -149,6 +149,7 @@ export default function SiteSetFavorite( { isFavorite, siteId, siteUrl }: Props 
 			onClick={ handleFavoriteChange }
 			className={ classNames(
 				'site-set-favorite__favorite-icon',
+				'disable-card-expand',
 				isFavorite && 'site-set-favorite__favorite-icon-active'
 			) }
 			aria-label={ translate( 'Toggle favorite site' ) }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content.tsx
@@ -4,7 +4,7 @@ import { addQueryArgs } from '@wordpress/url';
 import classNames from 'classnames';
 import { translate } from 'i18n-calypso';
 import page from 'page';
-import { useRef, useState, useMemo } from 'react';
+import { useRef, useState, useMemo, useContext } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import Badge from 'calypso/components/badge';
 import Tooltip from 'calypso/components/tooltip';
@@ -12,6 +12,8 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { selectLicense, unselectLicense } from 'calypso/state/jetpack-agency-dashboard/actions';
 import { hasSelectedLicensesOfType } from 'calypso/state/jetpack-agency-dashboard/selectors';
 import ToggleActivateMonitoring from '../downtime-monitoring/toggle-activate-monitoring';
+import SitesOverviewContext from './context';
+import SiteSelectCheckbox from './site-select-checkbox';
 import SiteSetFavorite from './site-set-favorite';
 import { getRowMetaData, getProductSlugFromProductType } from './utils';
 import type { AllowedTypes, SiteData } from './types';
@@ -41,6 +43,8 @@ export default function SiteStatusContent( {
 		siteDown,
 		eventName,
 	} = getRowMetaData( rows, type, isLargeScreen );
+
+	const { isBulkManagementActive } = useContext( SitesOverviewContext );
 
 	const siteId = rows.site.value.blog_id;
 	const siteUrl = rows.site.value.url;
@@ -123,11 +127,15 @@ export default function SiteStatusContent( {
 
 		return (
 			<>
-				<SiteSetFavorite
-					isFavorite={ isFavorite }
-					siteId={ rows.site.value.blog_id }
-					siteUrl={ siteUrl }
-				/>
+				{ isBulkManagementActive ? (
+					<SiteSelectCheckbox item={ rows } siteError={ siteError } />
+				) : (
+					<SiteSetFavorite
+						isFavorite={ isFavorite }
+						siteId={ rows.site.value.blog_id }
+						siteUrl={ siteUrl }
+					/>
+				) }
 				{ isLargeScreen ? (
 					<Button
 						className="sites-overview__row-text"

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table-row/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table-row/style.scss
@@ -16,6 +16,11 @@
 		.site-set-favorite__favorite-icon {
 			visibility: visible;
 		}
+
+		.site-select-checkbox input:disabled {
+			background: var(--color-neutral-10);
+			cursor: not-allowed;
+		}
 	}
 	&-disabled {
 		opacity: 0.5;

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/index.tsx
@@ -1,7 +1,10 @@
 import { Icon, starFilled } from '@wordpress/icons';
 import classNames from 'classnames';
+import { useContext } from 'react';
 import TextPlaceholder from 'calypso/jetpack-cloud/sections/partner-portal/text-placeholder';
 import './style.scss';
+import SitesOverviewContext from '../context';
+import SiteBulkSelect from '../site-bulk-select';
 import SiteTableRow from '../site-table-row';
 import type { SiteData, SiteColumns } from '../types';
 
@@ -12,21 +15,32 @@ interface Props {
 }
 
 export default function SiteTable( { isLoading, columns, items }: Props ) {
+	const { isBulkManagementActive } = useContext( SitesOverviewContext );
+
 	return (
 		<table className="site-table__table">
 			<thead>
 				<tr>
-					{ columns.map( ( column, index ) => (
-						<th key={ column.key }>
-							{ index === 0 && (
-								<Icon className="site-table__favorite-icon" size={ 24 } icon={ starFilled } />
-							) }
-							<span className={ classNames( index === 0 && 'site-table-site-title' ) }>
-								{ column.title }
-							</span>
+					{ isBulkManagementActive ? (
+						// Take full-width of the table
+						<th colSpan={ 100 }>
+							<SiteBulkSelect sites={ items } />
 						</th>
-					) ) }
-					<th></th>
+					) : (
+						<>
+							{ columns.map( ( column, index ) => (
+								<th key={ column.key }>
+									{ index === 0 && (
+										<Icon className="site-table__favorite-icon" size={ 24 } icon={ starFilled } />
+									) }
+									<span className={ classNames( index === 0 && 'site-table-site-title' ) }>
+										{ column.title }
+									</span>
+								</th>
+							) ) }
+							<th></th>
+						</>
+					) }
 				</tr>
 			</thead>
 			<tbody>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/index.tsx
@@ -24,7 +24,7 @@ export default function SiteTable( { isLoading, columns, items }: Props ) {
 					{ isBulkManagementActive ? (
 						// Take full-width of the table
 						<th colSpan={ 100 }>
-							<SiteBulkSelect sites={ items } />
+							<SiteBulkSelect sites={ items } isLoading={ isLoading } />
 						</th>
 					) : (
 						<>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/test/sites-overview.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/test/sites-overview.tsx
@@ -41,6 +41,7 @@ describe( '<SitesOverview>', () => {
 		currentPage: 1,
 		search: '',
 		filter: { issueTypes: [], showOnlyFavorites: false },
+		selectedSites: [],
 	};
 
 	const queryClient = new QueryClient();

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
@@ -131,8 +131,8 @@ export interface DashboardOverviewContextInterface {
 export interface SitesOverviewContextInterface extends DashboardOverviewContextInterface {
 	isBulkManagementActive: boolean;
 	setIsBulkManagementActive: ( value: boolean ) => void;
-	selectedSites: Array< number >;
-	setSelectedSites: ( value: Array< number > ) => void;
+	selectedSites: Array< Site >;
+	setSelectedSites: ( value: Array< Site > ) => void;
 }
 
 export type AgencyDashboardFilterOption =

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
@@ -40,6 +40,8 @@ export interface Site {
 	is_favorite: boolean;
 	monitor_settings: MonitorSettings;
 	monitor_last_status_change: string;
+	isSelected?: boolean;
+	onSelect?: ( value: boolean ) => void;
 }
 export interface SiteNode {
 	value: Site;
@@ -123,6 +125,8 @@ export interface SitesOverviewContextInterface {
 	search: string;
 	currentPage: number;
 	filter: { issueTypes: Array< AgencyDashboardFilterOption >; showOnlyFavorites: boolean };
+	isBulkManagementActive?: boolean;
+	setIsBulkManagementActive?: ( value: boolean ) => void;
 }
 
 export type AgencyDashboardFilterOption =

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
@@ -121,12 +121,18 @@ export type AllowedActionTypes = 'issue_license' | 'view_activity' | 'view_site'
 export type ActionEventNames = {
 	[ key in AllowedActionTypes ]: { small_screen: string; large_screen: string };
 };
-export interface SitesOverviewContextInterface {
+
+export interface DashboardOverviewContextInterface {
 	search: string;
 	currentPage: number;
 	filter: { issueTypes: Array< AgencyDashboardFilterOption >; showOnlyFavorites: boolean };
-	isBulkManagementActive?: boolean;
-	setIsBulkManagementActive?: ( value: boolean ) => void;
+}
+
+export interface SitesOverviewContextInterface extends DashboardOverviewContextInterface {
+	isBulkManagementActive: boolean;
+	setIsBulkManagementActive: ( value: boolean ) => void;
+	selectedSites: Array< number >;
+	setSelectedSites: ( value: Array< number > ) => void;
 }
 
 export type AgencyDashboardFilterOption =

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
@@ -407,6 +407,8 @@ export const formatSites = ( sites: Array< Site > = [] ): Array< SiteData > | []
 				updates: pluginUpdates?.length,
 			},
 			isFavorite: site.is_favorite,
+			isSelected: site.isSelected,
+			onSelect: site.onSelect,
 		};
 	} );
 };

--- a/client/jetpack-cloud/sections/agency-dashboard/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/style.scss
@@ -123,3 +123,24 @@
 .min-width-100px {
 	min-width: 100px;
 }
+
+
+.site-select-checkbox,
+.site-bulk-select__checkbox {
+	input[type="checkbox"] {
+
+		&:checked::before {
+			content: url(/calypso/images/checkbox-icons/checkmark-jetpack.svg);
+		}
+
+		&::after {
+			// Making tap area larger
+			content: "";
+			position: absolute;
+			inset-block-start: -18px;
+			inset-inline-start: -16px;
+			width: 40px;
+			height: 50px;
+		}
+	}
+}


### PR DESCRIPTION
#### Proposed Changes

This PR makes the below changes 
- Add a checkbox to all the sites to be able to select them to perform bulk actions.
- Add a checkbox to the site header to able to select all selectable sites(except the sites with error)
- Disable bulk actions if no sites are selected.

#### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

> **_NOTE:_** The UI fixes to buttons and dropdown will be down in a different PR.

**Instructions**

1. Run `git checkout add/implement-checkbox-for-dashboard-sites-bulk-actions` and `yarn start-jetpack-cloud`
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Open client/jetpack-cloud/sections/agency-dashboard/dashboard-overview/index.tsx and set `isBulkManagementActive` to true.
4. Verify that each site has a checkbox and is selectable(except site with an error)

<img width="440" alt="Screenshot 2023-01-13 at 11 54 36 AM" src="https://user-images.githubusercontent.com/10586875/212264916-33f37936-2270-4fde-8a90-ee905eaf7941.png">

<img width="497" alt="Screenshot 2023-01-13 at 11 54 54 AM" src="https://user-images.githubusercontent.com/10586875/212264930-f9725393-e52d-4b70-9fb7-bff521dce5ec.png">

<img width="1379" alt="Screenshot 2023-01-13 at 11 53 22 AM" src="https://user-images.githubusercontent.com/10586875/212264989-711ee5fa-0435-4e44-8faa-7716436d587c.png">

<img width="1379" alt="Screenshot 2023-01-13 at 11 53 32 AM" src="https://user-images.githubusercontent.com/10586875/212264998-c125d02c-7937-49ed-b592-58e5621ef00a.png">


5. Verify bulk select works and sites with errors are filtered.
6. Verify the bulk actions are disabled when no sites are selected.
7. Verify that selecting multiple sites work with pagination.

Page 1, all sites were selected.

<img width="209" alt="Screenshot 2023-01-16 at 11 34 28 AM" src="https://user-images.githubusercontent.com/10586875/212609375-276845af-0f84-4f3f-9b69-0ad7b7d07e4f.png">

Page 1, a few sites were selected.

<img width="255" alt="Screenshot 2023-01-16 at 11 34 35 AM" src="https://user-images.githubusercontent.com/10586875/212609380-53a7337b-d3f8-4a5a-8f6a-346fd28791c9.png">

Page 2, 19 selected from Page 1, and none selected from Page 2

<img width="239" alt="Screenshot 2023-01-16 at 11 34 46 AM" src="https://user-images.githubusercontent.com/10586875/212609381-cb37e52a-9aca-4e1f-8f27-682e8ae6db30.png">

Page 2, 19 selected from Page 1, and 2 selected from Page 2

<img width="190" alt="Screenshot 2023-01-16 at 11 34 52 AM" src="https://user-images.githubusercontent.com/10586875/212609384-d8a64d60-fe9c-48e7-b0ad-31114eaceed4.png">

Page 2, 19 selected from Page 1, and all selected from Page 2

<img width="272" alt="Screenshot 2023-01-16 at 11 38 37 AM" src="https://user-images.githubusercontent.com/10586875/212609594-41bb9f3a-52af-435f-afe6-a9a05e354c64.png">

8. Verify steps 4,5,6 & 7 work as expected on mobile view(Some minor UI fixes will be done in a different PR).

<img width="293" alt="Screenshot 2023-01-13 at 12 26 47 PM" src="https://user-images.githubusercontent.com/10586875/212265079-2939eb35-f2ee-44bc-a2df-053d883d2f4a.png">

<img width="355" alt="Screenshot 2023-01-13 at 12 27 22 PM" src="https://user-images.githubusercontent.com/10586875/212265085-3e57bfee-3234-4328-9266-22c934f35f0d.png">


**Screen recording**

https://user-images.githubusercontent.com/10586875/212687759-867d7a0f-6768-40c1-bf1a-874b77db8509.mov

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1203448324265423-as-1203507036638827