### PR TITLE
Fix arrow buttons in the Email Stats page

### DIFF
--- a/client/my-sites/stats/stats-email-chart-tabs/index.jsx
+++ b/client/my-sites/stats/stats-email-chart-tabs/index.jsx
@@ -47,6 +47,7 @@ class StatModuleChartTabs extends Component {
 		chartTab: PropTypes.string,
 		switchTab: PropTypes.func,
 		queryDate: PropTypes.string,
+		queryHour: PropTypes.string,
 		recordGoogleEvent: PropTypes.func,
 		sliceFromBeginning: PropTypes.bool,
 	};
@@ -119,7 +120,10 @@ const NO_SITE_STATE = {
 };
 
 const connectComponent = connect(
-	( state, { activeLegend, period: { period, endOf }, chartTab, queryDate, postId, statType } ) => {
+	(
+		state,
+		{ activeLegend, period: { period, endOf }, chartTab, queryDate, queryHour, postId, statType }
+	) => {
 		const siteId = getSelectedSiteId( state );
 		if ( ! siteId ) {
 			return NO_SITE_STATE;
@@ -127,7 +131,14 @@ const connectComponent = connect(
 
 		const quantity = 'hour' === period ? 24 : 30;
 		const counts = getCountRecords( state, siteId, postId, period, statType );
-		const chartData = buildChartData( activeLegend, chartTab, counts, period, queryDate );
+		const chartData = buildChartData(
+			activeLegend,
+			chartTab,
+			counts,
+			period,
+			queryDate,
+			queryHour
+		);
 		const isActiveTabLoading = isLoadingTabs(
 			state,
 			siteId,

--- a/client/my-sites/stats/stats-email-chart-tabs/utility.js
+++ b/client/my-sites/stats/stats-email-chart-tabs/utility.js
@@ -31,34 +31,47 @@ export function getQueryDate( queryDate, timezoneOffset, period, quantity ) {
 	return endOfPeriodDate;
 }
 
-const EMPTY_RESULT = [];
-export const buildChartData = memoizeLast( ( activeLegend, chartTab, data, period, queryDate ) => {
-	if ( ! data ) {
-		return EMPTY_RESULT;
+const checkIsSelected = ( record, queryDate, queryHour ) => {
+	let isSelected = record.period === queryDate;
+
+	if ( isSelected && record.hour ) {
+		isSelected = record.hour && record.hour.toString() === queryHour;
 	}
 
-	return data.map( ( record ) => {
-		const nestedValue = activeLegend.length ? record[ activeLegend[ 0 ] ] : null;
+	return isSelected;
+};
 
-		const recordClassName =
-			record.classNames && record.classNames.length ? record.classNames.join( ' ' ) : null;
-		const className = classNames( recordClassName, {
-			'is-selected': record.period === queryDate,
+const EMPTY_RESULT = [];
+export const buildChartData = memoizeLast(
+	( activeLegend, chartTab, data, period, queryDate, queryHour ) => {
+		if ( ! data ) {
+			return EMPTY_RESULT;
+		}
+
+		return data.map( ( record ) => {
+			const nestedValue = activeLegend.length ? record[ activeLegend[ 0 ] ] : null;
+
+			const recordClassName =
+				record.classNames && record.classNames.length ? record.classNames.join( ' ' ) : null;
+
+			const className = classNames( recordClassName, {
+				'is-selected': checkIsSelected( record, queryDate, queryHour ),
+			} );
+
+			return addTooltipData(
+				chartTab,
+				{
+					label: record[ `label${ capitalize( period ) }` ],
+					value: record[ chartTab ],
+					data: record,
+					nestedValue,
+					className,
+				},
+				period
+			);
 		} );
-
-		return addTooltipData(
-			chartTab,
-			{
-				label: record[ `label${ capitalize( period ) }` ],
-				value: record[ chartTab ],
-				data: record,
-				nestedValue,
-				className,
-			},
-			period
-		);
-	} );
-} );
+	}
+);
 
 function addTooltipData( chartTab, item, period ) {
 	const tooltipData = [];

--- a/client/my-sites/stats/stats-email-open-detail/index.jsx
+++ b/client/my-sites/stats/stats-email-open-detail/index.jsx
@@ -203,6 +203,7 @@ class StatsEmailOpenDetail extends Component {
 		} = this.props;
 
 		const queryDate = date.format( 'YYYY-MM-DD' );
+		const queryHour = date.format( 'H' );
 		const noViewsLabel = translate( 'Your email has not received any views yet!' );
 
 		const { period, endOf } = this.props.period;
@@ -281,6 +282,7 @@ class StatsEmailOpenDetail extends Component {
 									switchTab={ this.switchChart }
 									charts={ CHARTS }
 									queryDate={ queryDate }
+									queryHour={ queryHour }
 									period={ this.props.period }
 									chartTab={ this.props.chartTab }
 									postId={ postId }

--- a/client/my-sites/stats/stats-period-navigation/index.jsx
+++ b/client/my-sites/stats/stats-period-navigation/index.jsx
@@ -52,7 +52,9 @@ class StatsPeriodNavigation extends PureComponent {
 
 	handleArrowNext = () => {
 		const { date, moment, period, url, queryParams } = this.props;
-		const nextDay = moment( date ).add( 1, period ).format( 'YYYY-MM-DD' );
+
+		const usedPeriod = 'hour' === period ? 'day' : period;
+		const nextDay = moment( date ).add( 1, usedPeriod ).format( 'YYYY-MM-DD' );
 		const nextDayQuery = qs.stringify( Object.assign( {}, queryParams, { startDate: nextDay } ), {
 			addQueryPrefix: true,
 		} );

--- a/client/state/stats/emails/reducer.js
+++ b/client/state/stats/emails/reducer.js
@@ -73,12 +73,14 @@ export const requests = ( state = {}, action ) => {
  * @returns {object}        Updated state
  */
 export const items = withSchemaValidation( itemSchemas, ( state = {}, action ) => {
+	const checkState = ( actualState, period ) => ( 'hour' === period ? {} : actualState );
+
 	switch ( action.type ) {
 		case EMAIL_STATS_RECEIVE:
 			// eslint-disable-next-line no-case-declarations
 			const { siteId, postId, period, statType } = action;
 
-			return merge( {}, state, {
+			return merge( {}, checkState( state, period ), {
 				[ siteId ]: {
 					[ postId ]: {
 						[ period ]: {

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -988,6 +988,10 @@ export function parseEmailChartData( payload, nullAttributes = [] ) {
 		return [];
 	}
 
+	if ( 'hour' === payload.unit ) {
+		payload.fields.push( 'hour' );
+	}
+
 	return payload.data.map( function ( record ) {
 		// Initialize data
 		const dataRecord = nullAttributes.reduce( ( memo, attribute ) => {


### PR DESCRIPTION
#### Proposed Changes

This PR fixes the left and right arrows of the Email Stats chart when the `hours` period is selected.

<img width="1119" alt="Screenshot 2023-01-16 at 19 15 54" src="https://user-images.githubusercontent.com/3832570/212743634-4ac82763-1f2b-41a5-a2cb-c94ab86d4f36.png">

#### Testing Instructions

1. Apply this branch to your local Calypso repository and start the application.
2. Insert manually in the browser address bar an URL with this format: https://calypso.localhost:3000/stats/email/open/[the-doomain-of-your-blog]/day/[post-id]?flags=newsletter/stats. Note that you can change day for week and month.
3.  Click on the previous or the next arrow (as shown in the above picture). Wait for the data to come in. You should see the right day showing in the chart.

#### Known things to fix in next PRs
- We need to fix the selected column (the light blue column in the chart). Shouldn't be there as per design.
- The chart loads from the endpoint every time, so if we click the next arrow and then then previous arrow, the endpoint is still called. That doesn't happen with `days` is selected.

Fixes https://github.com/Automattic/wp-calypso/issues/71932