### PR TITLE
Refactor isThemePurchased() to remove lodash and switch to TS

### DIFF
--- a/client/state/themes/selectors/is-theme-purchased.ts
+++ b/client/state/themes/selectors/is-theme-purchased.ts
@@ -1,0 +1,27 @@
+import { getSitePurchases } from 'calypso/state/purchases/selectors';
+import type { AppState } from 'calypso/types';
+
+import 'calypso/state/themes/init';
+
+/**
+ * Returns whether the theme has been purchased for the given site. Note that this only works for
+ * premium themes that are added to A8c repos -- marketplace themes need to be checked via a different approach.
+ *
+ * Use this selector alongside with the <QuerySitePurchases /> component.
+ *
+ * @param {AppState} state Global state tree
+ * @param {string} themeId Theme ID
+ * @param {number} siteId  Site ID
+ * @returns {boolean}      True if the theme has been purchased for the site
+ */
+export function isThemePurchased(
+	state: AppState,
+	themeId: string,
+	siteId: number | null
+): boolean {
+	const sitePurchases = getSitePurchases( state, siteId );
+
+	return !! sitePurchases.find(
+		( purchase ) => purchase.productType === 'theme' && purchase.meta === themeId
+	);
+}

--- a/client/state/themes/selectors/is-theme-purchased.ts
+++ b/client/state/themes/selectors/is-theme-purchased.ts
@@ -4,15 +4,16 @@ import type { AppState } from 'calypso/types';
 import 'calypso/state/themes/init';
 
 /**
- * Returns whether the theme has been purchased for the given site. Note that this only works for
- * premium themes that are added to A8c repos -- marketplace themes need to be checked via a different approach.
+ * Returns whether the theme has been purchased for the given site. Note that
+ * this only works for premium themes that are added to A8c repos --
+ * marketplace themes need to be checked via isMarketplaceThemeSubscribed().
  *
  * Use this selector alongside with the <QuerySitePurchases /> component.
  *
- * @param {AppState} state Global state tree
- * @param {string} themeId Theme ID
- * @param {number} siteId  Site ID
- * @returns {boolean}      True if the theme has been purchased for the site
+ * @param   {AppState} state   Global state tree
+ * @param   {string}   themeId Theme ID
+ * @param   {number}   siteId  Site ID
+ * @returns {boolean}          True if the theme has been purchased for the site
  */
 export function isThemePurchased(
 	state: AppState,


### PR DESCRIPTION
#### Proposed Changes

* This PR refactors the `isThemePurchased()` selector to remove `lodash` and switch the implementation to TypeScript

#### Testing Instructions

* Run the code from this branch locally or via the Calypso.live branch
* Navigate to _Appearance_ -> _Themes_
* Verify that everything looks OK
* Purchase a standard premium theme (i.e. any premium theme that is not Makoney) -- you can also check if you have any previously purchased premium themes via `/me/purchases`; you can use one of those purchases if needed
* Navigate back to _Appearance_ -> _Themes_
* Find your purchased premium theme - if it is the currently active theme for your site, switch to another theme and then find the theme in the theme showcase
* Click on the theme to display more info
* Verify that you see an "Activate this design" CTA

#### Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [N/A] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [N/A] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [N/A] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?