### PR TITLE
Add domain upsell as secondary card option

### DIFF
--- a/client/my-sites/customer-home/cards/constants.js
+++ b/client/my-sites/customer-home/cards/constants.js
@@ -1,6 +1,5 @@
 export const ACTION_QUICK_LINKS = 'home-action-quick-links';
 export const ACTION_WP_FOR_TEAMS_QUICK_LINKS = 'home-action-wp-for-teams-quick-links';
-export const DOMAIN_UPSELL = 'home-feature-domain-upsell';
 export const EDUCATION_FREE_PHOTO_LIBRARY = 'home-education-free-photo-library';
 export const EDUCATION_EARN = 'home-education-earn';
 export const EDUCATION_STORE = 'home-education-store';
@@ -10,6 +9,7 @@ export const EDUCATION_FIND_SUCCESS = 'home-education-find-success';
 export const EDUCATION_RESPOND_TO_CUSTOMER_FEEDBACK = 'home-education-respond-to-customer-feedback';
 export const EDUCATION_BLOGGING_QUICK_START = 'home-education-blogging-quick-start';
 export const EDUCATION_SITE_EDITOR_QUICK_START = 'home-education-site-editor-quick-start';
+export const FEATURE_DOMAIN_UPSELL = 'home-feature-domain-upsell';
 export const FEATURE_GO_MOBILE = 'home-feature-go-mobile';
 export const FEATURE_QUICK_START = 'home-feature-quick-start';
 export const FEATURE_STATS = 'home-feature-stats';

--- a/client/my-sites/customer-home/cards/constants.js
+++ b/client/my-sites/customer-home/cards/constants.js
@@ -1,5 +1,6 @@
 export const ACTION_QUICK_LINKS = 'home-action-quick-links';
 export const ACTION_WP_FOR_TEAMS_QUICK_LINKS = 'home-action-wp-for-teams-quick-links';
+export const DOMAIN_UPSELL = 'home-feature-domain-upsell';
 export const EDUCATION_FREE_PHOTO_LIBRARY = 'home-education-free-photo-library';
 export const EDUCATION_EARN = 'home-education-earn';
 export const EDUCATION_STORE = 'home-education-store';

--- a/client/my-sites/customer-home/cards/features/domain-upsell/index.jsx
+++ b/client/my-sites/customer-home/cards/features/domain-upsell/index.jsx
@@ -1,12 +1,37 @@
 import { Card } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
 
 import './style.scss';
 
 export default function DomainUpsell() {
+	const translate = useTranslate();
+
 	return (
-		<Card>
+		<Card className="domain-upsell__card customer-home__card">
 			<div>
-				<h2>Own your online identity</h2>
+				<h3>{ translate( 'Own your online identity with a custom domain' ) }</h3>
+				<p>
+					{ translate(
+						"Find the perfect domain name and stake your claim on your corner of the web with a site address that's easy to find, share, and follow."
+					) }
+				</p>
+
+				<div className="eligibility-warnings__domain-names">
+					<div className="card is-compact">
+						<span>simplefree512.wordpress.com</span>
+						<div className="badge badge--info">current</div>
+					</div>
+					<div className="card is-compact">
+						<span>simplefree512.wpcomstaging.com</span>
+						<div className="badge badge--success">new</div>
+					</div>
+				</div>
+				<button type="button" className="button">
+					{ translate( 'Search a domain' ) }
+				</button>
+				<button type="button" className="button is-primary">
+					{ translate( 'Get your custom domain' ) }
+				</button>
 			</div>
 		</Card>
 	);

--- a/client/my-sites/customer-home/cards/features/domain-upsell/index.jsx
+++ b/client/my-sites/customer-home/cards/features/domain-upsell/index.jsx
@@ -1,10 +1,13 @@
 import { Card } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
+import { useSelector } from 'react-redux';
+import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 
 import './style.scss';
 
 export default function DomainUpsell() {
 	const translate = useTranslate();
+	const siteSlug = useSelector( ( state ) => getSelectedSiteSlug( state ) );
 
 	return (
 		<Card className="domain-upsell__card customer-home__card">
@@ -19,23 +22,23 @@ export default function DomainUpsell() {
 				<div className="suggested-domain-name">
 					<div className="card">
 						<span>
-							<strike>simplefree512.wordpress.com</strike>
+							<strike>{ siteSlug }</strike>
 						</span>
 						<div className="badge badge--info">Current</div>
 					</div>
 					<div className="card">
-						<span>simplefree512.wpcomstaging.com</span>
+						<span>{ siteSlug }</span>
 						<div className="badge badge--success">Available</div>
 					</div>
 				</div>
 
 				<div className="domain-upsell-actions">
-					<button type="button" className="button">
+					<a className="button" href={ '/domains/add/' + siteSlug }>
 						{ translate( 'Search a domain' ) }
-					</button>
-					<button type="button" className="button is-primary">
+					</a>
+					<a className="button is-primary" href={ '/plans/' + siteSlug }>
 						{ translate( 'Get your custom domain' ) }
-					</button>
+					</a>
 				</div>
 			</div>
 		</Card>

--- a/client/my-sites/customer-home/cards/features/domain-upsell/index.jsx
+++ b/client/my-sites/customer-home/cards/features/domain-upsell/index.jsx
@@ -16,22 +16,27 @@ export default function DomainUpsell() {
 					) }
 				</p>
 
-				<div className="eligibility-warnings__domain-names">
-					<div className="card is-compact">
-						<span>simplefree512.wordpress.com</span>
-						<div className="badge badge--info">current</div>
+				<div className="suggested-domain-name">
+					<div className="card">
+						<span>
+							<strike>simplefree512.wordpress.com</strike>
+						</span>
+						<div className="badge badge--info">Current</div>
 					</div>
-					<div className="card is-compact">
+					<div className="card">
 						<span>simplefree512.wpcomstaging.com</span>
-						<div className="badge badge--success">new</div>
+						<div className="badge badge--success">Available</div>
 					</div>
 				</div>
-				<button type="button" className="button">
-					{ translate( 'Search a domain' ) }
-				</button>
-				<button type="button" className="button is-primary">
-					{ translate( 'Get your custom domain' ) }
-				</button>
+
+				<div className="domain-upsell-actions">
+					<button type="button" className="button">
+						{ translate( 'Search a domain' ) }
+					</button>
+					<button type="button" className="button is-primary">
+						{ translate( 'Get your custom domain' ) }
+					</button>
+				</div>
 			</div>
 		</Card>
 	);

--- a/client/my-sites/customer-home/cards/features/domain-upsell/index.jsx
+++ b/client/my-sites/customer-home/cards/features/domain-upsell/index.jsx
@@ -1,0 +1,13 @@
+import { Card } from '@automattic/components';
+
+import './style.scss';
+
+export default function DomainUpsell() {
+	return (
+		<Card>
+			<div>
+				<h2>Own your online identity</h2>
+			</div>
+		</Card>
+	);
+}

--- a/client/my-sites/customer-home/cards/features/domain-upsell/style.scss
+++ b/client/my-sites/customer-home/cards/features/domain-upsell/style.scss
@@ -1,0 +1,1 @@
+/* coming soon */

--- a/client/my-sites/customer-home/cards/features/domain-upsell/style.scss
+++ b/client/my-sites/customer-home/cards/features/domain-upsell/style.scss
@@ -1,1 +1,20 @@
-/* coming soon */
+@import "@automattic/typography/styles/fonts";
+
+body .customer-home__layout .domain-upsell__card {
+	background-color: #f6f7f7;
+	padding: 40px 46px;
+}
+
+.domain-upsell__card h3 {
+	font-family: $brand-serif;
+	font-style: normal;
+	font-weight: 400;
+	font-size: rem(32px);
+	line-height: 40px;
+	letter-spacing: -0.32px;
+	color: #101517;
+}
+
+.domain-upsell__card p {
+	margin-top: 10px;
+}

--- a/client/my-sites/customer-home/cards/features/domain-upsell/style.scss
+++ b/client/my-sites/customer-home/cards/features/domain-upsell/style.scss
@@ -5,17 +5,53 @@ body .customer-home__layout .domain-upsell__card {
 	padding: 40px 46px;
 }
 
-.domain-upsell__card h3 {
-	font-family: $brand-serif;
-	font-style: normal;
-	font-weight: 400;
-	font-size: rem(32px);
-	line-height: 40px;
-	letter-spacing: -0.32px;
-	color: #101517;
-}
+.domain-upsell__card {
+	h3 {
+		font-family: $brand-serif;
+		font-style: normal;
+		font-weight: 400;
+		font-size: rem(32px);
+		line-height: 40px;
+		color: var(--studio-gray-100);
+	}
 
-.domain-upsell__card p {
-	margin-top: 10px;
-}
+	p {
+		margin-top: 8px;
+	}
 
+	.suggested-domain-name {
+		span {
+			font-size: rem(14px);
+			color: var(--studio-gray-80);
+			line-height: 20px;
+		}
+
+		.badge {
+			position: absolute;
+			right: 20px;
+			border-radius: 4px;
+			font-size: rem(12px);
+			color: var(--studio-gray-80);
+			font-weight: 500;
+		}
+
+		.card {
+			margin-bottom: 5px;
+			box-shadow: none;
+			padding: 8px 16px;
+			height: 36px;
+		}
+
+		.badge--success {
+			background-color: var(--studio-green-5);
+		}
+	}
+
+	.domain-upsell-actions {
+		display: flex;
+		flex-direction: row;
+		justify-content: right;
+		padding: 28px 0 0;
+		gap: 16px;
+	}
+}

--- a/client/my-sites/customer-home/cards/features/domain-upsell/style.scss
+++ b/client/my-sites/customer-home/cards/features/domain-upsell/style.scss
@@ -18,3 +18,4 @@ body .customer-home__layout .domain-upsell__card {
 .domain-upsell__card p {
 	margin-top: 10px;
 }
+

--- a/client/my-sites/customer-home/locations/secondary/index.jsx
+++ b/client/my-sites/customer-home/locations/secondary/index.jsx
@@ -1,16 +1,19 @@
 import { createElement } from 'react';
 import {
+	DOMAIN_UPSELL,
 	FEATURE_STATS,
 	SECTION_LEARN_GROW,
 	FEATURE_SUPPORT,
 	SECTION_BLOGGING_PROMPT,
 } from 'calypso/my-sites/customer-home/cards/constants';
 import BloggingPrompt from 'calypso/my-sites/customer-home/cards/features/blogging-prompt';
+import DomainUpsell from 'calypso/my-sites/customer-home/cards/features/domain-upsell';
 import HelpSearch from 'calypso/my-sites/customer-home/cards/features/help-search';
 import Stats from 'calypso/my-sites/customer-home/cards/features/stats';
 import LearnGrow from './learn-grow';
 
 const cardComponents = {
+	[ DOMAIN_UPSELL ]: DomainUpsell,
 	[ FEATURE_STATS ]: Stats,
 	[ SECTION_LEARN_GROW ]: LearnGrow,
 	[ SECTION_BLOGGING_PROMPT ]: BloggingPrompt,
@@ -24,6 +27,7 @@ const Secondary = ( { cards } ) => {
 
 	return (
 		<>
+			<DomainUpsell />
 			{ cards.map(
 				( card ) =>
 					cardComponents[ card ] &&

--- a/client/my-sites/customer-home/locations/secondary/index.jsx
+++ b/client/my-sites/customer-home/locations/secondary/index.jsx
@@ -1,6 +1,6 @@
 import { createElement } from 'react';
 import {
-	DOMAIN_UPSELL,
+	FEATURE_DOMAIN_UPSELL,
 	FEATURE_STATS,
 	SECTION_LEARN_GROW,
 	FEATURE_SUPPORT,
@@ -13,7 +13,7 @@ import Stats from 'calypso/my-sites/customer-home/cards/features/stats';
 import LearnGrow from './learn-grow';
 
 const cardComponents = {
-	[ DOMAIN_UPSELL ]: DomainUpsell,
+	[ FEATURE_DOMAIN_UPSELL ]: DomainUpsell,
 	[ FEATURE_STATS ]: Stats,
 	[ SECTION_LEARN_GROW ]: LearnGrow,
 	[ SECTION_BLOGGING_PROMPT ]: BloggingPrompt,
@@ -27,7 +27,6 @@ const Secondary = ( { cards } ) => {
 
 	return (
 		<>
-			<DomainUpsell />
 			{ cards.map(
 				( card ) =>
 					cardComponents[ card ] &&


### PR DESCRIPTION
#### Proposed Changes

* Adds a new "domain upsell" features card and associated css to My Home.
* This PR does not yet implement the suggested domain
* The buttons are simple links
* We should be able to merge this PR and the domain upsell will not appear on My Home until D99116-code is merged.

![my-home-domain-upsell](https://user-images.githubusercontent.com/140841/214172941-d688ea35-38d1-44b9-afc3-d785a96a5be2.png)

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this PR locally
* Confirm that going to My Home does not yet show the new domain upsell and no errors occur on screen or on the console.
* Apply this diff to your wpcom Sandbox D99116-code
* Sandbox your API
* View the new "domain upsell" feature on My Home.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #