### PR TITLE
Revert "Purchases: Update price text to be more clear for introductory offers"

### DIFF
--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -59,6 +59,7 @@ import {
 	getDisplayName,
 	getPartnerName,
 	getRenewalPrice,
+	getRenewalPriceInSmallestUnit,
 	handleRenewMultiplePurchasesClick,
 	handleRenewNowClick,
 	hasAmountAvailableToRefund,
@@ -956,7 +957,7 @@ class ManagePurchase extends Component {
 								</div>
 							) : (
 								<PlanPrice
-									rawPrice={ purchase.regularPriceInteger }
+									rawPrice={ getRenewalPriceInSmallestUnit( purchase ) }
 									isSmallestUnit
 									currencyCode={ purchase.currencyCode }
 									taxText={ purchase.taxText }

--- a/client/me/purchases/manage-purchase/purchase-meta-introductory-offer-detail.tsx
+++ b/client/me/purchases/manage-purchase/purchase-meta-introductory-offer-detail.tsx
@@ -1,135 +1,68 @@
-import {
-	PLAN_ANNUAL_PERIOD,
-	PLAN_BIENNIAL_PERIOD,
-	PLAN_MONTHLY_PERIOD,
-	PLAN_TRIENNIAL_PERIOD,
-} from '@automattic/calypso-products';
 import formatCurrency from '@automattic/format-currency';
+import { getIntroductoryOfferIntervalDisplay } from '@automattic/wpcom-checkout';
 import { useTranslate } from 'i18n-calypso';
-import { isWithinIntroductoryOfferPeriod } from 'calypso/lib/purchases';
-import type { Purchase } from 'calypso/lib/purchases/types';
-import type { ReactNode } from 'react';
+import {
+	isWithinIntroductoryOfferPeriod,
+	isIntroductoryOfferFreeTrial,
+} from 'calypso/lib/purchases';
+import { Purchase } from 'calypso/lib/purchases/types';
 
-function PurchaseMetaIntroductoryOfferDetail( {
-	purchase,
-}: {
-	purchase: Purchase;
-} ): JSX.Element | null {
+function PurchaseMetaIntroductoryOfferDetail( { purchase }: { purchase: Purchase } ) {
 	const translate = useTranslate();
 
 	if ( ! isWithinIntroductoryOfferPeriod( purchase ) ) {
 		return null;
 	}
-
-	const getPeriod = () => {
-		switch ( purchase.billPeriodDays ) {
-			case PLAN_TRIENNIAL_PERIOD:
-				return translate( 'three years' );
-			case PLAN_BIENNIAL_PERIOD:
-				return translate( 'two years' );
-			case PLAN_ANNUAL_PERIOD:
-				return translate( 'year' );
-			case PLAN_MONTHLY_PERIOD:
-				return translate( 'month' );
-		}
-		return null;
-	};
-
 	if ( purchase?.introductoryOffer && purchase.introductoryOffer !== null ) {
-		const timePeriod = getPeriod();
+		const text = getIntroductoryOfferIntervalDisplay(
+			translate,
+			purchase.introductoryOffer.intervalUnit,
+			purchase.introductoryOffer.intervalCount,
+			isIntroductoryOfferFreeTrial( purchase ),
+			'manage-purchases',
+			purchase.introductoryOffer.remainingRenewalsUsingOffer
+		);
 
-		if ( ! timePeriod && purchase.introductoryOffer.isNextRenewalUsingOffer ) {
-			return (
-				<RenewalSubtext
-					text={ translate(
-						'After the offer ends, the subscription price will be %(regularPrice)s',
-						{
-							args: {
-								regularPrice: formatCurrency( purchase.regularPriceInteger, purchase.currencyCode, {
-									isSmallestUnit: true,
-									stripZeros: true,
-								} ),
-							},
-						}
-					) }
-				/>
+		let regularPriceText = null;
+		if ( purchase.introductoryOffer.isNextRenewalUsingOffer ) {
+			regularPriceText = translate(
+				'After the offer ends, the subscription price will be %(regularPrice)s',
+				{
+					args: {
+						regularPrice: formatCurrency( purchase.regularPriceInteger, purchase.currencyCode, {
+							isSmallestUnit: true,
+							stripZeros: true,
+						} ),
+					},
+				}
+			);
+		} else if ( purchase.introductoryOffer.isNextRenewalProrated ) {
+			regularPriceText = translate(
+				'After the first renewal, the subscription price will be %(regularPrice)s',
+				{
+					args: {
+						regularPrice: formatCurrency( purchase.regularPriceInteger, purchase.currencyCode, {
+							isSmallestUnit: true,
+							stripZeros: true,
+						} ),
+					},
+				}
 			);
 		}
 
-		if (
-			! timePeriod &&
-			! purchase.introductoryOffer.isNextRenewalUsingOffer &&
-			purchase.introductoryOffer.isNextRenewalProrated
-		) {
-			return (
-				<RenewalSubtext
-					text={ translate(
-						'After the first renewal, the subscription price will be %(regularPrice)s',
-						{
-							args: {
-								regularPrice: formatCurrency( purchase.regularPriceInteger, purchase.currencyCode, {
-									isSmallestUnit: true,
-									stripZeros: true,
-								} ),
-							},
-						}
-					) }
-				/>
-			);
-		}
-
-		if ( timePeriod && purchase.introductoryOffer.isNextRenewalUsingOffer ) {
-			return (
-				<RenewalSubtext
-					text={ translate(
-						'After the offer ends, the subscription price will be %(regularPrice)s / %(timePeriod)s',
-						{
-							args: {
-								regularPrice: formatCurrency( purchase.regularPriceInteger, purchase.currencyCode, {
-									isSmallestUnit: true,
-									stripZeros: true,
-								} ),
-								timePeriod,
-							},
-						}
-					) }
-				/>
-			);
-		}
-
-		if (
-			timePeriod &&
-			! purchase.introductoryOffer.isNextRenewalUsingOffer &&
-			purchase.introductoryOffer.isNextRenewalProrated
-		) {
-			return (
-				<RenewalSubtext
-					text={ translate(
-						'After the first renewal, the subscription price will be %(regularPrice)s / %(timePeriod)s',
-						{
-							args: {
-								regularPrice: formatCurrency( purchase.regularPriceInteger, purchase.currencyCode, {
-									isSmallestUnit: true,
-									stripZeros: true,
-								} ),
-								timePeriod,
-							},
-						}
-					) }
-				/>
-			);
-		}
+		return (
+			<>
+				<br />
+				<small> { text } </small>
+				{ regularPriceText && (
+					<>
+						{ ' ' }
+						<br /> <small> { regularPriceText } </small>{ ' ' }
+					</>
+				) }
+			</>
+		);
 	}
-
-	return null;
-}
-
-function RenewalSubtext( { text }: { text: ReactNode } ): JSX.Element {
-	return (
-		<>
-			<br /> <br /> <small> { text } </small>{ ' ' }
-		</>
-	);
 }
 
 export default PurchaseMetaIntroductoryOfferDetail;

--- a/client/me/purchases/manage-purchase/purchase-meta-price.tsx
+++ b/client/me/purchases/manage-purchase/purchase-meta-price.tsx
@@ -104,15 +104,7 @@ function PurchaseMetaPrice( { purchase }: { purchase: Purchase } ) {
 	};
 
 	const getPriceLabel = ( period: string | null ) => {
-		if (
-			// If this is not a product that will renew, we should display the price
-			// without "x/year".
-			! period ||
-			// For introductory offers with prorated renewals, it's confusing to see
-			// the renewal price as "x/year", so we will just show the renewal
-			// price by itself.
-			purchase.introductoryOffer?.isNextRenewalProrated
-		) {
+		if ( ! period ) {
 			return (
 				<span>
 					{ formatCurrency( priceInteger, currencyCode, {

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -6,7 +6,7 @@ import {
 } from '@automattic/calypso-products';
 import { Card } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
-import i18n, { getLocaleSlug, useTranslate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import { times } from 'lodash';
 import PropTypes from 'prop-types';
 import { useState, useEffect } from 'react';
@@ -59,17 +59,12 @@ export default function PurchaseMeta( {
 
 	const showJetpackUserLicense = isJetpackProduct( purchase ) || isJetpackPlan( purchase );
 
-	const renewalPriceHeader =
-		getLocaleSlug().startsWith( 'en' ) || i18n.hasTranslation( 'Renewal Price' )
-			? translate( 'Renewal Price' )
-			: translate( 'Price' );
-
 	return (
 		<>
 			<ul className="manage-purchase__meta">
 				<PurchaseMetaOwner owner={ owner } />
 				<li>
-					<em className="manage-purchase__detail-label">{ renewalPriceHeader }</em>
+					<em className="manage-purchase__detail-label">{ translate( 'Price' ) }</em>
 					<span className="manage-purchase__detail">
 						<PurchaseMetaPrice purchase={ purchase } />
 						<PurchaseMetaIntroductoryOfferDetail purchase={ purchase } />

--- a/client/me/purchases/manage-purchase/test/purchase-meta-introductory-offer-detail.js
+++ b/client/me/purchases/manage-purchase/test/purchase-meta-introductory-offer-detail.js
@@ -7,64 +7,53 @@ import { Provider as ReduxProvider } from 'react-redux';
 import { createReduxStore } from 'calypso/state';
 import PurchaseMeta from '../purchase-meta';
 
-const basicPurchase = {
-	ID: 1,
-	bill_period_label: 'per year',
-	bill_period_days: 365,
-	amount: 26.37,
-	price_integer: 2637,
-	currency_code: 'USD',
-	currency_symbol: '$',
-	expiry_date: '2023-03-02T00:00:00+00:00',
-	expiry_status: 'expiring',
-	introductory_offer: {
-		cost_per_interval: 0,
-		end_date: '2023-03-02T00:00:00+00:00',
-		interval_count: 3,
-		interval_unit: 'month',
-		is_next_renewal_prorated: false,
-		is_next_renewal_using_offer: false,
-		is_within_period: true,
-		remaining_renewals_using_offer: 0,
-		should_prorate_when_offer_ends: false,
-		transition_after_renewal_count: 0,
-	},
-	regular_price_text: '$35',
-	regular_price_integer: 3500,
-};
-
-function createReduxStoreWithPurchase( purchase ) {
-	return createReduxStore(
-		{
-			purchases: {
-				data: [ purchase ],
-			},
-			sites: {
-				requestingAll: false,
-			},
-			currentUser: {
-				id: 1,
-				user: {
-					primary_blog: 'example',
+describe( 'PurchaseMetaIntroductoryOfferDetail', () => {
+	it( 'does render "First 3 months free"', () => {
+		const store = createReduxStore(
+			{
+				purchases: {
+					data: [
+						{
+							ID: 1,
+							bill_period_label: 'per year',
+							bill_period_days: 365,
+							amount: 26.37,
+							price_integer: 2637,
+							currency_code: 'USD',
+							currency_symbol: '$',
+							expiry_date: '2023-03-02T00:00:00+00:00',
+							expiry_status: 'expiring',
+							introductory_offer: {
+								cost_per_interval: 0,
+								end_date: '2023-03-02T00:00:00+00:00',
+								interval_count: 3,
+								interval_unit: 'month',
+								is_next_renewal_prorated: true,
+								is_next_renewal_using_offer: false,
+								is_within_period: true,
+								remaining_renewals_using_offer: 0,
+								should_prorate_when_offer_ends: true,
+								transition_after_renewal_count: 0,
+							},
+							regular_price_text: '$35',
+							regular_price_integer: 3500,
+						},
+					],
+				},
+				sites: {
+					requestingAll: false,
+				},
+				currentUser: {
+					id: 1,
+					user: {
+						primary_blog: 'example',
+					},
 				},
 			},
-		},
-		( state ) => state
-	);
-}
-
-describe( 'PurchaseMetaIntroductoryOfferDetail', () => {
-	it( 'renders "after first renewal" text yearly for an intro offer with prorated renewal where next renewal is not using offer', () => {
-		const purchase = {
-			...basicPurchase,
-			introductory_offer: {
-				...basicPurchase.introductory_offer,
-				is_next_renewal_prorated: true,
-				is_next_renewal_using_offer: false,
-			},
-		};
+			( state ) => state
+		);
 		render(
-			<ReduxProvider store={ createReduxStoreWithPurchase( purchase ) }>
+			<ReduxProvider store={ store }>
 				<PurchaseMeta
 					hasLoadedPurchasesFromServer={ true }
 					purchaseId={ 1 }
@@ -73,180 +62,9 @@ describe( 'PurchaseMetaIntroductoryOfferDetail', () => {
 				/>
 			</ReduxProvider>
 		);
+		expect( screen.getByText( /First 3 months free\b/ ) ).toBeInTheDocument();
 		expect(
-			screen.getByText( 'After the first renewal, the subscription price will be $35 / year' )
-		).toBeInTheDocument();
-	} );
-
-	it( 'renders "after first renewal" text monthly for an intro offer with prorated renewal where next renewal is not using offer', () => {
-		const purchase = {
-			...basicPurchase,
-			bill_period_days: 31,
-			introductory_offer: {
-				...basicPurchase.introductory_offer,
-				is_next_renewal_prorated: true,
-				is_next_renewal_using_offer: false,
-			},
-		};
-		render(
-			<ReduxProvider store={ createReduxStoreWithPurchase( purchase ) }>
-				<PurchaseMeta
-					hasLoadedPurchasesFromServer={ true }
-					purchaseId={ 1 }
-					siteSlug="test"
-					isDataLoading={ false }
-				/>
-			</ReduxProvider>
-		);
-		expect(
-			screen.getByText( 'After the first renewal, the subscription price will be $35 / month' )
-		).toBeInTheDocument();
-	} );
-
-	it( 'renders "after first renewal" text without period for an intro offer with prorated renewal where next renewal is not using offer', () => {
-		const purchase = {
-			...basicPurchase,
-			bill_period_days: 7, // A bill period not covered by the code.
-			introductory_offer: {
-				...basicPurchase.introductory_offer,
-				is_next_renewal_prorated: true,
-				is_next_renewal_using_offer: false,
-			},
-		};
-		render(
-			<ReduxProvider store={ createReduxStoreWithPurchase( purchase ) }>
-				<PurchaseMeta
-					hasLoadedPurchasesFromServer={ true }
-					purchaseId={ 1 }
-					siteSlug="test"
-					isDataLoading={ false }
-				/>
-			</ReduxProvider>
-		);
-		expect(
-			screen.getByText( 'After the first renewal, the subscription price will be $35' )
-		).toBeInTheDocument();
-	} );
-
-	it( 'renders no text for an intro offer without prorated renewal where next renewal is not using offer', () => {
-		const purchase = {
-			...basicPurchase,
-			introductory_offer: {
-				...basicPurchase.introductory_offer,
-				is_next_renewal_prorated: false,
-				is_next_renewal_using_offer: false,
-			},
-		};
-		render(
-			<ReduxProvider store={ createReduxStoreWithPurchase( purchase ) }>
-				<PurchaseMeta
-					hasLoadedPurchasesFromServer={ true }
-					purchaseId={ 1 }
-					siteSlug="test"
-					isDataLoading={ false }
-				/>
-			</ReduxProvider>
-		);
-		expect( screen.queryByText( /After the first renewal/ ) ).not.toBeInTheDocument();
-		expect( screen.queryByText( /After the offer ends/ ) ).not.toBeInTheDocument();
-	} );
-
-	it( 'renders "after offer ends" text yearly for an intro offer without prorated renewal where next renewal is using offer', () => {
-		const purchase = {
-			...basicPurchase,
-			introductory_offer: {
-				...basicPurchase.introductory_offer,
-				is_next_renewal_prorated: false,
-				is_next_renewal_using_offer: true,
-			},
-		};
-		render(
-			<ReduxProvider store={ createReduxStoreWithPurchase( purchase ) }>
-				<PurchaseMeta
-					hasLoadedPurchasesFromServer={ true }
-					purchaseId={ 1 }
-					siteSlug="test"
-					isDataLoading={ false }
-				/>
-			</ReduxProvider>
-		);
-		expect(
-			screen.getByText( 'After the offer ends, the subscription price will be $35 / year' )
-		).toBeInTheDocument();
-	} );
-
-	it( 'renders "after offer ends" text monthly for an intro offer without prorated renewal where next renewal is using offer', () => {
-		const purchase = {
-			...basicPurchase,
-			bill_period_days: 31,
-			introductory_offer: {
-				...basicPurchase.introductory_offer,
-				is_next_renewal_prorated: false,
-				is_next_renewal_using_offer: true,
-			},
-		};
-		render(
-			<ReduxProvider store={ createReduxStoreWithPurchase( purchase ) }>
-				<PurchaseMeta
-					hasLoadedPurchasesFromServer={ true }
-					purchaseId={ 1 }
-					siteSlug="test"
-					isDataLoading={ false }
-				/>
-			</ReduxProvider>
-		);
-		expect(
-			screen.getByText( 'After the offer ends, the subscription price will be $35 / month' )
-		).toBeInTheDocument();
-	} );
-
-	it( 'renders "after offer ends" text without period for an intro offer without prorated renewal where next renewal is using offer', () => {
-		const purchase = {
-			...basicPurchase,
-			bill_period_days: 7, // A bill period not covered by the code.
-			introductory_offer: {
-				...basicPurchase.introductory_offer,
-				is_next_renewal_prorated: false,
-				is_next_renewal_using_offer: true,
-			},
-		};
-		render(
-			<ReduxProvider store={ createReduxStoreWithPurchase( purchase ) }>
-				<PurchaseMeta
-					hasLoadedPurchasesFromServer={ true }
-					purchaseId={ 1 }
-					siteSlug="test"
-					isDataLoading={ false }
-				/>
-			</ReduxProvider>
-		);
-		expect(
-			screen.getByText( 'After the offer ends, the subscription price will be $35' )
-		).toBeInTheDocument();
-	} );
-
-	it( 'renders "after offer ends" text without period for an intro offer with prorated renewal where next renewal is using offer', () => {
-		const purchase = {
-			...basicPurchase,
-			bill_period_days: 7, // A bill period not covered by the code.
-			introductory_offer: {
-				...basicPurchase.introductory_offer,
-				is_next_renewal_prorated: true,
-				is_next_renewal_using_offer: true,
-			},
-		};
-		render(
-			<ReduxProvider store={ createReduxStoreWithPurchase( purchase ) }>
-				<PurchaseMeta
-					hasLoadedPurchasesFromServer={ true }
-					purchaseId={ 1 }
-					siteSlug="test"
-					isDataLoading={ false }
-				/>
-			</ReduxProvider>
-		);
-		expect(
-			screen.getByText( 'After the offer ends, the subscription price will be $35' )
+			screen.getByText( /After the first renewal, the subscription price will be \$35\b/ )
 		).toBeInTheDocument();
 	} );
 } );


### PR DESCRIPTION
Reverts Automattic/wp-calypso#72536 Just in case it's causing prerelease errors.