### PR TITLE
Plugins: Limit wporg plugin fetches

### DIFF
--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -60,6 +60,9 @@ import PluginsList from './plugins-list';
 
 import './style.scss';
 
+// Too many plugins will cause multiple requires to wporg which degrades performance,
+// so this constant disables wporg data for these cases.
+const WPORG_PLUGIN_COUNT_CUTOFF = 20;
 export class PluginsMain extends Component {
 	constructor( props ) {
 		super( props );
@@ -79,12 +82,14 @@ export class PluginsMain extends Component {
 			search,
 		} = this.props;
 
-		currentPlugins.map( ( plugin ) => {
-			const pluginData = this.props.wporgPlugins?.[ plugin.slug ];
-			if ( ! pluginData ) {
-				this.props.wporgFetchPluginData( plugin.slug );
-			}
-		} );
+		if ( currentPlugins.length <= WPORG_PLUGIN_COUNT_CUTOFF ) {
+			currentPlugins.forEach( ( plugin ) => {
+				const pluginData = this.props.wporgPlugins?.[ plugin.slug ];
+				if ( ! pluginData ) {
+					this.props.wporgFetchPluginData( plugin.slug );
+				}
+			} );
+		}
 
 		if (
 			( prevProps.isRequestingSites && ! this.props.isRequestingSites ) ||
@@ -177,7 +182,7 @@ export class PluginsMain extends Component {
 	addWporgDataToPlugins( plugins ) {
 		return plugins.map( ( plugin ) => {
 			const pluginData = this.props.wporgPlugins?.[ plugin.slug ];
-			return Object.assign( {}, plugin, pluginData );
+			return pluginData ? Object.assign( {}, plugin, pluginData ) : plugin;
 		} );
 	}
 


### PR DESCRIPTION
#### Proposed Changes

* TODO

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* TODO

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
