### PR TITLE
E2E: discontinue the use of Editor frames where possible.

### DIFF
--- a/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
@@ -213,6 +213,17 @@ export class EditorToolbarComponent {
 	/* Publish and unpublish */
 
 	/**
+	 * Returns the text present for the save/publish button.
+	 *
+	 * @returns {Promise<string>} String found on the button.
+	 */
+	async getPublishButtonText(): Promise< string > {
+		const publishButtonLocator = this.editor.locator( selectors.publishButton( 'enabled' ) );
+
+		return await publishButtonLocator.innerText();
+	}
+
+	/**
 	 * Clicks on the primary button to publish the article.
 	 *
 	 * This is applicable for the following scenarios:

--- a/packages/calypso-e2e/src/lib/components/page-template-modal-component.ts
+++ b/packages/calypso-e2e/src/lib/components/page-template-modal-component.ts
@@ -1,4 +1,4 @@
-import { Frame, Page } from 'playwright';
+import { Locator, Page } from 'playwright';
 import { envVariables } from '../..';
 
 type TemplateCategory = 'About';
@@ -8,17 +8,17 @@ type TemplateCategory = 'About';
  */
 export class PageTemplateModalComponent {
 	private page: Page;
-	private editorFrame: Page | Frame;
+	private editorWindow: Locator;
 
 	/**
 	 * Creates an instance of the page.
 	 *
-	 * @param {Page | Frame} editorFrame Frame for the gutenberg editor.
 	 * @param {Page} page Object representing the base page.
+	 * @param {Locator} editorWindow Locator to the editor window.
 	 */
-	constructor( editorFrame: Page | Frame, page: Page ) {
+	constructor( page: Page, editorWindow: Locator ) {
 		this.page = page;
-		this.editorFrame = editorFrame;
+		this.editorWindow = editorWindow;
 	}
 
 	/**
@@ -28,12 +28,11 @@ export class PageTemplateModalComponent {
 	 */
 	async selectTemplateCategory( category: TemplateCategory ): Promise< void > {
 		if ( envVariables.VIEWPORT_NAME === 'mobile' ) {
-			await this.editorFrame.selectOption(
-				'.page-pattern-modal__mobile-category-dropdown',
-				category.toLowerCase()
-			);
+			await this.editorWindow
+				.locator( '.page-pattern-modal__mobile-category-dropdown' )
+				.selectOption( category.toLowerCase() );
 		} else {
-			await this.editorFrame.getByRole( 'menuitem', { name: category, exact: true } ).click();
+			await this.editorWindow.getByRole( 'menuitem', { name: category, exact: true } ).click();
 		}
 	}
 
@@ -43,13 +42,13 @@ export class PageTemplateModalComponent {
 	 * @param {string} label Label for the template (the string underneath the preview).
 	 */
 	async selectTemplate( label: string ): Promise< void > {
-		await this.editorFrame.getByRole( 'option', { name: label, exact: true } ).click();
+		await this.editorWindow.getByRole( 'option', { name: label, exact: true } ).click();
 	}
 
 	/**
 	 * Select a blank page as your template.
 	 */
 	async selectBlankPage(): Promise< void > {
-		await this.editorFrame.getByRole( 'button', { name: 'Blank page' } ).click();
+		await this.editorWindow.getByRole( 'button', { name: 'Blank page' } ).click();
 	}
 }

--- a/packages/calypso-e2e/src/lib/pages/editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/editor-page.ts
@@ -621,13 +621,10 @@ export class EditorPage {
 	async unpublish(): Promise< void > {
 		await this.editorToolbarComponent.switchToDraft();
 
-		const frame = await this.getEditorHandle();
 		// @TODO: eventually refactor this out to a ConfirmationDialogComponent.
-		await frame.click( `div[role="dialog"] button:has-text("OK")` );
+		await this.editor.getByRole( 'button' ).getByText( 'OK' ).click();
 		// @TODO: eventually refactor this out to a EditorToastNotificationComponent.
-		await frame.waitForSelector(
-			'.components-editor-notices__snackbar :has-text("Post reverted to draft.")'
-		);
+		await this.editor.getByRole( 'button', { name: 'Dismiss this notice' } ).waitFor();
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/pages/editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/editor-page.ts
@@ -159,7 +159,7 @@ export class EditorPage {
 	 *
 	 * @returns A pointer to frame-safe, top-level locator within the editor.
 	 */
-	getEditorLocator(): Locator {
+	getEditorWindowLocator(): Locator {
 		return this.editor;
 	}
 

--- a/packages/calypso-e2e/src/lib/pages/editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/editor-page.ts
@@ -564,7 +564,10 @@ export class EditorPage {
 	//#region Publish, Draft & Schedule
 
 	/**
-	 * Publishes the post or page.
+	 * Publishes the post or page and returns the resulting URL.
+	 *
+	 * If the optional parameter `visit` parameter is specified, the page is navigated
+	 * to the published article.
 	 *
 	 * @param {boolean} visit Whether to then visit the page.
 	 * @returns {URL} Published article's URL.

--- a/packages/calypso-e2e/src/lib/pages/editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/editor-page.ts
@@ -570,7 +570,7 @@ export class EditorPage {
 		// is merely being updated.
 		// If not yet published, a second click on the EditorPublishPanelComponent
 		// is added to the array of actions.
-		if ( publishButtonText.toLowerCase() === 'publish' ) {
+		if ( publishButtonText.toLowerCase() !== 'update' ) {
 			actionsArray.push( this.editorPublishPanelComponent.publish() );
 		}
 
@@ -628,6 +628,21 @@ export class EditorPage {
 		await this.editor.getByRole( 'button' ).getByText( 'OK' ).click();
 		// @TODO: eventually refactor this out to a EditorToastNotificationComponent.
 		await this.editor.getByRole( 'button', { name: 'Dismiss this notice' } ).waitFor();
+	}
+
+	/**
+	 * Obtains the published article's URL from the post-publish toast.
+	 *
+	 * This method is only able to obtain the published article's URL if the
+	 * post-publish toast is still visible on the page.
+	 *
+	 * @deprecated Please use the return value from `EditorPage.publish` where possible.
+	 * @returns {URL} Published article's URL.
+	 */
+	async getPublishedURLFromToast(): Promise< URL > {
+		const toastLocator = this.editor.locator( selectors.toastViewPostLink );
+		const publishedURL = ( await toastLocator.getAttribute( 'href' ) ) as string;
+		return new URL( publishedURL );
 	}
 
 	/**

--- a/packages/calypso-e2e/src/types/rest-api-client.types.ts
+++ b/packages/calypso-e2e/src/types/rest-api-client.types.ts
@@ -90,6 +90,12 @@ export interface NewSiteResponse {
 	};
 }
 
+export interface NewPostResponse {
+	body: {
+		link: string;
+	};
+}
+
 export interface SiteDeletionResponse {
 	ID: number;
 	name: string;

--- a/packages/calypso-e2e/src/types/rest-api-client.types.ts
+++ b/packages/calypso-e2e/src/types/rest-api-client.types.ts
@@ -90,12 +90,6 @@ export interface NewSiteResponse {
 	};
 }
 
-export interface NewPostResponse {
-	body: {
-		link: string;
-	};
-}
-
 export interface SiteDeletionResponse {
 	ID: number;
 	name: string;

--- a/test/e2e/specs/blocks/blocks__coblocks__extensions__cover-styles.ts
+++ b/test/e2e/specs/blocks/blocks__coblocks__extensions__cover-styles.ts
@@ -13,7 +13,7 @@ import {
 	getTestAccountByFeature,
 	envToFeatureKey,
 } from '@automattic/calypso-e2e';
-import { Page, Browser } from 'playwright';
+import { Page, Browser, Locator } from 'playwright';
 import { skipDescribeIf } from '../../jest-helpers';
 import { TEST_IMAGE_PATH } from '../constants';
 
@@ -31,6 +31,7 @@ skipDescribeIf( features.siteType === 'atomic' )(
 		let editorPage: EditorPage;
 		let imageFile: TestFile;
 		let coverBlock: CoverBlock;
+		let editorWindowLocator: Locator;
 
 		beforeAll( async () => {
 			page = await browser.newPage();
@@ -57,8 +58,8 @@ skipDescribeIf( features.siteType === 'atomic' )(
 			await coverBlock.upload( imageFile.fullpath );
 			// After uploading the image the focus is switched to the inner
 			// paragraph block (Cover title), so we need to switch it back outside.
-			const editorFrame = await editorPage.getEditorHandle();
-			await editorFrame.click( '.wp-block-cover', { position: { x: 1, y: 1 } } );
+			editorWindowLocator = editorPage.getEditorWindowLocator();
+			await editorWindowLocator.locator( '.wp-block-cover' ).click( { position: { x: 1, y: 1 } } );
 		} );
 
 		it( 'Open settings sidebar', async function () {
@@ -66,8 +67,7 @@ skipDescribeIf( features.siteType === 'atomic' )(
 		} );
 
 		it.each( CoverBlock.coverStyles )( 'Verify "%s" style is available', async ( style ) => {
-			const editorFrame = await editorPage.getEditorHandle();
-			await editorFrame.waitForSelector( `button[aria-label="${ style }"]` );
+			await editorWindowLocator.locator( `button[aria-label="${ style }"]` ).waitFor();
 		} );
 
 		it( 'Set "Bottom Wave" style', async () => {

--- a/test/e2e/specs/blocks/blocks__coblocks__extensions__gutter-control.ts
+++ b/test/e2e/specs/blocks/blocks__coblocks__extensions__gutter-control.ts
@@ -55,8 +55,8 @@ skipDescribeIf( features.siteType === 'atomic' )(
 		it.each( PricingTableBlock.gutterValues )(
 			'Verify "%s" gutter button is present',
 			async ( value ) => {
-				const editorFrame = await editorPage.getEditorHandle();
-				await editorFrame.waitForSelector( `button[aria-label="${ value }"]` );
+				const editorWindowLocator = editorPage.getEditorWindowLocator();
+				await editorWindowLocator.locator( `button[aria-label="${ value }"]` ).waitFor();
 			}
 		);
 

--- a/test/e2e/specs/blocks/blocks__coblocks__extensions__replace-image.ts
+++ b/test/e2e/specs/blocks/blocks__coblocks__extensions__replace-image.ts
@@ -59,12 +59,12 @@ skipDescribeIf( features.siteType === 'atomic' )(
 		} );
 
 		it( `Replace uploaded image`, async () => {
-			const editorFrame = await editorPage.getEditorHandle();
-			await editorFrame.click( 'button:text("Replace")' );
-			await editorFrame.setInputFiles(
-				'.components-form-file-upload input[type="file"]',
-				imageFile.fullpath
-			);
+			const editorWindowLocator = editorPage.getEditorWindowLocator();
+			await editorWindowLocator.locator( 'button:text("Replace")' ).click();
+			await editorWindowLocator
+				.locator( '.components-form-file-upload input[type="file"]' )
+				.setInputFiles( imageFile.fullpath );
+
 			await imageBlock.waitUntilUploaded();
 
 			const newImage = await imageBlock.getImage();

--- a/test/e2e/specs/blocks/shared/block-smoke-testing.ts
+++ b/test/e2e/specs/blocks/shared/block-smoke-testing.ts
@@ -58,7 +58,7 @@ export function createBlockTests( specName: string, blockFlows: BlockFlow[] ): v
 					editorContext = {
 						page: page,
 						editorPage: editorPage,
-						editorLocator: editorPage.getEditorLocator(),
+						editorLocator: editorPage.getEditorWindowLocator(),
 					};
 				} );
 

--- a/test/e2e/specs/editor-tracking/editor-tracking__block-inserted-event.ts
+++ b/test/e2e/specs/editor-tracking/editor-tracking__block-inserted-event.ts
@@ -159,8 +159,12 @@ describe(
 
 			describe( 'From adding a page template', function () {
 				it( 'Add "Two column about me layout" page template', async function () {
-					const editorFrame = await editorPage.getEditorHandle();
-					const pageTemplateModalComponent = new PageTemplateModalComponent( editorFrame, page );
+					// @TODO Consider moving this to EditorPage.
+					const editorWindowLocator = editorPage.getEditorWindowLocator();
+					const pageTemplateModalComponent = new PageTemplateModalComponent(
+						page,
+						editorWindowLocator
+					);
 					await pageTemplateModalComponent.selectTemplateCategory( 'About' );
 					await pageTemplateModalComponent.selectTemplate( 'Two column about me layout' );
 				} );

--- a/test/e2e/specs/editor-tracking/editor-tracking__pattern-events.ts
+++ b/test/e2e/specs/editor-tracking/editor-tracking__pattern-events.ts
@@ -43,8 +43,12 @@ describe( DataHelper.createSuiteTitle( 'Editor tracking: Pattern-related events'
 		} );
 
 		it( 'Select blank template from modal', async function () {
-			const editorFrame = await editorPage.getEditorHandle();
-			const pageTemplateModalComponent = new PageTemplateModalComponent( editorFrame, page );
+			// @TODO Consider moving this to EditorPage.
+			const editorWindowLocator = editorPage.getEditorWindowLocator();
+			const pageTemplateModalComponent = new PageTemplateModalComponent(
+				page,
+				editorWindowLocator
+			);
 			await pageTemplateModalComponent.selectBlankPage();
 		} );
 

--- a/test/e2e/specs/editor/editor__page-basic-flow.ts
+++ b/test/e2e/specs/editor/editor__page-basic-flow.ts
@@ -70,8 +70,8 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 
 	it( 'Template content loads into editor', async function () {
 		// @TODO Consider moving this to EditorPage.
-		const editorIframe = await editorPage.getEditorHandle();
-		await editorIframe.waitForSelector( `h1:text-is("About Me")` );
+		const editorWindowLocator = editorPage.getEditorWindowLocator();
+		await editorWindowLocator.locator( `h1:text-is("About Me")` ).waitFor();
 	} );
 
 	it( 'Open setting sidebar', async function () {

--- a/test/e2e/specs/editor/editor__page-basic-flow.ts
+++ b/test/e2e/specs/editor/editor__page-basic-flow.ts
@@ -61,8 +61,8 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 		editorPage = new EditorPage( page, { target: features.siteType } );
 		await editorPage.waitUntilLoaded();
 
-		const editorIframe = await editorPage.getEditorHandle();
-		const pageTemplateModalComponent = new PageTemplateModalComponent( editorIframe, page );
+		const editorWindowLocator = editorPage.getEditorWindowLocator();
+		const pageTemplateModalComponent = new PageTemplateModalComponent( page, editorWindowLocator );
 
 		await pageTemplateModalComponent.selectTemplateCategory( 'About' );
 		await pageTemplateModalComponent.selectTemplate( 'About me' );

--- a/test/e2e/specs/editor/editor__post-advanced-flow.ts
+++ b/test/e2e/specs/editor/editor__post-advanced-flow.ts
@@ -46,9 +46,12 @@ describe( DataHelper.createSuiteTitle( `Editor: Advanced Post Flow` ), function 
 		await postsPage.newPost();
 	} );
 
+	beforeAll( async function () {
+		editorPage = new EditorPage( page, { target: features.siteType } );
+	} );
+
 	describe( 'Publish post', function () {
 		it( 'Enter post title', async function () {
-			editorPage = new EditorPage( page, { target: features.siteType } );
 			await editorPage.enterTitle( postTitle );
 		} );
 
@@ -88,7 +91,6 @@ describe( DataHelper.createSuiteTitle( `Editor: Advanced Post Flow` ), function 
 		} );
 
 		it( 'Editor is shown', async function () {
-			editorPage = new EditorPage( page, { target: features.siteType } );
 			await editorPage.waitUntilLoaded();
 		} );
 

--- a/test/e2e/specs/editor/shared/privacy-testing.ts
+++ b/test/e2e/specs/editor/shared/privacy-testing.ts
@@ -48,11 +48,16 @@ export function createPrivacyTests( { visibility }: { visibility: ArticlePrivacy
 			} );
 
 			it( 'Start new page', async function () {
+				// @TODO Consider moving this to EditorPage.
 				editorPage = new EditorPage( page, { target: features.siteType } );
 				await editorPage.visit( 'page' );
 				await editorPage.waitUntilLoaded();
-				const editorIframe = await editorPage.getEditorHandle();
-				const pageTemplateModalComponent = new PageTemplateModalComponent( editorIframe, page );
+
+				const editorWindowLocator = editorPage.getEditorWindowLocator();
+				const pageTemplateModalComponent = new PageTemplateModalComponent(
+					page,
+					editorWindowLocator
+				);
 				await pageTemplateModalComponent.selectBlankPage();
 			} );
 

--- a/test/e2e/specs/editor/shared/privacy-testing.ts
+++ b/test/e2e/specs/editor/shared/privacy-testing.ts
@@ -79,10 +79,14 @@ export function createPrivacyTests( { visibility }: { visibility: ArticlePrivacy
 			} );
 
 			it( 'Publish page', async function () {
-				// Note, private articles are published immediately when the option is
-				// selected. In other words, the publish action and call to API
-				// occurs as soon as the Private radio button is clicked.
-				url = await editorPage.publish();
+				// Private articles are published immediately as the option is
+				// selected. In other words, for Private articles the publish
+				// action happened in previous step.
+				if ( visibility === 'Private' ) {
+					url = await editorPage.getPublishedURLFromToast();
+				} else {
+					url = await editorPage.publish();
+				}
 			} );
 
 			it( `View published page`, async function () {

--- a/test/e2e/specs/editor/shared/privacy-testing.ts
+++ b/test/e2e/specs/editor/shared/privacy-testing.ts
@@ -79,14 +79,10 @@ export function createPrivacyTests( { visibility }: { visibility: ArticlePrivacy
 			} );
 
 			it( 'Publish page', async function () {
-				// Private articles are published immediately as the option is
-				// selected. In other words, for Private articles the publish
-				// action happened in previous step.
-				if ( visibility === 'Private' ) {
-					url = await editorPage.getPublishedURLFromToast();
-				} else {
-					url = await editorPage.publish();
-				}
+				// Note, private articles are published immediately when the option is
+				// selected. In other words, the publish action and call to API
+				// occurs as soon as the Private radio button is clicked.
+				url = await editorPage.publish();
 			} );
 
 			it( `View published page`, async function () {

--- a/test/e2e/specs/i18n/i18n__editor.ts
+++ b/test/e2e/specs/i18n/i18n__editor.ts
@@ -10,7 +10,7 @@ import {
 	envToFeatureKey,
 	RestAPIClient,
 } from '@automattic/calypso-e2e';
-import { Page, Frame, Browser } from 'playwright';
+import { Page, Browser, Locator } from 'playwright';
 import type { LanguageSlug } from '@automattic/languages';
 
 type Translations = {
@@ -292,9 +292,9 @@ describe( 'I18N: Editor', function () {
 
 				await editorPage.openEditorOptionsMenu();
 				await editorWindowLocator.locator( etkTranslations.welcomeGuide.openGuideSelector ).click();
-				await editorWindowLocator.locator(
-					etkTranslations.welcomeGuide.welcomeTitleSelector
-				).waitFor;
+				await editorWindowLocator
+					.locator( etkTranslations.welcomeGuide.welcomeTitleSelector )
+					.waitFor();
 				await editorWindowLocator
 					.locator( etkTranslations.welcomeGuide.closeButtonSelector )
 					.click();
@@ -307,7 +307,7 @@ describe( 'I18N: Editor', function () {
 			'Translations for block: $blockName',
 			( ...args ) => {
 				const block = args[ 0 ]; // Makes TS stop complaining about incompatible args type
-				let frame: Page | Frame;
+				let editorWindowLocator: Locator;
 				let editorPage: EditorPage;
 
 				it( 'Insert test block', async function () {
@@ -316,7 +316,7 @@ describe( 'I18N: Editor', function () {
 				} );
 
 				it( 'Render block content translations', async function () {
-					const editorWindowLocator = editorPage.getEditorWindowLocator();
+					editorWindowLocator = editorPage.getEditorWindowLocator();
 					// Ensure block contents are translated as expected.
 					await Promise.all(
 						block.blockEditorContent.map( ( content ) =>
@@ -327,24 +327,32 @@ describe( 'I18N: Editor', function () {
 
 				it( 'Render block title translations', async function () {
 					await editorPage.openSettings();
-					await frame.click( block.blockEditorSelector );
+					await editorWindowLocator.locator( block.blockEditorSelector ).click();
 
 					// Ensure the block is highlighted.
-					await frame.waitForSelector(
-						`:is( ${ block.blockEditorSelector }.is-selected, ${ block.blockEditorSelector }.has-child-selected)`
-					);
+					await editorWindowLocator
+						.locator(
+							`:is( ${ block.blockEditorSelector }.is-selected, ${ block.blockEditorSelector }.has-child-selected)`
+						)
+						.click();
 
 					// If on block insertion, one of the sub-blocks are selected, click on
 					// the first button in the floating toolbar which selects the overall
 					// block.
-					if ( await frame.isVisible( '.block-editor-block-parent-selector__button' ) ) {
-						await frame.click( '.block-editor-block-parent-selector__button' );
+					if (
+						await editorWindowLocator
+							.locator( '.block-editor-block-parent-selector__button:visible' )
+							.count()
+					) {
+						await editorWindowLocator
+							.locator( '.block-editor-block-parent-selector__button' )
+							.click();
 					}
 
 					// Ensure the Settings with the block selected shows the expected title.
-					await frame.waitForSelector(
-						`.block-editor-block-card__title:has-text("${ block.blockPanelTitle }")`
-					);
+					await editorWindowLocator
+						.locator( `.block-editor-block-card__title:has-text("${ block.blockPanelTitle }")` )
+						.waitFor();
 				} );
 			}
 		);

--- a/test/e2e/specs/i18n/i18n__editor.ts
+++ b/test/e2e/specs/i18n/i18n__editor.ts
@@ -318,9 +318,14 @@ describe( 'I18N: Editor', function () {
 				it( 'Render block content translations', async function () {
 					editorWindowLocator = editorPage.getEditorWindowLocator();
 					// Ensure block contents are translated as expected.
+					// To deal with multiple potential matches (eg. Jetpack/Business Hours > Add Hours)
+					// the first locator is matched.
 					await Promise.all(
 						block.blockEditorContent.map( ( content ) =>
-							editorWindowLocator.locator( `${ block.blockEditorSelector } ${ content }` ).waitFor()
+							editorWindowLocator
+								.locator( `${ block.blockEditorSelector } ${ content }` )
+								.first()
+								.waitFor()
 						)
 					);
 				} );

--- a/test/e2e/specs/i18n/i18n__editor.ts
+++ b/test/e2e/specs/i18n/i18n__editor.ts
@@ -284,15 +284,20 @@ describe( 'I18N: Editor', function () {
 			} );
 
 			it( 'Translations for Welcome Guide', async function () {
-				const frame = await editorPage.getEditorHandle();
+				const editorWindowLocator = editorPage.getEditorWindowLocator();
+
 				// We know these are all defined because of the filtering above. Non-null asserting is safe here.
 				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 				const etkTranslations = translations[ locale ]!.etkPlugin!;
 
 				await editorPage.openEditorOptionsMenu();
-				await frame.locator( etkTranslations.welcomeGuide.openGuideSelector ).click();
-				await frame.waitForSelector( etkTranslations.welcomeGuide.welcomeTitleSelector );
-				await frame.locator( etkTranslations.welcomeGuide.closeButtonSelector ).click();
+				await editorWindowLocator.locator( etkTranslations.welcomeGuide.openGuideSelector ).click();
+				await editorWindowLocator.locator(
+					etkTranslations.welcomeGuide.welcomeTitleSelector
+				).waitFor;
+				await editorWindowLocator
+					.locator( etkTranslations.welcomeGuide.closeButtonSelector )
+					.click();
 			} );
 		} );
 
@@ -311,11 +316,11 @@ describe( 'I18N: Editor', function () {
 				} );
 
 				it( 'Render block content translations', async function () {
-					frame = await editorPage.getEditorHandle();
+					const editorWindowLocator = editorPage.getEditorWindowLocator();
 					// Ensure block contents are translated as expected.
 					await Promise.all(
 						block.blockEditorContent.map( ( content ) =>
-							frame.waitForSelector( `${ block.blockEditorSelector } ${ content }` )
+							editorWindowLocator.locator( `${ block.blockEditorSelector } ${ content }` ).waitFor()
 						)
 					);
 				} );

--- a/test/e2e/specs/infrastructure/infrastructure__experimental-gutenberg.ts
+++ b/test/e2e/specs/infrastructure/infrastructure__experimental-gutenberg.ts
@@ -42,14 +42,17 @@ describe( DataHelper.createSuiteTitle( 'Gutenberg: Experimental Features' ), fun
 	] )(
 		'Experimental package %s and feature %s are available',
 		async function ( packageName, feature, featureType ) {
-			const frame = await editorPage.getEditorHandle();
-			const packageAvailable = await frame.evaluate( `typeof window[ "wp" ]["${ packageName }"]` );
+			const editorWindowLocator = editorPage.getEditorWindowLocator();
+
+			const packageAvailable = await editorWindowLocator.evaluate(
+				`typeof window[ "wp" ]["${ packageName }"]`
+			);
 
 			expect( packageAvailable ).not.toStrictEqual( 'undefined' );
 			// It should always be an object.
 			expect( packageAvailable ).toStrictEqual( 'object' );
 
-			const featureAvailable = await frame.evaluate(
+			const featureAvailable = await editorWindowLocator.evaluate(
 				`typeof window[ "wp" ]["${ packageName }"]["${ feature }"]`
 			);
 			expect( featureAvailable ).not.toStrictEqual( 'undefined' );
@@ -59,8 +62,8 @@ describe( DataHelper.createSuiteTitle( 'Gutenberg: Experimental Features' ), fun
 	);
 
 	it( 'Experimental data is available', async function () {
-		const frame = await editorPage.getEditorHandle();
-		const blockPatterns = await frame.evaluate(
+		const editorWindowLocator = editorPage.getEditorWindowLocator();
+		const blockPatterns = await editorWindowLocator.evaluate(
 			`Array.isArray( window.wp.data.select( 'core/editor' ).getEditorSettings().__experimentalBlockPatterns )`
 		);
 		// If this test fails, please contact #team-ganon to update premium pattern highlighting.
@@ -79,8 +82,8 @@ describe( DataHelper.createSuiteTitle( 'Gutenberg: Experimental Features' ), fun
 		// patterns will be added than removed. This also means if we see a dramatic
 		// change in the number to the lower end, then something is probably wrong.
 		const expectedBlockPatternCount = 50;
-		const frame = await editorPage.getEditorHandle();
-		const actualBlockPatternCount = await frame.evaluate(
+		const editorWindowLocator = editorPage.getEditorWindowLocator();
+		const actualBlockPatternCount = await editorWindowLocator.evaluate(
 			() =>
 				/* eslint-disable @typescript-eslint/ban-ts-comment */
 				new Promise( ( resolve ) => {


### PR DESCRIPTION
#### Proposed Changes

This PR refactors out the usage of the `getEditorHandle` method from specs where possible and feasible.

Context for this change: p1673294397010529-slack-CBTN58FTJ and p1673397395255099-slack-C1A1EKDGQ

In short:
Gutenberg 14.9.1 introduces a nested iframe for the editor canvas if a block-based theme is used (eg. Twenty-Twenty Two). This means that our current way of interacting with the editor using `EditorPage` is no longer workable if such themes are used.

We are currently bypassing the issue entirely by using an older, non-block-based theme (eg. Twenty-Twenty One) but this is unsustainable in the longer term.

This PR is part of a series in an attempt to update the `EditorPage` to work with both non-block-based and block-based themes. 

Key changes:
- rename the locator method to `getEditorWindowLocator`.
- discontinue usage of editor frame in favor of locators.

#### Testing Instructions

Ensure the following build configurations are passing:
  - [x] Gutenberg E2E (desktop)
  - [x] Calypso E2E (desktop)
  - [x] i18n E2E

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #