### PR TITLE
Copy Site: Update the processing subtitle and text on processing-step

### DIFF
--- a/client/landing/stepper/declarative-flow/copy-site.tsx
+++ b/client/landing/stepper/declarative-flow/copy-site.tsx
@@ -52,7 +52,7 @@ const copySite: Flow = {
 						{ ...props }
 						title={ translate( 'We’re copying your site' ) }
 						subtitle={ translate(
-							'This may take a few minutes. Feel free to close this window, we’ll email you when it’ done.'
+							'This may take a few minutes. Feel free to close this window, we’ll email you when it’s done.'
 						) }
 					/>
 				),

--- a/client/landing/stepper/declarative-flow/copy-site.tsx
+++ b/client/landing/stepper/declarative-flow/copy-site.tsx
@@ -52,7 +52,7 @@ const copySite: Flow = {
 						{ ...props }
 						title={ translate( 'We’re copying your site' ) }
 						subtitle={ translate(
-							'This may take a few minutes. Feel free to close this window and we will email you when the process is complete.'
+							'This may take a few minutes. Feel free to close this window, we’ll email you when it’ done.'
 						) }
 					/>
 				),

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/style.scss
@@ -91,10 +91,16 @@ $progress-duration: 800ms;
 .copy-site.processing-copy {
 	.processing-step {
 		margin: 5vh auto 0;
+		max-width: 660px;
 	}
 
 	.processing-step__progress-step {
 		font-size: 3rem;
 		margin-bottom: 24px;
+	}
+
+	.processing-step__progress-bar {
+		max-width: 540px;
+		margin: 0 auto;
 	}
 }


### PR DESCRIPTION
#### Proposed Changes
Update the text and the design to display the `processing-copy` step subtitle in one line.

* Update the subtitle and the design for `processing-copy`

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check https://github.com/Automattic/wp-calypso/pull/72287

### Screenshot

| **Before** | **After** |
|---|---|
| <img alt="Screenshot 2023-01-18 at 20 43 30" src="https://user-images.githubusercontent.com/779993/213292377-83849cab-6503-4ef4-8509-54459c063e3a.png"> | <img alt="Screenshot 2023-01-19 at 09 56 45" src="https://user-images.githubusercontent.com/779993/213412081-e3bccf3e-79b3-4292-b601-bf1a7a301377.png">
 |


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

- Related to https://github.com/Automattic/wp-calypso/pull/72287
