### PR TITLE
SMP: Add keyboard shortcut to focus search field

### DIFF
--- a/client/sites-dashboard/components/sites-content-controls.tsx
+++ b/client/sites-dashboard/components/sites-content-controls.tsx
@@ -78,6 +78,26 @@ const ControlsSelectDropdown = styled( SelectDropdown )( {
 	},
 } );
 
+const ShortcutKey = styled.div( {
+	position: 'absolute',
+	right: '10px',
+	color: '#979A9C',
+	fontFamily: 'monospace',
+	zIndex: 23, // Places the shortcut key above the placeholder fadeout gradient
+	borderRadius: 4,
+	border: '1px solid #979A9C',
+	width: 17,
+	height: 17,
+	textAlign: 'center',
+	lineHeight: '17px',
+	fontSize: 12,
+	boxShadow: '0 1px 2px rgba(151, 154, 156, 0.25)',
+
+	'.search-component.has-focus &': {
+		display: 'none',
+	},
+} );
+
 type Statuses = ReturnType< typeof useSitesListGrouping >[ 'statuses' ];
 
 type SitesContentControlsProps = {
@@ -131,11 +151,20 @@ export const SitesContentControls = ( {
 				searchIcon={ <SitesSearchIcon /> }
 				onSearch={ ( term ) => handleQueryParamChange( { search: term?.trim(), page: undefined } ) }
 				isReskinned
+				inputLabel={ __( 'Search sites, press "/" to focus search field' ) }
 				placeholder={ __( 'Search by name or domain…' ) }
 				disableAutocorrect={ true }
 				defaultValue={ initialSearch }
 				ref={ searchRef }
-			/>
+			>
+				<ShortcutKey
+					aria-hidden
+					onClick={ () => searchRef.current?.focus() }
+					style={ { display: initialSearch ? 'none' : undefined } }
+				>
+					/
+				</ShortcutKey>
+			</SitesSearch>
 			<DisplayControls>
 				<ControlsSelectDropdown
 					// Translators: `siteStatus` is one of the site statuses specified in the Sites page.

--- a/client/sites-dashboard/components/sites-content-controls.tsx
+++ b/client/sites-dashboard/components/sites-content-controls.tsx
@@ -78,26 +78,6 @@ const ControlsSelectDropdown = styled( SelectDropdown )( {
 	},
 } );
 
-const ShortcutKey = styled.div( {
-	position: 'absolute',
-	right: '10px',
-	color: '#979A9C',
-	fontFamily: 'monospace',
-	zIndex: 23, // Places the shortcut key above the placeholder fadeout gradient
-	borderRadius: 4,
-	border: '1px solid #979A9C',
-	width: 17,
-	height: 17,
-	textAlign: 'center',
-	lineHeight: '17px',
-	fontSize: 12,
-	boxShadow: '0 1px 2px rgba(151, 154, 156, 0.25)',
-
-	'.search-component.has-focus &': {
-		display: 'none',
-	},
-} );
-
 type Statuses = ReturnType< typeof useSitesListGrouping >[ 'statuses' ];
 
 type SitesContentControlsProps = {
@@ -151,20 +131,11 @@ export const SitesContentControls = ( {
 				searchIcon={ <SitesSearchIcon /> }
 				onSearch={ ( term ) => handleQueryParamChange( { search: term?.trim(), page: undefined } ) }
 				isReskinned
-				inputLabel={ __( 'Search sites, press "/" to focus search field' ) }
 				placeholder={ __( 'Search by name or domain…' ) }
 				disableAutocorrect={ true }
 				defaultValue={ initialSearch }
 				ref={ searchRef }
-			>
-				<ShortcutKey
-					aria-hidden
-					onClick={ () => searchRef.current?.focus() }
-					style={ { display: initialSearch ? 'none' : undefined } }
-				>
-					/
-				</ShortcutKey>
-			</SitesSearch>
+			/>
 			<DisplayControls>
 				<ControlsSelectDropdown
 					// Translators: `siteStatus` is one of the site statuses specified in the Sites page.

--- a/packages/search/src/index.ts
+++ b/packages/search/src/index.ts
@@ -1,2 +1,3 @@
 export { default } from './search';
+export type { ImperativeHandle } from './search';
 export { useFuzzySearch } from './use-fuzzy-search';

--- a/packages/search/src/search.tsx
+++ b/packages/search/src/search.tsx
@@ -102,7 +102,7 @@ const getScrollLeft = (
 	return scrollLeft;
 };
 
-type ImperativeHandle = {
+export type ImperativeHandle = {
 	focus: () => void;
 	blur: () => void;
 	clear: () => void;


### PR DESCRIPTION
#### Proposed changes

Use pdKhl6-1IQ-p2 to discuss the design and appropriateness of the feature. This PR can be for code-review specific comments.

Adds a global shortcut key to focus the site search box.

* Adds `/` shortcut global shortcut key to focus the search box
* Adds visual and screenreader affordance for the shortcut key
* Exports useful type information from the `@automattic/search` package

![CleanShot 2023-01-31 at 14 36 29@2x](https://user-images.githubusercontent.com/1500769/215637093-a2e8a494-311d-4573-b0ca-56871f4976aa.png)


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test at `/sites`
* Pressing "/" should focus search box
* The shortcut key affordance should disappear when the input box is focued
* The shortcut key affordance should disappear when the input box is non-empty
* Test that the keydown handling works on all supported browsers

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] ~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~
- [ ] ~Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?~
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~
- [ ] ~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~
- [ ] ~For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->