### PR TITLE
Pricing Grid 2023: Consolidate breakpoints

### DIFF
--- a/client/my-sites/plan-features-2023-grid/style.scss
+++ b/client/my-sites/plan-features-2023-grid/style.scss
@@ -1,4 +1,5 @@
 @import "@automattic/onboarding/styles/mixins";
+@import "calypso/signup/steps/plans/style.scss";
 $plan-features-header-banner-height: 20px;
 $plan-features-sidebar-width: 272px;
 
@@ -487,7 +488,7 @@ $plan-features-sidebar-width: 272px;
 				padding-top: 12px;
 			}
 
-			@media ( min-width: 880px ) {
+			@media ( min-width: $plans-2023-small-breakpoint ) {
 				position: relative;
 				top: 10px;
 				padding-top: 0;
@@ -530,7 +531,7 @@ $plan-features-sidebar-width: 272px;
 				}
 			}
 
-			@media ( min-width: 1340px ) {
+			@media ( min-width: $plans-2023-medium-breakpoint ) {
 				img:nth-child(1) {
 					padding-right: 24px;
 				}
@@ -570,7 +571,7 @@ $plan-features-sidebar-width: 272px;
 				}
 			}
 
-			@media ( min-width: 1500px ) {
+			@media ( min-width: $plans-2023-large-breakpoint ) {
 				img:nth-child(1) {
 					padding-right: 24px;
 				}

--- a/client/my-sites/plans-features-main/style.scss
+++ b/client/my-sites/plans-features-main/style.scss
@@ -1,5 +1,6 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "calypso/signup/steps/plans/style.scss";
 
 // Content group
 .plans-features-main__group {
@@ -58,22 +59,11 @@
 
 		@media ( min-width: 385px ) {
 			max-width: 375px;
+			margin: initial;
 		}
 
-		@media ( min-width: 880px ) {
-			max-width: 860px;
-			margin: auto;
-		}
-
-		@media ( min-width: 1340px ) {
-			max-width: 1320px;
-			margin: auto;
-		}
-
-		@media ( min-width: 1500px ) {
-			max-width: 1480px;
-			margin: auto;
-		}
+		@include onboarding-2023-pricing-grid-plans-breakpoints;
+		margin: auto;
 	}
 }
 

--- a/client/signup/steps/plans/style.scss
+++ b/client/signup/steps/plans/style.scss
@@ -1,3 +1,23 @@
+$plans-2023-small-breakpoint: 880px;
+$plans-2023-medium-breakpoint: 1340px;
+$plans-2023-large-breakpoint: 1500px;
+
+@mixin onboarding-2023-pricing-grid-plans-breakpoints {
+	max-width: 414px;
+
+	@media ( min-width: $plans-2023-small-breakpoint ) {
+		max-width: 860px;
+	}
+
+	@media ( min-width: $plans-2023-medium-breakpoint ) {
+		max-width: 1320px;
+	}
+
+	@media ( min-width: $plans-2023-large-breakpoint ) {
+		max-width: 1480px;
+	}
+}
+
 .plans-step {
 	margin: 0 auto;
 	max-width: 700px;
@@ -12,19 +32,7 @@
 	}
 
 	.is-onboarding-2023-pricing-grid &.is-wide-layout {
-		max-width: 414px;
-
-		@media ( min-width: 880px ) {
-			max-width: 860px;
-		}
-
-		@media ( min-width: 1340px ) {
-			max-width: 1320px;
-		}
-
-		@media ( min-width: 1500px ) {
-			max-width: 1480px;
-		}
+		@include onboarding-2023-pricing-grid-plans-breakpoints;
 	}
 
 	.formatted-header.is-without-subhead {
@@ -36,20 +44,8 @@
 			max-width: 1200px;
 		}
 
-		.is-onboarding-2023-pricing-grid &.is-wide-layout {
-			max-width: 414px;
-
-			@media ( min-width: 880px ) {
-				max-width: 860px;
-			}
-
-			@media ( min-width: 1340px ) {
-				max-width: 1320px;
-			}
-
-			@media ( min-width: 1500px ) {
-				max-width: 1480px;
-			}
+		.is-onboarding-2023-pricing-grid .signup__step &.is-wide-layout {
+			@include onboarding-2023-pricing-grid-plans-breakpoints;
 		}
 	}
 }


### PR DESCRIPTION
#### Proposed Changes

* Consolidates all breakpoints for the new plans grid into one place so that they can be modified easily.


Known Issues:
-  On Mobile, the cards should expand, leaving a fixed 20px margin on both ends at all times
- Tracked @ Automattic/martech#1430

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to `/start/onboarding-2023-pricing-grid/plans`
- Confirm that the page matches the Figma design.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes Automattic/martech#1404
