### PR TITLE
Copy Site: Only offer link for sites with 'copy-site' feature

### DIFF
--- a/client/sites-dashboard/components/sites-ellipsis-menu.tsx
+++ b/client/sites-dashboard/components/sites-ellipsis-menu.tsx
@@ -1,6 +1,6 @@
 import { isEnabled } from '@automattic/calypso-config';
 import {
-	WPCOM_FEATURES_ATOMIC,
+	WPCOM_FEATURES_COPY_SITE,
 	WPCOM_FEATURES_MANAGE_PLUGINS,
 	WPCOM_FEATURES_SITE_PREVIEW_LINKS,
 } from '@automattic/calypso-products';
@@ -184,13 +184,13 @@ const PreviewSiteModalItem = ( { recordTracks, site }: SitesMenuItemProps ) => {
 
 const CopySiteItem = ( { recordTracks, site }: SitesMenuItemProps ) => {
 	const { __ } = useI18n();
-	const hasAtomicFeature = useSafeSiteHasFeature( site.ID, WPCOM_FEATURES_ATOMIC );
+	const hasCopySiteFeature = useSafeSiteHasFeature( site.ID, WPCOM_FEATURES_COPY_SITE );
 	const userId = useSelector( ( state ) => getCurrentUserId( state ) );
 	const plan = site.plan;
 	const isSiteOwner = site.site_owner === userId;
 	const { setPlanCartItem } = useDispatch( ONBOARD_STORE );
 
-	if ( ! hasAtomicFeature || ! isSiteOwner || ! plan ) {
+	if ( ! hasCopySiteFeature || ! isSiteOwner || ! plan ) {
 		return null;
 	}
 	setPlanCartItem( { product_slug: plan.product_slug } );

--- a/packages/calypso-products/src/constants/features.ts
+++ b/packages/calypso-products/src/constants/features.ts
@@ -224,6 +224,7 @@ export const WPCOM_FEATURES_BACKUPS_RESTORE = 'restore';
 export const WPCOM_FEATURES_CDN = 'cdn';
 export const WPCOM_FEATURES_CLASSIC_SEARCH = 'search';
 export const WPCOM_FEATURES_CLOUDFLARE_CDN = 'cloudflare-cdn';
+export const WPCOM_FEATURES_COPY_SITE = 'copy-site';
 export const WPCOM_FEATURES_FULL_ACTIVITY_LOG = 'full-activity-log';
 export const WPCOM_FEATURES_INSTALL_PLUGINS = 'install-plugins';
 export const WPCOM_FEATURES_INSTALL_PURCHASED_PLUGINS = 'install-purchased-plugins';


### PR DESCRIPTION
## Proposed Changes

Switches the 'Copy site' link to reference a `WPCOM_FEATURES_COPY_SITE` feature.

We'll need to deploy D98470-code before we land this.

## Testing Instructions

1. Apply D98470-code to your sandbox.
2. Verify the 'Copy site' link only appears for Business sites on Atomic, not eCommerce sites.