### PR TITLE
Flaky E2E: replace `waitForNavigation` in `ElementHelper` with URL waiting.

### DIFF
--- a/packages/calypso-e2e/src/element-helper.ts
+++ b/packages/calypso-e2e/src/element-helper.ts
@@ -86,7 +86,9 @@ export async function clickNavTab(
 
 	// Click on the intended item and wait for navigation to finish.
 	const navTabItem = page.locator( selectors.navTabItem( { name: name, selected: false } ) );
-	await Promise.all( [ page.waitForNavigation(), navTabItem.click() ] );
+
+	const regex = new RegExp( `.*/${ name.toLowerCase() }/.*` );
+	await Promise.all( [ page.waitForURL( regex ), navTabItem.click() ] );
 
 	// Final verification, check that we are now on the expected navtab.
 	const newSelectedTabLocator = page.locator(

--- a/test/e2e/specs/editor/editor__post-advanced-flow.ts
+++ b/test/e2e/specs/editor/editor__post-advanced-flow.ts
@@ -135,6 +135,10 @@ describe( DataHelper.createSuiteTitle( `Editor: Advanced Post Flow` ), function 
 	} );
 
 	describe( 'Trash post', function () {
+		const successMessage = 'Post successfully moved to trash.';
+
+		let noticeComponent: NoticeComponent;
+
 		beforeAll( async function () {
 			await postsPage.visit();
 		} );
@@ -145,10 +149,15 @@ describe( DataHelper.createSuiteTitle( `Editor: Advanced Post Flow` ), function 
 		} );
 
 		it( 'Confirmation notice is shown', async function () {
-			const noticeComponent = new NoticeComponent( page );
-			await noticeComponent.noticeShown( 'Post successfully moved to trash.', {
+			noticeComponent = new NoticeComponent( page );
+			await noticeComponent.noticeShown( successMessage, {
 				type: 'Success',
 			} );
+		} );
+
+		it( 'Dismiss notice', async function () {
+			// On mobile viewports the notice banner overlaps with the navtab.
+			await noticeComponent.dismiss( successMessage );
 		} );
 	} );
 

--- a/test/e2e/specs/editor/editor__post-advanced-flow.ts
+++ b/test/e2e/specs/editor/editor__post-advanced-flow.ts
@@ -135,10 +135,6 @@ describe( DataHelper.createSuiteTitle( `Editor: Advanced Post Flow` ), function 
 	} );
 
 	describe( 'Trash post', function () {
-		const successMessage = 'Post successfully moved to trash.';
-
-		let noticeComponent: NoticeComponent;
-
 		beforeAll( async function () {
 			await postsPage.visit();
 		} );
@@ -149,8 +145,8 @@ describe( DataHelper.createSuiteTitle( `Editor: Advanced Post Flow` ), function 
 		} );
 
 		it( 'Confirmation notice is shown', async function () {
-			noticeComponent = new NoticeComponent( page );
-			await noticeComponent.noticeShown( successMessage, {
+			const noticeComponent = new NoticeComponent( page );
+			await noticeComponent.noticeShown( 'Post successfully moved to trash.', {
 				type: 'Success',
 			} );
 		} );

--- a/test/e2e/specs/editor/editor__post-advanced-flow.ts
+++ b/test/e2e/specs/editor/editor__post-advanced-flow.ts
@@ -154,11 +154,6 @@ describe( DataHelper.createSuiteTitle( `Editor: Advanced Post Flow` ), function 
 				type: 'Success',
 			} );
 		} );
-
-		it( 'Dismiss notice', async function () {
-			// On mobile viewports the notice banner overlaps with the navtab.
-			await noticeComponent.dismiss( successMessage );
-		} );
 	} );
 
 	describe( 'Permanently delete post', function () {


### PR DESCRIPTION
#### Proposed Changes

This PR replaces the usage of `waitForNavigation` with `ElementHelper.clickNavTab` with URL based waiting, as recommended by [upstream docs](https://playwright.dev/docs/api/class-page#page-wait-for-navigation).

#### Testing Instructions

Ensure the following build configurations are passing:
  - [x] Gutenberg E2E (desktop)
  - [x] Gutenberg E2E (mobile)
  - [x] Calypso E2E (desktop)
  - [x] Calypso E2E (mobile)

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes to https://github.com/Automattic/wp-calypso/issues/72618
