### PR TITLE
Blaze: /stats Move the launch your site banner to the mini-carousel

### DIFF
--- a/client/my-sites/stats/mini-carousel/index.jsx
+++ b/client/my-sites/stats/mini-carousel/index.jsx
@@ -2,6 +2,7 @@ import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { translate } from 'i18n-calypso';
 import { useEffect, useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
+import rocketImage from 'calypso/assets/images/customer-home/illustration--rocket.svg';
 import YoastLogo from 'calypso/assets/images/icons/yoast-logo.svg';
 import writePost from 'calypso/assets/images/onboarding/site-options.svg';
 import BlazeLogo from 'calypso/components/blaze-logo';
@@ -22,6 +23,9 @@ const EVENT_TRAFFIC_BLAZE_PROMO_DISMISS = 'calypso_stats_traffic_blaze_banner_di
 const EVENT_YOAST_PROMO_VIEW = 'calypso_stats_wordpress_seo_premium_banner_view';
 const EVENT_YOAST_PROMO_CLICK = 'calypso_stats_wordpress_seo_premium_banner_click';
 const EVENT_YOAST_PROMO_DISMISS = 'calypso_stats_wordpress_seo_premium_banner_dismiss';
+const EVENT_PRIVATE_SITE_BANNER_VIEW = 'calypso_stats_private_site_banner_view';
+const EVENT_PRIVATE_SITE_BANNER_CLICK = 'calypso_stats_private_site_banner_click';
+const EVENT_PRIVATE_SITE_BANNER_DISMISS = 'calypso_stats_private_site_banner_dismiss';
 const EVENT_NO_CONTENT_BANNER_VIEW = 'calypso_stats_no_content_banner_view';
 const EVENT_NO_CONTENT_BANNER_CLICK = 'calypso_stats_no_content_banner_click';
 const EVENT_NO_CONTENT_BANNER_DISMISS = 'calypso_stats_no_content_banner_dismiss';
@@ -44,6 +48,10 @@ const MiniCarousel = ( { slug, isOdysseyStats, isSitePrivate } ) => {
 
 	const shouldShowAdvertisingOption = usePromoteWidget() === PromoteWidgetStatus.ENABLED;
 
+	// Private site banner.
+	const showPrivateSiteBanner =
+		! useSelector( isBlockDismissed( EVENT_PRIVATE_SITE_BANNER_DISMISS ) ) && isSitePrivate;
+
 	// Write a Post banner.
 	const showWriteAPostBanner =
 		! useSelector( isBlockDismissed( EVENT_NO_CONTENT_BANNER_DISMISS ) ) &&
@@ -65,11 +73,12 @@ const MiniCarousel = ( { slug, isOdysseyStats, isSitePrivate } ) => {
 
 	const viewEvents = useMemo( () => {
 		const events = [];
+		isSitePrivate && events.push( EVENT_PRIVATE_SITE_BANNER_VIEW );
 		showWriteAPostBanner && events.push( EVENT_NO_CONTENT_BANNER_VIEW );
 		showBlazePromo && events.push( EVENT_TRAFFIC_BLAZE_PROMO_VIEW );
 		showYoastPromo && events.push( EVENT_YOAST_PROMO_VIEW );
 		return events;
-	}, [ showWriteAPostBanner, showBlazePromo, showYoastPromo ] );
+	}, [ isSitePrivate, showWriteAPostBanner, showBlazePromo, showYoastPromo ] );
 
 	// Handle view events upon initial mount and upon paging DotPager.
 	useEffect( () => {
@@ -86,6 +95,23 @@ const MiniCarousel = ( { slug, isOdysseyStats, isSitePrivate } ) => {
 	const pagerDidSelectPage = ( index ) => setDotPagerIndex( index );
 
 	const blocks = [];
+
+	if ( showPrivateSiteBanner ) {
+		blocks.push(
+			<MiniCarouselBlock
+				clickEvent={ EVENT_PRIVATE_SITE_BANNER_CLICK }
+				dismissEvent={ EVENT_PRIVATE_SITE_BANNER_DISMISS }
+				image={ <img src={ rocketImage } alt="" width={ 45 } height={ 45 } /> }
+				headerText={ translate( 'Launch your site to drive more visitors' ) }
+				contentText={ translate(
+					'Changing your site from private to public helps people find you and get more visitors. Don’t worry, you can keep working on your site.'
+				) }
+				ctaText={ translate( 'Launch your site' ) }
+				href={ `/settings/general/${ slug }` }
+				key="launch-your-site"
+			/>
+		);
+	}
 
 	if ( showWriteAPostBanner ) {
 		blocks.push(

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -10,12 +10,10 @@ import { parse as parseQs, stringify as stringifyQs } from 'qs';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import titlecase from 'to-title-case';
-import rocketImage from 'calypso/assets/images/customer-home/illustration--rocket.svg';
 import illustration404 from 'calypso/assets/images/illustrations/illustration-404.svg';
 import JetpackBackupCredsBanner from 'calypso/blocks/jetpack-backup-creds-banner';
 import StatsNavigation from 'calypso/blocks/stats-navigation';
 import Intervals from 'calypso/blocks/stats-navigation/intervals';
-import Banner from 'calypso/components/banner';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryJetpackModules from 'calypso/components/data/query-jetpack-modules';
 import QueryKeyringConnections from 'calypso/components/data/query-keyring-connections';
@@ -158,27 +156,6 @@ class StatsSite extends Component {
 		}
 	};
 
-	renderPrivateSiteBanner( siteId, siteSlug ) {
-		return (
-			<Banner
-				callToAction={ translate( 'Launch your site' ) }
-				className="stats__private-site-banner"
-				description={ translate(
-					'Changing your site from private to public helps people find you and get more visitors. Don’t worry, you can keep working on your site.'
-				) }
-				disableCircle={ true }
-				event="calypso_stats_private_site_banner"
-				dismissPreferenceName={ `stats-launch-private-site-${ siteId }` }
-				href={ `/settings/general/${ siteSlug }` }
-				iconPath={ rocketImage }
-				title={ translate( 'Launch your site to drive more visitors' ) }
-				tracksClickName="calypso_stats_private_site_banner_click"
-				tracksDismissName="calypso_stats_private_site_banner_dismiss"
-				tracksImpressionName="calypso_stats_private_site_banner_view"
-			/>
-		);
-	}
-
 	renderStats() {
 		const { date, siteId, slug, isJetpack, isSitePrivate, isOdysseyStats, context } = this.props;
 
@@ -273,8 +250,6 @@ class StatsSite extends Component {
 							period={ this.props.period }
 							chartTab={ this.props.chartTab }
 						/>
-
-						{ isSitePrivate ? this.renderPrivateSiteBanner( siteId, slug ) : null }
 					</>
 
 					<MiniCarousel


### PR DESCRIPTION
#### Proposed Changes

We moved the `Launch your site` banner inside the mini-carousel as first banner.

#### Acceptance criteria
- [x] Add the `Launch your site` banner to the mini-carousel before Blaze banner
- [x] Remove the banner outside the mini-carousel
- [x] Add view / click / dismiss track events like before.

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/402286/214188592-e0144b49-6ec4-430e-b5e1-555f72951490.png) | <img width="1334" alt="image" src="https://user-images.githubusercontent.com/402286/214189467-ae80ea0e-d54e-4c4e-b1f7-cb7c492a4500.png"> |

#### Testing Instructions

- Go to `/stats`, on a private site.
- You should see the `Launch your site` first on the mini-carousel
- You should not show up before the carousel
- Check track events ( `calypso_stats_private_site_banner_dismiss` / `calypso_stats_private_site_banner_click` / `calypso_stats_private_site_banner_view` )

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] ~~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~~
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~~
- [ ] ~~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~~
- [ ] ~~For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~~
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/1544
