### PR TITLE
Copy Site: use `exitFlow` in domains step back button

### DIFF
--- a/client/landing/stepper/declarative-flow/copy-site.tsx
+++ b/client/landing/stepper/declarative-flow/copy-site.tsx
@@ -77,9 +77,6 @@ const copySite: Flow = {
 
 			switch ( _currentStepSlug ) {
 				case 'domains': {
-					if ( providedDependencies.previousStep === true ) {
-						return window.location.assign( `/sites` );
-					}
 					return navigate( 'site-creation-step' );
 				}
 
@@ -133,7 +130,11 @@ const copySite: Flow = {
 			navigate( step );
 		};
 
-		return { goNext, goBack, goToStep, submit };
+		const exitFlow = ( location: string ) => {
+			window.location.assign( location );
+		};
+
+		return { goNext, goBack, goToStep, submit, exitFlow };
 	},
 };
 

--- a/client/landing/stepper/declarative-flow/copy-site.tsx
+++ b/client/landing/stepper/declarative-flow/copy-site.tsx
@@ -130,7 +130,7 @@ const copySite: Flow = {
 			navigate( step );
 		};
 
-		const exitFlow = ( location: string ) => {
+		const exitFlow = ( location = '/sites' ) => {
 			window.location.assign( location );
 		};
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
@@ -76,7 +76,7 @@ const DomainsStep: Step = function DomainsStep( { navigation, flow } ) {
 
 	const dispatch = useReduxDispatch();
 
-	const { submit } = navigation;
+	const { submit, exitFlow } = navigation;
 	const path = '/start/link-in-bio/domains?new=test';
 	let showExampleSuggestions: boolean | undefined = undefined;
 	let includeWordPressDotCom: boolean | undefined = undefined;
@@ -473,7 +473,7 @@ const DomainsStep: Step = function DomainsStep( { navigation, flow } ) {
 				</div>
 			}
 			recordTracksEvent={ recordTracksEvent }
-			goBack={ () => submit?.( { previousStep: true } ) }
+			goBack={ () => exitFlow?.( '/sites' ) }
 			goNext={ () => submit?.() }
 			formattedHeader={
 				<FormattedHeader

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
@@ -465,7 +465,7 @@ const DomainsStep: Step = function DomainsStep( { navigation, flow } ) {
 			shouldStickyNavButtons={ isCopySiteFlow( flow ) }
 			hideBack={ ! isCopySiteFlow( flow ) }
 			hideSkip={ true }
-			flowName="linkInBio"
+			flowName={ isCopySiteFlow( flow ) ? ( flow as string ) : 'linkInBio' }
 			stepContent={
 				<div className="domains__content">
 					{ isEmpty( productsList ) && <QueryProductsList /> }


### PR DESCRIPTION
#### Proposed Changes

* Use `exitFlow` instead of submit in Copy Site - Domains step.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check https://github.com/Automattic/wp-calypso/pull/72327

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

- Related to https://github.com/Automattic/dotcom-forge/issues/1519
