### PR TITLE
Ensure word-break is set to normal for pricing plan labels

### DIFF
--- a/apps/happy-blocks/src/pricing-plans/view.scss
+++ b/apps/happy-blocks/src/pricing-plans/view.scss
@@ -27,6 +27,7 @@ $brand-display: "SF Pro Display", $sans;
 	border-radius: 2px;
 	gap: 22px;
 	background-color: $studio-white;
+	word-break: initial;
 
 
 	&__settings {


### PR DESCRIPTION
#### Proposed Changes

This change fixes an issue which was first discovered in [this usage](https://wordpress.com/forums/topic/about-blogging-on-wp-with-a-different-hosting-service/) of the Upgrade Embed, where it looks like:

<img width="706" alt="image" src="https://user-images.githubusercontent.com/112691742/213389826-3d7d99d8-c082-41a6-97cb-54d7f237a54b.png">

This is happening because a parent dom element has the style `word-break: break-word`

This diff ensures this block has `word-break: initial` on all its children DOM nodes.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit [this page](https://wordpress.com/forums/topic/about-blogging-on-wp-with-a-different-hosting-service/) and verify the problem exists.
* Apply this change in your sandbox with `yarn dev --sync`
* Reload the previously accessed page and ensure the problem is now fixed.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
