### PR TITLE
Fix wording in premium theme upsell banner

### DIFF
--- a/client/my-sites/themes/single-site-wpcom.jsx
+++ b/client/my-sites/themes/single-site-wpcom.jsx
@@ -40,7 +40,7 @@ const ConnectedSingleSiteWpcom = connectOptions( ( props ) => {
 						event="calypso_themes_list_premium_themes"
 						feature={ WPCOM_FEATURES_PREMIUM_THEMES }
 						plan={ PLAN_PREMIUM }
-						title={ translate( 'Unlock ALL premium themes with our Premium and Business plans!' ) }
+						title={ translate( 'Unlock premium themes with our Premium and Business plans!' ) }
 						callToAction={ translate( 'Upgrade now' ) }
 						showIcon={ true }
 					/>

--- a/client/my-sites/themes/single-site-wpcom.jsx
+++ b/client/my-sites/themes/single-site-wpcom.jsx
@@ -7,6 +7,8 @@ import {
 	PLAN_BUSINESS,
 	WPCOM_FEATURES_PREMIUM_THEMES,
 } from '@automattic/calypso-products';
+import { useIsEnglishLocale } from '@automattic/i18n-utils';
+import i18n from 'i18n-calypso';
 import { connect } from 'react-redux';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
 import QueryActiveTheme from 'calypso/components/data/query-active-theme';
@@ -30,17 +32,23 @@ const ConnectedSingleSiteWpcom = connectOptions( ( props ) => {
 	const isNewDetailsAndPreview = isEnabled( 'themes/showcase-i4/details-and-preview' );
 	const displayUpsellBanner = ! requestingSitePlans && currentPlan && ! isVip;
 	const upsellUrl = `/plans/${ siteSlug }`;
+	const isEnglishLocale = useIsEnglishLocale();
 	let upsellBanner = null;
 	if ( displayUpsellBanner ) {
 		if ( isEnabled( 'themes/premium' ) ) {
 			if ( [ PLAN_PERSONAL, PLAN_FREE ].includes( currentPlan.productSlug ) ) {
+				const bannerTitle =
+					isEnglishLocale ||
+					i18n.hasTranslation( 'Unlock premium themes with our Premium and Business plans!' )
+						? translate( 'Unlock premium themes with our Premium and Business plans!' )
+						: translate( 'Unlock ALL premium themes with our Premium and Business plans!' );
 				upsellBanner = (
 					<UpsellNudge
 						className="themes__showcase-banner"
 						event="calypso_themes_list_premium_themes"
 						feature={ WPCOM_FEATURES_PREMIUM_THEMES }
 						plan={ PLAN_PREMIUM }
-						title={ translate( 'Unlock premium themes with our Premium and Business plans!' ) }
+						title={ bannerTitle }
 						callToAction={ translate( 'Upgrade now' ) }
 						showIcon={ true }
 					/>


### PR DESCRIPTION
#### Proposed Changes

* This PR removes the `ALL` wording from the premium theme upsell banner we show in the Theme Showcase to users on free or Personal plans
* We need to remove the word because marketplace themes require separate subscriptions

##### Screenshot

<img width="930" alt="Screenshot 2023-01-23 at 11 02 26" src="https://user-images.githubusercontent.com/3376401/214001140-0d7a9195-8eaf-4c4e-bf39-1b2d51528dfe.png">

#### Testing Instructions

* Run this branch locally or via Calypso.live
* For a free site or a site with the Personal plan, navigate to _Appearance_ -> _Themes_ while using an English locale (currently `en` or `en-gb`)
* Verify that you see the new text in the upsell banner:
> Unlock premium themes with our Premium and Business plans!
* Switch the language for your user to be a non-English language
* Verify that you still see the equivalent of the old text where the translated string for "ALL" is capitalised

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [N/A] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [N/A] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)? _We've implemented a progressive translation check._
- [N/A] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?