### PR TITLE
Stats: Preserve the active tab on the query string for period changing

### DIFF
--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -194,7 +194,9 @@ class StatsSite extends Component {
 			path: '/stats',
 		};
 		const slugPath = slug ? `/${ slug }` : '';
-		const pathTemplate = `${ traffic.path }/{{ interval }}${ slugPath }`;
+		const pathTemplate = `${ traffic.path }/{{ interval }}${ slugPath }?tab=${
+			this.state.activeTab ? this.state.activeTab.attr : 'views'
+		}`;
 
 		const wrapperClass = classNames( 'stats-content', {
 			'is-period-year': period === 'year',


### PR DESCRIPTION
#### Proposed Changes

* Append the active tab attr to the query string for period changing from `Intervals`.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up this change with the Calypso Live link.
* Navigate to the Stats `Traffic` page.
* Ensure changing period navigates to a new data section based on the previously selected tab.

##### Before
https://user-images.githubusercontent.com/6869813/212269423-6f035a96-34a4-46d9-9ad3-af20f0eb45ff.mov

##### After
https://user-images.githubusercontent.com/6869813/212268088-056791c0-f697-447f-9ca8-ef7f95927273.mov

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #71996 
