### PR TITLE
Stats: add script to build translations in teamcity

### DIFF
--- a/.teamcity/_self/projects/WPComPlugins.kt
+++ b/.teamcity/_self/projects/WPComPlugins.kt
@@ -158,6 +158,17 @@ private object OdysseyStats : WPComPluginBuild(
 	pluginSlug = "odyssey-stats",
 	archiveDir = "./dist/",
 	docsLink = "PejTkB-3N-p2",
+	buildSteps = {
+		bashNodeScript {
+			name = "Translate Odyssey Stats"
+			scriptContent = """
+				cd apps/odyssey-stats
+
+				# generate language files
+				yarn translate
+			"""
+		}
+	}
 )
 
 private object O2Blocks : WPComPluginBuild(


### PR DESCRIPTION
#### Proposed Changes

The ability to build language files for Odyssey was added in #71914. The PR proposes to add the building of translations to teamcity.

#### Testing Instructions

* The PR can only be verfied after merged, so IMHO it only needs some proof reading by the platform team

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
