### PR TITLE
Checkout: Add vatDetails to checkout data store

### DIFF
--- a/client/me/purchases/vat-info/index.tsx
+++ b/client/me/purchases/vat-info/index.tsx
@@ -15,7 +15,8 @@ import { CALYPSO_CONTACT } from 'calypso/lib/url/support';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { errorNotice, successNotice, removeNotice } from 'calypso/state/notices/actions';
 import useVatDetails from './use-vat-details';
-import type { VatDetails, UpdateError } from './use-vat-details';
+import type { UpdateError } from './use-vat-details';
+import type { VatDetails } from '@automattic/wpcom-checkout';
 
 import './style.scss';
 

--- a/client/me/purchases/vat-info/use-vat-details.ts
+++ b/client/me/purchases/vat-info/use-vat-details.ts
@@ -1,13 +1,7 @@
 import { useCallback, useMemo } from 'react';
 import { useQuery, useMutation, useQueryClient } from 'react-query';
 import wpcom from 'calypso/lib/wp';
-
-export interface VatDetails {
-	country?: string | null;
-	id?: string | null;
-	name?: string | null;
-	address?: string | null;
-}
+import type { VatDetails } from '@automattic/wpcom-checkout';
 
 export type SetVatDetails = ( vatDetails: VatDetails ) => void;
 

--- a/client/my-sites/checkout/composite-checkout/hooks/wpcom-store.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/wpcom-store.ts
@@ -11,6 +11,7 @@ import type {
 	WpcomStoreState,
 	ManagedContactDetails,
 	ManagedContactDetailsErrors,
+	VatDetails,
 } from '@automattic/wpcom-checkout';
 
 type WpcomStoreAction =
@@ -32,7 +33,8 @@ type WpcomStoreAction =
 	| {
 			type: 'LOAD_DOMAIN_CONTACT_DETAILS_FROM_CACHE';
 			payload: PossiblyCompleteDomainContactDetails;
-	  };
+	  }
+	| { type: 'SET_VAT_DETAILS'; payload: VatDetails };
 
 export function useWpcomStore(): void {
 	// Only register once
@@ -86,6 +88,15 @@ export function useWpcomStore(): void {
 		}
 	}
 
+	function vatDetailsReducer( state: VatDetails, action: WpcomStoreAction ): VatDetails {
+		switch ( action.type ) {
+			case 'SET_VAT_DETAILS':
+				return action.payload;
+			default:
+				return state;
+		}
+	}
+
 	registerStore( 'wpcom-checkout', {
 		reducer( state: WpcomStoreState | undefined, action: WpcomStoreAction ): WpcomStoreState {
 			const checkedState =
@@ -93,6 +104,7 @@ export function useWpcomStore(): void {
 			return {
 				contactDetails: contactReducer( checkedState.contactDetails, action ),
 				recaptchaClientId: recaptchaClientIdReducer( checkedState.recaptchaClientId, action ),
+				vatDetails: vatDetailsReducer( checkedState.vatDetails, action ),
 			};
 		},
 
@@ -152,6 +164,10 @@ export function useWpcomStore(): void {
 			): WpcomStoreAction {
 				return { type: 'LOAD_DOMAIN_CONTACT_DETAILS_FROM_CACHE', payload };
 			},
+
+			setVatDetails( payload: VatDetails ): WpcomStoreAction {
+				return { type: 'SET_VAT_DETAILS', payload };
+			},
 		},
 
 		selectors: {
@@ -161,6 +177,10 @@ export function useWpcomStore(): void {
 
 			getRecaptchaClientId( state: WpcomStoreState ): number {
 				return state.recaptchaClientId;
+			},
+
+			getVatDetails( state: WpcomStoreState ): VatDetails | undefined {
+				return state.vatDetails;
 			},
 		},
 	} );

--- a/client/my-sites/checkout/composite-checkout/types/wpcom-store-state.ts
+++ b/client/my-sites/checkout/composite-checkout/types/wpcom-store-state.ts
@@ -809,5 +809,6 @@ export function getInitialWpcomStoreState(
 		recaptchaClientId: -1,
 		transactionResult: undefined,
 		contactDetails,
+		vatDetails: {},
 	};
 }

--- a/packages/wpcom-checkout/src/types.ts
+++ b/packages/wpcom-checkout/src/types.ts
@@ -313,6 +313,7 @@ export type WpcomStoreState = {
 	recaptchaClientId: number;
 	transactionResult?: WPCOMTransactionEndpointResponse | undefined;
 	contactDetails: ManagedContactDetails;
+	vatDetails: VatDetails;
 };
 
 export interface FailedPurchase {

--- a/packages/wpcom-checkout/src/types.ts
+++ b/packages/wpcom-checkout/src/types.ts
@@ -323,6 +323,13 @@ export interface FailedPurchase {
 	product_name: string;
 }
 
+export interface VatDetails {
+	country?: string | null;
+	id?: string | null;
+	name?: string | null;
+	address?: string | null;
+}
+
 /*
  * Helper type which bundles the field updaters in a single object
  * to help keep import lists under control. All updaters should


### PR DESCRIPTION
#### Proposed Changes

This PR is extracted from https://github.com/Automattic/wp-calypso/pull/71285 which adds a VAT form to checkout. This PR adds the `vatDetails` property to the state of the `'wpcom-checkout'` `@wordpress/data` store that checkout uses to manage its contact forms.

#### Testing Instructions

None should be needed as this only adds unused state. For testing its functionality, see https://github.com/Automattic/wp-calypso/pull/71285
