### PR TITLE
Plugin Details: Update the plugin pre-installed check to also verify the plan

### DIFF
--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -146,7 +146,7 @@ const PluginDetailsCTA = ( { plugin, isPlaceholder } ) => {
 			<div className="plugin-details-cta__container">
 				<div className="plugin-details-cta__price">{ translate( 'Free' ) }</div>
 				<span className="plugin-details-cta__preinstalled">
-					{ selectedSite
+					{ selectedSite && shouldUpgrade
 						? translate(
 								'%s is automatically managed for you. Upgrade your plan and get access to another 50,000 WordPress plugins to extend functionality for your site.',
 								{ args: plugin.name }
@@ -154,7 +154,7 @@ const PluginDetailsCTA = ( { plugin, isPlaceholder } ) => {
 						: translate( '%s is automatically managed for you.', { args: plugin.name } ) }
 				</span>
 
-				{ selectedSite && (
+				{ selectedSite && shouldUpgrade && (
 					<Button
 						href={ upgradeToBusinessHref }
 						className="plugin-details-cta__install-button"


### PR DESCRIPTION
#### Proposed Changes

Update the verification to also verify if the site plan needs to be upgraded.

#### Testing Instructions
* With a lower than business plan, go to a preinstalled plugin page. Ex: `/plugins/gutenberg/:site`
* Check if the `Upgrade my plan` CTA and an upgrade text is shown.
* Upgrade your site to business plan and go back to the plugin details page
* Check if the upgrade CTA is not shown anymore and the only text shown is "*plugin* is automatically managed for you."

| Lower than Business   | Business and higher |
| ------------- | ------------- |
|<img width="994" alt="Screen Shot 2023-01-13 at 20 37 11" src="https://user-images.githubusercontent.com/5039531/212441807-7f4adbd7-f725-4c6d-bdeb-0b1d1f8a8eb7.png">|<img width="994" alt="Screen Shot 2023-01-13 at 20 36 55" src="https://user-images.githubusercontent.com/5039531/212441822-6fb82bad-fd26-421d-aa51-75190c5301d3.png">|

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #71614
