### PR TITLE
Launchpad: Fix launchpad screen flash after launching site

### DIFF
--- a/client/landing/stepper/declarative-flow/free.ts
+++ b/client/landing/stepper/declarative-flow/free.ts
@@ -96,9 +96,14 @@ const free: Flow = {
 					return navigate( 'processing' );
 
 				case 'processing':
+					if ( providedDependencies?.goToHome && providedDependencies?.siteSlug ) {
+						return window.location.replace( `/home/${ providedDependencies?.siteSlug }` );
+					}
+
 					if ( selectedDesign ) {
 						return navigate( `launchpad?siteSlug=${ siteSlug }` );
 					}
+
 					return navigate( `designSetup?siteSlug=${ providedDependencies?.siteSlug }` );
 
 				case 'designSetup':

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -194,7 +194,7 @@ export function getEnhancedTasks(
 									// Waits for half a second so that the loading screen doesn't flash away too quickly
 									await new Promise( ( res ) => setTimeout( res, 500 ) );
 									recordTaskClickTracksEvent( flow, siteLaunchCompleted, task.id );
-									window.location.assign( `/home/${ siteSlug }` );
+									return { goToHome: true, siteSlug };
 								} );
 
 								submit?.();
@@ -219,7 +219,7 @@ export function getEnhancedTasks(
 									// Waits for half a second so that the loading screen doesn't flash away too quickly
 									await new Promise( ( res ) => setTimeout( res, 500 ) );
 									recordTaskClickTracksEvent( flow, siteLaunchCompleted, task.id );
-									window.location.assign( `/home/${ siteSlug }` );
+									return { goToHome: true, siteSlug };
 								} );
 
 								submit?.();

--- a/client/landing/stepper/declarative-flow/link-in-bio-tld.ts
+++ b/client/landing/stepper/declarative-flow/link-in-bio-tld.ts
@@ -99,6 +99,9 @@ const linkInBio: Flow = {
 					return navigate( 'processing' );
 
 				case 'processing':
+					if ( providedDependencies?.goToHome && providedDependencies?.siteSlug ) {
+						return window.location.replace( `/home/${ providedDependencies?.siteSlug }` );
+					}
 					if ( providedDependencies?.goToCheckout ) {
 						const destination = `/setup/${ flowName }/launchpad?siteSlug=${ providedDependencies.siteSlug }`;
 						persistSignupDestination( destination );
@@ -114,6 +117,7 @@ const linkInBio: Flow = {
 							) }?redirect_to=${ returnUrl }&signup=1`
 						);
 					}
+
 					return navigate( `launchpad?siteSlug=${ providedDependencies?.siteSlug }` );
 
 				case 'launchpad': {

--- a/client/landing/stepper/declarative-flow/link-in-bio.ts
+++ b/client/landing/stepper/declarative-flow/link-in-bio.ts
@@ -103,6 +103,10 @@ const linkInBio: Flow = {
 					return navigate( 'processing' );
 
 				case 'processing':
+					if ( providedDependencies?.goToHome && providedDependencies?.siteSlug ) {
+						return window.location.replace( `/home/${ providedDependencies?.siteSlug }` );
+					}
+
 					if ( providedDependencies?.goToCheckout ) {
 						const destination = `/setup/${ flowName }/launchpad?siteSlug=${ providedDependencies.siteSlug }`;
 						persistSignupDestination( destination );
@@ -118,6 +122,7 @@ const linkInBio: Flow = {
 							) }?redirect_to=${ returnUrl }&signup=1`
 						);
 					}
+
 					return navigate( `launchpad?siteSlug=${ providedDependencies?.siteSlug }` );
 
 				case 'launchpad': {


### PR DESCRIPTION
#### Proposed Changes

* When launching a Link-in-bio or Free Flow site, the launchpad screen flashes for a moment and then navigates to `/home`. These changes remove the launchpad screen flash and directly navigates the user to `/home`.

![horizon-free-flow-launch-flash](https://user-images.githubusercontent.com/10482592/212404817-45ddb919-62fb-42d8-8cdf-4168fc299279.gif)


**Solution:**
When we launch a `link-in-bio` or `free` site, we set up a pending action (a function that will eventually get triggered) and then navigate the user to the `processing` screen. 

The pending action mainly consists of the logic to launch the site and redirect the user to the homepage using `window.location.assign(/home/{siteSlug})` - https://github.com/Automattic/wp-calypso/blob/trunk/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts#L215). 

When the processing screen loads, it triggers the pending action described above and then passes the return value of the pending action to the stepper submit() function for that particular flow.

This where the pendingAction is triggered: https://github.com/Automattic/wp-calypso/blob/trunk/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx#L60

This is where the return value (providedDependencies) is used within the `processing` step to determine where to navigate the user: https://github.com/Automattic/wp-calypso/blob/trunk/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx#L86


Using the `link-in-bio` flow as an example, we can see that when the submit() function is triggered from the `processing` step, we navigate to the launchpad by default. This is what causes the launchpad screen flash: https://github.com/Automattic/wp-calypso/blob/trunk/client/landing/stepper/declarative-flow/link-in-bio.ts#L121

To solve this issue, I added a return value (known as `providedDependencies` within the stepper framework) to the pendingAction for launching the site and also added an additional condition check to ensure that the user is navigated to the home page without seeing the launchpad screen flash.


#### Estimated Time to Test / Review:

Test -> Short
Review -> Short

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this branch
* Create a new link-in-bio site (`/setup/link-in-bio`), complete the `Add links` task, navigate back to `/setup/link-in-bio/launchpad?siteSlug={siteSlug}`, and launch the site to confirm the launchpad screen does not flash after the launch process.
* Create a new free site (`/setup/free`) , navigate back to `/setup/free/launchpad?siteSlug={siteSlug}` launch the site to confirm the launchpad screen does not flash after the launch process.
* Create a new link-in-bio-tld site (`/setup/link-in-bio-tld`), complete `Add links` tasks, navigate back to `/setup/link-in-bio-tld/launchpad?siteSlug={siteSlug}` and launch the site to confirm the launchpad screen does not flash after the launch process.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #72077