### PR TITLE
Users management: Add section navigation

### DIFF
--- a/client/my-sites/people/people-add-subscribers/index.jsx
+++ b/client/my-sites/people/people-add-subscribers/index.jsx
@@ -25,6 +25,7 @@ import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import isPrivateSite from 'calypso/state/selectors/is-private-site';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
+import PeopleSectionAddNav from '../people-section-add-nav';
 
 class PeopleInvites extends PureComponent {
 	static propTypes = {
@@ -55,6 +56,14 @@ class PeopleInvites extends PureComponent {
 						path="/people/add-subscribers/:site_id"
 						title="People > Add Subscribers"
 					/>
+					<HeaderCake onClick={ this.goBack }>
+						{ translate( 'Add subscribers to %(sitename)s', {
+							args: {
+								sitename: site.name,
+							},
+						} ) }
+					</HeaderCake>
+					<PeopleSectionAddNav selectedFilter="subscribers" />
 					<EmptyContent
 						title={ translate( 'You are not authorized to view this page' ) }
 						illustration="/calypso/images/illustrations/illustration-404.svg"
@@ -66,13 +75,14 @@ class PeopleInvites extends PureComponent {
 		return (
 			<Main>
 				<PageViewTracker path="/people/add-subscribers/:site_id" title="People > Add Subscribers" />
-				<HeaderCake isCompact onClick={ this.goBack }>
+				<HeaderCake onClick={ this.goBack }>
 					{ translate( 'Add subscribers to %(sitename)s', {
 						args: {
 							sitename: site.name,
 						},
 					} ) }
 				</HeaderCake>
+				<PeopleSectionAddNav selectedFilter="subscribers" />
 				<Card>
 					<EmailVerificationGate
 						noticeText={ this.props.translate( 'You must verify your email to add subscribers.' ) }

--- a/client/my-sites/people/people-add-subscribers/index.jsx
+++ b/client/my-sites/people/people-add-subscribers/index.jsx
@@ -63,7 +63,9 @@ class PeopleInvites extends PureComponent {
 							},
 						} ) }
 					</HeaderCake>
-					<PeopleSectionAddNav selectedFilter="subscribers" />
+					{ isEnabled( 'user-management-revamp' ) && (
+						<PeopleSectionAddNav selectedFilter="subscribers" />
+					) }
 					<EmptyContent
 						title={ translate( 'You are not authorized to view this page' ) }
 						illustration="/calypso/images/illustrations/illustration-404.svg"
@@ -75,14 +77,16 @@ class PeopleInvites extends PureComponent {
 		return (
 			<Main>
 				<PageViewTracker path="/people/add-subscribers/:site_id" title="People > Add Subscribers" />
-				<HeaderCake onClick={ this.goBack }>
+				<HeaderCake isCompact={ ! isEnabled( 'user-management-revamp' ) } onClick={ this.goBack }>
 					{ translate( 'Add subscribers to %(sitename)s', {
 						args: {
 							sitename: site.name,
 						},
 					} ) }
 				</HeaderCake>
-				<PeopleSectionAddNav selectedFilter="subscribers" />
+				{ isEnabled( 'user-management-revamp' ) && (
+					<PeopleSectionAddNav selectedFilter="subscribers" />
+				) }
 				<Card>
 					<EmailVerificationGate
 						noticeText={ this.props.translate( 'You must verify your email to add subscribers.' ) }

--- a/client/my-sites/people/people-section-add-nav/index.tsx
+++ b/client/my-sites/people/people-section-add-nav/index.tsx
@@ -1,0 +1,49 @@
+import { useTranslate } from 'i18n-calypso';
+import { useSelector } from 'react-redux';
+import SectionNav from 'calypso/components/section-nav';
+import NavItem from 'calypso/components/section-nav/item';
+import NavTabs from 'calypso/components/section-nav/tabs';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
+import './style.scss';
+
+interface Props {
+	selectedFilter: string;
+}
+function PeopleSectionAddNav( props: Props ) {
+	const _ = useTranslate();
+	const { selectedFilter } = props;
+	const site = useSelector( ( state ) => getSelectedSite( state ) );
+
+	const filters = [
+		{
+			id: 'team',
+			title: _( 'Add to team' ),
+			path: '/people/new/' + site?.slug,
+		},
+		{
+			id: 'subscribers',
+			title: _( 'Add subscribers' ),
+			path: '/people/add-subscribers/' + site?.slug,
+		},
+	];
+
+	return (
+		<SectionNav className="people-section-add-nav">
+			<NavTabs selectedText={ selectedFilter }>
+				{ filters.map( function ( filterItem ) {
+					return (
+						<NavItem
+							key={ filterItem.id }
+							path={ filterItem.path }
+							selected={ filterItem.id === selectedFilter }
+						>
+							{ filterItem.title }
+						</NavItem>
+					);
+				} ) }
+			</NavTabs>
+		</SectionNav>
+	);
+}
+
+export default PeopleSectionAddNav;

--- a/client/my-sites/people/people-section-add-nav/style.scss
+++ b/client/my-sites/people/people-section-add-nav/style.scss
@@ -1,0 +1,3 @@
+.people-section-add-nav.section-nav {
+	margin-bottom: 0;
+}

--- a/client/my-sites/people/people-section-nav-compact/index.tsx
+++ b/client/my-sites/people/people-section-nav-compact/index.tsx
@@ -19,14 +19,14 @@ function PeopleSectionNavCompact( props: Props ) {
 
 	const filters = [
 		{
-			id: 'subscribers',
-			title: _( 'Subscribers' ),
-			path: '/people/subscribers/' + site?.slug,
-		},
-		{
 			id: 'team',
 			title: _( 'Team' ),
 			path: '/people/team/' + site?.slug,
+		},
+		{
+			id: 'subscribers',
+			title: _( 'Subscribers' ),
+			path: '/people/subscribers/' + site?.slug,
 		},
 	];
 

--- a/client/my-sites/people/subscribers/style.scss
+++ b/client/my-sites/people/subscribers/style.scss
@@ -8,3 +8,7 @@
 		margin: 0;
 	}
 }
+
+.add-subscriber .add-subscriber__form--container label.add-subscriber__form-label-emails {
+	margin-top: 0;
+}

--- a/client/my-sites/people/team-invite/index.tsx
+++ b/client/my-sites/people/team-invite/index.tsx
@@ -14,6 +14,7 @@ import SectionHeader from 'calypso/components/section-header';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { userCan } from 'calypso/lib/site/utils';
 import P2TeamBanner from 'calypso/my-sites/people/p2-team-banner';
+import PeopleSectionAddNav from 'calypso/my-sites/people/people-section-add-nav';
 import { InviteLinkForm } from 'calypso/my-sites/people/team-invite/invite-link-form';
 import { isCurrentUserEmailVerified } from 'calypso/state/current-user/selectors';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
@@ -55,9 +56,12 @@ function TeamInvite( props: Props ) {
 		return (
 			<Main>
 				<PageViewTracker path="/people/new/:site" title="People > Invite People" />
-				<HeaderCake isCompact onClick={ goBack }>
-					{ _( 'Add team members' ) }
+				<HeaderCake onClick={ goBack }>
+					{ _( 'Add team members to %(sitename)s', {
+						args: { sitename: site.name },
+					} ) }
 				</HeaderCake>
+				<PeopleSectionAddNav selectedFilter="team" />
 				<EmptyContent
 					title={ _( 'Oops, only administrators can invite other people' ) }
 					illustration="/calypso/images/illustrations/illustration-empty-results.svg"
@@ -72,9 +76,13 @@ function TeamInvite( props: Props ) {
 			{ siteId && <QuerySiteInvites siteId={ siteId } /> }
 			{ siteId && isJetpack && <QueryJetpackModules siteId={ siteId } /> }
 
-			<HeaderCake isCompact onClick={ goBack }>
-				{ _( 'Add team members' ) }
+			<HeaderCake onClick={ goBack }>
+				{ _( 'Add team members to %(sitename)s', {
+					args: { sitename: site.name },
+				} ) }
 			</HeaderCake>
+
+			<PeopleSectionAddNav selectedFilter="team" />
 
 			{ isSiteForTeams && <P2TeamBanner context="invite" site={ site } /> }
 

--- a/client/my-sites/sidebar/utils.js
+++ b/client/my-sites/sidebar/utils.js
@@ -29,10 +29,13 @@ export const itemLinkMatches = ( path, currentPath ) => {
 	if ( pathIncludes( currentPath, 'people', 1 ) ) {
 		if ( pathIncludes( currentPath, 'new', 2 ) ) {
 			return fragmentIsEqual( path, currentPath, 2 );
-		}
-
-		if ( pathIncludes( currentPath, 'team-members', 2 ) ) {
+		} else if (
+			pathIncludes( currentPath, 'add-subscribers', 2 ) &&
+			pathIncludes( path, 'team', 2 )
+		) {
 			return fragmentIsEqual( path, currentPath, 2 );
+		} else if ( pathIncludes( currentPath, 'subscribers', 2 ) && pathIncludes( path, 'team', 2 ) ) {
+			return fragmentIsEqual( path, currentPath, 1 );
 		}
 	}
 


### PR DESCRIPTION
#### Proposed Changes

* Reordered positions of All users section navigation
* Added section navigation above  "Add team member" and "Add subscribers" form

#### Testing Instructions

* Go to the "All users" page
* Check if the section navigation is there

#### Screenshots
<img width="765" alt="Screenshot 2023-01-17 at 15 21 09" src="https://user-images.githubusercontent.com/1241413/212923400-25108cc9-9d8a-4314-a7f1-f12a50bde961.png">
<img width="761" alt="Screenshot 2023-01-17 at 15 21 21" src="https://user-images.githubusercontent.com/1241413/212923408-574c7ccf-2afe-47bb-9eb8-452879b8dbbd.png">
<img width="758" alt="Screenshot 2023-01-17 at 15 21 50" src="https://user-images.githubusercontent.com/1241413/212923412-151c56f7-259c-4ae4-8a20-98d33481fc6d.png">

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #72171
