### PR TITLE
Checkout: Only allow VAT fields in checkout version of TaxFields

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/contact-details-container.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/contact-details-container.tsx
@@ -132,6 +132,7 @@ export default function ContactDetailsContainer( {
 						onChange={ onChangeContactInfo }
 						countriesList={ countriesList }
 						isDisabled={ isDisabled }
+						allowVat
 					/>
 				</Fragment>
 			);

--- a/client/my-sites/checkout/composite-checkout/components/tax-fields.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/tax-fields.tsx
@@ -40,12 +40,14 @@ export default function TaxFields( {
 	taxInfo,
 	countriesList,
 	onChange,
+	allowVat,
 	isDisabled,
 }: {
 	section: string;
 	taxInfo: ManagedContactDetails;
 	countriesList: CountryListItem[];
 	onChange: ( taxInfo: ManagedContactDetails ) => void;
+	allowVat?: boolean;
 	isDisabled?: boolean;
 } ) {
 	const translate = useTranslate();
@@ -54,7 +56,7 @@ export default function TaxFields( {
 		countriesList.length && countryCode?.value
 			? getCountryPostalCodeSupport( countriesList, countryCode.value )
 			: false;
-	const isVatSupported = config.isEnabled( 'checkout/vat-form' );
+	const isVatSupported = config.isEnabled( 'checkout/vat-form' ) && allowVat;
 
 	return (
 		<>


### PR DESCRIPTION
#### Proposed Changes

Recently we added a special `VatForm` component to the `TaxFields` component so that we can request VAT details during checkout's contact step if no domain is in the cart. However, `TaxFields` is used in many places besides checkout, like the "Add credit card" form. Because `VatForm` relies on the checkout data store being available, it cannot be used in those other places.

In this diff we make showing the `VatForm` opt-in via a new Prop on `TaxFields` and only enable it in checkout.

Before:

<img width="609" alt="Screenshot 2023-01-31 at 10 57 09 AM" src="https://user-images.githubusercontent.com/2036909/215811590-d57ee79e-2f1f-48fd-94af-28b2fecb78a8.png">

After:

<img width="601" alt="Screenshot 2023-01-31 at 10 57 32 AM" src="https://user-images.githubusercontent.com/2036909/215811740-8e315432-3c36-408b-ae7e-df0755d59820.png">



#### Testing Instructions

Visit `/me/purchases/add-payment-method` and verify that no errors are shown.