### PR TITLE
VAT Info: Fix warnings

### DIFF
--- a/client/me/purchases/vat-info/use-vat-details.ts
+++ b/client/me/purchases/vat-info/use-vat-details.ts
@@ -9,7 +9,7 @@ export interface VatDetails {
 	address?: string | null;
 }
 
-export type SetVatDetails = ( vatDetails: VatDetails ) => void;
+export type SetVatDetails = ( vatDetails: VatDetails ) => Promise< VatDetails >;
 
 export interface UpdateError {
 	message: string;
@@ -62,7 +62,7 @@ export default function useVatDetails(): VatDetailsManager {
 	}, [] );
 	const setDetails = useCallback(
 		( vatDetails: VatDetails ) => {
-			mutation.mutate( formatVatDetails( vatDetails ) );
+			return mutation.mutateAsync( formatVatDetails( vatDetails ) );
 		},
 		[ mutation, formatVatDetails ]
 	);

--- a/client/me/purchases/vat-info/use-vat-details.ts
+++ b/client/me/purchases/vat-info/use-vat-details.ts
@@ -51,10 +51,10 @@ export default function useVatDetails(): VatDetailsManager {
 		const { country, id } = data;
 
 		if ( !! id && id?.length > 1 ) {
-			const first2UppercasedChars = id.substr( 0, 2 ).toUpperCase();
+			const first2UppercasedChars = id.slice( 0, 2 ).toUpperCase();
 
 			if ( isNaN( Number( first2UppercasedChars ) ) && first2UppercasedChars === country ) {
-				return { ...data, id: id.substr( 2 ) };
+				return { ...data, id: id.slice( 2 ) };
 			}
 		}
 
@@ -64,7 +64,7 @@ export default function useVatDetails(): VatDetailsManager {
 		( vatDetails: VatDetails ) => {
 			mutation.mutate( formatVatDetails( vatDetails ) );
 		},
-		[ mutation ]
+		[ mutation, formatVatDetails ]
 	);
 
 	return useMemo(


### PR DESCRIPTION
#### Proposed Changes

This PR is extracted from https://github.com/Automattic/wp-calypso/pull/71285 which adds a VAT form to checkout. This PR updates the `useVatDetails` hook (see https://github.com/Automattic/wp-calypso/pull/53133) to fix some linter warnings about deprecated functions, a missing useCallback dependency, and fixes the return type of its setter.

#### Testing Instructions

- Visit http://calypso.localhost:3000/me/purchases/vat-details
- Enter the County code UK and the VAT number 1234.
- Submit the form.
- Verify that you receive a validation error.
- Enter the County code UK and the VAT number 553557881. (Note: this is a test number that will only work when viewing the form sandboxed).
- Submit the form.
- Verify that the validation is successful and that the details are still correct.
- Verify that you can no longer edit the VAT number or country.
- Modify the Name field.
- Submit the form.
- Verify that the name field is successfully changed.