### PR TITLE
Fixes for the theme showcase Try & Customize menu item

### DIFF
--- a/client/state/themes/selectors/index.js
+++ b/client/state/themes/selectors/index.js
@@ -46,6 +46,7 @@ export { isAmbiguousThemeFilterTerm } from 'calypso/state/themes/selectors/is-am
 export { isDownloadableFromWpcom } from 'calypso/state/themes/selectors/is-downloadable-from-wpcom';
 export { isExternallyManagedTheme } from 'calypso/state/themes/selectors/is-externally-managed-theme';
 export { isFulfilledThemesForQuery } from 'calypso/state/themes/selectors/is-fulfilled-request-themes-for-query';
+export { isFullSiteEditingTheme } from 'calypso/state/themes/selectors/is-full-site-editing-theme';
 export { isInstallingTheme } from 'calypso/state/themes/selectors/is-installing-theme';
 export { isMarketplaceThemeSubscribed } from 'calypso/state/themes/selectors/is-marketplace-theme-subscribed';
 export { isPremiumThemeAvailable } from 'calypso/state/themes/selectors/is-premium-theme-available';

--- a/client/state/themes/selectors/is-full-site-editing-theme.ts
+++ b/client/state/themes/selectors/is-full-site-editing-theme.ts
@@ -1,0 +1,22 @@
+import { getTheme } from 'calypso/state/themes/selectors/get-theme';
+import { getThemeTaxonomySlugs } from 'calypso/state/themes/utils';
+import type { AppState } from 'calypso/types';
+
+import 'calypso/state/themes/init';
+
+export function isFullSiteEditingTheme(
+	state: AppState,
+	themeId: string | null | undefined
+): boolean {
+	if ( ! themeId ) {
+		return false;
+	}
+	const theme = getTheme( state, 'wpcom', themeId );
+	if ( ! theme ) {
+		return false;
+	}
+
+	const themeFeatures = getThemeTaxonomySlugs( theme, 'theme_feature' );
+
+	return themeFeatures.includes( 'full-site-editing' );
+}

--- a/client/state/themes/selectors/should-show-try-and-customize.js
+++ b/client/state/themes/selectors/should-show-try-and-customize.js
@@ -3,6 +3,7 @@ import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
 import { isJetpackSite, isJetpackSiteMultiSite } from 'calypso/state/sites/selectors';
 import {
+	isExternallyManagedTheme,
 	isPremiumThemeAvailable,
 	isThemeActive,
 	isThemeGutenbergFirst,
@@ -25,6 +26,15 @@ export function shouldShowTryAndCustomize( state, themeId, siteId ) {
 	 * If we're viewing a specific site and user does not have permissions, bail
 	 */
 	if ( siteId && ! canCurrentUser( state, siteId, 'edit_theme_options' ) ) {
+		return false;
+	}
+
+	/*
+	 * If this is a Marketplace theme, i.e. externally managed,
+	 * we can only show the customizer if the site is Atomic and has purchased the theme
+	 */
+	if ( isExternallyManagedTheme( state, themeId ) ) {
+		// TODO: isThemePurchased() only supports standard themes
 		return false;
 	}
 

--- a/client/state/themes/selectors/should-show-try-and-customize.js
+++ b/client/state/themes/selectors/should-show-try-and-customize.js
@@ -4,6 +4,7 @@ import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
 import { isJetpackSite, isJetpackSiteMultiSite } from 'calypso/state/sites/selectors';
 import {
 	isExternallyManagedTheme,
+	isMarketplaceThemeSubscribed,
 	isPremiumThemeAvailable,
 	isThemeActive,
 	isThemeGutenbergFirst,
@@ -34,8 +35,11 @@ export function shouldShowTryAndCustomize( state, themeId, siteId ) {
 	 * we can only show the customizer if the site is Atomic and has purchased the theme
 	 */
 	if ( isExternallyManagedTheme( state, themeId ) ) {
-		// TODO: isThemePurchased() only supports standard themes
-		return false;
+		return (
+			siteId &&
+			isSiteWpcomAtomic( state, siteId ) &&
+			isMarketplaceThemeSubscribed( state, themeId, siteId )
+		);
 	}
 
 	/*


### PR DESCRIPTION
#### Proposed Changes

* This PR tidies up some of the code involved in deciding whether we should show the `Try & Customize` menu item. It does so via the following changes:
  - For Marketplace themes, we will only show the menu item if _all_ of the following are true:
    - The site is Atomic
    - The site has a subscription for the marketplace theme
    - The theme does not have the `full-site-editing` feature _OR_ the theme does not have both the `global-styles` and `auto-loading-homepage` features
    - The theme is not the currently active theme
  - For standard themes, we will no longer show the menu item if the theme has the `full-site-editing` feature

#### Testing Instructions

* Run this branch locally or via the Calypso live branch - both environments have the `themes/third-party-premium` feature flag enabled
* Navigate to the theme showcase in _Appearance_ -> _Themes_ for a site on the Business or eCommerce plan while logged in using your Automattic account
* Click on the kebab menu for the Makoney theme
* Verify that the _Try & Customize_ menu item is not shown
* Purchase the Makoney theme
* After completing the purchase, navigate back to the theme showcase via _Appearance_ -> _Themes_
* Makoney should now be the active theme (if it is not, activate it)
* Click on the kebab menu for the Makoney theme
* Verify that the _Try & Customize_ menu item is not shown
* Activate another theme
* Click on the kebab menu for the Makoney theme
* Verify that the _Try & Customize_ menu item is not shown

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [N/A] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [N/A] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [N/A] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?