### PR TITLE
Update git ignore revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,3 +1,5 @@
+# Prettier format in #29931
+63917e91dd65dc95273759a786cb706b05d9f89e
 # Prettier format in #18282
 b855b7a8a7e9f6a24e4fc87e8fe251cfd10603fd
 # Prettier format in #41114
@@ -10,3 +12,5 @@ b855b7a8a7e9f6a24e4fc87e8fe251cfd10603fd
 b7a4a072ae2a13785fb6ccbf9c34ed8e65739705
 # Eslint format in #72303
 fb0aab8f67a8738d25d5426343df8599935cdd29
+# Eslint format in #72348
+a14b6727ffc1ed68b951c95f8a43ca6e1cb15ccc


### PR DESCRIPTION
Update ignore revs file with recent formats. I also included an older format I noticed while trying to use git blame.