### PR TITLE
Stepper: Record calypso page views on stepper screens

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/index.tsx
@@ -8,6 +8,7 @@ import { Switch, Route, Redirect, generatePath, useHistory, useLocation } from '
 import DocumentHead from 'calypso/components/data/document-head';
 import WordPressLogo from 'calypso/components/wordpress-logo';
 import { STEPPER_INTERNAL_STORE } from 'calypso/landing/stepper/stores';
+import { recordPageView } from 'calypso/lib/analytics/page-view';
 import SignupHeader from 'calypso/signup/signup-header';
 import { ONBOARD_STORE } from '../../stores';
 import recordStepStart from './analytics/record-step-start';
@@ -79,6 +80,11 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 		if ( currentStepRoute ) {
 			recordStepStart( flow.name, kebabCase( currentStepRoute ), { intent } );
 		}
+
+		// Also record page view for data and analytics
+		const pathname = window.location.pathname;
+		const pageTitle = `Setup > ${ flow.name } > ${ currentStepRoute }`;
+		recordPageView( pathname, pageTitle );
 
 		// We leave out intent from the dependency list, due to the ONBOARD_STORE being reset in the exit flow.
 		// This causes the intent to become empty, and thus this event being fired again.

--- a/client/landing/stepper/declarative-flow/internals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/index.tsx
@@ -79,12 +79,12 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 		// We record the event only when the step is not empty. Additionally, we should not fire this event whenever the intent is changed
 		if ( currentStepRoute ) {
 			recordStepStart( flow.name, kebabCase( currentStepRoute ), { intent } );
-		}
 
-		// Also record page view for data and analytics
-		const pathname = window.location.pathname;
-		const pageTitle = `Setup > ${ flow.name } > ${ currentStepRoute }`;
-		recordPageView( pathname, pageTitle );
+			// Also record page view for data and analytics
+			const pathname = window.location.pathname || '';
+			const pageTitle = `Setup > ${ flow.name } > ${ currentStepRoute }`;
+			recordPageView( pathname, pageTitle );
+		}
 
 		// We leave out intent from the dependency list, due to the ONBOARD_STORE being reset in the exit flow.
 		// This causes the intent to become empty, and thus this event being fired again.


### PR DESCRIPTION
### Proposed Changes

Ensure that we are recording Calypso page views on each screen or step of a stepper flow. This helps ensure reliable and accurate analytics (including Google analytics). It also helps with properly recording calypso_singup_complete tracks events. This is partially in response to a request in this P2: pau2Xa-4DX-p2

### Testing Instructions

1. Checkout this branch and run yarn and yarn start if needed. 
2. Get set up to view tracks events. You can use [Tracks Vigiliante](https://github.com/Automattic/tracks-chrome-extension). Or open Dev Tools, go to Network, and filter for t.gif.
3. Go to `http://calypso.localhost:3000/setup/free/intro`. Confirm that a calypso_page_view event fires, with the correct path.
4. Go through each subsequent step of the flow. For each **stepper* screen, confirm that a calypso_page_view event fires with the correct path. 
5. Bonus: Test one other flow (link in bio, newsletter, newsletter, etc). 

Also run through a stepper flow and confirm no unexpected issues (ie, the code changes don't introduce any unexpected regression or breakage). 