### PR TITLE
Social: Fix the introductory offer display price for the Jetpack Advanced Plan 

### DIFF
--- a/client/my-sites/plans/jetpack-plans/use-item-price.ts
+++ b/client/my-sites/plans/jetpack-plans/use-item-price.ts
@@ -168,7 +168,7 @@ const useItemPrice = (
 				? getMonthlyPrice( introductoryOfferPrices.introOfferCost )
 				: undefined;
 
-			// Override Jetpack Social and Jetpack Backup Tier 1 price by hard-coding it for now
+			// Override Jetpack Social Basic, Jetpack Social Advanced and Jetpack Backup Tier 1 price by hard-coding it for now
 			if (
 				[
 					...JETPACK_SOCIAL_PRODUCTS,

--- a/client/my-sites/plans/jetpack-plans/use-item-price.ts
+++ b/client/my-sites/plans/jetpack-plans/use-item-price.ts
@@ -2,6 +2,7 @@ import {
 	JETPACK_BACKUP_T1_PRODUCTS,
 	JETPACK_CRM_PRODUCTS,
 	JETPACK_SOCIAL_PRODUCTS,
+	JETPACK_SOCIAL_ADVANCED_PRODUCTS,
 	TERM_MONTHLY,
 } from '@automattic/calypso-products';
 import { useMemo } from 'react';
@@ -169,9 +170,14 @@ const useItemPrice = (
 
 			// Override Jetpack Social and Jetpack Backup Tier 1 price by hard-coding it for now
 			if (
-				[ ...JETPACK_SOCIAL_PRODUCTS, ...JETPACK_BACKUP_T1_PRODUCTS ].includes(
+				[
+					...JETPACK_SOCIAL_PRODUCTS,
+					...JETPACK_SOCIAL_ADVANCED_PRODUCTS,
+					...JETPACK_BACKUP_T1_PRODUCTS,
+				].includes(
 					item?.productSlug as
 						| typeof JETPACK_SOCIAL_PRODUCTS[ number ]
+						| typeof JETPACK_SOCIAL_ADVANCED_PRODUCTS[ number ]
 						| typeof JETPACK_BACKUP_T1_PRODUCTS[ number ]
 				)
 			) {


### PR DESCRIPTION
#### Proposed Changes

* Treat Jetpack Social Advanced plan in the same category as Jetpack Social Basic and the Backup VaultPress plans to display the introductory offer correctly on the UI. Products with the $1 introductory offers are treated differently on the UI. We are adding another plan called the Jetpack Social Advanced plan, for which we added the introductory offer.  The long term fix would be to rename JETPACK_SOCIAL_PRODUCTS to JETPACK_SOCIAL_BASIC_PRODUCTS to avoid the confusion that JETPACK_SOCIAL_PRODUCTS includes all the JETPACK_SOCIAL_PRODUCTS, but that will be a much bigger refactor, given the number of references, and I have added it to our asana board to make sure we clean it up.


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to https://cloud.jetpack.com/pricing?view=products and click on the "More about Social" under Social Basic and see the details about the advanced plan. 
<img width="1231" alt="Screenshot 2023-01-31 at 11 55 12" src="https://user-images.githubusercontent.com/6594561/215683037-a7fa4ea3-11d7-4685-a157-847493081de8.png">

* Boot up Jetpack Cloud and go to http://jetpack.cloud.localhost:3000/pricing?view=products and click on the "More about Social" under Social Basic and see the details about the advanced plan and make sure you see the $1 free trial. If you are using the live link, then append `/pricing?view=products` to the site URL to see the pricing pace with the $1 free trial being displayed correctly. 
<img width="1138" alt="Screenshot 2023-01-31 at 12 04 19" src="https://user-images.githubusercontent.com/6594561/215684605-061e6530-1243-420c-95ca-34c9280ca138.png">


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

