### PR TITLE
Add a site down filter option

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
@@ -185,6 +185,7 @@ export type AgencyDashboardFilterOption =
 	| 'backup_warning'
 	| 'threats_found'
 	| 'site_disconnected'
+	| 'site_down'
 	| 'plugin_updates';
 
 export type AgencyDashboardFilter = {

--- a/client/my-sites/activity/filterbar/type-selector/issue-type-selector.tsx
+++ b/client/my-sites/activity/filterbar/type-selector/issue-type-selector.tsx
@@ -31,6 +31,10 @@ const IssueTypeSelector: React.FunctionComponent< Props > = ( props ) => {
 			name: translate( 'Site disconnected' ),
 		},
 		{
+			key: 'site_down',
+			name: translate( 'Site down' ),
+		},
+		{
 			key: 'plugin_updates',
 			name: translate( 'Plugin needs updates' ),
 		},


### PR DESCRIPTION
Add a site down filter option to the agency dashboard filter option types.

#### Proposed Changes

* Update the filter options for the agency dashboard to include an option to filter by sites that have been identified as down

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
