### PR TITLE
Fix more button alignment: conditionally apply css if card has style variation

### DIFF
--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -515,7 +515,7 @@ export class Theme extends Component {
 			isPremiumTheme,
 			didPurchaseTheme,
 		} = this.props;
-		const { name, description, screenshot } = theme;
+		const { name, description, screenshot, style_variations = [] } = theme;
 		const isNewCardsOnly = isEnabled( 'themes/showcase-i4/cards-only' );
 		const isNewDetailsAndPreview = isEnabled( 'themes/showcase-i4/details-and-preview' );
 		const isActionable = this.props.screenshotClickUrl || this.props.onScreenshotClick;
@@ -594,7 +594,7 @@ export class Theme extends Component {
 
 					<div
 						className={ classNames( 'theme__info', {
-							'has-pricing': !! upsellUrl,
+							'has-style-variations': isNewDetailsAndPreview && style_variations.length > 0,
 						} ) }
 					>
 						<h2 className="theme__info-title">{ name }</h2>

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -184,7 +184,7 @@ body.is-section-themes-i4-2 {
 			text-rendering: optimizeLegibility;
 			-webkit-font-smoothing: antialiased;
 
-			&:not(.has-pricing) {
+			&:not(.has-style-variations) {
 				.theme__more-button {
 					top: 0;
 				}


### PR DESCRIPTION
This PR duplicates https://github.com/Automattic/wp-calypso/pull/72335, which I screwed up with a hot git mess, doing this p1664300488252399-slack-C7YPUHBB2

The work in that PR was done by @taipeicoder  (I'm "helping" while he is AFK.)

#### Proposed Changes


This PR fixes the more button overlapping with the style variations in the theme card.

| Before | After |
| --- | --- |
| ![Screenshot 2023-01-19 at 10 36 35 PM](https://user-images.githubusercontent.com/797888/213470554-ce474ea3-0400-432f-9da0-591a4efbd94f.png) |  ![Screenshot 2023-01-19 at 10 36 51 PM](https://user-images.githubusercontent.com/797888/213470589-b5301ff5-8b2f-4b96-8cbf-faa4856d2285.png) |

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the logged-in Theme Showcase. If using calypso.live, the flag `themes/showcase-i4/details-and-preview` is required.
* Ensure that the more button no longer overlaps with the style variations.
* Also test against the logged-out Theme Showcase.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes? Not needed
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?  Code changes don't impact Jetpack / self hosted.
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md) N/A
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)? N/A
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)? N/A
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #