### PR TITLE
Plugin card: Update icon size and remove additional information

### DIFF
--- a/client/my-sites/plugins/plugins-browser-item/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-item/index.jsx
@@ -7,9 +7,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useMemo, useCallback, useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import Badge from 'calypso/components/badge';
-import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import { formatNumberMetric } from 'calypso/lib/format-number-compact';
 import { getPluginPurchased, getSoftwareSlug } from 'calypso/lib/plugins/utils';
 import version_compare from 'calypso/lib/version-compare';
 import { IntervalLength } from 'calypso/my-sites/marketplace/components/billing-interval-switcher/constants';
@@ -44,7 +42,6 @@ const PluginsBrowserListElement = ( props ) => {
 	} = props;
 
 	const translate = useTranslate();
-	const moment = useLocalizedMoment();
 	const localizeUrl = useLocalizeUrl();
 	const { localizePath } = useLocalizedPlugins();
 
@@ -58,12 +55,6 @@ const PluginsBrowserListElement = ( props ) => {
 		currentSites
 			? getSitesWithPlugin( state, siteObjectsToSiteIds( currentSites ), softwareSlug )
 			: []
-	);
-
-	const dateFromNow = useMemo(
-		() =>
-			plugin.last_updated ? moment.utc( plugin.last_updated, 'YYYY-MM-DD hh:mma' ).fromNow() : null,
-		[ plugin.last_updated ]
 	);
 
 	const pluginLink = useMemo( () => {
@@ -182,18 +173,6 @@ const PluginsBrowserListElement = ( props ) => {
 								{ translate( 'by ' ) }
 								<span className="plugins-browser-item__author-name">{ plugin.author_name }</span>
 							</div>
-
-							<div className="plugins-browser-item__last-updated">
-								{ dateFromNow &&
-									translate( 'Last updated {{span}}%(ago)s{{/span}}', {
-										args: {
-											ago: dateFromNow,
-										},
-										components: {
-											span: <span className="plugins-browser-item__last-updated-value" />,
-										},
-									} ) }
-							</div>
 						</>
 					) }
 					<div className="plugins-browser-item__description">{ plugin.short_description }</div>
@@ -238,15 +217,6 @@ const PluginsBrowserListElement = ( props ) => {
 									inlineNumRatings
 									hideRatingNumber
 								/>
-							</div>
-						) }
-						{ !! plugin.active_installs && (
-							<div className="plugins-browser-item__active-installs">
-								<span className="plugins-browser-item__active-installs-value">{ `${ formatNumberMetric(
-									plugin.active_installs,
-									0
-								) }${ plugin.active_installs > 1000 ? '+' : '' }` }</span>
-								{ translate( ' Active Installs' ) }
 							</div>
 						) }
 					</div>

--- a/client/my-sites/plugins/plugins-browser-item/style.scss
+++ b/client/my-sites/plugins/plugins-browser-item/style.scss
@@ -148,6 +148,7 @@
 .plugins-browser-item__author {
 	color: var(--color-text-subtle);
 	font-size: $font-body-small;
+	padding-bottom: 5px;
 }
 
 .plugins-browser-item__author-name {

--- a/client/my-sites/plugins/plugins-browser-item/style.scss
+++ b/client/my-sites/plugins/plugins-browser-item/style.scss
@@ -19,8 +19,8 @@
 	}
 
 	.plugin-icon {
-		width: 60px;
-		height: 60px;
+		width: 47px;
+		height: 47px;
 		margin-right: 0;
 
 		&.is-placeholder {
@@ -33,7 +33,7 @@
 	.plugins-browser-item__last-updated {
 		text-overflow: ellipsis;
 		white-space: nowrap;
-		margin-left: calc(60px + 16px); // icon width + margin
+		margin-left: calc(47px + 16px); // icon width + margin
 	}
 
 	.plugins-browser-item__description {


### PR DESCRIPTION
#### Proposed Changes

* Update the icon size
* Remove the last updated info
* Remove the active installs info

| Before  | After |
| ------------- | ------------- |
|<img width="1113" alt="Screen Shot 2023-01-17 at 11 06 08" src="https://user-images.githubusercontent.com/5039531/212935226-f5402c82-5df6-4930-98d9-6445bb3e77ef.png">|<img width="1113" alt="Screen Shot 2023-01-17 at 11 05 30" src="https://user-images.githubusercontent.com/5039531/212935260-795122b2-1642-4dde-b1e0-ca1d4e467f76.png">|



#### Testing Instructions
* Go to `/plugins`
* Check all cards displayed on the screen matches the layout above and don't remove last updated or active installs info

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #70903
