### PR TITLE
Enable `marketplace-jetpack-plugin-search` feature flag on production

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -77,7 +77,7 @@
 		"mailchimp": true,
 		"marketplace-domain-bundle": false,
 		"marketplace-fetch-dynamic-plugin-details": false,
-		"marketplace-jetpack-plugin-search": false,
+		"marketplace-jetpack-plugin-search": true,
 		"marketplace-personal-premium": false,
 		"marketplace-test": false,
 		"me/account-close": true,


### PR DESCRIPTION
#### Proposed Changes

* Enables the `marketplace-jetpack-plugin-search` feature flag on the production environment

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

#### On the production environment
* Navigate to `/plugins`
* Open the dev tools
* Perform a search (eg. woocommerce)
* On the dev tools Network tab, validate that a search request was sent out to `https://public-api.wordpress.com/rest/v1.3/marketplace/search` and that the results contain free and paid products in a mixed order:
  <img width="1068" alt="CleanShot 2023-01-26 at 12 06 10@2x" src="https://user-images.githubusercontent.com/11555574/214831394-1d015884-3b99-41b9-a169-3d2d8d366c3d.png">

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
