### PR TITLE
Hide Writing Prompte View all responses link

### DIFF
--- a/client/my-sites/customer-home/cards/features/blogging-prompt/index.jsx
+++ b/client/my-sites/customer-home/cards/features/blogging-prompt/index.jsx
@@ -63,7 +63,7 @@ const BloggingPromptCard = () => {
 						</Button>
 					</EllipsisMenu>
 				</CardHeading>
-				<PromptsNavigation prompts={ prompts } />
+				<PromptsNavigation prompts={ prompts } showViewAllResponses={ false } />
 			</Card>
 		</div>
 	);

--- a/client/my-sites/customer-home/cards/features/blogging-prompt/prompts-navigation.jsx
+++ b/client/my-sites/customer-home/cards/features/blogging-prompt/prompts-navigation.jsx
@@ -10,7 +10,7 @@ import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import NoResponsesIcon from './no-responses-icon';
 import './style.scss';
 
-const PromptsNavigation = ( { prompts } ) => {
+const PromptsNavigation = ( { prompts, showViewAllResponses = false } ) => {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 	const [ promptIndex, setPromptIndex ] = useState( 0 );
@@ -113,7 +113,17 @@ const PromptsNavigation = ( { prompts } ) => {
 			</div>
 		);
 
-		const promptReaderURL = 'http://wordpress.com/tag/dailyprompt-' + prompt.id;
+		const viewAllResponses = (
+			<a
+				href={ 'http://wordpress.com/tag/dailyprompt-' + prompt.id }
+				target="_blank"
+				rel="noreferrer"
+				className="blogging-prompt__prompt-responses-link"
+				onClick={ trackClickViewAllResponses }
+			>
+				{ translate( 'View all responses' ) }
+			</a>
+		);
 
 		if ( prompt.answered_users_sample.length > 0 ) {
 			responses = (
@@ -123,15 +133,7 @@ const PromptsNavigation = ( { prompts } ) => {
 							return <img alt="answered-users" src={ sample.avatar } />;
 						} ) }
 					</div>
-					<a
-						href={ promptReaderURL }
-						target="_blank"
-						rel="noreferrer"
-						className="blogging-prompt__prompt-responses-link"
-						onClick={ trackClickViewAllResponses }
-					>
-						{ translate( 'View all responses' ) }
-					</a>
+					{ showViewAllResponses ? viewAllResponses : '' }
 				</div>
 			);
 		}


### PR DESCRIPTION
We want to hide the `View All Responses` link until the `dailyprompt-{id}` tag is being saved. 

This tag will be saved when Jetpack version updates on WPCOM. After that we will need to double check that the tag is live. If so, we can show this link again.

### Before
<img width="700" alt="Screenshot 2023-01-20 at 19 11 18" src="https://user-images.githubusercontent.com/5560595/213786019-7a310858-3fae-49c9-b8a5-a703cbff4418.png">
### After
<img width="701" alt="Screenshot 2023-01-20 at 19 10 30" src="https://user-images.githubusercontent.com/5560595/213786472-790b0d57-2e6e-4ded-a809-5624d217df3f.png">


Ref: pe7F0s-vl#comment-555

