### PR TITLE
Revert: Launchpad notice in calypso sidebar

### DIFF
--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -52,25 +52,6 @@ export class SiteNotice extends Component {
 		);
 	}
 
-	getLaunchpadNotice() {
-		const { site, translate } = this.props;
-
-		return (
-			<UpsellNudge
-				callToAction={ translate( 'Next Steps' ) }
-				className="current-site__launchpad-notice"
-				compact
-				dismissPreferenceName=""
-				dismissTemporary={ true }
-				forceHref={ true }
-				forceDisplay={ true }
-				href={ `/setup/${ site.options.site_intent }/launchpad?siteSlug=${ site.slug }` }
-				primaryButton={ false }
-				title={ translate( 'Keep setting up your site' ) }
-			/>
-		);
-	}
-
 	activeDiscountNotice() {
 		if ( ! this.props.activeDiscount ) {
 			return null;
@@ -120,34 +101,22 @@ export class SiteNotice extends Component {
 
 		const discountOrFreeToPaid = this.activeDiscountNotice();
 		const siteRedirectNotice = this.getSiteRedirectNotice( site );
-		const LaunchpadNotice = this.getLaunchpadNotice();
 
 		const showJitms =
 			! this.props.isSiteWPForTeams && ( discountOrFreeToPaid || config.isEnabled( 'jitms' ) );
 
-		const showLaunchpadNotice = site.options?.launchpad_screen === 'full';
-		let SidebarNotice = null;
-
-		if ( showJitms ) {
-			if ( showLaunchpadNotice ) {
-				SidebarNotice = LaunchpadNotice;
-			} else {
-				SidebarNotice = (
+		return (
+			<div className="current-site__notices">
+				<QueryActivePromotions />
+				{ siteRedirectNotice }
+				{ showJitms && (
 					<AsyncLoad
 						require="calypso/blocks/jitm"
 						placeholder={ null }
 						messagePath="calypso:sites:sidebar_notice"
 						template="sidebar-banner"
 					/>
-				);
-			}
-		}
-
-		return (
-			<div className="current-site__notices">
-				<QueryActivePromotions />
-				{ siteRedirectNotice }
-				{ SidebarNotice }
+				) }
 				<QuerySitePlans siteId={ site.ID } />
 			</div>
 		);

--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -1,6 +1,6 @@
 import config from '@automattic/calypso-config';
 import { getUrlParts } from '@automattic/calypso-url';
-import i18n, { localize } from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 import moment from 'moment';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
@@ -125,12 +125,7 @@ export class SiteNotice extends Component {
 		const showJitms =
 			! this.props.isSiteWPForTeams && ( discountOrFreeToPaid || config.isEnabled( 'jitms' ) );
 
-		const isEnglish = config( 'english_locales' ).includes( i18n.getLocaleSlug() );
-		const hasNonenTranslation =
-			i18n.hasTranslation( 'Keep setting up your site' ) && i18n.hasTranslation( 'Next Steps' );
-		const showLaunchpadNotice =
-			site.options?.launchpad_screen === 'full' && ( isEnglish || hasNonenTranslation );
-
+		const showLaunchpadNotice = site.options?.launchpad_screen === 'full';
 		let SidebarNotice = null;
 
 		if ( showJitms ) {

--- a/client/my-sites/current-site/style.scss
+++ b/client/my-sites/current-site/style.scss
@@ -119,9 +119,3 @@
 .sidebar .current-site .all-sites {
 	border-bottom: 0;
 }
-
-.current-site__launchpad-notice {
-	button {
-		background-color: var(--color-primary);
-	}
-}


### PR DESCRIPTION
#### Estimated Time to Test / Review:
- Test -> Short
- Review -> Short / Med

### Proposed Changes

* https://github.com/Automattic/wp-calypso/pull/70325 Added a Launchpad notice to the Calypso sidebar, which we'd like to roll back.
* https://github.com/Automattic/wp-calypso/pull/70399 Built on top of the aforementioned PR, handling fallbacks for non-existent notice translations.
* In this PR, we revert https://github.com/Automattic/wp-calypso/pull/70399 (because the bug fix is for a feature we're removing) and then https://github.com/Automattic/wp-calypso/pull/70325 (the feature we want to remove).

**NOTE**
I'm happy to split this up into two separate reverts if it makes it easier for folks to code review

### Screenshots
#### Before

![Screen Shot 2022-11-23 at 11 18 05 AM copy](https://user-images.githubusercontent.com/5414230/203629797-a29b0fa2-3b9e-4fd6-b6e9-22d095bafa8a.jpg)

#### After

![2023-01-23 17 05 02](https://user-images.githubusercontent.com/5414230/214192048-9bafed3b-146e-457c-b4b2-26648087f25f.gif)

### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a launchpad enabled site ( calypso.localhost:3000/setup/newsletter/intro or calypso.localhost:3000/setup/link-in-bio/intro ) or use an existing one
* **_Don't_** complete any launchpad tasks
* Click on the "Go to admin" button
* Verify that the notice loaded in the sidebar makes no mention of "Next Steps" or the Launchpad
* Return to the Launchpad
* Complete all tasks
* When redirected back to Calypso admin, verify that the notice is still **_not_** related to Launchpad

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/72430
