### PR TITLE
Email stats: add clicks summary card

### DIFF
--- a/client/my-sites/stats/grid-layout.scss
+++ b/client/my-sites/stats/grid-layout.scss
@@ -103,8 +103,8 @@ $grid-vertical-gutters: 32px;
 		"country country country country country country country country country country country country"
 		"authors authors authors authors search search search search clicks clicks clicks clicks"
 		"videos videos videos videos videos videos downloads downloads downloads downloads downloads downloads"
-		"emails-open emails-open emails-open emails-open emails-open emails-open emails-open emails-open emails-open emails-open emails-open emails-open",
-		5
+		"emails-open emails-open emails-open emails-open emails-open emails-open emails-click emails-click emails-click emails-click emails-click emails-click",
+		6
 	);
 
 	@include stats-tablet-grid(
@@ -113,8 +113,8 @@ $grid-vertical-gutters: 32px;
 		"authors authors authors authors search search search search"
 		"clicks clicks clicks clicks videos videos videos videos"
 		"downloads downloads downloads downloads downloads downloads downloads downloads"
-		"emails-open emails-open emails-open emails-open emails-open emails-open emails-open emails-open",
-		6
+		"emails-open emails-open emails-open emails-open emails-click emails-click emails-click emails-click",
+		7
 	);
 
 	@include stats-mobile-grid(
@@ -126,8 +126,9 @@ $grid-vertical-gutters: 32px;
 		"clicks clicks clicks clicks"
 		"videos videos videos videos"
 		"downloads downloads downloads downloads"
-		"emails-open emails-open emails-open emails-open",
-		9
+		"emails-open emails-open"
+		"emails-click emails-click",
+		10
 	);
 
 	.card.stats-module {
@@ -205,5 +206,10 @@ $grid-vertical-gutters: 32px;
 	.stats__module-wrapper--emails,
 	.list-emails-open {
 		grid-area: emails-open;
+	}
+
+	.stats__module-wrapper--emails,
+	.list-emails-click {
+		grid-area: emails-click;
 	}
 }

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -259,16 +259,6 @@ class StatsSite extends Component {
 					/>
 
 					<div className="stats__module-list stats__module-list--traffic is-events stats__module--unified">
-						{ config.isEnabled( 'newsletter/stats' ) && (
-							<StatsModule
-								path="emails-open"
-								moduleStrings={ moduleStrings.emailsOpenStats }
-								period={ this.props.period }
-								query={ query }
-								statType="statsEmailsOpen"
-								hideSummaryLink
-							/>
-						) }
 						<StatsModule
 							path="posts"
 							moduleStrings={ moduleStrings.posts }
@@ -327,12 +317,35 @@ class StatsSite extends Component {
 							statType="statsVideoPlays"
 							showSummaryLink
 						/>
+						{ config.isEnabled( 'newsletter/stats' ) && (
+							<>
+								<StatsModule
+									path="emails-open"
+									moduleStrings={ moduleStrings.emailsOpenStats }
+									period={ this.props.period }
+									query={ query }
+									statType="statsEmailsOpen"
+									hideSummaryLink
+									metricLabel={ translate( 'Opens' ) }
+								/>
+								<StatsModule
+									path="emails-click"
+									moduleStrings={ moduleStrings.emailsClickStats }
+									period={ this.props.period }
+									query={ query }
+									statType="statsEmailsClick"
+									hideSummaryLink
+									metricLabel={ translate( 'Clicks' ) }
+								/>
+							</>
+						) }
 						{
 							// File downloads are not yet supported in Jetpack Stats
 							// TODO: Confirm the above statement.
 							! isJetpack && (
 								<StatsModule
 									path="filedownloads"
+									metricLabel={ translate( 'Downloads' ) }
 									moduleStrings={ moduleStrings.filedownloads }
 									period={ this.props.period }
 									query={ query }

--- a/client/my-sites/stats/stats-list/stats-list-card.jsx
+++ b/client/my-sites/stats/stats-list/stats-list-card.jsx
@@ -5,7 +5,6 @@ import {
 	StatsCardAvatar,
 } from '@automattic/components';
 import debugFactory from 'debug';
-import { useTranslate } from 'i18n-calypso';
 import page from 'page';
 import React, { useState, useCallback } from 'react';
 import titlecase from 'to-title-case';
@@ -24,8 +23,8 @@ const StatsListCard = ( {
 	useShortLabel,
 	error,
 	heroElement,
+	metricLabel,
 } ) => {
-	const translate = useTranslate();
 	const moduleNameTitle = titlecase( moduleType );
 	const debug = debugFactory( `calypso:stats:list:${ moduleType }` );
 	const [ visibleRightItemKey, setVisibleRightItemKey ] = useState( undefined );
@@ -99,7 +98,7 @@ const StatsListCard = ( {
 			emptyMessage={ emptyMessage }
 			isEmpty={ ! loader && ( ! data || ! data?.length ) }
 			className={ `list-${ moduleType }` }
-			metricLabel={ moduleType === 'filedownloads' ? translate( 'Downloads' ) : undefined }
+			metricLabel={ metricLabel }
 			heroElement={ heroElement }
 		>
 			{ !! loader && loader }

--- a/client/my-sites/stats/stats-module/index.jsx
+++ b/client/my-sites/stats/stats-module/index.jsx
@@ -43,6 +43,7 @@ class StatsModule extends Component {
 		statType: PropTypes.string,
 		showSummaryLink: PropTypes.bool,
 		translate: PropTypes.func,
+		metricLabel: PropTypes.string,
 	};
 
 	static defaultProps = {
@@ -111,6 +112,7 @@ class StatsModule extends Component {
 			'statsClicks',
 			'statsReferrers',
 			'statsEmailsOpen',
+			'statsEmailsClick',
 		];
 		return summary && includes( summarizedTypes, statType );
 	}
@@ -130,6 +132,7 @@ class StatsModule extends Component {
 			translate,
 			useShortLabel,
 			hideNewModule, // remove when cleaning 'stats/horizontal-bars-everywhere' FF
+			metricLabel,
 		} = this.props;
 
 		const noData = data && this.state.loaded && ! data.length;
@@ -198,6 +201,7 @@ class StatsModule extends Component {
 							useShortLabel={ useShortLabel }
 							title={ this.props.moduleStrings?.title }
 							emptyMessage={ moduleStrings.empty }
+							metricLabel={ metricLabel }
 							showMore={
 								displaySummaryLink && ! summary
 									? {

--- a/client/my-sites/stats/stats-strings.js
+++ b/client/my-sites/stats/stats-strings.js
@@ -116,9 +116,20 @@ export default function () {
 	statsStrings.emailsOpenStats = {
 		title: translate( 'Email opens', { context: 'Stats: title of module' } ),
 		item: translate( 'Title', { context: 'Stats: module row header for post title.' } ),
-		value: translate( 'Views', { context: 'Stats: module row header for number of post views.' } ),
+		value: translate( 'Opens', { context: 'Stats: module row header for number of email opens.' } ),
 		empty: translate( 'No email opens', {
 			context: 'Stats: Info box label when the Email Open module is empty',
+		} ),
+	};
+
+	statsStrings.emailsClickStats = {
+		title: translate( 'Email clicks', { context: 'Stats: title of module' } ),
+		item: translate( 'Title', { context: 'Stats: module row header for post title.' } ),
+		value: translate( 'Clicks', {
+			context: 'Stats: module row header for number of email clicks.',
+		} ),
+		empty: translate( 'No email clicks', {
+			context: 'Stats: Info box label when the Email Click module is empty',
 		} ),
 	};
 

--- a/client/state/stats/lists/actions.js
+++ b/client/state/stats/lists/actions.js
@@ -34,6 +34,7 @@ const wpcomV1Endpoints = {
 	statsFileDownloads: 'stats/file-downloads',
 	statsAds: 'wordads/stats',
 	statsEmailsOpen: 'stats/opens/emails/summary',
+	statsEmailsClick: 'stats/clicks/emails/summary',
 };
 
 const wpcomV2Endpoints = {
@@ -76,6 +77,7 @@ export function requestSiteStats( siteId, statType, query ) {
 				case 'statsVideo':
 					return query.postId;
 				case 'statsEmailsOpen':
+				case 'statsEmailsClick':
 					return { period: PERIOD_ALL_TIME, quantity: 10 };
 				default:
 					return query;

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -953,9 +953,7 @@ export const normalizers = {
 		const emailsData = get( data, [ 'posts' ], [] );
 
 		return emailsData.map( ( { id, href, date, title, type, opens } ) => {
-			const detailPage = site
-				? `/stats/email/opens/${ site.slug }/${ query.period }/${ id }`
-				: null;
+			const detailPage = site ? `/stats/email/opens/${ site.slug }/day/${ id }` : null;
 			return {
 				id,
 				href,
@@ -963,6 +961,42 @@ export const normalizers = {
 				label: title,
 				type,
 				value: opens || '0',
+				page: detailPage,
+				actions: [
+					{
+						type: 'link',
+						data: href,
+					},
+				],
+			};
+		} );
+	},
+
+	/**
+	 * Returns a normalized statsEmailsClick array, ready for use in stats-module
+	 *
+	 * @param   {Object} data   Stats data
+	 * @param   {Object} query  Stats query
+	 * @param   {number} siteId  Site ID
+	 * @param   {Object} site    Site object
+	 * @returns {Array}       Normalized stats data
+	 */
+	statsEmailsClick( data, query = {}, siteId, site ) {
+		if ( ! data || ! query.period || ! query.date ) {
+			return [];
+		}
+
+		const emailsData = get( data, [ 'posts' ], [] );
+
+		return emailsData.map( ( { id, href, date, title, type, clicks } ) => {
+			const detailPage = site ? `/stats/email/clicks/${ site.slug }/day/${ id }` : null;
+			return {
+				id,
+				href,
+				date,
+				label: title,
+				type,
+				value: clicks || '0',
 				page: detailPage,
 				actions: [
 					{


### PR DESCRIPTION
#### Proposed Changes

* This PR adds the clicks summary card to the stats overview

![CleanShot 2023-01-25 at 13 44 20@2x](https://user-images.githubusercontent.com/528287/214570465-bbf1bdb1-2528-4da1-82cf-ebb28837b109.png)

It also fixes two things:
- Clicking on a link in the Email Opens card while being in another view than "Days" would error
- Add a property `metricLabel` to the `<StatsModule />` component. This allows overriding the default "Views" metric label. This property is then passed on to the `<StatsCard />` component. There was already a some code present to show a different metric label, but it was not as extensible:

```javascript
metricLabel={ moduleType === 'filedownloads' ? translate( 'Downloads' ) : undefined }
```

#### Testing Instructions

* Apply this PR
* Apply D99268-code
* Make sure `public-api.wordpress.com`
* Visit `http://calypso.localhost:3000/stats/day/<yoursite>?flags=newsletter/stats` (replace `yoursite` with your own site & don't forget the flag)

* Make sure two boxes are present at the bottom called "Email opens" & "Email clicks".
* Change the view to something else than "Days" & see if the links in both these boxes work.
* Make sure those boxes say Opens & Clicks as a metric:

![CleanShot 2023-01-25 at 13 51 52@2x](https://user-images.githubusercontent.com/528287/214568127-ce4d54eb-65d5-4ffe-91ef-ecaae6f4eedf.png)


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #