### PR TITLE
Updated mobile warning colors

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
@@ -286,11 +286,14 @@
 	}
 }
 .sites-overview__status-failed {
+	background-color: var(--studio-red-50);
 	border-color: var(--studio-red-50);
-	color: var(--studio-red-50);
+	color: var(--color-text-inverted);
 }
 .sites-overview__status-warning {
+	background-color: var(--studio-yellow-20);
 	border-color: var(--studio-yellow-20);
+	color: var(--color-warning-80);
 }
 @keyframes highlight-tab-animation {
 	0% {


### PR DESCRIPTION
#### Proposed Changes

* Updated mobile colors for warnings from outlined circles to filled circles

![image](https://user-images.githubusercontent.com/2293077/214685460-e24f4d22-e730-4aca-a41b-dc3b117d620e.png)


#### Testing Instructions

* Run `git checkout fix/agency-dashboard-mobile-warning-error-color` and `yarn start-jetpack-cloud`
* Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard
* Make sure you have a site connected with an outdated plugin. If not, the [WP Rollback](https://wordpress.org/plugins/wp-rollback/) plugin is a good one to use to roll back a version of a plugin to a previous version
* The warning label for an outdated plugin should be a full-yellow circle and the warning for a potential threat should be a full red circle.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1199980337313591-as-1202699478926005/f