### PR TITLE
Theme Showcase: Only enable theme card updates

### DIFF
--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -409,6 +409,7 @@ export class Theme extends Component {
 		 * and the theme isn't the active theme.
 		 */
 		const showPremiumBadge = isPremiumTheme && isPremiumThemeAvailable && ! active;
+		const isNewCardsOnly = isEnabled( 'themes/showcase-i4/cards-only' );
 		const isNewDetailsAndPreview = isEnabled( 'themes/showcase-i4/details-and-preview' );
 		const popoverContent = this.getUpsellPopoverContent();
 
@@ -418,7 +419,7 @@ export class Theme extends Component {
 					eventName="calypso_upgrade_nudge_impression"
 					eventProperties={ { cta_name: 'theme-upsell', theme: theme.id } }
 				/>
-				{ isNewDetailsAndPreview ? (
+				{ isNewCardsOnly || isNewDetailsAndPreview ? (
 					<>
 						{ ( ! doesThemeBundleSoftwareSet || isExternallyManagedTheme ) && (
 							<PremiumBadge
@@ -515,6 +516,7 @@ export class Theme extends Component {
 			didPurchaseTheme,
 		} = this.props;
 		const { name, description, screenshot } = theme;
+		const isNewCardsOnly = isEnabled( 'themes/showcase-i4/cards-only' );
 		const isNewDetailsAndPreview = isEnabled( 'themes/showcase-i4/details-and-preview' );
 		const isActionable = this.props.screenshotClickUrl || this.props.onScreenshotClick;
 		const themeClass = classNames( 'theme', {
@@ -603,13 +605,13 @@ export class Theme extends Component {
 								} ) }
 							</span>
 						) }
-						{ ! isNewDetailsAndPreview && active && (
+						{ ! isNewCardsOnly && ! isNewDetailsAndPreview && active && (
 							<span className={ priceClass }>{ price }</span>
 						) }
 						{ upsellUrl && // Do not show any pricing related infomation if there's no upsell action link.
 							( showUpsell
 								? this.renderUpsell()
-								: isNewDetailsAndPreview &&
+								: ( isNewCardsOnly || isNewDetailsAndPreview ) &&
 								  ! active && (
 										<span className="theme__info-upsell-description">{ translate( 'Free' ) }</span>
 								  ) ) }

--- a/client/my-sites/themes/logged-out.jsx
+++ b/client/my-sites/themes/logged-out.jsx
@@ -8,9 +8,16 @@ const ConnectedThemeShowcase = connectOptions( ThemeShowcase );
 
 export default ( props ) => (
 	<Main fullWidthLayout className="themes">
-		{ isEnabled( 'themes/showcase-i4/details-and-preview' ) && (
-			<BodySectionCssClass bodyClass={ [ 'is-section-themes-i4-2' ] } />
-		) }
+		<BodySectionCssClass
+			bodyClass={ [
+				...( isEnabled( 'themes/showcase-i4/cards-only' )
+					? [ 'is-section-themes-i4-cards-only' ]
+					: [] ),
+				...( isEnabled( 'themes/showcase-i4/details-and-preview' )
+					? [ 'is-section-themes-i4-2' ]
+					: [] ),
+			] }
+		/>
 		<ConnectedThemeShowcase
 			{ ...props }
 			origin="wpcom"

--- a/client/my-sites/themes/single-site-jetpack.jsx
+++ b/client/my-sites/themes/single-site-jetpack.jsx
@@ -49,6 +49,7 @@ const ConnectedSingleSiteJetpack = connectOptions( ( props ) => {
 		requestingSitePlans,
 	} = props;
 
+	const isNewCardsOnly = isEnabled( 'themes/showcase-i4/cards-only' );
 	const isNewDetailsAndPreview = isEnabled( 'themes/showcase-i4/details-and-preview' );
 	const displayUpsellBanner = isAtomic && ! requestingSitePlans && currentPlan;
 	const upsellUrl =
@@ -72,9 +73,12 @@ const ConnectedSingleSiteJetpack = connectOptions( ( props ) => {
 
 	return (
 		<Main fullWidthLayout className="themes">
-			{ isNewDetailsAndPreview && (
-				<BodySectionCssClass bodyClass={ [ 'is-section-themes-i4-2' ] } />
-			) }
+			<BodySectionCssClass
+				bodyClass={ [
+					...( isNewCardsOnly ? [ 'is-section-themes-i4-cards-only' ] : [] ),
+					...( isNewDetailsAndPreview ? [ 'is-section-themes-i4-2' ] : [] ),
+				] }
+			/>
 			<QueryActiveTheme siteId={ siteId } />
 			{ currentThemeId && <QueryCanonicalTheme themeId={ currentThemeId } siteId={ siteId } /> }
 

--- a/client/my-sites/themes/single-site-wpcom.jsx
+++ b/client/my-sites/themes/single-site-wpcom.jsx
@@ -26,6 +26,7 @@ const ConnectedSingleSiteWpcom = connectOptions( ( props ) => {
 	const { currentPlan, currentThemeId, isVip, requestingSitePlans, siteId, siteSlug, translate } =
 		props;
 
+	const isNewCardsOnly = isEnabled( 'themes/showcase-i4/cards-only' );
 	const isNewDetailsAndPreview = isEnabled( 'themes/showcase-i4/details-and-preview' );
 	const displayUpsellBanner = ! requestingSitePlans && currentPlan && ! isVip;
 	const upsellUrl = `/plans/${ siteSlug }`;
@@ -78,9 +79,12 @@ const ConnectedSingleSiteWpcom = connectOptions( ( props ) => {
 
 	return (
 		<Main fullWidthLayout className="themes">
-			{ isNewDetailsAndPreview && (
-				<BodySectionCssClass bodyClass={ [ 'is-section-themes-i4-2' ] } />
-			) }
+			<BodySectionCssClass
+				bodyClass={ [
+					...( isNewCardsOnly ? [ 'is-section-themes-i4-cards-only' ] : [] ),
+					...( isNewDetailsAndPreview ? [ 'is-section-themes-i4-2' ] : [] ),
+				] }
+			/>
 			<QueryActiveTheme siteId={ siteId } />
 			{ currentThemeId && <QueryCanonicalTheme themeId={ currentThemeId } siteId={ siteId } /> }
 

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -117,6 +117,7 @@ body.is-section-themes {
 	}
 }
 
+body.is-section-themes-i4-cards-only,
 body.is-section-themes-i4-2 {
 	.themes__selection .themes-list .theme {
 		background: none;
@@ -135,7 +136,7 @@ body.is-section-themes-i4-2 {
 				flex-direction: row;
 				gap: 16px;
 				margin-top: 0;
-				padding: 4px 24px;
+				padding: 8px 24px;
 			}
 
 			.theme__info-title {

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -145,6 +145,11 @@ body.is-section-themes-i4-2 {
 
 			.theme__more-button {
 				position: relative;
+
+				button {
+					color: var(--color-primary-10);
+					margin-top: -2px;
+				}
 			}
 		}
 

--- a/config/development.json
+++ b/config/development.json
@@ -172,6 +172,7 @@
 		"themes/atomic-homepage-replace": true,
 		"themes/plugin-bundling": true,
 		"themes/premium": true,
+		"themes/showcase-i4/cards-only": true,
 		"themes/showcase-i4/details-and-preview": true,
 		"themes/subscription-purchases": true,
 		"themes/theme-switch-persist-template": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -116,6 +116,7 @@
 		"themes/atomic-homepage-replace": true,
 		"themes/plugin-bundling": true,
 		"themes/premium": true,
+		"themes/showcase-i4/cards-only": false,
 		"themes/showcase-i4/details-and-preview": false,
 		"themes/subscription-purchases": false,
 		"themes/theme-switch-persist-template": true,

--- a/config/production.json
+++ b/config/production.json
@@ -136,6 +136,7 @@
 		"themes/atomic-homepage-replace": true,
 		"themes/plugin-bundling": true,
 		"themes/premium": true,
+		"themes/showcase-i4/cards-only": false,
 		"themes/showcase-i4/details-and-preview": false,
 		"themes/subscription-purchases": false,
 		"themes/theme-switch-persist-template": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -132,6 +132,7 @@
 		"themes/atomic-homepage-replace": true,
 		"themes/plugin-bundling": true,
 		"themes/premium": true,
+		"themes/showcase-i4/cards-only": false,
 		"themes/showcase-i4/details-and-preview": false,
 		"themes/subscription-purchases": false,
 		"themes/theme-switch-persist-template": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -142,6 +142,7 @@
 		"themes/atomic-homepage-replace": true,
 		"themes/plugin-bundling": true,
 		"themes/premium": true,
+		"themes/showcase-i4/cards-only": false,
 		"themes/showcase-i4/details-and-preview": false,
 		"themes/subscription-purchases": false,
 		"themes/theme-switch-persist-template": false,


### PR DESCRIPTION
#### Proposed Changes

This PR adds a flag that only enables theme card themes from the Theme Showcase i4 design spec 0EogtxvlmxMGcnEEaMVECv-fi-2010%3A60733. Note that the current implementation has diverged from design spec as per discussions with @SaxonF. See screenshot for comparison:

| Before | After |
| --- | --- |
| ![Screen Shot 2023-01-18 at 12 49 38 PM](https://user-images.githubusercontent.com/797888/213087123-9b978fcb-4384-473b-9857-66e7d043d219.png) |  ![Screen Shot 2023-01-18 at 12 51 36 PM](https://user-images.githubusercontent.com/797888/213087141-7d6a9c45-15b9-44cf-a9eb-843c16ecc92e.png) |

Also see pekYwv-vT-p2#comment-430 for more context behind this feature flag. 

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the logged-in Theme Showcase `/themes/${your_site}`. If using calypso.live, the flag `themes/showcase-i4/cards-only` is required.
* Ensure that the theme card UI is as described above.
* Ensure that both Atomic sites and logged-out Theme Showcase also has the theme card UI.
* Ensure that theme style variations are not visible in theme cards.
* Ensure that the theme preview is the same as the current one in production. 

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->