### PR TITLE
Extract remaining theme constants to make code consistent

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
@@ -25,6 +25,8 @@ import type { Step } from '../../types';
 import './styles.scss';
 
 const DEFAULT_WP_SITE_THEME = 'pub/zoologist';
+const DEFAULT_LINK_IN_BIO_THEME = 'pub/lynx';
+const DEFAULT_NEWSLETTER_THEME = 'pub/lettre';
 
 const SiteCreationStep: Step = function SiteCreationStep( { navigation, flow } ) {
 	const { submit } = navigation;
@@ -46,7 +48,7 @@ const SiteCreationStep: Step = function SiteCreationStep( { navigation, flow } )
 	if ( isMigrationFlow( flow ) || isCopySiteFlow( flow ) ) {
 		theme = DEFAULT_WP_SITE_THEME;
 	} else {
-		theme = isLinkInBioFlow( flow ) ? 'pub/lynx' : 'pub/lettre';
+		theme = isLinkInBioFlow( flow ) ? DEFAULT_LINK_IN_BIO_THEME : DEFAULT_NEWSLETTER_THEME;
 	}
 	const isPaidDomainItem = Boolean( domainCartItem?.product_slug );
 


### PR DESCRIPTION
#### Proposed Changes

In this PR, I propose to extract two other theme constants to make the code consistent. The first constant was extracted as a part of https://github.com/Automattic/wp-calypso/pull/71913

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* test copy site, link-in-bio and newsletter onboarding flows to ensure they get proper theme sets

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1468-gh-Automattic/dotcom-forge