### PR TITLE
Blaze: /stats Move the no-posts banner to the mini-carousel

### DIFF
--- a/client/my-sites/stats/mini-carousel/index.jsx
+++ b/client/my-sites/stats/mini-carousel/index.jsx
@@ -62,11 +62,11 @@ const MiniCarousel = ( { slug, isOdysseyStats, isSitePrivate } ) => {
 
 	const viewEvents = useMemo( () => {
 		const events = [];
-		showBlazePromo && events.push( EVENT_TRAFFIC_BLAZE_PROMO_VIEW );
 		showWriteAPostBanner && events.push( EVENT_NO_CONTENT_BANNER_VIEW );
+		showBlazePromo && events.push( EVENT_TRAFFIC_BLAZE_PROMO_VIEW );
 		showYoastPromo && events.push( EVENT_YOAST_PROMO_VIEW );
 		return events;
-	}, [ showBlazePromo, showWriteAPostBanner, showYoastPromo ] );
+	}, [ showWriteAPostBanner, showBlazePromo, showYoastPromo ] );
 
 	// Handle view events upon initial mount and upon paging DotPager.
 	useEffect( () => {

--- a/client/my-sites/stats/mini-carousel/index.jsx
+++ b/client/my-sites/stats/mini-carousel/index.jsx
@@ -23,6 +23,8 @@ const EVENT_YOAST_PROMO_VIEW = 'calypso_stats_wordpress_seo_premium_banner_view'
 const EVENT_YOAST_PROMO_CLICK = 'calypso_stats_wordpress_seo_premium_banner_click';
 const EVENT_YOAST_PROMO_DISMISS = 'calypso_stats_wordpress_seo_premium_banner_dismiss';
 const EVENT_NO_CONTENT_BANNER_VIEW = 'calypso_stats_no_content_banner_view';
+const EVENT_NO_CONTENT_BANNER_CLICK = 'calypso_stats_no_content_banner_click';
+const EVENT_NO_CONTENT_BANNER_DISMISS = 'calypso_stats_no_content_banner_dismiss';
 
 const MiniCarousel = ( { slug, isOdysseyStats, isSitePrivate } ) => {
 	const selectedSiteId = useSelector( ( state ) => getSelectedSiteId( state ) );
@@ -85,8 +87,8 @@ const MiniCarousel = ( { slug, isOdysseyStats, isSitePrivate } ) => {
 	if ( showWriteAPostBanner ) {
 		blocks.push(
 			<MiniCarouselBlock
-				clickEvent="calypso_stats_no_content_banner_click"
-				dismissEvent="calypso_stats_no_content_banner_dismiss"
+				clickEvent={ EVENT_NO_CONTENT_BANNER_CLICK }
+				dismissEvent={ EVENT_NO_CONTENT_BANNER_DISMISS }
 				image={ <img src={ writePost } alt="" width={ 45 } height={ 45 } /> }
 				headerText={ translate( 'Start writing your first post to get more views' ) }
 				contentText={ translate(
@@ -94,6 +96,7 @@ const MiniCarousel = ( { slug, isOdysseyStats, isSitePrivate } ) => {
 				) }
 				ctaText={ translate( 'Write a post' ) }
 				href={ `/post/${ slug }` }
+				key="write-a-post"
 			/>
 		);
 	}

--- a/client/my-sites/stats/mini-carousel/index.jsx
+++ b/client/my-sites/stats/mini-carousel/index.jsx
@@ -46,17 +46,20 @@ const MiniCarousel = ( { slug, isOdysseyStats, isSitePrivate } ) => {
 
 	// Write a Post banner.
 	const showWriteAPostBanner =
-		! isSitePrivate && hasNeverPublishedPost && ! isHasNeverPublishedPostLoading;
+		! useSelector( isBlockDismissed( EVENT_NO_CONTENT_BANNER_DISMISS ) ) &&
+		! isSitePrivate &&
+		hasNeverPublishedPost &&
+		! isHasNeverPublishedPostLoading;
 
 	// Blaze promo is disabled for Odyssey.
 	const showBlazePromo =
-		! useSelector( isBlockDismissed( 'calypso_stats_traffic_blaze_banner_dismiss' ) ) &&
+		! useSelector( isBlockDismissed( EVENT_TRAFFIC_BLAZE_PROMO_DISMISS ) ) &&
 		! isOdysseyStats &&
 		shouldShowAdvertisingOption;
 
 	// Yoast promo is disabled for Odyssey & self-hosted & non-traffic pages.
 	const showYoastPromo =
-		! useSelector( isBlockDismissed( 'calypso_stats_wordpress_seo_premium_banner_dismiss' ) ) &&
+		! useSelector( isBlockDismissed( EVENT_YOAST_PROMO_DISMISS ) ) &&
 		! isOdysseyStats &&
 		! jetpackNonAtomic;
 
@@ -105,6 +108,7 @@ const MiniCarousel = ( { slug, isOdysseyStats, isSitePrivate } ) => {
 		blocks.push(
 			<MiniCarouselBlock
 				clickEvent={ EVENT_TRAFFIC_BLAZE_PROMO_CLICK }
+				dismissEvent={ EVENT_TRAFFIC_BLAZE_PROMO_DISMISS }
 				image={ <BlazeLogo className="mini-carousel-blaze" size={ 45 } /> }
 				headerText={ translate( 'Promote your content with Blaze' ) }
 				contentText={ translate(
@@ -112,7 +116,6 @@ const MiniCarousel = ( { slug, isOdysseyStats, isSitePrivate } ) => {
 				) }
 				ctaText={ translate( 'Create campaign' ) }
 				href={ `/advertising/${ slug || '' }` }
-				dismissEvent={ EVENT_TRAFFIC_BLAZE_PROMO_DISMISS }
 				key="blaze"
 			/>
 		);
@@ -122,6 +125,7 @@ const MiniCarousel = ( { slug, isOdysseyStats, isSitePrivate } ) => {
 		blocks.push(
 			<MiniCarouselBlock
 				clickEvent={ EVENT_YOAST_PROMO_CLICK }
+				dismissEvent={ EVENT_YOAST_PROMO_DISMISS }
 				image={ <img src={ YoastLogo } alt="" width={ 45 } height={ 45 } /> }
 				headerText={ translate( 'Increase your site visitors with Yoast SEO Premium' ) }
 				contentText={ translate(
@@ -129,7 +133,6 @@ const MiniCarousel = ( { slug, isOdysseyStats, isSitePrivate } ) => {
 				) }
 				ctaText={ translate( 'Get Yoast' ) }
 				href={ `/plugins/wordpress-seo-premium/${ slug || '' }` }
-				dismissEvent={ EVENT_YOAST_PROMO_DISMISS }
 				key="yoast"
 			/>
 		);

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -27,7 +27,6 @@ import JetpackColophon from 'calypso/components/jetpack-colophon';
 import Main from 'calypso/components/main';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import memoizeLast from 'calypso/lib/memoize-last';
-import { StatsNoContentBanner } from 'calypso/my-sites/stats/stats-no-content-banner';
 import {
 	recordGoogleEvent,
 	recordTracksEvent,
@@ -276,10 +275,13 @@ class StatsSite extends Component {
 						/>
 
 						{ isSitePrivate ? this.renderPrivateSiteBanner( siteId, slug ) : null }
-						{ ! isSitePrivate && <StatsNoContentBanner siteId={ siteId } siteSlug={ slug } /> }
 					</>
 
-					<MiniCarousel isOdysseyStats={ isOdysseyStats } slug={ slug } />
+					<MiniCarousel
+						isOdysseyStats={ isOdysseyStats }
+						slug={ slug }
+						isSitePrivate={ isSitePrivate }
+					/>
 
 					<div className="stats__module-list stats__module-list--traffic is-events stats__module--unified">
 						{ config.isEnabled( 'newsletter/stats' ) && (


### PR DESCRIPTION
#### Proposed Changes

We moved the `Start writing your first posts to get more views` banner inside the mini-carousel as a second banner

#### Acceptance criteria
- [x] Add the `Start writing your first posts to get more views` banner to the mini-carousel after Blaze banner
- [x] Remove the banner outside the mini-carousel

![image](https://user-images.githubusercontent.com/402286/213470915-505367b8-8b25-4d48-b679-cc509ae800e9.png)

#### Testing Instructions

- Go to /stats using the flag `?flags=stats-mini-carousel`, on a site without posts.
- You should see the `Start writing your first posts to get more views` first on the mini-carousel
- You should not show up before the carousel

> **Note**
> If the dismiss button is not showing is because [this PR](https://github.com/Automattic/wp-calypso/pull/72354) is not merged yet.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] ~~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~~
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~~
- [ ] ~~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~~
- [ ] ~~For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~~
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/1528
