### PR TITLE
Marketplace: Decode html in plugin details title

### DIFF
--- a/client/components/breadcrumb/index.tsx
+++ b/client/components/breadcrumb/index.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import { Key } from 'react';
 import InfoPopover from 'calypso/components/info-popover';
+import { decodeEntities } from 'calypso/lib/formatting';
 
 const flexAligned = {
 	display: 'flex',
@@ -100,7 +101,7 @@ const Breadcrumb: React.FunctionComponent< Props > = ( props ) => {
 		const [ item ] = items;
 		return (
 			<StyledItem>
-				<StyledRootLabel>{ item.label }</StyledRootLabel>
+				<StyledRootLabel>{ decodeEntities( item.label ) }</StyledRootLabel>
 				{ renderHelpBubble( item ) }
 			</StyledItem>
 		);
@@ -112,7 +113,7 @@ const Breadcrumb: React.FunctionComponent< Props > = ( props ) => {
 		return (
 			<StyledBackLink href={ urlBack }>
 				<Gridicon icon="chevron-left" size={ 18 } />
-				{ label }
+				{ decodeEntities( label ) }
 			</StyledBackLink>
 		);
 	}
@@ -126,7 +127,7 @@ const Breadcrumb: React.FunctionComponent< Props > = ( props ) => {
 						{ item.href && index !== items.length - 1 ? (
 							<a href={ item.href }>{ item.label }</a>
 						) : (
-							<span>{ item.label }</span>
+							<span>{ decodeEntities( item.label ) }</span>
 						) }
 						{ renderHelpBubble( item ) }
 					</StyledLi>

--- a/client/my-sites/plugins/plugin-details-header/index.jsx
+++ b/client/my-sites/plugins/plugin-details-header/index.jsx
@@ -3,7 +3,7 @@ import { useSelector } from 'react-redux';
 import Badge from 'calypso/components/badge';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { formatNumberMetric } from 'calypso/lib/format-number-compact';
-import { preventWidows } from 'calypso/lib/formatting';
+import { preventWidows, decodeEntities } from 'calypso/lib/formatting';
 import PluginRatings from 'calypso/my-sites/plugins/plugin-ratings/';
 import { useLocalizedPlugins } from 'calypso/my-sites/plugins/utils';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
@@ -25,7 +25,7 @@ const PluginDetailsHeader = ( { plugin, isPlaceholder, isJetpackCloud } ) => {
 			<div className="plugin-details-header__main-info">
 				<img className="plugin-details-header__icon" src={ plugin.icon } alt="" />
 				<div className="plugin-details-header__title-container">
-					<h1 className="plugin-details-header__name">{ plugin.name }</h1>
+					<h1 className="plugin-details-header__name">{ decodeEntities( plugin.name ) }</h1>
 					<div className="plugin-details-header__subtitle">
 						<span className="plugin-details-header__author">
 							{ isJetpackCloud

--- a/client/my-sites/plugins/utils.js
+++ b/client/my-sites/plugins/utils.js
@@ -3,6 +3,7 @@ import { isMagnificentLocale } from '@automattic/i18n-utils';
 import { useTranslate, translate } from 'i18n-calypso';
 import { useCallback } from 'react';
 import { useSelector } from 'react-redux';
+import { decodeEntities } from 'calypso/lib/formatting';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 
 export function siteObjectsToSiteIds( sites ) {
@@ -109,7 +110,7 @@ const getConfirmationText = ( sites, selectedPlugins, actionText ) => {
 export const getPluginActionDailogMessage = ( sites, selectedPlugins, heading, actionText ) => {
 	return (
 		<div>
-			<div className="plugins__confirmation-modal-heading">{ heading }</div>
+			<div className="plugins__confirmation-modal-heading">{ decodeEntities( heading ) }</div>
 			<span className="plugins__confirmation-modal-desc">
 				{ getConfirmationText( sites, selectedPlugins, actionText ) }
 			</span>


### PR DESCRIPTION
#### Proposed Changes

* Use the utility `decodeEntitites` from `calypso/lib/formatting` to decode any html-encoded characters in the title of the Plugin Details screen

|Before | After|
|-------|------|
|![CleanShot 2023-01-23 at 13 46 41@2x](https://user-images.githubusercontent.com/3519124/214043311-ed053036-e504-476c-9b87-afe9c2b8be24.png)|![CleanShot 2023-01-23 at 13 46 27@2x](https://user-images.githubusercontent.com/3519124/214043339-eb3085e1-cf40-4449-923b-1533b5f9df61.png)|

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- On a site with a Business or eCommerce plan, navigate to `/plugins/:siteId`
- Search for a plugin that contains special HTML characters in the title, e.g. `Health & Check Troubleshooting`
- Click on the plugins to open the details screen
- Check that both the title of the plugin and the breadcrumb navigation on top do not contain html-encoded characters

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
~- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?~
- [x] Have you checked for TypeScript, React or other console errors?
~- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~
~- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~
~- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #70363
