### PR TITLE
Add domain upsell copy for translation

### DIFF
--- a/client/my-sites/customer-home/translations/domain-upsell.js
+++ b/client/my-sites/customer-home/translations/domain-upsell.js
@@ -19,13 +19,13 @@ translate(
 	}
 );
 translate( 'You need a plan to have a primary custom domain' );
+translate( 'Any domain you purchase without a plan will get redirected to %(domainName)s.', {
+	args: {
+		domainName: 'example.blog',
+	},
+} );
 translate(
-	'Any domain you purchase without a plan will get redirected to %(domainName)s. If you upgrade to a plan, you can use your custom domain name instead of having WordPress.com in your URL.',
-	{
-		args: {
-			domainName: 'example.blog',
-		},
-	}
+	'If you upgrade to a plan, you can use your custom domain name instead of having WordPress.com in your URL.'
 );
 translate( 'I want my domain as primary' );
 translate( 'That works for me' );

--- a/client/my-sites/customer-home/translations/domain-upsell.js
+++ b/client/my-sites/customer-home/translations/domain-upsell.js
@@ -1,0 +1,31 @@
+import { translate } from 'i18n-calypso';
+
+translate( 'Own your online identity with a custom domain' );
+translate(
+	"Find the perfect domain name and stake your claim on your corner of the web with a site address that's easy to find, share, and follow."
+);
+translate( 'Search a domain' );
+translate( 'Get your custom domain' );
+translate( 'Free for the first year!' );
+translate(
+	'With an annual plan, you can get {{strong}}%(domainName)s{{/strong}} for free for the first year, Jetpack essential features, live chat support, and all the features that will take your site to the next level.',
+	{
+		args: {
+			domainName: 'example.blog',
+		},
+		components: {
+			strong: <strong />,
+		},
+	}
+);
+translate( 'You need a plan to have a primary custom domain' );
+translate(
+	'Any domain you purchase without a plan will get redirected to %(domainName)s. If you upgrade to a plan, you can use your custom domain name instead of having WordPress.com in your URL.',
+	{
+		args: {
+			domainName: 'example.blog',
+		},
+	}
+);
+translate( 'I want my domain as primary' );
+translate( 'That works for me' );

--- a/client/my-sites/customer-home/translations/domain-upsell.js
+++ b/client/my-sites/customer-home/translations/domain-upsell.js
@@ -8,7 +8,7 @@ translate( 'Search a domain' );
 translate( 'Get your custom domain' );
 translate( 'Free for the first year!' );
 translate(
-	'With an annual plan, you can get {{strong}}%(domainName)s{{/strong}} for free for the first year, Jetpack essential features, live chat support, and all the features that will take your site to the next level.',
+	'With an annual plan, you can get {{strong}}%(domainName)s for free{{/strong}} for the first year, Jetpack essential features, live chat support, and all the features that will take your site to the next level.',
 	{
 		args: {
 			domainName: 'example.blog',


### PR DESCRIPTION
#### Proposed Changes

This PR adds preemptive translations for strings found in our design docs. When the project is in production and fully translated to the mag-16, this file and its containing folder can be removed.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

This code is never executed.

Please proof read the copy and make sure it matches what is in the Figma, linked in the comment here: pebzTe-xR-p2#comment-969

Is anything missing? Do the `translation` functions look ok?


#### Prints to help on translation

<img width="773" alt="image" src="https://user-images.githubusercontent.com/1044309/213451068-6adf376a-d164-4ca9-a733-0cd27fa7894c.png">

<img width="660" alt="image" src="https://user-images.githubusercontent.com/1044309/213451157-63028777-a4da-4980-a233-c83c2934bf85.png">

<img width="719" alt="image" src="https://user-images.githubusercontent.com/1044309/213451635-b1fb2875-36ec-4a99-b21f-9fe3ff9a33f5.png">





#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/71498