### PR TITLE
SMP: <SitesDisplayModeSwitcher> supports keyboard navigation

### DIFF
--- a/client/sites-dashboard/components/sites-display-mode-switcher.tsx
+++ b/client/sites-dashboard/components/sites-display-mode-switcher.tsx
@@ -2,6 +2,7 @@ import { Gridicon } from '@automattic/components';
 import { css } from '@emotion/css';
 import { Button } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
+import { useCallback, useRef } from 'react';
 import { useSelector } from 'react-redux';
 import { getCurrentUserSiteCount } from 'calypso/state/current-user/selectors';
 import { useAsyncPreference } from 'calypso/state/preferences/use-async-preference';
@@ -31,6 +32,35 @@ export const SitesDisplayModeSwitcher = ( {
 	onDisplayModeChange,
 }: SitesDisplayModeSwitcherProps ) => {
 	const { __ } = useI18n();
+	const tileRef = useRef< HTMLButtonElement >( null );
+	const listRef = useRef< HTMLButtonElement >( null );
+
+	const handleKeyDown = useCallback(
+		( event: React.KeyboardEvent, currentMode: SitesDisplayMode ) => {
+			if (
+				[
+					'Up',
+					'ArrowUp',
+					'Left',
+					'ArrowLeft',
+					'Down',
+					'ArrowDown',
+					'Right',
+					'ArrowRight',
+				].includes( event.key )
+			) {
+				event.preventDefault();
+				const newMode = currentMode === 'tile' ? 'list' : 'tile';
+				if ( newMode === 'tile' ) {
+					tileRef.current?.focus();
+				} else {
+					listRef.current?.focus();
+				}
+				onDisplayModeChange( newMode );
+			}
+		},
+		[ onDisplayModeChange ]
+	);
 
 	return (
 		<div className={ container } role="radiogroup" aria-label={ __( 'Sites display mode' ) }>
@@ -40,7 +70,13 @@ export const SitesDisplayModeSwitcher = ( {
 				title={ __( 'Switch to tile view' ) }
 				onClick={ () => onDisplayModeChange( 'tile' ) }
 				icon={ <Gridicon icon="grid" /> }
-				isPressed={ displayMode === 'tile' }
+				ref={ tileRef }
+				onKeyDown={ ( event: React.KeyboardEvent ) => handleKeyDown( event, 'tile' ) }
+				aria-checked={ displayMode === 'tile' }
+				tabIndex={ displayMode === 'tile' ? 0 : -1 }
+				// aria-checked is the correct attribute to show a radio button is selected, but we
+				// still want to use the Button component's built in isPressed styling.
+				className={ displayMode === 'tile' ? 'is-pressed' : '' }
 			/>
 			<Button
 				role="radio"
@@ -48,7 +84,11 @@ export const SitesDisplayModeSwitcher = ( {
 				title={ __( 'Switch to list view' ) }
 				onClick={ () => onDisplayModeChange( 'list' ) }
 				icon={ <Gridicon icon="list-unordered" /> }
-				isPressed={ displayMode === 'list' }
+				ref={ listRef }
+				onKeyDown={ ( event: React.KeyboardEvent ) => handleKeyDown( event, 'list' ) }
+				aria-checked={ displayMode === 'list' }
+				tabIndex={ displayMode === 'list' ? 0 : -1 }
+				className={ displayMode === 'list' ? 'is-pressed' : '' }
 			/>
 		</div>
 	);


### PR DESCRIPTION
#### Proposed Changes

Because the display mode toggle isn't a real radio group it means it's up to us to implement all the expected behaviour a radio group has. Simply setting `role="radio"` isn't enough. That announces to the screenreader that it's a radio button but it's up to us to implement it.

This'd require a lot less code if we used real `<input type="radio">` elements, but since we want the buttons to be styled like the `<Button>` component we need the manual implementation.

[This W3C resource defines how radio groups are supposed to behave](https://www.w3.org/WAI/ARIA/apg/patterns/radiobutton/).

In this case, I've gone with the method where only one of the buttons is focusable at one time by setting the tabindex.

![Jan-31-2023 16-39-53](https://user-images.githubusercontent.com/1500769/215657189-95effcc7-c2ff-49b9-b65f-8bf21e1e29f4.gif)

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test at `/sites`
* Only one of the display mode buttons is focusable at any given time
* Use left/right/up/down to toggle
* Test all supported browsers
* Compare with production and see nothing has changed visually

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] ~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~
- [ ] ~Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?~
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~
- [ ] ~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~
- [ ] ~For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

