### PR TITLE
Marketplace: Fix encoded html in remove modal

### DIFF
--- a/client/my-sites/plugins/plugin-remove-button/index.jsx
+++ b/client/my-sites/plugins/plugin-remove-button/index.jsx
@@ -13,6 +13,7 @@ import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import accept from 'calypso/lib/accept';
 import { gaRecordEvent } from 'calypso/lib/analytics/ga';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { decodeEntities } from 'calypso/lib/formatting';
 import { REMOVE_PLUGIN } from 'calypso/lib/plugins/constants';
 import { getSiteFileModDisableReason, isMainNetworkSite } from 'calypso/lib/site/utils';
 import PluginAction from 'calypso/my-sites/plugins/plugin-action/plugin-action';
@@ -34,7 +35,7 @@ class PluginRemoveButton extends Component {
 		};
 		const heading = translate( 'Remove %(pluginName)s', {
 			args: {
-				pluginName: plugin.name,
+				pluginName: decodeEntities( plugin.name ),
 			},
 		} );
 		accept(

--- a/client/my-sites/plugins/utils.js
+++ b/client/my-sites/plugins/utils.js
@@ -3,7 +3,6 @@ import { isMagnificentLocale } from '@automattic/i18n-utils';
 import { useTranslate, translate } from 'i18n-calypso';
 import { useCallback } from 'react';
 import { useSelector } from 'react-redux';
-import { decodeEntities } from 'calypso/lib/formatting';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 
 export function siteObjectsToSiteIds( sites ) {
@@ -110,7 +109,7 @@ const getConfirmationText = ( sites, selectedPlugins, actionText ) => {
 export const getPluginActionDailogMessage = ( sites, selectedPlugins, heading, actionText ) => {
 	return (
 		<div>
-			<div className="plugins__confirmation-modal-heading">{ decodeEntities( heading ) }</div>
+			<div className="plugins__confirmation-modal-heading">{ heading }</div>
 			<span className="plugins__confirmation-modal-desc">
 				{ getConfirmationText( sites, selectedPlugins, actionText ) }
 			</span>


### PR DESCRIPTION
#### Proposed Changes

* Apply the `decodeEntities` method to the remove modal displayed when removing a plugin

|Before | After|
|-------|------|
|![CleanShot 2023-01-23 at 17 37 45@2x](https://user-images.githubusercontent.com/3519124/214096680-cc6aba60-a7e3-44ae-ba86-97569eb880ea.png)|![CleanShot 2023-01-23 at 17 36 38@2x](https://user-images.githubusercontent.com/3519124/214096406-c04f4b07-7210-494f-afc4-8559297dd4fa.png)|

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*  Navigate to a site with an installed plugin that contains HTML sensitive characters (.e.g `&`) in the title. For example `/plugins/health-check/:siteId`
* If the plugin is not installed, please install it.
* Once installed, press the remove button and make sure the modal does not contain html-encoded characters

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
~- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~
~- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~
~- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #72424
Fixes #70363

