### PR TITLE
Flaky E2E: expect final landing URL instead of `waitForNavigation` in WPCC signup.

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/signup/user-signup-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/signup/user-signup-page.ts
@@ -102,7 +102,7 @@ export class UserSignupPage {
 		await this.page.fill( selectors.passwordInput, password );
 
 		const [ , response ] = await Promise.all( [
-			this.page.waitForNavigation(),
+			this.page.waitForURL( /.*crowdsignal\.com\/start\?plan=free.*/ ),
 			this.page.waitForResponse( /.*new\?.*/ ),
 			this.page.click( selectors.submitButton ),
 		] );


### PR DESCRIPTION
#### Proposed Changes

This PR replaces the usage of `waitForNavigation` at the WPCC signup spec with a `waitForURL` to work around issues caused by redirect.

![image](https://user-images.githubusercontent.com/6549265/215596548-ec1c0e4a-6ce4-4cc6-b6a1-da63e583ae74.png)

```
page.waitForNavigation: net::ERR_TOO_MANY_REDIRECTS
=========================== logs ===========================
waiting for navigation until "load"
============================================================
at UserSignupPage.signupWPCC (/home/teamcity-2/buildAgent/work/c4a9d5b38c1dacde/packages/calypso-e2e/src/lib/pages/signup/user-signup-page.ts:105:14)
    at Object.<anonymous> (/home/teamcity-2/buildAgent/work/c4a9d5b38c1dacde/test/e2e/specs/onboarding/signup__wpcc.ts:42:21)
```

Key changes:
- remove `waitForNavigation` and replace with `page.waitForURL`.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
