### PR TITLE
Email Stats: don't clean state before calling endpoint

### DIFF
--- a/client/components/data/query-email-stats/index.jsx
+++ b/client/components/data/query-email-stats/index.jsx
@@ -15,16 +15,7 @@ const requestAlltimeStats = ( siteId, postId, statType, quantity ) => ( dispatch
 	dispatch( requestEmailAlltimeStats( siteId, postId, statType, quantity ) );
 };
 
-function QueryEmailStats( {
-	siteId,
-	postId,
-	period,
-	date,
-	quantity,
-	hasValidDate,
-	statType,
-	isRequesting = false,
-} ) {
+function QueryEmailStats( { siteId, postId, period, date, quantity, hasValidDate, statType } ) {
 	const dispatch = useDispatch();
 
 	useEffect( () => {
@@ -39,7 +30,7 @@ function QueryEmailStats( {
 
 	useEffect( () => {
 		// if hasValidatedDate is false, the date was not set we don't have a post publish date yet
-		if ( siteId && postId > -1 && hasValidDate && ! isRequesting ) {
+		if ( siteId && postId > -1 && hasValidDate ) {
 			dispatch( requestPeriodStats( siteId, postId, period, date, statType, quantity ) );
 		}
 	}, [ dispatch, siteId, postId, hasValidDate, period, date, statType, quantity ] );

--- a/client/my-sites/stats/stats-email-chart-tabs/index.jsx
+++ b/client/my-sites/stats/stats-email-chart-tabs/index.jsx
@@ -130,6 +130,7 @@ const connectComponent = connect(
 			postId,
 			statType,
 			onChangeMaxBars,
+			maxBars,
 		}
 	) => {
 		const siteId = getSelectedSiteId( state );
@@ -139,17 +140,20 @@ const connectComponent = connect(
 
 		const quantity = 'hour' === period ? 24 : 30;
 		const counts = getCountRecords( state, siteId, postId, period, statType );
-		const chartData = buildChartData( activeLegend, chartTab, counts, period );
+		const timezoneOffset = getSiteOption( state, siteId, 'gmt_offset' ) || 0;
+		const date = getQueryDate( queryDate, timezoneOffset, period, quantity );
+		const chartData = buildChartData( activeLegend, chartTab, counts, period, queryDate );
+		const maxBarsForRequest = 'hour' === period ? quantity : maxBars;
 		const isActiveTabLoading = isLoadingTabs(
 			state,
 			siteId,
 			postId,
 			period,
 			statType,
-			endOf.format( 'YYYY-MM-DD' )
+			endOf.format( 'YYYY-MM-DD' ),
+			chartData.length,
+			maxBarsForRequest
 		);
-		const timezoneOffset = getSiteOption( state, siteId, 'gmt_offset' ) || 0;
-		const date = getQueryDate( queryDate, timezoneOffset, period, quantity );
 		const queryKey = `${ date }-${ period }-${ quantity }-${ siteId }`;
 
 		return {

--- a/client/my-sites/stats/stats-email-chart-tabs/utility.js
+++ b/client/my-sites/stats/stats-email-chart-tabs/utility.js
@@ -31,12 +31,13 @@ export function getQueryDate( queryDate, timezoneOffset, period, quantity ) {
 }
 
 const EMPTY_RESULT = [];
-export const buildChartData = memoizeLast( ( activeLegend, chartTab, data, period ) => {
+export const buildChartData = memoizeLast( ( activeLegend, chartTab, data, period, date ) => {
 	if ( ! data ) {
 		return EMPTY_RESULT;
 	}
 
-	return data.map( ( record ) => {
+	const filteredData = data.filter( ( record ) => moment( date ).isSameOrBefore( record.period ) );
+	return filteredData.map( ( record ) => {
 		const nestedValue = activeLegend.length ? record[ activeLegend[ 0 ] ] : null;
 
 		return addTooltipData(

--- a/client/my-sites/stats/stats-email-detail/index.jsx
+++ b/client/my-sites/stats/stats-email-detail/index.jsx
@@ -264,6 +264,7 @@ class StatsEmailDetail extends Component {
 									postId={ postId }
 									statType={ statType }
 									onChangeMaxBars={ this.onChangeMaxBars }
+									maxBars={ maxBars }
 								/>
 
 								{ isSitePrivate ? this.renderPrivateSiteBanner( siteId, slug ) : null }

--- a/client/state/stats/email-chart-tabs/selectors.js
+++ b/client/state/stats/email-chart-tabs/selectors.js
@@ -29,17 +29,31 @@ export function getCountRecords( state, siteId, postId, period, statType ) {
 /**
  * Returns a boolean indicating if the tabs are still loading
  *
- * @param   {Object}  state    Global state tree
- * @param   {number}  siteId   Site ID
- * @param   {number}  postId   Site ID
- * @param   {string}  period   Type of duration to include in the query (such as daily)
- * @param   {string}  statType The type of stat we are working with. For example: 'opens' for Email Open stats
- * @param   {string}  date     The date of the stat
- * @returns {boolean}          If the query is still loading
+ * @param   {Object}  state       Global state tree
+ * @param   {number}  siteId      Site ID
+ * @param   {number}  postId      Post ID
+ * @param   {string}  period      Type of duration to include in the query (such as daily)
+ * @param   {string}  statType    The type of stat we are working with. For example: 'opens' for Email Open stats
+ * @param   {string}  date        The date of the stat
+ * @param   {number}  dataLength  The number of rows the data being shown has
+ * @param   {number}  barNumber   The number of bars that the chart component can show at the moment
+ * @returns {boolean}             If the query is still loading
  */
-export function isLoadingTabs( state, siteId, postId, period, statType, date ) {
+export function isLoadingTabs(
+	state,
+	siteId,
+	postId,
+	period,
+	statType,
+	date,
+	dataLength,
+	barNumber
+) {
 	const stats = get( state.stats.emails.items, [ siteId, postId, period, statType, date ], null );
 	// if we have redux stats ready return false
+	if ( dataLength < barNumber ) {
+		return true;
+	}
 	if ( stats ) {
 		return false;
 	}

--- a/client/state/stats/emails/reducer.js
+++ b/client/state/stats/emails/reducer.js
@@ -73,15 +73,12 @@ export const requests = ( state = {}, action ) => {
  * @returns {Object}        Updated state
  */
 export const items = withSchemaValidation( itemSchemas, ( state = {}, action ) => {
-	const checkState = ( actualState, period ) =>
-		[ 'hour', 'day' ].includes( period ) ? {} : actualState;
-
 	switch ( action.type ) {
 		case EMAIL_STATS_RECEIVE:
 			// eslint-disable-next-line no-case-declarations
 			const { siteId, postId, period, statType } = action;
 
-			return merge( {}, checkState( state, period ), {
+			return merge( {}, state, {
 				[ siteId ]: {
 					[ postId ]: {
 						[ period ]: {


### PR DESCRIPTION
#### Proposed Changes

**The problem**
Each time the email stats endpoint was called, we were erasing the data in redux. That made the screen to be "loading" every time the user went back and forth, even if they were visiting that date moments ago.

**The solution**
This PR fixes that, but storing all the dates retrieved in redux, but then filtering those at the moment of reading them by the chart component.

#### Testing Instructions

1. Apply this branch to your local Calypso repository and start the application.
2. Insert manually in the browser address bar an URL with this format: https://calypso.localhost:3000/stats/email/opens/[the-domain-of-your-blog]/day/[post-id]?flags=newsletter/stats. Note that you can change day for week and month.
3. After the chart stops loading, click on "next" arrow. You should see the chart loading circle while the endpoint retrieves the data.
4. After the chart stops loading, click on "previous" arrow. You shouldn't see the chart loading circle, as the chart would use the data stored already on a previous call to that endpoint.
5. Click again on "previous" arrow. You should see the chart loading circle while the endpoint retrieves the data because that date has no data yet on the redux store.


Fixes https://github.com/Automattic/wp-calypso/issues/72375