### PR TITLE
Launchpad: Fix flow progress bar 

### DIFF
--- a/client/landing/stepper/declarative-flow/free.ts
+++ b/client/landing/stepper/declarative-flow/free.ts
@@ -20,6 +20,7 @@ import DesignSetup from './internals/steps-repository/design-setup';
 import FreeSetup from './internals/steps-repository/free-setup';
 import Intro from './internals/steps-repository/intro';
 import LaunchPad from './internals/steps-repository/launchpad';
+import { launchpadFlowTasks } from './internals/steps-repository/launchpad/tasks';
 import Processing from './internals/steps-repository/processing-step';
 import SiteCreationStep from './internals/steps-repository/site-creation-step';
 import type { Flow, ProvidedDependencies } from './internals/types';
@@ -54,7 +55,12 @@ const free: Flow = {
 	useStepNavigation( _currentStep, navigate ) {
 		const flowName = this.name;
 		const { setStepProgress } = useDispatch( ONBOARD_STORE );
-		const flowProgress = useFlowProgress( { stepName: _currentStep, flowName } );
+		const flowProgress = useFlowProgress( {
+			stepName: _currentStep,
+			flowName,
+			launchpadTasks: launchpadFlowTasks[ flowName ],
+		} );
+
 		setStepProgress( flowProgress );
 		const siteSlug = useSiteSlug();
 		const userIsLoggedIn = useSelect( ( select ) => select( USER_STORE ).isCurrentUserLoggedIn() );

--- a/client/landing/stepper/declarative-flow/link-in-bio-tld.ts
+++ b/client/landing/stepper/declarative-flow/link-in-bio-tld.ts
@@ -17,6 +17,7 @@ import { USER_STORE, ONBOARD_STORE } from '../stores';
 import { recordSubmitStep } from './internals/analytics/record-submit-step';
 import DomainsStep from './internals/steps-repository/domains';
 import LaunchPad from './internals/steps-repository/launchpad';
+import { launchpadFlowTasks } from './internals/steps-repository/launchpad/tasks';
 import LinkInBioSetup from './internals/steps-repository/link-in-bio-setup';
 import PatternsStep from './internals/steps-repository/patterns';
 import PlansStep from './internals/steps-repository/plans';
@@ -49,7 +50,11 @@ const linkInBio: Flow = {
 	useStepNavigation( _currentStepSlug, navigate ) {
 		const flowName = this.name;
 		const { setStepProgress } = useDispatch( ONBOARD_STORE );
-		const flowProgress = useFlowProgress( { stepName: _currentStepSlug, flowName } );
+		const flowProgress = useFlowProgress( {
+			stepName: _currentStepSlug,
+			flowName,
+			launchpadTasks: launchpadFlowTasks[ flowName ],
+		} );
 		const siteSlug = useSiteSlug();
 		const userIsLoggedIn = useSelect( ( select ) => select( USER_STORE ).isCurrentUserLoggedIn() );
 		const locale = useLocale();

--- a/client/landing/stepper/declarative-flow/link-in-bio.ts
+++ b/client/landing/stepper/declarative-flow/link-in-bio.ts
@@ -18,6 +18,7 @@ import { recordSubmitStep } from './internals/analytics/record-submit-step';
 import DomainsStep from './internals/steps-repository/domains';
 import Intro from './internals/steps-repository/intro';
 import LaunchPad from './internals/steps-repository/launchpad';
+import { launchpadFlowTasks } from './internals/steps-repository/launchpad/tasks';
 import LinkInBioSetup from './internals/steps-repository/link-in-bio-setup';
 import PatternsStep from './internals/steps-repository/patterns';
 import PlansStep from './internals/steps-repository/plans';
@@ -51,7 +52,11 @@ const linkInBio: Flow = {
 	useStepNavigation( _currentStepSlug, navigate ) {
 		const flowName = this.name;
 		const { setStepProgress } = useDispatch( ONBOARD_STORE );
-		const flowProgress = useFlowProgress( { stepName: _currentStepSlug, flowName } );
+		const flowProgress = useFlowProgress( {
+			stepName: _currentStepSlug,
+			flowName,
+			launchpadTasks: launchpadFlowTasks[ flowName ],
+		} );
 		const siteSlug = useSiteSlug();
 		const userIsLoggedIn = useSelect( ( select ) => select( USER_STORE ).isCurrentUserLoggedIn() );
 		const locale = useLocale();

--- a/client/landing/stepper/declarative-flow/newsletter.ts
+++ b/client/landing/stepper/declarative-flow/newsletter.ts
@@ -11,6 +11,7 @@ import { ONBOARD_STORE, USER_STORE } from '../stores';
 import { recordSubmitStep } from './internals/analytics/record-submit-step';
 import Intro from './internals/steps-repository/intro';
 import Launchpad from './internals/steps-repository/launchpad';
+import { launchpadFlowTasks } from './internals/steps-repository/launchpad/tasks';
 import NewsletterSetup from './internals/steps-repository/newsletter-setup';
 import Subscribers from './internals/steps-repository/subscribers';
 import { ProvidedDependencies } from './internals/types';
@@ -43,6 +44,7 @@ const newsletter: Flow = {
 		const flowProgress = useFlowProgress( {
 			stepName: _currentStep,
 			flowName,
+			launchpadTasks: launchpadFlowTasks[ flowName ],
 		} );
 		setStepProgress( flowProgress );
 		const locale = useLocale();

--- a/packages/onboarding/src/flow-progress/use-flow-progress.ts
+++ b/packages/onboarding/src/flow-progress/use-flow-progress.ts
@@ -10,6 +10,7 @@ import {
 interface FlowProgress {
 	stepName?: string;
 	flowName?: string;
+	launchpadTasks?: string[];
 }
 
 const flows: Record< string, { [ step: string ]: number } > = {
@@ -76,17 +77,24 @@ const flows: Record< string, { [ step: string ]: number } > = {
 	},
 };
 
-export const useFlowProgress = ( { stepName, flowName }: FlowProgress = {} ) => {
+export const useFlowProgress = ( {
+	stepName,
+	flowName,
+	launchpadTasks = [],
+}: FlowProgress = {} ) => {
 	if ( ! stepName || ! flowName ) {
 		return;
 	}
 
 	const flow = flows[ flowName ];
+	const flowCount = Math.max( ...Object.values( flow ) );
+	const tasksCount = launchpadTasks.length;
+	const totalCount = flowCount + tasksCount;
 
 	return (
 		flow && {
 			progress: flow[ stepName ],
-			count: Math.max( ...Object.values( flow ) ),
+			count: totalCount,
 		}
 	);
 };


### PR DESCRIPTION
### Proposed Changes

* Includes remaining launchpad tasks when handling progress bar calculations

### Screenshots
#### Before
<img width="1496" alt="Screen Shot 2023-01-13 at 10 01 24 PM" src="https://user-images.githubusercontent.com/5414230/212458329-7f9c84fc-f0cb-4b90-bb7d-47016c7b2219.png">

#### After
<img width="1495" alt="Screen Shot 2023-01-13 at 10 04 09 PM" src="https://user-images.githubusercontent.com/5414230/212458397-d29dc21e-e909-42d8-99b1-9c8beddd5f3d.png">

### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this branch
* Spin up a local dev environment `yarn start`
* Navigate to `http://calypso.localhost:3000/setup/free/intro`
* Verify that the progress bar at the top of the page properly reflects remaining tasks ( including unfinished launchpad tasks )

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/72073
