### PR TITLE
Adding const langParamSlug to help set href for localized canonicals …

### DIFF
--- a/client/controller/localized-links.js
+++ b/client/controller/localized-links.js
@@ -1,6 +1,5 @@
 import config from '@automattic/calypso-config';
 import { localizeUrl, getLanguageSlugs } from '@automattic/i18n-utils';
-import { getLocaleSlug } from 'i18n-calypso';
 import performanceMark from 'calypso/server/lib/performance-mark';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { setDocumentHeadLink } from 'calypso/state/document-head/actions';
@@ -28,7 +27,8 @@ export const setLocalizedCanonicalUrl = ( context, next ) => {
 		return;
 	}
 
-	const href = getLocalizedCanonicalUrl( context.originalUrl, getLocaleSlug() );
+	const langParamSlug = context.params.lang;
+	const href = getLocalizedCanonicalUrl( context.originalUrl, langParamSlug );
 	const link = {
 		rel: 'canonical',
 		href,

--- a/client/controller/localized-links.js
+++ b/client/controller/localized-links.js
@@ -27,7 +27,7 @@ export const setLocalizedCanonicalUrl = ( context, next ) => {
 		return;
 	}
 
-	const langParamSlug = context.params.lang;
+	const langParamSlug = context.i18n.getLocaleSlug();
 	const href = getLocalizedCanonicalUrl( context.originalUrl, langParamSlug );
 	const link = {
 		rel: 'canonical',


### PR DESCRIPTION
Canonicals on /themes and /plugins pages are always returning an EN value regardless of their locale. Since in almost all cases canonicals should self-reference, we should fix these to make sure they are pulling in the locale. 

Canonicals for localized /themes pages were previously set in #54643. At some point they stopped working, but we aren't sure exactly why yet. 

This PR introduces one solution to fix that issue. 

#### Proposed Changes

* Adds `const langParamSlug = context.params.lang;`
*  Uses `langParamSlug` for `getLocalizedCanonicalUrl` in href value

#### Testing Instructions

* Checkout branch or test with live link
* Visit localized /plugins pages while logged out or incognito such as `/es/plugins` `/es/plugins/browse/seo` and `/es/plugins/wordpress-seo` 
* View the page source or inspect the page to search for `canonical`
* Verify that the canonical points to itself and not to the default EN page.
* Complete these same steps above while visiting several /themes pages such as `/es/themes` `/es/themes/filter/blog` and `/es/theme/mugistore`

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
