### PR TITLE
WooExpress Trial: Users should not be able to launch sites on WooExpress Trial plan

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -585,6 +585,7 @@ export class SiteSettingsFormGeneral extends Component {
 		const btnText = translate( 'Launch site' );
 		let querySiteDomainsComponent;
 		let btnComponent;
+		let eCommerceTrailUpsell;
 		const isLaunchable = ! isSiteOnECommerceTrial;
 
 		if ( 0 === siteDomains.length ) {
@@ -616,10 +617,26 @@ export class SiteSettingsFormGeneral extends Component {
 
 		const LaunchCard = showPreviewLink ? CompactCard : Card;
 
+		if ( isSiteOnECommerceTrial ) {
+			eCommerceTrailUpsell = (
+				<a href={ `/plans/${ siteSlug }?plan=business-bundle-monthly` }>
+					<Notice
+						icon="info"
+						showDismiss={ false }
+						text={ translate(
+							'In order for everyone to see your store, you just need to subscribe to a eCommerce plan. Subscribe'
+						) }
+						isCompact={ false }
+					></Notice>
+				</a>
+			);
+		}
+
 		return (
 			<>
 				<SettingsSectionHeader title={ translate( 'Launch site' ) } />
 				<LaunchCard>
+					{ eCommerceTrailUpsell }
 					<div className="site-settings__general-settings-launch-site">
 						<div className="site-settings__general-settings-launch-site-text">
 							<p>

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -618,17 +618,24 @@ export class SiteSettingsFormGeneral extends Component {
 		const LaunchCard = showPreviewLink ? CompactCard : Card;
 
 		if ( isSiteOnECommerceTrial ) {
+			const eCommerceTrialUpsellText = translate(
+				'Before you can share your store with the world, you need to {{NoticeAction}}pick a plan{{/NoticeAction}}.',
+				{
+					components: {
+						NoticeAction: (
+							<NoticeAction href={ `/plans/${ siteSlug }?plan=ecommerce-bundle-monthly` } />
+						),
+					},
+				}
+			);
 			eCommerceTrialUpsell = (
-				<a href={ `/plans/${ siteSlug }?plan=business-bundle-monthly` }>
-					<Notice
-						icon="info"
-						showDismiss={ false }
-						text={ translate(
-							'In order for everyone to see your store, you just need to subscribe to a eCommerce plan. Subscribe'
-						) }
-						isCompact={ false }
-					></Notice>
-				</a>
+				<Notice
+					className="site-settings__ecommerce-trial-notice"
+					icon="info"
+					showDismiss={ false }
+					text={ eCommerceTrialUpsellText }
+					isCompact={ false }
+				></Notice>
 			);
 		}
 

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -44,6 +44,7 @@ import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 import { usePremiumGlobalStyles } from 'calypso/state/sites/hooks/use-premium-global-styles';
 import { launchSite } from 'calypso/state/sites/launch/actions';
+import { isSiteOnECommerceTrial as getIsSiteOnECommerceTrial } from 'calypso/state/sites/plans/selectors';
 import {
 	getSiteOption,
 	isJetpackSite,
@@ -575,6 +576,7 @@ export class SiteSettingsFormGeneral extends Component {
 			fields,
 			hasSitePreviewLink,
 			site,
+			isSiteOnECommerceTrial,
 		} = this.props;
 
 		const launchSiteClasses = classNames( 'site-settings__general-settings-launch-site-button', {
@@ -583,12 +585,17 @@ export class SiteSettingsFormGeneral extends Component {
 		const btnText = translate( 'Launch site' );
 		let querySiteDomainsComponent;
 		let btnComponent;
+		const isLaunchable = ! isSiteOnECommerceTrial;
 
 		if ( 0 === siteDomains.length ) {
 			querySiteDomainsComponent = <QuerySiteDomains siteId={ siteId } />;
 			btnComponent = <Button>{ btnText }</Button>;
 		} else if ( isPaidPlan && siteDomains.length > 1 ) {
-			btnComponent = <Button onClick={ this.props.launchSite }>{ btnText }</Button>;
+			btnComponent = (
+				<Button onClick={ this.props.launchSite } disabled={ ! isLaunchable }>
+					{ btnText }
+				</Button>
+			);
 			querySiteDomainsComponent = '';
 		} else {
 			btnComponent = (
@@ -869,6 +876,7 @@ const connectComponent = connect( ( state ) => {
 		siteSlug: getSelectedSiteSlug( state ),
 		hasSubscriptionGifting: siteHasFeature( state, siteId, WPCOM_FEATURES_SUBSCRIPTION_GIFTING ),
 		hasSitePreviewLink: siteHasFeature( state, siteId, WPCOM_FEATURES_SITE_PREVIEW_LINKS ),
+		isSiteOnECommerceTrial: getIsSiteOnECommerceTrial( state, siteId ),
 	};
 }, mapDispatchToProps );
 

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -577,6 +577,7 @@ export class SiteSettingsFormGeneral extends Component {
 			hasSitePreviewLink,
 			site,
 			isSiteOnECommerceTrial,
+			recordTracksEvent,
 		} = this.props;
 
 		const launchSiteClasses = classNames( 'site-settings__general-settings-launch-site-button', {
@@ -618,12 +619,17 @@ export class SiteSettingsFormGeneral extends Component {
 		const LaunchCard = showPreviewLink ? CompactCard : Card;
 
 		if ( isSiteOnECommerceTrial ) {
+			const recordTracksEventForClick = () =>
+				recordTracksEvent( 'calypso_ecommerce_trial_launch_banner_click' );
 			const eCommerceTrialUpsellText = translate(
-				'Before you can share your store with the world, you need to {{NoticeAction}}pick a plan{{/NoticeAction}}.',
+				'Before you can share your store with the world, you need to {{a}}pick a plan{{/a}}.',
 				{
 					components: {
-						NoticeAction: (
-							<NoticeAction href={ `/plans/${ siteSlug }?plan=ecommerce-bundle-monthly` } />
+						a: (
+							<a
+								href={ `/plans/${ siteSlug }?plan=ecommerce-bundle-monthly` }
+								onClick={ recordTracksEventForClick }
+							/>
 						),
 					},
 				}
@@ -635,7 +641,7 @@ export class SiteSettingsFormGeneral extends Component {
 					showDismiss={ false }
 					text={ eCommerceTrialUpsellText }
 					isCompact={ false }
-				></Notice>
+				/>
 			);
 		}
 

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -585,7 +585,7 @@ export class SiteSettingsFormGeneral extends Component {
 		const btnText = translate( 'Launch site' );
 		let querySiteDomainsComponent;
 		let btnComponent;
-		let eCommerceTrailUpsell;
+		let eCommerceTrialUpsell;
 		const isLaunchable = ! isSiteOnECommerceTrial;
 
 		if ( 0 === siteDomains.length ) {
@@ -618,7 +618,7 @@ export class SiteSettingsFormGeneral extends Component {
 		const LaunchCard = showPreviewLink ? CompactCard : Card;
 
 		if ( isSiteOnECommerceTrial ) {
-			eCommerceTrailUpsell = (
+			eCommerceTrialUpsell = (
 				<a href={ `/plans/${ siteSlug }?plan=business-bundle-monthly` }>
 					<Notice
 						icon="info"
@@ -636,7 +636,7 @@ export class SiteSettingsFormGeneral extends Component {
 			<>
 				<SettingsSectionHeader title={ translate( 'Launch site' ) } />
 				<LaunchCard>
-					{ eCommerceTrailUpsell }
+					{ eCommerceTrialUpsell }
 					<div className="site-settings__general-settings-launch-site">
 						<div className="site-settings__general-settings-launch-site-text">
 							<p>

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -5,6 +5,7 @@ import {
 	WPCOM_FEATURES_NO_WPCOM_BRANDING,
 	WPCOM_FEATURES_SITE_PREVIEW_LINKS,
 	FEATURE_ADVANCED_DESIGN_CUSTOMIZATION,
+	PLAN_ECOMMERCE_MONTHLY,
 } from '@automattic/calypso-products';
 import { WPCOM_FEATURES_SUBSCRIPTION_GIFTING } from '@automattic/calypso-products/src';
 import { Card, CompactCard, Button, Gridicon } from '@automattic/components';
@@ -627,7 +628,7 @@ export class SiteSettingsFormGeneral extends Component {
 					components: {
 						a: (
 							<a
-								href={ `/plans/${ siteSlug }?plan=ecommerce-bundle-monthly` }
+								href={ `/plans/${ siteSlug }?plan=${ PLAN_ECOMMERCE_MONTHLY }` }
 								onClick={ recordTracksEventForClick }
 							/>
 						),

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -572,6 +572,13 @@ button.site-settings__general-settings-set-guessed-timezone.button.is-borderless
 	white-space: nowrap;
 }
 
+.site-settings__ecommerce-trial-notice {
+	.notice__action {
+		display: inline-block;
+		padding: 0;
+	}
+}
+
 .site-settings__disable-privacy-settings {
 	opacity: 0.33;
 	pointer-events: none;

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -572,13 +572,6 @@ button.site-settings__general-settings-set-guessed-timezone.button.is-borderless
 	white-space: nowrap;
 }
 
-.site-settings__ecommerce-trial-notice {
-	.notice__action {
-		display: inline-block;
-		padding: 0;
-	}
-}
-
 .site-settings__disable-privacy-settings {
 	opacity: 0.33;
 	pointer-events: none;


### PR DESCRIPTION
#### Proposed Changes

* Adds a nudge on the "Launch site" card to let the users know that to launch the site, they need to upgrade to an eCommerce plan.

<img width="732" alt="Screenshot 2023-01-24 at 17 01 14" src="https://user-images.githubusercontent.com/3376401/214329285-10fa3238-721b-4a92-b032-14b25c22d66a.png">

#### Testing Instructions

* On your site with the WooExpress trial plan, navigate to `/settings/general/{SITE}`
* Scroll down to the "Launch site" card.
* You should see the nudge inviting the user to upgrade to an eCommerce plan.
* You can also click on the nudge, it should take you to the plans page.

Closes #71859