### PR TITLE
Plans 2023: Add Header and Footer section to comparison grid

### DIFF
--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -113,7 +113,14 @@ export class PlanFeatures2023Grid extends Component< PlanFeatures2023GridType > 
 	}
 
 	render() {
-		const { isInSignup, planTypeSelectorProps, planProperties, intervalType } = this.props;
+		const {
+			isInSignup,
+			planTypeSelectorProps,
+			planProperties,
+			intervalType,
+			isLaunchPage,
+			flowName,
+		} = this.props;
 
 		const planClasses = classNames( 'plan-features', {
 			'plan-features--signup': isInSignup,
@@ -128,7 +135,7 @@ export class PlanFeatures2023Grid extends Component< PlanFeatures2023GridType > 
 					<div className="plan-features-2023-grid__content">
 						<div>
 							<div className="plan-features-2023-grid__desktop-view">
-								{ this.renderTable( this.props.planProperties ) }
+								{ this.renderTable( planProperties ) }
 							</div>
 							<div className="plan-features-2023-grid__tablet-view">
 								{ this.renderTabletView() }
@@ -143,6 +150,9 @@ export class PlanFeatures2023Grid extends Component< PlanFeatures2023GridType > 
 					planTypeSelectorProps={ planTypeSelectorProps }
 					planProperties={ planProperties }
 					intervalType={ intervalType }
+					isInSignup={ isInSignup }
+					isLaunchPage={ isLaunchPage }
+					flowName={ flowName }
 				/>
 			</div>
 		);

--- a/client/my-sites/plan-features-2023-grid/plan-comparison-grid.tsx
+++ b/client/my-sites/plan-features-2023-grid/plan-comparison-grid.tsx
@@ -4,6 +4,7 @@ import {
 	getPlanClass,
 	isWpcomEnterpriseGridPlan,
 	isFreePlan,
+	isBusinessPlan,
 	FEATURE_GROUP_GENERAL_FEATURES,
 	getPlanFeaturesGrouped,
 	PLAN_ENTERPRISE_GRID_WPCOM,
@@ -15,6 +16,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import JetpackLogo from 'calypso/components/jetpack-logo';
+import PlanPill from 'calypso/components/plans/plan-pill';
 import { getPlanFeaturesObject } from 'calypso/lib/plans/features-list';
 import PlanTypeSelector, {
 	PlanTypeSelectorProps,
@@ -42,20 +44,37 @@ const Title = styled.div`
 
 const Grid = styled.div`
 	display: grid;
+	margin-top: 45px;
+	background: #fff;
+	border: solid 1px #e0e0e0;
 `;
 const Row = styled.div`
 	display: flex;
+	padding: 14px 0;
 	justify-content: space-between;
-	padding: 14px 0px;
 	border-bottom: 1px solid #eee;
+	margin: 0 20px;
+
+	&:last-of-type {
+		border-bottom: none;
+	}
 `;
 
 const Cell = styled.div< { textAlign?: string } >`
 	text-align: ${ ( props ) => props.textAlign ?? 'left' };
-	width: 150px;
+	width: 190px;
 	display: flex;
 	justify-content: space-between;
 	flex-direction: column;
+	align-items: center;
+	padding: 0 20px;
+
+	&:first-of-type {
+		padding-left: 0;
+	}
+	&:last-of-type {
+		padding-right: 0;
+	}
 `;
 
 const RowHead = styled.div`
@@ -155,26 +174,31 @@ export const PlanComparisonGrid: React.FC< PlanComparisonGridProps > = ( {
 			<PlanComparisonHeader className="wp-brand-font">
 				{ translate( 'Compare our plans and find yours' ) }
 			</PlanComparisonHeader>
+			<PlanTypeSelector
+				kind="interval"
+				plans={ displayedPlansProperties.map( ( { planName } ) => planName ) }
+				isInSignup={ planTypeSelectorProps.isInSignup }
+				eligibleForWpcomMonthlyPlans={ planTypeSelectorProps.eligibleForWpcomMonthlyPlans }
+				isPlansInsideStepper={ planTypeSelectorProps.isPlansInsideStepper }
+				intervalType={ planTypeSelectorProps.intervalType }
+				customerType={ planTypeSelectorProps.customerType }
+				hidePersonalPlan={ planTypeSelectorProps.hidePersonalPlan }
+				hideDiscountLabel={ true }
+			/>
 			<Grid>
 				<Row key="feature-group-header-row" className="plan-comparison-grid__plan-row">
-					<RowHead key="feature-name" className="plan-comparison-grid__interval-toggle">
-						<PlanTypeSelector
-							kind="interval"
-							plans={ displayedPlansProperties.map( ( { planName } ) => planName ) }
-							isInSignup={ planTypeSelectorProps.isInSignup }
-							eligibleForWpcomMonthlyPlans={ planTypeSelectorProps.eligibleForWpcomMonthlyPlans }
-							isPlansInsideStepper={ planTypeSelectorProps.isPlansInsideStepper }
-							intervalType={ planTypeSelectorProps.intervalType }
-							customerType={ planTypeSelectorProps.customerType }
-							hidePersonalPlan={ planTypeSelectorProps.hidePersonalPlan }
-							hideDiscountLabel={ true }
-						/>
-					</RowHead>
+					<RowHead
+						key="feature-name"
+						className="plan-comparison-grid__header plan-comparison-grid__interval-toggle"
+					/>
 					{ displayedPlansProperties.map(
 						( { planName, planConstantObj, ...planPropertiesObj } ) => {
 							const headerClasses = classNames(
 								'plan-comparison-grid__header',
-								getPlanClass( planName )
+								getPlanClass( planName ),
+								{
+									'popular-plan-parent-class': isBusinessPlan( planName ),
+								}
 							);
 
 							const rawPrice = planPropertiesObj.rawPrice;
@@ -182,31 +206,34 @@ export const PlanComparisonGrid: React.FC< PlanComparisonGridProps > = ( {
 
 							return (
 								<Cell key={ planName } className={ headerClasses } textAlign="left">
-									<header>
-										<h4 className="plan-features-2023-grid__header-title">
-											{ planConstantObj.getTitle() }
-										</h4>
-									</header>
-									{ rawPrice && (
-										<PlanFeatures2023GridHeaderPrice
-											currencyCode={ currencyCode }
-											discountPrice={ planPropertiesObj.discountPrice }
-											rawPrice={ rawPrice }
-											planName={ planName }
-											is2023OnboardingPricingGrid={ true }
-											isLargeCurrency={ isLargeCurrency }
-										/>
+									{ isBusinessPlan( planName ) && (
+										<div className="plan-features-2023-grid__popular-badge">
+											<PlanPill isInSignup={ isInSignup }>{ translate( 'Popular' ) }</PlanPill>
+										</div>
 									) }
-									<PlanFeatures2023GridBillingTimeframe
-										rawPrice={ rawPrice }
-										rawPriceAnnual={ planPropertiesObj.rawPriceAnnual }
+									<header>
+										<h4 className="plan-comparison-grid__title">{ planConstantObj.getTitle() }</h4>
+									</header>
+									<PlanFeatures2023GridHeaderPrice
 										currencyCode={ currencyCode }
-										annualPricePerMonth={ planPropertiesObj.annualPricePerMonth }
-										isMonthlyPlan={ planPropertiesObj.isMonthlyPlan }
+										discountPrice={ planPropertiesObj.discountPrice }
+										rawPrice={ rawPrice || 0 }
 										planName={ planName }
-										translate={ translate }
-										billingTimeframe={ planConstantObj.getBillingTimeFrame() }
+										is2023OnboardingPricingGrid={ true }
+										isLargeCurrency={ isLargeCurrency }
 									/>
+									<div className="plan-comparison-grid__billing-info">
+										<PlanFeatures2023GridBillingTimeframe
+											rawPrice={ rawPrice }
+											rawPriceAnnual={ planPropertiesObj.rawPriceAnnual }
+											currencyCode={ currencyCode }
+											annualPricePerMonth={ planPropertiesObj.annualPricePerMonth }
+											isMonthlyPlan={ planPropertiesObj.isMonthlyPlan }
+											planName={ planName }
+											translate={ translate }
+											billingTimeframe={ planConstantObj.getBillingTimeFrame() }
+										/>
+									</div>
 									<PlanFeatures2023GridActions
 										className={ getPlanClass( planName ) }
 										freePlan={ isFreePlan( planName ) }

--- a/client/my-sites/plan-features-2023-grid/plan-comparison-grid.tsx
+++ b/client/my-sites/plan-features-2023-grid/plan-comparison-grid.tsx
@@ -44,9 +44,10 @@ const Title = styled.div`
 
 const Grid = styled.div`
 	display: grid;
-	margin-top: 45px;
+	margin-top: 90px;
 	background: #fff;
 	border: solid 1px #e0e0e0;
+	border-radius: 5px;
 `;
 const Row = styled.div`
 	display: flex;
@@ -58,12 +59,12 @@ const Row = styled.div`
 
 const Cell = styled.div< { textAlign?: string } >`
 	text-align: ${ ( props ) => props.textAlign ?? 'left' };
-	width: 190px;
+	width: 156px;
 	display: flex;
 	justify-content: space-between;
 	flex-direction: column;
 	align-items: center;
-	padding: 0 20px;
+	padding: 0 14px;
 
 	&:first-of-type {
 		padding-left: 0;
@@ -71,11 +72,14 @@ const Cell = styled.div< { textAlign?: string } >`
 	&:last-of-type {
 		padding-right: 0;
 	}
+	@media ( min-width: 1500px ) {
+		width: 190px;
+	}
 `;
 
 const RowHead = styled.div`
-	width: 300px;
 	display: flex;
+	flex: 1;
 `;
 
 const StorageButton = styled.div`
@@ -106,6 +110,7 @@ type PlanComparisonGridHeaderProps = {
 	isFooter?: boolean;
 	flowName: string;
 };
+
 const PlanComparisonGridHeader: React.FC< PlanComparisonGridHeaderProps > = ( {
 	displayedPlansProperties,
 	isInSignup,
@@ -300,25 +305,24 @@ export const PlanComparisonGrid: React.FC< PlanComparisonGridProps > = ( {
 												</JetpackIconContainer>
 											) : null }
 										</RowHead>
-										{ ( displayedPlansProperties ?? [] ).map( ( { planName } ) =>
-											restructuredFeatures.featureMap[ planName ].has( featureSlug ) ? (
-												<Cell
-													key={ planName }
-													className={ `plan-comparison-grid__plan ${ planName }` }
-													textAlign="center"
-												>
-													<Gridicon icon="checkmark" color="#0675C4" />
+										{ ( displayedPlansProperties ?? [] ).map( ( { planName } ) => {
+											const cellClasses = classNames(
+												'plan-comparison-grid__plan',
+												getPlanClass( planName ),
+												{
+													'popular-plan-parent-class': isBusinessPlan( planName ),
+												}
+											);
+											return (
+												<Cell key={ planName } className={ cellClasses } textAlign="center">
+													{ restructuredFeatures.featureMap[ planName ].has( featureSlug ) ? (
+														<Gridicon icon="checkmark" color="#0675C4" />
+													) : (
+														<Gridicon icon="minus-small" color="#C3C4C7" />
+													) }
 												</Cell>
-											) : (
-												<Cell
-													key={ planName }
-													className={ `plan-comparison-grid__plan ${ planName }` }
-													textAlign="center"
-												>
-													<Gridicon icon="minus-small" />
-												</Cell>
-											)
-										) }
+											);
+										} ) }
 									</Row>
 								);
 							} ) }
@@ -333,13 +337,15 @@ export const PlanComparisonGrid: React.FC< PlanComparisonGridProps > = ( {
 									{ ( displayedPlansProperties ?? [] ).map( ( { planName } ) => {
 										const storageFeature = restructuredFeatures.planStorageOptionsMap[ planName ];
 										const [ featureObject ] = getPlanFeaturesObject( [ storageFeature ] );
-
+										const cellClasses = classNames(
+											'plan-comparison-grid__plan',
+											getPlanClass( planName ),
+											{
+												'popular-plan-parent-class': isBusinessPlan( planName ),
+											}
+										);
 										return (
-											<Cell
-												key={ planName }
-												className={ `plan-comparison-grid__plan ${ planName }` }
-												textAlign="center"
-											>
+											<Cell key={ planName } className={ cellClasses } textAlign="center">
 												<StorageButton
 													className="plan-features-2023-grid__storage-button"
 													key={ planName }

--- a/client/my-sites/plan-features-2023-grid/plan-comparison-grid.tsx
+++ b/client/my-sites/plan-features-2023-grid/plan-comparison-grid.tsx
@@ -54,10 +54,6 @@ const Row = styled.div`
 	justify-content: space-between;
 	border-bottom: 1px solid #eee;
 	margin: 0 20px;
-
-	&:last-of-type {
-		border-bottom: none;
-	}
 `;
 
 const Cell = styled.div< { textAlign?: string } >`
@@ -103,7 +99,88 @@ type PlanComparisonGridProps = {
 	isLaunchPage?: boolean;
 	flowName: string;
 };
+type PlanComparisonGridHeaderProps = {
+	displayedPlansProperties: Array< PlanProperties >;
+	isInSignup: boolean;
+	isLaunchPage?: boolean;
+	isFooter?: boolean;
+	flowName: string;
+};
+const PlanComparisonGridHeader: React.FC< PlanComparisonGridHeaderProps > = ( {
+	displayedPlansProperties,
+	isInSignup,
+	isLaunchPage,
+	flowName,
+	isFooter,
+} ) => {
+	const translate = useTranslate();
+	const currencyCode = useSelector( getCurrentUserCurrencyCode );
+	return (
+		<Row className="plan-comparison-grid__plan-row">
+			<RowHead
+				key="feature-name"
+				className="plan-comparison-grid__header plan-comparison-grid__interval-toggle"
+			/>
+			{ displayedPlansProperties.map( ( { planName, planConstantObj, ...planPropertiesObj } ) => {
+				const headerClasses = classNames(
+					'plan-comparison-grid__header',
+					getPlanClass( planName ),
+					{
+						'popular-plan-parent-class': isBusinessPlan( planName ),
+						'plan-is-footer': isFooter,
+					}
+				);
 
+				const rawPrice = planPropertiesObj.rawPrice;
+				const isLargeCurrency = rawPrice ? rawPrice > 99000 : false;
+
+				return (
+					<Cell key={ planName } className={ headerClasses } textAlign="left">
+						{ isBusinessPlan( planName ) && (
+							<div className="plan-features-2023-grid__popular-badge">
+								<PlanPill isInSignup={ isInSignup }>{ translate( 'Popular' ) }</PlanPill>
+							</div>
+						) }
+						<header>
+							<h4 className="plan-comparison-grid__title">{ planConstantObj.getTitle() }</h4>
+						</header>
+						<PlanFeatures2023GridHeaderPrice
+							currencyCode={ currencyCode }
+							discountPrice={ planPropertiesObj.discountPrice }
+							rawPrice={ rawPrice || 0 }
+							planName={ planName }
+							is2023OnboardingPricingGrid={ true }
+							isLargeCurrency={ isLargeCurrency }
+						/>
+						<div className="plan-comparison-grid__billing-info">
+							<PlanFeatures2023GridBillingTimeframe
+								rawPrice={ rawPrice }
+								rawPriceAnnual={ planPropertiesObj.rawPriceAnnual }
+								currencyCode={ planPropertiesObj.currencyCode }
+								annualPricePerMonth={ planPropertiesObj.annualPricePerMonth }
+								isMonthlyPlan={ planPropertiesObj.isMonthlyPlan }
+								planName={ planName }
+								translate={ translate }
+								billingTimeframe={ planConstantObj.getBillingTimeFrame() }
+							/>
+						</div>
+						<PlanFeatures2023GridActions
+							className={ getPlanClass( planName ) }
+							freePlan={ isFreePlan( planName ) }
+							isWpcomEnterpriseGridPlan={ isWpcomEnterpriseGridPlan( planName ) }
+							isPlaceholder={ planPropertiesObj.isPlaceholder }
+							isInSignup={ isInSignup }
+							isLaunchPage={ isLaunchPage }
+							planName={ planConstantObj.getTitle() }
+							planType={ planName }
+							flowName={ flowName }
+						/>
+					</Cell>
+				);
+			} ) }
+		</Row>
+	);
+};
 export const PlanComparisonGrid: React.FC< PlanComparisonGridProps > = ( {
 	planProperties,
 	intervalType,
@@ -113,7 +190,6 @@ export const PlanComparisonGrid: React.FC< PlanComparisonGridProps > = ( {
 	flowName,
 } ) => {
 	const translate = useTranslate();
-	const currencyCode = useSelector( getCurrentUserCurrencyCode );
 	const featureGroupMap = getPlanFeaturesGrouped();
 	const displayedPlansProperties = ( planProperties ?? [] ).filter(
 		( { planName } ) => ! ( planName === PLAN_ENTERPRISE_GRID_WPCOM )
@@ -186,70 +262,12 @@ export const PlanComparisonGrid: React.FC< PlanComparisonGridProps > = ( {
 				hideDiscountLabel={ true }
 			/>
 			<Grid>
-				<Row key="feature-group-header-row" className="plan-comparison-grid__plan-row">
-					<RowHead
-						key="feature-name"
-						className="plan-comparison-grid__header plan-comparison-grid__interval-toggle"
-					/>
-					{ displayedPlansProperties.map(
-						( { planName, planConstantObj, ...planPropertiesObj } ) => {
-							const headerClasses = classNames(
-								'plan-comparison-grid__header',
-								getPlanClass( planName ),
-								{
-									'popular-plan-parent-class': isBusinessPlan( planName ),
-								}
-							);
-
-							const rawPrice = planPropertiesObj.rawPrice;
-							const isLargeCurrency = rawPrice ? rawPrice > 99000 : false;
-
-							return (
-								<Cell key={ planName } className={ headerClasses } textAlign="left">
-									{ isBusinessPlan( planName ) && (
-										<div className="plan-features-2023-grid__popular-badge">
-											<PlanPill isInSignup={ isInSignup }>{ translate( 'Popular' ) }</PlanPill>
-										</div>
-									) }
-									<header>
-										<h4 className="plan-comparison-grid__title">{ planConstantObj.getTitle() }</h4>
-									</header>
-									<PlanFeatures2023GridHeaderPrice
-										currencyCode={ currencyCode }
-										discountPrice={ planPropertiesObj.discountPrice }
-										rawPrice={ rawPrice || 0 }
-										planName={ planName }
-										is2023OnboardingPricingGrid={ true }
-										isLargeCurrency={ isLargeCurrency }
-									/>
-									<div className="plan-comparison-grid__billing-info">
-										<PlanFeatures2023GridBillingTimeframe
-											rawPrice={ rawPrice }
-											rawPriceAnnual={ planPropertiesObj.rawPriceAnnual }
-											currencyCode={ currencyCode }
-											annualPricePerMonth={ planPropertiesObj.annualPricePerMonth }
-											isMonthlyPlan={ planPropertiesObj.isMonthlyPlan }
-											planName={ planName }
-											translate={ translate }
-											billingTimeframe={ planConstantObj.getBillingTimeFrame() }
-										/>
-									</div>
-									<PlanFeatures2023GridActions
-										className={ getPlanClass( planName ) }
-										freePlan={ isFreePlan( planName ) }
-										isWpcomEnterpriseGridPlan={ isWpcomEnterpriseGridPlan( planName ) }
-										isPlaceholder={ planPropertiesObj.isPlaceholder }
-										isInSignup={ isInSignup }
-										isLaunchPage={ isLaunchPage }
-										planName={ planConstantObj.getTitle() }
-										planType={ planName }
-										flowName={ flowName }
-									/>
-								</Cell>
-							);
-						}
-					) }
-				</Row>
+				<PlanComparisonGridHeader
+					displayedPlansProperties={ displayedPlansProperties }
+					isInSignup={ isInSignup }
+					isLaunchPage={ isLaunchPage }
+					flowName={ flowName }
+				/>
 
 				{ Object.values( featureGroupMap ).map( ( featureGroup: FeatureGroup ) => {
 					const features = featureGroup.get2023PricingGridSignupWpcomFeatures();
@@ -336,6 +354,13 @@ export const PlanComparisonGrid: React.FC< PlanComparisonGridProps > = ( {
 						</div>
 					);
 				} ) }
+				<PlanComparisonGridHeader
+					displayedPlansProperties={ displayedPlansProperties }
+					isInSignup={ isInSignup }
+					isLaunchPage={ isLaunchPage }
+					flowName={ flowName }
+					isFooter={ true }
+				/>
 			</Grid>
 		</div>
 	);

--- a/client/my-sites/plan-features-2023-grid/style.scss
+++ b/client/my-sites/plan-features-2023-grid/style.scss
@@ -882,18 +882,19 @@ body.is-section-signup.is-white-signup .is-onboarding-2023-pricing-grid .signup_
 		flex-direction: column;
 		align-items: stretch;
 		justify-content: flex-start;
-		padding-top: 30px;
+		padding-top: 34px;
 		padding-bottom: 20px;
 
 		&.plan-is-footer {
-			padding-top: 100px;
+			padding-top: 110px;
 		}
 
 		&.popular-plan-parent-class {
-			border: solid 1px #e0e0e0;
-			border-top: none;
-			border-bottom: none;
-			position: relative;
+			&::before,
+			&::after {
+				height: 100%;
+				bottom: 0;
+			}
 		}
 
 		&.popular-plan-parent-class:not(.plan-is-footer) {
@@ -902,15 +903,15 @@ body.is-section-signup.is-white-signup .is-onboarding-2023-pricing-grid .signup_
 				width: 100%;
 				background: #fff;
 				z-index: 2;
-				padding: 0 0 17px;
+				padding: 0 0 25px;
 
 				.plan-pill {
 					top: 20px;
 				}
 
-				@media ( min-width: 880px ) {
+				@media ( min-width: $plans-2023-small-breakpoint ) {
 					position: absolute;
-					top: -38px;
+					top: -43px;
 					right: -1px;
 					border-color: #e0e0e0;
 					border-width: 1px 1px 0 1px;
@@ -937,24 +938,41 @@ body.is-section-signup.is-white-signup .is-onboarding-2023-pricing-grid .signup_
 			right: unset;
 			border-radius: 4px;
 			background-color: var(--studio-gray-80);
-			transform: translate(20px, 0);
+			transform: translate(15px, 0);
 
-			@media ( min-width: 880px ) {
-				top: 60px;
+			@media ( min-width: $plans-2023-small-breakpoint ) {
+				top: 55px;
 			}
 		}
 	}
 
-	.plan-comparison-grid__title {
-		margin-bottom: 5px;
-		font-size: $font-title-large;
-		line-height: 0.7;
-		color: var(--studio-gray-100);
-		font-weight: 400;
-		@include onboarding-font-recoleta;
-		letter-spacing: 0;
+	.popular-plan-parent-class {
+		position: relative;
+		&::before,
+		&::after {
+			content: "";
+			display: block;
+			width: 1px;
+			height: 140px;
+			bottom: -20px;
+			background: #e0e0e0;
+			position: absolute;
+		}
+		&::before {
+			left: -1px;
+		}
+		&::after {
+			right: -1px;
+		}
 	}
 
+	.plan-comparison-grid__title {
+		margin-bottom: 12px;
+		font-size: $font-title-small;
+		line-height: 1.2;
+		color: var(--studio-gray-100);
+		font-weight: 400;
+	}
 
 	.plan-features-2023-grid__pricing {
 		padding: 0;
@@ -977,11 +995,11 @@ body.is-section-signup.is-white-signup .is-onboarding-2023-pricing-grid .signup_
 		font-weight: 400;
 		font-size: $font-body-extra-small;
 		margin: 3px 0 10px;
-		min-height: 28px;
-		line-height: 1.2;
+		min-height: 38px;
+		line-height: 1.3;
 
-		@media ( min-width: 880px ) {
-			margin: 13px 0 10px;
+		@media ( min-width: $plans-2023-small-breakpoint ) {
+			margin: 7px 0 10px;
 		}
 
 		.plan-features-2023-grid__vip-price {
@@ -990,12 +1008,12 @@ body.is-section-signup.is-white-signup .is-onboarding-2023-pricing-grid .signup_
 			font-weight: 400;
 			color: var(--studio-gray-80);
 
-			@media ( min-width: 880px ) {
+			@media ( min-width: $plans-2023-small-breakpoint ) {
 				font-size: $font-body-small;
 				line-height: 20px;
 			}
 
-			@media ( min-width: 1340px ) {
+			@media ( min-width: $plans-2023-medium-breakpoint ) {
 				font-size: $font-body-extra-small;
 				line-height: 16px;
 			}

--- a/client/my-sites/plan-features-2023-grid/style.scss
+++ b/client/my-sites/plan-features-2023-grid/style.scss
@@ -873,6 +873,7 @@ body.is-section-signup.is-white-signup .is-onboarding-2023-pricing-grid .signup_
 
 .plan-comparison-grid {
 	.plan-comparison-grid__plan-row {
+		padding-top: 0;
 		padding-bottom: 0;
 		border-bottom: none;
 	}
@@ -884,19 +885,28 @@ body.is-section-signup.is-white-signup .is-onboarding-2023-pricing-grid .signup_
 		padding-top: 30px;
 		padding-bottom: 20px;
 
+		&.plan-is-footer {
+			padding-top: 100px;
+		}
+
 		&.popular-plan-parent-class {
-			position: relative;
 			border: solid 1px #e0e0e0;
 			border-top: none;
 			border-bottom: none;
+			position: relative;
+		}
 
+		&.popular-plan-parent-class:not(.plan-is-footer) {
 			.plan-features-2023-grid__popular-badge {
 				margin-bottom: 24px;
 				width: 100%;
 				background: #fff;
-				z-index: 999999;
-				color: #fff;
+				z-index: 2;
 				padding: 0 0 17px;
+
+				.plan-pill {
+					top: 20px;
+				}
 
 				@media ( min-width: 880px ) {
 					position: absolute;
@@ -910,24 +920,27 @@ body.is-section-signup.is-white-signup .is-onboarding-2023-pricing-grid .signup_
 					padding-top: 20px;
 					margin-bottom: 0;
 				}
+			}
+		}
 
-				.plan-pill.is-in-signup {
-					font-family: Inter, $sans;
-					font-size: 0.75rem;
-					font-weight: 500;
-					color: var(--studio-white);
-					letter-spacing: 0.2px;
-					/* stylelint-disable-next-line declaration-property-unit-allowed-list */
-					line-height: 1.25rem;
-					padding: 0 9px;
-					right: unset;
-					left: unset;
-					top: unset;
-					bottom: 0;
-					border-radius: 4px;
-					background-color: var(--studio-gray-80);
-					transform: translate(20px, 0);
-				}
+		.plan-pill {
+			font-family: Inter, $sans;
+			font-size: 0.75rem;
+			font-weight: 500;
+			color: var(--studio-white);
+			letter-spacing: 0.2px;
+			/* stylelint-disable-next-line declaration-property-unit-allowed-list */
+			line-height: 1.25rem;
+			padding: 0 9px;
+			height: 20px;
+			left: 0;
+			right: unset;
+			border-radius: 4px;
+			background-color: var(--studio-gray-80);
+			transform: translate(20px, 0);
+
+			@media ( min-width: 880px ) {
+				top: 60px;
 			}
 		}
 	}

--- a/client/my-sites/plan-features-2023-grid/style.scss
+++ b/client/my-sites/plan-features-2023-grid/style.scss
@@ -7,9 +7,8 @@ $plan-features-sidebar-width: 272px;
 	margin-top: 300px;
 }
 
-.plan-features-2023-grid__table-item.is-top-buttons {
-	padding: 0 20px;
-
+.plan-features-2023-grid__table-item.is-top-buttons,
+.plan-comparison-grid {
 	.plan-features-2023-gridrison__actions-buttons {
 		.plan-features-2023-grid__actions-button {
 			font-weight: 500;
@@ -56,6 +55,9 @@ $plan-features-sidebar-width: 272px;
 			}
 		}
 	}
+}
+.plan-features-2023-grid__table-item.is-top-buttons {
+	padding: 0 20px;
 }
 
 .plan-features-2023-grid__header {
@@ -114,7 +116,8 @@ $plan-features-sidebar-width: 272px;
 	}
 }
 
-.is-2023-pricing-grid .plan-features--signup {
+.is-2023-pricing-grid .plan-features--signup,
+.plan-comparison-grid {
 	margin: 0 auto;
 
 	.signup__steps & {
@@ -864,6 +867,125 @@ body.is-section-signup.is-white-signup .is-onboarding-2023-pricing-grid .signup_
 
 		.segmented-control__text {
 			color: var(--studio-gray-90);
+		}
+	}
+}
+
+.plan-comparison-grid {
+	.plan-comparison-grid__plan-row {
+		padding-bottom: 0;
+		border-bottom: none;
+	}
+	.plan-comparison-grid__header {
+		display: flex;
+		flex-direction: column;
+		align-items: stretch;
+		justify-content: flex-start;
+		padding-top: 30px;
+		padding-bottom: 20px;
+
+		&.popular-plan-parent-class {
+			position: relative;
+			border: solid 1px #e0e0e0;
+			border-top: none;
+			border-bottom: none;
+
+			.plan-features-2023-grid__popular-badge {
+				margin-bottom: 24px;
+				width: 100%;
+				background: #fff;
+				z-index: 999999;
+				color: #fff;
+				padding: 0 0 17px;
+
+				@media ( min-width: 880px ) {
+					position: absolute;
+					top: -38px;
+					right: -1px;
+					border-color: #e0e0e0;
+					border-width: 1px 1px 0 1px;
+					/* stylelint-disable-next-line */
+					border-radius: 5px 5px 0 0;
+					border-style: solid;
+					padding-top: 20px;
+					margin-bottom: 0;
+				}
+
+				.plan-pill.is-in-signup {
+					font-family: Inter, $sans;
+					font-size: 0.75rem;
+					font-weight: 500;
+					color: var(--studio-white);
+					letter-spacing: 0.2px;
+					/* stylelint-disable-next-line declaration-property-unit-allowed-list */
+					line-height: 1.25rem;
+					padding: 0 9px;
+					right: unset;
+					left: unset;
+					top: unset;
+					bottom: 0;
+					border-radius: 4px;
+					background-color: var(--studio-gray-80);
+					transform: translate(20px, 0);
+				}
+			}
+		}
+	}
+
+	.plan-comparison-grid__title {
+		margin-bottom: 5px;
+		font-size: $font-title-large;
+		line-height: 0.7;
+		color: var(--studio-gray-100);
+		font-weight: 400;
+		@include onboarding-font-recoleta;
+		letter-spacing: 0;
+	}
+
+
+	.plan-features-2023-grid__pricing {
+		padding: 0;
+		flex: 1;
+		display: flex;
+		flex-direction: column;
+		justify-content: flex-end;
+
+		.plan-price.is-discounted {
+			color: var(--color-neutral-70);
+
+			.plan-price__integer-fraction {
+				color: inherit;
+			}
+		}
+	}
+
+	.plan-comparison-grid__billing-info {
+		color: var(--studio-gray-50);
+		font-weight: 400;
+		font-size: $font-body-extra-small;
+		margin: 3px 0 10px;
+		min-height: 28px;
+		line-height: 1.2;
+
+		@media ( min-width: 880px ) {
+			margin: 13px 0 10px;
+		}
+
+		.plan-features-2023-grid__vip-price {
+			font-size: $font-body;
+			line-height: 24px;
+			font-weight: 400;
+			color: var(--studio-gray-80);
+
+			@media ( min-width: 880px ) {
+				font-size: $font-body-small;
+				line-height: 20px;
+			}
+
+			@media ( min-width: 1340px ) {
+				font-size: $font-body-extra-small;
+				line-height: 16px;
+			}
 		}
 	}
 }


### PR DESCRIPTION
#### Proposed Changes

* Implements the elements for the Plan Comparison header and footer.
<img width="420" alt="Screenshot 2023-01-24 at 14 39 38" src="https://user-images.githubusercontent.com/2749938/214294295-8b47ea4b-1e47-44af-af20-f236bdaabd9e.png">
<img width="420" alt="Screenshot 2023-01-24 at 14 39 44" src="https://user-images.githubusercontent.com/2749938/214294285-c25ee366-88e8-44c3-bdce-ff9d1c68a2ee.png">


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /start/onboarding-2023-pricing-grid/plans
* The header and the footer should be visible
* The content of the section should match the Plans table on top


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/martech/issues/1421
