### PR TITLE
Fixed tooltip in Email Stat chart for hours period

### DIFF
--- a/client/my-sites/stats/stats-email-chart-tabs/utility.js
+++ b/client/my-sites/stats/stats-email-chart-tabs/utility.js
@@ -75,8 +75,15 @@ export const buildChartData = memoizeLast(
 
 function addTooltipData( chartTab, item, period ) {
 	const tooltipData = [];
+	const label = ( () => {
+		if ( 'hour' === period ) {
+			return item.label;
+		}
+		return formatDate( item.data.period, period );
+	} )();
+
 	tooltipData.push( {
-		label: formatDate( item.data.period, period ),
+		label,
 		className: 'is-date-label',
 		value: null,
 	} );


### PR DESCRIPTION
#### Proposed Changes

When the user selects `hours` period in the chart found in Email Stats page, the tooltips are wrong:

<img width="1123" alt="Screenshot 2023-01-17 at 16 05 23" src="https://user-images.githubusercontent.com/3832570/212970710-5dfdf595-e2bb-4d64-9d51-f5d1cd0777d0.png">

This PR fixes that problem.

#### Testing Instructions

1. Apply this branch to your local Calypso repository and start the application.
2. Insert manually in the browser address bar an URL with this format: https://calypso.localhost:3000/stats/email/open/[the-domain-of-your-blog]/hour/[post-id]?flags=newsletter/stats. Note that you can change day for week and month.
3. Hover over the columns in the chart. The correct date should show, as per this image:
<img width="1075" alt="Screenshot 2023-01-17 at 18 34 48" src="https://user-images.githubusercontent.com/3832570/212971408-9114e1c4-6397-4986-a810-62e95997a64a.png">
4. Change to `days` and hover over a column. Should be still ok, as per this image:
<img width="1107" alt="Screenshot 2023-01-17 at 18 37 07" src="https://user-images.githubusercontent.com/3832570/212971702-7f5fd852-d396-4c6c-a00c-54c9cd4d76d0.png">

Fixes https://github.com/Automattic/wp-calypso/issues/72215 