### PR TITLE
Added upsell modal on plans page connected to skip button

### DIFF
--- a/client/my-sites/plans/header.jsx
+++ b/client/my-sites/plans/header.jsx
@@ -1,12 +1,15 @@
 import config from '@automattic/calypso-config';
-import { Button, Gridicon } from '@automattic/components';
+import { Button, Dialog, Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
+import { useState } from 'react';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import './header.scss';
 
 export default function PlansHeader() {
 	const translate = useTranslate();
+	const [ showDomainUpsellDialog, setShowDomainUpsellDialog ] = useState( false );
+
 	// TODO: We need to determine if this is a domain upsell and show the domain here.
 	const domainName = 'exampledomain.com';
 
@@ -30,15 +33,59 @@ export default function PlansHeader() {
 	const isDomainUpsell = config.isEnabled( 'is_domain_upsell' );
 
 	const onBackClick = () => {
-		recordTracksEvent( 'calypso_upgrade_nudge_back_click' );
+		recordTracksEvent( 'calypso_plans_page_domain_upsell_back_click' );
 		history.back();
 	};
 
-	const onSkipClick = () => {
-		recordTracksEvent( 'calypso_upgrade_nudge_skip_click' );
-		// TODO: Connect this to the skip modal.
-		alert( 'Skip Clicked' );
+	const onCloseDialog = () => {
+		setShowDomainUpsellDialog( false );
 	};
+
+	const onSkipClick = () => {
+		event.preventDefault();
+		recordTracksEvent( 'calypso_plans_page_domain_upsell_skip_click' );
+		setShowDomainUpsellDialog( true );
+	};
+
+	function renderDeleteDialog() {
+		const buttons = [
+			{ action: 'cancel', label: translate( 'That works for me' ) },
+			{ action: 'delete', label: translate( 'I want my domain as primary' ), isPrimary: true },
+		];
+
+		return (
+			<Dialog
+				additionalClassNames="planspage__domain-upsell"
+				isVisible={ showDomainUpsellDialog }
+				buttons={ buttons }
+				onClose={ onCloseDialog }
+				shouldCloseOnEsc={ true }
+			>
+				<header className="domain-upsell__modal-header">
+					<button onClick={ onCloseDialog }>
+						<Gridicon icon="cross" />
+					</button>
+				</header>
+
+				<h1>{ translate( 'You need a plan to have a primary custom domain' ) }</h1>
+				<p>
+					{ translate(
+						'Any domain you purchase without a plan will get redirected to %(domainName)s.',
+						{
+							args: {
+								domainName: domainName,
+							},
+						}
+					) }
+				</p>
+				<p>
+					{ translate(
+						'If you upgrade to a plan, you can use your custom domain name instead of having WordPress.com in your URL.'
+					) }
+				</p>
+			</Dialog>
+		);
+	}
 
 	if ( false === isDomainUpsell ) {
 		return (
@@ -53,6 +100,7 @@ export default function PlansHeader() {
 
 	return (
 		<>
+			{ renderDeleteDialog() }
 			<header className="formatted-header navigation">
 				<Button onClick={ onBackClick } className="inline-help__cancel-button" borderless>
 					<Gridicon icon="arrow-left" size={ 18 } />

--- a/client/my-sites/plans/header.scss
+++ b/client/my-sites/plans/header.scss
@@ -14,3 +14,41 @@
 .is-section-plans .formatted-header.header-text {
 	max-width: $break-small;
 }
+
+.dialog.planspage__domain-upsell {
+
+	.dialog__content {
+		max-width: 572px;
+	}
+
+	.domain-upsell__modal-header {
+		text-align: right;
+
+		svg:hover {
+			cursor: pointer;
+			opacity: 0.5;
+		}
+	}
+
+	.dialog__action-buttons {
+		border: 0;
+		margin-bottom: 30px;
+		margin-right: 25px;
+	}
+
+	h1 {
+		color: var(--studio-gray-100);
+		font-family: Recoleta, Georgia, "Times New Roman", Times, serif;
+		font-size: 2rem;
+		font-weight: 400;
+		line-height: 40px;
+		overflow-wrap: anywhere;
+		margin: 10px 24px;
+	}
+
+	p {
+		color: var(--color-text-subtle);
+		font-size: 1rem;
+		margin: 0 24px;
+	}
+}


### PR DESCRIPTION
#### Proposed Changes

* Added a new modal if the user wants to skip the upsell flow

#### Desktop

<img width="1018" alt="image" src="https://user-images.githubusercontent.com/1044309/214672416-6e47bb76-2e85-42e6-b3d6-9b7508bb1402.png">

#### Mobile

<img width="384" alt="image" src="https://user-images.githubusercontent.com/1044309/214672688-8a5d393b-f2dc-4d46-b37a-100ed527d478.png">


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Access your plans page by adding `?flags=is_domain_upsell` on it
* Click on the skip button at the top right
* Make sure we open the modal and it follows the design: pebzTe-xR-p2#comment-969
* Make sure it works as expected (using esc, clicking outside, on mobile and desktop as well)
* Note: We use the default `domainName` while we don't have it available from the previous flow step
* Note: The focus here is the visual aspects, another PR will connect this to the domain flow

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #71501 