### PR TITLE
Plans 2023: Adjust the select Plans functionality in the compare grid, for the /plans page

### DIFF
--- a/client/my-sites/plan-features-2023-grid/actions.tsx
+++ b/client/my-sites/plan-features-2023-grid/actions.tsx
@@ -199,7 +199,9 @@ const PlanFeaturesActionsButton: React.FC< PlanFeaturesActionsButtonProps > = ( 
 } ) => {
 	const translate = useTranslate();
 
-	const classes = classNames( 'plan-features-2023-grid__actions-button', className );
+	const classes = classNames( 'plan-features-2023-grid__actions-button', className, {
+		'is-current-plan': current,
+	} );
 
 	const handleUpgradeButtonClick = () => {
 		if ( isPlaceholder ) {

--- a/client/my-sites/plan-features-2023-grid/plan-comparison-grid.tsx
+++ b/client/my-sites/plan-features-2023-grid/plan-comparison-grid.tsx
@@ -512,9 +512,8 @@ export const PlanComparisonGrid: React.FC< PlanComparisonGridProps > = ( {
 					const featureGroupClass = `feature-group-title-${ featureGroup.slug }`;
 					const isHiddenInMobile = ! visibleFeatureGroups.includes( featureGroup.slug );
 					return (
-						<div className={ featureGroupClass }>
+						<div key={ featureGroupClass } className={ featureGroupClass }>
 							<TitleRow
-								key={ featureGroupClass }
 								className="plan-comparison-grid__group-title-row"
 								onClick={ () => toggleFeatureGroup( featureGroup.slug ) }
 							>

--- a/client/my-sites/plan-features-2023-grid/plan-comparison-grid.tsx
+++ b/client/my-sites/plan-features-2023-grid/plan-comparison-grid.tsx
@@ -394,7 +394,14 @@ export const PlanComparisonGrid: React.FC< PlanComparisonGridProps > = ( {
 		}
 
 		setVisiblePlans( newVisiblePlans );
-	}, [ isLargestBreakpoint, isLargeBreakpoint, isMediumBreakpoint, intervalType ] );
+	}, [
+		isLargestBreakpoint,
+		isLargeBreakpoint,
+		isMediumBreakpoint,
+		intervalType,
+		planProperties,
+		isInSignup,
+	] );
 
 	const restructuredFeatures = useMemo( () => {
 		let previousPlan = null;

--- a/client/my-sites/plan-features-2023-grid/plan-comparison-grid.tsx
+++ b/client/my-sites/plan-features-2023-grid/plan-comparison-grid.tsx
@@ -368,9 +368,9 @@ export const PlanComparisonGrid: React.FC< PlanComparisonGridProps > = ( {
 		[ planProperties ]
 	);
 	const isMonthly = intervalType === 'monthly';
-	const isLargestBreakpoint = usePricingBreakpoint( 1600 );
-	const isLargeBreakpoint = usePricingBreakpoint( 1500 );
-	const isMediumBreakpoint = usePricingBreakpoint( 1340 );
+	const isLargestBreakpoint = usePricingBreakpoint( 1772 ); // 1500px + 272px (sidebar)
+	const isLargeBreakpoint = usePricingBreakpoint( 1612 ); // 1340px + 272px (sidebar)
+	const isMediumBreakpoint = usePricingBreakpoint( 1340 ); // keeping original breakpoint to match Plan Grid
 
 	const [ visiblePlans, setVisiblePlans ] = useState< string[] >( [] );
 	const [ firstSetOfFeatures ] = Object.keys( featureGroupMap );
@@ -390,10 +390,7 @@ export const PlanComparisonGrid: React.FC< PlanComparisonGridProps > = ( {
 		visibleLength = isMediumBreakpoint ? 2 : visibleLength;
 
 		if ( newVisiblePlans.length !== visibleLength ) {
-			const currentPlan = displayedPlansProperties.find( ( { current } ) => current );
-			if ( currentPlan ) {
-				newVisiblePlans.sort( ( a ) => ( a === currentPlan.planName ? -1 : 1 ) );
-			}
+			newVisiblePlans.sort( ( visiblePlan ) => ( visiblePlan === currentSitePlanSlug ? -1 : 1 ) );
 			newVisiblePlans = newVisiblePlans.slice( 0, visibleLength );
 		}
 
@@ -405,6 +402,7 @@ export const PlanComparisonGrid: React.FC< PlanComparisonGridProps > = ( {
 		intervalType,
 		displayedPlansProperties,
 		isInSignup,
+		currentSitePlanSlug,
 	] );
 
 	const restructuredFeatures = useMemo( () => {

--- a/client/my-sites/plan-features-2023-grid/plan-comparison-grid.tsx
+++ b/client/my-sites/plan-features-2023-grid/plan-comparison-grid.tsx
@@ -360,8 +360,12 @@ export const PlanComparisonGrid: React.FC< PlanComparisonGridProps > = ( {
 } ) => {
 	const translate = useTranslate();
 	const featureGroupMap = getPlanFeaturesGrouped();
-	const displayedPlansProperties = ( planProperties ?? [] ).filter(
-		( { planName } ) => ! ( planName === PLAN_ENTERPRISE_GRID_WPCOM )
+	const displayedPlansProperties = useMemo(
+		() =>
+			( planProperties ?? [] ).filter(
+				( { planName } ) => ! ( planName === PLAN_ENTERPRISE_GRID_WPCOM )
+			),
+		[ planProperties ]
 	);
 	const isMonthly = intervalType === 'monthly';
 	const isLargestBreakpoint = usePricingBreakpoint( 1600 );
@@ -399,7 +403,7 @@ export const PlanComparisonGrid: React.FC< PlanComparisonGridProps > = ( {
 		isLargeBreakpoint,
 		isMediumBreakpoint,
 		intervalType,
-		planProperties,
+		displayedPlansProperties,
 		isInSignup,
 	] );
 

--- a/client/my-sites/plan-features-2023-grid/plan-comparison-grid.tsx
+++ b/client/my-sites/plan-features-2023-grid/plan-comparison-grid.tsx
@@ -390,6 +390,7 @@ export const PlanComparisonGrid: React.FC< PlanComparisonGridProps > = ( {
 		visibleLength = isMediumBreakpoint ? 2 : visibleLength;
 
 		if ( newVisiblePlans.length !== visibleLength ) {
+			// ensures current plan is first in the list
 			newVisiblePlans.sort( ( visiblePlan ) => ( visiblePlan === currentSitePlanSlug ? -1 : 1 ) );
 			newVisiblePlans = newVisiblePlans.slice( 0, visibleLength );
 		}
@@ -521,7 +522,7 @@ export const PlanComparisonGrid: React.FC< PlanComparisonGridProps > = ( {
 					const featureGroupClass = `feature-group-title-${ featureGroup.slug }`;
 					const isHiddenInMobile = ! visibleFeatureGroups.includes( featureGroup.slug );
 					return (
-						<div key={ featureGroupClass } className={ featureGroupClass }>
+						<div key={ featureGroupClass } className={ featureGroup.slug }>
 							<TitleRow
 								className="plan-comparison-grid__group-title-row"
 								onClick={ () => toggleFeatureGroup( featureGroup.slug ) }

--- a/client/my-sites/plan-features-2023-grid/style.scss
+++ b/client/my-sites/plan-features-2023-grid/style.scss
@@ -53,6 +53,16 @@ $plan-features-sidebar-width: 272px;
 					color: var(--studio-gray-0);
 				}
 			}
+
+			&.is-current-plan {
+				background-color: var(--studio-white);
+				color: var(--studio-gray-100);
+				box-shadow: inset 0 0 0 1px var(--studio-gray-10);
+
+				&:hover {
+					box-shadow: inset 0 0 0 1px var(--studio-gray-80);
+				}
+			}
 		}
 	}
 }
@@ -875,6 +885,9 @@ body.is-section-signup.is-white-signup .is-onboarding-2023-pricing-grid .signup_
 }
 
 .plan-comparison-grid {
+	.plan-features-2023-gridrison__actions-buttons {
+		min-height: 40px;
+	}
 	.plan-comparison-grid__plan-row {
 		padding-top: 0;
 		padding-bottom: 0;

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -143,11 +143,14 @@ class Plans extends Component {
 			);
 		}
 
+		const hideFreePlan =
+			! isEnabled( 'onboarding/2023-pricing-grid' ) || currentPlan.productSlug !== 'free_plan';
+
 		return (
 			<PlansFeaturesMain
 				redirectToAddDomainFlow={ this.props.redirectToAddDomainFlow }
 				domainAndPlanPackage={ this.props.domainAndPlanPackage }
-				hideFreePlan={ true }
+				hideFreePlan={ hideFreePlan }
 				customerType={ this.props.customerType }
 				intervalType={ this.props.intervalType }
 				selectedFeature={ this.props.selectedFeature }

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -2,6 +2,7 @@ import { isEnabled } from '@automattic/calypso-config';
 import {
 	getPlan,
 	getIntervalTypeForTerm,
+	isFreePlan,
 	PLAN_FREE,
 	PLAN_ECOMMERCE_TRIAL_MONTHLY,
 } from '@automattic/calypso-products';
@@ -144,7 +145,7 @@ class Plans extends Component {
 		}
 
 		const hideFreePlan =
-			! isEnabled( 'onboarding/2023-pricing-grid' ) || currentPlan.productSlug !== 'free_plan';
+			! isEnabled( 'onboarding/2023-pricing-grid' ) || ! isFreePlan( currentPlan.productSlug );
 
 		return (
 			<PlansFeaturesMain

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -144,8 +144,9 @@ class Plans extends Component {
 			);
 		}
 
-		const hideFreePlan =
-			! isEnabled( 'onboarding/2023-pricing-grid' ) || ! isFreePlan( currentPlan.productSlug );
+		const hideFreePlan = isEnabled( 'onboarding/2023-pricing-grid' )
+			? ! isFreePlan( currentPlan.productSlug )
+			: true;
 
 		return (
 			<PlansFeaturesMain


### PR DESCRIPTION
#### Proposed Changes

This adjusts the Plans comparison grid with the following changes;
* handles alignment with missing CTA buttons
* add current plan CTA styling
* show the Free plan if it's the current plan
* reduces the number of columns and adds the Plan selection functionality. In this situation, the current plan is always first.

NOTE: There's a problem at around 880px where the first plan overlaps the Feature labels. Normally, we'd switch to mobile view (which hides the Feature labels) at this breakpoint but having a 272px sidebar means we'd need the switch to happen at 880 + 272px. Will need to follow up with a fix.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/plans/{CURRENT_SITE}?flags=onboarding/2023-pricing-grid` - where CURRENT_SITE is a Free plan
* 
* You should see the `Free` plan in the Plans and Plan Comparison Grids
* Go through different viewport sizes; the column number should adjust so that they can fit
* When there are fewer plans visible than the total number, the current plan should be first and un-selectable. All other plans should be selectable


https://user-images.githubusercontent.com/2749938/215505077-78c9837c-2491-44b0-ab84-2d56c3cd3c76.mp4


* Switch to a `Business` plan (or any paid plan)
* Free plan should not be visible anymore
* Make sure the current plan is **visible** on all viewport sizes


https://user-images.githubusercontent.com/2749938/215505232-b206c616-5828-445a-bd2c-d047f958f182.mp4


* Go to `/start/onboarding-2023-pricing-grid/plans?flags=onboarding/2023-pricing-grid`
* The page should be **unaffected**


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/martech/issues/1448 and https://github.com/Automattic/martech/issues/1446
