### PR TITLE
Site Assembler: Render patterns from the user site and disable cache of rendered patterns

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -362,7 +362,7 @@ const PatternAssembler: Step = ( { navigation, flow } ) => {
 		</div>
 	);
 
-	if ( ! selectedDesign ) {
+	if ( ! site?.ID || ! selectedDesign ) {
 		return null;
 	}
 
@@ -382,7 +382,7 @@ const PatternAssembler: Step = ( { navigation, flow } ) => {
 						<AsyncLoad
 							require="./pattern-assembler-container"
 							placeholder={ null }
-							siteId={ site.ID }
+							siteId={ site?.ID }
 							stylesheet={ selectedDesign?.recipe?.stylesheet }
 							patternIds={ allPatterns.map( ( pattern ) => encodePatternId( pattern.id ) ) }
 							siteInfo={ siteInfo }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -11,7 +11,6 @@ import { requestActiveTheme } from 'calypso/state/themes/actions';
 import { useSite } from '../../../../hooks/use-site';
 import { useSiteIdParam } from '../../../../hooks/use-site-id-param';
 import { useSiteSlugParam } from '../../../../hooks/use-site-slug-param';
-import { useThemeDetails } from '../../../../hooks/use-theme-details';
 import { SITE_STORE, ONBOARD_STORE } from '../../../../stores';
 import { recordSelectedDesign } from '../../analytics/record-design';
 import { SITE_TAGLINE } from './constants';
@@ -44,8 +43,6 @@ const PatternAssembler: Step = ( { navigation, flow } ) => {
 	const siteId = useSiteIdParam();
 	const siteSlugOrId = siteSlug ? siteSlug : siteId;
 	const allPatterns = useAllPatterns();
-	const { data: theme } = useThemeDetails( selectedDesign?.slug );
-	const themeDemoSiteSlug = theme?.demo_uri?.replace( /^https?:\/\//, '' ).replace( '/', '' );
 
 	const largePreviewProps = {
 		placeholder: null,
@@ -365,7 +362,7 @@ const PatternAssembler: Step = ( { navigation, flow } ) => {
 		</div>
 	);
 
-	if ( ! selectedDesign || ! themeDemoSiteSlug ) {
+	if ( ! selectedDesign ) {
 		return null;
 	}
 
@@ -385,7 +382,7 @@ const PatternAssembler: Step = ( { navigation, flow } ) => {
 						<AsyncLoad
 							require="./pattern-assembler-container"
 							placeholder={ null }
-							siteId={ themeDemoSiteSlug }
+							siteId={ site.ID }
 							stylesheet={ selectedDesign?.recipe?.stylesheet }
 							patternIds={ allPatterns.map( ( pattern ) => encodePatternId( pattern.id ) ) }
 							siteInfo={ siteInfo }

--- a/packages/block-renderer/src/components/patterns-renderer-provider.tsx
+++ b/packages/block-renderer/src/components/patterns-renderer-provider.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo } from 'react';
+import React from 'react';
 import useRenderedPatterns from '../hooks/use-rendered-patterns';
 import PatternsRendererContext from './patterns-renderer-context';
 import type { SiteInfo } from '../types';
@@ -18,26 +18,7 @@ const PatternsRendererProvider = ( {
 	children,
 	siteInfo = {},
 }: Props ) => {
-	const { data, isLoading, hasNextPage, fetchNextPage } = useRenderedPatterns(
-		siteId,
-		stylesheet,
-		patternIds,
-		siteInfo
-	);
-
-	const renderedPatterns = useMemo(
-		() =>
-			data?.pages
-				? data.pages.reduce( ( previous, current ) => ( { ...previous, ...current } ), {} )
-				: {},
-		[ data?.pages?.length ]
-	);
-
-	useEffect( () => {
-		if ( ! isLoading && hasNextPage ) {
-			fetchNextPage();
-		}
-	}, [ isLoading, hasNextPage, fetchNextPage ] );
+	const renderedPatterns = useRenderedPatterns( siteId, stylesheet, patternIds, siteInfo );
 
 	return (
 		<PatternsRendererContext.Provider value={ renderedPatterns }>

--- a/packages/block-renderer/src/hooks/use-rendered-patterns.ts
+++ b/packages/block-renderer/src/hooks/use-rendered-patterns.ts
@@ -4,8 +4,6 @@ import type { RenderedPatterns, SiteInfo } from '../types';
 
 const PAGE_SIZE = 20;
 
-const HOUR_IN_MS = 3600000;
-
 const fetchRenderedPatterns = (
 	siteId: number | string,
 	stylesheet: string,
@@ -40,7 +38,7 @@ const useRenderedPatterns = (
 	stylesheet: string,
 	patternIds: string[],
 	siteInfo: SiteInfo = {},
-	{ staleTime = HOUR_IN_MS, refetchOnMount = true }: UseQueryOptions = {}
+	{ staleTime = Infinity, refetchOnMount = 'always' }: UseQueryOptions = {}
 ) => {
 	// If we query too many patterns at once, the endpoint will be very slow.
 	// Hence, do local pagination to ensure the performance.


### PR DESCRIPTION
#### Proposed Changes

* Referring to p1673966406507379-slack-C048CUFRGFQ, non-a8c users cannot get the settings from the theme demo site. So, I change back to get the settings from the current user site to get settings and rendered patterns. The downside is the posts of the query blocks will be from the current user site, and it might only have 1 or 2 posts. But I think we can deal with it later.
* Referring to p1673926768597069-slack-CRWCHQGUB, there is an issue related to the cache of the rendered patterns. The last page might not be fetched while the cache is expired at that time. The new user might not encounter this issue because the cache won't be expired in the onboarding flow, but it's annoyed and make developers feel weird. So, I think it'd be better to disable it.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use non-a8c account and go to /setup?siteSlug=<your_site>
* Click the "Continue" button until you land on the Design Picker step
* Scroll to the bottom and select the Blank Canvas CTA
* When you're in the Pattern Assembler step
  * Verify the styles of the patterns are correct
  * Verify you won't see any "blank" pattern

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1673966406507379-slack-C048CUFRGFQ, p1673926768597069-slack-CRWCHQGUB