### PR TITLE
Launchpad: enable for write and build intents

### DIFF
--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -143,7 +143,7 @@ const siteSetupFlow: Flow = {
 		const storeType = useSelect( ( select ) => select( ONBOARD_STORE ).getStoreType() );
 		const { setPendingAction, setStepProgress, resetOnboardStoreWithSkipFlags } =
 			useDispatch( ONBOARD_STORE );
-		const { setIntentOnSite, setGoalsOnSite, setThemeOnSite, setLaunchpadScreenOnSite } =
+		const { setIntentOnSite, setGoalsOnSite, setThemeOnSite, saveSiteSettings } =
 			useDispatch( SITE_STORE );
 		const dispatch = reduxDispatch();
 
@@ -167,7 +167,7 @@ const siteSetupFlow: Flow = {
 					if ( ! siteSlug ) {
 						return;
 					}
-
+					const siteId = site?.ID;
 					const pendingActions = [
 						setIntentOnSite( siteSlug, intent ),
 						setGoalsOnSite( siteSlug, goals ),
@@ -183,8 +183,8 @@ const siteSetupFlow: Flow = {
 					}
 
 					// Add Launchpad to selected intents in General Onboarding
-					if ( isLaunchpadIntent( intent ) ) {
-						pendingActions.push( setLaunchpadScreenOnSite( siteSlug, 'full' ) );
+					if ( isLaunchpadIntent( intent ) && typeof siteId === 'number' ) {
+						pendingActions.push( saveSiteSettings( siteId, { launchpad_screen: 'full' } ) );
 					}
 
 					Promise.all( pendingActions ).then( () => window.location.assign( to ) );

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -59,11 +59,8 @@ const WRITE_INTENT_DEFAULT_THEME_STYLE_VARIATION = 'white';
 const SiteIntent = Onboard.SiteIntent;
 const SiteGoal = Onboard.SiteGoal;
 
-function isLaunchpadIntent( intent: SiteIntent ) {
-	if ( intent === SiteIntent.Write || intent === SiteIntent.Build ) {
-		return true;
-	}
-	return false;
+function isLaunchpadIntent( intent: string ) {
+	return intent === SiteIntent.Write || intent === SiteIntent.Build;
 }
 
 const siteSetupFlow: Flow = {

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -59,6 +59,13 @@ const WRITE_INTENT_DEFAULT_THEME_STYLE_VARIATION = 'white';
 const SiteIntent = Onboard.SiteIntent;
 const SiteGoal = Onboard.SiteGoal;
 
+function isLaunchpadIntent( intent: SiteIntent ) {
+	if ( intent === SiteIntent.Write || intent === SiteIntent.Build ) {
+		return true;
+	}
+	return false;
+}
+
 const siteSetupFlow: Flow = {
 	name: 'site-setup',
 
@@ -136,7 +143,8 @@ const siteSetupFlow: Flow = {
 		const storeType = useSelect( ( select ) => select( ONBOARD_STORE ).getStoreType() );
 		const { setPendingAction, setStepProgress, resetOnboardStoreWithSkipFlags } =
 			useDispatch( ONBOARD_STORE );
-		const { setIntentOnSite, setGoalsOnSite, setThemeOnSite } = useDispatch( SITE_STORE );
+		const { setIntentOnSite, setGoalsOnSite, setThemeOnSite, setLaunchpadScreenOnSite } =
+			useDispatch( SITE_STORE );
 		const dispatch = reduxDispatch();
 
 		const flowProgress = useSiteSetupFlowProgress( currentStep, intent );
@@ -172,6 +180,11 @@ const siteSetupFlow: Flow = {
 								WRITE_INTENT_DEFAULT_THEME_STYLE_VARIATION
 							)
 						);
+					}
+
+					// Add Launchpad to selected intents in General Onboarding
+					if ( isLaunchpadIntent( intent ) ) {
+						pendingActions.push( setLaunchpadScreenOnSite( siteSlug, 'full' ) );
 					}
 
 					Promise.all( pendingActions ).then( () => window.location.assign( to ) );
@@ -259,6 +272,9 @@ const siteSetupFlow: Flow = {
 						return exitFlow( `/setup/plugin-bundle/?siteSlug=${ siteSlug }` );
 					}
 
+					if ( isLaunchpadIntent( intent ) ) {
+						return exitFlow( `/setup/${ intent }/launchpad?siteSlug=${ siteSlug }` );
+					}
 					return exitFlow( `/home/${ siteSlug }` );
 				}
 

--- a/packages/calypso-e2e/src/lib/pages/editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/editor-page.ts
@@ -835,6 +835,7 @@ export class EditorPage {
 			this.page.waitForNavigation( { url: '**/posts/**' } ),
 			this.page.waitForNavigation( { url: '**/pages/**' } ),
 			this.page.waitForNavigation( { url: '**/wp-admin/edit**' } ),
+			this.page.waitForNavigation( { url: '**/write/launchpad/**' } ),
 		] );
 		const actions: Promise< unknown >[] = [ navigationPromise ];
 

--- a/packages/calypso-e2e/src/lib/pages/editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/editor-page.ts
@@ -835,7 +835,7 @@ export class EditorPage {
 			this.page.waitForNavigation( { url: '**/posts/**' } ),
 			this.page.waitForNavigation( { url: '**/pages/**' } ),
 			this.page.waitForNavigation( { url: '**/wp-admin/edit**' } ),
-			this.page.waitForNavigation( { url: '**/write/launchpad/**' } ),
+			this.page.waitForNavigation( { url: '**/write/launchpad**' } ),
 		] );
 		const actions: Promise< unknown >[] = [ navigationPromise ];
 

--- a/packages/data-stores/src/site/actions.ts
+++ b/packages/data-stores/src/site/actions.ts
@@ -306,17 +306,6 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		} catch ( e ) {}
 	}
 
-	function* setLaunchpadScreenOnSite( siteSlug: string, launchpadScreen: string ) {
-		try {
-			yield wpcomRequest( {
-				path: `/sites/${ encodeURIComponent( siteSlug ) }/settings`,
-				apiVersion: '1.4',
-				body: { launchpad_screen: launchpadScreen },
-				method: 'POST',
-			} );
-		} catch ( e ) {}
-	}
-
 	function* setStaticHomepageOnSite( siteID: number, pageId: number ) {
 		try {
 			yield wpcomRequest( {
@@ -669,7 +658,6 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		saveSiteTitle,
 		saveSiteSettings,
 		setIntentOnSite,
-		setLaunchpadScreenOnSite,
 		setStaticHomepageOnSite,
 		setGoalsOnSite,
 		receiveSiteTitle,

--- a/packages/data-stores/src/site/actions.ts
+++ b/packages/data-stores/src/site/actions.ts
@@ -306,6 +306,17 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		} catch ( e ) {}
 	}
 
+	function* setLaunchpadScreenOnSite( siteSlug: string, launchpadScreen: string ) {
+		try {
+			yield wpcomRequest( {
+				path: `/sites/${ encodeURIComponent( siteSlug ) }/settings`,
+				apiVersion: '1.4',
+				body: { launchpad_screen: launchpadScreen },
+				method: 'POST',
+			} );
+		} catch ( e ) {}
+	}
+
 	function* setStaticHomepageOnSite( siteID: number, pageId: number ) {
 		try {
 			yield wpcomRequest( {
@@ -658,6 +669,7 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		saveSiteTitle,
 		saveSiteSettings,
 		setIntentOnSite,
+		setLaunchpadScreenOnSite,
 		setStaticHomepageOnSite,
 		setGoalsOnSite,
 		receiveSiteTitle,

--- a/test/e2e/specs/onboarding/ftme__write.ts
+++ b/test/e2e/specs/onboarding/ftme__write.ts
@@ -128,6 +128,16 @@ describe( DataHelper.createSuiteTitle( 'FTME: Write' ), function () {
 			await page.keyboard.press( 'Escape' );
 		} );
 
+		it( 'Dismiss Launchpad modal if shown', async function () {
+			const selector = '.launchpad__save-modal-buttons button';
+			const locator = editorPage.getLocator( selector );
+			try {
+				await locator.click( { timeout: 2000 } );
+			} catch {
+				// 	// noop;
+			}
+		} );
+
 		it( 'Exit editor', async function () {
 			await editorPage.exitEditor();
 		} );

--- a/test/e2e/specs/onboarding/setup__build.ts
+++ b/test/e2e/specs/onboarding/setup__build.ts
@@ -60,11 +60,14 @@ describe(
 				await startSiteFlow.clickButton( `Start with ${ themeName }` );
 			} );
 
-			it( 'Land in Home dashboard', async function () {
-				await page.waitForURL( DataHelper.getCalypsoURL( `/home/${ siteSlug }` ), {
-					// This process takes a long time, uncertain why.
-					timeout: 30 * 1000,
-				} );
+			it( 'Land in Launchpad', async function () {
+				await page.waitForURL(
+					DataHelper.getCalypsoURL( `/setup/build/launchpad/?siteSlug=${ siteSlug }` ),
+					{
+						// This process takes a long time, uncertain why.
+						timeout: 30 * 1000,
+					}
+				);
 			} );
 		} );
 	}


### PR DESCRIPTION
#### Proposed Changes

* Enable the Launchpad for Write/Build(promote/other) flows in General Onboarding 

#### Testing Instructions

Create a new site through `/start/` OR with an existing, non-launchpad-enabled site, visit `/setup/site-setup/goals?siteSlug=YOURSITEURL` (note that the latter might not work as consistently)

In either case, when you land on the Goals screen:

<img width="1263" alt="Screenshot 2023-01-26 at 15 56 54" src="https://user-images.githubusercontent.com/195089/214959637-66cb67c7-3946-42ae-b41e-40e8f16208c3.png">

Choose "Write", "Promote…" or "Other". These flows will lead to Launchpad, the others will not. That's what needs testing.

(Note that **Write** will still land you wherever you specify on its screen, but Launchpad will be enabled behind the scenes.)

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #72571
