### PR TITLE
Users management: Remove border line to match a new design

### DIFF
--- a/client/my-sites/people/edit-team-member-form/style.scss
+++ b/client/my-sites/people/edit-team-member-form/style.scss
@@ -1,5 +1,4 @@
 .edit-team-member-form__form {
-	border-top: 1px solid var(--color-border-subtle);
 	padding-top: 24px;
 	margin-top: 24px;
 

--- a/client/my-sites/people/people-invite-details/style.scss
+++ b/client/my-sites/people/people-invite-details/style.scss
@@ -7,7 +7,6 @@
 }
 
 .people-invite-details__meta {
-	border-top: 1px solid var(--color-border-subtle);
 	padding-top: 24px;
 	margin-top: 24px;
 }

--- a/client/my-sites/people/subscriber-details/style.scss
+++ b/client/my-sites/people/subscriber-details/style.scss
@@ -4,7 +4,6 @@
 	}
 
 	.people-member-details__meta {
-		border-top: 1px solid var(--color-border-subtle);
 		padding-top: 24px;
 		margin-top: 24px;
 	}


### PR DESCRIPTION
#### Proposed Changes

* Remove the border line to match a new design

#### Testing Instructions

* Go to `/people/team/{SITE_SLUG}`
* Click on one of the users profiles
* Check if there is a border line separator on the User Details screen

#### Screenshots
![Markup on 2023-01-24 at 17:17:11](https://user-images.githubusercontent.com/1241413/214348466-029dd709-5211-4c69-b965-513f4b4dc961.png)
![Markup on 2023-01-24 at 17:17:51](https://user-images.githubusercontent.com/1241413/214348473-733148a6-6081-4957-bd11-da9d1e984975.png)


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #72487
