### PR TITLE
Upsell: Added domain upsell on the plans page

### DIFF
--- a/client/my-sites/plans/header.jsx
+++ b/client/my-sites/plans/header.jsx
@@ -1,0 +1,63 @@
+import { Button, Gridicon } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import FormattedHeader from 'calypso/components/formatted-header';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import './header.scss';
+
+export default function PlansHeader() {
+	const translate = useTranslate();
+	// TODO: We need to determine if this is a domain upsell and show the domain here.
+	const domainName = 'a domain';
+
+	const description = translate(
+		'With an annual plan, you can get {{strong}}%(domainName)s for free{{/strong}} for the first year, Jetpack essential features, live chat support, and all the features that will take your site to the next level.',
+		{
+			args: {
+				domainName: domainName,
+			},
+			components: {
+				strong: <strong />,
+			},
+		}
+	);
+
+	// TODO: We need to determine if this is a domain upsell.
+	const isDomainUpsell = false;
+
+	const onBackClick = () => {
+		recordTracksEvent( 'calypso_upgrade_nudge_back_click' );
+		history.back();
+	};
+
+	const onSkipClick = () => {
+		recordTracksEvent( 'calypso_upgrade_nudge_skip_click' );
+		// TODO: Connect this to the skip modal.
+		alert( 'Skip Clicked' );
+	};
+
+	return (
+		<>
+			<header className="formatted-header navigation">
+				<Button onClick={ onBackClick } className="inline-help__cancel-button" borderless>
+					<Gridicon icon="arrow-left" size={ 18 } />
+					{ translate( 'Back' ) }
+				</Button>
+
+				{ isDomainUpsell && (
+					<Button onClick={ onSkipClick } borderless href="/">
+						{ translate( 'Skip' ) }
+						<Gridicon icon="arrow-right" size={ 18 } />
+					</Button>
+				) }
+			</header>
+
+			<FormattedHeader
+				className="header-text"
+				brandFont
+				headerText={ translate( 'Free for the first year!' ) }
+				subHeaderText={ description }
+				align="left"
+			/>
+		</>
+	);
+}

--- a/client/my-sites/plans/header.scss
+++ b/client/my-sites/plans/header.scss
@@ -1,0 +1,16 @@
+@import "@wordpress/base-styles/breakpoints";
+
+.is-section-plans .formatted-header.navigation {
+	display: flex;
+	justify-content: space-between;
+	margin: 0;
+	margin-bottom: 20px;
+
+	@media ( max-width: $break-small ) {
+		margin: 0 16px;
+	}
+}
+
+.is-section-plans .formatted-header.header-text {
+	max-width: $break-small;
+}

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -12,7 +12,6 @@ import QueryContactDetailsCache from 'calypso/components/data/query-contact-deta
 import QueryPlans from 'calypso/components/data/query-plans';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import EmptyContent from 'calypso/components/empty-content';
-import FormattedHeader from 'calypso/components/formatted-header';
 import Main from 'calypso/components/main';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
@@ -29,6 +28,7 @@ import isEligibleForWpComMonthlyPlan from 'calypso/state/selectors/is-eligible-f
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
 import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
+import PlansHeader from './header';
 
 function DomainAndPlanUpsellNotice() {
 	const translate = useTranslate();
@@ -164,9 +164,7 @@ class Plans extends Component {
 		if ( ! selectedSite || this.isInvalidPlanInterval() || ! currentPlan ) {
 			return this.renderPlaceholder();
 		}
-		const description = translate(
-			'See and compare the features available on each WordPress.com plan.'
-		);
+
 		return (
 			<div>
 				{ selectedSite.ID && <QuerySitePurchases siteId={ selectedSite.ID } /> }
@@ -184,12 +182,8 @@ class Plans extends Component {
 					) }
 					{ canAccessPlans && (
 						<>
-							<FormattedHeader
-								brandFont
-								headerText={ translate( 'Plans' ) }
-								subHeaderText={ description }
-								align="left"
-							/>
+							<PlansHeader />
+
 							{ domainAndPlanPackage && <DomainAndPlanUpsellNotice /> }
 							<div id="plans" className="plans plans__has-sidebar">
 								<PlansNavigation path={ this.props.context.path } />


### PR DESCRIPTION
#### Proposed Changes

- Added domain upsell on the plans page.

Note: Used `a domain for free` instead of the domain while we don't have it available. [Add suggested domain to cart](https://github.com/Automattic/wp-calypso/issues/71500) will add this feature.

#### Desktop

<img width="1244" alt="image" src="https://user-images.githubusercontent.com/1044309/214442269-62d6ffe2-0cc5-4c46-b7cc-1c83242bfd16.png">


#### Mobile

<img width="487" alt="image" src="https://user-images.githubusercontent.com/1044309/214442339-1361a16d-0832-429b-9907-94519b08b85a.png">

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this diff to your wpcom Sandbox D99116-code
* Sandbox your API
* Change the [isDomainUpsell constant](https://github.com/Automattic/wp-calypso/blob/add/domain-upsell-on-plans-screen/client/my-sites/plans/header.jsx#L25) to true
* You should see a new header with `back` and `skip` buttons (skip functionality will be made in another PR)
* Make sure we can merge the current code and it will deliver value even without the home domain upsell being enabled

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #https://github.com/Automattic/wp-calypso/issues/71501