### PR TITLE
Purchase Management: Add early return to block loading of '/cancel' endpoint

### DIFF
--- a/client/me/purchases/cancel-purchase/index.jsx
+++ b/client/me/purchases/cancel-purchase/index.jsx
@@ -90,9 +90,13 @@ class CancelPurchase extends Component {
 			return true;
 		}
 
-		const { purchase } = props;
+		const { purchase, site } = props;
 
 		if ( ! purchase ) {
+			return false;
+		}
+
+		if ( ! site ) {
 			return false;
 		}
 


### PR DESCRIPTION
#### Proposed Changes

Main thread https://github.com/Automattic/payments-shilling/issues/1321

This small PR adds an early return to the CancelPurchase component to ensure that `/cancel` redirects back to the purchase list if no site is found for the purchase.

#### Testing Instructions

- This will require two wpcom accounts and a self-hosted site, I recommend using https://jurassic.ninja/
- Have account A create a site and connect Jetpack
- Have account A invite account B as an admin from the Calypso dashboard
- Have account B purchase a Jetpack Complete plan
- Have account A remove account B
- From account B, go to /me/purchases and click on the Jetpack Complete plan
- From the manage purchase page, click on Cancel, this should redirect you back to the Purchases list
- Now try going to `http://calypso.localhost:3000/me/purchases/[SITE URL]/[SUBSCRIPTION ID]/cancel`, it should redirect back to the Purchases list

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/payments-shilling/issues/1321