### PR TITLE
Copy Site: Append '_click' to Tracks event for clarity

### DIFF
--- a/client/sites-dashboard/components/sites-ellipsis-menu.tsx
+++ b/client/sites-dashboard/components/sites-ellipsis-menu.tsx
@@ -201,7 +201,7 @@ const CopySiteItem = ( { recordTracks, site }: SitesMenuItemProps ) => {
 	return (
 		<MenuItemLink
 			href={ copySiteHref }
-			onClick={ () => recordTracks( 'calypso_sites_dashboard_site_action_copy_site' ) }
+			onClick={ () => recordTracks( 'calypso_sites_dashboard_site_action_copy_site_click' ) }
 		>
 			{ __( 'Copy site' ) }
 		</MenuItemLink>


### PR DESCRIPTION
See https://github.com/Automattic/dotcom-forge/issues/1481

## Proposed Changes

Renames `calypso_sites_dashboard_site_action_copy_site` to `calypso_sites_dashboard_site_action_copy_site_click` for consistency with other action-based Tracks events.

Tracks update too https://github.com/Automattic/tracks-events-registration/pull/1334

## Testing Instructions

1. Verify the Tracks event still fires as expected.