### PR TITLE
Pattern Assembler - Add all wireframe patterns as sections in the pattern assembler

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/patterns-data.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/patterns-data.ts
@@ -183,6 +183,8 @@ const useSectionPatterns = () => {
 	const about = translate( 'About' );
 	const testimonials = translate( 'Testimonials' );
 	const links = translate( 'Links' );
+	const services = translate( 'Services' );
+	const portfolio = translate( 'CV/Portfolio' );
 
 	const sectionPatterns: Pattern[] = useMemo(
 		() => [
@@ -210,6 +212,51 @@ const useSectionPatterns = () => {
 				id: 7159,
 				name: 'Cover image with centered text and a button',
 				category: callToAction,
+			},
+			{
+				id: 3741,
+				name: 'Large CTA',
+				category: callToAction,
+			},
+			{
+				id: 6303,
+				name: 'Two Buttons Centered CTA',
+				category: callToAction,
+			},
+			{
+				id: 6304,
+				name: 'Centered Heading with CTA',
+				category: callToAction,
+			},
+			{
+				id: 6311,
+				name: 'Portfolio Project',
+				category: callToAction,
+			},
+			{
+				id: 3747,
+				name: 'Hero with CTA',
+				category: callToAction,
+			},
+			{
+				id: 6308,
+				name: 'Cover Image with CTA',
+				category: callToAction,
+			},
+			{
+				id: 6310,
+				name: 'Gallery with description on the left',
+				category: callToAction,
+			},
+			{
+				id: 6312,
+				name: 'Two Column CTA',
+				category: callToAction,
+			},
+			{
+				id: 6305,
+				name: 'Heading with Image Grid',
+				category: images,
 			},
 			{
 				id: 7149,
@@ -262,6 +309,16 @@ const useSectionPatterns = () => {
 				category: numbers,
 			},
 			{
+				id: 6309,
+				name: '6309',
+				category: about,
+			},
+			{
+				id: 6306,
+				name: 'Names List',
+				category: about,
+			},
+			{
 				id: 5663,
 				name: 'Large headline',
 				category: about,
@@ -282,9 +339,84 @@ const useSectionPatterns = () => {
 				category: testimonials,
 			},
 			{
+				id: 6307,
+				name: '3 Column Testimonials',
+				category: testimonials,
+			},
+			{
+				id: 6324,
+				name: 'Two Column Testimonials',
+				category: testimonials,
+			},
+			{
 				id: 1600,
 				name: 'Three column text and links',
 				category: links,
+			},
+			{
+				id: 6323,
+				name: "FAQ's",
+				category: services,
+			},
+			{
+				id: 3743,
+				name: 'Simple Two Column Layout',
+				category: services,
+			},
+			{
+				id: 39,
+				name: 'Topics with Image',
+				category: services,
+			},
+			{
+				id: 6313,
+				name: 'Portfolio Intro',
+				category: portfolio,
+			},
+			{
+				id: 6314,
+				name: 'Centered Intro',
+				category: portfolio,
+			},
+			{
+				id: 6315,
+				name: 'Large Intro Text',
+				category: portfolio,
+			},
+			{
+				id: 6316,
+				name: 'Squared Media & Text',
+				category: portfolio,
+			},
+			{
+				id: 6317,
+				name: 'Horizontal Media & Text',
+				category: portfolio,
+			},
+			{
+				id: 6318,
+				name: 'Offset Projects',
+				category: portfolio,
+			},
+			{
+				id: 6319,
+				name: 'Case Study',
+				category: portfolio,
+			},
+			{
+				id: 6320,
+				name: 'Heading with two images and descriptions',
+				category: portfolio,
+			},
+			{
+				id: 6321,
+				name: 'CV Text Grid',
+				category: portfolio,
+			},
+			{
+				id: 6322,
+				name: 'Tall Item One Column',
+				category: portfolio,
 			},
 		],
 		[]

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/patterns-data.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/patterns-data.ts
@@ -184,7 +184,7 @@ const useSectionPatterns = () => {
 	const testimonials = translate( 'Testimonials' );
 	const links = translate( 'Links' );
 	const services = translate( 'Services' );
-	const portfolio = translate( 'CV/Portfolio' );
+	const portfolio = translate( 'Portfolio' );
 
 	const sectionPatterns: Pattern[] = useMemo(
 		() => [


### PR DESCRIPTION
#### Proposed Changes

* Added the latest patterns created in the category `wireframe` to the list of sections in the Pattern Assembler

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new site
* Don't select any goal or vertical
* In the Design Picker, scroll down to find the button `Start designing` in the CTA `Create your own`.
* Click "Add sections" and scroll down to check the list of patterns
* Confirm that they are displayed correctly and the performance loading them is good

**Performance**

Here is a video showing the performance when the feature flag `pattern-assembler/client-side-render` is `false` so we use the slow preview endpoint as on production. It looks good to me. We can assume it will be better in production.

https://user-images.githubusercontent.com/1881481/212276560-fa452943-a815-4f09-9225-9ab7967c9b61.mov

### Known issues
There are some padding issues on some patterns, and one has an excessive height.

If CSS changes or other pattern adjustments are required to fix these issues, the patterns should be edited with the supervision of a designer. 

**Missing Paddings**
The issue affects all the previews, thumb, site, and editor. The pattern IDs are `6319`, `6320`, `6321`, `6313`, `3743`, and `6324`. 

<img width="1479" alt="Screenshot 2566-01-13 at 15 10 11" src="https://user-images.githubusercontent.com/1881481/212270481-076c4125-0593-4726-90a6-a898288740b8.png">
<img width="1482" alt="Screenshot 2566-01-13 at 15 10 35" src="https://user-images.githubusercontent.com/1881481/212270454-b8449dd6-9cf7-485e-a16d-de5d9d4ed643.png">
<img width="1503" alt="Screenshot 2566-01-13 at 15 17 45" src="https://user-images.githubusercontent.com/1881481/212271898-3861cc6a-ec13-4278-bc02-a89aaa5ae1a4.png">
<img width="1503" alt="Screenshot 2566-01-13 at 15 18 49" src="https://user-images.githubusercontent.com/1881481/212271911-a0f4dce4-6f6b-4b63-b83f-f556e1574c56.png">



Other patterns affected: 

<img width="329" alt="Screenshot 2566-01-13 at 14 45 46" src="https://user-images.githubusercontent.com/1881481/212267028-82fdb5c0-4840-444b-bf2b-9c37d380ec21.png">

**Excessive Height**
The issue only affects the thumb preview, not the site preview. The pattern ID is `3747`. 

<img width="1481" alt="Screenshot 2566-01-13 at 15 07 42" src="https://user-images.githubusercontent.com/1881481/212270004-ca561313-ef66-4772-b0ed-2a4cad38918f.png">


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [X] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [X] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [X] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [X] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [X] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/72041
p1673585093782499-slack-C048CUFRGFQ