### PR TITLE
Add subscribers form: add empty form validation handler

### DIFF
--- a/packages/subscriber/src/components/add-form/index.tsx
+++ b/packages/subscriber/src/components/add-form/index.tsx
@@ -303,6 +303,7 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 			: __( 'The required field is to enter at least one email.' );
 
 		return (
+			!! submitAttemptCount &&
 			submitAttemptCount !== prevSubmitAttemptCount.current &&
 			! emails.filter( ( x ) => !! x ).length &&
 			! selectedFile && <FormInputValidation isError={ true } text={ validationMsg } />

--- a/packages/subscriber/src/components/add-form/index.tsx
+++ b/packages/subscriber/src/components/add-form/index.tsx
@@ -297,10 +297,10 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 	function renderEmptyFormValidationMsg() {
 		const validationMsg = showCsvUpload
 			? __(
-					'The required fields are manually entering at least one email ' +
-						'or providing your mailing list by selecting a CSV file.'
+					"You'll need to add at least one email address " +
+						'or upload a CSV file of current subscribers to continue.'
 			  )
-			: __( 'The required field is to enter at least one email.' );
+			: __( "You'll need to add at least one subscriber to continue." );
 
 		return (
 			!! submitAttemptCount &&


### PR DESCRIPTION
#### Proposed Changes

* Add subscribers form: add empty form validation handler

#### Testing Instructions

* Go to `people/subscribers/{SITE_SLUG}`
* Press the `Add subscribers` button
* Check if there is a validation message once you submit the empty form

#### Screenshots

<img width="755" alt="Screenshot 2023-01-31 at 10 36 50" src="https://user-images.githubusercontent.com/1241413/215723586-7ce7d433-c472-4fff-bb15-885318aff5f1.png">
<img width="764" alt="Screenshot 2023-01-31 at 10 35 45" src="https://user-images.githubusercontent.com/1241413/215723598-5f6b4012-cb23-4667-b2b1-410c6948bc54.png">

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #72488
