### PR TITLE
Flaky E2E: strengthen plan verification logic in `PlansPage`.

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/plans-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plans-page.ts
@@ -27,14 +27,16 @@ const selectors = {
 	activeNavigationTab: ( tabName: PlansPageTab ) =>
 		`.is-selected.section-nav-tab:has-text("${ tabName }")`,
 
-	// Legacy plans view
+	// Plans tab
 	PlansGrid: '.plans-features-main',
 	actionButton: ( { plan, buttonText }: { plan: Plans; buttonText: PlanActionButton } ) => {
 		const viewportSuffix = envVariables.VIEWPORT_NAME === 'mobile' ? 'mobile' : 'table';
 		return `.plan-features__${ viewportSuffix } >> .plan-features__actions-button.is-${ plan.toLowerCase() }-plan:has-text("${ buttonText }")`;
 	},
+	activePlan: ( plan: Plans ) =>
+		`th.plan-features__table-item:has-text("${ plan }"):has-text("Your Plan")`,
 
-	// My Plans view
+	// My Plans tab
 	myPlanTitle: ( planName: Plans ) => `.my-plan-card__title:has-text("${ planName }")`,
 };
 
@@ -91,14 +93,20 @@ export class PlansPage {
 	/* Generic */
 
 	/**
-	 * Validates that the provided plan name is the title of the active plan in the My Plan tab of the Plans page. Throws if it isn't.
+	 * Validates the expected plan is active.
+	 *
+	 * This method accepts a parameter of `Plan` type which defines the expected
+	 * plan to be active on the site. This method then compares this against the
+	 * actual text on both the My Plans and Plans tabs.
 	 *
 	 * @param {Plans} expectedPlan Name of the expected plan.
 	 * @throws If the expected plan title is not found in the timeout period.
 	 */
 	async validateActivePlan( expectedPlan: Plans ): Promise< void > {
-		const expectedPlanLocator = this.page.locator( selectors.myPlanTitle( expectedPlan ) );
-		await expectedPlanLocator.waitFor();
+		await Promise.race( [
+			this.page.locator( selectors.myPlanTitle( expectedPlan ) ).waitFor(),
+			this.page.locator( selectors.activePlan( expectedPlan ) ).waitFor(),
+		] );
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/pages/plans-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plans-page.ts
@@ -33,8 +33,7 @@ const selectors = {
 		const viewportSuffix = envVariables.VIEWPORT_NAME === 'mobile' ? 'mobile' : 'table';
 		return `.plan-features__${ viewportSuffix } >> .plan-features__actions-button.is-${ plan.toLowerCase() }-plan:has-text("${ buttonText }")`;
 	},
-	activePlan: ( plan: Plans ) =>
-		`th.plan-features__table-item:has-text("${ plan }"):has-text("Your Plan")`,
+	activePlan: ( plan: Plans ) => `th .is-${ plan.toLowerCase() }-plan:has(.plan-pill)`,
 
 	// My Plans tab
 	myPlanTitle: ( planName: Plans ) => `.my-plan-card__title:has-text("${ planName }")`,
@@ -97,7 +96,7 @@ export class PlansPage {
 	 *
 	 * This method accepts a parameter of `Plan` type which defines the expected
 	 * plan to be active on the site. This method then compares this against the
-	 * actual text on both the My Plans and Plans tabs.
+	 * actual text on both the My Plans and Plans tabs, hence the race.
 	 *
 	 * @param {Plans} expectedPlan Name of the expected plan.
 	 * @throws If the expected plan title is not found in the timeout period.

--- a/test/e2e/specs/plans/plans__upgrade.ts
+++ b/test/e2e/specs/plans/plans__upgrade.ts
@@ -124,7 +124,6 @@ describe(
 
 			it( `Plans page states user is on WordPress.com ${ planName } plan`, async function () {
 				const plansPage = new PlansPage( page );
-				await plansPage.visit( 'My Plan', newSiteDetails.blog_details.site_slug );
 				await plansPage.validateActivePlan( 'Premium' );
 			} );
 		} );


### PR DESCRIPTION
#### Proposed Changes

This PR makes the `PlansPage.validateActivePlan` tab-agnostic.

Key changes:
- add a new selector to match whether the specified plan is active (not i18n-safe).
- update the `validateActivePlan` logic to race against the Plans and My Plan tabs.

#### Testing Instructions

Ensure the following build configurations are passing:
  - [x] Pre-Release E2E


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #72587.
