### PR TITLE
Plans 2023 : Add plans page to hero flow and launch site flow

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
@@ -1,4 +1,5 @@
 // import { subscribeIsDesktop } from '@automattic/viewport';
+import { isEnabled } from '@automattic/calypso-config';
 import { getPlan, PLAN_FREE } from '@automattic/calypso-products';
 import { getUrlParts } from '@automattic/calypso-url';
 import { Button } from '@automattic/components';
@@ -159,6 +160,7 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 					{ components: { link: freePlanButton } }
 			  );
 	};
+	const is2023OnboardingPricingGrid = isEnabled( 'onboarding/2023-pricing-grid' );
 
 	const plansFeaturesSelection = () => {
 		const { flowName } = props;
@@ -176,7 +178,8 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 					shouldHideNavButtons={ true }
 					fallbackHeaderText={ fallbackHeaderText }
 					fallbackSubHeaderText={ fallbackSubHeaderText }
-					isWideLayout={ true }
+					isWideLayout={ ! is2023OnboardingPricingGrid }
+					isExtraWideLayout={ is2023OnboardingPricingGrid }
 					stepContent={ plansFeaturesList() }
 					allowBackFirstStep={ false }
 				/>
@@ -187,7 +190,8 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 	const classes = classNames( 'plans-step', {
 		'in-vertically-scrolled-plans-experiment': isInVerticalScrollingPlansExperiment,
 		'has-no-sidebar': true,
-		'is-wide-layout': true,
+		'is-wide-layout': ! is2023OnboardingPricingGrid,
+		'is-extra-wide-layout': is2023OnboardingPricingGrid,
 	} );
 
 	return (

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/style.scss
@@ -43,6 +43,11 @@
 		max-width: 1200px;
 	}
 
+	// 2023 has extra wide layout
+	&.is-extra-wide-layout {
+		max-width: 1480px;
+	}
+
 	.formatted-header.is-without-subhead {
 		margin-bottom: 15px;
 	}

--- a/client/my-sites/plan-features-2023-grid/actions.tsx
+++ b/client/my-sites/plan-features-2023-grid/actions.tsx
@@ -84,9 +84,10 @@ const LaunchPagePlanFeatureActionButton = ( {
 			</Button>
 		);
 	}
+
 	return (
 		<Button className={ classes } onClick={ handleUpgradeButtonClick } disabled={ isPlaceholder }>
-			{ translate( 'Get %(plan)s', {
+			{ translate( 'Select %(plan)s', {
 				args: {
 					plan: planName,
 				},
@@ -235,9 +236,9 @@ const PlanFeaturesActionsButton: React.FC< PlanFeaturesActionsButtonProps > = ( 
 				} ) }
 			</Button>
 		);
-	} else if ( isInSignup ) {
+	} else if ( isLaunchPage ) {
 		return (
-			<SignupFlowPlanFeatureActionButton
+			<LaunchPagePlanFeatureActionButton
 				freePlan={ freePlan }
 				isPlaceholder={ isPlaceholder }
 				planName={ planName }
@@ -245,9 +246,9 @@ const PlanFeaturesActionsButton: React.FC< PlanFeaturesActionsButtonProps > = ( 
 				handleUpgradeButtonClick={ handleUpgradeButtonClick }
 			/>
 		);
-	} else if ( isLaunchPage ) {
+	} else if ( isInSignup ) {
 		return (
-			<LaunchPagePlanFeatureActionButton
+			<SignupFlowPlanFeatureActionButton
 				freePlan={ freePlan }
 				isPlaceholder={ isPlaceholder }
 				planName={ planName }

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -453,6 +453,7 @@ export class PlanFeatures2023Grid extends Component< PlanFeatures2023GridType > 
 
 		if ( isFreePlan( planName ) ) {
 			ownPropsOnUpgradeClick( null );
+			return;
 		}
 
 		const planPath = getPlanPath( planName ) || '';
@@ -779,10 +780,16 @@ const ConnectedPlanFeatures2023Grid = connect(
 )( localize( PlanFeatures2023Grid ) );
 /* eslint-enable wpcalypso/redux-no-bound-selectors */
 
-const ShoppingCartWrappedPlanFeatures2023Grid = ( props: PlanFeatures2023GridType ) => (
-	<CalypsoShoppingCartProvider>
-		<ConnectedPlanFeatures2023Grid { ...props } />
-	</CalypsoShoppingCartProvider>
-);
+const WrappedPlanFeatures2023Grid = ( props: PlanFeatures2023GridType ) => {
+	if ( props.isInSignup ) {
+		return <ConnectedPlanFeatures2023Grid { ...props } />;
+	}
 
-export default ShoppingCartWrappedPlanFeatures2023Grid;
+	return (
+		<CalypsoShoppingCartProvider>
+			<ConnectedPlanFeatures2023Grid { ...props } />
+		</CalypsoShoppingCartProvider>
+	);
+};
+
+export default WrappedPlanFeatures2023Grid;

--- a/client/my-sites/plans-features-main/plan-type-selector.tsx
+++ b/client/my-sites/plans-features-main/plan-type-selector.tsx
@@ -282,6 +282,7 @@ export default PlanTypeSelector;
 const IntervalTypeToggleWrapper = styled.div< { showingMonthly: boolean; isInSignup: boolean } >`
 	display: ${ ( { isInSignup } ) => ( isInSignup ? 'flex' : 'block' ) };
 	align-content: space-between;
+	justify-content: center;
 
 	> .segmented-control.is-compact:not( .is-signup ) {
 		margin: 8px auto 16px;

--- a/client/my-sites/plans-features-main/style.scss
+++ b/client/my-sites/plans-features-main/style.scss
@@ -55,16 +55,8 @@
 	margin: auto;
 	max-width: 335px;
 
-	.is-section-signup & {
+	@include onboarding-2023-pricing-grid-plans-breakpoints;
 
-		@media ( min-width: 385px ) {
-			max-width: 375px;
-			margin: initial auto;
-		}
-
-		@include onboarding-2023-pricing-grid-plans-breakpoints;
-		margin: auto;
-	}
 }
 
 .plans-features-main__group.is-wpcom:not(.is-2023-pricing-grid) {

--- a/client/signup/step-wrapper/index.jsx
+++ b/client/signup/step-wrapper/index.jsx
@@ -172,13 +172,13 @@ class StepWrapper extends Component {
 			hideNext,
 			isLargeSkipLayout,
 			isWideLayout,
-			isExtraWideLayout,
 			isFullLayout,
 			skipButtonAlign,
 			align,
 			headerImageUrl,
 			isHorizontalLayout,
 			customizedActionButtons,
+			isExtraWideLayout,
 		} = this.props;
 
 		const backButton = ! hideBack && this.renderBack();

--- a/client/signup/step-wrapper/index.jsx
+++ b/client/signup/step-wrapper/index.jsx
@@ -172,6 +172,7 @@ class StepWrapper extends Component {
 			hideNext,
 			isLargeSkipLayout,
 			isWideLayout,
+			isExtraWideLayout,
 			isFullLayout,
 			skipButtonAlign,
 			align,
@@ -190,6 +191,7 @@ class StepWrapper extends Component {
 		const classes = classNames( 'step-wrapper', this.props.className, {
 			'is-horizontal-layout': isHorizontalLayout,
 			'is-wide-layout': isWideLayout,
+			'is-extra-wide-layout': isExtraWideLayout,
 			'is-full-layout': isFullLayout,
 			'is-large-skip-layout': isLargeSkipLayout,
 			'has-navigation': hasNavigation,

--- a/client/signup/step-wrapper/style.scss
+++ b/client/signup/step-wrapper/style.scss
@@ -123,12 +123,13 @@
 	// Some steps (like plans) need a larger
 	// width column.
 	&.is-wide-layout {
-		max-width: 1480px;
+		max-width: 1040px;
 	}
 
 	// Some steps (like 2023 plans) need a larger width column
 	&.is-extra-wide-layout {
-		max-width: 1040px;
+		max-width: 1480px;
+
 	}
 
 	// Some steps (like courses) have their width limitation

--- a/client/signup/step-wrapper/style.scss
+++ b/client/signup/step-wrapper/style.scss
@@ -123,6 +123,11 @@
 	// Some steps (like plans) need a larger
 	// width column.
 	&.is-wide-layout {
+		max-width: 1480px;
+	}
+
+	// Some steps (like 2023 plans) need a larger width column
+	&.is-extra-wide-layout {
 		max-width: 1040px;
 	}
 

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -424,11 +424,14 @@ export class PlansStep extends Component {
 	}
 
 	render() {
+		const is2023OnboardingPricingGrid = isEnabled( 'onboarding/2023-pricing-grid' );
+
 		const classes = classNames( 'plans plans-step', {
 			'in-vertically-scrolled-plans-experiment':
 				! this.props.isOnboarding2023PricingGrid && this.props.isInVerticalScrollingPlansExperiment,
 			'has-no-sidebar': true,
-			'is-wide-layout': true,
+			'is-wide-layout': ! is2023OnboardingPricingGrid,
+			'is-extra-wide-layout': is2023OnboardingPricingGrid,
 		} );
 
 		return (
@@ -475,7 +478,7 @@ export const isDotBlogDomainRegistration = ( domainItem ) => {
 export default connect(
 	(
 		state,
-		{ path, flowName, signupDependencies: { siteSlug, domainItem, plans_reorder_abtest_variation } }
+		{ path, signupDependencies: { siteSlug, domainItem, plans_reorder_abtest_variation } }
 	) => ( {
 		// Blogger plan is only available if user chose either a free domain or a .blog domain registration
 		disableBloggerPlanWithNonBlogDomain:
@@ -496,8 +499,7 @@ export default connect(
 		isInVerticalScrollingPlansExperiment: true,
 		plansLoaded: Boolean( getPlanSlug( state, getPlan( PLAN_FREE )?.getProductId() || 0 ) ),
 		eligibleForProPlan: isEligibleForProPlan( state, getSiteBySlug( state, siteSlug )?.ID ),
-		isOnboarding2023PricingGrid:
-			isEnabled( 'onboarding/2023-pricing-grid' ) && flowName === 'onboarding-2023-pricing-grid',
+		isOnboarding2023PricingGrid: isEnabled( 'onboarding/2023-pricing-grid' ),
 	} ),
 	{ recordTracksEvent, saveSignupStep, submitSignupStep, errorNotice }
 )( localize( PlansStep ) );

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -369,8 +369,15 @@ export class PlansStep extends Component {
 	}
 
 	plansFeaturesSelection() {
-		const { flowName, stepName, positionInFlow, translate, hasInitializedSitesBackUrl, steps } =
-			this.props;
+		const {
+			flowName,
+			stepName,
+			positionInFlow,
+			translate,
+			hasInitializedSitesBackUrl,
+			steps,
+			isOnboarding2023PricingGrid,
+		} = this.props;
 
 		const headerText = this.getHeaderText();
 		const fallbackHeaderText = this.props.fallbackHeaderText || headerText;
@@ -412,7 +419,8 @@ export class PlansStep extends Component {
 					fallbackHeaderText={ fallbackHeaderText }
 					subHeaderText={ subHeaderText }
 					fallbackSubHeaderText={ fallbackSubHeaderText }
-					isWideLayout={ true }
+					isWideLayout={ ! isOnboarding2023PricingGrid }
+					isExtraWideLayout={ isOnboarding2023PricingGrid }
 					stepContent={ this.plansFeaturesList() }
 					allowBackFirstStep={ !! hasInitializedSitesBackUrl }
 					backUrl={ backUrl }

--- a/client/signup/steps/plans/style.scss
+++ b/client/signup/steps/plans/style.scss
@@ -56,6 +56,11 @@ $plans-2023-large-breakpoint: 1500px;
 		max-width: 1200px;
 	}
 
+	// 2023 has extra wide layout
+	&.is-extra-wide-layout {
+		max-width: 1480px;
+	}
+
 	.is-onboarding-2023-pricing-grid &.is-wide-layout {
 		@include onboarding-2023-pricing-grid-plans-breakpoints;
 	}


### PR DESCRIPTION
#### Proposed Changes
Adds the 2023 pricing grid to `/start` and launch site flows 

|  Launch Flow   |  Onboarding flow | 
| :---:      |       :---: |
| ![image](https://user-images.githubusercontent.com/3422709/214688394-2898bc39-b9d9-4b01-850d-3df0ab21a0fa.png)  |. ![image](https://user-images.githubusercontent.com/3422709/215070354-d9f7277d-59f6-4f16-ac34-e78f5f3c6804.png) | 


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start` OR enter the site launch flow
* Land on the plans page and make sure it works well
* Make sure the previous versions of those flows are unaffected
Eg: Remove the feature flag `/start/plans?flags=-onboarding%2F2023-pricing-grid`


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes Automattic/martech#1424
Fixes Automattic/martech#1436