### PR TITLE
HappyChat: Fix user geoLocation detail

### DIFF
--- a/apps/happychat/src/happychat.jsx
+++ b/apps/happychat/src/happychat.jsx
@@ -168,7 +168,7 @@ export default function Happychat( { auth } ) {
 				connectionStatus={ connectionStatus }
 				timeline={ timeline }
 				chatStatus={ chatStatus }
-				geoLocation={ auth.user.geoLocation }
+				geoLocation={ auth.user.geo_location }
 			/>
 			<Timeline
 				currentUserEmail={ currentUser.email }


### PR DESCRIPTION
## Proposed Changes

User's geoLocation was not being loaded correctly and consequently not being displayed for HE's.

More context p1673641943142919-slack-C0NTKV9RP

## Testing Instructions

1. Pull this branch
2. run `yarn start` on calypso root folder
3. `cd apps/happychat/ && yarn dev --sync`
4. Open HUD https://hud-staging.happychat.io/ and make yourself available
5. Open Happy Chat from wordpress.com
6. Send messages 
7. On HuD expande the 'Details' link button and you should see "Location" and the city/country:

<img width="731" alt="image" src="https://user-images.githubusercontent.com/2653810/213253655-aa1b095e-b35f-46a5-b70e-c5185766ec53.png">

Clicking on transcript should open the Happiness Dashboard with the same information
<img width="557" alt="image" src="https://user-images.githubusercontent.com/2653810/213253767-7ded5252-e472-4c45-9ae8-6ba2007ae52e.png">

<img width="1514" alt="image" src="https://user-images.githubusercontent.com/2653810/213253918-87bf2c9f-b47f-4d17-9e04-e58a61141edc.png">


