### PR TITLE
Plugin Card: Limit the description text to 2 lines

### DIFF
--- a/client/my-sites/plugins/plugins-browser-item/style.scss
+++ b/client/my-sites/plugins/plugins-browser-item/style.scss
@@ -41,6 +41,12 @@
 		font-size: $font-body-small;
 		font-weight: 400;
 		color: $studio-gray-60;
+
+		// limit to 2 lines
+		display: -webkit-box;
+		-webkit-line-clamp: 2;
+		-webkit-box-orient: vertical;
+		overflow: hidden;
 	}
 
 	&.compact {


### PR DESCRIPTION
#### Proposed Changes

Limit the plugin description text to 2 lines.

| Before  | After |
| ------------- | ------------- |
|<img width="1113" alt="Screen Shot 2023-01-17 at 09 42 36" src="https://user-images.githubusercontent.com/5039531/212914883-330f4db4-a776-4fd9-a13d-3646d7e5301f.png">|<img width="1113" alt="Screen Shot 2023-01-17 at 09 43 38" src="https://user-images.githubusercontent.com/5039531/212914924-32391bf7-5e1b-4d12-9510-a49b2fd0188b.png">|


#### Testing Instructions
* Go to `/plugins`
* Check all cards displayed on the screen if they have only 2 lines on the description
* Check if ellipsis is added to texts bigger than that.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #70907
