### PR TITLE
Pricing page: Fix the color of products with non-purchasable status.

### DIFF
--- a/client/my-sites/plans/jetpack-plans/product-store/item-price/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/item-price/index.tsx
@@ -32,9 +32,9 @@ export const ItemPrice: React.FC< ItemPriceProps > = ( {
 		);
 	} else if ( isOwned ) {
 		const message = isExpired ? translate( 'Expired' ) : translate( 'Active on your site' );
-		return <ItemPriceMessage expired={ isExpired } message={ message } />;
+		return <ItemPriceMessage active error={ isExpired } message={ message } />;
 	} else if ( isIncludedInPlan ) {
-		return <ItemPriceMessage message={ translate( 'Part of the current plan' ) } />;
+		return <ItemPriceMessage active message={ translate( 'Part of the current plan' ) } />;
 	}
 
 	return (

--- a/client/my-sites/plans/jetpack-plans/product-store/item-price/item-price-message.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/item-price/item-price-message.tsx
@@ -1,12 +1,19 @@
 import classNames from 'classnames';
 
-const ItemPriceMessage: React.FC< { message: React.ReactNode; expired?: boolean } > = ( {
+export type ItemPriceMessageProps = {
+	active?: boolean;
+	error?: boolean;
+	message: React.ReactNode;
+};
+
+const ItemPriceMessage: React.FC< ItemPriceMessageProps > = ( {
+	active = false,
+	error = false,
 	message,
-	expired = false,
 } ) => {
 	const messageClass = classNames( 'item-price__message', {
-		'item-price__message--expired': expired,
-		'item-price__message--active': ! expired,
+		'item-price__message--active': active && ! error,
+		'item-price__message--error': error,
 	} );
 
 	return (

--- a/client/my-sites/plans/jetpack-plans/product-store/item-price/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/item-price/style.scss
@@ -111,12 +111,13 @@ Hack to fix line-through not showing in the middle of the text in firefox browse
 
 .item-price__message {
 	font-size: $font-body-extra-small;
-	color: var(--studio-jetpack-green-50);
+	color: var(--studio-gray-30);
 	font-weight: 600;
 	display: flex;
 	align-items: center;
 
 	.item-price__message--dot {
+		background: var(--studio-gray-30);
 		display: inline-block;
 		width: 8px;
 		height: 8px;
@@ -129,14 +130,13 @@ Hack to fix line-through not showing in the middle of the text in firefox browse
 		.item-price__message--dot {
 			background: var(--studio-jetpack-green-50);
 		}
-
 	}
-	&--expired {
+
+	&--error {
 		color: var(--color-error-50);
 		.item-price__message--dot {
 			background: var(--color-error-50);
 		}
-
 	}
 }
 


### PR DESCRIPTION
#### Proposed Changes

This PR fixes issue #72064. 

* Update `ItemPriceMessage` properties to support a neutral state (grey color) aside Active (green) and error (red).

#### Testing Instructions

Run this branch by following the steps below (or you can use the Jetpack Cloud live link commented on this PR)
    * Run `git fetch && git checkout fix/text-color-of-non-purchasble-product`
    * Run `yarn start-jetpack-cloud`

##### Testing Inactive state
1. Spin up a JN multi site and connect Jetpack
2. Goto http://jetpack.cloud.localhost:3000/pricing/{YOUR-JN-SITE} or use the Jetpack cloud live link below and append `/pricing/{YOUR-JN-SITE}`
3. Confirm product such as **VaultPress Backup, Scan, Security & Complete**. Displays the non-purchasable message in grey color.
<img width="590" alt="Screen Shot 2023-01-17 at 1 47 39 PM" src="https://user-images.githubusercontent.com/56598660/212819701-e9106308-ad09-412b-87b8-29fca2287197.png">
4. Click the 'More info' link and also confirm the text is in grey. 
<img width="1099" alt="Screen Shot 2023-01-17 at 1 48 50 PM" src="https://user-images.githubusercontent.com/56598660/212819872-e379894f-1da7-43a1-97d9-9491c78d4b58.png">

##### Testing Active state
1. Spin up a JN simple site and connect Jetpack.
2. Goto http://jetpack.cloud.localhost:3000/pricing/{YOUR-JN-SITE} or use the Jetpack cloud live link below and append `/pricing/{YOUR-JN-SITE}`
3. Purchase **Jetpack Security**. (After purchasing return to the pricing page)
4. Confirm the included products in **Jetpack Security** will have the text below in green color. 
<img width="1304" alt="Screen Shot 2023-01-17 at 1 55 06 PM" src="https://user-images.githubusercontent.com/56598660/212820835-2e6dfe7e-863b-4466-9f82-a18814b94614.png">
5. Next is Purchase **Jetpack Social**.
6. Confirm the text appears in green color.
<img width="577" alt="Screen Shot 2023-01-17 at 1 59 24 PM" src="https://user-images.githubusercontent.com/56598660/212821311-55baddc6-4692-48a2-9808-a28d9fd7f6f7.png">


##### Testing Error state
1. We will need to have an expired Subscription to test this.
2. Once you have an expired subscription, Confirm the text will appear in red.
<img width="588" alt="Screen Shot 2023-01-17 at 2 04 32 PM" src="https://user-images.githubusercontent.com/56598660/212822071-c6f55fa7-5f6f-4470-85a3-5d91a0f00f67.png">

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1202858161751496-as-1203705736135088

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203705736135088