### PR TITLE
WooExpress Trial: Update copy for assignTrial step

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/assign-trial-plan/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/assign-trial-plan/index.tsx
@@ -48,7 +48,7 @@ const AssignTrialPlanStep: Step = function AssignTrialPlanStep( { navigation, da
 	}, [] );
 
 	const getCurrentMessage = () => {
-		return __( 'Setting up your trial' );
+		return __( "Woo! We're creating your store" );
 	};
 
 	return (


### PR DESCRIPTION
#### Proposed Changes

* Update "Setting up your trial" to "Woo! We're creating your store" while processing
* I didn't see copy on the site creation step but let me know if I missed it :) 

**Before**
<img width="570" alt="Screen Shot 2023-01-17 at 1 23 54 PM" src="https://user-images.githubusercontent.com/2124984/212980472-dc05931a-4032-4cf7-bc84-ede8ffa88436.png">

**After**

<img width="567" alt="Screen Shot 2023-01-17 at 1 18 14 PM" src="https://user-images.githubusercontent.com/2124984/212980133-78fae61a-635e-4091-b1d4-1870b998535e.png">


#### Testing Instructions

* Switch to this PR, navigate to `/setup/wooexpress`
* You should see the above copy change while your site is being created and set up

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- NA [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- NA Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- NA For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #72168
