### PR TITLE
Update site editor nav sidebar dashboard link hostname

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/class-wpcom-block-editor-nav-sidebar.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/class-wpcom-block-editor-nav-sidebar.php
@@ -95,7 +95,8 @@ class WPCOM_Block_Editor_Nav_Sidebar {
 	 */
 	public function add_wpcom_dashboard_link( $settings ) {
 		$site_slug                               = preg_replace( '|^https?:\/\/|', '', home_url() );
-		$settings['__experimentalDashboardLink'] = 'https://wordpress.com/home/' . $site_slug;
+		$site_hostname                           = ! empty( $_GET['origin'] ) ? $_GET['origin'] : 'https://wordpress.com'; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$settings['__experimentalDashboardLink'] = $site_hostname . '/home/' . $site_slug;
 		return $settings;
 	}
 }


### PR DESCRIPTION
#### Testing/Reviewing estimation

Test: Medium
Review: Short

#### Proposed Changes

* Updates the site-editor sidebar dashboard link to redirect back to Calypso home in the correct environment.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this branch
* Sandbox public api and a WordPress site
* Navigate to Calypso `apps/editing-toolkit/` directory and execute: `yarn dev --sync`
* Navigate to `wordpress.com/site-editor/{siteSlug}`. Click the site-editor navbar dashboard link and verify it navigates you back to `wordpress.com/home/{siteSlug}`.
* Repeat the step above for `horizon.wordpress.com/site-editor/{siteSlug}` and `calypso.localhost:3000/site-editor/{siteSlug}`. Verify that you navigated back to Calypso home in the correct environment.
* Follow the instructions to upload the ETK plugin to your atomic site: PCYsg-ly5-p2 and repeat the steps above.

![image](https://user-images.githubusercontent.com/10482592/215141223-cd2e1ded-a721-4b39-b2ac-f8879ea13bce.png)


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #