### PR TITLE
Checkout: Add VAT fields to domain contact fields

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/domain-contact-details.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/domain-contact-details.tsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { useShoppingCart } from '@automattic/shopping-cart';
 import { useTranslate } from 'i18n-calypso';
 import { Fragment } from 'react';
@@ -10,6 +11,7 @@ import {
 } from 'calypso/lib/cart-values/cart-items';
 import { getTopLevelOfTld } from 'calypso/lib/domains';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
+import { VatForm, isVatSupportedFor } from './vat-form';
 import type { DomainContactDetails as DomainContactDetailsData } from '@automattic/shopping-cart';
 import type { DomainContactDetailsErrors } from '@automattic/wpcom-checkout';
 
@@ -42,6 +44,10 @@ export default function DomainContactDetails( {
 	const getIsFieldDisabled = () => isDisabled;
 	const needsAlternateEmailForGSuite = needsOnlyGoogleAppsDetails;
 	const tlds = getAllTopLevelTlds( domainNames );
+
+	const isVatSupported =
+		config.isEnabled( 'checkout/vat-form' ) &&
+		Boolean( contactDetails.countryCode && isVatSupportedFor( contactDetails.countryCode ) );
 
 	return (
 		<Fragment>
@@ -97,6 +103,13 @@ export default function DomainContactDetails( {
 					getDomainNames={ () => domainNames }
 					translate={ translate }
 					isManaged={ true }
+				/>
+			) }
+			{ isVatSupported && (
+				<VatForm
+					section="domain-contact-form"
+					isDisabled={ isDisabled }
+					countryCode={ contactDetails.countryCode }
 				/>
 			) }
 		</Fragment>


### PR DESCRIPTION
#### Proposed Changes

This PR builds on the foundation established by https://github.com/Automattic/wp-calypso/pull/71285. That PR created a new VAT details form for use inside checkout (as opposed to the one available at `/me/purchases/vat-details`), but it only displayed it for the "tax" version of the first checkout step; this is the step that will be displayed when making a purchase without a domain or Google Workspace.

In this PR, we add the VAT form to checkout when a domain or Google Workspace is in the cart as well.

**Currently this new field will not be visible in production as it is behind a feature flag.**

Note: There are certain ccTLD domains (eg: `.fr`) which already ask for VAT info in the domain step. That information is used for the registrar and not for taxes. The fields added by this PR will be used for taxes and are totally separate, but this repetition may cause user confusion. 🤷  I can't think of an easy way around that right now.

Part of https://github.com/Automattic/payments-shilling/issues/1278

#### Screenshots

<img width="572" alt="domain-vat-unchecked" src="https://user-images.githubusercontent.com/2036909/214173857-8837fb19-4b51-47a2-947f-0d9fad2fbb47.png">

<img width="570" alt="domain-vat-checked" src="https://user-images.githubusercontent.com/2036909/214173867-3acfa39b-0ee7-4162-93ab-334f218cd9b4.png">

<img width="565" alt="domain-vat-uk" src="https://user-images.githubusercontent.com/2036909/214173880-14e3c6b7-8595-4143-b96d-8a8dd2c786fd.png">

#### Testing Instructions

##### Testing normal behavior

- On this branch, add a domain, product to your cart and visit checkout.
- If the checkout contact/billing details step is automatically completed, click the "Edit" button to make it active.
- Select a non-VAT country like "United States" in the country field.
- Verify that neither the VAT fields nor the VAT checkbox are visible.
- Click to continue past the step and verify that no VAT errors occur.

##### Testing that the fields work

- Click to edit the step again.
- Select a VAT country like "United Kingdom" in the country field and a valid postal code number like `NW1 4NP`.
- Verify that you see the VAT checkbox appear.
- Click the checkbox and verify that the VAT fields appear. Set the VAT Number to an invalid one like `1234` and the company name to `Test company` and click continue to complete the step.
- Verify that you see a validation error and that the step remains active.
- Change the VAT Number to a valid one like `553557881` and click continue to complete the step. (Note: this is a test number that will only work when the API is sandboxed).
- Verify that the validation is successful and that the step completes.
- Click to edit the step again.
- Verify that you can no longer edit the VAT Number.
- Visit `/me/purchases/vat-details` and verify that the form there has the same information entered in checkout.
- Return to checkout, edit the step again, and verify that the form is pre-populated with the VAT details you entered before.

##### Verifying the data is sent correctly

- Open your browser's devtools panel to monitor network traffic and look for transactions to the `/me/shopping-cart` endpoint.
- Click to complete the step and verify that the shopping-cart endpoint request includes the VAT information in its `tax` property.
- Edit the step again and uncheck the VAT checkbox, hiding the new fields.
- Click to complete the step and verify that the shopping-cart endpoint request _does not_ include the VAT information in its `tax` property.
