### PR TITLE
Changed the arrows behavior in Email Stats chart

### DIFF
--- a/client/components/chart/index.jsx
+++ b/client/components/chart/index.jsx
@@ -1,7 +1,7 @@
 import classNames from 'classnames';
 import { localize, withRtl } from 'i18n-calypso';
 import PropTypes from 'prop-types';
-import { useState, useCallback, useMemo } from 'react';
+import { useState, useCallback, useMemo, useEffect } from 'react';
 import Notice from 'calypso/components/notice';
 import Tooltip from 'calypso/components/tooltip';
 import { hasTouch } from 'calypso/lib/touch-detect';
@@ -55,6 +55,7 @@ function Chart( {
 	translate,
 	chartXPadding,
 	sliceFromBeginning,
+	onChangeMaxBars,
 } ) {
 	const [ tooltip, setTooltip ] = useState( { isTooltipVisible: false } );
 	const [ sizing, setSizing ] = useState( { clientWidth: 650, hasResized: false } );
@@ -107,6 +108,13 @@ function Chart( {
 
 	const width = isTouch && sizing.clientWidth <= 0 ? 350 : sizing.clientWidth - chartXPadding; // mobile safari bug with zero width
 	const maxBars = Math.floor( width / minWidth );
+
+	useEffect( () => {
+		if ( onChangeMaxBars ) {
+			onChangeMaxBars( maxBars );
+		}
+	}, [ maxBars, onChangeMaxBars ] );
+
 	// Memoize data calculations to avoid performing them too often.
 	const { chartData, isEmptyChart, yMax } = useMemo( () => {
 		const nextData = ( () => {

--- a/client/components/data/query-email-stats/index.jsx
+++ b/client/components/data/query-email-stats/index.jsx
@@ -15,7 +15,15 @@ const requestAlltimeStats = ( siteId, postId, statType, quantity ) => ( dispatch
 	dispatch( requestEmailAlltimeStats( siteId, postId, statType, quantity ) );
 };
 
-function QueryEmailStats( { siteId, postId, period, date, quantity, hasValidDate } ) {
+function QueryEmailStats( {
+	siteId,
+	postId,
+	period,
+	date,
+	quantity,
+	hasValidDate,
+	isRequesting = false,
+} ) {
 	const dispatch = useDispatch();
 	const statType = 'opens';
 
@@ -31,7 +39,7 @@ function QueryEmailStats( { siteId, postId, period, date, quantity, hasValidDate
 
 	useEffect( () => {
 		// if hasValidatedDate is false, the date was not set we don't have a post publish date yet
-		if ( siteId && postId > -1 && hasValidDate ) {
+		if ( siteId && postId > -1 && hasValidDate && ! isRequesting ) {
 			dispatch( requestPeriodStats( siteId, postId, period, date, statType, quantity ) );
 		}
 	}, [ dispatch, siteId, postId, hasValidDate, period, date, statType, quantity ] );

--- a/client/my-sites/stats/stats-email-chart-tabs/index.jsx
+++ b/client/my-sites/stats/stats-email-chart-tabs/index.jsx
@@ -70,7 +70,7 @@ class StatModuleChartTabs extends Component {
 	};
 
 	render() {
-		const { isActiveTabLoading } = this.props;
+		const { isActiveTabLoading, onChangeMaxBars } = this.props;
 
 		const classes = [
 			'is-chart-tabs',
@@ -98,6 +98,7 @@ class StatModuleChartTabs extends Component {
 					data={ chartData }
 					minBarWidth={ 35 }
 					sliceFromBeginning={ false }
+					onChangeMaxBars={ onChangeMaxBars }
 				/>
 				<StatTabs
 					data={ this.props.counts }
@@ -119,7 +120,18 @@ const NO_SITE_STATE = {
 };
 
 const connectComponent = connect(
-	( state, { activeLegend, period: { period, endOf }, chartTab, queryDate, postId, statType } ) => {
+	(
+		state,
+		{
+			activeLegend,
+			period: { period, endOf },
+			chartTab,
+			queryDate,
+			postId,
+			statType,
+			onChangeMaxBars,
+		}
+	) => {
 		const siteId = getSelectedSiteId( state );
 		if ( ! siteId ) {
 			return NO_SITE_STATE;
@@ -146,6 +158,7 @@ const connectComponent = connect(
 			isActiveTabLoading,
 			queryKey,
 			siteId,
+			onChangeMaxBars,
 		};
 	},
 	{ recordGoogleEvent }

--- a/client/my-sites/stats/stats-email-open-detail/index.jsx
+++ b/client/my-sites/stats/stats-email-open-detail/index.jsx
@@ -110,6 +110,7 @@ class StatsEmailOpenDetail extends Component {
 		showPreview: false,
 		activeTab: null,
 		activeLegend: null,
+		maxBars: 0,
 	};
 
 	static getDerivedStateFromProps( props, state ) {
@@ -173,6 +174,8 @@ class StatsEmailOpenDetail extends Component {
 
 	onChangeLegend = ( activeLegend ) => this.setState( { activeLegend } );
 
+	onChangeMaxBars = ( maxBars ) => this.setState( { maxBars } );
+
 	switchChart = ( tab ) => {
 		if ( ! tab.loading && tab.attr !== this.props.chartTab ) {
 			this.props.recordGoogleEvent( 'Stats', 'Clicked ' + titlecase( tab.attr ) + ' Tab' );
@@ -194,6 +197,7 @@ class StatsEmailOpenDetail extends Component {
 			post,
 			hasValidDate,
 		} = this.props;
+		const { maxBars } = this.state;
 
 		const queryDate = date.format( 'YYYY-MM-DD' );
 		const noViewsLabel = translate( 'Your email has not received any views yet!' );
@@ -215,6 +219,8 @@ class StatsEmailOpenDetail extends Component {
 						date={ query.date }
 						period={ query.period }
 						hasValidDate={ hasValidDate }
+						quantity={ maxBars }
+						isRequesting={ isRequestingStats }
 					/>
 
 					<DocumentHead title={ translate( 'Jetpack Stats' ) } />
@@ -248,6 +254,8 @@ class StatsEmailOpenDetail extends Component {
 										date={ date }
 										period={ period }
 										url={ `/stats/email/${ statType }/${ slug }/${ period }/${ postId }` }
+										maxBars={ maxBars }
+										isEmailStats
 									>
 										<DatePicker
 											period={ period }
@@ -277,6 +285,7 @@ class StatsEmailOpenDetail extends Component {
 									chartTab={ this.props.chartTab }
 									postId={ postId }
 									statType={ statType }
+									onChangeMaxBars={ this.onChangeMaxBars }
 								/>
 
 								{ isSitePrivate ? this.renderPrivateSiteBanner( siteId, slug ) : null }

--- a/client/my-sites/stats/stats-period-navigation/index.jsx
+++ b/client/my-sites/stats/stats-period-navigation/index.jsx
@@ -50,10 +50,18 @@ class StatsPeriodNavigation extends PureComponent {
 		}
 	};
 
+	isHoursPeriod = ( period ) => 'hour' === period;
+
+	getNumberOfDays = ( isEmailStats, period, maxBars ) =>
+		isEmailStats && ! this.isHoursPeriod( period ) ? maxBars : 1;
+
+	calculatePeriod = ( period ) => ( this.isHoursPeriod( period ) ? 'day' : period );
+
 	handleArrowNext = () => {
-		const { date, moment, period, url, queryParams } = this.props;
-		const usedPeriod = 'hour' === period ? 'day' : period;
-		const nextDay = moment( date ).add( 1, usedPeriod ).format( 'YYYY-MM-DD' );
+		const { date, moment, period, url, queryParams, isEmailStats, maxBars } = this.props;
+		const numberOfDAys = this.getNumberOfDays( isEmailStats, period, maxBars );
+		const usedPeriod = this.calculatePeriod( period );
+		const nextDay = moment( date ).add( numberOfDAys, usedPeriod ).format( 'YYYY-MM-DD' );
 		const nextDayQuery = qs.stringify( Object.assign( {}, queryParams, { startDate: nextDay } ), {
 			addQueryPrefix: true,
 		} );
@@ -62,9 +70,10 @@ class StatsPeriodNavigation extends PureComponent {
 	};
 
 	handleArrowPrevious = () => {
-		const { date, moment, period, url, queryParams } = this.props;
-		const usedPeriod = 'hour' === period ? 'day' : period;
-		const previousDay = moment( date ).subtract( 1, usedPeriod ).format( 'YYYY-MM-DD' );
+		const { date, moment, period, url, queryParams, isEmailStats, maxBars } = this.props;
+		const numberOfDAys = this.getNumberOfDays( isEmailStats, period, maxBars );
+		const usedPeriod = this.calculatePeriod( period );
+		const previousDay = moment( date ).subtract( numberOfDAys, usedPeriod ).format( 'YYYY-MM-DD' );
 		const previousDayQuery = qs.stringify(
 			Object.assign( {}, queryParams, { startDate: previousDay } ),
 			{ addQueryPrefix: true }

--- a/client/state/stats/emails/reducer.js
+++ b/client/state/stats/emails/reducer.js
@@ -73,7 +73,8 @@ export const requests = ( state = {}, action ) => {
  * @returns {object}        Updated state
  */
 export const items = withSchemaValidation( itemSchemas, ( state = {}, action ) => {
-	const checkState = ( actualState, period ) => ( 'hour' === period ? {} : actualState );
+	const checkState = ( actualState, period ) =>
+		[ 'hour', 'day' ].includes( period ) ? {} : actualState;
 
 	switch ( action.type ) {
 		case EMAIL_STATS_RECEIVE:

--- a/config/development.json
+++ b/config/development.json
@@ -189,6 +189,6 @@
 		"woop": false,
 		"wordpress-action-search": false,
 		"wpcom-user-bootstrap": false,
-		"newsletter/stats": false
+		"newsletter/stats": true
 	}
 }


### PR DESCRIPTION
#### Proposed Changes

The previous behavior of the left and right arrows in the Email Stats chart was to advance or move back one day. In the case of the period selected being `days` we want that to change to 30 days. That way we are moving onward or backward a "page" int he stats.

#### Testing Instructions

1. Apply this branch to your local Calypso repository and start the application.
2. Insert manually in the browser address bar an URL with this format: https://calypso.localhost:3000/stats/email/open/[the-domain-of-your-blog]/day/[post-id]?flags=newsletter/stats. Note that you can change day for week and month.
3. Click on the right arrow. You should see the new chart data to begin 30 days after your initial date. For example, if the first column of your chart is 9th Jan and you click the right arrow, you should see a chart with 8th Feb as the first one. 
4. Click on the left arrow and check that you are in the initial date again (in my example, the 9th Jan again). 
5. Click one more time in left arrow and check that you should be 30 days before the initial date (in my case 10th Dec).
6. Go back and forth and check that everything is ok.
7. Go to /stats/day/[blog-domain] and check that the arrows still works as intended: moving one day only.

Fixes https://github.com/Automattic/wp-calypso/issues/72229