### PR TITLE
Marketplace Themes: Adds the Premium badge

### DIFF
--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -514,6 +514,7 @@ export class Theme extends Component {
 			hasPremiumThemesFeature,
 			isPremiumTheme,
 			didPurchaseTheme,
+			isExternallyManagedTheme,
 		} = this.props;
 		const { name, description, screenshot, style_variations = [] } = theme;
 		const isNewCardsOnly = isEnabled( 'themes/showcase-i4/cards-only' );
@@ -525,7 +526,7 @@ export class Theme extends Component {
 		} );
 
 		const themeNeedsPurchase = isPremiumTheme && ! hasPremiumThemesFeature && ! didPurchaseTheme;
-		const showUpsell = upsellUrl && isPremiumTheme && ! active;
+		const showUpsell = upsellUrl && ( isPremiumTheme || isExternallyManagedTheme ) && ! active;
 		const priceClass = classNames( 'theme__badge-price', {
 			'theme__badge-price-upgrade': ! themeNeedsPurchase,
 			'theme__badge-price-upsell': showUpsell,


### PR DESCRIPTION
#### Proposed Changes

* Adds the Premium badge for Marketplace themes on the Theme Showcase.

<img width="550" alt="Screen Shot 2023-01-23 at 17 06 42" src="https://user-images.githubusercontent.com/1234758/214139072-5b60ea01-bf87-470c-b4fe-94e3d0cdf94a.png">

#### Testing Instructions

* Navigate to `/themes/{YOU-SITE}?s=Makoney`
* The theme card should contain the Premium badge

Closes #72201
