### PR TITLE
Site Assembler: Enable pattern-assembler/client-side-render flag on production (Second try)

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -76,7 +76,7 @@
 		"network-connection": true,
 		"onboarding/import-light-url-screen": true,
 		"p2/p2-plus": true,
-		"pattern-assembler/client-side-render": false,
+		"pattern-assembler/client-side-render": true,
 		"pattern-assembler/logged-out-showcase": false,
 		"plans/personal-plan": true,
 		"plans/pro-plan": false,

--- a/config/production.json
+++ b/config/production.json
@@ -90,7 +90,7 @@
 		"onboarding/import-light-url-screen": true,
 		"onboarding/import-redirect-to-themes": true,
 		"p2/p2-plus": true,
-		"pattern-assembler/client-side-render": false,
+		"pattern-assembler/client-side-render": true,
 		"pattern-assembler/logged-out-showcase": false,
 		"plans/personal-plan": true,
 		"plans/pro-plan": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -88,7 +88,7 @@
 		"onboarding/import-redirect-to-themes": true,
 		"p2/p2-plus": true,
 		"page/export": true,
-		"pattern-assembler/client-side-render": false,
+		"pattern-assembler/client-side-render": true,
 		"pattern-assembler/logged-out-showcase": false,
 		"plans/personal-plan": true,
 		"plans/pro-plan": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -98,7 +98,7 @@
 		"onboarding/import-redirect-to-themes": true,
 		"onboarding/2023-pricing-grid": true,
 		"p2/p2-plus": true,
-		"pattern-assembler/client-side-render": false,
+		"pattern-assembler/client-side-render": true,
 		"pattern-assembler/logged-out-showcase": false,
 		"plans/personal-plan": true,
 		"plans/pro-plan": false,


### PR DESCRIPTION
#### Proposed Changes

* Enable the `pattern-assembler/client-side-render` flag on production 🙂

**Screenshot with non-a8c account**

![image](https://user-images.githubusercontent.com/13596067/213347977-2c7d291f-4fdd-4644-a485-2c1ab1814ed5.png)

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use non-a8c account or register a new one
* Go to `/setup?siteSlug=<your_site>`
* Click the "Continue" button until you land on the Design Picker step
* Scroll to the bottom and select the Blank Canvas CTA
* When you're in the Pattern Assembler step, everything works well as before

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to pbxlJb-39t-p2