### PR TITLE
Marketplace Themes: Adapt billing cycle when upgrading the plan

### DIFF
--- a/client/state/themes/actions/add-external-managed-theme-to-cart.tsx
+++ b/client/state/themes/actions/add-external-managed-theme-to-cart.tsx
@@ -1,13 +1,19 @@
-import { PLAN_BUSINESS_MONTHLY } from '@automattic/calypso-products';
+import {
+	PLAN_BUSINESS_MONTHLY,
+	isWpComMonthlyPlan,
+	PLAN_BUSINESS,
+} from '@automattic/calypso-products';
 import { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 import { addQueryArgs } from '@wordpress/url';
 import page from 'page';
 import 'calypso/state/themes/init';
 import { marketplaceThemeProduct } from 'calypso/lib/cart-values/cart-items';
 import { cartManagerClient } from 'calypso/my-sites/checkout/cart-manager-client';
+import { SitePlanData } from 'calypso/my-sites/checkout/composite-checkout/hooks/product-variants';
 import { marketplaceThemeBillingProductSlug } from 'calypso/my-sites/themes/helpers';
 import { getProductsByBillingSlug } from 'calypso/state/products-list/selectors';
 import { ProductListItem } from 'calypso/state/products-list/selectors/get-products-list';
+import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
 import {
 	isExternallyManagedTheme as getIsExternallyManagedTheme,
@@ -31,11 +37,19 @@ const isLoadingCart = ( isLoading: boolean ) => ( dispatch: CalypsoDispatch ) =>
  * @param products list of products
  * @returns string
  */
-function getPreferredBillingCycleProductSlug( products: Array< ProductListItem > ): string {
+function getPreferredBillingCycleProductSlug(
+	products: Array< ProductListItem >,
+	currentPlan?: SitePlanData | any
+): string {
 	if ( products.length === 0 ) {
 		throw new Error( 'No products available' );
 	}
-	const preferredBillingCycle = 'month';
+	let preferredBillingCycle = 'month';
+
+	if ( currentPlan && ! isWpComMonthlyPlan( currentPlan.productSlug ) ) {
+		preferredBillingCycle = 'year';
+	}
+
 	const preferredProduct = products.find(
 		( product ) => product.product_term === preferredBillingCycle
 	);
@@ -53,26 +67,27 @@ function getPreferredBillingCycleProductSlug( products: Array< ProductListItem >
  */
 export function addExternalManagedThemeToCart( themeId: string, siteId: number ) {
 	return async ( dispatch: CalypsoDispatch, getState: AppState ) => {
-		const isExternallyManagedTheme = getIsExternallyManagedTheme( getState(), themeId );
+		const state = getState();
+		const isExternallyManagedTheme = getIsExternallyManagedTheme( state, themeId );
 
 		if ( ! isExternallyManagedTheme ) {
 			throw new Error( 'Theme is not externally managed' );
 		}
 
-		const isThemePurchased = isPremiumThemeAvailable( getState(), themeId, siteId );
+		const isThemePurchased = isPremiumThemeAvailable( state, themeId, siteId );
 
 		if ( isThemePurchased ) {
 			throw new Error( 'Theme is already purchased' );
 		}
 
-		const siteSlug = getSiteSlug( getState(), siteId );
+		const siteSlug = getSiteSlug( state, siteId );
 
 		if ( ! siteSlug ) {
 			throw new Error( 'Site could not be found matching id ' + siteId );
 		}
 
 		const products = getProductsByBillingSlug(
-			getState(),
+			state,
 			marketplaceThemeBillingProductSlug( themeId )
 		);
 
@@ -80,7 +95,8 @@ export function addExternalManagedThemeToCart( themeId: string, siteId: number )
 			throw new Error( 'No products available' );
 		}
 
-		const productSlug = getPreferredBillingCycleProductSlug( products );
+		const currentPlan = getCurrentPlan( state, siteId );
+		const productSlug = getPreferredBillingCycleProductSlug( products, currentPlan );
 
 		const externalManagedThemeProduct = marketplaceThemeProduct( productSlug );
 
@@ -95,12 +111,17 @@ export function addExternalManagedThemeToCart( themeId: string, siteId: number )
 		 * We need to add the business plan to the cart.
 		 */
 		const isSiteEligibleForManagedExternalThemes = getIsSiteEligibleForManagedExternalThemes(
-			getState(),
+			state,
 			siteId
 		);
 
 		if ( ! isSiteEligibleForManagedExternalThemes ) {
-			cartItems.push( { product_slug: PLAN_BUSINESS_MONTHLY } );
+			cartItems.push( {
+				product_slug:
+					currentPlan && ! isWpComMonthlyPlan( currentPlan.productSlug )
+						? PLAN_BUSINESS
+						: PLAN_BUSINESS_MONTHLY,
+			} );
 		}
 
 		const { origin = 'https://wordpress.com' } =


### PR DESCRIPTION
#### Proposed Changes

* An exception was thrown when upgrading from a yearly Premium to a monthly Business plan.
* Clicking on the CTA or the banner with a yearly subscription to the Premium plan will upgrade to a yearly subscription of the Business plan.

#### Testing Instructions

* Create a new site with a **yearly** subscription on the Premium plan
* Navigate to `/theme/makoney/{YOUR-SITE}`
* Click on the banner or on the CTA button to upgrade to the Business plan and subscribe to the theme.
* You should be redirected to the checkout page with a yearly Business plan added to your cart. The subscription for Makoney should also be yearly.


Closes #72448
