### PR TITLE
Purchases: Update price text to be more clear for introductory offers, take 2

### DIFF
--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -59,7 +59,6 @@ import {
 	getDisplayName,
 	getPartnerName,
 	getRenewalPrice,
-	getRenewalPriceInSmallestUnit,
 	handleRenewMultiplePurchasesClick,
 	handleRenewNowClick,
 	hasAmountAvailableToRefund,
@@ -957,7 +956,7 @@ class ManagePurchase extends Component {
 								</div>
 							) : (
 								<PlanPrice
-									rawPrice={ getRenewalPriceInSmallestUnit( purchase ) }
+									rawPrice={ purchase.regularPriceInteger }
 									isSmallestUnit
 									currencyCode={ purchase.currencyCode }
 									taxText={ purchase.taxText }

--- a/client/me/purchases/manage-purchase/purchase-meta-introductory-offer-detail.tsx
+++ b/client/me/purchases/manage-purchase/purchase-meta-introductory-offer-detail.tsx
@@ -1,3 +1,9 @@
+import {
+	PLAN_ANNUAL_PERIOD,
+	PLAN_BIENNIAL_PERIOD,
+	PLAN_MONTHLY_PERIOD,
+	PLAN_TRIENNIAL_PERIOD,
+} from '@automattic/calypso-products';
 import formatCurrency from '@automattic/format-currency';
 import { useTranslate } from 'i18n-calypso';
 import { isWithinIntroductoryOfferPeriod } from 'calypso/lib/purchases';
@@ -9,9 +15,26 @@ function PurchaseMetaIntroductoryOfferDetail( { purchase }: { purchase: Purchase
 	if ( ! isWithinIntroductoryOfferPeriod( purchase ) ) {
 		return null;
 	}
+
+	const getPeriod = () => {
+		switch ( purchase.billPeriodDays ) {
+			case PLAN_TRIENNIAL_PERIOD:
+				return translate( 'three years' );
+			case PLAN_BIENNIAL_PERIOD:
+				return translate( 'two years' );
+			case PLAN_ANNUAL_PERIOD:
+				return translate( 'year' );
+			case PLAN_MONTHLY_PERIOD:
+				return translate( 'month' );
+		}
+		return null;
+	};
+
 	if ( purchase?.introductoryOffer && purchase.introductoryOffer !== null ) {
+		const timePeriod = getPeriod();
 		let regularPriceText = null;
-		if ( purchase.introductoryOffer.isNextRenewalUsingOffer ) {
+
+		if ( ! timePeriod && purchase.introductoryOffer.isNextRenewalUsingOffer ) {
 			regularPriceText = translate(
 				'After the offer ends, the subscription price will be %(regularPrice)s',
 				{
@@ -23,7 +46,13 @@ function PurchaseMetaIntroductoryOfferDetail( { purchase }: { purchase: Purchase
 					},
 				}
 			);
-		} else if ( purchase.introductoryOffer.isNextRenewalProrated ) {
+		}
+
+		if (
+			! timePeriod &&
+			! purchase.introductoryOffer.isNextRenewalUsingOffer &&
+			purchase.introductoryOffer.isNextRenewalProrated
+		) {
 			regularPriceText = translate(
 				'After the first renewal, the subscription price will be %(regularPrice)s',
 				{
@@ -32,6 +61,40 @@ function PurchaseMetaIntroductoryOfferDetail( { purchase }: { purchase: Purchase
 							isSmallestUnit: true,
 							stripZeros: true,
 						} ),
+					},
+				}
+			);
+		}
+
+		if ( timePeriod && purchase.introductoryOffer.isNextRenewalUsingOffer ) {
+			regularPriceText = translate(
+				'After the offer ends, the subscription price will be %(regularPrice)s / %(timePeriod)',
+				{
+					args: {
+						regularPrice: formatCurrency( purchase.regularPriceInteger, purchase.currencyCode, {
+							isSmallestUnit: true,
+							stripZeros: true,
+						} ),
+						timePeriod,
+					},
+				}
+			);
+		}
+
+		if (
+			timePeriod &&
+			! purchase.introductoryOffer.isNextRenewalUsingOffer &&
+			purchase.introductoryOffer.isNextRenewalProrated
+		) {
+			regularPriceText = translate(
+				'After the first renewal, the subscription price will be %(regularPrice)s / %(timePeriod)',
+				{
+					args: {
+						regularPrice: formatCurrency( purchase.regularPriceInteger, purchase.currencyCode, {
+							isSmallestUnit: true,
+							stripZeros: true,
+						} ),
+						timePeriod,
 					},
 				}
 			);

--- a/client/me/purchases/manage-purchase/purchase-meta-introductory-offer-detail.tsx
+++ b/client/me/purchases/manage-purchase/purchase-meta-introductory-offer-detail.tsx
@@ -68,7 +68,7 @@ function PurchaseMetaIntroductoryOfferDetail( { purchase }: { purchase: Purchase
 
 		if ( timePeriod && purchase.introductoryOffer.isNextRenewalUsingOffer ) {
 			regularPriceText = translate(
-				'After the offer ends, the subscription price will be %(regularPrice)s / %(timePeriod)',
+				'After the offer ends, the subscription price will be %(regularPrice)s / %(timePeriod)s',
 				{
 					args: {
 						regularPrice: formatCurrency( purchase.regularPriceInteger, purchase.currencyCode, {
@@ -87,7 +87,7 @@ function PurchaseMetaIntroductoryOfferDetail( { purchase }: { purchase: Purchase
 			purchase.introductoryOffer.isNextRenewalProrated
 		) {
 			regularPriceText = translate(
-				'After the first renewal, the subscription price will be %(regularPrice)s / %(timePeriod)',
+				'After the first renewal, the subscription price will be %(regularPrice)s / %(timePeriod)s',
 				{
 					args: {
 						regularPrice: formatCurrency( purchase.regularPriceInteger, purchase.currencyCode, {

--- a/client/me/purchases/manage-purchase/purchase-meta-introductory-offer-detail.tsx
+++ b/client/me/purchases/manage-purchase/purchase-meta-introductory-offer-detail.tsx
@@ -1,10 +1,6 @@
 import formatCurrency from '@automattic/format-currency';
-import { getIntroductoryOfferIntervalDisplay } from '@automattic/wpcom-checkout';
 import { useTranslate } from 'i18n-calypso';
-import {
-	isWithinIntroductoryOfferPeriod,
-	isIntroductoryOfferFreeTrial,
-} from 'calypso/lib/purchases';
+import { isWithinIntroductoryOfferPeriod } from 'calypso/lib/purchases';
 import { Purchase } from 'calypso/lib/purchases/types';
 
 function PurchaseMetaIntroductoryOfferDetail( { purchase }: { purchase: Purchase } ) {
@@ -14,15 +10,6 @@ function PurchaseMetaIntroductoryOfferDetail( { purchase }: { purchase: Purchase
 		return null;
 	}
 	if ( purchase?.introductoryOffer && purchase.introductoryOffer !== null ) {
-		const text = getIntroductoryOfferIntervalDisplay(
-			translate,
-			purchase.introductoryOffer.intervalUnit,
-			purchase.introductoryOffer.intervalCount,
-			isIntroductoryOfferFreeTrial( purchase ),
-			'manage-purchases',
-			purchase.introductoryOffer.remainingRenewalsUsingOffer
-		);
-
 		let regularPriceText = null;
 		if ( purchase.introductoryOffer.isNextRenewalUsingOffer ) {
 			regularPriceText = translate(
@@ -53,7 +40,6 @@ function PurchaseMetaIntroductoryOfferDetail( { purchase }: { purchase: Purchase
 		return (
 			<>
 				<br />
-				<small> { text } </small>
 				{ regularPriceText && (
 					<>
 						{ ' ' }

--- a/client/me/purchases/manage-purchase/purchase-meta-introductory-offer-detail.tsx
+++ b/client/me/purchases/manage-purchase/purchase-meta-introductory-offer-detail.tsx
@@ -7,9 +7,14 @@ import {
 import formatCurrency from '@automattic/format-currency';
 import { useTranslate } from 'i18n-calypso';
 import { isWithinIntroductoryOfferPeriod } from 'calypso/lib/purchases';
-import { Purchase } from 'calypso/lib/purchases/types';
+import type { Purchase } from 'calypso/lib/purchases/types';
+import type { ReactNode } from 'react';
 
-function PurchaseMetaIntroductoryOfferDetail( { purchase }: { purchase: Purchase } ) {
+function PurchaseMetaIntroductoryOfferDetail( {
+	purchase,
+}: {
+	purchase: Purchase;
+} ): JSX.Element | null {
 	const translate = useTranslate();
 
 	if ( ! isWithinIntroductoryOfferPeriod( purchase ) ) {
@@ -32,19 +37,22 @@ function PurchaseMetaIntroductoryOfferDetail( { purchase }: { purchase: Purchase
 
 	if ( purchase?.introductoryOffer && purchase.introductoryOffer !== null ) {
 		const timePeriod = getPeriod();
-		let regularPriceText = null;
 
 		if ( ! timePeriod && purchase.introductoryOffer.isNextRenewalUsingOffer ) {
-			regularPriceText = translate(
-				'After the offer ends, the subscription price will be %(regularPrice)s',
-				{
-					args: {
-						regularPrice: formatCurrency( purchase.regularPriceInteger, purchase.currencyCode, {
-							isSmallestUnit: true,
-							stripZeros: true,
-						} ),
-					},
-				}
+			return (
+				<RenewalSubtext
+					text={ translate(
+						'After the offer ends, the subscription price will be %(regularPrice)s',
+						{
+							args: {
+								regularPrice: formatCurrency( purchase.regularPriceInteger, purchase.currencyCode, {
+									isSmallestUnit: true,
+									stripZeros: true,
+								} ),
+							},
+						}
+					) }
+				/>
 			);
 		}
 
@@ -53,31 +61,39 @@ function PurchaseMetaIntroductoryOfferDetail( { purchase }: { purchase: Purchase
 			! purchase.introductoryOffer.isNextRenewalUsingOffer &&
 			purchase.introductoryOffer.isNextRenewalProrated
 		) {
-			regularPriceText = translate(
-				'After the first renewal, the subscription price will be %(regularPrice)s',
-				{
-					args: {
-						regularPrice: formatCurrency( purchase.regularPriceInteger, purchase.currencyCode, {
-							isSmallestUnit: true,
-							stripZeros: true,
-						} ),
-					},
-				}
+			return (
+				<RenewalSubtext
+					text={ translate(
+						'After the first renewal, the subscription price will be %(regularPrice)s',
+						{
+							args: {
+								regularPrice: formatCurrency( purchase.regularPriceInteger, purchase.currencyCode, {
+									isSmallestUnit: true,
+									stripZeros: true,
+								} ),
+							},
+						}
+					) }
+				/>
 			);
 		}
 
 		if ( timePeriod && purchase.introductoryOffer.isNextRenewalUsingOffer ) {
-			regularPriceText = translate(
-				'After the offer ends, the subscription price will be %(regularPrice)s / %(timePeriod)s',
-				{
-					args: {
-						regularPrice: formatCurrency( purchase.regularPriceInteger, purchase.currencyCode, {
-							isSmallestUnit: true,
-							stripZeros: true,
-						} ),
-						timePeriod,
-					},
-				}
+			return (
+				<RenewalSubtext
+					text={ translate(
+						'After the offer ends, the subscription price will be %(regularPrice)s / %(timePeriod)s',
+						{
+							args: {
+								regularPrice: formatCurrency( purchase.regularPriceInteger, purchase.currencyCode, {
+									isSmallestUnit: true,
+									stripZeros: true,
+								} ),
+								timePeriod,
+							},
+						}
+					) }
+				/>
 			);
 		}
 
@@ -86,32 +102,34 @@ function PurchaseMetaIntroductoryOfferDetail( { purchase }: { purchase: Purchase
 			! purchase.introductoryOffer.isNextRenewalUsingOffer &&
 			purchase.introductoryOffer.isNextRenewalProrated
 		) {
-			regularPriceText = translate(
-				'After the first renewal, the subscription price will be %(regularPrice)s / %(timePeriod)s',
-				{
-					args: {
-						regularPrice: formatCurrency( purchase.regularPriceInteger, purchase.currencyCode, {
-							isSmallestUnit: true,
-							stripZeros: true,
-						} ),
-						timePeriod,
-					},
-				}
+			return (
+				<RenewalSubtext
+					text={ translate(
+						'After the first renewal, the subscription price will be %(regularPrice)s / %(timePeriod)s',
+						{
+							args: {
+								regularPrice: formatCurrency( purchase.regularPriceInteger, purchase.currencyCode, {
+									isSmallestUnit: true,
+									stripZeros: true,
+								} ),
+								timePeriod,
+							},
+						}
+					) }
+				/>
 			);
 		}
-
-		return (
-			<>
-				<br />
-				{ regularPriceText && (
-					<>
-						{ ' ' }
-						<br /> <small> { regularPriceText } </small>{ ' ' }
-					</>
-				) }
-			</>
-		);
 	}
+
+	return null;
+}
+
+function RenewalSubtext( { text }: { text: ReactNode } ): JSX.Element {
+	return (
+		<>
+			<br /> <br /> <small> { text } </small>{ ' ' }
+		</>
+	);
 }
 
 export default PurchaseMetaIntroductoryOfferDetail;

--- a/client/me/purchases/manage-purchase/purchase-meta-price.tsx
+++ b/client/me/purchases/manage-purchase/purchase-meta-price.tsx
@@ -104,7 +104,15 @@ function PurchaseMetaPrice( { purchase }: { purchase: Purchase } ) {
 	};
 
 	const getPriceLabel = ( period: string | null ) => {
-		if ( ! period ) {
+		if (
+			// If this is not a product that will renew, we should display the price
+			// without "x/year".
+			! period ||
+			// For introductory offers with prorated renewals, it's confusing to see
+			// the renewal price as "x/year", so we will just show the renewal
+			// price by itself.
+			purchase.introductoryOffer?.isNextRenewalProrated
+		) {
 			return (
 				<span>
 					{ formatCurrency( priceInteger, currencyCode, {

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -64,7 +64,7 @@ export default function PurchaseMeta( {
 			<ul className="manage-purchase__meta">
 				<PurchaseMetaOwner owner={ owner } />
 				<li>
-					<em className="manage-purchase__detail-label">{ translate( 'Price' ) }</em>
+					<em className="manage-purchase__detail-label">{ translate( 'Renewal Price' ) }</em>
 					<span className="manage-purchase__detail">
 						<PurchaseMetaPrice purchase={ purchase } />
 						<PurchaseMetaIntroductoryOfferDetail purchase={ purchase } />

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -6,7 +6,7 @@ import {
 } from '@automattic/calypso-products';
 import { Card } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
-import { useTranslate } from 'i18n-calypso';
+import i18n, { getLocaleSlug, useTranslate } from 'i18n-calypso';
 import { times } from 'lodash';
 import PropTypes from 'prop-types';
 import { useState, useEffect } from 'react';
@@ -59,12 +59,17 @@ export default function PurchaseMeta( {
 
 	const showJetpackUserLicense = isJetpackProduct( purchase ) || isJetpackPlan( purchase );
 
+	const renewalPriceHeader =
+		getLocaleSlug().startsWith( 'en' ) || i18n.hasTranslation( 'Renewal Price' )
+			? translate( 'Renewal Price' )
+			: translate( 'Price' );
+
 	return (
 		<>
 			<ul className="manage-purchase__meta">
 				<PurchaseMetaOwner owner={ owner } />
 				<li>
-					<em className="manage-purchase__detail-label">{ translate( 'Renewal Price' ) }</em>
+					<em className="manage-purchase__detail-label">{ renewalPriceHeader }</em>
 					<span className="manage-purchase__detail">
 						<PurchaseMetaPrice purchase={ purchase } />
 						<PurchaseMetaIntroductoryOfferDetail purchase={ purchase } />

--- a/client/me/purchases/manage-purchase/test/purchase-meta-introductory-offer-detail.js
+++ b/client/me/purchases/manage-purchase/test/purchase-meta-introductory-offer-detail.js
@@ -8,7 +8,7 @@ import { createReduxStore } from 'calypso/state';
 import PurchaseMeta from '../purchase-meta';
 
 describe( 'PurchaseMetaIntroductoryOfferDetail', () => {
-	it( 'does render "First 3 months free"', () => {
+	it( 'renders "after first renewal" text for an intro offer', () => {
 		const store = createReduxStore(
 			{
 				purchases: {
@@ -62,7 +62,6 @@ describe( 'PurchaseMetaIntroductoryOfferDetail', () => {
 				/>
 			</ReduxProvider>
 		);
-		expect( screen.getByText( /First 3 months free\b/ ) ).toBeInTheDocument();
 		expect(
 			screen.getByText( /After the first renewal, the subscription price will be \$35\b/ )
 		).toBeInTheDocument();

--- a/client/me/purchases/manage-purchase/test/purchase-meta-introductory-offer-detail.js
+++ b/client/me/purchases/manage-purchase/test/purchase-meta-introductory-offer-detail.js
@@ -54,12 +54,13 @@ function createReduxStoreWithPurchase( purchase ) {
 }
 
 describe( 'PurchaseMetaIntroductoryOfferDetail', () => {
-	it( 'renders "after first renewal" text for an intro offer with prorated renewal', () => {
+	it( 'renders "after first renewal" text yearly for an intro offer with prorated renewal where next renewal is not using offer', () => {
 		const purchase = {
 			...basicPurchase,
 			introductory_offer: {
 				...basicPurchase.introductory_offer,
 				is_next_renewal_prorated: true,
+				is_next_renewal_using_offer: false,
 			},
 		};
 		render(
@@ -74,6 +75,178 @@ describe( 'PurchaseMetaIntroductoryOfferDetail', () => {
 		);
 		expect(
 			screen.getByText( 'After the first renewal, the subscription price will be $35 / year' )
+		).toBeInTheDocument();
+	} );
+
+	it( 'renders "after first renewal" text monthly for an intro offer with prorated renewal where next renewal is not using offer', () => {
+		const purchase = {
+			...basicPurchase,
+			bill_period_days: 31,
+			introductory_offer: {
+				...basicPurchase.introductory_offer,
+				is_next_renewal_prorated: true,
+				is_next_renewal_using_offer: false,
+			},
+		};
+		render(
+			<ReduxProvider store={ createReduxStoreWithPurchase( purchase ) }>
+				<PurchaseMeta
+					hasLoadedPurchasesFromServer={ true }
+					purchaseId={ 1 }
+					siteSlug="test"
+					isDataLoading={ false }
+				/>
+			</ReduxProvider>
+		);
+		expect(
+			screen.getByText( 'After the first renewal, the subscription price will be $35 / month' )
+		).toBeInTheDocument();
+	} );
+
+	it( 'renders "after first renewal" text without period for an intro offer with prorated renewal where next renewal is not using offer', () => {
+		const purchase = {
+			...basicPurchase,
+			bill_period_days: 7, // A bill period not covered by the code.
+			introductory_offer: {
+				...basicPurchase.introductory_offer,
+				is_next_renewal_prorated: true,
+				is_next_renewal_using_offer: false,
+			},
+		};
+		render(
+			<ReduxProvider store={ createReduxStoreWithPurchase( purchase ) }>
+				<PurchaseMeta
+					hasLoadedPurchasesFromServer={ true }
+					purchaseId={ 1 }
+					siteSlug="test"
+					isDataLoading={ false }
+				/>
+			</ReduxProvider>
+		);
+		expect(
+			screen.getByText( 'After the first renewal, the subscription price will be $35' )
+		).toBeInTheDocument();
+	} );
+
+	it( 'renders no text for an intro offer without prorated renewal where next renewal is not using offer', () => {
+		const purchase = {
+			...basicPurchase,
+			introductory_offer: {
+				...basicPurchase.introductory_offer,
+				is_next_renewal_prorated: false,
+				is_next_renewal_using_offer: false,
+			},
+		};
+		render(
+			<ReduxProvider store={ createReduxStoreWithPurchase( purchase ) }>
+				<PurchaseMeta
+					hasLoadedPurchasesFromServer={ true }
+					purchaseId={ 1 }
+					siteSlug="test"
+					isDataLoading={ false }
+				/>
+			</ReduxProvider>
+		);
+		expect( screen.queryByText( /After the first renewal/ ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( /After the offer ends/ ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'renders "after offer ends" text yearly for an intro offer without prorated renewal where next renewal is using offer', () => {
+		const purchase = {
+			...basicPurchase,
+			introductory_offer: {
+				...basicPurchase.introductory_offer,
+				is_next_renewal_prorated: false,
+				is_next_renewal_using_offer: true,
+			},
+		};
+		render(
+			<ReduxProvider store={ createReduxStoreWithPurchase( purchase ) }>
+				<PurchaseMeta
+					hasLoadedPurchasesFromServer={ true }
+					purchaseId={ 1 }
+					siteSlug="test"
+					isDataLoading={ false }
+				/>
+			</ReduxProvider>
+		);
+		expect(
+			screen.getByText( 'After the offer ends, the subscription price will be $35 / year' )
+		).toBeInTheDocument();
+	} );
+
+	it( 'renders "after offer ends" text monthly for an intro offer without prorated renewal where next renewal is using offer', () => {
+		const purchase = {
+			...basicPurchase,
+			bill_period_days: 31,
+			introductory_offer: {
+				...basicPurchase.introductory_offer,
+				is_next_renewal_prorated: false,
+				is_next_renewal_using_offer: true,
+			},
+		};
+		render(
+			<ReduxProvider store={ createReduxStoreWithPurchase( purchase ) }>
+				<PurchaseMeta
+					hasLoadedPurchasesFromServer={ true }
+					purchaseId={ 1 }
+					siteSlug="test"
+					isDataLoading={ false }
+				/>
+			</ReduxProvider>
+		);
+		expect(
+			screen.getByText( 'After the offer ends, the subscription price will be $35 / month' )
+		).toBeInTheDocument();
+	} );
+
+	it( 'renders "after offer ends" text without period for an intro offer without prorated renewal where next renewal is using offer', () => {
+		const purchase = {
+			...basicPurchase,
+			bill_period_days: 7, // A bill period not covered by the code.
+			introductory_offer: {
+				...basicPurchase.introductory_offer,
+				is_next_renewal_prorated: false,
+				is_next_renewal_using_offer: true,
+			},
+		};
+		render(
+			<ReduxProvider store={ createReduxStoreWithPurchase( purchase ) }>
+				<PurchaseMeta
+					hasLoadedPurchasesFromServer={ true }
+					purchaseId={ 1 }
+					siteSlug="test"
+					isDataLoading={ false }
+				/>
+			</ReduxProvider>
+		);
+		expect(
+			screen.getByText( 'After the offer ends, the subscription price will be $35' )
+		).toBeInTheDocument();
+	} );
+
+	it( 'renders "after offer ends" text without period for an intro offer with prorated renewal where next renewal is using offer', () => {
+		const purchase = {
+			...basicPurchase,
+			bill_period_days: 7, // A bill period not covered by the code.
+			introductory_offer: {
+				...basicPurchase.introductory_offer,
+				is_next_renewal_prorated: true,
+				is_next_renewal_using_offer: true,
+			},
+		};
+		render(
+			<ReduxProvider store={ createReduxStoreWithPurchase( purchase ) }>
+				<PurchaseMeta
+					hasLoadedPurchasesFromServer={ true }
+					purchaseId={ 1 }
+					siteSlug="test"
+					isDataLoading={ false }
+				/>
+			</ReduxProvider>
+		);
+		expect(
+			screen.getByText( 'After the offer ends, the subscription price will be $35' )
 		).toBeInTheDocument();
 	} );
 } );

--- a/client/me/purchases/manage-purchase/test/purchase-meta-introductory-offer-detail.js
+++ b/client/me/purchases/manage-purchase/test/purchase-meta-introductory-offer-detail.js
@@ -7,53 +7,63 @@ import { Provider as ReduxProvider } from 'react-redux';
 import { createReduxStore } from 'calypso/state';
 import PurchaseMeta from '../purchase-meta';
 
-describe( 'PurchaseMetaIntroductoryOfferDetail', () => {
-	it( 'renders "after first renewal" text for an intro offer', () => {
-		const store = createReduxStore(
-			{
-				purchases: {
-					data: [
-						{
-							ID: 1,
-							bill_period_label: 'per year',
-							bill_period_days: 365,
-							amount: 26.37,
-							price_integer: 2637,
-							currency_code: 'USD',
-							currency_symbol: '$',
-							expiry_date: '2023-03-02T00:00:00+00:00',
-							expiry_status: 'expiring',
-							introductory_offer: {
-								cost_per_interval: 0,
-								end_date: '2023-03-02T00:00:00+00:00',
-								interval_count: 3,
-								interval_unit: 'month',
-								is_next_renewal_prorated: true,
-								is_next_renewal_using_offer: false,
-								is_within_period: true,
-								remaining_renewals_using_offer: 0,
-								should_prorate_when_offer_ends: true,
-								transition_after_renewal_count: 0,
-							},
-							regular_price_text: '$35',
-							regular_price_integer: 3500,
-						},
-					],
-				},
-				sites: {
-					requestingAll: false,
-				},
-				currentUser: {
-					id: 1,
-					user: {
-						primary_blog: 'example',
-					},
+const basicPurchase = {
+	ID: 1,
+	bill_period_label: 'per year',
+	bill_period_days: 365,
+	amount: 26.37,
+	price_integer: 2637,
+	currency_code: 'USD',
+	currency_symbol: '$',
+	expiry_date: '2023-03-02T00:00:00+00:00',
+	expiry_status: 'expiring',
+	introductory_offer: {
+		cost_per_interval: 0,
+		end_date: '2023-03-02T00:00:00+00:00',
+		interval_count: 3,
+		interval_unit: 'month',
+		is_next_renewal_prorated: false,
+		is_next_renewal_using_offer: false,
+		is_within_period: true,
+		remaining_renewals_using_offer: 0,
+		should_prorate_when_offer_ends: false,
+		transition_after_renewal_count: 0,
+	},
+	regular_price_text: '$35',
+	regular_price_integer: 3500,
+};
+
+function createReduxStoreWithPurchase( purchase ) {
+	return createReduxStore(
+		{
+			purchases: {
+				data: [ purchase ],
+			},
+			sites: {
+				requestingAll: false,
+			},
+			currentUser: {
+				id: 1,
+				user: {
+					primary_blog: 'example',
 				},
 			},
-			( state ) => state
-		);
+		},
+		( state ) => state
+	);
+}
+
+describe( 'PurchaseMetaIntroductoryOfferDetail', () => {
+	it( 'renders "after first renewal" text for an intro offer with prorated renewal', () => {
+		const purchase = {
+			...basicPurchase,
+			introductory_offer: {
+				...basicPurchase.introductory_offer,
+				is_next_renewal_prorated: true,
+			},
+		};
 		render(
-			<ReduxProvider store={ store }>
+			<ReduxProvider store={ createReduxStoreWithPurchase( purchase ) }>
 				<PurchaseMeta
 					hasLoadedPurchasesFromServer={ true }
 					purchaseId={ 1 }
@@ -63,7 +73,7 @@ describe( 'PurchaseMetaIntroductoryOfferDetail', () => {
 			</ReduxProvider>
 		);
 		expect(
-			screen.getByText( /After the first renewal, the subscription price will be \$35\b/ )
+			screen.getByText( 'After the first renewal, the subscription price will be $35 / year' )
 		).toBeInTheDocument();
 	} );
 } );


### PR DESCRIPTION
#### Take 2

This PR is identical to https://github.com/Automattic/wp-calypso/pull/72536. That PR was reverted because there were issues with the pre-release tests which ended up being unrelated (see Slack thread p1675098003762539-slack-C02DQP0FP for details).

#### Proposed Changes

This PR implements several updates to the purchases page which should help clarify the displayed prices for purchases which are introductory offers.

- Update the "Price" meta box title to say "Renewal Price" instead to clarify that this is not the previously paid price.
- When an intro offer with a pro-rated renewal exists, remove the time period (eg: "/ year") from the small renewal price in the meta box because the next time period's renewal price will probably differ from future renewal prices.
- Remove the "Discount for {intro period}" subtext for all purchases because it is too confusing to explain if this is referring to a previous payment or the next payment and how it relates to an introductory offer price's schedule.
- Leave the "After the first renewal…"/"After offer ends…" subtext for introductory offers but add the time period to the subscription price (e.g. "After the first renewal, the subscription price with be $120 / year"). Since we're removing the term from the small renewal price (see above), this will clarify how often renewals will occur.
- For the big price at the top of the page, make it the standard, un-discounted renewal price of the product instead of the next renewal price. It's very hard to know what that price represents (last paid price? next renewal price? regular renewal price?) but it's probably better to show the regular renewal price and represent discounts with more context in the meta box.

Fixes https://github.com/Automattic/payments-shilling/issues/1314

#### Screenshots

Before:

<img width="487" alt="Screenshot 2023-01-25 at 4 18 23 PM" src="https://user-images.githubusercontent.com/2036909/214693382-221aa10e-7b9b-4df5-abc6-ed86100822f7.png">

After:

<img width="484" alt="Screenshot 2023-01-25 at 4 19 45 PM" src="https://user-images.githubusercontent.com/2036909/214693417-8f7a3339-729a-4a8f-babe-44b5de854b00.png">

After for a non-introductory offer (only the "Renewal Price" text is different):

<img width="484" alt="Screenshot 2023-01-25 at 4 24 44 PM" src="https://user-images.githubusercontent.com/2036909/214694405-4480813e-8bdc-4bbc-8568-17cb50278dae.png">


#### Testing Instructions

- To test this, you'll need to have a purchased product that has an introductory offer. At the time of writing the only one I know of which falls into this category is Jetpack Social. Purchase this product.
- Visit the purchase page for the introductory offer product by visiting `/me/purchases` and clicking on the product.
- Compare the purchase page to the same page without this PR. Verify that the new page's text and prices make sense as per the description of this change.
