### PR TITLE
Site Assembler - Write Flow (dotcom patterns only)

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -100,9 +100,9 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 
 		const blankCanvasDesignOffset = allDesigns.static.designs.findIndex( isBlankCanvasDesign );
 		if ( blankCanvasDesignOffset !== -1 ) {
-			// Extract the blank canvas design first and then insert it into the last one for the build intent
+			// Extract the blank canvas design first and then insert it into the last one for the build and write intents
 			const blankCanvasDesign = allDesigns.static.designs.splice( blankCanvasDesignOffset, 1 );
-			if ( isEnabled( 'signup/design-picker-pattern-assembler' ) ) {
+			if ( isEnabled( 'signup/design-picker-pattern-assembler' ) && intent !== SiteIntent.Sell ) {
 				allDesigns.static.designs.push( ...blankCanvasDesign );
 			}
 		}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -102,7 +102,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 		if ( blankCanvasDesignOffset !== -1 ) {
 			// Extract the blank canvas design first and then insert it into the last one for the build intent
 			const blankCanvasDesign = allDesigns.static.designs.splice( blankCanvasDesignOffset, 1 );
-			if ( isEnabled( 'signup/design-picker-pattern-assembler' ) && intent === SiteIntent.Build ) {
+			if ( isEnabled( 'signup/design-picker-pattern-assembler' ) ) {
 				allDesigns.static.designs.push( ...blankCanvasDesign );
 			}
 		}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -51,6 +51,7 @@ import type { StarterDesigns } from '@automattic/data-stores';
 import type { Design, StyleVariation } from '@automattic/design-picker';
 
 const SiteIntent = Onboard.SiteIntent;
+const SITE_ASSEMBLER_AVAILABLE_INTENTS: string[] = [ SiteIntent.Build, SiteIntent.Write ];
 
 const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 	const { goBack, submit, exitFlow } = navigation;
@@ -102,7 +103,10 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 		if ( blankCanvasDesignOffset !== -1 ) {
 			// Extract the blank canvas design first and then insert it into the last one for the build and write intents
 			const blankCanvasDesign = allDesigns.static.designs.splice( blankCanvasDesignOffset, 1 );
-			if ( isEnabled( 'signup/design-picker-pattern-assembler' ) && intent !== SiteIntent.Sell ) {
+			if (
+				isEnabled( 'signup/design-picker-pattern-assembler' ) &&
+				SITE_ASSEMBLER_AVAILABLE_INTENTS.includes( intent )
+			) {
 				allDesigns.static.designs.push( ...blankCanvasDesign );
 			}
 		}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -51,7 +51,11 @@ import type { StarterDesigns } from '@automattic/data-stores';
 import type { Design, StyleVariation } from '@automattic/design-picker';
 
 const SiteIntent = Onboard.SiteIntent;
-const SITE_ASSEMBLER_AVAILABLE_INTENTS: string[] = [ SiteIntent.Build, SiteIntent.Write ];
+const SITE_ASSEMBLER_AVAILABLE_INTENTS: string[] = [ SiteIntent.Build ];
+
+if ( isEnabled( 'pattern-assembler/write-flow' ) ) {
+	SITE_ASSEMBLER_AVAILABLE_INTENTS.push( SiteIntent.Write );
+}
 
 const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 	const { goBack, submit, exitFlow } = navigation;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/constants.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/constants.ts
@@ -2,3 +2,4 @@ export const PATTERN_SOURCE_SITE_ID = 174455321; // dotcompatterns
 export const PUBLIC_API_URL = 'https://public-api.wordpress.com';
 export const PREVIEW_PATTERN_URL = PUBLIC_API_URL + '/wpcom/v2/block-previews/pattern';
 export const SITE_TAGLINE = 'Site Tagline';
+export const PLACEHOLDER_SITE_ID = 211865921; // blankcanvas3demo.wordpress.com

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -257,7 +257,7 @@ const PatternAssembler: Step = ( { navigation, flow } ) => {
 						createCustomHomeTemplateContent( stylesheet, !! header, !! footer, !! sections.length )
 					)
 				)
-				.then( () => runThemeSetupOnSite( siteSlugOrId, design ) )
+				.then( () => runThemeSetupOnSite( siteSlugOrId, design, { trimContent: true } ) )
 				.then( () => reduxDispatch( requestActiveTheme( site?.ID || -1 ) ) )
 		);
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -257,7 +257,12 @@ const PatternAssembler: Step = ( { navigation, flow } ) => {
 						createCustomHomeTemplateContent( stylesheet, !! header, !! footer, !! sections.length )
 					)
 				)
-				.then( () => runThemeSetupOnSite( siteSlugOrId, design, { trimContent: false } ) )
+				.then( () =>
+					runThemeSetupOnSite( siteSlugOrId, design, {
+						trimContent: false,
+						is_assembler_flow: true,
+					} )
+				)
 				.then( () => reduxDispatch( requestActiveTheme( site?.ID || -1 ) ) )
 		);
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -13,7 +13,7 @@ import { useSiteIdParam } from '../../../../hooks/use-site-id-param';
 import { useSiteSlugParam } from '../../../../hooks/use-site-slug-param';
 import { SITE_STORE, ONBOARD_STORE } from '../../../../stores';
 import { recordSelectedDesign } from '../../analytics/record-design';
-import { SITE_TAGLINE } from './constants';
+import { SITE_TAGLINE, PLACEHOLDER_SITE_ID } from './constants';
 import PatternLayout from './pattern-layout';
 import PatternSelectorLoader from './pattern-selector-loader';
 import { useAllPatterns } from './patterns-data';
@@ -260,7 +260,7 @@ const PatternAssembler: Step = ( { navigation, flow } ) => {
 				.then( () =>
 					runThemeSetupOnSite( siteSlugOrId, design, {
 						trimContent: false,
-						is_assembler_flow: true,
+						posts_source_site_id: PLACEHOLDER_SITE_ID,
 					} )
 				)
 				.then( () => reduxDispatch( requestActiveTheme( site?.ID || -1 ) ) )

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -257,7 +257,7 @@ const PatternAssembler: Step = ( { navigation, flow } ) => {
 						createCustomHomeTemplateContent( stylesheet, !! header, !! footer, !! sections.length )
 					)
 				)
-				.then( () => runThemeSetupOnSite( siteSlugOrId, design, { trimContent: true } ) )
+				.then( () => runThemeSetupOnSite( siteSlugOrId, design, { trimContent: false } ) )
 				.then( () => reduxDispatch( requestActiveTheme( site?.ID || -1 ) ) )
 		);
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-assembler-container.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-assembler-container.tsx
@@ -1,4 +1,5 @@
 import { BlockRendererProvider, PatternsRendererProvider } from '@automattic/block-renderer';
+import { POST_SITE_ID } from './constants';
 import type { SiteInfo } from '@automattic/block-renderer';
 
 interface Props {
@@ -18,11 +19,11 @@ const PatternAssemblerContainer = ( {
 }: Props ) => (
 	<BlockRendererProvider siteId={ siteId } stylesheet={ stylesheet }>
 		<PatternsRendererProvider
-			// Use theme demo site to render the site-related blocks for now.
-			// For example, site logo, site title, site tagline, posts.
-			siteId={ siteId }
+			// Use this site to render the posts of query patterns.
+			siteId={ POST_SITE_ID }
 			stylesheet={ stylesheet }
 			patternIds={ patternIds }
+			// Use siteInfo for user's site title, and tagline.
 			siteInfo={ siteInfo }
 		>
 			{ children }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-assembler-container.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-assembler-container.tsx
@@ -1,5 +1,5 @@
 import { BlockRendererProvider, PatternsRendererProvider } from '@automattic/block-renderer';
-import { POST_SITE_ID } from './constants';
+import { PLACEHOLDER_SITE_ID } from './constants';
 import type { SiteInfo } from '@automattic/block-renderer';
 
 interface Props {
@@ -19,11 +19,12 @@ const PatternAssemblerContainer = ( {
 }: Props ) => (
 	<BlockRendererProvider siteId={ siteId } stylesheet={ stylesheet }>
 		<PatternsRendererProvider
-			// Use this site to render the posts of query patterns.
-			siteId={ POST_SITE_ID }
+			// Site used to render site-related things on the previews,
+			// such as the logo, title, and tagline.
+			siteId={ PLACEHOLDER_SITE_ID }
 			stylesheet={ stylesheet }
 			patternIds={ patternIds }
-			// Use siteInfo for user's site title, and tagline.
+			// Use siteInfo to overwrite site-related things such as title, and tagline.
 			siteInfo={ siteInfo }
 		>
 			{ children }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/patterns-data.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/patterns-data.ts
@@ -185,6 +185,7 @@ const useSectionPatterns = () => {
 	const links = translate( 'Links' );
 	const services = translate( 'Services' );
 	const portfolio = translate( 'Portfolio' );
+	const posts = translate( 'Posts' );
 
 	const sectionPatterns: Pattern[] = useMemo(
 		() => [
@@ -254,8 +255,48 @@ const useSectionPatterns = () => {
 				category: callToAction,
 			},
 			{
+				id: 5645,
+				name: 'Four Recent Blog Posts',
+				category: posts,
+			},
+			{
+				id: 1784,
+				name: 'Recent Posts',
+				category: posts,
+			},
+			{
+				id: 8421,
+				name: 'Grid of posts 2x3',
+				category: posts,
+			},
+			{
+				id: 8435,
+				name: 'Grid of Posts 3x2',
+				category: posts,
+			},
+			{
+				id: 7996,
+				name: 'Grid of Posts 4x2',
+				category: posts,
+			},
+			{
+				id: 8437,
+				name: 'List of posts',
+				category: posts,
+			},
+			{
+				id: 3213,
+				name: 'Latest podcast episodes',
+				category: posts,
+			},
+			{
 				id: 6305,
 				name: 'Heading with Image Grid',
+				category: images,
+			},
+			{
+				id: 7149,
+				name: 'Two column image grid',
 				category: images,
 			},
 			{

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/patterns-data.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/patterns-data.ts
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import type { Pattern } from './types';
@@ -188,278 +189,281 @@ const useSectionPatterns = () => {
 	const posts = translate( 'Posts' );
 
 	const sectionPatterns: Pattern[] = useMemo(
-		() => [
-			{
-				id: 7156,
-				name: 'Media and text with image on the right',
-				category: callToAction,
-			},
-			{
-				id: 7153,
-				name: 'Media and text with image on the left',
-				category: callToAction,
-			},
-			{
-				id: 7146,
-				name: 'Four column list',
-				category: callToAction,
-			},
-			{
-				id: 7132,
-				name: 'Cover image with left-aligned call to action',
-				category: callToAction,
-			},
-			{
-				id: 7159,
-				name: 'Cover image with centered text and a button',
-				category: callToAction,
-			},
-			{
-				id: 3741,
-				name: 'Large CTA',
-				category: callToAction,
-			},
-			{
-				id: 6303,
-				name: 'Two Buttons Centered CTA',
-				category: callToAction,
-			},
-			{
-				id: 6304,
-				name: 'Centered Heading with CTA',
-				category: callToAction,
-			},
-			{
-				id: 6311,
-				name: 'Portfolio Project',
-				category: callToAction,
-			},
-			{
-				id: 3747,
-				name: 'Hero with CTA',
-				category: callToAction,
-			},
-			{
-				id: 6308,
-				name: 'Cover Image with CTA',
-				category: callToAction,
-			},
-			{
-				id: 6310,
-				name: 'Gallery with description on the left',
-				category: callToAction,
-			},
-			{
-				id: 6312,
-				name: 'Two Column CTA',
-				category: callToAction,
-			},
-			{
-				id: 5645,
-				name: 'Four Recent Blog Posts',
-				category: posts,
-			},
-			{
-				id: 1784,
-				name: 'Recent Posts',
-				category: posts,
-			},
-			{
-				id: 8421,
-				name: 'Grid of posts 2x3',
-				category: posts,
-			},
-			{
-				id: 8435,
-				name: 'Grid of Posts 3x2',
-				category: posts,
-			},
-			{
-				id: 7996,
-				name: 'Grid of Posts 4x2',
-				category: posts,
-			},
-			{
-				id: 8437,
-				name: 'List of posts',
-				category: posts,
-			},
-			{
-				id: 3213,
-				name: 'Latest podcast episodes',
-				category: posts,
-			},
-			{
-				id: 6305,
-				name: 'Heading with Image Grid',
-				category: images,
-			},
-			{
-				id: 7149,
-				name: 'Two column image grid',
-				category: images,
-			},
-			{
-				id: 7149,
-				name: 'Two column image grid',
-				category: images,
-			},
-			{
-				id: 5691,
-				name: 'Three logos, heading, and paragraphs',
-				category: images,
-			},
-			{
-				id: 7143,
-				name: 'Full-width image',
-				category: images,
-			},
-			{
-				id: 737,
-				name: 'Logos',
-				category: images,
-			},
-			{
-				id: 1585,
-				name: 'Quote and logos',
-				category: images,
-			},
-			{
-				id: 7135,
-				name: 'Three columns with images and text',
-				category: list,
-			},
-			{
-				id: 789,
-				name: 'Numbered list',
-				category: list,
-			},
-			{
-				id: 6712,
-				name: 'List of events',
-				category: list,
-			},
-			{
-				id: 5666,
-				name: 'Large numbers, heading, and paragraphs',
-				category: numbers,
-			},
-			{
-				id: 462,
-				name: 'Numbers',
-				category: numbers,
-			},
-			{
-				id: 6309,
-				name: '6309',
-				category: about,
-			},
-			{
-				id: 6306,
-				name: 'Names List',
-				category: about,
-			},
-			{
-				id: 5663,
-				name: 'Large headline',
-				category: about,
-			},
-			{
-				id: 7140,
-				name: 'Left-aligned headline',
-				category: about,
-			},
-			{
-				id: 7138,
-				name: 'Centered headline and text',
-				category: about,
-			},
-			{
-				id: 7161,
-				name: 'Two testimonials side by side',
-				category: testimonials,
-			},
-			{
-				id: 6307,
-				name: '3 Column Testimonials',
-				category: testimonials,
-			},
-			{
-				id: 6324,
-				name: 'Two Column Testimonials',
-				category: testimonials,
-			},
-			{
-				id: 1600,
-				name: 'Three column text and links',
-				category: links,
-			},
-			{
-				id: 6323,
-				name: "FAQ's",
-				category: services,
-			},
-			{
-				id: 3743,
-				name: 'Simple Two Column Layout',
-				category: services,
-			},
-			{
-				id: 39,
-				name: 'Topics with Image',
-				category: services,
-			},
-			{
-				id: 6313,
-				name: 'Portfolio Intro',
-				category: portfolio,
-			},
-			{
-				id: 6314,
-				name: 'Centered Intro',
-				category: portfolio,
-			},
-			{
-				id: 6315,
-				name: 'Large Intro Text',
-				category: portfolio,
-			},
-			{
-				id: 6316,
-				name: 'Squared Media & Text',
-				category: portfolio,
-			},
-			{
-				id: 6317,
-				name: 'Horizontal Media & Text',
-				category: portfolio,
-			},
-			{
-				id: 6318,
-				name: 'Offset Projects',
-				category: portfolio,
-			},
-			{
-				id: 6319,
-				name: 'Case Study',
-				category: portfolio,
-			},
-			{
-				id: 6320,
-				name: 'Heading with two images and descriptions',
-				category: portfolio,
-			},
-			{
-				id: 6321,
-				name: 'CV Text Grid',
-				category: portfolio,
-			},
-			{
-				id: 6322,
-				name: 'Tall Item One Column',
-				category: portfolio,
-			},
-		],
+		() =>
+			[
+				{
+					id: 7156,
+					name: 'Media and text with image on the right',
+					category: callToAction,
+				},
+				{
+					id: 7153,
+					name: 'Media and text with image on the left',
+					category: callToAction,
+				},
+				{
+					id: 7146,
+					name: 'Four column list',
+					category: callToAction,
+				},
+				{
+					id: 7132,
+					name: 'Cover image with left-aligned call to action',
+					category: callToAction,
+				},
+				{
+					id: 7159,
+					name: 'Cover image with centered text and a button',
+					category: callToAction,
+				},
+				{
+					id: 3741,
+					name: 'Large CTA',
+					category: callToAction,
+				},
+				{
+					id: 6303,
+					name: 'Two Buttons Centered CTA',
+					category: callToAction,
+				},
+				{
+					id: 6304,
+					name: 'Centered Heading with CTA',
+					category: callToAction,
+				},
+				{
+					id: 6311,
+					name: 'Portfolio Project',
+					category: callToAction,
+				},
+				{
+					id: 3747,
+					name: 'Hero with CTA',
+					category: callToAction,
+				},
+				{
+					id: 6308,
+					name: 'Cover Image with CTA',
+					category: callToAction,
+				},
+				{
+					id: 6310,
+					name: 'Gallery with description on the left',
+					category: callToAction,
+				},
+				{
+					id: 6312,
+					name: 'Two Column CTA',
+					category: callToAction,
+				},
+				{
+					id: 5645,
+					name: 'Four Recent Blog Posts',
+					category: posts,
+				},
+				{
+					id: 1784,
+					name: 'Recent Posts',
+					category: posts,
+				},
+				{
+					id: 8421,
+					name: 'Grid of posts 2x3',
+					category: posts,
+				},
+				{
+					id: 8435,
+					name: 'Grid of Posts 3x2',
+					category: posts,
+				},
+				{
+					id: 7996,
+					name: 'Grid of Posts 4x2',
+					category: posts,
+				},
+				{
+					id: 8437,
+					name: 'List of posts',
+					category: posts,
+				},
+				{
+					id: 3213,
+					name: 'Latest podcast episodes',
+					category: posts,
+				},
+				{
+					id: 6305,
+					name: 'Heading with Image Grid',
+					category: images,
+				},
+				{
+					id: 7149,
+					name: 'Two column image grid',
+					category: images,
+				},
+				{
+					id: 7149,
+					name: 'Two column image grid',
+					category: images,
+				},
+				{
+					id: 5691,
+					name: 'Three logos, heading, and paragraphs',
+					category: images,
+				},
+				{
+					id: 7143,
+					name: 'Full-width image',
+					category: images,
+				},
+				{
+					id: 737,
+					name: 'Logos',
+					category: images,
+				},
+				{
+					id: 1585,
+					name: 'Quote and logos',
+					category: images,
+				},
+				{
+					id: 7135,
+					name: 'Three columns with images and text',
+					category: list,
+				},
+				{
+					id: 789,
+					name: 'Numbered list',
+					category: list,
+				},
+				{
+					id: 6712,
+					name: 'List of events',
+					category: list,
+				},
+				{
+					id: 5666,
+					name: 'Large numbers, heading, and paragraphs',
+					category: numbers,
+				},
+				{
+					id: 462,
+					name: 'Numbers',
+					category: numbers,
+				},
+				{
+					id: 6309,
+					name: '6309',
+					category: about,
+				},
+				{
+					id: 6306,
+					name: 'Names List',
+					category: about,
+				},
+				{
+					id: 5663,
+					name: 'Large headline',
+					category: about,
+				},
+				{
+					id: 7140,
+					name: 'Left-aligned headline',
+					category: about,
+				},
+				{
+					id: 7138,
+					name: 'Centered headline and text',
+					category: about,
+				},
+				{
+					id: 7161,
+					name: 'Two testimonials side by side',
+					category: testimonials,
+				},
+				{
+					id: 6307,
+					name: '3 Column Testimonials',
+					category: testimonials,
+				},
+				{
+					id: 6324,
+					name: 'Two Column Testimonials',
+					category: testimonials,
+				},
+				{
+					id: 1600,
+					name: 'Three column text and links',
+					category: links,
+				},
+				{
+					id: 6323,
+					name: "FAQ's",
+					category: services,
+				},
+				{
+					id: 3743,
+					name: 'Simple Two Column Layout',
+					category: services,
+				},
+				{
+					id: 39,
+					name: 'Topics with Image',
+					category: services,
+				},
+				{
+					id: 6313,
+					name: 'Portfolio Intro',
+					category: portfolio,
+				},
+				{
+					id: 6314,
+					name: 'Centered Intro',
+					category: portfolio,
+				},
+				{
+					id: 6315,
+					name: 'Large Intro Text',
+					category: portfolio,
+				},
+				{
+					id: 6316,
+					name: 'Squared Media & Text',
+					category: portfolio,
+				},
+				{
+					id: 6317,
+					name: 'Horizontal Media & Text',
+					category: portfolio,
+				},
+				{
+					id: 6318,
+					name: 'Offset Projects',
+					category: portfolio,
+				},
+				{
+					id: 6319,
+					name: 'Case Study',
+					category: portfolio,
+				},
+				{
+					id: 6320,
+					name: 'Heading with two images and descriptions',
+					category: portfolio,
+				},
+				{
+					id: 6321,
+					name: 'CV Text Grid',
+					category: portfolio,
+				},
+				{
+					id: 6322,
+					name: 'Tall Item One Column',
+					category: portfolio,
+				},
+			].filter(
+				( { category } ) => isEnabled( 'pattern-assembler/write-flow' ) || category !== posts
+			),
 		[]
 	);
 

--- a/config/development.json
+++ b/config/development.json
@@ -131,6 +131,7 @@
 		"page/export": true,
 		"pattern-assembler/client-side-render": true,
 		"pattern-assembler/logged-out-showcase": true,
+		"pattern-assembler/write-flow": true,
 		"plans/personal-plan": true,
 		"plans/pro-plan": false,
 		"plans/starter-plan": false,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -82,6 +82,7 @@
 		"p2/p2-plus": true,
 		"pattern-assembler/client-side-render": true,
 		"pattern-assembler/logged-out-showcase": true,
+		"pattern-assembler/write-flow": false,
 		"plans/personal-plan": true,
 		"plans/pro-plan": false,
 		"plans/starter-plan": false,

--- a/config/production.json
+++ b/config/production.json
@@ -96,6 +96,7 @@
 		"p2/p2-plus": true,
 		"pattern-assembler/client-side-render": true,
 		"pattern-assembler/logged-out-showcase": false,
+		"pattern-assembler/write-flow": false,
 		"plans/personal-plan": true,
 		"plans/pro-plan": false,
 		"plans/starter-plan": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -94,6 +94,7 @@
 		"page/export": true,
 		"pattern-assembler/client-side-render": true,
 		"pattern-assembler/logged-out-showcase": false,
+		"pattern-assembler/write-flow": false,
 		"plans/personal-plan": true,
 		"plans/pro-plan": false,
 		"plans/starter-plan": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -103,6 +103,7 @@
 		"p2/p2-plus": true,
 		"pattern-assembler/client-side-render": true,
 		"pattern-assembler/logged-out-showcase": true,
+		"pattern-assembler/write-flow": true,
 		"plans/personal-plan": true,
 		"plans/pro-plan": false,
 		"plans/starter-plan": false,

--- a/packages/data-stores/src/site/actions.ts
+++ b/packages/data-stores/src/site/actions.ts
@@ -398,7 +398,7 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		}
 
 		const themeSetupOptions: ThemeSetupOptions = {
-			trim_content: true,
+			trim_content: options?.trimContent !== undefined ? options?.trimContent : true,
 		};
 
 		if ( verticalizable ) {

--- a/packages/data-stores/src/site/actions.ts
+++ b/packages/data-stores/src/site/actions.ts
@@ -399,8 +399,11 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 
 		const themeSetupOptions: ThemeSetupOptions = {
 			trim_content: options?.trimContent ?? true,
-			posts_source_site_id: options?.posts_source_site_id,
 		};
+
+		if ( options?.posts_source_site_id ) {
+			themeSetupOptions.posts_source_site_id = options.posts_source_site_id;
+		}
 
 		if ( verticalizable ) {
 			themeSetupOptions.vertical_id = options?.verticalId;

--- a/packages/data-stores/src/site/actions.ts
+++ b/packages/data-stores/src/site/actions.ts
@@ -399,6 +399,7 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 
 		const themeSetupOptions: ThemeSetupOptions = {
 			trim_content: options?.trimContent ?? true,
+			is_assembler_flow: options?.is_assembler_flow ?? false,
 		};
 
 		if ( verticalizable ) {

--- a/packages/data-stores/src/site/actions.ts
+++ b/packages/data-stores/src/site/actions.ts
@@ -399,7 +399,7 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 
 		const themeSetupOptions: ThemeSetupOptions = {
 			trim_content: options?.trimContent ?? true,
-			is_assembler_flow: options?.is_assembler_flow ?? false,
+			posts_source_site_id: options?.posts_source_site_id,
 		};
 
 		if ( verticalizable ) {

--- a/packages/data-stores/src/site/actions.ts
+++ b/packages/data-stores/src/site/actions.ts
@@ -398,7 +398,7 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		}
 
 		const themeSetupOptions: ThemeSetupOptions = {
-			trim_content: options?.trimContent !== undefined ? options?.trimContent : true,
+			trim_content: options?.trimContent ?? true,
 		};
 
 		if ( verticalizable ) {

--- a/packages/data-stores/src/site/test/actions.ts
+++ b/packages/data-stores/src/site/test/actions.ts
@@ -473,6 +473,7 @@ describe( 'Site Actions', () => {
 			expect( generator.next().value ).toEqual(
 				createMockedThemeSetupApiRequest( {
 					trim_content: true,
+					is_assembler_flow: false,
 				} )
 			);
 		} );
@@ -502,6 +503,7 @@ describe( 'Site Actions', () => {
 				createMockedThemeSetupApiRequest( {
 					trim_content: true,
 					vertical_id: mockedSiteVerticalId,
+					is_assembler_flow: false,
 				} )
 			);
 		} );
@@ -530,6 +532,7 @@ describe( 'Site Actions', () => {
 				createMockedThemeSetupApiRequest( {
 					trim_content: true,
 					pattern_ids: patternIds,
+					is_assembler_flow: false,
 				} )
 			);
 		} );
@@ -558,6 +561,7 @@ describe( 'Site Actions', () => {
 				createMockedThemeSetupApiRequest( {
 					trim_content: true,
 					header_pattern_ids: headerPatternIds,
+					is_assembler_flow: false,
 				} )
 			);
 		} );
@@ -586,6 +590,7 @@ describe( 'Site Actions', () => {
 				createMockedThemeSetupApiRequest( {
 					trim_content: true,
 					footer_pattern_ids: footerPatternIds,
+					is_assembler_flow: false,
 				} )
 			);
 		} );

--- a/packages/data-stores/src/site/test/actions.ts
+++ b/packages/data-stores/src/site/test/actions.ts
@@ -473,7 +473,7 @@ describe( 'Site Actions', () => {
 			expect( generator.next().value ).toEqual(
 				createMockedThemeSetupApiRequest( {
 					trim_content: true,
-					is_assembler_flow: false,
+					posts_source_site_id: undefined,
 				} )
 			);
 		} );
@@ -503,7 +503,7 @@ describe( 'Site Actions', () => {
 				createMockedThemeSetupApiRequest( {
 					trim_content: true,
 					vertical_id: mockedSiteVerticalId,
-					is_assembler_flow: false,
+					posts_source_site_id: undefined,
 				} )
 			);
 		} );
@@ -532,7 +532,7 @@ describe( 'Site Actions', () => {
 				createMockedThemeSetupApiRequest( {
 					trim_content: true,
 					pattern_ids: patternIds,
-					is_assembler_flow: false,
+					posts_source_site_id: undefined,
 				} )
 			);
 		} );
@@ -561,7 +561,7 @@ describe( 'Site Actions', () => {
 				createMockedThemeSetupApiRequest( {
 					trim_content: true,
 					header_pattern_ids: headerPatternIds,
-					is_assembler_flow: false,
+					posts_source_site_id: undefined,
 				} )
 			);
 		} );
@@ -590,7 +590,7 @@ describe( 'Site Actions', () => {
 				createMockedThemeSetupApiRequest( {
 					trim_content: true,
 					footer_pattern_ids: footerPatternIds,
-					is_assembler_flow: false,
+					posts_source_site_id: undefined,
 				} )
 			);
 		} );

--- a/packages/data-stores/src/site/test/actions.ts
+++ b/packages/data-stores/src/site/test/actions.ts
@@ -473,7 +473,6 @@ describe( 'Site Actions', () => {
 			expect( generator.next().value ).toEqual(
 				createMockedThemeSetupApiRequest( {
 					trim_content: true,
-					posts_source_site_id: undefined,
 				} )
 			);
 		} );
@@ -503,7 +502,6 @@ describe( 'Site Actions', () => {
 				createMockedThemeSetupApiRequest( {
 					trim_content: true,
 					vertical_id: mockedSiteVerticalId,
-					posts_source_site_id: undefined,
 				} )
 			);
 		} );
@@ -532,7 +530,6 @@ describe( 'Site Actions', () => {
 				createMockedThemeSetupApiRequest( {
 					trim_content: true,
 					pattern_ids: patternIds,
-					posts_source_site_id: undefined,
 				} )
 			);
 		} );
@@ -561,7 +558,6 @@ describe( 'Site Actions', () => {
 				createMockedThemeSetupApiRequest( {
 					trim_content: true,
 					header_pattern_ids: headerPatternIds,
-					posts_source_site_id: undefined,
 				} )
 			);
 		} );
@@ -590,7 +586,6 @@ describe( 'Site Actions', () => {
 				createMockedThemeSetupApiRequest( {
 					trim_content: true,
 					footer_pattern_ids: footerPatternIds,
-					posts_source_site_id: undefined,
 				} )
 			);
 		} );

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -472,7 +472,7 @@ export interface ThemeSetupOptions {
 	pattern_ids?: number[] | string[];
 	header_pattern_ids?: number[] | string[];
 	footer_pattern_ids?: number[] | string[];
-	is_assembler_flow?: boolean;
+	posts_source_site_id?: number;
 }
 
 export interface ActiveTheme {

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -472,6 +472,7 @@ export interface ThemeSetupOptions {
 	pattern_ids?: number[] | string[];
 	header_pattern_ids?: number[] | string[];
 	footer_pattern_ids?: number[] | string[];
+	is_assembler_flow?: boolean;
 }
 
 export interface ActiveTheme {

--- a/packages/design-picker/src/types.ts
+++ b/packages/design-picker/src/types.ts
@@ -117,6 +117,7 @@ export interface DesignOptions {
 	styleVariation?: StyleVariation;
 	verticalId?: string;
 	pageTemplate?: string;
+	trimContent?: boolean;
 }
 
 export interface DesignPreviewOptions {

--- a/packages/design-picker/src/types.ts
+++ b/packages/design-picker/src/types.ts
@@ -118,6 +118,7 @@ export interface DesignOptions {
 	verticalId?: string;
 	pageTemplate?: string;
 	trimContent?: boolean;
+	is_assembler_flow?: boolean;
 }
 
 export interface DesignPreviewOptions {

--- a/packages/design-picker/src/types.ts
+++ b/packages/design-picker/src/types.ts
@@ -118,7 +118,7 @@ export interface DesignOptions {
 	verticalId?: string;
 	pageTemplate?: string;
 	trimContent?: boolean;
-	is_assembler_flow?: boolean;
+	posts_source_site_id?: number;
 }
 
 export interface DesignPreviewOptions {


### PR DESCRIPTION
#### Proposed Changes

* Enables the feature flag "**pattern-assembler/write-flow**" in calypso and development environments to:
  * Show the assembler CTA in the Write flow.
  * Add query patterns from `dotcompatterns` in the sections list. 
* Render the query pattern previews using posts from `blankcanvas3demo` site.
* Pass the params `trim_content: false` and `post_source_site_id` to `/theme-setup` to copy all the posts (4) from `blankcanvas3demo` site into the user's site at the end of the flow. 

Note that changes made in the posts on `blankcanvas3demo` site will affect the following:
- the previews of query patterns in the assembler  
- the posts created on the user's site at the end of the assembler flow

https://user-images.githubusercontent.com/1881481/215760944-ea9a4567-bd7d-4353-b887-af67b760621c.mov

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Test using a non-a8c account (we do this to check that all users can request all the endpoints without having permission issues). 
- Create a new site from the admin or visit `/start`.
- Select a domain and a plan.
- In the goals screen:
  - in other environments different than development, or calypso, you'll need to add this param in the URL `&flags=pattern-assembler/write-flow` and press enter.  
  - then select Write & Publish.
- Continue until the Design picker and scroll down to click `Start designing` on the CTA. If you don't see it, check that the feature flag is in the URL.
- Click `Add sections` to choose query patterns. If you hover them, you'll see their category name `Posts` in a tooltip.
- Check that the previews use 4 posts with image placeholders as featured images.
- Click `Continue` to complete the flow and you'll land on the editor.
- Check that the previews in the editor and the site front-end match the previews in the assembler.
- Check that four posts with feature images have been created on your site.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [X] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [X] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [X] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [X] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [X] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/72565