### PR TITLE
Update/add WooPay marketing email category settings

### DIFF
--- a/client/mailing-lists/main.jsx
+++ b/client/mailing-lists/main.jsx
@@ -114,6 +114,8 @@ class MainComponent extends Component {
 			return this.props.translate( 'Jetpack Reports' );
 		} else if ( 'akismet_marketing' === category ) {
 			return this.props.translate( 'Akismet Marketing' );
+		} else if ( 'woopay_marketing' === category ) {
+			return this.props.translate( 'WooPay Marketing' );
 		}
 
 		return category;
@@ -157,6 +159,8 @@ class MainComponent extends Component {
 			return this.props.translate(
 				'Relevant tips and new features to get the most out of Akismet'
 			);
+		} else if ( 'woopay_marketing' === category ) {
+			return this.props.translate( 'Tips for getting the most out of WooPay.' );
 		}
 
 		return null;


### PR DESCRIPTION
This PR is based on #54026.

#### Changes proposed in this Pull Request

This PR adds a new email category "WooPay Marketing" to the unsubscribe logic. This is a new category that is being introduced to help further segment email campaigns and manage list subscriptions. The related patch can be found here: D98074-code.

Translators:
"WooPay Marketing"
"Tips for getting the most out of WooPay."

#### Testing instructions

Check out this branch locally
Start your local install of Calypso with `yarn` and `yarn start`
Navigate to http://calypso.localhost:3000/mailing-lists/unsubscribe?category=woopay_marketing
You should see the relevant category name and description displayed
Note that you will see an unsubscribe error message until the related Phabricator patch is deployed

![Screenshot 2023-01-13 at 7 41 02 PM](https://user-images.githubusercontent.com/1693223/212432278-c57f46a1-bbf1-4a1b-bcbb-c0189871e88b.png)

This PR does not add a setting to /me/notifications/updates - WooPay users have a special suffix appended on their email address so they doesn't have directly Calypso access.
