### PR TITLE
Stats: Append JetpackColophon to the post detail page

### DIFF
--- a/client/my-sites/stats/stats-post-detail/index.jsx
+++ b/client/my-sites/stats/stats-post-detail/index.jsx
@@ -10,6 +10,7 @@ import QueryPostStats from 'calypso/components/data/query-post-stats';
 import QueryPosts from 'calypso/components/data/query-posts';
 import EmptyContent from 'calypso/components/empty-content';
 import FixedNavigationHeader from 'calypso/components/fixed-navigation-header';
+import JetpackColophon from 'calypso/components/jetpack-colophon';
 import Main from 'calypso/components/main';
 import WebPreview from 'calypso/components/web-preview';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
@@ -181,6 +182,8 @@ class StatsPostDetail extends Component {
 							<PostDetailTableSection siteId={ siteId } postId={ postId } />
 						</>
 					) }
+
+					<JetpackColophon />
 				</div>
 
 				<WebPreview
@@ -247,6 +250,8 @@ class StatsPostDetail extends Component {
 						<PostWeeks siteId={ siteId } postId={ postId } />
 					</div>
 				) }
+
+				<JetpackColophon />
 
 				<WebPreview
 					showPreview={ this.state.showPreview }


### PR DESCRIPTION
#### Proposed Changes

* Append `JetpackColophon` to the post detail page regardless of the modernization feature flag.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up this change with the Calypso Live link.
* Navigate to the Stats `Post Detail` page (`/stats/post/${post-id}/${site-id}`).
* Ensure the `JetpackColophon` is at the bottom of the page.
* Append the feature flag `?flags=stats/enhance-post-detail` to the URL.
* Ensure the `JetpackColophon` is at the bottom of the page.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #70671 
