### PR TITLE
Email open stats: Change route

### DIFF
--- a/client/my-sites/stats/controller.jsx
+++ b/client/my-sites/stats/controller.jsx
@@ -102,33 +102,15 @@ function getSiteFilters( siteId ) {
 		},
 		{
 			title: i18n.translate( 'Hours' ),
-			path: '/stats/email/open/' + siteId + '/hour',
+			path: '/stats/email/opens/' + siteId + '/hour',
 			id: 'stats-email-opens-hour',
 			period: 'hour',
 		},
 		{
-			title: i18n.translate( 'Days' ),
-			path: '/stats/email/open/' + siteId + '/day',
+			title: i18n.translate( 'Hours' ),
+			path: '/stats/email/opens/' + siteId + '/day',
 			id: 'stats-email-opens-day',
 			period: 'day',
-		},
-		{
-			title: i18n.translate( 'Weeks' ),
-			path: '/stats/email/open/' + siteId + '/week',
-			id: 'stats-email-opens-week',
-			period: 'week',
-		},
-		{
-			title: i18n.translate( 'Months' ),
-			path: '/stats/email/open/' + siteId + '/month',
-			id: 'stats-email-opens-month',
-			period: 'month',
-		},
-		{
-			title: i18n.translate( 'Years' ),
-			path: '/stats/email/open/' + siteId + '/year',
-			id: 'stats-email-opens-year',
-			period: 'year',
 		},
 	];
 }

--- a/client/my-sites/stats/index.js
+++ b/client/my-sites/stats/index.js
@@ -81,7 +81,7 @@ export default function () {
 
 	// Email stats Pages
 	if ( config.isEnabled( 'newsletter/stats' ) ) {
-		statsPage( `/stats/email/open/:site/:period(${ validEmailPeriods })/:email_id`, emailOpen );
+		statsPage( `/stats/email/opens/:site/:period(${ validEmailPeriods })/:email_id`, emailOpen );
 	}
 
 	// Anything else should redirect to default stats page

--- a/client/my-sites/stats/stats-email-open-detail/index.jsx
+++ b/client/my-sites/stats/stats-email-open-detail/index.jsx
@@ -201,7 +201,7 @@ class StatsEmailOpenDetail extends Component {
 		const { period, endOf } = this.props.period;
 		const traffic = {
 			label: translate( 'Traffic' ),
-			path: '/stats/email/open',
+			path: `/stats/email/${ statType }`,
 		};
 		const query = memoizedQuery( period, endOf );
 		const slugPath = slug ? `/${ slug }` : '';
@@ -220,7 +220,7 @@ class StatsEmailOpenDetail extends Component {
 					<DocumentHead title={ translate( 'Jetpack Stats' ) } />
 
 					<PageViewTracker
-						path="/stats/email/open/:site/:period/:email_id"
+						path="/stats/email/opens/:site/:period/:email_id"
 						title="Stats > Single Email"
 					/>
 					<FixedNavigationHeader
@@ -247,7 +247,7 @@ class StatsEmailOpenDetail extends Component {
 									<StatsPeriodNavigation
 										date={ date }
 										period={ period }
-										url={ `/stats/email/open/${ slug }/${ period }/${ postId }` }
+										url={ `/stats/email/${ statType }/${ slug }/${ period }/${ postId }` }
 									>
 										<DatePicker
 											period={ period }

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -954,7 +954,9 @@ export const normalizers = {
 		const emailsData = get( data, [ 'posts' ], [] );
 
 		return emailsData.map( ( { id, href, date, title, type, opens } ) => {
-			const detailPage = site ? `/stats/email/open/${ site.slug }/${ query.period }/${ id }` : null;
+			const detailPage = site
+				? `/stats/email/opens/${ site.slug }/${ query.period }/${ id }`
+				: null;
 			return {
 				id,
 				href,


### PR DESCRIPTION
#### Proposed Changes

* This PR changes the route for email open stats from `/stats/email/open` to `/stats/email/opens`.


#### Testing Instructions

- Apply this PR
- Go to `http://calypso.localhost:3000/stats/day/<yoursite>?flags=newsletter/stats` (or click on "Stats" and add the feature flag to the URL).
- Scroll to the bottom ("Email opens").
- Click a post
- The page should load
- Now click on Hours and verify this also still loads/

If you don't have any email stats, you can SU to a site with lots of visitors. An overview is here: PdDOJh-1gb-p2


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #