### PR TITLE
Add suggested domain to upsell

### DIFF
--- a/client/my-sites/customer-home/cards/features/domain-upsell/index.jsx
+++ b/client/my-sites/customer-home/cards/features/domain-upsell/index.jsx
@@ -38,12 +38,12 @@ export default function DomainUpsell() {
 						<span>
 							<strike>{ siteSlug }</strike>
 						</span>
-						<div className="badge badge--info">Current</div>
+						<div className="badge badge--info">{ translate( 'Current' ) }</div>
 					</div>
 					<div className="card">
 						<span>{ domainSuggestionName }</span>
 						{ domainSuggestion?.domain_name ? (
-							<div className="badge badge--success">Available</div>
+							<div className="badge badge--success">{ translate( 'Available' ) }</div>
 						) : (
 							<div className="badge">
 								<Spinner />

--- a/client/my-sites/customer-home/cards/features/domain-upsell/index.jsx
+++ b/client/my-sites/customer-home/cards/features/domain-upsell/index.jsx
@@ -1,4 +1,6 @@
-import { Card } from '@automattic/components';
+import { Card, Spinner } from '@automattic/components';
+import { useDomainSuggestions } from '@automattic/domain-picker/src';
+import { useLocale } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
@@ -8,6 +10,18 @@ import './style.scss';
 export default function DomainUpsell() {
 	const translate = useTranslate();
 	const siteSlug = useSelector( ( state ) => getSelectedSiteSlug( state ) );
+	const siteSubDomain = siteSlug.split( '.' )[ 0 ];
+	const locale = useLocale();
+	const { allDomainSuggestions } =
+		useDomainSuggestions( siteSubDomain, 3, undefined, locale ) || {};
+
+	// Get first non-free suggested domain.
+	const domainSuggestion = allDomainSuggestions?.filter(
+		( suggestion ) => ! suggestion.is_free
+	)[ 0 ];
+
+	// It takes awhile to suggest a domain name. Set a default to siteSubDomain.blog.
+	const domainSuggestionName = domainSuggestion?.domain_name || siteSubDomain + '.blog';
 
 	return (
 		<Card className="domain-upsell__card customer-home__card">
@@ -27,8 +41,14 @@ export default function DomainUpsell() {
 						<div className="badge badge--info">Current</div>
 					</div>
 					<div className="card">
-						<span>{ siteSlug }</span>
-						<div className="badge badge--success">Available</div>
+						<span>{ domainSuggestionName }</span>
+						{ domainSuggestion?.domain_name ? (
+							<div className="badge badge--success">Available</div>
+						) : (
+							<div className="badge">
+								<Spinner />
+							</div>
+						) }
 					</div>
 				</div>
 


### PR DESCRIPTION
#### Proposed Changes

* This PR adds a suggested domain to the domain upsell on My Home.
* We load the first paid suggested domain.
* Suggesting a domain takes some time so we load a spinner while we wait.

![suggested-domain-upsell](https://user-images.githubusercontent.com/140841/214363387-cb68fb94-9227-43c1-939a-31fc9cf85377.png)

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this PR locally
* Apply this diff to your wpcom Sandbox D99116-code
* Sandbox your API
* View the new "domain upsell" feature on My Home. It should show on any My Home page that's in the site-setup state. AKA it has the checklist of things to do in the top right.
* There should be a spinner while the suggested domain loads.
* The spinner changes to "Available" when the suggested domain is loaded.
* Most likely the suggested domain will be the site-sub-domain.blog. But it could be something different if that domain is already taken.
* Because we use `useLocale` Test this in different languages to be sure it works properly.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/71499
