### PR TITLE
Stats: Enabling feature flag on summary pages

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -111,7 +111,7 @@
 		"signup/woo-verify-email": false,
 		"site-indicator": true,
 		"ssr/prefetch-timebox": true,
-		"stats/horizontal-bars-everywhere": false,
+		"stats/horizontal-bars-everywhere": true,
 		"stats/insights-page-grid": false,
 		"stepper-woocommerce-poc": true,
 		"subscriber-csv-upload": true,

--- a/config/production.json
+++ b/config/production.json
@@ -131,7 +131,7 @@
 		"ssr/log-prefetch-errors": true,
 		"ssr/prefetch-timebox": true,
 		"ssr/sample-log-cache-misses": true,
-		"stats/horizontal-bars-everywhere": false,
+		"stats/horizontal-bars-everywhere": true,
 		"stats/insights-page-grid": false,
 		"stepper-woocommerce-poc": true,
 		"subscriber-csv-upload": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -127,7 +127,7 @@
 		"signup/woo-verify-email": false,
 		"site-indicator": true,
 		"ssr/prefetch-timebox": true,
-		"stats/horizontal-bars-everywhere": false,
+		"stats/horizontal-bars-everywhere": true,
 		"stats/insights-page-grid": false,
 		"stepper-woocommerce-poc": true,
 		"subscriber-csv-upload": true,

--- a/config/test.json
+++ b/config/test.json
@@ -92,7 +92,7 @@
 		"signup/social": true,
 		"site-indicator": true,
 		"ssr/prefetch-timebox": true,
-		"stats/horizontal-bars-everywhere": false,
+		"stats/horizontal-bars-everywhere": true,
 		"stats/insights-page-grid": false,
 		"stepper-woocommerce-poc": true,
 		"themes/premium": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -137,7 +137,7 @@
 		"site-indicator": true,
 		"sites/copy-site": true,
 		"ssr/prefetch-timebox": true,
-		"stats/horizontal-bars-everywhere": false,
+		"stats/horizontal-bars-everywhere": true,
 		"stats/insights-page-grid": false,
 		"stepper-woocommerce-poc": true,
 		"subscriber-csv-upload": true,


### PR DESCRIPTION
#### Proposed Changes

* enabling `stats/horizontal-bars-everywhere` feature flag in all environments
* providing customers with the work merged in #71957 on summary pages 

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* go to the live branch
* Navigate to `View all`/`View details` for stats modules below the chart (summary detail page)
* check that the page loads properly and looks well for different screen sizes
* smoke test changing different periods in the navigation next to the date


* `Authors` and `File downloads` don't have navigation buttons (CSV export button is visible in that space) - aligning the page is in progress as part of another issue
* `Videos` still should have the old design due to the different table structure - aligning the page is in progress as part of another issue

Before:
![Screenshot 2023-01-27 at 3 01 46 PM](https://user-images.githubusercontent.com/112354940/215007597-08ba5a1c-285c-4d6a-8476-f66dfcb87712.png)

After:
![Screenshot 2023-01-27 at 3 04 36 PM](https://user-images.githubusercontent.com/112354940/215007618-b86e7bea-383c-4cc3-b2d8-2d26f7b52e10.png)


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
