### PR TITLE
Jetpack Pro Dashboard: add tooltip to the monitor column states

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/toggle-activate-monitoring/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/toggle-activate-monitoring/index.tsx
@@ -2,10 +2,11 @@ import { Button } from '@automattic/components';
 import { ToggleControl as OriginalToggleControl } from '@wordpress/components';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import { useState } from 'react';
+import { ReactChild, useState, useRef } from 'react';
 import { useSelector } from 'react-redux';
 import clockIcon from 'calypso/assets/images/jetpack/clock-icon.svg';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
+import Tooltip from 'calypso/components/tooltip';
 import { getSiteMonitorStatuses } from 'calypso/state/jetpack-agency-dashboard/selectors';
 import { useToggleActivateMonitor } from '../../hooks';
 import NotificationSettings from '../notification-settings';
@@ -17,15 +18,32 @@ interface Props {
 	site: Site;
 	status: AllowedStatusTypes | string;
 	settings: MonitorSettings | undefined;
+	tooltip: ReactChild | undefined;
+	tooltipId: string;
 	siteError: boolean;
 }
 
-export default function ToggleActivateMonitoring( { site, status, settings, siteError }: Props ) {
+export default function ToggleActivateMonitoring( {
+	site,
+	status,
+	settings,
+	tooltip,
+	tooltipId,
+	siteError,
+}: Props ) {
 	const moment = useLocalizedMoment();
 	const translate = useTranslate();
 	const toggleActivateMonitor = useToggleActivateMonitor( [ site ] );
 	const statuses = useSelector( getSiteMonitorStatuses );
 	const [ showNotificationSettings, setShowNotificationSettings ] = useState< boolean >( false );
+	const [ showTooltip, setShowTooltip ] = useState( false );
+
+	const handleShowTooltip = () => {
+		setShowTooltip( true );
+	};
+	const handleHideTooltip = () => {
+		setShowTooltip( false );
+	};
 
 	const ToggleControl = OriginalToggleControl as React.ComponentType<
 		OriginalToggleControl.Props & {
@@ -40,6 +58,8 @@ export default function ToggleActivateMonitoring( { site, status, settings, site
 	function handleToggleNotificationSettings() {
 		setShowNotificationSettings( ( isOpen ) => ! isOpen );
 	}
+
+	const statusContentRef = useRef< HTMLSpanElement | null >( null );
 
 	const isChecked = status !== 'disabled';
 	const isLoading = statuses?.[ site.blog_id ] === 'loading';
@@ -112,6 +132,9 @@ export default function ToggleActivateMonitoring( { site, status, settings, site
 	return (
 		<>
 			<span
+				ref={ statusContentRef }
+				onMouseEnter={ handleShowTooltip }
+				onMouseLeave={ handleHideTooltip }
 				className={ classNames( 'toggle-activate-monitoring__toggle-button', {
 					[ 'sites-overview__disabled' ]: siteError,
 				} ) }
@@ -129,6 +152,17 @@ export default function ToggleActivateMonitoring( { site, status, settings, site
 					sites={ [ site ] }
 					settings={ settings }
 				/>
+			) }
+			{ tooltip && (
+				<Tooltip
+					id={ tooltipId }
+					context={ statusContentRef.current }
+					isVisible={ showTooltip }
+					position="bottom"
+					className="sites-overview__tooltip"
+				>
+					{ tooltip }
+				</Tooltip>
 			) }
 		</>
 	);

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content.tsx
@@ -157,6 +157,8 @@ export default function SiteStatusContent( {
 				site={ rows.site.value }
 				settings={ rows.monitor.settings }
 				status={ status }
+				tooltip={ tooltip }
+				tooltipId={ tooltipId }
 				siteError={ siteError }
 			/>
 		);


### PR DESCRIPTION
#### Proposed Changes

This PR adds a tooltip to the monitor column states.
 - On: No downtime detected
 - Off: Monitor is off
 - Down: Site appears to be offline

#### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout add/tooltips-for-jetpack-pro-dashboard-monitor-column` and `yarn start-jetpack-cloud`
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Verify that the tooltip is being shown for different monitor states.

When the monitor is off

<img width="208" alt="Screenshot 2023-01-16 at 11 50 09 AM" src="https://user-images.githubusercontent.com/10586875/212613445-1af73587-1321-47fe-921c-dc93af9b0dbc.png">

When the monitor is on

<img width="213" alt="Screenshot 2023-01-16 at 11 49 59 AM" src="https://user-images.githubusercontent.com/10586875/212613434-e8c59541-af19-441a-9e8d-1066693823ea.png">

When the site is down

<img width="232" alt="Screenshot 2023-01-10 at 5 17 19 PM" src="https://user-images.githubusercontent.com/10586875/212613666-1f59d1de-0df2-4052-8a49-0c2836a57319.png">

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1203448324265423-as-1203661745205577