### PR TITLE
Checkout: Update all info at once when updating tax info

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/contact-details-container.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/contact-details-container.tsx
@@ -59,13 +59,11 @@ export default function ContactDetailsContainer( {
 		return null;
 	}
 
-	const { updateDomainContactFields, updateCountryCode, updatePostalCode, updateEmail } =
-		checkoutActions;
+	const { updateDomainContactFields, updateSomeFields, updateEmail } = checkoutActions;
 	const contactDetails = prepareDomainContactDetails( contactInfo );
 	const contactDetailsErrors = prepareDomainContactDetailsErrors( contactInfo );
 	const onChangeContactInfo = ( newInfo: ManagedContactDetails ) => {
-		updateCountryCode( newInfo.countryCode?.value ?? '' );
-		updatePostalCode( newInfo.postalCode?.value ?? '' );
+		updateSomeFields( newInfo );
 	};
 
 	const updateDomainContactRelatedData = ( details: DomainContactDetailsData ) => {

--- a/client/my-sites/checkout/composite-checkout/components/contact-details-container.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/contact-details-container.tsx
@@ -59,11 +59,11 @@ export default function ContactDetailsContainer( {
 		return null;
 	}
 
-	const { updateDomainContactFields, updateSomeFields, updateEmail } = checkoutActions;
+	const { updateDomainContactFields, updateTaxFields, updateEmail } = checkoutActions;
 	const contactDetails = prepareDomainContactDetails( contactInfo );
 	const contactDetailsErrors = prepareDomainContactDetailsErrors( contactInfo );
 	const onChangeContactInfo = ( newInfo: ManagedContactDetails ) => {
-		updateSomeFields( newInfo );
+		updateTaxFields( newInfo );
 	};
 
 	const updateDomainContactRelatedData = ( details: DomainContactDetailsData ) => {

--- a/client/my-sites/checkout/composite-checkout/hooks/wpcom-store.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/wpcom-store.ts
@@ -20,7 +20,7 @@ type WpcomStoreAction =
 			type: 'APPLY_DOMAIN_CONTACT_VALIDATION_RESULTS';
 			payload: ManagedContactDetailsErrors;
 	  }
-	| { type: 'UPDATE_SOME_FIELDS'; payload: ManagedContactDetails }
+	| { type: 'UPDATE_TAX_FIELDS'; payload: ManagedContactDetails }
 	| { type: 'UPDATE_DOMAIN_CONTACT_FIELDS'; payload: DomainContactDetails }
 	| { type: 'SET_RECAPTCHA_CLIENT_ID'; payload: number }
 	| { type: 'UPDATE_VAT_ID'; payload: string }
@@ -65,8 +65,8 @@ const actions = {
 		return { type: 'SET_RECAPTCHA_CLIENT_ID', payload };
 	},
 
-	updateSomeFields( payload: ManagedContactDetails ): WpcomStoreAction {
-		return { type: 'UPDATE_SOME_FIELDS', payload };
+	updateTaxFields( payload: ManagedContactDetails ): WpcomStoreAction {
+		return { type: 'UPDATE_TAX_FIELDS', payload };
 	},
 
 	updateDomainContactFields( payload: DomainContactDetails ): WpcomStoreAction {
@@ -146,8 +146,8 @@ export function useWpcomStore(): WpcomCheckoutStore | undefined {
 			case 'UPDATE_DOMAIN_CONTACT_FIELDS': {
 				return updaters.updateDomainContactFields( state, action.payload );
 			}
-			case 'UPDATE_SOME_FIELDS':
-				return updaters.updateSomeFields( state, action.payload );
+			case 'UPDATE_TAX_FIELDS':
+				return updaters.updateTaxFields( state, action.payload );
 			case 'UPDATE_VAT_ID':
 				return updaters.updateVatId( state, action.payload );
 			case 'UPDATE_PHONE':

--- a/client/my-sites/checkout/composite-checkout/hooks/wpcom-store.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/wpcom-store.ts
@@ -20,6 +20,7 @@ type WpcomStoreAction =
 			type: 'APPLY_DOMAIN_CONTACT_VALIDATION_RESULTS';
 			payload: ManagedContactDetailsErrors;
 	  }
+	| { type: 'UPDATE_SOME_FIELDS'; payload: ManagedContactDetails }
 	| { type: 'UPDATE_DOMAIN_CONTACT_FIELDS'; payload: DomainContactDetails }
 	| { type: 'SET_RECAPTCHA_CLIENT_ID'; payload: number }
 	| { type: 'UPDATE_VAT_ID'; payload: string }
@@ -62,6 +63,10 @@ const actions = {
 
 	setRecaptchaClientId( payload: number ): WpcomStoreAction {
 		return { type: 'SET_RECAPTCHA_CLIENT_ID', payload };
+	},
+
+	updateSomeFields( payload: ManagedContactDetails ): WpcomStoreAction {
+		return { type: 'UPDATE_SOME_FIELDS', payload };
 	},
 
 	updateDomainContactFields( payload: DomainContactDetails ): WpcomStoreAction {
@@ -141,6 +146,8 @@ export function useWpcomStore(): WpcomCheckoutStore | undefined {
 			case 'UPDATE_DOMAIN_CONTACT_FIELDS': {
 				return updaters.updateDomainContactFields( state, action.payload );
 			}
+			case 'UPDATE_SOME_FIELDS':
+				return updaters.updateSomeFields( state, action.payload );
 			case 'UPDATE_VAT_ID':
 				return updaters.updateVatId( state, action.payload );
 			case 'UPDATE_PHONE':

--- a/client/my-sites/checkout/composite-checkout/types/wpcom-store-state.ts
+++ b/client/my-sites/checkout/composite-checkout/types/wpcom-store-state.ts
@@ -720,6 +720,13 @@ export const managedContactDetailsUpdaters: ManagedContactDetailsUpdaters = {
 		};
 	},
 
+	updateSomeFields: (
+		oldDetails: ManagedContactDetails,
+		newDetails: ManagedContactDetails
+	): ManagedContactDetails => {
+		return { ...oldDetails, ...newDetails };
+	},
+
 	updateDomainContactFields: (
 		oldDetails: ManagedContactDetails,
 		newField: DomainContactDetails

--- a/client/my-sites/checkout/composite-checkout/types/wpcom-store-state.ts
+++ b/client/my-sites/checkout/composite-checkout/types/wpcom-store-state.ts
@@ -720,7 +720,7 @@ export const managedContactDetailsUpdaters: ManagedContactDetailsUpdaters = {
 		};
 	},
 
-	updateSomeFields: (
+	updateTaxFields: (
 		oldDetails: ManagedContactDetails,
 		newDetails: ManagedContactDetails
 	): ManagedContactDetails => {

--- a/packages/wpcom-checkout/src/types.ts
+++ b/packages/wpcom-checkout/src/types.ts
@@ -342,6 +342,10 @@ export type ManagedContactDetailsUpdaters = {
 	updatePostalCode: ( arg0: ManagedContactDetails, arg1: string ) => ManagedContactDetails;
 	updateEmail: ( arg0: ManagedContactDetails, arg1: string ) => ManagedContactDetails;
 	updateCountryCode: ( arg0: ManagedContactDetails, arg1: string ) => ManagedContactDetails;
+	updateSomeFields: (
+		arg0: ManagedContactDetails,
+		arg1: ManagedContactDetails
+	) => ManagedContactDetails;
 	updateDomainContactFields: (
 		arg0: ManagedContactDetails,
 		arg1: DomainContactDetails

--- a/packages/wpcom-checkout/src/types.ts
+++ b/packages/wpcom-checkout/src/types.ts
@@ -342,7 +342,7 @@ export type ManagedContactDetailsUpdaters = {
 	updatePostalCode: ( arg0: ManagedContactDetails, arg1: string ) => ManagedContactDetails;
 	updateEmail: ( arg0: ManagedContactDetails, arg1: string ) => ManagedContactDetails;
 	updateCountryCode: ( arg0: ManagedContactDetails, arg1: string ) => ManagedContactDetails;
-	updateSomeFields: (
+	updateTaxFields: (
 		arg0: ManagedContactDetails,
 		arg1: ManagedContactDetails
 	) => ManagedContactDetails;


### PR DESCRIPTION
#### Proposed Changes

When updating the tax location fields in checkout, we dispatch two separate actions to the `wpcom-checkout` data store reducer: one for the country code and one for the postal code. However, this is inefficient and if we ever want to include more information here, we will need to add more dispatch calls.

In this PR, we collapse both calls into one call that updates all the fields at once.

#### Testing Instructions

- Add a non-domain product to your cart and visit checkout.
- Edit your billing location and try changing the country and postal code.
- Verify that they change as expected.