### PR TITLE
Use 'Paid' badge for marketplace themes

### DIFF
--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -371,8 +371,22 @@ export class Theme extends Component {
 		);
 	};
 
+	getUpsellHeader = () => {
+		const { doesThemeBundleSoftwareSet, isExternallyManagedTheme, translate } = this.props;
+
+		if ( isExternallyManagedTheme ) {
+			return translate( 'Paid theme' );
+		}
+
+		if ( doesThemeBundleSoftwareSet ) {
+			return translate( 'WooCommerce theme' );
+		}
+
+		return translate( 'Premium theme' );
+	};
+
 	getUpsellPopoverContent = () => {
-		const { doesThemeBundleSoftwareSet, isExternallyManagedTheme, theme, translate } = this.props;
+		const { theme } = this.props;
 
 		return (
 			<>
@@ -382,11 +396,7 @@ export class Theme extends Component {
 				/>
 				<div>
 					<div data-testid="upsell-header" className="theme__upsell-header">
-						{ ( ! doesThemeBundleSoftwareSet || isExternallyManagedTheme ) &&
-							translate( 'Premium theme' ) }
-						{ doesThemeBundleSoftwareSet &&
-							! isExternallyManagedTheme &&
-							translate( 'WooCommerce theme' ) }
+						{ this.getUpsellHeader() }
 					</div>
 					<div data-testid="upsell-message">{ this.getUpsellMessage() }</div>
 				</div>
@@ -394,15 +404,35 @@ export class Theme extends Component {
 		);
 	};
 
+	getPremiumThemeBadge = () => {
+		const { doesThemeBundleSoftwareSet, isExternallyManagedTheme, translate } = this.props;
+
+		const commonProps = {
+			className: 'theme__upsell-popover',
+			tooltipClassName: 'theme__upsell-popover info-popover__tooltip',
+			tooltipContent: this.getUpsellPopoverContent(),
+			tooltipPosition: 'top',
+		};
+
+		if ( isExternallyManagedTheme ) {
+			return (
+				<PremiumBadge
+					{ ...commonProps }
+					className={ classNames( commonProps.className, 'theme__marketplace-theme' ) }
+					labelText={ translate( 'Paid', { textOnly: true } ) }
+				/>
+			);
+		}
+
+		if ( doesThemeBundleSoftwareSet ) {
+			return <WooCommerceBundledBadge { ...commonProps } />;
+		}
+
+		return <PremiumBadge { ...commonProps } />;
+	};
+
 	renderUpsell = () => {
-		const {
-			active,
-			doesThemeBundleSoftwareSet,
-			isExternallyManagedTheme,
-			isPremiumTheme,
-			isPremiumThemeAvailable,
-			theme,
-		} = this.props;
+		const { active, isPremiumTheme, isPremiumThemeAvailable, theme } = this.props;
 
 		/*
 		 * Only show the Premium badge if we're not already showing the price
@@ -411,7 +441,6 @@ export class Theme extends Component {
 		const showPremiumBadge = isPremiumTheme && isPremiumThemeAvailable && ! active;
 		const isNewCardsOnly = isEnabled( 'themes/showcase-i4/cards-only' );
 		const isNewDetailsAndPreview = isEnabled( 'themes/showcase-i4/details-and-preview' );
-		const popoverContent = this.getUpsellPopoverContent();
 
 		return (
 			<span className="theme__upsell">
@@ -420,24 +449,7 @@ export class Theme extends Component {
 					eventProperties={ { cta_name: 'theme-upsell', theme: theme.id } }
 				/>
 				{ isNewCardsOnly || isNewDetailsAndPreview ? (
-					<>
-						{ ( ! doesThemeBundleSoftwareSet || isExternallyManagedTheme ) && (
-							<PremiumBadge
-								className="theme__upsell-popover"
-								tooltipClassName="theme__upsell-popover info-popover__tooltip"
-								tooltipContent={ popoverContent }
-								tooltipPosition="top"
-							/>
-						) }
-						{ doesThemeBundleSoftwareSet && ! isExternallyManagedTheme && (
-							<WooCommerceBundledBadge
-								className="theme__upsell-popover"
-								tooltipClassName="theme__upsell-popover info-popover__tooltip"
-								tooltipContent={ popoverContent }
-								tooltipPosition="top"
-							/>
-						) }
-					</>
+					this.getPremiumThemeBadge()
 				) : (
 					<InfoPopover
 						icon="star"
@@ -448,7 +460,7 @@ export class Theme extends Component {
 						) }
 						position="top"
 					>
-						{ popoverContent }
+						{ this.getUpsellPopoverContent() }
 					</InfoPopover>
 				) }
 			</span>

--- a/client/components/theme/style.scss
+++ b/client/components/theme/style.scss
@@ -135,6 +135,9 @@ $soft-launch-badge-font-size: 0.725rem;
 		background: #008a20;
 		fill: #fff;
 	}
+	&.premium-badge.theme__marketplace-theme {
+		background: var(--color-primary);
+	}
 	&.popover.info-popover__tooltip {
 		.popover__inner {
 			max-width: 245px;


### PR DESCRIPTION
#### Proposed Changes

* This PR explores updating the badge for marketplace themes to use `Paid` as the main label, and changes the color. Both changes should make it much easier to distinguish between premium and marketplace themes.
* This change stems from the following internal discussion: pekYwv-Ax-p2

#### Testing Instructions

* Apply this PR or open the Calypso.live branch
* Navigate to _Appearance_ -> _Themes_
* Verify that marketplace themes have a blue label with `Paid` as the text
* Mouse over the label, and verify that the tooltip header is now `Paid theme`

#### Screenshots

##### Badge in theme showcase
<img width="1436" alt="Screenshot 2023-01-31 at 11 10 46" src="https://user-images.githubusercontent.com/3376401/215720194-2edd9449-4f83-4d61-b3b5-32a08c57a105.png">

##### Tooltip header
<img width="448" alt="Screenshot 2023-01-31 at 11 23 52" src="https://user-images.githubusercontent.com/3376401/215720310-069aa82d-ee9a-40e9-a806-4f35bcc4a4ef.png">

#### Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [N/A] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [N/A] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #72514