### PR TITLE
Add track event for clicking view all responses link

### DIFF
--- a/client/my-sites/customer-home/cards/features/blogging-prompt/prompts-navigation.jsx
+++ b/client/my-sites/customer-home/cards/features/blogging-prompt/prompts-navigation.jsx
@@ -69,6 +69,15 @@ const PromptsNavigation = ( { prompts } ) => {
 		}
 	};
 
+	const trackClickViewAllResponses = () => {
+		dispatch(
+			recordTracksEvent( `calypso_customer_home_view_all_responses`, {
+				site_id: siteId,
+				prompt_id: getPrompt().id,
+			} )
+		);
+	};
+
 	const renderPromptNavigation = () => {
 		const buttonClasses = classnames( 'navigation-link' );
 
@@ -104,7 +113,7 @@ const PromptsNavigation = ( { prompts } ) => {
 			</div>
 		);
 
-		const promptReaderURL = 'http://wordpress.com/tag/dailyprompts-' + prompt.id;
+		const promptReaderURL = 'http://wordpress.com/tag/dailyprompt-' + prompt.id;
 
 		if ( prompt.answered_users_sample.length > 0 ) {
 			responses = (
@@ -119,6 +128,7 @@ const PromptsNavigation = ( { prompts } ) => {
 						target="_blank"
 						rel="noreferrer"
 						className="blogging-prompt__prompt-responses-link"
+						onClick={ trackClickViewAllResponses }
 					>
 						{ translate( 'View all responses' ) }
 					</a>


### PR DESCRIPTION
This adds a track event for when a user clicks the `View All Responses` link on the writing prompt home card.

<img width="701" alt="Screenshot 2023-01-20 at 12 43 07" src="https://user-images.githubusercontent.com/5560595/213697740-e31ba12d-a908-41b7-b312-430c35daaa53.png">

The tracks event will be `calypso_customer_home_view_all_responses` and will include the prompt ID property.

This also fixes the link to use the correct tag `dailyprompt-{id}`.