### PR TITLE
Agency Dashboard: Improve onboarding help widget copy

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/primary/onboarding-widget/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/onboarding-widget/index.tsx
@@ -46,9 +46,9 @@ export default function OnboardingWidget( { isLicensesPage }: { isLicensesPage?:
 			stepCount: hasSites ? <Gridicon icon="checkmark" size={ 16 } /> : 1,
 			title: translate( 'Add your Jetpack sites' ),
 			description: translate(
-				'Add your clients’ sites to your dashboard to manage features and monitor them. To add your sites to the Pro Dashboard, simply connect them to Jetpack using the same {{strong}}%(displayName)s{{/strong}} user account.',
+				'Manage features and monitor your clients’ sites by adding them to your Jetpack Pro Dashboard. To do so, connect the sites to Jetpack using your {{strong}}%(userEmail)s{{/strong}} user account.',
 				{
-					args: { displayName: user?.display_name },
+					args: { userEmail: user?.email },
 					components: {
 						strong: <strong />,
 					},
@@ -73,7 +73,7 @@ export default function OnboardingWidget( { isLicensesPage }: { isLicensesPage?:
 			stepCount: 2,
 			title: translate( 'Issue product licenses' ),
 			description: translate(
-				'Add your first license and get up to a 60% discount on Jetpack products. Licenses can be revoked at any time, giving you the flexibility to add or remove products when it’s most convenient, meaning you only pay when you use them.'
+				'Save up to 60% on Jetpack products by adding your first license. You can revoke licenses anytime, allowing you to add or remove products as needed, so you only pay when using them.'
 			),
 			video:
 				'https://video.wordpress.com/embed/nsqG1pBO?hd=1&amp;autoPlay=0&amp;permalink=1&amp;loop=0&amp;preloadContent=metadata&amp;muted=0&amp;playsinline=0&amp;controls=1&amp;cover=1',


### PR DESCRIPTION
#### Proposed Changes

This PR updates the existing copy of the [help widget](https://github.com/Automattic/wp-calypso/pull/72551) we shipped earlier today.

**Screenshot:**

<img width="1052" alt="image" src="https://user-images.githubusercontent.com/1749918/214846650-ca1ce521-d070-4cff-a0b8-02fb83ebdee9.png">

#### Testing Instructions

* Apply D98977-code to your sandbox to make the testing easier.
* Visit the Jetpack Cloud Live and then visit the Dashboard (_or the Licensing page_).
* Verify the new copy is correct and that everything looks good.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #