### PR TITLE
Mobile App Banner: Ensure Android app link have UTM campaigns

### DIFF
--- a/client/blocks/app-banner/index.jsx
+++ b/client/blocks/app-banner/index.jsx
@@ -129,19 +129,20 @@ export class AppBanner extends Component {
 			const packageName = displayJetpackAppBranding
 				? 'com.jetpack.android'
 				: 'org.wordpress.android';
+			const utmDetails = `utm_source%3Dcalypso%26utm_campaign%3Dcalypso-mobile-banner`;
 
 			//TODO: update when section deep links are available.
 			switch ( currentSection ) {
 				case GUTENBERG:
-					return `intent://details?id=${ packageName }&referrer=calypso#Intent;scheme=market;action=android.intent.action.VIEW;package=com.android.vending;end`;
+					return `intent://details?id=${ packageName }&referrer=${ utmDetails }#Intent;scheme=market;action=android.intent.action.VIEW;package=com.android.vending;end`;
 				case HOME:
-					return `intent://details?id=${ packageName }&referrer=calypso#Intent;scheme=market;action=android.intent.action.VIEW;package=com.android.vending;end`;
+					return `intent://details?id=${ packageName }&referrer=${ utmDetails }#Intent;scheme=market;action=android.intent.action.VIEW;package=com.android.vending;end`;
 				case NOTES:
-					return `intent://details?id=${ packageName }&referrer=calypso#Intent;scheme=market;action=android.intent.action.VIEW;package=com.android.vending;end`;
+					return `intent://details?id=${ packageName }&referrer=${ utmDetails }#Intent;scheme=market;action=android.intent.action.VIEW;package=com.android.vending;end`;
 				case READER:
-					return `intent://details?id=${ packageName }&referrer=calypso#Intent;scheme=market;action=android.intent.action.VIEW;package=com.android.vending;end`;
+					return `intent://details?id=${ packageName }&referrer=${ utmDetails }#Intent;scheme=market;action=android.intent.action.VIEW;package=com.android.vending;end`;
 				case STATS:
-					return `intent://details?id=${ packageName }&referrer=calypso#Intent;scheme=market;action=android.intent.action.VIEW;package=com.android.vending;end`;
+					return `intent://details?id=${ packageName }&referrer=${ utmDetails }#Intent;scheme=market;action=android.intent.action.VIEW;package=com.android.vending;end`;
 			}
 		}
 


### PR DESCRIPTION
#### Proposed Changes

With this PR, the intent URIs associated with [Calypso's mobile app banners](https://github.com/Automattic/wp-calypso/tree/trunk/client/blocks/app-banner) have been updated to include UTM codes. The addition of the UTM codes will allow us to track the number of times the Android app is installed via these links.

You'll see from the following addition that a `utm_source` of `calypso` has been added alongside a `utm_campaign` of `calypso-mobile-banner`:

`utm_source%3Dcalypso%26utm_campaign%3Dcalypso-mobile-banner`

#### Testing Instructions

To test, the following HTML can be copied/pasted to the code/HTML editor a self-hosted WordPress site and then visited in a browser on an Android device:

```
<a href="intent://details?id=com.jetpack.android&amp;referrer=utm_source%3Dcalypso%26utm_campaign%3Dcalypso-mobile-banner#Intent;scheme=market;action=android.intent.action.VIEW;package=com.android.vending;end">Jetpack app link</a>
```

The updated links should work as before, with the only difference that the use of the link will now be logged in Google Play Store (it may take a couple of hours for the stat to be logged):

* Redirect to the Google Play store if the app is not installed on the Android device.
* If the app is installed, it should open and redirect to the feature specified in the deep link.

In addition, it'd be useful to verify that the link appears as expected within the banner's HTML with this branch checked out. The banner can be viewed via the mobile web (which can also be [emulated using browser tools](https://developer.chrome.com/docs/devtools/device-mode/#viewport)) when navigating directly to the Reader, Stats, Notifications, or the editor.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->