### PR TITLE
Fix first month discount display comparison page

### DIFF
--- a/client/components/jetpack/card/jetpack-product-card/display-price/paid.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/display-price/paid.tsx
@@ -112,7 +112,7 @@ const Paid: React.FC< OwnProps > = ( props ) => {
 				finalPrice={ finalPrice }
 				isDiscounted={ isDiscounted }
 			/>
-			<span aria-hidden="true">
+			<span className="display-price__prices" aria-hidden="true">
 				{ displayFrom && <span className="display-price__from">from</span> }
 				{ isDiscounted ? (
 					<DiscountedPrice { ...props } finalPrice={ finalPrice } />
@@ -125,7 +125,7 @@ const Paid: React.FC< OwnProps > = ( props ) => {
 					{ tooltipText }
 				</InfoPopover>
 			) }
-			<span aria-hidden="true">
+			<span className="display-price__details" aria-hidden="true">
 				<TimeFrame
 					billingTerm={ billingTerm }
 					discountedPriceDuration={ discountedPriceDuration }

--- a/client/components/jetpack/card/jetpack-product-card/display-price/style.scss
+++ b/client/components/jetpack/card/jetpack-product-card/display-price/style.scss
@@ -128,6 +128,11 @@
 		background-color: rgba(var(--studio-jetpack-green-10-rgb), 0.2);
 	}
 
+	&__prices {
+		display: flex;
+		flex-wrap: nowrap;
+	}
+
 	&__from {
 		margin-right: 12px;
 		color: var(--studio-gray-40);

--- a/client/jetpack-cloud/sections/comparison/table/index.tsx
+++ b/client/jetpack-cloud/sections/comparison/table/index.tsx
@@ -57,13 +57,18 @@ export const Table: React.FC = () => {
 								target={ ! isFree && getIsExternal( item ) ? '_blank' : undefined }
 								href={ ! isFree ? getCheckoutURL( item ) : links.connect_free }
 							>
-								{ isFree ? translate( 'Get started' ) : getCtaLabel( item, '' ) }
+								<span className="pricing-comparison__product-header--cta-desktop">
+									{ isFree ? translate( 'Get started' ) : getCtaLabel( item, '' ) }
+								</span>
+								<span className="pricing-comparison__product-header--cta-mobile">
+									{ isFree ? translate( 'Get started for free' ) : getCtaLabel( item, '' ) }
+								</span>
 							</Button>
 
 							{ ! isFree && <ItemPrice item={ item } siteId={ null } /> }
 
 							{ isFree ? (
-								<span className="more-info-link">{ translate( 'Get started for free' ) }</span>
+								<span className="more-info-link">{ translate( 'Basic Jetpack features' ) }</span>
 							) : (
 								<MoreInfoLink onClick={ onClickMoreInfoFactory( item ) } item={ item } />
 							) }

--- a/client/jetpack-cloud/sections/comparison/table/style.scss
+++ b/client/jetpack-cloud/sections/comparison/table/style.scss
@@ -31,13 +31,13 @@
 				.display-price__billing-time-frame {
 					line-height: 0.5;
 				}
-			}
 
-			.display-price__prices {
-				.plan-price__currency-symbol,
-				.plan-price__integer,
-				.plan-price__fraction {
-					font-size: 1.5rem;
+				.display-price__prices {
+					.plan-price__currency-symbol,
+					.plan-price__integer,
+					.plan-price__fraction {
+						font-size: 1.5rem;
+					}
 				}
 			}
 		}
@@ -69,6 +69,19 @@
 			font-size: 1rem;
 			white-space: nowrap;
 			margin-bottom: -0.5rem;
+		}
+
+		&--cta-mobile {
+			display: none;
+		}
+
+		@media (max-width: $break-medium) {
+			&--cta-mobile {
+				display: initial;
+			}
+			&--cta-desktop {
+				display: none;
+			}
 		}
 	}
 

--- a/client/jetpack-cloud/sections/comparison/table/style.scss
+++ b/client/jetpack-cloud/sections/comparison/table/style.scss
@@ -18,6 +18,36 @@
 		gap: 1rem;
 		align-items: center;
 
+		.item-price {
+			margin: 0.5rem 0;
+
+			.display-price:not(.is-placeholder) {
+				display: flex;
+				flex-direction: column;
+				align-items: center;
+				max-height: 2rem;
+
+				.display-price__details,
+				.display-price__billing-time-frame {
+					line-height: 0.5;
+				}
+			}
+
+			.display-price__prices {
+				.plan-price__currency-symbol,
+				.plan-price__integer,
+				.plan-price__fraction {
+					font-size: 1.5rem;
+				}
+			}
+		}
+
+		@media (max-width: $break-medium) {
+			.item-price > .display-price:not(.is-placeholder) {
+				align-items: flex-start;
+			}
+		}
+
 		@media (max-width: $break-large) {
 			align-items: normal;
 		}
@@ -75,6 +105,7 @@
 			font-weight: normal;
 			padding: 0.5em;
 			text-align: center;
+			white-space: nowrap;
 
 			&:nth-of-type(1) {
 				border-bottom: none;


### PR DESCRIPTION
#### Proposed Changes

The pricing on the comparison page looks bad when discounts are active

![image](https://user-images.githubusercontent.com/65001528/213273643-fe1d9236-0e8d-4451-b3ae-fa057162bb0b.png)

This diff fixes that issue. @ballio2000 was consulted in the design of this

Note: This also updates copy as it relates to Jetpack Free on the mobile view of the comparison table. It was very unclear on what the CTA was on mobile

![image](https://user-images.githubusercontent.com/65001528/213273833-929f9d16-9ad8-4d97-8352-b5fbabaa3354.png)

#### Testing Instructions

Figma comp: Jm2fjSeTtY0VGnCn4Wz0fQ-fi-3521%3A3645&t=zPa9bAVAuIDlO6FS-0

1. Check out these changes via `git switch fix/first-month-discount-display-comparison-page`
2. Start your local environment via `yarn start-jetpack-cloud`
3. Go to http://calypso.localhost:3000/features/comparison
4. Confirm the pricing matches the figma comp
![image](https://user-images.githubusercontent.com/65001528/213274211-c1770119-2488-4cbd-9677-f089dbe89b70.png)
![image](https://user-images.githubusercontent.com/65001528/213274262-11f80e39-46a5-493a-b028-ac435b7ba705.png)
5. Confirm that the wording update for Jetpack Free on mobile makes sense
![image](https://user-images.githubusercontent.com/65001528/213274341-52440972-083c-4237-a4da-ef6277032273.png)
6. Make sure the styling of the prices are not affected anywhere else, namely http://calypso.localhost:3000/pricing

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?