### PR TITLE
Plans 2023 : Adds the tooltip component,and some examples of the usage of the tooltip

### DIFF
--- a/client/components/tooltip/index.jsx
+++ b/client/components/tooltip/index.jsx
@@ -25,6 +25,7 @@ function Tooltip( props ) {
 			isVisible={ props.isVisible }
 			position={ props.position }
 			showDelay={ props.showDelay }
+			hideArrow
 		>
 			{ props.children }
 		</Popover>
@@ -40,6 +41,7 @@ Tooltip.propTypes = {
 	status: PropTypes.string,
 	showDelay: PropTypes.number,
 	showOnMobile: PropTypes.bool,
+	hideArrow: PropTypes.bool,
 	children: PropTypes.node,
 	context: PropTypes.any,
 };

--- a/client/components/tooltip/index.jsx
+++ b/client/components/tooltip/index.jsx
@@ -50,6 +50,7 @@ Tooltip.defaultProps = {
 	showDelay: 100,
 	position: 'top',
 	showOnMobile: false,
+	hideArrow: false,
 };
 
 export default Tooltip;

--- a/client/lib/plans/features-list.tsx
+++ b/client/lib/plans/features-list.tsx
@@ -229,13 +229,14 @@ import ExternalLinkWithTracking from 'calypso/components/external-link/with-trac
 import MaterialIcon from 'calypso/components/material-icon';
 import { DOMAIN_PRICING_AND_AVAILABLE_TLDS } from 'calypso/lib/url/support';
 
+const is2023OnboardingPricingGrid = isEnabled( 'onboarding/2023-pricing-grid' );
+
 export type FeatureObject = {
 	getSlug: () => string;
 	getTitle: ( domainName?: string ) => TranslateResult;
 	getAlternativeTitle?: () => TranslateResult;
 	getHeader?: () => TranslateResult;
 	getDescription?: ( domainName?: string ) => TranslateResult;
-	getExplanation?: () => TranslateResult;
 	getStoreSlug?: () => string;
 	getCompareTitle?: () => TranslateResult;
 	getIcon?: () => string | { icon: string; component: MemoExoticComponent< any > } | JSX.Element;
@@ -572,7 +573,11 @@ export const FEATURES_LIST: FeatureList = {
 					args: domainName,
 				} );
 			}
-
+			if ( is2023OnboardingPricingGrid ) {
+				return i18n.translate(
+					'Get a custom domain – like yoursite.com – free for the first year.'
+				);
+			}
 			return i18n.translate(
 				'All paid WordPress.com plans purchased for an annual term include one year of free domain registration. ' +
 					'Domains registered through this promotion will renew at our {{a}}standard rate{{/a}}, plus applicable taxes, after the first year.{{br /}}{{br /}}' +
@@ -591,8 +596,6 @@ export const FEATURES_LIST: FeatureList = {
 				}
 			);
 		},
-		getExplanation: () =>
-			i18n.translate( 'Get a custom domain – like yoursite.com – free for the first year.' ),
 	},
 
 	[ FEATURE_JETPACK_ESSENTIAL ]: {
@@ -1654,13 +1657,13 @@ export const FEATURES_LIST: FeatureList = {
 		getSlug: () => FEATURE_PAGES,
 		getTitle: () => i18n.translate( 'Unlimited pages' ),
 		getCompareTitle: () => i18n.translate( 'Add as many pages as you like.' ),
-		getExplanation: () => i18n.translate( 'Add as many pages as you like to your site.' ),
+		getDescription: () => i18n.translate( 'Add as many pages as you like to your site.' ),
 	},
 	[ FEATURE_USERS ]: {
 		getSlug: () => FEATURE_USERS,
 		getTitle: () => i18n.translate( 'Unlimited users' ),
 		getCompareTitle: () => i18n.translate( 'Invite others to contribute to your site.' ),
-		getExplanation: () =>
+		getDescription: () =>
 			i18n.translate( 'Invite others to contribute to your site and assign access permissions.' ),
 	},
 	[ FEATURE_NEWSLETTERS_RSS ]: {
@@ -1670,7 +1673,7 @@ export const FEATURES_LIST: FeatureList = {
 	[ FEATURE_POST_EDITS_HISTORY ]: {
 		getSlug: () => FEATURE_POST_EDITS_HISTORY,
 		getTitle: () => i18n.translate( 'Time machine for post edits' ),
-		getExplanation: () =>
+		getDescription: () =>
 			i18n.translate( 'Roll back your posts to an earlier edit with a built-in revision history.' ),
 	},
 	[ FEATURE_SECURITY_BRUTE_FORCE ]: {
@@ -1684,7 +1687,7 @@ export const FEATURES_LIST: FeatureList = {
 	[ FEATURE_ALWAYS_ONLINE ]: {
 		getSlug: () => FEATURE_ALWAYS_ONLINE,
 		getTitle: () => i18n.translate( 'Online forever' ),
-		getExplanation: () => i18n.translate( 'Build and count on a site designed to last forever.' ),
+		getDescription: () => i18n.translate( 'Build and count on a site designed to last forever.' ),
 	},
 	[ FEATURE_FAST_DNS ]: {
 		getSlug: () => FEATURE_FAST_DNS,
@@ -1724,7 +1727,7 @@ export const FEATURES_LIST: FeatureList = {
 	[ FEATURE_BANDWIDTH ]: {
 		getSlug: () => FEATURE_BANDWIDTH,
 		getTitle: () => i18n.translate( 'Unrestricted bandwidth' ),
-		getExplanation: () =>
+		getDescription: () =>
 			i18n.translate( 'Never fret about getting too much traffic or paying overage charges.' ),
 	},
 	[ FEATURE_BURST ]: {

--- a/client/lib/plans/features-list.tsx
+++ b/client/lib/plans/features-list.tsx
@@ -235,6 +235,7 @@ export type FeatureObject = {
 	getAlternativeTitle?: () => TranslateResult;
 	getHeader?: () => TranslateResult;
 	getDescription?: ( domainName?: string ) => TranslateResult;
+	getExplanation?: () => TranslateResult;
 	getStoreSlug?: () => string;
 	getCompareTitle?: () => TranslateResult;
 	getIcon?: () => string | { icon: string; component: MemoExoticComponent< any > } | JSX.Element;
@@ -590,6 +591,8 @@ export const FEATURES_LIST: FeatureList = {
 				}
 			);
 		},
+		getExplanation: () =>
+			i18n.translate( 'Get a custom domain – like yoursite.com – free for the first year.' ),
 	},
 
 	[ FEATURE_JETPACK_ESSENTIAL ]: {
@@ -1651,11 +1654,14 @@ export const FEATURES_LIST: FeatureList = {
 		getSlug: () => FEATURE_PAGES,
 		getTitle: () => i18n.translate( 'Unlimited pages' ),
 		getCompareTitle: () => i18n.translate( 'Add as many pages as you like.' ),
+		getExplanation: () => i18n.translate( 'Add as many pages as you like to your site.' ),
 	},
 	[ FEATURE_USERS ]: {
 		getSlug: () => FEATURE_USERS,
 		getTitle: () => i18n.translate( 'Unlimited users' ),
 		getCompareTitle: () => i18n.translate( 'Invite others to contribute to your site.' ),
+		getExplanation: () =>
+			i18n.translate( 'Invite others to contribute to your site and assign access permissions.' ),
 	},
 	[ FEATURE_NEWSLETTERS_RSS ]: {
 		getSlug: () => FEATURE_NEWSLETTERS_RSS,
@@ -1664,6 +1670,8 @@ export const FEATURES_LIST: FeatureList = {
 	[ FEATURE_POST_EDITS_HISTORY ]: {
 		getSlug: () => FEATURE_POST_EDITS_HISTORY,
 		getTitle: () => i18n.translate( 'Time machine for post edits' ),
+		getExplanation: () =>
+			i18n.translate( 'Roll back your posts to an earlier edit with a built-in revision history.' ),
 	},
 	[ FEATURE_SECURITY_BRUTE_FORCE ]: {
 		getSlug: () => FEATURE_SECURITY_BRUTE_FORCE,
@@ -1676,6 +1684,7 @@ export const FEATURES_LIST: FeatureList = {
 	[ FEATURE_ALWAYS_ONLINE ]: {
 		getSlug: () => FEATURE_ALWAYS_ONLINE,
 		getTitle: () => i18n.translate( 'Online forever' ),
+		getExplanation: () => i18n.translate( 'Build and count on a site designed to last forever.' ),
 	},
 	[ FEATURE_FAST_DNS ]: {
 		getSlug: () => FEATURE_FAST_DNS,
@@ -1715,6 +1724,8 @@ export const FEATURES_LIST: FeatureList = {
 	[ FEATURE_BANDWIDTH ]: {
 		getSlug: () => FEATURE_BANDWIDTH,
 		getTitle: () => i18n.translate( 'Unrestricted bandwidth' ),
+		getExplanation: () =>
+			i18n.translate( 'Never fret about getting too much traffic or paying overage charges.' ),
 	},
 	[ FEATURE_BURST ]: {
 		getSlug: () => FEATURE_BURST,

--- a/client/my-sites/plan-features-2023-grid/features.tsx
+++ b/client/my-sites/plan-features-2023-grid/features.tsx
@@ -2,15 +2,16 @@ import { getPlanClass, FEATURE_CUSTOM_DOMAIN } from '@automattic/calypso-product
 import classNames from 'classnames';
 import { localize, useTranslate } from 'i18n-calypso';
 import { PlanFeaturesItem } from './item';
-import type { PlanFeature } from './types';
+import { Plans2023Tooltip } from './plans-2023-tooltip';
+import { TransformedFeatureObject } from './types';
 
 const PlanFeatures2023GridFeatures: React.FC< {
-	features: Array< PlanFeature >;
+	features: Array< TransformedFeatureObject >;
 	planName: string;
 	domainName: string;
 } > = ( { features, planName, domainName } ) => {
 	const translate = useTranslate();
-	const annualPlansFeatureNotice = ( feature: PlanFeature ) => {
+	const annualPlansFeatureNotice = ( feature: TransformedFeatureObject ) => {
 		if ( ! feature.availableOnlyForAnnualPlans || feature.availableForCurrentPlan ) {
 			return '';
 		}
@@ -42,7 +43,9 @@ const PlanFeatures2023GridFeatures: React.FC< {
 						<PlanFeaturesItem annualOnlyContent={ annualPlansFeatureNotice( currentFeature ) }>
 							<span className={ spanClasses } key={ key }>
 								<span className={ itemTitleClasses }>
-									{ currentFeature.getTitle( domainName ) }
+									<Plans2023Tooltip text={ currentFeature.getDescription?.() }>
+										{ currentFeature.getTitle( domainName ) }
+									</Plans2023Tooltip>
 								</span>
 							</span>
 						</PlanFeaturesItem>

--- a/client/my-sites/plan-features-2023-grid/plan-comparison-grid.tsx
+++ b/client/my-sites/plan-features-2023-grid/plan-comparison-grid.tsx
@@ -25,6 +25,7 @@ import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selector
 import PlanFeatures2023GridActions from './actions';
 import PlanFeatures2023GridBillingTimeframe from './billing-timeframe';
 import PlanFeatures2023GridHeaderPrice from './header-price';
+import { Plans2023Tooltip } from './plans-2023-tooltip';
 import { PlanProperties } from './types';
 import { usePricingBreakpoint } from './util';
 
@@ -526,7 +527,9 @@ export const PlanComparisonGrid: React.FC< PlanComparisonGridProps > = ( {
 											key="feature-name"
 											className={ `plan-comparison-grid__feature-feature-name ${ feature.getTitle() }` }
 										>
-											{ feature.getTitle() }
+											<Plans2023Tooltip text={ feature.getExplanation?.() }>
+												{ feature.getTitle() }
+											</Plans2023Tooltip>
 											{ allJetpackFeatures.has( feature.getSlug() ) ? (
 												<JetpackIconContainer>
 													<JetpackLogo size={ 16 } />
@@ -582,7 +585,11 @@ export const PlanComparisonGrid: React.FC< PlanComparisonGridProps > = ( {
 										key="feature-name"
 										className="plan-comparison-grid__feature-feature-name storage"
 									>
-										{ translate( 'Storage' ) }
+										<Plans2023Tooltip
+											text={ translate( 'Space to store your photos, media, and more.' ) }
+										>
+											{ translate( 'Storage' ) }
+										</Plans2023Tooltip>
 									</RowHead>
 									{ ( visiblePlansProperties ?? [] ).map( ( { planName } ) => {
 										const storageFeature = restructuredFeatures.planStorageOptionsMap[ planName ];

--- a/client/my-sites/plan-features-2023-grid/plan-comparison-grid.tsx
+++ b/client/my-sites/plan-features-2023-grid/plan-comparison-grid.tsx
@@ -527,7 +527,7 @@ export const PlanComparisonGrid: React.FC< PlanComparisonGridProps > = ( {
 											key="feature-name"
 											className={ `plan-comparison-grid__feature-feature-name ${ feature.getTitle() }` }
 										>
-											<Plans2023Tooltip text={ feature.getExplanation?.() }>
+											<Plans2023Tooltip text={ feature.getDescription?.() }>
 												{ feature.getTitle() }
 											</Plans2023Tooltip>
 											{ allJetpackFeatures.has( feature.getSlug() ) ? (

--- a/client/my-sites/plan-features-2023-grid/plans-2023-tooltip.tsx
+++ b/client/my-sites/plan-features-2023-grid/plans-2023-tooltip.tsx
@@ -1,42 +1,52 @@
 import styled from '@emotion/styled';
 import { TranslateResult } from 'i18n-calypso';
-import { PropsWithChildren } from 'react';
+import { PropsWithChildren, useRef, useState } from 'react';
+import Tooltip from 'calypso/components/tooltip';
 
-const TooltipContainer = styled.div`
-	position: relative;
-	cursor: default;
-`;
-const Tooltip = styled.div`
-	background: #101517;
-	border-radius: 4px;
-	font-size: 12px;
-	color: #fff;
-	display: block;
-	width: 245px;
-	position: absolute;
-	padding: 8px 10px;
-	box-shadow: 0 1px 2px rgb( 0 0 0 / 5% );
-	font-weight: 400;
-	text-align: center;
-	pointer-events: none;
-	z-index: 55;
-	transition: opacity 0.2s ease;
-	left: -18px;
-	top: -55px;
-	opacity: 0;
-	${ TooltipContainer }:hover & {
-		opacity: 1;
+const HoverAreaContainer = styled.span``;
+
+const StyledTooltip = styled( Tooltip )`
+	&.tooltip.popover .popover__inner {
+		background: var( --color-masterbar-background );
+		text-align: center;
+		border-radius: 4px;
+		min-height: 48px;
+		width: 190px;
+		display: flex;
+		align-items: center;
+		font-style: normal;
+		font-weight: 400;
+		font-size: 1em;
+		padding: 8px 25px;
 	}
 `;
 
 export const Plans2023Tooltip = ( props: PropsWithChildren< { text?: TranslateResult } > ) => {
+	const [ isVisible, setIsVisible ] = useState( false );
+	const tooltipRef = useRef< HTMLDivElement >( null );
+
 	if ( ! props.text ) {
 		return <>{ props.children }</>;
 	}
+
 	return (
-		<TooltipContainer className="plans-tooltip">
-			{ props.children }
-			<Tooltip>{ props.text }</Tooltip>
-		</TooltipContainer>
+		<>
+			<HoverAreaContainer
+				className="plans-2023-tooltip__hover-area-container"
+				ref={ tooltipRef }
+				onMouseEnter={ () => setIsVisible( true ) }
+				onMouseLeave={ () => setIsVisible( false ) }
+			>
+				{ props.children }
+			</HoverAreaContainer>
+			<StyledTooltip
+				isVisible={ isVisible }
+				position="top"
+				context={ tooltipRef.current }
+				hideArrow
+			>
+				{ props.text }
+			</StyledTooltip>
+		</>
 	);
 };

--- a/client/my-sites/plan-features-2023-grid/plans-2023-tooltip.tsx
+++ b/client/my-sites/plan-features-2023-grid/plans-2023-tooltip.tsx
@@ -1,0 +1,42 @@
+import styled from '@emotion/styled';
+import { TranslateResult } from 'i18n-calypso';
+import { PropsWithChildren } from 'react';
+
+const TooltipContainer = styled.div`
+	position: relative;
+	cursor: default;
+`;
+const Tooltip = styled.div`
+	background: #101517;
+	border-radius: 4px;
+	font-size: 12px;
+	color: #fff;
+	display: block;
+	width: 245px;
+	position: absolute;
+	padding: 8px 10px;
+	box-shadow: 0 1px 2px rgb( 0 0 0 / 5% );
+	font-weight: 400;
+	text-align: center;
+	pointer-events: none;
+	z-index: 55;
+	transition: opacity 0.2s ease;
+	left: -18px;
+	top: -55px;
+	opacity: 0;
+	${ TooltipContainer }:hover & {
+		opacity: 1;
+	}
+`;
+
+export const Plans2023Tooltip = ( props: PropsWithChildren< { text?: TranslateResult } > ) => {
+	if ( ! props.text ) {
+		return <>{ props.children }</>;
+	}
+	return (
+		<TooltipContainer className="plans-tooltip">
+			{ props.children }
+			<Tooltip>{ props.text }</Tooltip>
+		</TooltipContainer>
+	);
+};

--- a/client/my-sites/plan-features-2023-grid/types.ts
+++ b/client/my-sites/plan-features-2023-grid/types.ts
@@ -2,7 +2,10 @@ import { applyTestFiltersToPlansList } from '@automattic/calypso-products';
 import { FeatureObject } from 'calypso/lib/plans/features-list';
 import type { PricedAPIPlan } from '@automattic/data-stores';
 
-export type TransformedFeatureObject = FeatureObject & { availableForCurrentPlan: boolean };
+export type TransformedFeatureObject = FeatureObject & {
+	availableForCurrentPlan: boolean;
+	availableOnlyForAnnualPlans: boolean;
+};
 
 export type PlanProperties = {
 	cartItemForPlan: {
@@ -10,8 +13,8 @@ export type PlanProperties = {
 	} | null;
 	currencyCode: string | null;
 	discountPrice: number | null;
-	features: PlanFeature[];
-	jpFeatures: PlanFeature[];
+	features: TransformedFeatureObject[];
+	jpFeatures: TransformedFeatureObject[];
 	isLandingPage?: boolean;
 	isPlaceholder?: boolean;
 	planConstantObj: ReturnType< typeof applyTestFiltersToPlansList >;
@@ -30,11 +33,3 @@ export type PlanProperties = {
 	availableForPurchase: boolean;
 	current?: boolean;
 };
-
-export interface PlanFeature {
-	availableForCurrentPlan?: boolean;
-	availableOnlyForAnnualPlans?: boolean;
-	getSlug: () => string;
-	getTitle: ( name?: string ) => React.ReactNode;
-	getDescription?: () => React.ReactNode;
-}

--- a/packages/components/src/popover/index.jsx
+++ b/packages/components/src/popover/index.jsx
@@ -368,7 +368,7 @@ class PopoverInner extends Component {
 // the outer `isVisible` prop by the `showDelay` timeout. One consequence is that the `RootChild`
 // is created on show and destroyed on hide, making sure that the last shown popover will be
 // also the last DOM element inside `document.body`, ensuring that it has a higher z-index.
-function Popover( { isVisible = false, showDelay = 0, hideArrow, ...props } ) {
+function Popover( { isVisible = false, showDelay = 0, hideArrow = false, ...props } ) {
 	const isRtl = useRtl();
 	const [ show, setShow ] = useState( isVisible );
 
@@ -399,7 +399,7 @@ function Popover( { isVisible = false, showDelay = 0, hideArrow, ...props } ) {
 
 	return (
 		<RootChild>
-			<PopoverInner { ...props } isRtl={ isRtl } hideArrow />
+			<PopoverInner { ...props } isRtl={ isRtl } hideArrow={ hideArrow } />
 		</RootChild>
 	);
 }

--- a/packages/components/src/popover/index.jsx
+++ b/packages/components/src/popover/index.jsx
@@ -30,6 +30,7 @@ class PopoverInner extends Component {
 		onClose: noop,
 		onMouseEnter: noop,
 		onMouseLeave: noop,
+		hideArrow: false,
 	};
 
 	/**
@@ -349,7 +350,7 @@ class PopoverInner extends Component {
 				onMouseEnter={ this.handleOnMouseEnter }
 				onMouseLeave={ this.handleOnMouseLeave }
 			>
-				<div className="popover__arrow" />
+				{ ! this.props.hideArrow ? <div className="popover__arrow" /> : null }
 				<div ref={ this.popoverInnerNodeRef } className="popover__inner">
 					{ this.props.children }
 				</div>
@@ -367,7 +368,7 @@ class PopoverInner extends Component {
 // the outer `isVisible` prop by the `showDelay` timeout. One consequence is that the `RootChild`
 // is created on show and destroyed on hide, making sure that the last shown popover will be
 // also the last DOM element inside `document.body`, ensuring that it has a higher z-index.
-function Popover( { isVisible = false, showDelay = 0, ...props } ) {
+function Popover( { isVisible = false, showDelay = 0, hideArrow, ...props } ) {
 	const isRtl = useRtl();
 	const [ show, setShow ] = useState( isVisible );
 
@@ -398,7 +399,7 @@ function Popover( { isVisible = false, showDelay = 0, ...props } ) {
 
 	return (
 		<RootChild>
-			<PopoverInner { ...props } isRtl={ isRtl } />
+			<PopoverInner { ...props } isRtl={ isRtl } hideArrow />
 		</RootChild>
 	);
 }
@@ -411,6 +412,7 @@ const PropTypeElement = PropTypes.oneOfType( [
 ] );
 
 Popover.propTypes = {
+	hideArrow: PropTypes.bool,
 	autoPosition: PropTypes.bool,
 	autoRtl: PropTypes.bool,
 	className: PropTypes.string,


### PR DESCRIPTION
#### Proposed Changes

* Adds the initial tooltip component
* Showcases a few examples of a few tooltips in operation

#### Please Note The Following Caveats
* All of the tooltips have not been added in this PR and will be added by a separate change (Automattic/martech#1460) . This PR is shipped prematurely to unblock any other developers that want to use the tooltip.

<img width="1376" alt="image" src="https://user-images.githubusercontent.com/3422709/215569792-4a0ef190-6279-4c02-96cd-1b749267db18.png">

#### Testing Instructions
- Go to /start/plans?flags=onboarding/2023-pricing-grid
- Make sure the tooltip popover works by hovering over `Storage` or any other features that have been provided with a feature explanation
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
Fixes Automattic/martech#1390