### PR TITLE
Jetpack Agency Dashboard: update monitor settings properties to match the backend API

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
@@ -68,11 +68,12 @@ export default function NotificationSettings( { onClose, sites, settings }: Prop
 	}, [ settings?.monitor_deferment_time ] );
 
 	useEffect( () => {
-		if ( settings?.monitor_user_emails ) {
-			setAddedEmailAddresses( settings.monitor_user_emails );
-			setEnableEmailNotification( true );
+		if ( settings ) {
+			setAddedEmailAddresses( settings.monitor_user_emails || [] );
+			setEnableEmailNotification( !! settings.monitor_user_email_notifications );
+			setEnableMobileNotification( !! settings.monitor_user_wp_note_notifications );
 		}
-	}, [ settings?.monitor_user_emails ] );
+	}, [ settings ] );
 
 	useEffect( () => {
 		if ( enableMobileNotification || enableEmailNotification ) {

--- a/client/jetpack-cloud/sections/agency-dashboard/hooks.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/hooks.tsx
@@ -210,8 +210,8 @@ export function useUpdateMonitorSettings( sites: Array< { blog_id: number; url: 
 								monitor_settings: {
 									...site.monitor_settings,
 									monitor_deferment_time: data.settings.jetmon_defer_status_down_minutes,
-									email_notifications: data.settings.email_notifications,
-									wp_note_notifications: data.settings.wp_note_notifications,
+									monitor_user_email_notifications: data.settings.email_notifications,
+									monitor_user_wp_note_notifications: data.settings.wp_note_notifications,
 								},
 							};
 						}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
@@ -23,6 +23,8 @@ export interface MonitorSettings {
 	last_down_time: string;
 	monitor_deferment_time: number;
 	monitor_user_emails: Array< string >;
+	monitor_user_email_notifications: boolean;
+	monitor_user_wp_note_notifications: boolean;
 }
 
 export interface Site {


### PR DESCRIPTION
#### Proposed Changes

This PR implements hide/show action bar(buttons)based on the content and shows a dropdown if the content is overflowing.

#### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout update/update-monitor-settings-properties` and `yarn start-jetpack-cloud`
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Create a new JN site or use an existing one -> Enable the monitor for a site -> Open the notification settings by clicking on the clock icon -> Verify that both Mobile & Email is enabled -> Try disabling mobile or email -> Save changes -> Open the notification settings for the same site -> Verify the changes are reflected -> Refresh the page and verify the changes are still reflected. Make sure to change and save both Mobile & Email separately and verify it works as expected.

<img width="493" alt="Screenshot 2023-01-17 at 6 36 16 PM" src="https://user-images.githubusercontent.com/10586875/212909670-1e0ae57c-6b83-4b11-8974-9c335e3a4fa0.png">

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1203448324265423-as-1203766037063470