### PR TITLE
Marketplace Themes: Fix the CTA on the Theme page when the user isn't logged in

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -675,7 +675,7 @@ class ThemeSheet extends Component {
 		const label = this.getDefaultOptionLabel();
 		const price = this.renderPrice();
 		const placeholder = <span className="theme__sheet-button-placeholder">loading......</span>;
-		const { isActive, isExternallyManagedTheme } = this.props;
+		const { isActive, isExternallyManagedTheme, isLoggedIn } = this.props;
 		const { isLoading } = this.props;
 
 		return (
@@ -683,7 +683,9 @@ class ThemeSheet extends Component {
 				className="theme__sheet-primary-button"
 				href={
 					getUrl &&
-					( ! isExternallyManagedTheme || ! config.isEnabled( 'themes/third-party-premium' ) )
+					( ! isExternallyManagedTheme ||
+						! isLoggedIn ||
+						! config.isEnabled( 'themes/third-party-premium' ) )
 						? getUrl( this.props.themeId )
 						: null
 				}
@@ -847,7 +849,7 @@ class ThemeSheet extends Component {
 
 		let onClick = null;
 
-		if ( isExternallyManagedTheme ) {
+		if ( isExternallyManagedTheme && isLoggedIn ) {
 			onClick = this.onButtonClick;
 		} else if ( ! isLoggedIn ) {
 			onClick = launchPricing;


### PR DESCRIPTION
#### Proposed Changes

* Clicking on the CTA button or on the upsell banner, wouldn't redirect the user to the appropriate page.

#### Testing Instructions

* Navigate to `/theme/makoney` in an incognito tab.
* Click on the CTA button. It should take you to the signup flow.
* Navigate again to `/theme/makoney` in an incognito tab.
* Click on the upsell banner, and you should be redirected to the pricing page.

Slack discussion #p1675112160128929-slack-C048CUFRGFQ