### PR TITLE
Copy Site: hide remove from cart buttons on checkout

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
@@ -13,9 +13,11 @@ import {
 } from '@automattic/wpcom-checkout';
 import styled from '@emotion/styled';
 import { useState } from 'react';
+import { isCopySiteFlow } from 'calypso/../packages/onboarding/src';
 import { useExperiment } from 'calypso/lib/explat';
 import { isWcMobileApp } from 'calypso/lib/mobile-app';
 import { useGetProductVariants } from 'calypso/my-sites/checkout/composite-checkout/hooks/product-variants';
+import { getSignupCompleteFlowName } from 'calypso/signup/storageUtils';
 import { ItemVariationPicker } from './item-variation-picker';
 import type { OnChangeItemVariant } from './item-variation-picker';
 import type { Theme } from '@automattic/composite-checkout';
@@ -177,7 +179,12 @@ function LineItemWrapper( {
 } ) {
 	const isRenewal = isWpComProductRenewal( product );
 	const isWooMobile = isWcMobileApp();
-	const isDeletable = canItemBeRemovedFromCart( product, responseCart ) && ! isWooMobile;
+	let isDeletable = canItemBeRemovedFromCart( product, responseCart ) && ! isWooMobile;
+
+	const signupFlowName = getSignupCompleteFlowName();
+	if ( isCopySiteFlow( signupFlowName ) ) {
+		isDeletable = false;
+	}
 
 	const shouldShowVariantSelector =
 		onChangePlanLength && ! isWooMobile && ! isRenewal && ! hasPartnerCoupon;

--- a/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
@@ -182,7 +182,7 @@ function LineItemWrapper( {
 	let isDeletable = canItemBeRemovedFromCart( product, responseCart ) && ! isWooMobile;
 
 	const signupFlowName = getSignupCompleteFlowName();
-	if ( isCopySiteFlow( signupFlowName ) ) {
+	if ( isCopySiteFlow( signupFlowName ) && ! product.is_domain_registration ) {
 		isDeletable = false;
 	}
 

--- a/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
@@ -1,5 +1,6 @@
 import { isJetpackPurchasableItem } from '@automattic/calypso-products';
 import { FormStatus, useFormStatus } from '@automattic/composite-checkout';
+import { isCopySiteFlow } from '@automattic/onboarding';
 import {
 	canItemBeRemovedFromCart,
 	getCouponLineItemFromCart,
@@ -13,7 +14,6 @@ import {
 } from '@automattic/wpcom-checkout';
 import styled from '@emotion/styled';
 import { useState } from 'react';
-import { isCopySiteFlow } from 'calypso/../packages/onboarding/src';
 import { useExperiment } from 'calypso/lib/explat';
 import { isWcMobileApp } from 'calypso/lib/mobile-app';
 import { useGetProductVariants } from 'calypso/my-sites/checkout/composite-checkout/hooks/product-variants';


### PR DESCRIPTION
#### Proposed Changes

I've found that users could remove products from the cart and still create the copied site. 

* In this PR we don't show the `remove from cart` buttons for any product. The user is forced in the UI to buy the site plan and extra products/plugins.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/sites`
* Clone a business site. Better if it includes plugins from the marketplace.
* Observe that in the checkout the `remove from cart` buttons are not visible, not in the DOM either.

#### Screenshots



| **Before** | **After** |
|---|---|
| ![Screenshot 2023-01-24 at 22 08 59](https://user-images.githubusercontent.com/779993/214432175-4f5c602d-f2aa-48f7-abcf-6260981d70c5.png) | ![Screenshot 2023-01-24 at 22 08 46](https://user-images.githubusercontent.com/779993/214432192-e06041b2-ada0-47ec-9952-837a22109e37.png) |


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to :
- https://github.com/Automattic/wp-calypso/pull/72291
- https://github.com/Automattic/wp-calypso/pull/72378
- https://github.com/Automattic/dotcom-forge/issues/1514
