### PR TITLE
E2E: use `getByRole` selector when starting new page.

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/pages-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/pages-page.ts
@@ -1,10 +1,6 @@
 import { Page, Response } from 'playwright';
 import { getCalypsoURL } from '../../data-helper';
 
-const selectors = {
-	addNewPageButton: 'a:has-text("Add new page")',
-};
-
 /**
  * Represents the Pages page
  */
@@ -34,7 +30,9 @@ export class PagesPage {
 	 * Start a new page using the 'Add new page' button.
 	 */
 	async addNewPage(): Promise< void > {
-		const locator = this.page.locator( selectors.addNewPageButton );
-		await locator.click();
+		await Promise.all( [
+			this.page.waitForNavigation(),
+			this.page.getByRole( 'link', { name: /(Add new|Start a) page/ } ).click(),
+		] );
 	}
 }


### PR DESCRIPTION
#### Proposed Changes

This PR updates the `PagesPage.addNewPage` to use a regex to match the `locator.getByRole` call.

Key changes:
- use `getByRole` locator combined with regex.

#### Testing Instructions

Ensure the following build configurations are passing:
  - [x] Gutenberg simple E2E production (desktop)
  - [x] Calypso E2E (desktop)

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #72461.
