### PR TITLE
Stats: Release the enhanced post details page

### DIFF
--- a/client/my-sites/stats/modernized-stats-table-styles.scss
+++ b/client/my-sites/stats/modernized-stats-table-styles.scss
@@ -51,14 +51,12 @@ $common-border-radius: 4px;
 		align-items: center;
 		justify-content: space-between;
 
-		@media ( max-width: $custom-mobile-breakpoint ) {
-			display: block;
+		.segmented-control__text {
+			white-space: normal;
 		}
 
-		@media ( max-width: $break-mobile ) {
-			.segmented-control__text {
-				white-space: normal;
-			}
+		@media ( max-width: $custom-mobile-breakpoint ) {
+			display: block;
 		}
 	}
 

--- a/client/my-sites/stats/modernized-stats-table-styles.scss
+++ b/client/my-sites/stats/modernized-stats-table-styles.scss
@@ -21,6 +21,10 @@ $common-border-radius: 4px;
 		.highlight-card {
 			padding: 32px;
 			min-width: 380px;
+
+			@media ( max-width: $break-mobile ) {
+				min-width: unset;
+			}
 		}
 
 		@media ( max-width: $custom-mobile-breakpoint ) {
@@ -49,6 +53,12 @@ $common-border-radius: 4px;
 
 		@media ( max-width: $custom-mobile-breakpoint ) {
 			display: block;
+		}
+
+		@media ( max-width: $break-mobile ) {
+			.segmented-control__text {
+				white-space: normal;
+			}
 		}
 	}
 

--- a/client/my-sites/stats/post-detail-highlights-section/index.tsx
+++ b/client/my-sites/stats/post-detail-highlights-section/index.tsx
@@ -2,6 +2,7 @@ import { Card, PostStatsCard } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import QuerySiteStats from 'calypso/components/data/query-site-stats';
+import { decodeEntities, stripHTML } from 'calypso/lib/formatting';
 import { getPostStat } from 'calypso/state/stats/posts/selectors';
 import PostLikes from '../stats-post-likes';
 
@@ -58,7 +59,7 @@ export default function PostDetailHighlightsSection( {
 	const postData = {
 		date: post?.date,
 		post_thumbnail: post?.post_thumbnail?.URL || null,
-		title: textTruncator( post?.title, POST_STATS_CARD_TITLE_LIMIT ),
+		title: decodeEntities( stripHTML( textTruncator( post?.title, POST_STATS_CARD_TITLE_LIMIT ) ) ),
 	};
 
 	return (

--- a/client/my-sites/stats/post-detail-table-section/index.tsx
+++ b/client/my-sites/stats/post-detail-table-section/index.tsx
@@ -36,7 +36,7 @@ export default function PostDetailTableSection( {
 	return (
 		<div className="stats__post-detail-table-section stats__modernized-stats-table">
 			<div className="highlight-cards">
-				<h1 className="highlight-cards-heading">{ translate( 'All-time Insights' ) }</h1>
+				<h1 className="highlight-cards-heading">{ translate( 'All-time insights' ) }</h1>
 
 				<div className="highlight-cards-list">
 					<Card className="highlight-card">

--- a/config/client.json
+++ b/config/client.json
@@ -25,6 +25,7 @@
 	"readerFollowingSource",
 	"siftscience_key",
 	"signup_url",
+	"stats/enhance-post-detail",
 	"stats/horizontal-bars-everywhere",
 	"stats/insights-page-grid",
 	"wpcom_concierge_schedule_id",

--- a/config/development.json
+++ b/config/development.json
@@ -168,6 +168,7 @@
 		"site-indicator": true,
 		"sites/copy-site": true,
 		"ssr/prefetch-timebox": false,
+		"stats/enhance-post-detail": true,
 		"stats/horizontal-bars-everywhere": true,
 		"stats/insights-page-grid": true,
 		"stepper-woocommerce-poc": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -112,6 +112,7 @@
 		"signup/woo-verify-email": false,
 		"site-indicator": true,
 		"ssr/prefetch-timebox": true,
+		"stats/enhance-post-detail": true,
 		"stats/horizontal-bars-everywhere": true,
 		"stats/insights-page-grid": false,
 		"stepper-woocommerce-poc": true,

--- a/config/production.json
+++ b/config/production.json
@@ -132,6 +132,7 @@
 		"ssr/log-prefetch-errors": true,
 		"ssr/prefetch-timebox": true,
 		"ssr/sample-log-cache-misses": true,
+		"stats/enhance-post-detail": true,
 		"stats/horizontal-bars-everywhere": true,
 		"stats/insights-page-grid": false,
 		"stepper-woocommerce-poc": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -128,6 +128,7 @@
 		"signup/woo-verify-email": false,
 		"site-indicator": true,
 		"ssr/prefetch-timebox": true,
+		"stats/enhance-post-detail": true,
 		"stats/horizontal-bars-everywhere": true,
 		"stats/insights-page-grid": false,
 		"stepper-woocommerce-poc": true,

--- a/config/test.json
+++ b/config/test.json
@@ -93,6 +93,7 @@
 		"signup/social": true,
 		"site-indicator": true,
 		"ssr/prefetch-timebox": true,
+		"stats/enhance-post-detail": true,
 		"stats/horizontal-bars-everywhere": true,
 		"stats/insights-page-grid": false,
 		"stepper-woocommerce-poc": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -138,6 +138,7 @@
 		"site-indicator": true,
 		"sites/copy-site": true,
 		"ssr/prefetch-timebox": true,
+		"stats/enhance-post-detail": true,
 		"stats/horizontal-bars-everywhere": true,
 		"stats/insights-page-grid": false,
 		"stepper-woocommerce-poc": true,


### PR DESCRIPTION
#### Proposed Changes

* Fix the modernized [table control styles on the mobile viewport](https://github.com/Automattic/wp-calypso/pull/72316#pullrequestreview-1262842873).
* Enable the feature flag `stats/enhance-post-detail` on all environments.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up this change with the Calypso Live link.
* Navigate to the Stats `Post Detail` page (`/stats/post/${post-id}/${site-id}`).
* Ensure the All-time insights tables controls work fine on the mobile (`width < 480px`) viewport.

|Before|After|
|-|-|
|<img width="441" alt="截圖 2023-02-01 上午1 24 29" src="https://user-images.githubusercontent.com/6869813/215836849-8d26d604-9c35-41ed-a6b4-507a26180527.png">|<img width="436" alt="截圖 2023-02-01 上午1 24 38" src="https://user-images.githubusercontent.com/6869813/215836922-cd4c7835-cf37-47c7-b2c0-c18e4844eb33.png">|


* Ensure the post details page work [in line with the design](https://github.com/Automattic/wp-calypso/issues/70671).

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #70671 
