### PR TITLE
Stats: Adds date range switching header to top Authors summary page

### DIFF
--- a/client/my-sites/stats/stats-module/index.jsx
+++ b/client/my-sites/stats/stats-module/index.jsx
@@ -109,6 +109,7 @@ class StatsModule extends Component {
 		const { summary, statType } = this.props;
 		const summarizedTypes = [
 			'statsCountryViews',
+			'statsTopAuthors',
 			'statsTopPosts',
 			'statsSearchTerms',
 			'statsClicks',

--- a/client/my-sites/stats/summary/index.jsx
+++ b/client/my-sites/stats/summary/index.jsx
@@ -124,7 +124,7 @@ class StatsSummary extends Component {
 						path="authors"
 						moduleStrings={ StatsStrings.authors }
 						period={ this.props.period }
-						query={ query }
+						query={ merge( {}, statsQueryOptions, query ) }
 						statType="statsTopAuthors"
 						className="stats__author-views"
 						summary={ true }


### PR DESCRIPTION
#### Proposed Changes

* Adds date range switching header to top Authors summary page

#### Testing Instructions

* Open Calypso live branch
* Navigate to `/stats/day/authors/[Site URL]` 
* Using the header menu buttons, switch between `Day Summary` , `7 Days`, `30 Days` etc and check that the displayed date ranges update. 

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
