### PR TITLE
Plans 2023: Implement plan selection in the comparison grid

### DIFF
--- a/client/my-sites/plan-features-2023-grid/plan-comparison-grid.tsx
+++ b/client/my-sites/plan-features-2023-grid/plan-comparison-grid.tsx
@@ -83,6 +83,34 @@ const RowHead = styled.div`
 	flex: 1;
 `;
 
+const PlanSelector = styled.header`
+	position: relative;
+
+	.plan-comparison-grid__title {
+		.gridicon {
+			margin-left: 6px;
+		}
+	}
+
+	.plan-comparison-grid__title-select {
+		appearance: none;
+		-moz-appearance: none;
+		-webkit-appearance: none;
+		background: 0 0;
+		border: none;
+		font-size: inherit;
+		color: inherit;
+		font-family: inherit;
+		opacity: 0;
+		width: 100%;
+		position: absolute;
+		top: 0;
+		left: 0;
+		cursor: pointer;
+		height: 30px;
+	}
+`;
+
 const StorageButton = styled.div`
 	background: #f2f2f2;
 	border-radius: 5px;
@@ -154,8 +182,11 @@ const PlanComparisonGridHeader: React.FC< PlanComparisonGridHeaderProps > = ( {
 								<PlanPill isInSignup={ isInSignup }>{ translate( 'Popular' ) }</PlanPill>
 							</div>
 						) }
-						<header>
-							<h4 className="plan-comparison-grid__title">{ planConstantObj.getTitle() }</h4>
+						<PlanSelector>
+							<h4 className="plan-comparison-grid__title">
+								{ planConstantObj.getTitle() }
+								{ showPlanSelect && <Gridicon icon="chevron-down" size={ 12 } color="#0675C4" /> }
+							</h4>
 							{ showPlanSelect && (
 								<select
 									onChange={ ( event: ChangeEvent ) => onPlanChange( planName, event ) }
@@ -181,7 +212,7 @@ const PlanComparisonGridHeader: React.FC< PlanComparisonGridHeaderProps > = ( {
 									) }
 								</select>
 							) }
-						</header>
+						</PlanSelector>
 						<PlanFeatures2023GridHeaderPrice
 							currencyCode={ currencyCode }
 							discountPrice={ planPropertiesObj.discountPrice }

--- a/client/my-sites/plan-features-2023-grid/plan-comparison-grid.tsx
+++ b/client/my-sites/plan-features-2023-grid/plan-comparison-grid.tsx
@@ -125,6 +125,7 @@ const PlanComparisonGridHeader: React.FC< PlanComparisonGridHeaderProps > = ( {
 } ) => {
 	const translate = useTranslate();
 	const currencyCode = useSelector( getCurrentUserCurrencyCode );
+	const allVisible = visiblePlansProperties.length === displayedPlansProperties.length;
 	return (
 		<Row className="plan-comparison-grid__plan-row">
 			<RowHead
@@ -143,7 +144,8 @@ const PlanComparisonGridHeader: React.FC< PlanComparisonGridHeaderProps > = ( {
 
 				const rawPrice = planPropertiesObj.rawPrice;
 				const isLargeCurrency = rawPrice ? rawPrice > 99000 : false;
-				const showPlanSelect = isInSignup || planName !== 'free_plan';
+
+				const showPlanSelect = ! allVisible && ( isInSignup || planName !== 'free_plan' );
 
 				return (
 					<Cell key={ planName } className={ headerClasses } textAlign="left">
@@ -249,7 +251,7 @@ export const PlanComparisonGrid: React.FC< PlanComparisonGridProps > = ( {
 		}
 
 		setVisiblePlans( newVisiblePlans );
-	}, [ isMediumBreakpoint ] );
+	}, [ isMediumBreakpoint, intervalType ] );
 
 	const restructuredFeatures = useMemo( () => {
 		let previousPlan = null;

--- a/client/my-sites/plan-features-2023-grid/plan-comparison-grid.tsx
+++ b/client/my-sites/plan-features-2023-grid/plan-comparison-grid.tsx
@@ -173,7 +173,7 @@ const PlanComparisonGridHeader: React.FC< PlanComparisonGridHeaderProps > = ( {
 				const rawPrice = planPropertiesObj.rawPrice;
 				const isLargeCurrency = rawPrice ? rawPrice > 99000 : false;
 
-				const showPlanSelect = ! allVisible && ( isInSignup || planName !== 'free_plan' );
+				const showPlanSelect = ! allVisible;
 
 				return (
 					<Cell key={ planName } className={ headerClasses } textAlign="left">

--- a/client/my-sites/plan-features-2023-grid/util.ts
+++ b/client/my-sites/plan-features-2023-grid/util.ts
@@ -5,6 +5,7 @@ import {
 	FEATURE_200GB_STORAGE,
 } from '@automattic/calypso-products';
 import { translate } from 'i18n-calypso';
+import { useCallback, useEffect, useState } from 'react';
 
 export const getStorageStringFromFeature = ( storageFeature: string ) => {
 	switch ( storageFeature ) {
@@ -19,4 +20,26 @@ export const getStorageStringFromFeature = ( storageFeature: string ) => {
 		default:
 			return null;
 	}
+};
+
+export const usePricingBreakpoint = ( targetBreakpoint: number ) => {
+	const [ breakpoint, setBreakpoint ] = useState( false );
+
+	const handleResize = useCallback( () => {
+		if ( typeof window === 'undefined' ) {
+			return;
+		}
+		setBreakpoint( window.innerWidth < targetBreakpoint );
+	}, [ targetBreakpoint ] );
+
+	useEffect( () => {
+		window.addEventListener( 'resize', handleResize );
+		return () => window.removeEventListener( 'resize', handleResize );
+	}, [ handleResize ] );
+
+	useEffect( () => {
+		handleResize();
+	}, [] );
+
+	return breakpoint;
 };


### PR DESCRIPTION
#### Proposed Changes

This shows only 2 selectable plans for screen sizes smaller than 880px, in the Plans comparison grid.
<img width="410" alt="Screenshot 2023-01-25 at 14 26 48" src="https://user-images.githubusercontent.com/2749938/214565278-bb52fa67-dcb5-465e-9af0-a6b2461c6be0.png">



#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /start/onboarding-2023-pricing-grid/plans
* Reduce the screen size to below <880px
* You should be able to switch between plans by clicking the plan titles (top and bottom)
* You should be able to compare two different plans
* Resizing back to large screens should return the initial state

NOTE: Will be following up with further styling work.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/martech/issues/1435
