### PR TITLE
General Onboarding: Add 'build' stepper flow

### DIFF
--- a/client/landing/stepper/declarative-flow/build.ts
+++ b/client/landing/stepper/declarative-flow/build.ts
@@ -2,6 +2,7 @@ import { useFlowProgress, BUILD_FLOW } from '@automattic/onboarding';
 import { useDispatch } from '@wordpress/data';
 import { translate } from 'i18n-calypso';
 import wpcom from 'calypso/lib/wp';
+import { useSiteSlug } from '../hooks/use-site-slug';
 import { ONBOARD_STORE } from '../stores';
 import { recordSubmitStep } from './internals/analytics/record-submit-step';
 import LaunchPad from './internals/steps-repository/launchpad';
@@ -23,6 +24,7 @@ const build: Flow = {
 	useStepNavigation( _currentStep, navigate ) {
 		const flowName = this.name;
 		const { setStepProgress } = useDispatch( ONBOARD_STORE );
+		const siteSlug = useSiteSlug();
 		const flowProgress = useFlowProgress( { stepName: _currentStep, flowName } );
 		setStepProgress( flowProgress );
 
@@ -55,7 +57,16 @@ const build: Flow = {
 			return providedDependencies;
 		};
 
-		return { submit };
+		const goNext = () => {
+			switch ( _currentStep ) {
+				case 'launchpad':
+					return window.location.assign( `/view/${ siteSlug }` );
+				default:
+					return navigate( 'freeSetup' );
+			}
+		};
+
+		return { goNext, submit };
 	},
 };
 

--- a/client/landing/stepper/declarative-flow/build.ts
+++ b/client/landing/stepper/declarative-flow/build.ts
@@ -5,6 +5,7 @@ import wpcom from 'calypso/lib/wp';
 import { ONBOARD_STORE } from '../stores';
 import { recordSubmitStep } from './internals/analytics/record-submit-step';
 import LaunchPad from './internals/steps-repository/launchpad';
+import Processing from './internals/steps-repository/processing-step';
 import { Flow, ProvidedDependencies } from './internals/types';
 
 const build: Flow = {
@@ -13,7 +14,10 @@ const build: Flow = {
 		return translate( 'Build' );
 	},
 	useSteps() {
-		return [ { slug: 'launchpad', component: LaunchPad } ];
+		return [
+			{ slug: 'launchpad', component: LaunchPad },
+			{ slug: 'processing', component: Processing },
+		];
 	},
 
 	useStepNavigation( _currentStep, navigate ) {
@@ -38,6 +42,12 @@ const build: Flow = {
 			recordSubmitStep( providedDependencies, '', flowName, _currentStep );
 
 			switch ( _currentStep ) {
+				case 'processing':
+					if ( providedDependencies?.goToHome && providedDependencies?.siteSlug ) {
+						return window.location.replace( `/home/${ providedDependencies?.siteSlug }` );
+					}
+
+					return navigate( `launchpad` );
 				case 'launchpad': {
 					return navigate( 'processing' );
 				}

--- a/client/landing/stepper/declarative-flow/build.ts
+++ b/client/landing/stepper/declarative-flow/build.ts
@@ -1,0 +1,52 @@
+import { useFlowProgress, BUILD_FLOW } from '@automattic/onboarding';
+import { useDispatch } from '@wordpress/data';
+import { translate } from 'i18n-calypso';
+import wpcom from 'calypso/lib/wp';
+import { ONBOARD_STORE } from '../stores';
+import { recordSubmitStep } from './internals/analytics/record-submit-step';
+import LaunchPad from './internals/steps-repository/launchpad';
+import { Flow, ProvidedDependencies } from './internals/types';
+
+const build: Flow = {
+	name: BUILD_FLOW,
+	get title() {
+		return translate( 'Build' );
+	},
+	useSteps() {
+		return [ { slug: 'launchpad', component: LaunchPad } ];
+	},
+
+	useStepNavigation( _currentStep, navigate ) {
+		const flowName = this.name;
+		const { setStepProgress } = useDispatch( ONBOARD_STORE );
+		const flowProgress = useFlowProgress( { stepName: _currentStep, flowName } );
+		setStepProgress( flowProgress );
+
+		// trigger guides on step movement, we don't care about failures or response
+		wpcom.req.post(
+			'guides/trigger',
+			{
+				apiNamespace: 'wpcom/v2/',
+			},
+			{
+				flow: flowName,
+				step: _currentStep,
+			}
+		);
+
+		const submit = ( providedDependencies: ProvidedDependencies = {} ) => {
+			recordSubmitStep( providedDependencies, '', flowName, _currentStep );
+
+			switch ( _currentStep ) {
+				case 'launchpad': {
+					return navigate( 'processing' );
+				}
+			}
+			return providedDependencies;
+		};
+
+		return { submit };
+	},
+};
+
+export default build;

--- a/client/landing/stepper/declarative-flow/build.ts
+++ b/client/landing/stepper/declarative-flow/build.ts
@@ -11,7 +11,7 @@ import { Flow, ProvidedDependencies } from './internals/types';
 const build: Flow = {
 	name: BUILD_FLOW,
 	get title() {
-		return translate( 'Build' );
+		return translate( 'WordPress' );
 	},
 	useSteps() {
 		return [

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/launchpad-site-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/launchpad-site-preview.tsx
@@ -1,6 +1,6 @@
 import { FEATURE_VIDEO_UPLOADS, planHasFeature } from '@automattic/calypso-products';
 import { DEVICE_TYPES } from '@automattic/components';
-import { FREE_FLOW, NEWSLETTER_FLOW } from '@automattic/onboarding';
+import { FREE_FLOW, NEWSLETTER_FLOW, BUILD_FLOW } from '@automattic/onboarding';
 import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import WebPreview from 'calypso/components/web-preview/component';
@@ -76,6 +76,8 @@ const LaunchpadSitePreview = ( {
 			case NEWSLETTER_FLOW:
 				return DEVICE_TYPES.COMPUTER;
 			case FREE_FLOW:
+				return DEVICE_TYPES.COMPUTER;
+			case BUILD_FLOW:
 				return DEVICE_TYPES.COMPUTER;
 			default:
 				return DEVICE_TYPES.PHONE;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
@@ -137,7 +137,8 @@
 .newsletter,
 .link-in-bio:not(.domains),
 .link-in-bio-tld:not(.domains),
-.free {
+.free,
+.build {
 	.step-container {
 		.step-container__content h1,
 		.step-container__content h1.launchpad__sidebar-h1 {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -93,6 +93,11 @@ export function getEnhancedTasks(
 						},
 					};
 					break;
+				case 'setup_general':
+					taskData = {
+						title: translate( 'Personalize your site' ),
+					};
+					break;
 				case 'design_edited':
 					taskData = {
 						title: translate( 'Edit site design' ),

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/tasks.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/tasks.tsx
@@ -75,6 +75,12 @@ export const tasks: Task[] = [
 		taskType: 'blog',
 	},
 	{
+		id: 'setup_general',
+		completed: true,
+		disabled: true,
+		taskType: 'blog',
+	},
+	{
 		id: 'design_edited',
 		completed: false,
 		disabled: false,
@@ -102,6 +108,13 @@ export const launchpadFlowTasks: LaunchpadFlowTaskList = {
 	[ LINK_IN_BIO_TLD_FLOW ]: linkInBioTaskList,
 	free: [
 		'setup_free',
+		'design_selected',
+		'first_post_published',
+		'design_edited',
+		'site_launched',
+	],
+	build: [
+		'setup_general',
 		'design_selected',
 		'first_post_published',
 		'design_edited',

--- a/client/landing/stepper/declarative-flow/registered-flows.ts
+++ b/client/landing/stepper/declarative-flow/registered-flows.ts
@@ -49,6 +49,8 @@ const availableFlows: Record< string, () => Promise< { default: Flow } > > = {
 
 	'free-post-setup': () =>
 		import( /* webpackChunkName: "free-post-setup-flow" */ '../declarative-flow/free-post-setup' ),
+
+	build: () => import( /* webpackChunkName: "build-flow" */ '../declarative-flow/build' ),
 };
 
 availableFlows[ 'plugin-bundle' ] = () =>

--- a/packages/onboarding/src/utils/flows.ts
+++ b/packages/onboarding/src/utils/flows.ts
@@ -11,6 +11,7 @@ export const FREE_FLOW = 'free';
 export const FREE_POST_SETUP_FLOW = 'free-post-setup';
 export const MIGRATION_FLOW = 'import-focused';
 export const COPY_SITE_FLOW = 'copy-site';
+export const BUILD_FLOW = 'build';
 
 export const isLinkInBioFlow = ( flowName: string | null ) => {
 	return Boolean(
@@ -56,6 +57,10 @@ export const isCopySiteFlow = ( flowName: string | null ) => {
 
 export const isWooExpressFlow = ( flowName: string | null ) => {
 	return Boolean( flowName && [ WOOEXPRESS_FLOW ].includes( flowName ) );
+};
+
+export const isBuildFlow = ( flowName: string | null ) => {
+	return Boolean( flowName && [ BUILD_FLOW ].includes( flowName ) );
 };
 
 export const ecommerceFlowRecurTypes = {


### PR DESCRIPTION
**Testing Time: Medium to Long**
**Review Time: Medium**

### Proposed Changes

The goal is to make Launchpad available to onboarding flows for which site_intent is 'build'. This is for any site where a user choose the "Promote my business" option during onboarding. Specifically, this PR adds a new 'build' stepper flow with a Launchpad step. This will be the version of launchpad to which we direct this category of users. 

### Testing Instructions

**Setup:**
1. Prepare a site to test.
   - Go to https://wordpress.com/start/domains?ref=calypso-selector&source=my-home
   - Go through the flow to create a new site.
   - **On the goals page, select 'Promote Myself or my Business'.** (this will set site_intent to build)
   - Continue on through flow until you get to the admin area (ie, finish with all onboarding pages). 
2. In your sandbox, use the following commands to enable the launchpad screen: 
   - `wpsh`
   - `switch_to_blog( YOURSITEID )` (that's the numeric site id for your new site)
   - `return get_posts()` or `return get_current_blog_id()` (you can do this to ensure you're working with the right site)
   - `return get_option( 'site_intent' )` (confirm site_intent is build)
   - `return update_option( 'launchpad_screen', 'full' )` (will update launchpad_screen option to full)
   - `return get_option( 'launchpad_screen' )` (to confirm launchpad_screen is full)
   
**Test:**
1. Go to http://calypso.localhost:3000/setup/build/launchpad?siteSlug=YOURSITESLUG
2. Verify Launchpad screen loads and works as expected
3. Verify that "Personalize your site" and "Select a design" are disabled.
4. Click "Write your first post". Confirm you go to the post editor. Publish a post. Return to Launchpad. Confirm that this task is now completed. 
5. Click "Edit site design". Confirm you go to the site editor. Return to launchpad (**you may need to use the back button - there's an unrelated bug with the site editor back button**). Confirm this task is now completed. 
6. Click "Launch your site". Confirm your site launches, you go to the admin area. My Home should no longer redirect to Launchpad. You can also confirm launchpad_screen is off by checking via wpsh (see above) or confirming that if you try to load the launchpad URL in step 1 above, you are redirected to your admin area. 