### PR TITLE
Stats: Adjust Post Stats Card for super small screens

### DIFF
--- a/packages/components/src/post-stats-card/index.tsx
+++ b/packages/components/src/post-stats-card/index.tsx
@@ -1,3 +1,5 @@
+import { eye } from '@automattic/components/src/icons';
+import { Icon, commentContent, starEmpty } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import { Card, ShortenedNumber } from '../';
@@ -41,18 +43,21 @@ export default function PostStatsCard( {
 			</div>
 			<div className="post-stats-card__counts">
 				<div className="post-stats-card__count post-stats-card__count--view">
+					<Icon className="gridicon" icon={ eye } />
 					<div className="post-stats-card__count-header">{ translate( 'Views' ) }</div>
 					<div className="post-stats-card__count-value">
 						<ShortenedNumber value={ viewCount } />
 					</div>
 				</div>
 				<div className="post-stats-card__count post-stats-card__count--like">
+					<Icon className="gridicon" icon={ starEmpty } />
 					<div className="post-stats-card__count-header">{ translate( 'Likes' ) }</div>
 					<div className="post-stats-card__count-value">
 						<ShortenedNumber value={ likeCount } />
 					</div>
 				</div>
 				<div className="post-stats-card__count post-stats-card__count--comment">
+					<Icon className="gridicon" icon={ commentContent } />
 					<div className="post-stats-card__count-header">{ translate( 'Comments' ) }</div>
 					<div className="post-stats-card__count-value">
 						<ShortenedNumber value={ commentCount } />

--- a/packages/components/src/post-stats-card/style.scss
+++ b/packages/components/src/post-stats-card/style.scss
@@ -154,6 +154,7 @@ $break-wpcom-smallest: 320px;
 	}
 
 	.post-stats-card__count-value {
+		font-family: inherit;
 		font-size: $font-body-small;
 		font-weight: 500;
 		line-height: 30px;

--- a/packages/components/src/post-stats-card/style.scss
+++ b/packages/components/src/post-stats-card/style.scss
@@ -63,6 +63,12 @@ $break-wpcom-smallest: 320px;
 	justify-content: space-between;
 }
 
+.post-stats-card__count {
+	.gridicon {
+		display: none;
+	}
+}
+
 .post-stats-card__count-header {
 	color: var(--studio-gray-100);
 	font-weight: 500;
@@ -134,13 +140,17 @@ $break-wpcom-smallest: 320px;
 		align-items: center;
 		border-bottom: 1px solid var(--color-neutral-5);
 		height: 60px;
+
+		.gridicon {
+			display: block;
+		}
 	}
 
 	.post-stats-card__count-header {
 		font-size: $font-body-small;
 		font-weight: 400;
 		line-height: 20px;
-		margin: 0 1em 0 0;
+		margin: 0 auto 0 8px;
 	}
 
 	.post-stats-card__count-value {

--- a/packages/components/src/post-stats-card/style.scss
+++ b/packages/components/src/post-stats-card/style.scss
@@ -4,6 +4,7 @@
 
 $card-padding: 24px;
 $border-radius: 5px; // stylelint-disable-line scales/radii
+$break-wpcom-smallest: 320px;
 
 @mixin header-typography {
 	font-family: $font-recoleta;
@@ -107,13 +108,15 @@ $border-radius: 5px; // stylelint-disable-line scales/radii
 	}
 }
 
-@media ( max-width: $break-zoomed-in ) {
+@media ( max-width: $break-wpcom-smallest ) {
 	.post-stats-card {
 		grid-template-areas:
 			"heading"
 			"thumbnail"
 			"post "
 			"counts";
+
+		border-bottom: 0;
 	}
 
 	.post-stats-card__thumbnail {
@@ -128,8 +131,21 @@ $border-radius: 5px; // stylelint-disable-line scales/radii
 		display: flex;
 		flex-flow: row;
 		justify-content: space-between;
+		align-items: center;
+		border-bottom: 1px solid var(--color-neutral-5);
+		height: 60px;
 	}
+
 	.post-stats-card__count-header {
-		margin-right: 1em;
+		font-size: $font-body-small;
+		font-weight: 400;
+		line-height: 20px;
+		margin: 0 1em 0 0;
+	}
+
+	.post-stats-card__count-value {
+		font-size: $font-body-small;
+		font-weight: 500;
+		line-height: 30px;
 	}
 }


### PR DESCRIPTION
#### Proposed Changes

* Introduce the smallest breakpoint `width <= 320px`.
* Adjust styles of `.post-stats-card__counts` rows as `Chart` tabs look on the smallest viewport.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up these changes on a local Storybook instance via `yarn workspace @automattic/components run storybook`.
* Take a look at the `Post Stats Card` stories and ensure they look like mobile `Chart` tabs on `width <= 320px`.

|Before on width <= 280px|After on width <= 320px|
|-|-|
|<img width="453" alt="截圖 2023-01-19 下午10 28 49" src="https://user-images.githubusercontent.com/6869813/213468492-e1a1cd84-32d8-48d2-bab7-70418f601640.png">|<img width="452" alt="截圖 2023-01-20 上午1 25 07" src="https://user-images.githubusercontent.com/6869813/213516434-5c184d57-6ffb-47b8-8536-1632dc2e3e28.png">|

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/70852#issuecomment-1353224082
