### PR TITLE
Allow theme demo URIs to be optional

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -45,8 +45,7 @@ const PatternAssembler: Step = ( { navigation, flow } ) => {
 	const siteSlugOrId = siteSlug ? siteSlug : siteId;
 	const allPatterns = useAllPatterns();
 	const { data: theme } = useThemeDetails( selectedDesign?.slug );
-	const themeDemoSiteSlug =
-		theme && theme.demo_uri.replace( /^https?:\/\//, '' ).replace( '/', '' );
+	const themeDemoSiteSlug = theme?.demo_uri?.replace( /^https?:\/\//, '' ).replace( '/', '' );
 
 	const largePreviewProps = {
 		placeholder: null,

--- a/client/landing/stepper/hooks/use-theme-details.ts
+++ b/client/landing/stepper/hooks/use-theme-details.ts
@@ -6,7 +6,7 @@ type Theme = {
 	name: string;
 	author: string;
 	author_uri: string;
-	demo_uri: string;
+	demo_uri?: string;
 	description: string;
 	date_updated: string;
 	price: string;

--- a/client/state/themes/reducer.js
+++ b/client/state/themes/reducer.js
@@ -312,6 +312,14 @@ function fromApi( theme ) {
 		return theme;
 	}
 
+	// When a theme has no demo URI, it's set to false. Many components work when
+	// this is falsey, so we'll convert it to undefined here. This avoids issues
+	// where schema validation will fail when demo_uri is set to false. It makes
+	// more sense to make it an optional value.
+	if ( typeof theme.demo_uri !== 'string' ) {
+		theme.demo_uri = undefined;
+	}
+
 	return { ...theme, description: decodeEntities( theme.description ) };
 }
 

--- a/client/state/themes/reducer.js
+++ b/client/state/themes/reducer.js
@@ -313,9 +313,8 @@ function fromApi( theme ) {
 	}
 
 	// When a theme has no demo URI, it's set to false. Many components work when
-	// this is falsey, so we'll convert it to undefined here. This avoids issues
-	// where schema validation will fail when demo_uri is set to false. It makes
-	// more sense to make it an optional value.
+	// this is falsey, so we'll convert it to undefined here. This allows schema
+	// validation to succeed, since demo_uri is not a required property there.
 	if ( typeof theme.demo_uri !== 'string' ) {
 		theme.demo_uri = undefined;
 	}

--- a/client/state/themes/schema.js
+++ b/client/state/themes/schema.js
@@ -15,7 +15,7 @@ const themesSchema = {
 				author_uri: { type: 'string' },
 				autoupdate: { type: 'boolean' },
 				autoupdate_translation: { type: 'boolean' },
-				demo_uri: { type: 'string' },
+				demo_uri: { type: 'string', required: false },
 				description: { type: 'string' },
 				id: { type: 'string' },
 				name: { type: 'string' },

--- a/client/state/themes/schema.js
+++ b/client/state/themes/schema.js
@@ -15,7 +15,7 @@ const themesSchema = {
 				author_uri: { type: 'string' },
 				autoupdate: { type: 'boolean' },
 				autoupdate_translation: { type: 'boolean' },
-				demo_uri: { type: 'string', required: false },
+				demo_uri: { type: 'string' },
 				description: { type: 'string' },
 				id: { type: 'string' },
 				name: { type: 'string' },

--- a/client/types.ts
+++ b/client/types.ts
@@ -25,7 +25,7 @@ export interface Theme {
 	cost: ThemeCost;
 	date_launched: string;
 	date_updated: string;
-	demo_uri: string;
+	demo_uri?: string;
 	description: string;
 	descriptionLong: string;
 	download: string;


### PR DESCRIPTION
#### Proposed Changes
Problem: sometimes a theme's demo URI is set to `false` when the demo site can't be found. This is usually an accident when a new theme is deployed. When this happens, the theme fails validation against the schema, because the schema expects the demo URI to be a string.

The result is that the theme response data is **never** cached in this scenario. Or rather, it's written to the cache, but when it's pulled from the cache, it fails validation and the data is **always** fetched again. (And the cycle continues -- garbage in, garbage out.)

The result of _that_ is terrible performance of the `/themes` route. About 10x worse than normal. (2000ms vs 200ms).

So to avoid tanking performance when this happens, we need to do two things:
1. Allow demo_uri's to be optional. This way, the theme can be cached, but the demo site button won't show up.
2. Discard any theme which doesn't have a demo_uri (e.g. which fails schema validation.) This way, the other themes can continue to be cached.

The first option is a lot easier to implement because every component I could find already handles the case that demo uri is falsey. So I just updated the other types related to that.

The second option is harder, but probably ideal in the long term. We shouldn't be persisting stuff which will already fail schema validation! (But the schema validation reducers only support validation at the time of de-serialization, meaning it'll be hard to validate when new data comes in.)

#### Testing Instructions
**Note: these won't work once Makoney's demo site is correctly set up.** The instructions do work and test correctly at the time of writing.

1. Load calypso.localhost with these changes
2. It should take ~2s to load. See "long request duration" messages in the logs.
3. Force-refresh the page.
4. It should load very quickly (a few ms). There is no "long request duration" in the logs.
5. Check the "makoney" theme. It won't have an "open live demo" button.
