### PR TITLE
Updated page title and SEO description

### DIFF
--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -10,15 +10,15 @@
 	"login_url": "/connect",
 	"logout_url": "https://jetpack.com",
 	"jetpack_connect_url": "https://wordpress.com/jetpack/connect",
-	"site_name": "Jetpack: WordPress Security, Backups, Speed, & Growth",
+	"site_name": "Jetpack Pro Dashboard",
 	"meta": [
 		{
 			"name": "description",
-			"content": "Pricing page for Jetpack security, performance, and marketing plans"
+			"content": "Manage all your Jetpack sites from one location"
 		},
 		{
 			"property": "og:description",
-			"content": "Pricing page for Jetpack security, performance, and marketing plans"
+			"content": "Manage all your Jetpack sites from one location"
 		},
 		{
 			"property": "og:image",

--- a/config/jetpack-cloud-horizon.json
+++ b/config/jetpack-cloud-horizon.json
@@ -8,15 +8,15 @@
 	"login_url": "https://wordpress.com/wp-login.php",
 	"logout_url": "https://wordpress.com/wp-login.php?action=logout&redirect_to=https%3A%2F%2F|subdomain|wordpress.com",
 	"jetpack_connect_url": "https://wordpress.com/jetpack/connect",
-	"site_name": "Jetpack.com",
+	"site_name": "Jetpack Pro Dashboard",
 	"meta": [
 		{
 			"name": "description",
-			"content": "Pricing page for Jetpack security, performance, and marketing plans"
+			"content": "Manage all your Jetpack sites from one location"
 		},
 		{
 			"property": "og:description",
-			"content": "Pricing page for Jetpack security, performance, and marketing plans"
+			"content": "Manage all your Jetpack sites from one location"
 		},
 		{
 			"property": "og:image",

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -8,15 +8,15 @@
 	"login_url": "/connect",
 	"logout_url": "https://jetpack.com",
 	"jetpack_connect_url": "https://wordpress.com/jetpack/connect",
-	"site_name": "Jetpack.com",
+	"site_name": "Jetpack Pro Dashboard",
 	"meta": [
 		{
 			"name": "description",
-			"content": "Pricing page for Jetpack security, performance, and marketing plans"
+			"content": "Manage all your Jetpack sites from one location"
 		},
 		{
 			"property": "og:description",
-			"content": "Pricing page for Jetpack security, performance, and marketing plans"
+			"content": "Manage all your Jetpack sites from one location"
 		},
 		{
 			"property": "og:image",

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -8,15 +8,15 @@
 	"login_url": "/connect",
 	"logout_url": "https://jetpack.com",
 	"jetpack_connect_url": "https://wordpress.com/jetpack/connect",
-	"site_name": "Jetpack.com",
+	"site_name": "Jetpack Pro Dashboard",
 	"meta": [
 		{
 			"name": "description",
-			"content": "Pricing page for Jetpack security, performance, and marketing plans"
+			"content": "Manage all your Jetpack sites from one location"
 		},
 		{
 			"property": "og:description",
-			"content": "Pricing page for Jetpack security, performance, and marketing plans"
+			"content": "Manage all your Jetpack sites from one location"
 		},
 		{
 			"property": "og:image",


### PR DESCRIPTION
#### Proposed Changes

This PR updates the meta information for the Jetpack Pro Dashboard

* Change the page name to reflect the Jetpack Pro Dashboard
* Update the SEO description

#### Testing Instructions

* Run `git checkout fix/dashboard-title-and-seo-description` and `yarn start-jetpack-cloud`
* Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
* Verify that the address bar says the name of the page and *Jetpack Pro Dashboard*

For example - the dashboard page will say: *Dashboard - Jetpack Pro Dashboard*

![image](https://user-images.githubusercontent.com/2293077/214415604-47dcb7ac-dbf6-4517-bb0a-99288e05ab86.png) 
![image](https://user-images.githubusercontent.com/2293077/214415757-2c4eec09-4b1b-48e5-a879-89168cea7edb.png)

The PR changes the description on all three: production, staging, and development.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1202619025189113-as-1203150632482184/f