### PR TITLE
Fix alignment of 0 price

### DIFF
--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -279,6 +279,7 @@ export class PlanFeatures2023Grid extends Component< PlanFeatures2023GridType > 
 			const { currencyCode, discountPrice, planName, rawPrice } = properties;
 			const classes = classNames( 'plan-features-2023-grid__table-item', {
 				'has-border-top': ! isReskinned,
+				'is-bottom-aligned': true,
 			} );
 
 			if ( rawPrice === undefined || rawPrice === null ) {

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -277,9 +277,8 @@ export class PlanFeatures2023Grid extends Component< PlanFeatures2023GridType > 
 
 		return planPropertiesObj.map( ( properties ) => {
 			const { currencyCode, discountPrice, planName, rawPrice } = properties;
-			const classes = classNames( 'plan-features-2023-grid__table-item', {
+			const classes = classNames( 'plan-features-2023-grid__table-item', 'is-bottom-aligned', {
 				'has-border-top': ! isReskinned,
-				'is-bottom-aligned': true,
 			} );
 
 			if ( rawPrice === undefined || rawPrice === null ) {

--- a/client/my-sites/plan-features-2023-grid/style.scss
+++ b/client/my-sites/plan-features-2023-grid/style.scss
@@ -308,6 +308,7 @@ $plan-features-sidebar-width: 272px;
 			line-height: $font-title-large;
 			display: flex;
 			@include onboarding-font-recoleta;
+			padding: 3px 0 6px;
 		}
 
 		.plan-price__currency-symbol {
@@ -357,7 +358,6 @@ $plan-features-sidebar-width: 272px;
 
 		.plan-price.is-discounted {
 			color: var(--color-neutral-70);
-			line-height: 50px;
 
 			.plan-price__integer-fraction {
 				color: var(--color-success);

--- a/client/my-sites/plan-features-2023-grid/style.scss
+++ b/client/my-sites/plan-features-2023-grid/style.scss
@@ -291,6 +291,10 @@ $plan-features-sidebar-width: 272px;
 		@media ( min-width: 880px ) {
 			border-right: solid 1px #e0e0e0;
 			border-left: solid 1px #e0e0e0;
+
+			&.is-bottom-aligned {
+				vertical-align: bottom;
+			}
 		}
 	}
 


### PR DESCRIPTION
#### Proposed Changes

This fixes the Free (uncrossed) pricing alignment by adjusting the vertical alignment of the cells from that row. 

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /start/onboarding-2023-pricing-grid/plans
* Switch to a currency with an ongoing discount via the SA.
* The Free plan's price should be aligned with the uncrossed prices
<img width="420" alt="Screenshot 2023-01-23 at 13 49 26" src="https://user-images.githubusercontent.com/2749938/214032627-7a95ce6b-48ad-4331-8620-a6009ce3e807.png">


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #72280
