### PR TITLE
Themes: Show loading modal when installing Dotorg themes

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -935,7 +935,7 @@ class ThemeSheet extends Component {
 				/>
 				{ this.renderBar() }
 				<QueryActiveTheme siteId={ siteId } />
-				<ThanksModal source="details" />
+				<ThanksModal source="details" themeId={ this.props.themeId } />
 				<AutoLoadingHomepageModal source="details" />
 				{ pageUpsellBanner }
 				<HeaderCake

--- a/client/state/themes/selectors/is-installing-theme.js
+++ b/client/state/themes/selectors/is-installing-theme.js
@@ -1,27 +1,8 @@
 import { isJetpackSite } from 'calypso/state/sites/selectors';
+import { suffixThemeIdForInstall } from 'calypso/state/themes/actions/suffix-theme-id-for-install';
 import { getTheme } from 'calypso/state/themes/selectors/get-theme';
 
 import 'calypso/state/themes/init';
-
-/**
- * When wpcom themes are installed on Jetpack sites, the
- * theme id is suffixed with -wpcom. Some operations require
- * the use of this suffixed ID. This util function adds the
- * suffix if the site is jetpack and the theme is not yet
- * installed on the site.
- *
- * @param {Object} state	Global state tree
- * @param {string} themeId	Theme ID
- * @param {number} siteId	Site ID
- * @returns {string} 		Potentially suffixed theme ID
- */
-const getSuffixedThemeId = ( state, themeId, siteId ) => {
-	const siteIsJetpack = siteId && isJetpackSite( state, siteId );
-	if ( siteIsJetpack && ! getTheme( state, siteId, themeId ) ) {
-		return `${ themeId }-wpcom`;
-	}
-	return themeId;
-};
 
 /**
  * Whether the theme is currently being installed on the (Jetpack) site.
@@ -32,6 +13,9 @@ const getSuffixedThemeId = ( state, themeId, siteId ) => {
  * @returns {boolean}         True if theme installation is ongoing
  */
 export function isInstallingTheme( state, themeId, siteId ) {
-	const suffixedThemeId = getSuffixedThemeId( state, themeId, siteId );
+	let suffixedThemeId = themeId;
+	if ( isJetpackSite( state, siteId ) && ! getTheme( state, siteId, themeId ) ) {
+		suffixedThemeId = suffixThemeIdForInstall( state, siteId, themeId );
+	}
 	return state.themes.themeInstalls[ siteId ]?.[ suffixedThemeId ] ?? false;
 }

--- a/client/state/themes/test/selectors.js
+++ b/client/state/themes/test/selectors.js
@@ -2007,7 +2007,12 @@ describe( 'themes selectors', () => {
 						},
 						queries: {
 							wpcom: new ThemeQueryManager( {
-								items: { karuna: { id: 'karuna' } },
+								items: {
+									karuna: {
+										id: 'karuna',
+										download: 'https://public-api.wordpress.com/rest/v1/themes/download/karuna.zip',
+									},
+								},
 							} ),
 						},
 					},


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/1452

#### Proposed Changes

Previously, the loading modal that indicates whether a theme is being activated wasn't displayed during the installation process of Dotorg themes.

This PR fixes that behavior by checking if theme is being installed and rendering the modal in such scenarios.

Before | After
--- | ---
![before](https://user-images.githubusercontent.com/1233880/213750057-05f5f58a-761c-4cf1-bb3a-cb4f1ee146d6.gif) | ![after](https://user-images.githubusercontent.com/1233880/213750074-b318994b-7bb1-47c2-8a82-ae518d4d51a9.gif)

#### Testing Instructions

- Use the Calypso live link below
- Switch to an Atomic site
- Go to Appearance > Themes
- Search a Dotorg theme that it is **NOT** currently installed on your Atomic site (otherwise the theme will be _only_ activated where the issue described in https://github.com/Automattic/dotcom-forge/issues/1452 is not present)
- Open the theme details
- Click on the activate button
- Make sure the loading modal immediately shows up