### PR TITLE
WooExpress Trial: Update LoadingBar to modify state across steps

### DIFF
--- a/client/components/loading-bar/index.tsx
+++ b/client/components/loading-bar/index.tsx
@@ -1,14 +1,16 @@
+import { useDispatch } from '@wordpress/data';
 import { useEffect, useState } from 'react';
+import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import './style.scss';
 
 type LoadingBar = {
 	className?: string;
 	progress: number;
-	setProgress: ( progress: number ) => void;
 };
 
-export function LoadingBar( { className, progress, setProgress }: LoadingBar ) {
+export function LoadingBar( { className, progress }: LoadingBar ) {
 	const [ simulatedProgress, setSimulatedProgress ] = useState( progress );
+	const { setProgress } = useDispatch( ONBOARD_STORE );
 
 	useEffect( () => {
 		let timeoutReference: NodeJS.Timeout;

--- a/client/components/loading-bar/index.tsx
+++ b/client/components/loading-bar/index.tsx
@@ -4,10 +4,10 @@ import './style.scss';
 type LoadingBar = {
 	className?: string;
 	progress: number;
+	setProgress: ( progress: number ) => void;
 };
 
-export function LoadingBar( { className, progress }: LoadingBar ) {
-	// Progress smoothing, works out to be around 40seconds unless step polling dictates otherwise
+export function LoadingBar( { className, progress, setProgress }: LoadingBar ) {
 	const [ simulatedProgress, setSimulatedProgress ] = useState( progress );
 
 	useEffect( () => {
@@ -26,11 +26,13 @@ export function LoadingBar( { className, progress }: LoadingBar ) {
 						return newProgress;
 					} );
 				}
+				// Save our simulated progress to state to persist between step changes
+				setProgress( simulatedProgress );
 			}, 1000 );
 		}
 
 		return () => clearTimeout( timeoutReference );
-	}, [ simulatedProgress, progress ] );
+	}, [ simulatedProgress, progress, setProgress ] );
 
 	return (
 		<div className={ className }>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/assign-trial-plan/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/assign-trial-plan/index.tsx
@@ -25,7 +25,6 @@ const AssignTrialPlanStep: Step = function AssignTrialPlanStep( { navigation, da
 	const { setProgress } = useDispatch( ONBOARD_STORE );
 
 	useEffect( () => {
-		setProgress( 0.4 );
 		if ( submit ) {
 			const assignTrialPlan = async () => {
 				try {
@@ -69,7 +68,7 @@ const AssignTrialPlanStep: Step = function AssignTrialPlanStep( { navigation, da
 						<div className="assign-trial-step">
 							<h1 className="assign-trial-step__progress-step">{ getCurrentMessage() }</h1>
 							{ progress >= 0 || isWooExpressFlow( flow ) ? (
-								<LoadingBar progress={ progress } />
+								<LoadingBar progress={ progress } setProgress={ setProgress } />
 							) : (
 								<LoadingEllipsis />
 							) }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/assign-trial-plan/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/assign-trial-plan/index.tsx
@@ -27,7 +27,6 @@ const AssignTrialPlanStep: Step = function AssignTrialPlanStep( { navigation, da
 	useEffect( () => {
 		setProgress( 0.4 );
 		if ( submit ) {
-			setProgress( 0.4 );
 			const assignTrialPlan = async () => {
 				try {
 					if ( ! data?.siteSlug ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/assign-trial-plan/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/assign-trial-plan/index.tsx
@@ -27,6 +27,7 @@ const AssignTrialPlanStep: Step = function AssignTrialPlanStep( { navigation, da
 	useEffect( () => {
 		setProgress( 0.4 );
 		if ( submit ) {
+			setProgress( 0.4 );
 			const assignTrialPlan = async () => {
 				try {
 					if ( ! data?.siteSlug ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/assign-trial-plan/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/assign-trial-plan/index.tsx
@@ -1,5 +1,5 @@
 import { isWooExpressFlow, StepContainer } from '@automattic/onboarding';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
 import { useEffect } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -22,7 +22,6 @@ const AssignTrialPlanStep: Step = function AssignTrialPlanStep( { navigation, da
 	const { __ } = useI18n();
 	const progress = useSelect( ( select ) => select( ONBOARD_STORE ).getProgress() );
 	const stepProgress = useSelect( ( select ) => select( ONBOARD_STORE ).getStepProgress() );
-	const { setProgress } = useDispatch( ONBOARD_STORE );
 
 	useEffect( () => {
 		if ( submit ) {
@@ -68,7 +67,7 @@ const AssignTrialPlanStep: Step = function AssignTrialPlanStep( { navigation, da
 						<div className="assign-trial-step">
 							<h1 className="assign-trial-step__progress-step">{ getCurrentMessage() }</h1>
 							{ progress >= 0 || isWooExpressFlow( flow ) ? (
-								<LoadingBar progress={ progress } setProgress={ setProgress } />
+								<LoadingBar progress={ progress } />
 							) : (
 								<LoadingEllipsis />
 							) }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/assign-trial-plan/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/assign-trial-plan/styles.scss
@@ -3,7 +3,7 @@
 
 
 .wooexpress.assign-trial-plan {
-	padding: 1em;
+	padding: 1.5em;
 	max-width: 540px;
 	text-align: center;
 	margin: 0 auto;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
@@ -6,7 +6,7 @@ import {
 	ECOMMERCE_FLOW,
 	isWooExpressFlow,
 } from '@automattic/onboarding';
-import { useSelect } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
 import { useEffect, useState } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -53,6 +53,7 @@ const ProcessingStep: React.FC< ProcessingStepProps > = function ( props ) {
 
 	const action = useSelect( ( select ) => select( ONBOARD_STORE ).getPendingAction() );
 	const progress = useSelect( ( select ) => select( ONBOARD_STORE ).getProgress() );
+	const { setProgress } = useDispatch( ONBOARD_STORE );
 	const progressTitle = useSelect( ( select ) => select( ONBOARD_STORE ).getProgressTitle() );
 	const stepProgress = useSelect( ( select ) => select( ONBOARD_STORE ).getStepProgress() );
 
@@ -119,6 +120,7 @@ const ProcessingStep: React.FC< ProcessingStepProps > = function ( props ) {
 							{ progress >= 0 || isWooExpressFlow( flow ) ? (
 								<LoadingBar
 									progress={ progress }
+									setProgress={ setProgress }
 									className="processing-step__content woocommerce-install__content"
 								/>
 							) : (

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
@@ -6,7 +6,7 @@ import {
 	ECOMMERCE_FLOW,
 	isWooExpressFlow,
 } from '@automattic/onboarding';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
 import { useEffect, useState } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -53,7 +53,6 @@ const ProcessingStep: React.FC< ProcessingStepProps > = function ( props ) {
 
 	const action = useSelect( ( select ) => select( ONBOARD_STORE ).getPendingAction() );
 	const progress = useSelect( ( select ) => select( ONBOARD_STORE ).getProgress() );
-	const { setProgress } = useDispatch( ONBOARD_STORE );
 	const progressTitle = useSelect( ( select ) => select( ONBOARD_STORE ).getProgressTitle() );
 	const stepProgress = useSelect( ( select ) => select( ONBOARD_STORE ).getStepProgress() );
 
@@ -120,7 +119,6 @@ const ProcessingStep: React.FC< ProcessingStepProps > = function ( props ) {
 							{ progress >= 0 || isWooExpressFlow( flow ) ? (
 								<LoadingBar
 									progress={ progress }
-									setProgress={ setProgress }
 									className="processing-step__content woocommerce-install__content"
 								/>
 							) : (

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
@@ -159,7 +159,7 @@ const SiteCreationStep: Step = function SiteCreationStep( { navigation, flow } )
 					<>
 						<h1>{ getCurrentMessage() }</h1>
 						{ progress >= 0 || isWooExpressFlow( flow ) ? (
-							<LoadingBar progress={ progress } setProgress={ setProgress } />
+							<LoadingBar progress={ progress } />
 						) : (
 							<LoadingEllipsis />
 						) }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
@@ -127,9 +127,7 @@ const SiteCreationStep: Step = function SiteCreationStep( { navigation, flow } )
 	}
 
 	useEffect( () => {
-		if ( isWooExpressFlow( flow ) ) {
-			setProgress( 0.2 );
-		}
+		setProgress( 0.1 );
 
 		if ( isMigrationFlow( flow ) ) {
 			setIsMigrateFromWp( true );
@@ -161,7 +159,7 @@ const SiteCreationStep: Step = function SiteCreationStep( { navigation, flow } )
 					<>
 						<h1>{ getCurrentMessage() }</h1>
 						{ progress >= 0 || isWooExpressFlow( flow ) ? (
-							<LoadingBar progress={ progress } />
+							<LoadingBar progress={ progress } setProgress={ setProgress } />
 						) : (
 							<LoadingEllipsis />
 						) }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/wait-for-atomic/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/wait-for-atomic/index.tsx
@@ -79,8 +79,6 @@ const WaitForAtomic: Step = function WaitForAtomic( { navigation, data } ) {
 		}
 
 		setPendingAction( async () => {
-			setProgress( 0.4 );
-
 			const startTime = new Date().getTime();
 			const totalTimeout = 1000 * 300;
 			const maxFinishTime = startTime + totalTimeout;
@@ -95,21 +93,6 @@ const WaitForAtomic: Step = function WaitForAtomic( { navigation, data } ) {
 				const transferError = getSiteLatestAtomicTransferError( siteId );
 				const transferStatus = transfer?.status;
 				const isTransferringStatusFailed = transferError && transferError?.status >= 500;
-
-				switch ( transferStatus ) {
-					case transferStates.PENDING:
-						setProgress( 0.5 );
-						break;
-					case transferStates.ACTIVE:
-						setProgress( 0.6 );
-						break;
-					case transferStates.PROVISIONED:
-						setProgress( 0.7 );
-						break;
-					case transferStates.COMPLETED:
-						setProgress( 0.8 );
-						break;
-				}
 
 				if ( isTransferringStatusFailed || transferStatus === transferStates.ERROR ) {
 					handleTransferFailure( {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/wait-for-atomic/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/wait-for-atomic/index.tsx
@@ -34,7 +34,7 @@ const wait = ( ms: number ) => new Promise( ( res ) => setTimeout( res, ms ) );
 
 const WaitForAtomic: Step = function WaitForAtomic( { navigation, data } ) {
 	const { submit } = navigation;
-	const { setPendingAction, setProgress } = useDispatch( ONBOARD_STORE );
+	const { setPendingAction } = useDispatch( ONBOARD_STORE );
 	const { requestLatestAtomicTransfer } = useDispatch( SITE_STORE );
 	const site = useSite();
 
@@ -114,8 +114,6 @@ const WaitForAtomic: Step = function WaitForAtomic( { navigation, data } ) {
 
 				stopPollingTransfer = transferStatus === transferStates.COMPLETED;
 			}
-
-			setProgress( 1 );
 
 			return { finishedWaitingForAtomic: true, siteSlug: data?.siteSlug };
 		} );


### PR DESCRIPTION
#### Proposed Changes

* I've removed most calls to `setProgress()` within individual flow steps and made `LoadingBar` responsible for updating changes to progress in the onboard store.
* This way the progress bar doesn't jump back and forth between steps in a single flow, and we don't have to keep track of arbitrary progress values across multiple steps.
* The progress bar should continue to work for single steps as well.

**Visual**

https://user-images.githubusercontent.com/2124984/214648513-cbf631b5-daec-4708-8e5d-5a4de66e3c2f.mov

#### Testing Instructions

* Switch to this PR
* Navigate to `/setup/wooexpress`
* The progress bar should maintain its progress as the flow progresses through multiple steps.
* Navigate to `/setup/link-in-bio`
* The progress bar during the second to last step of this flow (processing step) should behave as expected.
* Create a site from `/start` and choose a WooCommerce theme during design selection. The final processing screen post-checkout should show the familiar loading bar, and it should behave as expected.
* If you know of any other flows that use the processing step, please test those, too! (And let me know about 'em).

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- NA [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- NA Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- NA Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- NA Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- NA For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #72169
