### PR TITLE
CI: disable GitHub `commitStatusPublisher` by default.

### DIFF
--- a/.teamcity/_self/lib/customBuildType/E2EBuildType.kt
+++ b/.teamcity/_self/lib/customBuildType/E2EBuildType.kt
@@ -38,7 +38,8 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
  * @param getCalypsoLiveURL String containing the commands to be run in order to obtain the live URL. Only used for Calypso E2E.
  * @param testGroup String corresponding to an existing group defined for Jest Runner Group.
  * @param buildParams Environment variables and other parameters to set for the build.
- * @param buildFeatures Features to enable on top of the default feature set (perfmon, commitStatusPublisher).
+ * @param buildFeatures Features to enable on top of the default feature set (perfmon).
+ * @param enableCommitStatusPublisher Boolean toggle to enable the commit status publisher in Build Features.
  * @param buildTriggers Rules to trigger the build. By default, no triggers are defined.
  * @param buildDepedencies If the build configuration depends on another existing build configuration, define it here.
  */

--- a/.teamcity/_self/lib/customBuildType/E2EBuildType.kt
+++ b/.teamcity/_self/lib/customBuildType/E2EBuildType.kt
@@ -52,6 +52,7 @@ open class E2EBuildType(
 	var testGroup: String,
 	var buildParams: ParametrizedWithType.() -> Unit = {},
 	var buildFeatures: BuildFeatures.() -> Unit,
+	var enableCommitStatusPublisher: Boolean = false,
 	var buildTriggers: Triggers.() -> Unit = {},
 	var buildDependencies: Dependencies.() -> Unit = {},
 
@@ -62,6 +63,7 @@ open class E2EBuildType(
 		val testGroup = testGroup
 		val buildParams = buildParams
 		val buildFeatures = buildFeatures
+		val enableCommitStatusPublisher = enableCommitStatusPublisher
 		val buildTriggers = buildTriggers
 		val buildDependencies = buildDependencies
 		val params = params
@@ -163,15 +165,19 @@ open class E2EBuildType(
 		features {
 			perfmon {
 			}
-			commitStatusPublisher {
-				vcsRootExtId = "${Settings.WpCalypso.id}"
-				publisher = github {
-					githubUrl = "https://api.github.com"
-					authType = personalToken {
-						token = "credentialsJSON:57e22787-e451-48ed-9fea-b9bf30775b36"
+
+			if (enableCommitStatusPublisher) {
+				commitStatusPublisher {
+					vcsRootExtId = "${Settings.WpCalypso.id}"
+					publisher = github {
+						githubUrl = "https://api.github.com"
+						authType = personalToken {
+							token = "credentialsJSON:57e22787-e451-48ed-9fea-b9bf30775b36"
+						}
 					}
 				}
 			}
+
 			buildFeatures()
 		}
 

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -755,8 +755,9 @@ fun playwrightPrBuildType( targetDevice: String, buildUuid: String ): E2EBuildTy
 					}
 					filterAuthorRole = PullRequests.GitHubRoleFilter.EVERYBODY
 				}
-			}
+			},
 		},
+		enableCommitStatusPublisher = true,
 		buildTriggers = {
 			vcs {
 				branchFilter = """

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -755,7 +755,7 @@ fun playwrightPrBuildType( targetDevice: String, buildUuid: String ): E2EBuildTy
 					}
 					filterAuthorRole = PullRequests.GitHubRoleFilter.EVERYBODY
 				}
-			},
+			}
 		},
 		enableCommitStatusPublisher = true,
 		buildTriggers = {


### PR DESCRIPTION
#### Proposed Changes

This PR changes the `E2EBuildType` to disable the `commitStatusPublisher` feature by default.

Key changes:
- create a new boolean parameter value `enableCommitStatusPublisher` that defaults to false.
- wrap the `commitStatusPublisher` feature around a check for the boolean value.

Context: p1674800183798609-slack-C1A1EKDGQ

#### Testing Instructions

VCS settings should load successfully on all build configurations.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #