### PR TITLE
Plans 2023 : Adds a dummy downgrade button with a tooltip for eligible plans

### DIFF
--- a/client/my-sites/plan-features-2023-grid/actions.tsx
+++ b/client/my-sites/plan-features-2023-grid/actions.tsx
@@ -1,9 +1,12 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { getPlanClass, isMonthly, PLAN_P2_FREE, isFreePlan } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
+import styled from '@emotion/styled';
 import classNames from 'classnames';
 import { localize, TranslateResult, useTranslate } from 'i18n-calypso';
 import ExternalLinkWithTracking from 'calypso/components/external-link/with-tracking';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { Plans2023Tooltip } from './plans-2023-tooltip';
 
 type PlanFeaturesActionsButtonProps = {
 	availableForPurchase: boolean;
@@ -26,6 +29,18 @@ type PlanFeaturesActionsButtonProps = {
 	isWpcomEnterpriseGridPlan: boolean;
 	selectedSiteSlug: string | null;
 };
+
+const DummyDisabledButton = styled.div`
+	background-color: var( --studio-white );
+	color: var( --studio-gray-5 );
+	box-shadow: inset 0 0 0 1px var( --studio-gray-10 );
+	font-weight: 500;
+	line-height: 20px;
+	border-radius: 4px;
+	padding: 10px 14px;
+	border: unset;
+	text-align: center;
+`;
 
 const SignupFlowPlanFeatureActionButton = ( {
 	freePlan,
@@ -182,12 +197,23 @@ const LoggedInPlansFeatureActionButton = ( {
 		);
 	}
 
-	if ( ! availableForPurchase && forceDisplayButton ) {
-		return (
-			<Button className={ classes } disabled={ true }>
-				{ buttonText }
-			</Button>
-		);
+	const is2023OnboardingPricingGrid = isEnabled( 'onboarding/2023-pricing-grid' );
+	if ( ! availableForPurchase ) {
+		if ( is2023OnboardingPricingGrid ) {
+			return (
+				<Plans2023Tooltip text={ translate( 'Please, contact support to downgrade your plan' ) }>
+					<DummyDisabledButton>
+						{ translate( 'Downgrade', { context: 'verb' } ) }
+					</DummyDisabledButton>
+				</Plans2023Tooltip>
+			);
+		} else if ( forceDisplayButton ) {
+			return (
+				<Button className={ classes } disabled={ true }>
+					{ buttonText }
+				</Button>
+			);
+		}
 	}
 
 	return null;

--- a/client/my-sites/plan-features-2023-grid/actions.tsx
+++ b/client/my-sites/plan-features-2023-grid/actions.tsx
@@ -201,7 +201,7 @@ const LoggedInPlansFeatureActionButton = ( {
 	if ( ! availableForPurchase ) {
 		if ( is2023OnboardingPricingGrid ) {
 			return (
-				<Plans2023Tooltip text={ translate( 'Please, contact support to downgrade your plan' ) }>
+				<Plans2023Tooltip text={ translate( 'Please contact support to downgrade your plan.' ) }>
 					<DummyDisabledButton>
 						{ translate( 'Downgrade', { context: 'verb' } ) }
 					</DummyDisabledButton>

--- a/client/my-sites/plan-features-2023-grid/style.scss
+++ b/client/my-sites/plan-features-2023-grid/style.scss
@@ -75,6 +75,7 @@ $plan-features-sidebar-width: 272px;
 }
 .plan-features-2023-grid__table-item.is-top-buttons {
 	padding: 0 20px;
+	vertical-align: bottom;
 }
 
 .plan-features-2023-grid__header {


### PR DESCRIPTION
#### Proposed Changes

* This is a temporary change for the initial release, in the next release we will be adding a link to the pre-filled contact support form.

<img width="729" alt="image" src="https://user-images.githubusercontent.com/3422709/215834734-7dad719e-ed6e-4581-ba3b-67fbfab666aa.png">


#### Testing Instructions
- Purchase a personal plan or higher
- Go to /start/plans?flags=onboarding/2023-pricing-grid
- Make sure the above downgrade buttons are visible



#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes Automattic/martech#1459
