### PR TITLE
2x faster unit tests

### DIFF
--- a/.teamcity/_self/yarnInstall.kt
+++ b/.teamcity/_self/yarnInstall.kt
@@ -8,7 +8,7 @@ val yarn_install_cmd = """
 	export SKIP_TSC=true
 
 	# Install modules. We save to the file while also outputting it for visibility.
-	yarn_out="yarn-json-output.json"
+	yarn_out="/tmp/yarn-json-output.json"
 	yarn --json | tee -a "${'$'}yarn_out"
 
 	# Yarn --json saves as newline-delimited JSON. To make the JSON file valid,

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -59,6 +59,9 @@ project {
 	buildType(SmartBuildLauncher)
 
 	params {
+		// Force color support in chalk. For some reason it doesn't detect TeamCity
+		// as supported (even though both TeamCity and chalk support that.)
+		param("env.FORCE_COLOR", "1")
 		param("env.NODE_OPTIONS", "--max-old-space-size=32000")
 		text("JEST_E2E_WORKERS", "100%", label = "Magellan parallel workers", description = "Number of parallel workers in Magellan (e2e tests)", allowEmpty = true)
 		text("env.JEST_MAX_WORKERS", "16", label = "Jest max workers", description = "How many tests run in parallel", allowEmpty = true)
@@ -87,7 +90,6 @@ project {
 		password("CALYPSO_E2E_DASHBOARD_AWS_S3_SECRET_ACCESS_KEY", "credentialsJSON:782b4bde-b73d-4326-9970-5a79251bdf07", display = ParameterDisplay.HIDDEN)
 		password("MATTICBOT_GITHUB_BEARER_TOKEN", "credentialsJSON:34cb38a5-9124-41c4-8497-74ed6289d751", display = ParameterDisplay.HIDDEN, label = "Matticbot GitHub Bearer Token")
 		text("CALYPSO_E2E_DASHBOARD_AWS_S3_ROOT", "s3://a8c-calypso-e2e-reports", label = "Calypso E2E Dashboard S3 bucket root")
-
 	}
 
 	features {

--- a/bin/teamcity-task-runner.mjs
+++ b/bin/teamcity-task-runner.mjs
@@ -1,0 +1,90 @@
+import { spawn } from 'child_process';
+import chalk from 'chalk';
+
+// This is technically an import side-effect for the callee, but any TeamCity
+// suite using it will need the behavior.
+// It attempts to fix an issue where log messages are truncated on process.exit
+// due to poor behavior in NodeJS (which is that io streams don't flush on exit)
+// See https://github.com/nodejs/node/issues/6379
+for ( const stream of [ process.stdout, process.stderr ] ) {
+	stream?._handle?.setBlocking?.( true );
+}
+
+export default async function runTask( { name = 'yarn', args, env = {}, testId } ) {
+	return new Promise( ( resolve, reject ) => {
+		const startTime = Date.now();
+		console.log( `Spawning task: ${ name } ${ args }` );
+		const task = spawn( name, args.split( ' ' ), {
+			shell: true,
+			env: {
+				...process.env,
+				...env,
+				// This is used by the jest-teamcity reporter to let us nest test results in the log output.
+				TEAMCITY_FLOWID: testId,
+			},
+		} );
+
+		let stdout = '';
+		let stderr = '';
+		task.stdout.on( 'data', ( data ) => {
+			stdout += data;
+		} );
+		task.stderr.on( 'data', ( data ) => {
+			stderr += data;
+		} );
+
+		task.on( 'close', ( exitCode ) => {
+			const duration = Date.now() - startTime;
+
+			const color = exitCode === 0 ? chalk.green : chalk.red;
+
+			console.log(
+				chalk.bold(
+					color(
+						`Task ${ testId } ${ exitCode === 0 ? 'succeeded' : 'failed' } after ${ duration }ms.`
+					)
+				)
+			);
+
+			console.log( `##teamcity[blockOpened name='     Output for ${ testId }']` );
+
+			// Avoid logging empty blocks when there's no output:
+			// Essentially, any messages with a flowId will get nested inside the
+			// test suite. This happens with the jest-teamcity reporter, making it
+			// easy to nest Jest's test results. We put this inside a block without
+			// a flowId so that messages without a flowId can still be contained
+			// within the block. (Like stdout.)
+			console.log(
+				`##teamcity[testSuiteStarted name='     Tests for ${ testId }' flowId='${ testId }']`
+			);
+			if ( stdout.trim() ) {
+				// TeamCity will take the service messages with a flowId (like from
+				// the jest test reporter) and put them under the test suite block.
+				// Non-service-message output will not be nested, but would be shown
+				// below. If everything in stdout was a service message, it will
+				// appear empty here. So we add a message to indicate that.
+				console.log(
+					chalk.italic( 'If no output is shown, look for it under the test section for this task.' )
+				);
+				console.log( '....STDOUT....' );
+				console.log( stdout );
+			}
+			if ( stderr.trim() ) {
+				console.log( '....STDERR....' );
+				console.log( stderr );
+			}
+			console.log(
+				`##teamcity[testSuiteFinished name='     Tests for ${ testId }' flowId='${ testId }']`
+			);
+
+			console.log( `##teamcity[blockClosed name='     Output for ${ testId }']` );
+
+			if ( exitCode === 0 ) {
+				resolve();
+			} else {
+				reject( exitCode );
+			}
+		} );
+		task.on( 'error', reject );
+	} );
+}

--- a/bin/unit-test-suite.mjs
+++ b/bin/unit-test-suite.mjs
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+import util from 'util';
+import glob from 'glob';
+import runTask from './teamcity-task-runner.mjs';
+
+const globPromise = util.promisify( glob );
+
+function withTscInfo( { cmd, id } ) {
+	return {
+		testId: id,
+		name: 'yarn',
+		args: cmd,
+		env: { NODE_ENV: 'test' },
+	};
+}
+
+function withUnitTestInfo( cmd ) {
+	return {
+		testId: cmd.split( ' ' )[ 0 ],
+		name: 'yarn',
+		args: `${ cmd } --ci --reporters=default --reporters=jest-teamcity --silent`,
+	};
+}
+
+const allPackageTsconfigs = ( await globPromise( 'packages/*/tsconfig.json' ) ).join( ' ' );
+const tscPackages = withTscInfo( {
+	cmd: `tsc --build ${ allPackageTsconfigs }`,
+	id: 'type_check_packages',
+} );
+
+const tscCommands = [
+	{ cmd: 'tsc --noEmit --project apps/editing-toolkit/tsconfig.json', id: 'type_check_etk' },
+	{ cmd: 'tsc --noEmit --project client/tsconfig.json', id: 'type_check_client' },
+	{ cmd: 'tsc --noEmit --project test/e2e/tsconfig.json', id: 'type_check_tests' },
+].map( withTscInfo );
+
+// When Jest runs without --maxWorkers, each instance of Jest will try to use all
+// cores available. (Which is a lot in our CI.) This isn't a problem per se, because
+// everything ends up completing pretty quickly. However, with 100% CPU usage for
+// most of the test, it's possible for some tests which rely on i/o to time out.
+// This causes flakey tests. As a result, we need to manage the number of workers
+// manually so that there is some amount of margin.
+//
+// After some testing, I've found that 8+4 is a good setup. The largest task
+// runs by itself with 8 cores, and the other tasks run one by one with 4 other
+// cores. This leaves a final 4 cores free for tsc + any other tasks. This seems
+// to result in the fastest overall completion time.
+const testClient = withUnitTestInfo( 'test-client --maxWorkers=8' );
+const testPackages = withUnitTestInfo( 'test-packages --maxWorkers=4' );
+const testServer = withUnitTestInfo( 'test-server --maxWorkers=4' );
+const testBuildTools = withUnitTestInfo( 'test-build-tools --maxWorkers=4' );
+
+const testWorkspaces = {
+	name: 'yarn',
+	args: 'workspaces foreach --verbose --parallel run storybook --ci --smoke-test',
+	testId: 'check_storybook',
+};
+
+try {
+	// Since this task is so much larger than the others, we give it a large amount
+	// of CPU and run it by itself. We let other tasks complete in parallel with
+	// less CPU since they'll still finish much more quickly.
+	const testClientTask = runTask( testClient );
+
+	// The async () wrapper is needed so that the Promise settles only after
+	// all tasks finish. If we instead use Promise.all with a chain of Promises,
+	// Promise.all would complete when the first Promise in the chain settles.
+	//
+	// One note about the tsc tasks is that tsc doesn't parallelize well. This means
+	// it doesn't expand to take advantage of more cores. As a result, it's the
+	// limiting factor for overall build speed. We need to give it just enough cores
+	// so that it runs as fast as possible, but leave enough to other tasks so that
+	// they can finish by the time tsc finishes. I found that using 12 cores for
+	// jest and the remaining for tsc and anything else accomplished this.
+	const tscTasks = ( async () => {
+		// This task is a prerequisite for the other tsc tasks, so it must run separately.
+		await runTask( tscPackages );
+		await Promise.all( tscCommands.map( runTask ) );
+	} )();
+
+	// Run these smaller tasks in serial to keep a healthy amount of CPU available for the other tasks.
+	const otherTestTasks = ( async () => {
+		await runTask( testPackages );
+		await runTask( testServer );
+		await runTask( testBuildTools );
+		await runTask( testWorkspaces );
+	} )();
+
+	await Promise.all( [ testClientTask, tscTasks, otherTestTasks ] );
+} catch ( exitCode ) {
+	console.log( `A task failed with exit code ${ exitCode }` );
+	process.exit( exitCode );
+}


### PR DESCRIPTION
### Proposed Changes
This is an experiment to move the Calypso Unit Tests from individual build steps into a bash script, and then ultimately parallelize those steps.

From what I can tell, the TeamCity set up works like this:
- There are two servers with 64 cores and like 128GB RAM.
- Each runs 4 agents, giving 16 cores and 32GB per agent.
- Each agent can run only ONE build at a time.

As a result, any free CPU resources during a build run are literally wasted, and can't be used by any other agents or builds in the system.

This means we should probably be trying to max out the system as much as we can _per build._ So lightweight standalone builds are actually _not good_, because they essentially take up all 16 cores for the entire duration, despite not needing that much power.

### Problem with Current Build
Every task runs in serial. As a result, any step which doesn't parallelize well (e.g. doesn't use as many cores as it can) isn't performing optimally. After some resarch, I learned that Typescript doesn't parallelize well. In fact, even [the Deno project notes](https://deno.com/blog/v1#tsc-bottleneck) that `tsc` is a bottleneck. It seems to use only a few cores at a time, which in our system leaves about 12 cores unused.

Plus, while the various jest suites are using as many workers as there are cores, there are still parts of it that probably don't parallelize well (like reporting results, booting up, etc). So running some test suites simultaneously is still a good idea.

### Solution
After **a lot** of testing, I've landed on the following workflow:

In Parallel:
- Run the client test suite with 8 cores
- Run the assorted other test suites in serial with 4 cores
- Run typescript with the remaining CPU

The assorted other suites include package tests, server tests, build tool tests, and the storybook check. These run in serial, because they're each rather short. If we started them all simultaneously, it would eat so much CPU that the other tasks would become starved. (This can introduce timeouts and other flakiness)

The typescript stuff first builds all the packages. This takes a long time -- definitely a majority of the build. Once that's done, we can check types for the client, ETK, and e2e tests in parallel. We have to build the packages first because the other typescript configs depend on the package types being compiled.

This results in about a **2x faster build**. (What takes 6-7 minutes on trunk takes less than 3:30min in this branch.)

### Implementation
I originally wrote a solution in Bash. Unfortunately, Bash stopped being a good solution after I needed to run some things in serial, and others in parallel, all at the same time. The main thing which made Bash not work well was the need to capture all output and essentially re-order it, as well as generalizing how to run tasks in parallel. (And then a subtask in serial.)

So I ultimately wrote it in Node in two parts:
1. A function `runTask` which spawns a child process with the command, captures all the output, makes everything look good for TeamCity with service messages, and then resolves/rejects with the result.
2. A file which creates several tasks, then orchestrates calls to `runTask` using async/await. This file is called by TeamCity.

We can reuse this `runTask` concept for any other build we like. It took **a lot of trial and error** to figure out the TeamCity service messages to integrate with the existing tests. (66 commits, in fact...)

This is what it looks like with service messages working:
<img width="1114" alt="image" src="https://user-images.githubusercontent.com/6265975/218650405-f801a74e-3a82-4368-baca-733a211dd6d1.png">


### Testing Instructions
- TeamCity passes.

Various failure conditions work properly:
- [ ] Client unit test
- [ ] Package unit test
- [ ] Package type issue
- [ ] Client type issue