### PR TITLE
Licensing Portal: Adjust license cards to work with longer product names

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/license-product-card/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/license-product-card/style.scss
@@ -2,6 +2,8 @@
 @import "@wordpress/base-styles/mixins";
 
 .license-product-card {
+	display: flex;
+	justify-content: stretch;
 	width: 100%;
 
 	&.disabled {
@@ -22,6 +24,7 @@
 }
 
 .license-product-card__inner {
+	flex-grow: 1;
 	margin: 0.5rem 0;
 	padding: 1.5rem;
 	border: 1px solid var(--studio-gray-10);
@@ -41,20 +44,70 @@
 	box-shadow: 0 0 40px rgba(0, 0, 0, 0.08);
 }
 
+@mixin license-product-card-block__details {
+	flex-wrap: wrap;
+	align-items: flex-start;
+}
+
+@mixin license-product-card-line__details {
+	align-items: center;
+	flex-wrap: nowrap;
+}
+
 .license-product-card__details {
 	display: flex;
-	flex-wrap: wrap;
-	justify-content: stretch;
-	align-items: center;
+	justify-content: space-between;
+
+	@include license-product-card-block__details;
+
+	@include break-mobile {
+		@include license-product-card-line__details;
+	}
+
+	@include breakpoint-deprecated( ">660px" ) {
+		@include license-product-card-block__details;
+	}
+
+	@include break-medium {
+		@include license-product-card-line__details;
+	}
+
+	@include break-xlarge {
+		@include license-product-card-block__details;
+	}
+}
+
+@mixin license-product-card-block__title {
+	flex: 0 1  calc(100% - 34px);
+}
+
+@mixin license-product-card-line__title {
+	flex: 1 1 0;
 }
 
 .license-product-card__title {
-	flex: 1 0 auto;
-	white-space: nowrap;
 	font-size: 1.5rem;
 	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	line-height: 1.5rem;
 	color: var(--studio-gray-80);
+
+	@include license-product-card-block__title;
+
+	@include break-mobile {
+		@include license-product-card-line__title;
+	}
+
+	@include breakpoint-deprecated( ">660px" ) {
+		@include license-product-card-block__title;
+	}
+
+	@include break-medium {
+		@include license-product-card-line__title;
+	}
+
+	@include break-xlarge {
+		@include license-product-card-block__title;
+	}
 }
 
 @mixin license-product-card-block__select-button {


### PR DESCRIPTION
1201801459945917-as-1203781086996651

#### Proposed Changes

* Adjust license cards to work with longer product names for all breakpoints.

#### Testing Instructions

* You can apply D98717-code which will result in longer product names that make the issues apparent.
* Run Jetpack Cloud and open up http://jetpack.cloud.localhost:3000/partner-portal/issue-license
* Go through each browser endpoint and make sure the license cards look good.

Before:

https://user-images.githubusercontent.com/22746396/213492221-d6b70b7f-70a4-4599-b317-23c7422477d4.mov

After:

https://user-images.githubusercontent.com/22746396/213492279-512f7a17-a973-4ff6-bbab-690db6ccd410.mov

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->