### PR TITLE
Remove styles causing unintented wrap on pricing page

### DIFF
--- a/client/components/jetpack/card/jetpack-product-card/display-price/style.scss
+++ b/client/components/jetpack/card/jetpack-product-card/display-price/style.scss
@@ -128,11 +128,6 @@
 		background-color: rgba(var(--studio-jetpack-green-10-rgb), 0.2);
 	}
 
-	&__prices {
-		display: flex;
-		flex-wrap: nowrap;
-	}
-
 	&__from {
 		margin-right: 12px;
 		color: var(--studio-gray-40);


### PR DESCRIPTION
#### Proposed Changes

There is an issue being caused by this an unnecessary flexbox on mobile 

![image](https://user-images.githubusercontent.com/65001528/213348703-aa15f3e4-3485-47c2-83a7-9e25df318ca6.png)

#### Testing Instructions

1. Check out these changes
2. Start local environment
3. Confirm the issue is fix
![image](https://user-images.githubusercontent.com/65001528/213348785-a579b6d7-73a9-4425-bb05-d7f5354fa0d2.png)


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?

