### PR TITLE
POC: Implementing a new add domain flow

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -384,7 +384,8 @@ export default withCurrentRoute(
 		// TODO: Connect this to the actual experiment.
 		const userBelongsToExperiment = true;
 		const isStartDomainExperiment =
-			currentRoute.startsWith( '/domains/add' ) && userBelongsToExperiment;
+			( currentRoute.startsWith( '/domains/add' ) || currentRoute.startsWith( '/plans/yearly' ) ) &&
+			userBelongsToExperiment;
 		const isJetpack =
 			( isJetpackSite( state, siteId ) && ! isAtomicSite( state, siteId ) ) ||
 			currentRoute.startsWith( '/checkout/jetpack' );

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -381,10 +381,12 @@ export default withCurrentRoute(
 		const siteId = getSelectedSiteId( state );
 		const sectionJitmPath = getMessagePathForJITM( currentRoute );
 		const isJetpackLogin = currentRoute.startsWith( '/log-in/jetpack' );
+		const isStartDomainExperiment = true;
 		const isJetpack =
 			( isJetpackSite( state, siteId ) && ! isAtomicSite( state, siteId ) ) ||
 			currentRoute.startsWith( '/checkout/jetpack' );
-		const noMasterbarForRoute = isJetpackLogin || currentRoute === '/me/account/closed';
+		const noMasterbarForRoute =
+			isStartDomainExperiment || isJetpackLogin || currentRoute === '/me/account/closed';
 		const noMasterbarForSection = [ 'signup', 'jetpack-connect' ].includes( sectionName );
 		const masterbarIsHidden =
 			! masterbarIsVisible( state ) ||
@@ -409,7 +411,7 @@ export default withCurrentRoute(
 			'plugins',
 			'comments',
 		].includes( sectionName );
-		const sidebarIsHidden = ! secondary || isWcMobileApp();
+		const sidebarIsHidden = isStartDomainExperiment || ! secondary || isWcMobileApp();
 		const chatIsDocked = ! [ 'reader', 'theme' ].includes( sectionName ) && ! sidebarIsHidden;
 
 		const userAllowedToHelpCenter =

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -381,7 +381,10 @@ export default withCurrentRoute(
 		const siteId = getSelectedSiteId( state );
 		const sectionJitmPath = getMessagePathForJITM( currentRoute );
 		const isJetpackLogin = currentRoute.startsWith( '/log-in/jetpack' );
-		const isStartDomainExperiment = currentRoute.endsWith( '/v2' );
+		// TODO: Connect this to the actual experiment.
+		const userBelongsToExperiment = true;
+		const isStartDomainExperiment =
+			currentRoute.startsWith( '/domains/add' ) && userBelongsToExperiment;
 		const isJetpack =
 			( isJetpackSite( state, siteId ) && ! isAtomicSite( state, siteId ) ) ||
 			currentRoute.startsWith( '/checkout/jetpack' );

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -381,7 +381,7 @@ export default withCurrentRoute(
 		const siteId = getSelectedSiteId( state );
 		const sectionJitmPath = getMessagePathForJITM( currentRoute );
 		const isJetpackLogin = currentRoute.startsWith( '/log-in/jetpack' );
-		const isStartDomainExperiment = true;
+		const isStartDomainExperiment = currentRoute.endsWith( '/v2' );
 		const isJetpack =
 			( isJetpackSite( state, siteId ) && ! isAtomicSite( state, siteId ) ) ||
 			currentRoute.startsWith( '/checkout/jetpack' );

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -29,7 +29,7 @@ import { isWooOAuth2Client } from 'calypso/lib/oauth2-clients';
 import { getMessagePathForJITM } from 'calypso/lib/route';
 import UserVerificationChecker from 'calypso/lib/user/verification-checker';
 import { isOffline } from 'calypso/state/application/selectors';
-import { getCurrentUser, getCurrentUserId } from 'calypso/state/current-user/selectors';
+import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import hasActiveHappychatSession from 'calypso/state/happychat/selectors/has-active-happychat-session';
 import isHappychatOpen from 'calypso/state/happychat/selectors/is-happychat-open';
 import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
@@ -376,8 +376,8 @@ class Layout extends Component {
 
 export default withCurrentRoute(
 	connect( ( state, { currentSection, currentRoute, currentQuery, secondary } ) => {
-		const currentUser = getCurrentUser( state );
-		const userBelongsToExperiment = 'treatment' === currentUser?.calypso_sidebar_upsell_experiment;
+		const userBelongsToExperiment =
+			'treatment' === sessionStorage.getItem( 'calypso_sidebar_upsell_experiment' );
 		const sectionGroup = currentSection?.group ?? null;
 		const sectionName = currentSection?.name ?? null;
 		const siteId = getSelectedSiteId( state );

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -29,7 +29,7 @@ import { isWooOAuth2Client } from 'calypso/lib/oauth2-clients';
 import { getMessagePathForJITM } from 'calypso/lib/route';
 import UserVerificationChecker from 'calypso/lib/user/verification-checker';
 import { isOffline } from 'calypso/state/application/selectors';
-import { getCurrentUserId } from 'calypso/state/current-user/selectors';
+import { getCurrentUser, getCurrentUserId } from 'calypso/state/current-user/selectors';
 import hasActiveHappychatSession from 'calypso/state/happychat/selectors/has-active-happychat-session';
 import isHappychatOpen from 'calypso/state/happychat/selectors/is-happychat-open';
 import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
@@ -376,13 +376,13 @@ class Layout extends Component {
 
 export default withCurrentRoute(
 	connect( ( state, { currentSection, currentRoute, currentQuery, secondary } ) => {
+		const currentUser = getCurrentUser( state );
+		const userBelongsToExperiment = 'treatment' === currentUser?.calypso_sidebar_upsell_experiment;
 		const sectionGroup = currentSection?.group ?? null;
 		const sectionName = currentSection?.name ?? null;
 		const siteId = getSelectedSiteId( state );
 		const sectionJitmPath = getMessagePathForJITM( currentRoute );
 		const isJetpackLogin = currentRoute.startsWith( '/log-in/jetpack' );
-		// TODO: Connect this to the actual experiment.
-		const userBelongsToExperiment = true;
 		const isStartDomainExperiment =
 			( currentRoute.startsWith( '/domains/add' ) || currentRoute.startsWith( '/plans/yearly' ) ) &&
 			userBelongsToExperiment;

--- a/client/lib/user/shared-utils/filter-user-object.js
+++ b/client/lib/user/shared-utils/filter-user-object.js
@@ -32,6 +32,7 @@ const allowedKeys = [
 	'lasagna_jwt',
 	'i18n_empathy_mode',
 	'use_fallback_for_incomplete_languages',
+	'calypso_sidebar_upsell_experiment',
 ];
 const requiredKeys = [ 'ID' ];
 const decodedKeys = [ 'display_name', 'description', 'user_URL' ];

--- a/client/lib/user/user.d.ts
+++ b/client/lib/user/user.d.ts
@@ -44,4 +44,5 @@ export type OptionalUserData = {
 	username: string;
 	visible_site_count: number;
 	jetpack_visible_site_count?: number;
+	calypso_sidebar_upsell_experiment?: string;
 };

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -13,6 +13,7 @@ import { cloudSiteSelection } from 'calypso/jetpack-cloud/controller';
 import { recordPageView } from 'calypso/lib/analytics/page-view';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { loadExperimentAssignment } from 'calypso/lib/explat';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { navigate } from 'calypso/lib/navigate';
 import { onboardingUrl } from 'calypso/lib/paths';
@@ -425,6 +426,17 @@ export function noSite( context, next ) {
 
 	context.store.dispatch( setSelectedSiteId( null ) );
 	return next();
+}
+
+export async function setExperimentVariation( context, next ) {
+	const experimentAssignment = await loadExperimentAssignment(
+		'calypso_sidebar_upsell_dedicated_upgrade_flow_202301'
+	);
+
+	const variationName = experimentAssignment?.variationName;
+	sessionStorage.setItem( 'calypso_sidebar_upsell_experiment', variationName );
+
+	next();
 }
 
 /*

--- a/client/my-sites/domains/domain-search/index.jsx
+++ b/client/my-sites/domains/domain-search/index.jsx
@@ -64,6 +64,7 @@ class DomainSearch extends Component {
 	};
 
 	isMounted = false;
+	isStartDomainExperiment = true;
 
 	state = {
 		domainRegistrationAvailable: true,
@@ -101,6 +102,10 @@ class DomainSearch extends Component {
 	};
 
 	componentDidMount() {
+		if ( this.isStartDomainExperiment ) {
+			document.body.classList.add( 'is-experiment-user' );
+		}
+
 		this.checkSiteIsUpgradeable();
 
 		this.isMounted = true;
@@ -113,6 +118,10 @@ class DomainSearch extends Component {
 	}
 
 	componentWillUnmount() {
+		if ( this.isStartDomainExperiment ) {
+			document.body.classList.remove( 'is-experiment-user' );
+		}
+
 		this.isMounted = false;
 	}
 
@@ -204,6 +213,7 @@ class DomainSearch extends Component {
 
 		const classes = classnames( 'main-column', {
 			'domain-search-page-wrapper': this.state.domainRegistrationAvailable,
+			'is-experiment-user': this.isStartDomainExperiment,
 		} );
 		const { domainRegistrationMaintenanceEndTime } = this.state;
 

--- a/client/my-sites/domains/domain-search/style.scss
+++ b/client/my-sites/domains/domain-search/style.scss
@@ -29,3 +29,7 @@
 		font-size: 17px; /* stylelint-disable-line declaration-property-unit-allowed-list */
 	}
 }
+
+.is-experiment-user .main.is-wide-layout {
+	max-width: 100%;
+}

--- a/client/my-sites/domains/index.js
+++ b/client/my-sites/domains/index.js
@@ -4,6 +4,7 @@ import { recordSiftScienceUser } from 'calypso/lib/siftscience';
 import {
 	navigation,
 	siteSelection,
+	setExperimentVariation,
 	sites,
 	wpForTeamsGeneralNotSupportedRedirect,
 } from 'calypso/my-sites/controller';
@@ -204,6 +205,7 @@ export default function () {
 	page(
 		'/domains/add/:domain',
 		siteSelection,
+		setExperimentVariation,
 		navigation,
 		domainsController.redirectIfNoSite( '/domains/add' ),
 		domainsController.redirectToUseYourDomainIfVipSite(),

--- a/client/my-sites/domains/index.js
+++ b/client/my-sites/domains/index.js
@@ -214,6 +214,18 @@ export default function () {
 	);
 
 	page(
+		'/domains/add/:domain/v2',
+		siteSelection,
+		navigation,
+		domainsController.redirectIfNoSite( '/domains/add' ),
+		domainsController.redirectToUseYourDomainIfVipSite(),
+		domainsController.jetpackNoDomainsWarning,
+		domainsController.domainSearch,
+		makeLayout,
+		clientRender
+	);
+
+	page(
 		'/domains/add/:domain/email/:siteSlug',
 		siteSelection,
 		navigation,

--- a/client/my-sites/domains/index.js
+++ b/client/my-sites/domains/index.js
@@ -214,18 +214,6 @@ export default function () {
 	);
 
 	page(
-		'/domains/add/:domain/v2',
-		siteSelection,
-		navigation,
-		domainsController.redirectIfNoSite( '/domains/add' ),
-		domainsController.redirectToUseYourDomainIfVipSite(),
-		domainsController.jetpackNoDomainsWarning,
-		domainsController.domainSearch,
-		makeLayout,
-		clientRender
-	);
-
-	page(
 		'/domains/add/:domain/email/:siteSlug',
 		siteSelection,
 		navigation,

--- a/client/my-sites/domains/style.scss
+++ b/client/my-sites/domains/style.scss
@@ -10,3 +10,10 @@
 		align-items: center;
 	}
 }
+
+
+body.is-section-domains {
+	&.is-experiment-user {
+		background: #fdfdfd;
+	}
+}

--- a/client/my-sites/plan-features-comparison/index.jsx
+++ b/client/my-sites/plan-features-comparison/index.jsx
@@ -54,7 +54,7 @@ export class PlanFeaturesComparison extends Component {
 	}
 
 	render() {
-		const { isInSignup, planProperties, translate } = this.props;
+		const { isInSignup, planProperties, translate, isReskinned } = this.props;
 		const tableClasses = classNames(
 			'plan-features-comparison__table',
 			`has-${ planProperties.length }-cols`
@@ -64,6 +64,7 @@ export class PlanFeaturesComparison extends Component {
 		} );
 		const planWrapperClasses = classNames( {
 			'plans-wrapper': isInSignup,
+			'is-reskinned': isReskinned,
 		} );
 
 		return (

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -6,6 +6,7 @@ import {
 	PLAN_FREE,
 	PLAN_ECOMMERCE_TRIAL_MONTHLY,
 } from '@automattic/calypso-products';
+import { isDesktop, subscribeIsDesktop } from '@automattic/viewport';
 import { addQueryArgs } from '@wordpress/url';
 import { localize, useTranslate } from 'i18n-calypso';
 import page from 'page';
@@ -35,6 +36,7 @@ import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
 import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
 import PlansHeader from './header';
+import './style.scss';
 
 function DomainAndPlanUpsellNotice() {
 	const translate = useTranslate();
@@ -67,8 +69,15 @@ class Plans extends Component {
 		intervalType: 'yearly',
 	};
 
+	state = {
+		isDesktop: isDesktop(),
+	};
+
 	componentDidMount() {
 		this.redirectIfInvalidPlanInterval();
+		this.unsubscribe = subscribeIsDesktop( ( matchesDesktop ) =>
+			this.setState( { isDesktop: matchesDesktop } )
+		);
 
 		// Scroll to the top
 		if ( typeof window !== 'undefined' ) {
@@ -161,8 +170,12 @@ class Plans extends Component {
 				withDiscount={ this.props.withDiscount }
 				discountEndDate={ this.props.discountEndDate }
 				site={ selectedSite }
-				plansWithScroll={ false }
+				plansWithScroll={ this.state.isDesktop }
 				showTreatmentPlansReorderTest={ this.props.showTreatmentPlansReorderTest }
+				shouldShowPlansFeatureComparison={ this.state.isDesktop } // Show feature comparison layout in signup flow and desktop resolutions
+				isReskinned={ true } // for styles
+				isPlansInsideStepper={ true }
+				isInSignup={ true } // for the correct styles
 			/>
 		);
 	}
@@ -213,6 +226,7 @@ class Plans extends Component {
 							{ domainAndPlanPackage && <DomainAndPlanUpsellNotice /> }
 							<div id="plans" className="plans plans__has-sidebar">
 								<PlansNavigation path={ this.props.context.path } />
+
 								{ isEcommerceTrial ? this.renderEcommerceTrialPage() : this.renderPlansMain() }
 								<PerformanceTrackerStop />
 							</div>

--- a/client/my-sites/plans/style.scss
+++ b/client/my-sites/plans/style.scss
@@ -1,0 +1,61 @@
+body.is-section-plans .is-reskinned {
+	.plan-features-comparison__table-item {
+		border-left: none;
+		background-color: transparent;
+
+		&:last-of-type {
+			border-right: none;
+		}
+
+		.plan-pill.is-in-signup {
+			font-size: 0.75rem;
+			font-weight: 500;
+			letter-spacing: 0.2px;
+			/* stylelint-disable-next-line declaration-property-unit-allowed-list */
+			line-height: 1.25rem;
+			padding: 0 8px;
+			right: 52%;
+			transform: translate(50%);
+			border-radius: 4px;
+			background-color: var(--studio-green-5);
+			color: var(--studio-gray-80);
+		}
+	}
+
+	.plan-features-comparison__header {
+		background-color: transparent;
+	}
+
+	.plan-features-comparison__row:last-of-type .plan-features-comparison__table-item {
+		border-bottom: none;
+	}
+
+	.plan-features--signup .is-premium-plan .plan-features-comparison__header-title {
+		font-weight: 500;
+	}
+
+	.plan-features--signup .plan-features-comparison__pricing {
+		.plan-price {
+			font-weight: 500;
+
+			.plan-price__integer {
+				font-weight: 500;
+			}
+		}
+
+		.plan-features-comparison__header-billing-info {
+			font-weight: 500;
+		}
+	}
+
+	.plan-features-comparison__item-title {
+		color: var(--studio-gray-60);
+	}
+
+	.plan-features-comparison__item.plan-features-comparison__item-available {
+		.plan-features-comparison__item-annual-plan-container
+		.plan-features-comparison__item-annual-plan {
+			color: var(--studio-orange-40);
+		}
+	}
+}


### PR DESCRIPTION
task-related: https://github.com/Automattic/wp-calypso/issues/72818


#### Proposed Changes

Here we're adding a new domain flow: pebzTe-Fx-p2#comment-1131

### /domains/add/{domain}

<img width="1289" alt="image" src="https://user-images.githubusercontent.com/1044309/215856701-5debf02d-bc84-4298-97bd-2da8449eb75d.png">


### /yearly/plans 

![image](https://user-images.githubusercontent.com/1044309/216066473-7c1fbafe-e5fa-4539-bf37-050e3ace2ebc.png)




### Questions to answer
- [x] How to hide masterBar and sideBar with a given condition? Here: https://github.com/Automattic/wp-calypso/pull/72831/commits/19201af709cfb785c02f7dbe1ae3e8e8f87941f5
- [x] How to know we're in the experiment flow? Use a specific URL like `/domains/add/{domain}/v2`? No. We can use the URL as a reference and check if the user belongs to the experiment. Here: https://github.com/Automattic/wp-calypso/pull/72831/commits/987a0755ab1fdedc024581f66a8c271b704bcd81
- [x] How to use the entire screen size as we do at `/start/domains`? Here: https://github.com/Automattic/wp-calypso/pull/72831/commits/4244cdecf4457b10f0e87b902e4c71853618b373
- [x] Can we reuse the header of /start/domains ? It seems it doesn't worth it as it uses a [specific NavigationLink module](client/signup/navigation-link/index.jsx). We can [implement the Header and back button here](https://github.com/Automattic/wp-calypso/blob/add/poc-implement-new-domain-flow/client/my-sites/domains/domain-search/index.jsx#L249).
- [x] How can we have the same behavior on /plans/yearly page? We should be careful [to not use the new code launched recently EN-only](https://github.com/Automattic/wp-calypso/pull/71378) as it's different from our design. Here we removed the menus: https://github.com/Automattic/wp-calypso/pull/72831/commits/3d91ab92702265dd3871b9edbb9d1cd36f1c040b Still need to figure out how to render the correct plans page as we have on prod and not use [the isOnboarding2023PricingGrid one](https://github.com/Automattic/wp-calypso/blob/add/poc-implement-new-domain-flow/client/signup/steps/plans/index.jsx#L510). @candy02058912 discovered it here: https://github.com/Automattic/wp-calypso/pull/72831#issuecomment-1411855315
- [x] How can we change the search filter position to be at the bottom? We shouldn't have any bigger issues with this, we only need to make sure to make these changes connected to the experiment. We can [start here](https://github.com/Automattic/wp-calypso/blob/add/poc-implement-new-domain-flow/client/my-sites/domains/domain-search/index.jsx#L276).
- [x] How to connect the experiment [to our code conditions](https://github.com/Automattic/wp-calypso/pull/72831/files#diff-7d1eb73ef67c978553b9d47cf17a8f4b9d93bd396ee6cb5ce89e75aedb8b0f19R384)
