### PR TITLE
Plans Grid 2023: Styling changes for discounted prices

### DIFF
--- a/client/my-sites/plan-features-2023-grid/style.scss
+++ b/client/my-sites/plan-features-2023-grid/style.scss
@@ -351,7 +351,7 @@ $plan-features-sidebar-width: 272px;
 			}
 		}
 
-		.plan-price.is-discounted {
+		.plan-price.is-discounted.is-discounted {
 			color: var(--color-neutral-70);
 			line-height: 50px;
 

--- a/client/my-sites/plan-features-2023-grid/style.scss
+++ b/client/my-sites/plan-features-2023-grid/style.scss
@@ -294,11 +294,6 @@ $plan-features-sidebar-width: 272px;
 		}
 	}
 
-	.plan-features-2023-grid__pricing,
-	.plan-price.is-discounted {
-		color: var(--color-neutral-70);
-	}
-
 	.plan-features-2023-grid__pricing {
 		padding: 0 20px;
 		margin: 0;
@@ -331,12 +326,14 @@ $plan-features-sidebar-width: 272px;
 			color: var(--color-neutral-light);
 
 			&::before {
-				left: 0%;
-				top: 30%;
-				right: 65%;
+				left: -1%;
+				top: 43%;
+				right: 80%;
+				transform: rotate(16deg);
+				border-color: #000;
 
 				@media ( min-width: 880px ) {
-					right: 47%;
+					right: 68%;
 				}
 			}
 
@@ -344,10 +341,23 @@ $plan-features-sidebar-width: 272px;
 			.plan-price__tax-amount {
 				color: var(--color-text-subtle);
 			}
+
+			.plan-price__integer {
+				font-size: $font-title-medium;
+			}
+			.plan-price__currency-symbol {
+				font-size: $font-body-extra-small;
+				top: -4px;
+			}
 		}
 
-		.plan-price.is-discounted .plan-price__integer-fraction {
-			color: var(--color-success);
+		.plan-price.is-discounted {
+			color: var(--color-neutral-70);
+			line-height: 50px;
+
+			.plan-price__integer-fraction {
+				color: var(--color-success);
+			}
 		}
 
 		.plan-price.is-large-currency {

--- a/client/my-sites/plan-features-2023-grid/style.scss
+++ b/client/my-sites/plan-features-2023-grid/style.scss
@@ -351,7 +351,7 @@ $plan-features-sidebar-width: 272px;
 			}
 		}
 
-		.plan-price.is-discounted.is-discounted {
+		.plan-price.is-discounted {
 			color: var(--color-neutral-70);
 			line-height: 50px;
 


### PR DESCRIPTION
#### Proposed Changes

* For discounted prices, reduced the font size of the full price to 24px and increased the line height of the discounted price to 50px. Ref: p1673644344762499/1673465939.126259-slack-C040UAN6TPS

Figma: xkhhUlDowF13dRoXJqlRDM-fi-1%3A95&t=W3uQ0QTq5A4xVzge-0

Known Issues:
- The 0 price shown for the free plan must be aligned with the rest of the discounted prices.
- Tracked @ Automattic/martech#1429

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/onboarding-2023-pricing-grid/plans`
* Switch to a currency with an ongoing discount via the SA.
* Confirm that the page matches the Figma design.
<img width="1920" alt="image" src="https://user-images.githubusercontent.com/5436027/213223320-c4ad0e65-1cd8-467d-9501-c1139fb8512a.png">


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes Automattic/martech#1414