### PR TITLE
Email stats: Fix wrong label being displayed for Total Opens.

### DIFF
--- a/client/my-sites/stats/stats-email-top-row/index.jsx
+++ b/client/my-sites/stats/stats-email-top-row/index.jsx
@@ -53,7 +53,7 @@ export default function StatsEmailTopRow( { siteId, postId, statType, className 
 					<>
 						<TopCard
 							heading={ translate( 'Total opens' ) }
-							value={ counts?.total_sends ?? 0 }
+							value={ counts?.total_opens ?? 0 }
 							isLoading={ isRequesting && ! counts?.hasOwnProperty( 'total_opens' ) }
 							icon={ <Gridicon icon="mail" /> }
 						/>


### PR DESCRIPTION
#### Proposed Changes

* Fix 0 being displayed for the total numbers of Opens in the Email click stats

<img width="1175" alt="CleanShot 2023-01-27 at 14 52 33@2x" src="https://user-images.githubusercontent.com/528287/215103149-c4d71cf7-1227-413e-b347-d4dc94cfed20.png">


#### Testing Instructions

* Apply this PR
* Visit `http://calypso.localhost:3000/stats/day/<yoursite>?flags=newsletter/stats`
* Click any mail in the Open Clicks panel
* The boxes should be correct

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #72723
