### PR TITLE
Checkout: Enable the VAT form in checkout in all environments

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -17,7 +17,7 @@
 		"cancellation-offers": true,
 		"catch-js-errors": true,
 		"checkout/google-pay": true,
-		"checkout/vat-form": false,
+		"checkout/vat-form": true,
 		"cloudflare": true,
 		"composite-checkout-testing": true,
 		"current-site/domain-warning": true,

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -31,7 +31,7 @@
 		"activity-log/v2": true,
 		"always_use_logout_url": true,
 		"checkout/google-pay": false,
-		"checkout/vat-form": false,
+		"checkout/vat-form": true,
 		"current-site/domain-warning": false,
 		"current-site/notice": false,
 		"current-site/stale-cart-notice": false,

--- a/config/jetpack-cloud-horizon.json
+++ b/config/jetpack-cloud-horizon.json
@@ -28,7 +28,7 @@
 		"activity-log/v2": true,
 		"always_use_logout_url": false,
 		"checkout/google-pay": true,
-		"checkout/vat-form": false,
+		"checkout/vat-form": true,
 		"current-site/domain-warning": false,
 		"current-site/notice": false,
 		"current-site/stale-cart-notice": false,

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -30,7 +30,7 @@
 		"ad-tracking": true,
 		"always_use_logout_url": true,
 		"checkout/google-pay": false,
-		"checkout/vat-form": false,
+		"checkout/vat-form": true,
 		"current-site/domain-warning": false,
 		"current-site/notice": false,
 		"current-site/stale-cart-notice": false,

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -30,7 +30,7 @@
 		"ad-tracking": false,
 		"always_use_logout_url": true,
 		"checkout/google-pay": false,
-		"checkout/vat-form": false,
+		"checkout/vat-form": true,
 		"current-site/domain-warning": false,
 		"current-site/notice": false,
 		"current-site/stale-cart-notice": false,

--- a/config/production.json
+++ b/config/production.json
@@ -23,7 +23,7 @@
 		"cancellation-offers": true,
 		"catch-js-errors": true,
 		"checkout/google-pay": true,
-		"checkout/vat-form": false,
+		"checkout/vat-form": true,
 		"cloudflare": true,
 		"current-site/domain-warning": true,
 		"current-site/notice": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -20,7 +20,7 @@
 		"cancellation-offers": true,
 		"catch-js-errors": true,
 		"checkout/google-pay": true,
-		"checkout/vat-form": false,
+		"checkout/vat-form": true,
 		"cloudflare": true,
 		"current-site/domain-warning": true,
 		"current-site/notice": true,


### PR DESCRIPTION
#### Proposed Changes

This PR enables the feature flag that allows displaying the VAT form inside checkout's contact details step when a valid country code is selected.

You can see more of how this looks in https://github.com/Automattic/wp-calypso/pull/71285, https://github.com/Automattic/wp-calypso/pull/72464, and https://github.com/Automattic/wp-calypso/pull/72734.

<img width="570" alt="Screenshot 2023-01-27 at 2 07 25 PM" src="https://user-images.githubusercontent.com/2036909/215173979-3fca52b1-b289-4da6-a7a3-293cb53be648.png">

Fixes https://github.com/Automattic/payments-shilling/issues/1278

#### Testing Instructions

No testing should be especially required as this is already live in the test and development environments. However, here's how you can try it out:

- On this branch, add a product to your cart and visit checkout.
- If the checkout contact/billing details step is automatically completed, click the "Edit" button to make it active.
- Select a VAT country like "United Kingdom" in the country field and a valid postal code number like `NW1 4NP`.
- Click the VAT checkbox and verify that the VAT fields appear. Set the company name to `Test company`. Set the VAT Number to a valid one like `553557881` and fill in anything in the "Address for VAT" field.
- Click continue to complete the step. (Note: this is a test number that will only work when the API is sandboxed).
- Verify that the validation is successful and that the step completes.
- Click to edit the step again.
- Verify that you can no longer edit the VAT Number but that you can edit the organization and the address.
- Visit `/me/purchases/vat-details` and verify that the form there has the same information entered in checkout.
- Return to checkout (or reload the page), edit the step again, and verify that the form is pre-populated with the VAT details you entered before.