### PR TITLE
Update index.tsx

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
@@ -50,9 +50,6 @@ export default function NotificationSettings( {
 		if ( ! enableMobileNotification && ! enableEmailNotification ) {
 			return setValidationError( translate( 'Please select at least one contact method.' ) );
 		}
-		if ( enableEmailNotification && ! addedEmailAddresses.length ) {
-			return setValidationError( translate( 'Please add at least one email recipient' ) );
-		}
 		const params = {
 			wp_note_notifications: enableMobileNotification,
 			email_notifications: enableEmailNotification,

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
@@ -1,11 +1,9 @@
 import { Button } from '@automattic/components';
 import { Modal, ToggleControl } from '@wordpress/components';
-import emailValidator from 'email-validator';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
 import clockIcon from 'calypso/assets/images/jetpack/clock-icon.svg';
 import SelectDropdown from 'calypso/components/select-dropdown';
-import TokenField from 'calypso/components/token-field';
 import { useUpdateMonitorSettings, useJetpackAgencyDashboardRecordTrackEvent } from '../../hooks';
 import {
 	availableNotificationDurations as durations,
@@ -98,35 +96,11 @@ export default function NotificationSettings( {
 		}
 	}, [ enableMobileNotification, enableEmailNotification ] );
 
-	function handleAddEmail( recipients: Array< string > ) {
-		if ( recipients.length ) {
-			setValidationError( '' );
-			recipients.forEach( ( recipient ) => {
-				if ( ! emailValidator.validate( recipient ) ) {
-					setValidationError( translate( 'Please enter a valid email address.' ) );
-				}
-			} );
-		}
-		setAddedEmailAddresses( recipients );
-	}
 	useEffect( () => {
 		if ( isComplete ) {
 			onClose();
 		}
 	}, [ isComplete, onClose ] );
-
-	const addEmailsContent = enableEmailNotification && (
-		<div className="notification-settings__email-container">
-			<TokenField
-				isBorderless={ true }
-				tokenizeOnSpace
-				placeholder={ translate( 'Enter email addresses' ) }
-				value={ addedEmailAddresses }
-				onChange={ handleAddEmail }
-				disabled={ true }
-			/>
-		</div>
-	);
 
 	return (
 		<Modal
@@ -216,17 +190,12 @@ export default function NotificationSettings( {
 						<div className="notification-settings__toggle-content">
 							<div className="notification-settings__content-heading">{ translate( 'Email' ) }</div>
 							<div className="notification-settings__content-sub-heading">
-								{ translate( 'Receive email notifications with this email address.' ) }
+								{ translate( 'Receive email notifications with your account email address %s.', {
+									args: addedEmailAddresses,
+								} ) }
 							</div>
-							{
-								// We are using CSS to hide/show add email content on mobile/large screen view instead of the breakpoint
-								// hook since the 'useMobileBreakpont' hook returns true only when the width is > 480px, and we have some
-								// styles applied using the CSS breakpoint where '@include break-mobile' is true for width > 479px
-							 }
-							<div className="notification-settings__large-screen">{ addEmailsContent }</div>
 						</div>
 					</div>
-					<div className="notification-settings__small-screen">{ addEmailsContent }</div>
 				</div>
 
 				<div className="notification-settings__footer">


### PR DESCRIPTION
Update the agency dashboard down time notifications email field to remove the text field and replace it with text indicating that the notification email address is the same as the account email address

#### Proposed Changes

* This PR removes the text field for the email address and updates the information associated with the text field to indicate that the email address used for notifications is the same as the associated account email address.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run `git checkout update/update-agency-dashboard-notifications-email-field`
* Run `yarn start-jetpack-cloud`
* Visit the dashboard at http://jetpack.cloud.localhost:3000/dashboard
* Click on the clock icon to open the down time monitor notifications settings
* Ensure that the email address text field has been removed and replaced with text indicating the email address is the account email address
<img width="452" alt="Screenshot 2023-01-19 at 4 48 11 PM" src="https://user-images.githubusercontent.com/1273880/213587135-63f38379-f820-40b3-b58b-d06e2a77b90d.png">

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
