### PR TITLE
Reading Settings: Fix/subscription options text areas update

### DIFF
--- a/client/my-sites/marketing/traffic/index.js
+++ b/client/my-sites/marketing/traffic/index.js
@@ -144,6 +144,7 @@ const getFormSettings = ( settings ) =>
 		'roles',
 		'jetpack_relatedposts_allowed',
 		'jetpack_relatedposts_enabled',
+		'jetpack_relatedposts_show_context',
 		'jetpack_relatedposts_show_date',
 		'jetpack_relatedposts_show_headline',
 		'jetpack_relatedposts_show_thumbnails',

--- a/client/my-sites/marketing/traffic/index.js
+++ b/client/my-sites/marketing/traffic/index.js
@@ -144,6 +144,7 @@ const getFormSettings = ( settings ) =>
 		'roles',
 		'jetpack_relatedposts_allowed',
 		'jetpack_relatedposts_enabled',
+		'jetpack_relatedposts_show_date',
 		'jetpack_relatedposts_show_headline',
 		'jetpack_relatedposts_show_thumbnails',
 		'blog_public',

--- a/client/my-sites/site-settings/reading-newsletter-settings/EmailsTextSetting.tsx
+++ b/client/my-sites/site-settings/reading-newsletter-settings/EmailsTextSetting.tsx
@@ -7,8 +7,8 @@ import FormTextarea from 'calypso/components/forms/form-textarea';
 
 type EmailsTextSettingProps = {
 	value?: {
-		invitation: string;
-		comment_follow: string;
+		invitation?: string;
+		comment_follow?: string;
 	};
 	disabled?: boolean;
 	updateFields: ( fields: { [ key: string ]: unknown } ) => void;

--- a/client/my-sites/site-settings/reading-newsletter-settings/index.tsx
+++ b/client/my-sites/site-settings/reading-newsletter-settings/index.tsx
@@ -19,7 +19,9 @@ type NewsletterSettingsSectionProps = {
 	handleToggle: ( field: string ) => ( ( isChecked: boolean ) => void ) | undefined;
 	handleSubmitForm: ( event: React.FormEvent< HTMLFormElement > ) => void;
 	disabled?: boolean;
+	isSaveRequestSuccessful?: boolean;
 	isSavingSettings: boolean;
+	subscriptionOptions?: { invitation?: string; comment_follow?: string };
 	updateFields: ( fields: Fields ) => void;
 };
 
@@ -28,7 +30,9 @@ export const NewsletterSettingsSection = ( {
 	handleToggle,
 	handleSubmitForm,
 	disabled,
+	isSaveRequestSuccessful,
 	isSavingSettings,
+	subscriptionOptions,
 	updateFields,
 }: NewsletterSettingsSectionProps ) => {
 	const translate = useTranslate();
@@ -38,6 +42,10 @@ export const NewsletterSettingsSection = ( {
 		subscription_options,
 	} = fields;
 
+	/* eslint-disable no-console */
+	console.log( 'subscription_options', subscription_options ); // value in the form field
+	console.log( 'subscriptionOptions', subscriptionOptions ); // current value
+	console.log( 'isSaveRequestSuccessful', isSaveRequestSuccessful );
 	return (
 		<>
 			{ /* @ts-expect-error SettingsSectionHeader is not typed and is causing errors */ }

--- a/client/my-sites/site-settings/reading-site-settings/RelatedPostsSetting.tsx
+++ b/client/my-sites/site-settings/reading-site-settings/RelatedPostsSetting.tsx
@@ -6,6 +6,7 @@ type RelatedPostsFields = {
 	jetpack_relatedposts_enabled?: boolean;
 	jetpack_relatedposts_show_headline?: boolean;
 	jetpack_relatedposts_show_thumbnails?: boolean;
+	jetpack_relatedposts_show_date?: boolean;
 };
 
 type RelatedPostsSettingProps = {

--- a/client/my-sites/site-settings/reading-site-settings/RelatedPostsSetting.tsx
+++ b/client/my-sites/site-settings/reading-site-settings/RelatedPostsSetting.tsx
@@ -4,6 +4,7 @@ import { RelatedPostsSetting as RelatedPostsFormFieldset } from 'calypso/my-site
 
 type RelatedPostsFields = {
 	jetpack_relatedposts_enabled?: boolean;
+	jetpack_relatedposts_show_context?: boolean;
 	jetpack_relatedposts_show_date?: boolean;
 	jetpack_relatedposts_show_headline?: boolean;
 	jetpack_relatedposts_show_thumbnails?: boolean;

--- a/client/my-sites/site-settings/reading-site-settings/RelatedPostsSetting.tsx
+++ b/client/my-sites/site-settings/reading-site-settings/RelatedPostsSetting.tsx
@@ -4,9 +4,9 @@ import { RelatedPostsSetting as RelatedPostsFormFieldset } from 'calypso/my-site
 
 type RelatedPostsFields = {
 	jetpack_relatedposts_enabled?: boolean;
+	jetpack_relatedposts_show_date?: boolean;
 	jetpack_relatedposts_show_headline?: boolean;
 	jetpack_relatedposts_show_thumbnails?: boolean;
-	jetpack_relatedposts_show_date?: boolean;
 };
 
 type RelatedPostsSettingProps = {

--- a/client/my-sites/site-settings/reading-site-settings/index.tsx
+++ b/client/my-sites/site-settings/reading-site-settings/index.tsx
@@ -9,6 +9,7 @@ type Fields = {
 	jetpack_relatedposts_enabled?: boolean;
 	jetpack_relatedposts_show_headline?: boolean;
 	jetpack_relatedposts_show_thumbnails?: boolean;
+	jetpack_relatedposts_show_date?: boolean;
 	page_for_posts?: string;
 	page_on_front?: string;
 	posts_per_page?: number;

--- a/client/my-sites/site-settings/reading-site-settings/index.tsx
+++ b/client/my-sites/site-settings/reading-site-settings/index.tsx
@@ -7,9 +7,9 @@ import YourHomepageDisplaysSetting from './YourHomepageDisplaysSetting';
 
 type Fields = {
 	jetpack_relatedposts_enabled?: boolean;
+	jetpack_relatedposts_show_date?: boolean;
 	jetpack_relatedposts_show_headline?: boolean;
 	jetpack_relatedposts_show_thumbnails?: boolean;
-	jetpack_relatedposts_show_date?: boolean;
 	page_for_posts?: string;
 	page_on_front?: string;
 	posts_per_page?: number;

--- a/client/my-sites/site-settings/reading-site-settings/index.tsx
+++ b/client/my-sites/site-settings/reading-site-settings/index.tsx
@@ -7,6 +7,7 @@ import YourHomepageDisplaysSetting from './YourHomepageDisplaysSetting';
 
 type Fields = {
 	jetpack_relatedposts_enabled?: boolean;
+	jetpack_relatedposts_show_context?: boolean;
 	jetpack_relatedposts_show_date?: boolean;
 	jetpack_relatedposts_show_headline?: boolean;
 	jetpack_relatedposts_show_thumbnails?: boolean;

--- a/client/my-sites/site-settings/related-posts/index.jsx
+++ b/client/my-sites/site-settings/related-posts/index.jsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { Card } from '@automattic/components';
 import { ToggleControl } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
@@ -52,23 +53,27 @@ export const RelatedPostsSetting = ( {
 					label={ translate( 'Show a thumbnail image where available' ) }
 				/>
 
-				<ToggleControl
-					checked={ !! fields.jetpack_relatedposts_show_date }
-					disabled={
-						isRequestingSettings || isSavingSettings || ! fields.jetpack_relatedposts_enabled
-					}
-					onChange={ handleToggle( 'jetpack_relatedposts_show_date' ) }
-					label={ translate( 'Show post publish date' ) }
-				/>
+				{ config.isEnabled( 'settings/modernize-reading-settings' ) && (
+					<>
+						<ToggleControl
+							checked={ !! fields.jetpack_relatedposts_show_date }
+							disabled={
+								isRequestingSettings || isSavingSettings || ! fields.jetpack_relatedposts_enabled
+							}
+							onChange={ handleToggle( 'jetpack_relatedposts_show_date' ) }
+							label={ translate( 'Show post publish date' ) }
+						/>
 
-				<ToggleControl
-					checked={ !! fields.jetpack_relatedposts_show_context }
-					disabled={
-						isRequestingSettings || isSavingSettings || ! fields.jetpack_relatedposts_enabled
-					}
-					onChange={ handleToggle( 'jetpack_relatedposts_show_context' ) }
-					label={ translate( 'Show post category or tags' ) }
-				/>
+						<ToggleControl
+							checked={ !! fields.jetpack_relatedposts_show_context }
+							disabled={
+								isRequestingSettings || isSavingSettings || ! fields.jetpack_relatedposts_enabled
+							}
+							onChange={ handleToggle( 'jetpack_relatedposts_show_context' ) }
+							label={ translate( 'Show post category or tags' ) }
+						/>
+					</>
+				) }
 			</div>
 
 			<FormSettingExplanation>

--- a/client/my-sites/site-settings/related-posts/index.jsx
+++ b/client/my-sites/site-settings/related-posts/index.jsx
@@ -80,6 +80,7 @@ export const RelatedPostsSetting = ( {
 			</FormSettingExplanation>
 
 			<RelatedContentPreview
+				showDate={ fields.jetpack_relatedposts_show_date }
 				showHeadline={ fields.jetpack_relatedposts_show_headline }
 				showThumbnails={ fields.jetpack_relatedposts_show_thumbnails }
 			/>

--- a/client/my-sites/site-settings/related-posts/index.jsx
+++ b/client/my-sites/site-settings/related-posts/index.jsx
@@ -60,6 +60,15 @@ export const RelatedPostsSetting = ( {
 					onChange={ handleToggle( 'jetpack_relatedposts_show_date' ) }
 					label={ translate( 'Show post publish date' ) }
 				/>
+
+				<ToggleControl
+					checked={ !! fields.jetpack_relatedposts_show_context }
+					disabled={
+						isRequestingSettings || isSavingSettings || ! fields.jetpack_relatedposts_enabled
+					}
+					onChange={ handleToggle( 'jetpack_relatedposts_show_context' ) }
+					label={ translate( 'Show post category or tags' ) }
+				/>
 			</div>
 
 			<FormSettingExplanation>
@@ -80,6 +89,7 @@ export const RelatedPostsSetting = ( {
 			</FormSettingExplanation>
 
 			<RelatedContentPreview
+				showContext={ fields.jetpack_relatedposts_show_context }
 				showDate={ fields.jetpack_relatedposts_show_date }
 				showHeadline={ fields.jetpack_relatedposts_show_headline }
 				showThumbnails={ fields.jetpack_relatedposts_show_thumbnails }

--- a/client/my-sites/site-settings/related-posts/index.jsx
+++ b/client/my-sites/site-settings/related-posts/index.jsx
@@ -51,6 +51,15 @@ export const RelatedPostsSetting = ( {
 					onChange={ handleToggle( 'jetpack_relatedposts_show_thumbnails' ) }
 					label={ translate( 'Show a thumbnail image where available' ) }
 				/>
+
+				<ToggleControl
+					checked={ !! fields.jetpack_relatedposts_show_date }
+					disabled={
+						isRequestingSettings || isSavingSettings || ! fields.jetpack_relatedposts_enabled
+					}
+					onChange={ handleToggle( 'jetpack_relatedposts_show_date' ) }
+					label={ translate( 'Show post publish date' ) }
+				/>
 			</div>
 
 			<FormSettingExplanation>

--- a/client/my-sites/site-settings/related-posts/related-content-preview.jsx
+++ b/client/my-sites/site-settings/related-posts/related-content-preview.jsx
@@ -9,10 +9,10 @@ const RelatedContentPreview = ( { showDate, showHeadline, showThumbnails, transl
 				textOnly: true,
 				context: 'Demo content for related posts',
 			} ),
+			date: 'August 8, 2005',
 			topic: translate( 'In "Mobile"', {
 				context: 'topic post is located in',
 			} ),
-			date: 'August 8, 2005',
 		},
 		{
 			image: '/calypso/images/related-posts/devices.jpg',
@@ -20,10 +20,10 @@ const RelatedContentPreview = ( { showDate, showHeadline, showThumbnails, transl
 				textOnly: true,
 				context: 'Demo content for related posts',
 			} ),
+			date: 'August 8, 2005',
 			topic: translate( 'In "Mobile"', {
 				context: 'topic post is located in',
 			} ),
-			date: 'August 8, 2005',
 		},
 		{
 			image: '/calypso/images/related-posts/mobile-wedding.jpg',
@@ -31,10 +31,10 @@ const RelatedContentPreview = ( { showDate, showHeadline, showThumbnails, transl
 				textOnly: true,
 				context: 'Demo content for related posts',
 			} ),
+			date: 'August 8, 2005',
 			topic: translate( 'In "Upgrade"', {
 				context: 'topic post is located in',
 			} ),
-			date: 'August 8, 2005',
 		},
 	];
 

--- a/client/my-sites/site-settings/related-posts/related-content-preview.jsx
+++ b/client/my-sites/site-settings/related-posts/related-content-preview.jsx
@@ -1,7 +1,7 @@
 import { localize } from 'i18n-calypso';
 import FormLabel from 'calypso/components/forms/form-label';
 
-const RelatedContentPreview = ( { showHeadline, showThumbnails, translate } ) => {
+const RelatedContentPreview = ( { showDate, showHeadline, showThumbnails, translate } ) => {
 	const posts = [
 		{
 			image: '/calypso/images/related-posts/cat-blog.png',
@@ -12,6 +12,7 @@ const RelatedContentPreview = ( { showHeadline, showThumbnails, translate } ) =>
 			topic: translate( 'In "Mobile"', {
 				context: 'topic post is located in',
 			} ),
+			date: 'August 8, 2005',
 		},
 		{
 			image: '/calypso/images/related-posts/devices.jpg',
@@ -22,6 +23,7 @@ const RelatedContentPreview = ( { showHeadline, showThumbnails, translate } ) =>
 			topic: translate( 'In "Mobile"', {
 				context: 'topic post is located in',
 			} ),
+			date: 'August 8, 2005',
 		},
 		{
 			image: '/calypso/images/related-posts/mobile-wedding.jpg',
@@ -32,6 +34,7 @@ const RelatedContentPreview = ( { showHeadline, showThumbnails, translate } ) =>
 			topic: translate( 'In "Upgrade"', {
 				context: 'topic post is located in',
 			} ),
+			date: 'August 8, 2005',
 		},
 	];
 
@@ -57,6 +60,7 @@ const RelatedContentPreview = ( { showHeadline, showThumbnails, translate } ) =>
 								<h4 className="related-posts__preview-post-title">
 									<a className="related-posts__preview-post-a">{ post.title }</a>
 								</h4>
+								{ showDate && <span>{ post.date }</span> }
 								<p className="related-posts__preview-post-context">{ post.topic }</p>
 							</div>
 						);

--- a/client/my-sites/site-settings/related-posts/related-content-preview.jsx
+++ b/client/my-sites/site-settings/related-posts/related-content-preview.jsx
@@ -1,7 +1,13 @@
 import { localize } from 'i18n-calypso';
 import FormLabel from 'calypso/components/forms/form-label';
 
-const RelatedContentPreview = ( { showDate, showHeadline, showThumbnails, translate } ) => {
+const RelatedContentPreview = ( {
+	showContext,
+	showDate,
+	showHeadline,
+	showThumbnails,
+	translate,
+} ) => {
 	const posts = [
 		{
 			image: '/calypso/images/related-posts/cat-blog.png',
@@ -61,7 +67,9 @@ const RelatedContentPreview = ( { showDate, showHeadline, showThumbnails, transl
 									<a className="related-posts__preview-post-a">{ post.title }</a>
 								</h4>
 								{ showDate && <span>{ post.date }</span> }
-								<p className="related-posts__preview-post-context">{ post.topic }</p>
+								{ showContext && (
+									<p className="related-posts__preview-post-context">{ post.topic }</p>
+								) }
 							</div>
 						);
 					} ) }

--- a/client/my-sites/site-settings/settings-reading/main.tsx
+++ b/client/my-sites/site-settings/settings-reading/main.tsx
@@ -15,7 +15,7 @@ const isEnabled = config.isEnabled( 'settings/modernize-reading-settings' );
 
 type Fields = {
 	jetpack_relatedposts_enabled?: boolean;
-	jetpack_relatedposts_show_context: boolean;
+	jetpack_relatedposts_show_context?: boolean;
 	jetpack_relatedposts_show_date?: boolean;
 	jetpack_relatedposts_show_headline?: boolean;
 	jetpack_relatedposts_show_thumbnails?: boolean;

--- a/client/my-sites/site-settings/settings-reading/main.tsx
+++ b/client/my-sites/site-settings/settings-reading/main.tsx
@@ -15,6 +15,7 @@ const isEnabled = config.isEnabled( 'settings/modernize-reading-settings' );
 
 type Fields = {
 	jetpack_relatedposts_enabled?: boolean;
+	jetpack_relatedposts_show_context: boolean;
 	jetpack_relatedposts_show_date?: boolean;
 	jetpack_relatedposts_show_headline?: boolean;
 	jetpack_relatedposts_show_thumbnails?: boolean;
@@ -39,6 +40,7 @@ const getFormSettings = ( settings: unknown & Fields ) => {
 
 	const {
 		jetpack_relatedposts_enabled,
+		jetpack_relatedposts_show_context,
 		jetpack_relatedposts_show_date,
 		jetpack_relatedposts_show_headline,
 		jetpack_relatedposts_show_thumbnails,
@@ -55,6 +57,7 @@ const getFormSettings = ( settings: unknown & Fields ) => {
 
 	return {
 		...( jetpack_relatedposts_enabled && { jetpack_relatedposts_enabled } ),
+		...( jetpack_relatedposts_show_context && { jetpack_relatedposts_show_context } ),
 		...( jetpack_relatedposts_show_date && { jetpack_relatedposts_show_date } ),
 		...( jetpack_relatedposts_show_headline && { jetpack_relatedposts_show_headline } ),
 		...( jetpack_relatedposts_show_thumbnails && { jetpack_relatedposts_show_thumbnails } ),

--- a/client/my-sites/site-settings/settings-reading/main.tsx
+++ b/client/my-sites/site-settings/settings-reading/main.tsx
@@ -15,6 +15,7 @@ const isEnabled = config.isEnabled( 'settings/modernize-reading-settings' );
 
 type Fields = {
 	jetpack_relatedposts_enabled?: boolean;
+	jetpack_relatedposts_show_date?: boolean;
 	jetpack_relatedposts_show_headline?: boolean;
 	jetpack_relatedposts_show_thumbnails?: boolean;
 	page_for_posts?: string;
@@ -38,6 +39,7 @@ const getFormSettings = ( settings: unknown & Fields ) => {
 
 	const {
 		jetpack_relatedposts_enabled,
+		jetpack_relatedposts_show_date,
 		jetpack_relatedposts_show_headline,
 		jetpack_relatedposts_show_thumbnails,
 		page_for_posts,
@@ -53,6 +55,7 @@ const getFormSettings = ( settings: unknown & Fields ) => {
 
 	return {
 		...( jetpack_relatedposts_enabled && { jetpack_relatedposts_enabled } ),
+		...( jetpack_relatedposts_show_date && { jetpack_relatedposts_show_date } ),
 		...( jetpack_relatedposts_show_headline && { jetpack_relatedposts_show_headline } ),
 		...( jetpack_relatedposts_show_thumbnails && { jetpack_relatedposts_show_thumbnails } ),
 		...( page_for_posts && { page_for_posts } ),

--- a/client/my-sites/site-settings/settings-reading/main.tsx
+++ b/client/my-sites/site-settings/settings-reading/main.tsx
@@ -87,7 +87,9 @@ type ReadingSettingsFormProps = {
 	handleToggle: ( field: string ) => ( ( isChecked: boolean ) => void ) | undefined;
 	handleSubmitForm: ( event: React.FormEvent< HTMLFormElement > ) => void;
 	isRequestingSettings: boolean;
+	isSaveRequestSuccessful: boolean;
 	isSavingSettings: boolean;
+	settings: { subscription_options?: { invitation?: string; comment_follow?: string } };
 	siteUrl?: string;
 	updateFields: ( fields: Fields ) => void;
 };
@@ -100,11 +102,14 @@ const ReadingSettingsForm = wrapSettingsForm( getFormSettings )(
 			handleSubmitForm,
 			handleToggle,
 			isRequestingSettings,
+			isSaveRequestSuccessful,
 			isSavingSettings,
+			settings,
 			siteUrl,
 			updateFields,
 		}: ReadingSettingsFormProps ) => {
 			const disabled = isRequestingSettings || isSavingSettings;
+			const subscriptionOptions = settings?.subscription_options;
 			return (
 				<form onSubmit={ handleSubmitForm }>
 					<SiteSettingsSection
@@ -131,7 +136,9 @@ const ReadingSettingsForm = wrapSettingsForm( getFormSettings )(
 						handleToggle={ handleToggle }
 						handleSubmitForm={ handleSubmitForm }
 						disabled={ disabled }
+						isSaveRequestSuccessful={ isSaveRequestSuccessful }
 						isSavingSettings={ isSavingSettings }
+						subscriptionOptions={ subscriptionOptions }
 						updateFields={ updateFields }
 					/>
 				</form>


### PR DESCRIPTION
ℹ️ Closed in favor of https://github.com/Automattic/wp-calypso/pull/72418.

---

🚧 Work in progress. Not ready for review yet.

#### Proposed Changes

*

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
