### PR TITLE
Offer Jetpack Complete: add feature flag and page placeholder

### DIFF
--- a/client/my-sites/plans/jetpack-plans/controller.tsx
+++ b/client/my-sites/plans/jetpack-plans/controller.tsx
@@ -7,6 +7,7 @@ import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { getSlugInTerm } from './convert-slug-terms';
 import getParamsFromContext from './get-params-from-context';
+import JetpackCompletePage from './jetpack-complete';
 import { getPlanRecommendationFromContext } from './plan-upgrade/utils';
 import SelectorPage from './selector';
 import { StoragePricing } from './storage-pricing';
@@ -87,6 +88,11 @@ export const productSelect =
 
 		next();
 	};
+
+export function offerJetpackComplete( context: PageJS.Context, next: () => void ): void {
+	context.primary = <JetpackCompletePage />;
+	next();
+}
 
 export function jetpackFreeWelcome( context: PageJS.Context, next: () => void ): void {
 	context.primary = <JetpackFreeWelcomePage />;

--- a/client/my-sites/plans/jetpack-plans/index.ts
+++ b/client/my-sites/plans/jetpack-plans/index.ts
@@ -1,10 +1,11 @@
-import config from '@automattic/calypso-config';
+import config, { isEnabled } from '@automattic/calypso-config';
 import page from 'page';
 import { makeLayout, render as clientRender } from 'calypso/controller/index.web';
 import {
 	jetpackBoostWelcome,
 	jetpackFreeWelcome,
 	jetpackSocialWelcome,
+	offerJetpackComplete,
 	productSelect,
 } from './controller';
 
@@ -16,6 +17,12 @@ export default function ( rootUrl: string, ...rest: PageJS.Callback[] ): void {
 	if ( addBoostAndSocialRoutes ) {
 		page( `${ rootUrl }/jetpack-boost/welcome`, jetpackBoostWelcome, makeLayout, clientRender );
 		page( `${ rootUrl }/jetpack-social/welcome`, jetpackSocialWelcome, makeLayout, clientRender );
+	}
+
+	// We provide access to the page only when Feature Flag is enabled
+	if ( isEnabled( 'jetpack/offer-complete-after-activation' ) ) {
+		// Offer jetpack complete after Jetpack plugin activation
+		page( `${ rootUrl }/complete/:site?`, ...rest, offerJetpackComplete, makeLayout, clientRender );
 	}
 
 	page(

--- a/client/my-sites/plans/jetpack-plans/jetpack-complete/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/jetpack-complete/index.tsx
@@ -1,0 +1,5 @@
+const JetpackCompletePage = () => {
+	return <>Hello Jetpack Complete</>;
+};
+
+export default JetpackCompletePage;

--- a/config/development.json
+++ b/config/development.json
@@ -90,6 +90,7 @@
 		"jetpack/simplify-pricing-structure": false,
 		"jetpack/standalone-plugin-onboarding-update-v1": true,
 		"jetpack-social/advanced-plan": true,
+		"jetpack/offer-complete-after-activation": true,
 		"jitms": true,
 		"lasagna": true,
 		"layout/app-banner": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -57,6 +57,7 @@
 		"jetpack/simplify-pricing-structure": false,
 		"jetpack/standalone-plugin-onboarding-update-v1": true,
 		"jetpack-social/advanced-plan": false,
+		"jetpack/offer-complete-after-activation": false,
 		"jitms": true,
 		"lasagna": true,
 		"layout/app-banner": true,

--- a/config/production.json
+++ b/config/production.json
@@ -62,6 +62,7 @@
 		"jetpack/simplify-pricing-structure": false,
 		"jetpack/standalone-plugin-onboarding-update-v1": true,
 		"jetpack-social/advanced-plan": false,
+		"jetpack/offer-complete-after-activation": false,
 		"jitms": true,
 		"lasagna": true,
 		"layout/app-banner": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -59,6 +59,7 @@
 		"jetpack/simplify-pricing-structure": false,
 		"jetpack/standalone-plugin-onboarding-update-v1": true,
 		"jetpack-social/advanced-plan": false,
+		"jetpack/offer-complete-after-activation": false,
 		"jitms": true,
 		"lasagna": true,
 		"layout/app-banner": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -66,6 +66,7 @@
 		"jetpack/pricing-page-annual-only": true,
 		"jetpack/simplify-pricing-structure": false,
 		"jetpack-social/advanced-plan": false,
+		"jetpack/offer-complete-after-activation": false,
 		"jitms": true,
 		"lasagna": true,
 		"layout/app-banner": true,


### PR DESCRIPTION
#### Proposed Changes

This change handles 3 small aspects as they are related and easier to test together:
- Creating a feature flag to offer jetpack complete after Jetpack plugin activation
- Creating a blank placeholder page offering Jetpack Complete
- Make this page accessible via URL only when the feature flag is enabled.

For more context you could look through Technical Roadmap of the project: p1HpG7-jYo-p2#comment-60006

#### Testing Instructions
* boot up this PR 
    * Run `git fetch && git checkout fix/cloud-cart-lightbox-cta`
    * Run `yarn start-jetpack-cloud`
    * Goto http://jetpack.cloud.localhost:3000
* OR use the Live Link provided below
* Create a new JN site
* Navigate to `/jetpack/connect/plans/[JN Site]`. If running locally, you should see a message appear on a page `Hello Jetpack Complete`. If using the Live Link, please add `?flags=jetpack/offer-complete-after-activation` to see the same message.
* Disable feature flag by adding to the URL `?flags=-jetpack/offer-complete-after-activation`. You should see a regular pricing page.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?

Related to #
1203759331596262-as-1203791007131729/f
1203759331596262-as-1203791007131732/f

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203791007131729
  - https://app.asana.com/0/0/1203791007131732