### PR TITLE
Plans Grid 2023: Update cross-outs of unavailable features

### DIFF
--- a/client/my-sites/plan-features-2023-grid/features.tsx
+++ b/client/my-sites/plan-features-2023-grid/features.tsx
@@ -1,6 +1,6 @@
 import { getPlanClass, FEATURE_CUSTOM_DOMAIN } from '@automattic/calypso-products';
 import classNames from 'classnames';
-import { localize, useTranslate } from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 import { PlanFeaturesItem } from './item';
 import { Plans2023Tooltip } from './plans-2023-tooltip';
 import { TransformedFeatureObject } from './types';
@@ -10,19 +10,6 @@ const PlanFeatures2023GridFeatures: React.FC< {
 	planName: string;
 	domainName: string;
 } > = ( { features, planName, domainName } ) => {
-	const translate = useTranslate();
-	const annualPlansFeatureNotice = ( feature: TransformedFeatureObject ) => {
-		if ( ! feature.availableOnlyForAnnualPlans || feature.availableForCurrentPlan ) {
-			return '';
-		}
-
-		return (
-			<span className="plan-features-2023-grid__item-annual-plan">
-				{ translate( 'Included with annual plans' ) }
-			</span>
-		);
-	};
-
 	return (
 		<>
 			{ features.map( ( currentFeature, featureIndex ) => {
@@ -34,13 +21,16 @@ const PlanFeatures2023GridFeatures: React.FC< {
 					'is-available': currentFeature.availableForCurrentPlan,
 				} );
 				const itemTitleClasses = classNames( 'plan-features-2023-grid__item-title', {
-					'is-bold': currentFeature.getSlug() === FEATURE_CUSTOM_DOMAIN,
+					'is-bold':
+						currentFeature.getSlug() === FEATURE_CUSTOM_DOMAIN
+							? true
+							: ! currentFeature.availableForCurrentPlan,
 				} );
 				const key = `${ currentFeature.getSlug() }-${ featureIndex }`;
 
 				return (
 					<div key={ key } className={ divClasses }>
-						<PlanFeaturesItem annualOnlyContent={ annualPlansFeatureNotice( currentFeature ) }>
+						<PlanFeaturesItem>
 							<span className={ spanClasses } key={ key }>
 								<span className={ itemTitleClasses }>
 									<Plans2023Tooltip text={ currentFeature.getDescription?.() }>

--- a/client/my-sites/plan-features-2023-grid/item.jsx
+++ b/client/my-sites/plan-features-2023-grid/item.jsx
@@ -1,18 +1,7 @@
-import classNames from 'classnames';
-
 export function PlanFeaturesItem( props ) {
-	const itemInfoClasses = classNames( 'plan-features-2023-grid__item-info-container', {
-		'plan-features-2023-grid__item-info-annual-only': props.annualOnlyContent,
-	} );
-
 	return (
 		<div className="plan-features-2023-grid__item plan-features-2023-grid__item-available">
-			{ props.annualOnlyContent && (
-				<div className="plan-features-2023-grid__item-annual-plan-container">
-					{ props.annualOnlyContent }
-				</div>
-			) }
-			<div className={ itemInfoClasses }>{ props.children }</div>
+			<div className="plan-features-2023-grid__item-info-container">{ props.children }</div>
 		</div>
 	);
 }

--- a/client/my-sites/plan-features-2023-grid/style.scss
+++ b/client/my-sites/plan-features-2023-grid/style.scss
@@ -432,7 +432,6 @@ $plan-features-sidebar-width: 272px;
 
 			.plan-features-2023-grid__item-title {
 				text-decoration: line-through;
-				color: var(--color-neutral-30);
 			}
 		}
 	}
@@ -465,25 +464,8 @@ $plan-features-sidebar-width: 272px;
 			flex-direction: column;
 			position: relative;
 
-			& .plan-features-2023-grid__item-annual-plan-container {
-				display: flex;
-				position: absolute;
-				top: -3px;
-
-				& .plan-features-2023-grid__item-annual-plan {
-					font-weight: 600;
-					color: var(--color-error);
-					font-size: 0.6rem; /* stylelint-disable-line scales/font-sizes */
-					text-transform: uppercase;
-				}
-			}
-
 			& .plan-features-2023-grid__item-info-container {
 				display: flex;
-
-				&.plan-features-2023-grid__item-info-annual-only {
-					margin-top: 10px;
-				}
 			}
 		}
 


### PR DESCRIPTION
#### Proposed Changes

Addresses Automattic/martech#1397. 

- Removes `INCLUDED WITH ANNUAL PLANS` from plan features when unavailable in monthly plans
- **Bolds** the feature name and crosses it out instead
- Some cleanup of now-redundant parts

#### Media

_Before_

<img width="700" alt="Screenshot 2023-01-31 at 2 19 00 PM" src="https://user-images.githubusercontent.com/1705499/215757987-03b03e83-3a4d-4525-9b6b-177cce41671f.png">


_After_

<img width="700" alt="Screenshot 2023-01-31 at 2 19 22 PM" src="https://user-images.githubusercontent.com/1705499/215758065-70cb36b6-b435-4c0f-a779-cb5a4a61e160.png">


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Activate the onboarding/2023-pricing-grid feature flag
2. Navigate to `/plans` in Calypso http://calypso.localhost:3000/plans/[foo.com]
3. Toggle between "Pay Monthly" and "Pay Yearly" from the switch and confirm the changes.
4. Do a more general sanity check, check for console errors, etc. in case the stripped-out parts brought any side effects.
5. Do the same in the Signup flow `/start/plans`

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes Automattic/martech#1397
