### PR TITLE
Fix error that occurs when `site` is undefined in DeleteSite

### DIFF
--- a/client/my-sites/site-settings/delete-site/index.jsx
+++ b/client/my-sites/site-settings/delete-site/index.jsx
@@ -358,7 +358,7 @@ export default connect(
 		return {
 			hasLoadedSitePurchasesFromServer: hasLoadedSitePurchasesFromServer( state ),
 			isAtomic: isSiteAutomatedTransfer( state, siteId ),
-			isFreePlan: isFreePlanProduct( site.plan ),
+			isFreePlan: isFreePlanProduct( site?.plan ),
 			siteDomain,
 			siteId,
 			siteSlug,


### PR DESCRIPTION
#### Proposed Changes

This PR fixes an error that occurs when deleting sites. I have only observed this with simple sites, so it's possible that it doesn't affect atomic sites. The regression was introduced in #71380. 

I captured a screencast that illustrates the error:

https://user-images.githubusercontent.com/1101677/213129216-20e321b3-b1a2-410a-81df-09c84cd8556b.mp4

#### Testing Instructions

1. Have a site that can be deleted
2. Navigate to `/settings/delete-site/:site_slug`
3. Delete the site
4. Ensure that you are redirected to `/stats/day`

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
