### PR TITLE
Jetpack Pro Dashboard: add tracking events to downtime monitoring changes

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/dashboard-bulk-actions/edit-button.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/dashboard-bulk-actions/edit-button.tsx
@@ -2,6 +2,7 @@ import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useContext } from 'react';
 import ButtonGroup from 'calypso/components/button-group';
+import { useJetpackAgencyDashboardRecordTrackEvent } from '../hooks';
 import SitesOverviewContext from '../sites-overview/context';
 import type { SiteData } from '../sites-overview/types';
 
@@ -9,12 +10,14 @@ import './style.scss';
 
 interface Props {
 	sites: Array< SiteData >;
+	isLargeScreen?: boolean;
 }
 
-export default function EditButton( { sites }: Props ) {
+export default function EditButton( { sites, isLargeScreen }: Props ) {
 	const translate = useTranslate();
 
 	const { setIsBulkManagementActive, setSelectedSites } = useContext( SitesOverviewContext );
+	const recordEvent = useJetpackAgencyDashboardRecordTrackEvent( null, isLargeScreen );
 
 	const handleToggleSelect = () => {
 		// Filter sites with site error as they are not selectable.
@@ -23,6 +26,7 @@ export default function EditButton( { sites }: Props ) {
 	};
 
 	const handleEditAll = () => {
+		recordEvent( 'edit_all_click' );
 		setIsBulkManagementActive( true );
 		handleToggleSelect();
 	};

--- a/client/jetpack-cloud/sections/agency-dashboard/dashboard-bulk-actions/hooks.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/dashboard-bulk-actions/hooks.tsx
@@ -1,7 +1,11 @@
 import { useTranslate } from 'i18n-calypso';
 import { ReactChild, useCallback, useEffect, useState, useContext, RefObject } from 'react';
 import acceptDialog from 'calypso/lib/accept';
-import { useToggleActivateMonitor, useUpdateMonitorSettings } from '../hooks';
+import {
+	useJetpackAgencyDashboardRecordTrackEvent,
+	useToggleActivateMonitor,
+	useUpdateMonitorSettings,
+} from '../hooks';
 import SitesOverviewContext from '../sites-overview/context';
 import {
 	availableNotificationDurations as durations,
@@ -26,18 +30,20 @@ const dialogContent = (
 	return acceptDialog( content, action, heading, null, options );
 };
 
-export function useHandleToggleMonitor( selectedSites: Array< Site > ) {
+export function useHandleToggleMonitor( selectedSites: Array< Site >, isLargeScreen?: boolean ) {
 	const translate = useTranslate();
 
 	const toggleActivateMonitor = useToggleActivateMonitor( selectedSites );
+	const recordEvent = useJetpackAgencyDashboardRecordTrackEvent( selectedSites, isLargeScreen );
 
 	const toggleMonitor = useCallback(
 		( accepted: boolean, activate: boolean ) => {
 			if ( accepted ) {
 				toggleActivateMonitor( activate );
+				recordEvent( activate ? 'resume_monitor_save' : 'pause_monitor_save' );
 			}
 		},
-		[ toggleActivateMonitor ]
+		[ recordEvent, toggleActivateMonitor ]
 	);
 
 	const handleToggleActivateMonitor = useCallback(
@@ -74,9 +80,13 @@ export function useHandleToggleMonitor( selectedSites: Array< Site > ) {
 	return handleToggleActivateMonitor;
 }
 
-export function useHandleResetNotification( selectedSites: Array< Site > ) {
+export function useHandleResetNotification(
+	selectedSites: Array< Site >,
+	isLargeScreen?: boolean
+) {
 	const translate = useTranslate();
 	const { updateMonitorSettings } = useUpdateMonitorSettings( selectedSites );
+	const recordEvent = useJetpackAgencyDashboardRecordTrackEvent( selectedSites, isLargeScreen );
 
 	const resetMonitorDuration = useCallback(
 		( accepted: boolean ) => {
@@ -86,9 +96,10 @@ export function useHandleResetNotification( selectedSites: Array< Site > ) {
 					jetmon_defer_status_down_minutes: defaultDuration?.time,
 				};
 				updateMonitorSettings( params );
+				recordEvent( 'reset_notification_save' );
 			}
 		},
-		[ updateMonitorSettings ]
+		[ recordEvent, updateMonitorSettings ]
 	);
 
 	const handleResetNotification = useCallback( () => {

--- a/client/jetpack-cloud/sections/agency-dashboard/dashboard-bulk-actions/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/dashboard-bulk-actions/index.tsx
@@ -20,9 +20,14 @@ import './style.scss';
 interface Props {
 	selectedSites: Array< Site >;
 	monitorUserEmails: Array< string >;
+	isLargeScreen?: boolean;
 }
 
-export default function DashboardBulkActions( { selectedSites, monitorUserEmails }: Props ) {
+export default function DashboardBulkActions( {
+	selectedSites,
+	monitorUserEmails,
+	isLargeScreen,
+}: Props ) {
 	const actionBarRef = createRef< HTMLDivElement >();
 	const translate = useTranslate();
 	const { setIsBulkManagementActive } = useContext( SitesOverviewContext );
@@ -110,9 +115,10 @@ export default function DashboardBulkActions( { selectedSites, monitorUserEmails
 			</div>
 			{ showNotificationSettingsPopup && (
 				<NotificationSettings
-					monitorUserEmails={ monitorUserEmails }
 					sites={ selectedSites }
+					monitorUserEmails={ monitorUserEmails }
 					onClose={ toggleNotificationSettingsPopup }
+					isLargeScreen={ isLargeScreen }
 				/>
 			) }
 		</>

--- a/client/jetpack-cloud/sections/agency-dashboard/dashboard-bulk-actions/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/dashboard-bulk-actions/index.tsx
@@ -33,8 +33,8 @@ export default function DashboardBulkActions( {
 	const translate = useTranslate();
 	const { setIsBulkManagementActive } = useContext( SitesOverviewContext );
 
-	const handleToggleActivateMonitor = useHandleToggleMonitor( selectedSites );
-	const handleResetNotification = useHandleResetNotification( selectedSites );
+	const handleToggleActivateMonitor = useHandleToggleMonitor( selectedSites, isLargeScreen );
+	const handleResetNotification = useHandleResetNotification( selectedSites, isLargeScreen );
 	const { actionBarVisible } = useHandleShowHideActionBar( actionBarRef );
 	const recordEvent = useJetpackAgencyDashboardRecordTrackEvent( selectedSites, isLargeScreen );
 

--- a/client/jetpack-cloud/sections/agency-dashboard/dashboard-bulk-actions/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/dashboard-bulk-actions/index.tsx
@@ -5,6 +5,7 @@ import { useState, createRef, useContext } from 'react';
 import ButtonGroup from 'calypso/components/button-group';
 import SelectDropdown from 'calypso/components/select-dropdown';
 import NotificationSettings from '../downtime-monitoring/notification-settings';
+import { useJetpackAgencyDashboardRecordTrackEvent } from '../hooks';
 import SitesOverviewContext from '../sites-overview/context';
 import {
 	useHandleToggleMonitor,
@@ -35,6 +36,7 @@ export default function DashboardBulkActions( {
 	const handleToggleActivateMonitor = useHandleToggleMonitor( selectedSites );
 	const handleResetNotification = useHandleResetNotification( selectedSites );
 	const { actionBarVisible } = useHandleShowHideActionBar( actionBarRef );
+	const recordEvent = useJetpackAgencyDashboardRecordTrackEvent( selectedSites, isLargeScreen );
 
 	const [ showNotificationSettingsPopup, setShowNotificationSettingsPopup ] = useState( false );
 
@@ -46,10 +48,12 @@ export default function DashboardBulkActions( {
 		{
 			label: translate( 'Pause Monitor' ),
 			action: () => handleToggleActivateMonitor( false ),
+			actionName: 'pause_monitor_click',
 		},
 		{
 			label: translate( 'Resume Monitor' ),
 			action: () => handleToggleActivateMonitor( true ),
+			actionName: 'resume_monitor_click',
 		},
 	];
 
@@ -57,27 +61,43 @@ export default function DashboardBulkActions( {
 		{
 			label: translate( 'Custom Notification' ),
 			action: () => toggleNotificationSettingsPopup(),
+			actionName: 'custom_notification_click',
 		},
 		{
 			label: translate( 'Reset Notification' ),
 			action: () => handleResetNotification(),
+			actionName: 'reset_notification_click',
 		},
 	];
 
 	const disabled = selectedSites.length === 0;
 
+	const handleAction = ( action: () => void, actionName: string ) => {
+		recordEvent( actionName );
+		action();
+	};
+
 	const desktopContent = (
 		<>
 			<ButtonGroup>
-				{ toggleMonitorActions.map( ( { label, action } ) => (
-					<Button compact key={ label } disabled={ disabled } onClick={ action }>
+				{ toggleMonitorActions.map( ( { label, action, actionName } ) => (
+					<Button
+						compact
+						key={ label }
+						disabled={ disabled }
+						onClick={ () => handleAction( action, actionName ) }
+					>
 						{ label }
 					</Button>
 				) ) }
 			</ButtonGroup>
-			{ otherMonitorActions.map( ( { label, action } ) => (
+			{ otherMonitorActions.map( ( { label, action, actionName } ) => (
 				<ButtonGroup key={ label }>
-					<Button compact disabled={ disabled } onClick={ action }>
+					<Button
+						compact
+						disabled={ disabled }
+						onClick={ () => handleAction( action, actionName ) }
+					>
 						{ label }
 					</Button>
 				</ButtonGroup>
@@ -87,11 +107,17 @@ export default function DashboardBulkActions( {
 
 	const mobileContent = (
 		<SelectDropdown compact selectedText={ translate( 'Actions' ) }>
-			{ [ ...toggleMonitorActions, ...otherMonitorActions ].map( ( { label, action } ) => (
-				<SelectDropdown.Item key={ label } disabled={ disabled } onClick={ action }>
-					{ label }
-				</SelectDropdown.Item>
-			) ) }
+			{ [ ...toggleMonitorActions, ...otherMonitorActions ].map(
+				( { label, action, actionName } ) => (
+					<SelectDropdown.Item
+						key={ label }
+						disabled={ disabled }
+						onClick={ () => handleAction( action, actionName ) }
+					>
+						{ label }
+					</SelectDropdown.Item>
+				)
+			) }
 		</SelectDropdown>
 	);
 

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
@@ -6,7 +6,7 @@ import { useEffect, useState } from 'react';
 import clockIcon from 'calypso/assets/images/jetpack/clock-icon.svg';
 import SelectDropdown from 'calypso/components/select-dropdown';
 import TokenField from 'calypso/components/token-field';
-import { useUpdateMonitorSettings } from '../../hooks';
+import { useUpdateMonitorSettings, useJetpackAgencyDashboardRecordTrackEvent } from '../../hooks';
 import {
 	availableNotificationDurations as durations,
 	getSiteCountText,
@@ -23,6 +23,7 @@ interface Props {
 	onClose: () => void;
 	settings?: MonitorSettings;
 	monitorUserEmails?: Array< string >;
+	isLargeScreen?: boolean;
 }
 
 export default function NotificationSettings( {
@@ -30,9 +31,11 @@ export default function NotificationSettings( {
 	sites,
 	settings,
 	monitorUserEmails,
+	isLargeScreen,
 }: Props ) {
 	const translate = useTranslate();
 	const { updateMonitorSettings, isLoading, isComplete } = useUpdateMonitorSettings( sites );
+	const recordEvent = useJetpackAgencyDashboardRecordTrackEvent( sites, isLargeScreen );
 
 	const defaultDuration = durations.find( ( duration ) => duration.time === 5 );
 
@@ -57,10 +60,12 @@ export default function NotificationSettings( {
 			email_notifications: enableEmailNotification,
 			jetmon_defer_status_down_minutes: selectedDuration?.time,
 		};
+		recordEvent( 'notification_save_click' );
 		updateMonitorSettings( params );
 	}
 
 	function selectDuration( duration: Duration ) {
+		recordEvent( 'duration_select', { duration: duration.time } );
 		setSelectedDuration( duration );
 	}
 
@@ -139,6 +144,11 @@ export default function NotificationSettings( {
 							{ translate( 'Notify me about downtime:' ) }
 						</div>
 						<SelectDropdown
+							onToggle={ ( { open: isOpen }: { open: boolean } ) => {
+								if ( isOpen ) {
+									recordEvent( 'notification_duration_toggle' );
+								}
+							} }
 							selectedIcon={
 								<img
 									className="notification-settings__duration-icon"
@@ -162,7 +172,12 @@ export default function NotificationSettings( {
 					<div className="notification-settings__toggle-container">
 						<div className="notification-settings__toggle">
 							<ToggleControl
-								onChange={ setEnableMobileNotification }
+								onChange={ ( isEnabled ) => {
+									recordEvent(
+										isEnabled ? 'mobile_notification_enable' : 'mobile_notification_disable'
+									);
+									setEnableMobileNotification( isEnabled );
+								} }
 								checked={ enableMobileNotification }
 							/>
 						</div>
@@ -189,7 +204,12 @@ export default function NotificationSettings( {
 					<div className="notification-settings__toggle-container">
 						<div className="notification-settings__toggle">
 							<ToggleControl
-								onChange={ setEnableEmailNotification }
+								onChange={ ( isEnabled ) => {
+									recordEvent(
+										isEnabled ? 'email_notification_enable' : 'email_notification_disable'
+									);
+									setEnableEmailNotification( isEnabled );
+								} }
 								checked={ enableEmailNotification }
 							/>
 						</div>

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
@@ -60,7 +60,7 @@ export default function NotificationSettings( {
 			email_notifications: enableEmailNotification,
 			jetmon_defer_status_down_minutes: selectedDuration?.time,
 		};
-		recordEvent( 'notification_save_click' );
+		recordEvent( 'notification_save_click', params );
 		updateMonitorSettings( params );
 	}
 

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/toggle-activate-monitoring/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/toggle-activate-monitoring/index.tsx
@@ -8,7 +8,7 @@ import clockIcon from 'calypso/assets/images/jetpack/clock-icon.svg';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import Tooltip from 'calypso/components/tooltip';
 import { getSiteMonitorStatuses } from 'calypso/state/jetpack-agency-dashboard/selectors';
-import { useToggleActivateMonitor } from '../../hooks';
+import { useJetpackAgencyDashboardRecordTrackEvent, useToggleActivateMonitor } from '../../hooks';
 import NotificationSettings from '../notification-settings';
 import type { AllowedStatusTypes, MonitorSettings, Site } from '../../sites-overview/types';
 
@@ -21,6 +21,7 @@ interface Props {
 	tooltip: ReactChild | undefined;
 	tooltipId: string;
 	siteError: boolean;
+	isLargeScreen?: boolean;
 }
 
 export default function ToggleActivateMonitoring( {
@@ -30,10 +31,13 @@ export default function ToggleActivateMonitoring( {
 	tooltip,
 	tooltipId,
 	siteError,
+	isLargeScreen,
 }: Props ) {
 	const moment = useLocalizedMoment();
 	const translate = useTranslate();
+
 	const toggleActivateMonitor = useToggleActivateMonitor( [ site ] );
+	const recordEvent = useJetpackAgencyDashboardRecordTrackEvent( [ site ], isLargeScreen );
 	const statuses = useSelector( getSiteMonitorStatuses );
 	const [ showNotificationSettings, setShowNotificationSettings ] = useState< boolean >( false );
 	const [ showTooltip, setShowTooltip ] = useState( false );
@@ -52,10 +56,14 @@ export default function ToggleActivateMonitoring( {
 	>;
 
 	function handleToggleActivateMonitoring( checked: boolean ) {
+		recordEvent( checked ? 'enable_monitor_click' : 'disable_monitor_click' );
 		toggleActivateMonitor( checked );
 	}
 
 	function handleToggleNotificationSettings() {
+		if ( ! showNotificationSettings ) {
+			recordEvent( 'notification_settings_open' );
+		}
 		setShowNotificationSettings( ( isOpen ) => ! isOpen );
 	}
 

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/toggle-activate-monitoring/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/toggle-activate-monitoring/index.tsx
@@ -159,6 +159,7 @@ export default function ToggleActivateMonitoring( {
 					onClose={ handleToggleNotificationSettings }
 					sites={ [ site ] }
 					settings={ settings }
+					isLargeScreen={ isLargeScreen }
 				/>
 			) }
 			{ tooltip && (

--- a/client/jetpack-cloud/sections/agency-dashboard/hooks.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/hooks.tsx
@@ -335,12 +335,12 @@ export function useJetpackAgencyDashboardRecordTrackEvent(
 
 			if ( sites?.length ) {
 				siteProperties = {
-					siteCount: sites.length,
+					selected_site_count: sites.length,
 				};
 				if ( sites.length === 1 ) {
 					siteProperties = {
-						siteId: sites[ 0 ].blog_id,
-						siteUrl: sites[ 0 ].url,
+						selected_site_id: sites[ 0 ].blog_id,
+						selected_site_url: sites[ 0 ].url,
 					};
 				}
 			}

--- a/client/jetpack-cloud/sections/agency-dashboard/hooks.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/hooks.tsx
@@ -325,33 +325,42 @@ export function useJetpackAgencyDashboardRecordTrackEvent(
 ) {
 	const dispatch = useDispatch();
 
-	const dispatchEvent = useCallback(
-		( action, args = {} ) => {
-			const name = `calypso_jetpack_agency_dashboard_${ action }_${
+	const buildEventName = useCallback(
+		( action: string ) =>
+			`calypso_jetpack_agency_dashboard_${ action }_${
 				isLargeScreen ? 'large_screen' : 'small_screen'
-			}`;
+			}`,
+		[ isLargeScreen ]
+	);
 
-			let siteProperties = {};
+	const buildSiteProperties = useCallback( () => {
+		if ( ! sites?.length ) {
+			return {};
+		}
+		if ( sites.length === 1 ) {
+			const { blog_id, url } = sites[ 0 ];
+			return {
+				selected_site_id: blog_id,
+				selected_site_url: url,
+			};
+		}
+		return {
+			selected_site_count: sites.length,
+		};
+	}, [ sites ] );
 
-			if ( sites?.length ) {
-				siteProperties = {
-					selected_site_count: sites.length,
-				};
-				if ( sites.length === 1 ) {
-					siteProperties = {
-						selected_site_id: sites[ 0 ].blog_id,
-						selected_site_url: sites[ 0 ].url,
-					};
-				}
-			}
+	const dispatchTrackingEvent = useCallback(
+		( action, args = {} ) => {
+			const name = buildEventName( action );
+
 			const properties = {
-				...siteProperties,
+				...buildSiteProperties(),
 				...args,
 			};
 			dispatch( recordTracksEvent( name, properties ) );
 		},
-		[ dispatch, isLargeScreen, sites ]
+		[ buildEventName, buildSiteProperties, dispatch ]
 	);
 
-	return dispatchEvent;
+	return dispatchTrackingEvent;
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-bulk-select/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-bulk-select/index.tsx
@@ -10,9 +10,10 @@ import './style.scss';
 interface Props {
 	sites: Array< SiteData >;
 	isLoading: boolean;
+	isLargeScreen?: boolean;
 }
 
-export default function SiteBulkSelect( { sites, isLoading }: Props ) {
+export default function SiteBulkSelect( { sites, isLoading, isLargeScreen }: Props ) {
 	const translate = useTranslate();
 
 	const { selectedSites, setSelectedSites } = useContext( SitesOverviewContext );
@@ -83,6 +84,7 @@ export default function SiteBulkSelect( { sites, isLoading }: Props ) {
 			<DashboardBulkActions
 				selectedSites={ selectedSites }
 				monitorUserEmails={ sites[ 0 ].monitor.settings?.monitor_user_emails ?? [] }
+				isLargeScreen={ isLargeScreen }
 			/>
 		</div>
 	);

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-bulk-select/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-bulk-select/index.tsx
@@ -2,6 +2,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useContext } from 'react';
 import BulkSelect from 'calypso/components/bulk-select';
 import DashboardBulkActions from '../../dashboard-bulk-actions';
+import { useJetpackAgencyDashboardRecordTrackEvent } from '../../hooks';
 import SitesOverviewContext from '../context';
 import type { SiteData } from '../types';
 
@@ -15,6 +16,7 @@ interface Props {
 
 export default function SiteBulkSelect( { sites, isLoading, isLargeScreen }: Props ) {
 	const translate = useTranslate();
+	const recordEvent = useJetpackAgencyDashboardRecordTrackEvent( null, isLargeScreen );
 
 	const { selectedSites, setSelectedSites } = useContext( SitesOverviewContext );
 
@@ -32,22 +34,20 @@ export default function SiteBulkSelect( { sites, isLoading, isLargeScreen }: Pro
 		const filteredSites = sites.filter( ( site ) => ! site.site.error );
 		const isChecked = isAllChecked( filteredSites );
 
-		if ( isChecked ) {
-			setSelectedSites(
-				selectedSites.filter(
+		const allSelectedSites = isChecked
+			? selectedSites.filter(
 					( selectedSite ) =>
 						! filteredSites.find( ( site ) => site.site.value.blog_id === selectedSite.blog_id )
-				)
-			);
-		} else {
-			setSelectedSites(
-				[ ...selectedSites, ...filteredSites.map( ( site ) => site.site.value ) ].filter(
+			  )
+			: [ ...selectedSites, ...filteredSites.map( ( site ) => site.site.value ) ].filter(
 					( element, index, array ) =>
 						array.map( ( selectedSite ) => selectedSite.blog_id ).indexOf( element.blog_id ) ===
 						index
-				)
-			);
-		}
+			  );
+		setSelectedSites( allSelectedSites );
+		recordEvent( isChecked ? 'site_bulk_unselect_all' : 'site_bulk_select_select_all', {
+			...( allSelectedSites.length && { selected_site_count: allSelectedSites.length } ),
+		} );
 	};
 
 	const isChecked = isAllChecked( sites );

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-bulk-select/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-bulk-select/index.tsx
@@ -31,21 +31,20 @@ export default function SiteBulkSelect( { sites, isLoading, isLargeScreen }: Pro
 
 	const handleToggleSelect = () => {
 		// Filter sites with site error as they are not selectable.
-		const filteredSites = sites.filter( ( site ) => ! site.site.error );
+		const filteredSites = sites.filter( ( { site: { error } } ) => ! error );
 		const isChecked = isAllChecked( filteredSites );
 
 		const allSelectedSites = isChecked
 			? selectedSites.filter(
-					( selectedSite ) =>
-						! filteredSites.find( ( site ) => site.site.value.blog_id === selectedSite.blog_id )
+					( { blog_id } ) =>
+						! filteredSites.find( ( { site: { value } } ) => value.blog_id === blog_id )
 			  )
-			: [ ...selectedSites, ...filteredSites.map( ( site ) => site.site.value ) ].filter(
+			: [ ...selectedSites, ...filteredSites.map( ( { site: { value } } ) => value ) ].filter(
 					( element, index, array ) =>
-						array.map( ( selectedSite ) => selectedSite.blog_id ).indexOf( element.blog_id ) ===
-						index
+						array.map( ( { blog_id } ) => blog_id ).indexOf( element.blog_id ) === index
 			  );
 		setSelectedSites( allSelectedSites );
-		recordEvent( isChecked ? 'site_bulk_unselect_all' : 'site_bulk_select_select_all', {
+		recordEvent( isChecked ? 'site_bulk_unselect_all' : 'site_bulk_select_all', {
 			...( allSelectedSites.length && { selected_site_count: allSelectedSites.length } ),
 		} );
 	};

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-select-checkbox/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-select-checkbox/index.tsx
@@ -1,4 +1,5 @@
 import FormInputCheckbox from 'calypso/components/forms/form-checkbox';
+import { useJetpackAgencyDashboardRecordTrackEvent } from '../../hooks';
 import type { SiteData } from '../types';
 
 import './style.scss';
@@ -6,15 +7,26 @@ import './style.scss';
 interface Props {
 	item: SiteData;
 	siteError: boolean;
+	isLargeScreen?: boolean;
 }
 
-export default function SiteSelectCheckbox( { item, siteError }: Props ) {
+export default function SiteSelectCheckbox( { item, siteError, isLargeScreen }: Props ) {
+	const recordEvent = useJetpackAgencyDashboardRecordTrackEvent(
+		[ item.site.value ],
+		isLargeScreen
+	);
+
+	function handleCheckboxClick() {
+		item.onSelect( item );
+		recordEvent( item.isSelected ? 'site_unselected' : 'site_selected' );
+	}
+
 	return (
 		<span className="site-select-checkbox">
 			<FormInputCheckbox
 				className="disable-card-expand"
 				id={ item.blog_id }
-				onClick={ item.onSelect }
+				onClick={ handleCheckboxClick }
 				checked={ item.isSelected }
 				readOnly={ true }
 				disabled={ siteError }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content.tsx
@@ -128,7 +128,11 @@ export default function SiteStatusContent( {
 		return (
 			<>
 				{ isBulkManagementActive ? (
-					<SiteSelectCheckbox item={ rows } siteError={ siteError } />
+					<SiteSelectCheckbox
+						isLargeScreen={ isLargeScreen }
+						item={ rows }
+						siteError={ siteError }
+					/>
 				) : (
 					<SiteSetFavorite
 						isFavorite={ isFavorite }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content.tsx
@@ -168,6 +168,7 @@ export default function SiteStatusContent( {
 				tooltip={ tooltip }
 				tooltipId={ tooltipId }
 				siteError={ siteError }
+				isLargeScreen={ isLargeScreen }
 			/>
 		);
 	}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/index.tsx
@@ -43,7 +43,7 @@ export default function SiteTable( { isLoading, columns, items }: Props ) {
 							{ isEnabled( 'jetpack/partner-portal-downtime-monitoring-updates' ) ? (
 								<th>
 									<div className="plugin-common-table__bulk-actions">
-										<EditButton sites={ items } />
+										<EditButton isLargeScreen sites={ items } />
 									</div>
 								</th>
 							) : (

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/index.tsx
@@ -26,7 +26,7 @@ export default function SiteTable( { isLoading, columns, items }: Props ) {
 					{ isBulkManagementActive ? (
 						// Take full-width of the table
 						<th colSpan={ 100 }>
-							<SiteBulkSelect sites={ items } isLoading={ isLoading } />
+							<SiteBulkSelect isLargeScreen sites={ items } isLoading={ isLoading } />
 						</th>
 					) : (
 						<>


### PR DESCRIPTION
#### Proposed Changes

This PR adds tracking events to the downtime monitoring changes.

#### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout add/add-tracking-events-to-downtime-monitoring-changes` and `yarn start-jetpack-cloud`
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Verify bulk select works as expected.
4. Open the dev tool, go to the network tab, and apply the filters - `jetpack-cloud-development` as search and select `Img` filters.

<img width="739" alt="Screenshot 2023-01-19 at 12 43 57 PM" src="https://user-images.githubusercontent.com/10586875/213378720-624de9b6-dc14-489e-a9a2-d7f04cfa478c.png">

5. Perform the below actions and verify that the API call to track the event is made with the right action names. 

`L: Large screen(>1080px)`
`S: Small Screen(<1080px)`

----

#### Enable Monitor

Click the toggle "On"  to enable the monitor

`Event names`

L: calypso_jetpack_agency_dashboard_enable_monitor_click_large_screen
S: calypso_jetpack_agency_dashboard_enable_monitor_click_small_screen

----

#### Disable Monitor

Click the toggle "Off"  to enable the monitor

`Event names`

L: calypso_jetpack_agency_dashboard_disable_monitor_click_large_screen
S: calypso_jetpack_agency_dashboard_disable_monitor_click_small_screen

----

####  Open Custom Notification

**Click the clock icon to open the notification settings.**

`Event names`

L: calypso_jetpack_agency_dashboard_notification_settings_open_large_screen
S: calypso_jetpack_agency_dashboard_notification_settings_open_small_screen

----

####  Custom Notification Form

**User interactions on the custom notification form**

**Open the select box to select the duration.**

`Event names`

L: calypso_jetpack_agency_dashboard_notification_duration_toggle_large_screen
S: calypso_jetpack_agency_dashboard_notification_duration_toggle_small_screen

**Select the duration.**

`Event names`

L: calypso_jetpack_agency_dashboard_duration_select_large_screen
S: calypso_jetpack_agency_dashboard_duration_select_small_screen

Extra props - duration

**Enable Mobile Notification**

`Event names`

L: calypso_jetpack_agency_dashboard_mobile_notification_enable_large_screen
S: calypso_jetpack_agency_dashboard_mobile_notification_enable_small_screen

**Disable Mobile Notification**

`Event names`

L: calypso_jetpack_agency_dashboard_mobile_notification_disable_large_screen
S: calypso_jetpack_agency_dashboard_mobile_notification_disable_small_screen

**Enable Email Notification**

`Event names`

L: calypso_jetpack_agency_dashboard_email_notification_enable_large_screen
S: calypso_jetpack_agency_dashboard_email_notification_enable_small_screen

**Disable Email Notification**

`Event names`

L: calypso_jetpack_agency_dashboard_email_notification_disable_large_screen
S: calypso_jetpack_agency_dashboard_email_notification_disable_small_screen

**Save Custom Notification**

`Event names`

L: calypso_jetpack_agency_dashboard_notification_save_click_large_screen
S: calypso_jetpack_agency_dashboard_notification_save_click_small_screen

Extra props - wp_note_notifications, email_notifications, jetmon_defer_status_down_minutes

----

####  Click "Edit All"

**Click the "Edit All" button which opens the bulk actions menu**

**Event names**

L: calypso_jetpack_agency_dashboard_edit_all_click_large_screen
S: calypso_jetpack_agency_dashboard_edit_all_click_small_screen

----

#### Bulk select

**Select all**

**Event names**

L: calypso_jetpack_agency_dashboard_site_bulk_select_all_large_screen
S: calypso_jetpack_agency_dashboard_site_bulk_select_all_small_screen

**Unselect all**

**Event names**

L: calypso_jetpack_agency_dashboard_site_bulk_unselect_all_large_screen
S: calypso_jetpack_agency_dashboard_site_bulk_unselect_all_small_screen

----

#### Select Single Select

**Select**

**Event names**

L: calypso_jetpack_agency_dashboard_site_selected_large_screen
S: calypso_jetpack_agency_dashboard_site_selected_small_screen

**Unselect**

**Event names**

L: calypso_jetpack_agency_dashboard_site_unselected_large_screen
S: calypso_jetpack_agency_dashboard_site_unselected_small_screen

----

#### Bulk actions - click & save

**Click "Pause Monitor"**

`Event names`

L: calypso_jetpack_agency_dashboard_pause_monitor_click_large_screen
S: calypso_jetpack_agency_dashboard_pause_monitor_click_small_screen

**Save "Pause Monitor"**

`Event names`

L: calypso_jetpack_agency_dashboard_pause_monitor_save_large_screen
S: calypso_jetpack_agency_dashboard_pause_monitor_save_small_screen

**Click "Resume Monitor"**

`Event names`

L: calypso_jetpack_agency_dashboard_resume_monitor_click_large_screen
S: calypso_jetpack_agency_dashboard_resume_monitor_click_small_screen

**Save "Resume Monitor"**

`Event names`

L: calypso_jetpack_agency_dashboard_resume_monitor_save_large_screen
S: calypso_jetpack_agency_dashboard_resume_monitor_save_small_screen

**Click "Custom Notification"**

`Event names`

L: calypso_jetpack_agency_dashboard_custom_notification_click_large_screen
S: calypso_jetpack_agency_dashboard_custom_notification_click_small_screen

**Click "Reset Notification"**

`Event names`

L: calypso_jetpack_agency_dashboard_reset_notification_click_large_screen
S: calypso_jetpack_agency_dashboard_reset_notification_click_small_screen

**Save "Reset Notification"**

`Event names`

L: calypso_jetpack_agency_dashboard_reset_notification_save_large_screen
S: calypso_jetpack_agency_dashboard_reset_notification_save_small_screen

**Props**

If single site is selected

- selected_site_id
- selected_site_url

If > 1 site is selected

- selected_site_count

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1203448324265423-as-1203758045375312