### PR TITLE
Hide free plan when a custom domain is selected

### DIFF
--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -353,10 +353,12 @@ export class PlansStep extends Component {
 		}
 
 		if ( this.state.isDesktop ) {
-			return translate(
-				"Pick one that's right for you and unlock features that help you grow. Or {{link}}start with a free site{{/link}}.",
-				{ components: { link: freePlanButton } }
-			);
+			return hideFreePlan
+				? translate( 'Try risk-free with a 14-day money-back guarantee.' )
+				: translate(
+						"Pick one that's right for you and unlock features that help you grow. Or {{link}}start with a free site{{/link}}.",
+						{ components: { link: freePlanButton } }
+				  );
 		}
 
 		return translate( 'Choose a plan or {{link}}start with a free site{{/link}}.', {


### PR DESCRIPTION
#### Proposed Changes
Hide the “Start with Free” option in the signup flow plans step if a user has selected to connect a domain

Source: pau2Xa-4G5-p2#comment-13101

**Before**
![Screenshot 2023-01-20 at 14 30 58 (1)](https://user-images.githubusercontent.com/11347472/213688796-62af4236-ce99-482d-85fa-8453cd787126.jpeg)

**After**
<img width="1496" alt="Screenshot 2023-01-20 at 14 20 15" src="https://user-images.githubusercontent.com/11347472/213684465-488497f9-3c86-4871-8cc4-d61254c7cf58.png">


#### Testing Instructions
Go to the calypso live testing site[https://calypso.live/?image=registry.a8c.com/calypso/app:build-53952]( https://calypso.live/)
- Click the switch site menu
- Click the add a new site button
- Go through the steps until you reach the "Choose a domain" screen.
- Click the "Use a domain I own in the bottom right"
- Enter a domain that exists (You don't need to own it)
- Select Connect your domain option on the next screen
- On the Choose a plan screen, the option for a free plan shouldn't show.
<!--

-->

*

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #