### PR TITLE
Change magic sorting for remaining items from alphabetic to last updated

### DIFF
--- a/packages/sites/src/use-sites-list-sorting.tsx
+++ b/packages/sites/src/use-sites-list-sorting.tsx
@@ -147,7 +147,7 @@ function sortSitesByLastInteractedWith< T extends SiteDetailsForSorting >(
 
 	const sortedItems = [
 		...( sortInteractedItems( interactedItems ) as T[] ),
-		...remainingItems.sort( ( a, b ) => sortAlphabetically( a, b, 'asc' ) ),
+		...remainingItems.sort( ( a, b ) => sortByLastPublish( a, b, 'desc' ) ),
 	];
 
 	return sortOrder === 'desc' ? sortedItems : sortedItems.reverse();
@@ -172,6 +172,26 @@ function sortAlphabetically< T extends SiteDetailsForSorting >(
 	return 0;
 }
 
+function sortByLastPublish< T extends SiteDetailsForSorting >(
+	a: T,
+	b: T,
+	sortOrder: SitesSortOrder
+) {
+	if ( ! a.options?.updated_at || ! b.options?.updated_at ) {
+		return 0;
+	}
+
+	if ( a.options.updated_at > b.options.updated_at ) {
+		return sortOrder === 'asc' ? 1 : -1;
+	}
+
+	if ( a.options.updated_at < b.options.updated_at ) {
+		return sortOrder === 'asc' ? -1 : 1;
+	}
+
+	return 0;
+}
+
 function sortSitesAlphabetically< T extends SiteDetailsForSorting >(
 	sites: T[],
 	sortOrder: SitesSortOrder
@@ -183,21 +203,7 @@ function sortSitesByLastPublish< T extends SiteDetailsForSorting >(
 	sites: T[],
 	sortOrder: SitesSortOrder
 ): T[] {
-	return [ ...sites ].sort( ( a, b ) => {
-		if ( ! a.options?.updated_at || ! b.options?.updated_at ) {
-			return 0;
-		}
-
-		if ( a.options.updated_at > b.options.updated_at ) {
-			return sortOrder === 'asc' ? 1 : -1;
-		}
-
-		if ( a.options.updated_at < b.options.updated_at ) {
-			return sortOrder === 'asc' ? -1 : 1;
-		}
-
-		return 0;
-	} );
+	return [ ...sites ].sort( ( a, b ) => sortByLastPublish( a, b, sortOrder ) );
 }
 
 type SitesSortingProps = {


### PR DESCRIPTION
#### Proposed Changes

Magic Sort sorts sites based on how the user interacts with the sites. The remaining sites, which do not have any interactions logged, are sorted alphabetically ascending. 

In this PR, I propose to change magic sorting for remaining items from alphabetic to last updated descending. It should provide a more logical user experience.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Open the Sites page and sort by "Magic"
2. Review the list and identify sites sorted by interactions, and the remaining sites that are sorted alphabetically
3. Switch to this PR
4. Confirm that remaining sites are sorted by last updated date

| Before|After|
|---|---|
| <img width="854" alt="Screenshot 2023-01-25 at 14 15 27" src="https://user-images.githubusercontent.com/727413/214595655-ae1654a8-dbed-45b9-82e6-f4e1ffeeede5.png"> | <img width="856" alt="Screenshot 2023-01-25 at 14 14 53" src="https://user-images.githubusercontent.com/727413/214595658-796e294d-b06f-4962-821d-5cc54d74031b.png"> |

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1535-gh-Automattic/dotcom-forge