### PR TITLE
CI: use 100% of available CPUs when running E2E tests.

### DIFF
--- a/.teamcity/_self/lib/customBuildType/E2EBuildType.kt
+++ b/.teamcity/_self/lib/customBuildType/E2EBuildType.kt
@@ -135,7 +135,7 @@ open class E2EBuildType(
 					mkdir temp
 
 					# Run suite.
-					xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --maxWorkers=%E2E_WORKERS% --group=$testGroup
+					xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --maxWorkers=%JEST_E2E_WORKERS% --group=$testGroup
 				"""
 				dockerImage = "%docker_image_e2e%"
 				dockerRunParameters = "-u %env.UID% --shm-size=3g"

--- a/.teamcity/_self/projects/MarTech.kt
+++ b/.teamcity/_self/projects/MarTech.kt
@@ -76,7 +76,7 @@ object ToSAcceptanceTracking: BuildType ({
 				mkdir temp
 
 				# Run suite.
-				xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --maxWorkers=%E2E_WORKERS% --group=legal
+				xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --maxWorkers=%JEST_E2E_WORKERS% --group=legal
 			"""
 			dockerImage = "%docker_image_e2e%"
 		}

--- a/.teamcity/_self/projects/WPComTests.kt
+++ b/.teamcity/_self/projects/WPComTests.kt
@@ -89,7 +89,7 @@ fun gutenbergPlaywrightBuildType( targetDevice: String, buildUuid: String, atomi
 				// Overrides the inherited max workers settings and sets it to not run any tests in parallel.
 				// The reason for this is an inconsistent issue breaking the login in AT test sites when
 				// more than one test runs in parallel. Remove or set it to 16 after the issue is solved.
-				param("E2E_WORKERS", "1")
+				param("JEST_E2E_WORKERS", "1")
 			}
 			if (edge) {
 				param("env.GUTENBERG_EDGE", "true")

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -831,7 +831,7 @@ object PreReleaseE2ETests : BuildType({
 				mkdir temp
 
 				# Run suite.
-				xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --maxWorkers=%E2E_WORKERS% --group=calypso-release
+				xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --maxWorkers=%JEST_E2E_WORKERS% --group=calypso-release
 			"""
 			dockerImage = "%docker_image_e2e%"
 		}
@@ -1071,7 +1071,7 @@ object KPIDashboardTests : BuildType({
 				mkdir temp
 
 				# Run suite.
-				xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --maxWorkers=%E2E_WORKERS% --group=kpi
+				xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --maxWorkers=%JEST_E2E_WORKERS% --group=kpi
 			"""
 			dockerImage = "%docker_image_e2e%"
 		}

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -59,7 +59,7 @@ project {
 
 	params {
 		param("env.NODE_OPTIONS", "--max-old-space-size=32000")
-		text("E2E_WORKERS", "24", label = "Magellan parallel workers", description = "Number of parallel workers in Magellan (e2e tests)", allowEmpty = true)
+		text("JEST_E2E_WORKERS", "100%", label = "Magellan parallel workers", description = "Number of parallel workers in Magellan (e2e tests)", allowEmpty = true)
 		text("env.JEST_MAX_WORKERS", "16", label = "Jest max workers", description = "How many tests run in parallel", allowEmpty = true)
 		password("matticbot_oauth_token", "credentialsJSON:34cb38a5-9124-41c4-8497-74ed6289d751", display = ParameterDisplay.HIDDEN)
 		text("env.CHILD_CONCURRENCY", "15", label = "Yarn child concurrency", description = "How many packages yarn builds in parallel", allowEmpty = true)

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -59,7 +59,7 @@ project {
 
 	params {
 		param("env.NODE_OPTIONS", "--max-old-space-size=32000")
-		text("E2E_WORKERS", "16", label = "Magellan parallel workers", description = "Number of parallel workers in Magellan (e2e tests)", allowEmpty = true)
+		text("E2E_WORKERS", "24", label = "Magellan parallel workers", description = "Number of parallel workers in Magellan (e2e tests)", allowEmpty = true)
 		text("env.JEST_MAX_WORKERS", "16", label = "Jest max workers", description = "How many tests run in parallel", allowEmpty = true)
 		password("matticbot_oauth_token", "credentialsJSON:34cb38a5-9124-41c4-8497-74ed6289d751", display = ParameterDisplay.HIDDEN)
 		text("env.CHILD_CONCURRENCY", "15", label = "Yarn child concurrency", description = "How many packages yarn builds in parallel", allowEmpty = true)


### PR DESCRIPTION
#### Proposed Changes

This PR updates the `E2E_WORKERS` variable in TeamCity to allow 100% of available CPU cores to be used to spin up workers.

Key changes:
- rename `E2E_WORKERS` to `JEST_E2E_WORKERS` to better convey that this is for Jest and E2E.
- set the value to 100% of CPU instead of a specific number of workers.

#### Testing Instructions

Ensure all build configurations can execute without issues.

Furthermore, if interested, it is possible to do a performance comparison:

1. open an E2E build run under this branch in TeamCity.
2. open the' same E2E build type but run under `trunk` branch.
3. compare the time elapsed and the Perfmon stats.

Perfmon for this branch
![image](https://user-images.githubusercontent.com/6549265/214980341-57fadd43-6a33-46a0-9762-d86f2475f69f.png)

Perfmon for trunk
![image](https://user-images.githubusercontent.com/6549265/214980376-81eb80fa-ed9e-4e9c-874f-95523a141edc.png)

The gains are inconsistent, however.
For instance, the following spec `specs/infrastructure/infrastructure__ssr-enabled.ts` can vary as much as 2x between runs, on this feature branch:
- run 9378247: specs/infrastructure/infrastructure__ssr-enabled.ts (8.263 s)
- run 9378195: specs/infrastructure/infrastructure__ssr-enabled.ts (16.005 s)

## Possible factors
I think a major factor that we can't control in E2E tests is the network and the server.
If multiple E2E tests are hitting the same server, or if the server is having a particularly slow day, nothing we do for the build agents will matter.


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
