### PR TITLE
Changing short description of Boost on the pricing page

### DIFF
--- a/packages/calypso-products/src/translations.tsx
+++ b/packages/calypso-products/src/translations.tsx
@@ -511,7 +511,7 @@ export const getJetpackProductsShortDescriptions = (): Record< string, Translate
 	const backupT1ShortDescription = translate( 'Real-time cloud backups with one-click restores.' );
 	const backupT2ShortDescription = translate( 'Real-time cloud backups with one-click restores.' );
 	const boostShortDescription = translate(
-		'Essential tools to speed up your site - no developer required.'
+		'Speed up your site and improve SEO - no developer required.'
 	);
 	const searchShortDescription = translate( 'Help your site visitors find answers instantly.' );
 	const scanShortDescription = translate( 'Automatic malware scanning with one-click fixes.' );


### PR DESCRIPTION
Improving SEO by speeding up a site is one of the main value propositions of Boost. However, the relationship between SEO and site speed might not be obvious to some users. 

Therefore, we should mention SEO in Boost's short description on the pricing page so that everyone knows they can improve their SEO by using Boost. 

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

The short description of Boost should change to `Speed up your site and improve SEO - no developer required.`


<img width="1440" alt="Screen Shot 2023-01-13 at 15 46 20" src="https://user-images.githubusercontent.com/82706809/212323533-adb22de2-062f-4fc1-9118-0abe038206b6.png">



#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
