### PR TITLE
Users management: Optimize way of fetching subscriber by id

### DIFF
--- a/client/data/followers/use-follower-query.js
+++ b/client/data/followers/use-follower-query.js
@@ -1,0 +1,13 @@
+import { useQuery } from 'react-query';
+import wpcom from 'calypso/lib/wp';
+
+const useFollowerQuery = ( siteId, subscriberId, type ) => {
+	return useQuery( [ 'subscriber', subscriberId, type ], () =>
+		wpcom.req.get( {
+			path: `/sites/${ siteId }/followers/${ subscriberId }?type=${ type }&http_envelope=1`,
+			apiNamespace: 'rest/v1.1',
+		} )
+	);
+};
+
+export default useFollowerQuery;

--- a/client/my-sites/people/controller.js
+++ b/client/my-sites/people/controller.js
@@ -171,10 +171,13 @@ function renderSubscribersDetails( context, next ) {
 		return <DocumentHead title={ translate( 'User Details', { textOnly: true } ) } />;
 	};
 
+	// typeId is in the format "{type}-{id}
+	const [ type, id ] = context.params.typeId.split( '-' );
+
 	context.primary = (
 		<>
 			<SubscriberDetailsTitle />
-			<SubscriberDetails subscriberId={ context.params.id } />
+			<SubscriberDetails subscriberId={ id } subscriberType={ type } />
 		</>
 	);
 	next();

--- a/client/my-sites/people/index.js
+++ b/client/my-sites/people/index.js
@@ -55,7 +55,7 @@ export default function () {
 	);
 
 	page(
-		'/people/:filter(subscribers)/:site_id/:id',
+		'/people/:filter(subscribers)/:site_id/:typeId',
 		peopleController.enforceSiteEnding,
 		siteSelection,
 		navigation,

--- a/client/my-sites/people/people-list-item/index.jsx
+++ b/client/my-sites/people/people-list-item/index.jsx
@@ -62,24 +62,24 @@ class PeopleListItem extends PureComponent {
 	maybeGetCardLink = () => {
 		const { invite, site, type, user } = this.props;
 
-		if ( 'invite-details' === type ) {
-			return null;
-		}
-
-		const editLink = this.canLinkToProfile() && `/people/edit/${ site.slug }/${ user.login }`;
-		const inviteLink = invite && `/people/invites/${ site.slug }/${ invite.key }`;
-		const subscriberDetailsLink =
-			this.canLinkToSubscriberProfile() && `/people/subscribers/${ site.slug }/${ user.ID }`;
-
 		switch ( type ) {
-			case 'invite':
-				return inviteLink;
+			case 'invite-details':
+				return null;
 
-			case 'subscriber-details':
-				return subscriberDetailsLink;
+			case 'invite':
+				return invite && `/people/invites/${ site.slug }/${ invite.key }`;
+
+			case 'subscriber-details': {
+				const subscriberType = user.login ? 'wpcom' : 'email';
+
+				return (
+					this.canLinkToSubscriberProfile() &&
+					`/people/subscribers/${ site.slug }/${ subscriberType }-${ user.ID }`
+				);
+			}
 
 			default:
-				return editLink;
+				return this.canLinkToProfile() && `/people/edit/${ site.slug }/${ user.login }`;
 		}
 	};
 


### PR DESCRIPTION
#### Proposed Changes

- Integrated a new endpoint for fetching subscribers by id instead of the current passing through the list of items.
- Updated route: from `/people/:filter(subscribers)/:site_id/:id` to `/people/:filter(subscribers)/:site_id/:typeId`
  - `typeId` contains subscribers type and id in the format: `{type}-{id}`

#### Testing Instructions

From the UX perspective, nothing is changed except the route
* Go to `people/subscribers/{SITE_SLUG}`
* Click on one of the items
* Check if you are on the User Details page

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #72002
