### PR TITLE
Stats: Apply CSS grid to the Insights page

### DIFF
--- a/client/my-sites/stats/grid-layout.scss
+++ b/client/my-sites/stats/grid-layout.scss
@@ -3,27 +3,27 @@
 $grid-horizontal-gutters: 24px;
 $grid-vertical-gutters: 32px;
 
-@mixin stats-desktop-grid($grid-template-areas ) {
+@mixin stats-desktop-grid($grid-template-areas, $grid-template-rows) {
 	align-items: stretch;
 	display: grid;
 	grid-template-columns: repeat(12, 1fr);
-	grid-template-rows: repeat(5, min-content);
+	grid-template-rows: repeat($grid-template-rows, min-content);
 	gap: $grid-vertical-gutters $grid-horizontal-gutters;
 	grid-template-areas: $grid-template-areas;
 }
 
-@mixin stats-tablet-grid($grid-template-areas ) {
+@mixin stats-tablet-grid($grid-template-areas, $grid-template-rows) {
 	@media (max-width: $break-large ) {
 		grid-template-columns: repeat(8, 1fr);
-		grid-template-rows: repeat(6, min-content);
+		grid-template-rows: repeat($grid-template-rows, min-content);
 		grid-template-areas: $grid-template-areas;
 	}
 }
 
-@mixin stats-mobile-grid($grid-template-areas ) {
+@mixin stats-mobile-grid($grid-template-areas, $grid-template-rows) {
 	@media (max-width: $break-medium ) {
 		grid-template-columns: repeat(4, 1fr);
-		grid-template-rows: repeat(9, min-content);
+		grid-template-rows: repeat($grid-template-rows, min-content);
 		gap: 0;
 		grid-template-areas: $grid-template-areas;
 	}
@@ -34,14 +34,16 @@ $grid-vertical-gutters: 32px;
 	@include stats-desktop-grid(
 		"tags-categories tags-categories tags-categories tags-categories tags-categories tags-categories comments comments comments comments comments comments"
 		"shares shares shares shares followers followers followers followers publicize publicize publicize publicize"
-		"latest-post-summary latest-post-summary latest-post-summary latest-post-summary latest-post-summary latest-post-summary social-followers social-followers social-followers social-followers social-followers social-followers"
+		"latest-post-summary latest-post-summary latest-post-summary latest-post-summary latest-post-summary latest-post-summary social-followers social-followers social-followers social-followers social-followers social-followers",
+		3
 	);
 
 	@include stats-tablet-grid(
 		"tags-categories tags-categories tags-categories tags-categories comments comments comments comments"
 		"shares shares shares shares followers followers followers followers"
 		"publicize publicize publicize publicize latest-post-summary latest-post-summary latest-post-summary latest-post-summary"
-		"social-followers social-followers social-followers social-followers social-followers social-followers social-followers social-followers"
+		"social-followers social-followers social-followers social-followers social-followers social-followers social-followers social-followers",
+		4
 	);
 
 	@include stats-mobile-grid(
@@ -51,7 +53,8 @@ $grid-vertical-gutters: 32px;
 		"followers followers followers followers"
 		"publicize publicize publicize publicize"
 		"latest-post-summary latest-post-summary latest-post-summary latest-post-summary"
-		"social-followers social-followers social-followers social-followers"
+		"social-followers social-followers social-followers social-followers",
+		7
 	);
 
 	@media (max-width: 660px) {
@@ -100,7 +103,8 @@ $grid-vertical-gutters: 32px;
 		"country country country country country country country country country country country country"
 		"authors authors authors authors search search search search clicks clicks clicks clicks"
 		"videos videos videos videos videos videos downloads downloads downloads downloads downloads downloads"
-		"emails-open emails-open emails-open emails-open emails-open emails-open emails-open emails-open emails-open emails-open emails-open emails-open"
+		"emails-open emails-open emails-open emails-open emails-open emails-open emails-open emails-open emails-open emails-open emails-open emails-open",
+		5
 	);
 
 	@include stats-tablet-grid(
@@ -109,7 +113,8 @@ $grid-vertical-gutters: 32px;
 		"authors authors authors authors search search search search"
 		"clicks clicks clicks clicks videos videos videos videos"
 		"downloads downloads downloads downloads downloads downloads downloads downloads"
-		"emails-open emails-open emails-open emails-open emails-open emails-open emails-open emails-open"
+		"emails-open emails-open emails-open emails-open emails-open emails-open emails-open emails-open",
+		6
 	);
 
 	@include stats-mobile-grid(
@@ -121,7 +126,8 @@ $grid-vertical-gutters: 32px;
 		"clicks clicks clicks clicks"
 		"videos videos videos videos"
 		"downloads downloads downloads downloads"
-		"emails-open emails-open emails-open emails-open"
+		"emails-open emails-open emails-open emails-open",
+		9
 	);
 
 	.card.stats-module {

--- a/client/my-sites/stats/grid-layout.scss
+++ b/client/my-sites/stats/grid-layout.scss
@@ -3,50 +3,126 @@
 $grid-horizontal-gutters: 24px;
 $grid-vertical-gutters: 32px;
 
-.is-section-stats .stats__module-list--traffic {
+@mixin stats-desktop-grid($grid-template-areas ) {
 	align-items: stretch;
 	display: grid;
 	grid-template-columns: repeat(12, 1fr);
 	grid-template-rows: repeat(5, min-content);
 	gap: $grid-vertical-gutters $grid-horizontal-gutters;
-	grid-template-areas:
+	grid-template-areas: $grid-template-areas;
+}
+
+@mixin stats-tablet-grid($grid-template-areas ) {
+	@media (max-width: $break-large ) {
+		grid-template-columns: repeat(8, 1fr);
+		grid-template-rows: repeat(6, min-content);
+		grid-template-areas: $grid-template-areas;
+	}
+}
+
+@mixin stats-mobile-grid($grid-template-areas ) {
+	@media (max-width: $break-medium ) {
+		grid-template-columns: repeat(4, 1fr);
+		grid-template-rows: repeat(9, min-content);
+		gap: 0;
+		grid-template-areas: $grid-template-areas;
+	}
+}
+
+
+.stats__module-list.stats__module--unified.is-insights-page-enabled {
+	@include stats-desktop-grid(
+		"tags-categories tags-categories tags-categories tags-categories tags-categories tags-categories comments comments comments comments comments comments"
+		"shares shares shares shares followers followers followers followers publicize publicize publicize publicize"
+		"latest-post-summary latest-post-summary latest-post-summary latest-post-summary latest-post-summary latest-post-summary social-followers social-followers social-followers social-followers social-followers social-followers"
+	);
+
+	@include stats-tablet-grid(
+		"tags-categories tags-categories tags-categories tags-categories comments comments comments comments"
+		"shares shares shares shares followers followers followers followers"
+		"publicize publicize publicize publicize latest-post-summary latest-post-summary latest-post-summary latest-post-summary"
+		"social-followers social-followers social-followers social-followers social-followers social-followers social-followers social-followers"
+	);
+
+	@include stats-mobile-grid(
+		"tags-categories tags-categories tags-categories tags-categories"
+		"comments comments comments comments"
+		"shares shares shares shares"
+		"followers followers followers followers"
+		"publicize publicize publicize publicize"
+		"latest-post-summary latest-post-summary latest-post-summary latest-post-summary"
+		"social-followers social-followers social-followers social-followers"
+	);
+
+	@media (max-width: 660px) {
+		padding: 0 16px;
+	}
+
+	.stats__module-wrapper--tags-categories,
+	.list-tags-categories {
+		grid-area: tags-categories;
+	}
+
+	.stats__module-wrapper--comments,
+	.list-comments {
+		grid-area: comments;
+	}
+
+	.stats__module-wrapper--shares,
+	.list-shares {
+		grid-area: shares;
+	}
+
+	.stats__module-wrapper--followers,
+	.list-followers {
+		grid-area: followers;
+	}
+
+	.stats__module-wrapper--total-followers,
+	.list-total-followers {
+		grid-area: social-followers;
+	}
+
+	.stats__module-wrapper--latest-post-summary,
+	.list-latest-post-summary {
+		grid-area: latest-post-summary;
+	}
+
+	.stats__module-wrapper--publicize,
+	.list-publicize {
+		grid-area: publicize;
+	}
+}
+
+.is-section-stats .stats__module-list--traffic {
+	@include stats-desktop-grid(
 		"posts posts posts posts posts posts posts referrers referrers referrers referrers referrers"
 		"country country country country country country country country country country country country"
 		"authors authors authors authors search search search search clicks clicks clicks clicks"
 		"videos videos videos videos videos videos downloads downloads downloads downloads downloads downloads"
-		"emails-open emails-open emails-open emails-open emails-open emails-open emails-open emails-open emails-open emails-open emails-open emails-open";
+		"emails-open emails-open emails-open emails-open emails-open emails-open emails-open emails-open emails-open emails-open emails-open emails-open"
+	);
 
-	// Tablets
-	@media ( max-width: $break-large ) {
-		grid-template-columns: repeat(8, 1fr);
-		grid-template-rows: repeat(6, min-content);
-		grid-template-areas:
-			"posts posts posts posts referrers referrers referrers referrers"
-			"country country country country country country country country"
-			"authors authors authors authors search search search search"
-			"clicks clicks clicks clicks videos videos videos videos"
-			"downloads downloads downloads downloads downloads downloads downloads downloads"
-			"emails-open emails-open emails-open emails-open emails-open emails-open emails-open emails-open";
+	@include stats-tablet-grid(
+		"posts posts posts posts referrers referrers referrers referrers"
+		"country country country country country country country country"
+		"authors authors authors authors search search search search"
+		"clicks clicks clicks clicks videos videos videos videos"
+		"downloads downloads downloads downloads downloads downloads downloads downloads"
+		"emails-open emails-open emails-open emails-open emails-open emails-open emails-open emails-open"
+	);
 
-	}
-
-	// Mobile
-	@media ( max-width: $break-medium ) {
-		grid-template-columns: repeat(4, 1fr);
-		grid-template-rows: repeat(9, min-content);
-		gap: 0;
-		grid-template-areas:
-			"posts posts posts posts"
-			"referrers referrers referrers referrers"
-			"country country country country"
-			"authors authors authors authors"
-			"search search search search"
-			"clicks clicks clicks clicks"
-			"videos videos videos videos"
-			"downloads downloads downloads downloads"
-			"emails-open emails-open emails-open emails-open";
-
-	}
+	@include stats-mobile-grid(
+		"posts posts posts posts"
+		"referrers referrers referrers referrers"
+		"country country country country"
+		"authors authors authors authors"
+		"search search search search"
+		"clicks clicks clicks clicks"
+		"videos videos videos videos"
+		"downloads downloads downloads downloads"
+		"emails-open emails-open emails-open emails-open"
+	);
 
 	.card.stats-module {
 		margin-bottom: 0;
@@ -75,26 +151,32 @@ $grid-vertical-gutters: 32px;
 	.list-posts {
 		grid-area: posts;
 	}
+
 	.stats__module-wrapper--referrers,
 	.list-referrers {
 		grid-area: referrers;
 	}
+
 	.stats__module-wrapper--countryviews,
 	.list-countryviews {
 		grid-area: country;
 	}
+
 	.stats__module-wrapper--authors,
 	.list-authors {
 		grid-area: authors;
 	}
+
 	.stats__module-wrapper--searchterms,
 	.list-searchterms {
 		grid-area: search;
 	}
+
 	.stats__module-wrapper--clicks,
 	.list-clicks {
 		grid-area: clicks;
 	}
+
 	.stats__module-wrapper--videoplays,
 	.list-videoplays {
 		grid-area: videos;
@@ -108,10 +190,12 @@ $grid-vertical-gutters: 32px;
 			grid-column-end: downloads;
 		}
 	}
+
 	.stats__module-wrapper--filedownloads,
 	.list-filedownloads {
 		grid-area: downloads;
 	}
+
 	.stats__module-wrapper--emails,
 	.list-emails-open {
 		grid-area: emails-open;

--- a/client/my-sites/stats/post-performance/index.jsx
+++ b/client/my-sites/stats/post-performance/index.jsx
@@ -91,7 +91,7 @@ class StatsPostPerformance extends Component {
 
 		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		return (
-			<div>
+			<div className="list-latest-post-summary">
 				{ siteId && <QueryPosts siteId={ siteId } query={ query } /> }
 				{ siteId && post && (
 					<QueryPostStats siteId={ siteId } postId={ post.ID } fields={ [ 'views' ] } />

--- a/client/my-sites/stats/stats-comments/index.jsx
+++ b/client/my-sites/stats/stats-comments/index.jsx
@@ -122,7 +122,7 @@ class StatsComments extends Component {
 		} );
 
 		return (
-			<div>
+			<div className="list-comments">
 				{ siteId && <QuerySiteStats statType="statsComments" siteId={ siteId } /> }
 				{ siteId && (
 					<QuerySiteStats statType="statsCommentFollowers" siteId={ siteId } query={ { max: 7 } } />

--- a/client/my-sites/stats/stats-followers/index.jsx
+++ b/client/my-sites/stats/stats-followers/index.jsx
@@ -114,7 +114,7 @@ class StatModuleFollowers extends Component {
 		summaryPageLink = ! isOdysseyStats ? summaryPageLink : null;
 
 		return (
-			<div>
+			<div className="list-followers">
 				{ siteId && (
 					<QuerySiteStats statType="statsFollowers" siteId={ siteId } query={ wpcomQuery } />
 				) }

--- a/client/my-sites/stats/stats-insights/index.jsx
+++ b/client/my-sites/stats/stats-insights/index.jsx
@@ -1,4 +1,5 @@
 import config from '@automattic/calypso-config';
+import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import { flowRight } from 'lodash';
 import PropTypes from 'prop-types';
@@ -27,6 +28,11 @@ import statsStrings from '../stats-strings';
 const StatsInsights = ( props ) => {
 	const { siteId, siteSlug, translate, isOdysseyStats } = props;
 	const moduleStrings = statsStrings();
+	const isInsightsPageGridEnabled = config.isEnabled( 'stats/insights-page-grid' );
+
+	const statsModuleListClass = classNames( 'stats__module-list stats__module--unified', {
+		'is-insights-page-enabled': isInsightsPageGridEnabled,
+	} );
 
 	// Track the last viewed tab.
 	// Necessary to properly configure the fixed navigation headers.
@@ -58,37 +64,66 @@ const StatsInsights = ( props ) => {
 						vendor={ getSuggestionsVendor() }
 					/>
 				) }
-				<div className="stats-insights__nonperiodic has-recent">
-					<div className="stats__module-list stats__module--unified">
-						<div className="stats__module-column">
-							<LatestPostSummary />
+				{ isInsightsPageGridEnabled ? (
+					<div className={ statsModuleListClass }>
+						<StatsModule
+							path="tags-categories"
+							moduleStrings={ moduleStrings.tags }
+							statType="statsTags"
+							hideSummaryLink
+							hideNewModule // remove when cleaning 'stats/horizontal-bars-everywhere' FF
+						/>
+						<Comments path="comments" />
 
-							<StatsModule
-								path="tags-categories"
-								moduleStrings={ moduleStrings.tags }
-								statType="statsTags"
-								hideSummaryLink
-								hideNewModule // remove when cleaning 'stats/horizontal-bars-everywhere' FF
-							/>
-							{ /** TODO: The feature depends on Jetpack Sharing module and is disabled for Odyssey for now. */ }
-							{ ! isOdysseyStats && <StatShares siteId={ siteId } /> }
-						</div>
-						<div className="stats__module-column">
-							<Reach />
-							<Followers path="followers" />
-						</div>
-						<div className="stats__module-column">
-							<Comments path="comments" />
-							<StatsModule
-								path="publicize"
-								moduleStrings={ moduleStrings.publicize }
-								statType="statsPublicize"
-								hideSummaryLink
-								hideNewModule // remove when cleaning 'stats/horizontal-bars-everywhere' FF
-							/>
+						{ /** TODO: The feature depends on Jetpack Sharing module and is disabled for Odyssey for now. */ }
+						{ ! isOdysseyStats && <StatShares siteId={ siteId } /> }
+
+						<Followers path="followers" />
+						<StatsModule
+							path="publicize"
+							moduleStrings={ moduleStrings.publicize }
+							statType="statsPublicize"
+							hideSummaryLink
+							hideNewModule // remove when cleaning 'stats/horizontal-bars-everywhere' FF
+						/>
+
+						<LatestPostSummary />
+						<Reach />
+					</div>
+				) : (
+					// remove all this section when cleaning 'stats/insights-page-grid'
+					<div className="stats-insights__nonperiodic has-recent">
+						<div className={ statsModuleListClass }>
+							<div className="stats__module-column">
+								<LatestPostSummary />
+
+								<StatsModule
+									path="tags-categories"
+									moduleStrings={ moduleStrings.tags }
+									statType="statsTags"
+									hideSummaryLink
+									hideNewModule // remove when cleaning 'stats/horizontal-bars-everywhere' FF
+								/>
+								{ /** TODO: The feature depends on Jetpack Sharing module and is disabled for Odyssey for now. */ }
+								{ ! isOdysseyStats && <StatShares siteId={ siteId } /> }
+							</div>
+							<div className="stats__module-column">
+								<Reach />
+								<Followers path="followers" />
+							</div>
+							<div className="stats__module-column">
+								<Comments path="comments" />
+								<StatsModule
+									path="publicize"
+									moduleStrings={ moduleStrings.publicize }
+									statType="statsPublicize"
+									hideSummaryLink
+									hideNewModule // remove when cleaning 'stats/horizontal-bars-everywhere' FF
+								/>
+							</div>
 						</div>
 					</div>
-				</div>
+				) }
 				<JetpackColophon />
 			</div>
 		</Main>

--- a/client/my-sites/stats/stats-insights/index.jsx
+++ b/client/my-sites/stats/stats-insights/index.jsx
@@ -72,6 +72,7 @@ const StatsInsights = ( props ) => {
 							statType="statsTags"
 							hideSummaryLink
 							hideNewModule // remove when cleaning 'stats/horizontal-bars-everywhere' FF
+							className="list-tags-categories"
 						/>
 						<Comments path="comments" />
 
@@ -85,6 +86,7 @@ const StatsInsights = ( props ) => {
 							statType="statsPublicize"
 							hideSummaryLink
 							hideNewModule // remove when cleaning 'stats/horizontal-bars-everywhere' FF
+							className="list-publicize"
 						/>
 
 						<LatestPostSummary />

--- a/client/my-sites/stats/stats-insights/index.jsx
+++ b/client/my-sites/stats/stats-insights/index.jsx
@@ -72,7 +72,6 @@ const StatsInsights = ( props ) => {
 							statType="statsTags"
 							hideSummaryLink
 							hideNewModule // remove when cleaning 'stats/horizontal-bars-everywhere' FF
-							className="list-tags-categories"
 						/>
 						<Comments path="comments" />
 
@@ -86,7 +85,6 @@ const StatsInsights = ( props ) => {
 							statType="statsPublicize"
 							hideSummaryLink
 							hideNewModule // remove when cleaning 'stats/horizontal-bars-everywhere' FF
-							className="list-publicize"
 						/>
 
 						<LatestPostSummary />

--- a/client/my-sites/stats/stats-module/style.scss
+++ b/client/my-sites/stats/stats-module/style.scss
@@ -48,30 +48,37 @@ $grid-vertical-gutters: 32px;
 		padding: 0 16px;
 	}
 
+	.stats__module-wrapper--tags-categories,
 	.list-tags-categories {
 		grid-area: tags-categories;
 	}
 
+	.stats__module-wrapper--comments,
 	.list-comments {
 		grid-area: comments;
 	}
 
+	.stats__module-wrapper--shares,
 	.list-shares {
 		grid-area: shares;
 	}
 
+	.stats__module-wrapper--followers,
 	.list-followers {
 		grid-area: followers;
 	}
 
+	.stats__module-wrapper--total-followers,
 	.list-total-followers {
 		grid-area: social-followers;
 	}
 
+	.stats__module-wrapper--latest-post-summary,
 	.list-latest-post-summary {
 		grid-area: latest-post-summary;
 	}
 
+	.stats__module-wrapper--publicize,
 	.list-publicize {
 		grid-area: publicize;
 	}

--- a/client/my-sites/stats/stats-module/style.scss
+++ b/client/my-sites/stats/stats-module/style.scss
@@ -1,3 +1,8 @@
+@import "@wordpress/base-styles/breakpoints";
+
+$grid-horizontal-gutters: 24px;
+$grid-vertical-gutters: 32px;
+
 .stats-module {
 	.upsell-nudge.card {
 		margin: 16px;
@@ -26,6 +31,50 @@
 // Site sections
 .stats__module-list {
 	@include clear-fix;
+}
+
+.stats__module-list.stats__module--unified.is-insights-page-enabled {
+	align-items: stretch;
+	display: grid;
+	grid-template-columns: repeat(12, 1fr);
+	grid-template-rows: repeat(5, min-content);
+	gap: $grid-vertical-gutters $grid-horizontal-gutters;
+	grid-template-areas:
+		"tags-categories tags-categories tags-categories tags-categories tags-categories tags-categories comments comments comments comments comments comments"
+		"shares shares shares shares followers followers followers followers publicize publicize publicize publicize"
+		"latest-post-summary latest-post-summary latest-post-summary latest-post-summary latest-post-summary latest-post-summary social-followers social-followers social-followers social-followers social-followers social-followers";
+
+	@media (max-width: 660px) {
+		padding: 0 16px;
+	}
+
+	.list-tags-categories {
+		grid-area: tags-categories;
+	}
+
+	.list-comments {
+		grid-area: comments;
+	}
+
+	.list-shares {
+		grid-area: shares;
+	}
+
+	.list-followers {
+		grid-area: followers;
+	}
+
+	.list-total-followers {
+		grid-area: social-followers;
+	}
+
+	.list-latest-post-summary {
+		grid-area: latest-post-summary;
+	}
+
+	.list-publicize {
+		grid-area: publicize;
+	}
 }
 
 .stats-insights__nonperiodic {

--- a/client/my-sites/stats/stats-module/style.scss
+++ b/client/my-sites/stats/stats-module/style.scss
@@ -1,7 +1,3 @@
-@import "@wordpress/base-styles/breakpoints";
-
-$grid-horizontal-gutters: 24px;
-$grid-vertical-gutters: 32px;
 
 .stats-module {
 	.upsell-nudge.card {
@@ -31,57 +27,6 @@ $grid-vertical-gutters: 32px;
 // Site sections
 .stats__module-list {
 	@include clear-fix;
-}
-
-.stats__module-list.stats__module--unified.is-insights-page-enabled {
-	align-items: stretch;
-	display: grid;
-	grid-template-columns: repeat(12, 1fr);
-	grid-template-rows: repeat(5, min-content);
-	gap: $grid-vertical-gutters $grid-horizontal-gutters;
-	grid-template-areas:
-		"tags-categories tags-categories tags-categories tags-categories tags-categories tags-categories comments comments comments comments comments comments"
-		"shares shares shares shares followers followers followers followers publicize publicize publicize publicize"
-		"latest-post-summary latest-post-summary latest-post-summary latest-post-summary latest-post-summary latest-post-summary social-followers social-followers social-followers social-followers social-followers social-followers";
-
-	@media (max-width: 660px) {
-		padding: 0 16px;
-	}
-
-	.stats__module-wrapper--tags-categories,
-	.list-tags-categories {
-		grid-area: tags-categories;
-	}
-
-	.stats__module-wrapper--comments,
-	.list-comments {
-		grid-area: comments;
-	}
-
-	.stats__module-wrapper--shares,
-	.list-shares {
-		grid-area: shares;
-	}
-
-	.stats__module-wrapper--followers,
-	.list-followers {
-		grid-area: followers;
-	}
-
-	.stats__module-wrapper--total-followers,
-	.list-total-followers {
-		grid-area: social-followers;
-	}
-
-	.stats__module-wrapper--latest-post-summary,
-	.list-latest-post-summary {
-		grid-area: latest-post-summary;
-	}
-
-	.stats__module-wrapper--publicize,
-	.list-publicize {
-		grid-area: publicize;
-	}
 }
 
 .stats-insights__nonperiodic {

--- a/client/my-sites/stats/stats-reach/index.jsx
+++ b/client/my-sites/stats/stats-reach/index.jsx
@@ -37,7 +37,7 @@ export const StatsReach = ( props ) => {
 	);
 
 	return (
-		<div>
+		<div className="list-total-followers">
 			{ siteId && <QuerySiteStats siteId={ siteId } statType="statsFollowers" /> }
 			{ siteId && <QuerySiteStats siteId={ siteId } statType="statsPublicize" /> }
 			<SectionHeader label={ translate( 'Follower totals' ) } />

--- a/client/my-sites/stats/stats-shares/index.jsx
+++ b/client/my-sites/stats/stats-shares/index.jsx
@@ -31,7 +31,7 @@ const StatShares = ( { siteId } ) => {
 	];
 
 	return (
-		<div>
+		<div className="list-shares">
 			{ siteId && <QuerySiteStats siteId={ siteId } statType="stats" /> }
 			<SectionHeader label={ translate( 'Shares' ) } />
 			<Card className={ classNames( ...classes ) }>

--- a/config/client.json
+++ b/config/client.json
@@ -26,6 +26,7 @@
 	"siftscience_key",
 	"signup_url",
 	"stats/horizontal-bars-everywhere",
+	"stats/insights-page-grid",
 	"wpcom_concierge_schedule_id",
 	"wpcom_signup_id",
 	"wpcom_signup_key",

--- a/config/development.json
+++ b/config/development.json
@@ -165,6 +165,7 @@
 		"sites/copy-site": true,
 		"ssr/prefetch-timebox": false,
 		"stats/horizontal-bars-everywhere": true,
+		"stats/insights-page-grid": true,
 		"stepper-woocommerce-poc": true,
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -109,6 +109,7 @@
 		"site-indicator": true,
 		"ssr/prefetch-timebox": true,
 		"stats/horizontal-bars-everywhere": false,
+		"stats/insights-page-grid": false,
 		"stepper-woocommerce-poc": true,
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,

--- a/config/production.json
+++ b/config/production.json
@@ -129,6 +129,7 @@
 		"ssr/prefetch-timebox": true,
 		"ssr/sample-log-cache-misses": true,
 		"stats/horizontal-bars-everywhere": false,
+		"stats/insights-page-grid": false,
 		"stepper-woocommerce-poc": true,
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -125,6 +125,7 @@
 		"site-indicator": true,
 		"ssr/prefetch-timebox": true,
 		"stats/horizontal-bars-everywhere": false,
+		"stats/insights-page-grid": false,
 		"stepper-woocommerce-poc": true,
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,

--- a/config/test.json
+++ b/config/test.json
@@ -91,6 +91,7 @@
 		"site-indicator": true,
 		"ssr/prefetch-timebox": true,
 		"stats/horizontal-bars-everywhere": false,
+		"stats/insights-page-grid": false,
 		"stepper-woocommerce-poc": true,
 		"themes/premium": true,
 		"upgrades/redirect-payments": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -135,6 +135,7 @@
 		"sites/copy-site": true,
 		"ssr/prefetch-timebox": true,
 		"stats/horizontal-bars-everywhere": false,
+		"stats/insights-page-grid": false,
 		"stepper-woocommerce-poc": true,
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,


### PR DESCRIPTION
While modernizing the Traffic page, we created a CSS grid to place each module with horizontal bars in the correct place.
The same grid has to be applied to the insights page.

#### Proposed Changes

* Create a new flag called `stats/insights-page-grid`
* Apply the CSS grid to the `Insights` page when the new flag is enabled

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the Calypso Live link below
* Go to the `Insights` page and ensure it looks the same as before
* Apply the feature flag by adding `?flags=stats/insights-page-grid` to the URL
* Ensure the modules with horizontal bars are following what is described on #72038 (the UI of each module remains the same and it will be changed on follow-up PRs) 

#### Screenshots

| Before | After |
| ----- | ----- |
| ![image](https://user-images.githubusercontent.com/6406071/213302371-3d301a90-9f08-4b3e-98d9-fb6eb16c6be8.png) | ![image](https://user-images.githubusercontent.com/6406071/213302847-7cfcb3a6-f903-4eaf-8c05-098bc495e5ca.png) |

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #72038 