### PR TITLE
Reading Settings: Fix subscription options text areas update

### DIFF
--- a/client/my-sites/site-settings/reading-newsletter-settings/EmailsTextSetting.tsx
+++ b/client/my-sites/site-settings/reading-newsletter-settings/EmailsTextSetting.tsx
@@ -4,12 +4,10 @@ import FormLabel from 'calypso/components/forms/form-label';
 import FormLegend from 'calypso/components/forms/form-legend';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import FormTextarea from 'calypso/components/forms/form-textarea';
+import { SubscriptionOptions } from '../settings-reading/main';
 
 type EmailsTextSettingProps = {
-	value?: {
-		invitation: string;
-		comment_follow: string;
-	};
+	value?: SubscriptionOptions;
 	disabled?: boolean;
 	updateFields: ( fields: { [ key: string ]: unknown } ) => void;
 };

--- a/client/my-sites/site-settings/reading-newsletter-settings/index.tsx
+++ b/client/my-sites/site-settings/reading-newsletter-settings/index.tsx
@@ -21,7 +21,7 @@ type NewsletterSettingsSectionProps = {
 	handleSubmitForm: ( event: React.FormEvent< HTMLFormElement > ) => void;
 	disabled?: boolean;
 	isSavingSettings: boolean;
-	subscriptionOptions?: { invitation: string; comment_follow: string };
+	savedSubscriptionOptions?: { invitation: string; comment_follow: string };
 	updateFields: ( fields: Fields ) => void;
 };
 
@@ -31,7 +31,7 @@ export const NewsletterSettingsSection = ( {
 	handleSubmitForm,
 	disabled,
 	isSavingSettings,
-	subscriptionOptions,
+	savedSubscriptionOptions,
 	updateFields,
 }: NewsletterSettingsSectionProps ) => {
 	const translate = useTranslate();
@@ -43,12 +43,12 @@ export const NewsletterSettingsSection = ( {
 
 	/* eslint-disable no-console */
 	console.log( 'subscription_options', subscription_options ); // value in the form field
-	console.log( 'subscriptionOptions', subscriptionOptions ); // current value
+	console.log( 'savedSubscriptionOptions', savedSubscriptionOptions ); // current value
 
 	// useEffect to update subscription_options when subscriptionOptions changes
 	useEffect( () => {
-		updateFields( { subscription_options: subscriptionOptions } );
-	}, [ subscriptionOptions ] );
+		updateFields( { subscription_options: savedSubscriptionOptions } );
+	}, [ savedSubscriptionOptions ] );
 
 	return (
 		<>

--- a/client/my-sites/site-settings/reading-newsletter-settings/index.tsx
+++ b/client/my-sites/site-settings/reading-newsletter-settings/index.tsx
@@ -2,6 +2,7 @@ import { Card } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
+import { SubscriptionOptions } from '../settings-reading/main';
 import { EmailsTextSetting } from './EmailsTextSetting';
 import { ExcerptSetting } from './ExcerptSetting';
 import { FeaturedImageEmailSetting } from './FeaturedImageEmailSetting';
@@ -9,10 +10,7 @@ import { FeaturedImageEmailSetting } from './FeaturedImageEmailSetting';
 type Fields = {
 	wpcom_featured_image_in_email?: boolean;
 	wpcom_subscription_emails_use_excerpt?: boolean;
-	subscription_options?: {
-		invitation: string;
-		comment_follow: string;
-	};
+	subscription_options?: SubscriptionOptions;
 };
 
 type NewsletterSettingsSectionProps = {
@@ -21,7 +19,7 @@ type NewsletterSettingsSectionProps = {
 	handleSubmitForm: ( event: React.FormEvent< HTMLFormElement > ) => void;
 	disabled?: boolean;
 	isSavingSettings: boolean;
-	savedSubscriptionOptions?: { invitation: string; comment_follow: string };
+	savedSubscriptionOptions?: SubscriptionOptions;
 	updateFields: ( fields: Fields ) => void;
 };
 

--- a/client/my-sites/site-settings/reading-newsletter-settings/index.tsx
+++ b/client/my-sites/site-settings/reading-newsletter-settings/index.tsx
@@ -39,11 +39,8 @@ export const NewsletterSettingsSection = ( {
 		subscription_options,
 	} = fields;
 
-	/* eslint-disable no-console */
-	console.log( 'subscription_options', subscription_options ); // value in the form field
-	console.log( 'savedSubscriptionOptions', savedSubscriptionOptions ); // current value
-
-	// useEffect to update subscription_options when subscriptionOptions changes
+	// Update subscription_options form fields when savedSubscriptionOptions changes.
+	// This makes sure the form fields hold the current value after saving.
 	useEffect( () => {
 		updateFields( { subscription_options: savedSubscriptionOptions } );
 	}, [ savedSubscriptionOptions ] );

--- a/client/my-sites/site-settings/reading-newsletter-settings/index.tsx
+++ b/client/my-sites/site-settings/reading-newsletter-settings/index.tsx
@@ -1,5 +1,6 @@
 import { Card } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
+import { useEffect } from 'react';
 import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
 import { EmailsTextSetting } from './EmailsTextSetting';
 import { ExcerptSetting } from './ExcerptSetting';
@@ -20,6 +21,7 @@ type NewsletterSettingsSectionProps = {
 	handleSubmitForm: ( event: React.FormEvent< HTMLFormElement > ) => void;
 	disabled?: boolean;
 	isSavingSettings: boolean;
+	subscriptionOptions?: { invitation: string; comment_follow: string };
 	updateFields: ( fields: Fields ) => void;
 };
 
@@ -29,6 +31,7 @@ export const NewsletterSettingsSection = ( {
 	handleSubmitForm,
 	disabled,
 	isSavingSettings,
+	subscriptionOptions,
 	updateFields,
 }: NewsletterSettingsSectionProps ) => {
 	const translate = useTranslate();
@@ -37,6 +40,15 @@ export const NewsletterSettingsSection = ( {
 		wpcom_subscription_emails_use_excerpt,
 		subscription_options,
 	} = fields;
+
+	/* eslint-disable no-console */
+	console.log( 'subscription_options', subscription_options ); // value in the form field
+	console.log( 'subscriptionOptions', subscriptionOptions ); // current value
+
+	// useEffect to update subscription_options when subscriptionOptions changes
+	useEffect( () => {
+		updateFields( { subscription_options: subscriptionOptions } );
+	}, [ subscriptionOptions ] );
 
 	return (
 		<>

--- a/client/my-sites/site-settings/settings-reading/main.tsx
+++ b/client/my-sites/site-settings/settings-reading/main.tsx
@@ -107,7 +107,7 @@ const ReadingSettingsForm = wrapSettingsForm( getFormSettings )(
 			updateFields,
 		}: ReadingSettingsFormProps ) => {
 			const disabled = isRequestingSettings || isSavingSettings;
-			const subscriptionOptions = settings?.subscription_options;
+			const savedSubscriptionOptions = settings?.subscription_options;
 			return (
 				<form onSubmit={ handleSubmitForm }>
 					<SiteSettingsSection
@@ -135,7 +135,7 @@ const ReadingSettingsForm = wrapSettingsForm( getFormSettings )(
 						handleSubmitForm={ handleSubmitForm }
 						disabled={ disabled }
 						isSavingSettings={ isSavingSettings }
-						subscriptionOptions={ subscriptionOptions }
+						savedSubscriptionOptions={ savedSubscriptionOptions }
 						updateFields={ updateFields }
 					/>
 				</form>

--- a/client/my-sites/site-settings/settings-reading/main.tsx
+++ b/client/my-sites/site-settings/settings-reading/main.tsx
@@ -13,6 +13,11 @@ import wrapSettingsForm from '../wrap-settings-form';
 
 const isEnabled = config.isEnabled( 'settings/modernize-reading-settings' );
 
+export type SubscriptionOptions = {
+	invitation: string;
+	comment_follow: string;
+};
+
 type Fields = {
 	jetpack_relatedposts_enabled?: boolean;
 	jetpack_relatedposts_show_context?: boolean;
@@ -25,10 +30,7 @@ type Fields = {
 	posts_per_rss?: number;
 	rss_use_excerpt?: boolean;
 	show_on_front?: 'posts' | 'page';
-	subscription_options?: {
-		invitation: string;
-		comment_follow: string;
-	};
+	subscription_options?: SubscriptionOptions;
 	wpcom_featured_image_in_email?: boolean;
 	wpcom_subscription_emails_use_excerpt?: boolean;
 };
@@ -88,7 +90,7 @@ type ReadingSettingsFormProps = {
 	handleSubmitForm: ( event: React.FormEvent< HTMLFormElement > ) => void;
 	isRequestingSettings: boolean;
 	isSavingSettings: boolean;
-	settings: { subscription_options?: { invitation: string; comment_follow: string } };
+	settings: { subscription_options?: SubscriptionOptions };
 	siteUrl?: string;
 	updateFields: ( fields: Fields ) => void;
 };

--- a/client/my-sites/site-settings/settings-reading/main.tsx
+++ b/client/my-sites/site-settings/settings-reading/main.tsx
@@ -88,6 +88,7 @@ type ReadingSettingsFormProps = {
 	handleSubmitForm: ( event: React.FormEvent< HTMLFormElement > ) => void;
 	isRequestingSettings: boolean;
 	isSavingSettings: boolean;
+	settings: { subscription_options?: { invitation: string; comment_follow: string } };
 	siteUrl?: string;
 	updateFields: ( fields: Fields ) => void;
 };
@@ -101,10 +102,12 @@ const ReadingSettingsForm = wrapSettingsForm( getFormSettings )(
 			handleToggle,
 			isRequestingSettings,
 			isSavingSettings,
+			settings,
 			siteUrl,
 			updateFields,
 		}: ReadingSettingsFormProps ) => {
 			const disabled = isRequestingSettings || isSavingSettings;
+			const subscriptionOptions = settings?.subscription_options;
 			return (
 				<form onSubmit={ handleSubmitForm }>
 					<SiteSettingsSection
@@ -132,6 +135,7 @@ const ReadingSettingsForm = wrapSettingsForm( getFormSettings )(
 						handleSubmitForm={ handleSubmitForm }
 						disabled={ disabled }
 						isSavingSettings={ isSavingSettings }
+						subscriptionOptions={ subscriptionOptions }
 						updateFields={ updateFields }
 					/>
 				</form>


### PR DESCRIPTION
The proposed changes fix an edge case issue that occurs when user submits the subscription options text areas on the mew Reading settings page with content that is stripped out by related endpoint on save. Feel free to review the issue details in the link below.


Fixes https://github.com/Automattic/wp-calypso/issues/71839.

There's also Before/After screen recording available below in this PR.

#### Proposed Changes

* Introduction of `useEffect` that updates `subscription_options` value displayed in the form text areas (_Welcome email text_ and _Comment follow email text_) when the subscription options are saved (represented by `savedSubscriptionOptions`).
* Introduction of `SubscriptionOptions` type so it can be reused throughout the multiple files without repetition.

#### Testing Instructions

1. Check out this PR and build it locally.
2. Navigate to `http://calypso.localhost:3000/settings/reading/[site-address]`.
3. It should not be possible to reproduce the https://github.com/Automattic/wp-calypso/issues/71839 issue

In other words, if you try to save the _Welcome email text_ and _Comment follow email text_ text areas with content that is not allowed (e.g. `<strong>` tag), this content should be automatically **stripped out**. When you try to navigate to a different page or reload the page afterwards, there should be **no dialog/warning displayed**.

Here are the Before / After screen recordings.

**Before:**

https://user-images.githubusercontent.com/25105483/211526481-94837caf-7125-4c25-a412-5bf35e63ced2.mp4

**After:**

https://user-images.githubusercontent.com/25105483/214024532-b3f88ef1-9876-447b-b335-1db3242e5035.mp4

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #71839
