### PR TITLE
Email stats: change path of navigation tabs in email stats to new format.

### DIFF
--- a/client/my-sites/stats/stats-email-detail/index.jsx
+++ b/client/my-sites/stats/stats-email-detail/index.jsx
@@ -193,7 +193,7 @@ class StatsEmailDetail extends Component {
 		const navItems = [ 'opens', 'clicks' ].map( ( item ) => {
 			const attr = {
 				key: item,
-				path: `/stats/email/${ item }/${ givenSiteId }/${ period }/${ postId }`,
+				path: `/stats/email/${ item }/${ period }/${ postId }/${ givenSiteId }`,
 				selected: statType === item,
 			};
 


### PR DESCRIPTION
#### Proposed Changes

* This PR changes the format of the navigation tabs in email stats detail from `/stats/email/${ item }/${ givenSiteId }/${ period }/${ postId }` to `/stats/email/${ item }/${ period }/${ postId }/${ givenSiteId }`.


#### Testing Instructions

- Apply this PR
- Navigate to `http://calypso.localhost:3000/stats/day/<siteid>?flags=newsletter/stats`
- Click on any email in the Email Opens or Email Clicks boxes
- Verify that the tabs to switch between Opens & Clicks work.

<img width="1125" alt="CleanShot 2023-01-27 at 12 05 11@2x" src="https://user-images.githubusercontent.com/528287/215071590-4bbcf041-e038-411c-b195-747b700daf20.png">

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
