### PR TITLE
format-currency: Add more properties to the getCurrencyObject README

### DIFF
--- a/packages/format-currency/README.md
+++ b/packages/format-currency/README.md
@@ -27,11 +27,11 @@ Since rounding errors are common in floating point math, sometimes a price is pr
 
 `getCurrencyObject( number: number, code: string, options: FormatCurrencyOptions = {} ): CurrencyObject`
 
-Returns a formatted price object.
+Returns a formatted price object. See below for the details of that object's properties.
 
 The currency will define the properties to use for this formatting, but those properties can be overridden using the options. Be careful when doing this.
 
-For currencies that include decimals, this will always return the amount with decimals included, even if those decimals are zeros. To exclude the zeros, use the `stripZeros` option. For example, the function will normally format `10.00` in `USD` as `$10.00` but when this option is true, it will return `$10` instead.
+For currencies that include decimals, this will always return the amount with decimals included, even if those decimals are zeros. To exclude the zeros, use the `stripZeros` option. For example, the function will normally format `10.00` in `USD` as `$10.00` but when this option is true, it will return `$10` instead. Alternatively, you can use the `hasNonZeroFraction` return value to decide if the decimal section should be displayed.
 
 Since rounding errors are common in floating point math, sometimes a price is provided as an integer in the smallest unit of a currency (eg: cents in USD or yen in JPY). Set the `isSmallestUnit` to change the function to operate on integer numbers instead. If this option is not set or false, the function will format the amount `1025` in `USD` as `$1,025.00`, but when the option is true, it will return `$10.25` instead.
 
@@ -39,7 +39,7 @@ Since rounding errors are common in floating point math, sometimes a price is pr
 
 `setDefaultLocale( locale: string ): void`
 
-A function that can be used to set a default locale for use by `formatCurrency` and `getCurrencyObject`. Note that this is global and will override any browser locale that is set! Use it with care.
+A function that can be used to set a default locale for use by `formatCurrency()` and `getCurrencyObject()`. Note that this is global and will override any browser locale that is set! Use it with care.
 
 ## FormatCurrencyOptions
 
@@ -51,9 +51,9 @@ The number of decimal places to display.
 
 Will be set automatically by the currency code.
 
-## `locale?: string`
+### `locale?: string`
 
-The locale to use for the formatting. Defaults to using the browser's current locale.
+The locale to use for the formatting. Defaults to using the browser's current locale unless `setDefaultLocale()` has been called.
 
 ### `stripZeros?: boolean`
 
@@ -88,3 +88,11 @@ The integer part of a decimal currency. Note that this is not a number, but a lo
 ### `fraction: string`
 
 The decimal part of a decimal currency. Note that this is not a number, but a locale-formatted string that includes the decimal separator that may be a comma or a period.
+
+### `symbolPosition: 'before' | 'after'`
+
+The position of the currency symbol relative to the numeric price. If this is `'before'`, the symbol should be placed before the price like `US $ 10`; if this is `'after'`, the symbol should be placed after the price like `10 US $`.
+
+### `hasNonZeroFraction: boolean`
+
+True if the price has a decimal part and that decimal's value is greater than zero. This can be useful to mimic the `stripZeros` option behavior (hiding decimal places if the decimal is zero) without having to specify that option.


### PR DESCRIPTION
#### Proposed Changes

This PR improves the documentation for the `getCurrencyObject` function in the `@automattic/format-currency` package by listing some options that had been recently added: `symbolPosition` and `hasNonZeroFraction`.

#### Testing Instructions

None should be needed. This is a documentation change only.