### PR TITLE
Update jsdoc eslint plugin

### DIFF
--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -109,7 +109,7 @@ function waitForPreferredEditorView( context ) {
  *
  * @param {object} context  Shared context in the route.
  * @param {Function} next   Next registered callback for the route.
- * @returns {*}             Whatever the next callback returns.
+ * @returns {undefined}             Whatever the next callback returns.
  */
 export const authenticate = ( context, next ) => {
 	const state = context.store.getState();

--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -107,7 +107,7 @@ function waitForPreferredEditorView( context ) {
  * tracking), so we redirect the user to the WP Admin login page in order to store the auth cookie. Users will be
  * redirected back to Calypso when they are authenticated in WP Admin.
  *
- * @param {Object} context Shared context in the route.
+ * @param {object} context Shared context in the route.
  * @param {Function} next  Next registered callback for the route.
  * @returns {*|undefined}  Whatever the next callback returns.
  */

--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -107,9 +107,9 @@ function waitForPreferredEditorView( context ) {
  * tracking), so we redirect the user to the WP Admin login page in order to store the auth cookie. Users will be
  * redirected back to Calypso when they are authenticated in WP Admin.
  *
- * @param {object} context  Shared context in the route.
- * @param {Function} next   Next registered callback for the route.
- * @returns {undefined}             Whatever the next callback returns.
+ * @param {Object} context Shared context in the route.
+ * @param {Function} next  Next registered callback for the route.
+ * @returns {*|undefined}  Whatever the next callback returns.
  */
 export const authenticate = ( context, next ) => {
 	const state = context.store.getState();

--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -109,7 +109,7 @@ function waitForPreferredEditorView( context ) {
  *
  * @param {object} context Shared context in the route.
  * @param {Function} next  Next registered callback for the route.
- * @returns {*|undefined}  Whatever the next callback returns.
+ * @returns {*}            Whatever the next callback returns.
  */
 export const authenticate = ( context, next ) => {
 	const state = context.store.getState();

--- a/client/lib/media/utils/generate-gallery-shortcode.js
+++ b/client/lib/media/utils/generate-gallery-shortcode.js
@@ -11,7 +11,7 @@ import { stringify } from 'calypso/lib/shortcode';
  * optional set of parameters.
  *
  * @param  {object} settings Gallery settings
- * @returns {string}          Gallery shortcode
+ * @returns {string|undefined}          Gallery shortcode
  */
 export function generateGalleryShortcode( settings ) {
 	let attrs;

--- a/client/lib/media/utils/get-file-extension.js
+++ b/client/lib/media/utils/get-file-extension.js
@@ -11,7 +11,7 @@ import { isUri } from 'valid-url';
  * getFileExtension( new window.File( [''], 'example.gif' ) );
  * // All examples return 'gif'
  * @param  {(string|window.File|object)} media Media object or string
- * @returns {string}                     File extension
+ * @returns {string|undefined}                     File extension
  */
 export function getFileExtension( media ) {
 	let extension;

--- a/client/lib/media/utils/get-mime-prefix.js
+++ b/client/lib/media/utils/get-mime-prefix.js
@@ -9,7 +9,7 @@ import { getMimeType } from 'calypso/lib/media/utils/get-mime-type';
  * getMimeType( { mime_type: 'image/gif' } );
  * // All examples return 'image'
  * @param  {(string|window.File|object)} media Media object or mime type string
- * @returns {string}       The MIME type prefix
+ * @returns {string|undefined}       The MIME type prefix
  */
 export function getMimePrefix( media ) {
 	const mimeType = getMimeType( media );

--- a/client/lib/media/utils/get-mime-type.js
+++ b/client/lib/media/utils/get-mime-type.js
@@ -11,7 +11,7 @@ import { getFileExtension } from 'calypso/lib/media/utils/get-file-extension';
  * getMimeType( { mime_type: 'image/gif' } );
  * // All examples return 'image/gif'
  * @param  {(string|window.File|object)} media Media object or string
- * @returns {string}                     Mime type of the media, if known
+ * @returns {string|undefined}                     Mime type of the media, if known
  */
 export function getMimeType( media ) {
 	if ( ! media ) {

--- a/client/lib/media/utils/playtime.js
+++ b/client/lib/media/utils/playtime.js
@@ -5,7 +5,7 @@
  * @example
  * playtime( 7 ); // -> "0:07"
  * @param  {number} duration Duration in seconds
- * @returns {string}          Human-readable duration
+ * @returns {string|undefined}          Human-readable duration
  */
 export function playtime( duration ) {
 	if ( isNaN( duration ) ) {

--- a/client/lib/media/utils/url.js
+++ b/client/lib/media/utils/url.js
@@ -8,7 +8,7 @@ import resize from 'calypso/lib/resize-image-url';
  * @param  {object} media   Media object
  * @param  {object} options Optional options, accepting a `photon` boolean,
  *                          `maxWidth` pixel value, `resize` string, or `size`.
- * @returns {string}         URL to the media
+ * @returns {string|undefined} URL to the media
  */
 export function url( media, options ) {
 	if ( ! media ) {

--- a/client/lib/media/utils/validate-media-item.js
+++ b/client/lib/media/utils/validate-media-item.js
@@ -8,7 +8,7 @@ import { isSupportedFileTypeInPremium } from 'calypso/lib/media/utils/is-support
  *
  * @param  {object}      site Site object
  * @param  {object}      item Media item
- * @returns {Array|null}      Validation errors, or null if no site.
+ * @returns {Array|undefined} Validation errors, or null if no site.
  */
 export function validateMediaItem( site, item ) {
 	const itemErrors = [];

--- a/client/lib/media/utils/validate-media-item.js
+++ b/client/lib/media/utils/validate-media-item.js
@@ -6,8 +6,8 @@ import { isSupportedFileTypeInPremium } from 'calypso/lib/media/utils/is-support
 /**
  * Validates a media item for a site, and returns validation errors (if any).
  *
- * @param  {Object}      site Site object
- * @param  {Object}      item Media item
+ * @param  {object}      site Site object
+ * @param  {object}      item Media item
  * @returns {Array|undefined} Validation errors, or undefined if no site.
  */
 export function validateMediaItem( site, item ) {

--- a/client/lib/media/utils/validate-media-item.js
+++ b/client/lib/media/utils/validate-media-item.js
@@ -6,9 +6,9 @@ import { isSupportedFileTypeInPremium } from 'calypso/lib/media/utils/is-support
 /**
  * Validates a media item for a site, and returns validation errors (if any).
  *
- * @param  {object}      site Site object
- * @param  {object}      item Media item
- * @returns {Array|undefined} Validation errors, or null if no site.
+ * @param  {Object}      site Site object
+ * @param  {Object}      item Media item
+ * @returns {Array|undefined} Validation errors, or undefined if no site.
  */
 export function validateMediaItem( site, item ) {
 	const itemErrors = [];

--- a/client/lib/notifications/note-block-parser.js
+++ b/client/lib/notifications/note-block-parser.js
@@ -60,9 +60,11 @@ const encloses =
 	/**
 	 * Indicates if the given range encloses the first "inner" range
 	 *
-	 * @param {number} outerStart start of possibly-outer range
-	 * @param {number} outerEnd end of possibly-outer range
-	 * @returns {boolean} whether the "outer" range encloses the "inner" range
+	 * @param {object} range                      Range
+	 * @param {Array}  range.indices              Start and end of the range
+	 * @param {number} range.indices.0 innerStart Start index of the range
+	 * @param {number} range.indices.1 innerEnd   End index of the range
+	 * @returns {Function({indices: Number[]}): boolean} performs the check
 	 */
 	( { indices: [ outerStart, outerEnd ] = [ 0, 0 ] } ) =>
 		innerStart !== 0 && innerEnd !== 0 && outerStart <= innerStart && outerEnd >= innerEnd;

--- a/client/lib/payment-gateway-loader/index.js
+++ b/client/lib/payment-gateway-loader/index.js
@@ -6,7 +6,7 @@ const debug = debugFactory( 'calypso:payment-gateway' );
 /**
  * PaymentGatewayLoader component
  *
- * @returns { PaymentGatewayLoader } - an instance of PaymentGatewayLoader
+ * @returns {PaymentGatewayLoader|undefined} - an instance of PaymentGatewayLoader
  */
 function PaymentGatewayLoader() {
 	if ( ! ( this instanceof PaymentGatewayLoader ) ) {

--- a/client/lib/post-normalizer/rule-content-make-images-safe.js
+++ b/client/lib/post-normalizer/rule-content-make-images-safe.js
@@ -31,7 +31,7 @@ const removeUnwantedAttributes = ( node ) => {
  */
 const imageShouldBeRemovedFromContent = ( imageUrl ) => {
 	if ( ! imageUrl ) {
-		return;
+		return false;
 	}
 
 	const bannedUrlParts = [

--- a/client/lib/redux-bridge/index.js
+++ b/client/lib/redux-bridge/index.js
@@ -7,7 +7,7 @@ export function setReduxStore( store ) {
 /**
  * Dispatch an action against the current redux store
  *
- * @returns {any} Result of the dispatch
+ * @returns {undefined} Result of the dispatch
  */
 export function reduxDispatch( ...args ) {
 	if ( ! reduxStore ) {

--- a/client/lib/scroll-to/index.js
+++ b/client/lib/scroll-to/index.js
@@ -153,7 +153,7 @@ function circularOutEasing( val ) {
  * @param {Function} [options.onStart] - callback before start is called
  * @param {Function} [options.onComplete] - callback when scroll is finished
  * @param {HTMLElement} [options.container] - the container to scroll instead of window, if any
- * @returns {object} - the stepper
+ * @returns {object|undefined} - the stepper
  */
 export default function scrollTo( options ) {
 	const container = options.container || window;

--- a/client/my-sites/plans/legacy-plan-notice.jsx
+++ b/client/my-sites/plans/legacy-plan-notice.jsx
@@ -25,6 +25,7 @@ const maybeRenderLegacyPlanNotice = ( eligibleForProPlan, { plan } ) => {
 			></Notice>
 		);
 	}
+	return null;
 };
 
 export default maybeRenderLegacyPlanNotice;

--- a/client/my-sites/plans/legacy-plan-notice.jsx
+++ b/client/my-sites/plans/legacy-plan-notice.jsx
@@ -6,9 +6,9 @@ import Notice from 'calypso/components/notice';
  * Renders a "You're on a legacy plan" for sites on legacy plans (excluding free, business, and ecommerce plan).
  *
  * @param {boolean} eligibleForProPlan - Is the user eligible for pro plan?
- * @param {object} selectedSite - Site object from store.
- * @param {object} selectedSite.plan - The plan object nested inside the selectedSite object.
- * @returns - Legacy plan Notice component.
+ * @param {Object} selectedSite - Site object from store.
+ * @param {Object} selectedSite.plan - The plan object nested inside the selectedSite object.
+ * @returns {import('react').Element} - Legacy plan Notice component.
  */
 const maybeRenderLegacyPlanNotice = ( eligibleForProPlan, { plan } ) => {
 	const eligibleLegacyPlan = isBlogger( plan ) || isPersonal( plan ) || isPremium( plan );

--- a/client/my-sites/plans/legacy-plan-notice.jsx
+++ b/client/my-sites/plans/legacy-plan-notice.jsx
@@ -6,8 +6,8 @@ import Notice from 'calypso/components/notice';
  * Renders a "You're on a legacy plan" for sites on legacy plans (excluding free, business, and ecommerce plan).
  *
  * @param {boolean} eligibleForProPlan - Is the user eligible for pro plan?
- * @param {Object} selectedSite - Site object from store.
- * @param {Object} selectedSite.plan - The plan object nested inside the selectedSite object.
+ * @param {object} selectedSite - Site object from store.
+ * @param {object} selectedSite.plan - The plan object nested inside the selectedSite object.
  * @returns {import('react').Element} - Legacy plan Notice component.
  */
 const maybeRenderLegacyPlanNotice = ( eligibleForProPlan, { plan } ) => {

--- a/client/post-editor/media-modal/detail/detail-preview-media-file.tsx
+++ b/client/post-editor/media-modal/detail/detail-preview-media-file.tsx
@@ -35,10 +35,14 @@ const EditorMediaModalDetailPreviewMediaFile: React.FC< Props & LocalizeProps > 
 		);
 	}
 
+	const mediaUrl = url( item, {} );
+	if ( ! mediaUrl ) {
+		return null;
+	}
 	return (
 		<MediaFile
 			component={ component }
-			src={ url( item, {} ) }
+			src={ mediaUrl }
 			maxSize={ 20 * 1024 * 1024 }
 			onError={ () => setPreviewUnavailable( true ) }
 			controls

--- a/client/reader/lib/feed-display-helper/index.js
+++ b/client/reader/lib/feed-display-helper/index.js
@@ -5,7 +5,7 @@ const exported = {
 	 * Remove the starting https, www. and trailing slash from a URL string
 	 *
 	 * @param {string} url URL to format
-	 * @returns {string} Formatted URL e.g. "https://www.wordpress.com/" --> "wordpress.com"
+	 * @returns {string|undefined} Formatted URL e.g. "https://www.wordpress.com/" --> "wordpress.com"
 	 */
 	formatUrlForDisplay: function ( url ) {
 		if ( ! url ) {

--- a/client/server/render/index.js
+++ b/client/server/render/index.js
@@ -67,6 +67,8 @@ export function renderJsx( view, props ) {
 	return doctype + ReactDomServer.renderToStaticMarkup( createElement( component, props ) );
 }
 
+// JSdoc rule can't handle the function throwing an Error instead of returning.
+// eslint-disable-next-line jsdoc/require-returns-check
 /**
  * Render and cache supplied React element to a markup string.
  * Cache is keyed by stringified element by default.

--- a/client/server/render/index.js
+++ b/client/server/render/index.js
@@ -46,7 +46,7 @@ function bumpStat( group, name ) {
  * Render JSX template to a markup string.
  *
  * @param {string} view - JSX template to render (basename)
- * @param {object} props - Properties which got passed to the JSX template
+ * @param {Object} props - Properties which got passed to the JSX template
  * @returns {string} Rendered markup
  */
 export function renderJsx( view, props ) {
@@ -67,16 +67,14 @@ export function renderJsx( view, props ) {
 	return doctype + ReactDomServer.renderToStaticMarkup( createElement( component, props ) );
 }
 
-// JSdoc rule can't handle the function throwing an Error instead of returning.
-// eslint-disable-next-line jsdoc/require-returns-check
 /**
  * Render and cache supplied React element to a markup string.
  * Cache is keyed by stringified element by default.
  *
- * @param {object} element - React element to be rendered to html
+ * @param {Object} element - React element to be rendered to html
  * @param {string} key - cache key
- * @param {object} req - Request object
- * @returns {string} The rendered Layout
+ * @param {Object} req - Request object
+ * @returns {string|undefined} The rendered Layout
  */
 function render( element, key, req ) {
 	try {
@@ -302,7 +300,7 @@ export function serverRender( req, res ) {
  * Warning: Having context.serverSideRender=true is not sufficient for performing SSR. The app-level checks are also
  * applied before truly SSRing (@see isServerSideRenderCompatible)
  *
- * @param {object}   context  The entire request context
+ * @param {Object}   context  The entire request context
  * @param {Function} next     As all middlewares, will call next in the sequence
  */
 export function setShouldServerSideRender( context, next ) {
@@ -326,7 +324,7 @@ export function setShouldServerSideRender( context, next ) {
  * that set context.serverSideRender), think twice: the context may not be populated with all the necessary values
  * when the sections-specific middlewares are run (examples: context.layout, context.user).
  *
- * @param {object}   context The currently built context
+ * @param {Object}   context The currently built context
  * @returns {boolean} True if all the app-level criteria are fulfilled.
  */
 function isServerSideRenderCompatible( context ) {
@@ -342,7 +340,7 @@ function isServerSideRenderCompatible( context ) {
  *
  * Warning: the context needs to be 'ready' for these checks (needs to have all values)
  *
- * @param {object}   context The currently built context
+ * @param {Object}   context The currently built context
  * @returns {boolean} if the current page/request should return a SSR response
  */
 export function shouldServerSideRender( context ) {

--- a/client/server/render/index.js
+++ b/client/server/render/index.js
@@ -46,7 +46,7 @@ function bumpStat( group, name ) {
  * Render JSX template to a markup string.
  *
  * @param {string} view - JSX template to render (basename)
- * @param {Object} props - Properties which got passed to the JSX template
+ * @param {object} props - Properties which got passed to the JSX template
  * @returns {string} Rendered markup
  */
 export function renderJsx( view, props ) {
@@ -71,9 +71,9 @@ export function renderJsx( view, props ) {
  * Render and cache supplied React element to a markup string.
  * Cache is keyed by stringified element by default.
  *
- * @param {Object} element - React element to be rendered to html
+ * @param {object} element - React element to be rendered to html
  * @param {string} key - cache key
- * @param {Object} req - Request object
+ * @param {object} req - Request object
  * @returns {string|undefined} The rendered Layout
  */
 function render( element, key, req ) {
@@ -300,7 +300,7 @@ export function serverRender( req, res ) {
  * Warning: Having context.serverSideRender=true is not sufficient for performing SSR. The app-level checks are also
  * applied before truly SSRing (@see isServerSideRenderCompatible)
  *
- * @param {Object}   context  The entire request context
+ * @param {object}   context  The entire request context
  * @param {Function} next     As all middlewares, will call next in the sequence
  */
 export function setShouldServerSideRender( context, next ) {
@@ -324,7 +324,7 @@ export function setShouldServerSideRender( context, next ) {
  * that set context.serverSideRender), think twice: the context may not be populated with all the necessary values
  * when the sections-specific middlewares are run (examples: context.layout, context.user).
  *
- * @param {Object}   context The currently built context
+ * @param {object}   context The currently built context
  * @returns {boolean} True if all the app-level criteria are fulfilled.
  */
 function isServerSideRenderCompatible( context ) {
@@ -340,7 +340,7 @@ function isServerSideRenderCompatible( context ) {
  *
  * Warning: the context needs to be 'ready' for these checks (needs to have all values)
  *
- * @param {Object}   context The currently built context
+ * @param {object}   context The currently built context
  * @returns {boolean} if the current page/request should return a SSR response
  */
 export function shouldServerSideRender( context ) {

--- a/client/state/data-layer/wpcom-http/utils.js
+++ b/client/state/data-layer/wpcom-http/utils.js
@@ -10,7 +10,7 @@ const identity = ( data ) => data;
  * Returns response data from an HTTP request success action if available
  *
  * @param {object} action may contain HTTP response data
- * @returns {*|undefined} response data if available
+ * @returns {*} response data if available
  */
 export const getData = ( action ) => get( action, 'meta.dataLayer.data', undefined );
 
@@ -18,7 +18,7 @@ export const getData = ( action ) => get( action, 'meta.dataLayer.data', undefin
  * Returns error data from an HTTP request failure action if available
  *
  * @param {object} action may contain HTTP response error data
- * @returns {*|undefined} error data if available
+ * @returns {*} error data if available
  */
 export const getError = ( action ) => get( action, 'meta.dataLayer.error', undefined );
 
@@ -26,7 +26,7 @@ export const getError = ( action ) => get( action, 'meta.dataLayer.error', undef
  * Returns (response) headers data from an HTTP request action if available
  *
  * @param   {object}      action Request action for which to retrieve HTTP response headers
- * @returns {*|undefined}        Headers data if available
+ * @returns {*} Headers data if available
  */
 export const getHeaders = ( action ) => get( action, 'meta.dataLayer.headers', undefined );
 
@@ -48,7 +48,7 @@ export const getProgress = ( action ) => get( action, 'meta.dataLayer.progress',
  * Returns stream record from an HTTP request action if available
  *
  * @param {object} action may contain stream record
- * @returns {*|undefined} response data if available
+ * @returns {*} response data if available
  */
 export const getStreamRecord = ( action ) =>
 	get( action, 'meta.dataLayer.streamRecord', undefined );

--- a/client/state/data-layer/wpcom/activity-log/rewind/restore-status/index.js
+++ b/client/state/data-layer/wpcom/activity-log/rewind/restore-status/index.js
@@ -23,7 +23,7 @@ const ERROR_NOTICE_ID = 'AL_REW_RESTORESTATUS_ERR';
  * when it arrives. For now, it's statefully ugly.
  *
  * @param  {object} action Redux action
- * @returns {object}        Redux action
+ * @returns {object|undefined} Redux action
  */
 const fetchProgress = ( action ) => {
 	const { restoreId, siteId } = action;

--- a/client/state/data-layer/wpcom/read/streams/index.js
+++ b/client/state/data-layer/wpcom/read/streams/index.js
@@ -167,7 +167,7 @@ const streamApis = {
  * Request a page for the given stream
  *
  * @param  {object}   action   Action being handled
- * @returns {object} http action for data-layer to dispatch
+ * @returns {object|undefined} http action for data-layer to dispatch
  */
 export function requestPage( action ) {
 	const {

--- a/client/state/posts/utils/get-featured-image-id.js
+++ b/client/state/posts/utils/get-featured-image-id.js
@@ -6,7 +6,7 @@
  * in creating a post, the thumbnail ID is assigned to `featured_image`.
  *
  * @param  {object} post Post object
- * @returns {*} featured image id or undefined
+ * @returns {undefined|number|string} featured image id or undefined
  */
 export function getFeaturedImageId( post ) {
 	if ( ! post ) {

--- a/client/state/reader/lists/selectors.js
+++ b/client/state/reader/lists/selectors.js
@@ -65,7 +65,7 @@ export const getSubscribedLists = createSelector(
  * @param  {object}  state  Global state tree
  * @param  {string}  owner  List owner
  * @param  {string}  slug  List slug
- * @returns {?object}        Reader list
+ * @returns {object|undefined} Reader list
  */
 export function getListByOwnerAndSlug( state, owner, slug ) {
 	if ( ! owner || ! slug ) {

--- a/package.json
+++ b/package.json
@@ -240,7 +240,7 @@
 		"eslint-plugin-import": "^2.25.4",
 		"eslint-plugin-inclusive-language": "^2.2.0",
 		"eslint-plugin-jest": "^25.3.4",
-		"eslint-plugin-jsdoc": "^37.5.1",
+		"eslint-plugin-jsdoc": "^39.6.6",
 		"eslint-plugin-jsx-a11y": "^6.5.1",
 		"eslint-plugin-md": "^1.0.19",
 		"eslint-plugin-mocha": "^10.0.3",

--- a/package.json
+++ b/package.json
@@ -240,7 +240,7 @@
 		"eslint-plugin-import": "^2.25.4",
 		"eslint-plugin-inclusive-language": "^2.2.0",
 		"eslint-plugin-jest": "^25.3.4",
-		"eslint-plugin-jsdoc": "^39.6.6",
+		"eslint-plugin-jsdoc": "^39.6.7",
 		"eslint-plugin-jsx-a11y": "^6.5.1",
 		"eslint-plugin-md": "^1.0.19",
 		"eslint-plugin-mocha": "^10.0.3",

--- a/packages/babel-plugin-i18n-calypso/src/index.js
+++ b/packages/babel-plugin-i18n-calypso/src/index.js
@@ -80,7 +80,7 @@ const REGEXP_TRANSLATOR_COMMENT = /^\s*translators:\s*([\s\S]+)/im;
  * @param {object} path              Traversal path.
  * @param {number} _originalNodeLine Private: In recursion, line number of
  *                                     the original node passed.
- * @returns {?string} Extracted comment.
+ * @returns {string|undefined} Extracted comment.
  */
 function getExtractedComment( path, _originalNodeLine ) {
 	const { node, parent, parentPath } = path;

--- a/packages/calypso-build/webpack/util.js
+++ b/packages/calypso-build/webpack/util.js
@@ -3,8 +3,8 @@ const webpack = require( 'webpack' );
 /**
  * Transform webpack output.filename and output.chunkFilename to CSS variants
  *
- * @param {(string|undefined)} name filename, chunkFilename or undefined
- * @returns {(string|undefined)}     Transformed name or undefined
+ * @param {string|undefined} name filename, chunkFilename or undefined
+ * @returns {string|undefined}     Transformed name or undefined
  */
 function cssNameFromFilename( name ) {
 	if ( name ) {

--- a/packages/eslint-plugin-wpcalypso/package.json
+++ b/packages/eslint-plugin-wpcalypso/package.json
@@ -27,7 +27,7 @@
 		"@babel/core": ">=7.17.5",
 		"eslint": ">=8.6.0",
 		"eslint-plugin-inclusive-language": "^2.2.0",
-		"eslint-plugin-jsdoc": "^37.5.1",
+		"eslint-plugin-jsdoc": "^39.6.6",
 		"eslint-plugin-react": "^7.28.0",
 		"eslint-plugin-react-hooks": "^4.3.0"
 	},

--- a/packages/eslint-plugin-wpcalypso/package.json
+++ b/packages/eslint-plugin-wpcalypso/package.json
@@ -27,7 +27,7 @@
 		"@babel/core": ">=7.17.5",
 		"eslint": ">=8.6.0",
 		"eslint-plugin-inclusive-language": "^2.2.0",
-		"eslint-plugin-jsdoc": "^39.6.6",
+		"eslint-plugin-jsdoc": "^39.6.7",
 		"eslint-plugin-react": "^7.28.0",
 		"eslint-plugin-react-hooks": "^4.3.0"
 	},

--- a/packages/i18n-calypso-cli/preprocess-xgettextjs-match.js
+++ b/packages/i18n-calypso-cli/preprocess-xgettextjs-match.js
@@ -9,7 +9,7 @@
  *  - wraps quotes and backslashes for php consumption
  *
  * @param  {object} match - parser matching object
- * @returns {object} data object combining the strings and options passed into translate();
+ * @returns {object|undefined} data object combining the strings and options passed into translate();
  */
 module.exports = function preProcessXGettextJSMatch( match ) {
 	const finalProps = { line: match.line };

--- a/packages/i18n-calypso/src/i18n.js
+++ b/packages/i18n-calypso/src/i18n.js
@@ -357,7 +357,7 @@ I18N.prototype.hasTranslation = function () {
  * Exposes single translation method.
  * See sibling README
  *
- * @returns {string|object} translated text or an object containing React children that can be inserted into a parent component
+ * @returns {string|object|undefined} translated text or an object containing React children that can be inserted into a parent component
  */
 I18N.prototype.translate = function () {
 	const options = normalizeTranslateArguments( arguments );

--- a/packages/social-previews/src/twitter-preview/tweet.jsx
+++ b/packages/social-previews/src/twitter-preview/tweet.jsx
@@ -94,7 +94,7 @@ export class Tweet extends PureComponent {
 	 */
 	renderMedia( media ) {
 		if ( ! media ) {
-			return;
+			return null;
 		}
 
 		// Ensure we're only trying to show valid media, and the correct quantity.
@@ -133,7 +133,7 @@ export class Tweet extends PureComponent {
 		] );
 
 		if ( 0 === filteredMedia.length ) {
-			return;
+			return null;
 		}
 
 		return (
@@ -168,7 +168,7 @@ export class Tweet extends PureComponent {
 	 */
 	renderQuoteTweet( tweet ) {
 		if ( ! tweet ) {
-			return;
+			return null;
 		}
 
 		return (
@@ -192,7 +192,7 @@ export class Tweet extends PureComponent {
 	 */
 	renderCard( card ) {
 		if ( ! card ) {
-			return;
+			return null;
 		}
 
 		const { description, image, title, type, url } = card;

--- a/packages/wpcom.js/src/index.js
+++ b/packages/wpcom.js/src/index.js
@@ -26,7 +26,7 @@ const DEFAULT_ASYNC_TIMEOUT = 30000;
  *
  * @param {string} [token] - OAuth API access token
  * @param {Function} [reqHandler] - function Request Handler
- * @returns {WPCOM} wpcom instance
+ * @returns {WPCOM|undefined} wpcom instance
  */
 export default function WPCOM( token, reqHandler ) {
 	if ( ! ( this instanceof WPCOM ) ) {

--- a/packages/wpcom.js/src/lib/me.js
+++ b/packages/wpcom.js/src/lib/me.js
@@ -8,7 +8,7 @@ import MeTwoStep from './me.two-step';
  * Create `Me` instance
  *
  * @param {object} wpcom - wpcom instance
- * @returns {null} null
+ * @returns {undefined|Me} New Me instance or undefined.
  */
 export default function Me( wpcom ) {
 	if ( ! ( this instanceof Me ) ) {

--- a/packages/wpcom.js/src/lib/me.settings.js
+++ b/packages/wpcom.js/src/lib/me.settings.js
@@ -7,7 +7,7 @@ import MeProfileLinks from './me.settings.profile-links';
  * Use a `WPCOM#Me` instance to create a new `MeSettings` instance.
  *
  * @param {WPCOM} wpcom - wpcom instance
- * @returns {null} null
+ * @returns {MeSettings|undefined}
  */
 export default function MeSettings( wpcom ) {
 	if ( ! ( this instanceof MeSettings ) ) {

--- a/packages/wpcom.js/src/lib/me.settings.profile-links.js
+++ b/packages/wpcom.js/src/lib/me.settings.profile-links.js
@@ -7,7 +7,7 @@ const root = '/me/settings/profile-links';
  * `ProfileLinks` constructor.
  *
  * @param {WPCOM} wpcom - wpcom instance
- * @returns {null} null
+ * @returns {ProfileLinks|undefined}
  */
 export default function ProfileLinks( wpcom ) {
 	if ( ! ( this instanceof ProfileLinks ) ) {

--- a/packages/wpcom.js/src/lib/site.category.js
+++ b/packages/wpcom.js/src/lib/site.category.js
@@ -4,7 +4,7 @@
  * @param {string} [slug] - category slug
  * @param {string} sid - site id
  * @param {WPCOM} wpcom - wpcom instance
- * @returns {null} null
+ * @returns {Category|undefined}
  */
 export default function Category( slug, sid, wpcom ) {
 	if ( ! sid ) {

--- a/packages/wpcom.js/src/lib/site.comment.js
+++ b/packages/wpcom.js/src/lib/site.comment.js
@@ -7,7 +7,7 @@ import commentLike from './site.comment.like';
  * @param {string} [pid] post id
  * @param {string} sid site id
  * @param {WPCOM} wpcom - wpcom instance
- * @returns {null} null
+ * @returns {Comment|undefined}
  */
 export default function Comment( cid, pid, sid, wpcom ) {
 	if ( ! sid ) {

--- a/packages/wpcom.js/src/lib/site.comment.like.js
+++ b/packages/wpcom.js/src/lib/site.comment.like.js
@@ -4,7 +4,7 @@
  * @param {string} cid comment id
  * @param {string} sid site id
  * @param {WPCOM} wpcom - wpcom instance
- * @returns {null} null
+ * @returns {CommentLike|undefined}
  */
 export default function CommentLike( cid, sid, wpcom ) {
 	if ( ! sid ) {

--- a/packages/wpcom.js/src/lib/site.follow.js
+++ b/packages/wpcom.js/src/lib/site.follow.js
@@ -3,7 +3,7 @@
  *
  * @param {string} site_id - site id
  * @param {WPCOM} wpcom - wpcom instance
- * @returns {null} null
+ * @returns {Follow|undefined}
  */
 export default function Follow( site_id, wpcom ) {
 	if ( ! site_id ) {

--- a/packages/wpcom.js/src/lib/site.media.js
+++ b/packages/wpcom.js/src/lib/site.media.js
@@ -60,7 +60,7 @@ function buildFormData( files ) {
  * @param {string} id - media id
  * @param {string} sid site id
  * @param {WPCOM} wpcom - wpcom instance
- * @returns {null} null
+ * @returns {Media|undefined}
  */
 export default function Media( id, sid, wpcom ) {
 	if ( ! ( this instanceof Media ) ) {

--- a/packages/wpcom.js/src/lib/site.post.like.js
+++ b/packages/wpcom.js/src/lib/site.post.like.js
@@ -4,7 +4,7 @@
  * @param {string} pid - post id
  * @param {string} sid - site id
  * @param {WPCOM} wpcom - wpcom instance
- * @returns {null} null
+ * @returns {Like|undefined}
  */
 export default function Like( pid, sid, wpcom ) {
 	if ( ! sid ) {

--- a/packages/wpcom.js/src/lib/site.post.reblog.js
+++ b/packages/wpcom.js/src/lib/site.post.reblog.js
@@ -4,7 +4,7 @@
  * @param {string} pid post id
  * @param {string} sid site id
  * @param {WPCOM} wpcom - wpcom instance
- * @returns {null} null
+ * @returns {Reblog|undefined}
  */
 export default function Reblog( pid, sid, wpcom ) {
 	if ( ! sid ) {

--- a/packages/wpcom.js/src/lib/site.tag.js
+++ b/packages/wpcom.js/src/lib/site.tag.js
@@ -4,7 +4,7 @@
  * @param {string} [slug] - tag slug
  * @param {string} sid - site id
  * @param {WPCOM} wpcom - wpcom instance
- * @returns {null} null
+ * @returns {Tag|undefined}
  */
 export default function Tag( slug, sid, wpcom ) {
 	if ( ! sid ) {

--- a/packages/wpcom.js/src/lib/site.wordads.earnings.js
+++ b/packages/wpcom.js/src/lib/site.wordads.earnings.js
@@ -3,7 +3,7 @@
  *
  * @param {string} sid - site identifier
  * @param {WPCOM} wpcom - wpcom instance
- * @returns {null} null
+ * @returns {SiteWordAdsEarnings|undefined}
  */
 export default function SiteWordAdsEarnings( sid, wpcom ) {
 	if ( ! ( this instanceof SiteWordAdsEarnings ) ) {

--- a/packages/wpcom.js/src/lib/site.wordads.js
+++ b/packages/wpcom.js/src/lib/site.wordads.js
@@ -9,7 +9,7 @@ import SiteWordAdsTOS from './site.wordads.tos';
  *
  * @param {string} sid - site identifier
  * @param {WPCOM} wpcom - wpcom instance
- * @returns {null} null
+ * @returns {SiteWordAds|undefined}
  */
 export default function SiteWordAds( sid, wpcom ) {
 	if ( ! ( this instanceof SiteWordAds ) ) {

--- a/packages/wpcom.js/src/lib/site.wordads.settings.js
+++ b/packages/wpcom.js/src/lib/site.wordads.settings.js
@@ -3,7 +3,7 @@
  *
  * @param {string} sid - site identifier
  * @param {WPCOM} wpcom - wpcom instance
- * @returns {null} null
+ * @returns {SiteWordAdsSettings|undefined}
  */
 export default function SiteWordAdsSettings( sid, wpcom ) {
 	if ( ! ( this instanceof SiteWordAdsSettings ) ) {

--- a/packages/wpcom.js/src/lib/site.wordads.tos.js
+++ b/packages/wpcom.js/src/lib/site.wordads.tos.js
@@ -3,7 +3,7 @@
  *
  * @param {string} sid - site identifier
  * @param {WPCOM} wpcom - wpcom instance
- * @returns {null} null
+ * @returns {SiteWordAdsTOS|undefined}
  */
 export default function SiteWordAdsTOS( sid, wpcom ) {
 	if ( ! ( this instanceof SiteWordAdsTOS ) ) {

--- a/packages/wpcom.js/src/lib/users.js
+++ b/packages/wpcom.js/src/lib/users.js
@@ -2,7 +2,7 @@
  * Create a `Users` instance
  *
  * @param {WPCOM} wpcom - wpcom instance
- * @returns {null} null
+ * @returns {Users|undefined}
  */
 export default function Users( wpcom ) {
 	if ( ! ( this instanceof Users ) ) {

--- a/packages/wpcom.js/src/lib/util/pinghub.js
+++ b/packages/wpcom.js/src/lib/util/pinghub.js
@@ -6,7 +6,7 @@ const debug = debugFactory( 'wpcom:pinghub' );
  * Create a `Pinghub` instance
  *
  * @param {object} wpcom - wpcom instance
- * @returns {null} null
+ * @returns {Pinghub|undefined}
  */
 export default function Pinghub( wpcom ) {
 	if ( ! ( this instanceof Pinghub ) ) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3953,6 +3953,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@es-joy/jsdoccomment@npm:~0.36.1":
+  version: 0.36.1
+  resolution: "@es-joy/jsdoccomment@npm:0.36.1"
+  dependencies:
+    comment-parser: 1.3.1
+    esquery: ^1.4.0
+    jsdoc-type-pratt-parser: ~3.1.0
+  checksum: 7bb082c64a1270ec2a8d604a8fcfa8a9a98745200bf4945e93835e99ab09e93ac43180e24180e7710ac3e9ba2845c0c04ba6c4ce363f1e5ea0511680b33bc2ad
+  languageName: node
+  linkType: hard
+
 "@eslint/eslintrc@npm:^0.4.3":
   version: 0.4.3
   resolution: "@eslint/eslintrc@npm:0.4.3"
@@ -12770,6 +12781,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"comment-parser@npm:1.3.1":
+  version: 1.3.1
+  resolution: "comment-parser@npm:1.3.1"
+  checksum: 848b3bbcf2eeb780831a8dd5a4cc52f914dd8c321c610403539237324c507040ea8fdca7bd1f8edb0a477e7c90138f54c4d05328a9d87fe6d651d5a2822cb14b
+  languageName: node
+  linkType: hard
+
 "comment-parser@npm:^0.7.4":
   version: 0.7.6
   resolution: "comment-parser@npm:0.7.6"
@@ -15790,7 +15808,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-jsdoc@npm:^37.0.3, eslint-plugin-jsdoc@npm:^37.5.1":
+"eslint-plugin-jsdoc@npm:^37.0.3":
   version: 37.9.7
   resolution: "eslint-plugin-jsdoc@npm:37.9.7"
   dependencies:
@@ -15805,6 +15823,23 @@ __metadata:
   peerDependencies:
     eslint: ^7.0.0 || ^8.0.0
   checksum: 8ea51ffc3717cd27522f6984419e17ab7eaf6c8f7ff1a5c9dafc032a7ecbb62833ca7b6af28b4dd66b8d0fcd0a725ff4716259b91583fdfa291dda0526a14f2c
+  languageName: node
+  linkType: hard
+
+"eslint-plugin-jsdoc@npm:^39.6.6":
+  version: 39.6.6
+  resolution: "eslint-plugin-jsdoc@npm:39.6.6"
+  dependencies:
+    "@es-joy/jsdoccomment": ~0.36.1
+    comment-parser: 1.3.1
+    debug: ^4.3.4
+    escape-string-regexp: ^4.0.0
+    esquery: ^1.4.0
+    semver: ^7.3.8
+    spdx-expression-parse: ^3.0.1
+  peerDependencies:
+    eslint: ^7.0.0 || ^8.0.0
+  checksum: 8b8eec98e0c5ef23e791980092d7f9582fb847b8eecf4478008ec2f6b2c1bbcf56b2eeb286d7eec93c2dd77f385e3b362dea8891b2a7a75eb5bd36fed61127e3
   languageName: node
   linkType: hard
 
@@ -15945,7 +15980,7 @@ __metadata:
     "@babel/core": ">=7.17.5"
     eslint: ">=8.6.0"
     eslint-plugin-inclusive-language: ^2.2.0
-    eslint-plugin-jsdoc: ^37.5.1
+    eslint-plugin-jsdoc: ^39.6.6
     eslint-plugin-react: ^7.28.0
     eslint-plugin-react-hooks: ^4.3.0
   peerDependenciesMeta:
@@ -21181,6 +21216,13 @@ fsevents@^1.2.7:
   version: 2.2.5
   resolution: "jsdoc-type-pratt-parser@npm:2.2.5"
   checksum: 0ecd96f4b051fd600d3019ae7e5122731b8a856baee701966c0f37b060fb86a23296d22a39b49c593c50065978be5e4ffe0eeba931f3617ca8dd668cb40af6e6
+  languageName: node
+  linkType: hard
+
+"jsdoc-type-pratt-parser@npm:~3.1.0":
+  version: 3.1.0
+  resolution: "jsdoc-type-pratt-parser@npm:3.1.0"
+  checksum: b55f42b59d79fe22c22369c25defaf0b13522c623e6c45e9264ecba431d7b5d98c7a1316912bc1b59938b49faadb1b6abf9ae89fbffe29e74768f59cc8e6ca8b
   languageName: node
   linkType: hard
 
@@ -29330,6 +29372,17 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
+"semver@npm:^7.3.8":
+  version: 7.3.8
+  resolution: "semver@npm:7.3.8"
+  dependencies:
+    lru-cache: ^6.0.0
+  bin:
+    semver: bin/semver.js
+  checksum: 7e581d679530db31757301c2117721577a2bb36a301a443aac833b8efad372cda58e7f2a464fe4412ae1041cc1f63a6c1fe0ced8c57ce5aca1e0b57bb0d627b9
+  languageName: node
+  linkType: hard
+
 "send@npm:0.18.0":
   version: 0.18.0
   resolution: "send@npm:0.18.0"
@@ -33645,7 +33698,7 @@ resolve@^2.0.0-next.3:
     eslint-plugin-import: ^2.25.4
     eslint-plugin-inclusive-language: ^2.2.0
     eslint-plugin-jest: ^25.3.4
-    eslint-plugin-jsdoc: ^37.5.1
+    eslint-plugin-jsdoc: ^39.6.6
     eslint-plugin-jsx-a11y: ^6.5.1
     eslint-plugin-md: ^1.0.19
     eslint-plugin-mocha: ^10.0.3

--- a/yarn.lock
+++ b/yarn.lock
@@ -29361,18 +29361,7 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"semver@npm:^7.0.0, semver@npm:^7.2.1, semver@npm:^7.3.2, semver@npm:^7.3.4, semver@npm:^7.3.5":
-  version: 7.3.5
-  resolution: "semver@npm:7.3.5"
-  dependencies:
-    lru-cache: ^6.0.0
-  bin:
-    semver: bin/semver.js
-  checksum: d450455b2601396dbc7d9f058a6709b1c0b99d74a911f9436c77887600ffcdb5f63d5adffa0c3b8f0092937d8a41cc61c6437bcba375ef4151cb1335ebe4f1f9
-  languageName: node
-  linkType: hard
-
-"semver@npm:^7.3.8":
+"semver@npm:^7.0.0, semver@npm:^7.2.1, semver@npm:^7.3.2, semver@npm:^7.3.4, semver@npm:^7.3.5, semver@npm:^7.3.8":
   version: 7.3.8
   resolution: "semver@npm:7.3.8"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -15826,9 +15826,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-jsdoc@npm:^39.6.6":
-  version: 39.6.6
-  resolution: "eslint-plugin-jsdoc@npm:39.6.6"
+"eslint-plugin-jsdoc@npm:^39.6.7":
+  version: 39.6.7
+  resolution: "eslint-plugin-jsdoc@npm:39.6.7"
   dependencies:
     "@es-joy/jsdoccomment": ~0.36.1
     comment-parser: 1.3.1
@@ -15839,7 +15839,7 @@ __metadata:
     spdx-expression-parse: ^3.0.1
   peerDependencies:
     eslint: ^7.0.0 || ^8.0.0
-  checksum: 8b8eec98e0c5ef23e791980092d7f9582fb847b8eecf4478008ec2f6b2c1bbcf56b2eeb286d7eec93c2dd77f385e3b362dea8891b2a7a75eb5bd36fed61127e3
+  checksum: c0973999454d5bd3827d669eb2d88a33dea81e4d282312535188d7982684f401b1db7116214438e30edb5c61f6c72ff7c3a07f0b97ed3d3147b1f5eb8df2eeb9
   languageName: node
   linkType: hard
 
@@ -15980,7 +15980,7 @@ __metadata:
     "@babel/core": ">=7.17.5"
     eslint: ">=8.6.0"
     eslint-plugin-inclusive-language: ^2.2.0
-    eslint-plugin-jsdoc: ^39.6.6
+    eslint-plugin-jsdoc: ^39.6.7
     eslint-plugin-react: ^7.28.0
     eslint-plugin-react-hooks: ^4.3.0
   peerDependenciesMeta:
@@ -33687,7 +33687,7 @@ resolve@^2.0.0-next.3:
     eslint-plugin-import: ^2.25.4
     eslint-plugin-inclusive-language: ^2.2.0
     eslint-plugin-jest: ^25.3.4
-    eslint-plugin-jsdoc: ^39.6.6
+    eslint-plugin-jsdoc: ^39.6.7
     eslint-plugin-jsx-a11y: ^6.5.1
     eslint-plugin-md: ^1.0.19
     eslint-plugin-mocha: ^10.0.3


### PR DESCRIPTION
#### Proposed Changes
Separating this from #72245 to simplify things. Updates eslint-plugin-jsdoc across the repo to properly support Node 18. cc @anomiex 

The initial update introduced two problems:
1. Firstly, JSDoc wanted to replace `Object` with `object`. 
2. Secondly, there were a lot of issues with require-returns check. It seemed to have gotten a lot smarter :)

The first fix is easy -- just add a setting which allows both Object and object. I don't see a big reason to enforce one over the other at this point, especially since we'd rather use Typescript.

The second one just meant going through several files and fixing the return type. Almost every error was caused by functions like this:

```js
/**
 * @returns {string}
 */
function foo( x ) {
  if ( x ) {
    return "bar";
  }
}
```

This is obviously problematic, because the real return type is `string|undefined`. So I just made that adjustment in several files.

There are a few more issues reported by the main linter build below, but not enough to fail the build. I did find weird behavior in the eslint jsdoc lib, which I reported here: https://github.com/gajus/eslint-plugin-jsdoc/issues/949

#### Testing Instructions
CI, and verify that changes make sense. The full eslint build is running here: https://teamcity.a8c.com/buildConfiguration/calypso_CheckCodeStyle/9329626
