### PR TITLE
Theme Showcase: Fix Incorrect Search Logging

### DIFF
--- a/client/my-sites/themes/search-themes-tracks.js
+++ b/client/my-sites/themes/search-themes-tracks.js
@@ -7,9 +7,8 @@ import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 function useThemeSearchDetails( query ) {
 	const search = query.search || '';
-	const searchTaxonomies = useSelector( ( state ) =>
-		prependThemeFilterKeys( state, query.filter )
-	);
+	const searchTaxonomies =
+		useSelector( ( state ) => prependThemeFilterKeys( state, query.filter ) ) || '';
 	const searchTerm = searchTaxonomies + search;
 	const prevSearchTerm = usePrevious( searchTerm );
 	const searchTermHasChanged = prevSearchTerm !== searchTerm && !! searchTerm && searchTerm !== '';

--- a/client/my-sites/themes/search-themes-tracks.js
+++ b/client/my-sites/themes/search-themes-tracks.js
@@ -6,7 +6,7 @@ import { isRequestingThemesForQuery, prependThemeFilterKeys } from 'calypso/stat
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 function useThemeSearchDetails( query ) {
-	const search = query.search;
+	const search = query.search || '';
 	const searchTaxonomies = useSelector( ( state ) =>
 		prependThemeFilterKeys( state, query.filter )
 	);
@@ -68,8 +68,8 @@ export default function SearchThemesTracks( { query = {}, themes = [], wporgThem
 
 	const recordSearchEvent = recordTracksEvent( 'calypso_themes_search_results', {
 		search,
-		search_term: searchTerm?.trim(),
-		search_taxonomies: searchTaxonomies?.trim(),
+		search_term: searchTerm.trim(),
+		search_taxonomies: searchTaxonomies.trim(),
 		tier: query.tier,
 		result_count: totalCount,
 		actual_count: actualCount,

--- a/client/my-sites/themes/search-themes-tracks.js
+++ b/client/my-sites/themes/search-themes-tracks.js
@@ -1,0 +1,109 @@
+import { usePrevious } from '@wordpress/compose';
+import { useEffect, useMemo } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { isRequestingThemesForQuery, prependThemeFilterKeys } from 'calypso/state/themes/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+
+function useThemeSearchDetails( query ) {
+	const search = query.search;
+	const searchTaxonomies = useSelector( ( state ) =>
+		prependThemeFilterKeys( state, query.filter )
+	);
+	const searchTerm = searchTaxonomies + search;
+	const prevSearchTerm = usePrevious( searchTerm );
+	const searchTermHasChanged = prevSearchTerm !== searchTerm && !! searchTerm && searchTerm !== '';
+
+	return { search, searchTaxonomies, searchTerm, searchTermHasChanged };
+}
+
+function useThemeSearchResults( search, themes, wporgThemes ) {
+	const themesCount = themes.length;
+	const wporgThemesCount = wporgThemes.length;
+	const totalCount = themesCount + wporgThemesCount;
+
+	// In some cases, we don't show all themes that match a search.
+	// For example, when there are no WPCOM results, we only show WPORG themes
+	// whose names are an exact match for the search.
+	// @see https://github.com/Automattic/wp-calypso/pull/69461
+	const actualCount = useMemo( () => {
+		if ( themesCount > 0 || ! search ) {
+			return themesCount;
+		}
+
+		const matchingWporgThemes = wporgThemes.filter(
+			( theme ) =>
+				theme?.name?.toLowerCase() === search.toLowerCase() ||
+				theme?.id?.toLowerCase() === search.toLowerCase()
+		);
+		return matchingWporgThemes.length;
+	}, [ search, themesCount, wporgThemes ] );
+
+	return { actualCount, themesCount, totalCount, wporgThemesCount };
+}
+
+function useIsRequestingThemes( query ) {
+	const isRequesting = useSelector(
+		( state ) =>
+			isRequestingThemesForQuery( state, 'wpcom', query ) ||
+			isRequestingThemesForQuery( state, 'wporg', query ) ||
+			isRequestingThemesForQuery( state, getSelectedSiteId( state ), query )
+	);
+	const prevIsRequesting = usePrevious( isRequesting );
+
+	return { isRequesting, prevIsRequesting };
+}
+
+export default function SearchThemesTracks( { query = {}, themes = [], wporgThemes = [] } ) {
+	const { search, searchTaxonomies, searchTerm, searchTermHasChanged } =
+		useThemeSearchDetails( query );
+	const { actualCount, themesCount, totalCount, wporgThemesCount } = useThemeSearchResults(
+		search,
+		themes,
+		wporgThemes
+	);
+	const { isRequesting, prevIsRequesting } = useIsRequestingThemes( query );
+
+	const dispatch = useDispatch();
+
+	const recordSearchEvent = recordTracksEvent( 'calypso_themes_search_results', {
+		search,
+		search_term: searchTerm.trim(),
+		search_taxonomies: searchTaxonomies.trim(),
+		tier: query.tier,
+		result_count: totalCount,
+		actual_count: actualCount,
+		wpcom_result_count: themesCount,
+		wporg_result_count: wporgThemesCount,
+	} );
+
+	useEffect( () => {
+		// We don't need to record an event if the search term is empty.
+		if ( ! searchTerm ) {
+			return;
+		}
+
+		// If the count is immediately valued after a search, the query is retrieving
+		// results already available in the Redux store, skipping the remote fetches.
+		// We can just record the event straight away.
+		if ( searchTermHasChanged && ! isRequesting && actualCount > 0 ) {
+			dispatch( recordSearchEvent );
+			return;
+		}
+
+		// Otherwise, we wait until both WPCOM and WPORG requests are completed.
+		if ( prevIsRequesting && ! isRequesting ) {
+			dispatch( recordSearchEvent );
+		}
+	}, [
+		actualCount,
+		dispatch,
+		isRequesting,
+		prevIsRequesting,
+		recordSearchEvent,
+		searchTerm,
+		searchTermHasChanged,
+	] );
+
+	return null;
+}

--- a/client/my-sites/themes/search-themes-tracks.js
+++ b/client/my-sites/themes/search-themes-tracks.js
@@ -68,8 +68,8 @@ export default function SearchThemesTracks( { query = {}, themes = [], wporgThem
 
 	const recordSearchEvent = recordTracksEvent( 'calypso_themes_search_results', {
 		search,
-		search_term: searchTerm.trim(),
-		search_taxonomies: searchTaxonomies.trim(),
+		search_term: searchTerm?.trim(),
+		search_taxonomies: searchTaxonomies?.trim(),
 		tier: query.tier,
 		result_count: totalCount,
 		actual_count: actualCount,

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -24,6 +24,7 @@ import {
 	prependThemeFilterKeys,
 } from 'calypso/state/themes/selectors';
 import { trackClick } from './helpers';
+import SearchThemesTracks from './search-themes-tracks';
 import './themes-selection.scss';
 
 class ThemesSelection extends Component {
@@ -186,6 +187,8 @@ class ThemesSelection extends Component {
 	render() {
 		const { source, query, upsellUrl, siteId } = this.props;
 
+		const themes = this.props.customizedThemesList || this.props.themes;
+
 		return (
 			<div className="themes__selection">
 				<QueryThemes query={ query } siteId={ source } />
@@ -194,7 +197,7 @@ class ThemesSelection extends Component {
 				) }
 				<ThemesList
 					upsellUrl={ upsellUrl }
-					themes={ this.props.customizedThemesList || this.props.themes }
+					themes={ themes }
 					wpOrgThemes={ this.props.wpOrgThemes }
 					fetchNextPage={ this.fetchNextPage }
 					recordTracksEvent={ this.props.recordTracksEvent }
@@ -213,6 +216,11 @@ class ThemesSelection extends Component {
 					bookmarkRef={ this.props.bookmarkRef }
 					siteId={ siteId }
 					searchTerm={ query.search }
+				/>
+				<SearchThemesTracks
+					query={ query }
+					themes={ themes }
+					wporgThemes={ this.props.wpOrgThemes }
 				/>
 			</div>
 		);


### PR DESCRIPTION
#### Proposed Changes

* Create a new `SearchThemesTracks` component, entirely devoted to recording search events in the Theme Showcase.
* Introduce a new `calypso_themes_search_results` Tracks event with detailed information about theme searches.

#### Logic

The Theme Showcase displays themes in many different ways.

If themes matching the current query are already available in the Redux state, we don't call any external endpoints. Otherwise, we request:
- Dotcom themes.
- Dotorg themes.
- Locally installed themes (for Jetpack sites).

To ensure we record the complete count, we first have to determine if we are retrieving from the Redux state (immediate), or wait until all the fetches are complete.

Furthermore, currently, we only show Dotorg themes when there are no Dotcom results — and only Dotorg themes whose names are exact matches for the search query — despite always fetching Dotorg themes regardless of whether we need them or not.

To record the actual number of themes returned by a search and displayed to the user, we have to perform this additional matching.

#### Why a New Event?

We already have `calypso_themeshowcase_search` and `calypso_themeshowcase_search_empty_results`, but they are part of the remote fetches, meaning:
- They are actually logging the fetches, not what the client (and therefore the user) ends up displaying.
- They record Dotorg and Dotcom fetches for the same search separately: for every search, we'll have multiple events.
- They just don't give us accurate client-side data.

I'll leave it to other people to decide if we should remove those events, or leave them be, since they are recording different things compared to this new event.

#### The New Event: `calypso_themes_search_results`

- `search`: the search query (e.g. `foo`).
- `search_term`: the full search query including filters (e.g. `subject:blog foo`).
- `search_taxonomies`: the search filters (e.g. `subject:blog`).
- `tier`: the theme tier filter (e.g. `premium`).
- `result_count`: the total count of all themes matching the query (all Dotcom + all Dotorg results).
- `actual_count`: the count of themes actually displayed on the search results page (this is what the user is actually seeing, and the data we should use for analyzing the search).
- `wpcom_result_count`: the count of Dotcom results.
- `wporg_result_count`: the count of Dotorg results.

#### Additional Checks

@WBerredo I need to know if I have replicated correctly the "Dotorg exact match" introduced in https://github.com/Automattic/wp-calypso/pull/69461.
My concern at this point is that maybe I should not do it *for every search*, but only in some specific cases (maybe when the `forceWpOrgSearch` prop is true?).

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* In the browser's console, run `localStorage.setItem( 'debug', '*' );` to turn on the debug logging.
* Filter the console by `calypso:analytics Record event "calypso_themes_search_results" called with props` to remove all the noise.
* Navigate to `/themes` and play around with searching themes.
* Ensure that the event recording is consistent with what you are seeing on screen.
  * Especially: the amount of themes displayed should be the same as `actual_count`.
  * The event should only be recorded once per search (when changing search term or filters).
  * It should work for Jetpack sites when searching for their installed themes.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
