### PR TITLE
Add domain to shopping cart on domain upsell CTA click

### DIFF
--- a/client/my-sites/customer-home/cards/features/domain-upsell/index.jsx
+++ b/client/my-sites/customer-home/cards/features/domain-upsell/index.jsx
@@ -4,6 +4,7 @@ import { useDomainSuggestions } from '@automattic/domain-picker/src';
 import { useLocale } from '@automattic/i18n-utils';
 import { useShoppingCart } from '@automattic/shopping-cart';
 import { useTranslate } from 'i18n-calypso';
+import page from 'page';
 import { useSelector } from 'react-redux';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import { domainRegistration } from 'calypso/lib/cart-values/cart-items';
@@ -69,6 +70,7 @@ export function RenderDomainUpsell() {
 			// Nothing needs to be done here. CartMessages will display the error to the user.
 			return null;
 		}
+		page( purchaseLink );
 	};
 
 	return (
@@ -105,7 +107,7 @@ export function RenderDomainUpsell() {
 					<Button href={ searchLink } onClick={ getSearchClickHandler }>
 						{ translate( 'Search a domain' ) }
 					</Button>
-					<Button primary href={ purchaseLink } onClick={ getCtaClickHandler }>
+					<Button primary onClick={ getCtaClickHandler }>
 						{ translate( 'Get your custom domain' ) }
 					</Button>
 				</div>

--- a/client/my-sites/customer-home/cards/features/domain-upsell/index.jsx
+++ b/client/my-sites/customer-home/cards/features/domain-upsell/index.jsx
@@ -5,6 +5,7 @@ import { useLocale } from '@automattic/i18n-utils';
 import { useShoppingCart } from '@automattic/shopping-cart';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
+import { useState } from 'react';
 import { useSelector } from 'react-redux';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import { domainRegistration } from 'calypso/lib/cart-values/cart-items';
@@ -52,7 +53,9 @@ export function RenderDomainUpsell() {
 	};
 
 	const purchaseLink = '/plans/' + siteSlug;
+	const [ ctaIsBusy, setCtaIsBusy ] = useState( false );
 	const getCtaClickHandler = async () => {
+		setCtaIsBusy( true );
 		recordTracksEvent( 'calypso_my_home_domain_upsell_cta_click', {
 			button_url: purchaseLink,
 			domain_suggestion: domainSuggestionName,
@@ -107,7 +110,7 @@ export function RenderDomainUpsell() {
 					<Button href={ searchLink } onClick={ getSearchClickHandler }>
 						{ translate( 'Search a domain' ) }
 					</Button>
-					<Button primary onClick={ getCtaClickHandler }>
+					<Button primary onClick={ getCtaClickHandler } busy={ ctaIsBusy }>
 						{ translate( 'Get your custom domain' ) }
 					</Button>
 				</div>

--- a/client/my-sites/customer-home/cards/features/domain-upsell/index.jsx
+++ b/client/my-sites/customer-home/cards/features/domain-upsell/index.jsx
@@ -2,17 +2,26 @@ import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Button, Card, Spinner } from '@automattic/components';
 import { useDomainSuggestions } from '@automattic/domain-picker/src';
 import { useLocale } from '@automattic/i18n-utils';
-import { ShoppingCartProvider, useShoppingCart } from '@automattic/shopping-cart';
+import { useShoppingCart } from '@automattic/shopping-cart';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import { domainRegistration } from 'calypso/lib/cart-values/cart-items';
+import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 
 import './style.scss';
 
 export default function DomainUpsell() {
+	return (
+		<CalypsoShoppingCartProvider>
+			<RenderDomainUpsell />
+		</CalypsoShoppingCartProvider>
+	);
+}
+
+export function RenderDomainUpsell() {
 	const translate = useTranslate();
 	const siteSlug = useSelector( ( state ) => getSelectedSiteSlug( state ) );
 	const siteSubDomain = siteSlug.split( '.' )[ 0 ];
@@ -63,46 +72,44 @@ export default function DomainUpsell() {
 	};
 
 	return (
-		<ShoppingCartProvider>
-			<Card className="domain-upsell__card customer-home__card">
-				<TrackComponentView eventName="calypso_my_home_domain_upsell_impression" />
-				<div>
-					<h3>{ translate( 'Own your online identity with a custom domain' ) }</h3>
-					<p>
-						{ translate(
-							"Find the perfect domain name and stake your claim on your corner of the web with a site address that's easy to find, share, and follow."
-						) }
-					</p>
+		<Card className="domain-upsell__card customer-home__card">
+			<TrackComponentView eventName="calypso_my_home_domain_upsell_impression" />
+			<div>
+				<h3>{ translate( 'Own your online identity with a custom domain' ) }</h3>
+				<p>
+					{ translate(
+						"Find the perfect domain name and stake your claim on your corner of the web with a site address that's easy to find, share, and follow."
+					) }
+				</p>
 
-					<div className="suggested-domain-name">
-						<div className="card">
-							<span>
-								<strike>{ siteSlug }</strike>
-							</span>
-							<div className="badge badge--info">{ translate( 'Current' ) }</div>
-						</div>
-						<div className="card">
-							<span>{ domainSuggestionName }</span>
-							{ domainSuggestion?.domain_name ? (
-								<div className="badge badge--success">{ translate( 'Available' ) }</div>
-							) : (
-								<div className="badge">
-									<Spinner />
-								</div>
-							) }
-						</div>
+				<div className="suggested-domain-name">
+					<div className="card">
+						<span>
+							<strike>{ siteSlug }</strike>
+						</span>
+						<div className="badge badge--info">{ translate( 'Current' ) }</div>
 					</div>
-
-					<div className="domain-upsell-actions">
-						<Button href={ searchLink } onClick={ getSearchClickHandler }>
-							{ translate( 'Search a domain' ) }
-						</Button>
-						<Button primary href={ purchaseLink } onClick={ getCtaClickHandler }>
-							{ translate( 'Get your custom domain' ) }
-						</Button>
+					<div className="card">
+						<span>{ domainSuggestionName }</span>
+						{ domainSuggestion?.domain_name ? (
+							<div className="badge badge--success">{ translate( 'Available' ) }</div>
+						) : (
+							<div className="badge">
+								<Spinner />
+							</div>
+						) }
 					</div>
 				</div>
-			</Card>
-		</ShoppingCartProvider>
+
+				<div className="domain-upsell-actions">
+					<Button href={ searchLink } onClick={ getSearchClickHandler }>
+						{ translate( 'Search a domain' ) }
+					</Button>
+					<Button primary href={ purchaseLink } onClick={ getCtaClickHandler }>
+						{ translate( 'Get your custom domain' ) }
+					</Button>
+				</div>
+			</div>
+		</Card>
 	);
 }


### PR DESCRIPTION
#### Proposed Changes

* This PR wants to add a domain to the shopping cart when the domain upsell CTA is clicked.

https://user-images.githubusercontent.com/140841/214712129-dcc70feb-a453-4d18-ab34-1748e16e706d.mp4

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this PR locally
* Apply this diff to your wpcom Sandbox D99116-code
* Sandbox your API
* View the new "domain upsell" feature on My Home. It should show on any My Home page that's in the site-setup state. AKA it has the checklist of things to do in the top right.
* Click the CTA and check that the domain is added to the cart.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/71500
