### PR TITLE
Stats: Modify the PostStatsCard title and narrower layout on the PostDetailPage

### DIFF
--- a/client/my-sites/stats/post-detail-highlights-section/index.tsx
+++ b/client/my-sites/stats/post-detail-highlights-section/index.tsx
@@ -29,6 +29,19 @@ type Post = {
 	discussion: PostDiscussion;
 };
 
+const POST_STATS_CARD_TITLE_LIMIT = 48;
+
+// Use ellipsis when characters count over the limit
+const textTruncator = ( text: string, limit = 48 ) => {
+	if ( ! text ) {
+		return '';
+	}
+
+	const truncatedText = text.substring( 0, limit );
+
+	return `${ truncatedText }${ text.length > limit ? '...' : '' } `;
+};
+
 export default function PostDetailHighlightsSection( {
 	siteId,
 	postId,
@@ -45,7 +58,7 @@ export default function PostDetailHighlightsSection( {
 	const postData = {
 		date: post?.date,
 		post_thumbnail: post?.post_thumbnail?.URL || null,
-		title: post?.title,
+		title: textTruncator( post?.title, POST_STATS_CARD_TITLE_LIMIT ),
 	};
 
 	return (

--- a/client/my-sites/stats/post-detail-highlights-section/style.scss
+++ b/client/my-sites/stats/post-detail-highlights-section/style.scss
@@ -63,7 +63,7 @@
 		min-width: 770px;
 
 		@media ( max-width: $break-small ) {
-			gap: 12px;
+			gap: 24px 12px;
 		}
 
 		&::after {

--- a/client/my-sites/stats/post-detail-highlights-section/style.scss
+++ b/client/my-sites/stats/post-detail-highlights-section/style.scss
@@ -6,9 +6,23 @@
 	padding-top: $vertical-margin;
 	padding-bottom: $vertical-margin;
 
+	.stats > & {
+		@media ( max-width: $break-medium ) {
+			padding-left: 0;
+			padding-right: 0;
+		}
+	}
+
 	.highlight-cards {
 		background-color: inherit;
 		box-shadow: none;
+	}
+
+	.highlight-cards-heading {
+		@media ( max-width: $break-medium ) {
+			margin-left: 0.875rem;
+			margin-right: 0.875rem;
+		}
 	}
 
 	.highlight-cards-list {
@@ -18,13 +32,19 @@
 		column-gap: 10px;
 		overflow-x: auto;
 
-		@media ( max-width: $break-small ) {
+		@media ( max-width: $break-medium ) {
 			display: block;
 			padding: 0;
 
 			& > * {
 				padding: 24px;
 				min-width: unset;
+			}
+
+			.post-stats-card {
+				min-width: unset;
+				border-radius: 0;
+				border-top: 1px solid var(--color-border-subtle);
 			}
 
 			.highlight-card {
@@ -40,7 +60,11 @@
 	.post-stats-card {
 		margin: 0;
 		max-height: unset;
-		min-width: 450px;
+		min-width: 770px;
+
+		@media ( max-width: $break-small ) {
+			gap: 12px;
+		}
 
 		&::after {
 			display: none;
@@ -49,7 +73,10 @@
 
 	.post-stats-card__thumbnail {
 		max-height: 300px;
-		width: 300px;
+
+		@media ( max-width: $break-medium ) {
+			max-height: unset;
+		}
 	}
 
 	.highlight-card {

--- a/client/my-sites/stats/post-detail-highlights-section/style.scss
+++ b/client/my-sites/stats/post-detail-highlights-section/style.scss
@@ -38,7 +38,6 @@
 
 			& > * {
 				padding: 24px;
-				min-width: unset;
 			}
 
 			.post-stats-card {
@@ -48,6 +47,7 @@
 			}
 
 			.highlight-card {
+				min-width: unset;
 				height: 180px;
 				margin: math.div($vertical-margin, 2) 0;
 				border-left: 0;


### PR DESCRIPTION
#### Proposed Changes

* Cut off and append an ellipsis to the post title by `48` limited character count.
* Make Highlights cards as blocks under viewport `width <= 782px`.
* Fix the `PostStatsCard` layout and the thumbnail size on the narrower viewport.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up this change with the Calypso Live link.
* Navigate to the Stats `Post Detail` page (`/stats/post/${post-id}/${site-id}`).
* Append the feature flag `?flags=stats/enhance-post-detail` to the URL.
* Ensure the post title is cut off and appended with an ellipsis by `48` character count.
* Ensure the Highlights cards display in line with the [suggestion from design feedback](https://github.com/Automattic/wp-calypso/issues/70671#issuecomment-1371719954).

##### Mobile
<img width="604" alt="截圖 2023-01-19 下午3 27 16" src="https://user-images.githubusercontent.com/6869813/213386028-bdcde485-a21a-4615-ae08-21edd7da8939.png">

##### Tablet
<img width="702" alt="截圖 2023-01-19 下午3 27 29" src="https://user-images.githubusercontent.com/6869813/213386041-be60c18a-7e2a-4daf-8d8b-1e90f39017d7.png">

##### PC
<img width="1144" alt="截圖 2023-01-19 下午3 28 17" src="https://user-images.githubusercontent.com/6869813/213386055-d1387814-d51b-43d1-ba0b-7ad46dd01682.png">


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #70671 
