### PR TITLE
Odyssey: Replace Jetpack Colophon with standard Jetpack plugin footer

### DIFF
--- a/apps/odyssey-stats/src/styles/wp-admin.scss
+++ b/apps/odyssey-stats/src/styles/wp-admin.scss
@@ -83,4 +83,8 @@
 		// Override WP-Admin styles.
 		float: none;
 	}
+	.stats > .jp-dashboard-footer {
+		padding-top: 32px;
+		padding-bottom: 32px;
+	}
 }

--- a/apps/odyssey-stats/webpack.config.js
+++ b/apps/odyssey-stats/webpack.config.js
@@ -155,6 +155,10 @@ module.exports = {
 		// The sprite is loaded separately in Jetpack.
 		new webpack.NormalModuleReplacementPlugin( /^\.\.\/gridicon$/, '../gridicon/no-asset' ),
 		new webpack.NormalModuleReplacementPlugin( /^\.\/gridicon$/, './gridicon/no-asset' ),
+		new webpack.NormalModuleReplacementPlugin(
+			/^calypso\/components\/jetpack-colophon$/,
+			'calypso/components/jetpack/jetpack-footer'
+		),
 		shouldEmitStats &&
 			new BundleAnalyzerPlugin( {
 				analyzerMode: 'server',

--- a/client/components/jetpack/automattic-byline-logo/README.md
+++ b/client/components/jetpack/automattic-byline-logo/README.md
@@ -1,0 +1,16 @@
+# Automattic Byline Logo
+
+Component that renders the stylish `AN AUTOMATTIC AIRLINE`.
+It takes width and height properties but defaults to 7 in height.
+
+#### How to use:
+
+```js
+<AutomatticBylineLogo height={ 7 } className="jp-automattic-byline-logo-jetpack" />
+```
+
+#### Props
+
+- `className`: String - (default only: `jp-automattic-byline-logo`) the additional class name set on the SVG element.
+- `height`: Number - (default: 8) set the height of the title.
+- `title`: String - (default: `AN AUTOMATTIC AIRLINE`) title of the SVG.

--- a/client/components/jetpack/automattic-byline-logo/README.md
+++ b/client/components/jetpack/automattic-byline-logo/README.md
@@ -3,13 +3,13 @@
 Component that renders the stylish `AN AUTOMATTIC AIRLINE`.
 It takes width and height properties but defaults to 7 in height.
 
-#### How to use:
+## How to use
 
 ```js
-<AutomatticBylineLogo height={ 7 } className="jp-automattic-byline-logo-jetpack" />
+<AutomatticBylineLogo height={ 7 } className="jp-automattic-byline-logo-jetpack" />;
 ```
 
-#### Props
+## Props
 
 - `className`: String - (default only: `jp-automattic-byline-logo`) the additional class name set on the SVG element.
 - `height`: Number - (default: 8) set the height of the title.

--- a/client/components/jetpack/automattic-byline-logo/index.tsx
+++ b/client/components/jetpack/automattic-byline-logo/index.tsx
@@ -1,0 +1,38 @@
+import { __ } from '@wordpress/i18n';
+import classnames from 'classnames';
+import React from 'react';
+import { AutomatticBylineLogoProps } from './types';
+
+/**
+ * Automattic "By line" Logo component.
+ *
+ * @param {AutomatticBylineLogoProps} props - Component properties.
+ * @returns {React.ReactNode} AutomatticBylineLogo component.
+ */
+const AutomatticBylineLogo: React.FC< AutomatticBylineLogoProps > = ( {
+	title = __( 'An Automattic Airline', 'jetpack' ),
+	height = 7,
+	className,
+	...otherProps
+} ) => {
+	return (
+		<svg
+			role="img"
+			x="0"
+			y="0"
+			viewBox="0 0 935 38.2"
+			enableBackground="new 0 0 935 38.2"
+			aria-labelledby="jp-automattic-byline-logo-title"
+			height={ height }
+			className={ classnames( 'jp-automattic-byline-logo', className ) }
+			{ ...otherProps }
+		>
+			<desc id="jp-automattic-byline-logo-title">{ title }</desc>
+			<path d="M317.1 38.2c-12.6 0-20.7-9.1-20.7-18.5v-1.2c0-9.6 8.2-18.5 20.7-18.5 12.6 0 20.8 8.9 20.8 18.5v1.2C337.9 29.1 329.7 38.2 317.1 38.2zM331.2 18.6c0-6.9-5-13-14.1-13s-14 6.1-14 13v0.9c0 6.9 5 13.1 14 13.1s14.1-6.2 14.1-13.1V18.6zM175 36.8l-4.7-8.8h-20.9l-4.5 8.8h-7L157 1.3h5.5L182 36.8H175zM159.7 8.2L152 23.1h15.7L159.7 8.2zM212.4 38.2c-12.7 0-18.7-6.9-18.7-16.2V1.3h6.6v20.9c0 6.6 4.3 10.5 12.5 10.5 8.4 0 11.9-3.9 11.9-10.5V1.3h6.7V22C231.4 30.8 225.8 38.2 212.4 38.2zM268.6 6.8v30h-6.7v-30h-15.5V1.3h37.7v5.5H268.6zM397.3 36.8V8.7l-1.8 3.1 -14.9 25h-3.3l-14.7-25 -1.8-3.1v28.1h-6.5V1.3h9.2l14 24.4 1.7 3 1.7-3 13.9-24.4h9.1v35.5H397.3zM454.4 36.8l-4.7-8.8h-20.9l-4.5 8.8h-7l19.2-35.5h5.5l19.5 35.5H454.4zM439.1 8.2l-7.7 14.9h15.7L439.1 8.2zM488.4 6.8v30h-6.7v-30h-15.5V1.3h37.7v5.5H488.4zM537.3 6.8v30h-6.7v-30h-15.5V1.3h37.7v5.5H537.3zM569.3 36.8V4.6c2.7 0 3.7-1.4 3.7-3.4h2.8v35.5L569.3 36.8 569.3 36.8zM628 11.3c-3.2-2.9-7.9-5.7-14.2-5.7 -9.5 0-14.8 6.5-14.8 13.3v0.7c0 6.7 5.4 13 15.3 13 5.9 0 10.8-2.8 13.9-5.7l4 4.2c-3.9 3.8-10.5 7.1-18.3 7.1 -13.4 0-21.6-8.7-21.6-18.3v-1.2c0-9.6 8.9-18.7 21.9-18.7 7.5 0 14.3 3.1 18 7.1L628 11.3zM321.5 12.4c1.2 0.8 1.5 2.4 0.8 3.6l-6.1 9.4c-0.8 1.2-2.4 1.6-3.6 0.8l0 0c-1.2-0.8-1.5-2.4-0.8-3.6l6.1-9.4C318.7 11.9 320.3 11.6 321.5 12.4L321.5 12.4z" />
+			<path d="M37.5 36.7l-4.7-8.9H11.7l-4.6 8.9H0L19.4 0.8H25l19.7 35.9H37.5zM22 7.8l-7.8 15.1h15.9L22 7.8zM82.8 36.7l-23.3-24 -2.3-2.5v26.6h-6.7v-36H57l22.6 24 2.3 2.6V0.8h6.7v35.9H82.8z" />
+			<path d="M719.9 37l-4.8-8.9H694l-4.6 8.9h-7.1l19.5-36h5.6l19.8 36H719.9zM704.4 8l-7.8 15.1h15.9L704.4 8zM733 37V1h6.8v36H733zM781 37c-1.8 0-2.6-2.5-2.9-5.8l-0.2-3.7c-0.2-3.6-1.7-5.1-8.4-5.1h-12.8V37H750V1h19.6c10.8 0 15.7 4.3 15.7 9.9 0 3.9-2 7.7-9 9 7 0.5 8.5 3.7 8.6 7.9l0.1 3c0.1 2.5 0.5 4.3 2.2 6.1V37H781zM778.5 11.8c0-2.6-2.1-5.1-7.9-5.1h-13.8v10.8h14.4c5 0 7.3-2.4 7.3-5.2V11.8zM794.8 37V1h6.8v30.4h28.2V37H794.8zM836.7 37V1h6.8v36H836.7zM886.2 37l-23.4-24.1 -2.3-2.5V37h-6.8V1h6.5l22.7 24.1 2.3 2.6V1h6.8v36H886.2zM902.3 37V1H935v5.6h-26v9.2h20v5.5h-20v10.1h26V37H902.3z" />
+		</svg>
+	);
+};
+
+export default AutomatticBylineLogo;

--- a/client/components/jetpack/automattic-byline-logo/index.tsx
+++ b/client/components/jetpack/automattic-byline-logo/index.tsx
@@ -1,5 +1,5 @@
-import { __ } from '@wordpress/i18n';
 import classnames from 'classnames';
+import { useTranslate } from 'i18n-calypso';
 import React from 'react';
 import { AutomatticBylineLogoProps } from './types';
 
@@ -10,11 +10,13 @@ import { AutomatticBylineLogoProps } from './types';
  * @returns {React.ReactNode} AutomatticBylineLogo component.
  */
 const AutomatticBylineLogo: React.FC< AutomatticBylineLogoProps > = ( {
-	title = __( 'An Automattic Airline', 'jetpack' ),
+	title,
 	height = 7,
 	className,
 	...otherProps
 } ) => {
+	const tranlate = useTranslate();
+	title = title ?? tranlate( 'An Automattic Airline' );
 	return (
 		<svg
 			role="img"

--- a/client/components/jetpack/automattic-byline-logo/index.tsx
+++ b/client/components/jetpack/automattic-byline-logo/index.tsx
@@ -15,8 +15,8 @@ const AutomatticBylineLogo: React.FC< AutomatticBylineLogoProps > = ( {
 	className,
 	...otherProps
 } ) => {
-	const tranlate = useTranslate();
-	title = title ?? tranlate( 'An Automattic Airline' );
+	const translate = useTranslate();
+	title = title ?? translate( 'An Automattic Airline' );
 	return (
 		<svg
 			role="img"

--- a/client/components/jetpack/automattic-byline-logo/types.ts
+++ b/client/components/jetpack/automattic-byline-logo/types.ts
@@ -1,0 +1,18 @@
+import type React from 'react';
+
+export interface AutomatticBylineLogoProps extends React.SVGProps< SVGSVGElement > {
+	/**
+	 * Title for SVG.
+	 */
+	title?: string;
+
+	/**
+	 * Height for SVG.
+	 */
+	height?: number;
+
+	/**
+	 * Additional className for the a wrapper. `jp-automattic-byline-logo` always included
+	 */
+	className?: string;
+}

--- a/client/components/jetpack/jetpack-footer/README.md
+++ b/client/components/jetpack/jetpack-footer/README.md
@@ -1,0 +1,20 @@
+# Jetpack Admin Footer
+
+Component that renders Jetpack Admin Footer.
+It takes moduleName and URL to show in the footer.
+
+#### How to use:
+
+```js
+<JetpackFooter
+	moduleName="Jetpack Search"
+	a8cLogoHref="https://www.jetpack.com"
+	className="jp-dashboard-footer"
+/>
+```
+
+#### Props
+
+- `className`: String - (default: `jp-dashboard-footer`) the additional class name set on the element.
+- `a8cLogoHref`: String - (default: `https://www.jetpack.com`) link to be added on 'An Automattic Airline'.
+- `moduleName`: String - (default: `Jetpack`) set the name of the Module, e.g. `Jetpack Search`.

--- a/client/components/jetpack/jetpack-footer/README.md
+++ b/client/components/jetpack/jetpack-footer/README.md
@@ -3,17 +3,17 @@
 Component that renders Jetpack Admin Footer.
 It takes moduleName and URL to show in the footer.
 
-#### How to use:
+## How to use
 
 ```js
 <JetpackFooter
 	moduleName="Jetpack Search"
 	a8cLogoHref="https://www.jetpack.com"
 	className="jp-dashboard-footer"
-/>
+/>;
 ```
 
-#### Props
+## Props
 
 - `className`: String - (default: `jp-dashboard-footer`) the additional class name set on the element.
 - `a8cLogoHref`: String - (default: `https://www.jetpack.com`) link to be added on 'An Automattic Airline'.

--- a/client/components/jetpack/jetpack-footer/index.tsx
+++ b/client/components/jetpack/jetpack-footer/index.tsx
@@ -1,5 +1,5 @@
-import { __ } from '@wordpress/i18n';
 import classnames from 'classnames';
+import { useTranslate } from 'i18n-calypso';
 import React from 'react';
 import JetpackLogo from 'calypso/components/jetpack-logo';
 import AutomatticBylineLogo from 'calypso/components/jetpack/automattic-byline-logo';
@@ -15,11 +15,13 @@ import './style.scss';
  */
 const JetpackFooter: React.FC< JetpackFooterProps > = ( {
 	a8cLogoHref = 'https://automattic.com',
-	moduleName = __( 'Jetpack', 'jetpack' ),
+	moduleName,
 	className,
 	moduleNameHref = 'https://jetpack.com',
 	...otherProps
 } ) => {
+	const translate = useTranslate();
+	moduleName = moduleName ?? translate( 'Jetpack' );
 	return (
 		<div className={ classnames( 'jp-dashboard-footer', className ) } { ...otherProps }>
 			<div className="jp-dashboard-footer__footer-left">
@@ -27,7 +29,7 @@ const JetpackFooter: React.FC< JetpackFooterProps > = ( {
 					monochrome
 					size={ 16 }
 					className="jp-dashboard-footer__jetpack-symbol"
-					aria-label={ __( 'Jetpack logo', 'jetpack' ) }
+					aria-label={ translate( 'Jetpack logo' ) }
 				/>
 				<span className="jp-dashboard-footer__module-name">
 					{ moduleNameHref ? (
@@ -40,7 +42,7 @@ const JetpackFooter: React.FC< JetpackFooterProps > = ( {
 				</span>
 			</div>
 			<div className="jp-dashboard-footer__footer-right">
-				<a href={ a8cLogoHref } aria-label={ __( 'An Automattic Airline', 'jetpack' ) }>
+				<a href={ a8cLogoHref } aria-label={ translate( 'An Automattic Airline' ) }>
 					<AutomatticBylineLogo height={ 7 } />
 				</a>
 			</div>

--- a/client/components/jetpack/jetpack-footer/index.tsx
+++ b/client/components/jetpack/jetpack-footer/index.tsx
@@ -1,0 +1,51 @@
+import { __ } from '@wordpress/i18n';
+import classnames from 'classnames';
+import React from 'react';
+import JetpackLogo from 'calypso/components/jetpack-logo';
+import AutomatticBylineLogo from 'calypso/components/jetpack/automattic-byline-logo';
+import type { JetpackFooterProps } from './types';
+
+import './style.scss';
+
+/**
+ * JetpackFooter component displays a tiny Jetpack logo with the product name on the left and the Automattic Airline "by line" on the right.
+ *
+ * @param {JetpackFooterProps} props - Component properties.
+ * @returns {React.ReactNode} JetpackFooter component.
+ */
+const JetpackFooter: React.FC< JetpackFooterProps > = ( {
+	a8cLogoHref = 'https://automattic.com',
+	moduleName = __( 'Jetpack', 'jetpack' ),
+	className,
+	moduleNameHref = 'https://jetpack.com',
+	...otherProps
+} ) => {
+	return (
+		<div className={ classnames( 'jp-dashboard-footer', className ) } { ...otherProps }>
+			<div className="jp-dashboard-footer__footer-left">
+				<JetpackLogo
+					monochrome
+					size={ 16 }
+					className="jp-dashboard-footer__jetpack-symbol"
+					aria-label={ __( 'Jetpack logo', 'jetpack' ) }
+				/>
+				<span className="jp-dashboard-footer__module-name">
+					{ moduleNameHref ? (
+						<a href={ moduleNameHref } aria-label={ moduleName }>
+							{ moduleName }
+						</a>
+					) : (
+						moduleName
+					) }
+				</span>
+			</div>
+			<div className="jp-dashboard-footer__footer-right">
+				<a href={ a8cLogoHref } aria-label={ __( 'An Automattic Airline', 'jetpack' ) }>
+					<AutomatticBylineLogo height={ 7 } />
+				</a>
+			</div>
+		</div>
+	);
+};
+
+export default JetpackFooter;

--- a/client/components/jetpack/jetpack-footer/style.scss
+++ b/client/components/jetpack/jetpack-footer/style.scss
@@ -4,6 +4,8 @@
 	justify-content: space-between;
 	align-items: center;
 
+	padding: 32px 0;
+
 	color: #000;
 
 	a,

--- a/client/components/jetpack/jetpack-footer/style.scss
+++ b/client/components/jetpack/jetpack-footer/style.scss
@@ -1,0 +1,25 @@
+.jp-dashboard-footer {
+	display: flex;
+	flex-flow: row wrap;
+	justify-content: space-between;
+	align-items: center;
+
+	color: #000;
+
+	a,
+	a:hover,
+	a:visited {
+		color: #000;
+		text-decoration: none;
+	}
+}
+.jp-dashboard-footer__module-name,
+.jp-dashboard-footer__jetpack-symbol {
+	vertical-align: middle;
+	display: inline-block;
+}
+.jp-dashboard-footer__module-name {
+	margin-left: 5px;
+	font-size: $font-body-extra-small;
+	font-weight: 600;
+}

--- a/client/components/jetpack/jetpack-footer/types.ts
+++ b/client/components/jetpack/jetpack-footer/types.ts
@@ -1,0 +1,21 @@
+export type JetpackFooterProps = {
+	/**
+	 * Link for 'An Automattic Airline'.
+	 */
+	a8cLogoHref?: string;
+
+	/**
+	 * Name of the module, e.g. 'Jetpack Search'.
+	 */
+	moduleName?: string;
+
+	/**
+	 * additional className of the wrapper, `jp-dashboard-footer` always included.
+	 */
+	className?: string;
+
+	/**
+	 * Link that the Module name will link to (optional).
+	 */
+	moduleNameHref?: string;
+};


### PR DESCRIPTION
#### Proposed Changes

Forks `AutomatticBylineLogo` and `JetpackFooter` from Jetpack repository. Replaced dependencies of JetpackFooter with Calypso ones.

Replaces `JetpackColophone` with `JetpackFooter` by `NormalModuleReplacementPlugin` on Odyssey build.

#### Testing Instructions

* Setup Odyssey with Option 1 in `PejTkB-3E-p2`
* Open `/wp-admin/admin.php?page=stats`
* Ensure all footers are like the one in the screenshot below

<img width="1284" alt="image" src="https://user-images.githubusercontent.com/1425433/214459564-dd03df48-e27e-40c3-9e47-a3595e5cd75d.png">


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
