### PR TITLE
Flaky E2E: reorganize URL extraction logic in `EditorPage.publish`.

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/editor-page.ts
@@ -619,17 +619,6 @@ export class EditorPage {
 		const publishButtonText = await this.editorToolbarComponent.getPublishButtonText();
 		const actionsArray = [];
 
-		// Playwright does not have a way to differentiate
-		// between GET and POST requests. However, a new post
-		// has a post number following the article type.
-		// By matching on the regex we can filter out
-		// GET requests to the endpoint, focusing only on POST requests.
-		if ( this.target === 'atomic' ) {
-			actionsArray.push( this.page.waitForResponse( /v2\/(posts|pages)\/[\d]+/ ) );
-		} else {
-			actionsArray.push( this.page.waitForResponse( /sites\/[\d]+\/(posts|pages)\/[\d]+.*/ ) );
-		}
-
 		// Every publish action requires at least one click on the EditorToolbarComponent.
 		actionsArray.push( this.editorToolbarComponent.clickPublish() );
 
@@ -642,11 +631,14 @@ export class EditorPage {
 		}
 
 		// Resolve the promises.
-		const [ response ] = await Promise.all( actionsArray );
-
-		if ( ! response ) {
-			throw new Error( 'No response received from `publish` method.' );
-		}
+		const [ response ] = await Promise.all( [
+			// First URL matches Atomic requests while the second matches Simple requests.
+			Promise.race( [
+				this.page.waitForResponse( /v2\/(posts|pages)\/[\d]+/ ),
+				this.page.waitForResponse( /.*v2\/sites\/[\d]+\/(posts|pages)\/[\d]+.*/ ),
+			] ),
+			actionsArray,
+		] );
 
 		const json = await response.json();
 

--- a/packages/calypso-e2e/src/lib/pages/editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/editor-page.ts
@@ -637,7 +637,7 @@ export class EditorPage {
 				this.page.waitForResponse( /v2\/(posts|pages)\/[\d]+/ ),
 				this.page.waitForResponse( /.*v2\/sites\/[\d]+\/(posts|pages)\/[\d]+.*/ ),
 			] ),
-			actionsArray,
+			...actionsArray,
 		] );
 
 		const json = await response.json();


### PR DESCRIPTION
#### Proposed Changes

This PR restructures the changes introduced in #72112.

Key changes:
- remove the initial exception throwing as the second check should suffice.
- race both `waitForResponse` calls (Simple and Atomic request endpoints) in situations that are not clearly one or the other, such as signing up for a new Business site.

Context:
I believe the `Promise.all` and request interception construct I added in #72112 was causing, on some occasions, to either a) match on the wrong request, or; b) not start the `waitForResponse` in time.

I tried to handle the scenario in a) by racing the two possible requests instead in a `Promise.race` construct.
The scenario in b) is a bit trickier to address, as the number of clicks to actually trigger the request to the post publish endpoint differs depending on whether the post is being edited, or it is a new post being published.

#### Testing Instructions

Ensure the following build configurations are passing:
  - [x] Gutenberg E2E (desktop)
  - [x] Gutenberg E2E (mobile)
  - [x] Calypso E2E (desktop)
  - [x] Calypso E2E (mobile)
  - [x] Pre-Release E2E

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #72586.
