### PR TITLE
Writing prompts: conditionally shows responses link on Home card

### DIFF
--- a/client/data/blogging-prompt/use-blogging-prompts.ts
+++ b/client/data/blogging-prompt/use-blogging-prompts.ts
@@ -5,27 +5,21 @@ import wp from 'calypso/lib/wp';
 export interface BloggingPrompt {
 	id: string;
 	text: string;
+	title: string;
+	content: string;
+	attribution: string;
+	date: string;
+	answered: boolean;
+	answered_users_count: number;
 	answered_users_sample: Array< string >;
 }
 
-const selectPrompts = ( response: {
-	prompts: Array< { id: string; text: string; answered_users_sample: Array< string > } >;
-} ): BloggingPrompt[] | null => {
+const selectPrompts = ( response: { prompts: BloggingPrompt[] } ): BloggingPrompt[] | null => {
 	const prompts = response && response.prompts;
 	if ( ! prompts ) {
 		return null;
 	}
-	return prompts.map(
-		( prompt: {
-			id: string;
-			text: string;
-			answered_users_sample: Array< string >;
-		} ): BloggingPrompt => ( {
-			id: prompt.id,
-			text: prompt.text,
-			answered_users_sample: prompt.answered_users_sample,
-		} )
-	);
+	return prompts;
 };
 
 export const useBloggingPrompts = (

--- a/client/my-sites/customer-home/cards/features/blogging-prompt/index.jsx
+++ b/client/my-sites/customer-home/cards/features/blogging-prompt/index.jsx
@@ -63,7 +63,7 @@ const BloggingPromptCard = () => {
 						</Button>
 					</EllipsisMenu>
 				</CardHeading>
-				<PromptsNavigation prompts={ prompts } showViewAllResponses={ false } />
+				<PromptsNavigation prompts={ prompts } />
 			</Card>
 		</div>
 	);

--- a/client/my-sites/customer-home/cards/features/blogging-prompt/prompts-navigation.jsx
+++ b/client/my-sites/customer-home/cards/features/blogging-prompt/prompts-navigation.jsx
@@ -10,7 +10,7 @@ import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import NoResponsesIcon from './no-responses-icon';
 import './style.scss';
 
-const PromptsNavigation = ( { prompts, showViewAllResponses = false } ) => {
+const PromptsNavigation = ( { prompts } ) => {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 	const [ promptIndex, setPromptIndex ] = useState( 0 );
@@ -115,9 +115,7 @@ const PromptsNavigation = ( { prompts, showViewAllResponses = false } ) => {
 
 		const viewAllResponses = (
 			<a
-				href={ 'http://wordpress.com/tag/dailyprompt-' + prompt.id }
-				target="_blank"
-				rel="noreferrer"
+				href={ 'http://wordpress.com/tag/dailyprompt-' + encodeURIComponent( prompt.id ) }
 				className="blogging-prompt__prompt-responses-link"
 				onClick={ trackClickViewAllResponses }
 			>
@@ -133,7 +131,7 @@ const PromptsNavigation = ( { prompts, showViewAllResponses = false } ) => {
 							return <img alt="answered-users" src={ sample.avatar } />;
 						} ) }
 					</div>
-					{ showViewAllResponses ? viewAllResponses : '' }
+					{ prompt.answered_users_count > 0 ? viewAllResponses : '' }
 				</div>
 			);
 		}

--- a/client/my-sites/customer-home/cards/features/blogging-prompt/prompts-navigation.jsx
+++ b/client/my-sites/customer-home/cards/features/blogging-prompt/prompts-navigation.jsx
@@ -115,7 +115,7 @@ const PromptsNavigation = ( { prompts } ) => {
 
 		const viewAllResponses = (
 			<a
-				href={ 'http://wordpress.com/tag/dailyprompt-' + encodeURIComponent( prompt.id ) }
+				href={ '/tag/dailyprompt-' + encodeURIComponent( prompt.id ) }
 				className="blogging-prompt__prompt-responses-link"
 				onClick={ trackClickViewAllResponses }
 			>


### PR DESCRIPTION
#### Proposed Changes

Updates to the Daily writing prompt home card

* Conditionally show the "View all responses link" based on the answer count in the API
* Remove the target and rel attributes for the link, which seem unnecessary, and may inhibit accessibility
* Encode the prompt ID in the link url
* Use a relative tag page url to navigate to the correct Calypso enviroment

#### Testing Instructions

* Using a site set to show posts on the home page, go the My Home
* Find the Daily writing prompt card and click on the link
* You should land on a reader page for the daily prompt tag
