### PR TITLE
Add option to purchases to reinstall plugins

### DIFF
--- a/client/data/marketplace/reinstall-plugins-api.ts
+++ b/client/data/marketplace/reinstall-plugins-api.ts
@@ -9,7 +9,7 @@ import type { ReinstallPluginsResponse } from './types';
  */
 const reinstallPlugins = ( siteId: number ): Promise< ReinstallPluginsResponse > => {
 	return wpcom.req.get( {
-		path: `/marketplace/products/${ siteId }/reinstall`,
+		path: `/sites/${ siteId }/marketplace/products/reinstall`,
 		apiNamespace: 'wpcom/v2',
 	} );
 };

--- a/client/data/marketplace/reinstall-plugins-api.ts
+++ b/client/data/marketplace/reinstall-plugins-api.ts
@@ -1,0 +1,17 @@
+import wpcom from 'calypso/lib/wp';
+import type { ReinstallPluginsResponse } from './types';
+
+/**
+ * Calls the API to reinstall all the subscriptions given a site id.
+ *
+ * @param {number} siteId Site ID.
+ * @returns {Promise} Promise object represents the result of the request.
+ */
+const reinstallPlugins = ( siteId: number ): Promise< ReinstallPluginsResponse > => {
+	return wpcom.req.get( {
+		path: `/marketplace/products/${ siteId }/reinstall`,
+		apiNamespace: 'wpcom/v2',
+	} );
+};
+
+export default reinstallPlugins;

--- a/client/data/marketplace/types.ts
+++ b/client/data/marketplace/types.ts
@@ -86,3 +86,7 @@ export type SearchParams = {
 	pageSize: number;
 	locale: string;
 };
+
+export type ReinstallPluginsResponse = {
+	message: string;
+};

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -622,7 +622,7 @@ class ManagePurchase extends Component {
 				{ isReinstalling ? (
 					<>
 						<Spinner className="card__icon" />
-						{ translate( 'Reinstalling' ) }...
+						{ translate( 'Reinstalling…' ) }
 					</>
 				) : (
 					<>

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -31,7 +31,7 @@ import {
 	hasMarketplaceProduct,
 	isDIFMProduct,
 } from '@automattic/calypso-products';
-import { Button, Card, CompactCard, ProductIcon, Gridicon } from '@automattic/components';
+import { Spinner, Button, Card, CompactCard, ProductIcon, Gridicon } from '@automattic/components';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import page from 'page';
@@ -52,6 +52,7 @@ import MaterialIcon from 'calypso/components/material-icon';
 import Notice from 'calypso/components/notice';
 import NoticeAction from 'calypso/components/notice/notice-action';
 import VerticalNavItem from 'calypso/components/vertical-nav/item';
+import reinstallPlugins from 'calypso/data/marketplace/reinstall-plugins-api';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import {
@@ -94,6 +95,7 @@ import {
 	getCurrentUser,
 	getCurrentUserId,
 } from 'calypso/state/current-user/selectors';
+import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import { getProductsList } from 'calypso/state/products-list/selectors';
 import {
 	getSitePurchases,
@@ -169,6 +171,7 @@ class ManagePurchase extends Component {
 		cancelLink: null,
 		isRemoving: false,
 		isCancelSurveyVisible: false,
+		isReinstalling: false,
 	};
 
 	componentDidMount() {
@@ -593,6 +596,44 @@ class ManagePurchase extends Component {
 		);
 	}
 
+	handleReinstall = async () => {
+		this.setState( { isReinstalling: true } );
+		const siteId = this.props.purchase.siteId;
+		try {
+			const response = await reinstallPlugins( siteId );
+
+			this.props.successNotice( response.message, { duration: 5000 } );
+		} catch ( error ) {
+			this.props.errorNotice( error.message );
+		} finally {
+			this.setState( { isReinstalling: false } );
+		}
+	};
+
+	renderReinstall() {
+		const { purchase, productsList, translate } = this.props;
+		const { isReinstalling } = this.state;
+		if ( ! ( purchase.active && hasMarketplaceProduct( productsList, purchase.productSlug ) ) ) {
+			return null;
+		}
+
+		return (
+			<CompactCard tagName="a" onClick={ isReinstalling ? null : this.handleReinstall }>
+				{ isReinstalling ? (
+					<>
+						<Spinner className="card__icon" />
+						{ translate( 'Reinstalling' ) }...
+					</>
+				) : (
+					<>
+						<MaterialIcon icon="build" className="card__icon" />
+						{ translate( 'Reinstall' ) }
+					</>
+				) }
+			</CompactCard>
+		);
+	}
+
 	cancelSubscription = () => {
 		this.closeDialog();
 		page.redirect( this.props.purchaseListUrl );
@@ -998,6 +1039,7 @@ class ManagePurchase extends Component {
 						{ ! preventRenewal && renderMonthlyRenewalOption && this.renderRenewMonthlyNavItem() }
 						{ ! isJetpackTemporarySite && this.renderUpgradeNavItem() }
 						{ this.renderEditPaymentMethodNavItem() }
+						{ this.renderReinstall() }
 						{ this.renderCancelPurchaseNavItem() }
 						{ this.renderCancelSurvey() }
 						{ ! isJetpackTemporarySite && this.renderRemovePurchaseNavItem() }
@@ -1202,5 +1244,7 @@ export default connect(
 	{
 		handleRenewNowClick,
 		handleRenewMultiplePurchasesClick,
+		errorNotice,
+		successNotice,
 	}
 )( localize( ManagePurchase ) );


### PR DESCRIPTION







#### Proposed Changes

A new button card will be added to the `purchases` screen that will only be displayed for Marketplace products. That button will call an endpoint that will reinstall all the subscriptions. This will allow the user to restore accidentally removed plugins.

![CleanShot 2023-01-26 at 17 47 44](https://user-images.githubusercontent.com/3519124/214897406-4b3c428b-3ca1-4b07-86ed-d36db21716bf.gif)

|Click | Installing|Successful|
|-------|------|------|
|![CleanShot 2023-01-26 at 17 44 45@2x](https://user-images.githubusercontent.com/3519124/214896516-2e531be6-f4e6-4da6-b805-2b3b26151b7c.png)| e![CleanShot 2023-01-26 at 17 40 24@2x](https://user-images.githubusercontent.com/3519124/214896628-5ae3d6c9-21d5-4226-a838-daacc29e3954.png) | ![CleanShot 2023-01-26 at 17 40 39@2x](https://user-images.githubusercontent.com/3519124/214896697-578eeb34-fa59-4e8e-a423-a14cf4e94f21.png)|

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Follow the **Steps to Reproduce** in the original issue
  - https://github.com/Automattic/wp-calypso/issues/67624
* Make sure the following diff D99297-code is applied and you are sandboxed
* Go to `/purchases/subscriptons/:siteId`
* Select the subscription you have deleted in the first step
* Click on the `Reinstall` button card
* Ensure that after some seconds, a success notification should be displayed
* Go to plugins and search for the deleted plugin, e.g. `/plugins/woocommerce-subscriptions/:siteId`
* Make sure you can see `Installed and active` on top of the side bar on the right

- Go again to `/purchases/subscriptons/:siteId`
- Select any other purchase that is not from the Marketplace, e.g. select a plan
- Make sure the `Reinstall` button card is not displayed

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
~- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #67624