### PR TITLE
Site preview domain upsell: send copy for translation

### DIFF
--- a/client/gutenberg/translations/site-preview-upsell.js
+++ b/client/gutenberg/translations/site-preview-upsell.js
@@ -1,0 +1,4 @@
+import { translate } from 'i18n-calypso';
+
+translate( 'Customize your domain' );
+translate( 'Customize your domain name' );

--- a/client/my-sites/customer-home/translations/domain-upsell.js
+++ b/client/my-sites/customer-home/translations/domain-upsell.js
@@ -29,3 +29,6 @@ translate(
 );
 translate( 'I want my domain as primary' );
 translate( 'That works for me' );
+
+translate( 'Customize your domain' );
+translate( 'Customize your domain name' );

--- a/client/my-sites/customer-home/translations/domain-upsell.js
+++ b/client/my-sites/customer-home/translations/domain-upsell.js
@@ -29,6 +29,3 @@ translate(
 );
 translate( 'I want my domain as primary' );
 translate( 'That works for me' );
-
-translate( 'Customize your domain' );
-translate( 'Customize your domain name' );


### PR DESCRIPTION
#### Proposed Changes

These are preemptive translations for strings on our design to be used on the Site Preview Domain Upsell.
Slack: pb5gDS-2sr-p2

<img width="1154" alt="image" src="https://user-images.githubusercontent.com/402286/214125620-00e74f07-1d30-4923-9881-482195b03430.png">

#### Acceptance criteria
- [ ] Send `Customize your domain` for translation.
- [ ] Send `Customize your domain name` for translation.
- [ ] Add String Freeze label

#### Testing instructions
This code is never executed.

Fixes https://github.com/Automattic/wp-calypso/issues/72090