### PR TITLE
Theme Showcase: Only Show the Header for Logged-In Users

### DIFF
--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -480,21 +480,23 @@ class ThemeShowcase extends Component {
 					title={ this.props.analyticsPageTitle }
 					properties={ { is_logged_in: isLoggedIn } }
 				/>
-				<ThemesHeader
-					description={ translate(
-						'Select or update the visual design for your site. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
-						{
-							components: {
-								learnMoreLink: <InlineSupportLink supportContext="themes" showIcon={ false } />,
-							},
-						}
-					) }
-				>
-					<div className="themes__install-theme-button-container">
-						<InstallThemeButton />
-					</div>
-					<ScreenOptionsTab wpAdminPath="themes.php" />
-				</ThemesHeader>
+				{ isLoggedIn && (
+					<ThemesHeader
+						description={ translate(
+							'Select or update the visual design for your site. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+							{
+								components: {
+									learnMoreLink: <InlineSupportLink supportContext="themes" showIcon={ false } />,
+								},
+							}
+						) }
+					>
+						<div className="themes__install-theme-button-container">
+							<InstallThemeButton />
+						</div>
+						<ScreenOptionsTab wpAdminPath="themes.php" />
+					</ThemesHeader>
+				) }
 				<div className="themes__content" ref={ this.scrollRef }>
 					<QueryThemeFilters />
 					<SearchThemes


### PR DESCRIPTION
#### Proposed Changes

* Hide the Theme Showcase header for logged-out users.

| Before | After |
| - | - |
| <img width="998" alt="Screenshot 2023-01-13 at 16 08 41" src="https://user-images.githubusercontent.com/2070010/212366003-36d2591c-1d24-4112-8316-183f676fea2b.png"> | <img width="998" alt="Screenshot 2023-01-13 at 16 08 46" src="https://user-images.githubusercontent.com/2070010/212366026-21d5f1e4-1af9-4e3f-8365-3c08780bbd8d.png"> |

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Log out of Calypso (or use an incognito window).
* Navigate to `/themes`.
* Ensure the header is not displayed (compare with the screenshots above).
* Log in to Calypso.
* Navigate to `/themes` (you will need to select a site).
* Ensure the header is displayed.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
