### PR TITLE
Flaky E2E: force click through when adding patterns from the Editor sidebar.

### DIFF
--- a/packages/calypso-e2e/src/lib/components/editor-sidebar-block-inserter-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-sidebar-block-inserter-component.ts
@@ -77,7 +77,7 @@ export class EditorSidebarBlockInserterComponent {
 			locator = this.editor.locator( selectors.blockResultItem( name ) ).first();
 		}
 
-		await Promise.all( [ locator.hover(), locator.focus() ] );
-		await locator.click();
+		await locator.hover();
+		await locator.click( { force: true, noWaitAfter: true } );
 	}
 }

--- a/packages/calypso-e2e/src/lib/components/editor-sidebar-block-inserter-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-sidebar-block-inserter-component.ts
@@ -77,7 +77,9 @@ export class EditorSidebarBlockInserterComponent {
 			locator = this.editor.locator( selectors.blockResultItem( name ) ).first();
 		}
 
-		await locator.hover();
+		await this.page.waitForLoadState();
+
+		await locator.hover( { force: true, noWaitAfter: true } );
 		await locator.click( { force: true, noWaitAfter: true } );
 	}
 }

--- a/packages/calypso-e2e/src/lib/pages/editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/editor-page.ts
@@ -398,6 +398,7 @@ export class EditorPage {
 		await this.editorGutenbergComponent.resetSelectedBlock();
 		await this.editorToolbarComponent.openBlockInserter();
 		await this.addPatternFromInserter( patternName, this.editorSidebarBlockInserterComponent );
+		await this.editorSidebarBlockInserterComponent.closeBlockInserter();
 	}
 
 	/**


### PR DESCRIPTION
#### Proposed Changes

This PR aims to make the process of pattern insertion from the `EditorSidebarBlockInserter` more reliable.

Context:
The `EditorSidebarBlockInserter` is a moderately problematic component, as it provides live filtering of patterns and blocks based on the keyword entered. This means the layout and the content shown in the sidebar shifts with every network response that match the keyword.

This can lead to stability issues when selecting a pattern/block quickly (as Playwright does) as it has to account for shifting layouts.

Key changes:
- hover over the element then force a click overriding Playwight's navigation waits.

#### Testing Instructions

Ensure the following build configurations are passing:
  - [ ] Gutenberg E2E (desktop)
  - [ ] Gutenberg E2E (mobile)
  - [ ] Pre-Release E2E

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #72184.
