### PR TITLE
Fix 404 errors in /theme/:theme/:site for logged in users

### DIFF
--- a/client/my-sites/theme/controller.jsx
+++ b/client/my-sites/theme/controller.jsx
@@ -15,29 +15,42 @@ export function fetchThemeDetailsData( context, next ) {
 
 	const themeSlug = context.params.slug;
 	const theme = getTheme( context.store.getState(), 'wpcom', themeSlug );
+	const themeDotOrg = getTheme( context.store.getState(), 'wporg', themeSlug );
 
-	if ( theme ) {
-		debug( 'found theme!', theme.id );
+	if ( theme || themeDotOrg ) {
+		debug( 'found theme!', theme?.id ?? themeDotOrg.id );
 		return next();
 	}
 
-	Promise.all(
-		context.store.dispatch( requestTheme( themeSlug, 'wpcom', context.lang ) ),
-		context.store.dispatch( requestTheme( themeSlug, 'wporg', context.lang ) )
-	)
+	context.store
+		.dispatch( requestTheme( themeSlug, 'wpcom', context.lang ) )
 		.then( () => {
 			const themeDetails = getTheme( context.store.getState(), 'wpcom', themeSlug );
-			if ( ! themeDetails ) {
-				const error = getThemeRequestErrors( context.store.getState(), themeSlug, 'wpcom' );
-				debug( `Error fetching theme ${ themeSlug } details: `, error.message || error );
-				const err = {
-					status: 404,
-					message: 'Theme Not Found',
-					themeSlug,
-				};
-				return next( err );
+			if ( themeDetails ) {
+				return next();
 			}
-			next();
+
+			context.store
+				.dispatch( requestTheme( themeSlug, 'wporg', context.lang ) )
+				.then( () => {
+					const themeOrgDetails = getTheme( context.store.getState(), 'wporg', themeSlug );
+					if ( ! themeOrgDetails ) {
+						const err = {
+							status: 404,
+							message: 'Theme Not Found',
+							themeSlug,
+						};
+						const error = getThemeRequestErrors( context.store.getState(), themeSlug, 'wporg' );
+						debug( `Error fetching WPORG theme ${ themeSlug } details: `, error.message || error );
+						return next( err );
+					}
+
+					next();
+				} )
+				.catch( next );
+
+			const error = getThemeRequestErrors( context.store.getState(), themeSlug, 'wpcom' );
+			debug( `Error fetching WPCOM theme ${ themeSlug } details: `, error.message || error );
 		} )
 		.catch( next );
 }

--- a/client/my-sites/theme/controller.jsx
+++ b/client/my-sites/theme/controller.jsx
@@ -9,7 +9,7 @@ import ThemeNotFoundError from './theme-not-found-error';
 const debug = debugFactory( 'calypso:themes' );
 
 export function fetchThemeDetailsData( context, next ) {
-	if ( ! context.isServerSide || context.cachedMarkup ) {
+	if ( context.cachedMarkup ) {
 		return next();
 	}
 

--- a/client/my-sites/theme/controller.jsx
+++ b/client/my-sites/theme/controller.jsx
@@ -21,8 +21,10 @@ export function fetchThemeDetailsData( context, next ) {
 		return next();
 	}
 
-	context.store
-		.dispatch( requestTheme( themeSlug, 'wpcom', context.lang ) )
+	Promise.all(
+		context.store.dispatch( requestTheme( themeSlug, 'wpcom', context.lang ) ),
+		context.store.dispatch( requestTheme( themeSlug, 'wporg', context.lang ) )
+	)
 		.then( () => {
 			const themeDetails = getTheme( context.store.getState(), 'wpcom', themeSlug );
 			if ( ! themeDetails ) {

--- a/client/my-sites/theme/index.web.js
+++ b/client/my-sites/theme/index.web.js
@@ -29,8 +29,9 @@ function addNavigationIfLoggedIn( context, next ) {
 
 function setTitleAndSelectSiteIfLoggedIn( context, next ) {
 	const theme = getTheme( context.store.getState(), 'wpcom', context.params.slug );
-	if ( theme ) {
-		const themeName = theme.name;
+	const themeOrg = getTheme( context.store.getState(), 'wporg', context.params.slug );
+	if ( theme || themeOrg ) {
+		const themeName = theme?.name ?? themeOrg.name;
 
 		context.getSiteSelectionHeaderText = () =>
 			translate( 'Select a site to view {{strong}}%(themeName)s{{/strong}}', {

--- a/client/my-sites/themes/controller.jsx
+++ b/client/my-sites/themes/controller.jsx
@@ -47,7 +47,7 @@ export function loggedOut( context, next ) {
 }
 
 export function fetchThemeData( context, next ) {
-	if ( ! context.isServerSide || context.cachedMarkup ) {
+	if ( context.cachedMarkup ) {
 		debug( 'Skipping theme data fetch' );
 		return next();
 	}


### PR DESCRIPTION
#### Proposed Changes

* Remove the SSR guard for the fetch theme middlewares.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this branch locally
* Disable isomorphic routing on your local env (from sections.js) for `theme` and `themes`
* Go to `calypso.localhost:3000/theme/tu/:your-site from a direct link (otherwise the 404 is not reproduced)
* Make sure that you now get the details page instead of a 404

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/72161
