### PR TITLE
Fix wp-desktop-linux in CircleCi

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -234,7 +234,7 @@ jobs:
 
   wp-desktop-linux:
     docker:
-      - image: cimg/node:18.13.0-browsers
+      - image: cimg/node:18.0.0-browsers
     <<: *desktop_defaults
     shell: /bin/bash --login
     environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -234,7 +234,7 @@ jobs:
 
   wp-desktop-linux:
     docker:
-      - image: cimg/node:18.0.0-browsers
+      - image: cimg/node:18.12.0-browsers
     <<: *desktop_defaults
     shell: /bin/bash --login
     environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,7 +145,6 @@ jobs:
       - checkout
       - attach_workspace:
           at: ~/wp-calypso
-      - run: *update-node
       - when:
           condition: << pipeline.git.tag >>
           steps:
@@ -245,14 +244,17 @@ jobs:
       - checkout
       - attach_workspace:
           at: ~/wp-calypso
-      - run: *update-node
       - run:
           name: Install Linux deps
           command: |
             sudo apt update
             sudo apt-get install -y libsecret-1-dev
       - restore_cache: *restore-yarn-cache
-      - run: *yarn-install
+      # Since Node and Yarn are both bundled in the image, no need to add nvm and
+      # yarn ourselves. So we run the command directly here.
+      - run:
+          name: Yarn Install
+          command: yarn install --immutable --inline-builds
       - save_cache: *save-yarn-cache
       - run:
           name: Build Desktop Linux
@@ -261,8 +263,6 @@ jobs:
             USE_HARD_LINKS: 'false'
           command: |
             set +e
-            source $HOME/.nvm/nvm.sh
-            nvm use
 
             # Build all artifacts only when project config changes.
             # Otherwise only build application executable required for end-to-end testing.
@@ -273,10 +273,8 @@ jobs:
       - run:
           name: e2e Tests
           command: |
-            source $HOME/.nvm/nvm.sh
-            nvm use
-            npm install -g yarn
-
+            node --version
+            yarn --version
             cd desktop && yarn run test:e2e
       - run:
           when: always

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -234,7 +234,9 @@ jobs:
 
   wp-desktop-linux:
     docker:
-      - image: cimg/node:18.12.0-browsers
+    # Important: the build fails on 18.13.0, so we pin it to a slightly older
+    # version to keep this one working for now.
+      - image: cimg/node:18.7.0-browsers
     <<: *desktop_defaults
     shell: /bin/bash --login
     environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -236,7 +236,7 @@ jobs:
     docker:
     # Important: the build fails on 18.13.0, so we pin it to a slightly older
     # version to keep this one working for now.
-      - image: cimg/node:18.7.0-browsers
+      - image: cimg/node:18.10.0-browsers
     <<: *desktop_defaults
     shell: /bin/bash --login
     environment:


### PR DESCRIPTION
#### Proposed Changes

After the Node 18 update, the wp-desktop build in CircleCi has been failing. I don't know what the root cause is, but here are some interesting things:
1. The TeamCity build works fine. It's just CircleCI that's failing.
2. Node on other environments, like Windows, is working. It's just the linux desktop app.
3. wp-desktop-linux uses `nvm use` and `npm install yarn -g` despite node and yarn being installed by the docker image. (so we can remove those steps to simplify)
4. The linux desktop build fails on Node 18.13.0 and 18.12.0, but passes on 18.0.0.

Result is that at least 18.12.0 and newer is failing, whereas 18.10.0 and older is passing. I did not test 18.11, but just keeping it at 18.10 now that we found a relatively new version. This is only used in a CI system, unlike the Calypso server which is deployed to prod. So it's less important to have the latest updates in this CI system.

#### Testing Instructions
wp-desktop-linux should pass (eventually)
