### PR TITLE
Purchase Management: Add correct status information when owner removed from site

### DIFF
--- a/client/me/purchases/purchase-item/index.jsx
+++ b/client/me/purchases/purchase-item/index.jsx
@@ -98,7 +98,27 @@ class PurchaseItem extends Component {
 			if ( isJetpack ) {
 				return (
 					<span className="purchase-item__is-error">
-						{ translate( 'Disconnected from WordPress.com' ) }
+						{ translate(
+							'You no longer have access to this site. {{button}}Contact support{{/button}}',
+							{
+								args: {
+									site: name,
+								},
+								components: {
+									button: (
+										<button
+											className="purchase-item__link purchase-item__link--error"
+											onClick={ ( event ) => {
+												event.stopPropagation();
+												event.preventDefault();
+												page( CALYPSO_CONTACT );
+											} }
+											title={ translate( 'Contact Support' ) }
+										/>
+									),
+								},
+							}
+						) }
 					</span>
 				);
 			}


### PR DESCRIPTION
#### Proposed Changes

Main thread here https://github.com/Automattic/payments-shilling/issues/1321

In cases where the owner of the plan is removed from the site, the status text on `/me/purchases` incorrectly asserts "Disconnected from WordPress.com", this PR will more correctly notify the customer that they no longer have access to the site and its purchases and then ask them to contact support.

#### Testing Instructions

- This will require two wpcom accounts and a self-hosted site, I recommend using https://jurassic.ninja/
- Have account A create a site and connect Jetpack
- Have account A invite account B as an admin from the Calypso dashboard
- Have account B purchase a Jetpack Complete plan
- Have account A remove account B
- From account B, go to /me/purchases and look at the status column for the site we just added the Jetpack Complete plan to, it should read "You no longer have access to this site. Contact support" (it should **not** also read "and its purchases", which is separate line of code reserved for atomic sites)
- Ensure the 'Contact support' button works

![image](https://user-images.githubusercontent.com/16580129/215225717-77902a40-0d4e-4d0d-9809-adff9e947085.png)


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/payments-shilling/issues/1321
