### PR TITLE
Theme Showcase: Add Style selection Tracks events

### DIFF
--- a/client/components/theme-preview-modal/index.tsx
+++ b/client/components/theme-preview-modal/index.tsx
@@ -30,6 +30,7 @@ interface ThemePreviewModalProps {
 	onSelectVariation: ( variation: StyleVariation ) => void;
 	onClickCategory: ( category: Category ) => void;
 	onClose: () => void;
+	recordDeviceClick: ( device: string ) => void;
 }
 
 const ThemePreviewModal: React.FC< ThemePreviewModalProps > = ( {
@@ -41,6 +42,7 @@ const ThemePreviewModal: React.FC< ThemePreviewModalProps > = ( {
 	onSelectVariation,
 	onClickCategory,
 	onClose,
+	recordDeviceClick,
 } ) => {
 	const siteId = useSelector( getSelectedSiteId ) || -1;
 	const isThemePremium = useSelector( ( state ) => getIsThemePremium( state, theme.id ) );
@@ -136,6 +138,7 @@ const ThemePreviewModal: React.FC< ThemePreviewModalProps > = ( {
 						selectedVariation={ selectedStyleVariation }
 						onSelectVariation={ previewDesignVariation }
 						onClickCategory={ onClickCategory }
+						recordDeviceClick={ recordDeviceClick }
 						actionButtons={ actionButtons }
 						showGlobalStylesPremiumBadge={ shouldLimitGlobalStyles }
 					/>

--- a/client/components/theme-preview-modal/style.scss
+++ b/client/components/theme-preview-modal/style.scss
@@ -35,7 +35,7 @@ $break-design-preview: 1024px;
 	inset-inline-end: 0;
 	inset-inline-start: 0;
 	height: 60px;
-	gap: 24px;
+	gap: 16px;
 	margin: 0;
 	padding: 0 20px;
 	pointer-events: none;
@@ -45,6 +45,7 @@ $break-design-preview: 1024px;
 	z-index: z-index(".theme-preview-modal", ".theme-preview-modal__navigation");
 
 	@include break-design-preview {
+		gap: 24px;
 		position: absolute;
 		top: 8px;
 		inset-inline-end: 24px;
@@ -74,6 +75,7 @@ $break-design-preview: 1024px;
 		font-weight: 600;
 		margin-top: -2px;
 		padding: 0;
+		white-space: nowrap;
 
 		svg {
 			fill: var(--color-neutral-100);
@@ -96,6 +98,18 @@ $break-design-preview: 1024px;
 		gap: 10px;
 		justify-content: center;
 		line-height: 20px;
+	}
+
+	&-action {
+		display: flex;
+		flex-direction: row-reverse;
+		gap: 8px;
+		max-width: 50%;
+		white-space: nowrap;
+
+		button {
+			padding: 8px;
+		}
 	}
 
 	&-title,

--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -75,7 +75,8 @@ export class Theme extends Component {
 		onStyleVariationClick: PropTypes.func,
 		// Called when the more button is clicked
 		onMoreButtonClick: PropTypes.func,
-		// Options to populate the 'More' button popover menu with
+		// Called when a more button item is clicked
+		onMoreButtonItemClick: PropTypes.func,
 		buttonContents: PropTypes.objectOf(
 			PropTypes.shape( {
 				label: PropTypes.string,
@@ -107,6 +108,7 @@ export class Theme extends Component {
 		isPlaceholder: false,
 		buttonContents: {},
 		onMoreButtonClick: noop,
+		onMoreButtonItemClick: noop,
 		actionLabel: '',
 		active: false,
 	};
@@ -139,6 +141,7 @@ export class Theme extends Component {
 			nextProps.onScreenshotClick !== this.props.onScreenshotClick ||
 			nextProps.onStyleVariationClick !== this.props.onStyleVariationClick ||
 			nextProps.onMoreButtonClick !== this.props.onMoreButtonClick ||
+			nextProps.onMoreButtonItemClick !== this.props.onMoreButtonItemClick ||
 			themeThumbnailRefUpdated
 		);
 	}
@@ -473,7 +476,8 @@ export class Theme extends Component {
 	};
 
 	renderMoreButton = () => {
-		const { active, buttonContents, index, theme, onMoreButtonClick } = this.props;
+		const { active, buttonContents, index, theme, onMoreButtonClick, onMoreButtonItemClick } =
+			this.props;
 		if ( isEmpty( buttonContents ) ) {
 			return null;
 		}
@@ -485,6 +489,7 @@ export class Theme extends Component {
 				themeName={ theme.name }
 				active={ active }
 				onMoreButtonClick={ onMoreButtonClick }
+				onMoreButtonItemClick={ onMoreButtonItemClick }
 				options={ buttonContents }
 			/>
 		);

--- a/client/components/theme/more-button.jsx
+++ b/client/components/theme/more-button.jsx
@@ -38,10 +38,11 @@ class ThemeMoreButton extends Component {
 		}
 	};
 
-	popoverAction( action, label ) {
+	popoverAction( action, label, key ) {
 		return () => {
 			action( this.props.themeId, 'more button' );
 			this.props.onMoreButtonClick( this.props.themeId, this.props.index, 'popup_' + label );
+			this.props.onMoreButtonItemClick?.( this.props.themeId, this.props.index, key );
 		};
 	}
 
@@ -78,7 +79,7 @@ class ThemeMoreButton extends Component {
 								return (
 									<PopoverMenuItem
 										key={ `${ option.label }-geturl` }
-										action={ this.popoverAction( option.action, option.label ) }
+										action={ this.popoverAction( option.action, option.label, option.key ) }
 										href={ url }
 										target={ isOutsideCalypso( url ) ? '_blank' : null }
 									>
@@ -90,7 +91,7 @@ class ThemeMoreButton extends Component {
 								return (
 									<PopoverMenuItem
 										key={ `${ option.label }-action` }
-										action={ this.popoverAction( option.action, option.label ) }
+										action={ this.popoverAction( option.action, option.label, option.key ) }
 									>
 										{ option.label }
 									</PopoverMenuItem>
@@ -115,6 +116,7 @@ ThemeMoreButton.propTypes = {
 	// More elaborate onClick action, used for tracking.
 	// Made to not interfere with DOM onClick
 	onMoreButtonClick: PropTypes.func,
+	onMoreButtonItemClick: PropTypes.func,
 	// Options to populate the popover menu with
 	options: PropTypes.objectOf(
 		PropTypes.shape( {

--- a/client/components/themes-list/index.jsx
+++ b/client/components/themes-list/index.jsx
@@ -68,6 +68,7 @@ ThemesList.propTypes = {
 	onScreenshotClick: PropTypes.func.isRequired,
 	onStyleVariationClick: PropTypes.func,
 	onMoreButtonClick: PropTypes.func,
+	onMoreButtonItemClick: PropTypes.func,
 	getActionLabel: PropTypes.func,
 	isActive: PropTypes.func,
 	getPrice: PropTypes.func,
@@ -116,6 +117,7 @@ function ThemeBlock( props ) {
 			onScreenshotClick={ props.onScreenshotClick }
 			onStyleVariationClick={ props.onStyleVariationClick }
 			onMoreButtonClick={ props.onMoreButtonClick }
+			onMoreButtonItemClick={ props.onMoreButtonItemClick }
 			actionLabel={ props.getActionLabel( theme.id ) }
 			index={ index }
 			theme={ theme }

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -240,7 +240,10 @@ class ThemeSheet extends Component {
 		}
 		event.preventDefault();
 
-		this.props.recordTracksEvent( 'calypso_theme_live_demo_preview_click', { type } );
+		this.props.recordTracksEvent( 'calypso_theme_live_demo_preview_click', {
+			theme: this.props.themeId,
+			type,
+		} );
 
 		const { preview } = this.props.options;
 		this.props.setThemePreviewOptions(

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -107,8 +107,32 @@ class ThemesSelection extends Component {
 	};
 
 	onStyleVariationClick = ( themeId, resultsRank, variation ) => {
+		const { query, filterString } = this.props;
+		const search_taxonomies = filterString;
+		const search_term = search_taxonomies + ( query.search || '' );
 		if ( ! this.props.isThemeActive( themeId ) ) {
 			this.recordSearchResultsClick( themeId, resultsRank, 'style_variation', variation?.slug );
+		}
+
+		const tracksProps = {
+			search_term: search_term || null,
+			search_taxonomies,
+			theme: themeId,
+			results_rank: resultsRank + 1,
+			page_number: query.page,
+			theme_on_page: parseInt( ( resultsRank + 1 ) / query.number ),
+		};
+
+		if ( variation ) {
+			this.props.recordTracksEvent( 'calypso_themeshowcase_theme_style_variation_click', {
+				...tracksProps,
+				style_variation: variation.slug,
+			} );
+		} else {
+			this.props.recordTracksEvent(
+				'calypso_themeshowcase_theme_style_variation_more_click',
+				tracksProps
+			);
 		}
 
 		const options = this.getOptions(
@@ -120,6 +144,22 @@ class ThemesSelection extends Component {
 		if ( options && options.preview ) {
 			options.preview.action( themeId );
 		}
+	};
+
+	onMoreButtonItemClick = ( themeId, resultsRank, key ) => {
+		const { query, filterString } = this.props;
+		const search_taxonomies = filterString;
+		const search_term = search_taxonomies + ( query.search || '' );
+
+		this.props.recordTracksEvent( 'calypso_themeshowcase_theme_more_button_item_click', {
+			search_term: search_term || null,
+			search_taxonomies,
+			theme: themeId,
+			action: key,
+			results_rank: resultsRank + 1,
+			page_number: query.page,
+			theme_on_page: parseInt( ( resultsRank + 1 ) / query.number ),
+		} );
 	};
 
 	fetchNextPage = ( options ) => {
@@ -202,6 +242,7 @@ class ThemesSelection extends Component {
 					fetchNextPage={ this.fetchNextPage }
 					recordTracksEvent={ this.props.recordTracksEvent }
 					onMoreButtonClick={ this.recordSearchResultsClick }
+					onMoreButtonItemClick={ this.onMoreButtonItemClick }
 					getButtonOptions={ this.getOptions }
 					onScreenshotClick={ this.onScreenshotClick }
 					onStyleVariationClick={ this.onStyleVariationClick }

--- a/packages/design-preview/src/components/style.scss
+++ b/packages/design-preview/src/components/style.scss
@@ -54,7 +54,9 @@ $break-design-preview: 1024px;
 
 		@include break-design-preview {
 			bottom: 8px;
-			display: block;
+			display: flex;
+			flex-direction: column;
+			gap: 8px;
 			margin: 2rem 0 0;
 		}
 	}


### PR DESCRIPTION
#### Proposed Changes

This PR implements Tracks events as defined in pbxlJb-39D-p2. In addition, this PR also adds the support of secondary buttons in the preview modal. The list of Tracks events added/updated is as follows:



Event name | Description
-- | --  
calypso_themeshowcase_theme_style_variation_click | User clicks on a global style in the theme card. |  
calypso_themeshowcase_theme_style_variation_more_click | User clicks on the more global styles button in the theme card. |  
calypso_themeshowcase_theme_more_button_item_click | User clicks on a menu item from the more button’s popover menu. |  
calypso_theme_live_demo_preview_click | User clicks on the Live Demo button (type=link) or theme screenshot (type=screenshot) in the theme detail page. |  
calypso_theme_preview_category_click | User click on a category tag in the theme preview. |  
calypso_theme_preview_style_variation_click  | User clicks on a global style in the theme preview. |  
calypso_theme_preview_primary_button_click | User clicks on the theme preview primary button. |  
calypso_theme_preview_secondary_button_click | User clicks on the theme preview secondary action button. |  
calypso_theme_preview_device_switcher_click | User clicks on the device switcher in the theme preview. |  
calypso_theme_preview_close_click | User clicks on the Back button in the theme preview.



#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the Theme Showcase and ensure the Tracks events trigger as intended. If using calypso.live, the flag `themes/showcase-i4/details-and-preview` is required.
* For testing secondary buttons, pick a classic theme.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
