### PR TITLE
Plans 2023 : Add Interval toggle to comparison grid

### DIFF
--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -99,6 +99,7 @@ type PlanFeatures2023GridConnectedProps = {
 	translate: LocalizeProps[ 'translate' ];
 	recordTracksEvent: ( slug: string ) => void;
 	planProperties: Array< PlanProperties >;
+	allParentProps: any;
 };
 
 type PlanFeatures2023GridType = PlanFeatures2023GridProps &
@@ -111,7 +112,7 @@ export class PlanFeatures2023Grid extends Component< PlanFeatures2023GridType > 
 	}
 
 	render() {
-		const { isInSignup } = this.props;
+		const { isInSignup, allParentProps } = this.props;
 		const planClasses = classNames( 'plan-features', {
 			'plan-features--signup': isInSignup,
 		} );
@@ -137,6 +138,7 @@ export class PlanFeatures2023Grid extends Component< PlanFeatures2023GridType > 
 					</div>
 				</div>
 				<PlanComparisonGrid
+					allParentProps={ allParentProps }
 					planProperties={ this.props.planProperties }
 					intervalType={ this.props.intervalType }
 				/>

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -40,6 +40,7 @@ import PlanPill from 'calypso/components/plans/plan-pill';
 import { retargetViewPlans } from 'calypso/lib/analytics/ad-tracking';
 import { planItem as getCartItemForPlan } from 'calypso/lib/cart-values/cart-items';
 import { getPlanFeaturesObject } from 'calypso/lib/plans/features-list';
+import { PlanTypeSelectorProps } from 'calypso/my-sites/plans-features-main/plan-type-selector';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
 import {
@@ -99,7 +100,7 @@ type PlanFeatures2023GridConnectedProps = {
 	translate: LocalizeProps[ 'translate' ];
 	recordTracksEvent: ( slug: string ) => void;
 	planProperties: Array< PlanProperties >;
-	allParentProps: any;
+	planTypeSelectorProps: PlanTypeSelectorProps;
 };
 
 type PlanFeatures2023GridType = PlanFeatures2023GridProps &
@@ -112,7 +113,8 @@ export class PlanFeatures2023Grid extends Component< PlanFeatures2023GridType > 
 	}
 
 	render() {
-		const { isInSignup, allParentProps } = this.props;
+		const { isInSignup, planTypeSelectorProps, planProperties, intervalType } = this.props;
+
 		const planClasses = classNames( 'plan-features', {
 			'plan-features--signup': isInSignup,
 		} );
@@ -138,9 +140,9 @@ export class PlanFeatures2023Grid extends Component< PlanFeatures2023GridType > 
 					</div>
 				</div>
 				<PlanComparisonGrid
-					allParentProps={ allParentProps }
-					planProperties={ this.props.planProperties }
-					intervalType={ this.props.intervalType }
+					planTypeSelectorProps={ planTypeSelectorProps }
+					planProperties={ planProperties }
+					intervalType={ intervalType }
 				/>
 			</div>
 		);

--- a/client/my-sites/plan-features-2023-grid/plan-comparison-grid.tsx
+++ b/client/my-sites/plan-features-2023-grid/plan-comparison-grid.tsx
@@ -11,8 +11,8 @@ import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import JetpackLogo from 'calypso/components/jetpack-logo';
 import { getPlanFeaturesObject } from 'calypso/lib/plans/features-list';
+import PlanTypeSelector from '../plans-features-main/plan-type-selector';
 import { PlanProperties } from './types';
-
 const JetpackIconContainer = styled.div`
 	padding-left: 6px;
 `;
@@ -67,11 +67,13 @@ const StorageButton = styled.div`
 type PlanComparisonGridProps = {
 	planProperties?: Array< PlanProperties >;
 	intervalType: string;
+	allParentProps: any;
 };
 
 export const PlanComparisonGrid: React.FC< PlanComparisonGridProps > = ( {
 	planProperties,
 	intervalType,
+	allParentProps,
 } ) => {
 	const translate = useTranslate();
 	const featureGroupMap = getPlanFeaturesGrouped();
@@ -136,19 +138,19 @@ export const PlanComparisonGrid: React.FC< PlanComparisonGridProps > = ( {
 				{ translate( 'Compare our plans and find yours' ) }
 			</PlanComparisonHeader>
 			<Grid>
-				<Row key="feature-group-title" className="plan-comparison-grid__plan-row">
+				<Row key="feature-group-header-row" className="plan-comparison-grid__plan-row">
 					<RowHead key="feature-name" className="plan-comparison-grid__interval-toggle">
-						{ /* 
-						// This component was breaking scroll and the click was not working to be picked up later
-						<BrowserRouter>
-							<IntervalTypeToggle
-								eligibleForWpcomMonthlyPlans={ true }
-								intervalType={ intervalType }
-								plans={ [] }
-								isInSignup={ true }
-								isPlansInsideStepper={ true }
-							/>
-						</BrowserRouter> */ }
+						<PlanTypeSelector
+							kind="interval"
+							plans={ displayedPlansProperties.map( ( { planName } ) => planName ) }
+							isInSignup={ allParentProps.isInSignup }
+							eligibleForWpcomMonthlyPlans={ allParentProps.eligibleForWpcomMonthlyPlans }
+							isPlansInsideStepper={ allParentProps.isPlansInsideStepper }
+							intervalType={ allParentProps.intervalType }
+							customerType={ allParentProps.customerType }
+							hidePersonalPlan={ allParentProps.hidePersonalPlan }
+							hideDiscountLabel={ true }
+						/>
 					</RowHead>
 					{ displayedPlansProperties.map( ( { planName, planConstantObj } ) => (
 						<Cell key={ planName } className="plan-comparison-grid__plan-title" textAlign="center">
@@ -161,8 +163,11 @@ export const PlanComparisonGrid: React.FC< PlanComparisonGridProps > = ( {
 					const features = featureGroup.get2023PricingGridSignupWpcomFeatures();
 					const featureObjects = getPlanFeaturesObject( features );
 					return (
-						<>
-							<Row key="feature-group-title" className="plan-comparison-grid__group-title-row">
+						<div key={ `feature-group-title-${ featureGroup.slug }` }>
+							<Row
+								key={ `feature-group-title-${ featureGroup.slug }` }
+								className="plan-comparison-grid__group-title-row"
+							>
 								<Title className={ `plan-comparison-grid__group-${ featureGroup.slug }` }>
 									{ featureGroup.getTitle() }
 								</Title>
@@ -236,7 +241,7 @@ export const PlanComparisonGrid: React.FC< PlanComparisonGridProps > = ( {
 									} ) }
 								</Row>
 							) : null }
-						</>
+						</div>
 					);
 				} ) }
 			</Grid>

--- a/client/my-sites/plan-features-2023-grid/plan-comparison-grid.tsx
+++ b/client/my-sites/plan-features-2023-grid/plan-comparison-grid.tsx
@@ -11,7 +11,9 @@ import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import JetpackLogo from 'calypso/components/jetpack-logo';
 import { getPlanFeaturesObject } from 'calypso/lib/plans/features-list';
-import PlanTypeSelector from '../plans-features-main/plan-type-selector';
+import PlanTypeSelector, {
+	PlanTypeSelectorProps,
+} from 'calypso/my-sites/plans-features-main/plan-type-selector';
 import { PlanProperties } from './types';
 const JetpackIconContainer = styled.div`
 	padding-left: 6px;
@@ -67,13 +69,13 @@ const StorageButton = styled.div`
 type PlanComparisonGridProps = {
 	planProperties?: Array< PlanProperties >;
 	intervalType: string;
-	allParentProps: any;
+	planTypeSelectorProps: PlanTypeSelectorProps;
 };
 
 export const PlanComparisonGrid: React.FC< PlanComparisonGridProps > = ( {
 	planProperties,
 	intervalType,
-	allParentProps,
+	planTypeSelectorProps,
 } ) => {
 	const translate = useTranslate();
 	const featureGroupMap = getPlanFeaturesGrouped();
@@ -143,12 +145,12 @@ export const PlanComparisonGrid: React.FC< PlanComparisonGridProps > = ( {
 						<PlanTypeSelector
 							kind="interval"
 							plans={ displayedPlansProperties.map( ( { planName } ) => planName ) }
-							isInSignup={ allParentProps.isInSignup }
-							eligibleForWpcomMonthlyPlans={ allParentProps.eligibleForWpcomMonthlyPlans }
-							isPlansInsideStepper={ allParentProps.isPlansInsideStepper }
-							intervalType={ allParentProps.intervalType }
-							customerType={ allParentProps.customerType }
-							hidePersonalPlan={ allParentProps.hidePersonalPlan }
+							isInSignup={ planTypeSelectorProps.isInSignup }
+							eligibleForWpcomMonthlyPlans={ planTypeSelectorProps.eligibleForWpcomMonthlyPlans }
+							isPlansInsideStepper={ planTypeSelectorProps.isPlansInsideStepper }
+							intervalType={ planTypeSelectorProps.intervalType }
+							customerType={ planTypeSelectorProps.customerType }
+							hidePersonalPlan={ planTypeSelectorProps.hidePersonalPlan }
 							hideDiscountLabel={ true }
 						/>
 					</RowHead>

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -158,7 +158,11 @@ export class PlansFeaturesMain extends Component {
 				intervalType,
 			};
 			const asyncPlanFeatures2023Grid = (
-				<AsyncLoad require="calypso/my-sites/plan-features-2023-grid" { ...asyncProps } />
+				<AsyncLoad
+					require="calypso/my-sites/plan-features-2023-grid"
+					{ ...asyncProps }
+					allParentProps={ this.props }
+				/>
 			);
 			return (
 				<div
@@ -687,9 +691,7 @@ export default connect(
 		) {
 			customerType = 'business';
 		}
-		const is2023OnboardingPricingGrid =
-			isEnabled( 'onboarding/2023-pricing-grid' ) &&
-			props.flowName === 'onboarding-2023-pricing-grid';
+		const is2023OnboardingPricingGrid = isEnabled( 'onboarding/2023-pricing-grid' );
 		return {
 			isCurrentPlanRetired: isProPlan( sitePlanSlug ) || isStarterPlan( sitePlanSlug ),
 			currentPurchaseIsInAppPurchase: currentPurchase?.isInAppPurchase,

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -157,11 +157,19 @@ export class PlansFeaturesMain extends Component {
 				isPlansInsideStepper,
 				intervalType,
 			};
+			const planTypeSelectorProps = {
+				isInSignup: this.props.isInSignup,
+				eligibleForWpcomMonthlyPlans: this.props.eligibleForWpcomMonthlyPlans,
+				isPlansInsideStepper: this.props.isPlansInsideStepper,
+				intervalType: this.props.intervalType,
+				customerType: this.props.customerType,
+				hidePersonalPlan: this.props.hidePersonalPlan,
+			};
 			const asyncPlanFeatures2023Grid = (
 				<AsyncLoad
 					require="calypso/my-sites/plan-features-2023-grid"
 					{ ...asyncProps }
-					allParentProps={ this.props }
+					planTypeSelectorProps={ planTypeSelectorProps }
 				/>
 			);
 			return (

--- a/client/my-sites/plans-features-main/plan-type-selector.tsx
+++ b/client/my-sites/plans-features-main/plan-type-selector.tsx
@@ -39,6 +39,7 @@ type Props = {
 	plans: string[];
 	eligibleForWpcomMonthlyPlans?: boolean;
 	isPlansInsideStepper: boolean;
+	hideDiscountLabel: boolean;
 };
 
 interface PathArgs {
@@ -114,12 +115,17 @@ export const PopupMessages: React.FunctionComponent< PopupMessageProps > = ( {
 
 type IntervalTypeProps = Pick<
 	Props,
-	'intervalType' | 'plans' | 'isInSignup' | 'eligibleForWpcomMonthlyPlans' | 'isPlansInsideStepper'
+	| 'intervalType'
+	| 'plans'
+	| 'isInSignup'
+	| 'eligibleForWpcomMonthlyPlans'
+	| 'isPlansInsideStepper'
+	| 'hideDiscountLabel'
 >;
 
 export const IntervalTypeToggle: React.FunctionComponent< IntervalTypeProps > = ( props ) => {
 	const translate = useTranslate();
-	const { intervalType, isInSignup, eligibleForWpcomMonthlyPlans } = props;
+	const { intervalType, isInSignup, eligibleForWpcomMonthlyPlans, hideDiscountLabel } = props;
 	const [ spanRef, setSpanRef ] = useState< HTMLSpanElement >();
 	const segmentClasses = classNames( 'plan-features__interval-type', 'price-toggle', {
 		'is-signup': isInSignup,
@@ -151,15 +157,17 @@ export const IntervalTypeToggle: React.FunctionComponent< IntervalTypeProps > = 
 					isPlansInsideStepper={ props.isPlansInsideStepper }
 				>
 					<span ref={ ( ref ) => ref && setSpanRef( ref ) }>{ translate( 'Pay annually' ) }</span>
-					<PopupMessages context={ spanRef } isVisible={ popupIsVisible }>
-						{ translate(
-							'Save up to %(maxDiscount)d%% by paying annually and get a free domain for one year',
-							{
-								args: { maxDiscount },
-								comment: 'Will be like "Save up to 30% by paying annually..."',
-							}
-						) }
-					</PopupMessages>
+					{ hideDiscountLabel ? null : (
+						<PopupMessages context={ spanRef } isVisible={ popupIsVisible }>
+							{ translate(
+								'Save up to %(maxDiscount)d%% by paying annually and get a free domain for one year',
+								{
+									args: { maxDiscount },
+									comment: 'Will be like "Save up to 30% by paying annually..."',
+								}
+							) }
+						</PopupMessages>
+					) }
 				</SegmentedControl.Item>
 			</SegmentedControl>
 		</IntervalTypeToggleWrapper>

--- a/client/my-sites/plans-features-main/plan-type-selector.tsx
+++ b/client/my-sites/plans-features-main/plan-type-selector.tsx
@@ -25,7 +25,7 @@ import {
 	getDiscountedRawPrice,
 } from 'calypso/state/plans/selectors';
 
-type Props = {
+export type PlanTypeSelectorProps = {
 	kind: 'interval' | 'customer';
 	basePlansPath?: string | null;
 	intervalType: string;
@@ -46,7 +46,7 @@ interface PathArgs {
 	[ key: string ]: Primitive;
 }
 
-type GeneratePathFunction = ( props: Partial< Props >, args: PathArgs ) => string;
+type GeneratePathFunction = ( props: Partial< PlanTypeSelectorProps >, args: PathArgs ) => string;
 
 export const generatePath: GeneratePathFunction = ( props, additionalArgs = {} ) => {
 	const { intervalType = '' } = additionalArgs;
@@ -113,8 +113,8 @@ export const PopupMessages: React.FunctionComponent< PopupMessageProps > = ( {
 	);
 };
 
-type IntervalTypeProps = Pick<
-	Props,
+export type IntervalTypeProps = Pick<
+	PlanTypeSelectorProps,
 	| 'intervalType'
 	| 'plans'
 	| 'isInSignup'
@@ -194,7 +194,7 @@ export const ExperimentalIntervalTypeToggle: React.FunctionComponent< IntervalTy
 	);
 };
 
-type CustomerTypeProps = Pick< Props, 'customerType' | 'isInSignup' >;
+type CustomerTypeProps = Pick< PlanTypeSelectorProps, 'customerType' | 'isInSignup' >;
 
 export const CustomerTypeToggle: React.FunctionComponent< CustomerTypeProps > = ( props ) => {
 	const translate = useTranslate();
@@ -220,7 +220,10 @@ export const CustomerTypeToggle: React.FunctionComponent< CustomerTypeProps > = 
 	);
 };
 
-const PlanTypeSelector: React.FunctionComponent< Props > = ( { kind, ...props } ) => {
+const PlanTypeSelector: React.FunctionComponent< PlanTypeSelectorProps > = ( {
+	kind,
+	...props
+} ) => {
 	if ( kind === 'interval' ) {
 		return <IntervalTypeToggle { ...props } />;
 	}


### PR DESCRIPTION
#### Proposed Changes

* Adds interval toggle
![image](https://user-images.githubusercontent.com/3422709/214206138-9f0720c4-1053-4cee-b6e7-5bc5f2dba388.png)

#### Testing Instructions
* Go to `/start/onboarding-2023-pricing-grid/plans`
* The interval toggle should be visible in the plans comparison grid

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes Automattic/martech#1422
