### PR TITLE
Disable access to old backups if storage is full UI changes

### DIFF
--- a/client/components/backup-storage-space/hooks.tsx
+++ b/client/components/backup-storage-space/hooks.tsx
@@ -84,3 +84,30 @@ export const useStorageUsageText = (
 		);
 	}, [ translate, bytesUsed, bytesAvailable ] );
 };
+
+export const useDaysOfBackupsSavedText = (
+	daysOfBackupsSaved: number | undefined,
+	siteSlug: string
+): TranslateResult | null => {
+	const translate = useTranslate();
+
+	return useMemo( () => {
+		if ( undefined === daysOfBackupsSaved || 0 === daysOfBackupsSaved ) {
+			return null;
+		}
+
+		const daysOfBackupsSavedLinkTarget = `/activity-log/${ siteSlug }?group=rewind`;
+
+		return translate(
+			'{{a}}%(daysOfBackupsSaved)d day of backup saved{{/a}}',
+			'{{a}}%(daysOfBackupsSaved)d days of backups saved{{/a}}',
+			{
+				count: daysOfBackupsSaved,
+				args: { daysOfBackupsSaved },
+				components: {
+					a: <a href={ daysOfBackupsSavedLinkTarget } />,
+				},
+			}
+		);
+	}, [ translate, daysOfBackupsSaved, siteSlug ] );
+};

--- a/client/components/backup-storage-space/hooks.tsx
+++ b/client/components/backup-storage-space/hooks.tsx
@@ -1,10 +1,15 @@
 import { useTranslate, TranslateResult } from 'i18n-calypso';
 import { useMemo } from 'react';
 
-enum StorageUnits {
+export enum StorageUnits {
 	Gigabyte = 2 ** 30,
 	Terabyte = 2 ** 40,
 }
+
+type ConvertedUnitAmount = {
+	unitAmount: number;
+	unit: StorageUnits;
+};
 
 const getAppropriateStorageUnit = ( bytes: number ): StorageUnits => {
 	if ( bytes < StorageUnits.Terabyte ) {
@@ -15,6 +20,12 @@ const getAppropriateStorageUnit = ( bytes: number ): StorageUnits => {
 };
 
 const bytesToUnit = ( bytes: number, unit: StorageUnits ) => bytes / unit;
+
+export const convertBytesToUnitAmount = ( bytes: number ): ConvertedUnitAmount => {
+	const unit = getAppropriateStorageUnit( bytes );
+	const unitAmount = bytesToUnit( bytes, unit );
+	return { unitAmount, unit };
+};
 
 export const useStorageUsageText = (
 	bytesUsed: number | undefined,
@@ -30,38 +41,45 @@ export const useStorageUsageText = (
 		const usedGigabytes = bytesToUnit( bytesUsed, StorageUnits.Gigabyte );
 
 		if ( bytesAvailable === undefined ) {
-			return translate( '%(usedGigabytes).1fGB used', '%(usedGigabytes).1fGB used', {
-				count: usedGigabytes,
-				args: { usedGigabytes },
-				comment:
-					'Must use unit abbreviation; describes an amount of storage space in gigabytes (e.g., 15.4GB used)',
-			} );
+			return translate(
+				'{{usedStorage}}%(usedGigabytes).1fGB{{/usedStorage}} used',
+				'{{usedStorage}}%(usedGigabytes).1fGB{{/usedStorage}} used',
+				{
+					count: usedGigabytes,
+					args: { usedGigabytes },
+					comment:
+						'Must use unit abbreviation; describes an amount of storage space in gigabytes (e.g., 15.4GB used)',
+					components: { usedStorage: <span className="used-space__span" /> },
+				}
+			);
 		}
 
-		const availableUnit = getAppropriateStorageUnit( bytesAvailable );
-		const availableUnitAmount = bytesToUnit( bytesAvailable, availableUnit );
+		const { unitAmount: availableUnitAmount, unit: availableUnit } =
+			convertBytesToUnitAmount( bytesAvailable );
 
 		if ( availableUnit === StorageUnits.Gigabyte ) {
 			return translate(
-				'%(usedGigabytes).1fGB used of %(availableUnitAmount)dGB',
-				'%(usedGigabytes).1fGB used of %(availableUnitAmount)dGB',
+				'Using {{usedStorage}}%(usedGigabytes).1fGB{{/usedStorage}} of %(availableUnitAmount)dGB',
+				'Using {{usedStorage}}%(usedGigabytes).1fGB{{/usedStorage}} of %(availableUnitAmount)dGB',
 				{
 					count: usedGigabytes,
 					args: { usedGigabytes, availableUnitAmount },
 					comment:
-						'Must use unit abbreviation; describes used vs available storage amounts (e.g., 20.0GB of 30GB used, 0.5GB of 20GB used)',
+						'Must use unit abbreviation; describes used vs available storage amounts (e.g., Using 20.0GB of 30GB, Using 0.5GB of 20GB)',
+					components: { usedStorage: <span className="used-space__span" /> },
 				}
 			);
 		}
 
 		return translate(
-			'%(usedGigabytes).1fGB used of %(availableUnitAmount)dTB',
-			'%(usedGigabytes).1fGB used of %(availableUnitAmount)dTB',
+			'Using {{usedStorage}}%(usedGigabytes).1fGB{{/usedStorage}} of %(availableUnitAmount)dTB',
+			'Using {{usedStorage}}%(usedGigabytes).1fGB{{/usedStorage}} of %(availableUnitAmount)dTB',
 			{
 				count: usedGigabytes,
 				args: { usedGigabytes, availableUnitAmount },
 				comment:
-					'Must use unit abbreviation; describes used vs available storage amounts (e.g., 20.0GB of 1TB used, 0.5GB of 2TB used)',
+					'Must use unit abbreviation; describes used vs available storage amounts (e.g., Using 20.0GB of 1TB, Using 0.5GB of 2TB)',
+				components: { usedStorage: <span className="used-space__span" /> },
 			}
 		);
 	}, [ translate, bytesUsed, bytesAvailable ] );

--- a/client/components/backup-storage-space/index.tsx
+++ b/client/components/backup-storage-space/index.tsx
@@ -8,6 +8,9 @@ import {
 	getRewindBytesAvailable,
 	getRewindBytesUsed,
 	isRequestingRewindSize,
+	getActivityLogVisibleDays,
+	getRewindMinimumDaysOfBackupsAllowed,
+	getRewindDaysOfBackupsAllowed,
 } from 'calypso/state/rewind/selectors';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
 import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
@@ -25,7 +28,20 @@ const BackupStorageSpace: React.FC = () => {
 
 	const bytesUsed = useSelector( ( state ) => getRewindBytesUsed( state, siteId ) );
 	const bytesAvailable = useSelector( ( state ) => getRewindBytesAvailable( state, siteId ) );
-	const usageLevel = getUsageLevel( bytesUsed, bytesAvailable ) ?? StorageUsageLevels.Normal;
+	const planRetentionDays =
+		useSelector( ( state ) => getActivityLogVisibleDays( state, siteId ) ) || 0;
+	const minDaysOfBackupsAllowed =
+		useSelector( ( state ) => getRewindMinimumDaysOfBackupsAllowed( state, siteId ) ) || 0;
+	const daysOfBackupsAllowed =
+		useSelector( ( state ) => getRewindDaysOfBackupsAllowed( state, siteId ) ) || 0;
+	const usageLevel =
+		getUsageLevel(
+			bytesUsed,
+			bytesAvailable,
+			minDaysOfBackupsAllowed,
+			daysOfBackupsAllowed,
+			planRetentionDays
+		) ?? StorageUsageLevels.Normal;
 
 	const showUpsell = usageLevel !== StorageUsageLevels.Normal;
 	const requestingSize = useSelector( ( state ) => isRequestingRewindSize( state, siteId ) );
@@ -46,6 +62,7 @@ const BackupStorageSpace: React.FC = () => {
 					usageLevel={ usageLevel }
 					bytesUsed={ bytesUsed as number }
 					siteId={ siteId }
+					minDaysOfBackupsAllowed={ minDaysOfBackupsAllowed }
 				/>
 			) }
 		</Card>

--- a/client/components/backup-storage-space/index.tsx
+++ b/client/components/backup-storage-space/index.tsx
@@ -43,7 +43,8 @@ const BackupStorageSpace: React.FC = () => {
 			bytesAvailable,
 			minDaysOfBackupsAllowed,
 			daysOfBackupsAllowed,
-			planRetentionDays
+			planRetentionDays,
+			daysOfBackupsSaved
 		) ?? StorageUsageLevels.Normal;
 
 	const showUpsell = usageLevel !== StorageUsageLevels.Normal;

--- a/client/components/backup-storage-space/index.tsx
+++ b/client/components/backup-storage-space/index.tsx
@@ -11,6 +11,7 @@ import {
 	getActivityLogVisibleDays,
 	getRewindMinimumDaysOfBackupsAllowed,
 	getRewindDaysOfBackupsAllowed,
+	getRewindDaysOfBackupsSaved,
 } from 'calypso/state/rewind/selectors';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
 import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
@@ -30,6 +31,8 @@ const BackupStorageSpace: React.FC = () => {
 	const bytesAvailable = useSelector( ( state ) => getRewindBytesAvailable( state, siteId ) );
 	const planRetentionDays =
 		useSelector( ( state ) => getActivityLogVisibleDays( state, siteId ) ) || 0;
+	const daysOfBackupsSaved =
+		useSelector( ( state ) => getRewindDaysOfBackupsSaved( state, siteId ) ) || 0;
 	const minDaysOfBackupsAllowed =
 		useSelector( ( state ) => getRewindMinimumDaysOfBackupsAllowed( state, siteId ) ) || 0;
 	const daysOfBackupsAllowed =
@@ -62,6 +65,7 @@ const BackupStorageSpace: React.FC = () => {
 					usageLevel={ usageLevel }
 					bytesUsed={ bytesUsed as number }
 					siteId={ siteId }
+					daysOfBackupsSaved={ daysOfBackupsSaved }
 					minDaysOfBackupsAllowed={ minDaysOfBackupsAllowed }
 				/>
 			) }

--- a/client/components/backup-storage-space/storage-usage-help-tooltip.tsx
+++ b/client/components/backup-storage-space/storage-usage-help-tooltip.tsx
@@ -1,0 +1,86 @@
+import { Button, Gridicon } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import * as React from 'react';
+import Tooltip from 'calypso/components/tooltip';
+import { convertBytesToUnitAmount, StorageUnits } from './hooks';
+
+type OwnProps = {
+	className?: string;
+	bytesAvailable: number | undefined;
+};
+const StorageHelpTooltip: React.FC< OwnProps > = ( { className, bytesAvailable } ) => {
+	const translate = useTranslate();
+	const [ isTooltipVisible, setTooltipVisible ] = React.useState< boolean >( false );
+	const tooltip = React.useRef< SVGSVGElement >( null );
+
+	if ( undefined === bytesAvailable ) {
+		return null;
+	}
+
+	const { unitAmount: availableUnitAmount, unit: availableUnit } =
+		convertBytesToUnitAmount( bytesAvailable );
+
+	const toggleHelpTooltip = ( event: React.MouseEvent< HTMLButtonElement, MouseEvent > ): void => {
+		setTooltipVisible( ! isTooltipVisible );
+		// when the info tooltip inside a button, we don't want clicking it to propagate up
+		event.stopPropagation();
+	};
+	const closeHelpTooltip = () => {
+		setTooltipVisible( false );
+	};
+
+	return (
+		<span className={ className }>
+			<Button
+				borderless
+				className="storage-usage-help-tooltip__toggle-tooltip"
+				onClick={ toggleHelpTooltip }
+			>
+				<Gridicon ref={ tooltip } icon="info-outline" size={ 24 } />
+			</Button>
+			<Tooltip
+				className="storage-usage-help-tooltip__tooltip"
+				isVisible={ isTooltipVisible }
+				position="right"
+				context={ tooltip.current }
+				showOnMobile
+			>
+				<p>
+					{ translate(
+						'We store your backups on our cloud storage. Your total storage size is %(availableUnitAmount)d%(unit)s.',
+						{
+							args: {
+								availableUnitAmount,
+								unit: StorageUnits.Gigabyte === availableUnit ? 'GB' : 'TB',
+							},
+							comment:
+								'Describes available storage amounts (e.g., We store your backups on our cloud storage. Your total storage size is 20GB)',
+						}
+					) }
+					<Button
+						borderless
+						compact
+						className="storage-usage-help-tooltip__close-tooltip"
+						onClick={ closeHelpTooltip }
+					>
+						<Gridicon icon="cross" size={ 18 } />
+					</Button>
+				</p>
+				<hr />
+				{ translate( '{{a}}Learn more…{{/a}}', {
+					components: {
+						a: (
+							<a
+								href="https://jetpack.com/support/backup/#how-is-storage-usage-calculated"
+								target="_blank"
+								rel="external noreferrer noopener"
+							/>
+						),
+					},
+				} ) }
+			</Tooltip>
+		</span>
+	);
+};
+
+export default StorageHelpTooltip;

--- a/client/components/backup-storage-space/storage-usage-levels.ts
+++ b/client/components/backup-storage-space/storage-usage-levels.ts
@@ -30,15 +30,17 @@ export const getUsageLevel = (
 		return null;
 	}
 
-	// if current allowed days of backups is equal to the minimum, return storage full.
-	if ( minDaysOfBackupsAllowed === daysOfBackupsAllowed ) {
-		return StorageUsageLevels.Full;
-	}
+	if ( !! minDaysOfBackupsAllowed && !! daysOfBackupsAllowed && !! planRetentionDays ) {
+		// if current allowed days of backups is equal to the minimum, return storage full.
+		if ( minDaysOfBackupsAllowed === daysOfBackupsAllowed ) {
+			return StorageUsageLevels.Full;
+		}
 
-	// if current allowed days of backups is less than plan's retention days, that means
-	// we discarded some backups to make other fit in current storage limit.
-	if ( daysOfBackupsAllowed < planRetentionDays ) {
-		return StorageUsageLevels.BackupsDiscarded;
+		// if current allowed days of backups is less than plan's retention days, that means
+		// we discarded some backups to make other fit in current storage limit.
+		if ( daysOfBackupsAllowed < planRetentionDays ) {
+			return StorageUsageLevels.BackupsDiscarded;
+		}
 	}
 
 	// Guard against divide-by-zero

--- a/client/components/backup-storage-space/storage-usage-levels.ts
+++ b/client/components/backup-storage-space/storage-usage-levels.ts
@@ -1,9 +1,10 @@
-export type StorageUsageLevelName = 'Full' | 'Critical' | 'Warning' | 'Normal';
+export type StorageUsageLevelName = 'Full' | 'Critical' | 'Warning' | 'Normal' | 'BackupsDiscarded';
 export const StorageUsageLevels: Record< StorageUsageLevelName, StorageUsageLevelName > = {
 	Full: 'Full',
 	Critical: 'Critical',
 	Warning: 'Warning',
 	Normal: 'Normal',
+	BackupsDiscarded: 'BackupsDiscarded',
 } as const;
 
 const THRESHOLDS: Record< number, StorageUsageLevelName > = {
@@ -20,14 +21,28 @@ const THRESHOLD_VALUES = Object.keys( THRESHOLDS )
 
 export const getUsageLevel = (
 	used: number | undefined,
-	available: number | undefined
+	available: number | undefined,
+	minDaysOfBackupsAllowed: number,
+	daysOfBackupsAllowed: number,
+	planRetentionDays: number
 ): StorageUsageLevelName | null => {
 	if ( available === undefined || used === undefined ) {
 		return null;
 	}
 
+	// if current allowed days of backups is equal to the minimum, return storage full.
+	if ( minDaysOfBackupsAllowed === daysOfBackupsAllowed ) {
+		return StorageUsageLevels.Full;
+	}
+
+	// if current allowed days of backups is less than plan's retention days, that means
+	// we discarded some backups to make other fit in current storage limit.
+	if ( daysOfBackupsAllowed < planRetentionDays ) {
+		return StorageUsageLevels.BackupsDiscarded;
+	}
+
 	// Guard against divide-by-zero
-	if ( available === 0 ) {
+	if ( 0 === available ) {
 		return StorageUsageLevels.Normal;
 	}
 

--- a/client/components/backup-storage-space/storage-usage-levels.ts
+++ b/client/components/backup-storage-space/storage-usage-levels.ts
@@ -24,15 +24,26 @@ export const getUsageLevel = (
 	available: number | undefined,
 	minDaysOfBackupsAllowed: number,
 	daysOfBackupsAllowed: number,
-	planRetentionDays: number
+	planRetentionDays: number,
+	daysOfBackupsSaved: number
 ): StorageUsageLevelName | null => {
 	if ( available === undefined || used === undefined ) {
 		return null;
 	}
 
-	if ( !! minDaysOfBackupsAllowed && !! daysOfBackupsAllowed && !! planRetentionDays ) {
+	if (
+		!! minDaysOfBackupsAllowed &&
+		!! daysOfBackupsAllowed &&
+		!! planRetentionDays &&
+		!! daysOfBackupsSaved
+	) {
 		// if current allowed days of backups is equal to the minimum, return storage full.
-		if ( minDaysOfBackupsAllowed === daysOfBackupsAllowed ) {
+		if (
+			minDaysOfBackupsAllowed >= daysOfBackupsSaved &&
+			used > 0 &&
+			available > 0 &&
+			used >= available
+		) {
 			return StorageUsageLevels.Full;
 		}
 

--- a/client/components/backup-storage-space/style.scss
+++ b/client/components/backup-storage-space/style.scss
@@ -12,6 +12,12 @@
 		height: 24px;
 		box-shadow: none;
 	}
+
+	&__storage-full-icon {
+		color: var(--studio-red-50);
+		margin-right: 4px;
+		vertical-align: middle;
+	}
 }
 
 .backup-storage-space__progress-bar-container {
@@ -88,16 +94,12 @@
 .backup-storage-space__progress-heading {
 	margin-block-end: 24px;
 	white-space: nowrap;
-
+	line-height: 1;
 	font-weight: 600;
 	font-size: $font-title-small;
 
 	span {
 		vertical-align: middle;
-	}
-
-	.gridicons-info-outline {
-		color: var(--studio-gray-60);
 	}
 }
 
@@ -107,6 +109,7 @@
 	display: flex;
 	font-size: $font-body-small;
 	font-weight: 400;
+	line-height: 20px;
 
 	a {
 		text-decoration: underline;
@@ -114,6 +117,10 @@
 }
 
 .backup-storage-space__progress-storage-usage-text {
+	&.is-storage-full {
+		color: var(--studio-red-50);
+	}
+
 	.used-space__span {
 		font-weight: 700;
 	}
@@ -123,16 +130,19 @@
 	margin-left: auto;
 }
 
-.backup-storage-space-help-text__tooltip {
-	padding: 10px;
-	max-width: 200px;
-}
-
 .storage-usage-help-tooltip {
 
 	&__tooltip.popover {
 		&.is-right .popover__arrow {
 			border-right-color: #fff;
+		}
+
+		&.is-top-right .popover__arrow {
+			border-top-color: #fff;
+		}
+
+		&.is-bottom-right .popover__arrow {
+			border-bottom-color: #fff;
 		}
 
 		.popover__inner {
@@ -165,14 +175,15 @@
 	}
 
 	&__toggle-tooltip {
-		margin-right: 8px;
 		vertical-align: middle;
 
 		&.button {
 			padding: 0;
+			height: 20px;
 
 			.gridicon {
-				top: 4px;
+				top: 0;
+				color: var(--studio-gray-60);
 			}
 		}
 	}

--- a/client/components/backup-storage-space/style.scss
+++ b/client/components/backup-storage-space/style.scss
@@ -1,13 +1,68 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
 .backup-storage-space {
 	margin-top: 1rem;
-	padding: 16px 32px;
+	padding: 32px 24px;
 	background: #fff;
 	box-shadow: 0 0 0 1px var(--color-neutral-5);
 
 	&__loading {
-		@include placeholder( --color-neutral-10 );
+		@include placeholder(--color-neutral-10);
 		height: 24px;
 		box-shadow: none;
+	}
+
+	&__help-text-tooltip.popover {
+		&.is-right .popover__arrow {
+			border-right-color: #fff;
+		}
+
+		.popover__inner {
+			padding: 16px 58px 16px 16px;
+			color: var(--studio-gray-70);
+			background: #fff;
+			border-radius: 2px;
+			box-shadow: 0 0 40px rgba(0, 0, 0, 0.08);
+
+			p {
+				font-size: 1rem;
+				margin: 0;
+			}
+
+			hr {
+				margin-bottom: 0.25rem;
+			}
+		}
+
+		@include break-mobile() {
+			max-width: 200px;
+		}
+	}
+
+	&__open-help-text-tooltip {
+		margin-right: 8px;
+		vertical-align: middle;
+
+		&.button {
+			padding: 0;
+
+			.gridicon {
+				top: 4px;
+			}
+		}
+	}
+
+	&__close-help-text-tooltip {
+		position: absolute;
+		right: 16px;
+		top: 16px;
+		color: var(--studio-gray-40);
+
+		&.button {
+			height: 18px;
+			padding: 0;
+		}
 	}
 }
 
@@ -83,22 +138,38 @@
 }
 
 .backup-storage-space__progress-heading {
-	margin-block-end: 12px;
+	margin-block-end: 24px;
 	white-space: nowrap;
 
 	font-weight: 600;
-	font-size: $font-body-small;
+	font-size: $font-title-small;
+
+	span {
+		vertical-align: middle;
+	}
 }
 
 .backup-storage-space__progress-usage-text {
-	margin-block-start: 8px;
+	margin-block-start: 16px;
 	white-space: nowrap;
-
-	font-size: $font-body-extra-small;
-	color: var(--studio-green-50);
-	font-weight: 500;
+	display: flex;
+	font-size: $font-body-small;
+	font-weight: 400;
 
 	a {
 		text-decoration: underline;
 	}
+
+	.used-space__span {
+		font-weight: 700;
+	}
+
+	.backups-saved__container {
+		margin-left: auto;
+	}
+}
+
+.backup-storage-space-help-text__tooltip {
+	padding: 10px;
+	max-width: 200px;
 }

--- a/client/components/backup-storage-space/style.scss
+++ b/client/components/backup-storage-space/style.scss
@@ -12,58 +12,6 @@
 		height: 24px;
 		box-shadow: none;
 	}
-
-	&__help-text-tooltip.popover {
-		&.is-right .popover__arrow {
-			border-right-color: #fff;
-		}
-
-		.popover__inner {
-			padding: 16px 58px 16px 16px;
-			color: var(--studio-gray-70);
-			background: #fff;
-			border-radius: 2px;
-			box-shadow: 0 0 40px rgba(0, 0, 0, 0.08);
-
-			p {
-				font-size: 1rem;
-				margin: 0;
-			}
-
-			hr {
-				margin-bottom: 0.25rem;
-			}
-		}
-
-		@include break-mobile() {
-			max-width: 200px;
-		}
-	}
-
-	&__open-help-text-tooltip {
-		margin-right: 8px;
-		vertical-align: middle;
-
-		&.button {
-			padding: 0;
-
-			.gridicon {
-				top: 4px;
-			}
-		}
-	}
-
-	&__close-help-text-tooltip {
-		position: absolute;
-		right: 16px;
-		top: 16px;
-		color: var(--studio-gray-40);
-
-		&.button {
-			height: 18px;
-			padding: 0;
-		}
-	}
 }
 
 .backup-storage-space__progress-bar-container {
@@ -147,9 +95,13 @@
 	span {
 		vertical-align: middle;
 	}
+
+	.gridicons-info-outline {
+		color: var(--studio-gray-60);
+	}
 }
 
-.backup-storage-space__progress-usage-text {
+.backup-storage-space__progress-usage-container {
 	margin-block-start: 16px;
 	white-space: nowrap;
 	display: flex;
@@ -159,17 +111,81 @@
 	a {
 		text-decoration: underline;
 	}
+}
 
+.backup-storage-space__progress-storage-usage-text {
 	.used-space__span {
 		font-weight: 700;
 	}
+}
 
-	.backups-saved__container {
-		margin-left: auto;
-	}
+.backup-storage-space__progress-backups-saved-text {
+	margin-left: auto;
 }
 
 .backup-storage-space-help-text__tooltip {
 	padding: 10px;
 	max-width: 200px;
+}
+
+.storage-usage-help-tooltip {
+
+	&__tooltip.popover {
+		&.is-right .popover__arrow {
+			border-right-color: #fff;
+		}
+
+		.popover__inner {
+			padding: 16px;
+			color: var(--studio-gray-70);
+			background: #fff;
+			border-radius: 2px;
+			box-shadow: 0 0 40px rgba(0, 0, 0, 0.08);
+
+			p {
+				padding-right: 24px;
+				font-size: $font-body;
+				color: var(--studio-gray-60);
+				margin: 0;
+			}
+
+			hr {
+				margin-bottom: 0.25rem;
+			}
+
+			a {
+				font-size: $font-body;
+				text-decoration: underline;
+			}
+		}
+
+		@include break-mobile() {
+			max-width: 270px;
+		}
+	}
+
+	&__toggle-tooltip {
+		margin-right: 8px;
+		vertical-align: middle;
+
+		&.button {
+			padding: 0;
+
+			.gridicon {
+				top: 4px;
+			}
+		}
+	}
+
+	&__close-tooltip {
+		position: absolute;
+		right: 16px;
+		top: 16px;
+		color: var(--studio-gray-40);
+
+		&.button {
+			height: 18px;
+			padding: 0;
+		}
+	}
 }

--- a/client/components/backup-storage-space/style.scss
+++ b/client/components/backup-storage-space/style.scss
@@ -177,7 +177,7 @@
 	&__toggle-tooltip {
 		vertical-align: middle;
 
-		&.button {
+		&.button.is-borderless {
 			padding: 0;
 			height: 20px;
 

--- a/client/components/backup-storage-space/test/hooks.js
+++ b/client/components/backup-storage-space/test/hooks.js
@@ -18,16 +18,28 @@ jest.mock( 'calypso/state/analytics/actions/record' );
 
 import { render } from '@testing-library/react';
 import { renderHook } from '@testing-library/react-hooks';
-import { useStorageUsageText } from 'calypso/components/backup-storage-space/hooks';
+import {
+	useDaysOfBackupsSavedText,
+	useStorageUsageText,
+} from 'calypso/components/backup-storage-space/hooks';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 
 const GIGABYTE = 2 ** 30;
 const TERABYTE = 2 ** 40;
 
-function renderText( bytesUsed, bytesAvailable ) {
+function renderStorageUsageText( bytesUsed, bytesAvailable ) {
 	const {
 		result: { current: text },
 	} = renderHook( () => useStorageUsageText( bytesUsed, bytesAvailable ) );
+
+	const { container } = render( text );
+	return container;
+}
+
+function renderDaysOfBackupsSavedText( daysOfBackupsSaved, siteSlug ) {
+	const {
+		result: { current: text },
+	} = renderHook( () => useDaysOfBackupsSavedText( daysOfBackupsSaved, siteSlug ) );
 
 	const { container } = render( text );
 	return container;
@@ -46,7 +58,7 @@ describe( 'useStorageUsageText', () => {
 	] )(
 		'renders used storage in gigabytes to one decimal place, rounded',
 		( bytesUsed, expectedGB ) => {
-			const text = renderText( bytesUsed, 0 );
+			const text = renderStorageUsageText( bytesUsed, 0 );
 			expect( text ).toHaveTextContent( `${ expectedGB.toFixed( 1 ) }GB` );
 		}
 	);
@@ -59,7 +71,7 @@ describe( 'useStorageUsageText', () => {
 	] )(
 		'shows available storage in integer terabytes if bytesAvailable is >= 1TB',
 		( bytesAvailable, expectedTB ) => {
-			const text = renderText( 0, bytesAvailable );
+			const text = renderStorageUsageText( 0, bytesAvailable );
 			expect( text ).toHaveTextContent( `${ expectedTB }TB` );
 		}
 	);
@@ -72,19 +84,49 @@ describe( 'useStorageUsageText', () => {
 	] )(
 		'shows available storage in integer gigabytes if bytesAvailable is < 1TB',
 		( bytesAvailable, expectedGB ) => {
-			const text = renderText( 0, bytesAvailable );
+			const text = renderStorageUsageText( 0, bytesAvailable );
 			expect( text ).toHaveTextContent( `${ expectedGB }GB` );
 		}
 	);
 
 	test( "doesn't render available storage if availableBytes is undefined", () => {
-		const text = renderText( GIGABYTE, undefined );
+		const text = renderStorageUsageText( GIGABYTE, undefined );
 		expect( text ).toHaveTextContent( '1.0GB used' );
 		expect( text ).not.toHaveTextContent( ' of ' );
 	} );
 
 	test( 'renders null if bytesUsed is undefined', () => {
-		const text = renderText( undefined, GIGABYTE );
+		const text = renderStorageUsageText( undefined, GIGABYTE );
 		expect( text ).toBeEmptyDOMElement();
+	} );
+} );
+
+describe( 'useDaysOfBackupsSavedText', () => {
+	beforeEach( () => {
+		isJetpackCloud.mockClear();
+	} );
+	test.each( [ [ undefined ], [ 0 ] ] )(
+		"doesn't render backups saved if daysOfBackupsSaved is undefined or 0",
+		( daysOfBackupsSaved ) => {
+			const text = renderDaysOfBackupsSavedText( daysOfBackupsSaved, 'site-slug' );
+			expect( text ).toBeEmptyDOMElement();
+		}
+	);
+
+	test( 'renders `1 day of backup saved` when passed daysOfBackupsSaved as 1', () => {
+		const text = renderDaysOfBackupsSavedText( 1, 'site-slug' );
+		expect( text ).toHaveTextContent( '1 day of backup saved' );
+	} );
+
+	test( 'renders `7 days of backups` saved when passed daysOfBackupsSaved as 7', () => {
+		const text = renderDaysOfBackupsSavedText( 7, 'site-slug' );
+		expect( text ).toHaveTextContent( '7 days of backups saved' );
+	} );
+
+	test( 'renders `7 days of backups saved` with link to activity log with site-slug', () => {
+		const text = renderDaysOfBackupsSavedText( 7, 'site-slug' );
+		expect( text.childNodes[ 0 ] ).toContainHTML(
+			'<a href="/activity-log/site-slug?group=rewind">7 days of backups saved</a>'
+		);
 	} );
 } );

--- a/client/components/backup-storage-space/test/storage-usage-levels.js
+++ b/client/components/backup-storage-space/test/storage-usage-levels.js
@@ -7,21 +7,25 @@ describe( 'getUsageLevel', () => {
 	const MINIMUM_DAYS_OF_BACKUPS = 7;
 
 	test( 'returns Full when storage is 100% utilized', () => {
-		const result = getUsageLevel( 100, 100, MINIMUM_DAYS_OF_BACKUPS, 0, 0 );
+		const result = getUsageLevel( 100, 100, MINIMUM_DAYS_OF_BACKUPS, 0, 0, 0 );
 		expect( result ).toEqual( StorageUsageLevels.Full );
 	} );
 
-	test( 'returns Full when allowed days of backup equals to minimum allowed days of backups', () => {
+	test( 'returns Full when days of backups saved is less than or equal to minimum allowed days of backups', () => {
 		// let's take 7 as minimum allowed days of backups and allowed days of backups as 7 too!
-		// And 30 as plan retention days.
-		const result = getUsageLevel( 100, 100, MINIMUM_DAYS_OF_BACKUPS, 7, 30 );
+		// 30 as plan retention days and 1 as days of backups saved.
+		let result = getUsageLevel( 100, 100, MINIMUM_DAYS_OF_BACKUPS, 7, 30, 1 );
+		expect( result ).toEqual( StorageUsageLevels.Full );
+
+		// Same case but when we had 7 days of backups saved
+		result = getUsageLevel( 100, 100, MINIMUM_DAYS_OF_BACKUPS, 7, 30, 7 );
 		expect( result ).toEqual( StorageUsageLevels.Full );
 	} );
 
 	test( 'returns BackupsDiscarded when allowed days of backup is less than plan retention days', () => {
 		// let's take 7 as minimum allowed days of backups and allowed days of backups as 10
-		// And 30 as plan retention days.
-		const result = getUsageLevel( 100, 100, MINIMUM_DAYS_OF_BACKUPS, 10, 30 );
+		// 30 as plan retention days and 10 as days of backups saved.
+		const result = getUsageLevel( 100, 100, MINIMUM_DAYS_OF_BACKUPS, 10, 30, 10 );
 		expect( result ).toEqual( StorageUsageLevels.BackupsDiscarded );
 	} );
 
@@ -31,7 +35,7 @@ describe( 'getUsageLevel', () => {
 			// let's assume there are 20 backups available in last 30 days and all of the backups can under-fit
 			// the current storage and still it can fit more, so as per the rule allowed days of backup would
 			// always be same as plan retention days!
-			const result = getUsageLevel( used, 100, MINIMUM_DAYS_OF_BACKUPS, 30, 30 );
+			const result = getUsageLevel( used, 100, MINIMUM_DAYS_OF_BACKUPS, 30, 30, 15 );
 			expect( result ).toEqual( StorageUsageLevels.Critical );
 		}
 	);
@@ -39,7 +43,7 @@ describe( 'getUsageLevel', () => {
 	test.each( [ [ 65 ], [ 74.2 ], [ 79.999 ] ] )(
 		'returns Warning when storage is 65-79% utilized',
 		( used ) => {
-			const result = getUsageLevel( used, 100, MINIMUM_DAYS_OF_BACKUPS, 30, 30 );
+			const result = getUsageLevel( used, 100, MINIMUM_DAYS_OF_BACKUPS, 30, 30, 15 );
 			expect( result ).toEqual( StorageUsageLevels.Warning );
 		}
 	);
@@ -47,7 +51,7 @@ describe( 'getUsageLevel', () => {
 	test.each( [ [ 0 ], [ 20.3 ], [ 64.999 ] ] )(
 		'returns Normal when storage is <65% utilized',
 		( used ) => {
-			const result = getUsageLevel( used, 100, 7, 30, 30 );
+			const result = getUsageLevel( used, 100, 7, 30, 30, 10 );
 			expect( result ).toEqual( StorageUsageLevels.Normal );
 		}
 	);

--- a/client/components/backup-storage-space/test/storage-usage-levels.js
+++ b/client/components/backup-storage-space/test/storage-usage-levels.js
@@ -4,15 +4,34 @@ import {
 } from 'calypso/components/backup-storage-space/storage-usage-levels';
 
 describe( 'getUsageLevel', () => {
+	const MINIMUM_DAYS_OF_BACKUPS = 7;
+
 	test( 'returns Full when storage is 100% utilized', () => {
-		const result = getUsageLevel( 100, 100 );
+		const result = getUsageLevel( 100, 100, MINIMUM_DAYS_OF_BACKUPS, 0, 0 );
 		expect( result ).toEqual( StorageUsageLevels.Full );
+	} );
+
+	test( 'returns Full when allowed days of backup equals to minimum allowed days of backups', () => {
+		// let's take 7 as minimum allowed days of backups and allowed days of backups as 7 too!
+		// And 30 as plan retention days.
+		const result = getUsageLevel( 100, 100, MINIMUM_DAYS_OF_BACKUPS, 7, 30 );
+		expect( result ).toEqual( StorageUsageLevels.Full );
+	} );
+
+	test( 'returns BackupsDiscarded when allowed days of backup is less than plan retention days', () => {
+		// let's take 7 as minimum allowed days of backups and allowed days of backups as 10
+		// And 30 as plan retention days.
+		const result = getUsageLevel( 100, 100, MINIMUM_DAYS_OF_BACKUPS, 10, 30 );
+		expect( result ).toEqual( StorageUsageLevels.BackupsDiscarded );
 	} );
 
 	test.each( [ [ 80 ], [ 88.7 ], [ 99.999 ] ] )(
 		'returns Critical when storage is 80-99% utilized',
 		( used ) => {
-			const result = getUsageLevel( used, 100 );
+			// let's assume there are 20 backups available in last 30 days and all of the backups can under-fit
+			// the current storage and still it can fit more, so as per the rule allowed days of backup would
+			// always be same as plan retention days!
+			const result = getUsageLevel( used, 100, MINIMUM_DAYS_OF_BACKUPS, 30, 30 );
 			expect( result ).toEqual( StorageUsageLevels.Critical );
 		}
 	);
@@ -20,7 +39,7 @@ describe( 'getUsageLevel', () => {
 	test.each( [ [ 65 ], [ 74.2 ], [ 79.999 ] ] )(
 		'returns Warning when storage is 65-79% utilized',
 		( used ) => {
-			const result = getUsageLevel( used, 100 );
+			const result = getUsageLevel( used, 100, MINIMUM_DAYS_OF_BACKUPS, 30, 30 );
 			expect( result ).toEqual( StorageUsageLevels.Warning );
 		}
 	);
@@ -28,7 +47,7 @@ describe( 'getUsageLevel', () => {
 	test.each( [ [ 0 ], [ 20.3 ], [ 64.999 ] ] )(
 		'returns Normal when storage is <65% utilized',
 		( used ) => {
-			const result = getUsageLevel( used, 100 );
+			const result = getUsageLevel( used, 100, 7, 30, 30 );
 			expect( result ).toEqual( StorageUsageLevels.Normal );
 		}
 	);

--- a/client/components/backup-storage-space/usage-display.tsx
+++ b/client/components/backup-storage-space/usage-display.tsx
@@ -1,11 +1,17 @@
-import { ProgressBar } from '@automattic/components';
+import { Button, Gridicon, ProgressBar } from '@automattic/components';
 import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import * as React from 'react';
 import { useSelector } from 'react-redux';
-import { getRewindBytesAvailable, getRewindBytesUsed } from 'calypso/state/rewind/selectors';
+import Tooltip from 'calypso/components/tooltip';
+import {
+	getRewindBytesAvailable,
+	getRewindBytesUsed,
+	getRewindDaysOfBackupsSaved,
+} from 'calypso/state/rewind/selectors';
+import { getSiteSlug } from 'calypso/state/sites/selectors';
 import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
-import { useStorageUsageText } from './hooks';
+import { convertBytesToUnitAmount, StorageUnits, useStorageUsageText } from './hooks';
 import { StorageUsageLevelName, StorageUsageLevels } from './storage-usage-levels';
 
 const PROGRESS_BAR_CLASS_NAMES = {
@@ -22,15 +28,35 @@ type OwnProps = {
 
 const UsageDisplay: React.FC< OwnProps > = ( { loading = false, usageLevel } ) => {
 	const siteId = useSelector( getSelectedSiteId ) as number;
+	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) ) as string;
 
 	const translate = useTranslate();
 
 	const bytesAvailable = useSelector( ( state ) => getRewindBytesAvailable( state, siteId ) );
 	const bytesUsed = useSelector( ( state ) => getRewindBytesUsed( state, siteId ) );
 	const storageUsageText = useStorageUsageText( bytesUsed, bytesAvailable );
+	const daysOfBackupsSaved =
+		useSelector( ( state ) => getRewindDaysOfBackupsSaved( state, siteId ) ) || 0;
+
 	const loadingText = translate( 'Calculating…', {
 		comment: 'Loading text displayed while storage usage is being calculated',
 	} );
+
+	const [ isTooltipVisible, setTooltipVisible ] = React.useState< boolean >( false );
+	const tooltip = React.useRef< SVGSVGElement >( null );
+
+	const toggleHelpTooltip = ( event: React.MouseEvent< HTMLButtonElement, MouseEvent > ): void => {
+		setTooltipVisible( ! isTooltipVisible );
+		// when the info tooltip inside a button, we don't want clicking it to propagate up
+		event.stopPropagation();
+	};
+	const closeHelpTooltip = () => {
+		setTooltipVisible( false );
+	};
+	const { unitAmount: availableUnitAmount, unit: availableUnit } = convertBytesToUnitAmount(
+		bytesAvailable || 0
+	);
+	const daysOfBackupsSavedLinkTarget = `/activity-log/${ siteSlug }?group=rewind`;
 
 	return (
 		<div
@@ -38,7 +64,57 @@ const UsageDisplay: React.FC< OwnProps > = ( { loading = false, usageLevel } ) =
 				'is-loading': loading,
 			} ) }
 		>
-			<div className="backup-storage-space__progress-heading">{ translate( 'Storage space' ) }</div>
+			<div className="backup-storage-space__progress-heading">
+				<span>{ translate( 'Cloud storage space' ) } </span>
+				<Button
+					borderless
+					className="backup-storage-space__open-help-text-tooltip"
+					onClick={ toggleHelpTooltip }
+				>
+					<Gridicon ref={ tooltip } icon="info-outline" size={ 24 } />
+				</Button>
+				<Tooltip
+					className="backup-storage-space__help-text-tooltip"
+					isVisible={ isTooltipVisible }
+					position="right"
+					context={ tooltip.current }
+					showOnMobile
+				>
+					<div>
+						{ translate(
+							'We store your backups on our cloud storage. Your total storage size is %(availableUnitAmount)d%(unit)s.',
+							{
+								args: {
+									availableUnitAmount,
+									unit: StorageUnits.Gigabyte === availableUnit ? 'GB' : 'TB',
+								},
+								comment:
+									'Describes available storage amounts (e.g., We store your backups on our cloud storage. Your total storage size is 20GB)',
+							}
+						) }
+						<hr />
+						{ translate( '{{a}}Learn more…{{/a}}', {
+							components: {
+								a: (
+									<a
+										href="https://jetpack.com/support/backup/#how-is-storage-usage-calculated"
+										target="_blank"
+										rel="external noreferrer noopener"
+									/>
+								),
+							},
+						} ) }
+						<Button
+							borderless
+							compact
+							className="backup-storage-space__close-help-text-tooltip"
+							onClick={ closeHelpTooltip }
+						>
+							<Gridicon icon="cross" size={ 18 } />
+						</Button>
+					</div>
+				</Tooltip>
+			</div>
 			<div className="backup-storage-space__progress-bar">
 				<ProgressBar
 					className={ PROGRESS_BAR_CLASS_NAMES[ usageLevel ] }
@@ -47,7 +123,21 @@ const UsageDisplay: React.FC< OwnProps > = ( { loading = false, usageLevel } ) =
 				/>
 			</div>
 			<div className="backup-storage-space__progress-usage-text">
-				{ loading ? loadingText : storageUsageText }
+				<div>{ loading ? loadingText : storageUsageText } </div>
+				<div className="backups-saved__container">
+					{ ! loading &&
+						translate(
+							'{{a}}%(daysOfBackupsSaved)d day of backup saved{{/a}}',
+							'{{a}}%(daysOfBackupsSaved)d days of backups saved{{/a}}',
+							{
+								count: daysOfBackupsSaved,
+								args: { daysOfBackupsSaved },
+								components: {
+									a: <a href={ daysOfBackupsSavedLinkTarget } />,
+								},
+							}
+						) }
+				</div>
 			</div>
 		</div>
 	);

--- a/client/components/backup-storage-space/usage-display.tsx
+++ b/client/components/backup-storage-space/usage-display.tsx
@@ -19,6 +19,7 @@ const PROGRESS_BAR_CLASS_NAMES = {
 	[ StorageUsageLevels.Critical ]: 'red-warning',
 	[ StorageUsageLevels.Warning ]: 'yellow-warning',
 	[ StorageUsageLevels.Normal ]: 'no-warning',
+	[ StorageUsageLevels.BackupsDiscarded ]: 'red-warning',
 };
 
 type OwnProps = {

--- a/client/components/backup-storage-space/usage-display.tsx
+++ b/client/components/backup-storage-space/usage-display.tsx
@@ -1,4 +1,4 @@
-import { ProgressBar } from '@automattic/components';
+import { Gridicon, ProgressBar } from '@automattic/components';
 import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import * as React from 'react';
@@ -50,6 +50,9 @@ const UsageDisplay: React.FC< OwnProps > = ( { loading = false, usageLevel } ) =
 			} ) }
 		>
 			<div className="backup-storage-space__progress-heading">
+				<span hidden={ StorageUsageLevels.Full !== usageLevel }>
+					<Gridicon className="backup-storage-space__storage-full-icon" icon="notice" size={ 24 } />
+				</span>
 				<span>{ translate( 'Cloud storage space' ) } </span>
 				<StorageHelpTooltip
 					className="backup-storage-space__help-tooltip"
@@ -64,8 +67,12 @@ const UsageDisplay: React.FC< OwnProps > = ( { loading = false, usageLevel } ) =
 				/>
 			</div>
 			<div className="backup-storage-space__progress-usage-container">
-				<div className="backup-storage-space__progress-storage-usage-text">
-					{ loading ? loadingText : storageUsageText }{ ' ' }
+				<div
+					className={ classnames( 'backup-storage-space__progress-storage-usage-text', {
+						'is-storage-full': StorageUsageLevels.Full === usageLevel,
+					} ) }
+				>
+					{ loading ? loadingText : storageUsageText }
 				</div>
 				<div className="backup-storage-space__progress-backups-saved-text">
 					{ ! loading && daysOfBackupsSavedText }

--- a/client/components/backup-storage-space/usage-warning/action-button.tsx
+++ b/client/components/backup-storage-space/usage-warning/action-button.tsx
@@ -13,6 +13,7 @@ type OwnProps = {
 	storage: React.ReactChild;
 	onClick?: React.MouseEventHandler;
 	price: JSX.Element;
+	minDaysOfBackupsAllowed: number;
 };
 
 const ActionButton: React.FC< OwnProps > = ( {
@@ -22,8 +23,9 @@ const ActionButton: React.FC< OwnProps > = ( {
 	storage,
 	onClick,
 	price,
+	minDaysOfBackupsAllowed,
 } ) => {
-	const storageStatusText = useStorageStatusText( usageLevel );
+	const storageStatusText = useStorageStatusText( usageLevel, minDaysOfBackupsAllowed );
 
 	const hasClickableAction = Boolean( href || onClick );
 	const translate = useTranslate();

--- a/client/components/backup-storage-space/usage-warning/action-button.tsx
+++ b/client/components/backup-storage-space/usage-warning/action-button.tsx
@@ -13,6 +13,7 @@ type OwnProps = {
 	storage: React.ReactChild;
 	onClick?: React.MouseEventHandler;
 	price: JSX.Element;
+	daysOfBackupsSaved: number;
 	minDaysOfBackupsAllowed: number;
 };
 
@@ -23,9 +24,14 @@ const ActionButton: React.FC< OwnProps > = ( {
 	storage,
 	onClick,
 	price,
+	daysOfBackupsSaved,
 	minDaysOfBackupsAllowed,
 } ) => {
-	const storageStatusText = useStorageStatusText( usageLevel, minDaysOfBackupsAllowed );
+	const storageStatusText = useStorageStatusText(
+		usageLevel,
+		daysOfBackupsSaved,
+		minDaysOfBackupsAllowed
+	);
 
 	const hasClickableAction = Boolean( href || onClick );
 	const translate = useTranslate();

--- a/client/components/backup-storage-space/usage-warning/style.scss
+++ b/client/components/backup-storage-space/usage-warning/style.scss
@@ -55,7 +55,8 @@
 
 		color: var(--studio-jetpack-green);
 		font-size: $font-title-medium;
-		font-weight: 600;
+		font-weight: 700;
+		line-height: 24px;
 	}
 }
 

--- a/client/components/backup-storage-space/usage-warning/style.scss
+++ b/client/components/backup-storage-space/usage-warning/style.scss
@@ -8,7 +8,7 @@
 	width: 100%;
 	height: 100%;
 
-	margin-top: 10px;
+	margin-top: 24px;
 
 	flex-wrap: nowrap;
 	justify-content: space-between;
@@ -43,7 +43,7 @@
 	}
 
 	.action-button__status {
-		margin-bottom: 0.5rem;
+		margin-bottom: 0.25rem;
 	}
 
 	.action-button__action-text {

--- a/client/components/backup-storage-space/usage-warning/upsell.tsx
+++ b/client/components/backup-storage-space/usage-warning/upsell.tsx
@@ -16,6 +16,7 @@ type UpsellProps = {
 	bytesUsed: number;
 	usageLevel: StorageUsageLevelName;
 	siteId: number;
+	daysOfBackupsSaved: number;
 	minDaysOfBackupsAllowed: number;
 };
 
@@ -49,6 +50,7 @@ const UsageWarningUpsell: React.FC< UpsellProps > = ( {
 	bytesUsed,
 	usageLevel,
 	siteId,
+	daysOfBackupsSaved,
 	minDaysOfBackupsAllowed,
 } ) => {
 	const dispatch = useDispatch();
@@ -84,6 +86,7 @@ const UsageWarningUpsell: React.FC< UpsellProps > = ( {
 			onClick={ onClick }
 			price={ price }
 			storage={ upsellSlug.storage }
+			daysOfBackupsSaved={ daysOfBackupsSaved }
 			minDaysOfBackupsAllowed={ minDaysOfBackupsAllowed }
 		/>
 	);

--- a/client/components/backup-storage-space/usage-warning/upsell.tsx
+++ b/client/components/backup-storage-space/usage-warning/upsell.tsx
@@ -16,6 +16,7 @@ type UpsellProps = {
 	bytesUsed: number;
 	usageLevel: StorageUsageLevelName;
 	siteId: number;
+	minDaysOfBackupsAllowed: number;
 };
 
 type UpsellPriceProps = {
@@ -48,6 +49,7 @@ const UsageWarningUpsell: React.FC< UpsellProps > = ( {
 	bytesUsed,
 	usageLevel,
 	siteId,
+	minDaysOfBackupsAllowed,
 } ) => {
 	const dispatch = useDispatch();
 	const { upsellSlug, ...priceInfo } = useUpsellInfo( siteId );
@@ -82,6 +84,7 @@ const UsageWarningUpsell: React.FC< UpsellProps > = ( {
 			onClick={ onClick }
 			price={ price }
 			storage={ upsellSlug.storage }
+			minDaysOfBackupsAllowed={ minDaysOfBackupsAllowed }
 		/>
 	);
 };

--- a/client/components/backup-storage-space/usage-warning/use-storage-status-text.ts
+++ b/client/components/backup-storage-space/usage-warning/use-storage-status-text.ts
@@ -4,6 +4,7 @@ import { StorageUsageLevelName, StorageUsageLevels } from '../storage-usage-leve
 
 const useStorageStatusText = (
 	usageLevel: StorageUsageLevelName,
+	daysOfBackupsSaved: number,
 	minDaysOfBackupsAllowed: number
 ): TranslateResult | null => {
 	const translate = useTranslate();
@@ -22,9 +23,9 @@ const useStorageStatusText = (
 				);
 			case StorageUsageLevels.Full:
 				return translate(
-					'You have reached your storage limit with %(minDaysOfBackupsAllowed)d days of backups saved. Backups have been stopped. Please upgrade your storage to resume backups.',
+					'You have reached your storage limit with %(daysOfBackupsSaved)d days of backups saved. Backups have been stopped. Please upgrade your storage to resume backups.',
 					{
-						args: { minDaysOfBackupsAllowed },
+						args: { daysOfBackupsSaved },
 					}
 				);
 			case StorageUsageLevels.BackupsDiscarded:

--- a/client/components/backup-storage-space/usage-warning/use-storage-status-text.ts
+++ b/client/components/backup-storage-space/usage-warning/use-storage-status-text.ts
@@ -2,7 +2,10 @@ import { useTranslate, TranslateResult } from 'i18n-calypso';
 import { useMemo } from 'react';
 import { StorageUsageLevelName, StorageUsageLevels } from '../storage-usage-levels';
 
-const useStorageStatusText = ( usageLevel: StorageUsageLevelName ): TranslateResult | null => {
+const useStorageStatusText = (
+	usageLevel: StorageUsageLevelName,
+	minDaysOfBackupsAllowed: number
+): TranslateResult | null => {
 	const translate = useTranslate();
 
 	// TODO: For StorageUsageLevels.Warning, estimate how many days until
@@ -10,11 +13,27 @@ const useStorageStatusText = ( usageLevel: StorageUsageLevelName ): TranslateRes
 	return useMemo( () => {
 		switch ( usageLevel ) {
 			case StorageUsageLevels.Warning:
-				return translate( 'You will reach your storage limit soon.' );
+				return translate(
+					'You are close to reaching your storage limit. Once you do, we will delete your oldest backups to make space for new ones.'
+				);
 			case StorageUsageLevels.Critical:
-				return translate( "You're running out of storage space." );
+				return translate(
+					'You are very close to reaching your storage limit. Once you do, we will delete your oldest backups to make space for new ones.'
+				);
 			case StorageUsageLevels.Full:
-				return translate( 'You ran out of storage space.' );
+				return translate(
+					'You have reached your storage limit with %(minDaysOfBackupsAllowed)d days of backups saved. Backups have been stopped. Please upgrade your storage to resume backups.',
+					{
+						args: { minDaysOfBackupsAllowed },
+					}
+				);
+			case StorageUsageLevels.BackupsDiscarded:
+				return translate(
+					'We removed your oldest backup(s) to make space for new ones. We will continue to remove old backups as needed, up to the last %(minDaysOfBackupsAllowed)d days.',
+					{
+						args: { minDaysOfBackupsAllowed },
+					}
+				);
 		}
 
 		return null;

--- a/client/state/data-layer/wpcom/sites/rewind/size/from-api.ts
+++ b/client/state/data-layer/wpcom/sites/rewind/size/from-api.ts
@@ -4,10 +4,21 @@ type ApiResponse = {
 	ok: boolean;
 	error: string;
 	size: number;
+	days_of_backups_saved: number;
+	min_days_of_backups_allowed: number;
+	days_of_backups_allowed: number;
 };
 
-const fromApi = ( { size }: ApiResponse ): RewindSizeInfo => ( {
+const fromApi = ( {
+	size,
+	min_days_of_backups_allowed,
+	days_of_backups_allowed,
+	days_of_backups_saved,
+}: ApiResponse ): RewindSizeInfo => ( {
 	bytesUsed: size,
+	minDaysOfBackupsAllowed: min_days_of_backups_allowed,
+	daysOfBackupsAllowed: days_of_backups_allowed,
+	daysOfBackupsSaved: days_of_backups_saved,
 } );
 
 export default fromApi;

--- a/client/state/rewind/selectors/get-rewind-days-of-backups-allowed.ts
+++ b/client/state/rewind/selectors/get-rewind-days-of-backups-allowed.ts
@@ -1,0 +1,13 @@
+import type { AppState } from 'calypso/types';
+
+/**
+ * Retrieves the computed allowed days of backups as per the storage usage.
+ *
+ * @param state The application state.
+ * @param siteId The site ID for which to retrieve days of backups.
+ * @returns The maximum number of the days of backups allowed for the given site.
+ */
+const getRewindDaysOfBackupsAllowed = ( state: AppState, siteId: number ): number | undefined =>
+	state.rewind[ siteId ]?.size?.daysOfBackupsAllowed ?? undefined;
+
+export default getRewindDaysOfBackupsAllowed;

--- a/client/state/rewind/selectors/get-rewind-days-of-backups-saved.ts
+++ b/client/state/rewind/selectors/get-rewind-days-of-backups-saved.ts
@@ -1,0 +1,13 @@
+import type { AppState } from 'calypso/types';
+
+/**
+ * Retrieves number of days with valid backups saved.
+ *
+ * @param state The application state.
+ * @param siteId The site ID for which to retrieve days of backups saved.
+ * @returns The number of days of backups saved for the given site.
+ */
+const getRewindDaysOfBackupsSaved = ( state: AppState, siteId: number ): number | undefined =>
+	state.rewind[ siteId ]?.size?.daysOfBackupsSaved ?? undefined;
+
+export default getRewindDaysOfBackupsSaved;

--- a/client/state/rewind/selectors/get-rewind-minimum-days-of-backups-allowed.ts
+++ b/client/state/rewind/selectors/get-rewind-minimum-days-of-backups-allowed.ts
@@ -1,0 +1,15 @@
+import type { AppState } from 'calypso/types';
+
+/**
+ * Retrieves the minimum allowed days of backups.
+ *
+ * @param state The application state.
+ * @param siteId The site ID for which to retrieve days of backups.
+ * @returns The minimum number of the days of backups allowed.
+ */
+const getRewindMinimumDaysOfBackupsAllowed = (
+	state: AppState,
+	siteId: number
+): number | undefined => state.rewind[ siteId ]?.size?.minDaysOfBackupsAllowed ?? undefined;
+
+export default getRewindMinimumDaysOfBackupsAllowed;

--- a/client/state/rewind/selectors/index.ts
+++ b/client/state/rewind/selectors/index.ts
@@ -6,3 +6,7 @@ export { default as getRewindSizeRequestStatus } from './get-rewind-size-request
 export { default as isRequestingRewindPolicies } from './is-requesting-rewind-policies';
 export { default as isRequestingRewindSize } from './is-requesting-rewind-size';
 export { default as siteHasBackupInProgress } from './site-has-backup-in-progress';
+export { default as getRewindMinimumDaysOfBackupsAllowed } from './get-rewind-minimum-days-of-backups-allowed';
+export { default as getRewindDaysOfBackupsAllowed } from './get-rewind-days-of-backups-allowed';
+export { default as getRewindDaysOfBackupsSaved } from './get-rewind-days-of-backups-saved';
+export { default as getActivityLogVisibleDays } from './get-activity-log-visible-days';

--- a/client/state/rewind/size/reducer.ts
+++ b/client/state/rewind/size/reducer.ts
@@ -32,7 +32,43 @@ const bytesUsed = (
 	return size.bytesUsed ?? null;
 };
 
+const minDaysOfBackupsAllowed = (
+	state: AppState = null,
+	{ type, size }: AnyAction
+): AppState | number | null => {
+	if ( type !== REWIND_SIZE_SET ) {
+		return state;
+	}
+
+	return size.minDaysOfBackupsAllowed ?? null;
+};
+
+const daysOfBackupsAllowed = (
+	state: AppState = null,
+	{ type, size }: AnyAction
+): AppState | number | null => {
+	if ( type !== REWIND_SIZE_SET ) {
+		return state;
+	}
+
+	return size.daysOfBackupsAllowed ?? null;
+};
+
+const daysOfBackupsSaved = (
+	state: AppState = null,
+	{ type, size }: AnyAction
+): AppState | number | null => {
+	if ( type !== REWIND_SIZE_SET ) {
+		return state;
+	}
+
+	return size.daysOfBackupsSaved ?? null;
+};
+
 export default combineReducers( {
 	requestStatus,
 	bytesUsed,
+	minDaysOfBackupsAllowed,
+	daysOfBackupsAllowed,
+	daysOfBackupsSaved,
 } );

--- a/client/state/rewind/size/types.ts
+++ b/client/state/rewind/size/types.ts
@@ -1,3 +1,6 @@
 export type RewindSizeInfo = {
 	bytesUsed: number;
+	minDaysOfBackupsAllowed: number;
+	daysOfBackupsAllowed: number;
+	daysOfBackupsSaved: number;
 };


### PR DESCRIPTION
UI changes to support the project **_Disable access to old backups when storage is full_** P2 project thread (peaFOp-yh-p2).

#### Proposed Changes

* Design P2: Disable access to old backups when storage is full – i2 Designs & redlines (p1HpG7-jKQ-p2)

#### Testing Instructions
- Test a site with normal usage <65%

<img width="803" alt="usage_normal" src="https://user-images.githubusercontent.com/13975226/213136408-44e6dbd7-f9a3-494b-8a37-3248ee43fcdf.png">

  - The help tooltip!
<img width="749" alt="usage_normal_with_tooltip" src="https://user-images.githubusercontent.com/13975226/213136439-456472f1-cc23-41f4-ba63-80d605cc8bb3.png">

- Test a site with moderate usage <80% and >=65%

<img width="750" alt="usage_warning" src="https://user-images.githubusercontent.com/13975226/213136964-2217df46-412e-406e-80b7-f2f19548a0c7.png">

- Test a site with critical usage <100% and >=80%

<img width="764" alt="usage_critical" src="https://user-images.githubusercontent.com/13975226/213137161-65439bb9-cf33-4aa9-972c-380b78816385.png">

- Test a site with full usage (Note: The below screenshots are of Calypso Blue!)
   1) When the site uses all the storage within the initial 7 days
   
   <img width="771" alt="usage_full_within_6_days" src="https://user-images.githubusercontent.com/13975226/213137688-b5f7f39d-eb73-4288-a8e7-4f44fa079fee.png">

   2)  When the site uses all the storage within its plan retention days and we discarded some backups up to the maximum extent (currently up to the last 7 days)
   <img width="746" alt="usage_full_7_days_blue" src="https://user-images.githubusercontent.com/13975226/213138157-070d5b04-0fff-4b49-b314-a9a53c3399cc.png">
   
- Test a site that uses all of the storage and then we discarded some backups but not up to the maximum extent 

<img width="762" alt="usage_discarded" src="https://user-images.githubusercontent.com/13975226/213138685-e7384d2e-916d-466f-86d2-7a3471f5ff47.png">


Unit tests: 
```
$ yarn test-client client/components/backup-storage-space/test
 PASS  client/components/backup-storage-space/test/hooks.js
 PASS  client/components/backup-storage-space/test/storage-usage-levels.js

Test Suites: 2 passed, 2 total
Tests:       31 passed, 31 total
Snapshots:   0 total
Time:        1.143 s
Ran all test suites matching /client\/components\/backup-storage-space\/test/i.
```


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?

Asana Task: [Update banner "Storage usage" with the new info: num of backups and new texts](1203465157135577-as-1203558009266227)