### PR TITLE
Populate media Item with VideoPress data when it exists

### DIFF
--- a/client/gutenberg/editor/media-utils.js
+++ b/client/gutenberg/editor/media-utils.js
@@ -11,7 +11,7 @@ const DEFAULT_DISABLED_DATA_SOURCES = [ 'google_photos', 'openverse', 'pexels' ]
  * @returns {Array|object} Gutenberg media blocks input
  */
 export const mediaCalypsoToGutenberg = ( media ) => {
-	return {
+	const mediaData = {
 		id: get( media, 'ID' ),
 		url: get( media, 'URL' ),
 		alt: get( media, 'alt' ),
@@ -39,6 +39,15 @@ export const mediaCalypsoToGutenberg = ( media ) => {
 		type: get( media, 'mime_type', '' ).split( '/' )[ 0 ],
 		width: get( media, 'width' ),
 	};
+
+	// VideoPress data
+	if ( media.videopress_guid ) {
+		mediaData.allow_download = media.allow_download;
+		mediaData.rating = media.rating;
+		mediaData.videopress_guid = media.videopress_guid;
+	}
+
+	return mediaData;
 };
 
 export const getDisabledDataSources = ( allowedTypes ) => {


### PR DESCRIPTION
#### Proposed Changes

* This PR populates the data of the Media item when it exists, allowing it to pass them from the Media Library to the Block Editor though the iframe.

#### Testing Instructions
* Add/edit a post using the block editor
* Add a new VideoPress video block
* Set the video by picking it up from the Media Library
* Confirm the block renders the video player properly

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
