### PR TITLE
Stepper: Add visual screen for site creation step

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
@@ -9,11 +9,16 @@ import {
 	isMigrationFlow,
 	isCopySiteFlow,
 	isWooExpressFlow,
+	StepContainer,
 } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
+import { useI18n } from '@wordpress/react-i18n';
 import { useEffect } from 'react';
 import { useSelector } from 'react-redux';
+import DocumentHead from 'calypso/components/data/document-head';
+import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import {
 	retrieveSignupDestination,
 	getSignupCompleteFlowName,
@@ -32,6 +37,8 @@ const DEFAULT_NEWSLETTER_THEME = 'pub/lettre';
 
 const SiteCreationStep: Step = function SiteCreationStep( { navigation, flow } ) {
 	const { submit } = navigation;
+	const { __ } = useI18n();
+	const stepProgress = useSelect( ( select ) => select( ONBOARD_STORE ).getStepProgress() );
 
 	const { domainCartItem, planCartItem, siteAccentColor, getSelectedSiteTitle } = useSelect(
 		( select ) => ( {
@@ -127,7 +134,32 @@ const SiteCreationStep: Step = function SiteCreationStep( { navigation, flow } )
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [] );
 
-	return null;
+	const getCurrentMessage = () => {
+		return isWooExpressFlow( flow )
+			? __( "Woo! We're creating your store" )
+			: __( 'Creating your site' );
+	};
+
+	return (
+		<>
+			<DocumentHead title={ getCurrentMessage() } />
+			<StepContainer
+				shouldHideNavButtons={ true }
+				hideFormattedHeader={ true }
+				stepName="site-creation-step"
+				isHorizontalLayout={ true }
+				recordTracksEvent={ recordTracksEvent }
+				stepContent={
+					<>
+						<h1>{ getCurrentMessage() }</h1>
+						<LoadingEllipsis />
+					</>
+				}
+				stepProgress={ stepProgress }
+				showFooterWooCommercePowered={ false }
+			/>
+		</>
+	);
 };
 
 export default SiteCreationStep;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/styles.scss
@@ -8,6 +8,10 @@ $font-family: "SF Pro Text", $sans;
 		max-width: 540px;
 		text-align: center;
 		margin: 16vh auto 0;
+
+		.step-container__content {
+			margin: auto;
+		}
 	}
 }
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/styles.scss
@@ -2,6 +2,15 @@
 
 $font-family: "SF Pro Text", $sans;
 
+.wooexpress {
+	.site-creation-step {
+		padding: 1em;
+		max-width: 540px;
+		text-align: center;
+		margin: 16vh auto 0;
+	}
+}
+
 .link-in-bio-setup,
 .free-setup {
 	.step-container__content {


### PR DESCRIPTION
#### Proposed Changes

* Adds a `StepContainer` for the site creation step in case users encounter it on a slow connection.
* Ensure copy is different for the Woo flow (related to #72168)
* We should probably update the appearance to match the other Woo screens (background, progress bar standardization) but I think that can happen in a separate PR.

**Visual**

<img width="1678" alt="Screen Shot 2023-01-19 at 9 59 46 AM" src="https://user-images.githubusercontent.com/2124984/213476188-dde9cd9a-3761-46d7-be03-8b091c219418.png">


#### Testing Instructions

* Switch to this PR
* On line 96 of `trial-wooexpress-flow.ts` change `return navigate( 'processing' );` to `return;` to temporarily stop the flow from progressing
* Navigate to `/setup/wooexpress`
* You should see the above screen.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->