### PR TITLE
Update/my home domain upsell restrict

### DIFF
--- a/client/my-sites/customer-home/cards/features/domain-upsell/index.jsx
+++ b/client/my-sites/customer-home/cards/features/domain-upsell/index.jsx
@@ -52,7 +52,7 @@ export function RenderDomainUpsell() {
 		} );
 	};
 
-	const purchaseLink = '/plans/' + siteSlug;
+	const purchaseLink = '/plans/' + siteSlug + '?get_domain=' + domainSuggestionName;
 	const [ ctaIsBusy, setCtaIsBusy ] = useState( false );
 	const getCtaClickHandler = async () => {
 		setCtaIsBusy( true );

--- a/client/my-sites/customer-home/cards/features/domain-upsell/index.jsx
+++ b/client/my-sites/customer-home/cards/features/domain-upsell/index.jsx
@@ -1,4 +1,5 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { isFreePlanProduct } from '@automattic/calypso-products';
 import { Button, Card, Spinner } from '@automattic/components';
 import { useDomainSuggestions } from '@automattic/domain-picker/src';
 import { useLocale } from '@automattic/i18n-utils';
@@ -11,11 +12,19 @@ import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import { domainRegistration } from 'calypso/lib/cart-values/cart-items';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
-import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import { isCurrentUserEmailVerified } from 'calypso/state/current-user/selectors';
+import { getSelectedSite, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 
 import './style.scss';
 
 export default function DomainUpsell() {
+	const site = useSelector( ( state ) => getSelectedSite( state ) );
+	const isEmailVerified = useSelector( ( state ) => isCurrentUserEmailVerified( state ) );
+
+	if ( ! isEmailVerified || ! isFreePlanProduct( site.plan ) ) {
+		return null;
+	}
+
 	return (
 		<CalypsoShoppingCartProvider>
 			<RenderDomainUpsell />

--- a/client/my-sites/plans-features-main/plan-type-selector.tsx
+++ b/client/my-sites/plans-features-main/plan-type-selector.tsx
@@ -137,6 +137,10 @@ export const IntervalTypeToggle: React.FunctionComponent< IntervalTypeProps > = 
 		return null;
 	}
 
+	const domainFromHomeUpsellFlow = new URLSearchParams( window.location.search ).get(
+		'get_domain'
+	);
+
 	return (
 		<IntervalTypeToggleWrapper
 			showingMonthly={ intervalType === 'monthly' }
@@ -145,7 +149,10 @@ export const IntervalTypeToggle: React.FunctionComponent< IntervalTypeProps > = 
 			<SegmentedControl compact className={ segmentClasses } primary={ true }>
 				<SegmentedControl.Item
 					selected={ intervalType === 'monthly' }
-					path={ generatePath( props, { intervalType: 'monthly' } ) }
+					path={ generatePath( props, {
+						intervalType: 'monthly',
+						get_domain: domainFromHomeUpsellFlow,
+					} ) }
 					isPlansInsideStepper={ props.isPlansInsideStepper }
 				>
 					<span>{ translate( 'Pay monthly' ) }</span>
@@ -153,7 +160,10 @@ export const IntervalTypeToggle: React.FunctionComponent< IntervalTypeProps > = 
 
 				<SegmentedControl.Item
 					selected={ intervalType === 'yearly' }
-					path={ generatePath( props, { intervalType: 'yearly' } ) }
+					path={ generatePath( props, {
+						intervalType: 'yearly',
+						get_domain: domainFromHomeUpsellFlow,
+					} ) }
 					isPlansInsideStepper={ props.isPlansInsideStepper }
 				>
 					<span ref={ ( ref ) => ref && setSpanRef( ref ) }>{ translate( 'Pay annually' ) }</span>

--- a/client/my-sites/plans/header.jsx
+++ b/client/my-sites/plans/header.jsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { Button, Dialog, Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
@@ -16,8 +15,9 @@ export default function PlansHeader() {
 	const translate = useTranslate();
 	const [ showDomainUpsellDialog, setShowDomainUpsellDialog ] = useState( false );
 
-	// TODO: We need to determine if this is a domain upsell and show the domain here.
-	const domainName = 'exampledomain.com';
+	const domainFromHomeUpsellFlow = new URLSearchParams( window.location.search ).get(
+		'get_domain'
+	);
 
 	const plansDescription = translate(
 		'See and compare the features available on each WordPress.com plan.'
@@ -27,16 +27,13 @@ export default function PlansHeader() {
 		'With an annual plan, you can get {{strong}}%(domainName)s for free{{/strong}} for the first year, Jetpack essential features, live chat support, and all the features that will take your site to the next level.',
 		{
 			args: {
-				domainName: domainName,
+				domainName: domainFromHomeUpsellFlow,
 			},
 			components: {
 				strong: <strong />,
 			},
 		}
 	);
-
-	// TODO: We need to determine if this is a domain upsell.
-	const isDomainUpsell = config.isEnabled( 'is_domain_upsell' );
 
 	const onBackClick = () => {
 		recordTracksEvent( 'calypso_plans_page_domain_upsell_back_click' );
@@ -96,7 +93,7 @@ export default function PlansHeader() {
 						'Any domain you purchase without a plan will get redirected to %(domainName)s.',
 						{
 							args: {
-								domainName: domainName,
+								domainName: domainFromHomeUpsellFlow,
 							},
 						}
 					) }
@@ -110,7 +107,7 @@ export default function PlansHeader() {
 		);
 	}
 
-	if ( false === isDomainUpsell ) {
+	if ( null === domainFromHomeUpsellFlow ) {
 		return (
 			<FormattedHeader
 				brandFont
@@ -130,12 +127,10 @@ export default function PlansHeader() {
 					{ translate( 'Back' ) }
 				</Button>
 
-				{ isDomainUpsell && (
-					<Button onClick={ onSkipClick } borderless href="/">
-						{ translate( 'Skip' ) }
-						<Gridicon icon="arrow-right" size={ 18 } />
-					</Button>
-				) }
+				<Button onClick={ onSkipClick } borderless href="/">
+					{ translate( 'Skip' ) }
+					<Gridicon icon="arrow-right" size={ 18 } />
+				</Button>
 			</header>
 
 			<FormattedHeader

--- a/client/my-sites/plans/header.jsx
+++ b/client/my-sites/plans/header.jsx
@@ -1,12 +1,18 @@
 import config from '@automattic/calypso-config';
 import { Button, Dialog, Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
+import page from 'page';
 import { useState } from 'react';
+import { useSelector } from 'react-redux';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { getSiteSlug } from 'calypso/state/sites/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import './header.scss';
 
 export default function PlansHeader() {
+	const selectedSiteId = useSelector( getSelectedSiteId );
+	const siteSlug = useSelector( ( state ) => getSiteSlug( state, selectedSiteId ) );
 	const translate = useTranslate();
 	const [ showDomainUpsellDialog, setShowDomainUpsellDialog ] = useState( false );
 
@@ -34,23 +40,40 @@ export default function PlansHeader() {
 
 	const onBackClick = () => {
 		recordTracksEvent( 'calypso_plans_page_domain_upsell_back_click' );
-		history.back();
+		// We currently have only one flow that leads to the plans page domain upsell.
+		page( '/home/' + siteSlug );
 	};
 
 	const onCloseDialog = () => {
 		setShowDomainUpsellDialog( false );
 	};
 
-	const onSkipClick = () => {
+	const onSkipClick = ( event ) => {
 		event.preventDefault();
 		recordTracksEvent( 'calypso_plans_page_domain_upsell_skip_click' );
 		setShowDomainUpsellDialog( true );
 	};
 
+	const onCancelPlanClick = () => {
+		setShowDomainUpsellDialog( false );
+		recordTracksEvent( 'calypso_plans_page_domain_upsell_cancel_plan_click' );
+		page( '/checkout/' + siteSlug );
+	};
+
+	const onContinuePlanClick = () => {
+		setShowDomainUpsellDialog( false );
+		recordTracksEvent( 'calypso_plans_page_domain_upsell_continue_plan_click' );
+	};
+
 	function renderDeleteDialog() {
 		const buttons = [
-			{ action: 'cancel', label: translate( 'That works for me' ) },
-			{ action: 'delete', label: translate( 'I want my domain as primary' ), isPrimary: true },
+			{ action: 'cancel', label: translate( 'That works for me' ), onClick: onCancelPlanClick },
+			{
+				action: 'delete',
+				label: translate( 'I want my domain as primary' ),
+				isPrimary: true,
+				onClick: onContinuePlanClick,
+			},
 		];
 
 		return (


### PR DESCRIPTION
#### Proposed Changes

Restrict My Home domain upsell to free plans & email verified users.

#### Screenshot
<img width="701" alt="image" src="https://user-images.githubusercontent.com/402286/214868999-2e36fd20-db22-4246-8e73-d5b35a1f924e.png">

#### Testing Instructions

- Go to `/home` with a free plan site
- If email address is verified you should see the Domain upsell

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] ~~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~~
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~~
- [ ] ~~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~~
- [ ] ~~For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~~
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
