### PR TITLE
Only log react render duration stat if uncached

### DIFF
--- a/client/server/render/index.js
+++ b/client/server/render/index.js
@@ -114,11 +114,16 @@ function render( element, key, req ) {
 				name: `ssr.markup_cache.${ markupFromCache ? 'hit' : 'miss' }`,
 				type: 'counting',
 			},
-			{
-				name: 'ssr.react_render.duration',
-				type: 'timing',
-				value: rtsTimeMs,
-			},
+			// Only log the render time if we didn't get it from the cache.
+			...( markupFromCache
+				? []
+				: [
+						{
+							name: 'ssr.react_render.duration',
+							type: 'timing',
+							value: rtsTimeMs,
+						},
+				  ] ),
 		] );
 
 		if ( rtsTimeMs > 100 ) {


### PR DESCRIPTION
#### Proposed Changes
This stat (`ssr.react_render.duration`) is always logged no matter what. It measures the time it takes to render the react markup to an HTML string. Since we always log it, though, the stat includes times the markup is pulled from cache.

This makes the stat less useful, since we want to use it to understand how the actual render mechanism performs without cache.

#### Testing Instructions
TC, verify logic
