### PR TITLE
Changed Issue New License button to green

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/primary/licenses/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/licenses/index.tsx
@@ -78,7 +78,7 @@ export default function Licenses( {
 				<Button
 					href="/partner-portal/issue-license"
 					onClick={ onIssueNewLicenseClick }
-					primary={ ! showEmptyStateContent }
+					primary
 					style={ { marginLeft: 'auto' } }
 				>
 					{ translate( 'Issue New License' ) }


### PR DESCRIPTION
#### Proposed Changes

Change Issue New License Button to green on License page when Onboarding Wizard is enabled:

### Before

![CleanShot 2023-01-26 at 15 01 00](https://user-images.githubusercontent.com/2293077/214938104-4798a8d9-bcdd-4ff3-9363-9d886638152a.png)


### After

![CleanShot 2023-01-26 at 14 55 21](https://user-images.githubusercontent.com/2293077/214937044-b0f84de7-18a4-4643-8600-67455807c773.png)


#### Testing Instructions

* Run git checkout `fix/agency-dashboard-change-onboarding-button-color` and `yarn start-jetpack-cloud`
* Open http://jetpack.cloud.localhost:3000/, click on Licenses to be taken to the License page
* Verify that the top button color is green


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1202619025189113-as-1203836409692575/f