### PR TITLE
Fix launchpad infinite load edge cases

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
@@ -1,13 +1,14 @@
 import { StepContainer } from '@automattic/onboarding';
 import { useEffect } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { NavigationControls } from 'calypso/landing/stepper/declarative-flow/internals/types';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { useSiteSlugParam } from 'calypso/landing/stepper/hooks/use-site-slug-param';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { successNotice } from 'calypso/state/notices/actions';
 import { useQuery } from '../../../../hooks/use-query';
 import StepContent from './step-content';
@@ -27,6 +28,15 @@ const Launchpad: Step = ( { navigation, flow }: LaunchpadProps ) => {
 	const site = useSite();
 	const launchpadScreenOption = site?.options?.launchpad_screen;
 	const dispatch = useDispatch();
+	const isLoggedIn = useSelector( isUserLoggedIn );
+
+	if ( ! isLoggedIn ) {
+		window.location.replace( `/home/${ siteSlug }` );
+	}
+
+	if ( ! siteSlug ) {
+		window.location.replace( '/home' );
+	}
 
 	useEffect( () => {
 		if ( verifiedParam ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
@@ -1,4 +1,5 @@
 import { StepContainer } from '@automattic/onboarding';
+import { useSelect } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
 import { useDispatch, useSelector } from 'react-redux';
@@ -7,12 +8,14 @@ import FormattedHeader from 'calypso/components/formatted-header';
 import { NavigationControls } from 'calypso/landing/stepper/declarative-flow/internals/types';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { useSiteSlugParam } from 'calypso/landing/stepper/hooks/use-site-slug-param';
+import { SITE_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { successNotice } from 'calypso/state/notices/actions';
 import { useQuery } from '../../../../hooks/use-query';
 import StepContent from './step-content';
 import type { Step } from '../../types';
+
 import './style.scss';
 
 type LaunchpadProps = {
@@ -30,11 +33,13 @@ const Launchpad: Step = ( { navigation, flow }: LaunchpadProps ) => {
 	const dispatch = useDispatch();
 	const isLoggedIn = useSelector( isUserLoggedIn );
 
+	const fetchingSiteError = useSelect( ( select ) => select( SITE_STORE ).getFetchingSiteError() );
+
 	if ( ! isLoggedIn ) {
 		window.location.replace( `/home/${ siteSlug }` );
 	}
 
-	if ( ! siteSlug ) {
+	if ( ! siteSlug || fetchingSiteError?.error === 'unknown_blog' ) {
 		window.location.replace( '/home' );
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
@@ -39,7 +39,7 @@ const Launchpad: Step = ( { navigation, flow }: LaunchpadProps ) => {
 		window.location.replace( `/home/${ siteSlug }` );
 	}
 
-	if ( ! siteSlug || fetchingSiteError?.error === 'unknown_blog' ) {
+	if ( ! siteSlug || fetchingSiteError?.error ) {
 		window.location.replace( '/home' );
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/index.tsx
@@ -54,8 +54,14 @@ const user = {
 	email: 'testEmail@gmail.com',
 };
 
-function renderLaunchpad( props = {}, siteDetails = defaultSiteDetails ): void {
+function renderLaunchpad(
+	props = {},
+	siteDetails = defaultSiteDetails,
+	initialReduxState = {},
+	siteSlug
+): void {
 	function TestLaunchpad( props ) {
+		window.initialReduxState = initialReduxState;
 		const initialState = getInitialState( initialReducer, user.ID );
 		const reduxStore = createReduxStore( initialState, initialReducer );
 		setStore( reduxStore, getStateFromCache( user.ID ) );
@@ -93,6 +99,10 @@ describe( 'Launchpad', () => {
 		/* eslint-enable @typescript-eslint/no-empty-function */
 	};
 
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
 	afterAll( () => {
 		global.window = savedWindow;
 	} );
@@ -100,13 +110,15 @@ describe( 'Launchpad', () => {
 	describe( 'when loading the Launchpad view', () => {
 		describe( 'and the site is launchpad enabled', () => {
 			it( 'does not redirect', () => {
-				renderLaunchpad( props );
+				const initialReduxState = { currentUser: { id: user.ID } };
+				renderLaunchpad( props, defaultSiteDetails, initialReduxState, siteSlug );
 				expect( replaceMock ).not.toBeCalled();
 			} );
 		} );
 
 		describe( 'and the site is not launchpad enabled', () => {
 			it( 'redirects to Calypso My Home', () => {
+				const initialReduxState = { currentUser: { id: user.ID } };
 				renderLaunchpad(
 					props,
 					buildSiteDetails( {
@@ -114,11 +126,47 @@ describe( 'Launchpad', () => {
 							...defaultSiteDetails.options,
 							launchpad_screen: 'off',
 						},
-					} )
+					} ),
+					initialReduxState,
+					siteSlug
 				);
-
 				expect( replaceMock ).toBeCalledTimes( 1 );
 				expect( replaceMock ).toBeCalledWith( `/home/${ siteSlug }` );
+			} );
+		} );
+
+		describe( 'user is logged out', () => {
+			it( 'should redirect user to Calypso My Home', () => {
+				renderLaunchpad(
+					props,
+					buildSiteDetails( {
+						options: {
+							...defaultSiteDetails.options,
+							launchpad_screen: 'off',
+						},
+					} ),
+					{},
+					siteSlug
+				);
+				expect( replaceMock ).toBeCalledWith( `/home/${ siteSlug }` );
+			} );
+		} );
+
+		describe( 'site slug does not exist', () => {
+			it( 'should redirect user to Calypso My Home', () => {
+				const initialReduxState = { currentUser: { id: user.ID } };
+				renderLaunchpad(
+					props,
+					buildSiteDetails( {
+						options: {
+							...defaultSiteDetails.options,
+							launchpad_screen: 'off',
+						},
+					} ),
+					initialReduxState,
+					''
+				);
+				expect( replaceMock ).toBeCalledWith( `/home` );
 			} );
 		} );
 	} );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/index.tsx
@@ -41,6 +41,11 @@ jest.mock( 'calypso/state/sites/hooks/use-premium-global-styles', () => ( {
 // JSDOM doesn't support browser navigation, so we temporarily mock the
 // window.location object
 const replaceMock = jest.fn();
+declare global {
+	interface Window {
+		initialReduxState: object;
+	}
+}
 const savedWindow = window;
 global.window = Object.create( window );
 Object.defineProperty( window, 'location', {
@@ -58,7 +63,7 @@ function renderLaunchpad(
 	props = {},
 	siteDetails = defaultSiteDetails,
 	initialReduxState = {},
-	siteSlug
+	siteSlug = ''
 ): void {
 	function TestLaunchpad( props ) {
 		window.initialReduxState = initialReduxState;


### PR DESCRIPTION
#### Proposed Changes

* Users are currently seeing an infinite loading screen on the Launchpad when the site slug query parameter does not exist or is invalid and when they are logged out. These changes redirect the user back to `/home/{siteSlug}` if the user is logged out and `/home` if the site slug query parameter does not exist or site is invalid.

#### Testing / Review time

Test: Short
Review: Short

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this branch
* Create a new newsletter / link-in-bio / free flow site OR use existing launchpad enabled site.
* Navigate to the launchpad screen `setup/{flowName}/launchpad?siteSlug={siteSlug}`
* Confirm the launchpad is loading properly
* Replace the siteSlug parameter with an invalid site and confirm the launchpad navigates to `/home`
* Remove the siteSlug parameter and confirm the launchpad navigates to `/home`
* Log out , navigate to the launchpad screen , log in when redirected to the login page and confirm you are navigated to `/home/{siteSlug}`

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
