### PR TITLE
Shopping Cart: Add vatId/organization to cart tax data

### DIFF
--- a/packages/shopping-cart/src/cart-functions.ts
+++ b/packages/shopping-cart/src/cart-functions.ts
@@ -35,12 +35,20 @@ export function convertResponseCartToRequestCart( {
 	tax,
 }: TempResponseCart ): RequestCart {
 	let requestCartTax = null;
-	if ( tax.location.country_code || tax.location.postal_code || tax.location.subdivision_code ) {
+	if (
+		tax.location.country_code ||
+		tax.location.postal_code ||
+		tax.location.subdivision_code ||
+		tax.location.vat_id ||
+		tax.location.organization
+	) {
 		requestCartTax = {
 			location: {
 				country_code: tax.location.country_code,
 				postal_code: tax.location.postal_code,
 				subdivision_code: tax.location.subdivision_code,
+				vat_id: tax.location.vat_id,
+				organization: tax.location.organization,
 			},
 		};
 	}
@@ -108,6 +116,8 @@ export function addLocationToResponseCart(
 				country_code: location.countryCode || undefined,
 				postal_code: location.postalCode || undefined,
 				subdivision_code: location.subdivisionCode || undefined,
+				vat_id: location.vatId || undefined,
+				organization: location.organization || undefined,
 			},
 		},
 	};
@@ -121,11 +131,15 @@ export function doesCartLocationDifferFromResponseCartLocation(
 		countryCode: newCountryCode = '',
 		postalCode: newPostalCode = '',
 		subdivisionCode: newSubdivisionCode = '',
+		vatId: newVatId = '',
+		organization: newOrganization = '',
 	} = location;
 	const {
 		country_code: oldCountryCode = '',
 		postal_code: oldPostalCode = '',
 		subdivision_code: oldSubdivisionCode = '',
+		vat_id: oldVatId = '',
+		organization: oldOrganization = '',
 	} = cart.tax?.location ?? {};
 
 	if ( location.countryCode !== undefined && newCountryCode !== oldCountryCode ) {
@@ -135,6 +149,12 @@ export function doesCartLocationDifferFromResponseCartLocation(
 		return true;
 	}
 	if ( location.subdivisionCode !== undefined && newSubdivisionCode !== oldSubdivisionCode ) {
+		return true;
+	}
+	if ( location.vatId !== undefined && newVatId !== oldVatId ) {
+		return true;
+	}
+	if ( location.organization !== undefined && newOrganization !== oldOrganization ) {
 		return true;
 	}
 	return false;

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -204,6 +204,8 @@ export type RequestCartTaxData = null | {
 		country_code: string | undefined;
 		postal_code: string | undefined;
 		subdivision_code: string | undefined;
+		vat_id?: string;
+		organization?: string;
 	};
 };
 
@@ -311,6 +313,8 @@ export interface ResponseCartTaxData {
 		country_code?: string;
 		postal_code?: string;
 		subdivision_code?: string;
+		vat_id?: string;
+		organization?: string;
 	};
 	display_taxes: boolean;
 }
@@ -522,6 +526,8 @@ export interface CartLocation {
 	countryCode?: string;
 	postalCode?: string;
 	subdivisionCode?: string;
+	vatId?: string;
+	organization?: string;
 }
 
 export interface ResponseCartProductExtra {

--- a/packages/shopping-cart/test/shopping-cart-endpoint.js
+++ b/packages/shopping-cart/test/shopping-cart-endpoint.js
@@ -85,6 +85,8 @@ describe( 'addLocationToResponseCart', function () {
 			country_code: 'US',
 			postal_code: undefined,
 			subdivision_code: undefined,
+			vat_id: undefined,
+			organization: undefined,
 		} );
 	} );
 	it( 'resets existing codes not replaced', function () {
@@ -96,6 +98,8 @@ describe( 'addLocationToResponseCart', function () {
 			country_code: 'US',
 			postal_code: undefined,
 			subdivision_code: undefined,
+			vat_id: undefined,
+			organization: undefined,
 		} );
 	} );
 	it( 'adds the new location postalCode if set', function () {
@@ -104,6 +108,8 @@ describe( 'addLocationToResponseCart', function () {
 			country_code: undefined,
 			postal_code: '90210',
 			subdivision_code: undefined,
+			vat_id: undefined,
+			organization: undefined,
 		} );
 	} );
 	it( 'adds the new location subdivisionCode if set', function () {
@@ -112,6 +118,26 @@ describe( 'addLocationToResponseCart', function () {
 			country_code: undefined,
 			postal_code: undefined,
 			subdivision_code: 'CA',
+			vat_id: undefined,
+			organization: undefined,
+		} );
+	} );
+	it( 'adds the new location vatId if set', function () {
+		const result = addLocationToResponseCart( cart, { vatId: '123456' } );
+		expect( result.tax.location ).toEqual( {
+			country_code: undefined,
+			postal_code: undefined,
+			vat_id: '123456',
+			organization: undefined,
+		} );
+	} );
+	it( 'adds the new location organization if set', function () {
+		const result = addLocationToResponseCart( cart, { organization: 'Test Co.' } );
+		expect( result.tax.location ).toEqual( {
+			country_code: undefined,
+			postal_code: undefined,
+			vat_id: undefined,
+			organization: 'Test Co.',
 		} );
 	} );
 	it( 'adds all new location codes if set', function () {
@@ -119,11 +145,15 @@ describe( 'addLocationToResponseCart', function () {
 			subdivisionCode: 'CA',
 			postalCode: '90210',
 			countryCode: 'US',
+			vatId: '12345',
+			organization: 'Test Co.',
 		} );
 		expect( result.tax.location ).toEqual( {
 			country_code: 'US',
 			postal_code: '90210',
 			subdivision_code: 'CA',
+			vat_id: '12345',
+			organization: 'Test Co.',
 		} );
 	} );
 	it( 'resets all codes when no codes are set', function () {
@@ -132,7 +162,12 @@ describe( 'addLocationToResponseCart', function () {
 				...cart,
 				tax: {
 					...cart.tax,
-					location: { ...cart.tax.location, postal_code: '90210', country_code: 'US' },
+					location: {
+						...cart.tax.location,
+						postal_code: '90210',
+						country_code: 'US',
+						vat_id: '12345',
+					},
 				},
 			},
 			{}
@@ -141,6 +176,8 @@ describe( 'addLocationToResponseCart', function () {
 			country_code: undefined,
 			postal_code: undefined,
 			subdivision_code: undefined,
+			vat_id: undefined,
+			organization: undefined,
 		} );
 	} );
 } );
@@ -155,6 +192,8 @@ describe( 'doesCartLocationDifferFromResponseCartLocation', function () {
 				country_code: 'US',
 				subdivision_code: 'CA',
 				postal_code: '90210',
+				vat_id: '12345',
+				organization: 'Test Co.',
 			},
 		},
 	};
@@ -164,6 +203,8 @@ describe( 'doesCartLocationDifferFromResponseCartLocation', function () {
 			countryCode: '',
 			subdivisionCode: '',
 			postalCode: '',
+			vatId: '',
+			organization: '',
 		} );
 		expect( result ).toBe( true );
 	} );
@@ -172,6 +213,8 @@ describe( 'doesCartLocationDifferFromResponseCartLocation', function () {
 			countryCode: 'CA',
 			subdivisionCode: 'CA',
 			postalCode: '90210',
+			vatId: '12345',
+			organization: 'Test Co.',
 		} );
 		expect( result ).toBe( true );
 	} );
@@ -180,6 +223,8 @@ describe( 'doesCartLocationDifferFromResponseCartLocation', function () {
 			countryCode: 'US',
 			subdivisionCode: 'CA',
 			postalCode: '10001',
+			vatId: '12345',
+			organization: 'Test Co.',
 		} );
 		expect( result ).toBe( true );
 	} );
@@ -188,6 +233,28 @@ describe( 'doesCartLocationDifferFromResponseCartLocation', function () {
 			countryCode: 'US',
 			subdivisionCode: 'MA',
 			postalCode: '90210',
+			vatId: '12345',
+			organization: 'Test Co.',
+		} );
+		expect( result ).toBe( true );
+	} );
+	it( 'returns true if vatId differs', function () {
+		const result = doesCartLocationDifferFromResponseCartLocation( cartWithLocation, {
+			countryCode: 'US',
+			subdivisionCode: 'MA',
+			postalCode: '90210',
+			vatId: '545454',
+			organization: 'Test Co.',
+		} );
+		expect( result ).toBe( true );
+	} );
+	it( 'returns true if organization differs', function () {
+		const result = doesCartLocationDifferFromResponseCartLocation( cartWithLocation, {
+			countryCode: 'US',
+			subdivisionCode: 'MA',
+			postalCode: '90210',
+			vatId: '12345',
+			organization: 'Testers, Inc.',
 		} );
 		expect( result ).toBe( true );
 	} );
@@ -196,6 +263,8 @@ describe( 'doesCartLocationDifferFromResponseCartLocation', function () {
 			countryCode: 'US',
 			subdivisionCode: 'CA',
 			postalCode: '90210',
+			vatId: '12345',
+			organization: 'Test Co.',
 		} );
 		expect( result ).toBe( false );
 	} );
@@ -209,6 +278,8 @@ describe( 'doesCartLocationDifferFromResponseCartLocation', function () {
 						country_code: 'US',
 						subdivision_code: '',
 						postal_code: '90210',
+						vat_id: '12345',
+						organization: 'Test Co.',
 					},
 				},
 			},
@@ -216,6 +287,8 @@ describe( 'doesCartLocationDifferFromResponseCartLocation', function () {
 				countryCode: 'US',
 				subdivisionCode: '',
 				postalCode: '90210',
+				vatId: '12345',
+				organization: 'Test Co.',
 			}
 		);
 		expect( result ).toBe( false );
@@ -229,6 +302,8 @@ describe( 'doesCartLocationDifferFromResponseCartLocation', function () {
 					location: {
 						country_code: 'US',
 						postal_code: '90210',
+						vat_id: '12345',
+						organization: 'Test Co.',
 					},
 				},
 			},
@@ -236,6 +311,8 @@ describe( 'doesCartLocationDifferFromResponseCartLocation', function () {
 				countryCode: 'US',
 				subdivisionCode: '',
 				postalCode: '90210',
+				vatId: '12345',
+				organization: 'Test Co.',
 			}
 		);
 		expect( result ).toBe( false );
@@ -244,6 +321,8 @@ describe( 'doesCartLocationDifferFromResponseCartLocation', function () {
 		const result = doesCartLocationDifferFromResponseCartLocation( cartWithLocation, {
 			countryCode: 'US',
 			postalCode: '90210',
+			vatId: '12345',
+			organization: 'Test Co.',
 		} );
 		expect( result ).toBe( false );
 	} );
@@ -252,6 +331,8 @@ describe( 'doesCartLocationDifferFromResponseCartLocation', function () {
 			countryCode: undefined,
 			subdivisionCode: undefined,
 			postalCode: undefined,
+			vatId: '12345',
+			organization: 'Test Co.',
 		} );
 		expect( result ).toBe( false );
 	} );

--- a/packages/shopping-cart/test/use-shopping-cart.tsx
+++ b/packages/shopping-cart/test/use-shopping-cart.tsx
@@ -83,7 +83,7 @@ describe( 'useShoppingCart', () => {
 				);
 			};
 			render(
-				<MockProvider cartKeyOverride="asdjalkjdaldjsalkjdslka">
+				<MockProvider cartKeyOverride={ 1238798473 }>
 					<TestComponentWithKey />
 				</MockProvider>
 			);

--- a/packages/shopping-cart/test/utils/mock-components.tsx
+++ b/packages/shopping-cart/test/utils/mock-components.tsx
@@ -11,10 +11,11 @@ import type {
 	SetCart,
 	WithShoppingCartProps,
 	ShoppingCartManagerOptions,
+	CartKey,
 } from '../../src/types';
 
 export function ProductList( { initialProducts }: { initialProducts?: RequestCartProduct[] } ) {
-	const { isPendingUpdate, responseCart, addProductsToCart } = useShoppingCart();
+	const { isPendingUpdate, responseCart, addProductsToCart } = useShoppingCart( undefined );
 	useEffect( () => {
 		initialProducts && addProductsToCart( initialProducts );
 	}, [ addProductsToCart, initialProducts ] );
@@ -81,7 +82,7 @@ export function MockProvider( {
 	setCartOverride?: SetCart;
 	getCartOverride?: GetCart;
 	options?: ShoppingCartManagerOptions;
-	cartKeyOverride?: string | undefined;
+	cartKeyOverride?: CartKey;
 	useUndefinedCartKey?: boolean;
 } > ) {
 	const managerClient = createShoppingCartManagerClient( {

--- a/packages/shopping-cart/test/with-shopping-cart.tsx
+++ b/packages/shopping-cart/test/with-shopping-cart.tsx
@@ -46,7 +46,7 @@ describe( 'withShoppingCart', () => {
 		};
 
 		render(
-			<MockProvider cartKeyOverride="asjdasldjaldkjasldjsld">
+			<MockProvider cartKeyOverride={ 12317981732 }>
 				<TestComponent />
 			</MockProvider>
 		);


### PR DESCRIPTION
#### Proposed Changes

This PR is extracted from https://github.com/Automattic/wp-calypso/pull/71285 which adds a VAT form to checkout. This PR updates the `@automattic/shopping-cart` package to include optional `vatId` and `organization` properties in the tax data sent to the cart endpoint (already supported as of D96395-code).

#### Testing Instructions

Automated tests are included but this should not change any actual behavior. See https://github.com/Automattic/wp-calypso/pull/71285 for full testing instructions.