### PR TITLE
Email stats: make email opens overview an all-time stat

### DIFF
--- a/client/state/stats/lists/actions.js
+++ b/client/state/stats/lists/actions.js
@@ -4,8 +4,8 @@ import {
 	SITE_STATS_REQUEST,
 	SITE_STATS_REQUEST_FAILURE,
 } from 'calypso/state/action-types';
-
 import 'calypso/state/stats/init';
+import { PERIOD_ALL_TIME } from 'calypso/state/stats/emails/constants';
 
 /**
  * Returns an action object to be used in signalling that stats for a given type of stats and query
@@ -71,7 +71,17 @@ export function requestSiteStats( siteId, statType, query ) {
 			apiNamespace = 'wpcom/v2';
 		}
 
-		const options = 'statsVideo' === statType ? query.postId : query;
+		const options = ( () => {
+			switch ( statType ) {
+				case 'statsVideo':
+					return query.postId;
+				case 'statsEmailsOpen':
+					return { period: PERIOD_ALL_TIME, quantity: 20 };
+				default:
+					return query;
+			}
+		} )();
+
 		const requestStats = subpath
 			? wpcom.req.get(
 					{


### PR DESCRIPTION
#### Proposed Changes

Previously, email opens was bound by the date selected. This PR changes this and shows total opens for every email.

#### Testing Instructions

* Apply this PR
* Make sure to apply this patch to your sandbox: D98004-code
* Make sure `public-api.wordpress.com` is sandboxed.
* Visit `/stats/day/<yoursite>?flags=newsletter/stats`

You should see a list of your alltime best emails:

<img width="1281" alt="CleanShot 2023-01-13 at 17 02 06@2x" src="https://user-images.githubusercontent.com/528287/212367725-507a01e2-278d-417a-84bb-0f59d62df06e.png">


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
