### PR TITLE
Removed unneded code in Email Stats

### DIFF
--- a/client/my-sites/stats/stats-email-detail/index.jsx
+++ b/client/my-sites/stats/stats-email-detail/index.jsx
@@ -294,7 +294,6 @@ class StatsEmailDetail extends Component {
 									maxBars={ maxBars }
 								/>
 
-								{ isSitePrivate ? this.renderPrivateSiteBanner( siteId, slug ) : null }
 								{ ! isSitePrivate && <StatsNoContentBanner siteId={ siteId } siteSlug={ slug } /> }
 							</div>
 							<div className="stats__module-list">


### PR DESCRIPTION
#### Proposed Changes

This PR removes unused code from the Email Stats details page

#### Testing Instructions

1. Apply this branch to your local Calypso repository and start the application.
2. Insert manually in the browser address bar an URL with this format: https://calypso.localhost:3000/stats/email/opens/[the-domain-of-your-blog]/day/[post-id]?flags=newsletter/stats.  
3.  Check everything works there (changing from days to hours, arrow previous and arrow next, changing from opens to clicks...)
4. Insert manually in the browser address bar an URL with this format: https://calypso.localhost:3000/stats/day/[the-domain-of-your-blog]?flags=newsletter/stats.
5. Check the two email cards (opens and clicks) still load correctly and goes to the right place when clicked.
