### PR TITLE
Blaze: Add calypso_page_view track event to /advertising

### DIFF
--- a/client/my-sites/promote-post/main.tsx
+++ b/client/my-sites/promote-post/main.tsx
@@ -9,6 +9,7 @@ import FormattedHeader from 'calypso/components/formatted-header';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import Main from 'calypso/components/main';
 import useCampaignsQuery from 'calypso/data/promote-post/use-promote-post-campaigns-query';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { usePromoteWidget, PromoteWidgetStatus } from 'calypso/lib/promote-post';
 import CampaignsList from 'calypso/my-sites/promote-post/components/campaigns-list';
 import { Post } from 'calypso/my-sites/promote-post/components/post-item';
@@ -176,13 +177,18 @@ export default function PromotedPosts( { tab }: Props ) {
 			{ ! campaignsIsLoading && ! campaignsData?.length && <PostsListBanner /> }
 
 			<PromotePostTabBar tabs={ tabs } selectedTab={ selectedTab } />
-			{ selectedTab === 'campaigns' && (
-				<CampaignsList
-					hasLocalUser={ hasLocalUser }
-					isError={ isError }
-					isLoading={ campaignsIsLoading }
-					campaigns={ campaignsData || [] }
-				/>
+			{ selectedTab === 'campaigns' ? (
+				<>
+					<PageViewTracker path="/advertising/:site/campaigns" title="Advertising > Campaigns" />
+					<CampaignsList
+						hasLocalUser={ hasLocalUser }
+						isError={ isError }
+						isLoading={ campaignsIsLoading }
+						campaigns={ campaignsData || [] }
+					/>
+				</>
+			) : (
+				<PageViewTracker path="/advertising/:site/posts" title="Advertising > Ready to Blaze" />
 			) }
 
 			<QueryPosts siteId={ selectedSiteId } query={ queryPost } postId={ null } />


### PR DESCRIPTION
#### Proposed Changes

To measure the pageviews on `/advertising`, we added track events to "Ready to Promote" and "Campaigns" buttons:

![image](https://user-images.githubusercontent.com/402286/213037601-1058684a-d1e6-4619-bdbe-6c962024ba5e.png)


#### Testing Instructions
- Following these instructions to track events: PCYsg-cae-p2
- Go to [/advertising](http://calypso.localhost:3000/advertising/)
- Check `calypso_page_view` events on load and switching the tab.

#### Screenshots
| Ready to Blaze | Campaigns |
| --- | --- |
| <img width="756" alt="image" src="https://user-images.githubusercontent.com/402286/213038049-081fb83b-da88-4488-88ac-27b2c6a51725.png"> | <img width="749" alt="image" src="https://user-images.githubusercontent.com/402286/213038105-ed8afc6b-e94e-46ab-8644-47a294a7f52f.png"> |

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] ~~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~~
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~~
- [ ] ~~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~~
- [ ] ~~For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~~
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/1447