### PR TITLE
[HACK] Checkout: Prevent multiple replacements of 'log-in' to 'log-in/jetpack' in redirect

### DIFF
--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -217,8 +217,8 @@ export function redirectJetpack( context, next ) {
 	// 2023-01-23: For some reason (yet unknown), the path replacement below
 	// is happening twice. Until we determine and fix the root cause, this
 	// guard exists to stop it from happening.
-	const isJetpackLogin = context.path.includes( 'log-in/jetpack' );
-	if ( isJetpackLogin ) {
+	const pathAlreadyUpdated = context.path.includes( 'log-in/jetpack' );
+	if ( pathAlreadyUpdated ) {
 		next();
 		return;
 	}

--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -204,6 +204,7 @@ export function redirectJetpack( context, next ) {
 		redirect_to?.includes( 'source=jetpack-plans' ) ||
 		redirect_to?.includes( 'source=jetpack-connect-plans' );
 	const isUserComingFromMigrationPlugin = redirect_to?.includes( 'jetpack-migration' );
+
 	/**
 	 * Send arrivals from the jetpack connect process or jetpack's pricing page
 	 * (when site user email matches a wpcom account) to the jetpack branded login.
@@ -212,6 +213,16 @@ export function redirectJetpack( context, next ) {
 	 * because the iOS app relies on seeing a request to /log-in$ to show its
 	 * native credentials form.
 	 */
+
+	// 2023-01-23: For some reason (yet unknown), the path replacement below
+	// is happening twice. Until we determine and fix the root cause, this
+	// guard exists to stop it from happening.
+	const isJetpackLogin = context.path.includes( 'log-in/jetpack' );
+	if ( isJetpackLogin ) {
+		next();
+		return;
+	}
+
 	if (
 		( isJetpack !== 'jetpack' &&
 			redirect_to?.includes( 'jetpack/connect' ) &&

--- a/client/login/test/controller.js
+++ b/client/login/test/controller.js
@@ -1,0 +1,20 @@
+import { redirectJetpack } from '../controller';
+
+describe( 'redirectJetpack', () => {
+	it( "does not append 'jetpack' to the login path and redirect if it's already present", () => {
+		const context = {
+			path: '/log-in/jetpack',
+			params: { isJetpack: 'test string, not important' },
+			query: { redirect_to: 'source=jetpack-plans' },
+			redirect: ( path ) => {
+				throw new Error( `Browser redirected to unexpected path '${ path }'` );
+			},
+		};
+		const next = jest.fn();
+
+		redirectJetpack( context, next );
+
+		// If a redirect didn't occur, the test passes
+		expect( next ).toHaveBeenCalled();
+	} );
+} );


### PR DESCRIPTION
If a visitor with an existing WordPress.com account attempts to purchase a Jetpack product while not logged in, then attempts to log in at checkout, they're redirected to a 404 error page. This pull request adds a temporary guard condition to prevent an incorrect change to the login path, thereby allowing the visitor to log in and proceed with checkout.

Resolves `p1HpG7-ken-p2`, #72407.

#### Proposed Changes

* Add a guard statement that detects if `/log-in` has already been replaced with `/log-in/jetpack`.

#### Testing Instructions

_(Automatticians see `p1HpG7-ken-p2`.)_

##### Existing (unwanted) behavior

0. Ensure you are not logged into an account on https://cloud.jetpack.com.
1. Visit https://cloud.jetpack.com/pricing.
2. Choose any product (except CRM) and click the button to buy it.
3. At checkout, enter your existing WordPress.com account email under "Enter your billing information."
4. An error will appear below the input. Click the "please log in" link in the error text.
5. Observe that the browser goes to a 404 error page: "Uh oh. Page not found."

##### New (fixed) behavior

- Execute steps 0-4 from the above example.
- Observe that the browser goes to a Jetpack-branded login page.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203811299247304