### PR TITLE
Update the alignment between the subtitle and browse all option

### DIFF
--- a/client/my-sites/plugins/plugins-results-header/style.scss
+++ b/client/my-sites/plugins/plugins-results-header/style.scss
@@ -25,7 +25,7 @@
 		align-items: center;
 		justify-content: space-between;
 		margin-top: auto;
-		margin-bottom: 4px; // +20 from elements = 24 gap
+		margin-bottom: 6px; // +20 from elements = 26 gap
 
 		.plugins-results-header__action {
 			font-size: $font-body-small;


### PR DESCRIPTION
#### Proposed Changes

Update the alignment between the subtitle and browse all option

| Before  | After |
| ------------- | ------------- |
|<img width="1143" alt="CleanShot 2023-01-26 at 10 04 02@2x" src="https://user-images.githubusercontent.com/5039531/214855940-b7eb85a1-3de4-4532-9f1f-de2d6eb8c899.png">|<img width="1167" alt="CleanShot 2023-01-26 at 10 05 15@2x" src="https://user-images.githubusercontent.com/5039531/214856007-751c466c-2631-416a-9f5d-04fa56f9796f.png">|

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/plugins`
* Check the items are aligned as described above

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
