### PR TITLE
Blaze: /stats mini-carousel show blocks accordingly

### DIFF
--- a/client/my-sites/stats/mini-carousel/index.jsx
+++ b/client/my-sites/stats/mini-carousel/index.jsx
@@ -25,32 +25,45 @@ const MiniCarousel = ( { slug, isOdysseyStats } ) => {
 	// Yoast promo is disabled for Odyssey & self-hosted & non-traffic pages.
 	const showYoastPromo = ! isOdysseyStats && ! jetpackNonAtomic;
 
+	const blocks = [];
+
+	if ( showBlazePromo ) {
+		blocks.push(
+			<MiniCarouselBlock
+				clickEvent="calypso_stats_traffic_blaze_banner_click"
+				image={ <BlazeLogo className="mini-carousel-blaze" size={ 45 } /> }
+				headerText={ translate( 'Promote your content with Blaze' ) }
+				contentText={ translate(
+					'Grow your audience by promoting your content. Reach millions of users across Tumblr and WordPress.com'
+				) }
+				ctaText={ translate( 'Create campaign' ) }
+				href={ `/advertising/${ slug || '' }` }
+			/>
+		);
+	}
+
+	if ( showYoastPromo ) {
+		blocks.push(
+			<MiniCarouselBlock
+				clickEvent="calypso_stats_wordpress_seo_premium_banner_click"
+				image={ <img src={ YoastLogo } alt="" width={ 45 } height={ 45 } /> }
+				headerText={ translate( 'Increase your site visitors with Yoast SEO Premium' ) }
+				contentText={ translate(
+					'Purchase Yoast SEO Premium to ensure that more people find your incredible content.'
+				) }
+				ctaText={ translate( 'Get Yoast' ) }
+				href={ `/plugins/wordpress-seo-premium/${ slug || '' }` }
+			/>
+		);
+	}
+
+	if ( blocks.length === 0 ) {
+		return null;
+	}
+
 	return (
 		<DotPager className="mini-carousel" hasDynamicHeight>
-			{ showBlazePromo && (
-				<MiniCarouselBlock
-					clickEvent="calypso_stats_traffic_blaze_banner_click"
-					image={ <BlazeLogo className="mini-carousel-blaze" size={ 45 } /> }
-					headerText={ translate( 'Promote your content with Blaze' ) }
-					contentText={ translate(
-						'Grow your audience by promoting your content. Reach millions of users across Tumblr and WordPress.com'
-					) }
-					ctaText={ translate( 'Create campaign' ) }
-					href={ `/advertising/${ slug || '' }` }
-				/>
-			) }
-			{ showYoastPromo && (
-				<MiniCarouselBlock
-					clickEvent="calypso_stats_wordpress_seo_premium_banner_click"
-					image={ <img src={ YoastLogo } alt="" width={ 45 } height={ 45 } /> }
-					headerText={ translate( 'Increase your site visitors with Yoast SEO Premium' ) }
-					contentText={ translate(
-						'Purchase Yoast SEO Premium to ensure that more people find your incredible content.'
-					) }
-					ctaText={ translate( 'Get Yoast' ) }
-					href={ `/plugins/wordpress-seo-premium/${ slug || '' }` }
-				/>
-			) }
+			{ blocks }
 		</DotPager>
 	);
 };

--- a/client/my-sites/stats/mini-carousel/index.jsx
+++ b/client/my-sites/stats/mini-carousel/index.jsx
@@ -20,6 +20,7 @@ const MiniCarousel = ( { slug, isOdysseyStats } ) => {
 
 	const shouldShowAdvertisingOption = usePromoteWidget() === PromoteWidgetStatus.ENABLED;
 
+	// Blaze promo is disabled for Odyssey.
 	const showBlazePromo = ! isOdysseyStats && shouldShowAdvertisingOption;
 	// Yoast promo is disabled for Odyssey & self-hosted & non-traffic pages.
 	const showYoastPromo = ! isOdysseyStats && ! jetpackNonAtomic;

--- a/client/my-sites/stats/mini-carousel/index.jsx
+++ b/client/my-sites/stats/mini-carousel/index.jsx
@@ -1,34 +1,55 @@
 import { translate } from 'i18n-calypso';
+import { useSelector } from 'react-redux';
 import YoastLogo from 'calypso/assets/images/icons/yoast-logo.svg';
 import BlazeLogo from 'calypso/components/blaze-logo';
 import DotPager from 'calypso/components/dot-pager';
+import { PromoteWidgetStatus, usePromoteWidget } from 'calypso/lib/promote-post';
+import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
+import { isJetpackSite } from 'calypso/state/sites/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import MiniCarouselBlock from './mini-carousel-block';
 
 import './style.scss';
 
-const MiniCarousel = ( { slug } ) => {
+const MiniCarousel = ( { slug, isOdysseyStats } ) => {
+	const selectedSiteId = useSelector( ( state ) => getSelectedSiteId( state ) );
+
+	const jetpackNonAtomic = useSelector(
+		( state ) => isJetpackSite( state, selectedSiteId ) && ! isAtomicSite( state, selectedSiteId )
+	);
+
+	const shouldShowAdvertisingOption = usePromoteWidget() === PromoteWidgetStatus.ENABLED;
+
+	const showBlazePromo = ! isOdysseyStats && shouldShowAdvertisingOption;
+	// Yoast promo is disabled for Odyssey & self-hosted & non-traffic pages.
+	const showYoastPromo = ! isOdysseyStats && ! jetpackNonAtomic;
+
 	return (
 		<DotPager className="mini-carousel" hasDynamicHeight>
-			<MiniCarouselBlock
-				clickEvent="calypso_stats_traffic_blaze_banner_click"
-				image={ <BlazeLogo className="mini-carousel-blaze" size={ 45 } /> }
-				headerText={ translate( 'Promote your content with Blaze' ) }
-				contentText={ translate(
-					'Grow your audience by promoting your content. Reach millions of users across Tumblr and WordPress.com'
-				) }
-				ctaText={ translate( 'Create campaign' ) }
-				href={ `/advertising/${ slug || '' }` }
-			/>
-			<MiniCarouselBlock
-				clickEvent="calypso_stats_wordpress_seo_premium_banner_click"
-				image={ <img src={ YoastLogo } alt="" width={ 45 } height={ 45 } /> }
-				headerText={ translate( 'Increase your site visitors with Yoast SEO Premium' ) }
-				contentText={ translate(
-					'Purchase Yoast SEO Premium to ensure that more people find your incredible content.'
-				) }
-				ctaText={ translate( 'Get Yoast' ) }
-				href={ `/plugins/wordpress-seo-premium/${ slug || '' }` }
-			/>
+			{ showBlazePromo && (
+				<MiniCarouselBlock
+					clickEvent="calypso_stats_traffic_blaze_banner_click"
+					image={ <BlazeLogo className="mini-carousel-blaze" size={ 45 } /> }
+					headerText={ translate( 'Promote your content with Blaze' ) }
+					contentText={ translate(
+						'Grow your audience by promoting your content. Reach millions of users across Tumblr and WordPress.com'
+					) }
+					ctaText={ translate( 'Create campaign' ) }
+					href={ `/advertising/${ slug || '' }` }
+				/>
+			) }
+			{ showYoastPromo && (
+				<MiniCarouselBlock
+					clickEvent="calypso_stats_wordpress_seo_premium_banner_click"
+					image={ <img src={ YoastLogo } alt="" width={ 45 } height={ 45 } /> }
+					headerText={ translate( 'Increase your site visitors with Yoast SEO Premium' ) }
+					contentText={ translate(
+						'Purchase Yoast SEO Premium to ensure that more people find your incredible content.'
+					) }
+					ctaText={ translate( 'Get Yoast' ) }
+					href={ `/plugins/wordpress-seo-premium/${ slug || '' }` }
+				/>
+			) }
 		</DotPager>
 	);
 };

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -278,7 +278,9 @@ class StatsSite extends Component {
 						{ ! isSitePrivate && <StatsNoContentBanner siteId={ siteId } siteSlug={ slug } /> }
 					</>
 
-					{ config.isEnabled( 'stats-mini-carousel' ) && <MiniCarousel slug={ slug } /> }
+					{ config.isEnabled( 'stats-mini-carousel' ) && (
+						<MiniCarousel isOdysseyStats={ isOdysseyStats } slug={ slug } />
+					) }
 
 					<div className="stats__module-list stats__module-list--traffic is-events stats__module--unified">
 						{ config.isEnabled( 'newsletter/stats' ) && (


### PR DESCRIPTION
#### Proposed Changes

Show Yoast & Blaze on /stats mini-carousel using the same criteria [as before](https://github.com/Automattic/wp-calypso/blob/trunk/client/my-sites/stats/promo-cards/index.jsx#L35-L38)

#### Testing Instructions

Go to /stats using the flag `?flags=stats-mini-carousel`, and check the mini-carousel on the following criteria:
- Using a Jetpack non-Atomic should not show Yoast.
- Using a Simple or Atomic site should show Blaze & Yoast.
- Should match what the banner on the bottom shows (if [this issue](https://github.com/Automattic/dotcom-forge/issues/1488) is not closed)

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] ~~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~~
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~~
- [ ] ~~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~~
- [ ] ~~For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~~

Fixes https://github.com/Automattic/dotcom-forge/issues/1489
