### PR TITLE
Migration flow: WordPress: Hide confirm dialog if it comes from the migrate plugin

### DIFF
--- a/client/blocks/importer/wordpress/import-everything/confirm.tsx
+++ b/client/blocks/importer/wordpress/import-everything/confirm.tsx
@@ -1,5 +1,6 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Title, SubTitle, NextButton, Notice } from '@automattic/onboarding';
+import { useSelect } from '@wordpress/data';
 import { sprintf } from '@wordpress/i18n';
 import { Icon, check } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
@@ -8,6 +9,7 @@ import React, { useState, useEffect } from 'react';
 import { UrlData } from 'calypso/blocks/import/types';
 import { convertToFriendlyWebsiteName } from 'calypso/blocks/import/util';
 import SiteIcon from 'calypso/blocks/site-icon';
+import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import ConfirmModal from './confirm-modal';
 import ConfirmUpgradePlan from './confirm-upgrade-plan';
 import type { SiteDetails } from '@automattic/data-stores';
@@ -41,6 +43,7 @@ export const Confirm: React.FunctionComponent< Props > = ( props ) => {
 	} = props;
 	const [ isModalDetailsOpen, setIsModalDetailsOpen ] = useState( false );
 	const [ showUpgradePlanScreen, setShowUpgradePlanScreen ] = useState( false );
+	const isMigrateFromWp = useSelect( ( select ) => select( ONBOARD_STORE ).getIsMigrateFromWp() );
 
 	/**
 	 ↓ Effects
@@ -48,6 +51,17 @@ export const Confirm: React.FunctionComponent< Props > = ( props ) => {
 	useEffect( () => {
 		recordTracksEvent( 'calypso_site_importer_migration_confirmation' );
 	}, [] );
+
+	/**
+	 ↓ Functions
+	 */
+	function showConfirmDialogOrStartImport() {
+		if ( isMigrateFromWp ) {
+			startImport();
+		} else {
+			setIsModalDetailsOpen( true );
+		}
+	}
 
 	return (
 		<>
@@ -137,7 +151,7 @@ export const Confirm: React.FunctionComponent< Props > = ( props ) => {
 										step: 'importerWordpress',
 										action: 'startImport',
 									} );
-									setIsModalDetailsOpen( true );
+									showConfirmDialogOrStartImport();
 								} }
 							>
 								{ __( 'Start import' ) }
@@ -149,7 +163,7 @@ export const Confirm: React.FunctionComponent< Props > = ( props ) => {
 				{ showUpgradePlanScreen && (
 					<>
 						<ConfirmUpgradePlan sourceSite={ sourceSite } targetSite={ targetSite } />
-						<NextButton onClick={ () => setIsModalDetailsOpen( true ) }>
+						<NextButton onClick={ () => showConfirmDialogOrStartImport() }>
 							{ __( 'Upgrade and import' ) }
 						</NextButton>
 					</>

--- a/client/blocks/importer/wordpress/import-everything/confirm.tsx
+++ b/client/blocks/importer/wordpress/import-everything/confirm.tsx
@@ -1,6 +1,5 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Title, SubTitle, NextButton, Notice } from '@automattic/onboarding';
-import { useSelect } from '@wordpress/data';
 import { sprintf } from '@wordpress/i18n';
 import { Icon, check } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
@@ -9,7 +8,6 @@ import React, { useState, useEffect } from 'react';
 import { UrlData } from 'calypso/blocks/import/types';
 import { convertToFriendlyWebsiteName } from 'calypso/blocks/import/util';
 import SiteIcon from 'calypso/blocks/site-icon';
-import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import ConfirmModal from './confirm-modal';
 import ConfirmUpgradePlan from './confirm-upgrade-plan';
 import type { SiteDetails } from '@automattic/data-stores';
@@ -23,6 +21,7 @@ interface Props {
 	targetSite: SiteDetails | null;
 	targetSiteSlug: string;
 	isTargetSitePlanCompatible: boolean;
+	showConfirmDialog: boolean;
 	startImport: () => void;
 }
 
@@ -39,11 +38,11 @@ export const Confirm: React.FunctionComponent< Props > = ( props ) => {
 		targetSite,
 		targetSiteSlug,
 		isTargetSitePlanCompatible,
+		showConfirmDialog,
 		startImport,
 	} = props;
 	const [ isModalDetailsOpen, setIsModalDetailsOpen ] = useState( false );
 	const [ showUpgradePlanScreen, setShowUpgradePlanScreen ] = useState( false );
-	const isMigrateFromWp = useSelect( ( select ) => select( ONBOARD_STORE ).getIsMigrateFromWp() );
 
 	/**
 	 ↓ Effects
@@ -56,10 +55,10 @@ export const Confirm: React.FunctionComponent< Props > = ( props ) => {
 	 ↓ Functions
 	 */
 	function showConfirmDialogOrStartImport() {
-		if ( isMigrateFromWp ) {
-			startImport();
-		} else {
+		if ( showConfirmDialog ) {
 			setIsModalDetailsOpen( true );
+		} else {
+			startImport();
 		}
 	}
 

--- a/client/blocks/importer/wordpress/import-everything/index.tsx
+++ b/client/blocks/importer/wordpress/import-everything/index.tsx
@@ -33,6 +33,7 @@ interface Props {
 	targetSiteSlug: string;
 	targetSiteEligibleForProPlan: boolean;
 	stepNavigator?: StepNavigator;
+	showConfirmDialog: boolean;
 }
 
 interface State {
@@ -128,6 +129,7 @@ export class ImportEverything extends SectionMigrate {
 			sourceUrlAnalyzedData,
 			isTargetSitePlanCompatible,
 			stepNavigator,
+			showConfirmDialog = true,
 		} = this.props;
 
 		if ( sourceSite ) {
@@ -140,6 +142,7 @@ export class ImportEverything extends SectionMigrate {
 					sourceSite={ sourceSite }
 					sourceSiteUrl={ sourceSite.URL }
 					sourceUrlAnalyzedData={ sourceUrlAnalyzedData }
+					showConfirmDialog={ showConfirmDialog }
 				/>
 			);
 		}

--- a/client/blocks/importer/wordpress/index.tsx
+++ b/client/blocks/importer/wordpress/index.tsx
@@ -25,6 +25,7 @@ interface Props {
 	siteId: number;
 	siteSlug: string;
 	fromSite: string;
+	showConfirmDialog?: boolean;
 	stepNavigator?: StepNavigator;
 }
 
@@ -35,7 +36,7 @@ export const WordpressImporter: React.FunctionComponent< Props > = ( props ) => 
 	 ↓ Fields
 	 */
 	const [ option, setOption ] = useState< WPImportOption >();
-	const { job, fromSite, siteSlug, siteId, stepNavigator } = props;
+	const { job, fromSite, siteSlug, siteId, stepNavigator, showConfirmDialog } = props;
 	const siteItem = useSelector( ( state ) => getSite( state, siteId ) );
 	const fromSiteItem = useSelector( ( state ) =>
 		getSiteBySlug( state, fromSite ? convertToFriendlyWebsiteName( fromSite ) : '' )
@@ -145,6 +146,7 @@ export const WordpressImporter: React.FunctionComponent< Props > = ( props ) => 
 							targetSiteSlug={ siteSlug }
 							stepNavigator={ stepNavigator }
 							isMigrateFromWp={ isMigrateFromWp }
+							showConfirmDialog={ showConfirmDialog }
 						/>
 					);
 				} else if ( WPImportOption.CONTENT_ONLY === option ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/importer/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/importer/index.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 import { StepContainer } from '@automattic/onboarding';
+import { useSelect } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
 import { useEffect, useState } from 'react';
@@ -14,6 +15,7 @@ import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { useSiteSlugParam } from 'calypso/landing/stepper/hooks/use-site-slug-param';
+import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { EVERY_FIVE_SECONDS, Interval } from 'calypso/lib/interval';
 import { fetchImporterState, resetImport } from 'calypso/state/imports/actions';
@@ -55,6 +57,7 @@ export function withImporterWrapper( Importer: ImporterCompType ) {
 		const siteItem = useSelector( ( state ) => getSite( state, siteId ) );
 		const siteImports = useSelector( ( state ) => getImporterStatusForSiteId( state, siteId ) );
 		const isImporterStatusHydrated = useSelector( isImporterStatusHydratedSelector );
+		const isMigrateFromWp = useSelect( ( select ) => select( ONBOARD_STORE ).getIsMigrateFromWp() );
 
 		const fromSite = currentSearchParams.get( 'from' ) || '';
 		const fromSiteData = useSelector( getUrlData );
@@ -150,6 +153,7 @@ export function withImporterWrapper( Importer: ImporterCompType ) {
 					fromSite={ fromSite }
 					urlData={ fromSiteData }
 					stepNavigator={ stepNavigator }
+					showConfirmDialog={ ! isMigrateFromWp }
 				/>
 			);
 		}


### PR DESCRIPTION
#### Proposed Changes

WordPress flow: Hide confirm dialog if it comes from the migrate plugin

#### Testing Instructions

- Launch a [JN site with migration plugin](https://jurassic.ninja/create/?jetpack-beta) and click Set up Jetpack to connect the site to your target site user account, or use any self-hosted site you've already connected to your target user account.
- Once it's done, navigate to `http://calypso.localhost:3000/setup/import-focused/siteCreationStep?from=${TARGET_SITE_SLUG}`. The TARGET_SITE_SLUG here should be the site you want to migrate. For example, a testing Jurassic Ninja site.
- Check if the flow is simplified by not showing "Import and replace everything? dialog

<img width="999" alt="Screenshot 2023-01-23 at 13 31 56" src="https://user-images.githubusercontent.com/1241413/214041185-43d308ad-c809-4041-9118-a1243d3d1735.png">


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #72062
