### PR TITLE
Free Flow: Hide progress bar on account page

### DIFF
--- a/client/signup/signup-header/style.scss
+++ b/client/signup/signup-header/style.scss
@@ -22,7 +22,8 @@
 	.newsletter.progress-bar,
 	.link-in-bio.progress-bar,
 	.link-in-bio-tld.progress-bar,
-	.import.progress-bar {
+	.import.progress-bar,
+	.free.progress-bar {
 		position: absolute;
 		top: -8px;
 		background-color: #fff;


### PR DESCRIPTION
### Proposed Changes

Resolves: https://github.com/Automattic/wp-calypso/issues/72428

We noticed after launching Free Flow last week that there is a stray progress bar on the top of the account page for non-logged-in users. Looks like below. This PR removes that via some CSS. Looks like this had already been removed for other tailored flows, but not for Free Flow. 

<img width="1510" alt="progress-bar" src="https://user-images.githubusercontent.com/21228350/214141831-3b599e4e-1aab-4ed6-8225-62ed92e9fc9f.png">

### Testing Instructions

**Testing Time: Short**
**Reviewing Time: Short**

1. Log out of WordPress.com
2. Confirm you can see the issue. Go to `https://wordpress.com/setup/free/intro?ref=logged-out-homepage-lp`, click the Get Started button which should take you to the account page, and confirm you see the gray bar across the top. 
3. Checkout this branch locally and run yarn and yarn start if needed. 
4. From the same account page you are viewing in step 2, simply replace `worpress.com` with `calypso.localhost:3000`. Confirm that the gray progress bar no longer shows. 

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->