### PR TITLE
Marketplace Thank You: Vertical centralization

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/marketplace/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/style.scss
@@ -1,4 +1,9 @@
 .marketplace-thank-you__container {
+	min-height: 100vh;
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+
 	.thank-you__container {
 		padding-top: var(--masterbar-height);
 	}

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/style.scss
@@ -11,7 +11,7 @@
 	.thank-you__container-header {
 		min-height: auto;
 		padding: 0;
-		padding-top: 60px;
+		padding-top: 10px;
 	}
 
 	.thank-you__body {


### PR DESCRIPTION
#### Proposed Changes

* Decrease header padding
* Centralize the Marketplace Thank you page container when possible 

<img width="1511" alt="Screen Shot 2023-01-17 at 08 51 13" src="https://user-images.githubusercontent.com/5039531/212903528-f3466d34-1468-4511-9204-52005285dde5.png">

#### Testing Instructions
* Install a plugin
* On the Thank you page check if the design matches the above
* Purchase 1 plugin
* Check if the design matches the above
* Buy around 4 plugins
* Check if the Marketplace page properly shows its content with a scrollbar

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #72146
