### PR TITLE
Stats: remove PR comment for Odyssey

### DIFF
--- a/.teamcity/_self/projects/WPComPlugins.kt
+++ b/.teamcity/_self/projects/WPComPlugins.kt
@@ -157,6 +157,7 @@ private object OdysseyStats : WPComPluginBuild(
 	buildName = "Odyssey Stats",
 	pluginSlug = "odyssey-stats",
 	archiveDir = "./dist/",
+	withPRNotify = "false",
 	docsLink = "PejTkB-3N-p2",
 	buildSteps = {
 		bashNodeScript {


### PR DESCRIPTION
#### Proposed Changes

The comment stating the PR affected Odyssey has caused quite a few confusions and questions in the past few weeks. Since only the @Automattic/red team is handling the testing and deployment of the project, we'll remove the posting of the comment until we figure out a better to address this.

![image](https://user-images.githubusercontent.com/1425433/213553422-d7a48185-4ea5-4d41-bcd7-46ac94e86bc4.png)


#### Testing Instructions

* The PR needs to be merged to be tested
* After it's merged, new PRs wouldn't be prompted with similar comments in the screenshot above


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
