### PR TITLE
Theme Preview: Adjust height and scrollbar visibility of the sidebar

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
@@ -655,7 +655,7 @@ $design-button-primary-color: rgb(17, 122, 201);
 
 			.design-preview__sidebar {
 				margin: 72px -16px 0 -8px;
-				padding: 0 16px 96px 8px;
+				padding: 0 16px 32px 8px;
 			}
 		}
 	}

--- a/packages/design-preview/src/components/style-variation-preview.js
+++ b/packages/design-preview/src/components/style-variation-preview.js
@@ -1,4 +1,4 @@
-// This file is a copy of https://github.com/WordPress/gutenberg/blob/7005d47/packages/edit-site/src/components/global-styles/preview.js.
+// This file is a copy of https://github.com/WordPress/gutenberg/blob/8a4916feb4317234d3187435f2286e95a8a95d55/packages/edit-site/src/components/global-styles/preview.js.
 // Customizations are indicated with a "Custom WP.com code" comment.
 //
 // The reason this component is not imported directly from @wordpress/edit-site is that currently Calypso
@@ -106,148 +106,152 @@ const StylesPreview = ( { label, isFocused, withHoverView } ) => {
 
 		return styles;
 	}, [ styles ] );
+	const isReady = !! width;
 
 	return (
-		<Iframe
-			className="edit-site-global-styles-preview__iframe"
-			head={ <EditorStyles styles={ editorStyles } /> }
-			style={ {
-				height: normalizedHeight * ratio,
-				visibility: ! width ? 'hidden' : 'visible',
-			} }
-			onMouseEnter={ () => setIsHovered( true ) }
-			onMouseLeave={ () => setIsHovered( false ) }
-			tabIndex={ -1 }
-		>
-			{ containerResizeListener }
-			<motion.div
-				style={ {
-					height: normalizedHeight * ratio,
-					width: '100%',
-					background: gradientValue ?? backgroundColor,
-					cursor: 'pointer',
-				} }
-				initial="start"
-				animate={ ( isHovered || isFocused ) && ! disableMotion && label ? 'hover' : 'start' }
-			>
-				<motion.div
-					variants={ firstFrame }
+		<>
+			<div style={ { position: 'relative' } }>{ containerResizeListener }</div>
+			{ isReady && (
+				<Iframe
+					className="edit-site-global-styles-preview__iframe"
+					head={ <EditorStyles styles={ editorStyles } /> }
 					style={ {
-						height: '100%',
-						overflow: 'hidden',
+						height: normalizedHeight * ratio,
 					} }
+					onMouseEnter={ () => setIsHovered( true ) }
+					onMouseLeave={ () => setIsHovered( false ) }
+					tabIndex={ -1 }
 				>
-					<HStack
-						spacing={ 10 * ratio }
-						justify="center"
+					<motion.div
 						style={ {
-							height: '100%',
-							overflow: 'hidden',
+							height: normalizedHeight * ratio,
+							width: '100%',
+							background: gradientValue ?? backgroundColor,
+							cursor: 'pointer',
 						} }
+						initial="start"
+						animate={ ( isHovered || isFocused ) && ! disableMotion && label ? 'hover' : 'start' }
 					>
 						<motion.div
+							variants={ firstFrame }
 							style={ {
-								fontFamily: headingFontFamily,
-								fontSize: 65 * ratio,
-								color: headingColor,
-								fontWeight: headingFontWeight,
+								height: '100%',
+								overflow: 'hidden',
 							} }
-							animate={ { scale: 1, opacity: 1 } }
-							initial={ { scale: 0.1, opacity: 0 } }
-							transition={ { delay: 0.3, type: 'tween' } }
 						>
-							Aa
-						</motion.div>
-						<VStack spacing={ 4 * ratio }>
-							{ highlightedColors.map( ( { slug, color }, index ) => (
+							<HStack
+								spacing={ 10 * ratio }
+								justify="center"
+								style={ {
+									height: '100%',
+									overflow: 'hidden',
+								} }
+							>
 								<motion.div
-									key={ slug }
 									style={ {
-										height: normalizedColorSwatchSize * ratio,
-										width: normalizedColorSwatchSize * ratio,
-										background: color,
-										borderRadius: ( normalizedColorSwatchSize * ratio ) / 2,
+										fontFamily: headingFontFamily,
+										fontSize: 65 * ratio,
+										color: headingColor,
+										fontWeight: headingFontWeight,
 									} }
 									animate={ { scale: 1, opacity: 1 } }
 									initial={ { scale: 0.1, opacity: 0 } }
-									transition={ {
-										delay: index === 1 ? 0.2 : 0.1,
-									} }
-								/>
-							) ) }
-						</VStack>
-					</HStack>
-				</motion.div>
-				<motion.div
-					variants={ withHoverView && midFrame }
-					style={ {
-						height: '100%',
-						width: '100%',
-						position: 'absolute',
-						top: 0,
-						overflow: 'hidden',
-						filter: 'blur(60px)',
-						opacity: 0.1,
-					} }
-				>
-					<HStack
-						spacing={ 0 }
-						justify="flex-start"
-						style={ {
-							height: '100%',
-							overflow: 'hidden',
-						} }
-					>
-						{ paletteColors.slice( 0, 4 ).map( ( { color }, index ) => (
-							<div
-								key={ index }
+									transition={ { delay: 0.3, type: 'tween' } }
+								>
+									Aa
+								</motion.div>
+								<VStack spacing={ 4 * ratio }>
+									{ highlightedColors.map( ( { slug, color }, index ) => (
+										<motion.div
+											key={ slug }
+											style={ {
+												height: normalizedColorSwatchSize * ratio,
+												width: normalizedColorSwatchSize * ratio,
+												background: color,
+												borderRadius: ( normalizedColorSwatchSize * ratio ) / 2,
+											} }
+											animate={ { scale: 1, opacity: 1 } }
+											initial={ { scale: 0.1, opacity: 0 } }
+											transition={ {
+												delay: index === 1 ? 0.2 : 0.1,
+											} }
+										/>
+									) ) }
+								</VStack>
+							</HStack>
+						</motion.div>
+						<motion.div
+							variants={ withHoverView && midFrame }
+							style={ {
+								height: '100%',
+								width: '100%',
+								position: 'absolute',
+								top: 0,
+								overflow: 'hidden',
+								filter: 'blur(60px)',
+								opacity: 0.1,
+							} }
+						>
+							<HStack
+								spacing={ 0 }
+								justify="flex-start"
 								style={ {
 									height: '100%',
-									background: color,
-									flexGrow: 1,
-								} }
-							/>
-						) ) }
-					</HStack>
-				</motion.div>
-				<motion.div
-					variants={ secondFrame }
-					style={ {
-						height: '100%',
-						width: '100%',
-						overflow: 'hidden',
-						position: 'absolute',
-						top: 0,
-					} }
-				>
-					<VStack
-						spacing={ 3 * ratio }
-						justify="center"
-						style={ {
-							height: '100%',
-							overflow: 'hidden',
-							padding: 10 * ratio,
-							boxSizing: 'border-box',
-						} }
-					>
-						{ label && (
-							<div
-								style={ {
-									fontSize: 40 * ratio,
-									fontFamily: headingFontFamily,
-									color: headingColor,
-									fontWeight: headingFontWeight,
-									lineHeight: '1em',
-									textAlign: 'center',
+									overflow: 'hidden',
 								} }
 							>
-								{ label }
-							</div>
-						) }
-					</VStack>
-				</motion.div>
-			</motion.div>
-		</Iframe>
+								{ paletteColors.slice( 0, 4 ).map( ( { color }, index ) => (
+									<div
+										key={ index }
+										style={ {
+											height: '100%',
+											background: color,
+											flexGrow: 1,
+										} }
+									/>
+								) ) }
+							</HStack>
+						</motion.div>
+						<motion.div
+							variants={ secondFrame }
+							style={ {
+								height: '100%',
+								width: '100%',
+								overflow: 'hidden',
+								position: 'absolute',
+								top: 0,
+							} }
+						>
+							<VStack
+								spacing={ 3 * ratio }
+								justify="center"
+								style={ {
+									height: '100%',
+									overflow: 'hidden',
+									padding: 10 * ratio,
+									boxSizing: 'border-box',
+								} }
+							>
+								{ label && (
+									<div
+										style={ {
+											fontSize: 40 * ratio,
+											fontFamily: headingFontFamily,
+											color: headingColor,
+											fontWeight: headingFontWeight,
+											lineHeight: '1em',
+											textAlign: 'center',
+										} }
+									>
+										{ label }
+									</div>
+								) }
+							</VStack>
+						</motion.div>
+					</motion.div>
+				</Iframe>
+			) }
+		</>
 	);
 };
 

--- a/packages/design-preview/src/components/style-variation-preview.js
+++ b/packages/design-preview/src/components/style-variation-preview.js
@@ -1,5 +1,5 @@
-// This file is a copy of the Gutenberg file packages/edit-site/src/components/global-styles/preview.js (7005d47).
-// The only changes made are the internal depedency import paths.
+// This file is a copy of https://github.com/WordPress/gutenberg/blob/7005d47/packages/edit-site/src/components/global-styles/preview.js.
+// Customizations are indicated with a "Custom WP.com code" comment.
 //
 // The reason this component is not imported directly from @wordpress/edit-site is that currently Calypso
 // uses version 4.6.0. Updating @wordpress/edit-site affects other packages which also depends on 4.6.0.
@@ -96,7 +96,9 @@ const StylesPreview = ( { label, isFocused, withHoverView } ) => {
 			return [
 				...styles,
 				{
-					css: 'html{overflow:hidden}body{min-width: 0;padding: 0;border: none;}',
+					// Custom WP.com code - START.
+					css: 'html{overflow:hidden}body{min-width: 0;padding: 0;border: none;transform:scale(1);}',
+					// Custom WP.com code - END.
 					isGlobalStyles: true,
 				},
 			];

--- a/packages/design-preview/src/components/style.scss
+++ b/packages/design-preview/src/components/style.scss
@@ -276,13 +276,7 @@
 		box-shadow: 0 0 0 1px rgb(0 0 0 / 10%);
 		border: 0;
 		display: block;
-		max-height: 61.2903px;
 		max-width: 100%;
-		overflow: hidden;
-
-		@include break-xlarge {
-			max-height: 77.2258px;
-		}
 	}
 
 	.design-picker__premium-badge {

--- a/packages/design-preview/src/components/style.scss
+++ b/packages/design-preview/src/components/style.scss
@@ -62,8 +62,7 @@
 		border: 0;
 		box-shadow: none;
 		display: block;
-		height: 100%;
-		overflow: scroll;
+		height: auto;
 		padding: 0;
 		position: relative;
 		width: 311px;


### PR DESCRIPTION
#### Proposed Changes

* Adjust the height and scrollbar visibility of the Theme Preview sidebar.

This prevents showing an empty scrollbar even when unnecessary, and over-extending the sidebar height below the bottom edge of the screen.

cc @taipeicoder: this has been tested in the onboarding, but I'm not quite sure how to check other usages of the Theme Preview. The code suggests that the sidebar has slightly different styles, so I'd rather have a check from y'all.

| | Before | After |
| - | - | - |
| Full height<br>(note the empty scrollbar) | <img width="340" alt="Screenshot 2023-01-27 at 15 24 20" src="https://user-images.githubusercontent.com/2070010/215125373-a0233d97-817a-48df-a95f-91f1dcdd72fe.png"> | <img width="343" alt="Screenshot 2023-01-27 at 15 23 59" src="https://user-images.githubusercontent.com/2070010/215125406-a737d331-73e0-46f2-8f36-6e1dadd4d4b3.png"> |
| Short height, scrolled to top | <img width="339" alt="Screenshot 2023-01-27 at 15 25 22" src="https://user-images.githubusercontent.com/2070010/215125572-103e1c99-fd65-45a3-ab18-c0c3c5adb63b.png"> | <img width="341" alt="Screenshot 2023-01-27 at 15 23 46" src="https://user-images.githubusercontent.com/2070010/215125925-699aa8df-a22e-47dd-b7a1-9d93b7c61962.png"> |
| Short height, scrolled to bottom<br>(note cut-off scrollbar) | <img width="339" alt="Screenshot 2023-01-27 at 15 25 29" src="https://user-images.githubusercontent.com/2070010/215125595-cff4982e-da48-499d-9292-b083e2fc4461.png"> |<img width="339" alt="Screenshot 2023-01-27 at 15 23 51" src="https://user-images.githubusercontent.com/2070010/215125972-5cbdf2f6-7f36-4436-999b-7cae5cf98bd9.png"> |

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* To reproduce the scrollbar behaviour on MacOS 13:
  * System Settings -> Appearance -> Show scroll bars.
  * (Older versions of MacOS have different settings categories, but the option is there!)
* Head to the design picker `setup/site-setup/designSetup?siteSlug=${site_slug}`.
* Click on any theme that has a lot of style variations, such as Pixl or Twenty Twenty-Three.
* Check that the scrollbar is not visible when the screen height has room for all style variations.
* Resize the browser's height until the sidebar overflow.
* Ensure that the scrollbar appears and it works as expected.
* Ensure that, when scrolled to the bottom, the element does not extend below the browser's bottom border.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/71970
Fixes https://github.com/Automattic/wp-calypso/issues/71874
