### PR TITLE
Fixed padding in Email Stats

### DIFF
--- a/client/my-sites/stats/style.scss
+++ b/client/my-sites/stats/style.scss
@@ -41,6 +41,10 @@
 .is-section-stats .has-fixed-nav {
 	padding-top: 44px;
 
+	&.stats__email-detail {
+		padding: 44px 20px;
+	}
+
 	@media ( max-width: 782px ) {
 		padding-top: 65px;
 	}


### PR DESCRIPTION
#### Proposed Changes

This is a small PR to fix the padding of the Email Stats page in smaller resolutions. We pass from this...
<img width="817" alt="Screenshot 2023-01-25 at 16 06 54" src="https://user-images.githubusercontent.com/3832570/214600096-e94d2bb1-e312-4ca2-93be-fe2b807d7e0a.png">
...to this...
<img width="817" alt="Screenshot 2023-01-25 at 16 07 06" src="https://user-images.githubusercontent.com/3832570/214600187-0498ce17-cefa-4ebf-b68d-26505461fc63.png">


#### Testing Instructions

1. Apply this branch to your local Calypso repository and start the application.
2. Insert manually in the browser address bar an URL with this format: https://calypso.localhost:3000/stats/email/opens/[the-domain-of-your-blog]/day/[post-id]?flags=newsletter/stats. 
3. Resize the browser and check that there is 20px in both sides of the page at all times.

Fixes https://github.com/Automattic/wp-calypso/issues/72437
