### PR TITLE
WooExpress Flow: Update header logo

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -318,4 +318,9 @@ button {
 	.flow-progress.progress-bar {
 		display: none;
 	}
+
+	.signup-header .wordpress-logo {
+		display: block;
+		width: 500px;
+	}
 }

--- a/client/landing/stepper/declarative-flow/internals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/index.tsx
@@ -1,5 +1,5 @@
 import { ProgressBar } from '@automattic/components';
-import { isNewsletterOrLinkInBioFlow } from '@automattic/onboarding';
+import { isNewsletterOrLinkInBioFlow, isWooExpressFlow } from '@automattic/onboarding';
 import { useSelect, useDispatch } from '@wordpress/data';
 import classnames from 'classnames';
 import { useEffect, useState } from 'react';
@@ -106,6 +106,14 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 		}
 	};
 
+	const getShowWooLogo = () => {
+		if ( isWooExpressFlow( flow.name ) ) {
+			return true;
+		}
+
+		return false;
+	};
+
 	let progressBarExtraStyle: React.CSSProperties = {};
 	if ( 'videopress' === flow.name ) {
 		progressBarExtraStyle = {
@@ -132,7 +140,8 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 									total={ 100 }
 									style={ progressBarExtraStyle }
 								/>
-								<SignupHeader pageTitle={ flow.title } />
+
+								<SignupHeader pageTitle={ flow.title } showWooLogo={ getShowWooLogo() } />
 								{ renderStep( step ) }
 							</div>
 						</Route>

--- a/client/signup/signup-header/index.tsx
+++ b/client/signup/signup-header/index.tsx
@@ -1,4 +1,4 @@
-import { ProgressBar } from '@automattic/components';
+import { ProgressBar, WooCommerceWooLogo } from '@automattic/components';
 import {
 	useFlowProgress,
 	FREE_FLOW,
@@ -21,6 +21,7 @@ interface Props {
 	isReskinned?: boolean;
 	rightComponent?: Node;
 	pageTitle?: string;
+	showWooLogo?: boolean;
 }
 
 const SignupHeader = ( {
@@ -29,6 +30,7 @@ const SignupHeader = ( {
 	rightComponent,
 	progressBar = {},
 	pageTitle,
+	showWooLogo = false,
 }: Props ) => {
 	const logoClasses = classnames( 'wordpress-logo', {
 		'is-large': shouldShowLoadingScreen && ! isReskinned,
@@ -59,7 +61,10 @@ const SignupHeader = ( {
 					total={ flowProgress.count }
 				/>
 			) }
-			<WordPressLogo size={ 120 } className={ logoClasses } />
+			{ ! showWooLogo && <WordPressLogo size={ 120 } className={ logoClasses } /> }
+			{ showWooLogo && (
+				<WooCommerceWooLogo width={ 120 } height={ 120 } className={ logoClasses } />
+			) }
 			{ showPageTitle && <h1>{ variablePageTitle }</h1> }
 			{ /* This should show a sign in link instead of
 			   the progressIndicator on the account step. */ }

--- a/packages/components/src/woocommerce-woo-logo/index.tsx
+++ b/packages/components/src/woocommerce-woo-logo/index.tsx
@@ -1,11 +1,17 @@
 type WooCommerceWooLogoProps = {
+	className?: string;
 	height?: number;
 	width?: number;
 };
 
-const WooCommerceWooLogo = ( { height = 35, width = 20 }: WooCommerceWooLogoProps ) => {
+const WooCommerceWooLogo = ( {
+	className = 'woocommerce-logo',
+	height = 35,
+	width = 20,
+}: WooCommerceWooLogoProps ) => {
 	return (
 		<svg
+			className={ className }
 			width={ width }
 			height={ height }
 			viewBox="0 0 35 20"


### PR DESCRIPTION
#### Proposed Changes

Display the WooCommerce logo on all steps of the WooExpress flow.

We do this by adding the `showWooLogo` prop to the `SignupHeader` component. If it's true, we display the WooCommerce logo.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this branch and visit http://calypso.localhost:3000/setup/wooexpress.
* Each step should show the WooCommerce logo in the top-left header.
* Visit any other flow (`/start` is the easiest) and verify the WordPress logo still appears.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [NA] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [NA] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [NA] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [NA] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [NA] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #72167
