### PR TITLE
WooExpress Trial: Add notice on purchase details page

### DIFF
--- a/client/me/purchases/manage-purchase/notices.jsx
+++ b/client/me/purchases/manage-purchase/notices.jsx
@@ -1016,7 +1016,7 @@ class PurchaseNotice extends Component {
 				showDismiss={ false }
 				status="is-info"
 				text={ translate(
-					'You have %(expiry)s days remaining on your free trial. Upgrade your plan to keep your eCommerce features.',
+					'You have %(expiry)s days remaining on your free trial. Upgrade your plan to keep your ecommerce features.',
 					{
 						args: {
 							expiry: daysToExpiry,

--- a/client/me/purchases/manage-purchase/notices.jsx
+++ b/client/me/purchases/manage-purchase/notices.jsx
@@ -8,6 +8,7 @@ import {
 } from '@automattic/calypso-products';
 import { localize } from 'i18n-calypso';
 import { isEmpty, merge, minBy } from 'lodash';
+import page from 'page';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -287,7 +288,10 @@ class PurchaseNotice extends Component {
 		const currentPurchase = usePlanInsteadOfIncludedPurchase ? purchaseAttachedTo : purchase;
 		const includedPurchase = purchase;
 
-		if ( ! isExpiring( currentPurchase ) ) {
+		if (
+			! isExpiring( currentPurchase ) ||
+			'ecommerce-trial-bundle-monthly' === currentPurchase?.productSlug
+		) {
 			return null;
 		}
 
@@ -999,16 +1003,48 @@ class PurchaseNotice extends Component {
 		);
 	}
 
+	renderECommerceTrialNotice() {
+		const { moment, purchase, selectedSite, translate } = this.props;
+		const onClick = () => {
+			return page( `/plans/${ selectedSite?.slug }` );
+		};
+		const expiry = moment( purchase.expiryDate );
+		const daysToExpiry = moment( expiry.diff( moment() ) ).format( 'D' );
+
+		return (
+			<Notice
+				showDismiss={ false }
+				status="is-info"
+				text={ translate(
+					'You have %(expiry)s days remaining on your free trial. Upgrade your plan to keep your eCommerce features.',
+					{
+						args: {
+							expiry: daysToExpiry,
+						},
+					}
+				) }
+			>
+				<NoticeAction onClick={ onClick }>{ translate( 'Upgrade Now' ) }</NoticeAction>
+			</Notice>
+		);
+	}
+
 	render() {
+		const { purchase } = this.props;
+
 		if ( this.props.isDataLoading ) {
 			return null;
 		}
 
-		if ( isDomainTransfer( this.props.purchase ) ) {
+		if ( isDomainTransfer( purchase ) ) {
 			return null;
 		}
 
-		if ( this.props.purchase.isLocked && this.props.purchase.isInAppPurchase ) {
+		if ( purchase.productSlug === 'ecommerce-trial-bundle-monthly' ) {
+			return this.renderECommerceTrialNotice();
+		}
+
+		if ( purchase.isLocked && purchase.isInAppPurchase ) {
 			return this.renderInAppPurchaseNotice();
 		}
 
@@ -1030,7 +1066,7 @@ class PurchaseNotice extends Component {
 			return expiredNotice;
 		}
 
-		if ( isPartnerPurchase( this.props.purchase ) ) {
+		if ( isPartnerPurchase( purchase ) ) {
 			return null;
 		}
 


### PR DESCRIPTION
#### Proposed Changes

* Add a different notice at the top of `/purchases/subscriptions/[siteSlug]` when on the eCommerce Trial to be more useful/relevant.
* Point notice to the `/plans` page to upgrade rather than renewing since we can't renew a free trial

**Before**

<img width="1099" alt="Screen Shot 2023-01-17 at 3 31 01 PM" src="https://user-images.githubusercontent.com/2124984/213006169-1a1fdd47-df3f-4ad5-b170-7295c6f729fd.png">


**After**

<img width="1120" alt="Screen Shot 2023-01-23 at 11 45 08 AM" src="https://user-images.githubusercontent.com/2124984/214098365-2b90d5b1-3760-4652-a062-3c299cf05193.png">

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to this PR, navigate to `/setup/wooexpress` if you don't already have an eCommerce Trial test site to create one
* Visit the Purchases screen at `/purchases/[siteSlug]`
* Click on the eCommerce Trial in the purchases list
* You should see the above notice (pink) rather than the old notice (red)
* "Upgrade Now" should point to `/plans/[siteSlug]`

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- NA [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- NA Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- NA For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #71810
