### PR TITLE
Add/dailyprompt blockquote in reader

### DIFF
--- a/client/blocks/reader-excerpt/index.jsx
+++ b/client/blocks/reader-excerpt/index.jsx
@@ -43,7 +43,7 @@ const chooseExcerpt = ( post ) => {
 	// Need to figure out if custom excerpt is different to better_excerpt
 	if ( post.excerpt.length > 0 ) {
 		// If the post is a dailyprompt, attempt to replace the prompt text with a pullquote.
-		if ( post.tags && post.hasOwnPromperty( 'dailyprompt' ) ) {
+		if ( post.tags && post.tags.hasOwnProperty( 'dailyprompt' ) ) {
 			const dom = domForHtml( post.content );
 			const promptQuote = dom.querySelector( '.is-reader > .wp-block-pullquote:first-child' );
 

--- a/client/blocks/reader-excerpt/index.jsx
+++ b/client/blocks/reader-excerpt/index.jsx
@@ -58,7 +58,7 @@ const normalizeWhitespace = ( str ) => {
  */
 const getDailyPromptText = ( post ) => {
 	const dom = domForHtml( post.content );
-	const promptQuote = dom.querySelector( '.is-reader > .wp-block-pullquote:first-child' );
+	const promptQuote = dom.querySelector( '.wp-block-pullquote:first-child' );
 
 	if ( promptQuote && promptQuote.innerText ) {
 		// Remove double spaces which are not normalized by `HTMLElement.innerText`

--- a/client/blocks/reader-excerpt/index.jsx
+++ b/client/blocks/reader-excerpt/index.jsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames';
 import { trim, escapeRegExp } from 'lodash';
 import PropTypes from 'prop-types';
 import AutoDirection from 'calypso/components/auto-direction';
@@ -39,26 +40,47 @@ const convertExcerptNewlinesToBreaks = ( excerpt ) => {
 	return excerpt;
 };
 
+/**
+ * Removes double spaces and also &nbsp; characters which may be present in the excerpt.
+ *
+ * @param {string} str the string to normalize
+ * @returns a string with single space characters.
+ */
+const normalizeWhitespace = ( str ) => {
+	return str.replace( /\s+/g, ' ' );
+};
+
+/**
+ * Gets the writing prompt text which was inserted as a pullquote at the begining of the post's content.
+ *
+ * @param {Object} post the post object
+ * @returns writing prompt text
+ */
+const getDailyPromptText = ( post ) => {
+	const dom = domForHtml( post.content );
+	const promptQuote = dom.querySelector( '.is-reader > .wp-block-pullquote:first-child' );
+
+	if ( promptQuote && promptQuote.innerText ) {
+		// Remove double spaces which are not normalized by `HTMLElement.innerText`
+		return normalizeWhitespace( promptQuote.innerText );
+	}
+	return null;
+};
+
 const chooseExcerpt = ( post ) => {
 	// Need to figure out if custom excerpt is different to better_excerpt
 	if ( post.excerpt.length > 0 ) {
 		// If the post is a dailyprompt, attempt to replace the prompt text with a pullquote.
 		if ( post.tags && post.tags.hasOwnProperty( 'dailyprompt' ) ) {
-			const dom = domForHtml( post.content );
-			const promptQuote = dom.querySelector( '.is-reader > .wp-block-pullquote:first-child' );
-
-			if ( promptQuote ) {
-				const promptText = promptQuote.textContent;
-				if ( promptText ) {
-					// Remove the prompt text from start of the excerpt
-					const excerpt = post.excerpt.replace(
-						new RegExp( '^' + escapeRegExp( promptText ) ),
-						''
-					);
-					// And insert a blockquote with the prompt text
-					return `<blockquote class="wp-block-pullquote"> ${ promptText } </blockquote> ${ excerpt }`;
-				}
-				return post.excerpt;
+			const promptText = getDailyPromptText( post );
+			if ( promptText ) {
+				// Remove the prompt text from start of the excerpt
+				const excerpt = normalizeWhitespace( post.excerpt ).replace(
+					new RegExp( '^' + escapeRegExp( promptText ) ),
+					''
+				);
+				// And insert a blockquote with the prompt text
+				return `<blockquote class="wp-block-pullquote"> ${ promptText } </blockquote> ${ excerpt }`;
 			}
 		}
 		if ( post.short_excerpt === undefined ) {
@@ -96,10 +118,14 @@ const chooseExcerpt = ( post ) => {
 };
 
 const ReaderExcerpt = ( { post } ) => {
+	const isDailyPrompt = !! getDailyPromptText( post );
+
 	return (
 		<AutoDirection>
 			<div
-				className="reader-excerpt__content reader-excerpt"
+				className={ classNames( 'reader-excerpt__content reader-excerpt', {
+					'reader-excerpt__daily-prompt': isDailyPrompt,
+				} ) }
 				dangerouslySetInnerHTML={ { __html: chooseExcerpt( post ) } } // eslint-disable-line react/no-danger
 			/>
 		</AutoDirection>

--- a/client/blocks/reader-excerpt/style.scss
+++ b/client/blocks/reader-excerpt/style.scss
@@ -1,4 +1,8 @@
 .reader-excerpt {
+	blockquote {
+		margin: 0;
+		padding-top: 0;
+	}
 	sup,
 	sub {
 		vertical-align: baseline;

--- a/client/blocks/reader-excerpt/style.scss
+++ b/client/blocks/reader-excerpt/style.scss
@@ -2,6 +2,9 @@
 	blockquote {
 		margin: 0;
 		padding-top: 0;
+		border-left: 1px solid var(--studio-gray-0);
+		color: var(--studio-gray);
+		background: none;
 	}
 	sup,
 	sub {

--- a/client/blocks/reader-excerpt/style.scss
+++ b/client/blocks/reader-excerpt/style.scss
@@ -1,6 +1,12 @@
+/** specificity is necessary to overwrite rule from client/blocks/reader-post-card/style.scss */
+.reader-post-card.card .reader-excerpt.reader-excerpt__daily-prompt {
+	max-height: 100px;
+	-webkit-line-clamp: 3;
+}
+
 .reader-excerpt {
 	blockquote {
-		margin: 0;
+		margin: 16px 0;
 		padding-top: 0;
 		border-left: 1px solid var(--studio-gray-0);
 		color: var(--studio-gray);


### PR DESCRIPTION
#### Proposed Changes
 implements https://github.com/Automattic/wp-calypso/issues/72016

##### Design
<img width="632" alt="Screen Shot 2023-02-02 at 1 38 02 pm" src="https://user-images.githubusercontent.com/22446385/216225716-be15b2db-5ef2-484a-bc76-7693b6366d62.png">
brief discussion in slack p1674180489954289-slack-C03NLNTPZ2T

##### Implementation
I added another case to the `chooseExcerpt` function that checks to see if the post has a `dailyprompt` tag.
If the post has a dailyprompt tag, it searches the content for starting with a blockquote.
If the content starts with a blockquote, it replaces the start of the excerpt with the html markup for a `blockquote` with the prompt content.
I also had to apply a class to the excerpt which makes it taller to acomodate the space used by the blockquote.

#### Testing Instructions

Go to /tag/dailyprompt and view the prompts. There is quite a variety of random different content being generated to test with.
