### PR TITLE
Jetpack Agency Dashboard: pre-fill user email for bulk notification settings update

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/dashboard-bulk-actions/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/dashboard-bulk-actions/index.tsx
@@ -19,9 +19,10 @@ import './style.scss';
 
 interface Props {
 	selectedSites: Array< Site >;
+	monitorUserEmails: Array< string >;
 }
 
-export default function DashboardBulkActions( { selectedSites }: Props ) {
+export default function DashboardBulkActions( { selectedSites, monitorUserEmails }: Props ) {
 	const actionBarRef = createRef< HTMLDivElement >();
 	const translate = useTranslate();
 	const { setIsBulkManagementActive } = useContext( SitesOverviewContext );
@@ -108,7 +109,11 @@ export default function DashboardBulkActions( { selectedSites }: Props ) {
 				</ButtonGroup>
 			</div>
 			{ showNotificationSettingsPopup && (
-				<NotificationSettings sites={ selectedSites } onClose={ toggleNotificationSettingsPopup } />
+				<NotificationSettings
+					monitorUserEmails={ monitorUserEmails }
+					sites={ selectedSites }
+					onClose={ toggleNotificationSettingsPopup }
+				/>
 			) }
 		</>
 	);

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
@@ -22,9 +22,15 @@ interface Props {
 	sites: Array< Site >;
 	onClose: () => void;
 	settings?: MonitorSettings;
+	monitorUserEmails?: Array< string >;
 }
 
-export default function NotificationSettings( { onClose, sites, settings }: Props ) {
+export default function NotificationSettings( {
+	onClose,
+	sites,
+	settings,
+	monitorUserEmails,
+}: Props ) {
 	const translate = useTranslate();
 	const { updateMonitorSettings, isLoading, isComplete } = useUpdateMonitorSettings( sites );
 
@@ -74,6 +80,12 @@ export default function NotificationSettings( { onClose, sites, settings }: Prop
 			setEnableMobileNotification( !! settings.monitor_user_wp_note_notifications );
 		}
 	}, [ settings ] );
+
+	useEffect( () => {
+		if ( monitorUserEmails ) {
+			setAddedEmailAddresses( monitorUserEmails );
+		}
+	}, [ monitorUserEmails ] );
 
 	useEffect( () => {
 		if ( enableMobileNotification || enableEmailNotification ) {

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-bulk-select/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-bulk-select/index.tsx
@@ -80,7 +80,10 @@ export default function SiteBulkSelect( { sites, isLoading }: Props ) {
 					} ) }
 				</div>
 			</div>
-			<DashboardBulkActions selectedSites={ selectedSites } />
+			<DashboardBulkActions
+				selectedSites={ selectedSites }
+				monitorUserEmails={ sites[ 0 ].monitor.settings?.monitor_user_emails ?? [] }
+			/>
 		</div>
 	);
 }


### PR DESCRIPTION
#### Proposed Changes

This PR adds changes that prefill the user email for the bulk notification settings update.

#### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout add/prefill-user-email-for-bulk-notification-settings-update` and `yarn start-jetpack-cloud`
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Click `Edit All` -> Select `Custom Notification` -> Verify email field is filled with the user email ID.

<img width="530" alt="Screenshot 2023-01-19 at 12 01 55 PM" src="https://user-images.githubusercontent.com/10586875/213371820-5a8e1aa4-adda-4544-9332-34b17580ff70.png">


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1203448324265423-as-1203774205236223