### PR TITLE
Remove flag themes/plugin-bundling

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/design-picker-design-title.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/design-picker-design-title.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { WPCOM_FEATURES_PREMIUM_THEMES } from '@automattic/calypso-products';
 import { PremiumBadge } from '@automattic/design-picker';
 import { useSelect } from '@wordpress/data';
@@ -24,8 +23,7 @@ const DesignPickerDesignTitle: FC< Props > = ( { designTitle, selectedDesign } )
 		)
 	);
 
-	const showBundledBadge =
-		isEnabled( 'themes/plugin-bundling' ) && selectedDesign.is_bundled_with_woo_commerce;
+	const showBundledBadge = selectedDesign.is_bundled_with_woo_commerce;
 
 	let badge: React.ReactNode = null;
 	if ( showBundledBadge ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -279,9 +279,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 
 	const shouldUpgrade =
 		( selectedDesign?.is_premium && ! isPremiumThemeAvailable && ! didPurchaseSelectedTheme ) ||
-		( isEnabled( 'themes/plugin-bundling' ) &&
-			! isPluginBundleEligible &&
-			isBundledWithWooCommerce );
+		( ! isPluginBundleEligible && isBundledWithWooCommerce );
 
 	const [ showUpgradeModal, setShowUpgradeModal ] = useState( false );
 
@@ -320,7 +318,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 		);
 
 		let plan;
-		if ( isEnabled( 'themes/plugin-bundling' ) && themeHasWooCommerce ) {
+		if ( themeHasWooCommerce ) {
 			plan = 'business-bundle';
 		} else {
 			plan = isEligibleForProPlan && isEnabled( 'plans/pro-plan' ) ? 'pro' : 'premium';

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/upgrade-modal.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/upgrade-modal.tsx
@@ -34,7 +34,7 @@ const UpgradeModal = ( { slug, isOpen, closeModal, checkout }: UpgradeModalProps
 	const featuresHeading = translate( 'Theme features' ) as string;
 	// Check current theme: Does it have a plugin bundled?
 	const theme_software_set = theme?.data?.taxonomies?.theme_software_set?.length;
-	const showBundleVersion = isEnabled( 'themes/plugin-bundling' ) && theme_software_set;
+	const showBundleVersion = theme_software_set;
 
 	const premiumPlanProduct = useSelect( ( select ) =>
 		select( PRODUCTS_LIST_STORE ).getProductBySlug( 'value_bundle' )

--- a/client/landing/stepper/declarative-flow/plugin-bundle-flow.ts
+++ b/client/landing/stepper/declarative-flow/plugin-bundle-flow.ts
@@ -37,10 +37,6 @@ const pluginBundleFlow: Flow = {
 			select( SITE_STORE ).getBundledPluginSlug( siteSlugParam || '' )
 		) as BundledPlugin;
 
-		if ( ! isEnabled( 'themes/plugin-bundling' ) ) {
-			window.location.replace( `/home/${ siteSlugParam }` );
-		}
-
 		const steps = [
 			{
 				slug: 'getCurrentThemeSoftwareSets',

--- a/client/landing/stepper/declarative-flow/registered-flows.ts
+++ b/client/landing/stepper/declarative-flow/registered-flows.ts
@@ -51,10 +51,8 @@ const availableFlows: Record< string, () => Promise< { default: Flow } > > = {
 		import( /* webpackChunkName: "free-post-setup-flow" */ '../declarative-flow/free-post-setup' ),
 };
 
-if ( config.isEnabled( 'themes/plugin-bundling' ) ) {
-	availableFlows[ 'plugin-bundle' ] = () =>
-		import( /* webpackChunkName: "plugin-bundle-flow" */ '../declarative-flow/plugin-bundle-flow' );
-}
+availableFlows[ 'plugin-bundle' ] = () =>
+	import( /* webpackChunkName: "plugin-bundle-flow" */ '../declarative-flow/plugin-bundle-flow' );
 
 if ( config.isEnabled( 'sites/copy-site' ) ) {
 	availableFlows[ 'copy-site' ] = () =>

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -251,7 +251,6 @@ const siteSetupFlow: Flow = {
 					// If so, send them to the plugin-bundle flow.
 					const theme_software_set = currentTheme?.taxonomies?.theme_software_set;
 					if (
-						isEnabled( 'themes/plugin-bundling' ) &&
 						theme_software_set &&
 						theme_software_set.length > 0 &&
 						isPluginBundleEligible &&

--- a/client/state/themes/selectors/does-theme-bundle-software-set.js
+++ b/client/state/themes/selectors/does-theme-bundle-software-set.js
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { getTheme } from 'calypso/state/themes/selectors/get-theme';
 
 import 'calypso/state/themes/init';
@@ -13,7 +12,5 @@ import 'calypso/state/themes/init';
 export function doesThemeBundleSoftwareSet( state, themeId ) {
 	const theme = getTheme( state, 'wpcom', themeId );
 	const theme_software_set = theme?.taxonomies?.theme_software_set;
-	return (
-		isEnabled( 'themes/plugin-bundling' ) && theme_software_set && theme_software_set.length > 0
-	);
+	return theme_software_set && theme_software_set.length > 0;
 }

--- a/config/development.json
+++ b/config/development.json
@@ -172,7 +172,6 @@
 		"subscriber-importer": true,
 		"subscription-gifting": true,
 		"themes/atomic-homepage-replace": true,
-		"themes/plugin-bundling": true,
 		"themes/premium": true,
 		"themes/showcase-i4/cards-only": true,
 		"themes/showcase-i4/details-and-preview": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -115,7 +115,6 @@
 		"subscriber-importer": true,
 		"subscription-gifting": true,
 		"themes/atomic-homepage-replace": true,
-		"themes/plugin-bundling": true,
 		"themes/premium": true,
 		"themes/showcase-i4/cards-only": false,
 		"themes/showcase-i4/details-and-preview": false,

--- a/config/production.json
+++ b/config/production.json
@@ -135,7 +135,6 @@
 		"subscriber-importer": true,
 		"subscription-gifting": true,
 		"themes/atomic-homepage-replace": true,
-		"themes/plugin-bundling": true,
 		"themes/premium": true,
 		"themes/showcase-i4/cards-only": false,
 		"themes/showcase-i4/details-and-preview": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -131,7 +131,6 @@
 		"subscriber-importer": true,
 		"subscription-gifting": true,
 		"themes/atomic-homepage-replace": true,
-		"themes/plugin-bundling": true,
 		"themes/premium": true,
 		"themes/showcase-i4/cards-only": false,
 		"themes/showcase-i4/details-and-preview": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -141,7 +141,6 @@
 		"subscriber-importer": true,
 		"subscription-gifting": true,
 		"themes/atomic-homepage-replace": true,
-		"themes/plugin-bundling": true,
 		"themes/premium": true,
 		"themes/showcase-i4/cards-only": false,
 		"themes/showcase-i4/details-and-preview": false,

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { isEnabled } from '@automattic/calypso-config';
 import { FEATURE_WOOP } from '@automattic/calypso-products';
 import { MShotsImage } from '@automattic/onboarding';
 import { useViewportMatch } from '@wordpress/compose';
@@ -167,8 +166,7 @@ const DesignButton: React.FC< DesignButtonProps > = ( {
 	const shouldUpgrade = isPremium && ! isPremiumThemeAvailable && ! hasPurchasedTheme;
 	const currentSiteCanInstallWoo = currentPlanFeatures?.includes( FEATURE_WOOP ) ?? false;
 
-	const designIsBundledWithWoo =
-		isEnabled( 'themes/plugin-bundling' ) && design.is_bundled_with_woo_commerce;
+	const designIsBundledWithWoo = design.is_bundled_with_woo_commerce;
 
 	function getPricingDescription() {
 		let text: React.ReactNode = null;


### PR DESCRIPTION
#### Proposed Changes

This PR removes all references to the `themes/plugin-bundling` feature flag since it's now `true` in all environments.

#### Testing Instructions

There shouldn't be any changes from the user's perspective.

Most of the changes happened within the stepper framework, on the `site-setup-flow` and `plugin-bundle-flow`.
There are also a few changes on the unified design picker.

Removing the flag should have the same effect of replacing it with `true`.

Closes https://github.com/Automattic/wp-calypso/issues/72244
