### PR TITLE
CopySite: small improvements and protect it behind the `sites/copy-site` feature flag

### DIFF
--- a/client/landing/stepper/declarative-flow/copy-site.tsx
+++ b/client/landing/stepper/declarative-flow/copy-site.tsx
@@ -33,6 +33,13 @@ const copySite: Flow = {
 			recordFullStoryEvent( 'calypso_signup_start_copy_site', { flow: this.name } );
 		}, [] );
 
+		const urlQueryParams = useQuery();
+		const sourceSlug = urlQueryParams.get( 'sourceSlug' );
+		if ( ! sourceSlug ) {
+			window.location.assign( `/sites` );
+			return [];
+		}
+
 		return [
 			{ slug: 'intro', component: Intro },
 			{ slug: 'site-creation-step', component: SiteCreationStep },

--- a/client/landing/stepper/declarative-flow/copy-site.tsx
+++ b/client/landing/stepper/declarative-flow/copy-site.tsx
@@ -35,10 +35,10 @@ const copySite: Flow = {
 
 		return [
 			{ slug: 'intro', component: Intro },
-			{ slug: 'siteCreationStep', component: SiteCreationStep },
+			{ slug: 'site-creation-step', component: SiteCreationStep },
 			{ slug: 'processing', component: ProcessingStep },
-			{ slug: 'automatedCopy', component: AutomatedCopySite },
-			{ slug: 'processingCopy', component: ProcessingStep },
+			{ slug: 'automated-copy', component: AutomatedCopySite },
+			{ slug: 'processing-copy', component: ProcessingStep },
 		];
 	},
 
@@ -72,15 +72,15 @@ const copySite: Flow = {
 			switch ( _currentStepSlug ) {
 				case 'intro': {
 					clearSignupDestinationCookie();
-					return navigate( 'siteCreationStep' );
+					return navigate( 'site-creation-step' );
 				}
 
-				case 'siteCreationStep': {
+				case 'site-creation-step': {
 					return navigate( 'processing' );
 				}
 
 				case 'processing': {
-					const destination = addQueryArgs( `/setup/${ this.name }/automatedCopy`, {
+					const destination = addQueryArgs( `/setup/${ this.name }/automated-copy`, {
 						sourceSlug: urlQueryParams.get( 'sourceSlug' ),
 						siteSlug: providedDependencies?.siteSlug,
 					} );
@@ -95,11 +95,11 @@ const copySite: Flow = {
 					);
 				}
 
-				case 'automatedCopy': {
-					return navigate( 'processingCopy' );
+				case 'automated-copy': {
+					return navigate( 'processing-copy' );
 				}
 
-				case 'processingCopy': {
+				case 'processing-copy': {
 					const processingResult = params[ 0 ] as ProcessingResult;
 
 					if ( processingResult === ProcessingResult.FAILURE ) {

--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -159,12 +159,10 @@ button {
 	}
 
 	.step-container {
-
 		.step-container__content h1,
 		.step-container__header h1.formatted-header__title {
 			font-size: $font-title-medium;
-			line-height: 1.2em;
-			/* stylelint-disable-line declaration-property-unit-allowed-list */
+			line-height: 1.2em; /* stylelint-disable-line declaration-property-unit-allowed-list */
 
 			@include break-medium {
 				font-size: $font-headline-medium;
@@ -222,15 +220,12 @@ button {
 						}
 					}
 				}
-
 				&:focus {
 					background-color: var(--studio-blue-50);
 					box-shadow: none;
-
 					svg {
 						fill: #fff;
 					}
-
 					span {
 						color: var(--studio-blue-50);
 					}
@@ -299,7 +294,7 @@ button {
 }
 
 
-@media (max-width: 660px) {
+@media ( max-width: 660px ) {
 	body.is-section-stepper .wpcom-site {
 		.inline-help {
 			bottom: 74px;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/automated-copy-site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/automated-copy-site/index.tsx
@@ -34,8 +34,8 @@ const AutomatedCopySite: Step = function AutomatedCopySite( { navigation } ) {
 	const urlQueryParams = useQuery();
 	const siteSlug = urlQueryParams.get( 'siteSlug' );
 	const sourceSlug = urlQueryParams.get( 'sourceSlug' );
-	const sourceSite = useSelect(
-		( select ) => sourceSlug && select( SITE_STORE ).getSite( sourceSlug )
+	const sourceSite = useSelect( ( select ) =>
+		sourceSlug ? select( SITE_STORE ).getSite( sourceSlug ) : undefined
 	);
 	const sourceSiteId = sourceSite?.ID;
 	const { setPendingAction, setProgress, setProgressTitle } = useDispatch( ONBOARD_STORE );

--- a/client/landing/stepper/declarative-flow/registered-flows.ts
+++ b/client/landing/stepper/declarative-flow/registered-flows.ts
@@ -45,8 +45,6 @@ const availableFlows: Record< string, () => Promise< { default: Flow } > > = {
 			/* webpackChunkName: "trial-wooexpress-flow" */ '../declarative-flow/trial-wooexpress-flow'
 		),
 
-	'copy-site': () => import( /* webpackChunkName: "copy-site" */ '../declarative-flow/copy-site' ),
-
 	free: () => import( /* webpackChunkName: "free-flow" */ '../declarative-flow/free' ),
 
 	'free-post-setup': () =>
@@ -56,6 +54,11 @@ const availableFlows: Record< string, () => Promise< { default: Flow } > > = {
 if ( config.isEnabled( 'themes/plugin-bundling' ) ) {
 	availableFlows[ 'plugin-bundle' ] = () =>
 		import( /* webpackChunkName: "plugin-bundle-flow" */ '../declarative-flow/plugin-bundle-flow' );
+}
+
+if ( config.isEnabled( 'sites/copy-site' ) ) {
+	availableFlows[ 'copy-site' ] = () =>
+		import( /* webpackChunkName: "copy-site" */ '../declarative-flow/copy-site' );
 }
 
 export default availableFlows;

--- a/client/sites-dashboard/components/sites-ellipsis-menu.tsx
+++ b/client/sites-dashboard/components/sites-ellipsis-menu.tsx
@@ -201,7 +201,7 @@ const CopySiteItem = ( { recordTracks, site }: SitesMenuItemProps ) => {
 			href={ copySiteHref }
 			onClick={ () => recordTracks( 'calypso_sites_dashboard_site_action_copy_site' ) }
 		>
-			{ __( 'Create a copy of this site' ) }
+			{ __( 'Copy site' ) }
 		</MenuItemLink>
 	);
 };

--- a/packages/onboarding/src/flow-progress/use-flow-progress.ts
+++ b/packages/onboarding/src/flow-progress/use-flow-progress.ts
@@ -69,10 +69,10 @@ const flows: Record< string, { [ step: string ]: number } > = {
 	},
 	[ COPY_SITE_FLOW ]: {
 		intro: 0,
-		siteCreationStep: 1,
+		'site-creation-step': 1,
 		processing: 1,
-		automatedCopy: 3,
-		processingCopy: 3,
+		'automated-copy': 3,
+		'processing-copy': 3,
 	},
 };
 


### PR DESCRIPTION
#### Proposed Changes

- use hyphens in step urls
- reduce the text in Copy Site SMP CTA Action
- use `siteDetails` type
- add a guard to make sourceSlug a required param
- Move the flow behind the feature flag `sites/copy-site`
- Fix globa.scss changes

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check https://github.com/Automattic/wp-calypso/pull/71913

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

- Related to https://github.com/Automattic/dotcom-forge/issues/1468
