### PR TITLE
Teamcity: improve webpack cache hit rate

### DIFF
--- a/.teamcity/_self/bashNodeScript.kt
+++ b/.teamcity/_self/bashNodeScript.kt
@@ -30,6 +30,7 @@ fun BuildSteps.bashNodeScript(init: ScriptBuildStep.() -> Unit): ScriptBuildStep
 		# Existing script content set by caller:
 		${result.scriptContent}
 	""".trimIndent()
+
 	result.dockerImagePlatform = ScriptBuildStep.ImagePlatform.Linux
 	result.dockerPull = true
 	result.dockerImage = result.dockerImage ?: "%docker_image%"

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -47,6 +47,7 @@ object BuildDockerImage : BuildType({
 
 	params {
 		text("base_image", "registry.a8c.com/calypso/base:latest", label = "Base docker image", description = "Base docker image", allowEmpty = false)
+		text("base_image_publish_tag", "latest", label = "Tag to use for the published base image", description = "Base docker image tag", allowEmpty = false)
 		checkbox(
 			name = "MANUAL_SENTRY_RELEASE",
 			value = "false",
@@ -55,6 +56,15 @@ object BuildDockerImage : BuildType({
 			checked = "true",
 			unchecked = "false"
 		)
+		checkbox(
+			name = "UPDATE_BASE_IMAGE_CACHE",
+			value = "false",
+			label = "Update the base image from the cache.",
+			description = "Updates the base image by copying .cache files from the current build. Runs on trunk by default if the cache invalidates during the build.",
+			checked = "true",
+			unchecked = "false"
+		)
+		param("env.WEBPACK_CACHE_INVALIDATED", "false")
 	}
 
 	vcs {
@@ -63,15 +73,13 @@ object BuildDockerImage : BuildType({
 	}
 
 	steps {
-
 		script {
 			name = "Webhook Start"
+			conditions {
+				equals("teamcity.build.branch.is_default", "true")
+			}
 			scriptContent = """
 				#!/usr/bin/env bash
-
-				if [[ "%teamcity.build.branch.is_default%" != "true" ]]; then
-					exit 0
-				fi
 
 				payload=${'$'}(jq -n \
 					--arg action "start" \
@@ -87,11 +95,11 @@ object BuildDockerImage : BuildType({
 
 		script {
 			name = "Post PR comment"
+			conditions {
+				doesNotEqual("teamcity.build.branch.is_default", "true")
+			}
 			scriptContent = """
 				#!/usr/bin/env bash
-				if [[ "%teamcity.build.branch.is_default%" == "true" ]]; then
-					exit 0
-				fi
 
 				export GH_TOKEN="%matticbot_oauth_token%"
 				chmod +x ./bin/add-pr-comment.sh
@@ -114,6 +122,19 @@ object BuildDockerImage : BuildType({
 			dockerPull = true
 			dockerImagePlatform = ScriptBuildStep.ImagePlatform.Linux
 		}
+		
+		val commonArgs = """
+			--label com.a8c.image-builder=teamcity
+			--label com.a8c.build-id=%teamcity.build.id%
+			--build-arg workers=32
+			--build-arg node_memory=32768
+			--build-arg use_cache=true
+			--build-arg base_image=%base_image%
+			--build-arg commit_sha=${Settings.WpCalypso.paramRefs.buildVcsNumber}
+			--build-arg manual_sentry_release=%MANUAL_SENTRY_RELEASE%
+			--build-arg is_default_branch=%teamcity.build.branch.is_default%
+			--build-arg sentry_auth_token=%SENTRY_AUTH_TOKEN%
+		""".trimIndent().replace("\n"," ")
 
 		dockerCommand {
 			name = "Build docker image"
@@ -126,20 +147,7 @@ object BuildDockerImage : BuildType({
 					registry.a8c.com/calypso/app:commit-${Settings.WpCalypso.paramRefs.buildVcsNumber}
 					registry.a8c.com/calypso/app:latest
 				""".trimIndent()
-				commandArgs = """
-					--pull
-					--label com.a8c.image-builder=teamcity
-					--label com.a8c.target=calypso-live
-					--label com.a8c.build-id=%teamcity.build.id%
-					--build-arg workers=32
-					--build-arg node_memory=32768
-					--build-arg use_cache=true
-					--build-arg base_image=%base_image%
-					--build-arg commit_sha=${Settings.WpCalypso.paramRefs.buildVcsNumber}
-					--build-arg manual_sentry_release=%MANUAL_SENTRY_RELEASE%
-					--build-arg is_default_branch=%teamcity.build.branch.is_default%
-					--build-arg sentry_auth_token=%SENTRY_AUTH_TOKEN%
-				""".trimIndent().replace("\n"," ")
+				commandArgs = "--pull --label com.a8c.target=calypso-live $commonArgs"
 			}
 			param("dockerImage.platform", "linux")
 		}
@@ -156,12 +164,11 @@ object BuildDockerImage : BuildType({
 		script {
 			name = "Webhook fail OR webhook done and push trunk tag for deploy"
 			executionMode = BuildStep.ExecutionMode.ALWAYS
+			conditions {
+				equals("teamcity.build.branch.is_default", "true")
+			}
 			scriptContent = """
 				#!/usr/bin/env bash
-
-				if [[ "%teamcity.build.branch.is_default%" != "true" ]]; then
-					exit 0
-				fi
 
 				ACTION="fail"
 				SUCCESS=$(curl --silent -X GET -H "Content-Type: text/plain" https://teamcity.a8c.com/guestAuth/app/rest/builds/?locator=id:%teamcity.build.id% | grep -c 'status="SUCCESS"')
@@ -184,11 +191,11 @@ object BuildDockerImage : BuildType({
 
 		script {
 			name = "Post PR comment with link"
+			conditions {
+				doesNotEqual("teamcity.build.branch.is_default", "true")
+			}
 			scriptContent = """
 				#!/usr/bin/env bash
-				if [[ "%teamcity.build.branch.is_default%" == "true" ]]; then
-					exit 0
-				fi
 
 				export GH_TOKEN="%matticbot_oauth_token%"
 				chmod +x ./bin/add-pr-comment.sh
@@ -221,6 +228,52 @@ object BuildDockerImage : BuildType({
 				</details>
 				EOF
 			"""
+		}
+
+		// Conditions don't seem to support and/or, so we do this in a separate step.
+		// Essentially, UPDATE_BASE_IMAGE_CACHE will remain false by default, but
+		// if we're on trunk and get WEBPACK_CACHE_INVALIDATED set by the docker build,
+		// then we can flip it to true to trigger the cache rebuild.
+		script {
+			name = "Set cache update"
+			conditions {
+				equals("env.WEBPACK_CACHE_INVALIDATED", "true")
+				equals("teamcity.build.branch.is_default", "true")
+			}
+			scriptContent = """
+				echo "##teamcity[setParameter name='UPDATE_BASE_IMAGE_CACHE' value='true']"
+			"""
+		}
+
+		// This updates the base docker image when the webpack cache invalidates.
+		// It does so by re-using the layers already generated above, and simply
+		// copying the .cache directory as a new layer into the base image. On
+		// trunk, this will update the latest base image for future builds.
+		//
+		// Runs after everything else to avoid blocking the deploy system or calypso.live.
+		dockerCommand {
+			name = "Rebuild cache image"
+			conditions {
+				equals("UPDATE_BASE_IMAGE_CACHE", "true")
+			}
+			commandType = build {
+				source = file {
+					path = "Dockerfile"
+				}
+				namesAndTags = "registry.a8c.com/calypso/base:%base_image_publish_tag%"
+				commandArgs = "--target update-base-cache $commonArgs"
+			}
+			param("dockerImage.platform", "linux")
+		}
+
+		dockerCommand {
+			name = "Push cache image"
+			conditions {
+				equals("UPDATE_BASE_IMAGE_CACHE", "true")
+			}
+			commandType = push {
+				namesAndTags = "registry.a8c.com/calypso/base:%base_image_publish_tag%"
+			}
 		}
 	}
 

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -261,7 +261,11 @@ object BuildDockerImage : BuildType({
 					path = "Dockerfile"
 				}
 				namesAndTags = "registry.a8c.com/calypso/base:%base_image_publish_tag%"
-				commandArgs = "--target update-base-cache $commonArgs"
+				commandArgs = """
+					--target update-base-cache
+					--cache-from=registry.a8c.com/calypso/app:commit-${Settings.WpCalypso.paramRefs.buildVcsNumber},%base_image%
+					$commonArgs
+				""".trimIndent().replace("\n"," ")
 			}
 			param("dockerImage.platform", "linux")
 		}

--- a/Dockerfile
+++ b/Dockerfile
@@ -77,9 +77,7 @@ RUN find /calypso/build /calypso/public -name "*.*.map" -exec rm {} \;
 FROM ${base_image} as update-base-cache
 
 # Update webpack cache in the base image so that it can be re-used in future builds.
-# We only copy this part of the cache to make --push faster, and because webpack
-# is the main thing which will impact build performance when the cache invalidates.
-COPY --from=builder /calypso/.cache/evergreen/webpack /calypso/.cache/evergreen/webpack
+COPY --from=builder /calypso/.cache/ /calypso/.cache/
 
 ###################
 FROM node:${node_version}-alpine as app

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,11 +58,6 @@ RUN bash /tmp/env-config.sh
 #
 # This layer is populated with up-to-date files from
 # Calypso development.
-#
-# We remove apps, tests and desktop because they are not needed to
-# build or run calypso, but yarn will still install their
-# dependencies which end up bloating the image.
-# /apps/notifications is not removed because it is required by Calypso
 COPY . /calypso/
 RUN yarn install --immutable --check-cache
 
@@ -71,10 +66,20 @@ RUN yarn install --immutable --check-cache
 # This contains built environments of Calypso. It will
 # change any time any of the Calypso source-code changes.
 ENV NODE_ENV production
-RUN yarn run build
+RUN yarn run build 2>&1 | tee build_log.txt && \
+	./bin/check-log-for-cache-invalidation.sh build_log.txt
 
 # Delete any sourcemaps which may have been generated to avoid creating a large artifact.
 RUN find /calypso/build /calypso/public -name "*.*.map" -exec rm {} \;
+
+###################
+# A cache-only update can be generated with "docker build --target update-base-cache"
+FROM ${base_image} as update-base-cache
+
+# Update webpack cache in the base image so that it can be re-used in future builds.
+# We only copy this part of the cache to make --push faster, and because webpack
+# is the main thing which will impact build performance when the cache invalidates.
+COPY --from=builder /calypso/.cache/evergreen/webpack /calypso/.cache/evergreen/webpack
 
 ###################
 FROM node:${node_version}-alpine as app

--- a/Dockerfile
+++ b/Dockerfile
@@ -77,7 +77,9 @@ RUN find /calypso/build /calypso/public -name "*.*.map" -exec rm {} \;
 FROM ${base_image} as update-base-cache
 
 # Update webpack cache in the base image so that it can be re-used in future builds.
-COPY --from=builder /calypso/.cache/ /calypso/.cache/
+# We only copy this part of the cache to make --push faster, and because webpack
+# is the main thing which will impact build performance when the cache invalidates.
+COPY --from=builder /calypso/.cache/evergreen/webpack /calypso/.cache/evergreen/webpack
 
 ###################
 FROM node:${node_version}-alpine as app

--- a/bin/check-log-for-cache-invalidation.sh
+++ b/bin/check-log-for-cache-invalidation.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# This file should be used when building the Dockerfile. It will output a TeamCity
+# service message if the Webpack cache is invalidated. That in turn will help us
+# update the cache. Its input should be the full output of the webpack log.
+# Unfortunately, I don't know how to tap into the actual webpack log system to do
+# this, so this will have to do for now.
+
+build_file=$1
+if [[ ! -f $build_file ]] ; then
+	echo "$build_file does not exist. This should contain the webpack output."
+	exit 0
+fi
+
+if grep "resolving of build dependencies is invalid" $build_file ; then
+	echo "##teamcity[message text='Webpack cache invalidated!' errorDetails='This commit invalidated the webpack cache. Base image will be updated with new cache contents if on trunk.' status='warning']"
+	echo "Relevant details:"
+	grep "cache.PackFileCacheStrategy" $build_file
+
+	echo "##teamcity[setParameter name='env.WEBPACK_CACHE_INVALIDATED' value='true']"
+fi

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -114,7 +114,7 @@ function filterEntrypoints( entrypoints ) {
  * Note this is not the same as looking for `__dirname+'/node_modules/'+pkgName`, as the package may be in a parent
  * `node_modules`
  *
- * @param {string} pkgName Name of the package to search for
+ * @param {string} pkgName Name of the package to search for.
  */
 function findPackage( pkgName ) {
 	const fullPath = require.resolve( pkgName );


### PR DESCRIPTION
The goal of this PR is to improve performance of the "build docker image" TeamCity build by increasing the number of webpack cache hits.

### The issue with the webpack cache:
The main problem with the webpack cache is that a changing "build dependency" will invalidate the _entire_ cache. This adds at least two minutes to a build. This can also happen frequently (several times a day) for two reasons:
1. The webpack cache is not usually up to date. Before a recent experiment, it was up to a day old, since it was regenerated once per day.
2. A build dependency is anything that the webpack config `requires`, recursively. This covers a lot of files in Calypso and even the client's package.json file, along with several others.

Combining this, if you update client/package.json in a PR _after_ the base image build refreshed the webpack cache, every single build between then and the _next_ base image build (at least several hours) will be two minutes longer. With hundreds of these builds per day, that adds up!

### How to fix it?
Ideally, we'd constantly keep the webpack cache updated, so that every commit can use a very up-to-date cache. One solution is to run the base image build more frequently. However, this comes with a performance overhead: 10 minutes extra per base image build. Running that a lot can easily consume our limited agent space. We could also dynamically trigger the base image build when we notice the webpack cache invalidating. While better than before, we still end up with a lot of extra time in the queue -- maybe too much we happen to invalidate the cache several times in a day!

So I think we should attempt to persist and reuse the cache in a granular way:

 - Detect when the cache invalidates in Webpack
 - If so, copy the .cache directory into the base image
 - Push an updated `latest` tag for the base image.

Some benefits:
- An invalidated cache doesn't "spill over." E.g. this invalidation doesn't become a part of every build afterwards for several hours.
- Avoids running webpack twice -- we already calculated the cache per commit in the first place, we just don't persist it per commit.

### Implementation:
- We save the webpack output to a file
- We add a script which checks that file for the string which indicates the cache was invalidated
- That script then sets a TeamCity build parameter
- If on trunk and if that parameter exists, then trigger a cache update
- Cache update is a separate image in the Dockerfile, which we target directly. This should re-use the docker build cache (e.g. the cached layers) from previously in the build, making it pretty fast.

Looking at the parameters tab, we can see the invalidation flag getting set correctly:
<img width="940" alt="image" src="https://user-images.githubusercontent.com/6265975/216215977-660fbf18-765d-49e5-b75f-bc05cd5759a1.png">

### Todo:
- [x] Docker layer cache is not being fully utilized (--cache-from seemed to help this)
- [ ] Measure performance of updating just webpack cache, or the whole .cache directory. (With whole .cache directory, doing a cache update takes 2-3minutes. Probably 1 minute faster without).

Example build: https://teamcity.a8c.com/buildConfiguration/calypso_BuildDockerImage/9414013