### PR TITLE
My Home: Complete "Update your site's design" upon clicking action button

### DIFF
--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
@@ -223,6 +223,13 @@ export const getTask = (
 				),
 				actionText: isFSEActive ? translate( 'Edit site' ) : translate( 'Edit homepage' ),
 				actionUrl: taskUrls?.front_page_updated,
+				// Mark the task as completed upon clicking on the action button when redirecting to the site editor
+				// since we don't have any good way to track changes within the site editor.
+				...( ! task.isCompleted &&
+					isFSEActive && {
+						actionDispatch: requestSiteChecklistTaskUpdate,
+						actionDispatchArgs: [ siteId, task.id ],
+					} ),
 			};
 			break;
 		case CHECKLIST_KNOWN_TASKS.SITE_MENU_UPDATED:

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
@@ -270,7 +270,7 @@ const SiteSetupList = ( {
 					aria-orientation="vertical"
 				>
 					{ tasks.map( ( task ) => {
-						const enhancedTask = getTask( task, { isBlogger, userEmail } );
+						const enhancedTask = getTask( task, { isBlogger, isFSEActive, userEmail } );
 						const isCurrent = task.id === currentTask.id;
 						const isCompleted = task.isCompleted;
 


### PR DESCRIPTION
Part of https://github.com/Automattic/wp-calypso/issues/71277

#### Proposed Changes

- Changes the completion logic to mark the "Update your site's design" task as completed upon clicking on the CTA button, since we don't have any good way to track changes within the site editor (similarly to how the “Edit site design” task from the Launchpad is completed upon loading the site editor).
- Fixes a minor bug to ensure that the task title in the sidebar matches the big title displayed within the card (by adding the missing `isFSEActive` param to the `getTask` function).

Before | After
--- | ---
<img width="960" alt="Screenshot 2023-01-17 at 17 02 27" src="https://user-images.githubusercontent.com/1233880/212954311-1691bb46-8b45-4c87-8832-eb60e9e43e96.png"> | <img width="959" alt="Screenshot 2023-01-17 at 17 12 23" src="https://user-images.githubusercontent.com/1233880/212954331-ba1a178a-9fab-4a6e-b4ab-a4ef8fa02ac9.png">


#### Testing Instructions

- Use the Calypso live link below
- Create a new site
- Go to My Home
- Observe the site setup
- Make sure the title of the 2nd task has changed to "Update your site's design"
- Click on it
- Click on the CTA button
- Go back to My Home
- Make sure the task has been completed
