### PR TITLE
Add code path for eCommerce trial on My Plan page

### DIFF
--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -155,38 +155,45 @@ class CurrentPlan extends Component {
 		return <PaidPlanThankYou />;
 	}
 
-	renderEcommerceTrialPage() {
-		const { path, selectedSiteId, translate } = this.props;
+	renderMain() {
+		const { selectedSiteId, selectedSite, showJetpackChecklist, translate } = this.props;
 		const isLoading = this.isLoading();
+		const currentPlanSlug = selectedSite.plan.product_slug;
+		const planTitle = getPlan( currentPlanSlug ).getTitle();
+		const planFeaturesHeader = translate( '{{planName/}} plan features', {
+			components: { planName: <>{ planTitle }</> },
+		} );
 
 		return (
-			<Main className="current-plan" wideLayout>
-				<DocumentHead title={ translate( 'My Plan' ) } />
-				<FormattedHeader
-					brandFont
-					className="current-plan__page-heading"
-					headerText={ translate( 'Plans' ) }
-					subHeaderText={ translate(
-						'Learn about the features included in your WordPress.com plan.'
-					) }
-					align="left"
-				/>
-				<div className="current-plan__content">
-					<QuerySites siteId={ selectedSiteId } />
-					<QuerySitePlans siteId={ selectedSiteId } />
-					<QuerySitePurchases siteId={ selectedSiteId } />
-					<QuerySiteProducts siteId={ selectedSiteId } />
-					<PlansNavigation path={ path } />
-					<PurchasesListing />
-					<div
-						className={ classNames( 'current-plan__header-text current-plan__text', {
-							'is-placeholder': { isLoading },
-						} ) }
-					></div>
-					<div>eCommerce Trial special content</div>
+			<>
+				<PurchasesListing />
+
+				{ showJetpackChecklist && (
+					<Fragment>
+						<QueryJetpackPlugins siteIds={ [ selectedSiteId ] } />
+						<JetpackChecklist />
+					</Fragment>
+				) }
+
+				<div
+					className={ classNames( 'current-plan__header-text current-plan__text', {
+						'is-placeholder': { isLoading },
+					} ) }
+				>
+					<h1 className="current-plan__header-heading">{ planFeaturesHeader }</h1>
 				</div>
-			</Main>
+				<AsyncLoad
+					require="calypso/blocks/product-purchase-features-list"
+					placeholder={ null }
+					plan={ currentPlanSlug }
+					isPlaceholder={ isLoading }
+				/>
+			</>
 		);
+	}
+
+	renderEcommerceTrialPage() {
+		return <div className="ecomeerce-trial">{ this.renderMain() }</div>;
 	}
 
 	render() {
@@ -198,7 +205,6 @@ class CurrentPlan extends Component {
 			selectedSite,
 			selectedSiteId,
 			shouldShowDomainWarnings,
-			showJetpackChecklist,
 			showThankYou,
 			translate,
 			eligibleForProPlan,
@@ -206,12 +212,6 @@ class CurrentPlan extends Component {
 
 		const currentPlanSlug = selectedSite.plan.product_slug;
 		const isEcommerceTrial = currentPlanSlug === PLAN_ECOMMERCE_TRIAL_MONTHLY;
-		const isLoading = this.isLoading();
-		const planTitle = getPlan( currentPlanSlug ).getTitle();
-
-		const planFeaturesHeader = translate( '{{planName/}} plan features', {
-			components: { planName: <>{ planTitle }</> },
-		} );
 
 		const shouldQuerySiteDomains = selectedSiteId && shouldShowDomainWarnings;
 		const showDomainWarnings = hasDomainsLoaded && shouldShowDomainWarnings;
@@ -229,10 +229,6 @@ class CurrentPlan extends Component {
 			page.redirect( `/plans/${ selectedSite.slug }` );
 
 			return null;
-		}
-
-		if ( isEcommerceTrial ) {
-			return this.renderEcommerceTrialPage();
 		}
 
 		return (
@@ -296,28 +292,7 @@ class CurrentPlan extends Component {
 
 					{ legacyPlanNotice( eligibleForProPlan, selectedSite ) }
 
-					<PurchasesListing />
-
-					{ showJetpackChecklist && (
-						<Fragment>
-							<QueryJetpackPlugins siteIds={ [ selectedSiteId ] } />
-							<JetpackChecklist />
-						</Fragment>
-					) }
-
-					<div
-						className={ classNames( 'current-plan__header-text current-plan__text', {
-							'is-placeholder': { isLoading },
-						} ) }
-					>
-						<h1 className="current-plan__header-heading">{ planFeaturesHeader }</h1>
-					</div>
-					<AsyncLoad
-						require="calypso/blocks/product-purchase-features-list"
-						placeholder={ null }
-						plan={ currentPlanSlug }
-						isPlaceholder={ isLoading }
-					/>
+					{ isEcommerceTrial ? this.renderEcommerceTrialPage() : this.renderMain() }
 
 					<TrackComponentView eventName="calypso_plans_my_plan_view" />
 				</div>

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -14,6 +14,7 @@ import {
 	JETPACK_VIDEOPRESS_PRODUCTS,
 	isFreeJetpackPlan,
 	isFreePlanProduct,
+	PLAN_ECOMMERCE_TRIAL_MONTHLY,
 } from '@automattic/calypso-products';
 import { Dialog } from '@automattic/components';
 import classNames from 'classnames';
@@ -154,6 +155,39 @@ class CurrentPlan extends Component {
 		return <PaidPlanThankYou />;
 	}
 
+	renderEcommerceTrialPage() {
+		const { path, selectedSiteId, translate } = this.props;
+		const isLoading = this.isLoading();
+
+		return (
+			<Main className="current-plan" wideLayout>
+				<DocumentHead title={ translate( 'My Plan' ) } />
+				<FormattedHeader
+					brandFont
+					className="current-plan__page-heading"
+					headerText={ translate( 'Plans' ) }
+					subHeaderText={ translate(
+						'Learn about the features included in your WordPress.com plan.'
+					) }
+					align="left"
+				/>
+				<div className="current-plan__content">
+					<QuerySites siteId={ selectedSiteId } />
+					<QuerySitePlans siteId={ selectedSiteId } />
+					<QuerySitePurchases siteId={ selectedSiteId } />
+					<QuerySiteProducts siteId={ selectedSiteId } />
+					<PlansNavigation path={ path } />
+					<PurchasesListing />
+					<div
+						className={ classNames( 'current-plan__header-text current-plan__text', {
+							'is-placeholder': { isLoading },
+						} ) }
+					></div>
+				</div>
+			</Main>
+		);
+	}
+
 	render() {
 		const {
 			domains,
@@ -170,6 +204,7 @@ class CurrentPlan extends Component {
 		} = this.props;
 
 		const currentPlanSlug = selectedSite.plan.product_slug;
+		const isEcommerceTrial = currentPlanSlug === PLAN_ECOMMERCE_TRIAL_MONTHLY;
 		const isLoading = this.isLoading();
 		const planTitle = getPlan( currentPlanSlug ).getTitle();
 
@@ -193,6 +228,10 @@ class CurrentPlan extends Component {
 			page.redirect( `/plans/${ selectedSite.slug }` );
 
 			return null;
+		}
+
+		if ( isEcommerceTrial ) {
+			return this.renderEcommerceTrialPage();
 		}
 
 		return (

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -193,7 +193,7 @@ class CurrentPlan extends Component {
 	}
 
 	renderEcommerceTrialPage() {
-		return <div className="ecomeerce-trial">{ this.renderMain() }</div>;
+		return <div className="ecommerce-trial">{ this.renderMain() }</div>;
 	}
 
 	render() {

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -183,6 +183,7 @@ class CurrentPlan extends Component {
 							'is-placeholder': { isLoading },
 						} ) }
 					></div>
+					<div>eCommerce Trial special content</div>
 				</div>
 			</Main>
 		);

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -193,7 +193,7 @@ class CurrentPlan extends Component {
 	}
 
 	renderEcommerceTrialPage() {
-		return <div className="ecommerce-trial">{ this.renderMain() }</div>;
+		return <div className="current-plan__ecommerce-trial-wrapper">{ this.renderMain() }</div>;
 	}
 
 	render() {

--- a/packages/calypso-products/test/plan-lookups.js
+++ b/packages/calypso-products/test/plan-lookups.js
@@ -962,7 +962,6 @@ describe( 'findPlansKeys', () => {
 			PLAN_FREE,
 			PLAN_JETPACK_FREE,
 			PLAN_P2_FREE,
-			PLAN_ECOMMERCE_TRIAL_MONTHLY,
 		] );
 		expect( findPlansKeys( { type: TYPE_BLOGGER } ) ).toEqual( [
 			PLAN_BLOGGER,

--- a/packages/calypso-products/test/plan-lookups.js
+++ b/packages/calypso-products/test/plan-lookups.js
@@ -962,6 +962,7 @@ describe( 'findPlansKeys', () => {
 			PLAN_FREE,
 			PLAN_JETPACK_FREE,
 			PLAN_P2_FREE,
+			PLAN_ECOMMERCE_TRIAL_MONTHLY,
 		] );
 		expect( findPlansKeys( { type: TYPE_BLOGGER } ) ).toEqual( [
 			PLAN_BLOGGER,


### PR DESCRIPTION
#### Proposed Changes

* As part of https://github.com/Automattic/wp-calypso/issues/72102, this PR adds the new code path in the My Plan page for when the selected site has the eCommerce trial plan.

#### Testing Instructions

* Create a site with the new eCommerce Trial plan
* Open the My Plan page (`/plans/my-plan/<site-slug>`)
* Check if the special path was triggered:
![image](https://user-images.githubusercontent.com/3801502/214177459-2fdf006b-8d0e-4b7f-8abb-0ca837e19e12.png)
* Sites with other plans shouldn't be affected.


Fixes  https://github.com/Automattic/wp-calypso/issues/72102