### PR TITLE
Free Flow: Remove feature flag

### DIFF
--- a/client/landing/stepper/declarative-flow/free.ts
+++ b/client/landing/stepper/declarative-flow/free.ts
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { useLocale } from '@automattic/i18n-utils';
 import { useFlowProgress, FREE_FLOW } from '@automattic/onboarding';
 import { useSelect, useDispatch } from '@wordpress/data';
@@ -33,9 +32,6 @@ const free: Flow = {
 		const { resetOnboardStore } = useDispatch( ONBOARD_STORE );
 
 		useEffect( () => {
-			if ( ! isEnabled( 'signup/free-flow' ) ) {
-				return window.location.assign( '/start/free' );
-			}
 			resetOnboardStore();
 			recordTracksEvent( 'calypso_signup_start', { flow: this.name } );
 			recordFullStoryEvent( 'calypso_signup_start_free', { flow: this.name } );

--- a/config/development.json
+++ b/config/development.json
@@ -158,7 +158,6 @@
 		"sign-in-with-apple": true,
 		"sign-in-with-apple/redirect": true,
 		"signup/design-picker-pattern-assembler": true,
-		"signup/free-flow": true,
 		"signup/inline-help": false,
 		"signup/professional-email-step": false,
 		"signup/social": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -103,7 +103,6 @@
 		"settings/security/monitor": true,
 		"sign-in-with-apple": false,
 		"signup/design-picker-pattern-assembler": true,
-		"signup/free-flow": true,
 		"signup/inline-help": false,
 		"signup/professional-email-step": false,
 		"signup/social": true,

--- a/config/production.json
+++ b/config/production.json
@@ -121,7 +121,6 @@
 		"sign-in-with-apple": true,
 		"sign-in-with-apple/redirect": true,
 		"signup/design-picker-pattern-assembler": true,
-		"signup/free-flow": true,
 		"signup/inline-help": false,
 		"signup/professional-email-step": false,
 		"signup/social": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -119,7 +119,6 @@
 		"sign-in-with-apple": true,
 		"sign-in-with-apple/redirect": true,
 		"signup/design-picker-pattern-assembler": true,
-		"signup/free-flow": true,
 		"signup/inline-help": false,
 		"signup/professional-email-step": false,
 		"signup/social": true,


### PR DESCRIPTION
#### Estimated Time to Test / Review:
- Test -> Short
- Review -> Short

#### Proposed Changes

* Removes feature flag for free flow

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this branch
* Run local calypso dev `yarn start`
* Verify that the free flow is still navigable and functional http://calypso.localhost:3000/setup/free/intro
* We will reconfirm this in the calypso staging environment before merging into production

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/72269
