### PR TITLE
Stats: no need to load language file for default locale

### DIFF
--- a/apps/odyssey-stats/src/lib/set-locale.js
+++ b/apps/odyssey-stats/src/lib/set-locale.js
@@ -21,6 +21,10 @@ export default ( dispatch ) => {
 	const siteLocale = config( 'i18n_locale_slug' );
 	const localeSlug = siteLocale || defaultLocale;
 
+	if ( localeSlug === defaultLocale ) {
+		return;
+	}
+
 	getLanguageFile( localeSlug ).then(
 		// Success.
 		( body ) => {


### PR DESCRIPTION
#### Proposed Changes

If the locale of the site is default (en), then skip the language file loading process.

#### Testing Instructions

* Follow `Option 1` in `PejTkB-3E-p2` 
* Set site language to English
* Open `/wp-admin/admin.php?page=stats`
* Ensure no request sent to `https://widgets.wp.com/odyssey-stats/v1/languages/en-v1.1.json`

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #