### PR TITLE
Pricing: Add conditional logic to format symbol position correctly in PlanPrice

### DIFF
--- a/client/my-sites/plan-price/index.tsx
+++ b/client/my-sites/plan-price/index.tsx
@@ -231,7 +231,10 @@ function FlatPriceDisplay( {
 	className?: string;
 	isSmallestUnit?: boolean;
 } ) {
-	const { symbol: currencySymbol } = getCurrencyObject( smallerPrice, currencyCode );
+	const { symbol: currencySymbol, symbolPosition } = getCurrencyObject(
+		smallerPrice,
+		currencyCode
+	);
 	const translate = useTranslate();
 
 	// TODO: render currencySymbol on the localized side (before or after) of
@@ -239,12 +242,13 @@ function FlatPriceDisplay( {
 	if ( ! higherPrice ) {
 		return (
 			<span className={ className }>
-				{ currencySymbol }
+				{ symbolPosition === 'before' ? currencySymbol : null }
 				<PriceWithoutHtml
 					price={ smallerPrice }
 					currencyCode={ currencyCode }
 					isSmallestUnit={ isSmallestUnit }
 				/>
+				{ symbolPosition === 'after' ? currencySymbol : null }
 			</span>
 		);
 	}
@@ -298,16 +302,21 @@ function MultiPriceDisplay( {
 	is2023OnboardingPricingGrid?: boolean;
 	isSmallestUnit?: boolean;
 } ) {
-	const { symbol: currencySymbol } = getCurrencyObject( smallerPrice, currencyCode );
+	const { symbol: currencySymbol, symbolPosition } = getCurrencyObject(
+		smallerPrice,
+		currencyCode
+	);
 	const translate = useTranslate();
-
 	// TODO: render currencySymbol on the localized side (before or after) of
 	// the price. We can use `symbolPosition` from `getCurrencyObject`.
 	return createElement(
 		tagName,
 		{ className },
 		<>
-			<sup className="plan-price__currency-symbol">{ currencySymbol }</sup>
+			{ symbolPosition === 'before' ? (
+				<sup className="plan-price__currency-symbol">{ currencySymbol }</sup>
+			) : null }
+
 			{ ! higherPrice && (
 				<HtmlPriceDisplay
 					price={ smallerPrice }
@@ -338,6 +347,11 @@ function MultiPriceDisplay( {
 					},
 					comment: 'The price range for a particular product',
 				} ) }
+
+			{ symbolPosition === 'after' ? (
+				<sup className="plan-price__currency-symbol">{ currencySymbol }</sup>
+			) : null }
+
 			{ taxText && (
 				<sup className="plan-price__tax-amount">
 					{ translate( '(+%(taxText)s tax)', { args: { taxText } } ) }

--- a/client/my-sites/plan-price/index.tsx
+++ b/client/my-sites/plan-price/index.tsx
@@ -237,8 +237,6 @@ function FlatPriceDisplay( {
 	);
 	const translate = useTranslate();
 
-	// TODO: render currencySymbol on the localized side (before or after) of
-	// the price. We can use `symbolPosition` from `getCurrencyObject`.
 	if ( ! higherPrice ) {
 		return (
 			<span className={ className }>
@@ -255,7 +253,7 @@ function FlatPriceDisplay( {
 
 	return (
 		<span className={ className }>
-			{ currencySymbol }
+			{ symbolPosition === 'before' ? currencySymbol : null }
 			{ translate( '%(smallerPrice)s-%(higherPrice)s', {
 				args: {
 					smallerPrice: (
@@ -275,6 +273,7 @@ function FlatPriceDisplay( {
 				},
 				comment: 'The price range for a particular product',
 			} ) }
+			{ symbolPosition === 'after' ? currencySymbol : null }
 		</span>
 	);
 }
@@ -307,8 +306,7 @@ function MultiPriceDisplay( {
 		currencyCode
 	);
 	const translate = useTranslate();
-	// TODO: render currencySymbol on the localized side (before or after) of
-	// the price. We can use `symbolPosition` from `getCurrencyObject`.
+
 	return createElement(
 		tagName,
 		{ className },

--- a/client/my-sites/plan-price/test/index.tsx
+++ b/client/my-sites/plan-price/test/index.tsx
@@ -1,10 +1,16 @@
 /**
  * @jest-environment jsdom
  */
+import { setDefaultLocale } from '@automattic/format-currency';
 import { render, screen } from '@testing-library/react';
+import React from 'react';
 import PlanPrice from '../index';
 
 describe( 'PlanPrice', () => {
+	beforeEach( () => {
+		setDefaultLocale( 'en-US' );
+	} );
+
 	it( 'renders a zero when rawPrice is passed a "0"', () => {
 		render( <PlanPrice rawPrice={ 0 } /> );
 		expect( document.body ).toHaveTextContent( '$0' );
@@ -314,5 +320,17 @@ describe( 'PlanPrice', () => {
 		render( <PlanPrice rawPrice={ 44700.5 } currencyCode="IDR" isLargeCurrency={ true } /> );
 		expect( document.body ).toHaveTextContent( 'Rp44,700.50' );
 		expect( document.querySelector( '.is-large-currency' ) ).toBeTruthy();
+	} );
+
+	it( 'renders the symbol to the left of the integer when symbolPosition is "before"', () => {
+		setDefaultLocale( 'en-US' );
+		render( <PlanPrice rawPrice={ 48 } currencyCode="CAD" /> );
+		expect( document.body ).toHaveTextContent( 'C$48' );
+	} );
+
+	it( 'renders the symbol to the right of the integer when symbolPosition is "after"', () => {
+		setDefaultLocale( 'fr-CA' );
+		render( <PlanPrice rawPrice={ 48 } currencyCode="CAD" /> );
+		expect( document.body ).toHaveTextContent( '48C$' );
 	} );
 } );


### PR DESCRIPTION
#### Proposed Changes

This PR adds logic to use the `symbolPosition` provided by `getCurrencyObject()` to left or right align the currency symbol correctly for `<PlanPrice>`.

#### Testing Instructions
**Left aligned symbols**
* Go to /me/account and change **Interface Language** to English
* Go to any page that uses the <PlanPrice> component, i.e. plans, purchase management etc
* Currency symbol should be left aligned 

**Right aligned symbols**
* Go to /me/account and change **Interface Language** to French Canadian
* Go to any page that uses the <PlanPrice> component, i.e. plans, purchase management etc
* Currency symbol should be right aligned 


Fixes https://github.com/Automattic/wp-calypso/issues/72115
