### PR TITLE
VAT Info: Correct UK country code in VatInfo

### DIFF
--- a/client/me/purchases/vat-info/index.tsx
+++ b/client/me/purchases/vat-info/index.tsx
@@ -189,9 +189,15 @@ function CountryCodeInput( {
 		'SE',
 		'SI',
 		'SK',
-		'UK',
+		'GB',
 		'XI',
 	];
+
+	// Some historical country codes were set to 'UK', but that is not a valid
+	// country code. It should read 'GB'.
+	if ( value === 'UK' ) {
+		value = 'GB';
+	}
 
 	return (
 		<FormSelect


### PR DESCRIPTION
#### Proposed Changes

At `/me/purchases/vat-details` we provide the option for people to give us their VAT details. We currently use two letter country codes in the dropdown instead of full country names, and we're using `UK` for United Kingdom instead of `GB`, the ISO 2-letter code.

This PR fixes the mistake by changing the form to use `GB`. It also adds a fallback to support countries that were already set to `UK`.

Partially takes care of https://github.com/Automattic/payments-shilling/issues/1276

Before:

<img width="954" alt="Screenshot 2023-01-24 at 2 06 26 PM" src="https://user-images.githubusercontent.com/2036909/214385345-8106305f-c8d8-4cba-81b5-e29bbbfee079.png">

After:

<img width="952" alt="Screenshot 2023-01-24 at 2 07 24 PM" src="https://user-images.githubusercontent.com/2036909/214385526-cfc574ed-793d-4fb9-baf3-f9ab9deb3bf7.png">


#### Testing Instructions

First, set up VAT data with `UK` as the country code. One way to do this is to use trunk's version of calypso and visit `/me/purchases/vat-details`. You can use the VAT number `553557881` if the API is sandboxed.

Next, using this PR's branch:

- Visit `/me/purchases/vat-details`.
- Verify that the selected country code reads `GB`.
