### PR TITLE
Improve the nudge for dotorg themes

### DIFF
--- a/client/blocks/eligibility-warnings/hold-list.tsx
+++ b/client/blocks/eligibility-warnings/hold-list.tsx
@@ -223,7 +223,7 @@ export const HoldList = ( { context, holds, isMarketplace, isPlaceholder, transl
 
 	return (
 		<>
-			{ ! isPlaceholder && context !== 'plugin-details' && (
+			{ ! isPlaceholder && context !== 'plugin-details' && context !== 'themes' && (
 				<HardBlockingNotice
 					holds={ holds }
 					translate={ translate }
@@ -258,9 +258,11 @@ export const HoldList = ( { context, holds, isMarketplace, isPlaceholder, transl
 						! isKnownHoldType( hold, holdMessages ) ? null : (
 							<div className="eligibility-warnings__hold" key={ hold }>
 								<div className="eligibility-warnings__message">
-									<div className="eligibility-warnings__message-title">
-										{ holdMessages[ hold ].title }
-									</div>
+									{ holds.length > 1 && (
+										<div className="eligibility-warnings__message-title">
+											{ holdMessages[ hold ].title }
+										</div>
+									) }
 									<div className="eligibility-warnings__message-description">
 										{ holdMessages[ hold ].description }
 									</div>

--- a/client/blocks/eligibility-warnings/index.tsx
+++ b/client/blocks/eligibility-warnings/index.tsx
@@ -96,7 +96,7 @@ export const EligibilityWarnings = ( {
 			'eligibility-warnings__placeholder': isPlaceholder,
 			'eligibility-warnings--with-indent': showWarnings,
 			'eligibility-warnings--blocking-hold': hasBlockingHold( listHolds ),
-			'eligibility-warnings--without-title': context !== 'plugin-details',
+			'eligibility-warnings--without-title': context !== 'plugin-details' && context !== 'themes',
 		},
 		className
 	);
@@ -135,7 +135,7 @@ export const EligibilityWarnings = ( {
 	const blockingMessages = getBlockingMessages( translate );
 
 	let filteredHolds = listHolds;
-	if ( context === 'plugin-details' ) {
+	if ( context === 'plugin-details' || context === 'themes' ) {
 		filteredHolds = listHolds.filter( ( hold ) => hold !== 'NO_BUSINESS_PLAN' );
 	}
 
@@ -150,15 +150,17 @@ export const EligibilityWarnings = ( {
 				eventName="calypso_automated_transfer_eligibility_show_warnings"
 				eventProperties={ { context } }
 			/>
-			{ ! isPlaceholder && context === 'plugin-details' && hasBlockingHold( listHolds ) && (
-				<CompactCard>
-					<HardBlockingNotice
-						holds={ listHolds }
-						translate={ translate }
-						blockingMessages={ blockingMessages }
-					/>
-				</CompactCard>
-			) }
+			{ ! isPlaceholder &&
+				( context === 'plugin-details' || context === 'themes' ) &&
+				hasBlockingHold( listHolds ) && (
+					<CompactCard>
+						<HardBlockingNotice
+							holds={ listHolds }
+							translate={ translate }
+							blockingMessages={ blockingMessages }
+						/>
+					</CompactCard>
+				) }
 			{ ! isPlaceholder && context === 'plugin-details' && (
 				<CompactCard>
 					<div className="eligibility-warnings__header">
@@ -171,6 +173,25 @@ export const EligibilityWarnings = ( {
 							{ listHolds.indexOf( 'NO_BUSINESS_PLAN' ) !== -1
 								? translate(
 										'Installing plugins is a premium feature. Unlock the ability to install this and 50,000 other plugins by upgrading to the Business plan for %(monthlyCost)s/month.',
+										{ args: { monthlyCost } }
+								  )
+								: '' }
+						</div>
+					</div>
+				</CompactCard>
+			) }
+			{ ! isPlaceholder && context === 'themes' && (
+				<CompactCard>
+					<div className="eligibility-warnings__header">
+						<div className="eligibility-warnings__title">
+							{ listHolds.indexOf( 'NO_BUSINESS_PLAN' ) !== -1
+								? translate( 'Upgrade to install third party themes' )
+								: translate( 'Before you continue' ) }
+						</div>
+						<div className="eligibility-warnings__primary-text">
+							{ listHolds.indexOf( 'NO_BUSINESS_PLAN' ) !== -1
+								? translate(
+										'Installing third party themes is a premium feature. Unlock the ability to install this theme and get access to lots of other features by upgrading to the Business plan for %(monthlyCost)s per month.',
 										{ args: { monthlyCost } }
 								  )
 								: '' }
@@ -415,7 +436,7 @@ function mergeProps(
 		context = 'plugins';
 		feature = FEATURE_UPLOAD_PLUGINS;
 		ctaName = 'calypso-plugin-eligibility-upgrade-nudge';
-	} else if ( includes( ownProps.backUrl, 'themes' ) ) {
+	} else if ( ownProps.currentContext === 'themes' || includes( ownProps.backUrl, 'themes' ) ) {
 		context = 'themes';
 		feature = FEATURE_UPLOAD_THEMES;
 		ctaName = 'calypso-theme-eligibility-upgrade-nudge';

--- a/client/blocks/eligibility-warnings/warning-list.tsx
+++ b/client/blocks/eligibility-warnings/warning-list.tsx
@@ -29,7 +29,7 @@ export const WarningList = ( { context, translate, warnings, showContact = true 
 		{ warnings.map( ( { name, description, supportUrl, domainNames }, index ) => (
 			<div className="eligibility-warnings__warning" key={ index }>
 				<div className="eligibility-warnings__message">
-					{ context !== 'plugin-details' && (
+					{ context !== 'plugin-details' && context !== 'themes' && (
 						<Fragment>
 							<span className="eligibility-warnings__message-title">{ name }</span>:&nbsp;
 						</Fragment>
@@ -97,14 +97,7 @@ function getWarningDescription(
 			return '';
 
 		case 'themes':
-			return translate(
-				'By installing a theme the following change will be made to the site:',
-				'By installing a theme the following changes will be made to the site:',
-				{
-					count: warningCount,
-					args: warningCount,
-				}
-			);
+			return '';
 
 		case 'hosting':
 			return translate(

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -885,7 +885,7 @@ class ThemeSheet extends Component {
 				<UpsellNudge
 					plan={ PLAN_BUSINESS }
 					className="theme__page-upsell-banner"
-					title={ translate( 'Access this theme for FREE with a Business plan!' ) }
+					title={ translate( 'Upgrade your plan to install third-party themes' ) }
 					description={ preventWidows(
 						translate(
 							'Instantly unlock thousands of different themes and install your own when you upgrade.'

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -893,8 +893,9 @@ class ThemeSheet extends Component {
 						)
 					) }
 					forceHref={ false }
-					disableHref={ true }
-					onClick={ () => this.setState( { upgradeDialogVisible: true } ) }
+					disableHref={ !! siteId }
+					href={ ! siteId ? '/plans' : null }
+					onClick={ siteId ? () => this.setState( { upgradeDialogVisible: true } ) : null }
 					displayAsLink={ true }
 					feature={ FEATURE_UPLOAD_THEMES }
 					forceDisplay

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -5,7 +5,7 @@ import {
 	PLAN_PREMIUM,
 	WPCOM_FEATURES_PREMIUM_THEMES,
 } from '@automattic/calypso-products';
-import { Button, Card, Gridicon } from '@automattic/components';
+import { Button, Card, Dialog, Gridicon } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import classNames from 'classnames';
 import { localize, getLocaleSlug } from 'i18n-calypso';
@@ -15,6 +15,7 @@ import PropTypes from 'prop-types';
 import { cloneElement, Component } from 'react';
 import { connect } from 'react-redux';
 import titlecase from 'to-title-case';
+import EligibilityWarnings from 'calypso/blocks/eligibility-warnings';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
 import AsyncLoad from 'calypso/components/async-load';
 import Badge from 'calypso/components/badge';
@@ -891,10 +892,12 @@ class ThemeSheet extends Component {
 							'Instantly unlock thousands of different themes and install your own when you upgrade.'
 						)
 					) }
-					forceHref
+					forceHref={ false }
+					disableHref={ true }
+					onClick={ () => this.setState( { upgradeDialogVisible: true } ) }
+					displayAsLink={ true }
 					feature={ FEATURE_UPLOAD_THEMES }
 					forceDisplay
-					href={ ! siteId ? '/plans' : null }
 					showIcon
 					event="theme_upsell_plan_click"
 					tracksClickName="calypso_theme_upsell_plan_click"
@@ -938,6 +941,18 @@ class ThemeSheet extends Component {
 				<ThanksModal source="details" />
 				<AutoLoadingHomepageModal source="details" />
 				{ pageUpsellBanner }
+				<Dialog
+					isVisible={ this.state?.upgradeDialogVisible }
+					onClose={ () => this.setState( { upgradeDialogVisible: false } ) }
+					shouldCloseOnEsc={ true }
+					showCloseIcon={ true }
+				>
+					<EligibilityWarnings
+						currentContext="themes"
+						siteId={ siteId }
+						feature={ FEATURE_UPLOAD_THEMES }
+					/>
+				</Dialog>
 				<HeaderCake
 					className="theme__sheet-action-bar"
 					backText={ translate( 'All Themes' ) }

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -535,7 +535,7 @@
 	display: none;
 }
 
-.banner.theme__page-upsell-banner {
+.banner.theme__page-upsell-banner.card.is-card-link {
 	width: 50%;
 	margin: 0 0 10px;
 


### PR DESCRIPTION
#### Proposed Changes

Reworded nudge
Before | After
-------|------
![image](https://user-images.githubusercontent.com/93301/213511999-637821c7-b187-440d-81bd-3087583f9711.png) | ![image](https://user-images.githubusercontent.com/93301/213511959-ad56e892-d43d-44d5-84e5-5440bb6974dc.png)

New dialog

Custom domain | wpcom subdomain
-------|------
![image](https://user-images.githubusercontent.com/93301/213512618-21a685be-596c-4488-b4e0-ebda4bc93a0b.png) | ![image](https://user-images.githubusercontent.com/93301/213512695-c9a24c06-e473-4659-9ebd-7cf90743115a.png)




#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

 1. Use live link go to /themes on a < business site
 2. Search for a dot org only theme (not a TTn theme)
 3. Click on the theme
 4. You should see the theme detail page, including a nudge
 'Upgrade your plan to install third-party themes'
 5. Click the nudge and a dialog should appear
 6. The dialog should explain your domain will change (if on a wordpress.com subdomain) along with some enticing wording about upgrading.
 7. The dialog should have a button that takes you through the purchase process.
 8. Reasonable tracks events should also be emitted

You should test with a site with a custom domain as well as with a subdomain to ensure the dialog is worded correctly.

You should also test with zaino (woo specific theme) and Makoney (marketplace theme). They should not use the new wording or trigger the new dialog

##### Tracks events
Event name | Description | Properties
-----------|-------------|-----------------
calypso_theme_upsell_plan_click | Click on the upsell nudge | `cta_name:theme_upsell_plan_click, cta_feature:upload-themes`
calypso_automated_transfer_eligibility_ineligible | Display of the dialog | `holds: NO_BUSINESS_PLAN`
calypso_automated_transfer_eligibilty_click_proceed | Click proceed on the dialog | `context:themes`

 
#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
  - There are none 
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/1299
