### PR TITLE
WooExpress: Update onboarding with Woo fonts and colors

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -360,6 +360,9 @@ button {
 	.flow-progress.progress-bar {
 		display: none;
 	}
+	.processing-step__progress-bar {
+		width: 520px;
+	}
 	.processing-step__progress-bar::before {
 		background: var(--wooexpress-purple);
 	}

--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -12,6 +12,7 @@
  */
 body {
 	--color-body-background: #fdfdfd;
+	--wooexpress-purple: #7f54b3;
 	background-color: var(--color-body-background);
 }
 
@@ -314,17 +315,6 @@ button {
 	}
 }
 
-.wooexpress {
-	.flow-progress.progress-bar {
-		display: none;
-	}
-
-	.signup-header .wordpress-logo {
-		display: block;
-		width: 500px;
-	}
-}
-
 .assign-trial-plan,
 .processing {
 	&.wooexpress,
@@ -359,4 +349,23 @@ button {
 				url(calypso/assets/images/onboarding/ecommerce-intro-3.jpg);
 		}
 	}
+}
+
+.wooexpress {
+	.step-container .step-container__content h1 {
+		font-family: proxima-nova, sans-serif;
+		font-weight: 600;
+		font-size: $font-title-large;
+	}
+	.flow-progress.progress-bar {
+		display: none;
+	}
+	.processing-step__progress-bar::before {
+		background: var(--wooexpress-purple);
+	}
+	.signup-header .wordpress-logo {
+		display: block;
+		width: 500px;
+	}
+
 }

--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -362,6 +362,7 @@ button {
 	}
 	.processing-step__progress-bar {
 		width: 520px;
+		max-width: 100%;
 	}
 	.processing-step__progress-bar::before {
 		background: var(--wooexpress-purple);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/assign-trial-plan/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/assign-trial-plan/styles.scss
@@ -14,9 +14,6 @@
 
 	.step-container__content {
 		width: 100%;
-
-		h1 {
-			@include onboarding-font-recoleta;
-		}
+		margin-top: 16vh;
 	}
 }


### PR DESCRIPTION
#### Proposed Changes

* Update heading font family, size, and weight to match mockups
* Update progress bar color to match mockups
* Update progress bar width to match mockups

**Before**

<img width="1676" alt="Screen Shot 2023-01-18 at 11 26 43 AM" src="https://user-images.githubusercontent.com/2124984/213235671-0bd7ad87-0faf-4b3c-8873-e769e23372fe.png">

**After**

https://user-images.githubusercontent.com/2124984/213235727-4a28d0bb-9ab9-40fb-89f2-f2ca8684bba5.mov


#### Testing Instructions

* Switch to this PR, navigate to `/setup/wooexpress`
* Note visual changes to fonts and colors!
* Make sure nothing looks broken as the flow progresses

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- NA [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- NA Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- NA Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- NA For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #72166
