### PR TITLE
Users management: Fix pre-release e2e tests

### DIFF
--- a/client/my-sites/people/team-invite/invite-form.tsx
+++ b/client/my-sites/people/team-invite/invite-form.tsx
@@ -1,6 +1,7 @@
 import { Button, FormInputValidation } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { Icon, check } from '@wordpress/icons';
+import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useState, ChangeEvent, useEffect, FormEvent, useRef } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
@@ -153,7 +154,11 @@ function InviteForm( props: Props ) {
 	}
 
 	return (
-		<form className="team-invite-form" autoComplete="off" onSubmit={ onFormSubmit }>
+		<form
+			autoComplete="off"
+			className={ classNames( 'team-invite-form', { 'team-invite-form-valid': readyForSubmit } ) }
+			onSubmit={ onFormSubmit }
+		>
 			<RoleSelect
 				id="role"
 				name="role"

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -154,6 +154,7 @@
 		"upgrades/wpcom-monthly-plans": true,
 		"upsell/concierge-session": true,
 		"use-translation-chunks": true,
+		"user-management-revamp": true,
 		"woop": false,
 		"wordpress-action-search": false,
 		"wpcom-user-bootstrap": true,

--- a/packages/calypso-e2e/src/lib/pages/add-people-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/add-people-page.ts
@@ -1,0 +1,61 @@
+import { Page } from 'playwright';
+
+export type RoleValue = 'administrator' | 'editor' | 'author' | 'contributor' | 'follower';
+
+const selectors = {
+	// Form inputs
+	emailInput: '#token-0',
+	roleSelect: `#role`,
+	messageInput: '#message',
+	addMessageButton: 'button:text("+ Add a message")',
+	sendInviteButton: 'button:text("Send invitation")',
+	formReadyForSubmit: '.team-invite-form-valid',
+
+	// Banner
+	inviteSuccessful: 'span:text("Invitation sent successfully")',
+};
+
+/**
+ * Represents the Users > Add New page.
+ */
+export class AddPeoplePage {
+	private page: Page;
+
+	/**
+	 * Constructs an instance of the component.
+	 *
+	 * @param {Page} page The underlying page.
+	 */
+	constructor( page: Page ) {
+		this.page = page;
+	}
+
+	/**
+	 * Given an email address, role and optinally a message, sends an invite.
+	 *
+	 * @param param0 Keyed parameter object.
+	 * @param {string} param0.email Email address of the invited user.
+	 * @param {RoleValue} param0.role Role of the invited user.
+	 * @param {string} param0.message Optional message for the invitation.
+	 */
+	async addTeamMember( {
+		email,
+		role,
+		message = '',
+	}: {
+		email: string;
+		role: RoleValue;
+		message?: string;
+	} ): Promise< void > {
+		await this.page.fill( selectors.emailInput, email );
+		await this.page.press( selectors.emailInput, 'Tab' );
+		await this.page.selectOption( selectors.roleSelect, role );
+		if ( message ) {
+			await this.page.click( selectors.addMessageButton );
+			await this.page.fill( selectors.messageInput, message );
+		}
+		await this.page.waitForSelector( selectors.formReadyForSubmit );
+		await this.page.click( selectors.sendInviteButton );
+		await this.page.waitForSelector( selectors.inviteSuccessful );
+	}
+}

--- a/packages/calypso-e2e/src/lib/pages/index.ts
+++ b/packages/calypso-e2e/src/lib/pages/index.ts
@@ -1,4 +1,5 @@
 export * from './account-closed-page';
+export * from './add-people-page';
 export * from './cart-checkout-page';
 export * from './checkout-thank-you-page';
 export * from './domains-page';

--- a/packages/calypso-e2e/src/lib/pages/people-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/people-page.ts
@@ -16,6 +16,7 @@ const selectors = {
 	deleteConfirmBanner: ':text("Successfully deleted")',
 
 	// Header
+	addPeopleButton: 'a:text("Add a team member")',
 	invitePeopleButton: '.people-list-section-header__add-button',
 
 	// Invites
@@ -122,6 +123,15 @@ export class PeoplePage {
 			this.page.waitForNavigation(),
 			this.page.click( selectors.invitePeopleButton ),
 		] );
+	}
+
+	/**
+	 * Click on the `Invite` button to navigate to the invite user page.
+	 */
+	async clickAddTeamMember(): Promise< void > {
+		await this.waitUntilLoaded();
+
+		await this.page.click( selectors.addPeopleButton );
 	}
 
 	/**

--- a/test/e2e/specs/users/invite__revoke.ts
+++ b/test/e2e/specs/users/invite__revoke.ts
@@ -31,6 +31,7 @@ describe( DataHelper.createSuiteTitle( `Invite: Revoke` ), function () {
 	let page: Page;
 	let restAPIClient: RestAPIClient;
 	let revoked = false;
+	let userManagementRevampFeature = false;
 
 	describe( 'Setup', function () {
 		beforeAll( async () => {
@@ -61,6 +62,9 @@ describe( DataHelper.createSuiteTitle( `Invite: Revoke` ), function () {
 			page = await browser.newPage();
 			const testAccount = new TestAccount( 'defaultUser' );
 			await testAccount.authenticate( page );
+			userManagementRevampFeature = await page.evaluate(
+				`configData.features['user-management-revamp']`
+			);
 		} );
 
 		it( 'Navigate to User > All Users', async function () {
@@ -70,7 +74,12 @@ describe( DataHelper.createSuiteTitle( `Invite: Revoke` ), function () {
 
 		it( 'View pending invites', async function () {
 			peoplePage = new PeoplePage( page );
-			await peoplePage.clickTab( 'Invites' );
+
+			if ( userManagementRevampFeature ) {
+				await peoplePage.clickTab( 'Team' );
+			} else {
+				await peoplePage.clickTab( 'Invites' );
+			}
 		} );
 
 		it( 'Revoke the invite for test user', async function () {


### PR DESCRIPTION
#### Proposed Changes

Fixed pre-release e2e tests that fail when the new `user-management-revamp` feature is turned on.
The new "User management UI revamp" feature introduces changes to the UI, like navigation updates and different button positions. 

Once we realize that feature is stable enough, we can eliminate the conditions made by this PR.

#### Testing Instructions

- TeamCity test run against the live link of this PR

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
