### PR TITLE
Block Renderer: Support viewportHeight to render 100vh correctly

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
@@ -2,7 +2,7 @@ import { PatternRenderer } from '@automattic/block-renderer';
 import { DeviceSwitcher } from '@automattic/components';
 import { Icon, layout } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
-import { useRef, useEffect } from 'react';
+import { useRef, useEffect, useState } from 'react';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { encodePatternId } from './utils';
 import type { Pattern } from './types';
@@ -23,12 +23,13 @@ const PatternLargePreview = ( { header, sections, footer, activePosition }: Prop
 	const hasSelectedPattern = header || sections.length || footer;
 	const frameRef = useRef< HTMLDivElement | null >( null );
 	const listRef = useRef< HTMLUListElement | null >( null );
+	const [ viewportHeight, setViewportHeight ] = useState< number | undefined >( 0 );
 
 	const renderPattern = ( key: string, pattern: Pattern ) => (
 		<li key={ key }>
 			<PatternRenderer
 				patternId={ encodePatternId( pattern.id ) }
-				viewportHeight={ frameRef.current?.clientHeight }
+				viewportHeight={ viewportHeight || frameRef.current?.clientHeight }
 			/>
 		</li>
 	);
@@ -69,9 +70,10 @@ const PatternLargePreview = ( { header, sections, footer, activePosition }: Prop
 			isShowDeviceSwitcherToolbar
 			isShowFrameBorder
 			frameRef={ frameRef }
-			onDeviceChange={ ( device ) =>
-				recordTracksEvent( 'calypso_signup_pattern_assembler_preview_device_click', { device } )
-			}
+			onDeviceChange={ ( device ) => {
+				window.setTimeout( () => setViewportHeight( frameRef.current?.clientHeight ), 205 );
+				recordTracksEvent( 'calypso_signup_pattern_assembler_preview_device_click', { device } );
+			} }
 		>
 			{ hasSelectedPattern ? (
 				<ul className="pattern-large-preview__patterns" ref={ listRef }>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
@@ -21,18 +21,22 @@ const PATTERN_RENDERER_MIN_HEIGHT = 1;
 const PatternLargePreview = ( { header, sections, footer, activePosition }: Props ) => {
 	const translate = useTranslate();
 	const hasSelectedPattern = header || sections.length || footer;
-	const containerRef = useRef< HTMLUListElement | null >( null );
+	const frameRef = useRef< HTMLDivElement | null >( null );
+	const listRef = useRef< HTMLUListElement | null >( null );
 
 	const renderPattern = ( key: string, pattern: Pattern ) => (
 		<li key={ key }>
-			<PatternRenderer patternId={ encodePatternId( pattern.id ) } />
+			<PatternRenderer
+				patternId={ encodePatternId( pattern.id ) }
+				viewportHeight={ frameRef.current?.clientHeight }
+			/>
 		</li>
 	);
 
 	useEffect( () => {
 		let timerId: number;
 		const scrollIntoView = () => {
-			const element = containerRef.current?.children[ activePosition ];
+			const element = listRef.current?.children[ activePosition ];
 			if ( ! element ) {
 				return;
 			}
@@ -64,12 +68,13 @@ const PatternLargePreview = ( { header, sections, footer, activePosition }: Prop
 			className="pattern-large-preview"
 			isShowDeviceSwitcherToolbar
 			isShowFrameBorder
+			frameRef={ frameRef }
 			onDeviceChange={ ( device ) =>
 				recordTracksEvent( 'calypso_signup_pattern_assembler_preview_device_click', { device } )
 			}
 		>
 			{ hasSelectedPattern ? (
-				<ul className="pattern-large-preview__patterns" ref={ containerRef }>
+				<ul className="pattern-large-preview__patterns" ref={ listRef }>
 					{ header && renderPattern( 'header', header ) }
 					{ sections.map( ( pattern ) => renderPattern( pattern.key!, pattern ) ) }
 					{ footer && renderPattern( 'footer', footer ) }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
@@ -34,6 +34,10 @@ const PatternLargePreview = ( { header, sections, footer, activePosition }: Prop
 		</li>
 	);
 
+	const updateViewportHeight = () => {
+		setViewportHeight( frameRef.current?.clientHeight );
+	};
+
 	useEffect( () => {
 		let timerId: number;
 		const scrollIntoView = () => {
@@ -64,6 +68,13 @@ const PatternLargePreview = ( { header, sections, footer, activePosition }: Prop
 		};
 	}, [ activePosition, header, sections, footer ] );
 
+	useEffect( () => {
+		const handleResize = () => updateViewportHeight();
+		window.addEventListener( 'resize', handleResize );
+
+		return () => window.removeEventListener( 'resize', handleResize );
+	} );
+
 	return (
 		<DeviceSwitcher
 			className="pattern-large-preview"
@@ -71,8 +82,9 @@ const PatternLargePreview = ( { header, sections, footer, activePosition }: Prop
 			isShowFrameBorder
 			frameRef={ frameRef }
 			onDeviceChange={ ( device ) => {
-				window.setTimeout( () => setViewportHeight( frameRef.current?.clientHeight ), 205 );
 				recordTracksEvent( 'calypso_signup_pattern_assembler_preview_device_click', { device } );
+				// Wait for the animation to end in 200ms
+				window.setTimeout( updateViewportHeight, 205 );
 			} }
 		>
 			{ hasSelectedPattern ? (

--- a/packages/block-renderer/src/components/block-renderer-container.tsx
+++ b/packages/block-renderer/src/components/block-renderer-container.tsx
@@ -107,7 +107,7 @@ const ScaledBlockRendererContainer = ( {
 				style={ {
 					position: 'absolute',
 					width: viewportWidth,
-					height: ( contentHeight as number ) || viewportHeight,
+					height: viewportHeight || ( contentHeight as number ),
 					pointerEvents: 'none',
 					// This is a catch-all max-height for patterns.
 					// See: https://github.com/WordPress/gutenberg/pull/38175.

--- a/packages/block-renderer/src/components/block-renderer-container.tsx
+++ b/packages/block-renderer/src/components/block-renderer-container.tsx
@@ -17,6 +17,7 @@ interface BlockRendererContainerProps {
 	styles?: RenderedStyle[];
 	inlineCss?: string;
 	viewportWidth?: number;
+	viewportHeight?: number;
 	maxHeight?: number;
 	minHeight?: number;
 }
@@ -30,6 +31,7 @@ const ScaledBlockRendererContainer = ( {
 	styles: customStyles,
 	inlineCss = '',
 	viewportWidth = 1200,
+	viewportHeight,
 	containerWidth,
 	maxHeight = BLOCK_MAX_HEIGHT,
 	minHeight,
@@ -105,7 +107,7 @@ const ScaledBlockRendererContainer = ( {
 				style={ {
 					position: 'absolute',
 					width: viewportWidth,
-					height: contentHeight as number,
+					height: ( contentHeight as number ) || viewportHeight,
 					pointerEvents: 'none',
 					// This is a catch-all max-height for patterns.
 					// See: https://github.com/WordPress/gutenberg/pull/38175.

--- a/packages/block-renderer/src/components/pattern-renderer.tsx
+++ b/packages/block-renderer/src/components/pattern-renderer.tsx
@@ -6,10 +6,11 @@ import { usePatternsRendererContext } from './patterns-renderer-context';
 interface Props {
 	patternId: string;
 	viewportWidth?: number;
+	viewportHeight?: number;
 	minHeight?: number;
 }
 
-const PatternRenderer = ( { patternId, viewportWidth, minHeight }: Props ) => {
+const PatternRenderer = ( { patternId, viewportWidth, viewportHeight, minHeight }: Props ) => {
 	const renderedPatterns = usePatternsRendererContext();
 	const pattern = renderedPatterns[ patternId ];
 
@@ -17,6 +18,7 @@ const PatternRenderer = ( { patternId, viewportWidth, minHeight }: Props ) => {
 		<BlockRendererContainer
 			styles={ pattern?.styles ?? [] }
 			viewportWidth={ viewportWidth }
+			viewportHeight={ viewportHeight }
 			maxHeight={ BLOCK_MAX_HEIGHT }
 			minHeight={ minHeight }
 		>

--- a/packages/components/src/device-switcher/device-switcher.tsx
+++ b/packages/components/src/device-switcher/device-switcher.tsx
@@ -11,6 +11,7 @@ interface Props {
 	defaultDevice?: Device;
 	isShowDeviceSwitcherToolbar?: boolean;
 	isShowFrameBorder?: boolean;
+	frameRef?: React.MutableRefObject< HTMLDivElement | null >;
 	onDeviceChange?: ( device: Device ) => void;
 }
 
@@ -20,6 +21,7 @@ const DeviceSwitcher = ( {
 	defaultDevice = DEVICE_TYPES.COMPUTER,
 	isShowDeviceSwitcherToolbar,
 	isShowFrameBorder,
+	frameRef,
 	onDeviceChange,
 }: Props ) => {
 	const [ device, setDevice ] = useState< Device >( defaultDevice );
@@ -41,7 +43,9 @@ const DeviceSwitcher = ( {
 			{ isShowDeviceSwitcherToolbar && (
 				<DeviceSwitcherToolbar device={ device } onDeviceClick={ handleDeviceClick } />
 			) }
-			<div className="device-switcher__frame">{ children }</div>
+			<div className="device-switcher__frame" ref={ frameRef }>
+				{ children }
+			</div>
 		</div>
 	);
 };


### PR DESCRIPTION
#### Proposed Changes

* Make `block-renderer-container` support the `viewportHeight` and pass it to the height of iframe before the content is loaded. So, the `100vh` of the content will render correctly.

Note that this is **not a perfect solution** and we still need to resolve the following issues
* If you add the pattern too fast, the `100vh` might not be rendered correctly as the `viewportHeight` might be `undefined` at the beginning
* ~~If you resize the window height (including switching the device to mobile), the rendered `100vh` won't be changed.~~

**Screenshots**

![image](https://user-images.githubusercontent.com/13596067/213393815-07195234-2b28-4777-b413-ccd19846e709.png)


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Add the following pattern to [patterns-data.tsx](https://github.com/Automattic/wp-calypso/blob/b576934649d8cba228c05d9066067d36b1a66462/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/patterns-data.ts#L188)
  ```js
  {
    id: 3747,
    name: 'Hero',
    category: 'posts',
  },
  ``` 
* Go to /setup?siteSlug=<your_site>
* Click the "Continue" button until you land on the Design Picker step
* Scroll to the bottom and select the Blank Canvas CTA
* When you're in the Pattern Assembler step, select the newly added section and verify its height is correct

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/72191
