### PR TITLE
Added eCommerce trial plan to plans list

### DIFF
--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -2603,7 +2603,7 @@ PLANS_LIST[ PLAN_WPCOM_PRO_MONTHLY ] = {
 
 PLANS_LIST[ PLAN_ECOMMERCE_TRIAL_MONTHLY ] = {
 	...getDotcomPlanDetails(),
-	type: TYPE_FREE,
+	type: TYPE_ECOMMERCE,
 	group: GROUP_WPCOM,
 	getProductId: () => 1052,
 	getPathSlug: () => PLAN_ECOMMERCE_TRIAL_MONTHLY,

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -154,6 +154,7 @@ import {
 	PLAN_ECOMMERCE_2_YEARS,
 	PLAN_ECOMMERCE_3_YEARS,
 	PLAN_ECOMMERCE_MONTHLY,
+	PLAN_ECOMMERCE_TRIAL_MONTHLY,
 	PLAN_ENTERPRISE_GRID_WPCOM,
 	PLAN_FREE,
 	PLAN_JETPACK_BUSINESS,
@@ -2598,4 +2599,18 @@ PLANS_LIST[ PLAN_WPCOM_PRO_MONTHLY ] = {
 	getProductId: () => 1034,
 	getStoreSlug: () => PLAN_WPCOM_PRO_MONTHLY,
 	getPathSlug: () => 'pro-monthly',
+};
+
+PLANS_LIST[ PLAN_ECOMMERCE_TRIAL_MONTHLY ] = {
+	...getDotcomPlanDetails(),
+	type: TYPE_FREE,
+	group: GROUP_WPCOM,
+	getProductId: () => 1052,
+	getPathSlug: () => PLAN_ECOMMERCE_TRIAL_MONTHLY,
+	term: TERM_MONTHLY,
+	getBillingTimeFrame: () => i18n.translate( 'free trial' ),
+	getStoreSlug: () => PLAN_ECOMMERCE_TRIAL_MONTHLY,
+	getTitle: () => i18n.translate( 'eCommerce free trial' ),
+	getDescription: () => i18n.translate( 'eCommerce free trial' ),
+	getTagline: () => i18n.translate( 'Get a taste of the world’s most popular eCommerce software.' ),
 };

--- a/packages/calypso-products/test/plan-lookups.js
+++ b/packages/calypso-products/test/plan-lookups.js
@@ -962,7 +962,6 @@ describe( 'findPlansKeys', () => {
 			PLAN_FREE,
 			PLAN_JETPACK_FREE,
 			PLAN_P2_FREE,
-			PLAN_ECOMMERCE_TRIAL_MONTHLY,
 		] );
 		expect( findPlansKeys( { type: TYPE_BLOGGER } ) ).toEqual( [
 			PLAN_BLOGGER,

--- a/packages/calypso-products/test/plan-lookups.js
+++ b/packages/calypso-products/test/plan-lookups.js
@@ -61,6 +61,7 @@ import {
 	PLAN_P2_PLUS,
 	PLAN_P2_FREE,
 	PLAN_ENTERPRISE_GRID_WPCOM,
+	PLAN_ECOMMERCE_TRIAL_MONTHLY,
 } from '../src/constants';
 import {
 	getPlan,
@@ -952,6 +953,7 @@ describe( 'findPlansKeys', () => {
 			PLAN_JETPACK_SECURITY_T2_MONTHLY,
 			PLAN_P2_PLUS,
 			PLAN_WPCOM_PRO_MONTHLY,
+			PLAN_ECOMMERCE_TRIAL_MONTHLY,
 		] );
 	} );
 
@@ -960,6 +962,7 @@ describe( 'findPlansKeys', () => {
 			PLAN_FREE,
 			PLAN_JETPACK_FREE,
 			PLAN_P2_FREE,
+			PLAN_ECOMMERCE_TRIAL_MONTHLY,
 		] );
 		expect( findPlansKeys( { type: TYPE_BLOGGER } ) ).toEqual( [
 			PLAN_BLOGGER,
@@ -1019,6 +1022,7 @@ describe( 'findPlansKeys', () => {
 			PLAN_WPCOM_FLEXIBLE,
 			PLAN_WPCOM_PRO,
 			PLAN_WPCOM_PRO_MONTHLY,
+			PLAN_ECOMMERCE_TRIAL_MONTHLY,
 		] );
 		expect( findPlansKeys( { group: GROUP_JETPACK } ) ).toEqual( [
 			PLAN_JETPACK_FREE,


### PR DESCRIPTION
As part of https://github.com/Automattic/wp-calypso/issues/72102, this PR adds the new eCommerce Trial plan to the Plans List, so the "My Plan" page (`/plans/my-plan/<site-slug>`) works correctly.

Before:
![image](https://user-images.githubusercontent.com/3801502/213292125-3b81933a-ca1c-4de6-9e81-db505b614277.png)


After:
![image](https://user-images.githubusercontent.com/3801502/213291881-e8ae845d-b785-4b16-97b6-53496512dd36.png)

The copy is not final, since we don't have the designs yet.