### PR TITLE
Pattern Assembler - Fast preview component max-height: 2000px cuts off patterns in tablet viewport

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
@@ -30,6 +30,8 @@ const PatternLargePreview = ( { header, sections, footer, activePosition }: Prop
 			<PatternRenderer
 				patternId={ encodePatternId( pattern.id ) }
 				viewportHeight={ viewportHeight || frameRef.current?.clientHeight }
+				// Disable default max-height
+				maxHeight="none"
 			/>
 		</li>
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-list-renderer.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-list-renderer.tsx
@@ -21,6 +21,7 @@ interface PatternListRendererProps {
 }
 
 const PLACEHOLDER_HEIGHT = 100;
+const MAX_HEIGHT_FOR_100VH = 500;
 
 const PatternListItem = ( { pattern, className, show, onSelect }: PatternListItemProps ) => {
 	return (
@@ -34,6 +35,7 @@ const PatternListItem = ( { pattern, className, show, onSelect }: PatternListIte
 				patternId={ encodePatternId( pattern.id ) }
 				viewportWidth={ 1060 }
 				minHeight={ PLACEHOLDER_HEIGHT }
+				maxHeightFor100vh={ MAX_HEIGHT_FOR_100VH }
 			/>
 		</Button>
 	);

--- a/packages/block-renderer/src/components/block-renderer-container.tsx
+++ b/packages/block-renderer/src/components/block-renderer-container.tsx
@@ -20,6 +20,8 @@ interface BlockRendererContainerProps {
 	viewportHeight?: number;
 	maxHeight?: string | number;
 	minHeight?: number;
+	isMinHeight100vh?: boolean;
+	maxHeightFor100vh?: number;
 }
 
 interface ScaledBlockRendererContainerProps extends BlockRendererContainerProps {
@@ -35,6 +37,8 @@ const ScaledBlockRendererContainer = ( {
 	containerWidth,
 	maxHeight = BLOCK_MAX_HEIGHT,
 	minHeight,
+	isMinHeight100vh,
+	maxHeightFor100vh,
 }: ScaledBlockRendererContainerProps ) => {
 	const [ contentResizeListener, { height: contentHeight } ] = useResizeObserver();
 	const { styles, assets, duotone } = useSelect( ( select ) => {
@@ -84,9 +88,19 @@ const ScaledBlockRendererContainer = ( {
 	}, [] );
 
 	const scale = containerWidth / viewportWidth;
-	let iframeHeight = contentHeight as number;
-	if ( viewportHeight && ( contentHeight as number ) < viewportHeight ) {
-		iframeHeight = viewportHeight;
+
+	let scaledHeight = ( contentHeight as number ) * scale || minHeight;
+	if ( isMinHeight100vh && maxHeightFor100vh && ! viewportHeight ) {
+		scaledHeight = maxHeightFor100vh * scale;
+	}
+
+	let iframeHeight = ( contentHeight as number ) || minHeight;
+	if ( isMinHeight100vh ) {
+		if ( viewportHeight ) {
+			iframeHeight = viewportHeight;
+		} else if ( maxHeightFor100vh ) {
+			iframeHeight = maxHeightFor100vh;
+		}
 	}
 
 	return (
@@ -94,7 +108,7 @@ const ScaledBlockRendererContainer = ( {
 			className="scaled-block-renderer"
 			style={ {
 				transform: `scale(${ scale })`,
-				height: ( contentHeight as number ) * scale || minHeight,
+				height: scaledHeight,
 				maxHeight:
 					maxHeight !== 'none' && ( contentHeight as number ) > maxHeight
 						? ( maxHeight as number ) * scale

--- a/packages/block-renderer/src/components/block-renderer-container.tsx
+++ b/packages/block-renderer/src/components/block-renderer-container.tsx
@@ -18,7 +18,7 @@ interface BlockRendererContainerProps {
 	inlineCss?: string;
 	viewportWidth?: number;
 	viewportHeight?: number;
-	maxHeight?: number;
+	maxHeight?: string | number;
 	minHeight?: number;
 }
 
@@ -84,6 +84,10 @@ const ScaledBlockRendererContainer = ( {
 	}, [] );
 
 	const scale = containerWidth / viewportWidth;
+	let iframeHeight = contentHeight as number;
+	if ( viewportHeight && ( contentHeight as number ) < viewportHeight ) {
+		iframeHeight = viewportHeight;
+	}
 
 	return (
 		<div
@@ -91,7 +95,10 @@ const ScaledBlockRendererContainer = ( {
 			style={ {
 				transform: `scale(${ scale })`,
 				height: ( contentHeight as number ) * scale || minHeight,
-				maxHeight: ( contentHeight as number ) > maxHeight ? maxHeight * scale : undefined,
+				maxHeight:
+					maxHeight !== 'none' && ( contentHeight as number ) > maxHeight
+						? ( maxHeight as number ) * scale
+						: undefined,
 				minHeight: '1px',
 				// Try to avoid showing the content when the styles are not ready
 				opacity: contentHeight ? 1 : 0,
@@ -107,7 +114,7 @@ const ScaledBlockRendererContainer = ( {
 				style={ {
 					position: 'absolute',
 					width: viewportWidth,
-					height: viewportHeight || ( contentHeight as number ),
+					height: iframeHeight,
 					pointerEvents: 'none',
 					// This is a catch-all max-height for patterns.
 					// See: https://github.com/WordPress/gutenberg/pull/38175.

--- a/packages/block-renderer/src/components/pattern-renderer.tsx
+++ b/packages/block-renderer/src/components/pattern-renderer.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { BLOCK_MAX_HEIGHT } from '../constants';
 import BlockRendererContainer from './block-renderer-container';
 import { usePatternsRendererContext } from './patterns-renderer-context';
 
@@ -8,9 +7,16 @@ interface Props {
 	viewportWidth?: number;
 	viewportHeight?: number;
 	minHeight?: number;
+	maxHeight?: string | number;
 }
 
-const PatternRenderer = ( { patternId, viewportWidth, viewportHeight, minHeight }: Props ) => {
+const PatternRenderer = ( {
+	patternId,
+	viewportWidth,
+	viewportHeight,
+	minHeight,
+	maxHeight,
+}: Props ) => {
 	const renderedPatterns = usePatternsRendererContext();
 	const pattern = renderedPatterns[ patternId ];
 
@@ -19,7 +25,7 @@ const PatternRenderer = ( { patternId, viewportWidth, viewportHeight, minHeight 
 			styles={ pattern?.styles ?? [] }
 			viewportWidth={ viewportWidth }
 			viewportHeight={ viewportHeight }
-			maxHeight={ BLOCK_MAX_HEIGHT }
+			maxHeight={ maxHeight }
 			minHeight={ minHeight }
 		>
 			<div

--- a/packages/block-renderer/src/components/pattern-renderer.tsx
+++ b/packages/block-renderer/src/components/pattern-renderer.tsx
@@ -8,6 +8,7 @@ interface Props {
 	viewportHeight?: number;
 	minHeight?: number;
 	maxHeight?: string | number;
+	maxHeightFor100vh?: number;
 }
 
 const PatternRenderer = ( {
@@ -16,6 +17,7 @@ const PatternRenderer = ( {
 	viewportHeight,
 	minHeight,
 	maxHeight,
+	maxHeightFor100vh,
 }: Props ) => {
 	const renderedPatterns = usePatternsRendererContext();
 	const pattern = renderedPatterns[ patternId ];
@@ -27,6 +29,8 @@ const PatternRenderer = ( {
 			viewportHeight={ viewportHeight }
 			maxHeight={ maxHeight }
 			minHeight={ minHeight }
+			isMinHeight100vh={ pattern?.html?.includes( 'min-height:100vh' ) }
+			maxHeightFor100vh={ maxHeightFor100vh }
 		>
 			<div
 				// eslint-disable-next-line react/no-danger


### PR DESCRIPTION
#### Proposed Changes

* Allow overwriting the default block renderer `maxHeight`
* Disable `maxHeight` in the large preview
* Limit the height of `100vh` patterns to `500px` instead of `2000px` or use the viewport height if it's passed

This solution fixes the pattern cut-off issue in the large preview while still supporting `viewportHeight` for patterns with `100vh` and sets a height of `500px` for their thumbnail preview, which looks better than `2000px`.

**Thumbnail for 100vh patterns**

|Before|After|
|------|-----|
|<img width="294" alt="Screenshot 2566-01-20 at 11 35 24" src="https://user-images.githubusercontent.com/1881481/213640897-b97a3c56-d05a-4e5f-84ad-00061f962a3d.png">|<img width="288" alt="Screenshot 2566-01-20 at 14 30 22" src="https://user-images.githubusercontent.com/1881481/213640988-9b79647c-d6ab-4dc5-aaaf-c6d7b0d2924b.png">|

**Large preview for patterns that create viewport scroll**

|Before|After|
|------|-----|
|<img width="1204" alt="Screenshot 2566-01-20 at 14 35 57" src="https://user-images.githubusercontent.com/1881481/213641844-cfafd606-bcc8-40f3-91dc-a9090148cd78.png">|<img width="1204" alt="Screenshot 2566-01-20 at 14 33 35" src="https://user-images.githubusercontent.com/1881481/213641511-c29074fc-d244-491a-acb4-8fdb5957d63e.png">|


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
- Create a new site, choose a domain, and a plan...
- Click continue until the Design picker, and scroll down to click `Start designing`
- Add the pattern with four images in a grid 2x2
![Image](https://user-images.githubusercontent.com/1881481/213375052-7edcc32e-ed6b-46ab-ba16-38328f803b02.png)
- In the large preview, use the `tablet` viewport, and the scroll should appear because the pattern height is taller
- Confirm that the whole pattern is visible when you scroll the viewport down and it's not cut off

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [X] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [X] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [X] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [X] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [X] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/72313 https://github.com/Automattic/wp-calypso/pull/70063
