### PR TITLE
Stats: Enhance the Google My Business page with modernized layouts

### DIFF
--- a/client/my-sites/google-my-business/stats/index.js
+++ b/client/my-sites/google-my-business/stats/index.js
@@ -9,6 +9,7 @@ import DocumentHead from 'calypso/components/data/document-head';
 import QueryKeyringConnections from 'calypso/components/data/query-keyring-connections';
 import QueryKeyringServices from 'calypso/components/data/query-keyring-services';
 import QuerySiteKeyrings from 'calypso/components/data/query-site-keyrings';
+import FormattedHeader from 'calypso/components/formatted-header';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import Main from 'calypso/components/main';
 import Notice from 'calypso/components/notice';
@@ -193,67 +194,89 @@ class GoogleMyBusinessStats extends Component {
 		const { isLocationVerified, locationData, siteId, siteSlug, translate } = this.props;
 
 		return (
-			<Main wideLayout>
+			<Main fullWidthLayout>
 				<PageViewTracker
 					path="/google-my-business/stats/:site"
 					title="Google My Business > Stats"
 				/>
 
-				<DocumentHead title={ translate( 'Stats' ) } />
-
-				<StatsNavigation
-					selectedItem="googleMyBusiness"
-					siteId={ siteId }
-					slug={ siteSlug }
-					isLegacy
-				/>
+				<DocumentHead title={ translate( 'Jetpack Stats' ) } />
 
 				<QuerySiteKeyrings siteId={ siteId } />
 				<QueryKeyringConnections forceRefresh />
 				<QueryKeyringServices />
 
-				{ ! locationData && (
-					<Notice
-						status="is-error"
-						showDismiss={ false }
-						text={ translate( 'There is an error with your Google My Business account.' ) }
-					>
-						<NoticeAction href={ CALYPSO_CONTACT }>{ translate( 'Contact Support' ) }</NoticeAction>
-					</Notice>
-				) }
-
-				{ !! locationData && ! isLocationVerified && (
-					<Notice
-						status="is-error"
-						text={ translate(
-							'Your location has not been verified. ' +
-								'Statistics are not available until you have {{a}}verified your location{{/a}} with Google.',
+				<div className="stats">
+					<FormattedHeader
+						brandFont
+						className="stats__section-header modernized-header"
+						headerText={ translate( 'Google My Business' ) }
+						align="left"
+						subHeaderText={ translate(
+							'Integrate your business with Google and get stats on your locations. {{learnMoreLink}}Learn more{{/learnMoreLink}}',
 							{
 								components: {
-									a: (
+									learnMoreLink: (
 										<a
-											href="https://support.google.com/business/answer/7107242"
+											href="https://wordpress.com/support/google-my-business-integration/#checking-the-impact-of-your-google-my-business-connection"
 											target="_blank"
-											rel="noopener noreferrer"
+											rel="noreferrer noopener"
 										/>
 									),
 								},
 							}
 						) }
 					/>
-				) }
 
-				<GoogleMyBusinessLocation location={ locationData }>
-					<Button
-						href="https://business.google.com/"
-						onClick={ this.trackUpdateListingClick }
-						target="_blank"
-					>
-						{ translate( 'Update Listing' ) } <Gridicon icon="external" />
-					</Button>
-				</GoogleMyBusinessLocation>
+					<StatsNavigation selectedItem="googleMyBusiness" siteId={ siteId } slug={ siteSlug } />
 
-				{ this.renderStats() }
+					{ ! locationData && (
+						<Notice
+							status="is-error"
+							showDismiss={ false }
+							text={ translate( 'There is an error with your Google My Business account.' ) }
+						>
+							<NoticeAction href={ CALYPSO_CONTACT }>
+								{ translate( 'Contact Support' ) }
+							</NoticeAction>
+						</Notice>
+					) }
+
+					{ !! locationData && ! isLocationVerified && (
+						<Notice
+							status="is-error"
+							text={ translate(
+								'Your location has not been verified. ' +
+									'Statistics are not available until you have {{a}}verified your location{{/a}} with Google.',
+								{
+									components: {
+										a: (
+											<a
+												href="https://support.google.com/business/answer/7107242"
+												target="_blank"
+												rel="noopener noreferrer"
+											/>
+										),
+									},
+								}
+							) }
+						/>
+					) }
+
+					<div className="stats__gmb-location-wrapper">
+						<GoogleMyBusinessLocation location={ locationData }>
+							<Button
+								href="https://business.google.com/"
+								onClick={ this.trackUpdateListingClick }
+								target="_blank"
+							>
+								{ translate( 'Update Listing' ) } <Gridicon icon="external" />
+							</Button>
+						</GoogleMyBusinessLocation>
+					</div>
+
+					{ this.renderStats() }
+				</div>
 			</Main>
 		);
 	}

--- a/client/my-sites/google-my-business/stats/style.scss
+++ b/client/my-sites/google-my-business/stats/style.scss
@@ -1,3 +1,5 @@
+@import "calypso/my-sites/stats/modernized-layout-styles.scss";
+
 .stats__metrics {
 	.pie-chart__chart-drawing,
 	.pie-chart__placeholder-drawing {
@@ -43,5 +45,11 @@
 
 	@include breakpoint-deprecated( "<480px" ) {
 		width: 100%;
+	}
+}
+
+.stats__gmb-location-wrapper {
+	.gmb-location {
+		margin-bottom: 0;
 	}
 }

--- a/client/my-sites/google-my-business/stats/style.scss
+++ b/client/my-sites/google-my-business/stats/style.scss
@@ -11,6 +11,10 @@
 	display: inline-block;
 	margin-top: 1px; // Fixes shadow truncated at the top of the second column
 	width: 100%;
+
+	.stats .card-heading {
+		margin-left: 0;
+	}
 }
 
 .gmb-stats__chart {

--- a/client/my-sites/stats/modernized-layout-styles.scss
+++ b/client/my-sites/stats/modernized-layout-styles.scss
@@ -23,7 +23,8 @@ $sidebar-appearance-break-point: 783px;
 	> .stats__all-time-highlights-section,
 	> .stats__all-time-views-section,
 	> .stats__post-detail-highlights-section,
-	> .stats__post-detail-table-section {
+	> .stats__post-detail-table-section,
+	> .stats__gmb-location-wrapper {
 		padding-top: $vertical-margin;
 		padding-bottom: $vertical-margin;
 	}

--- a/client/my-sites/stats/modernized-layout-styles.scss
+++ b/client/my-sites/stats/modernized-layout-styles.scss
@@ -1,3 +1,5 @@
+// Must be included in root style.scss of /stats, /store, and /google-my-business/stats
+
 @use "sass:math";
 @import "@automattic/components/src/highlight-cards/variables.scss";
 
@@ -46,9 +48,12 @@ $sidebar-appearance-break-point: 783px;
 	}
 }
 
-// this overrides the default .layout__content that adds unwanted padding
 .is-section-stats,
-.is-section-woocommerce {
+.is-section-woocommerce,
+.is-section-google-my-business {
+	background: var(--studio-white);
+
+	// this overrides the default .layout__content that adds unwanted padding
 	& .layout__content,
 	&.theme-default .focus-content .layout__content {
 		padding: $stats-layout-contnet-padding-top 0 0 0;

--- a/client/my-sites/stats/style.scss
+++ b/client/my-sites/stats/style.scss
@@ -228,8 +228,6 @@
 
 // Stats section scoped styles
 .is-section-stats {
-	background: var(--studio-white);
-
 	&.color-scheme.is-classic-dark {
 		@include apply-improved-classic-dark-colors();
 	}

--- a/client/my-sites/store/style.scss
+++ b/client/my-sites/store/style.scss
@@ -1,5 +1,5 @@
 @import "client/my-sites/stats/modernized-tooltip-styles.scss";
-@import "client/my-sites/stats/modernized-layout-styles.scss";
+@import "calypso/my-sites/stats/modernized-layout-styles.scss";
 
 .woocommerce {
 	@import "app/dashboard/style";
@@ -46,8 +46,6 @@
 }
 
 .is-section-woocommerce {
-	background: var(--studio-white);
-
 	// overwrite notice styles due to sticky bar
 	.global-notices {
 		z-index: z-index("root", ".is-section-woocommerce .global-notices");


### PR DESCRIPTION
#### Proposed Changes

* Adjust the `Google My Business` page HTML structure and import modernizing layouts.
* Refactor shared layout styles across pages.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* a12s: Su into a local instance with details from `p1670518452086579-slack-C0438NHCLSY` to have a site with a Google My Business connection.
* Navigate to the Stats `Google My Business` page.
* Ensure the Google My Business page is enhanced with modernized layout styles.

|Before|After|
|-|-|
|<img width="1709" alt="截圖 2023-01-17 下午12 01 47" src="https://user-images.githubusercontent.com/6869813/212809954-886f3f82-f86a-4303-add9-cabfb680e49c.png">|<img width="1715" alt="截圖 2023-01-17 上午11 59 33" src="https://user-images.githubusercontent.com/6869813/212809976-1c2f1cce-7c14-45ca-9e94-0b4e98c942fa.png">|



#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #70973 
