### PR TITLE
Update query string parsing/stringification

### DIFF
--- a/client/lib/wp/localization/index.js
+++ b/client/lib/wp/localization/index.js
@@ -16,7 +16,7 @@ export function addLocaleQueryParam( params ) {
 	}
 
 	let localeQueryParam;
-	const query = parse( params.query );
+	const query = parse( params.query, { depth: 10 } );
 
 	if ( params.apiNamespace ) {
 		// v2 api request

--- a/client/lib/wp/localization/index.js
+++ b/client/lib/wp/localization/index.js
@@ -26,7 +26,7 @@ export function addLocaleQueryParam( params ) {
 	}
 
 	return Object.assign( params, {
-		query: stringify( Object.assign( localeQueryParam, query ) ),
+		query: stringify( Object.assign( localeQueryParam, query ), { arrayFormat: 'brackets' } ),
 	} );
 }
 


### PR DESCRIPTION
For Marketplace category requests that use a language other than English, the queries have been formatted incorrectly. This is because the query string are prepared differently in the [`wpcom.js`](https://github.com/Automattic/wp-calypso/blob/b84a346a2d43e711e08ec4c28caf4e6b6c4c69a1/packages/wpcom.js/src/lib/util/send-request.js#L65) and [`localization`](https://github.com/Automattic/wp-calypso/blob/b84a346a2d43e711e08ec4c28caf4e6b6c4c69a1/client/lib/wp/localization/index.js#L29) packages.
#### Proposed Changes

For localized requests, update the query handling to:
- parse nested objects up to a greater depth
- stringify the query object back by using brackets array formatting instead of the default indices

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* visit [`/me/account`](https://wordpress.com/me/account) and set Calypso language to be different from English
* visit `/plugins`
* click on any category below the search bar
* verify that results appear (the request is successful)
  Before | After
  --- | --- 
  <img width="1103" alt="CleanShot 2023-01-19 at 11 51 22@2x" src="https://user-images.githubusercontent.com/11555574/213435388-7c607932-014a-49d4-b281-8b2d4d966952.png"> | <img width="1127" alt="CleanShot 2023-01-19 at 11 49 58@2x" src="https://user-images.githubusercontent.com/11555574/213435094-53930a1b-38e2-4e05-8057-f6ecc61d7c0e.png">
* Set the language to English
* Repeat the above steps and verify that there are no regressions

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #70331
