### PR TITLE
General Onboarding: Create write stepper flow

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/launchpad-site-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/launchpad-site-preview.tsx
@@ -1,6 +1,6 @@
 import { FEATURE_VIDEO_UPLOADS, planHasFeature } from '@automattic/calypso-products';
 import { DEVICE_TYPES } from '@automattic/components';
-import { FREE_FLOW, NEWSLETTER_FLOW, BUILD_FLOW } from '@automattic/onboarding';
+import { FREE_FLOW, NEWSLETTER_FLOW, BUILD_FLOW, WRITE_FLOW } from '@automattic/onboarding';
 import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import WebPreview from 'calypso/components/web-preview/component';
@@ -78,6 +78,8 @@ const LaunchpadSitePreview = ( {
 			case FREE_FLOW:
 				return DEVICE_TYPES.COMPUTER;
 			case BUILD_FLOW:
+				return DEVICE_TYPES.COMPUTER;
+			case WRITE_FLOW:
 				return DEVICE_TYPES.COMPUTER;
 			default:
 				return DEVICE_TYPES.PHONE;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
@@ -138,7 +138,8 @@
 .link-in-bio:not(.domains),
 .link-in-bio-tld:not(.domains),
 .free,
-.build {
+.build,
+.write {
 	.step-container {
 		.step-container__content h1,
 		.step-container__content h1.launchpad__sidebar-h1 {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -71,6 +71,13 @@ export function getEnhancedTasks(
 		tasks.map( ( task ) => {
 			let taskData = {};
 			switch ( task.id ) {
+				case 'setup_write':
+					taskData = {
+						title: translate( 'Personalize your site' ),
+						// eslint-disable-next-line @typescript-eslint/no-empty-function
+						actionDispatch: () => {},
+					};
+					break;
 				case 'setup_free':
 					taskData = {
 						title: translate( 'Personalize your site' ),

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -74,8 +74,6 @@ export function getEnhancedTasks(
 				case 'setup_write':
 					taskData = {
 						title: translate( 'Personalize your site' ),
-						// eslint-disable-next-line @typescript-eslint/no-empty-function
-						actionDispatch: () => {},
 					};
 					break;
 				case 'setup_free':

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/tasks.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/tasks.tsx
@@ -92,6 +92,12 @@ export const tasks: Task[] = [
 		disabled: false,
 		taskType: 'blog',
 	},
+	{
+		id: 'setup_write',
+		completed: true,
+		disabled: true,
+		taskType: 'blog',
+	},
 ];
 
 const linkInBioTaskList = [
@@ -115,6 +121,13 @@ export const launchpadFlowTasks: LaunchpadFlowTaskList = {
 	],
 	build: [
 		'setup_general',
+		'design_selected',
+		'first_post_published',
+		'design_edited',
+		'site_launched',
+	],
+	write: [
+		'setup_write',
 		'design_selected',
 		'first_post_published',
 		'design_edited',

--- a/client/landing/stepper/declarative-flow/registered-flows.ts
+++ b/client/landing/stepper/declarative-flow/registered-flows.ts
@@ -51,6 +51,7 @@ const availableFlows: Record< string, () => Promise< { default: Flow } > > = {
 		import( /* webpackChunkName: "free-post-setup-flow" */ '../declarative-flow/free-post-setup' ),
 
 	build: () => import( /* webpackChunkName: "build-flow" */ '../declarative-flow/build' ),
+	write: () => import( /* webpackChunkName: "write-flow" */ '../declarative-flow/write' ),
 };
 
 availableFlows[ 'plugin-bundle' ] = () =>

--- a/client/landing/stepper/declarative-flow/write.ts
+++ b/client/landing/stepper/declarative-flow/write.ts
@@ -3,6 +3,7 @@ import { useFlowProgress, WRITE_FLOW } from '@automattic/onboarding';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { translate } from 'i18n-calypso';
 import wpcom from 'calypso/lib/wp';
+import { useSiteSlug } from '../hooks/use-site-slug';
 import { USER_STORE, ONBOARD_STORE } from '../stores';
 import { recordSubmitStep } from './internals/analytics/record-submit-step';
 import LaunchPad from './internals/steps-repository/launchpad';
@@ -31,6 +32,7 @@ const write: Flow = {
 		const { setStepProgress } = useDispatch( ONBOARD_STORE );
 		const flowProgress = useFlowProgress( { stepName: _currentStep, flowName } );
 		setStepProgress( flowProgress );
+		const siteSlug = useSiteSlug();
 
 		// trigger guides on step movement, we don't care about failures or response
 		wpcom.req.post(
@@ -60,7 +62,17 @@ const write: Flow = {
 			}
 		};
 
-		return { submit };
+		const goNext = () => {
+			switch ( _currentStep ) {
+				case 'launchpad':
+					return window.location.assign( `/view/${ siteSlug }` );
+
+				default:
+					return navigate( 'freeSetup' );
+			}
+		};
+
+		return { goNext, submit };
 	},
 
 	useAssertConditions(): AssertConditionResult {

--- a/client/landing/stepper/declarative-flow/write.ts
+++ b/client/landing/stepper/declarative-flow/write.ts
@@ -9,6 +9,7 @@ import { useSiteSlug } from '../hooks/use-site-slug';
 import { USER_STORE, ONBOARD_STORE } from '../stores';
 import { recordSubmitStep } from './internals/analytics/record-submit-step';
 import LaunchPad from './internals/steps-repository/launchpad';
+import Processing from './internals/steps-repository/processing-step';
 import {
 	AssertConditionResult,
 	AssertConditionState,
@@ -26,7 +27,10 @@ const write: Flow = {
 			recordFullStoryEvent( 'calypso_signup_start_free', { flow: this.name } );
 		}, [] );
 
-		return [ { slug: 'launchpad', component: LaunchPad } ];
+		return [
+			{ slug: 'launchpad', component: LaunchPad },
+			{ slug: 'processing', component: Processing },
+		];
 	},
 
 	useStepNavigation( _currentStep, navigate ) {
@@ -52,11 +56,16 @@ const write: Flow = {
 			recordSubmitStep( providedDependencies, '', flowName, _currentStep );
 
 			switch ( _currentStep ) {
+				case 'processing':
+					if ( providedDependencies?.goToHome && providedDependencies?.siteSlug ) {
+						return window.location.replace( `/home/${ providedDependencies?.siteSlug }` );
+					}
+
+					return navigate( `launchpad` );
 				case 'launchpad': {
 					return navigate( 'processing' );
 				}
 			}
-			return providedDependencies;
 		};
 
 		const goBack = () => {

--- a/client/landing/stepper/declarative-flow/write.ts
+++ b/client/landing/stepper/declarative-flow/write.ts
@@ -23,10 +23,7 @@ const write: Flow = {
 		return translate( 'Write' );
 	},
 	useSteps() {
-		const { resetOnboardStore } = useDispatch( ONBOARD_STORE );
-
 		useEffect( () => {
-			resetOnboardStore();
 			recordTracksEvent( 'calypso_signup_start', { flow: this.name } );
 			recordFullStoryEvent( 'calypso_signup_start_free', { flow: this.name } );
 		}, [] );

--- a/client/landing/stepper/declarative-flow/write.ts
+++ b/client/landing/stepper/declarative-flow/write.ts
@@ -5,7 +5,6 @@ import { translate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import { recordFullStoryEvent } from 'calypso/lib/analytics/fullstory';
 import wpcom from 'calypso/lib/wp';
-import { useSiteSlug } from '../hooks/use-site-slug';
 import { USER_STORE, ONBOARD_STORE } from '../stores';
 import { recordSubmitStep } from './internals/analytics/record-submit-step';
 import LaunchPad from './internals/steps-repository/launchpad';
@@ -38,7 +37,6 @@ const write: Flow = {
 		const { setStepProgress } = useDispatch( ONBOARD_STORE );
 		const flowProgress = useFlowProgress( { stepName: _currentStep, flowName } );
 		setStepProgress( flowProgress );
-		const siteSlug = useSiteSlug();
 
 		// trigger guides on step movement, we don't care about failures or response
 		wpcom.req.post(
@@ -68,25 +66,7 @@ const write: Flow = {
 			}
 		};
 
-		const goBack = () => {
-			return;
-		};
-
-		const goNext = () => {
-			switch ( _currentStep ) {
-				case 'launchpad':
-					return window.location.assign( `/view/${ siteSlug }` );
-
-				default:
-					return navigate( 'freeSetup' );
-			}
-		};
-
-		const goToStep = ( step: string ) => {
-			navigate( step );
-		};
-
-		return { goNext, goBack, goToStep, submit };
+		return { submit };
 	},
 
 	useAssertConditions(): AssertConditionResult {

--- a/client/landing/stepper/declarative-flow/write.ts
+++ b/client/landing/stepper/declarative-flow/write.ts
@@ -1,0 +1,137 @@
+import { useLocale } from '@automattic/i18n-utils';
+import { useFlowProgress, WRITE_FLOW } from '@automattic/onboarding';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { translate } from 'i18n-calypso';
+import { useEffect } from 'react';
+import { recordFullStoryEvent } from 'calypso/lib/analytics/fullstory';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import wpcom from 'calypso/lib/wp';
+import { useSiteSlug } from '../hooks/use-site-slug';
+import { USER_STORE, ONBOARD_STORE } from '../stores';
+import { recordSubmitStep } from './internals/analytics/record-submit-step';
+import LaunchPad from './internals/steps-repository/launchpad';
+import {
+	AssertConditionResult,
+	AssertConditionState,
+	Flow,
+	ProvidedDependencies,
+} from './internals/types';
+
+const write: Flow = {
+	name: WRITE_FLOW,
+	get title() {
+		return translate( 'Write' );
+	},
+	useSteps() {
+		const { resetOnboardStore } = useDispatch( ONBOARD_STORE );
+
+		useEffect( () => {
+			resetOnboardStore();
+			recordTracksEvent( 'calypso_signup_start', { flow: this.name } );
+			recordFullStoryEvent( 'calypso_signup_start_free', { flow: this.name } );
+		}, [] );
+
+		return [ { slug: 'launchpad', component: LaunchPad } ];
+	},
+
+	useStepNavigation( _currentStep, navigate ) {
+		const flowName = this.name;
+		const { setStepProgress } = useDispatch( ONBOARD_STORE );
+		const flowProgress = useFlowProgress( { stepName: _currentStep, flowName } );
+		setStepProgress( flowProgress );
+		const siteSlug = useSiteSlug();
+
+		// trigger guides on step movement, we don't care about failures or response
+		wpcom.req.post(
+			'guides/trigger',
+			{
+				apiNamespace: 'wpcom/v2/',
+			},
+			{
+				flow: flowName,
+				step: _currentStep,
+			}
+		);
+
+		const submit = ( providedDependencies: ProvidedDependencies = {} ) => {
+			recordSubmitStep( providedDependencies, '', flowName, _currentStep );
+
+			switch ( _currentStep ) {
+				case 'launchpad': {
+					return navigate( 'processing' );
+				}
+			}
+			return providedDependencies;
+		};
+
+		const goBack = () => {
+			return;
+		};
+
+		const goNext = () => {
+			switch ( _currentStep ) {
+				case 'launchpad':
+					return window.location.assign( `/view/${ siteSlug }` );
+
+				default:
+					return navigate( 'freeSetup' );
+			}
+		};
+
+		const goToStep = ( step: string ) => {
+			navigate( step );
+		};
+
+		return { goNext, goBack, goToStep, submit };
+	},
+
+	useAssertConditions(): AssertConditionResult {
+		const userIsLoggedIn = useSelect( ( select ) => select( USER_STORE ).isCurrentUserLoggedIn() );
+		let result: AssertConditionResult = { state: AssertConditionState.SUCCESS };
+
+		const queryParams = new URLSearchParams( window.location.search );
+		const flowName = this.name;
+		const locale = useLocale();
+		const flags = queryParams.get( 'flags' );
+		const siteSlug = queryParams.get( 'siteSlug' );
+
+		const getStartUrl = () => {
+			let hasFlowParams = false;
+			const flowParams = new URLSearchParams();
+
+			if ( siteSlug ) {
+				flowParams.set( 'siteSlug', siteSlug );
+				hasFlowParams = true;
+			}
+
+			if ( locale && locale !== 'en' ) {
+				flowParams.set( 'locale', locale );
+				hasFlowParams = true;
+			}
+
+			const redirectTarget =
+				window?.location?.pathname +
+				( hasFlowParams ? encodeURIComponent( '?' + flowParams.toString() ) : '' );
+
+			const url =
+				locale && locale !== 'en'
+					? `/start/account/user/${ locale }?variationName=${ flowName }&redirect_to=${ redirectTarget }`
+					: `/start/account/user?variationName=${ flowName }&redirect_to=${ redirectTarget }`;
+
+			return url + ( flags ? `&flags=${ flags }` : '' );
+		};
+
+		if ( ! userIsLoggedIn ) {
+			const logInUrl = getStartUrl();
+			window.location.assign( logInUrl );
+			result = {
+				state: AssertConditionState.FAILURE,
+				message: 'write-flow requires a logged in user',
+			};
+		}
+
+		return result;
+	},
+};
+
+export default write;

--- a/client/landing/stepper/declarative-flow/write.ts
+++ b/client/landing/stepper/declarative-flow/write.ts
@@ -2,8 +2,6 @@ import { useLocale } from '@automattic/i18n-utils';
 import { useFlowProgress, WRITE_FLOW } from '@automattic/onboarding';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { translate } from 'i18n-calypso';
-import { useEffect } from 'react';
-import { recordFullStoryEvent } from 'calypso/lib/analytics/fullstory';
 import wpcom from 'calypso/lib/wp';
 import { USER_STORE, ONBOARD_STORE } from '../stores';
 import { recordSubmitStep } from './internals/analytics/record-submit-step';
@@ -22,10 +20,6 @@ const write: Flow = {
 		return translate( 'Write' );
 	},
 	useSteps() {
-		useEffect( () => {
-			recordFullStoryEvent( 'calypso_signup_start_free', { flow: this.name } );
-		}, [] );
-
 		return [
 			{ slug: 'launchpad', component: LaunchPad },
 			{ slug: 'processing', component: Processing },

--- a/client/landing/stepper/declarative-flow/write.ts
+++ b/client/landing/stepper/declarative-flow/write.ts
@@ -4,7 +4,6 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { translate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import { recordFullStoryEvent } from 'calypso/lib/analytics/fullstory';
-import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import wpcom from 'calypso/lib/wp';
 import { useSiteSlug } from '../hooks/use-site-slug';
 import { USER_STORE, ONBOARD_STORE } from '../stores';
@@ -24,7 +23,6 @@ const write: Flow = {
 	},
 	useSteps() {
 		useEffect( () => {
-			recordTracksEvent( 'calypso_signup_start', { flow: this.name } );
 			recordFullStoryEvent( 'calypso_signup_start_free', { flow: this.name } );
 		}, [] );
 

--- a/packages/onboarding/src/utils/flows.ts
+++ b/packages/onboarding/src/utils/flows.ts
@@ -12,6 +12,7 @@ export const FREE_POST_SETUP_FLOW = 'free-post-setup';
 export const MIGRATION_FLOW = 'import-focused';
 export const COPY_SITE_FLOW = 'copy-site';
 export const BUILD_FLOW = 'build';
+export const WRITE_FLOW = 'write';
 
 export const isLinkInBioFlow = ( flowName: string | null ) => {
 	return Boolean(


### PR DESCRIPTION
#### Estimated Time to Test / Review:
- Test -> Med
- Review -> Med / Long

#### Proposed Changes

* Adds a new "write" flow to accommodate the launchpad in general onboarding initiative

**NOTE:**
- Redirects to the Launchpad from other parts of the UI will not behave properly for the time being ( e.g. myHome redirects to Launchpad, editor redirects to Launchpad, etc. ) This is because the scaffolding to create Launchpad enabled sites for the `write` flow are not in place, and, for the sake of testing this standalone PR, we'll be using a Launchpad sites that are created for a different flow ( link in bio, newsletter, etc. )
- The task progress may behave oddly until we explicitly add task tracking for the `write` flow in fbhepr%2Skers%2Sjcpbz%2Sjc%2Qpbagrag%2Szh%2Qcyhtvaf%2Synhapucnq.cuc%3Se%3Q75p64nso-og

#### GIFS
![2023-01-24 12 28 45](https://user-images.githubusercontent.com/5414230/214401792-7fa5de6a-a8d8-423c-ab41-fefb261e41c1.gif)

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this branch and `yarn start`
* Get the site slug for an existing launchpad enabled site, or, alternatively, create a new launchpad enabled site ( doesn't matter which flow )
* Comment out L60-71 in the following file https://github.com/Automattic/wp-calypso/blob/b110f37417c00d0b45a70d3d2c663c2c99b0b3ae/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx#L60-L71
* Navigate to http://calypso.localhost:3000/setup/write/launchpad?siteSlug={SLUG_FOR_EXISTING_LAUNCHPAD_ENABLED_SITE}
* Verify Launchpad functionality
  * Copy url button works
  * "Customize" upsell pill redirects to the domains page 
  * "Personalize your site" task is disabled
  * "Select a design" task is disabled
  * "Write your first post" task is enabled redirects to the post editor
  * "Edit site design" task is enabled redirects to the site editor
  * "Launch your site" button probably will not function properly until D99271-code is merged
  * Iframe preview Edit overlay works as expected 

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #72570