### PR TITLE
Email stats: fix crash when there are no "Other" links in the click stats

### DIFF
--- a/client/state/stats/emails/utils.js
+++ b/client/state/stats/emails/utils.js
@@ -245,18 +245,19 @@ export function parseEmailLinksData( links ) {
 		return count;
 	}, 0 );
 
-	return [
-		...filteredLinks.map( ( link ) => {
-			return {
-				label: stringMap[ link[ 0 ] ],
-				value: parseInt( link[ 1 ], 10 ),
-			};
-		} ),
-		otherCount
-			? {
-					label: translate( 'Other', { context: 'Email link type' } ),
-					value: otherCount,
-			  }
-			: null,
-	];
+	const mappedLinks = filteredLinks.map( ( link ) => {
+		return {
+			label: stringMap[ link[ 0 ] ],
+			value: parseInt( link[ 1 ], 10 ),
+		};
+	} );
+
+	if ( otherCount ) {
+		mappedLinks.push( {
+			label: translate( 'Other', { context: 'Email link type' } ),
+			value: otherCount,
+		} );
+	}
+
+	return mappedLinks;
 }


### PR DESCRIPTION
#### Proposed Changes

The email click stats currently crash when there are no "Other" links that were clicked. This is due to a coding error on my end.

<img width="549" alt="CleanShot 2023-01-27 at 08 44 26@2x" src="https://user-images.githubusercontent.com/528287/215034241-f2c47e30-c297-4a29-a034-a876090b5d7c.png">

#### Testing Instructions

- This PR can probably just be code reviewed, since it requires a very specific set of conditions to reproduce.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
