### PR TITLE
Jetpack Pro Dashboard: Remove downtime monitoring notifications feature flag code

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/index.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { Card } from '@automattic/components';
 import { useMobileBreakpoint } from '@automattic/viewport-react';
 import page from 'page';
@@ -49,18 +48,16 @@ export default function SiteContent( { data, isLoading, currentPage, isFavorites
 				<SiteTable isLoading={ isLoading } columns={ siteColumns } items={ sites } />
 			</div>
 			<div className="site-content__small-screen-view">
-				{ isEnabled( 'jetpack/partner-portal-downtime-monitoring-updates' ) && (
-					<Card className="site-content__bulk-select">
-						{ isBulkManagementActive ? (
-							<SiteBulkSelect sites={ sites } isLoading={ isLoading } />
-						) : (
-							<>
-								<span className="site-content__bulk-select-label">{ siteColumns[ 0 ].title }</span>
-								<EditButton sites={ sites } />
-							</>
-						) }
-					</Card>
-				) }
+				<Card className="site-content__bulk-select">
+					{ isBulkManagementActive ? (
+						<SiteBulkSelect sites={ sites } isLoading={ isLoading } />
+					) : (
+						<>
+							<span className="site-content__bulk-select-label">{ siteColumns[ 0 ].title }</span>
+							<EditButton sites={ sites } />
+						</>
+					) }
+				</Card>
 				<div className="site-content__mobile-view">
 					<>
 						{ isLoading ? (

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { Button, Gridicon } from '@automattic/components';
 import { addQueryArgs } from '@wordpress/url';
 import classNames from 'classnames';
@@ -158,12 +157,8 @@ export default function SiteStatusContent( {
 		);
 	}
 
-	const isDownTimeMonitorEnabled = isEnabled(
-		'jetpack/partner-portal-downtime-monitoring-updates'
-	);
-
 	// We will show "Site Down" when the site is down which is handled differently.
-	if ( isDownTimeMonitorEnabled && type === 'monitor' && ! siteDown ) {
+	if ( type === 'monitor' && ! siteDown ) {
 		return (
 			<ToggleActivateMonitoring
 				site={ rows.site.value }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/index.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { Icon, starFilled } from '@wordpress/icons';
 import classNames from 'classnames';
 import { useContext } from 'react';
@@ -40,15 +39,11 @@ export default function SiteTable( { isLoading, columns, items }: Props ) {
 									</span>
 								</th>
 							) ) }
-							{ isEnabled( 'jetpack/partner-portal-downtime-monitoring-updates' ) ? (
-								<th>
-									<div className="plugin-common-table__bulk-actions">
-										<EditButton isLargeScreen sites={ items } />
-									</div>
-								</th>
-							) : (
-								<th></th>
-							) }
+							<th>
+								<div className="plugin-common-table__bulk-actions">
+									<EditButton isLargeScreen sites={ items } />
+								</div>
+							</th>
 						</>
 					) }
 				</tr>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/test/site-table.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/test/site-table.tsx
@@ -5,6 +5,7 @@
 import { render } from '@testing-library/react';
 import { translate } from 'i18n-calypso';
 import nock from 'nock';
+import React from 'react';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
@@ -114,14 +115,6 @@ describe( '<SiteTable>', () => {
 		expect( scanEle.getAttribute( 'href' ) ).toEqual( `/scan/${ siteUrl }` );
 		expect( scanEle.getElementsByClassName( 'sites-overview__badge' )[ 0 ].textContent ).toEqual(
 			`${ scanThreats } Threats`
-		);
-
-		const monitorEle = getByTestId( `row-${ blogId }-monitor` );
-		expect( monitorEle.getAttribute( 'href' ) ).toEqual(
-			`https://jptools.wordpress.com/debug/?url=${ siteUrl }`
-		);
-		expect( monitorEle.getElementsByClassName( 'sites-overview__badge' )[ 0 ].textContent ).toEqual(
-			'Site Down'
 		);
 
 		const pluginEle = getByTestId( `row-${ blogId }-plugin` );

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -43,7 +43,6 @@
 		"jetpack/agency-dashboard": true,
 		"jetpack/backup-messaging-i3": true,
 		"jetpack/backup-retention-settings": true,
-		"jetpack/partner-portal-downtime-monitoring-updates": true,
 		"jetpack/partner-portal-payment": true,
 		"jetpack/plugin-management": true,
 		"jetpack/pricing-add-boost-social": true,

--- a/config/jetpack-cloud-horizon.json
+++ b/config/jetpack-cloud-horizon.json
@@ -37,7 +37,6 @@
 		"jetpack/agency-dashboard": true,
 		"jetpack/backup-messaging-i3": true,
 		"jetpack/backup-retention-settings": true,
-		"jetpack/partner-portal-downtime-monitoring-updates": true,
 		"jetpack/partner-portal-payment": true,
 		"jetpack/plugin-management": true,
 		"jetpack/pricing-add-boost-social": true,

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -39,7 +39,6 @@
 		"jetpack-cloud": true,
 		"jetpack/agency-dashboard": true,
 		"jetpack/backup-messaging-i3": true,
-		"jetpack/partner-portal-downtime-monitoring-updates": true,
 		"jetpack/partner-portal-payment": true,
 		"jetpack/plugin-management": true,
 		"jetpack/pricing-add-boost-social": true,

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -40,7 +40,6 @@
 		"jetpack/agency-dashboard": true,
 		"jetpack/backup-messaging-i3": true,
 		"jetpack/backup-retention-settings": true,
-		"jetpack/partner-portal-downtime-monitoring-updates": true,
 		"jetpack/partner-portal-payment": true,
 		"jetpack/plugin-management": true,
 		"jetpack/pricing-add-boost-social": true,


### PR DESCRIPTION
#### Proposed Changes

This PR removes the feature flags and their related logic for the downtime monitoring notification project changes.

#### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout update/remove-downtime-monitoring-feature-flag-code` and `yarn start-jetpack-cloud`
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Verify `Edit All` button is visible on large and small screen devices. 
4. Verify the monitor column shows the toggle to enable/disable the monitor. 

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1203448324265423-as-1203773179107813