### PR TITLE
Stats: Add highlights to Ads page

### DIFF
--- a/client/my-sites/stats/wordads/earnings.jsx
+++ b/client/my-sites/stats/wordads/earnings.jsx
@@ -12,21 +12,12 @@ class WordAdsEarnings extends Component {
 	static propTypes = {
 		siteId: PropTypes.number,
 		earnings: PropTypes.object,
-		showTotalsSection: PropTypes.bool,
 	};
 
 	state = {
-		showEarningsNotice: false,
 		showWordadsInfo: false,
 		showSponsoredInfo: false,
 		showAdjustmentInfo: false,
-	};
-
-	handleEarningsNoticeToggle = ( event ) => {
-		event.preventDefault();
-		this.setState( {
-			showEarningsNotice: ! this.state.showEarningsNotice,
-		} );
 	};
 
 	handleInfoToggle = ( type ) => ( event ) => {
@@ -110,36 +101,6 @@ class WordAdsEarnings extends Component {
 		);
 	}
 
-	/* eslint-disable wpcalypso/jsx-classname-namespace */
-	payoutNotice() {
-		const { earnings, numberFormat, translate } = this.props;
-		const owed =
-			earnings && earnings.total_amount_owed
-				? numberFormat( earnings.total_amount_owed, 2 )
-				: '0.00';
-		const notice = translate(
-			'Outstanding amount of $%(amountOwed)s does not exceed the minimum $100 needed to make the payment. ' +
-				'Payment will be made as soon as the total outstanding amount has reached $100.',
-			{
-				comment: 'Insufficient balance for payout.',
-				args: { amountOwed: owed },
-			}
-		);
-		const payout = translate(
-			'Outstanding amount of $%(amountOwed)s will be paid approximately 45 days following the end of the month in which it was earned.',
-			{
-				comment: 'Payout will proceed.',
-				args: { amountOwed: owed },
-			}
-		);
-
-		return (
-			<div className="ads__module-content-text module-content-text module-content-text-info">
-				<p>{ owed < 100 ? notice : payout }</p>
-			</div>
-		);
-	}
-
 	infoNotice() {
 		const { translate } = this.props;
 
@@ -183,36 +144,6 @@ class WordAdsEarnings extends Component {
 					</em>
 				</p>
 			</div>
-		);
-	}
-
-	earningsBreakdown() {
-		const { earnings, numberFormat, translate } = this.props;
-		const total = earnings && earnings.total_earnings ? Number( earnings.total_earnings ) : 0;
-		const owed = earnings && earnings.total_amount_owed ? Number( earnings.total_amount_owed ) : 0;
-		const paid = total - owed;
-
-		return (
-			<ul className="ads__earnings-breakdown-list">
-				<li className="ads__earnings-breakdown-item">
-					<span className="ads__earnings-breakdown-label">
-						{ translate( 'Total earnings', { context: 'Sum of earnings' } ) }
-					</span>
-					<span className="ads__earnings-breakdown-value">${ numberFormat( total, 2 ) }</span>
-				</li>
-				<li className="ads__earnings-breakdown-item">
-					<span className="ads__earnings-breakdown-label">
-						{ translate( 'Total paid', { context: 'Sum of earnings that have been distributed' } ) }
-					</span>
-					<span className="ads__earnings-breakdown-value">${ numberFormat( paid, 2 ) }</span>
-				</li>
-				<li className="ads__earnings-breakdown-item">
-					<span className="ads__earnings-breakdown-label">
-						{ translate( 'Outstanding amount', { context: 'Sum earnings left unpaid' } ) }
-					</span>
-					<span className="ads__earnings-breakdown-value">${ numberFormat( owed, 2 ) }</span>
-				</li>
-			</ul>
 		);
 	}
 
@@ -281,43 +212,12 @@ class WordAdsEarnings extends Component {
 	}
 
 	render() {
-		const { siteId, showTotalsSection, earnings, translate } = this.props;
-		const infoIcon = this.state.showEarningsNotice ? 'info' : 'info-outline';
-		const classes = classNames( 'earnings_breakdown', {
-			'is-showing-info': this.state.showEarningsNotice,
-		} );
+		const { siteId, earnings, translate } = this.props;
 
 		return (
 			<div>
 				<QueryWordadsEarnings siteId={ siteId } />
 
-				{ showTotalsSection && (
-					<Card className={ classes }>
-						<div className="ads__module-header module-header">
-							<h1 className="ads__module-header-title module-header-title">
-								{ translate( 'Totals' ) }
-							</h1>
-							<ul className="ads__module-header-actions module-header-actions">
-								<li className="ads__module-header-action module-header-action toggle-info">
-									{ /* eslint-disable-next-line jsx-a11y/anchor-is-valid */ }
-									<a
-										href="#"
-										className="ads__module-header-action-link module-header-action-link"
-										aria-label={ translate( 'Show or hide panel information' ) }
-										title={ translate( 'Show or hide panel information' ) }
-										onClick={ this.handleEarningsNoticeToggle }
-									>
-										<Gridicon icon={ infoIcon } />
-									</a>
-								</li>
-							</ul>
-						</div>
-						<div className="ads__module-content module-content">
-							{ this.payoutNotice() }
-							{ this.earningsBreakdown() }
-						</div>
-					</Card>
-				) }
 				{ earnings && this.checkSize( earnings.wordads )
 					? this.earningsTable( earnings.wordads, translate( 'Earnings history' ), 'wordads' )
 					: null }

--- a/client/my-sites/stats/wordads/earnings.jsx
+++ b/client/my-sites/stats/wordads/earnings.jsx
@@ -12,6 +12,7 @@ class WordAdsEarnings extends Component {
 	static propTypes = {
 		siteId: PropTypes.number,
 		earnings: PropTypes.object,
+		showTotalsSection: PropTypes.bool,
 	};
 
 	state = {
@@ -280,7 +281,7 @@ class WordAdsEarnings extends Component {
 	}
 
 	render() {
-		const { siteId, earnings, translate } = this.props;
+		const { siteId, showTotalsSection, earnings, translate } = this.props;
 		const infoIcon = this.state.showEarningsNotice ? 'info' : 'info-outline';
 		const classes = classNames( 'earnings_breakdown', {
 			'is-showing-info': this.state.showEarningsNotice,
@@ -290,31 +291,33 @@ class WordAdsEarnings extends Component {
 			<div>
 				<QueryWordadsEarnings siteId={ siteId } />
 
-				<Card className={ classes }>
-					<div className="ads__module-header module-header">
-						<h1 className="ads__module-header-title module-header-title">
-							{ translate( 'Totals' ) }
-						</h1>
-						<ul className="ads__module-header-actions module-header-actions">
-							<li className="ads__module-header-action module-header-action toggle-info">
-								{ /* eslint-disable-next-line jsx-a11y/anchor-is-valid */ }
-								<a
-									href="#"
-									className="ads__module-header-action-link module-header-action-link"
-									aria-label={ translate( 'Show or hide panel information' ) }
-									title={ translate( 'Show or hide panel information' ) }
-									onClick={ this.handleEarningsNoticeToggle }
-								>
-									<Gridicon icon={ infoIcon } />
-								</a>
-							</li>
-						</ul>
-					</div>
-					<div className="ads__module-content module-content">
-						{ this.payoutNotice() }
-						{ this.earningsBreakdown() }
-					</div>
-				</Card>
+				{ showTotalsSection && (
+					<Card className={ classes }>
+						<div className="ads__module-header module-header">
+							<h1 className="ads__module-header-title module-header-title">
+								{ translate( 'Totals' ) }
+							</h1>
+							<ul className="ads__module-header-actions module-header-actions">
+								<li className="ads__module-header-action module-header-action toggle-info">
+									{ /* eslint-disable-next-line jsx-a11y/anchor-is-valid */ }
+									<a
+										href="#"
+										className="ads__module-header-action-link module-header-action-link"
+										aria-label={ translate( 'Show or hide panel information' ) }
+										title={ translate( 'Show or hide panel information' ) }
+										onClick={ this.handleEarningsNoticeToggle }
+									>
+										<Gridicon icon={ infoIcon } />
+									</a>
+								</li>
+							</ul>
+						</div>
+						<div className="ads__module-content module-content">
+							{ this.payoutNotice() }
+							{ this.earningsBreakdown() }
+						</div>
+					</Card>
+				) }
 				{ earnings && this.checkSize( earnings.wordads )
 					? this.earningsTable( earnings.wordads, translate( 'Earnings history' ), 'wordads' )
 					: null }

--- a/client/my-sites/stats/wordads/highlight-card-simple.jsx
+++ b/client/my-sites/stats/wordads/highlight-card-simple.jsx
@@ -6,7 +6,9 @@ function HighlightCardSimple( { heading, icon, value } ) {
 		<Card className="highlight-card">
 			<div className="highlight-card-icon">{ icon }</div>
 			<div className="highlight-card-heading">{ heading }</div>
-			<div className="highlight-card-count">{ displayValue }</div>
+			<div className="highlight-card-count">
+				<span className="highlight-card-count-value">{ displayValue }</span>
+			</div>
 		</Card>
 	);
 }

--- a/client/my-sites/stats/wordads/highlight-card-simple.jsx
+++ b/client/my-sites/stats/wordads/highlight-card-simple.jsx
@@ -1,7 +1,6 @@
 import { Card } from '@automattic/components';
 
 function HighlightCardSimple( { heading, icon, value } ) {
-	// typeof myVar === 'string'
 	const displayValue = typeof value === 'string' ? value : '-';
 	return (
 		<Card className="highlight-card">

--- a/client/my-sites/stats/wordads/highlight-card-simple.jsx
+++ b/client/my-sites/stats/wordads/highlight-card-simple.jsx
@@ -1,0 +1,15 @@
+import { Card } from '@automattic/components';
+
+function HighlightCardSimple( { heading, icon, value } ) {
+	// typeof myVar === 'string'
+	const displayValue = typeof value === 'string' ? value : '-';
+	return (
+		<Card className="highlight-card">
+			<div className="highlight-card-icon">{ icon }</div>
+			<div className="highlight-card-heading">{ heading }</div>
+			<div className="highlight-card-count">{ displayValue }</div>
+		</Card>
+	);
+}
+
+export default HighlightCardSimple;

--- a/client/my-sites/stats/wordads/highlights-section.jsx
+++ b/client/my-sites/stats/wordads/highlights-section.jsx
@@ -1,0 +1,37 @@
+import { Gridicon, HighlightCard } from '@automattic/components';
+import { Icon, starEmpty } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
+
+// TODO: HighlightCard does not accept string values.
+// Should refactor to accept strings and move the business logic into the callers.
+
+export default function HighlightsSection( props ) {
+	const translate = useTranslate();
+	if ( ! props.isVisible ) {
+		return null;
+	}
+	return (
+		<div className="highlight-cards">
+			<h1 className="highlight-cards-heading">
+				{ translate( 'Totals' ) } <Gridicon icon="info-outline" />
+			</h1>
+			<div className="highlight-cards-list">
+				<HighlightCard
+					heading={ translate( 'Earnings' ) }
+					icon={ <Icon icon={ starEmpty } /> }
+					count={ 0 }
+				/>
+				<HighlightCard
+					heading={ translate( 'Paid' ) }
+					icon={ <Icon icon={ starEmpty } /> }
+					count={ 0 }
+				/>
+				<HighlightCard
+					heading={ translate( 'Outstanding amount' ) }
+					icon={ <Icon icon={ starEmpty } /> }
+					count={ 0 }
+				/>
+			</div>
+		</div>
+	);
+}

--- a/client/my-sites/stats/wordads/highlights-section.jsx
+++ b/client/my-sites/stats/wordads/highlights-section.jsx
@@ -8,6 +8,7 @@ import HighlightCardSimple from './highlight-card-simple';
 // Then refactor this Comp to use HighlightCard again.
 
 function HighlightsSectionHeader( props ) {
+	// TODO: Add support for popup.
 	const translate = useTranslate();
 	const localizedTitle = translate( 'Totals' );
 	return props.showInfoIcon ? (

--- a/client/my-sites/stats/wordads/highlights-section.jsx
+++ b/client/my-sites/stats/wordads/highlights-section.jsx
@@ -56,15 +56,15 @@ function getHighlights( earnings ) {
 }
 
 function payoutNotices( earnings ) {
-	const owed =
-		earnings && earnings.total_amount_owed ? numberFormat( earnings.total_amount_owed, 2 ) : '0.00';
+	const amountOwed = earnings?.total_amount_owed || 0;
+	const amountOwedFormatted = getAmountAsFormattedString( amountOwed );
 	const notice = {
 		id: 'notice',
 		value: translate(
-			'Outstanding amount of $%(amountOwed)s does not exceed the minimum $100 needed to make the payment.',
+			'Outstanding amount of %(amountOwed)s does not exceed the minimum $100 needed to make the payment.',
 			{
 				comment: 'WordAds: Insufficient balance for payout.',
-				args: { amountOwed: owed },
+				args: { amountOwed: amountOwedFormatted },
 			}
 		),
 	};
@@ -80,14 +80,14 @@ function payoutNotices( earnings ) {
 	const payout = {
 		id: 'payout',
 		value: translate(
-			'Outstanding amount of $%(amountOwed)s will be paid approximately 45 days following the end of the month in which it was earned.',
+			'Outstanding amount of %(amountOwed)s will be paid approximately 45 days following the end of the month in which it was earned.',
 			{
 				comment: 'WordAds: Payout will proceed.',
-				args: { amountOwed: owed },
+				args: { amountOwed: amountOwedFormatted },
 			}
 		),
 	};
-	return owed < 100 ? [ notice, limit ] : [ payout ];
+	return amountOwed < 100 ? [ notice, limit ] : [ payout ];
 }
 
 function HighlightsSectionHeader( props ) {

--- a/client/my-sites/stats/wordads/highlights-section.jsx
+++ b/client/my-sites/stats/wordads/highlights-section.jsx
@@ -13,7 +13,11 @@ function getAmountAsFormattedString( amount ) {
 	// Takes a Number, formats it to 2 decimal places, and prepends a "$".
 	// This mimics the existing behaviour. I'm assuming we only view/report
 	// on earnings in USD.
-	return '$' + numberFormat( amount, 2 );
+	const formattedAmount = '$' + numberFormat( amount, 2 );
+	// Differs from previous behaviour in that we don't want "$0.00" as a result.
+	// Per design spec we'll return "$0" in this scenario.
+	// https://github.com/Automattic/wp-calypso/issues/72045
+	return formattedAmount === '$0.00' ? '$0' : formattedAmount;
 }
 
 function getHighlights( earnings ) {

--- a/client/my-sites/stats/wordads/highlights-section.jsx
+++ b/client/my-sites/stats/wordads/highlights-section.jsx
@@ -21,17 +21,17 @@ export default function HighlightsSection( props ) {
 				<HighlightCardSimple
 					heading={ translate( 'Earnings' ) }
 					icon={ <Icon icon={ starEmpty } /> }
-					value="0"
+					value="$563.76"
 				/>
 				<HighlightCardSimple
 					heading={ translate( 'Paid' ) }
 					icon={ <Icon icon={ starEmpty } /> }
-					value="hi"
+					value="$500.35"
 				/>
 				<HighlightCardSimple
 					heading={ translate( 'Outstanding amount' ) }
 					icon={ <Icon icon={ starEmpty } /> }
-					value="bye!"
+					value="$63.41"
 				/>
 			</div>
 		</div>

--- a/client/my-sites/stats/wordads/highlights-section.jsx
+++ b/client/my-sites/stats/wordads/highlights-section.jsx
@@ -35,7 +35,7 @@ function getHighlights( earnings ) {
 			amount: paid,
 		},
 		{
-			heading: translate( 'Outstanding' ),
+			heading: translate( 'Outstanding amount' ),
 			amount: owed,
 		},
 	];

--- a/client/my-sites/stats/wordads/highlights-section.jsx
+++ b/client/my-sites/stats/wordads/highlights-section.jsx
@@ -19,31 +19,55 @@ function HighlightsSectionHeader( props ) {
 	);
 }
 
+function HighlightsListing( props ) {
+	// TODO: Adjust min-width as needed.
+	// Current styling defaults to 180px which is not wide enough for more than 5 figures.
+	// Should check the longest display string and update CSS class based on that.
+	return (
+		<div className="highlight-cards-list">
+			{ props.highlights.map( ( highlight ) => (
+				<HighlightCardSimple
+					heading={ highlight.heading }
+					icon={ <Icon icon={ starEmpty } /> }
+					value={ highlight.amount }
+				/>
+			) ) }
+		</div>
+	);
+}
+
 export default function HighlightsSection( props ) {
 	const translate = useTranslate();
 	if ( ! props.isVisible ) {
 		return null;
 	}
+	// TODO: Get data from API.
+	const highlights = [
+		{
+			heading: translate( 'Earnings' ),
+			icon: <Icon icon={ starEmpty } />,
+			amount: '$153,841.29',
+		},
+		{
+			heading: translate( 'Paid' ),
+			icon: <Icon icon={ starEmpty } />,
+			amount: '$153,841.29',
+		},
+		{
+			heading: translate( 'Outstanding' ),
+			icon: <Icon icon={ starEmpty } />,
+			amount: '$0',
+		},
+		{
+			heading: translate( 'Other' ),
+			icon: <Icon icon={ starEmpty } />,
+			amount: '$9.99',
+		},
+	];
 	return (
 		<div className="highlight-cards">
 			<HighlightsSectionHeader showInfoIcon={ false } />
-			<div className="highlight-cards-list">
-				<HighlightCardSimple
-					heading={ translate( 'Earnings' ) }
-					icon={ <Icon icon={ starEmpty } /> }
-					value="$563.76"
-				/>
-				<HighlightCardSimple
-					heading={ translate( 'Paid' ) }
-					icon={ <Icon icon={ starEmpty } /> }
-					value="$500.35"
-				/>
-				<HighlightCardSimple
-					heading={ translate( 'Outstanding amount' ) }
-					icon={ <Icon icon={ starEmpty } /> }
-					value="$63.41"
-				/>
-			</div>
+			<HighlightsListing highlights={ highlights } />
 		</div>
 	);
 }

--- a/client/my-sites/stats/wordads/highlights-section.jsx
+++ b/client/my-sites/stats/wordads/highlights-section.jsx
@@ -61,9 +61,6 @@ function HighlightsSectionHeader( props ) {
 }
 
 function HighlightsListing( props ) {
-	// TODO: Adjust min-width as needed.
-	// Current styling defaults to 180px which is not wide enough for more than 5 figures.
-	// Should check the longest display string and update CSS class based on that.
 	return (
 		<div className="highlight-cards-list">
 			{ props.highlights.map( ( highlight ) => (
@@ -85,7 +82,7 @@ export default function HighlightsSection( props ) {
 	}
 	const highlights = getHighlights( earningsData );
 	return (
-		<div className="highlight-cards">
+		<div className="highlight-cards wordads">
 			<HighlightsSectionHeader showInfoIcon={ false } />
 			<HighlightsListing highlights={ highlights } />
 		</div>

--- a/client/my-sites/stats/wordads/highlights-section.jsx
+++ b/client/my-sites/stats/wordads/highlights-section.jsx
@@ -7,6 +7,32 @@ import HighlightCardSimple from './highlight-card-simple';
 // Should refactor to accept strings and move the business logic into the callers.
 // Then refactor this Comp to use HighlightCard again.
 
+function getHighlights( translate ) {
+	// TODO: Get data from API.
+	return [
+		{
+			heading: translate( 'Earnings' ),
+			icon: <Icon icon={ starEmpty } />,
+			amount: '$153,841.29',
+		},
+		{
+			heading: translate( 'Paid' ),
+			icon: <Icon icon={ starEmpty } />,
+			amount: '$153,841.29',
+		},
+		{
+			heading: translate( 'Outstanding' ),
+			icon: <Icon icon={ starEmpty } />,
+			amount: '$0',
+		},
+		{
+			heading: translate( 'Other' ),
+			icon: <Icon icon={ starEmpty } />,
+			amount: '$9.99',
+		},
+	];
+}
+
 function HighlightsSectionHeader( props ) {
 	// TODO: Add support for popup.
 	const translate = useTranslate();
@@ -42,29 +68,7 @@ export default function HighlightsSection( props ) {
 	if ( ! props.isVisible ) {
 		return null;
 	}
-	// TODO: Get data from API.
-	const highlights = [
-		{
-			heading: translate( 'Earnings' ),
-			icon: <Icon icon={ starEmpty } />,
-			amount: '$153,841.29',
-		},
-		{
-			heading: translate( 'Paid' ),
-			icon: <Icon icon={ starEmpty } />,
-			amount: '$153,841.29',
-		},
-		{
-			heading: translate( 'Outstanding' ),
-			icon: <Icon icon={ starEmpty } />,
-			amount: '$0',
-		},
-		{
-			heading: translate( 'Other' ),
-			icon: <Icon icon={ starEmpty } />,
-			amount: '$9.99',
-		},
-	];
+	const highlights = getHighlights( translate );
 	return (
 		<div className="highlight-cards">
 			<HighlightsSectionHeader showInfoIcon={ false } />

--- a/client/my-sites/stats/wordads/highlights-section.jsx
+++ b/client/my-sites/stats/wordads/highlights-section.jsx
@@ -28,18 +28,18 @@ function getHighlights( earnings ) {
 
 	const highlights = [
 		{
-			heading: translate( 'Earnings', { context: 'Total WordAds earnings to date' } ),
+			heading: translate( 'Earnings', { comment: 'Total WordAds earnings to date' } ),
 			amount: total,
 		},
 		{
 			heading: translate( 'Paid', {
-				context: 'Total WordAds earnings that have been paid out',
+				comment: 'Total WordAds earnings that have been paid out',
 			} ),
 			amount: paid,
 		},
 		{
 			heading: translate( 'Outstanding amount', {
-				context: 'Total WordAds earnings currently unpaid',
+				comment: 'Total WordAds earnings currently unpaid',
 			} ),
 			amount: owed,
 		},
@@ -92,7 +92,7 @@ function HighlightsSectionHeader( props ) {
 	const [ isTooltipVisible, setTooltipVisible ] = useState( false );
 	const iconReference = useRef( null );
 	const localizedTitle = translate( 'Totals', {
-		context: 'Heading for WordAds earnings highlights section',
+		comment: 'Heading for WordAds earnings highlights section',
 	} );
 	if ( ! props.notices || props.notices.length === 0 ) {
 		return <h1 className="highlight-cards-heading">{ localizedTitle }</h1>;

--- a/client/my-sites/stats/wordads/highlights-section.jsx
+++ b/client/my-sites/stats/wordads/highlights-section.jsx
@@ -1,5 +1,5 @@
-import { Gridicon, Popover } from '@automattic/components';
-import { Icon, payment, receipt, tip } from '@wordpress/icons';
+import { Popover } from '@automattic/components';
+import { Icon, info, payment, receipt, tip } from '@wordpress/icons';
 import { numberFormat, translate } from 'i18n-calypso';
 import { useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
@@ -92,7 +92,7 @@ function payoutNotices( earnings ) {
 
 function HighlightsSectionHeader( props ) {
 	const [ isTooltipVisible, setTooltipVisible ] = useState( false );
-	const iconReference = useRef( null );
+	const infoReferenceElement = useRef( null );
 	const localizedTitle = translate( 'Totals', {
 		comment: 'Heading for WordAds earnings highlights section',
 	} );
@@ -102,17 +102,19 @@ function HighlightsSectionHeader( props ) {
 	return (
 		<h1 className="highlight-cards-heading">
 			{ localizedTitle }{ ' ' }
-			<Gridicon
-				icon="info-outline"
-				ref={ iconReference }
+			<span
+				className="info-wrapper"
+				ref={ infoReferenceElement }
 				onMouseEnter={ () => setTooltipVisible( true ) }
 				onMouseLeave={ () => setTooltipVisible( false ) }
-			/>
+			>
+				<Icon className="info-icon" icon={ info } />
+			</span>
 			<Popover
 				className="tooltip tooltip--darker tooltip-wordads highlight-card-tooltip"
 				isVisible={ isTooltipVisible }
 				position="bottom right"
-				context={ iconReference.current }
+				context={ infoReferenceElement.current }
 			>
 				<div className="highlight-card-tooltip-content">
 					{ props.notices.map( ( notice ) => (

--- a/client/my-sites/stats/wordads/highlights-section.jsx
+++ b/client/my-sites/stats/wordads/highlights-section.jsx
@@ -27,15 +27,19 @@ function getHighlights( earnings ) {
 
 	const highlights = [
 		{
-			heading: translate( 'Earnings' ),
+			heading: translate( 'Earnings', { context: 'Total WordAds earnings to date' } ),
 			amount: total,
 		},
 		{
-			heading: translate( 'Paid' ),
+			heading: translate( 'Paid', {
+				context: 'Total WordAds earnings that have been paid out',
+			} ),
 			amount: paid,
 		},
 		{
-			heading: translate( 'Outstanding amount' ),
+			heading: translate( 'Outstanding amount', {
+				context: 'Total WordAds earnings currently unpaid',
+			} ),
 			amount: owed,
 		},
 	];
@@ -50,7 +54,9 @@ function getHighlights( earnings ) {
 
 function HighlightsSectionHeader( props ) {
 	// TODO: Add support for popup.
-	const localizedTitle = translate( 'Totals' );
+	const localizedTitle = translate( 'Totals', {
+		context: 'Heading for WordAds earnings highlights section',
+	} );
 	return props.showInfoIcon ? (
 		<h1 className="highlight-cards-heading">
 			{ localizedTitle } <Gridicon icon="info-outline" />

--- a/client/my-sites/stats/wordads/highlights-section.jsx
+++ b/client/my-sites/stats/wordads/highlights-section.jsx
@@ -9,7 +9,7 @@ import HighlightCardSimple from './highlight-card-simple';
 
 function getHighlights( translate ) {
 	// TODO: Get data from API.
-	return [
+	const highlights = [
 		{
 			heading: translate( 'Earnings' ),
 			icon: <Icon icon={ starEmpty } />,
@@ -31,6 +31,11 @@ function getHighlights( translate ) {
 			amount: '$9.99',
 		},
 	];
+	// Index the data for use with React.
+	return highlights.map( ( highlight, i ) => ( {
+		id: i,
+		...highlight,
+	} ) );
 }
 
 function HighlightsSectionHeader( props ) {
@@ -54,6 +59,7 @@ function HighlightsListing( props ) {
 		<div className="highlight-cards-list">
 			{ props.highlights.map( ( highlight ) => (
 				<HighlightCardSimple
+					key={ highlight.id }
 					heading={ highlight.heading }
 					icon={ <Icon icon={ starEmpty } /> }
 					value={ highlight.amount }

--- a/client/my-sites/stats/wordads/highlights-section.jsx
+++ b/client/my-sites/stats/wordads/highlights-section.jsx
@@ -1,9 +1,11 @@
-import { Gridicon, HighlightCard } from '@automattic/components';
+import { Gridicon } from '@automattic/components';
 import { Icon, starEmpty } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
+import HighlightCardSimple from './highlight-card-simple';
 
 // TODO: HighlightCard does not accept string values.
 // Should refactor to accept strings and move the business logic into the callers.
+// Then refactor this Comp to use HighlightCard again.
 
 export default function HighlightsSection( props ) {
 	const translate = useTranslate();
@@ -16,20 +18,20 @@ export default function HighlightsSection( props ) {
 				{ translate( 'Totals' ) } <Gridicon icon="info-outline" />
 			</h1>
 			<div className="highlight-cards-list">
-				<HighlightCard
+				<HighlightCardSimple
 					heading={ translate( 'Earnings' ) }
 					icon={ <Icon icon={ starEmpty } /> }
-					count={ 0 }
+					value="0"
 				/>
-				<HighlightCard
+				<HighlightCardSimple
 					heading={ translate( 'Paid' ) }
 					icon={ <Icon icon={ starEmpty } /> }
-					count={ 0 }
+					value="hi"
 				/>
-				<HighlightCard
+				<HighlightCardSimple
 					heading={ translate( 'Outstanding amount' ) }
 					icon={ <Icon icon={ starEmpty } /> }
-					count={ 0 }
+					value="bye!"
 				/>
 			</div>
 		</div>

--- a/client/my-sites/stats/wordads/highlights-section.jsx
+++ b/client/my-sites/stats/wordads/highlights-section.jsx
@@ -1,5 +1,5 @@
 import { Gridicon, Popover } from '@automattic/components';
-import { Icon, starEmpty } from '@wordpress/icons';
+import { Icon, payment, receipt, tip } from '@wordpress/icons';
 import { numberFormat, translate } from 'i18n-calypso';
 import { useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
@@ -29,18 +29,21 @@ function getHighlights( earnings ) {
 	const highlights = [
 		{
 			heading: translate( 'Earnings', { comment: 'Total WordAds earnings to date' } ),
+			icon: <Icon icon={ payment } />,
 			amount: total,
 		},
 		{
 			heading: translate( 'Paid', {
 				comment: 'Total WordAds earnings that have been paid out',
 			} ),
+			icon: <Icon icon={ receipt } />,
 			amount: paid,
 		},
 		{
 			heading: translate( 'Outstanding amount', {
 				comment: 'Total WordAds earnings currently unpaid',
 			} ),
+			icon: <Icon icon={ tip } />,
 			amount: owed,
 		},
 	];
@@ -48,7 +51,6 @@ function getHighlights( earnings ) {
 	return highlights.map( ( highlight, i ) => ( {
 		id: i,
 		formattedAmount: getAmountAsFormattedString( highlight.amount ),
-		icon: <Icon icon={ starEmpty } />,
 		...highlight,
 	} ) );
 }

--- a/client/my-sites/stats/wordads/highlights-section.jsx
+++ b/client/my-sites/stats/wordads/highlights-section.jsx
@@ -22,8 +22,8 @@ function getAmountAsFormattedString( amount ) {
 }
 
 function getHighlights( earnings ) {
-	const total = earnings && earnings.total_earnings ? Number( earnings.total_earnings ) : 0;
-	const owed = earnings && earnings.total_amount_owed ? Number( earnings.total_amount_owed ) : 0;
+	const total = earnings?.total_earnings ? Number( earnings.total_earnings ) : 0;
+	const owed = earnings?.total_amount_owed ? Number( earnings.total_amount_owed ) : 0;
 	const paid = total - owed;
 
 	const highlights = [

--- a/client/my-sites/stats/wordads/highlights-section.jsx
+++ b/client/my-sites/stats/wordads/highlights-section.jsx
@@ -143,9 +143,6 @@ function HighlightsListing( props ) {
 
 export default function HighlightsSection( props ) {
 	const earningsData = useSelector( ( state ) => getWordAdsEarnings( state, props.siteId ) );
-	if ( ! props.isVisible ) {
-		return null;
-	}
 	const highlights = getHighlights( earningsData );
 	const notices = payoutNotices( earningsData );
 	return (

--- a/client/my-sites/stats/wordads/highlights-section.jsx
+++ b/client/my-sites/stats/wordads/highlights-section.jsx
@@ -96,32 +96,34 @@ function HighlightsSectionHeader( props ) {
 	const localizedTitle = translate( 'Totals', {
 		comment: 'Heading for WordAds earnings highlights section',
 	} );
-	if ( ! props.notices || props.notices.length === 0 ) {
-		return <h1 className="highlight-cards-heading">{ localizedTitle }</h1>;
-	}
+	const showNotices = props?.notices?.length > 0;
 	return (
 		<h1 className="highlight-cards-heading">
 			{ localizedTitle }{ ' ' }
-			<span
-				className="info-wrapper"
-				ref={ infoReferenceElement }
-				onMouseEnter={ () => setTooltipVisible( true ) }
-				onMouseLeave={ () => setTooltipVisible( false ) }
-			>
-				<Icon className="info-icon" icon={ info } />
-			</span>
-			<Popover
-				className="tooltip tooltip--darker tooltip-wordads highlight-card-tooltip"
-				isVisible={ isTooltipVisible }
-				position="bottom right"
-				context={ infoReferenceElement.current }
-			>
-				<div className="highlight-card-tooltip-content">
-					{ props.notices.map( ( notice ) => (
-						<p key={ notice.id }>{ notice.value }</p>
-					) ) }
-				</div>
-			</Popover>
+			{ showNotices && (
+				<>
+					<span
+						className="info-wrapper"
+						ref={ infoReferenceElement }
+						onMouseEnter={ () => setTooltipVisible( true ) }
+						onMouseLeave={ () => setTooltipVisible( false ) }
+					>
+						<Icon className="info-icon" icon={ info } />
+					</span>
+					<Popover
+						className="tooltip tooltip--darker tooltip-wordads highlight-card-tooltip"
+						isVisible={ isTooltipVisible }
+						position="bottom right"
+						context={ infoReferenceElement.current }
+					>
+						<div className="highlight-card-tooltip-content">
+							{ props.notices.map( ( notice ) => (
+								<p key={ notice.id }>{ notice.value }</p>
+							) ) }
+						</div>
+					</Popover>
+				</>
+			) }
 		</h1>
 	);
 }

--- a/client/my-sites/stats/wordads/highlights-section.jsx
+++ b/client/my-sites/stats/wordads/highlights-section.jsx
@@ -7,6 +7,18 @@ import HighlightCardSimple from './highlight-card-simple';
 // Should refactor to accept strings and move the business logic into the callers.
 // Then refactor this Comp to use HighlightCard again.
 
+function HighlightsSectionHeader( props ) {
+	const translate = useTranslate();
+	const localizedTitle = translate( 'Totals' );
+	return props.showInfoIcon ? (
+		<h1 className="highlight-cards-heading">
+			{ localizedTitle } <Gridicon icon="info-outline" />
+		</h1>
+	) : (
+		<h1 className="highlight-cards-heading">{ localizedTitle }</h1>
+	);
+}
+
 export default function HighlightsSection( props ) {
 	const translate = useTranslate();
 	if ( ! props.isVisible ) {
@@ -14,9 +26,7 @@ export default function HighlightsSection( props ) {
 	}
 	return (
 		<div className="highlight-cards">
-			<h1 className="highlight-cards-heading">
-				{ translate( 'Totals' ) } <Gridicon icon="info-outline" />
-			</h1>
+			<HighlightsSectionHeader showInfoIcon={ false } />
 			<div className="highlight-cards-list">
 				<HighlightCardSimple
 					heading={ translate( 'Earnings' ) }

--- a/client/my-sites/stats/wordads/index.jsx
+++ b/client/my-sites/stats/wordads/index.jsx
@@ -30,6 +30,7 @@ import StatsPeriodHeader from '../stats-period-header';
 import StatsPeriodNavigation from '../stats-period-navigation';
 import WordAdsChartTabs from '../wordads-chart-tabs';
 import WordAdsEarnings from './earnings';
+import HighlightsSection from './highlights-section';
 
 import './style.scss';
 import 'calypso/my-sites/earn/ads/style.scss';
@@ -203,6 +204,8 @@ class WordAds extends Component {
 								siteId={ siteId }
 								slug={ slug }
 							/>
+
+							<HighlightsSection isVisible={ true } siteId={ siteId } />
 
 							<div id="my-stats-content" className={ statsWrapperClass }>
 								<>

--- a/client/my-sites/stats/wordads/index.jsx
+++ b/client/my-sites/stats/wordads/index.jsx
@@ -137,11 +137,8 @@ class WordAds extends Component {
 		);
 	};
 
-	isLocal3000() {
-		return window.location.host === 'calypso.localhost:3000';
-	}
-	isCalypsoLive() {
-		return window.location.host.endsWith( '.calypso.live' );
+	isProduction() {
+		return window.location.host === 'wordpress.com';
 	}
 
 	render() {
@@ -172,8 +169,9 @@ class WordAds extends Component {
 			'is-period-year': period === 'year',
 		} );
 
-		// TODO: Put behind feature flag as needed.
-		const showNewHighlights = this.isLocal3000() || this.isCalypsoLive();
+		// TODO: Enable on production.
+		// And remove isProduction helper.
+		const showNewHighlights = ! this.isProduction();
 
 		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		return (

--- a/client/my-sites/stats/wordads/index.jsx
+++ b/client/my-sites/stats/wordads/index.jsx
@@ -137,10 +137,6 @@ class WordAds extends Component {
 		);
 	};
 
-	isProduction() {
-		return window.location.host === 'wordpress.com';
-	}
-
 	render() {
 		const { canAccessAds, canUpgradeToUseWordAds, date, site, siteId, slug } = this.props;
 
@@ -168,10 +164,6 @@ class WordAds extends Component {
 		const statsWrapperClass = classNames( 'wordads stats-content', {
 			'is-period-year': period === 'year',
 		} );
-
-		// TODO: Enable on production.
-		// And remove isProduction helper.
-		const showNewHighlights = ! this.isProduction();
 
 		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		return (
@@ -213,7 +205,7 @@ class WordAds extends Component {
 								slug={ slug }
 							/>
 
-							<HighlightsSection isVisible={ showNewHighlights } siteId={ siteId } />
+							<HighlightsSection siteId={ siteId } />
 
 							<div id="my-stats-content" className={ statsWrapperClass }>
 								<>
@@ -256,7 +248,7 @@ class WordAds extends Component {
 								</>
 
 								<div className="stats__module-list stats__module-headerless--unified">
-									<WordAdsEarnings site={ site } showTotalsSection={ ! showNewHighlights } />
+									<WordAdsEarnings site={ site } />
 								</div>
 							</div>
 

--- a/client/my-sites/stats/wordads/index.jsx
+++ b/client/my-sites/stats/wordads/index.jsx
@@ -137,6 +137,13 @@ class WordAds extends Component {
 		);
 	};
 
+	isLocal3000() {
+		return window.location.host === 'calypso.localhost:3000';
+	}
+	isCalypsoLive() {
+		return window.location.host.endsWith( '.calypso.live' );
+	}
+
 	render() {
 		const { canAccessAds, canUpgradeToUseWordAds, date, site, siteId, slug } = this.props;
 
@@ -164,6 +171,9 @@ class WordAds extends Component {
 		const statsWrapperClass = classNames( 'wordads stats-content', {
 			'is-period-year': period === 'year',
 		} );
+
+		// TODO: Put behind feature flag as needed.
+		const showNewHighlights = this.isLocal3000() || this.isCalypsoLive();
 
 		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		return (
@@ -205,7 +215,7 @@ class WordAds extends Component {
 								slug={ slug }
 							/>
 
-							<HighlightsSection isVisible={ true } siteId={ siteId } />
+							<HighlightsSection isVisible={ showNewHighlights } siteId={ siteId } />
 
 							<div id="my-stats-content" className={ statsWrapperClass }>
 								<>

--- a/client/my-sites/stats/wordads/index.jsx
+++ b/client/my-sites/stats/wordads/index.jsx
@@ -258,7 +258,7 @@ class WordAds extends Component {
 								</>
 
 								<div className="stats__module-list stats__module-headerless--unified">
-									<WordAdsEarnings site={ site } />
+									<WordAdsEarnings site={ site } showTotalsSection={ ! showNewHighlights } />
 								</div>
 							</div>
 

--- a/client/my-sites/stats/wordads/style.scss
+++ b/client/my-sites/stats/wordads/style.scss
@@ -17,6 +17,7 @@
 .highlight-cards.wordads {
 	h1 {
 		display: flex;
+		flex-flow: nowrap;
 		align-items: center;
 	}
 	.highlight-card {

--- a/client/my-sites/stats/wordads/style.scss
+++ b/client/my-sites/stats/wordads/style.scss
@@ -23,9 +23,12 @@
 	.highlight-card {
 		min-width: 280px;
 	}
-	.gridicon {
-		fill: var(--studio-gray-40);
+	.info-wrapper {
+		display: flex;
 		margin-left: 8px;
+	}
+	.info-icon {
+		fill: var(--studio-gray-40);
 	}
 }
 

--- a/client/my-sites/stats/wordads/style.scss
+++ b/client/my-sites/stats/wordads/style.scss
@@ -19,3 +19,14 @@
 		min-width: 280px;
 	}
 }
+
+.tooltip-wordads {
+	.highlight-card-tooltip-content {
+		display: block;
+		max-width: 260px;
+
+		p:last-child {
+			margin: 0;
+		}
+	}
+}

--- a/client/my-sites/stats/wordads/style.scss
+++ b/client/my-sites/stats/wordads/style.scss
@@ -12,5 +12,10 @@
 	.earnings_history tbody tr:nth-child(odd) {
 		background-color: var(--studio-gray-0);
 	}
+}
 
+.highlight-cards.wordads {
+	.highlight-card {
+		min-width: 280px;
+	}
 }

--- a/client/my-sites/stats/wordads/style.scss
+++ b/client/my-sites/stats/wordads/style.scss
@@ -15,8 +15,16 @@
 }
 
 .highlight-cards.wordads {
+	h1 {
+		display: flex;
+		align-items: center;
+	}
 	.highlight-card {
 		min-width: 280px;
+	}
+	.gridicon {
+		fill: var(--studio-gray-40);
+		margin-left: 8px;
 	}
 }
 

--- a/client/my-sites/stats/wordads/style.scss
+++ b/client/my-sites/stats/wordads/style.scss
@@ -21,7 +21,7 @@
 		align-items: center;
 	}
 	.highlight-card {
-		min-width: 280px;
+		min-width: 240px;
 	}
 	.info-wrapper {
 		display: flex;


### PR DESCRIPTION
#### Proposed Changes

Add highlights section to top of Ads page.

The first pass at getting the highlights working. Uses the existing data from the store and formats it for display.

- Adds new highlights section at the top of the page
- Tooltip should show correct payout/status notices
- Hides old Totals section (below chart)

![AdsHighlightsSnap](https://user-images.githubusercontent.com/40267301/213646405-8f31e0b1-a66d-4f0b-8c23-d8acd759b9e6.png)

Does not yet:

* use correct icon data
* remove the previous implementation

I'd like to address these in follow up PRs.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit the Calypso Live link.
* View a site with WordAds enabled.
* Visit Stats → Ads and confirm highlights are shown correctly.
* Confirm things work correctly on smaller screen sizes.
* Confirm hover works correctly with the tooltip.

If you need to compare with the old Totals section, you can enable it via the React dev tools. Select the `WordAdsEarnings` component and toggle the `showTotalsSection` property.

![DevTools](https://user-images.githubusercontent.com/40267301/213647731-a290ceb6-71e3-4267-a0ac-348321b28630.png)

The new code is only active on non-production domains so it can safely be merged as is.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #72045.
