### PR TITLE
Jetpack App Promo: Enable 'app-branding' feature flag across all environments

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -44,6 +44,7 @@
 		"i18n/translation-scanner": true,
 		"inline-help": true,
 		"jetpack/api-cache": true,
+		"jetpack/app-branding": true,
 		"jetpack/backup-messaging-i3": true,
 		"jetpack/cancel-through-main-flow": true,
 		"jetpack/concierge-sessions": false,

--- a/config/production.json
+++ b/config/production.json
@@ -47,6 +47,7 @@
 		"inline-help": true,
 		"jetpack/agency-dashboard": true,
 		"jetpack/api-cache": false,
+		"jetpack/app-branding": true,
 		"jetpack/backup-messaging-i3": true,
 		"jetpack/cancel-through-main-flow": true,
 		"jetpack/concierge-sessions": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -44,6 +44,7 @@
 		"inline-help": true,
 		"jetpack/agency-dashboard": true,
 		"jetpack/api-cache": true,
+		"jetpack/app-branding": true,
 		"jetpack/backup-messaging-i3": true,
 		"jetpack/cancel-through-main-flow": true,
 		"jetpack/concierge-sessions": false,


### PR DESCRIPTION
#### Proposed Changes

* This PR enables the `jetpack/app-branding` feature flag (first enabled on `development` and `wpcalyspo` https://github.com/Automattic/wp-calypso/pull/66814) on all environments. It follows [the guidance here](https://github.com/Automattic/wp-calypso/tree/trunk/config#feature-flags) to enable the flag on the remaining environments: `horizon`, `stage`, and `production`.

#### Testing Instructions

* It'll only be possible to confirm that the changes are enabled on production when this PR is merged. For now, we can verify that all the changes behind this flag appear as expected when checked out locally (i.e. navigate to different parts of Calypso where the app is mentioned).

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
