### PR TITLE
Blaze: /stats mini-carousel Hide this function

### DIFF
--- a/client/my-sites/stats/mini-carousel/actions.js
+++ b/client/my-sites/stats/mini-carousel/actions.js
@@ -1,0 +1,12 @@
+import { savePreference, setPreference } from 'calypso/state/preferences/actions';
+import { getPreferenceKey } from './utils';
+
+export const dismissBlock = ( preferenceName, temporary ) => {
+	const prefKey = getPreferenceKey( preferenceName );
+
+	if ( temporary ) {
+		return setPreference( prefKey, true );
+	}
+
+	return savePreference( prefKey, true );
+};

--- a/client/my-sites/stats/mini-carousel/index.jsx
+++ b/client/my-sites/stats/mini-carousel/index.jsx
@@ -10,11 +10,16 @@ import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import MiniCarouselBlock from './mini-carousel-block';
+import { isBlockDismissed } from './selectors';
 
 import './style.scss';
 
 const EVENT_TRAFFIC_BLAZE_PROMO_VIEW = 'calypso_stats_traffic_blaze_banner_view';
+const EVENT_TRAFFIC_BLAZE_PROMO_CLICK = 'calypso_stats_traffic_blaze_banner_click';
+const EVENT_TRAFFIC_BLAZE_PROMO_DISMISS = 'calypso_stats_traffic_blaze_banner_dismiss';
 const EVENT_YOAST_PROMO_VIEW = 'calypso_stats_wordpress_seo_premium_banner_view';
+const EVENT_YOAST_PROMO_CLICK = 'calypso_stats_wordpress_seo_premium_banner_click';
+const EVENT_YOAST_PROMO_DISMISS = 'calypso_stats_wordpress_seo_premium_banner_dismiss';
 
 const MiniCarousel = ( { slug, isOdysseyStats } ) => {
 	const selectedSiteId = useSelector( ( state ) => getSelectedSiteId( state ) );
@@ -30,9 +35,15 @@ const MiniCarousel = ( { slug, isOdysseyStats } ) => {
 	const [ dotPagerIndex, setDotPagerIndex ] = useState( 0 );
 
 	// Blaze promo is disabled for Odyssey.
-	const showBlazePromo = ! isOdysseyStats && shouldShowAdvertisingOption;
+	const showBlazePromo =
+		! useSelector( isBlockDismissed( 'calypso_stats_traffic_blaze_banner_dismiss' ) ) &&
+		! isOdysseyStats &&
+		shouldShowAdvertisingOption;
 	// Yoast promo is disabled for Odyssey & self-hosted & non-traffic pages.
-	const showYoastPromo = ! isOdysseyStats && ! jetpackNonAtomic;
+	const showYoastPromo =
+		! useSelector( isBlockDismissed( 'calypso_stats_wordpress_seo_premium_banner_dismiss' ) ) &&
+		! isOdysseyStats &&
+		! jetpackNonAtomic;
 
 	const viewEvents = useMemo( () => {
 		const events = [];
@@ -60,7 +71,7 @@ const MiniCarousel = ( { slug, isOdysseyStats } ) => {
 	if ( showBlazePromo ) {
 		blocks.push(
 			<MiniCarouselBlock
-				clickEvent="calypso_stats_traffic_blaze_banner_click"
+				clickEvent={ EVENT_TRAFFIC_BLAZE_PROMO_CLICK }
 				image={ <BlazeLogo className="mini-carousel-blaze" size={ 45 } /> }
 				headerText={ translate( 'Promote your content with Blaze' ) }
 				contentText={ translate(
@@ -68,6 +79,8 @@ const MiniCarousel = ( { slug, isOdysseyStats } ) => {
 				) }
 				ctaText={ translate( 'Create campaign' ) }
 				href={ `/advertising/${ slug || '' }` }
+				dismissEvent={ EVENT_TRAFFIC_BLAZE_PROMO_DISMISS }
+				key="blaze"
 			/>
 		);
 	}
@@ -75,7 +88,7 @@ const MiniCarousel = ( { slug, isOdysseyStats } ) => {
 	if ( showYoastPromo ) {
 		blocks.push(
 			<MiniCarouselBlock
-				clickEvent="calypso_stats_wordpress_seo_premium_banner_click"
+				clickEvent={ EVENT_YOAST_PROMO_CLICK }
 				image={ <img src={ YoastLogo } alt="" width={ 45 } height={ 45 } /> }
 				headerText={ translate( 'Increase your site visitors with Yoast SEO Premium' ) }
 				contentText={ translate(
@@ -83,6 +96,8 @@ const MiniCarousel = ( { slug, isOdysseyStats } ) => {
 				) }
 				ctaText={ translate( 'Get Yoast' ) }
 				href={ `/plugins/wordpress-seo-premium/${ slug || '' }` }
+				dismissEvent={ EVENT_YOAST_PROMO_DISMISS }
+				key="yoast"
 			/>
 		);
 	}

--- a/client/my-sites/stats/mini-carousel/mini-carousel-block.jsx
+++ b/client/my-sites/stats/mini-carousel/mini-carousel-block.jsx
@@ -1,16 +1,36 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Button } from '@automattic/components';
+import { Icon, chevronDown } from '@wordpress/icons';
+import { translate } from 'i18n-calypso';
 import page from 'page';
 import { useCallback } from 'react';
+import { useDispatch } from 'react-redux';
 import FormattedHeader from 'calypso/components/formatted-header';
+import { dismissBlock } from './actions';
 
 import './mini-carousel-block.scss';
 
-const MiniCarouselBlock = ( { clickEvent, contentText, ctaText, headerText, href, image } ) => {
+const MiniCarouselBlock = ( {
+	clickEvent,
+	contentText,
+	ctaText,
+	headerText,
+	href,
+	image,
+	dismissEvent,
+	dismissText,
+} ) => {
+	const dispatch = useDispatch();
+
 	const onClick = useCallback( () => {
 		recordTracksEvent( clickEvent );
 		page( href );
 	}, [ clickEvent, href ] );
+
+	const onDismiss = useCallback( () => {
+		recordTracksEvent( dismissEvent );
+		dispatch( dismissBlock( dismissEvent ) );
+	}, [ dismissEvent, dispatch ] );
 
 	return (
 		<div className="mini-carousel-block">
@@ -26,6 +46,16 @@ const MiniCarouselBlock = ( { clickEvent, contentText, ctaText, headerText, href
 			<Button primary onClick={ onClick }>
 				{ ctaText }
 			</Button>
+			{ dismissEvent && (
+				<Button onClick={ onDismiss } className="mini-carousel-block__close-button">
+					{ dismissText ? dismissText : translate( 'Hide this' ) }
+					<Icon
+						className="mini-carousel-block__close-button-icon"
+						icon={ chevronDown }
+						size={ 18 }
+					/>
+				</Button>
+			) }
 		</div>
 	);
 };

--- a/client/my-sites/stats/mini-carousel/mini-carousel-block.scss
+++ b/client/my-sites/stats/mini-carousel/mini-carousel-block.scss
@@ -1,3 +1,4 @@
+@import "@automattic/typography/styles/variables";
 .mini-carousel-block {
 	display: flex;
 	align-items: center;
@@ -22,5 +23,15 @@
 		@include breakpoint-deprecated( "<660px" ) {
 			margin-top: 16px;
 		}
+	}
+
+	&__close-button {
+		border: 0 !important;
+		font-size: $font-body-extra-small !important;
+	}
+
+	&__close-button-icon {
+		vertical-align: middle;
+		margin-top: -4px;
 	}
 }

--- a/client/my-sites/stats/mini-carousel/selectors.js
+++ b/client/my-sites/stats/mini-carousel/selectors.js
@@ -1,0 +1,5 @@
+import { getPreference } from 'calypso/state/preferences/selectors';
+import { getPreferenceKey } from './utils';
+
+export const isBlockDismissed = ( preferenceName ) => ( state ) =>
+	getPreference( state, getPreferenceKey( preferenceName ) );

--- a/client/my-sites/stats/mini-carousel/utils.js
+++ b/client/my-sites/stats/mini-carousel/utils.js
@@ -1,0 +1,3 @@
+const PREFERENCE_PREFIX = 'dismissible-mini-carousel-block-';
+
+export const getPreferenceKey = ( preferenceName ) => `${ PREFERENCE_PREFIX }${ preferenceName }`;


### PR DESCRIPTION
#### Proposed Changes

Add the "dismiss" function to the mini-carousel, including tracks and custom dismiss text.
Added the `dismissEvent` to Blaze & Yoast.

![image](https://user-images.githubusercontent.com/402286/213560303-37a6bced-62f0-4d4f-8282-72c5a4a7602f.png)

#### Acceptance criteria
- [x] Add hide this with a one-time dismissal function.
- [x] Add track event for dismiss
- [x] Add dismiss track event to Blaze & Yoast

#### Pre-Testing Instructions

If the preference is already saved, you won't see the banner.

You can reset in the Redux DevTools to forget the preference by dispatching:

For Blaze
```json
{
  type: 'PREFERENCES_SET',
  key: 'dismissible-mini-carousel-block-calypso_stats_traffic_blaze_banner_dismiss',
  value: false
}
```

For Yoast
```json
{
  type: 'PREFERENCES_SET',
  key: 'dismissible-mini-carousel-block-calypso_stats_wordpress_seo_premium_banner_dismiss',
  value: false
}
```

#### Testing instructions

- Go to /stats, and you should see the mini-carousel
- Click on `Hide this` on Blaze or Yoast, and it should disappear.
- Reload the page, and the one you hide should not appear.
- If you want to re-enable all banners, follow the pre-testing instructions.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] ~~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~~
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~~
- [ ] ~~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~~
- [ ] ~~For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~~
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/1517
