### PR TITLE
Implement LinkedIn tracker in Jetpack Checkout

### DIFF
--- a/client/lib/analytics/ad-tracking/record-order.js
+++ b/client/lib/analytics/ad-tracking/record-order.js
@@ -401,6 +401,10 @@ function recordOrderInGoogleAds( cart, orderId, wpcomJetpackCartInfo ) {
 		debug( 'recordOrderInGoogleAds: Record Jetpack Purchase', params );
 		window.gtag( ...params );
 	}
+
+	if ( mayWeTrackByTracker( 'linkedin' ) && wpcomJetpackCartInfo.containsJetpackProducts ) {
+		window.lintrk( 'track', { conversion_id: 10947410 } );
+	}
 }
 
 function recordOrderInGAEnhancedEcommerce( cart, orderId, wpcomJetpackCartInfo ) {

--- a/client/lib/analytics/ad-tracking/record-order.js
+++ b/client/lib/analytics/ad-tracking/record-order.js
@@ -127,6 +127,13 @@ export async function recordOrder( cart, orderId ) {
 		window.adRoll.trackPurchase();
 	}
 
+	if ( mayWeTrackByTracker( 'linkedin' ) && wpcomJetpackCartInfo.containsJetpackProducts ) {
+		const params = { conversion_id: 10947410 };
+
+		debug( 'recordOrder: [LinkedIn]', params );
+		window.lintrk( 'track', params );
+	}
+
 	// Uses JSON.stringify() to print the expanded object because during localhost or .live testing after firing this
 	// event we redirect the user to wordpress.com which causes a domain change preventing the expanding and inspection
 	// of any object in the JS console since they are no longer available.
@@ -400,10 +407,6 @@ function recordOrderInGoogleAds( cart, orderId, wpcomJetpackCartInfo ) {
 		];
 		debug( 'recordOrderInGoogleAds: Record Jetpack Purchase', params );
 		window.gtag( ...params );
-	}
-
-	if ( mayWeTrackByTracker( 'linkedin' ) && wpcomJetpackCartInfo.containsJetpackProducts ) {
-		window.lintrk( 'track', { conversion_id: 10947410 } );
 	}
 }
 

--- a/client/lib/analytics/ad-tracking/setup.js
+++ b/client/lib/analytics/ad-tracking/setup.js
@@ -1,3 +1,4 @@
+import isJetpackCheckout from 'calypso/lib/jetpack/is-jetpack-checkout';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { mayWeInitTracker, mayWeTrackByTracker } from '../tracker-buckets';
 import {
@@ -49,7 +50,9 @@ if ( typeof window !== 'undefined' ) {
 
 	// Linkedin
 	if ( mayWeInitTracker( 'linkedin' ) ) {
-		setupLinkedinInsight( isJetpackCloud() ? TRACKING_IDS.jetpackLinkedinId : null );
+		setupLinkedinInsight(
+			isJetpackCloud() || isJetpackCheckout() ? TRACKING_IDS.jetpackLinkedinId : null
+		);
 	}
 
 	// Quora

--- a/client/lib/analytics/tracker-buckets.ts
+++ b/client/lib/analytics/tracker-buckets.ts
@@ -8,6 +8,7 @@ import {
 } from 'calypso/lib/analytics/utils';
 import { isE2ETest } from 'calypso/lib/e2e';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
+import isJetpackCheckout from '../jetpack/is-jetpack-checkout';
 
 const allAdTrackers = [
 	'bing',
@@ -56,8 +57,8 @@ export const AdTrackersBuckets: { [ key in AdTracker ]: Bucket | null } = {
 	twitter: Bucket.ADVERTISING,
 	facebook: Bucket.ADVERTISING,
 
-	// Advertising trackers (only Jetpack Cloud):
-	linkedin: isJetpackCloud() ? Bucket.ADVERTISING : null,
+	// Advertising trackers (only Jetpack Cloud or on Jetpack Checkout):
+	linkedin: isJetpackCloud() || isJetpackCheckout() ? Bucket.ADVERTISING : null,
 
 	// Disabled trackers:
 	quantcast: null,

--- a/client/lib/jetpack/is-jetpack-checkout.ts
+++ b/client/lib/jetpack/is-jetpack-checkout.ts
@@ -1,0 +1,3 @@
+const isJetpackCheckout = () => window.location.pathname.startsWith( '/checkout/jetpack' );
+
+export default isJetpackCheckout;

--- a/client/lib/jetpack/is-jetpack-checkout.ts
+++ b/client/lib/jetpack/is-jetpack-checkout.ts
@@ -1,3 +1,8 @@
-const isJetpackCheckout = () => window.location.pathname.startsWith( '/checkout/jetpack' );
+/*
+    The function isJetpackCheckout() is used to determine if the current page is a Jetpack checkout page. 
+    It always returns false on the server side as window object is not available there (assumption that checkout pages are not rendered server-side).
+ */
+const isJetpackCheckout = () =>
+	'undefined' !== typeof document && window.location.pathname.startsWith( '/checkout/jetpack' );
 
 export default isJetpackCheckout;


### PR DESCRIPTION
#### Proposed Changes

- Implement isJetpackCheckout() to identify Jetpack related pages in calypso env
- Trigger Jetpack-related trackers in checkout process in calypso
- Track jetpack purchase conversion by linkedin tracker


#### Testing Instructions

* Checkout the PR, and run `yarn start`
* Go to `http://calypso.localhost:3000/checkout/jetpack/jetpack_boost_monthly?flags=ad-tracking,cookie-banner`
* Ensure that you allow for advertising trackers (`sensitive_pixel_options=%7B%22ok%22%3Atrue%2C%22buckets%22%3A%7B%22essential%22%3Atrue%2C%22analytics%22%3Atrue%2C%22advertising%22%3Atrue%7D%7D`)
* See that `window.lintrk` is not undefined

Additional: To test the conversion event [ A12s only ]
* Point public-api.wordpress.com to your sandbox and enable store sandbox
* Go to `http://calypso.localhost:3000/checkout/jetpack/jetpack_boost_monthly?flags=ad-tracking,cookie-banner`
* Enter `localStorage.setItem( 'debug', 'calypso:analytics:*' );` in console
* Finish the payment using credit card
* In console logs, you should see `recordOrder: [LinkedIn]` debug log with correct `conversionId` = `10947410`

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
