### PR TITLE
Update changelog and package file for eslint plugin wpcalypso

### DIFF
--- a/packages/eslint-plugin-wpcalypso/CHANGELOG.md
+++ b/packages/eslint-plugin-wpcalypso/CHANGELOG.md
@@ -11,7 +11,7 @@
   in more rule violations which were not previously detected.
 - Breaking: Require at least NodeJS 14, since dependencies dropped support for older versions.
 - Enhancement: The `jsdoc/check-types` rule now sets `unifyParentAndChildTypeChecks`
-  to true to enforce preferredTypes on unions as well (e.g. `{string | Object}`).
+  to true to enforce `preferredTypes` on unions as well (e.g. `{string | Object}`).
 
 #### v6.1.0 (2022-08-24)
 

--- a/packages/eslint-plugin-wpcalypso/CHANGELOG.md
+++ b/packages/eslint-plugin-wpcalypso/CHANGELOG.md
@@ -1,10 +1,17 @@
 #### Unreleased
 
-#### Breaking change
+#### v7.0.0 (2022-01-24)
 
-- For jsdoc types `array` and `object`, prefer capitalized variants to match the
-  WordPress coding style. Violations are autofixable.
-- Updated peer dependency requirement `eslint-plugin-jsdoc` to v39.6.7.
+- Breaking: For JSDoc types like `{object}`, prefer capitalized variants to match
+  the WordPress coding style. (Like `{Object}`.) Violations are autofixable. You
+  can override this by setting `settings.jsdoc.preferredTypes.object` to 'object'
+  in your eslint config.
+- Breaking: Updated peer dependency `eslint-plugin-jsdoc` to v39.6.7, which includes
+  fixes to some JSDoc rules like `jsdoc/require-returns-check`. This may result
+  in more rule violations which were not previously detected.
+- Breaking: Require at least NodeJS 14, since dependencies dropped support for older versions.
+- Enhancement: The `jsdoc/check-types` rule now sets `unifyParentAndChildTypeChecks`
+  to true to enforce preferredTypes on unions as well (e.g. `{string | Object}`).
 
 #### v6.1.0 (2022-08-24)
 

--- a/packages/eslint-plugin-wpcalypso/package.json
+++ b/packages/eslint-plugin-wpcalypso/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "eslint-plugin-wpcalypso",
-	"version": "6.1.0",
+	"version": "7.0.0",
 	"description": "Custom ESLint rules for the WordPress.com Calypso project.",
 	"repository": {
 		"type": "git",
@@ -21,7 +21,7 @@
 		"lib/"
 	],
 	"engines": {
-		"node": ">=10"
+		"node": ">=14"
 	},
 	"peerDependencies": {
 		"@babel/core": ">=7.17.5",


### PR DESCRIPTION
#### Proposed Changes
Updates the changelog and package.json file for `eslint-plugin-wpcalypso` to prepare for a new release. I plan to release tomorrow (hence the date), and it's a major version because it's pretty likely that installing this update will result in more rule violations which need to be fixed.

This update was requested by @anomiex to support Node 18.

These other PRs were merged beforehand to make this possible:
- https://github.com/Automattic/wp-calypso/pull/72303
- https://github.com/Automattic/wp-calypso/pull/72308
- https://github.com/Automattic/wp-calypso/pull/72348
- https://github.com/Automattic/wp-calypso/pull/72245

I only set `engines` to Node 14, because the jsdoc eslint update dropped support for older versions. So this just aligns with that for now.

#### Testing Instructions
None

