### PR TITLE
WooExpress Trial: Extract loading bar into a separate component

### DIFF
--- a/client/components/loading-bar/index.tsx
+++ b/client/components/loading-bar/index.tsx
@@ -15,7 +15,7 @@ export function LoadingBar( { className, progress }: LoadingBar ) {
 		if ( progress >= 0 ) {
 			timeoutReference = setTimeout( () => {
 				if ( progress > simulatedProgress || progress === 1 ) {
-					setSimulatedProgress( () => progress );
+					setSimulatedProgress( progress );
 				} else if ( simulatedProgress < 1 ) {
 					setSimulatedProgress( ( previousProgress: number ) => {
 						let newProgress = previousProgress + Math.random() * 0.04;

--- a/client/components/loading-bar/index.tsx
+++ b/client/components/loading-bar/index.tsx
@@ -1,0 +1,47 @@
+import { useEffect, useState } from 'react';
+import './style.scss';
+
+type LoadingBar = {
+	className?: string;
+	progress: number;
+};
+
+export function LoadingBar( { className, progress }: LoadingBar ) {
+	// Progress smoothing, works out to be around 40seconds unless step polling dictates otherwise
+	const [ simulatedProgress, setSimulatedProgress ] = useState( progress );
+
+	useEffect( () => {
+		let timeoutReference: NodeJS.Timeout;
+		if ( progress >= 0 ) {
+			timeoutReference = setTimeout( () => {
+				if ( progress > simulatedProgress || progress === 1 ) {
+					setSimulatedProgress( () => progress );
+				} else if ( simulatedProgress < 1 ) {
+					setSimulatedProgress( ( previousProgress: number ) => {
+						let newProgress = previousProgress + Math.random() * 0.04;
+						// Stall at 95%, allow complete to finish up
+						if ( newProgress >= 0.95 ) {
+							newProgress = 0.95;
+						}
+						return newProgress;
+					} );
+				}
+			}, 1000 );
+		}
+
+		return () => clearTimeout( timeoutReference );
+	}, [ simulatedProgress, progress ] );
+
+	return (
+		<div className={ className }>
+			<div
+				className="loading-bar"
+				style={
+					{
+						'--progress': simulatedProgress > 1 ? 1 : simulatedProgress,
+					} as React.CSSProperties
+				}
+			/>
+		</div>
+	);
+}

--- a/client/components/loading-bar/style.scss
+++ b/client/components/loading-bar/style.scss
@@ -1,0 +1,23 @@
+$progress-duration: 800ms;
+
+.loading-bar {
+	position: relative;
+	overflow: hidden;
+	height: 6px;
+	margin-top: 1em;
+	background: var(--studio-gray-10);
+
+	--progress: 0;
+
+	&::before {
+		background: var(--studio-blue-50);
+		transform: translateX(calc(-100% * min(1 - var(--progress, 0), 1)));
+		position: absolute;
+		content: "";
+		top: 0;
+		left: 0;
+		right: 0;
+		bottom: 0;
+		transition: transform $progress-duration ease-out;
+	}
+}

--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -360,11 +360,13 @@ button {
 	.flow-progress.progress-bar {
 		display: none;
 	}
-	.processing-step__progress-bar {
+	.loading-bar {
 		width: 520px;
 		max-width: 100%;
+		margin-left: auto;
+		margin-right: auto;
 	}
-	.processing-step__progress-bar::before {
+	.loading-bar::before {
 		background: var(--wooexpress-purple);
 	}
 	.signup-header .wordpress-logo {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/assign-trial-plan/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/assign-trial-plan/index.tsx
@@ -21,12 +21,12 @@ const AssignTrialPlanStep: Step = function AssignTrialPlanStep( { navigation, da
 	const { submit } = navigation;
 	const { __ } = useI18n();
 	const progress = useSelect( ( select ) => select( ONBOARD_STORE ).getProgress() );
-	const { setProgress } = useDispatch( ONBOARD_STORE );
 	const stepProgress = useSelect( ( select ) => select( ONBOARD_STORE ).getStepProgress() );
+	const { setProgress } = useDispatch( ONBOARD_STORE );
 
 	useEffect( () => {
+		setProgress( 0.4 );
 		if ( submit ) {
-			setProgress( 0.4 );
 			const assignTrialPlan = async () => {
 				try {
 					if ( ! data?.siteSlug ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/assign-trial-plan/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/assign-trial-plan/index.tsx
@@ -1,8 +1,9 @@
-import { StepContainer } from '@automattic/onboarding';
-import { useSelect } from '@wordpress/data';
+import { isWooExpressFlow, StepContainer } from '@automattic/onboarding';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
 import { useEffect } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
+import { LoadingBar } from 'calypso/components/loading-bar';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -16,13 +17,16 @@ export enum AssignTrialResult {
 	FAILURE = 'failure',
 }
 
-const AssignTrialPlanStep: Step = function AssignTrialPlanStep( { navigation, data } ) {
+const AssignTrialPlanStep: Step = function AssignTrialPlanStep( { navigation, data, flow } ) {
 	const { submit } = navigation;
 	const { __ } = useI18n();
+	const progress = useSelect( ( select ) => select( ONBOARD_STORE ).getProgress() );
+	const { setProgress } = useDispatch( ONBOARD_STORE );
 	const stepProgress = useSelect( ( select ) => select( ONBOARD_STORE ).getStepProgress() );
 
 	useEffect( () => {
 		if ( submit ) {
+			setProgress( 0.4 );
 			const assignTrialPlan = async () => {
 				try {
 					if ( ! data?.siteSlug ) {
@@ -62,8 +66,14 @@ const AssignTrialPlanStep: Step = function AssignTrialPlanStep( { navigation, da
 				recordTracksEvent={ recordTracksEvent }
 				stepContent={
 					<>
-						<h1>{ getCurrentMessage() }</h1>
-						<LoadingEllipsis />
+						<div className="assign-trial-step">
+							<h1 className="assign-trial-step__progress-step">{ getCurrentMessage() }</h1>
+							{ progress >= 0 || isWooExpressFlow( flow ) ? (
+								<LoadingBar progress={ progress } />
+							) : (
+								<LoadingEllipsis />
+							) }
+						</div>
 					</>
 				}
 				stepProgress={ stepProgress }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
@@ -4,11 +4,13 @@ import {
 	isLinkInBioFlow,
 	isFreeFlow,
 	ECOMMERCE_FLOW,
+	isWooExpressFlow,
 } from '@automattic/onboarding';
 import { useSelect } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
 import { useEffect, useState } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
+import { LoadingBar } from 'calypso/components/loading-bar';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -94,31 +96,6 @@ const ProcessingStep: React.FC< ProcessingStepProps > = function ( props ) {
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ hasActionSuccessfullyRun ] );
 
-	// Progress smoothing, works out to be around 40seconds unless step polling dictates otherwise
-	const [ simulatedProgress, setSimulatedProgress ] = useState( 0 );
-
-	useEffect( () => {
-		let timeoutReference: NodeJS.Timeout;
-		if ( progress >= 0 ) {
-			timeoutReference = setTimeout( () => {
-				if ( progress > simulatedProgress || progress === 1 ) {
-					setSimulatedProgress( progress );
-				} else if ( simulatedProgress < 1 ) {
-					setSimulatedProgress( ( previousProgress ) => {
-						let newProgress = previousProgress + Math.random() * 0.04;
-						// Stall at 95%, allow complete to finish up
-						if ( newProgress >= 0.95 ) {
-							newProgress = 0.95;
-						}
-						return newProgress;
-					} );
-				}
-			}, 1000 );
-		}
-
-		return () => clearTimeout( timeoutReference );
-	}, [ simulatedProgress, progress, __ ] );
-
 	const flowName = props.flow || '';
 	const isJetpackPowered = isNewsletterOrLinkInBioFlow( flowName );
 	const isWooCommercePowered = flowName === ECOMMERCE_FLOW;
@@ -140,17 +117,11 @@ const ProcessingStep: React.FC< ProcessingStepProps > = function ( props ) {
 					<>
 						<div className="processing-step">
 							<h1 className="processing-step__progress-step">{ getCurrentMessage() }</h1>
-							{ progress >= 0 ? (
-								<div className="processing-step__content woocommerce-install__content">
-									<div
-										className="processing-step__progress-bar"
-										style={
-											{
-												'--progress': simulatedProgress > 1 ? 1 : simulatedProgress,
-											} as React.CSSProperties
-										}
-									/>
-								</div>
+							{ progress >= 0 || isWooExpressFlow( flow ) ? (
+								<LoadingBar
+									progress={ progress }
+									className="processing-step__content woocommerce-install__content"
+								/>
 							) : (
 								<LoadingEllipsis />
 							) }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
@@ -112,7 +112,6 @@ const ProcessingStep: React.FC< ProcessingStepProps > = function ( props ) {
 				shouldHideNavButtons={ true }
 				hideFormattedHeader={ true }
 				stepName="processing-step"
-				isHorizontalLayout={ true }
 				stepContent={
 					<>
 						<div className="processing-step">

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/style.scss
@@ -2,8 +2,6 @@
 @import "calypso/assets/stylesheets/shared/_loading";
 @import "@automattic/onboarding/styles/mixins";
 
-$progress-duration: 800ms;
-
 .processing-step {
 	padding: 1em;
 	max-width: 540px;
@@ -30,29 +28,6 @@ $progress-duration: 800ms;
 	}
 }
 
-.processing-step__progress-bar {
-	position: relative;
-	overflow: hidden;
-	height: 6px;
-	margin-top: 1em;
-	background: var(--studio-gray-10);
-
-	--progress: 0;
-
-	&::before {
-		background: var(--studio-blue-50);
-		transform: translateX(calc(-100% * min(1 - var(--progress, 0), 1)));
-		position: absolute;
-		content: "";
-		top: 0;
-		left: 0;
-		right: 0;
-		bottom: 0;
-		transition: transform $progress-duration ease-out;
-	}
-}
-
-.import-focused .step-container__content,
 .site-setup.processing .step-container__content,
 .anchor-fm.processing .step-container__content {
 	width: 100%;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/style.scss
@@ -28,6 +28,7 @@
 	}
 }
 
+.import-focused .step-container__content,
 .site-setup.processing .step-container__content,
 .anchor-fm.processing .step-container__content {
 	width: 100%;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/tailored-flow-precheckout-screen/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/tailored-flow-precheckout-screen/index.tsx
@@ -3,6 +3,7 @@ import { useI18n } from '@wordpress/react-i18n';
 import PropTypes from 'prop-types';
 import { useRef, useState, useEffect } from 'react';
 import JetpackLogo from 'calypso/components/jetpack-logo';
+import { LoadingBar } from 'calypso/components/loading-bar';
 import { useInterval } from 'calypso/lib/interval/use-interval';
 import './style.scss';
 
@@ -80,13 +81,9 @@ export default function TailoredFlowPreCheckoutScreen( { flowName }: { flowName:
 		<div className="processing-step__container">
 			<div className="processing-step">
 				<h1 className="processing-step__progress-step">{ steps.current[ currentStep ]?.title }</h1>
-				<div
+				<LoadingBar
 					className="processing-step__progress-bar"
-					style={
-						{
-							'--progress': ! hasStarted ? /* initial 10% progress */ 0.1 : progress,
-						} as React.CSSProperties
-					}
+					progress={ ! hasStarted ? /* initial 10% progress */ 0.1 : progress }
 				/>
 			</div>
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
@@ -16,6 +16,7 @@ import { useI18n } from '@wordpress/react-i18n';
 import { useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
+import { LoadingBar } from 'calypso/components/loading-bar';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -63,6 +64,7 @@ const SiteCreationStep: Step = function SiteCreationStep( { navigation, flow } )
 	}
 	const isPaidDomainItem = Boolean( domainCartItem?.product_slug );
 
+	const progress = useSelect( ( select ) => select( ONBOARD_STORE ).getProgress() );
 	const { setProgress } = useDispatch( ONBOARD_STORE );
 
 	// Default visibility is public
@@ -158,7 +160,11 @@ const SiteCreationStep: Step = function SiteCreationStep( { navigation, flow } )
 				stepContent={
 					<>
 						<h1>{ getCurrentMessage() }</h1>
-						<LoadingEllipsis />
+						{ progress >= 0 || isWooExpressFlow( flow ) ? (
+							<LoadingBar progress={ progress } />
+						) : (
+							<LoadingEllipsis />
+						) }
 					</>
 				}
 				stepProgress={ stepProgress }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
@@ -63,6 +63,8 @@ const SiteCreationStep: Step = function SiteCreationStep( { navigation, flow } )
 	}
 	const isPaidDomainItem = Boolean( domainCartItem?.product_slug );
 
+	const { setProgress } = useDispatch( ONBOARD_STORE );
+
 	// Default visibility is public
 	let siteVisibility = Site.Visibility.PublicIndexed;
 
@@ -123,6 +125,10 @@ const SiteCreationStep: Step = function SiteCreationStep( { navigation, flow } )
 	}
 
 	useEffect( () => {
+		if ( isWooExpressFlow( flow ) ) {
+			setProgress( 0.2 );
+		}
+
 		if ( isMigrationFlow( flow ) ) {
 			setIsMigrateFromWp( true );
 		}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/wait-for-atomic/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/wait-for-atomic/index.tsx
@@ -79,7 +79,7 @@ const WaitForAtomic: Step = function WaitForAtomic( { navigation, data } ) {
 		}
 
 		setPendingAction( async () => {
-			setProgress( 0 );
+			setProgress( 0.4 );
 
 			const startTime = new Date().getTime();
 			const totalTimeout = 1000 * 300;
@@ -98,16 +98,16 @@ const WaitForAtomic: Step = function WaitForAtomic( { navigation, data } ) {
 
 				switch ( transferStatus ) {
 					case transferStates.PENDING:
-						setProgress( 0.2 );
-						break;
-					case transferStates.ACTIVE:
-						setProgress( 0.4 );
-						break;
-					case transferStates.PROVISIONED:
 						setProgress( 0.5 );
 						break;
-					case transferStates.COMPLETED:
+					case transferStates.ACTIVE:
+						setProgress( 0.6 );
+						break;
+					case transferStates.PROVISIONED:
 						setProgress( 0.7 );
+						break;
+					case transferStates.COMPLETED:
+						setProgress( 0.8 );
 						break;
 				}
 


### PR DESCRIPTION
#### Proposed Changes

* Extract loading bar from processing step into its own component so we can use it on multiple steps
* For consistency throughout the flow, always show the LoadingBar for WooExpress steps
* Adjust flow `progress` state to account for the whole flow
* The progress bar doesn't currently alter the actual progress state so it doesn't save between step changes. I'd suggest we tackle this in a separate PR since this one is already pretty hefty.

**Demo**

https://user-images.githubusercontent.com/2124984/213499828-9228704b-efa5-4ca5-8177-3157690dd133.mov

#### Testing Instructions

* Switch to this PR, navigate to `/setup/wooexpress`
* The same purple progress bar should be seen under the main title throughout the flow
* Other `setup` flows should stay the same as production; the two I'm aware of are `/start` and `/setup/link-in-bio`, but there may be more

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- NA Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- NA Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- NA For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #72169
