### PR TITLE
Disable flag themes/theme-switch-persist-template in all enviroments

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -178,7 +178,7 @@
 		"themes/showcase-i4/cards-only": true,
 		"themes/showcase-i4/details-and-preview": true,
 		"themes/subscription-purchases": true,
-		"themes/theme-switch-persist-template": true,
+		"themes/theme-switch-persist-template": false,
 		"themes/third-party-premium": true,
 		"titan/iframe-control-panel": false,
 		"unified-pages/virtual-home-page": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -122,7 +122,7 @@
 		"themes/showcase-i4/cards-only": true,
 		"themes/showcase-i4/details-and-preview": false,
 		"themes/subscription-purchases": false,
-		"themes/theme-switch-persist-template": true,
+		"themes/theme-switch-persist-template": false,
 		"themes/third-party-premium": true,
 		"unified-pages/virtual-home-page": true,
 		"upgrades/redirect-payments": true,


### PR DESCRIPTION
#### Proposed Changes

* Disable flag themes/theme-switch-persist-template in development and horizon envs

This change avoids but doesn't fix the error 500 when switching to any theme preserving the homepage. See https://github.com/Automattic/wp-calypso/issues/72811

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the logged-in theme showcase on horizon or development envs
* Switch to another theme preserving your homepage
* The theme switch should work, you'll see a confirmation modal and no error should be displayed

|Before|after|
|------|-----|
|![image](https://user-images.githubusercontent.com/1881481/215683670-df0ef4c2-b024-453f-9442-f6848725ebcb.png)|<img width="743" alt="Screenshot 2566-01-31 at 13 30 25" src="https://user-images.githubusercontent.com/1881481/215684094-5f1a9bd9-ce5b-4d30-a580-8e5d348012ea.png">|


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [X] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [X] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [X] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [X] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [X] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/72811