### PR TITLE
Blaze: Update /stats bottom banner

### DIFF
--- a/client/my-sites/stats/promo-cards/index.jsx
+++ b/client/my-sites/stats/promo-cards/index.jsx
@@ -21,7 +21,7 @@ const EVENT_YOAST_PROMO_VIEW = 'calypso_stats_wordpress_seo_premium_banner_view'
 const EVENT_ANNUAL_BLAZE_PROMO_VIEW = 'calypso_stats_annual_insights_blaze_banner_view';
 const EVENT_ANNUAL_MOBILE_PROMO_VIEW = 'calypso_stats_annual_insights_mobile_cta_jetpack_view';
 
-export default function PromoCards( { isOdysseyStats, slug, pageSlug } ) {
+export default function PromoCards( { isOdysseyStats, slug, pageSlug, isSecondaryBanner } ) {
 	// Keep a replica of the pager index state.
 	// TODO: Figure out an approach that doesn't require replicating state value from DotPager.
 	const [ dotPagerIndex, setDotPagerIndex ] = useState( 0 );
@@ -33,9 +33,10 @@ export default function PromoCards( { isOdysseyStats, slug, pageSlug } ) {
 	const shouldShowAdvertisingOption = usePromoteWidget() === PromoteWidgetStatus.ENABLED;
 
 	// Blaze promo is disabled for Odyssey.
-	const showBlazePromo = ! isOdysseyStats && shouldShowAdvertisingOption;
+	const showBlazePromo = ! isSecondaryBanner && ! isOdysseyStats && shouldShowAdvertisingOption;
 	// Yoast promo is disabled for Odyssey & self-hosted & non-traffic pages.
-	const showYoastPromo = ! isOdysseyStats && ! jetpackNonAtomic && pageSlug === 'traffic';
+	const showYoastPromo =
+		! isSecondaryBanner && ! isOdysseyStats && ! jetpackNonAtomic && pageSlug === 'traffic';
 
 	const viewEvents = useMemo( () => {
 		const events = [];

--- a/client/my-sites/stats/promo-cards/index.jsx
+++ b/client/my-sites/stats/promo-cards/index.jsx
@@ -1,6 +1,7 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { MobilePromoCard } from '@automattic/components';
 import { translate } from 'i18n-calypso';
+import page from 'page';
 import { useEffect, useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
 import blazeDropDownIllustration from 'calypso/assets/images/illustrations/blaze-drop-down.svg';
@@ -21,7 +22,7 @@ const EVENT_YOAST_PROMO_VIEW = 'calypso_stats_wordpress_seo_premium_banner_view'
 const EVENT_ANNUAL_BLAZE_PROMO_VIEW = 'calypso_stats_annual_insights_blaze_banner_view';
 const EVENT_ANNUAL_MOBILE_PROMO_VIEW = 'calypso_stats_annual_insights_mobile_cta_jetpack_view';
 
-export default function PromoCards( { isOdysseyStats, slug, pageSlug, isSecondaryBanner } ) {
+export default function PromoCards( { isOdysseyStats, slug, pageSlug } ) {
 	// Keep a replica of the pager index state.
 	// TODO: Figure out an approach that doesn't require replicating state value from DotPager.
 	const [ dotPagerIndex, setDotPagerIndex ] = useState( 0 );
@@ -32,11 +33,14 @@ export default function PromoCards( { isOdysseyStats, slug, pageSlug, isSecondar
 	);
 	const shouldShowAdvertisingOption = usePromoteWidget() === PromoteWidgetStatus.ENABLED;
 
+	// This is used to show some banner only on annual stats page.
+	const isAnnualStatsPage = page.current.includes( 'annualstats' );
+
 	// Blaze promo is disabled for Odyssey.
-	const showBlazePromo = ! isSecondaryBanner && ! isOdysseyStats && shouldShowAdvertisingOption;
+	const showBlazePromo = isAnnualStatsPage && ! isOdysseyStats && shouldShowAdvertisingOption;
 	// Yoast promo is disabled for Odyssey & self-hosted & non-traffic pages.
 	const showYoastPromo =
-		! isSecondaryBanner && ! isOdysseyStats && ! jetpackNonAtomic && pageSlug === 'traffic';
+		isAnnualStatsPage && ! isOdysseyStats && ! jetpackNonAtomic && pageSlug === 'traffic';
 
 	const viewEvents = useMemo( () => {
 		const events = [];

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -372,6 +372,7 @@ class StatsSite extends Component {
 				<PromoCards
 					isJetpack={ isJetpack }
 					isOdysseyStats={ isOdysseyStats }
+					isSecondaryBanner={ true }
 					pageSlug="traffic"
 					slug={ slug }
 				/>

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -279,9 +279,7 @@ class StatsSite extends Component {
 						{ ! isSitePrivate && <StatsNoContentBanner siteId={ siteId } siteSlug={ slug } /> }
 					</>
 
-					{ config.isEnabled( 'stats-mini-carousel' ) && (
-						<MiniCarousel isOdysseyStats={ isOdysseyStats } slug={ slug } />
-					) }
+					<MiniCarousel isOdysseyStats={ isOdysseyStats } slug={ slug } />
 
 					<div className="stats__module-list stats__module-list--traffic is-events stats__module--unified">
 						{ config.isEnabled( 'newsletter/stats' ) && (

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -370,7 +370,6 @@ class StatsSite extends Component {
 				<PromoCards
 					isJetpack={ isJetpack }
 					isOdysseyStats={ isOdysseyStats }
-					isSecondaryBanner={ true }
 					pageSlug="traffic"
 					slug={ slug }
 				/>


### PR DESCRIPTION
#### Proposed Changes

Remove Blaze & Yoast from the bottom banner as it is showing on the mini-carousel.

Bottom banner:
![Image](https://user-images.githubusercontent.com/6586048/212283615-4cdef843-49f7-4e44-ad90-a6a9dae4a84f.png)

#### Acceptance criteria:

- [x] Remove the Yoast and Blaze banner from the bottom carrousel (they should be in the mini-carousel)
- [x] The bottom carrousel will only have Jetpack mobile on it
- [x] At the same time, remove the feature flag from the new mini-carousel

#### Testing Instructions

- Go to /stats, and you should see the mini-carousel (without any flag) following criteria:
- Using a Jetpack non-Atomic should not show Yoast.
- Using a Simple or Atomic site should show Blaze & Yoast.
- Bottom Banner should show only the Jetpack Mobile banner

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] ~~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~~
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~~
- [ ] ~~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~~
- [ ] ~~For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~~
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/1488
