### PR TITLE
Plugins: Update the placeholder grid to allow 2 columns

### DIFF
--- a/client/my-sites/plugins/plugins-browser-item/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-item/index.jsx
@@ -143,7 +143,7 @@ const PluginsBrowserListElement = ( props ) => {
 
 	if ( isPlaceholder ) {
 		// eslint-disable-next-line no-use-before-define
-		return <Placeholder />;
+		return <Placeholder variant={ variant } />;
 	}
 
 	const classNames = classnames( 'plugins-browser-item', variant, {
@@ -349,9 +349,9 @@ const InstalledInOrPricing = ( {
 	);
 };
 
-const Placeholder = () => {
+const Placeholder = ( { variant } ) => {
 	return (
-		<li className="plugins-browser-item is-placeholder">
+		<li className={ classnames( 'plugins-browser-item is-placeholder', variant ) }>
 			<span className="plugins-browser-item__link">
 				<div className="plugins-browser-item__info">
 					<PluginIcon isPlaceholder={ true } />

--- a/client/my-sites/plugins/plugins-browser-list/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-list/index.jsx
@@ -27,6 +27,10 @@ const PluginsBrowserList = ( {
 	search,
 	noHeader = false,
 } ) => {
+	const extendedVariant = extended
+		? PluginsBrowserElementVariant.Extended
+		: PluginsBrowserElementVariant.Compact;
+
 	const renderPluginsViewList = () => {
 		const pluginsViewsList = plugins.map( ( plugin, n ) => {
 			// Needs a beter fix but something is leaking empty objects into this list.
@@ -42,9 +46,7 @@ const PluginsBrowserList = ( {
 					currentSites={ currentSites }
 					listName={ listName }
 					listType={ listType }
-					variant={
-						extended ? PluginsBrowserElementVariant.Extended : PluginsBrowserElementVariant.Compact
-					}
+					variant={ extendedVariant }
 					search={ search }
 				/>
 			);
@@ -59,7 +61,11 @@ const PluginsBrowserList = ( {
 
 	const renderPlaceholdersViews = () => {
 		return times( size || DEFAULT_PLACEHOLDER_NUMBER, ( i ) => (
-			<PluginBrowserItem isPlaceholder key={ 'placeholder-plugin-' + i } />
+			<PluginBrowserItem
+				isPlaceholder
+				key={ 'placeholder-plugin-' + i }
+				variant={ extendedVariant }
+			/>
 		) );
 	};
 


### PR DESCRIPTION
#### Proposed Changes

Add browser item variant to placeholder to fix width issue.

| Before  | After |
| ------------- | ------------- |
|<img width="1093" alt="CleanShot 2023-01-24 at 11 59 48@2x" src="https://user-images.githubusercontent.com/5039531/214361780-cf630053-5a73-4ba8-b730-2129945ecf87.png">|<img width="1119" alt="CleanShot 2023-01-24 at 12 01 04@2x" src="https://user-images.githubusercontent.com/5039531/214361804-d814ce65-fcbe-456f-b870-82136107d200.png">|


#### Testing Instructions
* On `/plugins`, search or categories page
* Check if the placeholder state (initial) has more than 1 column (as above)
* It might be needed to remove the local storage to remove the cache and be easier to see this transition

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes [#1540](https://github.com/Automattic/dotcom-forge/issues/1540)
