### PR TITLE
Followers: remove unused translations from PeopleListSectionHeader

### DIFF
--- a/client/my-sites/people/people-list-section-header/index.jsx
+++ b/client/my-sites/people/people-list-section-header/index.jsx
@@ -1,6 +1,6 @@
 import { Button, Gridicon } from '@automattic/components';
 import classNames from 'classnames';
-import i18n, { localize } from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 import { get, startsWith } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
@@ -55,19 +55,11 @@ class PeopleListSectionHeader extends Component {
 		const { currentRoute, translate } = this.props;
 
 		if ( startsWith( currentRoute, '/people/followers' ) ) {
-			// Adding a dot at the end of the translation. New translation for RTL languages.
-			return i18n.hasTranslation( 'A list of people currently following your site.' )
-				? translate( 'A list of people currently following your site.' )
-				: translate( 'A list of people currently following your site' ) + '.';
+			return translate( 'A list of people currently following your site.' );
 		}
 
 		if ( startsWith( currentRoute, '/people/email-followers' ) ) {
-			// Adding a dot at the end of the translation. New translation for RTL languages.
-			return i18n.hasTranslation(
-				'A list of people who are subscribed to your blog via email only.'
-			)
-				? translate( 'A list of people who are subscribed to your blog via email only.' )
-				: translate( 'A list of people who are subscribed to your blog via email only' ) + '.';
+			return translate( 'A list of people who are subscribed to your blog via email only.' );
 		}
 
 		return null;


### PR DESCRIPTION
#### Proposed Changes

* This PR cleans and removes unused translations added to `PeopleListSectionHeader` using `hasTranslation`.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Follow the testing instructions described on https://github.com/Automattic/wp-calypso/pull/71536

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/71536
