### PR TITLE
Remove selected column from `hours` period in Email Stats

### DIFF
--- a/client/my-sites/stats/stats-email-chart-tabs/utility.js
+++ b/client/my-sites/stats/stats-email-chart-tabs/utility.js
@@ -54,9 +54,13 @@ export const buildChartData = memoizeLast(
 			const recordClassName =
 				record.classNames && record.classNames.length ? record.classNames.join( ' ' ) : null;
 
-			const className = classNames( recordClassName, {
-				'is-selected': checkIsSelected( record, queryDate, queryHour ),
-			} );
+			const className = ( () => {
+				if ( 'hour' !== period ) {
+					return classNames( recordClassName, {
+						'is-selected': checkIsSelected( record, queryDate, queryHour ),
+					} );
+				}
+			} )();
 
 			return addTooltipData(
 				chartTab,


### PR DESCRIPTION
#### Proposed Changes

This PR removes the "selected hour" indicator from the `hours` period in the Email Chart (the lightblue background):
<img width="1092" alt="Screenshot 2023-01-17 at 16 15 33" src="https://user-images.githubusercontent.com/3832570/212959441-47c2b5d8-8d10-468a-9677-80853acb41ff.png">


This is done because selecting an hour has no meaning anymore, as all the other metrics doesn't react to that change as before.

#### Testing Instructions

1. Apply this branch to your local Calypso repository and start the application.
2. Insert manually in the browser address bar an URL with this format: https://calypso.localhost:3000/stats/email/open/[the-doomain-of-your-blog]/hour/[post-id]?flags=newsletter/stats. Note that you can change day for week and month.
3.  You shouldn't see the light blue background anymore in any of the columns of the chart.
4. Change to `days`. You should see the light blue background in the first column of the chart for this `days` period (like in the image above).

Fixes https://github.com/Automattic/wp-calypso/issues/72195