### PR TITLE
Copy site: marketing products to cart for copy site

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
@@ -4,13 +4,13 @@ import {
 	WOOEXPRESS_FLOW,
 	isLinkInBioFlow,
 	addPlanToCart,
-	addProductToCart,
 	createSiteWithCart,
 	isFreeFlow,
 	isMigrationFlow,
 	isCopySiteFlow,
 	isWooExpressFlow,
 	StepContainer,
+	addProductsToCart,
 } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
@@ -42,14 +42,14 @@ const SiteCreationStep: Step = function SiteCreationStep( { navigation, flow } )
 	const stepProgress = useSelect( ( select ) => select( ONBOARD_STORE ).getStepProgress() );
 
 	// @TODO fetch all productCartItems too
-	const { domainCartItem, planCartItem, siteAccentColor, getSelectedSiteTitle } = useSelect(
-		( select ) => ( {
+	const { domainCartItem, planCartItem, siteAccentColor, getSelectedSiteTitle, productCartItems } =
+		useSelect( ( select ) => ( {
 			domainCartItem: select( ONBOARD_STORE ).getDomainCartItem(),
 			siteAccentColor: select( ONBOARD_STORE ).getSelectedSiteAccentColor(),
 			planCartItem: select( ONBOARD_STORE ).getPlanCartItem(),
+			productCartItems: select( ONBOARD_STORE ).getProductCartItems(),
 			getSelectedSiteTitle: select( ONBOARD_STORE ).getSelectedSiteTitle(),
-		} )
-	);
+		} ) );
 
 	const username = useSelector( ( state ) => getCurrentUserName( state ) );
 
@@ -118,10 +118,7 @@ const SiteCreationStep: Step = function SiteCreationStep( { navigation, flow } )
 			await addPlanToCart( site?.siteSlug as string, flow as string, true, theme, planCartItem );
 		}
 
-		// @TODO update to iterate through productCartItems
-		await addProductToCart( site?.siteSlug as string, flow as string, {
-			product_slug: 'wordpress_seo_premium_monthly',
-		} );
+		await addProductsToCart( site?.siteSlug as string, flow as string, productCartItems );
 
 		return {
 			siteSlug: site?.siteSlug,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
@@ -41,7 +41,6 @@ const SiteCreationStep: Step = function SiteCreationStep( { navigation, flow } )
 	const { __ } = useI18n();
 	const stepProgress = useSelect( ( select ) => select( ONBOARD_STORE ).getStepProgress() );
 
-	// @TODO fetch all productCartItems too
 	const { domainCartItem, planCartItem, siteAccentColor, getSelectedSiteTitle, productCartItems } =
 		useSelect( ( select ) => ( {
 			domainCartItem: select( ONBOARD_STORE ).getDomainCartItem(),

--- a/client/sites-dashboard/components/sites-ellipsis-menu.tsx
+++ b/client/sites-dashboard/components/sites-ellipsis-menu.tsx
@@ -217,11 +217,6 @@ const CopySiteItem = ( { recordTracks, site }: SitesMenuItemProps ) => {
 					.filter( ( purchase ) => purchase.productType === 'marketplace_plugin' )
 					.map( ( purchase ) => ( { product_slug: purchase.productSlug } ) );
 
-				//Toy example
-				marketplacePluginProducts.push( {
-					product_slug: 'wordpress_seo_premium_monthly',
-				} );
-
 				setProductCartItems( marketplacePluginProducts );
 				recordTracks( 'calypso_sites_dashboard_site_action_copy_site_click' );
 			} }

--- a/client/sites-dashboard/components/sites-ellipsis-menu.tsx
+++ b/client/sites-dashboard/components/sites-ellipsis-menu.tsx
@@ -192,15 +192,15 @@ const PreviewSiteModalItem = ( { recordTracks, site }: SitesMenuItemProps ) => {
 const CopySiteItem = ( { recordTracks, site }: SitesMenuItemProps ) => {
 	const { __ } = useI18n();
 	useQuerySitePurchases( site.ID );
-	const { setPlanCartItem, addProductCartItem } = useDispatch( ONBOARD_STORE );
-	const plan = site.plan;
+	const { setPlanCartItem, setProductCartItems } = useDispatch( ONBOARD_STORE );
+	const plan = site?.plan;
 
 	const purchases = useSelector( ( state ) => getSitePurchases( state, site.ID ) );
 	const isLoadingPurchase = useSelector(
 		( state ) => isFetchingSitePurchases( state ) || ! hasLoadedSitePurchasesFromServer( state )
 	);
 
-	if ( isLoadingPurchase ) {
+	if ( isLoadingPurchase || ! plan ) {
 		return null;
 	}
 
@@ -213,11 +213,16 @@ const CopySiteItem = ( { recordTracks, site }: SitesMenuItemProps ) => {
 			onClick={ () => {
 				clearSignupDestinationCookie();
 				setPlanCartItem( { product_slug: plan.product_slug } );
-				purchases.forEach( ( purchase ) => {
-					if ( 'marketplace_plugin' === purchase.productType ) {
-						addProductCartItem( { product_slug: purchase.productSlug } );
-					}
+				const marketplacePluginProducts = purchases
+					.filter( ( purchase ) => purchase.productType === 'marketplace_plugin' )
+					.map( ( purchase ) => ( { product_slug: purchase.productSlug } ) );
+
+				//Toy example
+				marketplacePluginProducts.push( {
+					product_slug: 'wordpress_seo_premium_monthly',
 				} );
+
+				setProductCartItems( marketplacePluginProducts );
 				recordTracks( 'calypso_sites_dashboard_site_action_copy_site_click' );
 			} }
 		>

--- a/packages/data-stores/src/onboard/actions.ts
+++ b/packages/data-stores/src/onboard/actions.ts
@@ -226,9 +226,9 @@ export const setPlanCartItem = ( planCartItem: MinimalRequestCartProduct | null 
 	planCartItem,
 } );
 
-export const addProductCartItem = ( productCartItem: MinimalRequestCartProduct | null ) => ( {
-	type: 'ADD_PRODUCT_CART_ITEM' as const,
-	productCartItem,
+export const setProductCartItems = ( productCartItems: MinimalRequestCartProduct[] | null ) => ( {
+	type: 'SET_PRODUCT_CART_ITEMS' as const,
+	productCartItems,
 } );
 
 export const setRandomizedDesigns = ( randomizedDesigns: { featured: Design[] } ) => ( {
@@ -468,6 +468,7 @@ export type OnboardAction = ReturnType<
 	| typeof setStoreLocationCountryCode
 	| typeof setEcommerceFlowRecurType
 	| typeof setHideFreePlan
+	| typeof setProductCartItems
 	| typeof setPlanCartItem
 	| typeof setIsMigrateFromWp
 >;

--- a/packages/data-stores/src/onboard/reducer.ts
+++ b/packages/data-stores/src/onboard/reducer.ts
@@ -217,6 +217,19 @@ const siteLogo: Reducer< null | string, OnboardAction > = ( state = null, action
 	return state;
 };
 
+const productCartItems: Reducer< MinimalRequestCartProduct[] | null, OnboardAction > = (
+	state = [],
+	action
+) => {
+	if ( action.type === 'SET_PRODUCT_CART_ITEMS' ) {
+		return action.productCartItems;
+	}
+	if ( action.type === 'RESET_ONBOARD_STORE' ) {
+		return [];
+	}
+	return state;
+};
+
 const planCartItem: Reducer< MinimalRequestCartProduct | null, OnboardAction > = (
 	state = null,
 	action
@@ -511,6 +524,7 @@ const reducer = combineReducers( {
 	storeLocationCountryCode,
 	ecommerceFlowRecurType,
 	planCartItem,
+	productCartItems,
 	isMigrateFromWp,
 } );
 

--- a/packages/data-stores/src/onboard/selectors.ts
+++ b/packages/data-stores/src/onboard/selectors.ts
@@ -6,6 +6,7 @@ export const getAnchorSpotifyUrl = ( state: State ) => state.anchorSpotifyUrl;
 export const getIsRedirecting = ( state: State ) => state.isRedirecting;
 export const getPlanProductId = ( state: State ) => state.planProductId;
 export const getPlanCartItem = ( state: State ) => state.planCartItem;
+export const getProductCartItems = ( state: State ) => state.productCartItems;
 export const getLastLocation = ( state: State ) => state.lastLocation;
 export const getRandomizedDesigns = ( state: State ) => state.randomizedDesigns;
 export const getSelectedDesign = ( state: State ) => state.selectedDesign;

--- a/packages/onboarding/src/cart/index.tsx
+++ b/packages/onboarding/src/cart/index.tsx
@@ -227,12 +227,29 @@ const addToCartAndProceed = async (
 	}
 };
 
-export async function addProductToCart(
+export async function addProductsToCart(
 	siteSlug: string,
 	flowName: string,
-	cartItem: MinimalRequestCartProduct
+	cartItems: MinimalRequestCartProduct[] | null
 ) {
-	await addToCartAndProceed( cartItem, siteSlug, flowName );
+	if ( Array.isArray( cartItems ) ) {
+		const cartItemsToAdd = cartItems.map( ( cartItem ) =>
+			prepareItemForAddingToCart( cartItem, flowName )
+		);
+
+		debug( 'adding products to cart', cartItems );
+		const cartKey = await cartManagerClient.getCartKeyForSiteSlug( siteSlug );
+
+		try {
+			const updatedCart = await cartManagerClient
+				.forCartKey( cartKey )
+				.actions.addProductsToCart( cartItemsToAdd );
+
+			debug( 'product add request complete', updatedCart );
+		} catch ( error ) {
+			debug( 'product add request had an error', error );
+		}
+	}
 }
 
 export async function setThemeOnSite( siteSlug: string, themeSlugWithRepo: string ) {

--- a/packages/onboarding/src/index.ts
+++ b/packages/onboarding/src/index.ts
@@ -7,7 +7,7 @@ export {
 	SkipButton,
 	ArrowButton,
 } from './action-buttons';
-export { createSiteWithCart, addPlanToCart, addProductToCart } from './cart';
+export { createSiteWithCart, addPlanToCart, addProductsToCart } from './cart';
 export { setupSiteAfterCreation, base64ImageToBlob } from './setup-tailored-site-after-creation';
 export { uploadAndSetSiteLogo } from './upload-and-set-site-logo';
 export { default as FeatureIcon } from './feature-icon';


### PR DESCRIPTION
#### Proposed Changes

Cleanup and fix code for including marketing plugins when the user copies his site.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Create a site with `Business plan`
2. Navigate to `Plugins > Add new`. Find `Yoast SEO premium` and buy a subscription for that plugin.
3. Ensure that your site is atomic.
4. Navigate to `/sites` in calypso.
5. Find your site and select `Copy Site` in the right corner (the three dots menu)
5. Make sure that the Yoast subscriptions exist in your cart items

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
