### PR TITLE
Theme Showcase: Enable flag themes/showcase-i4/cards-only for all environments

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -119,7 +119,7 @@
 		"subscription-gifting": true,
 		"themes/atomic-homepage-replace": true,
 		"themes/premium": true,
-		"themes/showcase-i4/cards-only": false,
+		"themes/showcase-i4/cards-only": true,
 		"themes/showcase-i4/details-and-preview": false,
 		"themes/subscription-purchases": false,
 		"themes/theme-switch-persist-template": true,

--- a/config/production.json
+++ b/config/production.json
@@ -139,7 +139,7 @@
 		"subscription-gifting": true,
 		"themes/atomic-homepage-replace": true,
 		"themes/premium": true,
-		"themes/showcase-i4/cards-only": false,
+		"themes/showcase-i4/cards-only": true,
 		"themes/showcase-i4/details-and-preview": false,
 		"themes/subscription-purchases": false,
 		"themes/theme-switch-persist-template": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -135,7 +135,7 @@
 		"subscription-gifting": true,
 		"themes/atomic-homepage-replace": true,
 		"themes/premium": true,
-		"themes/showcase-i4/cards-only": false,
+		"themes/showcase-i4/cards-only": true,
 		"themes/showcase-i4/details-and-preview": false,
 		"themes/subscription-purchases": false,
 		"themes/theme-switch-persist-template": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -145,7 +145,7 @@
 		"subscription-gifting": true,
 		"themes/atomic-homepage-replace": true,
 		"themes/premium": true,
-		"themes/showcase-i4/cards-only": false,
+		"themes/showcase-i4/cards-only": true,
 		"themes/showcase-i4/details-and-preview": false,
 		"themes/subscription-purchases": false,
 		"themes/theme-switch-persist-template": false,

--- a/packages/calypso-e2e/src/lib/pages/themes-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/themes-page.ts
@@ -61,7 +61,7 @@ export class ThemesPage {
 		const searchInput = await this.page.waitForSelector( selectors.searchInput );
 		await searchInput.fill( keyword );
 		await Promise.all( [ this.page.waitForNavigation(), searchInput.press( 'Enter' ) ] );
-		await this.page.waitForSelector( selectors.placeholder, { state: 'hidden' } );
+		await this.page.waitForSelector( selectors.placeholder, { state: 'detached' } );
 	}
 
 	/**


### PR DESCRIPTION
#### Proposed Changes

This PR enables the flag `themes/showcase-i4/cards-only` for all environments.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Ensure that all environment configs that contains the flag `themes/showcase-i4/cards-only` are set to true.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

