### PR TITLE
Theme Preview: Add Limited Global Styles Tracks Events

### DIFF
--- a/client/components/theme/more-button.jsx
+++ b/client/components/theme/more-button.jsx
@@ -41,7 +41,7 @@ class ThemeMoreButton extends Component {
 	popoverAction( action, label, key ) {
 		return () => {
 			action( this.props.themeId, 'more button' );
-			this.props.onMoreButtonClick( this.props.themeId, this.props.index, 'popup_' + label, key );
+			this.props.onMoreButtonClick( this.props.themeId, this.props.index, 'popup_' + label );
 			this.props.onMoreButtonItemClick?.( this.props.themeId, this.props.index, key );
 		};
 	}

--- a/client/components/theme/more-button.jsx
+++ b/client/components/theme/more-button.jsx
@@ -41,7 +41,7 @@ class ThemeMoreButton extends Component {
 	popoverAction( action, label, key ) {
 		return () => {
 			action( this.props.themeId, 'more button' );
-			this.props.onMoreButtonClick( this.props.themeId, this.props.index, 'popup_' + label );
+			this.props.onMoreButtonClick( this.props.themeId, this.props.index, 'popup_' + label, key );
 			this.props.onMoreButtonItemClick?.( this.props.themeId, this.props.index, key );
 		};
 	}

--- a/client/my-sites/themes/theme-preview.jsx
+++ b/client/my-sites/themes/theme-preview.jsx
@@ -99,7 +99,7 @@ class ThemePreview extends Component {
 
 		this.props.recordTracksEvent( 'calypso_theme_preview_primary_button_click', {
 			theme: themeId,
-			...( option.key && { action: option.key } ),
+			...( option.action && { action: option.action.key } ),
 		} );
 
 		option.action && option.action( themeId );
@@ -112,7 +112,7 @@ class ThemePreview extends Component {
 
 		this.props.recordTracksEvent( 'calypso_theme_preview_secondary_button_click', {
 			theme: themeId,
-			...( secondary.key && { action: secondary.key } ),
+			...( secondary.action && { action: secondary.action.key } ),
 		} );
 
 		secondary.action && secondary.action( themeId );

--- a/client/my-sites/themes/theme-preview.jsx
+++ b/client/my-sites/themes/theme-preview.jsx
@@ -99,7 +99,7 @@ class ThemePreview extends Component {
 
 		this.props.recordTracksEvent( 'calypso_theme_preview_primary_button_click', {
 			theme: themeId,
-			...( option.action && { action: option.action.key } ),
+			...( option.key && { action: option.key } ),
 		} );
 
 		option.action && option.action( themeId );
@@ -112,7 +112,7 @@ class ThemePreview extends Component {
 
 		this.props.recordTracksEvent( 'calypso_theme_preview_secondary_button_click', {
 			theme: themeId,
-			...( secondary.action && { action: secondary.action.key } ),
+			...( secondary.key && { action: secondary.key } ),
 		} );
 
 		secondary.action && secondary.action( themeId );

--- a/client/my-sites/themes/theme-preview.jsx
+++ b/client/my-sites/themes/theme-preview.jsx
@@ -78,6 +78,15 @@ class ThemePreview extends Component {
 		return this.props.themeOptions?.styleVariation;
 	};
 
+	getPremiumGlobalStylesEventProps = () => {
+		const { themeId } = this.props;
+		const styleVariationOption = this.getStyleVariationOption();
+		return {
+			theme: themeId,
+			style_variation: styleVariationOption?.slug,
+		};
+	};
+
 	shouldShowUnlockStyleButton = () => {
 		const { options, shouldLimitGlobalStyles, themeOptions } = this.props;
 		if ( ! themeOptions ) {
@@ -120,20 +129,40 @@ class ThemePreview extends Component {
 	};
 
 	onUnlockStyleButtonClick = () => {
+		this.props.recordTracksEvent(
+			'calypso_theme_preview_global_styles_gating_modal_show',
+			this.getPremiumGlobalStylesEventProps()
+		);
+
 		this.setState( { showUnlockStyleUpgradeModal: true } );
 	};
 
 	onPremiumGlobalStylesUpgradeModalCheckout = () => {
+		this.props.recordTracksEvent(
+			'calypso_theme_preview_global_styles_gating_modal_checkout_button_click',
+			this.getPremiumGlobalStylesEventProps()
+		);
+
 		this.setState( { showUnlockStyleUpgradeModal: false } );
 		page( `/checkout/${ this.props.siteSlug || '' }/premium` );
 	};
 
 	onPremiumGlobalStylesUpgradeModalTryStyle = () => {
+		this.props.recordTracksEvent(
+			'calypso_theme_preview_global_styles_gating_modal_try_button_click',
+			this.getPremiumGlobalStylesEventProps()
+		);
+
 		this.setState( { showUnlockStyleUpgradeModal: false } );
 		this.onPrimaryButtonClick();
 	};
 
 	onPremiumGlobalStylesUpgradeModalClose = () => {
+		this.props.recordTracksEvent(
+			'calypso_theme_preview_global_styles_gating_modal_close_button_click',
+			this.getPremiumGlobalStylesEventProps()
+		);
+
 		this.setState( { showUnlockStyleUpgradeModal: false } );
 	};
 


### PR DESCRIPTION
#### Proposed Changes

* Add Tracks events for the Limited Global Styles modal in the Theme Preview.

| Event | Action |
| - | - |
| `calypso_theme_preview_global_styles_gating_modal_show` | With a premium style variation selected, click on "Unlock this style". |
| `calypso_theme_preview_global_styles_gating_modal_checkout_button_click` | In the modal, click on "Upgrade plan". |
| `calypso_theme_preview_global_styles_gating_modal_try_button_click` | In the modal, click on "Try it out first". |
| `calypso_theme_preview_global_styles_gating_modal_close_button_click` | Close the modal. |

This PR is branched off https://github.com/Automattic/wp-calypso/pull/72142, which is a bit stale and requires an older Node version (cc @taipeicoder for a rebase 🙂).

I've reused the very same names from the onboarding Design Selection, just swapping `signup_design` with `theme_preview`.

In the Design Selection, the corresponding events record more or slightly different details, but IMHO just `theme` and `style_variation` are enough for now.

The only property I'd like to see but couldn't readily find is whether the theme is a premium theme. It's not a blocker, but something we might want to revisit in the future.

Also, @taipeicoder feel free to merge this into the base PR if you wish, or I'll just proceed once that gets merged. ✨ 

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* This feature is only accessible in the local environment; if using calypso.live, the flag `themes/showcase-i4/details-and-preview` is required.
* Head to the Theme Showcase and find a theme showing the little style variation circles.
* Click on one of those to enter the Theme Preview with style variations options.
* Ensure that the following events are recorded correctly when using a premium style variation:
  * `calypso_theme_preview_global_styles_gating_modal_show`
  * `calypso_theme_preview_global_styles_gating_modal_checkout_button_click`
  * `calypso_theme_preview_global_styles_gating_modal_try_button_click`
  * `calypso_theme_preview_global_styles_gating_modal_close_button_click`


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
