### PR TITLE
WPCC Login: Add IntenseDebate to flow so wpcc signup works correctly

### DIFF
--- a/client/layout/masterbar/oauth-client.scss
+++ b/client/layout/masterbar/oauth-client.scss
@@ -713,3 +713,8 @@
 		color: var(--color-text);
 	}
 }
+
+.layout.dops.intensedebate .masterbar__oauth-client-logo img {
+	max-height: 30px;
+	margin-left: 10px;
+}

--- a/client/layout/masterbar/oauth-client.scss
+++ b/client/layout/masterbar/oauth-client.scss
@@ -701,8 +701,9 @@
 }
 
 // Adding some CSS to cover the --color-primary
-// background color in the signup flow for Akismet.
-.layout.dops.akismet {
+// background color in the signup flow for Akismet/IntenseDebate.
+.layout.dops.akismet,
+.layout.dops.intensedebate {
 	background: var(--color-neutral-0);
 	min-height: 100%;
 

--- a/client/lib/login/index.js
+++ b/client/lib/login/index.js
@@ -7,6 +7,7 @@ import {
 	isGravatarOAuth2Client,
 	isJetpackCloudOAuth2Client,
 	isWooOAuth2Client,
+	isIntenseDebateOAuth2Client,
 } from 'calypso/lib/oauth2-clients';
 
 export function getSocialServiceFromClientId( clientId ) {
@@ -74,7 +75,11 @@ export function getSignupUrl( currentQuery, currentRoute, oauth2Client, locale, 
 		signupUrl += '/' + signupFlow;
 	}
 
-	if ( isAkismetOAuth2Client( oauth2Client ) || isGravatarOAuth2Client( oauth2Client ) ) {
+	if (
+		isAkismetOAuth2Client( oauth2Client ) ||
+		isGravatarOAuth2Client( oauth2Client ) ||
+		isIntenseDebateOAuth2Client( oauth2Client )
+	) {
 		const oauth2Flow = 'wpcc';
 		const oauth2Params = new URLSearchParams( {
 			oauth2_client_id: oauth2Client.id,

--- a/client/lib/oauth2-clients.js
+++ b/client/lib/oauth2-clients.js
@@ -19,3 +19,7 @@ export const isJetpackCloudOAuth2Client = ( oauth2Client ) => {
 	// 68663 => Jetpack Cloud Dev,
 	return oauth2Client && [ 68663, 69040, 69041 ].includes( oauth2Client.id );
 };
+
+export const isIntenseDebateOAuth2Client = ( oauth2Client ) => {
+	return oauth2Client?.id === 2665;
+};

--- a/client/state/oauth2-clients/reducer.js
+++ b/client/state/oauth2-clients/reducer.js
@@ -32,7 +32,7 @@ export const initialClientsData = {
 		id: 2665,
 		name: 'intensedebate',
 		title: 'IntenseDebate',
-		icon: 'https://intensedebate.com/images/intensedebate.png',
+		icon: 'https://intensedebate.com/images/svg/intensedebate-logo.svg',
 	},
 	50019: {
 		id: 50019,

--- a/client/state/oauth2-clients/reducer.js
+++ b/client/state/oauth2-clients/reducer.js
@@ -28,6 +28,12 @@ export const initialClientsData = {
 		title: 'Gravatar',
 		icon: 'https://gravatar.com/images/grav-logo-2x.png',
 	},
+	2665: {
+		id: 2665,
+		name: 'intensedebate',
+		title: 'IntenseDebate',
+		icon: 'https://app.crowdsignal.com/images/logo-white.png', // TODO: new logo
+	},
 	50019: {
 		id: 50019,
 		name: 'woo',

--- a/client/state/oauth2-clients/reducer.js
+++ b/client/state/oauth2-clients/reducer.js
@@ -32,7 +32,7 @@ export const initialClientsData = {
 		id: 2665,
 		name: 'intensedebate',
 		title: 'IntenseDebate',
-		icon: 'https://app.crowdsignal.com/images/logo-white.png', // TODO: new logo
+		icon: 'https://intensedebate.com/images/intensedebate.png',
 	},
 	50019: {
 		id: 50019,


### PR DESCRIPTION
#### Proposed Changes

* Add IntenseDebate oauth client details to oauth client lists
* add "is intense debate" helper to condition that renders the wpcc signup flow

| step 1 | step 2 |
| --- | --- |
| <img width="875" alt="SCR-20230119-d0y" src="https://user-images.githubusercontent.com/4081020/213466937-3d082371-f18e-43f3-b076-310dd099a61c.png"> | <img width="653" alt="SCR-20230118-nxh" src="https://user-images.githubusercontent.com/4081020/213307017-3e1f1e42-1ccd-4eda-a3bf-e62716e990cb.png"> |

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* In an incognito window, start on intensedebate.com
* click Sign up -> Login Here -> Sign In With WordPress.com
* change the url from `https://wordpress.com` to your calypso url (either your `http://calypso.localhost:3000` or a docker image from the PR)
* check the "Create an Account" link at the bottom of the login page, it should point to `/start/wpcc?oauth2_client_id=2665&...` and not `/start?user_email=`
* follow through with account creation, the page should look "nice" (I had to change a bad blue default background for intensedebate specifically)
* eventually complete your signup, activate your account from the email you receive, log in, authenticate oauth flow for IntenseDebate and you should eventually be logged in to the site with your account
* At no point should you end up in a "Choose your domain / create a new site" flow like what currently happens in Prod


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
