### PR TITLE
Odyssey Stats: Hide Odyssey preview JITM

### DIFF
--- a/apps/odyssey-stats/src/styles/wp-admin.scss
+++ b/apps/odyssey-stats/src/styles/wp-admin.scss
@@ -100,3 +100,8 @@
 		margin-left: 32px;
 	}
 }
+
+// Hide Odyssey Stats preview JITM inside odyssey.
+.jitm-card.jitm-banner.odyssey-stats-preview {
+	display: none;
+}


### PR DESCRIPTION
#### Proposed Changes

|Before|After|
|-|-|
|<img width="1785" alt="image" src="https://user-images.githubusercontent.com/4044428/215612264-8ba28986-4919-48c0-9234-6d2acf96847c.png">|<img width="1272" alt="image" src="https://user-images.githubusercontent.com/4044428/215612213-1625535f-94f6-4a44-b60e-00a8bd465437.png">|

* Hides Odyssey Stats preview JITM in Odyssey Stats. See D99513-code#2047920.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Build Odyssey Stats into your local Jetpack instance (option 1 from PejTkB-3E-p2).
* Follow testing steps in D99513-code to enable the Odyssey Stats JITM.
* Ensure that the JITM is hidden on your local Jetpack site's Odyssey Stats.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->