### PR TITLE
Revert "Remove links to /courses and replace it with /learn in Universal Header & Footer Navbars for Calypso"

### DIFF
--- a/client/layout/universal-navbar-footer/index.tsx
+++ b/client/layout/universal-navbar-footer/index.tsx
@@ -172,8 +172,8 @@ const UniversalNavbarFooter = () => {
 									</a>
 								</li>
 								<li>
-									<a href={ localizeUrl( 'https://wordpress.com/learn/' ) } target="_self">
-										{ translate( 'Learn WordPress' ) }
+									<a href={ localizeUrl( 'https://wordpress.com/courses/' ) } target="_self">
+										{ translate( 'WordPress Courses' ) }
 									</a>
 								</li>
 								<li>

--- a/client/layout/universal-navbar-header/index.jsx
+++ b/client/layout/universal-navbar-header/index.jsx
@@ -207,9 +207,9 @@ const UniversalNavbarHeader = () => {
 													target="_self"
 												/>
 												<UniversalNavbarLiMenuItem
-													titleValue={ translate( 'Learn WordPress' ) }
-													elementContent={ translate( 'Learn WordPress' ) }
-													urlValue={ localizeUrl( '//wordpress.com/learn/' ) }
+													titleValue={ translate( 'WordPress Courses' ) }
+													elementContent={ translate( 'WordPress Courses' ) }
+													urlValue={ localizeUrl( '//wordpress.com/courses/' ) }
 													type="dropdown"
 													target="_self"
 												/>
@@ -423,9 +423,9 @@ const UniversalNavbarHeader = () => {
 										type="menu"
 									/>
 									<UniversalNavbarLiMenuItem
-										titleValue={ translate( 'Learn WordPress' ) }
-										elementContent={ translate( 'Learn WordPress' ) }
-										urlValue={ localizeUrl( '//wordpress.com/learn/' ) }
+										titleValue={ translate( 'WordPress Courses' ) }
+										elementContent={ translate( 'WordPress Courses' ) }
+										urlValue={ localizeUrl( '//wordpress.com/courses/' ) }
 										type="menu"
 									/>
 								</ul>


### PR DESCRIPTION
Reverts Automattic/wp-calypso#72634

We need to revert this because, /learn is available only for the English Locale