### PR TITLE
Disable Ecommerce Home Redirection when SSO is disabled

### DIFF
--- a/client/my-sites/customer-home/controller.jsx
+++ b/client/my-sites/customer-home/controller.jsx
@@ -1,7 +1,9 @@
 import { isEcommerce } from '@automattic/calypso-products/src';
 import page from 'page';
+import { fetchModuleList } from 'calypso/state/jetpack/modules/actions';
 import { fetchSitePlugins } from 'calypso/state/plugins/installed/actions';
 import { getPluginOnSite } from 'calypso/state/plugins/installed/selectors';
+import isJetpackModuleActive from 'calypso/state/selectors/is-jetpack-module-active';
 import { requestSite } from 'calypso/state/sites/actions';
 import {
 	canCurrentUserUseCustomerHome,
@@ -70,10 +72,14 @@ export async function maybeRedirect( context, next ) {
 			// We need to make sure that sites on the eCommerce plan actually have WooCommerce installed before we redirect to the WooCommerce Home
 			// So we need to trigger a fetch of site plugins
 			await context.store.dispatch( fetchSitePlugins( siteId ) );
+			await context.store.dispatch( fetchModuleList( siteId ) );
 
 			const refetchedState = context.store.getState();
+
 			const installedWooCommercePlugin = getPluginOnSite( refetchedState, siteId, 'woocommerce' );
-			if ( installedWooCommercePlugin && installedWooCommercePlugin.active ) {
+			const isSSOEnabled = !! isJetpackModuleActive( refetchedState, siteId, 'sso' );
+
+			if ( isSSOEnabled && installedWooCommercePlugin && installedWooCommercePlugin.active ) {
 				window.location.replace( siteUrl + '/wp-admin/admin.php?page=wc-admin' );
 			}
 		}

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -28,6 +28,8 @@ import {
 	isRequesting as isRequestingInstalledPlugins,
 } from 'calypso/state/plugins/installed/selectors';
 import { getSelectedEditor } from 'calypso/state/selectors/get-selected-editor';
+import isFetchingJetpackModules from 'calypso/state/selectors/is-fetching-jetpack-modules';
+import isJetpackModuleActive from 'calypso/state/selectors/is-jetpack-module-active';
 import isUserRegistrationDaysWithinRange from 'calypso/state/selectors/is-user-registration-days-within-range';
 import {
 	canCurrentUserUseCustomerHome,
@@ -42,6 +44,8 @@ const Home = ( {
 	canUserUseCustomerHome,
 	hasWooCommerceInstalled,
 	isRequestingSitePlugins,
+	ssoModuleActive,
+	fetchingJetpackModules,
 	site,
 	siteId,
 	trackViewSiteAction,
@@ -85,7 +89,11 @@ const Home = ( {
 
 	// Ecommerce Plan's Home redirects to WooCommerce Home, so we show a placeholder
 	// while doing the redirection.
-	if ( isEcommerce( sitePlan ) && ( isRequestingSitePlugins || hasWooCommerceInstalled ) ) {
+	if (
+		isEcommerce( sitePlan ) &&
+		( isRequestingSitePlugins || hasWooCommerceInstalled ) &&
+		( fetchingJetpackModules || ssoModuleActive )
+	) {
 		return <WooCommerceHomePlaceholder />;
 	}
 
@@ -152,6 +160,8 @@ Home.propTypes = {
 	hasWooCommerceInstalled: PropTypes.bool.isRequired,
 	isStaticHomePage: PropTypes.bool.isRequired,
 	isRequestingSitePlugins: PropTypes.bool.isRequired,
+	ssoModuleActive: PropTypes.bool.isRequired,
+	fetchingJetpackModules: PropTypes.bool.isRequired,
 	site: PropTypes.object.isRequired,
 	siteId: PropTypes.number.isRequired,
 	trackViewSiteAction: PropTypes.func.isRequired,
@@ -172,6 +182,8 @@ const mapStateToProps = ( state ) => {
 			! isClassicEditor && 'page' === getSiteOption( state, siteId, 'show_on_front' ),
 		hasWooCommerceInstalled: !! ( installedWooCommercePlugin && installedWooCommercePlugin.active ),
 		isRequestingSitePlugins: isRequestingInstalledPlugins( state, siteId ),
+		ssoModuleActive: !! isJetpackModuleActive( state, siteId, 'sso' ),
+		fetchingJetpackModules: !! isFetchingJetpackModules( state, siteId ),
 	};
 };
 


### PR DESCRIPTION
#### Proposed Changes

This PR aims to disable the Ecommerce home redirection when a site has not enabled Jetpack's SSO. That's because the Home redirection only makes sense when the menu is the new Ecommerce Atomic menu; thus, the Calypso Home is replaced with the WooCommerce one.

#### Specification

Please note that I'm done my best to tackle this issue, but it's not yet optimal. 

I get a flash of content when navigating through sites, and I cannot bypass this. Check [this screencast](https://d.pr/v/tX1SLH) that navigates to (a) a Simple site, (b) an Ecommerce site with SSO disabled, and (c) to an Ecommerce site with SSO enabled (which results in redirection). 

Note that all Ecommerce sites have a flash of the Home content before showing the loader. How can we bypass this?

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
Ensure that you have at least one Ecommerce site with SSO disabled. 

**To disable SSO:**
- Navigate to **Settings > Security** and disable the "_Allow users to log in to this site using WordPress.com accounts_" option.

**Testing instructions:**
- Navigate to the site's home (`wordpress.com/home/[site_suffix]`) that has SSO disabled.
- Notice that you get redirected to WooCommerce Home (or the wp-admin login page, depending on the login cookie).
- Apply this PR.
- Navigate to home again and ensure that the redirection is removed; therefore, you should see the Calypso home.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wc-calypso-bridge/pull/925
