### PR TITLE
Plugins: Update plugins cache key

### DIFF
--- a/client/data/marketplace/use-wpcom-plugins-query.ts
+++ b/client/data/marketplace/use-wpcom-plugins-query.ts
@@ -22,7 +22,7 @@ const dynamicPluginsApiBase = '/marketplace/products-dynamic';
 const featuredPluginsApiBase = '/plugins/featured';
 const pluginsApiNamespace = 'wpcom/v2';
 
-const WPCOM_PLUGINS_CACHE_VERSION = 1;
+const WPCOM_PLUGINS_CACHE_VERSION = 2;
 const getCacheKey = ( key: string ): QueryKey => [
 	WPCOM_PLUGINS_CACHE_VERSION.toString(),
 	'wpcom-plugins',


### PR DESCRIPTION
#### Proposed Changes

Update plugins cache key to refresh all plugins caches after the build of this version.

On #72383 and #72441 we changed how ratings are calculated and displayed, which might mean we have some outdated caches out there. This change should send a new request for those endpoints when the user try to see those pages.

| Before  | After |
| ------------- | ------------- |
|<img width="1111" alt="CleanShot 2023-01-25 at 17 27 58@2x" src="https://user-images.githubusercontent.com/5039531/214695760-7ced862f-6bf0-4bb5-94f1-3778b4054825.png">|<img width="1086" alt="CleanShot 2023-01-25 at 17 29 25@2x" src="https://user-images.githubusercontent.com/5039531/214695778-15a12b24-02c3-4469-a0d3-903010083654.png">|


#### Testing Instructions
* Go to `/plugins` page 
* Check if all the ratings are correct (less or equal 5)
* Go to some categories pages to check the same thing

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

