### PR TITLE
fix: Remove product_slug from copy site parameters

### DIFF
--- a/client/landing/stepper/declarative-flow/copy-site.tsx
+++ b/client/landing/stepper/declarative-flow/copy-site.tsx
@@ -1,5 +1,5 @@
 import { useFlowProgress, COPY_SITE_FLOW } from '@automattic/onboarding';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useDispatch } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
 import { translate } from 'i18n-calypso';
 import { useEffect } from 'react';
@@ -55,25 +55,12 @@ const copySite: Flow = {
 		const flowProgress = useFlowProgress( { stepName: _currentStepSlug, flowName } );
 		const urlQueryParams = useQuery();
 
-		const { setPlanCartItem } = useDispatch( ONBOARD_STORE );
-		const { getPlanCartItem } = useSelect( ( select ) => select( ONBOARD_STORE ) );
-
 		setStepProgress( flowProgress );
 
 		const submit = async (
 			providedDependencies: ProvidedDependencies = {},
 			...params: string[]
 		) => {
-			// We need to do this here to avoid any race conditions
-			// due to dispatch and window.assign
-			const productSlug = urlQueryParams.get( 'productSlug' );
-			if ( productSlug && ! getPlanCartItem() ) {
-				const productToAdd = {
-					product_slug: productSlug,
-				};
-				setPlanCartItem( productToAdd );
-			}
-
 			recordSubmitStep( providedDependencies, '', flowName, _currentStepSlug );
 
 			switch ( _currentStepSlug ) {

--- a/client/sites-dashboard/components/sites-ellipsis-menu.tsx
+++ b/client/sites-dashboard/components/sites-ellipsis-menu.tsx
@@ -134,7 +134,7 @@ const modalOverlayClassName = css( {
 } );
 
 function useSafeSiteHasFeature( siteId: number, feature: string ) {
-	const dispatch = useDispatch();
+	const dispatch = useReduxDispatch();
 	useEffect( () => {
 		dispatch( fetchSiteFeatures( siteId ) );
 	}, [ dispatch, siteId ] );
@@ -255,7 +255,7 @@ export const SitesEllipsisMenu = ( {
 	className?: string;
 	site: SiteExcerptData;
 } ) => {
-	const dispatch = useDispatch();
+	const dispatch = useReduxDispatch();
 	const { __ } = useI18n();
 	const props: SitesMenuItemProps = {
 		site,

--- a/client/sites-dashboard/components/sites-ellipsis-menu.tsx
+++ b/client/sites-dashboard/components/sites-ellipsis-menu.tsx
@@ -8,11 +8,13 @@ import { Gridicon } from '@automattic/components';
 import { css } from '@emotion/css';
 import styled from '@emotion/styled';
 import { DropdownMenu, MenuGroup, MenuItem as CoreMenuItem, Modal } from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
 import { addQueryArgs } from '@wordpress/url';
 import { ComponentType, useEffect, useState } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch as useReduxDispatch, useSelector } from 'react-redux';
 import SitePreviewLink from 'calypso/components/site-preview-link';
+import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
@@ -51,7 +53,7 @@ const MenuItemLink = MenuItem as ComponentType< MenuItemLinkProps >;
 
 const LaunchItem = ( { site, recordTracks }: SitesMenuItemProps ) => {
 	const { __ } = useI18n();
-	const dispatch = useDispatch();
+	const dispatch = useReduxDispatch();
 
 	return (
 		<MenuItem
@@ -186,13 +188,14 @@ const CopySiteItem = ( { recordTracks, site }: SitesMenuItemProps ) => {
 	const userId = useSelector( ( state ) => getCurrentUserId( state ) );
 	const plan = site.plan;
 	const isSiteOwner = site.site_owner === userId;
+	const { setPlanCartItem } = useDispatch( ONBOARD_STORE );
 
 	if ( ! hasAtomicFeature || ! isSiteOwner || ! plan ) {
 		return null;
 	}
+	setPlanCartItem( { product_slug: plan.product_slug } );
 
 	const copySiteHref = addQueryArgs( `/setup/copy-site`, {
-		productSlug: plan.product_slug,
 		sourceSlug: site.slug,
 		sourceUrl: site.URL,
 	} );


### PR DESCRIPTION
#### Proposed Changes

* Remove `productSlug` from copy site parameters.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to /sites.
- On an atomic site you own, Click on the ellipsis action menu.
- Click on Create a copy of this site.
- Observe a new flow is open.
- Ensure that there is no `productSlug` parameter in the URL

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/1490
