### PR TITLE
Copy Site: remove intro step and custom intro modifications

### DIFF
--- a/client/landing/stepper/declarative-flow/copy-site.tsx
+++ b/client/landing/stepper/declarative-flow/copy-site.tsx
@@ -15,7 +15,6 @@ import {
 } from 'calypso/signup/storageUtils';
 import { recordSubmitStep } from './internals/analytics/record-submit-step';
 import AutomatedCopySite from './internals/steps-repository/automated-copy-site';
-import Intro from './internals/steps-repository/intro';
 import ProcessingStep, { ProcessingResult } from './internals/steps-repository/processing-step';
 import SiteCreationStep from './internals/steps-repository/site-creation-step';
 import type { Flow, ProvidedDependencies } from './internals/types';
@@ -41,7 +40,6 @@ const copySite: Flow = {
 		}
 
 		return [
-			{ slug: 'intro', component: Intro },
 			{ slug: 'site-creation-step', component: SiteCreationStep },
 			{ slug: 'processing', component: ProcessingStep },
 			{ slug: 'automated-copy', component: AutomatedCopySite },

--- a/client/landing/stepper/declarative-flow/copy-site.tsx
+++ b/client/landing/stepper/declarative-flow/copy-site.tsx
@@ -62,11 +62,6 @@ const copySite: Flow = {
 			recordSubmitStep( providedDependencies, '', flowName, _currentStepSlug );
 
 			switch ( _currentStepSlug ) {
-				case 'intro': {
-					clearSignupDestinationCookie();
-					return navigate( 'site-creation-step' );
-				}
-
 				case 'site-creation-step': {
 					return navigate( 'processing' );
 				}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/intro/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/intro/index.tsx
@@ -4,12 +4,10 @@ import {
 	VIDEOPRESS_FLOW,
 	FREE_FLOW,
 	isLinkInBioFlow,
-	isCopySiteFlow,
 } from '@automattic/onboarding';
 import { createInterpolateElement, useMemo } from '@wordpress/element';
 import { useI18n } from '@wordpress/react-i18n';
 import { StepContainer } from 'calypso/../packages/onboarding/src';
-import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import IntroStep, { IntroContent } from './intro';
 import type { Step } from '../../types';
@@ -18,24 +16,8 @@ import './styles.scss';
 
 const useIntroContent = ( flowName: string | null ): IntroContent => {
 	const { __ } = useI18n();
-	const urlQueryParams = useQuery();
-	return useMemo( () => {
-		if ( isCopySiteFlow( flowName ) ) {
-			return {
-				title: __( 'Copy Site' ),
-				text: createInterpolateElement(
-					__(
-						'You’re 5 minutes away from<br />creating a new copy site from <SourceSlug/>.<br />Ready?'
-					),
-					{
-						br: <br />,
-						SourceSlug: <span>{ urlQueryParams.get( 'sourceSlug' ) }</span>,
-					}
-				),
-				buttonText: __( 'Start copying' ),
-			};
-		}
 
+	return useMemo( () => {
 		if ( isLinkInBioFlow( flowName ) ) {
 			return {
 				title: createInterpolateElement(
@@ -92,7 +74,7 @@ const useIntroContent = ( flowName: string | null ): IntroContent => {
 			),
 			buttonText: __( 'Get started' ),
 		};
-	}, [ flowName, __, urlQueryParams ] );
+	}, [ flowName, __ ] );
 };
 
 const Intro: Step = function Intro( { navigation, flow } ) {

--- a/packages/onboarding/src/flow-progress/use-flow-progress.ts
+++ b/packages/onboarding/src/flow-progress/use-flow-progress.ts
@@ -68,8 +68,7 @@ const flows: Record< string, { [ step: string ]: number } > = {
 		storeAddress: 5,
 	},
 	[ COPY_SITE_FLOW ]: {
-		intro: 0,
-		'site-creation-step': 1,
+		'site-creation-step': 0,
 		processing: 1,
 		'automated-copy': 3,
 		'processing-copy': 3,


### PR DESCRIPTION
#### Proposed Changes

* Remove Intro step from Copy Site flow
* Currently the free site will be created automatically and the user is landing to the checkout page. In the near future we will add the Domain step.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/sites`
* Click on the three dots actions
* Click on `Copy Site`
* Observe that you see the processing screen and land on the checkout page. The intro step is not visible anymore.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:
-  https://github.com/Automattic/dotcom-forge/issues/1479
- https://github.com/Automattic/wp-calypso/pull/72206