### PR TITLE
Users management: Add member/subscribers, improve Back redirection

### DIFF
--- a/client/my-sites/people/people-add-subscribers/index.jsx
+++ b/client/my-sites/people/people-add-subscribers/index.jsx
@@ -38,10 +38,11 @@ class PeopleInvites extends PureComponent {
 
 		if ( isEnabled( 'user-management-revamp' ) ) {
 			fallback = '/people/subscribers/' + siteSlug;
+			page.redirect( fallback );
+		} else {
+			// Go back to last route with /people/team/$site as the fallback
+			page.back( fallback );
 		}
-
-		// Go back to last route with /people/team/$site as the fallback
-		page.back( fallback );
 	};
 
 	render() {

--- a/client/my-sites/people/team-invite/index.tsx
+++ b/client/my-sites/people/team-invite/index.tsx
@@ -43,9 +43,7 @@ function TeamInvite( props: Props ) {
 	function goBack() {
 		const fallback = site?.slug ? '/people/team/' + site?.slug : '/people/team';
 
-		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-		// @ts-ignore: There are no type definitions for page.back.
-		page.back( fallback );
+		page.redirect( fallback );
 	}
 
 	function checkPermission() {


### PR DESCRIPTION
#### Proposed Changes

* Improve back button redirection

#### Testing Instructions

* Go to `/people/team/{site_slug}`
* Click on the `Add a team member` button
* Switch between the `Add to team` and `Add subscribers` screens a few times
* Check if the back button leads to the parent screen

**Before:**
![Screen Capture on 2023-01-19 at 11-53-55](https://user-images.githubusercontent.com/1241413/213424667-b7892e8f-3a98-4bc2-9689-6788f7e7f4cb.gif)

**After:** 
![Screen Capture on 2023-01-19 at 11-55-06](https://user-images.githubusercontent.com/1241413/213424722-729b2fab-8926-4703-b3d1-459e4f630fb3.gif)


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
