### PR TITLE
SMP: Fix keyboard navigation for sort dropdown

### DIFF
--- a/client/sites-dashboard/components/sites-sorting-dropdown.tsx
+++ b/client/sites-dashboard/components/sites-sorting-dropdown.tsx
@@ -93,7 +93,7 @@ export const SitesSortingDropdown = ( {
 				</SortingButton>
 			) }
 			renderContent={ ( { onClose } ) => (
-				<NavigableMenu>
+				<NavigableMenu cycle={ false }>
 					<MenuItemsChoice
 						value={ currentSortingValue }
 						onSelect={ ( value: typeof choices[ 0 ][ 'value' ] ) => {

--- a/client/sites-dashboard/components/sites-sorting-dropdown.tsx
+++ b/client/sites-dashboard/components/sites-sorting-dropdown.tsx
@@ -1,6 +1,6 @@
 import { Gridicon } from '@automattic/components';
 import styled from '@emotion/styled';
-import { Button, Dropdown, MenuItemsChoice } from '@wordpress/components';
+import { Button, Dropdown, MenuItemsChoice, NavigableMenu } from '@wordpress/components';
 import { useMediaQuery } from '@wordpress/compose';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
@@ -79,6 +79,12 @@ export const SitesSortingDropdown = ( {
 					aria-label={ sprintf( __( 'Sorting by %s. Switch sorting mode' ), currentSortingLabel ) }
 					onClick={ onToggle }
 					aria-expanded={ isOpen }
+					onKeyDown={ ( event: React.KeyboardEvent ) => {
+						if ( ! isOpen && event.code === 'ArrowDown' ) {
+							event.preventDefault();
+							onToggle();
+						}
+					} }
 				>
 					{
 						// translators: %s is the current sorting mode.
@@ -87,14 +93,16 @@ export const SitesSortingDropdown = ( {
 				</SortingButton>
 			) }
 			renderContent={ ( { onClose } ) => (
-				<MenuItemsChoice
-					value={ currentSortingValue }
-					onSelect={ ( value: typeof choices[ 0 ][ 'value' ] ) => {
-						onSitesSortingChange( parseSitesSorting( value ) );
-						onClose();
-					} }
-					choices={ choices }
-				/>
+				<NavigableMenu>
+					<MenuItemsChoice
+						value={ currentSortingValue }
+						onSelect={ ( value: typeof choices[ 0 ][ 'value' ] ) => {
+							onSitesSortingChange( parseSitesSorting( value ) );
+							onClose();
+						} }
+						choices={ choices }
+					/>
+				</NavigableMenu>
 			) }
 		/>
 	);


### PR DESCRIPTION
#### Proposed Changes

Combo boxes/dropdown menus should be navigable using the keyboard. This PR fixes that accessibility issue.

This adds keyboard control using similar code to how Gutenberg's `<DropdownMenu>` component does it: 
https://github.com/WordPress/gutenberg/blob/b333d1d515c7fe91ec063112a6c178d5ed66b1e4/packages/components/src/dropdown-menu/index.js#L45
 
![Jan-31-2023 15-16-55](https://user-images.githubusercontent.com/1500769/215643062-1a459405-e138-467b-a97e-aff28feb8043.gif)



#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test at `/sites`
* Sorting should work just like it used to
* Keyboard control should work on all supported browsers

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] ~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~
- [ ] ~Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?~
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~
- [ ] ~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~
- [ ] ~For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

