### PR TITLE
Email Stats: only 10 posts in the card

### DIFF
--- a/client/state/stats/lists/actions.js
+++ b/client/state/stats/lists/actions.js
@@ -76,7 +76,7 @@ export function requestSiteStats( siteId, statType, query ) {
 				case 'statsVideo':
 					return query.postId;
 				case 'statsEmailsOpen':
-					return { period: PERIOD_ALL_TIME, quantity: 20 };
+					return { period: PERIOD_ALL_TIME, quantity: 10 };
 				default:
 					return query;
 			}


### PR DESCRIPTION
#### Proposed Changes

This PR makes the email card in Stats Dashboard to show 10 entries instead of 20:
![index](https://user-images.githubusercontent.com/3832570/214342805-cb97f65b-0102-43e2-8655-2485b54be6ca.png)


#### Testing Instructions

1. Apply this branch to your local Calypso repository and start the application.
2. Insert manually in the browser address bar an URL with this format: https://calypso.localhost:3000/stats/day/[the-domain-of-your-blog]?flags=newsletter/stats. Note that you can change day for week and month.
3. Check that the email card has only the top 10 entries.

Fixes https://github.com/Automattic/wp-calypso/issues/72432