### PR TITLE
Reading Settings: Rename 'Default posts page' default option to 'None'

### DIFF
--- a/client/my-sites/site-settings/reading-site-settings/YourHomepageDisplaysSetting.tsx
+++ b/client/my-sites/site-settings/reading-site-settings/YourHomepageDisplaysSetting.tsx
@@ -1,4 +1,5 @@
-import { localizeUrl } from '@automattic/i18n-utils';
+import { useLocale, localizeUrl } from '@automattic/i18n-utils';
+import { useI18n } from '@wordpress/react-i18n';
 import { useTranslate } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
@@ -64,6 +65,8 @@ const YourHomepageDisplaysSetting = ( {
 	disabled,
 	siteId,
 }: YourHomepageDisplaysSettingProps ) => {
+	const { hasTranslation } = useI18n();
+	const locale = useLocale();
 	const translate = useTranslate();
 
 	const { data: pages, isLoading } = useDropdownPagesQuery( siteId, {
@@ -123,7 +126,11 @@ const YourHomepageDisplaysSetting = ( {
 					value={ page_for_posts }
 					onChange={ handlePageForPostsChange }
 				>
-					<option value="">{ translate( '—— None ——' ) }</option>
+					<option value="">
+						{ locale.startsWith( 'en' ) || hasTranslation( '—— None ——' )
+							? translate( '—— None ——' )
+							: translate( '—— Select ——' ) }
+					</option>
 					{ pages?.map( ( page ) => {
 						return (
 							<option

--- a/client/my-sites/site-settings/reading-site-settings/YourHomepageDisplaysSetting.tsx
+++ b/client/my-sites/site-settings/reading-site-settings/YourHomepageDisplaysSetting.tsx
@@ -123,7 +123,7 @@ const YourHomepageDisplaysSetting = ( {
 					value={ page_for_posts }
 					onChange={ handlePageForPostsChange }
 				>
-					<option value="">{ translate( '—— Select ——' ) }</option>
+					<option value="">{ translate( '—— None ——' ) }</option>
 					{ pages?.map( ( page ) => {
 						return (
 							<option


### PR DESCRIPTION
#### Proposed Changes

* Rename 'Default posts page' default option to 'None'

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `http://calypso.localhost:3000/settings/reading/$site`
* Ensure the default option displays "None" instead of "Select"
![Screen Shot 2023-01-27 at 12 52 13](https://user-images.githubusercontent.com/2019970/215080355-421e6b75-3f5e-409d-aaa5-346e1946a10a.png)


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #72603 
