### PR TITLE
Plans 2023: Add button to show/hide comparison

### DIFF
--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -21,6 +21,7 @@ import {
 	getPlanPath,
 } from '@automattic/calypso-products';
 import { MinimalRequestCartProduct } from '@automattic/shopping-cart';
+import { Button } from '@wordpress/components';
 import classNames from 'classnames';
 import { localize, LocalizeProps } from 'i18n-calypso';
 import page from 'page';
@@ -119,11 +120,28 @@ type PlanFeatures2023GridConnectedProps = {
 type PlanFeatures2023GridType = PlanFeatures2023GridProps &
 	PlanFeatures2023GridConnectedProps & { children?: React.ReactNode };
 
-export class PlanFeatures2023Grid extends Component< PlanFeatures2023GridType > {
+type PlanFeatures2023GridState = {
+	showPlansComparisonGrid: boolean;
+};
+
+export class PlanFeatures2023Grid extends Component<
+	PlanFeatures2023GridType,
+	PlanFeatures2023GridState
+> {
+	state = {
+		showPlansComparisonGrid: false,
+	};
+
 	componentDidMount() {
 		this.props.recordTracksEvent( 'calypso_wp_plans_test_view' );
 		retargetViewPlans();
 	}
+
+	toggleShowPlansComparisonGrid = () => {
+		this.setState( ( { showPlansComparisonGrid } ) => ( {
+			showPlansComparisonGrid: ! showPlansComparisonGrid,
+		} ) );
+	};
 
 	render() {
 		const {
@@ -136,6 +154,7 @@ export class PlanFeatures2023Grid extends Component< PlanFeatures2023GridType > 
 			currentSitePlanSlug,
 			manageHref,
 			canUserPurchasePlan,
+			translate,
 		} = this.props;
 		return (
 			<div className="plans-wrapper">
@@ -154,17 +173,26 @@ export class PlanFeatures2023Grid extends Component< PlanFeatures2023GridType > 
 						</div>
 					</div>
 				</div>
-				<PlanComparisonGrid
-					planTypeSelectorProps={ planTypeSelectorProps }
-					planProperties={ planProperties }
-					intervalType={ intervalType }
-					isInSignup={ isInSignup }
-					isLaunchPage={ isLaunchPage }
-					flowName={ flowName }
-					currentSitePlanSlug={ currentSitePlanSlug }
-					manageHref={ manageHref }
-					canUserPurchasePlan={ canUserPurchasePlan }
-				/>
+				<div className="plan-features-2023-grid__toggle-plan-comparison-button-container">
+					<Button onClick={ this.toggleShowPlansComparisonGrid }>
+						{ this.state.showPlansComparisonGrid
+							? translate( 'Hide comparison' )
+							: translate( 'Compare plans' ) }
+					</Button>
+				</div>
+				{ this.state.showPlansComparisonGrid ? (
+					<PlanComparisonGrid
+						planTypeSelectorProps={ planTypeSelectorProps }
+						planProperties={ planProperties }
+						intervalType={ intervalType }
+						isInSignup={ isInSignup }
+						isLaunchPage={ isLaunchPage }
+						flowName={ flowName }
+						currentSitePlanSlug={ currentSitePlanSlug }
+						manageHref={ manageHref }
+						canUserPurchasePlan={ canUserPurchasePlan }
+					/>
+				) : null }
 			</div>
 		);
 	}

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -25,7 +25,7 @@ import { Button } from '@wordpress/components';
 import classNames from 'classnames';
 import { localize, LocalizeProps } from 'i18n-calypso';
 import page from 'page';
-import { Component } from 'react';
+import { Component, createRef } from 'react';
 import { connect } from 'react-redux';
 import BloombergLogo from 'calypso/assets/images/onboarding/bloomberg-logo.svg';
 import CNNLogo from 'calypso/assets/images/onboarding/cnn-logo.svg';
@@ -43,6 +43,7 @@ import PlanPill from 'calypso/components/plans/plan-pill';
 import { retargetViewPlans } from 'calypso/lib/analytics/ad-tracking';
 import { planItem as getCartItemForPlan } from 'calypso/lib/cart-values/cart-items';
 import { getPlanFeaturesObject } from 'calypso/lib/plans/features-list';
+import scrollIntoViewport from 'calypso/lib/scroll-into-viewport';
 import { PlanTypeSelectorProps } from 'calypso/my-sites/plans-features-main/plan-type-selector';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
@@ -132,6 +133,8 @@ export class PlanFeatures2023Grid extends Component<
 		showPlansComparisonGrid: false,
 	};
 
+	plansComparisonGridContainerRef = createRef< HTMLDivElement >();
+
 	componentDidMount() {
 		this.props.recordTracksEvent( 'calypso_wp_plans_test_view' );
 		retargetViewPlans();
@@ -142,6 +145,22 @@ export class PlanFeatures2023Grid extends Component<
 			showPlansComparisonGrid: ! showPlansComparisonGrid,
 		} ) );
 	};
+
+	componentDidUpdate(
+		prevProps: Readonly< PlanFeatures2023GridType >,
+		prevState: Readonly< PlanFeatures2023GridState >
+	) {
+		// If the "Compare plans" button is clicked, scroll to the plans comparison grid.
+		if (
+			prevState.showPlansComparisonGrid === false &&
+			this.plansComparisonGridContainerRef.current
+		) {
+			scrollIntoViewport( this.plansComparisonGridContainerRef.current, {
+				behavior: 'smooth',
+				scrollMode: 'if-needed',
+			} );
+		}
+	}
 
 	render() {
 		const {
@@ -181,7 +200,7 @@ export class PlanFeatures2023Grid extends Component<
 					</Button>
 				</div>
 				{ this.state.showPlansComparisonGrid ? (
-					<>
+					<div ref={ this.plansComparisonGridContainerRef }>
 						<PlanComparisonGrid
 							planTypeSelectorProps={ planTypeSelectorProps }
 							planProperties={ planProperties }
@@ -198,7 +217,7 @@ export class PlanFeatures2023Grid extends Component<
 								{ translate( 'Hide comparison' ) }
 							</Button>
 						</div>
-					</>
+					</div>
 				) : null }
 			</div>
 		);

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -200,7 +200,10 @@ export class PlanFeatures2023Grid extends Component<
 					</Button>
 				</div>
 				{ this.state.showPlansComparisonGrid ? (
-					<div ref={ this.plansComparisonGridContainerRef }>
+					<div
+						ref={ this.plansComparisonGridContainerRef }
+						className="plan-features-2023-grid__plan-comparison-grid-container"
+					>
 						<PlanComparisonGrid
 							planTypeSelectorProps={ planTypeSelectorProps }
 							planProperties={ planProperties }

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -181,17 +181,24 @@ export class PlanFeatures2023Grid extends Component<
 					</Button>
 				</div>
 				{ this.state.showPlansComparisonGrid ? (
-					<PlanComparisonGrid
-						planTypeSelectorProps={ planTypeSelectorProps }
-						planProperties={ planProperties }
-						intervalType={ intervalType }
-						isInSignup={ isInSignup }
-						isLaunchPage={ isLaunchPage }
-						flowName={ flowName }
-						currentSitePlanSlug={ currentSitePlanSlug }
-						manageHref={ manageHref }
-						canUserPurchasePlan={ canUserPurchasePlan }
-					/>
+					<>
+						<PlanComparisonGrid
+							planTypeSelectorProps={ planTypeSelectorProps }
+							planProperties={ planProperties }
+							intervalType={ intervalType }
+							isInSignup={ isInSignup }
+							isLaunchPage={ isLaunchPage }
+							flowName={ flowName }
+							currentSitePlanSlug={ currentSitePlanSlug }
+							manageHref={ manageHref }
+							canUserPurchasePlan={ canUserPurchasePlan }
+						/>
+						<div className="plan-features-2023-grid__toggle-plan-comparison-button-container">
+							<Button onClick={ this.toggleShowPlansComparisonGrid }>
+								{ translate( 'Hide comparison' ) }
+							</Button>
+						</div>
+					</>
 				) : null }
 			</div>
 		);

--- a/client/my-sites/plan-features-2023-grid/style.scss
+++ b/client/my-sites/plan-features-2023-grid/style.scss
@@ -1126,7 +1126,7 @@ body.is-section-signup.is-white-signup .is-onboarding-2023-pricing-grid .signup_
 
 	button {
 		background: var(--studio-white);
-		border: 1px solid #c3c4c7;
+		border: 1px solid var(--studio-gray-10);
 		border-radius: 4px;
 		box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
 		color: var(--studio-gray-100);

--- a/client/my-sites/plan-features-2023-grid/style.scss
+++ b/client/my-sites/plan-features-2023-grid/style.scss
@@ -1118,3 +1118,29 @@ body.is-section-signup.is-white-signup .is-onboarding-2023-pricing-grid .signup_
 		}
 	}
 }
+
+.plan-features-2023-grid__toggle-plan-comparison-button-container {
+	display: flex;
+	justify-content: center;
+	margin: 32px 20px 0 20px;
+
+	button {
+		background: var(--studio-white);
+		border: 1px solid #c3c4c7;
+		border-radius: 4px;
+		box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+		color: var(--studio-gray-100);
+		font-size: $font-body-small;
+		font-weight: 500;
+		height: 48px;
+		justify-content: center;
+		line-height: 20px;
+		padding: 0 24px;
+		width: 100%;
+
+		@media ( min-width: $plans-2023-small-breakpoint ) {
+			width: initial;
+			height: 40px;
+		}
+	}
+}

--- a/client/my-sites/plan-features-2023-grid/style.scss
+++ b/client/my-sites/plan-features-2023-grid/style.scss
@@ -1144,3 +1144,12 @@ body.is-section-signup.is-white-signup .is-onboarding-2023-pricing-grid .signup_
 		}
 	}
 }
+
+/**
+ * We auto-scroll to the plan comparison grid when it is shown.
+ * However, on the /plans page, due to the presence of the masterbar on top,
+ * we need to add a scroll offset.
+ */
+.is-section-plans .plan-features-2023-grid__plan-comparison-grid-container {
+	scroll-margin-top: $plan-features-header-banner-height + 24px;
+}


### PR DESCRIPTION
#### Proposed Changes

* Adds a button on the plans component that will toggle the visibility of the plans comparison grid. This button is visible both on the plans step and on `/plans`.

**Note:** This is not a part of the spec, but IMO, on clicking the button, the page should automatically scroll to show the comparison table. I can add this as a separate commit.

Design: xkhhUlDowF13dRoXJqlRDM-fi-511%3A25001

#### Screenshots
<details>
<summary>Default</summary>
<img width="967" alt="image" src="https://user-images.githubusercontent.com/5436027/215783806-14a721eb-b376-40f9-8b8b-1be5ea78b9f0.png">
</details>
<details>
<summary>Expanded</summary>
<img width="1919" alt="image" src="https://user-images.githubusercontent.com/5436027/215783877-282b12bb-645a-47ad-873d-a3bfadf3e752.png">
</details>
<details>
<summary>Mobile Default</summary>
<img width="350" alt="image" src="https://user-images.githubusercontent.com/5436027/215783753-886e55c3-90e6-4c5a-bfe8-d6db75b19323.png">
</details>
<details>
<summary>Mobile Expanded</summary>
<img width="354" alt="image" src="https://user-images.githubusercontent.com/5436027/215784213-03dca96a-fad6-4963-adc6-4591c0ca2520.png">
</details>


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/plans?flags=onboarding/2023-pricing-grid`.
* Confirm that the "Compare plans" button matches the design.
* Confirm that clicking on the button shows the comparison grid below.
* Confirm that clicking on the button again hides the comparison grid.
* Repeat the above steps for mobile and tablet resolutions.
* Go to `/plans/<site slug>`. Repeat the above steps.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes Automattic/martech#1456