### PR TITLE
Theme Showcase: Theme card UI update

### DIFF
--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -608,6 +608,7 @@ export class Theme extends Component {
 						{ ! isNewCardsOnly && ! isNewDetailsAndPreview && active && (
 							<span className={ priceClass }>{ price }</span>
 						) }
+						{ isNewDetailsAndPreview && ! active && this.renderStyleVariations() }
 						{ upsellUrl && // Do not show any pricing related infomation if there's no upsell action link.
 							( showUpsell
 								? this.renderUpsell()
@@ -615,7 +616,6 @@ export class Theme extends Component {
 								  ! active && (
 										<span className="theme__info-upsell-description">{ translate( 'Free' ) }</span>
 								  ) ) }
-						{ isNewDetailsAndPreview && ! active && this.renderStyleVariations() }
 						{ this.renderMoreButton() }
 					</div>
 				</div>

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -181,6 +181,8 @@ body.is-section-themes-i4-2 {
 			gap: 4px;
 			margin-top: 16px;
 			position: relative;
+			text-rendering: optimizeLegibility;
+			-webkit-font-smoothing: antialiased;
 
 			&:not(.has-pricing) {
 				.theme__more-button {
@@ -190,16 +192,19 @@ body.is-section-themes-i4-2 {
 		}
 
 		.theme__info-title {
-			color: var(--color-neutral-100);
+			color: var(--color-neutral-80);
 			font-size: 1rem;
+			font-weight: 500;
 			line-height: 24px;
 			margin: 0;
 			padding: 0;
 		}
 
 		.theme__upsell {
+			display: flex;
+			flex-basis: 100%;
 			font-size: 0;
-			line-height: 24px;
+			line-height: 20px;
 			padding: 0;
 
 			.premium-badge,
@@ -211,8 +216,10 @@ body.is-section-themes-i4-2 {
 
 		.theme__info-upsell-description {
 			color: var(--color-neutral-60);
+			display: flex;
+			flex-basis: 100%;
 			font-size: 0.875rem;
-			line-height: 24px;
+			line-height: 20px;
 		}
 
 		.theme__badge-active {
@@ -226,10 +233,10 @@ body.is-section-themes-i4-2 {
 		}
 
 		.theme__info-style-variations {
-			align-content: center;
+			align-items: center;
 			display: flex;
-			flex-basis: 100%;
 			font-size: 0;
+			height: 24px;
 			gap: 4px;
 
 			.style-variation__badge-more-wrapper > * {


### PR DESCRIPTION
#### Proposed Changes

This PR updates the theme card UI as proposed in pekYwv-yc-p2, mainly changing:
1. Text consistency (color, weight, size).
2. Swap the positioning of the pricing badge and style variation indicators.

See the before/after screenshots:
| Before | After |
| --- | --- |
| ![Screen Shot 2023-01-19 at 3 03 17 PM](https://user-images.githubusercontent.com/797888/213376874-4ebad4ef-40bd-4d66-a99f-2ec2df3d1fbb.png) | ![Screen Shot 2023-01-19 at 3 04 26 PM](https://user-images.githubusercontent.com/797888/213377078-d22f4085-9905-4a84-a83d-9ac28e933c31.png) |


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the Theme Showcase, either Simple or Atomic site or logged-out. If using calypso.live, the flag `themes/showcase-i4/details-and-preview` or `themes/showcase-i4/cards-only` is required.
* Ensure that the UI update is as described above.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
