### PR TITLE
Improve tooltips in theme showcase

### DIFF
--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -372,9 +372,9 @@ export class Theme extends Component {
 				}
 			);
 		} else if ( isUsablePremiumTheme ) {
-			return translate( 'The premium theme is included in your plan.' );
+			return translate( 'This premium theme is included in your plan.' );
 		} else if ( isUsableBundledTheme ) {
-			return translate( 'The WooCommerce theme is included in your plan.' );
+			return translate( 'This WooCommerce theme is included in your plan.' );
 		} else if ( doesThemeBundleSoftwareSet ) {
 			return createInterpolateElement(
 				translate( 'This WooCommerce theme is included in the <Link>Business plan</Link>.' ),

--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -22,19 +22,19 @@ import Tooltip from 'calypso/components/tooltip';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import { decodeEntities } from 'calypso/lib/formatting';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { getProductDisplayCost, getProductTerm } from 'calypso/state/products-list/selectors';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
 import { updateThemes } from 'calypso/state/themes/actions/theme-update';
 import {
 	doesThemeBundleSoftwareSet as getDoesThemeBundleSoftwareSet,
-	isSiteEligibleForBundledSoftware as getIsSiteEligibleForBundledSoftware,
-	isPremiumThemeAvailable as getIsPremiumThemeAvailable,
+	getMarketplaceThemeSubscriptionPrices,
 	isExternallyManagedTheme as getIsExternallyManagedTheme,
+	isPremiumThemeAvailable as getIsPremiumThemeAvailable,
+	isSiteEligibleForBundledSoftware as getIsSiteEligibleForBundledSoftware,
 	isSiteEligibleForManagedExternalThemes as getIsSiteEligibleForManagedExternalThemes,
+	isThemePremium as getIsThemePremium,
+	isThemePurchased,
 } from 'calypso/state/themes/selectors';
-import { isThemePremium as getIsThemePremium } from 'calypso/state/themes/selectors/is-theme-premium';
-import { isThemePurchased } from 'calypso/state/themes/selectors/is-theme-purchased';
 import { setThemesBookmark } from 'calypso/state/themes/themes-ui/actions';
 import ThemeMoreButton from './more-button';
 
@@ -633,23 +633,6 @@ export class Theme extends Component {
 	}
 }
 
-function getMarketplaceThemePrices( state, theme ) {
-	if ( ! Array.isArray( theme?.product_details ) ) {
-		return {};
-	}
-
-	return theme.product_details.reduce( ( interimPrices, { product_slug } ) => {
-		const currentProductTerm = getProductTerm( state, product_slug );
-		const currentProductPrice = getProductDisplayCost( state, product_slug );
-
-		if ( currentProductTerm && currentProductPrice ) {
-			interimPrices[ currentProductTerm ] = currentProductPrice;
-		}
-
-		return interimPrices;
-	}, {} );
-}
-
 export default connect(
 	( state, { theme, siteId, hasPremiumThemesFeature } ) => {
 		const {
@@ -658,7 +641,7 @@ export default connect(
 		const { themesUpdateFailed, themesUpdating, themesUpdated } = themesUpdate;
 		const isExternallyManagedTheme = getIsExternallyManagedTheme( state, theme.id );
 		const themeSubscriptionPrices = isExternallyManagedTheme
-			? getMarketplaceThemePrices( state, theme )
+			? getMarketplaceThemeSubscriptionPrices( state, theme?.id )
 			: {};
 
 		return {

--- a/client/components/theme/style.scss
+++ b/client/components/theme/style.scss
@@ -147,6 +147,9 @@ $soft-launch-badge-font-size: 0.725rem;
 		.popover__arrow {
 			display: none;
 		}
+		.components-button {
+			font-size: inherit;
+		}
 	}
 	.theme__upsell-header {
 		font-weight: 500;

--- a/client/components/theme/test/premium-popover.jsx
+++ b/client/components/theme/test/premium-popover.jsx
@@ -67,7 +67,7 @@ describe( 'Theme', () => {
 			expect( screen.queryByTestId( 'upsell-header' ) ).toBeDefined();
 			expect( screen.queryByTestId( 'upsell-header' ).innerHTML ).toBe( 'Premium theme' );
 			expect( screen.queryByTestId( 'upsell-message' ).innerHTML ).toContain(
-				'The premium theme is included in your plan.'
+				'This premium theme is included in your plan.'
 			);
 		} );
 

--- a/client/components/theme/test/premium-popover.jsx
+++ b/client/components/theme/test/premium-popover.jsx
@@ -79,7 +79,7 @@ describe( 'Theme', () => {
 			expect( screen.queryByTestId( 'upsell-header' ) ).toBeDefined();
 			expect( screen.queryByTestId( 'upsell-header' ).innerHTML ).toBe( 'Premium theme' );
 			expect( screen.queryByTestId( 'upsell-message' ).innerHTML ).toContain(
-				'You have purchased an annual subscription for this theme'
+				'You have purchased this theme.'
 			);
 		} );
 	} );

--- a/client/state/themes/selectors/get-marketplace-theme-subscription-prices.ts
+++ b/client/state/themes/selectors/get-marketplace-theme-subscription-prices.ts
@@ -1,0 +1,42 @@
+import { getProductDisplayCost, getProductTerm } from 'calypso/state/products-list/selectors';
+import { getTheme } from './get-theme';
+import type { AppState, Theme } from 'calypso/types';
+
+import 'calypso/state/themes/init';
+
+const PRODUCT_TERM_MONTH = 'month' as const;
+const PRODUCT_TERM_YEAR = 'year' as const;
+type PRODUCT_TERMS = typeof PRODUCT_TERM_MONTH | typeof PRODUCT_TERM_YEAR;
+
+type MarketplaceThemeSubscriptionPrices = Partial< Record< PRODUCT_TERMS, string > >;
+
+export function getMarketplaceThemeSubscriptionPrices(
+	state: AppState,
+	themeId: string | null
+): MarketplaceThemeSubscriptionPrices {
+	const emptyPrices = {};
+
+	const theme: Theme | undefined = getTheme( state, 'wpcom', themeId );
+
+	if ( ! theme || ! Array.isArray( theme.product_details ) ) {
+		return emptyPrices;
+	}
+
+	return theme.product_details.reduce(
+		( interimPrices: MarketplaceThemeSubscriptionPrices, { product_slug } ) => {
+			const currentProductTerm = getProductTerm( state, product_slug );
+			const currentProductPrice = getProductDisplayCost( state, product_slug );
+
+			if (
+				currentProductTerm &&
+				currentProductPrice &&
+				( currentProductTerm === PRODUCT_TERM_MONTH || currentProductTerm === PRODUCT_TERM_YEAR )
+			) {
+				interimPrices[ currentProductTerm ] = currentProductPrice;
+			}
+
+			return interimPrices;
+		},
+		emptyPrices
+	);
+}

--- a/client/state/themes/selectors/index.js
+++ b/client/state/themes/selectors/index.js
@@ -8,6 +8,7 @@ export { getActiveTheme } from 'calypso/state/themes/selectors/get-active-theme'
 export { getCanonicalTheme } from 'calypso/state/themes/selectors/get-canonical-theme';
 export { getJetpackUpgradeUrlIfPremiumTheme } from 'calypso/state/themes/selectors/get-jetpack-upgrade-url-if-premium-theme';
 export { getLastThemeQuery } from 'calypso/state/themes/selectors/get-last-theme-query';
+export { getMarketplaceThemeSubscriptionPrices } from 'calypso/state/themes/selectors/get-marketplace-theme-subscription-prices';
 export { getPreActivateThemeId } from 'calypso/state/themes/selectors/get-pre-activate-theme-id';
 export { getPremiumThemePrice } from 'calypso/state/themes/selectors/get-premium-theme-price';
 export { getPurchasedThemes } from 'calypso/state/themes/selectors/get-purchased-themes';

--- a/client/types.ts
+++ b/client/types.ts
@@ -37,6 +37,7 @@ export interface Theme {
 	name: string;
 	next: string;
 	popularity_rank: string;
+	product_details?: MarketplaceThemeProductDetails[];
 	preview_url: string;
 	screenshot: string;
 	screenshots: string[];
@@ -52,6 +53,11 @@ export interface Theme {
 	theme_uri: string;
 	trending_rank: number;
 	version: string;
+}
+
+interface MarketplaceThemeProductDetails {
+	product_id: number;
+	product_slug: string;
 }
 
 interface ThemeCost {


### PR DESCRIPTION
#### Proposed Changes

This PR makes a number of small improvements to the tooltips we show for premium themes in the theme showcase:
* When you have purchased a premium theme via a one-time purchase, we now show "You have purchased this theme." instead of "You have purchased an annual subscription for this theme."
* When you have a subscription to a marketplace theme, we now show one of the following two messages instead of "This premium theme is only available while your current plan is active and costs per year."
  - When you have a plan that allows access to the Atomic platform: "You have a subscription for this theme, and it will be usable as long as you keep a Business plan or higher on your site."
  - When you have a plan that doesn't allow access to the Atomic platform: "You have a subscription for this theme, but it will only be usable if you have the <ins>Business plan</ins> on your site." - this link takes the user to checkout with the business plan; we do need to improve that flow in a follow-up PR
* When you are looking at a premium theme on a site without access to premium themes (i.e. free or with the Personal plan), we now show "This premium theme is included in the <ins>Premium plan</ins>, or you can purchase individually for [price]." where we removed an incorrect "a year" from the end of the text
* When viewing a marketplace theme that requires the Business plan on a site with a lower plan, we now show both the monthly and annual prices (and actually show the price!), as well as a link to purchase the Business plan
* When viewing a marketplace theme on a site with a Business plan or higher, we now show the text "This premium theme is only available while your current plan is active and costs [annualPrice] per year or [monthlyPrice] per month." We previously tried to show the annual price (and weren't getting that right).
* Finally, I fixed the font size for the links in the tooltips. It used to be slightly smaller.

#### Screenshots

##### Purchased theme: one-time purchase

| Before | After |
| ------ | -----|
| <img width="376" alt="Screenshot 2023-01-25 at 22 55 58" src="https://user-images.githubusercontent.com/3376401/214689178-c312d24d-4d1f-4a6a-be98-8a2b9a9cbbc6.png"> | <img width="416" alt="Screenshot 2023-01-25 at 22 55 08" src="https://user-images.githubusercontent.com/3376401/214689152-a36b9067-0042-483b-92a1-e13552418b9e.png">

##### Purchased theme: subscription

| Before | After |
| ------ | -----|
| <img width="488" alt="Screenshot 2023-01-25 at 23 11 43" src="https://user-images.githubusercontent.com/3376401/214692025-cbf16d90-1d67-41cd-8cc9-da12bf329dce.png"> | <img width="539" alt="Screenshot 2023-01-25 at 23 20 51" src="https://user-images.githubusercontent.com/3376401/214693548-b25e301f-7929-4ffc-8d29-6f85175a6b66.png"> <img width="539" alt="Screenshot 2023-01-25 at 23 21 59" src="https://user-images.githubusercontent.com/3376401/214693818-f9d2b3cc-d6fb-436d-8cbc-905519955c34.png"> |

##### Premium theme on plan lower than Premium

| Before | After |
| ------ | -----|
| <img width="491" alt="theme-showcase-premium-tooltip" src="https://user-images.githubusercontent.com/3376401/214694629-8bc28fd4-c2e7-4153-86eb-a0969e2d0cdf.png"> | <img width="441" alt="Screenshot 2023-01-25 at 22 39 43" src="https://user-images.githubusercontent.com/3376401/214694767-c3a5d3e0-4eb6-4777-815d-921c755bbe42.png"> |

##### Marketplace theme on plan lower than Business

| Before | After |
| ------ | -----|
| <img width="441" alt="theme-showcase-marketplace-tooltip" src="https://user-images.githubusercontent.com/3376401/214694949-8dff940b-47c8-4528-b8af-1de64b71356b.png"> | <img width="446" alt="Screenshot 2023-01-25 at 22 38 56" src="https://user-images.githubusercontent.com/3376401/214695084-18f1964a-9024-4640-91d9-56b6100ef69e.png"> |

##### Marketplace theme on Business plan or higher

| Before | After |
| ------ | -----|
| <img width="488" alt="Screenshot 2023-01-25 at 23 11 43" src="https://user-images.githubusercontent.com/3376401/214695478-3cfe062d-8ce6-42cc-8f38-72befa2a0904.png"> | <img width="539" alt="Screenshot 2023-01-25 at 23 31 22" src="https://user-images.githubusercontent.com/3376401/214695665-e91bf305-6779-4385-9766-e656f98d5add.png"> |

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this branch locally and perform the following tests:
* Work with a free site and navigate to _Appearance_ -> _Themes_
* Mouse over the badge for a premium A8c-owned theme, and verify that the "a year" suffix has been removed
* Purchase a premium theme
* Navigate to _Appearance_ -> _Themes_
* Mouse over the badge for your purchased theme and verify the text is "You have purchased this theme."
* Mouse over the badge for a marketplace theme
* Verify that the text now reads "This premium theme costs [annualPrice] per year or [monthlyPrice] per month, and can only be purchased if you have the <ins>Business plan</ins> on your site."
  - Also verify that the Business plan link has the same font size
* Either purchase a Business plan for your site, or switch to a site that has the Business plan already
* Ensure that the site is Atomic - the easiest path is to visit _Settings_ -> _Hosting Configuration_ and activating your hosting features
* Navigate to _Appearance_ -> _Themes_
* Mouse over the badge for a marketplace theme
* Verify that the text reads: "This premium theme is only available while your current plan is active and costs [annualPrice] per year or [monthlyPrice] per month."
* Purchase a marketplace theme
* Navigate to _Appearance_ -> _Themes_
* Mouse over the badge for the marketplace theme you purchased
* Verify that you see the following text: "You have a subscription for this theme, and it will be usable as long as you keep a Business plan or higher on your site."
* Open Store Admin for your user, and find your test site that has a Business (or higher) plan and your marketplace theme subscription
* Remove the Business plan from the site
* Navigate to _Appearance_ -> _Themes_
* Mouse over the badge for the marketplace theme you purchased
* Verify that you see the following text: "You have a subscription for this theme, but it will only be usable if you have the <ins>Business plan</ins> on your site."

#### Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [N/A] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [N/A] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?