### PR TITLE
[Spike] Pattern Assembler - Added all the query patterns from dotcompatterns

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-assembler-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-assembler-preview.tsx
@@ -33,7 +33,7 @@ const PatternAssemblerPreview = ( { header, sections = [], footer, activePositio
 		null
 	);
 	const totalPatterns = [ header, ...sections, footer ].filter( Boolean );
-	const hasSelectedPatterns = totalPatterns.length > 1;
+	const hasSelectedPatterns = totalPatterns.length > 0;
 	const selectedDesign = useSelect( ( select ) => select( ONBOARD_STORE ).getSelectedDesign() );
 
 	const mergedDesign = {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/patterns-data.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/patterns-data.ts
@@ -223,6 +223,21 @@ const useSectionPatterns = () => {
 				category: posts,
 			},
 			{
+				id: 3213,
+				name: 'Latest podcast episodes',
+				category: posts,
+			},
+			{
+				id: 1784,
+				name: 'Recent Posts',
+				category: posts,
+			},
+			{
+				id: 1593,
+				name: 'Heading and Three Images',
+				category: posts,
+			},
+			{
 				id: 7153,
 				name: 'Media and text with image on the left',
 				category: callToAction,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/patterns-data.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/patterns-data.ts
@@ -183,13 +183,44 @@ const useSectionPatterns = () => {
 	const about = translate( 'About' );
 	const testimonials = translate( 'Testimonials' );
 	const links = translate( 'Links' );
+	const posts = translate( 'Posts' );
 
 	const sectionPatterns: Pattern[] = useMemo(
 		() => [
 			{
-				id: 7156,
-				name: 'Media and text with image on the right',
-				category: callToAction,
+				id: 8437,
+				name: 'List of posts',
+				category: posts,
+			},
+			{
+				id: 8435,
+				name: 'Grid of Posts 3x2',
+				category: posts,
+			},
+			{
+				id: 8421,
+				name: 'Grid of posts 2x3',
+				category: posts,
+			},
+			{
+				id: 7996,
+				name: 'Grid of Posts 4x2',
+				category: posts,
+			},
+			{
+				id: 3685, // Only mobile
+				name: 'Blog',
+				category: posts,
+			},
+			{
+				id: 3681,
+				name: 'Blog',
+				category: posts,
+			},
+			{
+				id: 3395, // Only mobile
+				name: 'Blog',
+				category: posts,
 			},
 			{
 				id: 7153,


### PR DESCRIPTION
#### Proposed Changes

* Added at the beginning of the `sections` list, all the query patterns from `dotcompatterns`. 

|<img width="332" alt="Screenshot 2566-01-13 at 19 47 26" src="https://user-images.githubusercontent.com/1881481/212323751-4afa5118-f893-4f59-a10c-04b142911a16.png">|<img width="339" alt="Screenshot 2566-01-13 at 19 46 54" src="https://user-images.githubusercontent.com/1881481/212323771-ca4fae52-1ecc-4510-8ad7-541fe2d39602.png">|

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new site
* Don't select any goal or vertical
* In the Design Picker, scroll down to find the button `Start designing` in the CTA `Create your own`.
* Click "Add sections" to add the first seven patterns
* Confirm that they are displayed correctly, and the performance loading them is good

**Known issue**

If you only add one pattern, the site preview is not updated. This issue is only in the development environment and will be solved soon. See p1673607227478539-slack-CRWCHQGUB

**Spike results**
- The query patterns in `dotcompatterns` are rendered well when using the old preview endpoint and the new fast preview on the client-side. 
 - There is a minor rendering issue related to the loading time of the CSS when using the new fast preview on the client-side. The styles that hide the list bullets load later, and we can see the bullets for a few seconds.

https://user-images.githubusercontent.com/1881481/212321360-5de843db-e636-44f6-a4ba-d8c5ce76cf03.mov

- The previews in the patterns assembler use the posts in the demo site for `blankcanvas3demo`, which only has one post.
- The previews in the editor use the posts from the site, which are three because somewhere during the theme setup process, three posts are automatically created when there is a query pattern in the content. We should check how the param `pattern_ids` is handled in the endpoint `/theme-setup`.
- The posts created on the site must match the posts in the demo site for `blankcanvas3demo` so the previews in the site editor will match the previews in the pattern assembler.
- The posts must have featured images 
- Are three posts enough? I think some more would be better for the preview of grids of posts.

https://user-images.githubusercontent.com/1881481/212318981-44a534a9-0a6c-4539-840d-44f7cc0da4a7.mov

https://user-images.githubusercontent.com/1881481/212319959-c8c72585-cab7-49d5-b1c0-61a9a4e85673.mov

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [X] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [X] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [X] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [X] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [X] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/68133