### PR TITLE
Add Tracks to domain upsell impressions and clicks

### DIFF
--- a/client/my-sites/customer-home/cards/features/domain-upsell/index.jsx
+++ b/client/my-sites/customer-home/cards/features/domain-upsell/index.jsx
@@ -1,8 +1,10 @@
-import { Card, Spinner } from '@automattic/components';
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { Button, Card, Spinner } from '@automattic/components';
 import { useDomainSuggestions } from '@automattic/domain-picker/src';
 import { useLocale } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
+import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 
 import './style.scss';
@@ -21,10 +23,30 @@ export default function DomainUpsell() {
 	)[ 0 ];
 
 	// It takes awhile to suggest a domain name. Set a default to siteSubDomain.blog.
-	const domainSuggestionName = domainSuggestion?.domain_name || siteSubDomain + '.blog';
+	const domainSuggestionName = domainSuggestion?.domain_name ?? siteSubDomain + '.blog';
+	const domainSuggestionProductSlug = domainSuggestion?.product_slug;
+
+	const searchLink = '/domains/add/' + siteSlug;
+	const getSearchClickHandler = () => {
+		recordTracksEvent( 'calypso_my_home_domain_upsell_search_click', {
+			button_url: searchLink,
+			domain_suggestion: domainSuggestionName,
+			product_slug: domainSuggestionProductSlug,
+		} );
+	};
+
+	const purchaseLink = '/plans/' + siteSlug;
+	const getCtaClickHandler = () => {
+		recordTracksEvent( 'calypso_my_home_domain_upsell_cta_click', {
+			button_url: purchaseLink,
+			domain_suggestion: domainSuggestionName,
+			product_slug: domainSuggestionProductSlug,
+		} );
+	};
 
 	return (
 		<Card className="domain-upsell__card customer-home__card">
+			<TrackComponentView eventName="calypso_my_home_domain_upsell_impression" />
 			<div>
 				<h3>{ translate( 'Own your online identity with a custom domain' ) }</h3>
 				<p>
@@ -53,12 +75,12 @@ export default function DomainUpsell() {
 				</div>
 
 				<div className="domain-upsell-actions">
-					<a className="button" href={ '/domains/add/' + siteSlug }>
+					<Button href={ searchLink } onClick={ getSearchClickHandler }>
 						{ translate( 'Search a domain' ) }
-					</a>
-					<a className="button is-primary" href={ '/plans/' + siteSlug }>
+					</Button>
+					<Button primary href={ purchaseLink } onClick={ getCtaClickHandler }>
 						{ translate( 'Get your custom domain' ) }
-					</a>
+					</Button>
 				</div>
 			</div>
 		</Card>


### PR DESCRIPTION
#### Proposed Changes

* This PR adds Tracks impression and clicks events to the My Home domain upsell.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this PR locally
* Apply this diff to your wpcom Sandbox D99116-code
* Sandbox your API
* View the new "domain upsell" feature on My Home. It should show on any My Home page that's in the site-setup state. AKA it has the checklist of things to do in the top right.
* View the Tracks events firing in real-time PCYsg-cae-p2
* You should also be able to see them in the "Tracks Live View" dashboard
* The buttons should take you to the correct location

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/71499