### PR TITLE
Odyssey: add Jetpack plugin standard header

### DIFF
--- a/apps/odyssey-stats/src/styles/wp-admin.scss
+++ b/apps/odyssey-stats/src/styles/wp-admin.scss
@@ -96,4 +96,7 @@
 		padding-left: 0;
 		padding-right: 0;
 	}
+	.stats-navigation.stats-navigation--modernized .section-nav-tab:not(:first-child) {
+		margin-left: 32px;
+	}
 }

--- a/apps/odyssey-stats/src/styles/wp-admin.scss
+++ b/apps/odyssey-stats/src/styles/wp-admin.scss
@@ -83,8 +83,17 @@
 		// Override WP-Admin styles.
 		float: none;
 	}
+
+	// Jetpack custom styles.
 	.stats > .jp-dashboard-footer {
 		padding-top: 32px;
 		padding-bottom: 32px;
+	}
+	.stats .jetpack-header {
+		padding-bottom: 12px;
+	}
+	.stats-navigation.stats-navigation--modernized .section-nav-tab .section-nav-tab__link {
+		padding-left: 0;
+		padding-right: 0;
 	}
 }

--- a/apps/odyssey-stats/webpack.config.js
+++ b/apps/odyssey-stats/webpack.config.js
@@ -159,6 +159,10 @@ module.exports = {
 			/^calypso\/components\/jetpack-colophon$/,
 			'calypso/components/jetpack/jetpack-footer'
 		),
+		new webpack.NormalModuleReplacementPlugin(
+			/^calypso\/components\/formatted-header$/,
+			'calypso/components/jetpack/jetpack-header'
+		),
 		shouldEmitStats &&
 			new BundleAnalyzerPlugin( {
 				analyzerMode: 'server',

--- a/client/components/jetpack/jetpack-header/index.jsx
+++ b/client/components/jetpack/jetpack-header/index.jsx
@@ -1,0 +1,25 @@
+import classNames from 'classnames';
+import PropTypes from 'prop-types';
+import JetpackLogo from 'calypso/components/jetpack-logo';
+
+import './style.scss';
+
+function JetpackHeader( { className } ) {
+	const classes = classNames( 'jetpack-header', className );
+
+	return (
+		<header className={ classes }>
+			<JetpackLogo size={ 32 } full />
+		</header>
+	);
+}
+
+JetpackHeader.propTypes = {
+	className: PropTypes.string,
+};
+
+JetpackHeader.defaultProps = {
+	className: '',
+};
+
+export default JetpackHeader;

--- a/client/components/jetpack/jetpack-header/style.scss
+++ b/client/components/jetpack/jetpack-header/style.scss
@@ -1,3 +1,3 @@
 .jetpack-header {
-	padding: 8px 0;
+	padding: 12px 0;
 }

--- a/client/components/jetpack/jetpack-header/style.scss
+++ b/client/components/jetpack/jetpack-header/style.scss
@@ -1,0 +1,3 @@
+.jetpack-header {
+	padding: 8px 0;
+}


### PR DESCRIPTION
#### Proposed Changes

The PR replaces `FormattedHeader` with standard Jetpack header `JetpackHeader`. ~~Will adjust styles per design (#72107) in a follow up PR and ask design review from there~~.

#### Testing Instructions

* Setup Odyssey with Option 1 in `PejTkB-3E-p2`
* Open `/wp-admin/admin.php?page=stats`
* Ensure all headers are like the one in the screenshot below

<img width="971" alt="image" src="https://user-images.githubusercontent.com/1425433/214983533-c1309250-6e34-4fdf-a276-a6e96b86aa5a.png">



#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
