### PR TITLE
Device Switcher: Adjust spacing to align with Figma

### DIFF
--- a/packages/components/src/device-switcher/toolbar.scss
+++ b/packages/components/src/device-switcher/toolbar.scss
@@ -7,7 +7,7 @@
 	.device-switcher__toolbar-devices {
 		display: flex;
 		height: 58px;
-		margin-bottom: 28px;
+		margin-bottom: 13px;
 		justify-content: center;
 
 		> button {


### PR DESCRIPTION
#### Proposed Changes

* Adjust the spacing between devices and the frame to align with 7l53h5fxAUNjVRBQ82YFwn-fi-1603%3A58763

| Before | After |
| - | - |
| ![image](https://user-images.githubusercontent.com/13596067/212796339-3a0584cf-6ea4-4fc4-b978-60bb978f0e58.png) | ![image](https://user-images.githubusercontent.com/13596067/212796419-97e184e6-402e-41b1-bce7-d92f223b2131.png) |

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /setup?siteSlug=<your_site>
* Click the "Continue" button until you land on the Design Picker step
* Preview any design with style variation or select Blank Canvas CTA
* When you're previewing the design, verify the spacing is correct.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #