### PR TITLE
Remove links to /courses and replace it with /learn in Universal Header & Footer Navbars for Calypso

### DIFF
--- a/client/layout/universal-navbar-footer/index.tsx
+++ b/client/layout/universal-navbar-footer/index.tsx
@@ -172,8 +172,8 @@ const UniversalNavbarFooter = () => {
 									</a>
 								</li>
 								<li>
-									<a href={ localizeUrl( 'https://wordpress.com/courses/' ) } target="_self">
-										{ translate( 'WordPress Courses' ) }
+									<a href={ localizeUrl( 'https://wordpress.com/learn/' ) } target="_self">
+										{ translate( 'Learn WordPress' ) }
 									</a>
 								</li>
 								<li>

--- a/client/layout/universal-navbar-header/index.jsx
+++ b/client/layout/universal-navbar-header/index.jsx
@@ -207,9 +207,9 @@ const UniversalNavbarHeader = () => {
 													target="_self"
 												/>
 												<UniversalNavbarLiMenuItem
-													titleValue={ translate( 'WordPress Courses' ) }
-													elementContent={ translate( 'WordPress Courses' ) }
-													urlValue={ localizeUrl( '//wordpress.com/courses/' ) }
+													titleValue={ translate( 'Learn WordPress' ) }
+													elementContent={ translate( 'Learn WordPress' ) }
+													urlValue={ localizeUrl( '//wordpress.com/learn/' ) }
 													type="dropdown"
 													target="_self"
 												/>
@@ -423,9 +423,9 @@ const UniversalNavbarHeader = () => {
 										type="menu"
 									/>
 									<UniversalNavbarLiMenuItem
-										titleValue={ translate( 'WordPress Courses' ) }
-										elementContent={ translate( 'WordPress Courses' ) }
-										urlValue={ localizeUrl( '//wordpress.com/courses/' ) }
+										titleValue={ translate( 'Learn WordPress' ) }
+										elementContent={ translate( 'Learn WordPress' ) }
+										urlValue={ localizeUrl( '//wordpress.com/learn/' ) }
 										type="menu"
 									/>
 								</ul>


### PR DESCRIPTION
#### Proposed Changes

* As part of the Learn Revamp Project, we are replacing links to WordPress Courses with the Learn WordPress Section - See: p5uIfZ-cyH-p2 & 1244-gh-Automattic/martech

#### Testing Instructions

* Log out
* Navigate to /themes or /plugins
* Ensure that you see the Learn WordPress Link in the Resources Menu Item in Header (For both themes and plugins sections)
* Ensure that you see the Learn WordPress Link in the Resources Section in Footer (Only for Plugins section)

#### Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
