### PR TITLE
Users management: Include Viewer role in the team members list

### DIFF
--- a/client/data/viewers/use-viewer-query.js
+++ b/client/data/viewers/use-viewer-query.js
@@ -1,0 +1,13 @@
+import { useQuery } from 'react-query';
+import wpcom from 'calypso/lib/wp';
+
+const useViewerQuery = ( siteId, userId ) => {
+	return useQuery( [ 'viewer', userId ], () =>
+		wpcom.req.get( {
+			path: `/sites/${ siteId }/viewer/${ userId }?http_envelope=1`,
+			apiNamespace: 'rest/v1.1',
+		} )
+	);
+};
+
+export default useViewerQuery;

--- a/client/my-sites/people/controller.js
+++ b/client/my-sites/people/controller.js
@@ -15,6 +15,7 @@ import PeopleInvites from './people-invites';
 import SubscriberDetails from './subscriber-details';
 import SubscribersTeam from './subscribers-team';
 import TeamInvite from './team-invite';
+import ViewerDetails from './viewer-details';
 
 export default {
 	redirectToTeam,
@@ -51,6 +52,10 @@ export default {
 
 	teamMembers( context, next ) {
 		renderTeamMembers( context, next );
+	},
+
+	viewerTeamMember( context, next ) {
+		renderViewerTeamMember( context, next );
 	},
 
 	subscribers( context, next ) {
@@ -228,5 +233,22 @@ function renderSingleTeamMember( context, next ) {
 			<EditTeamMember userLogin={ context.params.user_login } />
 		</>
 	);
+	next();
+}
+
+function renderViewerTeamMember( context, next ) {
+	const SingleTeamMemberTitle = () => {
+		const translate = useTranslate();
+
+		return <DocumentHead title={ translate( 'View Team Member', { textOnly: true } ) } />;
+	};
+
+	context.primary = (
+		<>
+			<SingleTeamMemberTitle />
+			<ViewerDetails userId={ context.params.user_id } />
+		</>
+	);
+
 	next();
 }

--- a/client/my-sites/people/index.js
+++ b/client/my-sites/people/index.js
@@ -22,6 +22,16 @@ export default function () {
 		clientRender
 	);
 
+	page(
+		'/people/:filter(viewers)/:site_id/:user_id',
+		peopleController.enforceSiteEnding,
+		siteSelection,
+		navigation,
+		peopleController.viewerTeamMember,
+		makeLayout,
+		clientRender
+	);
+
 	page( '/people/invites', siteSelection, sites, makeLayout, clientRender );
 
 	page(

--- a/client/my-sites/people/people-list-item/index.jsx
+++ b/client/my-sites/people/people-list-item/index.jsx
@@ -23,10 +23,12 @@ class PeopleListItem extends PureComponent {
 		site: PropTypes.object,
 		invite: PropTypes.object,
 		showStatus: PropTypes.bool,
+		clickableItem: PropTypes.bool,
 		RevokeClearBtn: PropTypes.elementType,
 	};
 
 	static defaultProps = {
+		clickableItem: true,
 		RevokeClearBtn: null,
 	};
 
@@ -60,7 +62,11 @@ class PeopleListItem extends PureComponent {
 	};
 
 	maybeGetCardLink = () => {
-		const { invite, site, type, user } = this.props;
+		const { invite, site, type, user, clickableItem } = this.props;
+
+		if ( ! clickableItem ) {
+			return false;
+		}
 
 		switch ( type ) {
 			case 'invite-details':

--- a/client/my-sites/people/people-list-item/index.jsx
+++ b/client/my-sites/people/people-list-item/index.jsx
@@ -84,6 +84,9 @@ class PeopleListItem extends PureComponent {
 				);
 			}
 
+			case 'viewer':
+				return `/people/viewers/${ site.slug }/${ user.ID }`;
+
 			default:
 				return this.canLinkToProfile() && `/people/edit/${ site.slug }/${ user.login }`;
 		}

--- a/client/my-sites/people/people-profile/index.jsx
+++ b/client/my-sites/people/people-profile/index.jsx
@@ -289,6 +289,17 @@ const PeopleProfile = ( { siteId, type, user, invite, showDate, showRole = true 
 		);
 	};
 
+	const renderViewerRole = () => {
+		const role = 'viewer';
+		return (
+			<div className="people-profile__badges">
+				<div className={ classNames( 'people-profile__role-badge', getRoleBadgeClass( role ) ) }>
+					{ getRoleBadgeText( role ) }
+				</div>
+			</div>
+		);
+	};
+
 	const isFollowerType = () => {
 		return user && ! user.roles && user.date_subscribed;
 	};
@@ -307,6 +318,7 @@ const PeopleProfile = ( { siteId, type, user, invite, showDate, showRole = true 
 				{ renderLogin() }
 				{ showDate && renderSubscribedDate() }
 				{ showRole && isFollowerType() ? renderSubscribedRole() : renderRole() }
+				{ type === 'viewer' && renderViewerRole() }
 			</div>
 		</div>
 	);

--- a/client/my-sites/people/subscriber-details/index.tsx
+++ b/client/my-sites/people/subscriber-details/index.tsx
@@ -115,7 +115,7 @@ export default function SubscriberDetails( props: Props ) {
 	}
 
 	return (
-		<Main className="people-subscriber-details">
+		<Main className="people-member-details">
 			<PageViewTracker path="/people/subscribers/:site/:id" title="People > User Details" />
 
 			<FormattedHeader
@@ -142,19 +142,19 @@ export default function SubscriberDetails( props: Props ) {
 			) }
 
 			{ templateState === 'default' && (
-				<Card className="subscriber-details">
+				<Card className="member-details">
 					<PeopleListItem
 						key={ `subscriber-details-${ subscriberId }` }
 						site={ site }
 						user={ subscriber }
 						onRemove={ onRemove }
 					/>
-					<div className="people-subscriber-details__meta">
+					<div className="people-member-details__meta">
 						{ subscriber?.date_subscribed && (
-							<div className="people-subscriber-details__meta-item">
+							<div className="people-member-details__meta-item">
 								<strong>{ _( 'Status' ) }</strong>
 								<div>
-									<span className="people-subscriber-details__meta-status-active">
+									<span className="people-member-details__meta-status-active">
 										{ _( 'Active' ) }
 									</span>
 								</div>
@@ -162,7 +162,7 @@ export default function SubscriberDetails( props: Props ) {
 						) }
 
 						{ subscriber?.date_subscribed && (
-							<div className="people-subscriber-details__meta-item">
+							<div className="people-member-details__meta-item">
 								<strong>{ _( 'Subscriber since' ) }</strong>
 								<div>
 									<span>{ moment( subscriber?.date_subscribed ).format( 'LLL' ) }</span>
@@ -171,7 +171,7 @@ export default function SubscriberDetails( props: Props ) {
 						) }
 
 						{ subscriber?.url && (
-							<div className="people-subscriber-details__meta-item">
+							<div className="people-member-details__meta-item">
 								<strong>{ _( 'Source' ) }</strong>
 								<div>
 									<span>{ subscriber.url }</span>

--- a/client/my-sites/people/subscriber-details/index.tsx
+++ b/client/my-sites/people/subscriber-details/index.tsx
@@ -15,7 +15,7 @@ import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import PeopleListItem from 'calypso/my-sites/people/people-list-item';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
-import type { Follower } from 'calypso/my-sites/people/subscribers/types';
+import type { Member } from '../types';
 
 import './style.scss';
 
@@ -74,7 +74,7 @@ export default function SubscriberDetails( props: Props ) {
 		page.back( fallback );
 	}
 
-	function removeSubscriber( subscriber: Follower ) {
+	function removeSubscriber( subscriber: Member ) {
 		const listType = 'email' === subscriberType ? 'Email Follower' : 'Follower';
 		dispatch(
 			recordGoogleEvent( 'People', 'Clicked Remove Follower Button On ' + listType + ' list' )

--- a/client/my-sites/people/subscriber-details/style.scss
+++ b/client/my-sites/people/subscriber-details/style.scss
@@ -1,15 +1,15 @@
-.subscriber-details {
+.member-details {
 	.people-list-item.card.is-compact {
 		padding: 0;
 	}
 
-	.people-subscriber-details__meta {
+	.people-member-details__meta {
 		border-top: 1px solid var(--color-border-subtle);
 		padding-top: 24px;
 		margin-top: 24px;
 	}
 
-	.people-subscriber-details__meta-item {
+	.people-member-details__meta-item {
 		margin-bottom: 1rem;
 		overflow: hidden;
 		white-space: nowrap;
@@ -19,7 +19,7 @@
 			color: var(--studio-gray-70);
 		}
 
-		.people-subscriber-details__meta-status {
+		.people-member-details__meta-status {
 			&-pending {
 				color: var(--color-warning);
 			}

--- a/client/my-sites/people/subscribers-team/index.tsx
+++ b/client/my-sites/people/subscribers-team/index.tsx
@@ -28,12 +28,14 @@ function SubscribersTeam( props: Props ) {
 
 	// fetching data config
 	const followersFetchOptions = { search };
+	const defaultTeamFetchOptions = { include_viewers: true };
 	const teamFetchOptions = search
 		? {
 				search: `*${ search }*`,
-				search_columns: [ 'display_name', 'user_login' ],
+				search_columns: [ 'display_name', 'user_login', 'user_email' ],
+				...defaultTeamFetchOptions,
 		  }
-		: {};
+		: defaultTeamFetchOptions;
 
 	const followersQuery = useFollowersQuery(
 		site?.ID,

--- a/client/my-sites/people/subscribers-team/index.tsx
+++ b/client/my-sites/people/subscribers-team/index.tsx
@@ -13,7 +13,6 @@ import { getSelectedSite } from 'calypso/state/ui/selectors';
 import PeopleSectionNavCompact from '../people-section-nav-compact';
 import Subscribers from '../subscribers';
 import TeamInvites from '../team-invites';
-import TeamInvitesAccepted from '../team-invites-accepted';
 import TeamMembers from '../team-members';
 import type { FollowersQuery } from '../subscribers/types';
 import type { UsersQuery } from '../team-members/types';
@@ -103,7 +102,6 @@ function SubscribersTeam( props: Props ) {
 
 									<TeamMembers search={ search } usersQuery={ usersQuery } />
 									<TeamInvites />
-									<TeamInvitesAccepted />
 								</>
 							);
 					}

--- a/client/my-sites/people/subscribers/index.tsx
+++ b/client/my-sites/people/subscribers/index.tsx
@@ -12,7 +12,8 @@ import PeopleListItem from 'calypso/my-sites/people/people-list-item';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import PeopleListSectionHeader from '../people-list-section-header';
-import type { Follower, FollowersQuery } from './types';
+import type { Member } from '../types';
+import type { FollowersQuery } from './types';
 
 import './style.scss';
 
@@ -49,11 +50,11 @@ function Subscribers( props: Props ) {
 		);
 	}
 
-	function getFollowerRef( follower: Follower ) {
+	function getFollowerRef( follower: Member ) {
 		return 'follower-' + follower.ID;
 	}
 
-	function renderFollower( follower: Follower ) {
+	function renderFollower( follower: Member ) {
 		return (
 			<PeopleListItem
 				key={ follower?.ID }

--- a/client/my-sites/people/subscribers/types.ts
+++ b/client/my-sites/people/subscribers/types.ts
@@ -1,24 +1,10 @@
-export type Follower = {
-	ID: number | string;
-	url?: string;
-	label: string;
-	login: string;
-	avatar: string;
-	avatar_URL: string;
-	date_subscribed: string;
-	follow_data?: any;
-};
+import type { Member, UseQuery } from '../types';
 
 export type FollowersQueryData = {
-	followers: Follower[];
+	followers: Member[];
 	total: number;
 };
 
 export type FollowersQuery = {
 	data?: FollowersQueryData;
-	hasNextPage: boolean;
-	refetch: () => void;
-	fetchNextPage: () => void;
-	isLoading: boolean;
-	isFetchingNextPage: boolean;
-};
+} & UseQuery;

--- a/client/my-sites/people/team-invites/types.ts
+++ b/client/my-sites/people/team-invites/types.ts
@@ -1,11 +1,11 @@
-import { UserData as User } from 'calypso/lib/user/user';
+import type { Member } from '../types';
 
 export type Invite = {
 	key: string;
-	user: User;
+	user: Member;
 	role: string;
 	isPending: boolean;
-	invitedBy: User;
+	invitedBy: Member;
 	inviteDate: string;
 	acceptedDate?: string;
 };

--- a/client/my-sites/people/team-members/index.tsx
+++ b/client/my-sites/people/team-members/index.tsx
@@ -49,8 +49,10 @@ function TeamMembers( props: Props ) {
 		return _( 'You have %(number)d team member', 'You have %(number)d team members', options );
 	}
 
-	function renderPerson( user: User ) {
-		return <PeopleListItem key={ user?.ID } user={ user } site={ site } type="email" />;
+	function renderPerson( user: Member ) {
+		const type = user.roles ? 'email' : 'viewer';
+
+		return <PeopleListItem key={ user?.ID } user={ user } site={ site } type={ type } />;
 	}
 
 	function renderLoadingPeople() {

--- a/client/my-sites/people/team-members/index.tsx
+++ b/client/my-sites/people/team-members/index.tsx
@@ -2,11 +2,11 @@ import { Card, Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import InfiniteList from 'calypso/components/infinite-list';
-import { UserData as User } from 'calypso/lib/user/user';
 import NoResults from 'calypso/my-sites/no-results';
 import PeopleListItem from 'calypso/my-sites/people/people-list-item';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import PeopleListSectionHeader from '../people-list-section-header';
+import type { Member } from '../types';
 import type { UsersQuery } from './types';
 
 import './style.scss';
@@ -28,7 +28,7 @@ function TeamMembers( props: Props ) {
 
 	const addTeamMemberLink = `/people/new/${ site?.slug }`;
 
-	function getPersonRef( user: User ) {
+	function getPersonRef( user: Member ) {
 		return 'user-' + user?.ID;
 	}
 

--- a/client/my-sites/people/team-members/types.ts
+++ b/client/my-sites/people/team-members/types.ts
@@ -1,15 +1,10 @@
-import { UserData as User } from 'calypso/lib/user/user';
+import type { Member, UseQuery } from '../types';
 
 export type UsersQueryData = {
-	users: User[];
+	users: Member[];
 	total: number;
 };
 
 export type UsersQuery = {
 	data?: UsersQueryData;
-	hasNextPage: boolean;
-	refetch: () => void;
-	fetchNextPage: () => void;
-	isLoading: boolean;
-	isFetchingNextPage: boolean;
-};
+} & UseQuery;

--- a/client/my-sites/people/types.ts
+++ b/client/my-sites/people/types.ts
@@ -1,0 +1,26 @@
+export type Member = {
+	ID: number | string;
+	URL?: string;
+	avatar_URL: string;
+	email: boolean | string;
+	first_name: string;
+	invite_key?: string;
+	ip_address: boolean | string;
+	is_super_admin?: boolean;
+	last_name: string;
+	login: string;
+	name: string;
+	nice_name: string;
+	profile_URL: string;
+	roles?: string[];
+	site_ID: number;
+	site_visible: boolean;
+};
+
+export type UseQuery = {
+	hasNextPage: boolean;
+	refetch: () => void;
+	fetchNextPage: () => void;
+	isLoading: boolean;
+	isFetchingNextPage: boolean;
+};

--- a/client/my-sites/people/viewer-details/index.tsx
+++ b/client/my-sites/people/viewer-details/index.tsx
@@ -1,0 +1,193 @@
+import { Card } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import page from 'page';
+import { useEffect, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import QuerySiteInvites from 'calypso/components/data/query-site-invites';
+import EmptyContent from 'calypso/components/empty-content';
+import FormattedHeader from 'calypso/components/formatted-header';
+import HeaderCake from 'calypso/components/header-cake';
+import { useLocalizedMoment } from 'calypso/components/localized-moment';
+import Main from 'calypso/components/main';
+import useRemoveViewer from 'calypso/data/viewers/use-remove-viewer-mutation';
+import useViewerQuery from 'calypso/data/viewers/use-viewer-query';
+import accept from 'calypso/lib/accept';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import PeopleListItem from 'calypso/my-sites/people/people-list-item';
+import { recordGoogleEvent } from 'calypso/state/analytics/actions';
+import { deleteInvite } from 'calypso/state/invites/actions';
+import { getAcceptedInvitesForSite } from 'calypso/state/invites/selectors';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
+import type { Member } from '../types';
+import type { Invite } from 'calypso/my-sites/people/team-invites/types';
+
+interface Props {
+	userId: string;
+}
+export default function ViewerDetails( props: Props ) {
+	const __ = useTranslate();
+	const moment = useLocalizedMoment();
+	const dispatch = useDispatch();
+
+	const { userId } = props;
+	const site = useSelector( ( state ) => getSelectedSite( state ) );
+	const acceptedInvites = useSelector( ( state ) =>
+		getAcceptedInvitesForSite( state, site?.ID as number )
+	);
+	const [ invite, setInvite ] = useState< Invite >();
+	const [ templateState, setTemplateState ] = useState( 'loading' );
+	const { data: viewer, isLoading } = useViewerQuery( site?.ID, userId ) as {
+		data: Member;
+		isLoading: boolean;
+	};
+	const { removeViewer } = useRemoveViewer();
+
+	useEffect( () => checkTemplateState(), [ viewer ] );
+	useEffect( () => findInviteObject(), [ acceptedInvites, viewer ] );
+
+	function findInviteObject() {
+		const inv =
+			viewer && acceptedInvites && acceptedInvites.find( ( x ) => x.key === viewer.invite_key );
+
+		inv && setInvite( inv );
+	}
+
+	function checkTemplateState() {
+		if ( isLoading ) {
+			setTemplateState( 'loading' );
+		} else if ( ! viewer ) {
+			setTemplateState( 'not-found' );
+		} else {
+			setTemplateState( 'default' );
+		}
+	}
+
+	function onRemove() {
+		dispatch( recordGoogleEvent( 'People', 'Clicked Remove Viewer Button On Viewer Details' ) );
+		showConfirmDialog();
+	}
+
+	function onRemoveAccept() {
+		// since we show the full user details with the invite information,
+		// the button Remove simultaneously calls, remove the viewer | delete the invite
+		viewer && removeViewer( site?.ID, viewer.ID );
+		invite && dispatch( deleteInvite( site?.ID, invite.key ) );
+		goBack();
+	}
+
+	function onBackClick() {
+		dispatch( recordGoogleEvent( 'People', 'Clicked Back Button on Viewer Details' ) );
+		goBack();
+	}
+
+	function showConfirmDialog() {
+		accept(
+			<div>
+				<p>{ __( 'If you remove this viewer, he or she will not be able to visit this site.' ) }</p>
+				<p>{ __( 'Would you still like to remove this viewer?' ) }</p>
+			</div>,
+			( accepted: boolean ) => {
+				if ( accepted ) {
+					dispatch(
+						recordGoogleEvent( 'People', 'Clicked Remove Button In Remove Viewer Confirmation' )
+					);
+					onRemoveAccept();
+				} else {
+					dispatch(
+						recordGoogleEvent( 'People', 'Clicked Cancel Button In Remove Viewer Confirmation' )
+					);
+				}
+			},
+			__( 'Remove', { context: 'Confirm Remove viewer button text.' } )
+		);
+	}
+
+	function goBack() {
+		const fallback = site?.slug ? '/people/team/' + site.slug : '/people/team/';
+
+		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+		// @ts-ignore: There are no type definitions for page.back.
+		page.back( fallback );
+	}
+
+	return (
+		<Main className="people-member-details">
+			<PageViewTracker path="/people/viewers/:site/:id" title="People > User Details" />
+			{ site?.ID && <QuerySiteInvites siteId={ site?.ID } /> }
+
+			<FormattedHeader
+				brandFont
+				className="people__page-heading"
+				headerText={ __( 'Users' ) }
+				subHeaderText={ __( 'People who have subscribed to your site and team members.' ) }
+				align="left"
+				hasScreenOptions
+			/>
+
+			<HeaderCake isCompact onClick={ onBackClick }>
+				{ __( 'User Details' ) }
+			</HeaderCake>
+
+			{ templateState === 'loading' && (
+				<Card>
+					<PeopleListItem key="people-list-item-placeholder" />
+				</Card>
+			) }
+
+			{ templateState === 'not-found' && (
+				<EmptyContent title={ __( 'The requested subscriber does not exist.' ) } />
+			) }
+
+			{ templateState === 'default' && (
+				<Card className="member-details">
+					<PeopleListItem
+						key={ `viewer-details-${ viewer.ID }` }
+						site={ site }
+						user={ viewer }
+						type="viewer"
+						clickableItem={ false }
+						onRemove={ onRemove }
+					/>
+					{ invite && (
+						<div className="people-member-details__meta">
+							{ invite?.acceptedDate && (
+								<div className="people-member-details__meta-item">
+									<strong>{ __( 'Status' ) }</strong>
+									<div>
+										<span className="people-member-details__meta-status-active">
+											{ __( 'Active' ) }
+										</span>
+									</div>
+								</div>
+							) }
+
+							{ invite?.invitedBy && (
+								<div className="people-invite-details__meta-item">
+									<strong>{ __( 'Added By' ) }</strong>
+									<div>
+										<span>
+											{ invite.invitedBy.name !== invite.invitedBy.login && (
+												<>{ invite.invitedBy.name }</>
+											) }
+											&nbsp;
+											{ '@' + invite.invitedBy.login }
+										</span>
+									</div>
+								</div>
+							) }
+
+							{ invite?.acceptedDate && (
+								<div className="people-member-details__meta-item">
+									<strong>{ __( 'Viewer since' ) }</strong>
+									<div>
+										<span>{ moment( invite?.acceptedDate ).format( 'LLL' ) }</span>
+									</div>
+								</div>
+							) }
+						</div>
+					) }
+				</Card>
+			) }
+		</Main>
+	);
+}


### PR DESCRIPTION
#### Proposed Changes

For the code review, follow commit by commit; it will be more convenient.

* Introduced a dedicated route/page showing User details of the Viewer role.
  * Viewer details are a combination of **user details** (login, full name, avatar) and **invite details** (status, added by, viewer since)
  * If invite object is missing, there will be only **user details**
* Team members: Reconfigured fetch settings allowing getting of Viewer role
* Rearranged and fixed some typing issues
* Got rid of the Accepted invites block from the team members page.

#### Testing Instructions

The Follower member type will not be presented since the BE endpoint is not deployed yet, you can follow it in [the PR](https://github.com/Automattic/jetpack/pull/28317).

The good thing, these changes can be applied/deployed, and nothing will be changed against the current app state.

Scenario 1:
* Go to `/people/team/{SITE}`
* Check if everything works as before
* Check if there are members and pending invites list

Scenario 2:
* Configure your sandbox to consume changes from [the PR](https://github.com/Automattic/jetpack/pull/28317)
* Go to `/people/team/{SIMPLE_SITE}`
* Add and accept the Viewer role as a team member
* Check if the member list shows the Viewer role
* Check if a selection of the Viewer role list item leads you to the newly created route `/people/viewers/{SITE}/{USER_ID}`
* Check if a Remove button functionality works correctly from the Viewer profile screen

#### Screenshots

![Markup on 2023-01-18 at 16:01:24](https://user-images.githubusercontent.com/1241413/213207560-35290af0-e769-49c7-a054-9a94cacb4d98.png)
![Markup on 2023-01-18 at 16:02:08](https://user-images.githubusercontent.com/1241413/213207574-d5b0a424-5114-4963-a6bd-6618696667de.png)
![Markup on 2023-01-18 at 16:03:06](https://user-images.githubusercontent.com/1241413/213207585-1a3c5620-7a0b-4760-823e-7fa3ba514799.png)

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #72000
