### PR TITLE
Users management: Switch team routes content based on the feature flag

### DIFF
--- a/client/my-sites/people/controller.js
+++ b/client/my-sites/people/controller.js
@@ -85,7 +85,12 @@ function renderPeopleList( context, next ) {
 	context.primary = (
 		<>
 			<PeopleListTitle />
-			<PeopleList filter={ context.params.filter } search={ context.query.s } />
+			{ ! isEnabled( 'user-management-revamp' ) && (
+				<PeopleList filter={ context.params.filter } search={ context.query.s } />
+			) }
+			{ isEnabled( 'user-management-revamp' ) && (
+				<SubscribersTeam filter={ context.params.filter } search={ context.query.s } />
+			) }
 		</>
 	);
 	next();

--- a/client/my-sites/people/index.js
+++ b/client/my-sites/people/index.js
@@ -45,16 +45,6 @@ export default function () {
 	);
 
 	page(
-		'/people/:filter(team-members)/:site_id',
-		peopleController.enforceSiteEnding,
-		siteSelection,
-		navigation,
-		peopleController.teamMembers,
-		makeLayout,
-		clientRender
-	);
-
-	page(
 		'/people/:filter(subscribers)/:site_id',
 		peopleController.enforceSiteEnding,
 		siteSelection,

--- a/client/my-sites/people/people-section-nav-compact/index.tsx
+++ b/client/my-sites/people/people-section-nav-compact/index.tsx
@@ -22,9 +22,9 @@ function PeopleSectionNavCompact( props: Props ) {
 			path: '/people/subscribers/' + site?.slug,
 		},
 		{
-			id: 'team-members',
+			id: 'team',
 			title: _( 'Team' ),
-			path: '/people/team-members/' + site?.slug,
+			path: '/people/team/' + site?.slug,
 		},
 	];
 

--- a/client/my-sites/people/subscribers-team/index.tsx
+++ b/client/my-sites/people/subscribers-team/index.tsx
@@ -72,8 +72,8 @@ function SubscribersTeam( props: Props ) {
 						selectedFilter={ filter }
 						searchTerm={ search }
 						filterCount={ {
+							team: usersQuery.data?.total,
 							subscribers: followersQuery.data?.total,
-							'team-members': usersQuery.data?.total,
 						} }
 					/>
 				</SectionNav>
@@ -93,11 +93,11 @@ function SubscribersTeam( props: Props ) {
 								</>
 							);
 
-						case 'team-members':
+						case 'team':
 							return (
 								<>
 									<PageViewTracker
-										path="/people/team-members/:site"
+										path="/people/team/:site"
 										title="People > Team Members / Invites"
 									/>
 

--- a/client/my-sites/people/team-invite/index.tsx
+++ b/client/my-sites/people/team-invite/index.tsx
@@ -40,7 +40,7 @@ function TeamInvite( props: Props ) {
 	useEffect( checkPermission, [ site ] );
 
 	function goBack() {
-		const fallback = site?.slug ? '/people/team-members/' + site?.slug : '/people/team-members';
+		const fallback = site?.slug ? '/people/team/' + site?.slug : '/people/team';
 
 		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 		// @ts-ignore: There are no type definitions for page.back.


### PR DESCRIPTION
#### Proposed Changes

* Switch `team` route's content based on the feature flag
* Got rid of the disused `team-members` route.

#### Testing Instructions

**Test case 1:**
* Go to `/people/team/{SITE_SLUG}`
* Check if there is a new revamp nav with two options, "Subscribers" and "Team"


**Test case 2:**
* Go to `/people/team/{SITE_SLUG}?flags=-user-management-revamp`
* Check if there is the old nav with multiple items such as "Team", "Followers", "Email subscribers", etc.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #71995
