### PR TITLE
Contact validation: Fix dead end in Jetpack siteless checkout flow 

### DIFF
--- a/client/my-sites/checkout/composite-checkout/lib/contact-validation.tsx
+++ b/client/my-sites/checkout/composite-checkout/lib/contact-validation.tsx
@@ -48,12 +48,18 @@ const getEmailTakenLoginRedirectMessage = (
 
 	// Users with a WP.com account should return to the checkout page
 	// once they are logged in to complete the process. The flow for them is
+
 	// checkout -> login -> checkout.
 	const currentURLQueryParameters = Object.fromEntries( new URL( href ).searchParams.entries() );
 
+	if ( currentURLQueryParameters.source ) {
+		currentURLQueryParameters.from = currentURLQueryParameters.source;
+		delete currentURLQueryParameters.source;
+	}
+
 	const redirectTo =
 		isJetpackCheckout || isGiftingCheckout
-			? addQueryArgs( { currentURLQueryParameters, flow: 'coming_from_login' }, pathname )
+			? addQueryArgs( { ...currentURLQueryParameters, flow: 'coming_from_login' }, pathname )
 			: '/checkout/no-site?cart=no-user';
 
 	const loginUrl = login( { isJetpack: isJetpackCheckout, redirectTo, emailAddress } );

--- a/client/my-sites/checkout/composite-checkout/lib/contact-validation.tsx
+++ b/client/my-sites/checkout/composite-checkout/lib/contact-validation.tsx
@@ -50,12 +50,13 @@ const getEmailTakenLoginRedirectMessage = (
 	// once they are logged in to complete the process. The flow for them is
 	// checkout -> login -> checkout.
 	const currentURLQueryParameters = Object.fromEntries( new URL( href ).searchParams.entries() );
+
 	const redirectTo =
 		isJetpackCheckout || isGiftingCheckout
-			? addQueryArgs( { ...currentURLQueryParameters, flow: 'coming_from_login' }, pathname )
+			? addQueryArgs( { currentURLQueryParameters, flow: 'coming_from_login' }, pathname )
 			: '/checkout/no-site?cart=no-user';
 
-	const loginUrl = login( { redirectTo, emailAddress } );
+	const loginUrl = login( { isJetpack: isJetpackCheckout, redirectTo, emailAddress } );
 
 	reduxDispatch(
 		recordTracksEvent( 'calypso_checkout_wpcom_email_exists', {


### PR DESCRIPTION
The [currentURLQueryParameters](https://github.com/Automattic/wp-calypso/blob/45bed64d0d7c77b84954abd727578abca5a5c6a0/client/my-sites/checkout/composite-checkout/lib/contact-validation.tsx#L52) that are passed as a redirectTo to login() is resulting in the 404 trying to get to the login page. Specifically, there is something that doesn't like when `source` is passed as an object property, which is set somewhere in in the pricing page.  

Separately, `isJetpack` is never set in the login() call. This means that even the login screen rendered, it would be wordpress.com branded. We want it landing on https://wordpress.com/log-in/jetpack. 

Internal discussion: p1HpG7-ken-p2

#### Proposed Changes
This is mostly to demonstrate the issue. 

- Pass Jetpack context to `login()` redirect. 
- Fix currentURLQueryParameters breaking login() 

#### Testing Instructions

- [Logged out of wpcom]
- https://cloud.jetpack.com/pricing
- Choose a thing to buy
- Enter email that exists
- Continue
- Click the log in link in the error.
- 404

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->