### PR TITLE
BBE: Update copy for the existing site flow

### DIFF
--- a/client/signup/steps/difm-site-picker/site-delete-confirmation-dialog.tsx
+++ b/client/signup/steps/difm-site-picker/site-delete-confirmation-dialog.tsx
@@ -129,17 +129,14 @@ function SiteDeleteConfirmationDialog( {
 					</ul>
 				</Subtitle>
 				<FormLabel htmlFor="confirmTextChangeInput">
-					{ translate(
-						'Type {{strong}}%(deleteWord)s{{/strong}} to confirm to confirm and continue.',
-						{
-							components: {
-								strong: <strong />,
-							},
-							args: {
-								deleteWord: TRANSLATED_DELETE_WORD,
-							},
-						}
-					) }
+					{ translate( 'Type {{strong}}%(deleteWord)s{{/strong}} to confirm and continue.', {
+						components: {
+							strong: <strong />,
+						},
+						args: {
+							deleteWord: TRANSLATED_DELETE_WORD,
+						},
+					} ) }
 				</FormLabel>
 
 				<FormTextInput

--- a/client/signup/steps/difm-site-picker/site-delete-confirmation-dialog.tsx
+++ b/client/signup/steps/difm-site-picker/site-delete-confirmation-dialog.tsx
@@ -69,7 +69,7 @@ function SiteDeleteConfirmationDialog( {
 	const siteDomain = useSelector( ( state ) => getSiteDomain( state, siteId ?? 0 ) );
 	const siteTitle = useSelector( ( state ) => getSiteTitle( state, siteId ) );
 	const translate = useTranslate();
-	const TRANSLATED_DELETE_WORD = translate( 'DELETE' );
+	const TRANSLATED_DELETE_WORD = translate( 'YES' );
 	const deleteDisabled = confirmText !== TRANSLATED_DELETE_WORD;
 
 	return (
@@ -80,7 +80,7 @@ function SiteDeleteConfirmationDialog( {
 			buttons={ [
 				<DialogButton onClick={ onClose }>{ translate( 'Cancel' ) }</DialogButton>,
 				<DialogButton primary disabled={ deleteDisabled } onClick={ onConfirm }>
-					{ translate( 'Delete site content' ) }
+					{ translate( 'Use Existing Site' ) }
 				</DialogButton>,
 			] }
 			onClose={ onClose }
@@ -92,14 +92,14 @@ function SiteDeleteConfirmationDialog( {
 				<FormattedHeader
 					align="center"
 					brandFont
-					headerText={ translate( 'Site Reset Confirmation' ) }
+					headerText={ translate( 'Content Confirmation' ) }
 				/>
 				<Subtitle>
 					<ul>
 						<li>
 							{ translate(
-								'The current content of your website {{strong}}%(siteTitle)s{{/strong}} (%(siteAddress)s) will be deleted. ' +
-									'This includes pages, posts, media, comments, third party plugins and themes.',
+								'The current content of your website {{strong}}%(siteTitle)s{{/strong}} (%(siteAddress)s) may be edited or deleted as part of our build process. ' +
+									'This includes pages, posts, products, media, plugins, and themes.',
 								{
 									components: {
 										strong: <strong />,
@@ -118,7 +118,7 @@ function SiteDeleteConfirmationDialog( {
 						</li>
 						<li>
 							{ translate(
-								"If you don't want your site content to be deleted you can create a {{a}}new site{{/a}} instead.",
+								'If you do not want your content to be edited or deleted, you can create a {{a}}new site{{/a}} instead.',
 								{
 									components: {
 										a: <a href="/start/do-it-for-me" />,
@@ -130,7 +130,7 @@ function SiteDeleteConfirmationDialog( {
 				</Subtitle>
 				<FormLabel htmlFor="confirmTextChangeInput">
 					{ translate(
-						'Type {{strong}}%(deleteWord)s{{/strong}} to confirm that your site’s current content will be deleted after purchase.',
+						'Type {{strong}}%(deleteWord)s{{/strong}} to confirm to confirm and continue.',
 						{
 							components: {
 								strong: <strong />,
@@ -144,6 +144,7 @@ function SiteDeleteConfirmationDialog( {
 
 				<FormTextInput
 					autoCapitalize="off"
+					autoComplete="off"
 					onChange={ ( event: React.ChangeEvent< HTMLInputElement > ) =>
 						setConfirmText( event.target.value )
 					}

--- a/client/signup/steps/new-or-existing-site/index.tsx
+++ b/client/signup/steps/new-or-existing-site/index.tsx
@@ -88,7 +88,7 @@ export default function NewOrExistingSiteStep( props: Props ) {
 			description: (
 				<p>
 					{ translate(
-						'Use an existing site. Any existing content will be deleted, but you will be able to submit your content for your new site in later steps.'
+						'Use an existing site. Current site content may be deleted, we will build your new site using the content you provide in the following steps.'
 					) }
 				</p>
 			),


### PR DESCRIPTION
#### Proposed Changes

P2: pdh1Xd-1I7-p2#comment-1935
Copy doc: 2ec9b-pb

A few copy changes for the BBE flow when an existing site needs to be chosen.

* On the New/Existing site screen, updated the description of the "Existing Site" choice.
<img width="577" alt="image" src="https://user-images.githubusercontent.com/5436027/212658054-1e7010cf-327d-4d2b-818f-a282523d3f5b.png">

* A few updates on the site reset modal:
  * Updated the title to "Content Confirmation"
  * Updated the explainer copy.
  * Updated the delete word to "YES".
  * Updated the CTA text to "Use Existing Site".
<img width="757" alt="image" src="https://user-images.githubusercontent.com/5436027/213356329-20f768e5-8daf-4884-a9c6-0b48dd897d79.png">



#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/do-it-for-me`.
* Confirm the copy for the "Existing Site" choice matches the one in the copy document.
* Select "Existing Site". Choose any site on the next page.
* Confirm the changes on the modal match the ones mentioned in the copy document.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes Automattic/martech#1378