### PR TITLE
Adding new assembler flow

### DIFF
--- a/client/landing/stepper/declarative-flow/assembler.ts
+++ b/client/landing/stepper/declarative-flow/assembler.ts
@@ -1,0 +1,53 @@
+import { useFlowProgress, ASSEMBLER_FLOW } from '@automattic/onboarding';
+import { useDispatch } from '@wordpress/data';
+import { useSiteSlug } from '../hooks/use-site-slug';
+import { ONBOARD_STORE } from '../stores';
+import { recordSubmitStep } from './internals/analytics/record-submit-step';
+import PatternAssembler from './internals/steps-repository/pattern-assembler';
+import Processing from './internals/steps-repository/processing-step';
+import { Flow, ProvidedDependencies } from './internals/types';
+
+const assembler: Flow = {
+	name: ASSEMBLER_FLOW,
+	useSteps() {
+		return [
+			{ slug: 'patternAssembler', component: PatternAssembler },
+			{ slug: 'processing', component: Processing },
+		];
+	},
+
+	useStepNavigation( _currentStep, navigate ) {
+		const flowName = this.name;
+		const { setStepProgress, setPendingAction } = useDispatch( ONBOARD_STORE );
+		const flowProgress = useFlowProgress( { stepName: _currentStep, flowName } );
+		setStepProgress( flowProgress );
+		const siteSlug = useSiteSlug();
+
+		const exitFlow = ( to: string ) => {
+			setPendingAction( () => {
+				return new Promise( () => {
+					window.location.assign( to );
+				} );
+			} );
+
+			return navigate( 'processing' );
+		};
+
+		const submit = ( providedDependencies: ProvidedDependencies = {} ) => {
+			recordSubmitStep( providedDependencies, '', flowName, _currentStep );
+
+			switch ( _currentStep ) {
+				case 'processing':
+					return exitFlow( `/site-editor/${ siteSlug }` );
+
+				case 'patternAssembler': {
+					return navigate( 'processing' );
+				}
+			}
+		};
+
+		return { submit };
+	},
+};
+
+export default assembler;

--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -74,7 +74,7 @@ button {
 .free-setup,
 .free-post-setup,
 .free,
-.assembler {
+.site-assembler {
 	padding: 60px 0 0;
 	box-sizing: border-box;
 

--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -73,7 +73,8 @@ button {
 .intro,
 .free-setup,
 .free-post-setup,
-.free {
+.free,
+.assembler {
 	padding: 60px 0 0;
 	box-sizing: border-box;
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/constants.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/constants.ts
@@ -2,3 +2,12 @@ export const PATTERN_SOURCE_SITE_ID = 174455321; // dotcompatterns
 export const PUBLIC_API_URL = 'https://public-api.wordpress.com';
 export const PREVIEW_PATTERN_URL = PUBLIC_API_URL + '/wpcom/v2/block-previews/pattern';
 export const SITE_TAGLINE = 'Site Tagline';
+
+export const BLANK_CANVAS_DESIGN = {
+	slug: 'blank-canvas-3',
+	title: 'Blank Canvas',
+	recipe: {
+		stylesheet: 'pub/blank-canvas-3',
+	},
+	design_type: 'assembler',
+};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -1,5 +1,5 @@
 import { isEnabled } from '@automattic/calypso-config';
-import { StepContainer, SITE_SETUP_FLOW, ASSEMBLER_FLOW } from '@automattic/onboarding';
+import { StepContainer, SITE_SETUP_FLOW, SITE_ASSEMBLER_FLOW } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
 import { useState, useRef, useEffect } from 'react';
@@ -13,7 +13,7 @@ import { useSiteIdParam } from '../../../../hooks/use-site-id-param';
 import { useSiteSlugParam } from '../../../../hooks/use-site-slug-param';
 import { SITE_STORE, ONBOARD_STORE } from '../../../../stores';
 import { recordSelectedDesign } from '../../analytics/record-design';
-import { SITE_TAGLINE, BLANK_CANVAS_DESIGN } from './constants';
+import { SITE_TAGLINE } from './constants';
 import PatternLayout from './pattern-layout';
 import PatternSelectorLoader from './pattern-selector-loader';
 import { useAllPatterns } from './patterns-data';
@@ -371,7 +371,7 @@ const PatternAssembler: Step = ( { navigation, flow } ) => {
 			<DocumentHead title={ translate( 'Design your home' ) } />
 			<StepContainer
 				stepName="pattern-assembler"
-				hideBack={ showPatternSelectorType !== null || flow === ASSEMBLER_FLOW }
+				hideBack={ showPatternSelectorType !== null || flow === SITE_ASSEMBLER_FLOW }
 				goBack={ onBack }
 				goNext={ goNext }
 				isHorizontalLayout={ false }
@@ -401,4 +401,3 @@ const PatternAssembler: Step = ( { navigation, flow } ) => {
 };
 
 export default PatternAssembler;
-export { BLANK_CANVAS_DESIGN };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -8,7 +8,6 @@ import AsyncLoad from 'calypso/components/async-load';
 import DocumentHead from 'calypso/components/data/document-head';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { requestActiveTheme } from 'calypso/state/themes/actions';
-import { useQuery } from '../../../../hooks/use-query';
 import { useSite } from '../../../../hooks/use-site';
 import { useSiteIdParam } from '../../../../hooks/use-site-id-param';
 import { useSiteSlugParam } from '../../../../hooks/use-site-slug-param';
@@ -36,7 +35,7 @@ const PatternAssembler: Step = ( { navigation, flow } ) => {
 	const { goBack, goNext, submit, goToStep } = navigation;
 	const { setThemeOnSite, runThemeSetupOnSite, createCustomTemplate } = useDispatch( SITE_STORE );
 	const reduxDispatch = useReduxDispatch();
-	const { setPendingAction, setSelectedDesign } = useDispatch( ONBOARD_STORE );
+	const { setPendingAction } = useDispatch( ONBOARD_STORE );
 	const selectedDesign = useSelect( ( select ) => select( ONBOARD_STORE ).getSelectedDesign() );
 	const intent = useSelect( ( select ) => select( ONBOARD_STORE ).getIntent() );
 	const site = useSite();
@@ -44,7 +43,6 @@ const PatternAssembler: Step = ( { navigation, flow } ) => {
 	const siteId = useSiteIdParam();
 	const siteSlugOrId = siteSlug ? siteSlug : siteId;
 	const allPatterns = useAllPatterns();
-	const selectedTheme = useQuery().get( 'theme' );
 
 	const largePreviewProps = {
 		placeholder: null,
@@ -63,9 +61,6 @@ const PatternAssembler: Step = ( { navigation, flow } ) => {
 		// Require to start the flow from the first step
 		if ( ! selectedDesign && flow === SITE_SETUP_FLOW ) {
 			goToStep?.( 'goals' );
-		} else if ( selectedTheme === 'blank-canvas-3' && flow === ASSEMBLER_FLOW ) {
-			// User has selected blank-canvas-3 theme from theme showcase and enter assembler flow
-			setSelectedDesign( BLANK_CANVAS_DESIGN as Design );
 		}
 	}, [] );
 
@@ -406,3 +401,4 @@ const PatternAssembler: Step = ( { navigation, flow } ) => {
 };
 
 export default PatternAssembler;
+export { BLANK_CANVAS_DESIGN };

--- a/client/landing/stepper/declarative-flow/registered-flows.ts
+++ b/client/landing/stepper/declarative-flow/registered-flows.ts
@@ -47,6 +47,8 @@ const availableFlows: Record< string, () => Promise< { default: Flow } > > = {
 
 	free: () => import( /* webpackChunkName: "free-flow" */ '../declarative-flow/free' ),
 
+	assembler: () => import( /* webpackChunkName: "free-flow" */ '../declarative-flow/assembler' ),
+
 	'free-post-setup': () =>
 		import( /* webpackChunkName: "free-post-setup-flow" */ '../declarative-flow/free-post-setup' ),
 

--- a/client/landing/stepper/declarative-flow/registered-flows.ts
+++ b/client/landing/stepper/declarative-flow/registered-flows.ts
@@ -47,7 +47,8 @@ const availableFlows: Record< string, () => Promise< { default: Flow } > > = {
 
 	free: () => import( /* webpackChunkName: "free-flow" */ '../declarative-flow/free' ),
 
-	assembler: () => import( /* webpackChunkName: "free-flow" */ '../declarative-flow/assembler' ),
+	'site-assembler': () =>
+		import( /* webpackChunkName: "site-assembler-flow" */ './site-assembler-flow' ),
 
 	'free-post-setup': () =>
 		import( /* webpackChunkName: "free-post-setup-flow" */ '../declarative-flow/free-post-setup' ),

--- a/client/landing/stepper/declarative-flow/site-assembler-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-assembler-flow.ts
@@ -18,7 +18,7 @@ const siteAssemblerFlow: Flow = {
 		const selectedTheme = useQuery().get( 'theme' );
 
 		useEffect( () => {
-			if ( selectedTheme === 'blank-canvas-3' && this.name === SITE_ASSEMBLER_FLOW ) {
+			if ( selectedTheme === BLANK_CANVAS_DESIGN.slug && this.name === SITE_ASSEMBLER_FLOW ) {
 				// User has selected blank-canvas-3 theme from theme showcase and enter assembler flow
 				setSelectedDesign( BLANK_CANVAS_DESIGN as Design );
 			}

--- a/client/landing/stepper/declarative-flow/site-assembler-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-assembler-flow.ts
@@ -1,15 +1,28 @@
 import { useFlowProgress, ASSEMBLER_FLOW } from '@automattic/onboarding';
+import { useEffect } from 'react';
 import { useDispatch } from '@wordpress/data';
 import { useSiteSlug } from '../hooks/use-site-slug';
+import { useQuery } from '../hooks/use-query';
 import { ONBOARD_STORE } from '../stores';
 import { recordSubmitStep } from './internals/analytics/record-submit-step';
-import PatternAssembler from './internals/steps-repository/pattern-assembler';
+import type { Design } from '@automattic/design-picker/src/types';
+import PatternAssembler, { BLANK_CANVAS_DESIGN } from './internals/steps-repository/pattern-assembler';
 import Processing from './internals/steps-repository/processing-step';
 import { Flow, ProvidedDependencies } from './internals/types';
 
-const assembler: Flow = {
+const siteAssemblerFlow: Flow = {
 	name: ASSEMBLER_FLOW,
 	useSteps() {
+		const { setSelectedDesign } = useDispatch( ONBOARD_STORE );
+		const selectedTheme = useQuery().get( 'theme' );
+
+		useEffect( () => {
+			if ( selectedTheme === 'blank-canvas-3' && this.name === ASSEMBLER_FLOW ) {
+				// User has selected blank-canvas-3 theme from theme showcase and enter assembler flow
+				setSelectedDesign( BLANK_CANVAS_DESIGN as Design );
+			}
+		}, [] );
+
 		return [
 			{ slug: 'patternAssembler', component: PatternAssembler },
 			{ slug: 'processing', component: Processing },
@@ -50,4 +63,4 @@ const assembler: Flow = {
 	},
 };
 
-export default assembler;
+export default siteAssemblerFlow;

--- a/client/landing/stepper/declarative-flow/site-assembler-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-assembler-flow.ts
@@ -1,25 +1,24 @@
-import { useFlowProgress, ASSEMBLER_FLOW } from '@automattic/onboarding';
+import { useFlowProgress, SITE_ASSEMBLER_FLOW } from '@automattic/onboarding';
 import { useDispatch } from '@wordpress/data';
 import { useEffect } from 'react';
 import { useQuery } from '../hooks/use-query';
 import { useSiteSlug } from '../hooks/use-site-slug';
 import { ONBOARD_STORE } from '../stores';
 import { recordSubmitStep } from './internals/analytics/record-submit-step';
-import PatternAssembler, {
-	BLANK_CANVAS_DESIGN,
-} from './internals/steps-repository/pattern-assembler';
+import PatternAssembler from './internals/steps-repository/pattern-assembler';
+import { BLANK_CANVAS_DESIGN } from './internals/steps-repository/pattern-assembler/constants';
 import Processing from './internals/steps-repository/processing-step';
 import { Flow, ProvidedDependencies } from './internals/types';
 import type { Design } from '@automattic/design-picker/src/types';
 
 const siteAssemblerFlow: Flow = {
-	name: ASSEMBLER_FLOW,
+	name: SITE_ASSEMBLER_FLOW,
 	useSteps() {
 		const { setSelectedDesign } = useDispatch( ONBOARD_STORE );
 		const selectedTheme = useQuery().get( 'theme' );
 
 		useEffect( () => {
-			if ( selectedTheme === 'blank-canvas-3' && this.name === ASSEMBLER_FLOW ) {
+			if ( selectedTheme === 'blank-canvas-3' && this.name === SITE_ASSEMBLER_FLOW ) {
 				// User has selected blank-canvas-3 theme from theme showcase and enter assembler flow
 				setSelectedDesign( BLANK_CANVAS_DESIGN as Design );
 			}

--- a/client/landing/stepper/declarative-flow/site-assembler-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-assembler-flow.ts
@@ -1,14 +1,16 @@
 import { useFlowProgress, ASSEMBLER_FLOW } from '@automattic/onboarding';
-import { useEffect } from 'react';
 import { useDispatch } from '@wordpress/data';
-import { useSiteSlug } from '../hooks/use-site-slug';
+import { useEffect } from 'react';
 import { useQuery } from '../hooks/use-query';
+import { useSiteSlug } from '../hooks/use-site-slug';
 import { ONBOARD_STORE } from '../stores';
 import { recordSubmitStep } from './internals/analytics/record-submit-step';
-import type { Design } from '@automattic/design-picker/src/types';
-import PatternAssembler, { BLANK_CANVAS_DESIGN } from './internals/steps-repository/pattern-assembler';
+import PatternAssembler, {
+	BLANK_CANVAS_DESIGN,
+} from './internals/steps-repository/pattern-assembler';
 import Processing from './internals/steps-repository/processing-step';
 import { Flow, ProvidedDependencies } from './internals/types';
+import type { Design } from '@automattic/design-picker/src/types';
 
 const siteAssemblerFlow: Flow = {
 	name: ASSEMBLER_FLOW,

--- a/client/landing/stepper/declarative-flow/site-assembler-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-assembler-flow.ts
@@ -52,6 +52,7 @@ const siteAssemblerFlow: Flow = {
 
 			switch ( _currentStep ) {
 				case 'processing':
+					window.sessionStorage.setItem( 'wpcom_signup_completed_flow', 'pattern_assembler' );
 					return exitFlow( `/site-editor/${ siteSlug }` );
 
 				case 'patternAssembler': {

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -1,6 +1,7 @@
 import config from '@automattic/calypso-config';
 import { isDesktop } from '@automattic/viewport';
 import { get, includes, reject } from 'lodash';
+import { BLANK_CANVAS_DESIGN } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/constants';
 import detectHistoryNavigation from 'calypso/lib/detect-history-navigation';
 import { getQueryArgs } from 'calypso/lib/query-args';
 import { addQueryArgs } from 'calypso/lib/url';
@@ -112,7 +113,7 @@ function getChecklistThemeDestination( { siteSlug, themeParameter } ) {
 	const canGoToAssemblerFlow = isDesktop();
 
 	if (
-		themeParameter === 'blank-canvas-3' &&
+		themeParameter === BLANK_CANVAS_DESIGN.slug &&
 		config.isEnabled( 'pattern-assembler/logged-out-showcase' )
 	) {
 		if ( canGoToAssemblerFlow ) {

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -1,4 +1,5 @@
 import config from '@automattic/calypso-config';
+import { isDesktop } from '@automattic/viewport';
 import { get, includes, reject } from 'lodash';
 import detectHistoryNavigation from 'calypso/lib/detect-history-navigation';
 import { getQueryArgs } from 'calypso/lib/query-args';
@@ -108,7 +109,10 @@ function getThankYouNoSiteDestination() {
 }
 
 function getChecklistThemeDestination( { siteSlug, themeParameter } ) {
+	const canGoToAssemblerFlow = isDesktop();
+
 	if (
+		canGoToAssemblerFlow &&
 		themeParameter === 'blank-canvas-3' &&
 		config.isEnabled( 'pattern-assembler/logged-out-showcase' )
 	) {

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -112,7 +112,13 @@ function getChecklistThemeDestination( { siteSlug, themeParameter } ) {
 		themeParameter === 'blank-canvas-3' &&
 		config.isEnabled( 'pattern-assembler/logged-out-showcase' )
 	) {
-		return `/setup/site-setup/patternAssembler?siteSlug=${ siteSlug }`;
+		return addQueryArgs(
+			{
+				theme: themeParameter,
+				siteSlug: siteSlug,
+			},
+			`/setup/assembler`
+		);
 	}
 	return `/home/${ siteSlug }`;
 }

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -112,17 +112,20 @@ function getChecklistThemeDestination( { siteSlug, themeParameter } ) {
 	const canGoToAssemblerFlow = isDesktop();
 
 	if (
-		canGoToAssemblerFlow &&
 		themeParameter === 'blank-canvas-3' &&
 		config.isEnabled( 'pattern-assembler/logged-out-showcase' )
 	) {
-		return addQueryArgs(
-			{
-				theme: themeParameter,
-				siteSlug: siteSlug,
-			},
-			`/setup/assembler`
-		);
+		if ( canGoToAssemblerFlow ) {
+			return addQueryArgs(
+				{
+					theme: themeParameter,
+					siteSlug: siteSlug,
+				},
+				`/setup/site-assembler`
+			);
+		}
+
+		return `/site-editor/${ siteSlug }`;
 	}
 	return `/home/${ siteSlug }`;
 }

--- a/packages/onboarding/src/utils/flows.ts
+++ b/packages/onboarding/src/utils/flows.ts
@@ -13,6 +13,8 @@ export const MIGRATION_FLOW = 'import-focused';
 export const COPY_SITE_FLOW = 'copy-site';
 export const BUILD_FLOW = 'build';
 export const WRITE_FLOW = 'write';
+export const ASSEMBLER_FLOW = 'assembler';
+export const SITE_SETUP_FLOW = 'site-setup';
 
 export const isLinkInBioFlow = ( flowName: string | null ) => {
 	return Boolean(

--- a/packages/onboarding/src/utils/flows.ts
+++ b/packages/onboarding/src/utils/flows.ts
@@ -13,7 +13,7 @@ export const MIGRATION_FLOW = 'import-focused';
 export const COPY_SITE_FLOW = 'copy-site';
 export const BUILD_FLOW = 'build';
 export const WRITE_FLOW = 'write';
-export const ASSEMBLER_FLOW = 'assembler';
+export const ASSEMBLER_FLOW = 'site-assembler';
 export const SITE_SETUP_FLOW = 'site-setup';
 
 export const isLinkInBioFlow = ( flowName: string | null ) => {

--- a/packages/onboarding/src/utils/flows.ts
+++ b/packages/onboarding/src/utils/flows.ts
@@ -13,7 +13,7 @@ export const MIGRATION_FLOW = 'import-focused';
 export const COPY_SITE_FLOW = 'copy-site';
 export const BUILD_FLOW = 'build';
 export const WRITE_FLOW = 'write';
-export const ASSEMBLER_FLOW = 'site-assembler';
+export const SITE_ASSEMBLER_FLOW = 'site-assembler';
 export const SITE_SETUP_FLOW = 'site-setup';
 
 export const isLinkInBioFlow = ( flowName: string | null ) => {


### PR DESCRIPTION
#### Proposed Changes

* Instead of redirect to the PA step of site-setup flow, we should create new Assembler flow with only PA step
* This will help introduce the pattern assembler flow into logged-out and logged-in theme showcase 
* PR #71852 will be retired

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
 
* Checkout this branch, if you are using calypso live link, open the browser console and run this to make sure the feature flag is enabled `document.cookie = 'flags=pattern-assembler/logged-out-showcase;max-age=1209600;path=/'`
* Log out from your wp account
* Access theme showcase via /themes
* Select blank-canvas-3 theme and confirm that /patternAssembler step is shown after finishing site creation
* Select other theme and confirm that the end of flow is /home

| Blank Canvas Card  <br> Large screen ( > 960px ) | Blank Canvas Card <br> Small Screen | Other Card |
|---------------------------------------------|--------------------------------|------------|
|   <video src="https://user-images.githubusercontent.com/10071857/215333419-d896a860-0113-45f0-ad6b-92f3be23f500.mp4"></video> |               <video src="https://user-images.githubusercontent.com/10071857/215333504-43a1c1ef-242c-4acc-b7c9-6d0b6c3910cb.mp4"></video>                 |   <video src="https://user-images.githubusercontent.com/10071857/215333705-bb4b69ed-06d3-4ea0-92e8-608951830cf4.mov"></video>  |





#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

#### Reference
Related to #71706
Detailed post pbxlJb-3oe-p2