### PR TITLE
Run base image build every four hours

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -180,9 +180,8 @@ object BuildBaseImages : BuildType({
 
 	triggers {
 		schedule {
-			schedulingPolicy = daily {
-				// Time in UTC. Roughly EU mid day, before US starts
-				hour = 11
+			schedulingPolicy = cron {
+				hours = "*/4"
 			}
 			branchFilter = """
 				+:trunk


### PR DESCRIPTION
Runs the base build every four hours. We'll have to experiment with this over the course of a day. The _hope_ is that this results in more webpack cache hits, resulting in faster docker image builds down the line. It looks like the downstream docker image build can be as fast as 2 minutes under the right conditions, so we want to make those conditions more probable. The slowest downstream builds are typically around 6 minutes, and the fastest are between 3-4 minutes. 

The downside is more time spent in queue. This will now take up one hour per day in the queue (6*10min). However, if this speeds up builds by 1 minute on average (and I'd hope it'd be even more than that), and we have approximately 150 builds which could be impacted, we should at the very least break even. If we see 2 minutes improvement on average, that's 5 less hours per day.

This will probably take some trial and error, potentially decreasing or increasing the value as needed.