### PR TITLE
Launchpad: Update post editor sidebar exit button to redirect to launchpad

### DIFF
--- a/client/state/selectors/get-editor-close-config.js
+++ b/client/state/selectors/get-editor-close-config.js
@@ -21,6 +21,19 @@ export default function getEditorCloseConfig( state, siteId, postType ) {
 
 	const doesRouteMatch = ( matcher ) => lastNonEditorRoute.match( matcher );
 
+	const currentSiteId = state?.ui?.selectedSiteId;
+	const currentSite = state?.sites?.items[ currentSiteId ];
+
+	// Redirect user to Launchpad screen if launchpad is enabled
+	if ( currentSite?.options?.launchpad_screen === 'full' ) {
+		const siteSlug = getSiteSlug( state, currentSiteId );
+		const flow = currentSite?.options?.site_intent;
+		return {
+			url: `/setup/${ flow }/launchpad?siteSlug=${ siteSlug }`,
+			label: translate( 'Next steps' ),
+		};
+	}
+
 	// Back to the themes list.
 	if ( doesRouteMatch( /^\/themes\/?/ ) ) {
 		return {

--- a/client/state/selectors/test/get-editor-close-config.js
+++ b/client/state/selectors/test/get-editor-close-config.js
@@ -11,6 +11,8 @@ const siteSlug = 'fake.url.wordpress.com';
 const siteUrl = `https://${ siteSlug }`;
 const customerHomeUrl = `/home/${ siteSlug }`;
 const themesUrl = `/themes/${ siteSlug }`;
+const launchpadSiteIntent = 'free';
+const launchpadUrl = `/setup/${ launchpadSiteIntent }/launchpad?siteSlug=${ siteSlug }`;
 
 describe( 'getEditorCloseConfig()', () => {
 	test( 'should return URL for customer home as default when no previous route is given', () => {
@@ -125,6 +127,35 @@ describe( 'getEditorCloseConfig()', () => {
 
 		expect( getEditorCloseConfig( state, siteId, siteEditorPostType, '' ).url ).toEqual(
 			themesUrl
+		);
+	} );
+
+	test( 'should return to launchpad screen and update label to "next steps" if launchpad_screen option is "full"', () => {
+		const state = {
+			sites: {
+				items: {
+					[ siteId ]: {
+						URL: siteUrl,
+						options: {
+							site_intent: 'free',
+							launchpad_screen: 'full',
+						},
+					},
+				},
+			},
+
+			ui: {
+				selectedSiteId: siteId,
+			},
+		};
+
+		const editorConfigResult = {
+			url: launchpadUrl,
+			label: 'Next steps',
+		};
+
+		expect( getEditorCloseConfig( state, siteId, siteEditorPostType, '' ) ).toEqual(
+			editorConfigResult
 		);
 	} );
 } );

--- a/client/state/selectors/test/get-editor-close-config.js
+++ b/client/state/selectors/test/get-editor-close-config.js
@@ -11,8 +11,8 @@ const siteSlug = 'fake.url.wordpress.com';
 const siteUrl = `https://${ siteSlug }`;
 const customerHomeUrl = `/home/${ siteSlug }`;
 const themesUrl = `/themes/${ siteSlug }`;
-const launchpadSiteIntent = 'free';
-const launchpadUrl = `/setup/${ launchpadSiteIntent }/launchpad?siteSlug=${ siteSlug }`;
+const launchpadFreeSiteIntent = 'free';
+const launchpadUrl = `/setup/${ launchpadFreeSiteIntent }/launchpad?siteSlug=${ siteSlug }`;
 
 describe( 'getEditorCloseConfig()', () => {
 	test( 'should return URL for customer home as default when no previous route is given', () => {
@@ -137,7 +137,7 @@ describe( 'getEditorCloseConfig()', () => {
 					[ siteId ]: {
 						URL: siteUrl,
 						options: {
-							site_intent: 'free',
+							site_intent: launchpadFreeSiteIntent,
 							launchpad_screen: 'full',
 						},
 					},


### PR DESCRIPTION
#### Estimated Time to Test / Review:

Test -> Short
Review -> Short

#### Proposed Changes

* These changes will replace the post editor sidebar exit button to ensure the user will always be navigated back to the launchpad screen as long it's enabled.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this branch
* Create a newsletter/free site ('/setup/{flow}`) or use an existing launchpad-enabled site.
* Select the `Write your first post` task on the launchpad screen to navigate to the post editor
* Confirm the sidebar exit button label is "Next steps" and that it redirects you to the launchpad screen.
* Click `Go to admin` in the launchpad screen and navigate to `Posts` (`/posts/{siteSlug}`) then select an existing post or create a new post.
* Confirm the sidebar exit button label is "Next steps" and that it redirects you to the launchpad screen.
* Launch your site and confirm that the exit button label is **no longer** "Next steps" and it **does not** redirect you to the launchpad screen.
* Confirm the modified test cases are passing: `yarn run test-client client/state/selectors/test/get-editor-close-config.js`
* Bonus: Test out different flows to ensure the code is still working correctly.

**Before:**
<img width="1509" alt="image" src="https://user-images.githubusercontent.com/10482592/213555523-78e47de8-89a7-428d-bb27-dbe61b60b3ad.png">

**After:**
![image](https://user-images.githubusercontent.com/10482592/213555813-0ff31d1a-814a-426c-a058-2be8c5757c58.png)


 

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #71888
