### PR TITLE
Copy Site: Tweak domains subheading

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
@@ -205,7 +205,7 @@ const DomainsStep: Step = function DomainsStep( { navigation, flow } ) {
 					decideLaterComponent
 				);
 			case COPY_SITE_FLOW:
-				return __( 'Help your freshly copied site stand out with a custom domain.' );
+				return __( 'Make your copied site unique with a custom domain all of its own.' );
 			default:
 				return createInterpolateElement(
 					__(


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/1533

## Proposed Changes

Tweaks the domains subheading:

<img width="1285" alt="image" src="https://user-images.githubusercontent.com/36432/214176928-7686c955-b2fe-46b2-bae1-bc81f38e6eb2.png">


## Testing Instructions

1. Click 'Copy site'.
2. View the new subheading.