### PR TITLE
feat: Disable Jetpack app banner Android deep links

### DIFF
--- a/client/blocks/app-banner/index.jsx
+++ b/client/blocks/app-banner/index.jsx
@@ -126,7 +126,6 @@ export class AppBanner extends Component {
 
 		if ( this.isAndroid() ) {
 			const displayJetpackAppBranding = config.isEnabled( 'jetpack/app-branding' );
-			const scheme = displayJetpackAppBranding ? 'jetpack' : 'wordpress';
 			const packageName = displayJetpackAppBranding
 				? 'com.jetpack.android'
 				: 'org.wordpress.android';
@@ -134,15 +133,15 @@ export class AppBanner extends Component {
 			//TODO: update when section deep links are available.
 			switch ( currentSection ) {
 				case GUTENBERG:
-					return `intent://details?id=${ packageName }&url=${ scheme }://post&referrer=calypso#Intent;scheme=market;action=android.intent.action.VIEW;package=com.android.vending;end`;
+					return `intent://details?id=${ packageName }&referrer=calypso#Intent;scheme=market;action=android.intent.action.VIEW;package=com.android.vending;end`;
 				case HOME:
-					return `intent://details?id=${ packageName }&url=${ scheme }://home&referrer=calypso#Intent;scheme=market;action=android.intent.action.VIEW;package=com.android.vending;end`;
+					return `intent://details?id=${ packageName }&referrer=calypso#Intent;scheme=market;action=android.intent.action.VIEW;package=com.android.vending;end`;
 				case NOTES:
-					return `intent://details?id=${ packageName }&url=${ scheme }://notifications&referrer=calypso#Intent;scheme=market;action=android.intent.action.VIEW;package=com.android.vending;end`;
+					return `intent://details?id=${ packageName }&referrer=calypso#Intent;scheme=market;action=android.intent.action.VIEW;package=com.android.vending;end`;
 				case READER:
-					return `intent://details?id=${ packageName }&url=${ scheme }://read&referrer=calypso#Intent;scheme=market;action=android.intent.action.VIEW;package=com.android.vending;end`;
+					return `intent://details?id=${ packageName }&referrer=calypso#Intent;scheme=market;action=android.intent.action.VIEW;package=com.android.vending;end`;
 				case STATS:
-					return `intent://details?id=${ packageName }&url=${ scheme }://stats&referrer=calypso#Intent;scheme=market;action=android.intent.action.VIEW;package=com.android.vending;end`;
+					return `intent://details?id=${ packageName }&referrer=calypso#Intent;scheme=market;action=android.intent.action.VIEW;package=com.android.vending;end`;
 			}
 		}
 


### PR DESCRIPTION
#### Proposed Changes

Remove the `url` parameter as a workaround for the WordPress to Jetpack app migration experience not launching when installing/launching the Jetpack app via Calypso marketing banners. 

Removing the `url` parameter means deep links from these banners will not navigate the user to the correct screen after the app launches. We intend to reinstate this `url` parameter once the Jetpack app is updated to launch the migration experience alongside deep links via https://github.com/wordpress-mobile/WordPress-Android/pull/17742.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use an Android device for the following steps.
* Install the WordPress mobile app and log in.
* In your Android browser, navigate to the Calypso Live environment for this PR and log in.
* If the banner is not visible...
  * Connect your Android device to your development machine via USB. 
  * Visit `chrome://inspect/#devices` in Chrome on your development machine.
  * Inspect the Android device's browser.
  * Execute the following in the console: 
      `dispatch( { type: 'PREFERENCES_SET', key: 'appBannerDismissTimes', value: null } );`
* Tap the "Open in the Jetpack app" button.
* Install the Jetpack app.
* **Expected:** After opening the installed app, the migration experience
  begins.

<details><summary>Expected Outcome Screen Capture</summary>

https://user-images.githubusercontent.com/438664/213772987-7c91200e-f305-4aa7-a13d-66ced9a048df.mp4

</details>

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


