### PR TITLE
Update index.tsx

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { Button } from '@automattic/components';
 import { isWithinBreakpoint } from '@automattic/viewport';
 import { useMobileBreakpoint } from '@automattic/viewport-react';
@@ -100,8 +99,6 @@ export default function SitesOverview() {
 	}, [ refetch, jetpackSiteDisconnected ] );
 
 	const pageTitle = translate( 'Dashboard' );
-
-	const downTimeMonitoringUpdates = 'Dashboard - Down Time Monitoring Updates Enabled';
 
 	const basePath = '/dashboard';
 
@@ -233,11 +230,7 @@ export default function SitesOverview() {
 								} ) }
 							>
 								<div className="sites-overview__page-heading">
-									{ isEnabled( 'jetpack/partner-portal-downtime-monitoring-updates' ) ? (
-										<h2 className="sites-overview__page-title">{ downTimeMonitoringUpdates }</h2>
-									) : (
-										<h2 className="sites-overview__page-title">{ pageTitle }</h2>
-									) }
+									<h2 className="sites-overview__page-title">{ pageTitle }</h2>
 									<div className="sites-overview__page-subtitle">
 										{ translate( 'Manage all your Jetpack sites from one location' ) }
 									</div>


### PR DESCRIPTION
Remove the page title for the dashboard for the down time monitoring feature flag

#### Proposed Changes

* Remove the custom title `Dashboard - Down Time Monitoring Updates Enabled` for the feature flag for down time monitoring. Revert this to the former pageTitle

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this PR
* Run `yarn start-jetpack-cloud`
* Visit the dashboard at `http://jetpack.cloud.localhost:3000/dashboard`
* Ensure that the page title is no longer `Dashboard - Down Time Monitoring Updates Enabled` and is now `Dashboard`

<img width="954" alt="Screenshot 2023-01-18 at 8 47 55 AM" src="https://user-images.githubusercontent.com/1273880/213219744-9e128e4f-6342-4288-9626-29eb7bc8059e.png">
<img width="1526" alt="Screenshot 2023-01-18 at 8 48 03 AM" src="https://user-images.githubusercontent.com/1273880/213219755-26fca024-c577-4cb9-b37e-72b1ffed22d5.png">


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
