### PR TITLE
Flaky E2E: make plan selection page more robust.

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/plans-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plans-page.ts
@@ -39,7 +39,10 @@ const selectors = {
 };
 
 /**
- * Page representing the Plans page accessible at Upgrades >> Plans
+ * Page representing the Plans page under `/plans` endpoint.
+ *
+ * Also forms a component of the `SignupPickPlanPage` used in the
+ * signup stepper flow.
  */
 export class PlansPage {
 	private page: Page;
@@ -80,12 +83,9 @@ export class PlansPage {
 	 */
 	async selectPlan( plan: Plans ): Promise< void > {
 		const locator = this.page.locator( selectors.selectPlanButton( plan ) );
-		// In the /plans view, there are two buttons for "Upgrade" on the
-		// plan comparison chart.
-		await Promise.all( [
-			this.page.waitForNavigation( { timeout: 30 * 1000 } ),
-			locator.first().click(),
-		] );
+		// In the `/plans` view, there are two buttons for "Upgrade" on the
+		// plan comparison chart. Select the first one.
+		await locator.first().click();
 	}
 
 	/* Generic */

--- a/packages/calypso-e2e/src/lib/pages/signup/signup-pick-plan-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/signup/signup-pick-plan-page.ts
@@ -28,17 +28,26 @@ export class SignupPickPlanPage {
 	 * @returns {Promise<SiteDetails>} Details of the newly created site.
 	 */
 	async selectPlan( name: Plans ): Promise< NewSiteResponse > {
+		await Promise.all( [
+			this.page.waitForURL( /.*start\/plans.*/ ),
+			this.page.waitForLoadState(),
+		] );
+
 		const [ response ] = await Promise.all( [
 			this.page.waitForResponse( /.*sites\/new\?.*/ ),
+			// Should redirect to the Checkout cart and this may
+			// take some time.
+			this.page.waitForURL( /.*checkout.*/, { timeout: 30 * 1000 } ),
 			this.plansPage.selectPlan( name ),
 		] );
 
-		if ( ! response ) {
-			throw new Error( 'Failed to create new site when selecting a plan at signup.' );
-		}
-
 		const responseJSON = await response.json();
 		const body: NewSiteResponse = responseJSON.body;
+
+		if ( ! body.blog_details.blogid ) {
+			console.error( body );
+			throw new Error( 'Failed to create new site when selecting a plan at signup.' );
+		}
 
 		// Cast the blogID value to a number, in case it comes in as a string.
 		body.blog_details.blogid = Number( body.blog_details.blogid );


### PR DESCRIPTION
#### Proposed Changes

This PR aims to make the plans selection page at `/start/plans` more robust.

Suddenly as of 2023/01/30 we began seeing failures on both `Free` and `Personal` plan selection flows. For the Personal plan, Playwright is able to locate the button to select such plan, but the click is either swallowed up or never registered by the page in the first place, thus no navigation takes place.

Key changes:
- remove a `waitForNavigation` from `PlansPage` as per upstream recommendation.
- add wait for URL and 'load' state in `SignupPickPlanPage`.
- move the error handling in `SignupPickPlanPage.pickPlan` and add response body output as error log if something goes wrong.

#### Testing Instructions

Ensure the following build configurations are passing:
  - [ ] Calypso E2E (desktop)
  - [ ] Pre-Release E2E

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
