### PR TITLE
Users management: 'Add subscribers' and 'Invite" form updates

### DIFF
--- a/client/my-sites/people/people-add-subscribers/index.jsx
+++ b/client/my-sites/people/people-add-subscribers/index.jsx
@@ -85,6 +85,7 @@ class PeopleInvites extends PureComponent {
 							showTitle={ false }
 							showFormManualListLabel={ true }
 							showCsvUpload={ isEnabled( 'subscriber-csv-upload' ) }
+							submitBtnAlwaysEnable={ true }
 							recordTracksEvent={ recordTracksEvent }
 							onImportFinished={ () => {
 								defer( () => {

--- a/client/my-sites/people/subscribers/index.tsx
+++ b/client/my-sites/people/subscribers/index.tsx
@@ -3,6 +3,7 @@ import { AddSubscriberForm } from '@automattic/subscriber';
 import { useTranslate } from 'i18n-calypso';
 import { useDispatch, useSelector } from 'react-redux';
 import EllipsisMenu from 'calypso/components/ellipsis-menu';
+import EmailVerificationGate from 'calypso/components/email-verification/email-verification-gate';
 import InfiniteList from 'calypso/components/infinite-list';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import { addQueryArgs } from 'calypso/lib/url';
@@ -120,11 +121,20 @@ function Subscribers( props: Props ) {
 			return (
 				<Card>
 					{ site && (
-						<AddSubscriberForm
-							siteId={ site?.ID }
-							submitBtnAlwaysEnable={ true }
-							onImportFinished={ refetch }
-						/>
+						<>
+							{ /* eslint-disable-next-line @typescript-eslint/ban-ts-comment */ }
+							{ /* @ts-ignore */ }
+							<EmailVerificationGate
+								noticeText={ _( 'You must verify your email to add subscribers.' ) }
+								noticeStatus="is-info"
+							>
+								<AddSubscriberForm
+									siteId={ site?.ID }
+									submitBtnAlwaysEnable={ true }
+									onImportFinished={ refetch }
+								/>
+							</EmailVerificationGate>
+						</>
 					) }
 				</Card>
 			);

--- a/client/my-sites/people/subscribers/index.tsx
+++ b/client/my-sites/people/subscribers/index.tsx
@@ -119,7 +119,13 @@ function Subscribers( props: Props ) {
 		case 'empty':
 			return (
 				<Card>
-					{ site && <AddSubscriberForm siteId={ site?.ID } onImportFinished={ refetch } /> }
+					{ site && (
+						<AddSubscriberForm
+							siteId={ site?.ID }
+							submitBtnAlwaysEnable={ true }
+							onImportFinished={ refetch }
+						/>
+					) }
 				</Card>
 			);
 

--- a/client/my-sites/people/team-invite/hooks/use-inviting-notifications.ts
+++ b/client/my-sites/people/team-invite/hooks/use-inviting-notifications.ts
@@ -8,6 +8,7 @@ export function useInvitingNotifications( tokenValues: string[] ) {
 	const _ = useTranslate();
 	const dispatch = useDispatch();
 	const { error, errorType, success, failure } = useSelector( getSendInviteState );
+	const noticeConfig = { displayOnNextPage: true };
 
 	useEffect( () => error && showInvitingErrorNotice(), [ error ] );
 	useEffect( () => success && showInvitingSuccessNotice(), [ success ] );
@@ -24,18 +25,18 @@ export function useInvitingNotifications( tokenValues: string[] ) {
 				context: 'Displayed in a notice when all invitations failed to send.',
 			} );
 		}
-		dispatch( errorNotice( msg ) );
+		dispatch( errorNotice( msg, noticeConfig ) );
 	}
 
 	function showInvitingFailureNotice() {
 		const msg = _( "Sorry, we couldn't process your invitations. Please try again later." );
-		dispatch( errorNotice( msg ) );
+		dispatch( errorNotice( msg, noticeConfig ) );
 	}
 
 	function showInvitingSuccessNotice() {
 		const msg = _( 'Invitation sent successfully', 'Invitations sent successfully', {
 			count: tokenValues.length,
 		} );
-		dispatch( successNotice( msg ) );
+		dispatch( successNotice( msg, noticeConfig ) );
 	}
 }

--- a/client/my-sites/people/team-invite/hooks/use-inviting-notifications.ts
+++ b/client/my-sites/people/team-invite/hooks/use-inviting-notifications.ts
@@ -1,5 +1,5 @@
 import { useTranslate } from 'i18n-calypso';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { getSendInviteState } from 'calypso/state/invites/selectors';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
@@ -7,12 +7,14 @@ import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 export function useInvitingNotifications( tokenValues: string[] ) {
 	const _ = useTranslate();
 	const dispatch = useDispatch();
-	const { error, errorType, success, failure } = useSelector( getSendInviteState );
+	const { error, errorType, success, failure, progress } = useSelector( getSendInviteState );
+	const [ prevProgress, setPrevProgress ] = useState( progress );
 	const noticeConfig = { displayOnNextPage: true };
 
-	useEffect( () => error && showInvitingErrorNotice(), [ error ] );
-	useEffect( () => success && showInvitingSuccessNotice(), [ success ] );
-	useEffect( () => failure && showInvitingFailureNotice(), [ failure ] );
+	useEffect( () => setPrevProgress( progress ), [ progress ] );
+	useEffect( () => prevProgress && error && showInvitingErrorNotice(), [ error ] );
+	useEffect( () => prevProgress && success && showInvitingSuccessNotice(), [ success ] );
+	useEffect( () => prevProgress && failure && showInvitingFailureNotice(), [ failure ] );
 
 	function showInvitingErrorNotice() {
 		let msg;

--- a/client/my-sites/people/team-invite/index.tsx
+++ b/client/my-sites/people/team-invite/index.tsx
@@ -85,7 +85,7 @@ function TeamInvite( props: Props ) {
 							{ /* eslint-disable-next-line @typescript-eslint/ban-ts-comment */ }
 							{ /* @ts-ignore */ }
 							<EmailVerificationGate>
-								<InviteForm />
+								<InviteForm onInviteSuccess={ goBack } />
 							</EmailVerificationGate>
 						</Card>
 					);
@@ -93,7 +93,7 @@ function TeamInvite( props: Props ) {
 					return (
 						<SsoNotice siteId={ siteId }>
 							<Card>
-								<InviteForm />
+								<InviteForm onInviteSuccess={ goBack } />
 							</Card>
 						</SsoNotice>
 					);

--- a/client/my-sites/people/team-invite/invite-form.tsx
+++ b/client/my-sites/people/team-invite/invite-form.tsx
@@ -76,7 +76,9 @@ function InviteForm( props: Props ) {
 			return;
 		}
 
-		dispatch( sendInvites( siteId, tokenValues, role, message, contractor ) );
+		const _tokenValues = tokenValues.filter( ( x ) => !! x );
+
+		dispatch( sendInvites( siteId, _tokenValues, role, message, contractor ) );
 		dispatch( recordTracksEvent( 'calypso_invite_people_form_submit' ) );
 	}
 

--- a/client/my-sites/people/team-invite/invite-form.tsx
+++ b/client/my-sites/people/team-invite/invite-form.tsx
@@ -23,9 +23,14 @@ import { useValidationNotifications } from './hooks/use-validation-notifications
 
 const TOKEN_CONTROL_MAX_NUM = 10;
 
-function InviteForm() {
+interface Props {
+	onInviteSuccess?: () => void;
+}
+
+function InviteForm( props: Props ) {
 	const _ = useTranslate();
 	const dispatch = useDispatch();
+	const { onInviteSuccess } = props;
 
 	const site = useSelector( ( state ) => getSelectedSite( state ) );
 	const siteId = site?.ID as number;
@@ -52,9 +57,18 @@ function InviteForm() {
 	useEffect( extendTokenFormControls, [ tokenValues ] );
 	useEffect( toggleShowContractorCb, [ role ] );
 	useEffect( checkSubmitReadiness, [ tokenErrors, validationProgress ] );
-	useEffect( () => invitingSuccess && resetFormValues(), [ invitingSuccess ] );
+	useEffect( reactOnInvitationSuccess, [ invitingSuccess ] );
 	useValidationNotifications();
 	useInvitingNotifications( tokenValues );
+
+	function reactOnInvitationSuccess() {
+		if ( ! invitingSuccess ) {
+			return;
+		}
+
+		resetFormValues();
+		onInviteSuccess?.();
+	}
 
 	function onFormSubmit( e: FormEvent ) {
 		e.preventDefault();

--- a/client/my-sites/people/team-invite/invite-form.tsx
+++ b/client/my-sites/people/team-invite/invite-form.tsx
@@ -208,7 +208,6 @@ function InviteForm() {
 				primary
 				busy={ invitingProgress }
 				className="team-invite-form__submit-btn"
-				disabled={ ! readyForSubmit }
 			>
 				{ _( 'Send invitation' ) }
 			</Button>

--- a/client/my-sites/people/team-invite/invite-form.tsx
+++ b/client/my-sites/people/team-invite/invite-form.tsx
@@ -32,6 +32,13 @@ function InviteForm( props: Props ) {
 	const dispatch = useDispatch();
 	const { onInviteSuccess } = props;
 
+	const emailControlPlaceholder = [
+		_( 'sibling@example.com' ),
+		_( 'parents@example.com' ),
+		_( 'friend@example.com' ),
+	];
+	const defaultEmailControlPlaceholder = _( 'Add another email or username' );
+
 	const site = useSelector( ( state ) => getSelectedSite( state ) );
 	const siteId = site?.ID as number;
 	const defaultUserRole = useInitialRole( siteId );
@@ -167,6 +174,7 @@ function InviteForm( props: Props ) {
 							name={ `token-${ i }` }
 							value={ tokenValues[ i ] || '' }
 							isError={ tokenErrors && !! tokenErrors[ tokenValues[ i ] ] }
+							placeholder={ emailControlPlaceholder[ i ] || defaultEmailControlPlaceholder }
 							onBlur={ () => onTokenBlur( i ) }
 							onChange={ ( e: ChangeEvent< HTMLInputElement > ) =>
 								onTokenChange( e.target.value, i )

--- a/client/my-sites/people/team-invite/style.scss
+++ b/client/my-sites/people/team-invite/style.scss
@@ -9,6 +9,10 @@
 
 	input[type="text"].form-text-input {
 		padding-inline-end: 2rem;
+
+		&::placeholder {
+			color: var(--studio-gray-20);
+		}
 	}
 
 	.form-input-validation {

--- a/packages/subscriber/src/components/add-form/index.tsx
+++ b/packages/subscriber/src/components/add-form/index.tsx
@@ -33,6 +33,7 @@ interface Props {
 	showCsvUpload?: boolean;
 	showFormManualListLabel?: boolean;
 	submitBtnName?: string;
+	submitBtnAlwaysEnable?: boolean;
 	allowEmptyFormSubmit?: boolean;
 	manualListEmailInviting?: boolean;
 	recordTracksEvent?: RecordTrackEvents;
@@ -55,6 +56,7 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 		showCsvUpload,
 		showFormManualListLabel,
 		submitBtnName = __( 'Add subscribers' ),
+		submitBtnAlwaysEnable,
 		allowEmptyFormSubmit,
 		manualListEmailInviting,
 		recordTracksEvent,
@@ -112,7 +114,7 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 	}, [ inProgress ] );
 	useEffect( () => {
 		setIsSubmitBtnReady( isSubmitButtonReady() );
-	}, [ isValidEmails, selectedFile, allowEmptyFormSubmit ] );
+	}, [ isValidEmails, selectedFile, allowEmptyFormSubmit, submitBtnAlwaysEnable ] );
 
 	useRecordAddFormEvents( recordTracksEvent, flowName );
 
@@ -209,7 +211,12 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 	}
 
 	function isSubmitButtonReady(): boolean {
-		return !! allowEmptyFormSubmit || !! getValidEmails().length || !! selectedFile;
+		return (
+			submitBtnAlwaysEnable ||
+			!! allowEmptyFormSubmit ||
+			!! getValidEmails().length ||
+			!! selectedFile
+		);
 	}
 
 	function resetFormState(): void {


### PR DESCRIPTION
#### Proposed Changes

* Made the CTA initially active on `Add subscribers` and `Add a team member` forms
* Invite form: Added back redirection on the invite success
* Invite form: Added input placeholders

#### Testing Instructions

* Go to `/people/team-members/{SITE_SLUG}`
* Click on `Add a team member` button
* Check if the submit button is initially enabled
* Invite an user and check if the redirection on the invite success 

#### Screenshot
**Placeholders**
<img width="743" alt="Screenshot 2023-01-15 at 02 55 41" src="https://user-images.githubusercontent.com/1241413/212512471-44b99190-7a46-4acf-82c5-9b729d874910.png">

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #71999
Closes #71998
