### PR TITLE
Display PatternAssembler CTA on Logged-out ThemShowcase

### DIFF
--- a/client/components/theme/style.scss
+++ b/client/components/theme/style.scss
@@ -5,7 +5,7 @@ $soft-launch-badge-font-size: 0.725rem;
 	padding: 0;
 	margin: 0 10px 20px;
 	width: 230px; // Fixed width gives desired wrapping...
-	flex-grow: 1; // ...grow allows expansion to fill space after wrap.
+	flex-grow: 0; // ...grow allows expansion to fill space after wrap.
 	transition: all 100ms ease-in-out;
 
 	&.is-active {

--- a/client/components/theme/style.scss
+++ b/client/components/theme/style.scss
@@ -4,8 +4,6 @@ $soft-launch-badge-font-size: 0.725rem;
 .theme {
 	padding: 0;
 	margin: 0 10px 20px;
-	width: 230px; // Fixed width gives desired wrapping...
-	flex-grow: 1; // ...grow allows expansion to fill space after wrap.
 	transition: all 100ms ease-in-out;
 
 	&.is-active {

--- a/client/components/theme/style.scss
+++ b/client/components/theme/style.scss
@@ -5,7 +5,7 @@ $soft-launch-badge-font-size: 0.725rem;
 	padding: 0;
 	margin: 0 10px 20px;
 	width: 230px; // Fixed width gives desired wrapping...
-	flex-grow: 0; // ...grow allows expansion to fill space after wrap.
+	flex-grow: 1; // ...grow allows expansion to fill space after wrap.
 	transition: all 100ms ease-in-out;
 
 	&.is-active {

--- a/client/components/themes-list/index.jsx
+++ b/client/components/themes-list/index.jsx
@@ -1,7 +1,7 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { FEATURE_INSTALL_THEMES, PLAN_BUSINESS } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
-import { PatternAssemblerCta } from '@automattic/design-picker';
+import { PatternAssemblerCta, BLANK_CANVAS_DESIGN } from '@automattic/design-picker';
 import { localize } from 'i18n-calypso';
 import { isEmpty, times } from 'lodash';
 import page from 'page';
@@ -58,7 +58,9 @@ export const ThemesList = ( props ) => {
 				! isLoggedIn && (
 					<PatternAssemblerCta
 						onButtonClick={ () =>
-							window.location.assign( '/start/with-theme?ref=calypshowcase&theme=blank-canvas-3' )
+							window.location.assign(
+								`/start/with-theme?ref=calypshowcase&theme=${ BLANK_CANVAS_DESIGN.slug }`
+							)
 						}
 					/>
 				) }

--- a/client/components/themes-list/index.jsx
+++ b/client/components/themes-list/index.jsx
@@ -361,13 +361,7 @@ function TrailingItems( { spacersCount } ) {
 	const DEFAULT_NUM_SPACERS = 11; // gives enough spacers for a theoretical 12 column layout
 	const numSpacers = spacersCount ?? DEFAULT_NUM_SPACERS;
 	return times( numSpacers, function ( i ) {
-		return (
-			<div
-				className="themes-list__spacer"
-				key={ 'themes-list__spacer-' + i }
-				data-key={ 'themes-list__spacer-' + i }
-			/>
-		);
+		return <div className="themes-list__spacer" key={ 'themes-list__spacer-' + i } />;
 	} );
 }
 

--- a/client/components/themes-list/index.jsx
+++ b/client/components/themes-list/index.jsx
@@ -1,5 +1,6 @@
 import { FEATURE_INSTALL_THEMES, PLAN_BUSINESS } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
+import PatternAssemblerCta from '@automattic/design-picker';
 import { localize } from 'i18n-calypso';
 import { isEmpty, times } from 'lodash';
 import page from 'page';
@@ -45,6 +46,7 @@ export const ThemesList = ( props ) => {
 
 	return (
 		<div className="themes-list">
+			<PatternAssemblerCta></PatternAssemblerCta>
 			{ props.themes.map( ( theme, index ) => (
 				<ThemeBlock key={ 'theme-block' + index } theme={ theme } index={ index } { ...props } />
 			) ) }

--- a/client/components/themes-list/index.jsx
+++ b/client/components/themes-list/index.jsx
@@ -81,8 +81,9 @@ export const ThemesList = ( props ) => {
 							<PatternAssemblerCta
 								key="pattern-assembler-cta"
 								onButtonClick={ () =>
-									( window.location.href =
-										'/start/with-theme?ref=calypshowcase&theme=blank-canvas-3' )
+									window.location.assign(
+										'/start/with-theme?ref=calypshowcase&theme=blank-canvas-3'
+									)
 								}
 							></PatternAssemblerCta>,
 					  ]

--- a/client/components/themes-list/index.jsx
+++ b/client/components/themes-list/index.jsx
@@ -28,7 +28,10 @@ const THEM_CARD_MARGIN = 16; // used to calculate the max-width of column in the
 
 export const ThemesList = ( props ) => {
 	const isLoggedIn = useSelector( isUserLoggedIn );
-	const [ patternAssemblerCtaPlacement, setPatternAssemblerCtaPlacement ] = useState( { position: -1, trailing: 0 } );
+	const [ patternAssemblerCtaPlacement, setPatternAssemblerCtaPlacement ] = useState( {
+		position: -1,
+		trailing: 0,
+	} );
 
 	const fetchNextPage = useCallback(
 		( options ) => {
@@ -44,12 +47,15 @@ export const ThemesList = ( props ) => {
 					contentRect.width / ( THEME_CARD_WIDTH + THEM_CARD_MARGIN * 2 )
 				);
 				const relativeCtaPosition =
-					columnCount * 3 - 1 < props.themes.length - 1 ? columnCount * 3 - 1 : props.themes.length - 1;
-				const trailingSpacersCount = Math.ceil( props.themes.length / columnCount ) * columnCount - props.themes.length;
-				
+					columnCount * 3 - 1 < props.themes.length - 1
+						? columnCount * 3 - 1
+						: props.themes.length - 1;
+				const trailingSpacersCount =
+					Math.ceil( props.themes.length / columnCount ) * columnCount - props.themes.length;
+
 				setPatternAssemblerCtaPlacement( {
 					position: relativeCtaPosition,
-					trailing: trailingSpacersCount
+					trailing: trailingSpacersCount,
 				} );
 			}
 		},
@@ -77,17 +83,19 @@ export const ThemesList = ( props ) => {
 		<div ref={ resizeRef } className="themes-list">
 			{ props.themes.map( ( theme, index ) => [
 				<ThemeBlock key={ 'theme-block' + index } theme={ theme } index={ index } { ...props } />,
-				...( index === patternAssemblerCtaPlacement.position && isEnabled( 'pattern-assembler/logged-out-showcase' ) && ! isLoggedIn
+				...( index === patternAssemblerCtaPlacement.position &&
+				isEnabled( 'pattern-assembler/logged-out-showcase' ) &&
+				! isLoggedIn
 					? [
-						<TrailingItems spacersCount={ patternAssemblerCtaPlacement.trailing } />,
-						<PatternAssemblerCta
-							key="pattern-assembler-cta"
-							onButtonClick={ () =>
-								window.location.assign(
-									'/start/with-theme?ref=calypshowcase&theme=blank-canvas-3'
-								)
-							}
-						></PatternAssemblerCta>,
+							<TrailingItems spacersCount={ patternAssemblerCtaPlacement.trailing } />,
+							<PatternAssemblerCta
+								key="pattern-assembler-cta"
+								onButtonClick={ () =>
+									window.location.assign(
+										'/start/with-theme?ref=calypshowcase&theme=blank-canvas-3'
+									)
+								}
+							></PatternAssemblerCta>,
 					  ]
 					: [] ),
 			] ) }

--- a/client/components/themes-list/index.jsx
+++ b/client/components/themes-list/index.jsx
@@ -1,7 +1,6 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { FEATURE_INSTALL_THEMES, PLAN_BUSINESS } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
-// eslint-disable-next-line import/named
 import { PatternAssemblerCta } from '@automattic/design-picker';
 import { localize } from 'i18n-calypso';
 import { isEmpty, times } from 'lodash';

--- a/client/components/themes-list/index.jsx
+++ b/client/components/themes-list/index.jsx
@@ -43,18 +43,21 @@ export const ThemesList = ( props ) => {
 	const handleContentRectChange = useCallback(
 		( contentRect ) => {
 			if ( contentRect ) {
+				const themesCount = props.themes.length;
 				const columnCount = Math.floor(
 					contentRect.width / ( THEME_CARD_WIDTH + THEM_CARD_MARGIN * 2 )
 				);
-				const relativeCtaPosition =
-					columnCount * 3 - 1 < props.themes.length - 1
-						? columnCount * 3 - 1
-						: props.themes.length - 1;
-				const trailingSpacersCount =
-					Math.ceil( props.themes.length / columnCount ) * columnCount - props.themes.length;
+				const relativeCtaPosition = columnCount * 3 - 1;
+				const actualCtaPosition =
+					relativeCtaPosition < themesCount - 1 ? relativeCtaPosition : themesCount - 1;
+
+				let trailingSpacersCount = 0;
+				if ( actualCtaPosition >= themesCount - 1 ) {
+					trailingSpacersCount = Math.ceil( themesCount / columnCount ) * columnCount - themesCount;
+				}
 
 				setPatternAssemblerCtaPlacement( {
-					position: relativeCtaPosition,
+					position: actualCtaPosition,
 					trailing: trailingSpacersCount,
 				} );
 			}
@@ -87,7 +90,10 @@ export const ThemesList = ( props ) => {
 				isEnabled( 'pattern-assembler/logged-out-showcase' ) &&
 				! isLoggedIn
 					? [
-							<TrailingItems spacersCount={ patternAssemblerCtaPlacement.trailing } />,
+							<TrailingItems
+								key="theme-trailing-items"
+								spacersCount={ patternAssemblerCtaPlacement.trailing }
+							/>,
 							<PatternAssemblerCta
 								key="pattern-assembler-cta"
 								onButtonClick={ () =>
@@ -353,9 +359,15 @@ function LoadingPlaceholders( { placeholderCount } ) {
 
 function TrailingItems( { spacersCount } ) {
 	const DEFAULT_NUM_SPACERS = 11; // gives enough spacers for a theoretical 12 column layout
-	const numSpacers = spacersCount || DEFAULT_NUM_SPACERS;
+	const numSpacers = spacersCount ?? DEFAULT_NUM_SPACERS;
 	return times( numSpacers, function ( i ) {
-		return <div className="themes-list__spacer" key={ 'themes-list__spacer-' + i } />;
+		return (
+			<div
+				className="themes-list__spacer"
+				key={ 'themes-list__spacer-' + i }
+				data-key={ 'themes-list__spacer-' + i }
+			/>
+		);
 	} );
 }
 

--- a/client/components/themes-list/index.jsx
+++ b/client/components/themes-list/index.jsx
@@ -39,7 +39,9 @@ export const ThemesList = ( props ) => {
 	const handleContentRectChange = useCallback(
 		( contentRect, elementRef ) => {
 			if ( contentRect ) {
-				const rowCount = Math.floor( contentRect.width / THEME_CARD_WIDTH );
+				const rowCount = Math.floor(
+					contentRect.width / ( THEME_CARD_WIDTH + THEM_CARD_MARGIN * 2 )
+				);
 				const relativeCtaPosition =
 					rowCount * 3 - 1 < props.themes.length - 1 ? rowCount * 3 - 1 : props.themes.length - 1;
 				setCtaPosition( relativeCtaPosition );

--- a/client/components/themes-list/index.jsx
+++ b/client/components/themes-list/index.jsx
@@ -27,6 +27,7 @@ const THEME_CARD_WIDTH = 320; // used to calculate the number of column in theme
 const THEM_CARD_MARGIN = 16; // used to calculate the max-width of column in theme-list
 
 export const ThemesList = ( props ) => {
+	const isLoggedIn = useSelector( isUserLoggedIn );
 	const [ ctaPosition, setCtaPosition ] = useState( 0 );
 
 	const fetchNextPage = useCallback(
@@ -76,7 +77,7 @@ export const ThemesList = ( props ) => {
 		<div ref={ resizeRef } className="themes-list">
 			{ props.themes.map( ( theme, index ) => [
 				<ThemeBlock key={ 'theme-block' + index } theme={ theme } index={ index } { ...props } />,
-				...( index === ctaPosition && isEnabled( 'pattern-assembler/logged-out-showcase' )
+				...( index === ctaPosition && isEnabled( 'pattern-assembler/logged-out-showcase' ) && ! isLoggedIn
 					? [
 							<PatternAssemblerCta
 								key="pattern-assembler-cta"

--- a/client/components/themes-list/style.scss
+++ b/client/components/themes-list/style.scss
@@ -1,6 +1,9 @@
 .themes-list {
+	$theme-item-min-width: 320px;
+	$theme-item-horizontal-margin: 32px; // Keep using margin as there might be an empty row
+
 	display: grid;
-	grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+	grid-template-columns: repeat(auto-fill, minmax($theme-item-min-width + $theme-item-horizontal-margin, 1fr));
 	list-style: none;
 	padding: 0;
 	margin: 0 -10px; // items flush against list edge

--- a/client/components/themes-list/style.scss
+++ b/client/components/themes-list/style.scss
@@ -1,6 +1,6 @@
 .themes-list {
-	display: flex;
-	flex-flow: row wrap;
+	display: grid;
+	grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
 	list-style: none;
 	padding: 0;
 	margin: 0 -10px; // items flush against list edge
@@ -11,19 +11,12 @@
 	}
 
 	.pattern-assembler-cta-wrapper {
-		width: 100%;
+		grid-column: 1/-1;
+		grid-row-start: 4;
 		background: #fff;
 		box-shadow: 0 0 0 1px var(--color-border-subtle);
 		margin: 0 16px 48px;
-		order: 0;
 	}
-}
-
-.themes-list__spacer {
-	width: 230px;
-	height: 0;
-	margin: 0 10px;
-	flex-grow: 1;
 }
 
 .themes-list__empty-container {

--- a/client/components/themes-list/style.scss
+++ b/client/components/themes-list/style.scss
@@ -9,6 +9,14 @@
 		max-width: 1000px;
 		margin: auto;
 	}
+
+	.pattern-assembler-cta-wrapper {
+		width: 100%;
+		background: #fff;
+		box-shadow: 0 0 0 1px var(--color-border-subtle);
+		margin: 0 16px 48px;
+		order: 0;
+	}
 }
 
 .themes-list__spacer {

--- a/client/components/themes-list/test/__snapshots__/index.jsx.snap
+++ b/client/components/themes-list/test/__snapshots__/index.jsx.snap
@@ -11,39 +11,6 @@ exports[`ThemesList should render a div with a className of "themes-list" 1`] = 
     <div
       data-testid="theme-2"
     />
-    <div
-      class="themes-list__spacer"
-    />
-    <div
-      class="themes-list__spacer"
-    />
-    <div
-      class="themes-list__spacer"
-    />
-    <div
-      class="themes-list__spacer"
-    />
-    <div
-      class="themes-list__spacer"
-    />
-    <div
-      class="themes-list__spacer"
-    />
-    <div
-      class="themes-list__spacer"
-    />
-    <div
-      class="themes-list__spacer"
-    />
-    <div
-      class="themes-list__spacer"
-    />
-    <div
-      class="themes-list__spacer"
-    />
-    <div
-      class="themes-list__spacer"
-    />
     <div />
   </div>
 </div>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/constants.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/constants.ts
@@ -2,12 +2,3 @@ export const PATTERN_SOURCE_SITE_ID = 174455321; // dotcompatterns
 export const PUBLIC_API_URL = 'https://public-api.wordpress.com';
 export const PREVIEW_PATTERN_URL = PUBLIC_API_URL + '/wpcom/v2/block-previews/pattern';
 export const SITE_TAGLINE = 'Site Tagline';
-
-export const BLANK_CANVAS_DESIGN = {
-	slug: 'blank-canvas-3',
-	title: 'Blank Canvas',
-	recipe: {
-		stylesheet: 'pub/blank-canvas-3',
-	},
-	design_type: 'assembler',
-};

--- a/client/landing/stepper/declarative-flow/site-assembler-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-assembler-flow.ts
@@ -1,3 +1,4 @@
+import { BLANK_CANVAS_DESIGN } from '@automattic/design-picker';
 import { useFlowProgress, SITE_ASSEMBLER_FLOW } from '@automattic/onboarding';
 import { useDispatch } from '@wordpress/data';
 import { useEffect } from 'react';
@@ -6,7 +7,6 @@ import { useSiteSlug } from '../hooks/use-site-slug';
 import { ONBOARD_STORE } from '../stores';
 import { recordSubmitStep } from './internals/analytics/record-submit-step';
 import PatternAssembler from './internals/steps-repository/pattern-assembler';
-import { BLANK_CANVAS_DESIGN } from './internals/steps-repository/pattern-assembler/constants';
 import Processing from './internals/steps-repository/processing-step';
 import { Flow, ProvidedDependencies } from './internals/types';
 import type { Design } from '@automattic/design-picker/src/types';

--- a/client/lib/track-element-size/index.ts
+++ b/client/lib/track-element-size/index.ts
@@ -50,7 +50,7 @@ function rectIsZero( rect: NullableDOMRect ) {
  * @returns The ref to be set on the consumer component.
  */
 export function useWindowResizeCallback(
-	callback: ( boundingClientRect: NullableDOMRect, elementRef: any ) => void
+	callback: ( boundingClientRect: NullableDOMRect ) => void
 ) {
 	const lastRect = useRef< NullableDOMRect >( null );
 	const elementRef = useRef< NullableElement >( null );
@@ -68,7 +68,7 @@ export function useWindowResizeCallback(
 				lastRect.current = rect;
 
 				// Notify consumer of bounding client rect change.
-				callback( rect, elementRef );
+				callback( rect );
 			}
 		};
 

--- a/client/lib/track-element-size/index.ts
+++ b/client/lib/track-element-size/index.ts
@@ -50,7 +50,7 @@ function rectIsZero( rect: NullableDOMRect ) {
  * @returns The ref to be set on the consumer component.
  */
 export function useWindowResizeCallback(
-	callback: ( boundingClientRect: NullableDOMRect ) => void
+	callback: ( boundingClientRect: NullableDOMRect, elementRef: any ) => void
 ) {
 	const lastRect = useRef< NullableDOMRect >( null );
 	const elementRef = useRef< NullableElement >( null );
@@ -68,7 +68,7 @@ export function useWindowResizeCallback(
 				lastRect.current = rect;
 
 				// Notify consumer of bounding client rect change.
-				callback( rect );
+				callback( rect, elementRef );
 			}
 		};
 

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -20,7 +20,6 @@ body.is-section-themes {
 		.theme,
 		.themes-list__spacer {
 			width: 320px;
-			min-width: var(--theme-list-item-width);
 		}
 
 		.theme {

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -20,6 +20,7 @@ body.is-section-themes {
 		.theme,
 		.themes-list__spacer {
 			width: 320px;
+			min-width: var(--theme-list-item-width);
 		}
 
 		.theme {

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -17,17 +17,8 @@ body.is-section-themes {
 	.themes__selection .themes-list {
 		margin: 32px -16px 0;
 
-		.theme,
-		.themes-list__spacer {
-			width: 320px;
-		}
-
 		.theme {
 			margin: 0 16px 32px;
-		}
-
-		.themes-list__spacer {
-			margin: 0 16px;
 		}
 	}
 

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -1,7 +1,7 @@
 import config from '@automattic/calypso-config';
+import { BLANK_CANVAS_DESIGN } from '@automattic/design-picker';
 import { isDesktop } from '@automattic/viewport';
 import { get, includes, reject } from 'lodash';
-import { BLANK_CANVAS_DESIGN } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/constants';
 import detectHistoryNavigation from 'calypso/lib/detect-history-navigation';
 import { getQueryArgs } from 'calypso/lib/query-args';
 import { addQueryArgs } from 'calypso/lib/url';

--- a/client/state/themes/actions/request-themes.js
+++ b/client/state/themes/actions/request-themes.js
@@ -50,9 +50,10 @@ export function requestThemes( siteId, query = {}, locale ) {
 						{
 							...query,
 							apiVersion: '1.2',
-							include_blankcanvas_theme: config.isEnabled( 'pattern-assembler/logged-out-showcase' )
-								? 'true'
-								: null,
+							// We should keep the blank-canvas-3 stay hidden according to below discussion
+							// https://github.com/Automattic/wp-calypso/issues/71911#issuecomment-1381284172
+							// User can be redirected to PatternAssembler flow using the PatternAssemblerCTA on theme-list
+							include_blankcanvas_theme: null,
 							include_marketplace_themes: config.isEnabled( 'themes/third-party-premium' )
 								? 'true'
 								: null,

--- a/packages/design-picker/src/constants.ts
+++ b/packages/design-picker/src/constants.ts
@@ -64,3 +64,15 @@ export const MOBILE_VIEWPORT_WIDTH = 599;
  * Generated design picker
  */
 export const STICKY_OFFSET_TOP = 109;
+
+/**
+ * Hard-coded design
+ */
+export const BLANK_CANVAS_DESIGN = {
+	slug: 'blank-canvas-3',
+	title: 'Blank Canvas',
+	recipe: {
+		stylesheet: 'pub/blank-canvas-3',
+	},
+	design_type: 'assembler',
+};

--- a/packages/design-picker/src/index.ts
+++ b/packages/design-picker/src/index.ts
@@ -23,6 +23,7 @@ export {
 	DEFAULT_VIEWPORT_HEIGHT,
 	MOBILE_VIEWPORT_WIDTH,
 	STICKY_OFFSET_TOP,
+	BLANK_CANVAS_DESIGN,
 } from './constants';
 export type {
 	FontPair,

--- a/packages/design-picker/src/index.ts
+++ b/packages/design-picker/src/index.ts
@@ -6,6 +6,7 @@ export { default as StyleVariationBadges } from './components/style-variation-ba
 export { default as ThemePreview } from './components/theme-preview';
 export { default as UnifiedDesignPicker } from './components/unified-design-picker';
 export { default as WooCommerceBundledBadge } from './components/woocommerce-bundled-badge';
+export { default as PatternAssemblerCta } from './components/pattern-assembler-cta';
 export {
 	availableDesignsConfig,
 	getAvailableDesigns,


### PR DESCRIPTION
#### Proposed Changes

* Display the PatternAssemblerCTA on logged-out theme showcase
* This PR should be addressed after #72747 has been merged

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
 
* Checkout this branch, if you are using calypso live link, open the browser console and run this to make sure the feature flag is enabled `document.cookie = 'flags=pattern-assembler/logged-out-showcase;max-age=1209600;path=/'`
* Log out from your wp account
* Access theme showcase via /themes
* Confirm the Blank-canvas-3 theme card is stayed hidden ( more on this https://github.com/Automattic/wp-calypso/issues/71911#issuecomment-1381284172 )
* Select the PatternAssemblerCTA on different screen size, confirm the destination has been navigated correctly
* The styling of the CTA is also modified to match the style of theme showcase, CTA will be placed on 4th row of the theme list

**Testing Flow Recording**
| Large screen ( > 960px ) <br> Go to Assembler Flow | Small Screen <br> Go to Editor
|---------------------------------------------|--------------------------------|
|   <video src="https://user-images.githubusercontent.com/10071857/215334891-f2986984-f2fe-4077-a544-f6b6e1aef0ad.mov"></video> |               <video src="https://user-images.githubusercontent.com/10071857/215335648-580075f6-c308-4a9c-95c7-11d1ec183028.mov"></video>                

**CTA position**
| Small screen | Medium screen | Large screen |
|-------------------------|----------------------|----------------------------|
|              ![2iQ7JZ.png](https://user-images.githubusercontent.com/10071857/215386000-51cc20fb-2755-452d-905a-b73367da19aa.png)       |           ![IKB3x1.png](https://user-images.githubusercontent.com/10071857/215386087-36fceaf8-87cc-4edf-a5eb-af0ebfceb432.png)        |           ![EkD1UI.png](https://user-images.githubusercontent.com/10071857/215386146-8b7c945b-4c50-40c5-8c27-f0b65db8233a.png)               |

**CTA styling**
| CTA on designSetup step | CTA on ThemeShowcase | Empty search card on ThemShowcase |
|-------------------------|----------------------|----------------------------|
|               ![tjROgO.png](https://user-images.githubusercontent.com/10071857/215335831-f592788c-9b99-4ff5-b219-75115d210435.png)          |            ![4T5bb7.png](https://user-images.githubusercontent.com/10071857/215335985-f2e8b272-8c88-43c2-8362-b3c9e91e8087.png)          |             ![asccRA.png](https://user-images.githubusercontent.com/10071857/215335939-e21405d6-8dcf-40ac-815c-a2e1b0376605.png)               |








#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #71706