### PR TITLE
Marketplace Thank You: Add a delay to the Confetti animation

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
@@ -312,7 +312,7 @@ const MarketplaceThankYou = ( { productSlug }: { productSlug: string } ) => {
 			) }
 			{ ! showProgressBar && (
 				<div className="marketplace-thank-you__container">
-					<ConfettiAnimation />
+					<ConfettiAnimation delay={ 1000 } />
 					<ThankYou
 						containerClassName="marketplace-thank-you"
 						sections={ [ pluginsSection, footerSection ] }

--- a/packages/components/src/confetti/index.ts
+++ b/packages/components/src/confetti/index.ts
@@ -56,12 +56,12 @@ function fireConfetti() {
 	} );
 }
 
-const ConfettiAnimation = ( { trigger = true } ) => {
+const ConfettiAnimation = ( { trigger = true, delay = 0 } ) => {
 	useEffect( () => {
 		if ( trigger ) {
-			fireConfetti();
+			setTimeout( () => fireConfetti(), delay );
 		}
-	}, [ trigger ] );
+	}, [ trigger, delay ] );
 
 	return null;
 };


### PR DESCRIPTION
#### Proposed Changes

* Add a delay property to confetti animation
* Use this property to add a delay on the Marketplace Thank You page animation

![Kapture 2023-01-18 at 13 10 35](https://user-images.githubusercontent.com/5039531/213252507-e87b577a-34e9-45f7-b29c-c19f5c2f94b6.gif)

#### Testing Instructions

* Purchase or install a plugin
* On the Thank you page check if the confetti animation is delayed `1s` after the final content is shown.
#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
