### PR TITLE
Add unified importer feature flag

### DIFF
--- a/client/my-sites/importer/author-mapping-item.jsx
+++ b/client/my-sites/importer/author-mapping-item.jsx
@@ -36,25 +36,28 @@ class ImporterAuthorMapping extends Component {
 	};
 
 	componentDidMount() {
-		const { onSelect: selectAuthor } = this.props;
+		const { hasSingleAuthor, onSelect: selectAuthor } = this.props;
 
-		/**
-		 * Using `defer` here is a leftover from using Flux store in the past.
-		 *
-		 * It's not ideal and should be refactored in the future to read
-		 * the state, instead of automating the UI in this way.
-		 *
-		 * This effort is quite big as it requires refactoring a few things on more fundamental
-		 * level in the imports section.
-		 *
-		 * TODO: Refactor this to not automate the UI but use proper state
-		 * TODO: A better way might be to handle this call in the backend and leave the UI out of the decision
-		 */
-		defer( () => selectAuthor( this.props.currentUser ) );
+		if ( hasSingleAuthor ) {
+			/**
+			 * Using `defer` here is a leftover from using Flux store in the past.
+			 *
+			 * It's not ideal and should be refactored in the future to read
+			 * the state, instead of automating the UI in this way.
+			 *
+			 * This effort is quite big as it requires refactoring a few things on more fundamental
+			 * level in the imports section.
+			 *
+			 * TODO: Refactor this to not automate the UI but use proper state
+			 * TODO: A better way might be to handle this call in the backend and leave the UI out of the decision
+			 */
+			defer( () => selectAuthor( this.props.currentUser ) );
+		}
 	}
 
 	render() {
 		const {
+			hasSingleAuthor,
 			siteId,
 			onSelect,
 			sourceAuthor: {
@@ -64,8 +67,6 @@ class ImporterAuthorMapping extends Component {
 			},
 			currentUser,
 		} = this.props;
-
-		const hasSingleAuthor = true;
 
 		return (
 			<div className="importer__author-mapping">

--- a/client/my-sites/importer/author-mapping-item.jsx
+++ b/client/my-sites/importer/author-mapping-item.jsx
@@ -36,28 +36,25 @@ class ImporterAuthorMapping extends Component {
 	};
 
 	componentDidMount() {
-		const { hasSingleAuthor, onSelect: selectAuthor } = this.props;
+		const { onSelect: selectAuthor } = this.props;
 
-		if ( hasSingleAuthor ) {
-			/**
-			 * Using `defer` here is a leftover from using Flux store in the past.
-			 *
-			 * It's not ideal and should be refactored in the future to read
-			 * the state, instead of automating the UI in this way.
-			 *
-			 * This effort is quite big as it requires refactoring a few things on more fundamental
-			 * level in the imports section.
-			 *
-			 * TODO: Refactor this to not automate the UI but use proper state
-			 * TODO: A better way might be to handle this call in the backend and leave the UI out of the decision
-			 */
-			defer( () => selectAuthor( this.props.currentUser ) );
-		}
+		/**
+		 * Using `defer` here is a leftover from using Flux store in the past.
+		 *
+		 * It's not ideal and should be refactored in the future to read
+		 * the state, instead of automating the UI in this way.
+		 *
+		 * This effort is quite big as it requires refactoring a few things on more fundamental
+		 * level in the imports section.
+		 *
+		 * TODO: Refactor this to not automate the UI but use proper state
+		 * TODO: A better way might be to handle this call in the backend and leave the UI out of the decision
+		 */
+		defer( () => selectAuthor( this.props.currentUser ) );
 	}
 
 	render() {
 		const {
-			hasSingleAuthor,
 			siteId,
 			onSelect,
 			sourceAuthor: {
@@ -67,6 +64,8 @@ class ImporterAuthorMapping extends Component {
 			},
 			currentUser,
 		} = this.props;
+
+		const hasSingleAuthor = true;
 
 		return (
 			<div className="importer__author-mapping">

--- a/client/my-sites/importer/section-import.jsx
+++ b/client/my-sites/importer/section-import.jsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { CompactCard } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import { once } from 'lodash';
@@ -12,8 +13,8 @@ import InlineSupportLink from 'calypso/components/inline-support-link';
 import Main from 'calypso/components/main';
 import ScreenOptionsTab from 'calypso/components/screen-options-tab';
 import SectionHeader from 'calypso/components/section-header';
-import { getImporters, getImporterByKey } from 'calypso/lib/importer/importer-config';
-import { Interval, EVERY_FIVE_SECONDS } from 'calypso/lib/interval';
+import { getImporterByKey, getImporters } from 'calypso/lib/importer/importer-config';
+import { EVERY_FIVE_SECONDS, Interval } from 'calypso/lib/interval';
 import memoizeLast from 'calypso/lib/memoize-last';
 import BloggerImporter from 'calypso/my-sites/importer/importer-blogger';
 import MediumImporter from 'calypso/my-sites/importer/importer-medium';
@@ -23,7 +24,7 @@ import WixImporter from 'calypso/my-sites/importer/importer-wix';
 import WordPressImporter from 'calypso/my-sites/importer/importer-wordpress';
 import JetpackImporter from 'calypso/my-sites/importer/jetpack-importer';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { fetchImporterState, startImport, cancelImport } from 'calypso/state/imports/actions';
+import { cancelImport, fetchImporterState, startImport } from 'calypso/state/imports/actions';
 import { appStates } from 'calypso/state/imports/constants';
 import {
 	getImporterStatusForSiteId,
@@ -33,8 +34,8 @@ import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import { getSiteTitle } from 'calypso/state/sites/selectors';
 import {
 	getSelectedSite,
-	getSelectedSiteSlug,
 	getSelectedSiteId,
+	getSelectedSiteSlug,
 } from 'calypso/state/ui/selectors';
 
 import './section-import.scss';
@@ -303,7 +304,11 @@ class SectionImport extends Component {
 					hasScreenOptions
 				/>
 				<EmailVerificationGate allowUnlaunched>
-					{ isJetpack && ! isAtomic ? <JetpackImporter /> : this.renderImportersList() }
+					{ isJetpack && ! isAtomic && ! config.isEnabled( 'importer/unified' ) ? (
+						<JetpackImporter />
+					) : (
+						this.renderImportersList()
+					) }
 				</EmailVerificationGate>
 			</Main>
 		);

--- a/client/my-sites/importer/section-import.jsx
+++ b/client/my-sites/importer/section-import.jsx
@@ -143,11 +143,11 @@ class SectionImport extends Component {
 	 */
 	renderIdleImporters( importerState ) {
 		const { site, siteTitle } = this.props;
-		let importers = getImporters();
+		const importers = getImporters();
 
 		// Filter out all importers except the WordPress ones for Atomic sites.
 		if ( site.options.is_wpcom_atomic ) {
-			importers = importers.filter( ( importer ) => importer.engine === 'wordpress' );
+			// importers = importers.filter( ( importer ) => importer.engine === 'wordpress' );
 		}
 
 		const importerElements = importers.map( ( { engine } ) => {

--- a/client/my-sites/importer/section-import.jsx
+++ b/client/my-sites/importer/section-import.jsx
@@ -1,9 +1,4 @@
 import { CompactCard } from '@automattic/components';
-import { localize } from 'i18n-calypso';
-import { once } from 'lodash';
-import PropTypes from 'prop-types';
-import { Component } from 'react';
-import { connect } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
 import EmailVerificationGate from 'calypso/components/email-verification/email-verification-gate';
 import EmptyContent from 'calypso/components/empty-content';
@@ -12,8 +7,8 @@ import InlineSupportLink from 'calypso/components/inline-support-link';
 import Main from 'calypso/components/main';
 import ScreenOptionsTab from 'calypso/components/screen-options-tab';
 import SectionHeader from 'calypso/components/section-header';
-import { getImporters, getImporterByKey } from 'calypso/lib/importer/importer-config';
-import { Interval, EVERY_FIVE_SECONDS } from 'calypso/lib/interval';
+import { getImporterByKey, getImporters } from 'calypso/lib/importer/importer-config';
+import { EVERY_FIVE_SECONDS, Interval } from 'calypso/lib/interval';
 import memoizeLast from 'calypso/lib/memoize-last';
 import BloggerImporter from 'calypso/my-sites/importer/importer-blogger';
 import MediumImporter from 'calypso/my-sites/importer/importer-medium';
@@ -21,9 +16,8 @@ import SquarespaceImporter from 'calypso/my-sites/importer/importer-squarespace'
 import SubstackImporter from 'calypso/my-sites/importer/importer-substack';
 import WixImporter from 'calypso/my-sites/importer/importer-wix';
 import WordPressImporter from 'calypso/my-sites/importer/importer-wordpress';
-import JetpackImporter from 'calypso/my-sites/importer/jetpack-importer';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { fetchImporterState, startImport, cancelImport } from 'calypso/state/imports/actions';
+import { cancelImport, fetchImporterState, startImport } from 'calypso/state/imports/actions';
 import { appStates } from 'calypso/state/imports/constants';
 import {
 	getImporterStatusForSiteId,
@@ -33,10 +27,17 @@ import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import { getSiteTitle } from 'calypso/state/sites/selectors';
 import {
 	getSelectedSite,
-	getSelectedSiteSlug,
 	getSelectedSiteId,
+	getSelectedSiteSlug,
 } from 'calypso/state/ui/selectors';
+import { localize } from 'i18n-calypso';
+import { once } from 'lodash';
+import PropTypes from 'prop-types';
+import { Component } from 'react';
+import { connect } from 'react-redux';
 
+import { Button } from '@automattic/components';
+import wpcom from 'calypso/lib/wp';
 import './section-import.scss';
 
 /**
@@ -243,6 +244,15 @@ class SectionImport extends Component {
 		this.props.siteId && this.props.fetchImporterState( this.props.siteId );
 	};
 
+	dangerous = async () => {
+		const { siteId } = this.props;
+
+		await wpcom.req.post( {
+			path: `/sites/${ siteId }/debug-imports`,
+			formData: [],
+		} );
+	};
+
 	renderImportersList() {
 		const { translate } = this.props;
 		const isSpecificImporter = this.props.siteImports.length > 0;
@@ -265,7 +275,7 @@ class SectionImport extends Component {
 	}
 
 	render() {
-		const { site, translate, canImport } = this.props;
+		const { /*site, */ translate, canImport } = this.props;
 
 		if ( ! canImport ) {
 			return (
@@ -278,10 +288,10 @@ class SectionImport extends Component {
 			);
 		}
 
-		const {
+		/*const {
 			jetpack: isJetpack,
 			options: { is_wpcom_atomic: isAtomic },
-		} = site;
+		} = site;*/
 
 		return (
 			<Main>
@@ -302,8 +312,12 @@ class SectionImport extends Component {
 					align="left"
 					hasScreenOptions
 				/>
+				<Button primary className="is-scary" onClick={ this.dangerous }>
+					Debug import
+				</Button>
+				<div style={ { paddingBottom: '20px' } }></div>
 				<EmailVerificationGate allowUnlaunched>
-					{ isJetpack && ! isAtomic ? <JetpackImporter /> : this.renderImportersList() }
+					{ this.renderImportersList() }
 				</EmailVerificationGate>
 			</Main>
 		);

--- a/client/my-sites/importer/section-import.jsx
+++ b/client/my-sites/importer/section-import.jsx
@@ -1,4 +1,4 @@
-import config from '@automattic/calypso-config';
+import { isEnabled } from '@automattic/calypso-config';
 import { CompactCard } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import { once } from 'lodash';
@@ -147,7 +147,7 @@ class SectionImport extends Component {
 		let importers = getImporters();
 
 		// Filter out all importers except the WordPress ones for Atomic sites.
-		if ( site.options.is_wpcom_atomic ) {
+		if ( ! isEnabled( 'importer/unified' ) && site.options.is_wpcom_atomic ) {
 			importers = importers.filter( ( importer ) => importer.engine === 'wordpress' );
 		}
 
@@ -304,7 +304,7 @@ class SectionImport extends Component {
 					hasScreenOptions
 				/>
 				<EmailVerificationGate allowUnlaunched>
-					{ isJetpack && ! isAtomic && ! config.isEnabled( 'importer/unified' ) ? (
+					{ isJetpack && ! isAtomic && ! isEnabled( 'importer/unified' ) ? (
 						<JetpackImporter />
 					) : (
 						this.renderImportersList()

--- a/client/my-sites/migrate/helpers/index.js
+++ b/client/my-sites/migrate/helpers/index.js
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import page from 'page';
 
 /**
@@ -23,13 +24,14 @@ export function redirectTo( url ) {
 
 /**
  * Get the Import Section URL depending on if the site is Jetpack or WordPress.com Simple site.
+ * If the unified importer is enabled always return the Calypso page.
  *
  * @param siteSlug The Site Slug
  * @param isJetpack If the site is a Jetpack site
  * @returns {string} The URL that points to the import section
  */
 export function getImportSectionLocation( siteSlug, isJetpack = false ) {
-	return isJetpack
+	return isJetpack && ! config.isEnabled( 'importer/unified' )
 		? `https://${ siteSlug }/wp-admin/import.php`
 		: `/import/${ siteSlug }/?engine=wordpress`;
 }

--- a/client/my-sites/sidebar/static-data/jetpack-fallback-menu.js
+++ b/client/my-sites/sidebar/static-data/jetpack-fallback-menu.js
@@ -190,7 +190,7 @@ export default function jetpackMenu( { siteDomain } ) {
 					slug: 'tools-export',
 					title: translate( 'Export' ),
 					type: 'submenu-item',
-					url: `https://${ siteDomain }/wp-admin/import.php?calypsoify=0`,
+					url: `https://${ siteDomain }/wp-admin/export.php?calypsoify=0`,
 				},
 			],
 		},

--- a/client/my-sites/sidebar/static-data/jetpack-fallback-menu.js
+++ b/client/my-sites/sidebar/static-data/jetpack-fallback-menu.js
@@ -10,7 +10,7 @@ import { translate } from 'i18n-calypso';
 
 const JETPACK_ICON = `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='20' height='20' viewBox='0 0 40 40' %3E%3Cpath fill='%23a0a5aa' d='M20 0c11.046 0 20 8.954 20 20s-8.954 20-20 20S0 31.046 0 20 8.954 0 20 0zm11 17H21v19l10-19zM19 4L9 23h10V4z'/%3E%3C/svg%3E`;
 
-export default function jetpackMenu( { siteDomain } ) {
+export default function jetpackMenu( { siteDomain, hasUnifiedImporter } ) {
 	return [
 		{
 			icon: 'dashicons-chart-bar',
@@ -168,14 +168,14 @@ export default function jetpackMenu( { siteDomain } ) {
 					parent: 'tools.php',
 					slug: 'tools-marketing',
 					title: translate( 'Marketing' ),
-					type: 'menu-item',
+					type: 'submenu-item',
 					url: `/marketing/tools/${ siteDomain }`,
 				},
 				{
 					parent: 'tools.php',
 					slug: 'tools-earn',
 					title: translate( 'Earn' ),
-					type: 'menu-item',
+					type: 'submenu-item',
 					url: `/earn/${ siteDomain }`,
 				},
 				{
@@ -183,7 +183,9 @@ export default function jetpackMenu( { siteDomain } ) {
 					slug: 'tools-import',
 					title: translate( 'Import' ),
 					type: 'submenu-item',
-					url: `https://${ siteDomain }/wp-admin/import.php?calypsoify=0`,
+					url: hasUnifiedImporter
+						? `/import/${ siteDomain }`
+						: `https://${ siteDomain }/wp-admin/import.php?calypsoify=0`,
 				},
 				{
 					parent: 'tools.php',

--- a/client/my-sites/sidebar/use-site-menu-items.js
+++ b/client/my-sites/sidebar/use-site-menu-items.js
@@ -57,6 +57,8 @@ const useSiteMenuItems = () => {
 
 	const hasSiteWithPlugins = useSelector( canAnySiteHavePlugins );
 
+	const hasUnifiedImporter = isEnabled( 'importer/unified' );
+
 	/**
 	 * When no site domain is provided, lets show only menu items that support all sites screens.
 	 */
@@ -68,7 +70,7 @@ const useSiteMenuItems = () => {
 	 * When we have a jetpack connected site & we cannot retrieve the dynamic menu from that site.
 	 */
 	if ( isJetpack && ! isAtomic && ! menuItems ) {
-		return jetpackMenu( { siteDomain } );
+		return jetpackMenu( { siteDomain, hasUnifiedImporter } );
 	}
 
 	/**

--- a/config/development.json
+++ b/config/development.json
@@ -70,7 +70,7 @@
 		"i18n/community-translator": false,
 		"i18n/empathy-mode": true,
 		"i18n/translation-scanner": true,
-		"importer/unified": true,
+		"importer/unified": false,
 		"importers/substack": true,
 		"inline-help": true,
 		"jetpack/agency-dashboard": true,

--- a/config/development.json
+++ b/config/development.json
@@ -70,6 +70,7 @@
 		"i18n/community-translator": false,
 		"i18n/empathy-mode": true,
 		"i18n/translation-scanner": true,
+		"importer/unified": true,
 		"importers/substack": true,
 		"inline-help": true,
 		"jetpack/agency-dashboard": true,


### PR DESCRIPTION
#### Proposed Changes

* Added `importer/unified` feature flag to development config
* Unlocked complete list of importers in WoA and Jetpack sites
* Fix `tools-export` fallback menu link

#### Testing Instructions

* Open `http://calypso.localhost:3000/import/SLUG?flags=importer/unified` in a WoA/Atomic/Simple site.
* The three pages must list all the importers.
* The `Tools > Import` menu entry must point to `/import/SLUG` and not to `wp-admin`.
* The "upload it to import content" link on `/migrate/SLUG` must point to `/import/SLUG` and not to `wp-admin`.
* Try it again removing the flag. Everything must work as in `trunk`.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #72210
