### PR TITLE
Fix displaying <TimeFrame /> in Jetpack product lightbox

### DIFF
--- a/client/my-sites/plans/jetpack-plans/product-lightbox/payment-plan.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-lightbox/payment-plan.tsx
@@ -73,7 +73,10 @@ const PaymentPlan: React.FC< PaymentPlanProps > = ( {
 									'is-compact': isCompact,
 								} ) }
 							>
-								<TimeFrame billingTerm={ billingTerm } />
+								<TimeFrame
+									billingTerm={ billingTerm }
+									discountedPriceDuration={ discountedPriceDuration }
+								/>
 							</div>
 						</div>
 						{ discountedPrice && (


### PR DESCRIPTION
#### Proposed Changes

* Pass information about discounts to support displaying intro offer in the product lightbox on Jetpack pricing

#### Testing Instructions

* Checkout this PR and run `yarn start-jetpack-cloud`
* Open `http://jetpack.cloud.localhost:3000/pricing`
* Click "More about Social"
* Information on the right of the price should be "for the first month, billed yearly"
 
<img width="305" alt="CleanShot 2023-01-17 at 09 15 28@2x" src="https://user-images.githubusercontent.com/8419292/212844336-6a6ade41-c1d4-4d54-92a5-87b6160c6184.png">

* Close modal and open "More about VaultPress"
* Information on the right of the price should be "for the first month, billed yearly" - but only for 10GB storage option
<img width="331" alt="CleanShot 2023-01-17 at 09 15 16@2x" src="https://user-images.githubusercontent.com/8419292/212844290-af953eea-84a9-467d-8d0f-9097e80d1f97.png">

* Click "More about VideoPress"
* It should display without any change

<img width="312" alt="CleanShot 2023-01-17 at 09 13 49@2x" src="https://user-images.githubusercontent.com/8419292/212844012-1fc71e49-3b48-4eb6-99e7-cae62ce9a84a.png">


