### PR TITLE
Users management: Replace the way of querying invites by relying on useQuery

### DIFF
--- a/client/data/invites/use-get-invites-query.ts
+++ b/client/data/invites/use-get-invites-query.ts
@@ -1,0 +1,19 @@
+import { useQuery } from 'react-query';
+import { useDispatch, useSelector } from 'react-redux';
+import { requestSiteInvites } from 'calypso/state/invites/actions';
+import { isRequestingInvitesForSite } from 'calypso/state/invites/selectors';
+
+const useGetInvitesQuery = ( siteId: number ) => {
+	const dispatch = useDispatch();
+	const requestingInProgress = useSelector( ( state ) =>
+		isRequestingInvitesForSite( state, siteId )
+	);
+
+	return useQuery( [ 'invites', siteId ], () => {
+		if ( siteId && ! requestingInProgress ) {
+			dispatch( requestSiteInvites( siteId ) );
+		}
+	} );
+};
+
+export default useGetInvitesQuery;

--- a/client/my-sites/people/team-invites/index.tsx
+++ b/client/my-sites/people/team-invites/index.tsx
@@ -1,7 +1,7 @@
 import { Card } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
-import QuerySiteInvites from 'calypso/components/data/query-site-invites';
+import useGetInvitesQuery from 'calypso/data/invites/use-get-invites-query';
 import PeopleListItem from 'calypso/my-sites/people/people-list-item';
 import { getPendingInvitesForSite } from 'calypso/state/invites/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
@@ -15,6 +15,8 @@ function TeamInvites() {
 	const site = useSelector( ( state ) => getSelectedSite( state ) );
 	const siteId = site?.ID as number;
 	const pendingInvites = useSelector( ( state ) => getPendingInvitesForSite( state, siteId ) );
+
+	useGetInvitesQuery( siteId );
 
 	function renderInvite( invite: Invite ) {
 		const user = invite.user;
@@ -33,7 +35,6 @@ function TeamInvites() {
 
 	return (
 		<>
-			<QuerySiteInvites siteId={ siteId } />
 			{ !! pendingInvites?.length && (
 				<>
 					<PeopleListSectionHeader


### PR DESCRIPTION
#### Proposed Changes

Replaced the way of querying invites by relying on `useQuery`.
`useQuery` by default triggers a query on the window focus event, which matches the way of getting data for the Teams content.

#### Testing Instructions

* Go to `/people/team/{SITE_SLUG}`
* Invite your testing account
* Check if there is a newly created pending invite
* In another tab with the test user, accept the invite
* Go back to the initial tab
* Check if a test member is part of the `Team` block
* Check if a test member disappears from the `Pending Invites` block

More info about the issue we fixed in this PR: https://github.com/Automattic/wp-calypso/issues/72636

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/wp-calypso/issues/72636
