### PR TITLE
Licensing Portal: Add descriptions for Social and Search plans

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/license-bundle-card-description/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-bundle-card-description/index.tsx
@@ -65,6 +65,15 @@ export default function LicenseBundleCardDescription( { product }: Props ) {
 				'High-quality, ad-free video built specifically for WordPress.'
 			);
 			break;
+		case 'jetpack-social-basic':
+			textDescription = translate( 'Write once, post everywhere.' );
+			break;
+		case 'jetpack-social-advanced':
+			textDescription = translate( 'Write once, post everywhere.' );
+			break;
+		case 'jetpack-search':
+			textDescription = translate( 'Help your site visitors find answers instantly.' );
+			break;
 	}
 
 	return (


### PR DESCRIPTION
Context: 1201801459945917-as-1203781086996644

#### Proposed Changes

* Add descriptions for the new Social and Search plans in the Jetpack Licensing Portal Prices section. Descriptions are taken from https://cloud.jetpack.com/pricing.

#### Testing Instructions

* Apply D92724
* Apply billing scheme 836 to your test partner key.
* Please reach out to team Avalon if you are not sure what any of the above means.
* Run Jetpack Cloud locally and open up http://jetpack.cloud.localhost:3000/partner-portal/prices
* Confirm Jetpack Search, Jetpack Social Basic, and Jetpack Social Advanced all have descriptions. Social Advanced uses a placeholder description for now.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->