### PR TITLE
Redirect to stats overview page when changing sites

### DIFF
--- a/client/my-sites/stats/stats-email-detail/index.jsx
+++ b/client/my-sites/stats/stats-email-detail/index.jsx
@@ -134,6 +134,13 @@ class StatsEmailDetail extends Component {
 		window.scrollTo( 0, 0 );
 	}
 
+	componentDidUpdate( prevProps ) {
+		// since it doesn't make sense showing the same postId on a different site, let's redirect to the stats overview page
+		if ( prevProps.siteSlug !== this.props.siteSlug ) {
+			page.redirect( `/stats/day/${ this.props.siteSlug }` );
+		}
+	}
+
 	getTitle() {
 		const { post } = this.props;
 


### PR DESCRIPTION
#### Proposed Changes

This PR redirects the user to the main stats page, when they change sites while viewing the email open/click stats. 

Currently, when you're at http://calypso.localhost:3000/stats/email/opens/day/3625/<siteid>, and you change sites to another site, the URL changes to http://calypso.localhost:3000/stats/email/opens/day/3625/<newsiteid>.

However, the postId stays the same. Chances are slim that you want to view the stats of the post with the same id. This PR changes that behavior.

#### Testing Instructions

* Apply this PR
* Merge it with branch `fix/email-stats-routes` (if it hasn't been merged with trunk yet) ([PR](https://github.com/Automattic/wp-calypso/pull/72700))
* Check that when viewing Open/Click email stats, and you change the site, you get redirected to the main stats overview.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #71523
