### PR TITLE
Auto-tag cancelation_chat_prompt

### DIFF
--- a/client/components/marketing-survey/cancel-purchase-form/step-components/upsell-step.tsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/upsell-step.tsx
@@ -136,6 +136,7 @@ export default function UpsellStep( { upsell, site, purchase, ...props }: StepPr
 						const userInfo = happyChat.getUserInfo( { site } );
 
 						happyChat.open();
+						happyChat.setChatTag( 'cancelation_chat_prompt' );
 						happyChat.sendUserInfo( { ...userInfo, cancellationReason: props.cancellationReason } );
 						props.closeDialog();
 					} }


### PR DESCRIPTION
#### Proposed Changes

* For chats that prompted from the cancellation flow, auto-tag `cancelation_chat_prompt`. 

https://user-images.githubusercontent.com/6586048/213417510-29961a15-9fd9-4423-a521-b29366819d0d.mp4


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Setting up:
* The testing site should have a plan
* Login to https://hud-staging.happychat.io/ as an operator

Action:
* Go to /plans/my-plan/:site
* Manage plan
* Remove plan
* Select Domain
* Select Other Domain Issues
* Click "Let's have a chat"
* Check if the tag shows up in happychat hud

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] ~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] ~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~
- [ ] ~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~
- [ ] ~For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #72325
