### PR TITLE
Removed click event from chart in Email Stats

### DIFF
--- a/client/my-sites/stats/stats-email-chart-tabs/index.jsx
+++ b/client/my-sites/stats/stats-email-chart-tabs/index.jsx
@@ -47,7 +47,6 @@ class StatModuleChartTabs extends Component {
 		chartTab: PropTypes.string,
 		switchTab: PropTypes.func,
 		queryDate: PropTypes.string,
-		queryHour: PropTypes.string,
 		recordGoogleEvent: PropTypes.func,
 		sliceFromBeginning: PropTypes.bool,
 	};
@@ -120,10 +119,7 @@ const NO_SITE_STATE = {
 };
 
 const connectComponent = connect(
-	(
-		state,
-		{ activeLegend, period: { period, endOf }, chartTab, queryDate, queryHour, postId, statType }
-	) => {
+	( state, { activeLegend, period: { period, endOf }, chartTab, queryDate, postId, statType } ) => {
 		const siteId = getSelectedSiteId( state );
 		if ( ! siteId ) {
 			return NO_SITE_STATE;
@@ -131,14 +127,7 @@ const connectComponent = connect(
 
 		const quantity = 'hour' === period ? 24 : 30;
 		const counts = getCountRecords( state, siteId, postId, period, statType );
-		const chartData = buildChartData(
-			activeLegend,
-			chartTab,
-			counts,
-			period,
-			queryDate,
-			queryHour
-		);
+		const chartData = buildChartData( activeLegend, chartTab, counts, period );
 		const isActiveTabLoading = isLoadingTabs(
 			state,
 			siteId,

--- a/client/my-sites/stats/stats-email-chart-tabs/utility.js
+++ b/client/my-sites/stats/stats-email-chart-tabs/utility.js
@@ -1,5 +1,4 @@
 import { Icon, people, starEmpty, chevronRight, postContent } from '@wordpress/icons';
-import classNames from 'classnames';
 import { numberFormat, translate } from 'i18n-calypso';
 import { capitalize } from 'lodash';
 import moment from 'moment';
@@ -31,51 +30,27 @@ export function getQueryDate( queryDate, timezoneOffset, period, quantity ) {
 	return endOfPeriodDate;
 }
 
-const checkIsSelected = ( record, queryDate, queryHour ) => {
-	let isSelected = record.period === queryDate;
-
-	if ( isSelected && record.hour ) {
-		isSelected = record.hour && record.hour.toString() === queryHour;
-	}
-
-	return isSelected;
-};
-
 const EMPTY_RESULT = [];
-export const buildChartData = memoizeLast(
-	( activeLegend, chartTab, data, period, queryDate, queryHour ) => {
-		if ( ! data ) {
-			return EMPTY_RESULT;
-		}
-
-		return data.map( ( record ) => {
-			const nestedValue = activeLegend.length ? record[ activeLegend[ 0 ] ] : null;
-
-			const recordClassName =
-				record.classNames && record.classNames.length ? record.classNames.join( ' ' ) : null;
-
-			const className = ( () => {
-				if ( 'hour' !== period ) {
-					return classNames( recordClassName, {
-						'is-selected': checkIsSelected( record, queryDate, queryHour ),
-					} );
-				}
-			} )();
-
-			return addTooltipData(
-				chartTab,
-				{
-					label: record[ `label${ capitalize( period ) }` ],
-					value: record[ chartTab ],
-					data: record,
-					nestedValue,
-					className,
-				},
-				period
-			);
-		} );
+export const buildChartData = memoizeLast( ( activeLegend, chartTab, data, period ) => {
+	if ( ! data ) {
+		return EMPTY_RESULT;
 	}
-);
+
+	return data.map( ( record ) => {
+		const nestedValue = activeLegend.length ? record[ activeLegend[ 0 ] ] : null;
+
+		return addTooltipData(
+			chartTab,
+			{
+				label: record[ `label${ capitalize( period ) }` ],
+				value: record[ chartTab ],
+				data: record,
+				nestedValue,
+			},
+			period
+		);
+	} );
+} );
 
 function addTooltipData( chartTab, item, period ) {
 	const tooltipData = [];

--- a/client/my-sites/stats/stats-email-open-detail/index.jsx
+++ b/client/my-sites/stats/stats-email-open-detail/index.jsx
@@ -173,13 +173,6 @@ class StatsEmailOpenDetail extends Component {
 
 	onChangeLegend = ( activeLegend ) => this.setState( { activeLegend } );
 
-	barClick = ( bar ) => {
-		this.props.recordGoogleEvent( 'Stats', 'Clicked Chart Bar' );
-		const parsed = getPageUrl();
-		const updatedQs = stringifyQs( updateQueryString( parsed, { startDate: bar.data.period } ) );
-		page.redirect( `${ parsed.pathname }?${ updatedQs }` );
-	};
-
 	switchChart = ( tab ) => {
 		if ( ! tab.loading && tab.attr !== this.props.chartTab ) {
 			this.props.recordGoogleEvent( 'Stats', 'Clicked ' + titlecase( tab.attr ) + ' Tab' );
@@ -203,7 +196,6 @@ class StatsEmailOpenDetail extends Component {
 		} = this.props;
 
 		const queryDate = date.format( 'YYYY-MM-DD' );
-		const queryHour = date.format( 'H' );
 		const noViewsLabel = translate( 'Your email has not received any views yet!' );
 
 		const { period, endOf } = this.props.period;
@@ -278,11 +270,9 @@ class StatsEmailOpenDetail extends Component {
 									activeLegend={ this.state.activeLegend }
 									availableLegend={ this.getAvailableLegend() }
 									onChangeLegend={ this.onChangeLegend }
-									barClick={ this.barClick }
 									switchTab={ this.switchChart }
 									charts={ CHARTS }
 									queryDate={ queryDate }
-									queryHour={ queryHour }
 									period={ this.props.period }
 									chartTab={ this.props.chartTab }
 									postId={ postId }


### PR DESCRIPTION
#### Proposed Changes

In the past, clicking on the columns in the chart found in the Email Stats page had meaning: the rest of the stats changed according to the date clicked. Now, with the recent changes, that's not happening anymore.

This PR removes the click event from the chart for the Email Stats page.

#### Testing Instructions

1. Apply this branch to your local Calypso repository and start the application.
2. Insert manually in the browser address bar an URL with this format: https://calypso.localhost:3000/stats/email/open/[the-domain-of-your-blog]/day/[post-id]?flags=newsletter/stats. Note that you can change day for week and month.
3. Click on any column in the chart. Nothing should happen: no column selection with light blue background, no change in the route, etc.
4. Click on the `hours` and check nothing happens when clicking on the columns too.
5. Go to http://calypso.localhost:3000/stats/day/[the-domain-of-your-blog] and check that clicking on the columns of the chart still works, changing the route, selecting the column with light blue background, and the rest of the cards change their values according to the selection.

Thanks for testing! ❤️

Fixes https://github.com/Automattic/wp-calypso/issues/72197
