### PR TITLE
Marketplace: scrolls to search results on plugin searches.

### DIFF
--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -62,6 +62,7 @@ const PluginsBrowser = ( { trackPageViews = true, category, search, hideHeader }
 		referenceRef: navigationHeaderRef,
 	} = useScrollAboveElement();
 	const searchRef = useRef( null );
+	const categoriesRef = useRef();
 	//  another temporary solution until phase 4 is merged
 	const [ isFetchingPluginsBySearchTerm, setIsFetchingPluginsBySearchTerm ] = useState( false );
 
@@ -150,6 +151,7 @@ const PluginsBrowser = ( { trackPageViews = true, category, search, hideHeader }
 			<JetpackDisconnectedNotice />
 			<SearchBoxHeader
 				searchRef={ searchRef }
+				categoriesRef={ categoriesRef }
 				stickySearchBoxRef={ searchHeaderRef }
 				isSticky={ isAboveElement }
 				searchTerm={ search }
@@ -171,7 +173,9 @@ const PluginsBrowser = ( { trackPageViews = true, category, search, hideHeader }
 				renderTitleInH1={ ! category }
 			/>
 
-			<Categories selected={ category } noSelection={ search ? true : false } />
+			<div ref={ categoriesRef }>
+				<Categories selected={ category } noSelection={ search ? true : false } />
+			</div>
 			<div className="plugins-browser__main-container">{ renderList() }</div>
 			{ ! category && ! search && <EducationFooter /> }
 		</MainComponent>


### PR DESCRIPTION
#### Proposed Changes

In Plugins Browser page 
* Blurs the search input after hitting enter
* Scrolls to the search results

Note: I used categories as an anchor because it's more consistent - it doesn't include the nudge which might display or not.

|Before | After|
|-------|------|
|![CleanShot 2023-01-27 at 20 40 47](https://user-images.githubusercontent.com/12430020/215168658-032620aa-9b32-4a2f-9169-f3801d49addc.gif)|![CleanShot 2023-01-27 at 20 41 33](https://user-images.githubusercontent.com/12430020/215168695-b3ae1ac2-fbf8-4e8d-9e9a-9a4de66063f0.gif)|


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open calypso live link
* Go to **Plugins**
* Search for anyhing
* Notice the focus is removed from the search input
* Notice the scroll to the search results

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #62933
