### PR TITLE
Add Jetpack Complete and Blaze to header

### DIFF
--- a/client/jetpack-cloud/sections/pricing/jpcom-masterbar/index.tsx
+++ b/client/jetpack-cloud/sections/pricing/jpcom-masterbar/index.tsx
@@ -139,18 +139,21 @@ const JetpackComMasterbar: React.FC< Props > = ( { pathname } ) => {
 		[ translate ]
 	);
 	const bundles = useMemo(
-		() => [
-			{
-				label: translate( 'Complete' ),
-				tagline: translate( 'The ultimate toolkit' ),
-				href: `${ JETPACK_COM_BASE_URL }/complete/`,
-			},
-			{
-				label: translate( 'Security' ),
-				tagline: translate( 'Comprehensive site security' ),
-				href: `${ JETPACK_COM_BASE_URL }/features/security/`,
-			},
-		],
+		() => ( {
+			label: translate( 'Bundles' ),
+			items: [
+				{
+					label: translate( 'Complete' ),
+					tagline: translate( 'The ultimate toolkit' ),
+					href: `${ JETPACK_COM_BASE_URL }/complete/`,
+				},
+				{
+					label: translate( 'Security' ),
+					tagline: translate( 'Comprehensive site security' ),
+					href: `${ JETPACK_COM_BASE_URL }/features/security/`,
+				},
+			],
+		} ),
 		[ translate ]
 	);
 
@@ -294,11 +297,11 @@ const JetpackComMasterbar: React.FC< Props > = ( { pathname } ) => {
 																	<hr />
 
 																	<p className="header__submenu-bundles-heading">
-																		{ translate( 'Bundles' ) }
+																		{ bundles.label }
 																	</p>
 
 																	<ul className="header__submenu-links-list">
-																		{ bundles.map( ( { label, tagline, href } ) => {
+																		{ bundles.items.map( ( { label, tagline, href } ) => {
 																			return (
 																				<li key={ `bundles-${ href }` }>
 																					<ExternalLink

--- a/client/jetpack-cloud/sections/pricing/jpcom-masterbar/index.tsx
+++ b/client/jetpack-cloud/sections/pricing/jpcom-masterbar/index.tsx
@@ -133,6 +133,21 @@ const JetpackComMasterbar: React.FC< Props > = ( { pathname } ) => {
 		],
 		[ translate ]
 	);
+	const bundles = useMemo(
+		() => [
+			{
+				label: translate( 'Complete' ),
+				tagline: translate( 'The ultimate toolkit' ),
+				href: `${ JETPACK_COM_BASE_URL }/complete/`,
+			},
+			{
+				label: translate( 'Security' ),
+				tagline: translate( 'Comprehensive site security' ),
+				href: `${ JETPACK_COM_BASE_URL }/features/security/`,
+			},
+		],
+		[ translate ]
+	);
 
 	const shouldShowCart = useSelector( isJetpackCloudCartEnabled );
 
@@ -269,6 +284,33 @@ const JetpackComMasterbar: React.FC< Props > = ( { pathname } ) => {
 																		</li>
 																	) ) }
 																</ul>
+
+																<div className="header__submenu-bundles">
+																	<hr />
+
+																	<p className="header__submenu-bundles-heading">
+																		{ translate( 'Bundles' ) }
+																	</p>
+
+																	<ul className="header__submenu-links-list">
+																		{ bundles.map( ( { label, tagline, href } ) => {
+																			return (
+																				<li key={ `bundles-${ href }` }>
+																					<ExternalLink
+																						className="header__submenu-link"
+																						href={ localizeUrl( href, locale ) }
+																						onClick={ onLinkClick }
+																					>
+																						<span className="header__submenu-label">{ label }</span>
+																						<span className="header__submenu-tagline">
+																							{ tagline }
+																						</span>
+																					</ExternalLink>
+																				</li>
+																			);
+																		} ) }
+																	</ul>
+																</div>
 															</div>
 														</div>
 													) }

--- a/client/jetpack-cloud/sections/pricing/jpcom-masterbar/index.tsx
+++ b/client/jetpack-cloud/sections/pricing/jpcom-masterbar/index.tsx
@@ -110,6 +110,11 @@ const JetpackComMasterbar: React.FC< Props > = ( { pathname } ) => {
 								tagline: translate( 'Connect with your people' ),
 								href: 'https://jetpackcrm.com/?utm_medium=automattic_referred&utm_source=jpcom_header',
 							},
+							{
+								label: translate( 'Blaze' ),
+								tagline: translate( 'Advertise your best content' ),
+								href: `${ JETPACK_COM_BASE_URL }/blaze/`,
+							},
 						],
 					},
 				],

--- a/client/jetpack-cloud/sections/pricing/jpcom-masterbar/style.scss
+++ b/client/jetpack-cloud/sections/pricing/jpcom-masterbar/style.scss
@@ -669,7 +669,8 @@
 		}
 	}
 	.header__submenu-categories-list > li .header__category,
-	.header__submenu-categories-list > li .header__submenu-link {
+	.header__submenu-categories-list > li .header__submenu-link,
+	.header__submenu-bundles > .header__submenu-links-list > li .header__submenu-link {
 		animation-fill-mode: backwards;
 		animation-name: submenu-item;
 		animation-duration: 0.25s;
@@ -677,14 +678,16 @@
 	}
 	@media ( prefers-reduced-motion ) {
 		.header__submenu-categories-list > li .header__category,
-		.header__submenu-categories-list > li .header__submenu-link {
+		.header__submenu-categories-list > li .header__submenu-link,
+		.header__submenu-bundles > .header__submenu-links-list > li .header__submenu-link {
 			animation-duration: 0;
 			animation-delay: 0;
 		}
 	}
 	@media ( max-width: 900px ) {
 		.header__submenu-categories-list > li .header__category,
-		.header__submenu-categories-list > li .header__submenu-link {
+		.header__submenu-categories-list > li .header__submenu-link,
+		.header__submenu-bundles > .header__submenu-links-list > li .header__submenu-link {
 			animation: none;
 		}
 	}
@@ -732,6 +735,88 @@
 	.header__submenu-categories-list > li:nth-of-type(3)
 	.header__submenu-links-list > li:nth-of-type(3) > a {
 		animation-delay: calc(calc(0.085s * 7) + calc(0.35s / 1.5));
+	}
+
+	.header__submenu-bundles {
+		hr,
+		.header__submenu-bundles-heading,
+		.header__submenu-links-list {
+			max-width: 1200px;
+			width: 85%;
+			margin-left: auto;
+			margin-right: auto;
+		}
+
+		hr {
+			background-color: var(--studio-gray-10);
+			margin-bottom: 1.125rem;
+		}
+
+		.header__submenu-bundles-heading {
+			color: var(--studio-gray-50);
+			font-size: 1.25rem;
+			margin-bottom: 0;
+		}
+
+		.header__submenu-links-list {
+			display: flex;
+			justify-content: flex-start;
+			gap: 2rem;
+
+			> li {
+				flex: 0;
+				min-width: 200px;
+				animation-fill-mode: backwards;
+				animation-name: submenu-item;
+				animation-duration: 0.25s;
+				animation-timing-function: ease-in-out;
+				animation-delay: calc(calc(0.085s * 8) + calc(0.35s / 1.5));
+			}
+		}
+
+		@media ( prefers-reduced-motion ) {
+			.header__submenu-links-list > li {
+				animation-duration: 0;
+				animation-delay: 0;
+			}
+		}
+
+		@media ( max-width: 1300px ) {
+			.header__submenu-bundles-heading,
+			.header__submenu-links-list,
+			hr {
+				width: 90%;
+			}
+		}
+		@media ( max-width: 1100px ) {
+			.header__submenu-bundles-heading,
+			.header__submenu-links-list,
+			hr {
+				width: 95%;
+			}
+		}
+		@media ( max-width: 900px ) {
+			.header__submenu-links-list {
+				display: block;
+			}
+
+			.header__submenu-links-list > li {
+				animation: none;
+			}
+		}
+		@media ( max-width: 782px ) {
+			.header__submenu-bundles-heading,
+			.header__submenu-links-list {
+				padding: 0 2rem;
+				width: 100%;
+			}
+
+			hr {
+				margin-left: 2rem;
+				margin-right: 2rem;
+				width: auto;
+			}
+		}
 	}
 
 	.header__submenu-links-list {


### PR DESCRIPTION
#### Proposed Changes

This PR adds a new "Bundles" section to the header, including Jetpack Complete, similar to the added section to the header on jetpack.com

It also adds the new "Blaze" landing page to the header

Figma: wz3fF5ybLUaYqd4AFw8VGv-fi-4534%3A33085&t=gvOiRXcHCsL334bj-0

#### Testing Instructions

1. Check out these changes via `git switch add/complete-to-jpcom-masterbar-header`
2. Start your local environment via `yarn start-jetpack-cloud`
3. Go to http://calypso.localhost:3000/pricing
4. Ensure design matches figma comp
![image](https://user-images.githubusercontent.com/65001528/213014637-bc5f9262-5701-4425-8046-8a3b8315993b.png)
5. Check on mobile too
![image](https://user-images.githubusercontent.com/65001528/213014702-00f762c0-9b66-4716-afaf-9ab57d0926f2.png)
6. Make sure all scales well
7. Make sure the new links work

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?

