### PR TITLE
Reading Settings: Uptake the dropdown-page api's change in its response format

### DIFF
--- a/client/data/dropdown-pages/use-dropdown-pages.ts
+++ b/client/data/dropdown-pages/use-dropdown-pages.ts
@@ -1,7 +1,10 @@
 import { useQuery } from 'react-query';
 import wpcom from 'calypso/lib/wp';
 
-type Response = PageNode[];
+export type DropdownPagesResponse = {
+	found: number;
+	dropdown_pages: PageNode[];
+};
 
 export type PageNode = {
 	ID: number;
@@ -9,10 +12,13 @@ export type PageNode = {
 	children?: PageNode[];
 };
 
-const useDropdownPagesQuery = ( siteId?: number, queryOptions = {} ) => {
-	return useQuery(
+const useDropdownPagesQuery = < TData = DropdownPagesResponse >(
+	siteId?: number,
+	queryOptions = {}
+) => {
+	return useQuery< DropdownPagesResponse, unknown, TData >(
 		[ 'sites', siteId, 'dropdown-pages' ],
-		(): Promise< Response > => wpcom.req.get( `/sites/${ siteId }/dropdown-pages` ),
+		(): Promise< DropdownPagesResponse > => wpcom.req.get( `/sites/${ siteId }/dropdown-pages` ),
 		{
 			enabled: !! siteId,
 			...queryOptions,

--- a/client/my-sites/site-settings/reading-site-settings/YourHomepageDisplaysSetting.tsx
+++ b/client/my-sites/site-settings/reading-site-settings/YourHomepageDisplaysSetting.tsx
@@ -5,7 +5,10 @@ import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormSelect from 'calypso/components/forms/form-select';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
-import useDropdownPagesQuery, { PageNode } from 'calypso/data/dropdown-pages/use-dropdown-pages';
+import useDropdownPagesQuery, {
+	DropdownPagesResponse,
+	PageNode,
+} from 'calypso/data/dropdown-pages/use-dropdown-pages';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 const PAGE_TITLE_DEPTH_PADDING = '—'; // em dash
@@ -36,7 +39,9 @@ const insertPageNodeToDropdownPages = (
 	} );
 };
 
-const toFlatDropdownPages = ( pageNodes: PageNode[] ): DropdownPage[] => {
+const toFlatDropdownPages = ( {
+	dropdown_pages: pageNodes,
+}: DropdownPagesResponse ): DropdownPage[] => {
 	const dropdownPages: DropdownPage[] = [];
 	pageNodes.forEach( ( pageNode ) => {
 		insertPageNodeToDropdownPages( pageNode, dropdownPages );
@@ -66,7 +71,9 @@ const YourHomepageDisplaysSetting = ( {
 }: YourHomepageDisplaysSettingProps ) => {
 	const translate = useTranslate();
 
-	const { data: pages, isLoading } = useDropdownPagesQuery( siteId, {
+	const { data: pages, isLoading } = useDropdownPagesQuery<
+		ReturnType< typeof toFlatDropdownPages >
+	>( siteId, {
 		select: toFlatDropdownPages,
 	} );
 


### PR DESCRIPTION
#### Proposed Changes

* accomadate the new response format of the `GET /sites/$site/dopdown-pages/` api

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply the latest Jetpack trunk to your sandbox
* Sandbox `public-api.wordpress.com`
* Go to `https://wordpress.com/settings/reading/$site` and ensure the options for the **Your homepage displays** select inputs are loaded as expected
![Screen Shot 2023-01-27 at 12 31 45](https://user-images.githubusercontent.com/2019970/215076376-d92219b9-7f36-4812-8136-7d9b177e7faf.png)


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/72655
