### PR TITLE
Flaky E2E: do not use `waitForNavigation` with `ReaderPage` POM.

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/reader-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/reader-page.ts
@@ -53,35 +53,21 @@ export class ReaderPage {
 	/**
 	 * Visits a post in the Reader.
 	 *
-	 * This method supports either a 1-indexed number or partial or full string matching.
+	 * This method supports partial or full string matching.
 	 *
-	 * 	index: 1-indexed value, starting from top of page.
 	 * 	text: partial or full text matching of text contained in a reader entry. If multiple
 	 * 		matches are found,  the first match is used.
 	 *
-	 * @param param0 Keyed object parameter.
-	 * @param {number} param0.index n-th post to view on the reader page. 1-indexed.
-	 * @param {string} param0.text Text string to match.
+	 * @param {string} text Text string to match.
+	 * @returns {Promise<string>} URL of the visited post.
 	 * @throws {Error} If neither index or text are specified.
 	 */
-	async visitPost( { index, text }: { index?: number; text?: string } = {} ): Promise< void > {
+	async visitPost( text: string ): Promise< string > {
 		// Wait for main reader stream to populate.
-		await this.page.waitForSelector( selectors.streamPlaceholder, { state: 'hidden' } );
+		await this.page.locator( selectors.streamPlaceholder ).waitFor( { state: 'hidden' } );
 
-		let selector = '';
-
-		if ( index ) {
-			selector = `:nth-match(${ selectors.readerCard }, ${ index })`;
-		} else if ( text ) {
-			selector = `${ selectors.readerCard }:has-text("${ text }")`;
-		} else {
-			throw new Error( 'Unable to select and visit post - specify one of index or text.' );
-		}
-
-		await Promise.all( [
-			this.page.waitForNavigation( { waitUntil: 'networkidle' } ),
-			this.page.click( selector ),
-		] );
+		await this.page.getByText( text ).click();
+		return this.page.url();
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/pages/reader-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/reader-page.ts
@@ -66,7 +66,8 @@ export class ReaderPage {
 	 */
 	async visitPost( { index, text }: { index?: number; text?: string } = {} ): Promise< void > {
 		// Wait for main reader stream to populate.
-		await this.page.locator( selectors.streamPlaceholder ).waitFor( { state: 'hidden' } );
+		// Use the `last` method to narrow down the locators in case more than 1 placeholders exist.
+		await this.page.locator( selectors.streamPlaceholder ).last().waitFor( { state: 'hidden' } );
 
 		let selector = '';
 

--- a/test/e2e/specs/published-content/reader__view.ts
+++ b/test/e2e/specs/published-content/reader__view.ts
@@ -2,7 +2,7 @@
  * @group calypso-pr
  */
 
-import { DataHelper, TestAccount, ReaderPage, SecretsManager } from '@automattic/calypso-e2e';
+import { DataHelper, TestAccount, ReaderPage } from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
 
 declare const browser: Browser;
@@ -14,18 +14,13 @@ describe( DataHelper.createSuiteTitle( 'Reader: View' ), function () {
 
 	beforeAll( async function () {
 		page = await browser.newPage();
+
 		testAccount = new TestAccount( 'commentingUser' );
 		await testAccount.authenticate( page );
 	} );
 
-	it( 'View the Reader stream', async function () {
-		readerPage = new ReaderPage( page );
-		const testSiteForNotifications = SecretsManager.secrets.otherTestSites.notifications;
-		const siteOfLatestPost = await readerPage.siteOfLatestPost();
-		expect( siteOfLatestPost ).toEqual( testSiteForNotifications );
-	} );
-
 	it( 'Visit latest post', async function () {
-		await readerPage.visitPost( { index: 1 } );
+		readerPage = new ReaderPage( page );
+		await readerPage.visitPost( 'A new post for commenting' );
 	} );
 } );

--- a/test/e2e/specs/published-content/reader__view.ts
+++ b/test/e2e/specs/published-content/reader__view.ts
@@ -2,7 +2,7 @@
  * @group calypso-pr
  */
 
-import { DataHelper, TestAccount, ReaderPage } from '@automattic/calypso-e2e';
+import { DataHelper, TestAccount, ReaderPage, SecretsManager } from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
 
 declare const browser: Browser;
@@ -14,13 +14,18 @@ describe( DataHelper.createSuiteTitle( 'Reader: View' ), function () {
 
 	beforeAll( async function () {
 		page = await browser.newPage();
-
 		testAccount = new TestAccount( 'commentingUser' );
 		await testAccount.authenticate( page );
 	} );
 
-	it( 'Visit latest post', async function () {
+	it( 'View the Reader stream', async function () {
 		readerPage = new ReaderPage( page );
-		await readerPage.visitPost( 'A new post for commenting' );
+		const testSiteForNotifications = SecretsManager.secrets.otherTestSites.notifications;
+		const siteOfLatestPost = await readerPage.siteOfLatestPost();
+		expect( siteOfLatestPost ).toEqual( testSiteForNotifications );
+	} );
+
+	it( 'Visit latest post', async function () {
+		await readerPage.visitPost( { index: 1 } );
 	} );
 } );


### PR DESCRIPTION
#### Proposed Changes

This PR removes one use of `waitForNavigation` out of the POMs, specifically in the `ReaderPage`.

#### Testing Instructions

Ensure the following build configurations are passing:
  - [ ] Calypso E2E (desktop)
  - [ ] Calypso E2E (mobile)

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #72620 
