### PR TITLE
Fix solid white circle when reader "Automattic" section is selected

### DIFF
--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -590,10 +590,6 @@ $font-size: rem(14px);
 				&::after {
 					display: block;
 				}
-
-				.sidebar__menu-icon {
-					fill: var(--color-sidebar-menu-selected-text);
-				}
 			}
 		}
 	}


### PR DESCRIPTION
## Description

Minor bug fix for "Automattic" reader menu. Once selected, it's showing a solid white circle. This PR fixes the issue with no regressions that I can find.

### Before
<img width="275" alt="before" src="https://user-images.githubusercontent.com/5634774/212402612-e191dd66-3229-4868-870f-32e70cbf33c8.png">

### After
<img width="273" alt="after" src="https://user-images.githubusercontent.com/5634774/212402641-bfe417b7-8236-47ed-ba08-e4cb8d79b9bd.png">
