### PR TITLE
PlanPrice: add isSmallestUnit option

### DIFF
--- a/client/my-sites/plan-price/README.md
+++ b/client/my-sites/plan-price/README.md
@@ -7,7 +7,7 @@ flexbox container.
 
 ## Usage
 
-PlanPrice can take a `productDisplayPrice` or a `rawPrice` (deprecated) prop, though `productDisplayPrice` is the preferred option.
+PlanPrice can take a `productDisplayPrice` or a `rawPrice` prop.
 
 A `productDisplayPrice` can be retrieved from the `/purchases` or `/plans` REST endpoints and are stored in Redux; for example:
 
@@ -18,12 +18,6 @@ function MyComponent( { purchaseId } ) {
 }
 ```
 
-`productDisplayPrice` is preferred because it provides an HTML wrapped, geo-IDed, and properly formatted currency string. Whereas, `rawPrice` is not geo-IDed and requires extra work to format correctly on the front end.
-
-You can pass along `rawPrice` (not required) with `productDisplayPrice` and when available the `productDisplayPrice` will be used by default.
-
-**Preferred usage**
-
 ```jsx
 <PlanPrice
 	productDisplayPrice={ purchase.productDisplayPrice }
@@ -31,8 +25,6 @@ You can pass along `rawPrice` (not required) with `productDisplayPrice` and when
 	isOnSale={ !! purchase.saleAmount }
 />;
 ```
-
-**Backwards compatible usage**
 
 ```jsx
 <PlanPrice
@@ -68,15 +60,3 @@ export default class extends React.Component {
 	}
 }
 ```
-
-## Props
-
-| Prop                | Type           | Description                                             |
-| ------------------- | -------------- | ------------------------------------------------------- |
-| productDisplayPrice | number         | HTML wrapped display price                              |
-| rawPrice            | number / array | Price or price range of the plan                        |
-| original            | bool           | Is the price discounted and this is the original one?   |
-| discounted          | bool           | Is the price discounted and this is the discounted one? |
-| isOnSale            | bool           | Is the product this price is for on sale?               |
-| currencyCode        | string         | Currency of the price                                   |
-| className           | string         | If you need to add additional classes                   |

--- a/client/my-sites/plan-price/index.tsx
+++ b/client/my-sites/plan-price/index.tsx
@@ -195,12 +195,20 @@ export interface PlanPriceProps {
 	is2023OnboardingPricingGrid?: boolean;
 }
 
-function renderBasicPrice( price: number, currencyCode: string, isSmallestUnit?: boolean ): string {
+function PriceWithoutHtml( {
+	price,
+	currencyCode,
+	isSmallestUnit,
+}: {
+	price: number;
+	currencyCode: string;
+	isSmallestUnit?: boolean;
+} ) {
 	const priceObj = getCurrencyObject( price, currencyCode, { isSmallestUnit } );
 	if ( ! Number.isInteger( price ) ) {
-		return `${ priceObj.integer }${ priceObj.fraction }`;
+		return <>{ `${ priceObj.integer }${ priceObj.fraction }` }</>;
 	}
-	return priceObj.integer;
+	return <>{ priceObj.integer }</>;
 }
 
 function FlatPriceDisplay( {
@@ -225,7 +233,11 @@ function FlatPriceDisplay( {
 		return (
 			<span className={ className }>
 				{ currencySymbol }
-				{ renderBasicPrice( smallerPrice, currencyCode, isSmallestUnit ) }
+				<PriceWithoutHtml
+					price={ smallerPrice }
+					currencyCode={ currencyCode }
+					isSmallestUnit={ isSmallestUnit }
+				/>
 			</span>
 		);
 	}
@@ -235,8 +247,20 @@ function FlatPriceDisplay( {
 			{ currencySymbol }
 			{ translate( '%(smallerPrice)s-%(higherPrice)s', {
 				args: {
-					smallerPrice: renderBasicPrice( smallerPrice, currencyCode, isSmallestUnit ),
-					higherPrice: renderBasicPrice( higherPrice, currencyCode, isSmallestUnit ),
+					smallerPrice: (
+						<PriceWithoutHtml
+							price={ smallerPrice }
+							currencyCode={ currencyCode }
+							isSmallestUnit={ isSmallestUnit }
+						/>
+					),
+					higherPrice: (
+						<PriceWithoutHtml
+							price={ higherPrice }
+							currencyCode={ currencyCode }
+							isSmallestUnit={ isSmallestUnit }
+						/>
+					),
 				},
 				comment: 'The price range for a particular product',
 			} ) }

--- a/client/my-sites/plan-price/index.tsx
+++ b/client/my-sites/plan-price/index.tsx
@@ -205,7 +205,7 @@ function PriceWithoutHtml( {
 	isSmallestUnit?: boolean;
 } ) {
 	const priceObj = getCurrencyObject( price, currencyCode, { isSmallestUnit } );
-	if ( ! Number.isInteger( price ) ) {
+	if ( priceObj.hasNonZeroFraction ) {
 		return <>{ `${ priceObj.integer }${ priceObj.fraction }` }</>;
 	}
 	return <>{ priceObj.integer }</>;
@@ -367,14 +367,15 @@ function HtmlPriceDisplay( {
 	is2023OnboardingPricingGrid?: boolean;
 	isSmallestUnit?: boolean;
 } ) {
-	const hasFraction = ! Number.isInteger( price );
 	const priceObj = getCurrencyObject( price, currencyCode, { isSmallestUnit } );
 
 	if ( is2023OnboardingPricingGrid ) {
 		return (
 			<div className="plan-price__integer-fraction">
 				<span className="plan-price__integer">{ priceObj.integer }</span>
-				<sup className="plan-price__fraction">{ hasFraction && priceObj.fraction }</sup>
+				<sup className="plan-price__fraction">
+					{ priceObj.hasNonZeroFraction && priceObj.fraction }
+				</sup>
 			</div>
 		);
 	}
@@ -382,7 +383,9 @@ function HtmlPriceDisplay( {
 	return (
 		<>
 			<span className="plan-price__integer">{ priceObj.integer }</span>
-			<sup className="plan-price__fraction">{ hasFraction && priceObj.fraction }</sup>
+			<sup className="plan-price__fraction">
+				{ priceObj.hasNonZeroFraction && priceObj.fraction }
+			</sup>
 		</>
 	);
 }

--- a/client/my-sites/plan-price/index.tsx
+++ b/client/my-sites/plan-price/index.tsx
@@ -11,6 +11,7 @@ export class PlanPrice extends Component< PlanPriceProps > {
 		const {
 			currencyCode = 'USD',
 			rawPrice,
+			isSmallestUnit,
 			original,
 			discounted,
 			className,
@@ -63,6 +64,7 @@ export class PlanPrice extends Component< PlanPriceProps > {
 					higherPrice={ rawPriceRange[ 1 ] }
 					currencyCode={ currencyCode }
 					className={ classes }
+					isSmallestUnit={ isSmallestUnit }
 				/>
 			);
 		}
@@ -78,6 +80,7 @@ export class PlanPrice extends Component< PlanPriceProps > {
 				displayPerMonthNotation={ displayPerMonthNotation }
 				isOnSale={ isOnSale }
 				is2023OnboardingPricingGrid={ is2023OnboardingPricingGrid }
+				isSmallestUnit={ isSmallestUnit }
 			/>
 		);
 	}
@@ -99,6 +102,14 @@ export interface PlanPriceProps {
 	 * it is an array, in which case `productDisplayPrice` will be ignored.
 	 */
 	rawPrice?: number | [ number, number ];
+
+	/**
+	 * If true, the number(s) in `rawPrice` will be interpreted as integers in
+	 * the currency's smallest unit rather than floating point numbers.
+	 *
+	 * Has no effect if `productDisplayPrice` is being used.
+	 */
+	isSmallestUnit?: boolean;
 
 	/**
 	 * Adds the `is-original` CSS class.
@@ -184,8 +195,8 @@ export interface PlanPriceProps {
 	is2023OnboardingPricingGrid?: boolean;
 }
 
-function renderBasicPrice( price: number, currencyCode: string ): string {
-	const priceObj = getCurrencyObject( price, currencyCode );
+function renderBasicPrice( price: number, currencyCode: string, isSmallestUnit?: boolean ): string {
+	const priceObj = getCurrencyObject( price, currencyCode, { isSmallestUnit } );
 	if ( ! Number.isInteger( price ) ) {
 		return `${ priceObj.integer }${ priceObj.fraction }`;
 	}
@@ -197,11 +208,13 @@ function FlatPriceDisplay( {
 	higherPrice,
 	currencyCode,
 	className,
+	isSmallestUnit,
 }: {
 	smallerPrice: number;
 	higherPrice?: number;
 	currencyCode: string;
 	className?: string;
+	isSmallestUnit?: boolean;
 } ) {
 	const { symbol: currencySymbol } = getCurrencyObject( smallerPrice, currencyCode );
 	const translate = useTranslate();
@@ -212,7 +225,7 @@ function FlatPriceDisplay( {
 		return (
 			<span className={ className }>
 				{ currencySymbol }
-				{ renderBasicPrice( smallerPrice, currencyCode ) }
+				{ renderBasicPrice( smallerPrice, currencyCode, isSmallestUnit ) }
 			</span>
 		);
 	}
@@ -222,8 +235,8 @@ function FlatPriceDisplay( {
 			{ currencySymbol }
 			{ translate( '%(smallerPrice)s-%(higherPrice)s', {
 				args: {
-					smallerPrice: renderBasicPrice( smallerPrice, currencyCode ),
-					higherPrice: renderBasicPrice( higherPrice, currencyCode ),
+					smallerPrice: renderBasicPrice( smallerPrice, currencyCode, isSmallestUnit ),
+					higherPrice: renderBasicPrice( higherPrice, currencyCode, isSmallestUnit ),
 				},
 				comment: 'The price range for a particular product',
 			} ) }
@@ -241,6 +254,7 @@ function MultiPriceDisplay( {
 	displayPerMonthNotation,
 	isOnSale,
 	is2023OnboardingPricingGrid,
+	isSmallestUnit,
 }: {
 	tagName: 'h4' | 'span';
 	className?: string;
@@ -251,6 +265,7 @@ function MultiPriceDisplay( {
 	displayPerMonthNotation?: boolean;
 	isOnSale?: boolean;
 	is2023OnboardingPricingGrid?: boolean;
+	isSmallestUnit?: boolean;
 } ) {
 	const { symbol: currencySymbol } = getCurrencyObject( smallerPrice, currencyCode );
 	const translate = useTranslate();
@@ -267,6 +282,7 @@ function MultiPriceDisplay( {
 					price={ smallerPrice }
 					currencyCode={ currencyCode }
 					is2023OnboardingPricingGrid={ is2023OnboardingPricingGrid }
+					isSmallestUnit={ isSmallestUnit }
 				/>
 			) }
 			{ higherPrice &&
@@ -277,6 +293,7 @@ function MultiPriceDisplay( {
 								price={ smallerPrice }
 								currencyCode={ currencyCode }
 								is2023OnboardingPricingGrid={ is2023OnboardingPricingGrid }
+								isSmallestUnit={ isSmallestUnit }
 							/>
 						),
 						higherPrice: (
@@ -284,6 +301,7 @@ function MultiPriceDisplay( {
 								price={ higherPrice }
 								currencyCode={ currencyCode }
 								is2023OnboardingPricingGrid={ is2023OnboardingPricingGrid }
+								isSmallestUnit={ isSmallestUnit }
 							/>
 						),
 					},
@@ -318,13 +336,15 @@ function HtmlPriceDisplay( {
 	price,
 	currencyCode,
 	is2023OnboardingPricingGrid,
+	isSmallestUnit,
 }: {
 	price: number;
 	currencyCode: string;
 	is2023OnboardingPricingGrid?: boolean;
+	isSmallestUnit?: boolean;
 } ) {
 	const hasFraction = ! Number.isInteger( price );
-	const priceObj = getCurrencyObject( price, currencyCode );
+	const priceObj = getCurrencyObject( price, currencyCode, { isSmallestUnit } );
 
 	if ( is2023OnboardingPricingGrid ) {
 		return (

--- a/client/my-sites/plan-price/test/index.js
+++ b/client/my-sites/plan-price/test/index.js
@@ -23,6 +23,14 @@ describe( 'PlanPrice', () => {
 		expect( screen.getByText( '.01' ) ).toBeInTheDocument();
 	} );
 
+	it( 'renders a rawPrice if isSmallestUnit is set', () => {
+		render( <PlanPrice rawPrice={ 5001 } isSmallestUnit /> );
+		expect( document.body ).toHaveTextContent( '$50.01' );
+		expect( screen.queryByText( '50.01' ) ).not.toBeInTheDocument();
+		expect( screen.getByText( '50' ) ).toBeInTheDocument();
+		expect( screen.getByText( '.01' ) ).toBeInTheDocument();
+	} );
+
 	it( 'renders a range of prices', () => {
 		render( <PlanPrice rawPrice={ [ 10, 50 ] } /> );
 		expect( document.body ).toHaveTextContent( '$10-50' );
@@ -138,6 +146,12 @@ describe( 'PlanPrice', () => {
 
 	it( 'renders a price without html when displayFlatPrice is set', () => {
 		render( <PlanPrice rawPrice={ 44700.5 } currencyCode="IDR" displayFlatPrice /> );
+		expect( document.body ).toHaveTextContent( 'Rp44,700.50' );
+		expect( screen.getByText( 'Rp44,700.50' ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders a price without html when displayFlatPrice and isSmallestUnit are set', () => {
+		render( <PlanPrice rawPrice={ 4470050 } currencyCode="IDR" isSmallestUnit displayFlatPrice /> );
 		expect( document.body ).toHaveTextContent( 'Rp44,700.50' );
 		expect( screen.getByText( 'Rp44,700.50' ) ).toBeInTheDocument();
 	} );

--- a/packages/format-currency/src/types.ts
+++ b/packages/format-currency/src/types.ts
@@ -70,4 +70,9 @@ export interface CurrencyObject {
 	 * include symbols like spaces, commas, or periods as the decimal separator.
 	 */
 	fraction: string;
+
+	/**
+	 * True if the formatted number has a non-0 decimal part.
+	 */
+	hasNonZeroFraction: boolean;
 }

--- a/packages/format-currency/test/index.ts
+++ b/packages/format-currency/test/index.ts
@@ -163,8 +163,10 @@ describe( 'formatCurrency', () => {
 				integer: '0',
 				fraction: '.00',
 				sign: '',
+				hasNonZeroFraction: false,
 			} );
 		} );
+
 		test( 'handles negative values', () => {
 			const money = getCurrencyObject( -1234.56789, 'USD' );
 			expect( money ).toEqual( {
@@ -173,8 +175,10 @@ describe( 'formatCurrency', () => {
 				integer: '1,234',
 				fraction: '.57',
 				sign: '-',
+				hasNonZeroFraction: true,
 			} );
 		} );
+
 		test( 'handles values that round up', () => {
 			const money = getCurrencyObject( 9.99876, 'USD' );
 			expect( money ).toEqual( {
@@ -183,8 +187,10 @@ describe( 'formatCurrency', () => {
 				integer: '10',
 				fraction: '.00',
 				sign: '',
+				hasNonZeroFraction: false,
 			} );
 		} );
+
 		test( 'handles values that round down', () => {
 			const money = getCurrencyObject( 9.99432, 'USD' );
 			expect( money ).toEqual( {
@@ -193,6 +199,7 @@ describe( 'formatCurrency', () => {
 				integer: '9',
 				fraction: '.99',
 				sign: '',
+				hasNonZeroFraction: true,
 			} );
 		} );
 
@@ -204,6 +211,7 @@ describe( 'formatCurrency', () => {
 				integer: '99',
 				fraction: '.32',
 				sign: '',
+				hasNonZeroFraction: true,
 			} );
 		} );
 
@@ -215,6 +223,7 @@ describe( 'formatCurrency', () => {
 				integer: '9,932',
 				fraction: '',
 				sign: '',
+				hasNonZeroFraction: false,
 			} );
 		} );
 
@@ -226,6 +235,7 @@ describe( 'formatCurrency', () => {
 				integer: '99',
 				fraction: '.32',
 				sign: '',
+				hasNonZeroFraction: true,
 			} );
 		} );
 
@@ -238,8 +248,10 @@ describe( 'formatCurrency', () => {
 					integer: '9,800,900',
 					fraction: '.32',
 					sign: '',
+					hasNonZeroFraction: true,
 				} );
 			} );
+
 			test( 'AUD', () => {
 				const money = getCurrencyObject( 9800900.32, 'AUD' );
 				expect( money ).toEqual( {
@@ -248,8 +260,10 @@ describe( 'formatCurrency', () => {
 					integer: '9,800,900',
 					fraction: '.32',
 					sign: '',
+					hasNonZeroFraction: true,
 				} );
 			} );
+
 			test( 'CAD', () => {
 				const money = getCurrencyObject( 9800900.32, 'CAD', { locale: 'en-US' } );
 				expect( money ).toEqual( {
@@ -258,8 +272,10 @@ describe( 'formatCurrency', () => {
 					integer: '9,800,900',
 					fraction: '.32',
 					sign: '',
+					hasNonZeroFraction: true,
 				} );
 			} );
+
 			test( 'EUR', () => {
 				const money = getCurrencyObject( 9800900.32, 'EUR', { locale: 'de-DE' } );
 				expect( money ).toEqual( {
@@ -268,8 +284,10 @@ describe( 'formatCurrency', () => {
 					integer: '9.800.900',
 					fraction: ',32',
 					sign: '',
+					hasNonZeroFraction: true,
 				} );
 			} );
+
 			test( 'GBP', () => {
 				const money = getCurrencyObject( 9800900.32, 'GBP' );
 				expect( money ).toEqual( {
@@ -278,8 +296,10 @@ describe( 'formatCurrency', () => {
 					integer: '9,800,900',
 					fraction: '.32',
 					sign: '',
+					hasNonZeroFraction: true,
 				} );
 			} );
+
 			test( 'JPY', () => {
 				const money = getCurrencyObject( 9800900.32, 'JPY' );
 				expect( money ).toEqual( {
@@ -288,8 +308,10 @@ describe( 'formatCurrency', () => {
 					integer: '9,800,900',
 					fraction: '',
 					sign: '',
+					hasNonZeroFraction: false,
 				} );
 			} );
+
 			test( 'BRL', () => {
 				const money = getCurrencyObject( 9800900.32, 'BRL', { locale: 'pt-BR' } );
 				expect( money ).toEqual( {
@@ -298,6 +320,7 @@ describe( 'formatCurrency', () => {
 					integer: '9.800.900',
 					fraction: ',32',
 					sign: '',
+					hasNonZeroFraction: true,
 				} );
 			} );
 		} );


### PR DESCRIPTION
#### Proposed Changes

This alters `PlanPrice` to support a `isSmallestUnit` prop. When set along with `rawPrice`, the number(s) provided will be treated as being integers in the currency's smallest unit rather than floats.

This will allow using `PlanPrice` to display integer prices retrieved from our payments system (eg: all prices from the shopping cart endpoint or the purchases page prices added in D97932-code and D97268-code).

In order for this to work, this PR also adds a new return value from `getCurrencyObject()` called `hasNonZeroFraction` which allows us to determine if the formatted price has a non-zero decimal part without needing to inspect strings.

Needed by https://github.com/Automattic/wp-calypso/pull/71952

#### Testing Instructions

Automated tests are included.

This PR should not have any actual user-facing effects on its own.