### PR TITLE
Users management: Change search placeholder for subscribers tab

### DIFF
--- a/client/my-sites/people/people-section-nav-compact/index.tsx
+++ b/client/my-sites/people/people-section-nav-compact/index.tsx
@@ -14,6 +14,8 @@ function PeopleSectionNavCompact( props: Props ) {
 	const _ = useTranslate();
 	const { selectedFilter, searchTerm, filterCount } = props;
 	const site = useSelector( ( state ) => getSelectedSite( state ) );
+	const searchPlaceholder =
+		selectedFilter === 'subscribers' ? _( 'Search by email...' ) : undefined;
 
 	const filters = [
 		{
@@ -46,7 +48,8 @@ function PeopleSectionNavCompact( props: Props ) {
 					);
 				} ) }
 			</NavTabs>
-			<PeopleSearch search={ searchTerm } />
+
+			<PeopleSearch search={ searchTerm } placeholder={ searchPlaceholder } />
 		</>
 	);
 }

--- a/client/my-sites/people/people-section-nav/people-search.jsx
+++ b/client/my-sites/people/people-section-nav/people-search.jsx
@@ -2,16 +2,21 @@ import PropTypes from 'prop-types';
 import Search from 'calypso/components/search';
 import urlSearch from 'calypso/lib/url-search';
 
-export const PeopleSearch = ( { doSearch, search } ) => (
-	<Search
-		pinned
-		fitsContainer
-		onSearch={ doSearch }
-		initialValue={ search }
-		delaySearch
-		analyticsGroup="People"
-	/>
-);
+export const PeopleSearch = ( props ) => {
+	const { doSearch, search, placeholder } = props;
+
+	return (
+		<Search
+			pinned
+			fitsContainer
+			onSearch={ doSearch }
+			initialValue={ search }
+			delaySearch
+			placeholder={ placeholder }
+			analyticsGroup="People"
+		/>
+	);
+};
 
 PeopleSearch.propTypes = {
 	doSearch: PropTypes.func.isRequired,


### PR DESCRIPTION
#### Proposed Changes

* Subscribers tab:  Change search placeholder from 'Search..." to 'Search by email...'

#### Testing Instructions

* Go to `/people/subscribers/{SITE_SLUG`
* Click on the magnifier icon inside the navigation component
* Check if the search bar has the proper placeholder value

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #71994
