### PR TITLE
Jetpack Pro Dashboard: implement hide/show action bar based on the content

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/dashboard-bulk-actions/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/dashboard-bulk-actions/index.tsx
@@ -1,28 +1,34 @@
 import { Button, Gridicon } from '@automattic/components';
-import { useBreakpoint } from '@automattic/viewport-react';
+import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import { useState, useContext } from 'react';
+import { useState, createRef, useContext } from 'react';
 import ButtonGroup from 'calypso/components/button-group';
 import SelectDropdown from 'calypso/components/select-dropdown';
 import NotificationSettings from '../downtime-monitoring/notification-settings';
 import SitesOverviewContext from '../sites-overview/context';
-import { useHandleToggleMonitor, useHandleResetNotification } from './hooks';
+import {
+	useHandleToggleMonitor,
+	useHandleResetNotification,
+	useHandleShowHideActionBar,
+} from './hooks';
 import type { Site } from '../sites-overview/types';
 
 import './style.scss';
+
+// Constants help determine if the action bar should be a dropdown
 
 interface Props {
 	selectedSites: Array< Site >;
 }
 
 export default function DashboardBulkActions( { selectedSites }: Props ) {
+	const actionBarRef = createRef< HTMLDivElement >();
 	const translate = useTranslate();
 	const { setIsBulkManagementActive } = useContext( SitesOverviewContext );
 
-	const isDesktop = useBreakpoint( '>1040px' );
-
 	const handleToggleActivateMonitor = useHandleToggleMonitor( selectedSites );
 	const handleResetNotification = useHandleResetNotification( selectedSites );
+	const { actionBarVisible } = useHandleShowHideActionBar( actionBarRef );
 
 	const [ showNotificationSettingsPopup, setShowNotificationSettingsPopup ] = useState( false );
 
@@ -52,51 +58,55 @@ export default function DashboardBulkActions( { selectedSites }: Props ) {
 		},
 	];
 
-	let content = null;
 	const disabled = selectedSites.length === 0;
 
-	if ( isDesktop ) {
-		content = (
-			<>
-				<ButtonGroup>
-					{ toggleMonitorActions.map( ( { label, action } ) => (
-						<Button compact key={ label } disabled={ disabled } onClick={ action }>
-							{ label }
-						</Button>
-					) ) }
-				</ButtonGroup>
-				{ otherMonitorActions.map( ( { label, action } ) => (
-					<ButtonGroup key={ label }>
-						<Button compact disabled={ disabled } onClick={ action }>
-							{ label }
-						</Button>
-					</ButtonGroup>
-				) ) }
-			</>
-		);
-	} else {
-		content = (
-			<SelectDropdown compact selectedText={ translate( 'Actions' ) }>
-				{ [ ...toggleMonitorActions, ...otherMonitorActions ].map( ( { label, action } ) => (
-					<SelectDropdown.Item key={ label } disabled={ disabled } onClick={ action }>
+	const desktopContent = (
+		<>
+			<ButtonGroup>
+				{ toggleMonitorActions.map( ( { label, action } ) => (
+					<Button compact key={ label } disabled={ disabled } onClick={ action }>
 						{ label }
-					</SelectDropdown.Item>
+					</Button>
 				) ) }
-			</SelectDropdown>
-		);
-	}
+			</ButtonGroup>
+			{ otherMonitorActions.map( ( { label, action } ) => (
+				<ButtonGroup key={ label }>
+					<Button compact disabled={ disabled } onClick={ action }>
+						{ label }
+					</Button>
+				</ButtonGroup>
+			) ) }
+		</>
+	);
+
+	const mobileContent = (
+		<SelectDropdown compact selectedText={ translate( 'Actions' ) }>
+			{ [ ...toggleMonitorActions, ...otherMonitorActions ].map( ( { label, action } ) => (
+				<SelectDropdown.Item key={ label } disabled={ disabled } onClick={ action }>
+					{ label }
+				</SelectDropdown.Item>
+			) ) }
+		</SelectDropdown>
+	);
 
 	return (
 		<>
-			<div className="dashboard-bulk-actions">
-				{ content }
+			<div
+				ref={ actionBarRef }
+				className={ classNames( 'dashboard-bulk-actions', {
+					'dashboard-bulk-actions__is-action-bar-visible': actionBarVisible,
+				} ) }
+			>
+				<div className="dashboard-bulk-actions__content">
+					<div className="dashboard-bulk-actions__large-screen">{ desktopContent }</div>
+					<div className="dashboard-bulk-actions__small-screen">{ mobileContent }</div>
+				</div>
 				<ButtonGroup>
 					<Button compact borderless className="dashboard-bulk-actions__close-icon">
 						<Gridicon icon="cross" onClick={ () => setIsBulkManagementActive( false ) } />
 					</Button>
 				</ButtonGroup>
 			</div>
-
 			{ showNotificationSettingsPopup && (
 				<NotificationSettings sites={ selectedSites } onClose={ toggleNotificationSettingsPopup } />
 			) }

--- a/client/jetpack-cloud/sections/agency-dashboard/dashboard-bulk-actions/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/dashboard-bulk-actions/style.scss
@@ -1,3 +1,6 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
 .dashboard-bulk-actions-modal {
 	.dashboard-bulk-actions-modal-heading {
 		font-size: 1rem;
@@ -26,7 +29,9 @@
 .dashboard-bulk-actions {
 	width: 100%;
 	text-align: right;
-	display: inline-block;
+	display: inline-flex;
+	justify-content: flex-end;
+
 	.button-group {
 		margin-inline-start: 14px;
 		.button {
@@ -64,3 +69,25 @@ button.dashboard-bulk-actions__edit-button {
 		border-width: 1px !important;
 	}
 }
+
+.dashboard-bulk-actions__large-screen {
+	display: none;
+}
+
+.dashboard-bulk-actions__content {
+	width: 70%;
+}
+
+
+.dashboard-bulk-actions__is-action-bar-visible {
+	@include break-xlarge {
+		.dashboard-bulk-actions__small-screen {
+			display: none;
+		}
+
+		.dashboard-bulk-actions__large-screen {
+			display: block;
+		}
+	}
+}
+

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/style.scss
@@ -19,14 +19,17 @@
 }
 
 .site-content__bulk-select {
+	margin-block-end: 8px;
+
 	.dashboard-bulk-actions {
 		display: flex;
 		justify-content: end;
 
 		.select-dropdown.is-compact {
-			width: 65%;
+			width: 95%;
+			float: right;
 
-			@include break-small {
+			@include break-mobile {
 				width: auto;
 			}
 		}
@@ -43,6 +46,22 @@
 	.site-content__bulk-select-label {
 		color: var(--color-neutral-70);
 		font-size: 0.875rem;
+	}
+
+	@include break-mobile {
+		padding: 12px 16px;
+	}
+
+}
+
+.dashboard-bulk-actions {
+	.select-dropdown.is-compact {
+		width: 95%;
+		float: right;
+
+		@include break-mobile {
+			width: auto;
+		}
 	}
 }
 

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/style.scss
@@ -14,7 +14,7 @@
 		font-size: 0.75rem;
 		color: var(--studio-gray-50);
 		font-weight: 400;
-		height: 40px;
+		height: 50px;
 	}
 
 	td {


### PR DESCRIPTION
#### Proposed Changes

This PR implements hide/show action bar(buttons)based on the content and shows a dropdown if the content is overflowing.

#### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout add/implement-hide-show-action-bar` and `yarn start-jetpack-cloud`
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Verify the dropdown is shown if the content size of buttons is very large and is about to overflow. You can switch to 1100px to verify if the dropdown is down. We will show the dropdown on any screen <1080px. It should show buttons on large screens(~1200px)

Screen size: >1200px

<img width="1451" alt="Screenshot 2023-01-17 at 6 02 12 PM" src="https://user-images.githubusercontent.com/10586875/212900214-6f794b51-110c-4c0e-8c3f-5a6979ddf364.png">

Screen size: 1100px

<img width="796" alt="Screenshot 2023-01-17 at 6 02 42 PM" src="https://user-images.githubusercontent.com/10586875/212900238-82442653-e33f-4535-863c-deac43bd20f3.png">

Screen size: 768px

<img width="530" alt="Screenshot 2023-01-17 at 6 02 56 PM" src="https://user-images.githubusercontent.com/10586875/212900247-654a2a60-f61a-4cf4-bde5-30e8e3ab61fa.png">

Screen size: 375px

<img width="373" alt="Screenshot 2023-01-17 at 6 03 14 PM" src="https://user-images.githubusercontent.com/10586875/212900256-a3d6c453-0317-457b-923d-6ed9ef572ffa.png">


https://user-images.githubusercontent.com/10586875/212899373-f187ed98-ff6e-4228-aabf-48f2f380e1ee.mov


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1203448324265423-as-1203706311193972