### PR TITLE
Free flow: Update launchpad sidebar subtitle

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/translations.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/translations.ts
@@ -19,8 +19,8 @@ describe( 'Translations', () => {
 
 				const freeFlowTranslations = getLaunchpadTranslations( 'free' );
 				expect( freeFlowTranslations.flowName ).toEqual( 'Free Website' );
-				expect( freeFlowTranslations.title ).toEqual( 'Your website is almost ready!' );
-				expect( freeFlowTranslations.launchTitle ).toEqual( 'Your website is almost ready!' );
+				expect( freeFlowTranslations.title ).toEqual( "Your new site's ready!" );
+				expect( freeFlowTranslations.launchTitle ).toEqual( "Your new site's ready!" );
 			} );
 		} );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/translations.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/translations.tsx
@@ -36,7 +36,9 @@ export function getLaunchpadTranslations( flow: string | null ): TranslatedLaunc
 			translatedStrings.flowName = translate( 'Free Website' );
 			translatedStrings.title = translate( 'Your website is almost ready!' );
 			translatedStrings.launchTitle = translate( 'Your website is almost ready!' );
-			translatedStrings.subtitle = translate( 'Keep the momentum going with these final steps.' );
+			translatedStrings.subtitle = translate(
+				'What would you like to do next? You can come back to these steps anytime.'
+			);
 			break;
 		case VIDEOPRESS_FLOW:
 			translatedStrings.flowName = translate( 'Video' );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/translations.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/translations.tsx
@@ -34,10 +34,10 @@ export function getLaunchpadTranslations( flow: string | null ): TranslatedLaunc
 			break;
 		case FREE_FLOW:
 			translatedStrings.flowName = translate( 'Free Website' );
-			translatedStrings.title = translate( 'Your website is almost ready!' );
-			translatedStrings.launchTitle = translate( 'Your website is almost ready!' );
+			translatedStrings.title = translate( "Your new site's ready!" );
+			translatedStrings.launchTitle = translate( "Your new site's ready!" );
 			translatedStrings.subtitle = translate(
-				'What would you like to do next? You can come back to these steps anytime.'
+				'Launch it to the world. Or add some finishing touches. (You can come back to make changes any time.)'
 			);
 			break;
 		case VIDEOPRESS_FLOW:


### PR DESCRIPTION
#### Estimated Time to Test / Review:
- Test -> short
- Review -> short

#### Proposed Changes

* Free flow launchpad sidebar subtitle text changes to reflect that the proceeding steps are optional "What would you like to do next? You can come back to these steps anytime."

![Screen Shot 2023-01-18 at 4 43 49 PM copy](https://user-images.githubusercontent.com/5414230/213329332-ec62af6d-09a1-4531-a052-92d9906fd135.jpg)

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this branch
* Visit http://calypso.localhost:3000/setup/free/intro
* Walk through the tailored onboarding flow until at the Launchpad
* Verify that the subtitle in the sidebar reads "What would you like to do next? You can come back to these steps anytime."

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
