### PR TITLE
Users management: Handled edge cases for "shop_manager" and "customer" roles

### DIFF
--- a/client/my-sites/people/people-profile/index.jsx
+++ b/client/my-sites/people/people-profile/index.jsx
@@ -86,6 +86,12 @@ const PeopleProfile = ( { siteId, type, user, invite, showDate, showRole = true 
 			case 'viewer':
 				text = translate( 'Viewer' );
 				break;
+			case 'shop_manager':
+				text = translate( 'Shop manager' );
+				break;
+			case 'customer':
+				text = translate( 'Customer' );
+				break;
 			default:
 				text = role;
 		}

--- a/client/my-sites/people/role-select/index.jsx
+++ b/client/my-sites/people/role-select/index.jsx
@@ -68,7 +68,7 @@ export default function RoleSelect( {
 							</option>
 						) ) }
 				</FormSelect>
-				{ explanation && (
+				{ explanation && ROLES_LIST[ value ] && (
 					<FormSettingExplanation className="with-icon">
 						<Icon icon={ tip } /> { ROLES_LIST[ value ].getDescription( isWPForTeamsSite ) }
 						{ explanation && <>&nbsp;{ explanation }</> }


### PR DESCRIPTION
#### Proposed Changes

* Handled the issue of accessing an undefined value
* Handled role badges text for `shop_manager` and `customer` roles

#### Testing Instructions

* Go to `people/new/{ATOMIC_SITE_WITH_E_COMMERECE_PLAN}`
* Select `Shop manager` or `Customer` role
* Check if inviting user work properly (before this changes, there was a blank screen)

#### Screenshots
![Markup on 2023-01-24 at 15:54:52](https://user-images.githubusercontent.com/1241413/214327932-6e366879-2c22-4c3c-b1d1-ddec4aa9bb5c.png)
![Markup on 2023-01-24 at 15:55:34](https://user-images.githubusercontent.com/1241413/214327945-6381daf6-a8dc-475e-972e-fd61cc92590d.png)


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #72491