### PR TITLE
Plans 2023: Styling changes for large currencies

### DIFF
--- a/client/my-sites/plan-features-2023-grid/header-price.tsx
+++ b/client/my-sites/plan-features-2023-grid/header-price.tsx
@@ -1,7 +1,15 @@
 import { isWpcomEnterpriseGridPlan } from '@automattic/calypso-products';
-import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import PlanPrice from 'calypso/my-sites/plan-price';
+
+interface PlanFeatures2023GridHeaderPriceProps {
+	planName: string;
+	discountPrice: number | null;
+	currencyCode: string | null;
+	rawPrice: number;
+	is2023OnboardingPricingGrid: boolean;
+	isLargeCurrency: boolean;
+}
 
 const PlanFeatures2023GridHeaderPrice = ( {
 	planName,
@@ -9,7 +17,8 @@ const PlanFeatures2023GridHeaderPrice = ( {
 	currencyCode,
 	rawPrice,
 	is2023OnboardingPricingGrid,
-} ) => {
+	isLargeCurrency,
+}: PlanFeatures2023GridHeaderPriceProps ) => {
 	if ( isWpcomEnterpriseGridPlan( planName ) ) {
 		return null;
 	}
@@ -24,6 +33,7 @@ const PlanFeatures2023GridHeaderPrice = ( {
 							rawPrice={ rawPrice }
 							displayPerMonthNotation={ false }
 							is2023OnboardingPricingGrid={ is2023OnboardingPricingGrid }
+							isLargeCurrency={ isLargeCurrency }
 							original
 						/>
 						<PlanPrice
@@ -31,6 +41,7 @@ const PlanFeatures2023GridHeaderPrice = ( {
 							rawPrice={ discountPrice }
 							displayPerMonthNotation={ false }
 							is2023OnboardingPricingGrid={ is2023OnboardingPricingGrid }
+							isLargeCurrency={ isLargeCurrency }
 							discounted
 						/>
 					</div>
@@ -42,6 +53,7 @@ const PlanFeatures2023GridHeaderPrice = ( {
 					rawPrice={ rawPrice }
 					displayPerMonthNotation={ false }
 					is2023OnboardingPricingGrid={ is2023OnboardingPricingGrid }
+					isLargeCurrency={ isLargeCurrency }
 				/>
 			) }
 		</div>
@@ -56,4 +68,4 @@ PlanFeatures2023GridHeaderPrice.propTypes = {
 	is2023OnboardingPricingGrid: PropTypes.bool,
 };
 
-export default localize( PlanFeatures2023GridHeaderPrice );
+export default PlanFeatures2023GridHeaderPrice;

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -267,11 +267,19 @@ export class PlanFeatures2023Grid extends Component< PlanFeatures2023GridType > 
 	renderPlanPrice( planPropertiesObj: PlanProperties[], options?: PlanRowOptions ) {
 		const { isReskinned, is2023OnboardingPricingGrid } = this.props;
 
+		const isLargeCurrency = planPropertiesObj.some(
+			( properties ) => properties?.rawPrice && properties?.rawPrice > 99000
+		);
+
 		return planPropertiesObj.map( ( properties ) => {
 			const { currencyCode, discountPrice, planName, rawPrice } = properties;
 			const classes = classNames( 'plan-features-2023-grid__table-item', {
 				'has-border-top': ! isReskinned,
 			} );
+
+			if ( rawPrice === undefined || rawPrice === null ) {
+				return;
+			}
 
 			return (
 				<Container
@@ -286,6 +294,7 @@ export class PlanFeatures2023Grid extends Component< PlanFeatures2023GridType > 
 						rawPrice={ rawPrice }
 						planName={ planName }
 						is2023OnboardingPricingGrid={ is2023OnboardingPricingGrid }
+						isLargeCurrency={ isLargeCurrency }
 					/>
 				</Container>
 			);

--- a/client/my-sites/plan-features-2023-grid/style.scss
+++ b/client/my-sites/plan-features-2023-grid/style.scss
@@ -353,7 +353,7 @@ $plan-features-sidebar-width: 272px;
 			.plan-price__integer {
 				font-size: rem(38px);
 			}
-			&.is-discounted {
+			&.is-original {
 				.plan-price__integer {
 					font-size: $font-body-small;
 				}

--- a/client/my-sites/plan-features-2023-grid/style.scss
+++ b/client/my-sites/plan-features-2023-grid/style.scss
@@ -348,6 +348,17 @@ $plan-features-sidebar-width: 272px;
 		.plan-price.is-discounted .plan-price__integer-fraction {
 			color: var(--color-success);
 		}
+
+		.plan-price.is-large-currency {
+			.plan-price__integer {
+				font-size: rem(38px);
+			}
+			&.is-discounted {
+				.plan-price__integer {
+					font-size: $font-body-small;
+				}
+			}
+		}
 	}
 
 	.plan-features-2023-grid__header-annual-discount {

--- a/client/my-sites/plan-price/index.tsx
+++ b/client/my-sites/plan-price/index.tsx
@@ -22,11 +22,13 @@ export class PlanPrice extends Component< PlanPriceProps > {
 			taxText,
 			omitHeading,
 			is2023OnboardingPricingGrid,
+			isLargeCurrency,
 		} = this.props;
 
 		const classes = classNames( 'plan-price', className, {
 			'is-original': original,
 			'is-discounted': discounted,
+			'is-large-currency': isLargeCurrency,
 		} );
 
 		const tagName = omitHeading ? 'span' : 'h4';
@@ -193,6 +195,11 @@ export interface PlanPriceProps {
 	 * Ignored if `productDisplayPrice` is set and `rawPrice` is not an array.
 	 */
 	is2023OnboardingPricingGrid?: boolean;
+
+	/**
+	 * If true, this renders the price with a smaller font size by adding the `is-large-currency` class.
+	 */
+	isLargeCurrency?: boolean;
 }
 
 function PriceWithoutHtml( {

--- a/client/my-sites/plan-price/test/index.js
+++ b/client/my-sites/plan-price/test/index.js
@@ -274,39 +274,45 @@ describe( 'PlanPrice', () => {
 		expect( document.querySelector( 'div.plan-price__integer-fraction' ) ).toBeFalsy();
 	} );
 
-	it( 'renders a price without the "is-discounted" tag if discounted is not set', () => {
+	it( 'renders a price without the "is-discounted" class if discounted is not set', () => {
 		render( <PlanPrice rawPrice={ 44700.5 } currencyCode="IDR" /> );
 		expect( document.body ).toHaveTextContent( 'Rp44,700.50' );
 		expect( document.querySelector( '.is-discounted' ) ).toBeFalsy();
 	} );
 
-	it( 'renders a price with the "is-discounted" tag if discounted is set', () => {
+	it( 'renders a price with the "is-discounted" class if discounted is set', () => {
 		render( <PlanPrice rawPrice={ 44700.5 } currencyCode="IDR" discounted /> );
 		expect( document.body ).toHaveTextContent( 'Rp44,700.50' );
 		expect( document.querySelector( '.is-discounted' ) ).toBeTruthy();
 	} );
 
-	it( 'renders a price with the "is-discounted" tag if using productDisplayPrice and discounted is set', () => {
+	it( 'renders a price with the "is-discounted" class if using productDisplayPrice and discounted is set', () => {
 		render( <PlanPrice productDisplayPrice="$45" discounted /> );
 		expect( document.body ).toHaveTextContent( '$45' );
 		expect( document.querySelector( '.is-discounted' ) ).toBeTruthy();
 	} );
 
-	it( 'renders a price without the "is-original" tag if original is not set', () => {
+	it( 'renders a price without the "is-original" class if original is not set', () => {
 		render( <PlanPrice rawPrice={ 44700.5 } currencyCode="IDR" /> );
 		expect( document.body ).toHaveTextContent( 'Rp44,700.50' );
 		expect( document.querySelector( '.is-discounted' ) ).toBeFalsy();
 	} );
 
-	it( 'renders a price with the "is-original" tag if original is set', () => {
+	it( 'renders a price with the "is-original" class if original is set', () => {
 		render( <PlanPrice rawPrice={ 44700.5 } currencyCode="IDR" original /> );
 		expect( document.body ).toHaveTextContent( 'Rp44,700.50' );
 		expect( document.querySelector( '.is-original' ) ).toBeTruthy();
 	} );
 
-	it( 'renders a price with the "is-original" tag if using productDisplayPrice and original is set', () => {
+	it( 'renders a price with the "is-original" class if using productDisplayPrice and original is set', () => {
 		render( <PlanPrice productDisplayPrice="$45" original /> );
 		expect( document.body ).toHaveTextContent( '$45' );
 		expect( document.querySelector( '.is-original' ) ).toBeTruthy();
+	} );
+
+	it( 'renders a price with the "is-large-currency" class if isLargeCurrency is set', () => {
+		render( <PlanPrice rawPrice={ 44700.5 } currencyCode="IDR" isLargeCurrency={ true } /> );
+		expect( document.body ).toHaveTextContent( 'Rp44,700.50' );
+		expect( document.querySelector( '.is-large-currency' ) ).toBeTruthy();
 	} );
 } );


### PR DESCRIPTION
#### Proposed Changes

* For large currencies, reduced the font-size from 44px to 38px on currencies bigger than 99,000. On mobile, the font size is kept as it is to 44px.

Figma: xkhhUlDowF13dRoXJqlRDM-fi-1%3A95&t=W3uQ0QTq5A4xVzge-0

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to a currency which has large values via the SA.
* Go to `/start/onboarding-2023-pricing-grid/plans`
* Confirm that the page matches the Figma design.

<img width="1919" alt="image" src="https://user-images.githubusercontent.com/5436027/213222519-cfcfd3c2-b101-4874-b0fa-a4951a380b09.png">

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes Automattic/martech#1413