### PR TITLE
Copy site: Add site copy hook to site tools

### DIFF
--- a/client/data/sites/use-site-copy.tsx
+++ b/client/data/sites/use-site-copy.tsx
@@ -1,0 +1,72 @@
+import { WPCOM_FEATURES_COPY_SITE } from '@automattic/calypso-products';
+import { useDispatch } from '@wordpress/data';
+import { useEffect, useMemo, useCallback } from 'react';
+import { useDispatch as useReduxDispatch, useSelector } from 'react-redux';
+import { useQuerySitePurchases } from 'calypso/components/data/query-site-purchases';
+import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
+import { clearSignupDestinationCookie } from 'calypso/signup/storageUtils';
+import { getCurrentUserId } from 'calypso/state/current-user/selectors';
+import {
+	getSitePurchases,
+	hasLoadedSitePurchasesFromServer,
+	isFetchingSitePurchases,
+} from 'calypso/state/purchases/selectors';
+import siteHasFeature from 'calypso/state/selectors/site-has-feature';
+import { fetchSiteFeatures } from 'calypso/state/sites/features/actions';
+import type { SiteExcerptData } from 'calypso/data/sites/site-excerpt-types';
+
+function useSafeSiteHasFeature( siteId: number, feature: string ) {
+	const dispatch = useReduxDispatch();
+	useEffect( () => {
+		dispatch( fetchSiteFeatures( siteId ) );
+	}, [ dispatch, siteId ] );
+
+	return useSelector( ( state ) => {
+		return siteHasFeature( state, siteId, feature );
+	} );
+}
+interface CopySiteProps {
+	site: SiteExcerptData;
+	recordTracks: ( eventName: string, extraProps?: Record< string, any > ) => void;
+}
+
+const useCopySite = ( { site, recordTracks }: CopySiteProps ) => {
+	const userId = useSelector( ( state ) => getCurrentUserId( state ) );
+	const hasCopySiteFeature = useSafeSiteHasFeature( site.ID, WPCOM_FEATURES_COPY_SITE );
+	const plan = site?.plan;
+	const isSiteOwner = site.site_owner === userId;
+	useQuerySitePurchases( site.ID );
+	const isLoadingPurchase = useSelector(
+		( state ) => isFetchingSitePurchases( state ) || ! hasLoadedSitePurchasesFromServer( state )
+	);
+
+	const { setPlanCartItem, setProductCartItems } = useDispatch( ONBOARD_STORE );
+
+	const purchases = useSelector( ( state ) => getSitePurchases( state, site.ID ) );
+
+	const showCopySiteItem = useCallback( () => {
+		return ! hasCopySiteFeature || ! isSiteOwner || ! plan || isLoadingPurchase;
+	}, [ hasCopySiteFeature, isSiteOwner, plan, isLoadingPurchase ] );
+
+	const startCopySite = useCallback( () => {
+		if ( ! plan || ! purchases ) {
+			return;
+		}
+		clearSignupDestinationCookie();
+		setPlanCartItem( { product_slug: plan.product_slug } );
+		const marketplacePluginProducts = purchases
+			.filter( ( purchase ) => purchase.productType === 'marketplace_plugin' )
+			.map( ( purchase ) => ( { product_slug: purchase.productSlug } ) );
+
+		setProductCartItems( marketplacePluginProducts );
+		recordTracks( 'calypso_sites_dashboard_site_action_copy_site_click' );
+	}, [ plan, recordTracks, setPlanCartItem, setProductCartItems, purchases ] );
+
+	return useMemo(
+		() => ( {
+			showCopySiteItem,
+			startCopySite,
+		} ),
+		[ showCopySiteItem, startCopySite ]
+	);
+};

--- a/client/landing/stepper/hooks/use-site-copy.tsx
+++ b/client/landing/stepper/hooks/use-site-copy.tsx
@@ -39,7 +39,7 @@ export const useSiteCopy = ( site: SiteExcerptData ) => {
 
 	const { setPlanCartItem } = useDispatch( ONBOARD_STORE );
 
-	const shouldShowSiteCopyItem = useCallback( () => {
+	const shouldShowSiteCopyItem = useMemo( () => {
 		return hasCopySiteFeature && isSiteOwner && plan && ! isLoadingPurchase;
 	}, [ hasCopySiteFeature, isSiteOwner, plan, isLoadingPurchase ] );
 

--- a/client/landing/stepper/hooks/use-site-copy.tsx
+++ b/client/landing/stepper/hooks/use-site-copy.tsx
@@ -5,6 +5,7 @@ import { useEffect, useMemo, useCallback } from 'react';
 import { useDispatch as useReduxDispatch, useSelector } from 'react-redux';
 import { useQuerySitePurchases } from 'calypso/components/data/query-site-purchases';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { clearSignupDestinationCookie } from 'calypso/signup/storageUtils';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import {
@@ -43,13 +44,14 @@ export const useSiteCopy = ( site: SiteExcerptData ) => {
 	}, [ hasCopySiteFeature, isSiteOwner, plan, isLoadingPurchase ] );
 
 	const startSiteCopy = useCallback(
-		( recordTracks: () => void ) => {
+		//eslint-disable-next-line @typescript-eslint/no-explicit-any
+		( eventName: string, extraProps?: Record< string, any > ) => {
 			if ( ! plan ) {
 				return;
 			}
 			clearSignupDestinationCookie();
 			setPlanCartItem( { product_slug: plan.product_slug } );
-			recordTracks();
+			recordTracksEvent( eventName, extraProps );
 		},
 		[ plan, setPlanCartItem ]
 	);

--- a/client/landing/stepper/hooks/use-site-copy.tsx
+++ b/client/landing/stepper/hooks/use-site-copy.tsx
@@ -65,7 +65,6 @@ export const useSiteCopy = ( site: SiteExcerptData ) => {
 
 export const withSiteCopy = createHigherOrderComponent(
 	( Wrapped ) => ( props ) => {
-		// Limit query to 1 since we are only interested in the totalItems count.
 		const { shouldShowSiteCopyItem, startSiteCopy } = useSiteCopy( props.site );
 		return (
 			<Wrapped

--- a/client/landing/stepper/hooks/use-site-copy.tsx
+++ b/client/landing/stepper/hooks/use-site-copy.tsx
@@ -8,7 +8,6 @@ import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { clearSignupDestinationCookie } from 'calypso/signup/storageUtils';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import {
-	getSitePurchases,
 	hasLoadedSitePurchasesFromServer,
 	isFetchingSitePurchases,
 } from 'calypso/state/purchases/selectors';
@@ -37,9 +36,7 @@ export const useSiteCopy = ( site: SiteExcerptData ) => {
 		( state ) => isFetchingSitePurchases( state ) || ! hasLoadedSitePurchasesFromServer( state )
 	);
 
-	const { setPlanCartItem, setProductCartItems } = useDispatch( ONBOARD_STORE );
-
-	const purchases = useSelector( ( state ) => getSitePurchases( state, site.ID ) );
+	const { setPlanCartItem } = useDispatch( ONBOARD_STORE );
 
 	const shouldShowSiteCopyItem = useCallback( () => {
 		return hasCopySiteFeature && isSiteOwner && plan && ! isLoadingPurchase;
@@ -47,19 +44,14 @@ export const useSiteCopy = ( site: SiteExcerptData ) => {
 
 	const startSiteCopy = useCallback(
 		( recordTracks: () => void ) => {
-			if ( ! plan || ! purchases ) {
+			if ( ! plan ) {
 				return;
 			}
 			clearSignupDestinationCookie();
 			setPlanCartItem( { product_slug: plan.product_slug } );
-			const marketplacePluginProducts = purchases
-				.filter( ( purchase ) => purchase.productType === 'marketplace_plugin' )
-				.map( ( purchase ) => ( { product_slug: purchase.productSlug } ) );
-
-			setProductCartItems( marketplacePluginProducts );
 			recordTracks();
 		},
-		[ plan, setPlanCartItem, setProductCartItems, purchases ]
+		[ plan, setPlanCartItem ]
 	);
 
 	return useMemo(

--- a/client/landing/stepper/hooks/use-site-copy.tsx
+++ b/client/landing/stepper/hooks/use-site-copy.tsx
@@ -25,12 +25,11 @@ function useSafeSiteHasFeature( siteId: number, feature: string ) {
 		return siteHasFeature( state, siteId, feature );
 	} );
 }
-interface CopySiteProps {
-	site: SiteExcerptData;
-	recordTracks: ( eventName: string, extraProps?: Record< string, any > ) => void;
-}
 
-const useCopySite = ( { site, recordTracks }: CopySiteProps ) => {
+export const useSiteCopy = (
+	site: SiteExcerptData,
+	recordTracks: ( eventName: string, extraProps?: Record< string, any > ) => void
+) => {
 	const userId = useSelector( ( state ) => getCurrentUserId( state ) );
 	const hasCopySiteFeature = useSafeSiteHasFeature( site.ID, WPCOM_FEATURES_COPY_SITE );
 	const plan = site?.plan;
@@ -44,11 +43,11 @@ const useCopySite = ( { site, recordTracks }: CopySiteProps ) => {
 
 	const purchases = useSelector( ( state ) => getSitePurchases( state, site.ID ) );
 
-	const showCopySiteItem = useCallback( () => {
-		return ! hasCopySiteFeature || ! isSiteOwner || ! plan || isLoadingPurchase;
+	const shouldShowSiteCopyItem = useCallback( () => {
+		return hasCopySiteFeature && isSiteOwner && plan && ! isLoadingPurchase;
 	}, [ hasCopySiteFeature, isSiteOwner, plan, isLoadingPurchase ] );
 
-	const startCopySite = useCallback( () => {
+	const startSiteCopy = useCallback( () => {
 		if ( ! plan || ! purchases ) {
 			return;
 		}
@@ -64,9 +63,9 @@ const useCopySite = ( { site, recordTracks }: CopySiteProps ) => {
 
 	return useMemo(
 		() => ( {
-			showCopySiteItem,
-			startCopySite,
+			shouldShowSiteCopyItem,
+			startSiteCopy,
 		} ),
-		[ showCopySiteItem, startCopySite ]
+		[ shouldShowSiteCopyItem, startSiteCopy ]
 	);
 };

--- a/client/my-sites/site-settings/site-tools/index.jsx
+++ b/client/my-sites/site-settings/site-tools/index.jsx
@@ -102,7 +102,7 @@ class SiteTools extends Component {
 					<SiteToolsLink
 						href={ copySiteUrl }
 						onClick={ () => {
-							startSiteCopy( () => recordTracksEvent( 'calypso_settings_copy_site_option_click' ) );
+							startSiteCopy( 'calypso_settings_copy_site_option_click' );
 						} }
 						title={ copyTitle }
 						description={ copyText }

--- a/client/my-sites/site-settings/site-tools/index.jsx
+++ b/client/my-sites/site-settings/site-tools/index.jsx
@@ -98,7 +98,7 @@ class SiteTools extends Component {
 						description={ translate( "Register a new domain or change your site's address." ) }
 					/>
 				) }
-				{ isEnabled( 'sites/copy-site' ) && shouldShowSiteCopyItem() && (
+				{ isEnabled( 'sites/copy-site' ) && shouldShowSiteCopyItem && (
 					<SiteToolsLink
 						href={ copySiteUrl }
 						onClick={ () => {

--- a/client/my-sites/site-settings/site-tools/index.jsx
+++ b/client/my-sites/site-settings/site-tools/index.jsx
@@ -1,19 +1,15 @@
 import { isEnabled } from '@automattic/calypso-config';
-import { WPCOM_FEATURES_COPY_SITE } from '@automattic/calypso-products';
 import { compose } from '@wordpress/compose';
-import { withDispatch } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
 import { localize } from 'i18n-calypso';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import QueryRewindState from 'calypso/components/data/query-rewind-state';
 import withP2HubP2Count from 'calypso/data/p2/with-p2-hub-p2-count';
-import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
+import { withSiteCopy } from 'calypso/landing/stepper/hooks/use-site-copy';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import DeleteSiteWarningDialog from 'calypso/my-sites/site-settings/delete-site-warning-dialog';
 import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
-import { clearSignupDestinationCookie } from 'calypso/signup/storageUtils';
-import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { errorNotice } from 'calypso/state/notices/actions';
 import {
 	hasLoadedSitePurchasesFromServer,
@@ -25,8 +21,7 @@ import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-t
 import isSiteP2Hub from 'calypso/state/selectors/is-site-p2-hub';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 import isVipSite from 'calypso/state/selectors/is-vip-site';
-import siteHasFeature from 'calypso/state/selectors/site-has-feature';
-import { isJetpackSite, getSitePlanSlug, getSite } from 'calypso/state/sites/selectors';
+import { isJetpackSite, getSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import SiteToolsLink from './link';
 
@@ -51,13 +46,12 @@ class SiteTools extends Component {
 
 	render() {
 		const {
-			canSiteBeCopied,
+			shouldShowSiteCopyItem,
+			startSiteCopy,
 			translate,
 			siteSlug,
 			copySiteUrl,
 			cloneUrl,
-			planSlug,
-			setPlanCartItem,
 			showChangeAddress,
 			showClone,
 			showDeleteContent,
@@ -104,13 +98,11 @@ class SiteTools extends Component {
 						description={ translate( "Register a new domain or change your site's address." ) }
 					/>
 				) }
-				{ isEnabled( 'sites/copy-site' ) && canSiteBeCopied && (
+				{ isEnabled( 'sites/copy-site' ) && shouldShowSiteCopyItem() && (
 					<SiteToolsLink
 						href={ copySiteUrl }
 						onClick={ () => {
-							clearSignupDestinationCookie();
-							setPlanCartItem( { product_slug: planSlug } );
-							recordTracksEvent( 'calypso_settings_copy_site_option_click' );
+							startSiteCopy( () => recordTracksEvent( 'calypso_settings_copy_site_option_click' ) );
 						} }
 						title={ copyTitle }
 						description={ copyText }
@@ -181,23 +173,16 @@ class SiteTools extends Component {
 export default compose( [
 	connect(
 		( state ) => {
-			const currentUser = getCurrentUser( state );
 			const siteId = getSelectedSiteId( state );
 			const site = getSite( state, siteId );
-			const siteOwner = site?.site_owner;
 			const siteSlug = getSelectedSiteSlug( state );
 			const isAtomic = isSiteAutomatedTransfer( state, siteId );
-			const planSlug = getSitePlanSlug( state, siteId );
 			const isJetpack = isJetpackSite( state, siteId );
 			const isVip = isVipSite( state, siteId );
 			const isP2 = isSiteWPForTeams( state, siteId );
 			const isP2Hub = isSiteP2Hub( state, siteId );
 			const rewindState = getRewindState( state, siteId );
 			const sitePurchasesLoaded = hasLoadedSitePurchasesFromServer( state );
-			const canSiteBeCopied =
-				siteHasFeature( state, siteId, WPCOM_FEATURES_COPY_SITE ) &&
-				planSlug &&
-				currentUser?.ID === siteOwner;
 
 			const cloneUrl = `/start/clone-site/${ siteSlug }`;
 
@@ -206,13 +191,12 @@ export default compose( [
 			} );
 
 			return {
-				canSiteBeCopied,
+				site,
 				isAtomic,
 				copySiteUrl,
 				siteSlug,
 				purchasesError: getPurchasesError( state ),
 				cloneUrl,
-				planSlug,
 				showChangeAddress: ! isJetpack && ! isVip && ! isP2,
 				showClone: 'active' === rewindState.state && ! isAtomic,
 				showDeleteContent: ! isJetpack && ! isVip && ! isP2Hub,
@@ -226,9 +210,4 @@ export default compose( [
 			errorNotice,
 		}
 	),
-	withDispatch( ( dispatch ) => {
-		return {
-			setPlanCartItem: dispatch( ONBOARD_STORE ).setPlanCartItem,
-		};
-	} ),
-] )( localize( withP2HubP2Count( SiteTools ) ) );
+] )( localize( withSiteCopy( withP2HubP2Count( SiteTools ) ) ) );


### PR DESCRIPTION
#### Proposed Changes

Create a hook for initiating a site copy transfer, and move reusable code from Site Tools.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Navigate to `Settings -> General -> Site Tools`
2. Ensure you have a site with a `Business` plan
3. Make sure that you see the "Site tools" section

<img width="841" alt="image" src="https://user-images.githubusercontent.com/36432/214060577-402af5ea-b62c-4d66-84c6-1dfebaa97055.png">

4. Press the copy site, and go through the steps. Ensure that your site is copied successfully.
5. Make sure that you can see the analytics tracking when you click the copy site button

<img width="1626" alt="image" src="https://user-images.githubusercontent.com/36432/214062039-72203e5a-1934-4a90-bd43-fb38e8bea31a.png">

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/1556