### PR TITLE
Copy site: add product to cart after onClick

### DIFF
--- a/client/sites-dashboard/components/sites-ellipsis-menu.tsx
+++ b/client/sites-dashboard/components/sites-ellipsis-menu.tsx
@@ -15,6 +15,7 @@ import { ComponentType, useEffect, useState } from 'react';
 import { useDispatch as useReduxDispatch, useSelector } from 'react-redux';
 import SitePreviewLink from 'calypso/components/site-preview-link';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
+import { clearSignupDestinationCookie } from 'calypso/signup/storageUtils';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
@@ -201,6 +202,7 @@ const CopySiteItem = ( { recordTracks, site }: SitesMenuItemProps ) => {
 		<MenuItemLink
 			href={ copySiteHref }
 			onClick={ () => {
+				clearSignupDestinationCookie();
 				setPlanCartItem( { product_slug: plan.product_slug } );
 				recordTracks( 'calypso_sites_dashboard_site_action_copy_site_click' );
 			} }

--- a/client/sites-dashboard/components/sites-ellipsis-menu.tsx
+++ b/client/sites-dashboard/components/sites-ellipsis-menu.tsx
@@ -193,16 +193,16 @@ const CopySiteItem = ( { recordTracks, site }: SitesMenuItemProps ) => {
 	if ( ! hasAtomicFeature || ! isSiteOwner || ! plan ) {
 		return null;
 	}
-	setPlanCartItem( { product_slug: plan.product_slug } );
+	const onClick = () => {
+		setPlanCartItem( { product_slug: plan.product_slug } );
+		recordTracks( 'calypso_sites_dashboard_site_action_copy_site' );
+	};
 
 	const copySiteHref = addQueryArgs( `/setup/copy-site`, {
 		sourceSlug: site.slug,
 	} );
 	return (
-		<MenuItemLink
-			href={ copySiteHref }
-			onClick={ () => recordTracks( 'calypso_sites_dashboard_site_action_copy_site' ) }
-		>
+		<MenuItemLink href={ copySiteHref } onClick={ onClick }>
 			{ __( 'Copy site' ) }
 		</MenuItemLink>
 	);

--- a/client/sites-dashboard/components/sites-ellipsis-menu.tsx
+++ b/client/sites-dashboard/components/sites-ellipsis-menu.tsx
@@ -193,16 +193,18 @@ const CopySiteItem = ( { recordTracks, site }: SitesMenuItemProps ) => {
 	if ( ! hasAtomicFeature || ! isSiteOwner || ! plan ) {
 		return null;
 	}
-	const onClick = () => {
-		setPlanCartItem( { product_slug: plan.product_slug } );
-		recordTracks( 'calypso_sites_dashboard_site_action_copy_site' );
-	};
 
 	const copySiteHref = addQueryArgs( `/setup/copy-site`, {
 		sourceSlug: site.slug,
 	} );
 	return (
-		<MenuItemLink href={ copySiteHref } onClick={ onClick }>
+		<MenuItemLink
+			href={ copySiteHref }
+			onClick={ () => {
+				setPlanCartItem( { product_slug: plan.product_slug } );
+				recordTracks( 'calypso_sites_dashboard_site_action_copy_site_click' );
+			} }
+		>
 			{ __( 'Copy site' ) }
 		</MenuItemLink>
 	);


### PR DESCRIPTION
#### Proposed Changes

* Currently, we are adding the product to the cart just by opening the actions menu
* This PR moves the logic to be executed inside the onClick function

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/sites`
* Open the actions menu of a business site
* Click on Copy Site
* Observe that you land on the Checkout page with the right product added

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

- Related to 1468-gh-Automattic/dotcom-forge
