### PR TITLE
WooExpress Trial: Update individual plugins page CTA and upgrade callout

### DIFF
--- a/client/my-sites/plugins/plugin-details-CTA/usps.tsx
+++ b/client/my-sites/plugins/plugin-details-CTA/usps.tsx
@@ -181,6 +181,9 @@ export const PlanUSPS: React.FC< Props > = ( {
 		translate( 'Best-in-class hosting' ),
 		supportText,
 		...( isPreInstalledPlugin ? preInstalledPluginUSPS : [] ),
+		...( requiredPlan === PLAN_ECOMMERCE_TRIAL_MONTHLY
+			? [ translate( 'Tools for store management and growth' ) ]
+			: [] ),
 	];
 
 	return (

--- a/client/my-sites/plugins/plugin-details-CTA/usps.tsx
+++ b/client/my-sites/plugins/plugin-details-CTA/usps.tsx
@@ -162,7 +162,7 @@ export const PlanUSPS: React.FC< Props > = ( {
 			} );
 			break;
 		case PLAN_ECOMMERCE_TRIAL_MONTHLY:
-			planText = translate( 'Included in eCommerce plans:' );
+			planText = translate( 'Included in ecommerce plans:' );
 			break;
 	}
 

--- a/client/my-sites/plugins/plugin-details-CTA/usps.tsx
+++ b/client/my-sites/plugins/plugin-details-CTA/usps.tsx
@@ -4,6 +4,7 @@ import {
 	PLAN_BUSINESS,
 	PLAN_PERSONAL,
 	PLAN_PERSONAL_MONTHLY,
+	PLAN_ECOMMERCE_TRIAL_MONTHLY,
 } from '@automattic/calypso-products';
 import { Gridicon } from '@automattic/components';
 import styled from '@emotion/styled';
@@ -14,6 +15,7 @@ import PluginDetailsSidebarUSP from 'calypso/my-sites/plugins/plugin-details-sid
 import usePluginsSupportText from 'calypso/my-sites/plugins/use-plugins-support-text/';
 import { getBillingInterval } from 'calypso/state/marketplace/billing-interval/selectors';
 import { getProductDisplayCost } from 'calypso/state/products-list/selectors';
+import { isSiteOnECommerceTrial } from 'calypso/state/sites/plans/selectors';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { IAppState } from 'calypso/state/types';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
@@ -50,6 +52,10 @@ const GreenGridicon = styled( Gridicon )`
 `;
 
 const useRequiredPlan = ( shouldUpgrade: boolean ) => {
+	const siteId = useSelector( getSelectedSite )?.ID;
+	const isECommerceTrial = useSelector(
+		( state: IAppState ) => siteId && isSiteOnECommerceTrial( state, siteId )
+	);
 	return useSelector( ( state: IAppState ) => {
 		if ( ! shouldUpgrade ) {
 			return '';
@@ -58,6 +64,10 @@ const useRequiredPlan = ( shouldUpgrade: boolean ) => {
 		const isAnnualPeriod = billingPeriod === IntervalLength.ANNUALLY;
 		if ( config.isEnabled( 'marketplace-personal-premium' ) ) {
 			return isAnnualPeriod ? PLAN_PERSONAL : PLAN_PERSONAL_MONTHLY;
+		}
+
+		if ( isECommerceTrial ) {
+			return PLAN_ECOMMERCE_TRIAL_MONTHLY;
 		}
 
 		return isAnnualPeriod ? PLAN_BUSINESS : PLAN_BUSINESS_MONTHLY;
@@ -150,6 +160,9 @@ export const PlanUSPS: React.FC< Props > = ( {
 					periodicity: periodicityLabel,
 				},
 			} );
+			break;
+		case PLAN_ECOMMERCE_TRIAL_MONTHLY:
+			planText = translate( 'Included in eCommerce plans:' );
 			break;
 	}
 

--- a/client/my-sites/plugins/plugin-details-sidebar/index.jsx
+++ b/client/my-sites/plugins/plugin-details-sidebar/index.jsx
@@ -99,7 +99,7 @@ const PluginDetailsSidebar = ( {
 					id="woo"
 					title={ translate( 'Your store foundations' ) }
 					description={ translate(
-						'This plugin requires the WooCommerce plugin to work.{{br/}}If you do not have it installed, it will be installed automatically for free.',
+						'This plugin requires WooCommerce to work.{{br/}}If you do not have it installed, it will be installed automatically for free.',
 						{
 							components: {
 								br: <br />,

--- a/client/my-sites/plugins/use-plugins-support-text/index.js
+++ b/client/my-sites/plugins/use-plugins-support-text/index.js
@@ -36,7 +36,7 @@ export default function usePluginsSupportText() {
 	const isLiveSupport = useSelector( hasOrIntendsToBuyLiveSupport );
 	const supportTextNonPro = isLiveSupport
 		? translate( 'Live chat support' )
-		: translate( 'Unlimited Email Support' );
+		: translate( 'Unlimited email support' );
 	const supportText = eligibleForProPlan ? translate( 'Premium support' ) : supportTextNonPro;
 	return supportText;
 }


### PR DESCRIPTION
#### Proposed Changes

* Update the button copy and action when installing a plugin that requires a plan upgrade while viewing the page from a site on the eCommerce Trial
* The CTA copy should say "Upgrade your plan" since we're pointing folks toward the Plans page rather than directly to checkout, and therefore won't automatically activate the given plugin for them after upgrading (unless there's a way to do so I'm unaware of)
* Point to the Plans page with the plugins feature highlighted rather than directly to checkout for eCommerce Trials
* Update the upgrade copy to say "Included with eCommerce plans" since (in theory) users will have multiple plans to choose from
* Once we've agreed on the correct copy we need to add the String Freeze label to get new strings translated.

**Before**
<img width="1118" alt="Screen Shot 2023-01-17 at 12 55 35 PM" src="https://user-images.githubusercontent.com/2124984/212975280-3180b8be-fdd7-4b1f-8a1e-9014c59ccaeb.png">

**After**

<img width="1085" alt="Screen Shot 2023-01-23 at 11 38 08 AM" src="https://user-images.githubusercontent.com/2124984/214096715-ef026810-b196-4afb-8e3f-adddddd99dc4.png">

**Marketplace plugins**

Minor copy update to these screens to reduce wordiness.

<img width="1103" alt="Screen Shot 2023-01-23 at 11 38 56 AM" src="https://user-images.githubusercontent.com/2124984/214096988-0ed76511-6893-435e-9d51-25cb33d61206.png">

#### Testing Instructions

* Switch to this PR
* Create a new eCommerce Trial site from `/setup/wooexpress`
* Go to `/plugins/[siteSlug]` (you may need to do this manually in your browser because the Plugins screen gets taken off the menu for eCommerce Trial sites)
* Visit a non-marketplace plugin page (like Contact Form 7)
* The plans copy underneath the CTA should read "Included with eCommerce plans:" and list the same features as are currently listed for Business sites on this same page
* The CTA should read "Upgrade your plan", and clicking it should take you to `/plans/[siteSlug]?feature=install-plugins`
* Switch to multiple sites on each different plan (Free, Premium, Business, eCommerce) to confirm they behave as they currently do in production with this PR

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- NA [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- NA Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- NA For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #71853
