### PR TITLE
Hosting Configuration: End upsell experiment and update copy

### DIFF
--- a/client/my-sites/hosting/hosting-upsell-nudge/index.tsx
+++ b/client/my-sites/hosting/hosting-upsell-nudge/index.tsx
@@ -1,5 +1,6 @@
 import { FEATURE_SFTP, PLAN_BUSINESS } from '@automattic/calypso-products';
-import { useTranslate } from 'i18n-calypso';
+import { useIsEnglishLocale } from '@automattic/i18n-utils';
+import i18n, { useTranslate } from 'i18n-calypso';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
 import { preventWidows } from 'calypso/lib/formatting';
 import iconCloud from './icons/icon-cloud.svg';
@@ -49,46 +50,85 @@ export function HostingUpsellNudge( { siteId }: { siteId: number | null } ) {
 
 function useFeatureList(): FeatureListItem[] {
 	const translate = useTranslate();
+	const isEn = useIsEnglishLocale();
 
 	return [
 		{
 			title: translate( 'SFTP' ),
-			description: translate(
-				`Access and edit your website's files directly using an SFTP client`
-			),
+			description:
+				isEn ||
+				i18n.hasTranslation(
+					'Streamline your workflow and edit your files with precision using an SFTP client.'
+				)
+					? translate(
+							'Streamline your workflow and edit your files with precision using an SFTP client.'
+					  )
+					: translate( `Access and edit your website's files directly using an SFTP client` ),
 			icon: iconCloud,
 		},
 		{
 			title: translate( 'CLI Access' ),
-			description: translate(
-				'Use WP-CLI to manage plugins and users, or perform search-and-replace across your site'
-			),
+			description:
+				isEn ||
+				i18n.hasTranslation(
+					'Use WP-CLI to manage plugins and users, or automate repetitive tasks from your terminal.'
+				)
+					? translate(
+							'Use WP-CLI to manage plugins and users, or automate repetitive tasks from your terminal.'
+					  )
+					: translate(
+							'Use WP-CLI to manage plugins and users, or perform search-and-replace across your site'
+					  ),
 			icon: iconTerminal,
 		},
 		{
 			title: translate( 'SSH' ),
-			description: translate(
-				`Work the way you're used to working with SSH access to your website`
-			),
+			description:
+				isEn ||
+				i18n.hasTranslation( 'Take control of your website’s performance and security using SSH.' )
+					? translate( 'Take control of your website’s performance and security using SSH.' )
+					: translate( `Work the way you're used to working with SSH access to your website` ),
 			icon: iconSSH,
 		},
 		{
 			title: translate( 'Pick Your Data Center' ),
-			description: translate(
-				'Choose a primary data center for your site while still enjoying multi-region redundancy'
-			),
+			description:
+				isEn ||
+				i18n.hasTranslation(
+					'Choose a primary data center for your site while still enjoying geo-redundant architecture.'
+				)
+					? translate(
+							'Choose a primary data center for your site while still enjoying geo-redundant architecture.'
+					  )
+					: translate(
+							'Choose a primary data center for your site while still enjoying multi-region redundancy'
+					  ),
 			icon: iconServerRacks,
 		},
 		{
 			title: translate( 'Database Access' ),
-			description: translate( `Inspect your website's tables and run SQL queries via phpMyAdmin` ),
+			description:
+				isEn ||
+				i18n.hasTranslation(
+					'Manage your website’s data easily, using phpMyAdmin to inspect tables and run queries.'
+				)
+					? translate(
+							'Manage your website’s data easily, using phpMyAdmin to inspect tables and run queries.'
+					  )
+					: translate( `Inspect your website's tables and run SQL queries via phpMyAdmin` ),
 			icon: iconDatabase,
 		},
 		{
 			title: translate( 'Live Support' ),
-			description: translate(
-				'Either have questions or need help, get instant support from our Happiness Engineers'
-			),
+			description:
+				isEn ||
+				i18n.hasTranslation(
+					'Whenever you’re stuck, our Happiness Engineers have the answers on hand.'
+				)
+					? translate( 'Whenever you’re stuck, our Happiness Engineers have the answers on hand.' )
+					: translate(
+							'Either have questions or need help, get instant support from our Happiness Engineers'
+					  ),
 			icon: iconComments,
 		},
 	];

--- a/client/my-sites/hosting/hosting-upsell-nudge/style.scss
+++ b/client/my-sites/hosting/hosting-upsell-nudge/style.scss
@@ -1,3 +1,4 @@
+@use "sass:math";
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 
@@ -62,5 +63,9 @@
 	.hosting-upsell-nudge__feature-description {
 		font-size: $font-body-small;
 		color: var(--color-neutral-50);
+
+		[lang^="en"] & {
+			letter-spacing: math.div(-0.15px, $root-font-size) * 1rem;
+		}
 	}
 }

--- a/client/my-sites/hosting/main.js
+++ b/client/my-sites/hosting/main.js
@@ -1,6 +1,4 @@
-import { PLAN_BUSINESS, FEATURE_SFTP, FEATURE_SFTP_DATABASE } from '@automattic/calypso-products';
-import { englishLocales } from '@automattic/i18n-utils';
-import { Spinner } from '@wordpress/components';
+import { FEATURE_SFTP, FEATURE_SFTP_DATABASE } from '@automattic/calypso-products';
 import { localize } from 'i18n-calypso';
 import { Component, Fragment } from 'react';
 import wrapWithClickOutside from 'react-click-outside';
@@ -16,7 +14,6 @@ import Notice from 'calypso/components/notice';
 import NoticeAction from 'calypso/components/notice/notice-action';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
-import { Experiment } from 'calypso/lib/explat';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { fetchAutomatedTransferStatus } from 'calypso/state/automated-transfer/actions';
 import { transferStates } from 'calypso/state/automated-transfer/constants';
@@ -73,7 +70,6 @@ class Hosting extends Component {
 			isDisabled,
 			isECommerceTrial,
 			isTransferring,
-			locale,
 			requestSiteById,
 			siteId,
 			siteSlug,
@@ -82,7 +78,7 @@ class Hosting extends Component {
 		} = this.props;
 
 		const getUpgradeBanner = () => {
-			//eCommerce Trial should not see the experiment
+			//eCommerce Trial requires different wording because Business is not the obvious upgrade path
 			if ( isECommerceTrial ) {
 				return (
 					<UpsellNudge
@@ -95,26 +91,7 @@ class Hosting extends Component {
 				);
 			}
 
-			return (
-				<Experiment
-					name="calypso_hosting_configuration_upsell_list_features"
-					defaultExperience={
-						<UpsellNudge
-							title={ translate( 'Upgrade to the Business plan to access all hosting features' ) }
-							event="calypso_hosting_configuration_upgrade_click"
-							href={ `/checkout/${ siteId }/business` }
-							plan={ PLAN_BUSINESS }
-							feature={ FEATURE_SFTP }
-							showIcon={ true }
-						/>
-					}
-					treatmentExperience={ <HostingUpsellNudge siteId={ siteId } /> }
-					loadingExperience={ <Spinner className="hosting__upsell-experiment-spinner" /> }
-					options={ {
-						isEligible: englishLocales.includes( locale ),
-					} }
-				/>
-			);
+			return <HostingUpsellNudge siteId={ siteId } />;
 		};
 
 		const getAtomicActivationNotice = () => {


### PR DESCRIPTION
#### Proposed Changes

Review each commit individually to see the 3 changes more clearly

* Removes the `calypso_hosting_configuration_upsell_list_features` test and rolls out the new to all users pet6gk-11-p2#comment-74
* Update copy to match new figma pet6gk-11-p2#comment-72
* Special case letter spacing for `en` users

I usually try not to overthink how text is wrapped since I can't give the same attention to what it looks like once translated. However, it looks like the mockup is crafted so each feature description takes exactly two lines. So I'm adjusting letter spacing to match that used in Figma, which is why everything is magically fitting.

I'm only making the letter spacing adjustment for `en` because I don't want to accidentally make a language that uses characters I don't understand less readable.

The new banner can roll out to all languages because translations of the early copy was completed recently: https://github.com/Automattic/wp-calypso/pull/71750#issuecomment-1398254234 and  https://github.com/Automattic/wp-calypso/pull/71898#issuecomment-1398254261. When this PRs translations complete we can remove the `i18n.hasTranslation` checks.
 
The experiment should also be stopped in Abacus 20995-explat-experiment

#### Screenshot

<img width="1078" alt="CleanShot 2023-01-23 at 21 01 58@2x" src="https://user-images.githubusercontent.com/1500769/213991032-95f1027d-1096-4ed4-8899-7841ce8673c8.png">


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test on site with a plan lower than Business
* `/hosting-config`
* In `en` or `en-gb` confirm the upsell matches the new design pet6gk-11-p2#comment-72
* Switch language and confirm you see the new upsell (if the text isn't translated you might need to update your sandbox to get the latest translations)

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] ~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), ~Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?~
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~
- [ ] ~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~
- [ ] ~For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->