### PR TITLE
Fix stats email top row to accommodate click stats

### DIFF
--- a/client/my-sites/stats/stats-email-top-row/index.jsx
+++ b/client/my-sites/stats/stats-email-top-row/index.jsx
@@ -17,7 +17,7 @@ export default function StatsEmailTopRow( { siteId, postId, statType, className 
 	const translate = useTranslate();
 
 	const counts = useSelector( ( state ) =>
-		getEmailStatsNormalizedData( state, siteId, postId, PERIOD_ALL_TIME, statType, null, 'rate' )
+		getEmailStatsNormalizedData( state, siteId, postId, PERIOD_ALL_TIME, statType, '', 'rate' )
 	);
 	const isRequesting = useSelector( ( state ) =>
 		isRequestingEmailStats( state, siteId, postId, PERIOD_ALL_TIME, statType )
@@ -30,13 +30,13 @@ export default function StatsEmailTopRow( { siteId, postId, statType, className 
 					<>
 						<TopCard
 							heading={ translate( 'Recipients' ) }
-							value={ counts?.total_sends }
+							value={ counts?.total_sends ?? 0 }
 							isLoading={ isRequesting && ! counts?.hasOwnProperty( 'total_sends' ) }
 							icon={ <Gridicon icon="mail" /> }
 						/>
 						<TopCard
 							heading={ translate( 'Total opens' ) }
-							value={ counts?.total_opens }
+							value={ counts?.total_opens ?? 0 }
 							isLoading={ isRequesting && ! counts?.hasOwnProperty( 'total_opens' ) }
 							icon={ <Icon icon={ eye } /> }
 						/>
@@ -52,14 +52,14 @@ export default function StatsEmailTopRow( { siteId, postId, statType, className 
 				return (
 					<>
 						<TopCard
-							heading={ translate( 'Recipients' ) }
-							value={ counts?.total_sends }
-							isLoading={ isRequesting && ! counts?.hasOwnProperty( 'total_sends' ) }
+							heading={ translate( 'Total opens' ) }
+							value={ counts?.total_sends ?? 0 }
+							isLoading={ isRequesting && ! counts?.hasOwnProperty( 'total_opens' ) }
 							icon={ <Gridicon icon="mail" /> }
 						/>
 						<TopCard
 							heading={ translate( 'Total clicks' ) }
-							value={ counts?.total_clicks }
+							value={ counts?.total_clicks ?? 0 }
 							isLoading={ isRequesting && ! counts?.hasOwnProperty( 'total_clicks' ) }
 							icon={ <Icon icon={ eye } /> }
 						/>

--- a/client/my-sites/stats/stats-email-top-row/top-card.jsx
+++ b/client/my-sites/stats/stats-email-top-row/top-card.jsx
@@ -1,7 +1,7 @@
 import { Card, ShortenedNumber, Spinner } from '@automattic/components';
 
 /* This is a very stripped down version of HighlightCard
- * HighlightCard doens't support non-numeric values
+ * HighlightCard doesn't support non-numeric values
  * */
 
 const TopCardValue = ( { value, isLoading } ) => {


### PR DESCRIPTION
#### Proposed Changes

This PR changes the Top Row of email stats to accommodate the data return from the click stats API.

<img width="1073" alt="CleanShot 2023-01-24 at 10 02 14@2x" src="https://user-images.githubusercontent.com/528287/214250618-4791e8f5-322d-4fa2-a5c5-3efb86ea6e7b.png">


#### Testing Instructions

* Apply this PR
* Go to `/stats/email/clicks/<siteid>/day/<postid>?flags=newsletter/stats``
* The top row should be: Total Opens / Total Clicks / Click Rate

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
