### PR TITLE
Revert "Launchpad: Enable Site Editor redirect from Launchpad iframe"

### DIFF
--- a/client/components/web-preview/component.jsx
+++ b/client/components/web-preview/component.jsx
@@ -63,8 +63,6 @@ export class WebPreviewModal extends Component {
 		fixedViewportWidth: PropTypes.number,
 		// Prevents tabbing into the iframe.
 		disableTabbing: PropTypes.bool,
-		// Edit overlay that redirects to the Site Editor
-		enableEditOverlay: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -83,7 +81,6 @@ export class WebPreviewModal extends Component {
 		hasSidebar: false,
 		overridePost: null,
 		autoHeight: false,
-		enableEditOverlay: false,
 	};
 
 	constructor( props ) {

--- a/client/components/web-preview/content.jsx
+++ b/client/components/web-preview/content.jsx
@@ -31,7 +31,6 @@ export default class WebPreviewContent extends Component {
 		loaded: false,
 		isLoadingSubpage: false,
 		isMobile: isWithinBreakpoint( '<660px' ),
-		showIFrameOverlay: false,
 	};
 
 	setIframeInstance = ( ref ) => {
@@ -407,16 +406,6 @@ export default class WebPreviewContent extends Component {
 					) }
 					{ 'seo' !== this.state.device && (
 						<div
-							onMouseEnter={ () => {
-								if ( this.props.enableEditOverlay ) {
-									this.setState( { showIFrameOverlay: true } );
-								}
-							} }
-							onMouseLeave={ () => {
-								if ( this.props.enableEditOverlay ) {
-									this.setState( { showIFrameOverlay: false } );
-								}
-							} }
 							className={ classNames( 'web-preview__frame-wrapper', {
 								'is-resizable': ! this.props.isModalWindow,
 							} ) }
@@ -424,11 +413,7 @@ export default class WebPreviewContent extends Component {
 							<iframe
 								ref={ this.setIframeInstance }
 								className="web-preview__frame"
-								style={ {
-									...this.state.iframeStyle,
-									height: this.state.viewport?.height,
-									pointerEvents: this.props.enableEditOverlay ? 'auto' : 'all',
-								} }
+								style={ { ...this.state.iframeStyle, height: this.state.viewport?.height } }
 								src="about:blank"
 								onLoad={ () => this.setLoaded( 'iframe-onload' ) }
 								title={ this.props.iframeTitle || translate( 'Preview' ) }
@@ -436,35 +421,6 @@ export default class WebPreviewContent extends Component {
 								scrolling={ autoHeight ? 'no' : undefined }
 								tabIndex={ disableTabbing ? -1 : 0 }
 							/>
-							{ this.props.enableEditOverlay && (
-								<div
-									className="web-preview__frame-edit-overlay"
-									style={ {
-										opacity: this.state.showIFrameOverlay ? '1' : '0',
-										background: this.state.showIFrameOverlay
-											? `rgba(16, 21, 23, 0.5)`
-											: 'rgba(16, 21, 23, 0)',
-										transition: 'background 0.2s ease',
-									} }
-								>
-									<button
-										style={ {
-											position: 'relative',
-											top: this.state.showIFrameOverlay ? '0' : '15px',
-											transition: 'all 0.2s ease',
-										} }
-										aria-label="Edit your new site"
-										className="web-preview__frame-edit-button"
-										onClick={ () => {
-											window.location.assign( `/site-editor/${ this.props.externalUrl }` );
-										} }
-										onFocus={ () => this.setState( { showIFrameOverlay: true } ) }
-										onBlur={ () => this.setState( { showIFrameOverlay: false } ) }
-									>
-										{ translate( 'Edit' ) }
-									</button>
-								</div>
-							) }
 						</div>
 					) }
 					{ 'seo' === this.state.device && (
@@ -551,8 +507,6 @@ WebPreviewContent.propTypes = {
 	inlineCss: PropTypes.string,
 	// Uses the CSS selector to scroll to it
 	scrollToSelector: PropTypes.string,
-	// Edit overlay that redirects to the Site Editor
-	enableEditOverlay: PropTypes.bool,
 };
 
 WebPreviewContent.defaultProps = {
@@ -578,5 +532,4 @@ WebPreviewContent.defaultProps = {
 	autoHeight: false,
 	inlineCss: null,
 	scrollToSelector: null,
-	enableEditOverlay: false,
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/launchpad-site-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/launchpad-site-preview.tsx
@@ -102,7 +102,6 @@ const LaunchpadSitePreview = ( {
 				defaultViewportDevice={ defaultDevice }
 				devicesToShow={ devicesToShow }
 				showSiteAddressBar={ false }
-				enableEditOverlay
 			/>
 		</div>
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
@@ -458,78 +458,25 @@
 
 	.web-preview__placeholder {
 		overflow-y: visible;
-		display: flex;
-		justify-content: center;
-		align-items: start;
+		min-height: 720px;
 	}
 
 	.preview-toolbar__devices {
 		margin-bottom: 28px;
 	}
 
-	.is-phone .web-preview__frame-wrapper.is-resizable {
-		height: 100%;
-
-		@include break-large {
-			max-width: 340px;
-			height: 680px;
-		}
-
-		.web-preview__frame-edit-overlay {
-			@include break-large {
-				border-radius: 40px; /* stylelint-disable-line scales/radii */
-			}
-		}
-
-	}
-
 	.web-preview__frame-wrapper.is-resizable {
 		margin: 0;
 		padding: 0;
 		background-color: transparent;
-		position: relative;
-		max-width: 95%;
-
-		@include break-large {
-			height: 880px;
-		}
-
-		.web-preview__frame-edit-overlay {
-			position: absolute;
-			top: 0;
-			left: 0;
-			right: 0;
-			bottom: 0;
-			border-radius: 40px;  /* stylelint-disable-line scales/radii */
-
-			display: flex;
-			justify-content: center;
-			align-items: center;
-
-			@include break-large {
-				border-radius: 20px; /* stylelint-disable-line scales/radii */
-			}
-
-			.web-preview__frame-edit-button {
-				font-size: 14px;  /* stylelint-disable-line declaration-property-unit-allowed-list */
-				line-height: 20px;
-				padding: 10px 24px;
-				color: #000;
-				background: #fff;
-				border-radius: 4px;
-				border-color: #c3c4c7;
-				border-width: 2px;
-				cursor: pointer;
-			}
-		}
 	}
 
 	.web-preview__frame {
 		border: 10px solid var(--color-print);
 		border-radius: 40px; /* stylelint-disable-line scales/radii */
 		box-sizing: border-box;
+		max-width: 95%;
 		box-shadow: 0 5px 15px rgba(0 0 0 / 7%), 0 3px 10px rgba(0 0 0 / 4%);
-		min-height: 720px;
 
 		@include break-large {
 			margin-top: 0;
@@ -538,11 +485,13 @@
 				0 13px 10px rgb(0 0 0 / 3%),
 				0 6px 6px rgb(0 0 0 / 2%);
 			border-radius: 20px; /* stylelint-disable-line scales/radii */
+			min-height: 585px;
+			height: calc(100% - 120px);
 		}
 	}
 
 	.is-phone .web-preview__frame-wrapper.is-resizable .web-preview__frame {
-		max-width: 100%;
+		max-width: 95%;
 
 		@include break-large {
 			box-shadow:
@@ -552,8 +501,9 @@
 				0 15px 13px rgba(0 0 0 / 2%),
 				0 6px 5px rgba(0 0 0 / 2%),
 				0 2px 3px rgba(0 0 0 / 1%);
+			max-width: 340px;
 			border-radius: 40px; /* stylelint-disable-line scales/radii */
-			min-height: 680px;
+			height: 680px;
 		}
 	}
 


### PR DESCRIPTION
### Proposed Changes
We noticed that this PR introduced a bug where the user is unable to scroll inside the site preview due to the overlay.

### Testing Instructions
1. Checkout this branch
2. Go to the Launchpad screen (any flow)
3. Verify that there's no overlay showing on the web preview when you hover over it
4. Verify that you are able to scroll inside the web preview.
4. Verify that the styling of the web preview looks good - both Desktop and Mobile from the device selector and also by using the Chrome DevTools to test on a smaller screen size

Reverts Automattic/wp-calypso#71688