### PR TITLE
Stats: Add mobile promo card to Ads page.

### DIFF
--- a/client/my-sites/stats/annual-site-stats/index.js
+++ b/client/my-sites/stats/annual-site-stats/index.js
@@ -11,7 +11,7 @@ import SectionHeader from 'calypso/components/section-header';
 import PromoCards from 'calypso/my-sites/stats/promo-cards';
 import ErrorPanel from 'calypso/my-sites/stats/stats-error';
 import StatsModulePlaceholder from 'calypso/my-sites/stats/stats-module/placeholder';
-import { getSiteSlug, isJetpackSite } from 'calypso/state/sites/selectors';
+import { getSiteSlug } from 'calypso/state/sites/selectors';
 import { getSiteStatsNormalizedData } from 'calypso/state/stats/lists/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import './style.scss';
@@ -142,8 +142,7 @@ class AnnualSiteStats extends Component {
 	}
 
 	render() {
-		const { isJetpack, isOdysseyStats, isWidget, moment, siteId, siteSlug, translate, years } =
-			this.props;
+		const { isOdysseyStats, isWidget, moment, siteId, siteSlug, translate, years } = this.props;
 		const strings = this.getStrings();
 		const now = moment();
 		const currentYear = now.format( 'YYYY' );
@@ -192,7 +191,6 @@ class AnnualSiteStats extends Component {
 					) }
 				</Card>
 				<PromoCards
-					isJetpack={ isJetpack }
 					isOdysseyStats={ isOdysseyStats }
 					pageSlug="annual-insights"
 					slug={ siteSlug }
@@ -209,7 +207,6 @@ export default connect( ( state ) => {
 	const insights = getSiteStatsNormalizedData( state, siteId, statType, {} );
 
 	return {
-		isJetpack: isJetpackSite( state, siteId ),
 		isOdysseyStats: config.isEnabled( 'is_running_in_jetpack_site' ),
 		siteId,
 		siteSlug: getSiteSlug( state, siteId ),

--- a/client/my-sites/stats/promo-cards/index.jsx
+++ b/client/my-sites/stats/promo-cards/index.jsx
@@ -75,6 +75,30 @@ export default function PromoCards( { isOdysseyStats, slug, pageSlug } ) {
 		// Events need to incorporate the page and the click type.
 		// This will allow us to account for integration across different pages.
 		// FORMAT: calypso_stats_PAGE_mobile_cta_EVENT
+		// Current known events across Stats pages are listed below.
+		// This comment will fall out of date if the PromoCards component
+		// is added to any new pages.
+		// Ads:
+		// - calypso_stats_ads_mobile_cta_jetpack_click_a8c
+		// - calypso_stats_ads_mobile_cta_jetpack_click_apple
+		// - calypso_stats_ads_mobile_cta_jetpack_click_google
+		// - calypso_stats_ads_mobile_cta_woo_click_a8c
+		// - calypso_stats_ads_mobile_cta_woo_click_apple
+		// - calypso_stats_ads_mobile_cta_woo_click_google
+		// Annual Insights:
+		// - calypso_stats_annual_insights_mobile_cta_jetpack_click_a8c
+		// - calypso_stats_annual_insights_mobile_cta_jetpack_click_apple
+		// - calypso_stats_annual_insights_mobile_cta_jetpack_click_google
+		// - calypso_stats_annual_insights_mobile_cta_woo_click_a8c
+		// - calypso_stats_annual_insights_mobile_cta_woo_click_apple
+		// - calypso_stats_annual_insights_mobile_cta_woo_click_google
+		// Traffic
+		// - calypso_stats_traffic_mobile_cta_jetpack_click_a8c
+		// - calypso_stats_traffic_mobile_cta_jetpack_click_apple
+		// - calypso_stats_traffic_mobile_cta_jetpack_click_google
+		// - calypso_stats_traffic_mobile_cta_woo_click_a8c
+		// - calypso_stats_traffic_mobile_cta_woo_click_apple
+		// - calypso_stats_traffic_mobile_cta_woo_click_google
 		const tracksEventName = `calypso_stats_${ pageSlug }_mobile_cta_${ event }`.replaceAll(
 			'-',
 			'_'

--- a/client/my-sites/stats/promo-cards/index.jsx
+++ b/client/my-sites/stats/promo-cards/index.jsx
@@ -14,6 +14,7 @@ import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import './style.scss';
 
+const EVENT_ADS_MOBILE_PROMO_VIEW = 'calypso_stats_ads_mobile_cta_jetpack_view';
 const EVENT_TRAFFIC_BLAZE_PROMO_VIEW = 'calypso_stats_traffic_blaze_banner_view';
 const EVENT_TRAFFIC_MOBILE_PROMO_VIEW = 'calypso_stats_traffic_mobile_cta_jetpack_view';
 const EVENT_YOAST_PROMO_VIEW = 'calypso_stats_wordpress_seo_premium_banner_view';
@@ -51,6 +52,8 @@ export default function PromoCards( { isOdysseyStats, slug, pageSlug } ) {
 		} else if ( pageSlug === 'annual-insights' ) {
 			showBlazePromo && events.push( EVENT_ANNUAL_BLAZE_PROMO_VIEW );
 			events.push( EVENT_ANNUAL_MOBILE_PROMO_VIEW );
+		} else if ( pageSlug === 'ads' ) {
+			events.push( EVENT_ADS_MOBILE_PROMO_VIEW );
 		}
 		return events;
 	}, [ pageSlug, showBlazePromo, showYoastPromo ] );
@@ -72,7 +75,10 @@ export default function PromoCards( { isOdysseyStats, slug, pageSlug } ) {
 		// Events need to incorporate the page and the click type.
 		// This will allow us to account for integration across different pages.
 		// FORMAT: calypso_stats_PAGE_mobile_cta_EVENT
-		const tracksEventName = `calypso_stats_traffic_mobile_cta_${ event.replaceAll( '-', '_' ) }`;
+		const tracksEventName = `calypso_stats_${ pageSlug }_mobile_cta_${ event }`.replaceAll(
+			'-',
+			'_'
+		);
 		recordTracksEvent( tracksEventName );
 	};
 

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -357,12 +357,7 @@ class StatsSite extends Component {
 						}
 					</div>
 				</div>
-				<PromoCards
-					isJetpack={ isJetpack }
-					isOdysseyStats={ isOdysseyStats }
-					pageSlug="traffic"
-					slug={ slug }
-				/>
+				<PromoCards isOdysseyStats={ isOdysseyStats } pageSlug="traffic" slug={ slug } />
 				<JetpackColophon />
 			</div>
 		);

--- a/client/my-sites/stats/wordads/index.jsx
+++ b/client/my-sites/stats/wordads/index.jsx
@@ -20,7 +20,7 @@ import Main from 'calypso/components/main';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
-import { canAccessWordAds, isJetpackSite } from 'calypso/state/sites/selectors';
+import { canAccessWordAds } from 'calypso/state/sites/selectors';
 import {
 	getSelectedSite,
 	getSelectedSiteId,
@@ -134,16 +134,8 @@ class WordAds extends Component {
 	};
 
 	render() {
-		const {
-			canAccessAds,
-			canUpgradeToUseWordAds,
-			date,
-			isJetpack,
-			isOdysseyStats,
-			site,
-			siteId,
-			slug,
-		} = this.props;
+		const { canAccessAds, canUpgradeToUseWordAds, date, isOdysseyStats, site, siteId, slug } =
+			this.props;
 
 		const { period, endOf } = this.props.period;
 
@@ -257,12 +249,7 @@ class WordAds extends Component {
 								</div>
 							</div>
 
-							<PromoCards
-								isJetpack={ isJetpack }
-								isOdysseyStats={ isOdysseyStats }
-								pageSlug="ads"
-								slug={ slug }
-							/>
+							<PromoCards isOdysseyStats={ isOdysseyStats } pageSlug="ads" slug={ slug } />
 
 							<JetpackColophon />
 						</Fragment>
@@ -278,10 +265,8 @@ export default connect(
 	( state ) => {
 		const site = getSelectedSite( state );
 		const siteId = getSelectedSiteId( state );
-		const isJetpack = isJetpackSite( state, siteId );
 		const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
 		return {
-			isJetpack,
 			isOdysseyStats,
 			site,
 			siteId,

--- a/client/my-sites/stats/wordads/index.jsx
+++ b/client/my-sites/stats/wordads/index.jsx
@@ -135,11 +135,11 @@ class WordAds extends Component {
 
 	render() {
 		const {
-			isJetpack,
-			isOdysseyStats,
 			canAccessAds,
 			canUpgradeToUseWordAds,
 			date,
+			isJetpack,
+			isOdysseyStats,
 			site,
 			siteId,
 			slug,

--- a/client/my-sites/stats/wordads/index.jsx
+++ b/client/my-sites/stats/wordads/index.jsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { Icon, chartBar, trendingUp } from '@wordpress/icons';
 import classNames from 'classnames';
 import { localize, translate, numberFormat } from 'i18n-calypso';
@@ -19,12 +20,13 @@ import Main from 'calypso/components/main';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
-import { canAccessWordAds } from 'calypso/state/sites/selectors';
+import { canAccessWordAds, isJetpackSite } from 'calypso/state/sites/selectors';
 import {
 	getSelectedSite,
 	getSelectedSiteId,
 	getSelectedSiteSlug,
 } from 'calypso/state/ui/selectors';
+import PromoCards from '../promo-cards';
 import DatePicker from '../stats-date-picker';
 import StatsPeriodHeader from '../stats-period-header';
 import StatsPeriodNavigation from '../stats-period-navigation';
@@ -132,7 +134,16 @@ class WordAds extends Component {
 	};
 
 	render() {
-		const { canAccessAds, canUpgradeToUseWordAds, date, site, siteId, slug } = this.props;
+		const {
+			isJetpack,
+			isOdysseyStats,
+			canAccessAds,
+			canUpgradeToUseWordAds,
+			date,
+			site,
+			siteId,
+			slug,
+		} = this.props;
 
 		const { period, endOf } = this.props.period;
 
@@ -246,6 +257,13 @@ class WordAds extends Component {
 								</div>
 							</div>
 
+							<PromoCards
+								isJetpack={ isJetpack }
+								isOdysseyStats={ isOdysseyStats }
+								pageSlug="ads"
+								slug={ slug }
+							/>
+
 							<JetpackColophon />
 						</Fragment>
 					) }
@@ -260,7 +278,11 @@ export default connect(
 	( state ) => {
 		const site = getSelectedSite( state );
 		const siteId = getSelectedSiteId( state );
+		const isJetpack = isJetpackSite( state, siteId );
+		const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
 		return {
+			isJetpack,
+			isOdysseyStats,
 			site,
 			siteId,
 			slug: getSelectedSiteSlug( state ),


### PR DESCRIPTION
#### Proposed Changes

Ads the mobile promo card to the bottom of the Ads page.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the Calypso Live link.
* Navigate to Stats → Ads.
* Scroll to the bottom and confirm the card is visible.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #72675.
