### PR TITLE
Checkout: Keep VAT country in sync with parent country

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/domain-contact-details.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/domain-contact-details.tsx
@@ -11,7 +11,7 @@ import {
 } from 'calypso/lib/cart-values/cart-items';
 import { getTopLevelOfTld } from 'calypso/lib/domains';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
-import { VatForm, isVatSupportedFor } from './vat-form';
+import { VatForm } from './vat-form';
 import type { DomainContactDetails as DomainContactDetailsData } from '@automattic/shopping-cart';
 import type { DomainContactDetailsErrors } from '@automattic/wpcom-checkout';
 
@@ -45,9 +45,7 @@ export default function DomainContactDetails( {
 	const needsAlternateEmailForGSuite = needsOnlyGoogleAppsDetails;
 	const tlds = getAllTopLevelTlds( domainNames );
 
-	const isVatSupported =
-		config.isEnabled( 'checkout/vat-form' ) &&
-		Boolean( contactDetails.countryCode && isVatSupportedFor( contactDetails.countryCode ) );
+	const isVatSupported = config.isEnabled( 'checkout/vat-form' );
 
 	return (
 		<Fragment>

--- a/client/my-sites/checkout/composite-checkout/components/tax-fields.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/tax-fields.tsx
@@ -9,7 +9,7 @@ import { useTranslate } from 'i18n-calypso';
 import { isValid } from '../types/wpcom-store-state';
 import CountrySelectMenu from './country-select-menu';
 import { LeftColumn, RightColumn } from './ie-fallback';
-import { VatForm, isVatSupportedFor } from './vat-form';
+import { VatForm } from './vat-form';
 import type {
 	CountryListItem,
 	ManagedContactDetails,
@@ -54,9 +54,7 @@ export default function TaxFields( {
 		countriesList.length && countryCode?.value
 			? getCountryPostalCodeSupport( countriesList, countryCode.value )
 			: false;
-	const isVatSupported =
-		config.isEnabled( 'checkout/vat-form' ) &&
-		Boolean( countryCode?.value && isVatSupportedFor( countryCode.value ) );
+	const isVatSupported = config.isEnabled( 'checkout/vat-form' );
 
 	return (
 		<>

--- a/client/my-sites/checkout/composite-checkout/components/vat-form/index.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/vat-form/index.tsx
@@ -87,7 +87,7 @@ export function VatForm( {
 	// Northern Ireland checkbox is checked.
 	const didPreFill = useRef( false );
 	useEffect( () => {
-		if ( isLoadingVatDetails ) {
+		if ( isLoadingVatDetails || ! countryCode ) {
 			return;
 		}
 		if ( didPreFill.current ) {
@@ -133,7 +133,12 @@ export function VatForm( {
 			setVatDetailsInForm( {} );
 		} else {
 			// Pre-fill the VAT form when the checkbox is checked.
-			setVatDetailsInForm( savedVatDetails );
+			setVatDetailsInForm( {
+				...savedVatDetails,
+				// Initialize the VAT country to match the country in the form, which may
+				// differ from the country in the saved VAT details.
+				country: countryCode,
+			} );
 		}
 		setIsFormActive( isChecked );
 	};

--- a/client/my-sites/checkout/composite-checkout/components/vat-form/index.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/vat-form/index.tsx
@@ -233,7 +233,7 @@ export function VatForm( {
 					} }
 				/>
 			</div>
-			{ savedVatDetails.id && (
+			{ vatDetailsFromServer.id && (
 				<div>
 					<FormSettingExplanation>
 						{ translate(

--- a/client/my-sites/checkout/composite-checkout/test/checkout-contact-step.js
+++ b/client/my-sites/checkout/composite-checkout/test/checkout-contact-step.js
@@ -612,12 +612,10 @@ describe( 'Checkout contact step', () => {
 		mockContactDetailsValidationEndpoint( 'tax', { success: false, messages: [ 'Invalid' ] } );
 		const vatId = '12345';
 		const vatName = 'Test company';
-		const vatAddress = '123 Main Street';
 		const countryCode = 'GB';
 		nock( 'https://public-api.wordpress.com' ).get( '/rest/v1.1/me/vat-info' ).reply( 200, {
 			id: vatId,
 			name: vatName,
-			address: vatAddress,
 			country: countryCode,
 		} );
 		const user = userEvent.setup();
@@ -633,17 +631,11 @@ describe( 'Checkout contact step', () => {
 		expect( await screen.findByLabelText( 'Add VAT details' ) ).toBeChecked();
 		expect( await screen.findByLabelText( 'VAT Number' ) ).toHaveValue( vatId );
 		expect( await screen.findByLabelText( 'Organization for VAT' ) ).toHaveValue( vatName );
-		expect( await screen.findByLabelText( 'Address for VAT' ) ).toHaveValue( vatAddress );
 
 		mockContactDetailsValidationEndpoint( 'tax', { success: true } );
 		const mockVatEndpoint = nock( 'https://public-api.wordpress.com' )
 			.post( '/rest/v1.1/me/vat-info', ( body ) => {
-				if (
-					body.id === vatId &&
-					body.name === vatName &&
-					body.country === cachedContactCountry &&
-					body.address === vatAddress
-				) {
+				if ( body.id === vatId && body.name === vatName && body.country === cachedContactCountry ) {
 					return true;
 				}
 				return false;

--- a/client/my-sites/checkout/composite-checkout/test/checkout-contact-step.js
+++ b/client/my-sites/checkout/composite-checkout/test/checkout-contact-step.js
@@ -235,7 +235,10 @@ describe( 'Checkout contact step', () => {
 		const cartChanges = { products: [ planWithoutDomain ] };
 		render( <MyCheckout cartChanges={ cartChanges } /> );
 		// Wait for the cart to load
-		await screen.findByText( 'Country' );
+		const countryField = await screen.findByLabelText( 'Country' );
+
+		// Validate that fields are pre-filled
+		expect( countryField.selectedOptions[ 0 ].value ).toBe( 'US' );
 
 		// Wait for the validation to complete.
 		await screen.findAllByText( 'Please wait…' );
@@ -524,28 +527,46 @@ describe( 'Checkout contact step', () => {
 
 	it( 'renders the VAT fields and checks the box on load if the VAT endpoint returns data', async () => {
 		nock.cleanAll();
+		mockCachedContactDetailsEndpoint( {
+			country_code: 'GB',
+			postal_code: '',
+		} );
+		mockContactDetailsValidationEndpoint( 'tax', { success: false, messages: [ 'Invalid' ] } );
 		nock( 'https://public-api.wordpress.com' ).get( '/rest/v1.1/me/vat-info' ).reply( 200, {
 			id: '12345',
 			name: 'Test company',
+			country: 'GB',
 		} );
-		const user = userEvent.setup();
 		const cartChanges = { products: [ planWithoutDomain ] };
 		render( <MyCheckout cartChanges={ cartChanges } /> );
-		await user.selectOptions( await screen.findByLabelText( 'Country' ), 'GB' );
+
+		// Wait for checkout to load.
+		const countryField = await screen.findByLabelText( 'Country' );
+
+		expect( countryField.selectedOptions[ 0 ].value ).toBe( 'GB' );
 		expect( await screen.findByLabelText( 'Add VAT details' ) ).toBeChecked();
 		expect( await screen.findByLabelText( 'VAT Number' ) ).toBeInTheDocument();
 	} );
 
 	it( 'renders the VAT fields pre-filled if the VAT endpoint returns data', async () => {
 		nock.cleanAll();
+		mockCachedContactDetailsEndpoint( {
+			country_code: 'GB',
+			postal_code: '',
+		} );
+		mockContactDetailsValidationEndpoint( 'tax', { success: false, messages: [ 'Invalid' ] } );
 		nock( 'https://public-api.wordpress.com' ).get( '/rest/v1.1/me/vat-info' ).reply( 200, {
 			id: '12345',
 			name: 'Test company',
+			country: 'GB',
 		} );
-		const user = userEvent.setup();
 		const cartChanges = { products: [ planWithoutDomain ] };
 		render( <MyCheckout cartChanges={ cartChanges } /> );
-		await user.selectOptions( await screen.findByLabelText( 'Country' ), 'GB' );
+
+		// Wait for checkout to load.
+		const countryField = await screen.findByLabelText( 'Country' );
+
+		expect( countryField.selectedOptions[ 0 ].value ).toBe( 'GB' );
 		expect( await screen.findByLabelText( 'VAT Number' ) ).toHaveValue( '12345' );
 		expect( await screen.findByLabelText( 'Organization for VAT' ) ).toHaveValue( 'Test company' );
 	} );

--- a/client/my-sites/checkout/composite-checkout/test/checkout-contact-step.js
+++ b/client/my-sites/checkout/composite-checkout/test/checkout-contact-step.js
@@ -509,6 +509,19 @@ describe( 'Checkout contact step', () => {
 		).toBeInTheDocument();
 	} );
 
+	it( 'hides the Northern Ireland checkbox is if the VAT checkbox is checked and the country is changed from GB to ES', async () => {
+		const user = userEvent.setup();
+		const cartChanges = { products: [ planWithoutDomain ] };
+		render( <MyCheckout cartChanges={ cartChanges } /> );
+		await user.selectOptions( await screen.findByLabelText( 'Country' ), 'GB' );
+		await user.click( await screen.findByLabelText( 'Add VAT details' ) );
+		expect(
+			await screen.findByLabelText( 'Is the VAT for Northern Ireland?' )
+		).toBeInTheDocument();
+		await user.selectOptions( await screen.findByLabelText( 'Country' ), 'ES' );
+		expect( screen.queryByLabelText( 'Is the VAT for Northern Ireland?' ) ).not.toBeInTheDocument();
+	} );
+
 	it( 'renders the VAT fields and checks the box on load if the VAT endpoint returns data', async () => {
 		nock.cleanAll();
 		nock( 'https://public-api.wordpress.com' ).get( '/rest/v1.1/me/vat-info' ).reply( 200, {

--- a/client/my-sites/checkout/composite-checkout/test/checkout-contact-step.js
+++ b/client/my-sites/checkout/composite-checkout/test/checkout-contact-step.js
@@ -3,7 +3,7 @@
  */
 import { StripeHookProvider } from '@automattic/calypso-stripe';
 import { ShoppingCartProvider, createShoppingCartManagerClient } from '@automattic/shopping-cart';
-import { render, screen, within, waitForElementToBeRemoved } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import nock from 'nock';
 import { QueryClient, QueryClientProvider } from 'react-query';
@@ -235,6 +235,7 @@ describe( 'Checkout contact step', () => {
 		const cartChanges = { products: [ planWithoutDomain ] };
 		render( <MyCheckout cartChanges={ cartChanges } /> );
 		// Wait for the cart to load
+		await screen.findByLabelText( 'Continue with the entered contact details' );
 		const countryField = await screen.findByLabelText( 'Country' );
 
 		// Validate that fields are pre-filled
@@ -242,7 +243,6 @@ describe( 'Checkout contact step', () => {
 
 		// Wait for the validation to complete.
 		await screen.findAllByText( 'Please wait…' );
-		await waitForElementToBeRemoved( () => screen.queryAllByText( 'Please wait…' ) );
 
 		expect( await screen.findByTestId( 'payment-method-step--visible' ) ).toBeInTheDocument();
 	} );
@@ -541,6 +541,7 @@ describe( 'Checkout contact step', () => {
 		render( <MyCheckout cartChanges={ cartChanges } /> );
 
 		// Wait for checkout to load.
+		await screen.findByLabelText( 'Continue with the entered contact details' );
 		const countryField = await screen.findByLabelText( 'Country' );
 
 		expect( countryField.selectedOptions[ 0 ].value ).toBe( 'GB' );
@@ -564,6 +565,7 @@ describe( 'Checkout contact step', () => {
 		render( <MyCheckout cartChanges={ cartChanges } /> );
 
 		// Wait for checkout to load.
+		await screen.findByLabelText( 'Continue with the entered contact details' );
 		const countryField = await screen.findByLabelText( 'Country' );
 
 		expect( countryField.selectedOptions[ 0 ].value ).toBe( 'GB' );
@@ -587,6 +589,10 @@ describe( 'Checkout contact step', () => {
 		const user = userEvent.setup();
 		const cartChanges = { products: [ planWithoutDomain ] };
 		render( <MyCheckout cartChanges={ cartChanges } /> );
+
+		// Wait for the cart to load
+		await screen.findByLabelText( 'Continue with the entered contact details' );
+
 		await user.selectOptions( await screen.findByLabelText( 'Country' ), countryCode );
 		await user.click( await screen.findByLabelText( 'Add VAT details' ) );
 		await user.type( await screen.findByLabelText( 'VAT Number' ), vatId );
@@ -619,6 +625,7 @@ describe( 'Checkout contact step', () => {
 		render( <MyCheckout cartChanges={ cartChanges } /> );
 
 		// Wait for the cart to load
+		await screen.findByLabelText( 'Continue with the entered contact details' );
 		const countryField = await screen.findByLabelText( 'Country' );
 
 		// Make sure the form has the autocompleted data.

--- a/client/my-sites/checkout/composite-checkout/test/checkout-contact-step.js
+++ b/client/my-sites/checkout/composite-checkout/test/checkout-contact-step.js
@@ -314,6 +314,7 @@ describe( 'Checkout contact step', () => {
 				.post( '/rest/v1.1/logstash' )
 				.reply( 200 );
 			nock( 'https://public-api.wordpress.com' )
+				.persist()
 				.get( '/rest/v1.1/me/vat-info' )
 				.optionally()
 				.reply( 200, {} );
@@ -532,11 +533,14 @@ describe( 'Checkout contact step', () => {
 			postal_code: '',
 		} );
 		mockContactDetailsValidationEndpoint( 'tax', { success: false, messages: [ 'Invalid' ] } );
-		nock( 'https://public-api.wordpress.com' ).get( '/rest/v1.1/me/vat-info' ).reply( 200, {
-			id: '12345',
-			name: 'Test company',
-			country: 'GB',
-		} );
+		nock( 'https://public-api.wordpress.com' )
+			.persist()
+			.get( '/rest/v1.1/me/vat-info' )
+			.reply( 200, {
+				id: '12345',
+				name: 'Test company',
+				country: 'GB',
+			} );
 		const cartChanges = { products: [ planWithoutDomain ] };
 		render( <MyCheckout cartChanges={ cartChanges } /> );
 
@@ -556,11 +560,14 @@ describe( 'Checkout contact step', () => {
 			postal_code: '',
 		} );
 		mockContactDetailsValidationEndpoint( 'tax', { success: false, messages: [ 'Invalid' ] } );
-		nock( 'https://public-api.wordpress.com' ).get( '/rest/v1.1/me/vat-info' ).reply( 200, {
-			id: '12345',
-			name: 'Test company',
-			country: 'GB',
-		} );
+		nock( 'https://public-api.wordpress.com' )
+			.persist()
+			.get( '/rest/v1.1/me/vat-info' )
+			.reply( 200, {
+				id: '12345',
+				name: 'Test company',
+				country: 'GB',
+			} );
 		const cartChanges = { products: [ planWithoutDomain ] };
 		render( <MyCheckout cartChanges={ cartChanges } /> );
 
@@ -613,11 +620,14 @@ describe( 'Checkout contact step', () => {
 		const vatId = '12345';
 		const vatName = 'Test company';
 		const countryCode = 'GB';
-		nock( 'https://public-api.wordpress.com' ).get( '/rest/v1.1/me/vat-info' ).reply( 200, {
-			id: vatId,
-			name: vatName,
-			country: countryCode,
-		} );
+		nock( 'https://public-api.wordpress.com' )
+			.persist()
+			.get( '/rest/v1.1/me/vat-info' )
+			.reply( 200, {
+				id: vatId,
+				name: vatName,
+				country: countryCode,
+			} );
 		const user = userEvent.setup();
 		const cartChanges = { products: [ planWithoutDomain ] };
 		render( <MyCheckout cartChanges={ cartChanges } /> );

--- a/client/my-sites/checkout/composite-checkout/test/util/index.ts
+++ b/client/my-sites/checkout/composite-checkout/test/util/index.ts
@@ -100,11 +100,7 @@ export const domainProduct: ResponseCartProduct = {
 	currency: 'BRL',
 	extra: {
 		context: 'signup',
-		privacy: true,
-		privacy_available: true,
-		registrar: 'KS_RAM',
 	},
-	free_trial: false,
 	meta: 'foo.cash',
 	product_id: 6,
 	volume: 1,
@@ -289,7 +285,7 @@ export const planLevel2Biannual: ResponseCartProduct = {
 export const fetchStripeConfiguration = async () => stripeConfiguration;
 
 export function mockSetCartEndpointWith( { currency, locale } ): SetCart {
-	return async ( _: number, requestCart: RequestCart ) => {
+	return async ( _: number, requestCart: RequestCart ): Promise< ResponseCart > => {
 		const { products: requestProducts, coupon: requestCoupon } = requestCart;
 		const products = requestProducts.map( convertRequestProductToResponseProduct( currency ) );
 
@@ -308,10 +304,8 @@ export function mockSetCartEndpointWith( { currency, locale } ): SetCart {
 			cart_key: 1234,
 			coupon: requestCoupon,
 			coupon_discounts_integer: [],
-			coupon_savings_total_display: requestCoupon ? 'R$10' : 'R$0',
 			coupon_savings_total_integer: requestCoupon ? 1000 : 0,
 			create_new_blog: false,
-			credits_display: '0',
 			credits_integer: 0,
 			currency,
 			is_coupon_applied: true,
@@ -319,20 +313,16 @@ export function mockSetCartEndpointWith( { currency, locale } ): SetCart {
 			locale,
 			next_domain_is_free: false,
 			products,
-			sub_total_display: 'R$149',
 			sub_total_integer: totalInteger - taxInteger,
-			sub_total_with_taxes_display: 'R$156',
 			sub_total_with_taxes_integer: totalInteger,
 			tax: {
 				location: requestCart.tax?.location ?? {},
 				display_taxes: !! requestCart.tax?.location?.postal_code,
 			},
 			total_cost: 0,
-			total_cost_display: 'R$156',
 			total_cost_integer: totalInteger,
 			total_tax: '',
 			total_tax_breakdown: [],
-			total_tax_display: 'R$7',
 			total_tax_integer: taxInteger,
 			next_domain_condition: '',
 		};

--- a/client/my-sites/checkout/composite-checkout/test/util/index.ts
+++ b/client/my-sites/checkout/composite-checkout/test/util/index.ts
@@ -93,15 +93,13 @@ export const countryList: CountryListItem[] = [
 
 export const siteId = 13579;
 
-export const domainProduct = {
+export const domainProduct: ResponseCartProduct = {
 	...getEmptyResponseCartProduct(),
 	product_name: '.cash Domain',
 	product_slug: 'domain_reg',
 	currency: 'BRL',
 	extra: {
 		context: 'signup',
-		domain_registration_agreement_url:
-			'https://wordpress.com/automattic-domain-name-registration-agreement/',
 		privacy: true,
 		privacy_available: true,
 		registrar: 'KS_RAM',
@@ -112,84 +110,63 @@ export const domainProduct = {
 	volume: 1,
 	is_domain_registration: true,
 	item_original_cost_integer: 500,
-	item_original_cost_display: 'R$5',
 	item_subtotal_integer: 500,
-	item_subtotal_display: 'R$5',
 	bill_period: '365',
 	months_per_bill_period: 12,
 };
 
-export const caDomainProduct = {
+export const caDomainProduct: ResponseCartProduct = {
 	...getEmptyResponseCartProduct(),
 	product_name: '.ca Domain',
 	product_slug: 'domain_reg',
 	currency: 'BRL',
 	extra: {
 		context: 'signup',
-		domain_registration_agreement_url:
-			'https://wordpress.com/automattic-domain-name-registration-agreement/',
-		privacy: true,
-		privacy_available: true,
-		registrar: 'KS_RAM',
 	},
-	free_trial: false,
 	meta: 'foo.ca',
 	product_id: 6,
 	volume: 1,
 	is_domain_registration: true,
 	item_original_cost_integer: 500,
-	item_original_cost_display: 'R$5',
 	item_subtotal_integer: 500,
-	item_subtotal_display: 'R$5',
 	bill_period: '365',
 	months_per_bill_period: 12,
 };
 
-export const gSuiteProduct = {
+export const gSuiteProduct: ResponseCartProduct = {
 	...getEmptyResponseCartProduct(),
 	product_name: 'G Suite',
 	product_slug: 'gapps',
 	currency: 'BRL',
 	extra: {},
-	free_trial: false,
 	meta: 'foo.cash',
 	product_id: 9,
 	volume: 1,
 	is_domain_registration: false,
 	item_original_cost_integer: 500,
-	item_original_cost_display: 'R$5',
 	item_subtotal_integer: 500,
-	item_subtotal_display: 'R$5',
 	bill_period: '365',
 	months_per_bill_period: 12,
 };
 
-export const domainTransferProduct = {
+export const domainTransferProduct: ResponseCartProduct = {
 	...getEmptyResponseCartProduct(),
 	product_name: '.cash Domain',
 	product_slug: 'domain_transfer',
 	currency: 'BRL',
 	extra: {
 		context: 'signup',
-		domain_registration_agreement_url:
-			'https://wordpress.com/automattic-domain-name-registration-agreement/',
-		privacy: true,
-		privacy_available: true,
-		registrar: 'KS_RAM',
 	},
-	free_trial: false,
 	meta: 'foo.cash',
 	product_id: 6,
 	volume: 1,
 	item_original_cost_integer: 500,
-	item_original_cost_display: 'R$5',
 	item_subtotal_integer: 500,
-	item_subtotal_display: 'R$5',
 	bill_period: '365',
 	months_per_bill_period: 12,
 };
 
-export const planWithBundledDomain = {
+export const planWithBundledDomain: ResponseCartProduct = {
 	...getEmptyResponseCartProduct(),
 	product_name: 'WordPress.com Personal',
 	product_slug: 'personal-bundle',
@@ -198,19 +175,16 @@ export const planWithBundledDomain = {
 		context: 'signup',
 		domain_to_bundle: 'foo.cash',
 	},
-	free_trial: false,
 	meta: '',
 	product_id: 1009,
 	volume: 1,
 	item_original_cost_integer: 14400,
-	item_original_cost_display: 'R$144',
 	item_subtotal_integer: 14400,
-	item_subtotal_display: 'R$144',
 	bill_period: '365',
 	months_per_bill_period: 12,
 };
 
-export const planWithoutDomain = {
+export const planWithoutDomain: ResponseCartProduct = {
 	...getEmptyResponseCartProduct(),
 	product_name: 'WordPress.com Personal',
 	product_slug: 'personal-bundle',
@@ -218,19 +192,16 @@ export const planWithoutDomain = {
 	extra: {
 		context: 'signup',
 	},
-	free_trial: false,
 	meta: '',
 	product_id: 1009,
 	volume: 1,
 	item_original_cost_integer: 14400,
-	item_original_cost_display: 'R$144',
 	item_subtotal_integer: 14400,
-	item_subtotal_display: 'R$144',
 	bill_period: '365',
 	months_per_bill_period: 12,
 };
 
-export const planWithoutDomainMonthly = {
+export const planWithoutDomainMonthly: ResponseCartProduct = {
 	...getEmptyResponseCartProduct(),
 	product_name: 'WordPress.com Personal Monthly',
 	product_slug: 'personal-bundle-monthly',
@@ -238,19 +209,16 @@ export const planWithoutDomainMonthly = {
 	extra: {
 		context: 'signup',
 	},
-	free_trial: false,
 	meta: '',
 	product_id: 1019,
 	volume: 1,
 	item_original_cost_integer: 14400,
-	item_original_cost_display: 'R$144',
 	item_subtotal_integer: 14400,
-	item_subtotal_display: 'R$144',
 	bill_period: '31',
 	months_per_bill_period: 1,
 };
 
-export const planWithoutDomainBiannual = {
+export const planWithoutDomainBiannual: ResponseCartProduct = {
 	...getEmptyResponseCartProduct(),
 	product_name: 'WordPress.com Personal 2 Year',
 	product_slug: 'personal-bundle-2y',
@@ -258,19 +226,16 @@ export const planWithoutDomainBiannual = {
 	extra: {
 		context: 'signup',
 	},
-	free_trial: false,
 	meta: '',
 	product_id: 1029,
 	volume: 1,
 	item_original_cost_integer: 14400,
-	item_original_cost_display: 'R$144',
 	item_subtotal_integer: 14400,
-	item_subtotal_display: 'R$144',
 	bill_period: '730',
 	months_per_bill_period: 24,
 };
 
-export const planLevel2 = {
+export const planLevel2: ResponseCartProduct = {
 	...getEmptyResponseCartProduct(),
 	product_name: 'WordPress.com Business',
 	product_slug: 'business-bundle',
@@ -278,14 +243,11 @@ export const planLevel2 = {
 	extra: {
 		context: 'signup',
 	},
-	free_trial: false,
 	meta: '',
 	product_id: 1008,
 	volume: 1,
 	item_original_cost_integer: 14400,
-	item_original_cost_display: 'R$144',
 	item_subtotal_integer: 14400,
-	item_subtotal_display: 'R$144',
 	bill_period: '365',
 	months_per_bill_period: 12,
 };
@@ -302,9 +264,7 @@ export const planLevel2Monthly: ResponseCartProduct = {
 	product_id: 1018,
 	volume: 1,
 	item_original_cost_integer: 14400,
-	item_original_cost_display: 'R$144',
 	item_subtotal_integer: 14400,
-	item_subtotal_display: 'R$144',
 	bill_period: '31',
 	months_per_bill_period: 1,
 };
@@ -321,9 +281,7 @@ export const planLevel2Biannual: ResponseCartProduct = {
 	product_id: 1028,
 	volume: 1,
 	item_original_cost_integer: 14400,
-	item_original_cost_display: 'R$144',
 	item_subtotal_integer: 14400,
-	item_subtotal_display: 'R$144',
 	bill_period: '730',
 	months_per_bill_period: 24,
 };
@@ -456,7 +414,6 @@ function convertRequestProductToResponseProduct(
 					item_original_cost_integer: 7000,
 					item_original_cost_display: 'R$70',
 					item_subtotal_integer: 7000,
-					item_subtotal_display: 'R$70',
 					bill_period: '365',
 					months_per_bill_period: 12,
 					item_tax: 0,
@@ -473,9 +430,7 @@ function convertRequestProductToResponseProduct(
 					currency: currency,
 					is_domain_registration: false,
 					item_original_cost_integer: 6900,
-					item_original_cost_display: 'R$69',
 					item_subtotal_integer: 6900,
-					item_subtotal_display: 'R$69',
 					item_tax: 0,
 					meta: product.meta,
 					volume: 1,
@@ -490,9 +445,7 @@ function convertRequestProductToResponseProduct(
 					currency: currency,
 					is_domain_registration: false,
 					item_original_cost_integer: 4900,
-					item_original_cost_display: 'R$49',
 					item_subtotal_integer: 4900,
-					item_subtotal_display: 'R$49',
 					item_tax: 0,
 					meta: product.meta,
 					volume: 1,
@@ -507,9 +460,7 @@ function convertRequestProductToResponseProduct(
 					currency: currency,
 					is_domain_registration: false,
 					item_original_cost_integer: 4100,
-					item_original_cost_display: 'R$41',
 					item_subtotal_integer: 4100,
-					item_subtotal_display: 'R$41',
 					bill_period: '365',
 					months_per_bill_period: 12,
 					item_tax: 0,
@@ -526,9 +477,7 @@ function convertRequestProductToResponseProduct(
 					currency: currency,
 					is_domain_registration: false,
 					item_original_cost_integer: 4200,
-					item_original_cost_display: 'R$42',
 					item_subtotal_integer: 4200,
-					item_subtotal_display: 'R$42',
 					bill_period: '365',
 					months_per_bill_period: 12,
 					item_tax: 0,
@@ -545,9 +494,7 @@ function convertRequestProductToResponseProduct(
 					currency: currency,
 					is_domain_registration: false,
 					item_original_cost_integer: planLevel2.item_original_cost_integer,
-					item_original_cost_display: planLevel2.item_original_cost_display,
 					item_subtotal_integer: planLevel2.item_subtotal_integer,
-					item_subtotal_display: planLevel2.item_subtotal_display,
 					bill_period: planLevel2.bill_period,
 					months_per_bill_period: 12,
 					item_tax: 0,
@@ -564,9 +511,7 @@ function convertRequestProductToResponseProduct(
 					currency: currency,
 					is_domain_registration: false,
 					item_original_cost_integer: planLevel2Biannual.item_original_cost_integer,
-					item_original_cost_display: planLevel2Biannual.item_original_cost_display,
 					item_subtotal_integer: planLevel2Biannual.item_subtotal_integer,
-					item_subtotal_display: planLevel2Biannual.item_subtotal_display,
 					bill_period: planLevel2Biannual.bill_period,
 					months_per_bill_period: 24,
 					item_tax: 0,
@@ -583,7 +528,6 @@ function convertRequestProductToResponseProduct(
 			product_slug: 'unknown',
 			currency: currency,
 			is_domain_registration: false,
-			item_subtotal_display: '$0',
 			item_subtotal_integer: 0,
 			item_tax: 0,
 		};
@@ -598,7 +542,6 @@ export function getBasicCart(): ResponseCart {
 		...cart,
 		coupon: '',
 		coupon_savings_total_integer: 0,
-		coupon_savings_total_display: '0',
 		currency: 'BRL',
 		locale: 'br-pt',
 		is_coupon_applied: false,
@@ -609,11 +552,8 @@ export function getBasicCart(): ResponseCart {
 		},
 		allowed_payment_methods: [ 'WPCOM_Billing_PayPal_Express' ],
 		total_tax_integer: 700,
-		total_tax_display: 'R$7',
 		total_cost_integer: 15600,
-		total_cost_display: 'R$156',
 		sub_total_integer: 15600,
-		sub_total_display: 'R$156',
 		coupon_discounts_integer: [],
 	};
 }
@@ -814,7 +754,6 @@ export function createTestReduxStore() {
 						product_type: 'bundle',
 						available: true,
 						is_domain_registration: false,
-						cost_display: planWithoutDomain.item_subtotal_display,
 						currency_code: planWithoutDomain.currency,
 					},
 					[ planWithoutDomainMonthly.product_slug ]: {
@@ -823,7 +762,6 @@ export function createTestReduxStore() {
 						product_type: 'bundle',
 						available: true,
 						is_domain_registration: false,
-						cost_display: planWithoutDomainMonthly.item_subtotal_display,
 						currency_code: planWithoutDomainMonthly.currency,
 					},
 					[ planWithoutDomainBiannual.product_slug ]: {
@@ -832,7 +770,6 @@ export function createTestReduxStore() {
 						product_type: 'bundle',
 						available: true,
 						is_domain_registration: false,
-						cost_display: planWithoutDomainBiannual.item_subtotal_display,
 						currency_code: planWithoutDomainBiannual.currency,
 					},
 					[ planLevel2.product_slug ]: {
@@ -841,7 +778,6 @@ export function createTestReduxStore() {
 						product_type: 'bundle',
 						available: true,
 						is_domain_registration: false,
-						cost_display: planLevel2.item_subtotal_display,
 						currency_code: planLevel2.currency,
 					},
 					[ planLevel2Monthly.product_slug ]: {
@@ -850,7 +786,6 @@ export function createTestReduxStore() {
 						product_type: 'bundle',
 						available: true,
 						is_domain_registration: false,
-						cost_display: planLevel2Monthly.item_subtotal_display,
 						currency_code: planLevel2Monthly.currency,
 					},
 					[ planLevel2Biannual.product_slug ]: {
@@ -859,7 +794,6 @@ export function createTestReduxStore() {
 						product_type: 'bundle',
 						available: true,
 						is_domain_registration: false,
-						cost_display: planLevel2Biannual.item_subtotal_display,
 						currency_code: planLevel2Biannual.currency,
 					},
 					domain_map: {
@@ -1190,6 +1124,8 @@ function buildVariant( data: ResponseCartProduct ): ResponseCartProductVariant {
 				product_slug: data.product_slug,
 				currency: planLevel2Monthly.currency,
 				price_integer: getVariantPrice( planLevel2Monthly ),
+				price_before_discounts_integer: getVariantPrice( planLevel2Monthly ),
+				introductory_offer_terms: {},
 			};
 		case planLevel2.product_slug:
 			return {
@@ -1198,6 +1134,8 @@ function buildVariant( data: ResponseCartProduct ): ResponseCartProductVariant {
 				product_slug: data.product_slug,
 				currency: planLevel2.currency,
 				price_integer: getVariantPrice( planLevel2 ),
+				price_before_discounts_integer: getVariantPrice( planLevel2Monthly ),
+				introductory_offer_terms: {},
 			};
 		case planLevel2Biannual.product_slug:
 			return {
@@ -1206,6 +1144,8 @@ function buildVariant( data: ResponseCartProduct ): ResponseCartProductVariant {
 				product_slug: data.product_slug,
 				currency: planLevel2Biannual.currency,
 				price_integer: getVariantPrice( planLevel2Biannual ),
+				price_before_discounts_integer: getVariantPrice( planLevel2Monthly ),
+				introductory_offer_terms: {},
 			};
 		case planWithoutDomainMonthly.product_slug:
 			return {
@@ -1214,6 +1154,8 @@ function buildVariant( data: ResponseCartProduct ): ResponseCartProductVariant {
 				product_slug: data.product_slug,
 				currency: planWithoutDomainMonthly.currency,
 				price_integer: getVariantPrice( planWithoutDomainMonthly ),
+				price_before_discounts_integer: getVariantPrice( planLevel2Monthly ),
+				introductory_offer_terms: {},
 			};
 		case planWithoutDomain.product_slug:
 			return {
@@ -1222,6 +1164,8 @@ function buildVariant( data: ResponseCartProduct ): ResponseCartProductVariant {
 				product_slug: data.product_slug,
 				currency: planWithoutDomain.currency,
 				price_integer: getVariantPrice( planWithoutDomain ),
+				price_before_discounts_integer: getVariantPrice( planLevel2Monthly ),
+				introductory_offer_terms: {},
 			};
 		case planWithoutDomainBiannual.product_slug:
 			return {
@@ -1230,6 +1174,8 @@ function buildVariant( data: ResponseCartProduct ): ResponseCartProductVariant {
 				product_slug: data.product_slug,
 				currency: planWithoutDomainBiannual.currency,
 				price_integer: getVariantPrice( planWithoutDomainBiannual ),
+				price_before_discounts_integer: getVariantPrice( planLevel2Monthly ),
+				introductory_offer_terms: {},
 			};
 	}
 

--- a/client/my-sites/checkout/composite-checkout/test/util/index.ts
+++ b/client/my-sites/checkout/composite-checkout/test/util/index.ts
@@ -826,6 +826,26 @@ export function createTestReduxStore() {
 	return createStore( rootReducer, applyMiddleware( thunk ) );
 }
 
+export function mockGetVatInfoEndpoint( response ) {
+	nock( 'https://public-api.wordpress.com' )
+		.persist()
+		.get( '/rest/v1.1/me/vat-info' )
+		.optionally()
+		.reply( 200, response );
+}
+
+export function mockSetVatInfoEndpoint() {
+	const endpoint = jest.fn();
+	endpoint.mockReturnValue( true );
+
+	nock( 'https://public-api.wordpress.com' )
+		.post( '/rest/v1.1/me/vat-info', ( body ) => {
+			return endpoint( body );
+		} )
+		.reply( 200 );
+	return endpoint;
+}
+
 export function mockPayPalEndpoint( endpointResponse ) {
 	const endpoint = jest.fn();
 	endpoint.mockReturnValue( true );

--- a/client/my-sites/checkout/composite-checkout/test/util/index.ts
+++ b/client/my-sites/checkout/composite-checkout/test/util/index.ts
@@ -1134,7 +1134,7 @@ function buildVariant( data: ResponseCartProduct ): ResponseCartProductVariant {
 				product_slug: data.product_slug,
 				currency: planLevel2.currency,
 				price_integer: getVariantPrice( planLevel2 ),
-				price_before_discounts_integer: getVariantPrice( planLevel2Monthly ),
+				price_before_discounts_integer: getVariantPrice( planLevel2 ),
 				introductory_offer_terms: {},
 			};
 		case planLevel2Biannual.product_slug:
@@ -1144,7 +1144,7 @@ function buildVariant( data: ResponseCartProduct ): ResponseCartProductVariant {
 				product_slug: data.product_slug,
 				currency: planLevel2Biannual.currency,
 				price_integer: getVariantPrice( planLevel2Biannual ),
-				price_before_discounts_integer: getVariantPrice( planLevel2Monthly ),
+				price_before_discounts_integer: getVariantPrice( planLevel2Biannual ),
 				introductory_offer_terms: {},
 			};
 		case planWithoutDomainMonthly.product_slug:
@@ -1154,7 +1154,7 @@ function buildVariant( data: ResponseCartProduct ): ResponseCartProductVariant {
 				product_slug: data.product_slug,
 				currency: planWithoutDomainMonthly.currency,
 				price_integer: getVariantPrice( planWithoutDomainMonthly ),
-				price_before_discounts_integer: getVariantPrice( planLevel2Monthly ),
+				price_before_discounts_integer: getVariantPrice( planWithoutDomainMonthly ),
 				introductory_offer_terms: {},
 			};
 		case planWithoutDomain.product_slug:
@@ -1164,7 +1164,7 @@ function buildVariant( data: ResponseCartProduct ): ResponseCartProductVariant {
 				product_slug: data.product_slug,
 				currency: planWithoutDomain.currency,
 				price_integer: getVariantPrice( planWithoutDomain ),
-				price_before_discounts_integer: getVariantPrice( planLevel2Monthly ),
+				price_before_discounts_integer: getVariantPrice( planWithoutDomain ),
 				introductory_offer_terms: {},
 			};
 		case planWithoutDomainBiannual.product_slug:
@@ -1174,7 +1174,7 @@ function buildVariant( data: ResponseCartProduct ): ResponseCartProductVariant {
 				product_slug: data.product_slug,
 				currency: planWithoutDomainBiannual.currency,
 				price_integer: getVariantPrice( planWithoutDomainBiannual ),
-				price_before_discounts_integer: getVariantPrice( planLevel2Monthly ),
+				price_before_discounts_integer: getVariantPrice( planWithoutDomainBiannual ),
 				introductory_offer_terms: {},
 			};
 	}


### PR DESCRIPTION
#### Background

When VAT form support was added to checkout in https://github.com/Automattic/wp-calypso/pull/71285, there was a subtle bug. Checkout only has one country code form field and it has three uses: the shopping cart endpoint tax country, the cached domain contact endpoint country, and (now) the VAT data endpoint country. Normally, all three of these values are the same, but the VAT form has to have its own local version of the data because there are cases (Northern Ireland) where the country code for the VAT form will differ from the other two (although the shopping cart tax data will also use this value, it is still stored in a separate place in the code).

Here's the bug: if the cached contact details endpoint returns one country code, but the VAT data endpoint returns a different country code, we need to make sure that we use the correct one. In this case that's the cached contact details endpoint code because that is the one that the checkout form uses; if we used the VAT country code, which is essentially a hidden field, there would be no way to see or change it and you'd get strange validation errors from the VAT endpoint.

#### Proposed Changes

To prevent this bug, in this PR we make a more concerted effort to keep the "hidden" VAT country code field (it's not actually a field; just a variable) in sync with the `VatForm`'s parent country code field. Any time the parent's country code field (the only one on the form) changes, we update the VAT country code to match. We only break that sync if the Northern Ireland checkbox is checked.

In addition, this fixes a bug where changing the country from a VAT-supported country to a non-VAT-supported country would still send any existing VAT data to the shopping cart. This was happening because while the VAT data is cleared when the "Add VAT details" checkbox is unchecked, that side effect was not happening when the `VatForm` itself was unmounted as a result of the country no longer being applicable. Here we fix that issue by always rendering `VatForm` and having it hide itself when the country does not apply so it can continue to run side effects as needed.

#### Testing Instructions

This PR adds tests to reproduce the bugs mentioned above and prove that they are fixed. This also fixes several other tests that weren't quite testing what they claimed to be testing.

You can test this manually by using checkout to set a cached country code in the EU (like "Spain") and clicking "Continue"; then using the `/me/purchases/vat-details` page to set a VAT country that's different (like `GB`, along with valid VAT details; you can use the Vat ID `553557881` if the store is sandboxed).

After that's set up, visit checkout and you'll see that the country field shows the cached country (eg: "Spain"), but if you try to submit the form and then look at the contact step summary. Before this PR you'll see it reads `GB`; after this PR you'll see `ES`.

Finally, change the country code to "United States" and set a valid postal code like `90210`. Press "Continue" and verify that the summary shows `US`.