### PR TITLE
Fix CoBlocks fonts issue for simple sites

### DIFF
--- a/apps/wpcom-block-editor/README.md
+++ b/apps/wpcom-block-editor/README.md
@@ -75,6 +75,22 @@ The block editor integration provides features for the following combination of 
     <td>✅</td>
     <td>❌</td>
   </tr>
+   <tr>
+    <td rowspan="2">
+      <a href="./src/wpcom/features/fix-coblocks-fonts.js"><code>fix-coblocks-fonts</code></a>:
+      Prevents CoBlocks typography support inserting unnecessary content into saved blocks
+    </td>
+    <td>WP Admin</td>
+    <td>✅</td>
+    <td>✅</td>
+    <td>❌</td>
+  </tr>
+  <tr>
+    <td>Calypso</td>
+    <td>✅</td>
+    <td>✅</td>
+    <td>❌</td>
+  </tr>
   <tr>
     <td rowspan="2">
       <a href="./src/wpcom/features/reorder-block-categories.js"><code>reorder-block-categories</code></a>:

--- a/apps/wpcom-block-editor/src/wpcom/editor.js
+++ b/apps/wpcom-block-editor/src/wpcom/editor.js
@@ -1,6 +1,7 @@
 import { registerPlugin } from '@wordpress/plugins';
 import './features/deprecate-coblocks-buttons';
 import './features/fix-block-invalidation-errors';
+import './features/fix-coblocks-fonts';
 import './features/reorder-block-categories';
 import './features/override-edit-site-back-button';
 import './features/tracking';

--- a/apps/wpcom-block-editor/src/wpcom/features/fix-coblocks-fonts.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/fix-coblocks-fonts.js
@@ -9,6 +9,10 @@ import { isEditorReadyWithBlocks } from '../../utils';
  * content which includes a rule for the font-family. As wpcom doesn't use
  * the CoBlocks typography controls, we can safely remove the filter.
  *
+ * Note that this doesn't work in versions of co-blocks released from 2022
+ * onwards - all of the filters across CoBlocks were reconciled into one
+ * so we can't remove the filter for just the font styles.
+ *
  * @see https://github.com/godaddy-wordpress/coblocks/issues/2475
  */
 async function removeCoBlocksFontStyles() {

--- a/apps/wpcom-block-editor/src/wpcom/features/fix-coblocks-fonts.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/fix-coblocks-fonts.js
@@ -1,0 +1,23 @@
+import { removeFilter } from '@wordpress/hooks';
+import { isEditorReadyWithBlocks } from '../../utils';
+
+/**
+ * Remove the CoBlocks font styles filter from the block save content.
+ *
+ * The CoBlocks font styles filter is causing invalid blocks to be saved.
+ * Specifically, the filter is adding a style attribute to the block save
+ * content which includes a rule for the font-family. As wpcom doesn't use
+ * the CoBlocks typography controls, we can safely remove the filter.
+ *
+ * @see https://github.com/godaddy-wordpress/coblocks/issues/2475
+ */
+async function removeCoBlocksFontStyles() {
+	const editorHasBlocks = await isEditorReadyWithBlocks();
+	if ( ! editorHasBlocks ) {
+		return;
+	}
+
+	removeFilter( 'blocks.getSaveContent.extraProps', 'coblocks/applyFontSettings' );
+}
+
+removeCoBlocksFontStyles();

--- a/apps/wpcom-block-editor/src/wpcom/features/fix-coblocks-fonts.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/fix-coblocks-fonts.js
@@ -16,10 +16,7 @@ import { isEditorReadyWithBlocks } from '../../utils';
  * @see https://github.com/godaddy-wordpress/coblocks/issues/2475
  */
 async function removeCoBlocksFontStyles() {
-	const editorHasBlocks = await isEditorReadyWithBlocks();
-	if ( ! editorHasBlocks ) {
-		return;
-	}
+	await isEditorReadyWithBlocks();
 
 	removeFilter( 'blocks.getSaveContent.extraProps', 'coblocks/applyFontSettings' );
 }


### PR DESCRIPTION
CoBlocks typography support is adding an extra style rule to blocks when using setting fonts. This causes a block validation error.

This change removes the filter that does that - we disable typography support anyway.

#### Proposed Changes

Don't allow the CoBlocks font settings filter to run on simple sites. We don't display the font controls but the filter that process them still runs. This filter was causing an 'unexpected or invalid content' block error when pasting blocks with custom fonts (or inserting patterns with the same)

Note that this does not fix the problem for atomic sites. Atomic sites use the latest upstream versions of CoBlocks which aren't possible to do surgical fixes on, since the [filter](https://github.com/godaddy-wordpress/coblocks/blob/master/src/extensions/typography/apply-style.js#L14) is bundled into a [megafilter](https://github.com/godaddy-wordpress/coblocks/blob/master/src/extensions/apply-extensions.js#L222). An [issue has been opened upstream](https://github.com/godaddy-wordpress/coblocks/issues/2475) to fix the root problem.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

 1. Have a site that pre-dates 2021-10-26 (or make `wpcom_is_site_eligible_for_coblocks` return true in your sandbox)
 2. Visit the post editor
 3. Paste this into the editor:
```
<!-- wp:heading {"className":"has-custom-font","fontFamily":"dm-sans"} -->
<h2 class="wp-block-heading has-custom-font has-dm-sans-font-family">Summer<br>Vibe</h2>
<!-- /wp:heading -->
```
 4. You should see an error about unexpected or invalid content
 5. Use the install script comment below
 6. Sandbox widgets.wp.com
 7. Repeat steps 2 & 3
 8. You should not see an error, you should see a heading block using the dm-sans font.

Ensure you test pasting the content into a brand new post, and when editing an existing post.

Before | After
-------|------
![image](https://user-images.githubusercontent.com/93301/214958111-cac813f4-8261-46d0-b8c6-c538625339d1.png) | ![image](https://user-images.githubusercontent.com/93301/214958157-49580b8d-fe33-45c9-ac75-b38039701e08.png)


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready fortranslation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #72261 & pekYwv-mT-p2#comment-301