### PR TITLE
Launchpad: improve the domain step with focus

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
@@ -140,7 +140,7 @@ const Sidebar = ( { sidebarDomain, siteSlug, submit, goNext, goToStep, flow }: S
 						) }
 					</div>
 					{ sidebarDomain?.isWPCOMDomain && (
-						<a href={ `/domains/add/${ siteSlug }` }>
+						<a href={ `/domains/add/${ siteSlug }?is-launchpad-step=true` }>
 							<Badge className="launchpad__domain-upgrade-badge" type="info-blue">
 								{ translate( 'Customize' ) }
 							</Badge>

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -409,7 +409,7 @@ export default withCurrentRoute(
 			'plugins',
 			'comments',
 		].includes( sectionName );
-		const sidebarIsHidden = ! secondary || isWcMobileApp();
+		const sidebarIsHidden = ! secondary || isWcMobileApp() || currentQuery?.[ 'is-launchpad-step' ];
 		const chatIsDocked = ! [ 'reader', 'theme' ].includes( sectionName ) && ! sidebarIsHidden;
 
 		const userAllowedToHelpCenter =

--- a/client/my-sites/domains/domain-search/index.jsx
+++ b/client/my-sites/domains/domain-search/index.jsx
@@ -23,6 +23,7 @@ import {
 	updatePrivacyForDomain,
 } from 'calypso/lib/cart-values/cart-items';
 import { getSuggestionsVendor } from 'calypso/lib/domains/suggestions';
+import { getQueryArgs } from 'calypso/lib/query-args';
 import withCartKey from 'calypso/my-sites/checkout/with-cart-key';
 import NewDomainsRedirectionNoticeUpsell from 'calypso/my-sites/domains/domain-management/components/domain/new-domains-redirection-notice-upsell';
 import {
@@ -208,6 +209,10 @@ class DomainSearch extends Component {
 		const { domainRegistrationMaintenanceEndTime } = this.state;
 
 		const hasPlanInCart = hasPlan( cart );
+		// When the sidebar is hidden by launchpad, go back to Launchpad
+		const backButtonUrl = getQueryArgs()?.[ 'is-launchpad-step' ]
+			? 'javascript:history.back()'
+			: domainManagementList( selectedSiteSlug );
 
 		let content;
 
@@ -236,10 +241,7 @@ class DomainSearch extends Component {
 			content = (
 				<span>
 					<div className="domain-search__content">
-						<BackButton
-							className="domain-search__go-back"
-							href={ domainManagementList( selectedSiteSlug ) }
-						>
+						<BackButton className="domain-search__go-back" href={ backButtonUrl }>
 							<Gridicon icon="arrow-left" size={ 18 } />
 							{ translate( 'Back' ) }
 						</BackButton>


### PR DESCRIPTION
#### Proposed Changes

* hide the nav sidebar when doing the domains step

This works but I haven't tested it until the end of upgrading the domain, just wanted some feedback on the approach.

#### Testing Instructions

With an existing Launchpad-enabled site, visit Launchpad. Or create one ([Free](http://calypso.localhost:3000/setup/free/intro), [LIB](http://calypso.localhost:3000/setup/link-in-bio/intro), [Newsletter](http://calypso.localhost:3000/setup/newsletter/intro)).

1. In Launchpad, click "Customize" in domains.
2. You should see no nav sidebar
3. Clicking `<- Back` at the top should take you back to Launchpad

<img width="1276" alt="Screenshot 2023-01-13 at 16 16 24" src="https://user-images.githubusercontent.com/195089/212429566-a643cce2-57ae-4d5c-9d4c-12cccd739f52.png">

<img width="1273" alt="Screenshot 2023-01-13 at 16 17 10" src="https://user-images.githubusercontent.com/195089/212429563-69a28d3d-05bf-4f92-92e3-da5762177de2.png">




#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
