### PR TITLE
Tailored Flows: Remove border from cta

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/setup-form/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/setup-form/style.scss
@@ -76,9 +76,10 @@
 	}
 
 	.setup-form__submit {
-		color: var(--color-surface);
+		border: none;
 		background-color: var(--studio-blue-50);
 		border-radius: 4px;
+		color: var(--color-surface);
 		font-weight: 500;
 		width: 100%;
 		// adds +2 px of padding to the button to match the input field height


### PR DESCRIPTION
#### Proposed Changes

On the Tailored Use Flows (both Newsletter & LIB) remove the same border from the button CTA

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit Live Link
* Go to `[CALYPSO_LIVE_LINK]/setup/link-in-bio/linkInBioSetup` and `[CALYPSO_LIVE_LINK]/setup/newsletter/linkInBioSetup`
* Check the CTA border


Fixes #72715
