### PR TITLE
Add site_intent to Sensei onboarding flow

### DIFF
--- a/packages/data-stores/src/onboard/actions.ts
+++ b/packages/data-stores/src/onboard/actions.ts
@@ -125,6 +125,7 @@ export function* createSenseiSite( {
 				font_headings: selectedFonts.headings,
 			} ),
 			use_patterns: true,
+			site_intent: 'sensei',
 			selected_features: selectedFeatures,
 			...( selectedDesign && { is_blank_canvas: isBlankCanvasDesign( selectedDesign ) } ),
 		},


### PR DESCRIPTION
#### Proposed Changes

* Add the `site_intent` option to the site. This will let us run scripts after the site has been created that specifically target sites created in this flow.

#### Testing Instructions

* Go through the Sensei flow (http://calypso.localhost:3000/setup/sensei/senseiSetup)
* After the flow has finished, you can check the site options page `wp-admin/options.php` and check for the `site_intent` option and make sure it says `sensei`.
