### PR TITLE
Writing Prompts: Show View Responses link in home card

### DIFF
--- a/client/my-sites/customer-home/cards/features/blogging-prompt/index.jsx
+++ b/client/my-sites/customer-home/cards/features/blogging-prompt/index.jsx
@@ -63,7 +63,7 @@ const BloggingPromptCard = () => {
 						</Button>
 					</EllipsisMenu>
 				</CardHeading>
-				<PromptsNavigation prompts={ prompts } showViewAllResponses={ false } />
+				<PromptsNavigation prompts={ prompts } showViewAllResponses={ true } />
 			</Card>
 		</div>
 	);


### PR DESCRIPTION
This PR simply toggles the `View Responses` link in the writing prompt home card.

<img width="710" alt="Screenshot 2023-01-31 at 12 33 10" src="https://user-images.githubusercontent.com/5560595/215760937-f45e47a7-160b-4732-82c7-5ca432e79d7b.png">

This link will direct users to reader where they can see answers/responses to this specific writing prompt. Each writing prompt has a tag `dailyprompt-{prompt-id}` that is used to identify these responses.

This link was hidden in https://github.com/Automattic/wp-calypso/pull/72387 because the tag was not set on posts yet. 

This was introduced in https://github.com/Automattic/jetpack/pull/28387.
We also ran a script to backfill posts that were missing this tag in https://github.com/Automattic/loop/issues/59.

It should be ok to show this link again now that posts have this tag and the reader experience is complete.