### PR TITLE
Checkout: Add "Address for VAT" field to VatForm

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/vat-form/index.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/vat-form/index.tsx
@@ -233,7 +233,7 @@ export function VatForm( {
 					} }
 				/>
 			</div>
-			<div className="vat-form__row">
+			<div className="vat-form__row vat-form__row--full-width">
 				<Field
 					id={ section + '-address' }
 					type="text"

--- a/client/my-sites/checkout/composite-checkout/components/vat-form/index.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/vat-form/index.tsx
@@ -233,6 +233,22 @@ export function VatForm( {
 					} }
 				/>
 			</div>
+			<div className="vat-form__row">
+				<Field
+					id={ section + '-address' }
+					type="text"
+					label={ String( translate( 'Address for VAT' ) ) }
+					value={ vatDetailsInForm.address ?? '' }
+					autoComplete="address"
+					disabled={ isDisabled }
+					onChange={ ( newValue: string ) => {
+						setVatDetailsInForm( {
+							...vatDetailsInForm,
+							address: newValue,
+						} );
+					} }
+				/>
+			</div>
 			{ vatDetailsFromServer.id && (
 				<div>
 					<FormSettingExplanation>

--- a/client/my-sites/checkout/composite-checkout/components/vat-form/style.css
+++ b/client/my-sites/checkout/composite-checkout/components/vat-form/style.css
@@ -9,3 +9,6 @@
 	margin-top: 16px;
 }
 
+.vat-form__row--full-width {
+	display: block;
+}

--- a/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts
@@ -99,7 +99,8 @@ export function createTransactionEndpointCartFromResponseCart( {
 function createTransactionEndpointTaxFromResponseCartTax(
 	tax: ResponseCartTaxData
 ): RequestCartTaxData {
-	const { country_code, postal_code, subdivision_code, vat_id, organization } = tax.location;
+	const { country_code, postal_code, subdivision_code, vat_id, organization, address } =
+		tax.location;
 	return {
 		location: {
 			country_code,
@@ -107,6 +108,7 @@ function createTransactionEndpointTaxFromResponseCartTax(
 			subdivision_code,
 			vat_id,
 			organization,
+			address,
 		},
 	};
 }

--- a/client/my-sites/checkout/composite-checkout/lib/update-cart-contact-details-for-checkout.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/update-cart-contact-details-for-checkout.ts
@@ -42,5 +42,6 @@ export async function updateCartContactDetailsForCheckout(
 		subdivisionCode,
 		vatId: vatDetails.id ?? '',
 		organization: vatDetails.name ?? '',
+		address: vatDetails.address ?? '',
 	} );
 }

--- a/client/my-sites/checkout/composite-checkout/test/checkout-contact-step.js
+++ b/client/my-sites/checkout/composite-checkout/test/checkout-contact-step.js
@@ -753,6 +753,7 @@ describe( 'Checkout contact step', () => {
 	it( 'does not send VAT data to the shopping-cart endpoint when completing the step if the box is not checked', async () => {
 		const vatId = '12345';
 		const vatName = 'Test company';
+		const vatAddress = '123 Main Street';
 		const countryCode = 'GB';
 		const postalCode = 'NW1 4NP';
 		mockSetVatInfoEndpoint();
@@ -771,6 +772,7 @@ describe( 'Checkout contact step', () => {
 		// Fill in the details
 		await user.type( await screen.findByLabelText( 'VAT Number' ), vatId );
 		await user.type( await screen.findByLabelText( 'Organization for VAT' ), vatName );
+		await user.type( await screen.findByLabelText( 'Address for VAT' ), vatAddress );
 
 		// Uncheck the box
 		await user.click( await screen.findByLabelText( 'Add VAT details' ) );
@@ -790,6 +792,7 @@ describe( 'Checkout contact step', () => {
 	it( 'does not send VAT data to the shopping-cart endpoint when completing the step if the box is checked but the country no longer supports VAT', async () => {
 		const vatId = '12345';
 		const vatName = 'Test company';
+		const vatAddress = '123 Main Street';
 		const countryCode = 'GB';
 		const nonVatCountryCode = 'US';
 		const postalCode = 'NW1 4NP';
@@ -809,6 +812,7 @@ describe( 'Checkout contact step', () => {
 		// Fill in the details
 		await user.type( await screen.findByLabelText( 'VAT Number' ), vatId );
 		await user.type( await screen.findByLabelText( 'Organization for VAT' ), vatName );
+		await user.type( await screen.findByLabelText( 'Address for VAT' ), vatAddress );
 
 		// Change the country to one that does not support VAT
 		await user.selectOptions( await screen.findByLabelText( 'Country' ), nonVatCountryCode );

--- a/client/my-sites/checkout/composite-checkout/test/checkout-contact-step.js
+++ b/client/my-sites/checkout/composite-checkout/test/checkout-contact-step.js
@@ -534,6 +534,7 @@ describe( 'Checkout contact step', () => {
 		mockGetVatInfoEndpoint( {
 			id: '12345',
 			name: 'Test company',
+			address: '123 Main Street',
 			country: 'GB',
 		} );
 		const cartChanges = { products: [ planWithoutDomain ] };
@@ -554,6 +555,7 @@ describe( 'Checkout contact step', () => {
 			country_code: 'GB',
 			postal_code: '',
 			address: '123 Main Street',
+			country: 'GB',
 		} );
 		mockContactDetailsValidationEndpoint( 'tax', { success: false, messages: [ 'Invalid' ] } );
 		mockGetVatInfoEndpoint( {

--- a/client/my-sites/checkout/composite-checkout/test/checkout-contact-step.js
+++ b/client/my-sites/checkout/composite-checkout/test/checkout-contact-step.js
@@ -554,13 +554,12 @@ describe( 'Checkout contact step', () => {
 		mockCachedContactDetailsEndpoint( {
 			country_code: 'GB',
 			postal_code: '',
-			address: '123 Main Street',
-			country: 'GB',
 		} );
 		mockContactDetailsValidationEndpoint( 'tax', { success: false, messages: [ 'Invalid' ] } );
 		mockGetVatInfoEndpoint( {
 			id: '12345',
 			name: 'Test company',
+			address: '123 Main Street',
 			country: 'GB',
 		} );
 		const cartChanges = { products: [ planWithoutDomain ] };
@@ -615,10 +614,12 @@ describe( 'Checkout contact step', () => {
 		mockContactDetailsValidationEndpoint( 'tax', { success: false, messages: [ 'Invalid' ] } );
 		const vatId = '12345';
 		const vatName = 'Test company';
+		const vatAddress = '123 Main Street';
 		const countryCode = 'GB';
 		mockGetVatInfoEndpoint( {
 			id: vatId,
 			name: vatName,
+			address: vatAddress,
 			country: countryCode,
 		} );
 		const user = userEvent.setup();
@@ -634,6 +635,7 @@ describe( 'Checkout contact step', () => {
 		expect( await screen.findByLabelText( 'Add VAT details' ) ).toBeChecked();
 		expect( await screen.findByLabelText( 'VAT Number' ) ).toHaveValue( vatId );
 		expect( await screen.findByLabelText( 'Organization for VAT' ) ).toHaveValue( vatName );
+		expect( await screen.findByLabelText( 'Address for VAT' ) ).toHaveValue( vatAddress );
 
 		mockContactDetailsValidationEndpoint( 'tax', { success: true } );
 		const mockVatEndpoint = mockSetVatInfoEndpoint();
@@ -645,6 +647,7 @@ describe( 'Checkout contact step', () => {
 		expect( mockVatEndpoint ).toHaveBeenCalledWith( {
 			id: vatId,
 			name: vatName,
+			address: vatAddress,
 			country: cachedContactCountry,
 		} );
 	} );
@@ -705,6 +708,7 @@ describe( 'Checkout contact step', () => {
 	it( 'sends VAT data to the shopping-cart endpoint when completing the step if the box is checked', async () => {
 		const vatId = '12345';
 		const vatName = 'Test company';
+		const vatAddress = '123 Main Street';
 		const countryCode = 'GB';
 		const postalCode = 'NW1 4NP';
 		mockSetVatInfoEndpoint();
@@ -723,6 +727,7 @@ describe( 'Checkout contact step', () => {
 		// Fill in the details
 		await user.type( await screen.findByLabelText( 'VAT Number' ), vatId );
 		await user.type( await screen.findByLabelText( 'Organization for VAT' ), vatName );
+		await user.type( await screen.findByLabelText( 'Address for VAT' ), vatAddress );
 
 		await user.click( screen.getByText( 'Continue' ) );
 		expect( await screen.findByTestId( 'payment-method-step--visible' ) ).toBeInTheDocument();
@@ -738,6 +743,7 @@ describe( 'Checkout contact step', () => {
 						subdivision_code: undefined,
 						vat_id: vatId,
 						organization: vatName,
+						address: vatAddress,
 					},
 				},
 			} )

--- a/client/my-sites/checkout/composite-checkout/test/checkout-contact-step.js
+++ b/client/my-sites/checkout/composite-checkout/test/checkout-contact-step.js
@@ -242,9 +242,7 @@ describe( 'Checkout contact step', () => {
 
 		// Validate that fields are pre-filled
 		expect( countryField.selectedOptions[ 0 ].value ).toBe( 'US' );
-
-		// Wait for the validation to complete.
-		await screen.findAllByText( 'Please wait…' );
+		expect( await screen.findByLabelText( 'Postal code' ) ).toHaveValue( '10001' );
 
 		expect( await screen.findByTestId( 'payment-method-step--visible' ) ).toBeInTheDocument();
 	} );

--- a/client/my-sites/checkout/composite-checkout/test/checkout-contact-step.js
+++ b/client/my-sites/checkout/composite-checkout/test/checkout-contact-step.js
@@ -553,6 +553,7 @@ describe( 'Checkout contact step', () => {
 		mockCachedContactDetailsEndpoint( {
 			country_code: 'GB',
 			postal_code: '',
+			address: '123 Main Street',
 		} );
 		mockContactDetailsValidationEndpoint( 'tax', { success: false, messages: [ 'Invalid' ] } );
 		mockGetVatInfoEndpoint( {
@@ -570,11 +571,13 @@ describe( 'Checkout contact step', () => {
 		expect( countryField.selectedOptions[ 0 ].value ).toBe( 'GB' );
 		expect( await screen.findByLabelText( 'VAT Number' ) ).toHaveValue( '12345' );
 		expect( await screen.findByLabelText( 'Organization for VAT' ) ).toHaveValue( 'Test company' );
+		expect( await screen.findByLabelText( 'Address for VAT' ) ).toHaveValue( '123 Main Street' );
 	} );
 
 	it( 'sends data to the VAT endpoint when completing the step if the box is checked', async () => {
 		const vatId = '12345';
 		const vatName = 'Test company';
+		const vatAddress = '123 Main Street';
 		const countryCode = 'GB';
 		const mockVatEndpoint = mockSetVatInfoEndpoint();
 		mockContactDetailsValidationEndpoint( 'tax', { success: true } );
@@ -589,12 +592,14 @@ describe( 'Checkout contact step', () => {
 		await user.click( await screen.findByLabelText( 'Add VAT details' ) );
 		await user.type( await screen.findByLabelText( 'VAT Number' ), vatId );
 		await user.type( await screen.findByLabelText( 'Organization for VAT' ), vatName );
+		await user.type( await screen.findByLabelText( 'Address for VAT' ), vatAddress );
 		await user.click( screen.getByText( 'Continue' ) );
 		expect( await screen.findByTestId( 'payment-method-step--visible' ) ).toBeInTheDocument();
 		expect( mockVatEndpoint ).toHaveBeenCalledWith( {
 			id: vatId,
 			name: vatName,
 			country: countryCode,
+			address: vatAddress,
 		} );
 	} );
 
@@ -645,6 +650,7 @@ describe( 'Checkout contact step', () => {
 	it( 'sends data to the VAT endpoint with Northern Ireland country code when completing the step if the XI box is checked', async () => {
 		const vatId = '12345';
 		const vatName = 'Test company';
+		const vatAddress = '123 Main Street';
 		const countryCode = 'GB';
 		const mockVatEndpoint = mockSetVatInfoEndpoint();
 		mockContactDetailsValidationEndpoint( 'tax', { success: true } );
@@ -656,11 +662,13 @@ describe( 'Checkout contact step', () => {
 		await user.click( await screen.findByLabelText( 'Is the VAT for Northern Ireland?' ) );
 		await user.type( await screen.findByLabelText( 'VAT Number' ), vatId );
 		await user.type( await screen.findByLabelText( 'Organization for VAT' ), vatName );
+		await user.type( await screen.findByLabelText( 'Address for VAT' ), vatAddress );
 		await user.click( screen.getByText( 'Continue' ) );
 		expect( await screen.findByTestId( 'payment-method-step--visible' ) ).toBeInTheDocument();
 		expect( mockVatEndpoint ).toHaveBeenCalledWith( {
 			id: vatId,
 			name: vatName,
+			address: vatAddress,
 			country: 'XI',
 		} );
 	} );
@@ -668,6 +676,7 @@ describe( 'Checkout contact step', () => {
 	it( 'does not send data to the VAT endpoint when completing the step if the box is not checked', async () => {
 		const vatId = '12345';
 		const vatName = 'Test company';
+		const vatAddress = '123 Main Street';
 		const countryCode = 'GB';
 		const mockVatEndpoint = mockSetVatInfoEndpoint();
 		mockContactDetailsValidationEndpoint( 'tax', { success: true } );
@@ -681,6 +690,7 @@ describe( 'Checkout contact step', () => {
 		// Fill in the details
 		await user.type( await screen.findByLabelText( 'VAT Number' ), vatId );
 		await user.type( await screen.findByLabelText( 'Organization for VAT' ), vatName );
+		await user.type( await screen.findByLabelText( 'Address for VAT' ), vatAddress );
 
 		// Uncheck the box
 		await user.click( await screen.findByLabelText( 'Add VAT details' ) );
@@ -810,6 +820,7 @@ describe( 'Checkout contact step', () => {
 	it( 'does not complete the step if the VAT endpoint returns an error', async () => {
 		const vatId = '12345';
 		const vatName = 'Test company';
+		const vatAddress = '123 Main Street';
 		const countryCode = 'GB';
 		nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/me/vat-info' ).reply( 400 );
 		mockContactDetailsValidationEndpoint( 'tax', { success: true } );
@@ -820,6 +831,7 @@ describe( 'Checkout contact step', () => {
 		await user.click( await screen.findByLabelText( 'Add VAT details' ) );
 		await user.type( await screen.findByLabelText( 'VAT Number' ), vatId );
 		await user.type( await screen.findByLabelText( 'Organization for VAT' ), vatName );
+		await user.type( await screen.findByLabelText( 'Address for VAT' ), vatAddress );
 		await user.click( screen.getByText( 'Continue' ) );
 		await expect( screen.findByTestId( 'payment-method-step--visible' ) ).toNeverAppear();
 	} );

--- a/packages/shopping-cart/src/cart-functions.ts
+++ b/packages/shopping-cart/src/cart-functions.ts
@@ -40,7 +40,8 @@ export function convertResponseCartToRequestCart( {
 		tax.location.postal_code ||
 		tax.location.subdivision_code ||
 		tax.location.vat_id ||
-		tax.location.organization
+		tax.location.organization ||
+		tax.location.address
 	) {
 		requestCartTax = {
 			location: {
@@ -49,6 +50,7 @@ export function convertResponseCartToRequestCart( {
 				subdivision_code: tax.location.subdivision_code,
 				vat_id: tax.location.vat_id,
 				organization: tax.location.organization,
+				address: tax.location.address,
 			},
 		};
 	}
@@ -118,6 +120,7 @@ export function addLocationToResponseCart(
 				subdivision_code: location.subdivisionCode || undefined,
 				vat_id: location.vatId || undefined,
 				organization: location.organization || undefined,
+				address: location.address || undefined,
 			},
 		},
 	};
@@ -133,6 +136,7 @@ export function doesCartLocationDifferFromResponseCartLocation(
 		subdivisionCode: newSubdivisionCode = '',
 		vatId: newVatId = '',
 		organization: newOrganization = '',
+		address: newAddress = '',
 	} = location;
 	const {
 		country_code: oldCountryCode = '',
@@ -140,6 +144,7 @@ export function doesCartLocationDifferFromResponseCartLocation(
 		subdivision_code: oldSubdivisionCode = '',
 		vat_id: oldVatId = '',
 		organization: oldOrganization = '',
+		address: oldAddress = '',
 	} = cart.tax?.location ?? {};
 
 	if ( location.countryCode !== undefined && newCountryCode !== oldCountryCode ) {
@@ -155,6 +160,9 @@ export function doesCartLocationDifferFromResponseCartLocation(
 		return true;
 	}
 	if ( location.organization !== undefined && newOrganization !== oldOrganization ) {
+		return true;
+	}
+	if ( location.address !== undefined && newAddress !== oldAddress ) {
 		return true;
 	}
 	return false;

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -206,6 +206,7 @@ export type RequestCartTaxData = null | {
 		subdivision_code: string | undefined;
 		vat_id?: string;
 		organization?: string;
+		address?: string;
 	};
 };
 
@@ -315,6 +316,7 @@ export interface ResponseCartTaxData {
 		subdivision_code?: string;
 		vat_id?: string;
 		organization?: string;
+		address?: string;
 	};
 	display_taxes: boolean;
 }
@@ -528,6 +530,7 @@ export interface CartLocation {
 	subdivisionCode?: string;
 	vatId?: string;
 	organization?: string;
+	address?: string;
 }
 
 export interface ResponseCartProductExtra {

--- a/packages/shopping-cart/test/shopping-cart-endpoint.js
+++ b/packages/shopping-cart/test/shopping-cart-endpoint.js
@@ -87,6 +87,7 @@ describe( 'addLocationToResponseCart', function () {
 			subdivision_code: undefined,
 			vat_id: undefined,
 			organization: undefined,
+			address: undefined,
 		} );
 	} );
 	it( 'resets existing codes not replaced', function () {
@@ -100,6 +101,7 @@ describe( 'addLocationToResponseCart', function () {
 			subdivision_code: undefined,
 			vat_id: undefined,
 			organization: undefined,
+			address: undefined,
 		} );
 	} );
 	it( 'adds the new location postalCode if set', function () {
@@ -110,6 +112,7 @@ describe( 'addLocationToResponseCart', function () {
 			subdivision_code: undefined,
 			vat_id: undefined,
 			organization: undefined,
+			address: undefined,
 		} );
 	} );
 	it( 'adds the new location subdivisionCode if set', function () {
@@ -120,6 +123,7 @@ describe( 'addLocationToResponseCart', function () {
 			subdivision_code: 'CA',
 			vat_id: undefined,
 			organization: undefined,
+			address: undefined,
 		} );
 	} );
 	it( 'adds the new location vatId if set', function () {
@@ -129,6 +133,7 @@ describe( 'addLocationToResponseCart', function () {
 			postal_code: undefined,
 			vat_id: '123456',
 			organization: undefined,
+			address: undefined,
 		} );
 	} );
 	it( 'adds the new location organization if set', function () {
@@ -138,6 +143,17 @@ describe( 'addLocationToResponseCart', function () {
 			postal_code: undefined,
 			vat_id: undefined,
 			organization: 'Test Co.',
+			address: undefined,
+		} );
+	} );
+	it( 'adds the new location address if set', function () {
+		const result = addLocationToResponseCart( cart, { address: '432 Foo bar' } );
+		expect( result.tax.location ).toEqual( {
+			country_code: undefined,
+			postal_code: undefined,
+			vat_id: undefined,
+			organization: undefined,
+			address: '432 Foo bar',
 		} );
 	} );
 	it( 'adds all new location codes if set', function () {
@@ -147,6 +163,7 @@ describe( 'addLocationToResponseCart', function () {
 			countryCode: 'US',
 			vatId: '12345',
 			organization: 'Test Co.',
+			address: undefined,
 		} );
 		expect( result.tax.location ).toEqual( {
 			country_code: 'US',
@@ -154,6 +171,7 @@ describe( 'addLocationToResponseCart', function () {
 			subdivision_code: 'CA',
 			vat_id: '12345',
 			organization: 'Test Co.',
+			address: undefined,
 		} );
 	} );
 	it( 'resets all codes when no codes are set', function () {
@@ -178,6 +196,7 @@ describe( 'addLocationToResponseCart', function () {
 			subdivision_code: undefined,
 			vat_id: undefined,
 			organization: undefined,
+			address: undefined,
 		} );
 	} );
 } );
@@ -194,6 +213,7 @@ describe( 'doesCartLocationDifferFromResponseCartLocation', function () {
 				postal_code: '90210',
 				vat_id: '12345',
 				organization: 'Test Co.',
+				address: '1555 Main street',
 			},
 		},
 	};
@@ -205,6 +225,7 @@ describe( 'doesCartLocationDifferFromResponseCartLocation', function () {
 			postalCode: '',
 			vatId: '',
 			organization: '',
+			address: '',
 		} );
 		expect( result ).toBe( true );
 	} );
@@ -215,6 +236,7 @@ describe( 'doesCartLocationDifferFromResponseCartLocation', function () {
 			postalCode: '90210',
 			vatId: '12345',
 			organization: 'Test Co.',
+			address: '1555 Main street',
 		} );
 		expect( result ).toBe( true );
 	} );
@@ -225,6 +247,7 @@ describe( 'doesCartLocationDifferFromResponseCartLocation', function () {
 			postalCode: '10001',
 			vatId: '12345',
 			organization: 'Test Co.',
+			address: '1555 Main street',
 		} );
 		expect( result ).toBe( true );
 	} );
@@ -235,6 +258,7 @@ describe( 'doesCartLocationDifferFromResponseCartLocation', function () {
 			postalCode: '90210',
 			vatId: '12345',
 			organization: 'Test Co.',
+			address: '1555 Main street',
 		} );
 		expect( result ).toBe( true );
 	} );
@@ -245,6 +269,7 @@ describe( 'doesCartLocationDifferFromResponseCartLocation', function () {
 			postalCode: '90210',
 			vatId: '545454',
 			organization: 'Test Co.',
+			address: '1555 Main street',
 		} );
 		expect( result ).toBe( true );
 	} );
@@ -255,6 +280,18 @@ describe( 'doesCartLocationDifferFromResponseCartLocation', function () {
 			postalCode: '90210',
 			vatId: '12345',
 			organization: 'Testers, Inc.',
+			address: '1555 Main street',
+		} );
+		expect( result ).toBe( true );
+	} );
+	it( 'returns true if address differs', function () {
+		const result = doesCartLocationDifferFromResponseCartLocation( cartWithLocation, {
+			countryCode: 'US',
+			subdivisionCode: 'MA',
+			postalCode: '90210',
+			vatId: '12345',
+			organization: 'Test Co.',
+			address: '2114 Main street',
 		} );
 		expect( result ).toBe( true );
 	} );
@@ -265,6 +302,7 @@ describe( 'doesCartLocationDifferFromResponseCartLocation', function () {
 			postalCode: '90210',
 			vatId: '12345',
 			organization: 'Test Co.',
+			address: '1555 Main street',
 		} );
 		expect( result ).toBe( false );
 	} );
@@ -280,6 +318,7 @@ describe( 'doesCartLocationDifferFromResponseCartLocation', function () {
 						postal_code: '90210',
 						vat_id: '12345',
 						organization: 'Test Co.',
+						address: '1555 Main street',
 					},
 				},
 			},
@@ -289,6 +328,7 @@ describe( 'doesCartLocationDifferFromResponseCartLocation', function () {
 				postalCode: '90210',
 				vatId: '12345',
 				organization: 'Test Co.',
+				address: '1555 Main street',
 			}
 		);
 		expect( result ).toBe( false );
@@ -304,6 +344,7 @@ describe( 'doesCartLocationDifferFromResponseCartLocation', function () {
 						postal_code: '90210',
 						vat_id: '12345',
 						organization: 'Test Co.',
+						address: '1555 Main street',
 					},
 				},
 			},
@@ -313,6 +354,7 @@ describe( 'doesCartLocationDifferFromResponseCartLocation', function () {
 				postalCode: '90210',
 				vatId: '12345',
 				organization: 'Test Co.',
+				address: '1555 Main street',
 			}
 		);
 		expect( result ).toBe( false );
@@ -323,6 +365,7 @@ describe( 'doesCartLocationDifferFromResponseCartLocation', function () {
 			postalCode: '90210',
 			vatId: '12345',
 			organization: 'Test Co.',
+			address: '1555 Main street',
 		} );
 		expect( result ).toBe( false );
 	} );
@@ -333,6 +376,7 @@ describe( 'doesCartLocationDifferFromResponseCartLocation', function () {
 			postalCode: undefined,
 			vatId: '12345',
 			organization: 'Test Co.',
+			address: '1555 Main street',
 		} );
 		expect( result ).toBe( false );
 	} );


### PR DESCRIPTION
#### Proposed Changes

This adds a new field to the `VatForm` component in checkout for the address (sometimes) required by our VAT processors. This field matches the one that already exists on the `/me/purchases/vat-details` page. It was left out of the checkout form intentionally in https://github.com/Automattic/wp-calypso/pull/71285 because, to quote myself,

> First, the checkout version of the form does not include the "Address" field. I did this intentionally because I felt that it cluttered the form, added friction, and may not actually be required. I also did it because once we add this form to the domain form, which already includes address fields, it's likely to feel redundant and awkward (we can't use those address fields because they are separated into address1/address2/city/state/etc.).

However, it's recently been decided that the address field is necessary in checkout as well.

<img width="570" alt="Screenshot 2023-01-27 at 2 07 25 PM" src="https://user-images.githubusercontent.com/2036909/215173979-3fca52b1-b289-4da6-a7a3-293cb53be648.png">

Part of implementing https://github.com/Automattic/payments-shilling/issues/1278

D99532-code is required for this to update the data on the server.

Depends on https://github.com/Automattic/wp-calypso/pull/72740

#### Testing Instructions

- Apply D99532-code if it is not already merged.
- On this branch, add a product to your cart and visit checkout.
- If the checkout contact/billing details step is automatically completed, click the "Edit" button to make it active.
- Select a VAT country like "United Kingdom" in the country field and a valid postal code number like `NW1 4NP`.
- Click the VAT checkbox and verify that the VAT fields appear. Set the company name to `Test company`. Set the VAT Number to a valid one like `553557881` and fill in anything in the "Address for VAT" field.
- Click continue to complete the step. (Note: this is a test number that will only work when the API is sandboxed).
- Verify that the validation is successful and that the step completes.
- Click to edit the step again.
- Verify that you can no longer edit the VAT Number but that you can edit the organization and the address.
- Visit `/me/purchases/vat-details` and verify that the form there has the same information entered in checkout.
- Return to checkout (or reload the page), edit the step again, and verify that the form is pre-populated with the VAT details you entered before.

##### Verifying the data is sent correctly

- Open your browser's devtools panel to monitor network traffic and look for transactions to the `/me/shopping-cart` endpoint.
- Click to complete the step and verify that the shopping-cart endpoint request includes the VAT `address` information in its `tax` property.