### PR TITLE
Added info message about email data not available

### DIFF
--- a/client/my-sites/stats/stats-email-detail/index.jsx
+++ b/client/my-sites/stats/stats-email-detail/index.jsx
@@ -2,6 +2,7 @@ import { getUrlParts } from '@automattic/calypso-url';
 import { Spinner } from '@automattic/components';
 import { localize, translate } from 'i18n-calypso';
 import { find, flowRight } from 'lodash';
+import moment from 'moment';
 import page from 'page';
 import PropTypes from 'prop-types';
 import { parse as parseQs, stringify as stringifyQs } from 'qs';
@@ -178,6 +179,7 @@ class StatsEmailDetail extends Component {
 			post,
 			statType,
 			hasValidDate,
+			showNoDataInfo,
 		} = this.props;
 		const { maxBars } = this.state;
 
@@ -278,6 +280,11 @@ class StatsEmailDetail extends Component {
 									/>
 								</StatsPeriodHeader>
 
+								{ showNoDataInfo && (
+									<div className="no-data">
+										{ translate( '⚠️ There is no data before 2022-11-24 for the email stats' ) }
+									</div>
+								) }
 								<ChartTabs
 									activeTab={ getActiveTab( this.props.chartTab, statType ) }
 									activeLegend={ this.state.activeLegend }
@@ -358,6 +365,8 @@ const connectComponent = connect(
 			hasValidDate,
 		} = getPeriodWithFallback( ownProps.period, ownProps.date, isValidStartDate, post?.date );
 
+		const showNoDataInfo = moment( date ).isBefore( moment( '2022-11-24' ) );
+
 		return {
 			countViews: getEmailStat( state, siteId, postId, period, statType ),
 			isRequestingStats: isRequestingEmailStats(
@@ -376,6 +385,7 @@ const connectComponent = connect(
 			period: { period, endOf },
 			date,
 			hasValidDate,
+			showNoDataInfo,
 		};
 	},
 	{ recordGoogleEvent }

--- a/client/my-sites/stats/stats-email-detail/style.scss
+++ b/client/my-sites/stats/stats-email-detail/style.scss
@@ -4,6 +4,10 @@ $break-large-stats-countries: 1280px;
 
 // Countries
 .stats__email-detail {
+	.no-data {
+		text-align: center;
+	}
+
 	.section-nav {
 		box-shadow: inset 0 -1px 0 #0000000d;
 		margin-bottom: 16px;


### PR DESCRIPTION
#### Proposed Changes

The data transformation for the email stats started on 2022-11-24. Before that date there is no data.

This PR adds a message about the lack of data if the user selects a date before 2022-11-24.

#### Testing Instructions

1. Apply this branch to your local Calypso repository and start the application.
2. Insert manually in the browser address bar an URL with this format: https://calypso.localhost:3000/stats/email/opens/[the-domain-of-your-blog]/day/[post-id]?flags=newsletter/stats.  
3. Click the left arrow in the chart until the selected date is before 2022-11-24. When that happens, you should see a message like this one:

<img width="1144" alt="Screenshot 2023-01-27 at 17 15 53" src="https://user-images.githubusercontent.com/3832570/215138515-c840c4ef-cf0e-4d10-a72b-78f31e86f3ee.png">

Related to https://github.com/Automattic/wp-calypso/issues/72434
