### PR TITLE
Free Onboarding Flow: Enable in production

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -119,7 +119,7 @@
 		"sign-in-with-apple": true,
 		"sign-in-with-apple/redirect": true,
 		"signup/design-picker-pattern-assembler": true,
-		"signup/free-flow": false,
+		"signup/free-flow": true,
 		"signup/inline-help": false,
 		"signup/professional-email-step": false,
 		"signup/social": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -117,7 +117,7 @@
 		"sign-in-with-apple": true,
 		"sign-in-with-apple/redirect": true,
 		"signup/design-picker-pattern-assembler": true,
-		"signup/free-flow": false,
+		"signup/free-flow": true,
 		"signup/inline-help": false,
 		"signup/professional-email-step": false,
 		"signup/social": true,


### PR DESCRIPTION
#### Estimated Time to Test / Review:
- Test -> None
- Review -> Short

#### Proposed Changes

* Releases the free onboarding flow to a general audience by enabling the feature on wordpress.com production -- not just horizon and calypso local dev.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Since this is a flag that enables production, the established convention is to trust that it will work and to test on Calypso staging (after merging the PR) before the final release p1673987197613579-slack-C7YPUHBB2

- Once merged, verify that wordpress.com/setup/free/intro is accessible

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/72269