### PR TITLE
fix: Change the theme to the default for WP Sites at copy site flow

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
@@ -24,6 +24,8 @@ import type { Step } from '../../types';
 
 import './styles.scss';
 
+const DEFAULT_WP_SITE_THEME = 'pub/zoologist';
+
 const SiteCreationStep: Step = function SiteCreationStep( { navigation, flow } ) {
 	const { submit } = navigation;
 
@@ -40,10 +42,9 @@ const SiteCreationStep: Step = function SiteCreationStep( { navigation, flow } )
 
 	const { setPendingAction, setIsMigrateFromWp } = useDispatch( ONBOARD_STORE );
 
-	const defaultWPSiteTheme = 'pub/zoologist';
 	let theme: string;
 	if ( isMigrationFlow( flow ) || isCopySiteFlow( flow ) ) {
-		theme = defaultWPSiteTheme;
+		theme = DEFAULT_WP_SITE_THEME;
 	} else {
 		theme = isLinkInBioFlow( flow ) ? 'pub/lynx' : 'pub/lettre';
 	}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
@@ -7,6 +7,7 @@ import {
 	createSiteWithCart,
 	isFreeFlow,
 	isMigrationFlow,
+	isCopySiteFlow,
 } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect } from 'react';
@@ -39,9 +40,10 @@ const SiteCreationStep: Step = function SiteCreationStep( { navigation, flow } )
 
 	const { setPendingAction, setIsMigrateFromWp } = useDispatch( ONBOARD_STORE );
 
+	const defaultWPSiteTheme = 'pub/zoologist';
 	let theme: string;
-	if ( isMigrationFlow( flow ) ) {
-		theme = 'pub/zoologist';
+	if ( isMigrationFlow( flow ) || isCopySiteFlow( flow ) ) {
+		theme = defaultWPSiteTheme;
 	} else {
 		theme = isLinkInBioFlow( flow ) ? 'pub/lynx' : 'pub/lettre';
 	}


### PR DESCRIPTION
#### Proposed Changes

* When the user copies a site, use the default theme that is used by default on WP sites.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Go to `/sites`.
2. On an atomic site you own, Click on the ellipsis action menu.
3. Click on Create a copy of this site.
4. Observe a new flow is open.
5. When you get navigated to the `checkout`, change the URL to exit the flow (eg: change your URL to `/sites`)
6. Check that there is a new free site listed under your sites.
7. Ensure that the newly created site has `zoologist` (default WP site theme) as a theme.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #https://github.com/Automattic/dotcom-forge/issues/1499
