### PR TITLE
Themes: Add force_site_id in the recordTracksEvent for the theme search

### DIFF
--- a/client/my-sites/themes/search-themes-tracks.js
+++ b/client/my-sites/themes/search-themes-tracks.js
@@ -74,6 +74,7 @@ export default function SearchThemesTracks( { query = {}, themes = [], wporgThem
 		actual_count: actualCount,
 		wpcom_result_count: themesCount,
 		wporg_result_count: wporgThemesCount,
+		force_site_id: true,
 	} );
 
 	useEffect( () => {

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -85,6 +85,7 @@ class ThemesSelection extends Component {
 			page_number: query.page,
 			theme_on_page: parseInt( ( resultsRank + 1 ) / query.number ),
 			action: snakeCase( action ),
+			force_site_id: true,
 		} );
 	};
 


### PR DESCRIPTION
In order to collect the blog_id and the site_plan_id, we can pass the `force_site_id` flag so that they are automatically passed to the events.

#### Proposed Changes

* Pass `force_site_id` for the `calypso_themeshowcase_theme_click` and `calypso_themes_search_results`  events

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the calypso.live link
* Open DevTools
* Go to /themes/:site-id and search for a string
* Check if the t.gif for the events are now containing `blog_id`, `site_plan_id` and `site_id_label`

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
