### PR TITLE
Users management: Wrap no-result component with Card

### DIFF
--- a/client/my-sites/people/subscribers/index.tsx
+++ b/client/my-sites/people/subscribers/index.tsx
@@ -142,13 +142,15 @@ function Subscribers( props: Props ) {
 
 		case 'no-result':
 			return (
-				<NoResults
-					image="/calypso/images/people/mystery-person.svg"
-					text={ _( 'No results found for {{em}}%(searchTerm)s{{/em}}', {
-						args: { searchTerm: search },
-						components: { em: <em /> },
-					} ) }
-				/>
+				<Card>
+					<NoResults
+						image="/calypso/images/people/mystery-person.svg"
+						text={ _( 'No results found for {{em}}%(searchTerm)s{{/em}}', {
+							args: { searchTerm: search },
+							components: { em: <em /> },
+						} ) }
+					/>
+				</Card>
 			);
 	}
 


### PR DESCRIPTION
#### Proposed Changes

* Wrap no-result component with Card

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/people/subscribers/{SITE_SLUG}`
* Click on the magnifier icon
* Type something that does not exist in the list
* Check if there is a Card component wrapped around the no-result comp

#### Screenshots

Before:
<img width="766" alt="Screenshot 2023-01-26 at 13 03 48" src="https://user-images.githubusercontent.com/1241413/214831369-007d52ad-6b49-45dd-915b-0edc0d7ee3c8.png">

Now:
<img width="772" alt="Screenshot 2023-01-26 at 13 03 57" src="https://user-images.githubusercontent.com/1241413/214831383-c55ef8bc-2496-4ddc-9df8-5df04db59f13.png">


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #72637
