### PR TITLE
Ensure eCommerce redirect only occurs when WooCommerce is active

### DIFF
--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -23,6 +23,10 @@ import WooCommerceHomePlaceholder from 'calypso/my-sites/customer-home/wc-home-p
 import PluginsAnnouncementModal from 'calypso/my-sites/plugins/plugins-announcement-modal';
 import { bumpStat, composeAnalytics, recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUserCountryCode } from 'calypso/state/current-user/selectors';
+import {
+	getPluginOnSite,
+	isRequesting as isRequestingInstalledPlugins,
+} from 'calypso/state/plugins/installed/selectors';
 import { getSelectedEditor } from 'calypso/state/selectors/get-selected-editor';
 import isUserRegistrationDaysWithinRange from 'calypso/state/selectors/is-user-registration-days-within-range';
 import {
@@ -36,6 +40,8 @@ import './style.scss';
 
 const Home = ( {
 	canUserUseCustomerHome,
+	hasWooCommerceInstalled,
+	isRequestingSitePlugins,
 	site,
 	siteId,
 	trackViewSiteAction,
@@ -79,7 +85,7 @@ const Home = ( {
 
 	// Ecommerce Plan's Home redirects to WooCommerce Home, so we show a placeholder
 	// while doing the redirection.
-	if ( isEcommerce( sitePlan ) ) {
+	if ( isEcommerce( sitePlan ) && ( isRequestingSitePlugins || hasWooCommerceInstalled ) ) {
 		return <WooCommerceHomePlaceholder />;
 	}
 
@@ -143,7 +149,9 @@ const Home = ( {
 
 Home.propTypes = {
 	canUserUseCustomerHome: PropTypes.bool.isRequired,
+	hasWooCommerceInstalled: PropTypes.bool.isRequired,
 	isStaticHomePage: PropTypes.bool.isRequired,
+	isRequestingSitePlugins: PropTypes.bool.isRequired,
 	site: PropTypes.object.isRequired,
 	siteId: PropTypes.number.isRequired,
 	trackViewSiteAction: PropTypes.func.isRequired,
@@ -152,6 +160,7 @@ Home.propTypes = {
 const mapStateToProps = ( state ) => {
 	const siteId = getSelectedSiteId( state );
 	const isClassicEditor = getSelectedEditor( state, siteId ) === 'classic';
+	const installedWooCommercePlugin = getPluginOnSite( state, siteId, 'woocommerce' );
 
 	return {
 		site: getSelectedSite( state ),
@@ -161,6 +170,8 @@ const mapStateToProps = ( state ) => {
 		canUserUseCustomerHome: canCurrentUserUseCustomerHome( state, siteId ),
 		isStaticHomePage:
 			! isClassicEditor && 'page' === getSiteOption( state, siteId, 'show_on_front' ),
+		hasWooCommerceInstalled: !! ( installedWooCommercePlugin && installedWooCommercePlugin.active ),
+		isRequestingSitePlugins: isRequestingInstalledPlugins( state, siteId ),
 	};
 };
 


### PR DESCRIPTION
#### Proposed Changes

* This PR addresses the problem raised in #72022, where our redirection logic for the eCommerce plan is broken when WooCommerce is not installed or is not active
* The PR addresses the problem by checking whether the WooCommerce plugin is installed and active before we perform the redirect, which does involve a forced fetch to the server to make sure we have the site's current set of installed plugins
  - In a future PR, it might be worth adding some data to track whether we have site plugin data available in the store, but I think the right medium-term change will be to have the URL for _My Home_ point at the appropriate URL to start with.

#### Testing Instructions

* Ensure you have an eCommerce site to test with
* Run this branch locally or via the Calypso Live branch
* Click on the "My Home" link for your eCommerce site
* Verify that you are taken to WooCommerce home for your site
* Ensure that SSH access is enabled for your site by visiting _Settings_ -> _Hosting Configuration_ and following the prompts to enable SSH access - make a note of your SSH password and login
* SSH to your eCommerce site
* From the terminal, run the following command to deactivate WooCommerce: `wp plugin deactivate woocommerce`
* Navigate to `/home/[yourSiteSlug]`, either directly or by visiting _My Home_ for a non-eCommerce site and then switching to this site
* Verify that you are _not_redirected to WooCommerce home

#### Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [N/A] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [N/A] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?

Fixes #72022
