### PR TITLE
Stats: Fix missing stats images

### DIFF
--- a/client/my-sites/customer-home/cards/features/stats/index.jsx
+++ b/client/my-sites/customer-home/cards/features/stats/index.jsx
@@ -5,6 +5,7 @@ import { numberFormat, useTranslate } from 'i18n-calypso';
 import moment from 'moment';
 import { useEffect } from 'react';
 import { connect, useDispatch } from 'react-redux';
+import IllustrationStatsIntro from 'calypso/assets/images/stats/illustration-stats-intro.svg';
 import CardHeading from 'calypso/components/card-heading';
 import Chart from 'calypso/components/chart';
 import QuerySiteStats from 'calypso/components/data/query-site-stats';
@@ -105,7 +106,7 @@ export const StatsV2 = ( {
 				{ ! isSiteUnlaunched && ! isLoading && views === 0 && (
 					<div className="stats__empty">
 						<div className="stats__empty-illustration">
-							<img src="calypso/assets/images/stats/illustration-stats-intro.svg" alt="" />
+							<img src={ IllustrationStatsIntro } alt="" />
 						</div>
 						<div className="stats__empty-text">
 							{ translate(

--- a/client/my-sites/stats/stats-post-detail/index.jsx
+++ b/client/my-sites/stats/stats-post-detail/index.jsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import titlecase from 'to-title-case';
-import IllustrationStatsIntro from 'calypso/assets/images/stats/illustration-stats-intro.svg';
+import IllustrationStatsIntro from 'calypso/assets/images/stats/illustration-stats.svg';
 import QueryPostStats from 'calypso/components/data/query-post-stats';
 import QueryPosts from 'calypso/components/data/query-posts';
 import EmptyContent from 'calypso/components/empty-content';

--- a/client/my-sites/stats/stats-post-detail/index.jsx
+++ b/client/my-sites/stats/stats-post-detail/index.jsx
@@ -6,6 +6,7 @@ import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import titlecase from 'to-title-case';
+import IllustrationStatsIntro from 'calypso/assets/images/stats/illustration-stats-intro.svg';
 import QueryPostStats from 'calypso/components/data/query-post-stats';
 import QueryPosts from 'calypso/components/data/query-posts';
 import EmptyContent from 'calypso/components/empty-content';
@@ -171,7 +172,7 @@ class StatsPostDetail extends Component {
 							action={ translate( 'Get more traffic!' ) }
 							actionURL="https://wordpress.com/support/getting-more-views-and-traffic/"
 							actionTarget="blank"
-							illustration="calypso/assets/images/stats/illustration-stats.svg"
+							illustration={ IllustrationStatsIntro }
 							illustrationWidth={ 150 }
 						/>
 					) }
@@ -224,7 +225,7 @@ class StatsPostDetail extends Component {
 						action={ translate( 'Get more traffic!' ) }
 						actionURL="https://wordpress.com/support/getting-more-views-and-traffic/"
 						actionTarget="blank"
-						illustration="calypso/assets/images/stats/illustration-stats.svg"
+						illustration={ IllustrationStatsIntro }
 						illustrationWidth={ 150 }
 					/>
 				) }

--- a/client/my-sites/stats/stats-post-detail/index.jsx
+++ b/client/my-sites/stats/stats-post-detail/index.jsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import titlecase from 'to-title-case';
-import IllustrationStatsIntro from 'calypso/assets/images/stats/illustration-stats.svg';
+import IllustrationStats from 'calypso/assets/images/stats/illustration-stats.svg';
 import QueryPostStats from 'calypso/components/data/query-post-stats';
 import QueryPosts from 'calypso/components/data/query-posts';
 import EmptyContent from 'calypso/components/empty-content';
@@ -172,7 +172,7 @@ class StatsPostDetail extends Component {
 							action={ translate( 'Get more traffic!' ) }
 							actionURL="https://wordpress.com/support/getting-more-views-and-traffic/"
 							actionTarget="blank"
-							illustration={ IllustrationStatsIntro }
+							illustration={ IllustrationStats }
 							illustrationWidth={ 150 }
 						/>
 					) }
@@ -225,7 +225,7 @@ class StatsPostDetail extends Component {
 						action={ translate( 'Get more traffic!' ) }
 						actionURL="https://wordpress.com/support/getting-more-views-and-traffic/"
 						actionTarget="blank"
-						illustration={ IllustrationStatsIntro }
+						illustration={ IllustrationStats }
 						illustrationWidth={ 150 }
 					/>
 				) }


### PR DESCRIPTION
#### Proposed Changes

The issue was discovered by @a8ck3n [here](https://github.com/Automattic/wp-calypso/pull/70347#discussion_r1086336173).  The PR fixes the issue where image `src` is not loaded by webpack by importing them explicitly.

#### Testing Instructions

* Visit the My Home for a site without any recent traffic  e.g.`/home/xxx.wpcomstaging.com`
* Find the card is 3rd from the top on my test site
* Ensure

Not this:
![image](https://user-images.githubusercontent.com/1425433/214701320-097ea9bb-b5ac-4199-bf01-7f2f31262487.png)

But this:
![image](https://user-images.githubusercontent.com/1425433/214701638-139a59ee-6bcc-44b8-9290-0c752cdb0bff.png)


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
