### PR TITLE
Publish cache in app docker images

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -144,6 +144,21 @@ object BuildDockerImage : BuildType({
 			param("dockerImage.platform", "linux")
 		}
 
+		// Since the Docker layers from "build docker image" were done on the
+		// same agent just seconds ago, they should be available here, meaning
+		// this shouldn't take long. We shouldn't need --pull, since images were
+		// already pulled in the previous step.
+		dockerCommand {
+			name = "Update cache image"
+			commandType = build {
+				source = file {
+					path = "Dockerfile"
+				}
+				namesAndTags = "registry.a8c.com/calypso/base:latest"
+			}
+			commandArgs = "--target update-base-cache"
+		}
+	
 		dockerCommand {
 			commandType = push {
 				namesAndTags = """

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -115,27 +115,31 @@ object BuildDockerImage : BuildType({
 			dockerImagePlatform = ScriptBuildStep.ImagePlatform.Linux
 		}
 
-		val buildImageArgs = """
-			--label com.a8c.image-builder=teamcity
-			--label com.a8c.build-id=%teamcity.build.id%
-			--build-arg workers=32
-			--build-arg node_memory=32768
-			--build-arg use_cache=true
-			--build-arg base_image=%base_image%
-			--build-arg commit_sha=${Settings.WpCalypso.paramRefs.buildVcsNumber}
-			--build-arg manual_sentry_release=%MANUAL_SENTRY_RELEASE%
-			--build-arg is_default_branch=%teamcity.build.branch.is_default%
-			--build-arg sentry_auth_token=%SENTRY_AUTH_TOKEN%
-		""".trimIndent().replace("\n"," ");
-	
 		dockerCommand {
 			name = "Build docker image"
 			commandType = build {
 				source = file {
 					path = "Dockerfile"
 				}
-				namesAndTags = "--pull --label com.a8c.target=calypso-live $buildImageArgs"
-				commandArgs = .trimIndent().replace("\n"," ")
+				namesAndTags = """
+					registry.a8c.com/calypso/app:build-%build.number%
+					registry.a8c.com/calypso/app:commit-${Settings.WpCalypso.paramRefs.buildVcsNumber}
+					registry.a8c.com/calypso/app:latest
+				""".trimIndent()
+				commandArgs = """
+					--pull
+					--label com.a8c.image-builder=teamcity
+					--label com.a8c.target=calypso-live
+					--label com.a8c.build-id=%teamcity.build.id%
+					--build-arg workers=32
+					--build-arg node_memory=32768
+					--build-arg use_cache=true
+					--build-arg base_image=%base_image%
+					--build-arg commit_sha=${Settings.WpCalypso.paramRefs.buildVcsNumber}
+					--build-arg manual_sentry_release=%MANUAL_SENTRY_RELEASE%
+					--build-arg is_default_branch=%teamcity.build.branch.is_default%
+					--build-arg sentry_auth_token=%SENTRY_AUTH_TOKEN%
+				""".trimIndent().replace("\n"," ")
 			}
 			param("dockerImage.platform", "linux")
 		}
@@ -151,8 +155,8 @@ object BuildDockerImage : BuildType({
 					path = "Dockerfile"
 				}
 				namesAndTags = "registry.a8c.com/calypso/base:latest"
-				commandArgs = buildImageArgs
 			}
+			commandArgs = "--target update-base-cache"
 		}
 	
 		dockerCommand {

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -115,31 +115,27 @@ object BuildDockerImage : BuildType({
 			dockerImagePlatform = ScriptBuildStep.ImagePlatform.Linux
 		}
 
+		val buildImageArgs = """
+			--label com.a8c.image-builder=teamcity
+			--label com.a8c.build-id=%teamcity.build.id%
+			--build-arg workers=32
+			--build-arg node_memory=32768
+			--build-arg use_cache=true
+			--build-arg base_image=%base_image%
+			--build-arg commit_sha=${Settings.WpCalypso.paramRefs.buildVcsNumber}
+			--build-arg manual_sentry_release=%MANUAL_SENTRY_RELEASE%
+			--build-arg is_default_branch=%teamcity.build.branch.is_default%
+			--build-arg sentry_auth_token=%SENTRY_AUTH_TOKEN%
+		""".trimIndent().replace("\n"," ");
+	
 		dockerCommand {
 			name = "Build docker image"
 			commandType = build {
 				source = file {
 					path = "Dockerfile"
 				}
-				namesAndTags = """
-					registry.a8c.com/calypso/app:build-%build.number%
-					registry.a8c.com/calypso/app:commit-${Settings.WpCalypso.paramRefs.buildVcsNumber}
-					registry.a8c.com/calypso/app:latest
-				""".trimIndent()
-				commandArgs = """
-					--pull
-					--label com.a8c.image-builder=teamcity
-					--label com.a8c.target=calypso-live
-					--label com.a8c.build-id=%teamcity.build.id%
-					--build-arg workers=32
-					--build-arg node_memory=32768
-					--build-arg use_cache=true
-					--build-arg base_image=%base_image%
-					--build-arg commit_sha=${Settings.WpCalypso.paramRefs.buildVcsNumber}
-					--build-arg manual_sentry_release=%MANUAL_SENTRY_RELEASE%
-					--build-arg is_default_branch=%teamcity.build.branch.is_default%
-					--build-arg sentry_auth_token=%SENTRY_AUTH_TOKEN%
-				""".trimIndent().replace("\n"," ")
+				namesAndTags = "--pull --label com.a8c.target=calypso-live $buildImageArgs"
+				commandArgs = .trimIndent().replace("\n"," ")
 			}
 			param("dockerImage.platform", "linux")
 		}
@@ -155,8 +151,8 @@ object BuildDockerImage : BuildType({
 					path = "Dockerfile"
 				}
 				namesAndTags = "registry.a8c.com/calypso/base:latest"
+				commandArgs = buildImageArgs
 			}
-			commandArgs = "--target update-base-cache"
 		}
 	
 		dockerCommand {

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -155,8 +155,8 @@ object BuildDockerImage : BuildType({
 					path = "Dockerfile"
 				}
 				namesAndTags = "registry.a8c.com/calypso/base:latest"
+				commandArgs = "--target update-base-cache $commonArgs"
 			}
-			commandArgs = "--target update-base-cache $commonArgs"
 		}
 	
 		dockerCommand {

--- a/Dockerfile
+++ b/Dockerfile
@@ -72,7 +72,7 @@ RUN yarn run build
 RUN find /calypso/build /calypso/public -name "*.*.map" -exec rm {} \;
 
 ###################
-# A cache-only update can be generated with "docker build --target update_base_cache"
+# A cache-only update can be generated with "docker build --target update-base-cache"
 FROM ${base_image} as update-base-cache
 
 # Update cache in the base image so that it can be re-used in future builds.

--- a/Dockerfile
+++ b/Dockerfile
@@ -85,6 +85,7 @@ ENV NODE_ENV production
 WORKDIR /calypso
 
 RUN apk add --no-cache tini
+COPY --from=builder --chown=nobody:nobody /calypso/.cache /calypso/.cache
 COPY --from=builder --chown=nobody:nobody /calypso/build /calypso/build
 COPY --from=builder --chown=nobody:nobody /calypso/public /calypso/public
 COPY --from=builder --chown=nobody:nobody /calypso/config /calypso/config

--- a/Dockerfile
+++ b/Dockerfile
@@ -85,6 +85,7 @@ ENV NODE_ENV production
 WORKDIR /calypso
 
 RUN apk add --no-cache tini
+# Publish cache so that it can be re-used in future builds app builds.
 COPY --from=builder --chown=nobody:nobody /calypso/.cache /calypso/.cache
 COPY --from=builder --chown=nobody:nobody /calypso/build /calypso/build
 COPY --from=builder --chown=nobody:nobody /calypso/public /calypso/public


### PR DESCRIPTION
Publishes the .cache directory in the docker image so that it's available for future builds. Required for #72687 to work.

The main downside here is that the image will be larger, but I'm not sure by how much. Will test.

Pending question: What's the latest build? The most recent one to build, or just trunk? Unsure. I think latest might get tagged locally, but not published.

To test... not quite sure! I don't have the registry set up locally, so that's probably the first step.