### PR TITLE
Domain Upsell: Handle long domain names with CSS

### DIFF
--- a/client/my-sites/customer-home/cards/features/domain-upsell/index.jsx
+++ b/client/my-sites/customer-home/cards/features/domain-upsell/index.jsx
@@ -88,21 +88,23 @@ export function RenderDomainUpsell() {
 				</p>
 
 				<div className="suggested-domain-name">
+					<div className="badge badge--info">{ translate( 'Current' ) }</div>
 					<div className="card">
 						<span>
-							<strike>{ siteSlug }</strike>
+							<strike>
+								kasfljasasdfasdlkjfasdfasdfasdfsdfsadfsadfasdasdfasdfasdfsadfasdfasdfasdflaksdjflksjdfkl.wordpress.com
+							</strike>
 						</span>
-						<div className="badge badge--info">{ translate( 'Current' ) }</div>
 					</div>
+					{ domainSuggestion?.domain_name ? (
+						<div className="badge badge--success">{ translate( 'Available' ) }</div>
+					) : (
+						<div className="badge">
+							<Spinner />
+						</div>
+					) }
 					<div className="card">
 						<span>{ domainSuggestionName }</span>
-						{ domainSuggestion?.domain_name ? (
-							<div className="badge badge--success">{ translate( 'Available' ) }</div>
-						) : (
-							<div className="badge">
-								<Spinner />
-							</div>
-						) }
 					</div>
 				</div>
 

--- a/client/my-sites/customer-home/cards/features/domain-upsell/index.jsx
+++ b/client/my-sites/customer-home/cards/features/domain-upsell/index.jsx
@@ -88,21 +88,21 @@ export function RenderDomainUpsell() {
 				</p>
 
 				<div className="suggested-domain-name">
-					<div className="badge badge--info">{ translate( 'Current' ) }</div>
 					<div className="card">
 						<span>
 							<strike>{ siteSlug }</strike>
 						</span>
+						<div className="badge badge--info">{ translate( 'Current' ) }</div>
 					</div>
-					{ domainSuggestion?.domain_name ? (
-						<div className="badge badge--success">{ translate( 'Available' ) }</div>
-					) : (
-						<div className="badge">
-							<Spinner />
-						</div>
-					) }
 					<div className="card">
 						<span>{ domainSuggestionName }</span>
+						{ domainSuggestion?.domain_name ? (
+							<div className="badge badge--success">{ translate( 'Available' ) }</div>
+						) : (
+							<div className="badge">
+								<Spinner />
+							</div>
+						) }
 					</div>
 				</div>
 

--- a/client/my-sites/customer-home/cards/features/domain-upsell/index.jsx
+++ b/client/my-sites/customer-home/cards/features/domain-upsell/index.jsx
@@ -91,9 +91,7 @@ export function RenderDomainUpsell() {
 					<div className="badge badge--info">{ translate( 'Current' ) }</div>
 					<div className="card">
 						<span>
-							<strike>
-								kasfljasasdfasdlkjfasdfasdfasdfsdfsadfsadfasdasdfasdfasdfsadfasdfasdfasdflaksdjflksjdfkl.wordpress.com
-							</strike>
+							<strike>{ siteSlug }</strike>
 						</span>
 					</div>
 					{ domainSuggestion?.domain_name ? (

--- a/client/my-sites/customer-home/cards/features/domain-upsell/style.scss
+++ b/client/my-sites/customer-home/cards/features/domain-upsell/style.scss
@@ -1,8 +1,13 @@
 @import "@automattic/typography/styles/fonts";
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
 
 body .customer-home__layout .domain-upsell__card {
 	background-color: #f6f7f7;
-	padding: 40px 46px;
+	padding: 16px 16px 20px;
+	@include break-small {
+		padding: 40px 46px;
+	}
 }
 
 .domain-upsell__card {
@@ -28,18 +33,24 @@ body .customer-home__layout .domain-upsell__card {
 
 		.badge {
 			position: absolute;
-			right: 20px;
+			right: 27px;
 			border-radius: 4px;
 			font-size: rem(12px);
 			color: var(--studio-gray-80);
 			font-weight: 500;
+			margin-top: 9px;
+			z-index: 1;
+			@include break-small {
+				right: 63px;
+			}
 		}
 
 		.card {
 			margin-bottom: 5px;
 			box-shadow: none;
 			padding: 8px 16px;
-			height: 36px;
+			min-height: 40px;
+			overflow: scroll;
 		}
 
 		.badge--success {

--- a/client/my-sites/customer-home/cards/features/domain-upsell/style.scss
+++ b/client/my-sites/customer-home/cards/features/domain-upsell/style.scss
@@ -50,7 +50,7 @@ body .customer-home__layout .domain-upsell__card {
 			box-shadow: none;
 			padding: 8px 16px;
 			min-height: 40px;
-			overflow: scroll;
+			overflow-x: auto;
 		}
 
 		.badge--success {

--- a/client/my-sites/customer-home/cards/features/domain-upsell/style.scss
+++ b/client/my-sites/customer-home/cards/features/domain-upsell/style.scss
@@ -29,20 +29,19 @@ body .customer-home__layout .domain-upsell__card {
 			font-size: rem(14px);
 			color: var(--studio-gray-80);
 			line-height: 20px;
+			word-break: break-all;
+			flex-direction: column;
+			display: flex;
+			flex: 1;
 		}
 
 		.badge {
-			position: absolute;
-			right: 27px;
 			border-radius: 4px;
 			font-size: rem(12px);
 			color: var(--studio-gray-80);
 			font-weight: 500;
-			margin-top: 9px;
-			z-index: 1;
-			@include break-small {
-				right: 63px;
-			}
+			flex-direction: column;
+			display: flex;
 		}
 
 		.card {
@@ -51,6 +50,9 @@ body .customer-home__layout .domain-upsell__card {
 			padding: 8px 16px;
 			min-height: 40px;
 			overflow-x: auto;
+			flex-direction: row;
+			display: flex;
+			align-items: center;
 		}
 
 		.badge--success {


### PR DESCRIPTION
#### Proposed Changes

- This PR decreases the domain upsell card margin for small and mobile view sizes, thus allowing more room for the domain name.
- It also uses flex box and word-break, so if the domain is too long, it wraps to the next line.

<img src="https://user-images.githubusercontent.com/140841/214948045-6cc56199-6a84-4841-bbcf-ba8220f3090d.png" width="200" />

Before | After
--|--
![domain-upsell-before](https://user-images.githubusercontent.com/140841/214918857-1c407934-b4e3-4de3-86fc-0eadc15950dd.png)  | ![domain-upsell-after](https://user-images.githubusercontent.com/140841/214918879-3672c9cd-ddd7-417c-8441-91e479382905.png)

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Load this PR
* Test in mobile and desktop sizes.
* Test in different browsers.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
