### PR TITLE
Pricing page: Fix Jetpack successful connection toast message.

### DIFF
--- a/client/components/jetpack/licensing-prompt-dialog/index.tsx
+++ b/client/components/jetpack/licensing-prompt-dialog/index.tsx
@@ -47,7 +47,7 @@ function LicensingPromptDialog( { siteId }: Props ) {
 	}, [ dispatch ] );
 
 	let titleToRender = window.location.pathname.startsWith( JPC_PATH_PLANS )
-		? translate( 'Jetpack is successfully installed' )
+		? translate( 'Jetpack is successfully connected' )
 		: '';
 
 	if ( ! titleToRender ) {

--- a/client/my-sites/plans/jetpack-plans/product-store/user-licenses-dialog.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/user-licenses-dialog.tsx
@@ -13,7 +13,7 @@ export const UserLicensesDialog: React.FC< ProductStoreBaseProps > = ( { siteId 
 
 	useEffect( () => {
 		if ( window.location.pathname.startsWith( JPC_PATH_PLANS ) ) {
-			dispatch( successNotice( translate( 'Jetpack is successfully installed' ) ) );
+			dispatch( successNotice( translate( 'Jetpack is successfully connected' ) ) );
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [] );


### PR DESCRIPTION
#### Proposed Changes

This PR updates the current connection toast message to **_Jetpack is successfully connected_**. 

**Before**
<img width="666" alt="Screen Shot 2023-01-17 at 9 02 05 PM" src="https://user-images.githubusercontent.com/56598660/212905989-1089f0d8-e9e5-433d-a8ac-ec4e607e8f7f.png">
<img width="338" alt="Screen Shot 2023-01-17 at 9 02 15 PM" src="https://user-images.githubusercontent.com/56598660/212906012-67b3f83e-01bf-43fc-8f11-6c50eb8bbf9c.png">
**After**
<img width="661" alt="Screen Shot 2023-01-17 at 9 01 39 PM" src="https://user-images.githubusercontent.com/56598660/212906127-0a88b7f3-015e-4ff7-b0c2-831c6d7a410d.png">
<img width="350" alt="Screen Shot 2023-01-17 at 9 01 49 PM" src="https://user-images.githubusercontent.com/56598660/212906150-1609fb9c-7e03-4793-a8f6-3e70433dc922.png">

#### Testing Instructions

Run this branch by following the steps below (or you can use the Jetpack Cloud live link commented on this PR)
    * Run `git fetch && git checkout fix/jp-connect-notice-message`
    * Run `yarn start`

1. Spin up a JN site
2. Go to https://cloud.jetpack.com/pricing and purchase any product. make sure you do not activate the license.
3. Go to http://calypso.localhost:3000/jetpack/connect/plans/{JN_SITE} or use the calypso live link and append `/jetpack/connect/plans/{JN_SITE}`
4. Confirm the toast message and modal title shows the **Jetpack is successfully connected** message.
<img width="2560" alt="Screen Shot 2023-01-17 at 9 11 08 PM" src="https://user-images.githubusercontent.com/56598660/212907696-df18d99b-4bc6-45d9-a223-0bbec467d412.png">

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1202858161751496-as-1201755771716290

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1201755771716290