### PR TITLE
Marketplace Thank You: Update footer icons

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
@@ -1,8 +1,7 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { ConfettiAnimation } from '@automattic/components';
+import { ConfettiAnimation, Gridicon } from '@automattic/components';
 import { ThemeProvider, Global, css } from '@emotion/react';
 import { Button } from '@wordpress/components';
-import { Icon, table } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
 import { useEffect, useState, useMemo, useCallback } from 'react';
@@ -225,7 +224,7 @@ const MarketplaceThankYou = ( { productSlug }: { productSlug: string } ) => {
 		nextStepsClassName: 'thank-you__footer',
 		nextSteps: [
 			{
-				stepIcon: <Icon icon={ table } size={ 20 } />,
+				stepIcon: <FooterIcon icon="next-page" />,
 				stepKey: 'thank_you_footer_support_guides',
 				stepTitle: translate( 'Support guides' ),
 				stepDescription: translate(
@@ -243,7 +242,7 @@ const MarketplaceThankYou = ( { productSlug }: { productSlug: string } ) => {
 				),
 			},
 			{
-				stepIcon: <Icon icon={ table } size={ 20 } />,
+				stepIcon: <FooterIcon icon="create" />,
 				stepKey: 'thank_you_footer_explore',
 				stepTitle: translate( 'Keep growing' ),
 				stepDescription: translate(
@@ -261,7 +260,7 @@ const MarketplaceThankYou = ( { productSlug }: { productSlug: string } ) => {
 				),
 			},
 			{
-				stepIcon: <Icon icon={ table } size={ 20 } />,
+				stepIcon: <FooterIcon icon="help-outline" />,
 				stepKey: 'thank_you_footer_support',
 				stepTitle: translate( 'How can we support?' ),
 				stepDescription: translate(
@@ -333,5 +332,16 @@ const MarketplaceThankYou = ( { productSlug }: { productSlug: string } ) => {
 		</ThemeProvider>
 	);
 };
+
+function FooterIcon( { icon }: { icon: string } ) {
+	return (
+		<Gridicon
+			className="marketplace-thank-you__footer-icon"
+			size={ 18 }
+			color="var(--studio-gray-30)"
+			icon={ icon }
+		/>
+	);
+}
 
 export default MarketplaceThankYou;

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/style.scss
@@ -77,7 +77,7 @@
 		}
 
 		.thank-you__step-icon {
-			width: 50px;
+			width: calc(18px + 25px); // icon size + padding
 			flex-basis: 100%;
 		}
 


### PR DESCRIPTION
#### Proposed Changes

* Update footer icons to grid icons
* Update padding between footer icon and title/text

<img width="1136" alt="Screen Shot 2023-01-18 at 11 25 01" src="https://user-images.githubusercontent.com/5039531/213212450-ccdf5db5-9776-4f70-a67d-5d1ae18f708b.png">


#### Testing Instructions
* Install or purchase a plugin
* Check if the footer layout looks like the above
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #72148
