### PR TITLE
Marketplace Thank you: Update footer styling and text

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
@@ -263,7 +263,7 @@ const MarketplaceThankYou = ( { productSlug }: { productSlug: string } ) => {
 			{
 				stepIcon: <Icon icon={ table } size={ 20 } />,
 				stepKey: 'thank_you_footer_support',
-				stepTitle: translate( 'How can we support?' ),
+				stepTitle: translate( 'How can we support you?' ),
 				stepDescription: translate(
 					'Our team is here if you need help, or if you have any questions.'
 				),

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/style.scss
@@ -97,7 +97,7 @@
 		}
 
 		div {
-			max-width: 240px;
+			max-width: 260px;
 
 			@media ( max-width: 740px ) {
 				min-width: auto;

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/style.scss
@@ -52,6 +52,7 @@
 	.thank-you__footer {
 		max-width: 1072px;
 		padding: 40px;
+		padding-top: 5px;
 		display: flex;
 		flex-wrap: wrap;
 		gap: 75px;


### PR DESCRIPTION
#### Proposed Changes

* Update the footer text width to allow the text to fit in 2 lines
* Update the distances between the sections to match
* Update a footer title text

| Before  | After |
| ------------- | ------------- |
|<img width="1509" alt="Screen Shot 2023-01-18 at 12 11 11" src="https://user-images.githubusercontent.com/5039531/213231643-7a7cca69-28ba-4951-968c-96202f9063b5.png">|<img width="1509" alt="Screen Shot 2023-01-18 at 12 12 53" src="https://user-images.githubusercontent.com/5039531/213231785-8ef43107-e8e1-4819-bf1a-c0d7fef74866.png">|

#### Testing Instructions
* Install or purchase a plugin
* Check if the thank you page matches the changes above

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
