### PR TITLE
Update the retiring design list to include hari and quadrat

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/constants.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/constants.ts
@@ -13,6 +13,8 @@ export const RETIRING_DESIGN_SLUGS = [
 	'calvin',
 	'dorna',
 	'farrow',
+	'hari',
 	'heiwa',
 	'meraki',
+	'quadrat',
 ];


### PR DESCRIPTION
In #71910 we created a  blocklist `RETIRING_DESIGN_SLUGS` of themes that are soon to be retired.  @autumnfjeld forgot to include Quadrat and Hari in the original issue, so this PRs adds the two themes.

#### Proposed Changes

* Add 'hari` and `quadrat` to https://github.com/Automattic/wp-calypso/blob/c9be7412521d5633429a1880cdbb14d66e250e1e/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/constants.ts

#### Testing Instructions

Go to /setup?siteSlug={siteSlug}
Select a goal and vertical
View the Design Picker
Verify that none of the above themes are showns


<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes? 
  - NO. I think for this interim blocklist they aren't needed.
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
  - Only on simple sites since the onboarding DP is only for simple sites. 
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #71835
