### PR TITLE
Connect home domain upsell to plans page upsell

### DIFF
--- a/client/my-sites/customer-home/cards/features/domain-upsell/index.jsx
+++ b/client/my-sites/customer-home/cards/features/domain-upsell/index.jsx
@@ -52,7 +52,7 @@ export function RenderDomainUpsell() {
 		} );
 	};
 
-	const purchaseLink = '/plans/' + siteSlug;
+	const purchaseLink = '/plans/' + siteSlug + '?get_domain=' + domainSuggestionName;
 	const [ ctaIsBusy, setCtaIsBusy ] = useState( false );
 	const getCtaClickHandler = async () => {
 		setCtaIsBusy( true );

--- a/client/my-sites/plans-features-main/plan-type-selector.tsx
+++ b/client/my-sites/plans-features-main/plan-type-selector.tsx
@@ -137,6 +137,10 @@ export const IntervalTypeToggle: React.FunctionComponent< IntervalTypeProps > = 
 		return null;
 	}
 
+	const domainFromHomeUpsellFlow = new URLSearchParams( window.location.search ).get(
+		'get_domain'
+	);
+
 	return (
 		<IntervalTypeToggleWrapper
 			showingMonthly={ intervalType === 'monthly' }
@@ -145,7 +149,10 @@ export const IntervalTypeToggle: React.FunctionComponent< IntervalTypeProps > = 
 			<SegmentedControl compact className={ segmentClasses } primary={ true }>
 				<SegmentedControl.Item
 					selected={ intervalType === 'monthly' }
-					path={ generatePath( props, { intervalType: 'monthly' } ) }
+					path={ generatePath( props, {
+						intervalType: 'monthly',
+						get_domain: domainFromHomeUpsellFlow,
+					} ) }
 					isPlansInsideStepper={ props.isPlansInsideStepper }
 				>
 					<span>{ translate( 'Pay monthly' ) }</span>
@@ -153,7 +160,10 @@ export const IntervalTypeToggle: React.FunctionComponent< IntervalTypeProps > = 
 
 				<SegmentedControl.Item
 					selected={ intervalType === 'yearly' }
-					path={ generatePath( props, { intervalType: 'yearly' } ) }
+					path={ generatePath( props, {
+						intervalType: 'yearly',
+						get_domain: domainFromHomeUpsellFlow,
+					} ) }
 					isPlansInsideStepper={ props.isPlansInsideStepper }
 				>
 					<span ref={ ( ref ) => ref && setSpanRef( ref ) }>{ translate( 'Pay annually' ) }</span>

--- a/client/my-sites/plans/header.jsx
+++ b/client/my-sites/plans/header.jsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { Button, Dialog, Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
@@ -16,8 +15,9 @@ export default function PlansHeader() {
 	const translate = useTranslate();
 	const [ showDomainUpsellDialog, setShowDomainUpsellDialog ] = useState( false );
 
-	// TODO: We need to determine if this is a domain upsell and show the domain here.
-	const domainName = 'exampledomain.com';
+	const domainFromHomeUpsellFlow = new URLSearchParams( window.location.search ).get(
+		'get_domain'
+	);
 
 	const plansDescription = translate(
 		'See and compare the features available on each WordPress.com plan.'
@@ -27,16 +27,13 @@ export default function PlansHeader() {
 		'With an annual plan, you can get {{strong}}%(domainName)s for free{{/strong}} for the first year, Jetpack essential features, live chat support, and all the features that will take your site to the next level.',
 		{
 			args: {
-				domainName: domainName,
+				domainName: domainFromHomeUpsellFlow,
 			},
 			components: {
 				strong: <strong />,
 			},
 		}
 	);
-
-	// TODO: We need to determine if this is a domain upsell.
-	const isDomainUpsell = config.isEnabled( 'is_domain_upsell' );
 
 	const onBackClick = () => {
 		recordTracksEvent( 'calypso_plans_page_domain_upsell_back_click' );
@@ -96,7 +93,7 @@ export default function PlansHeader() {
 						'Any domain you purchase without a plan will get redirected to %(domainName)s.',
 						{
 							args: {
-								domainName: domainName,
+								domainName: domainFromHomeUpsellFlow,
 							},
 						}
 					) }
@@ -110,7 +107,7 @@ export default function PlansHeader() {
 		);
 	}
 
-	if ( false === isDomainUpsell ) {
+	if ( null === domainFromHomeUpsellFlow ) {
 		return (
 			<FormattedHeader
 				brandFont
@@ -130,12 +127,10 @@ export default function PlansHeader() {
 					{ translate( 'Back' ) }
 				</Button>
 
-				{ isDomainUpsell && (
-					<Button onClick={ onSkipClick } borderless href="/">
-						{ translate( 'Skip' ) }
-						<Gridicon icon="arrow-right" size={ 18 } />
-					</Button>
-				) }
+				<Button onClick={ onSkipClick } borderless href="/">
+					{ translate( 'Skip' ) }
+					<Gridicon icon="arrow-right" size={ 18 } />
+				</Button>
 			</header>
 
 			<FormattedHeader

--- a/client/my-sites/plans/header.jsx
+++ b/client/my-sites/plans/header.jsx
@@ -1,12 +1,18 @@
 import config from '@automattic/calypso-config';
 import { Button, Dialog, Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
+import page from 'page';
 import { useState } from 'react';
+import { useSelector } from 'react-redux';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { getSiteSlug } from 'calypso/state/sites/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import './header.scss';
 
 export default function PlansHeader() {
+	const selectedSiteId = useSelector( getSelectedSiteId );
+	const siteSlug = useSelector( ( state ) => getSiteSlug( state, selectedSiteId ) );
 	const translate = useTranslate();
 	const [ showDomainUpsellDialog, setShowDomainUpsellDialog ] = useState( false );
 
@@ -34,23 +40,40 @@ export default function PlansHeader() {
 
 	const onBackClick = () => {
 		recordTracksEvent( 'calypso_plans_page_domain_upsell_back_click' );
-		history.back();
+		// We currently have only one flow that leads to the plans page domain upsell.
+		page( '/home/' + siteSlug );
 	};
 
 	const onCloseDialog = () => {
 		setShowDomainUpsellDialog( false );
 	};
 
-	const onSkipClick = () => {
+	const onSkipClick = ( event ) => {
 		event.preventDefault();
 		recordTracksEvent( 'calypso_plans_page_domain_upsell_skip_click' );
 		setShowDomainUpsellDialog( true );
 	};
 
+	const onCancelPlanClick = () => {
+		setShowDomainUpsellDialog( false );
+		recordTracksEvent( 'calypso_plans_page_domain_upsell_cancel_plan_click' );
+		page( '/checkout/' + siteSlug );
+	};
+
+	const onContinuePlanClick = () => {
+		setShowDomainUpsellDialog( false );
+		recordTracksEvent( 'calypso_plans_page_domain_upsell_continue_plan_click' );
+	};
+
 	function renderDeleteDialog() {
 		const buttons = [
-			{ action: 'cancel', label: translate( 'That works for me' ) },
-			{ action: 'delete', label: translate( 'I want my domain as primary' ), isPrimary: true },
+			{ action: 'cancel', label: translate( 'That works for me' ), onClick: onCancelPlanClick },
+			{
+				action: 'delete',
+				label: translate( 'I want my domain as primary' ),
+				isPrimary: true,
+				onClick: onContinuePlanClick,
+			},
 		];
 
 		return (

--- a/client/my-sites/plans/header.scss
+++ b/client/my-sites/plans/header.scss
@@ -12,7 +12,7 @@
 }
 
 .is-section-plans .formatted-header.header-text {
-	max-width: $break-small;
+	max-width: $break-medium;
 }
 
 .dialog.planspage__domain-upsell {


### PR DESCRIPTION
#### Proposed Changes

* Connected home domain upsell flow to the plans page
* Shown the suggested domain at upsell flow and Dialog window

<img width="1205" alt="image" src="https://user-images.githubusercontent.com/1044309/214840312-8c900078-3d59-496b-8bbc-23be4107ae03.png">


<img width="700" alt="image" src="https://user-images.githubusercontent.com/1044309/214840559-4cb52b4e-905e-4394-94a3-a1db7f0460a1.png">


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this PR locally
* Apply this diff to your wpcom Sandbox D99116-code
* Sandbox your API
* Click on "Get your custom domain" at the "domain upsell" feature on My Home.
* Make sure the `?get_domain=your-suggested-domain` parameter shows at the URL on /plans page
* Switch between monthly and yearly plans to make sure the `get_domain` parameter is still there
* Make sure we don't have any error while switching monthly and yearly /plans page without `get_domain` parameter
* You should see /plans page domain upsell `Free for the first year!` the entire time
* Make sure `Free for the first year!` only appears if we have `get_domain` parameter at the URL
* Make sure we're seeing the correct domain in that upsell and on Dialog window (when clicking on the skip button)
* Play around with the `Skip` and `Back` buttons and make sure everything works as expected
* Make sure we're tracking everything correctly

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/71501