### PR TITLE
Checkout: Add types to checkout data store actions and selectors

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/checkout-main.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-main.tsx
@@ -62,11 +62,7 @@ import WPCheckout from './wp-checkout';
 import type { PaymentProcessorOptions } from '../types/payment-processors';
 import type { CheckoutPageErrorCallback } from '@automattic/composite-checkout';
 import type { MinimalRequestCartProduct } from '@automattic/shopping-cart';
-import type {
-	ManagedContactDetails,
-	CountryListItem,
-	CheckoutPaymentMethodSlug,
-} from '@automattic/wpcom-checkout';
+import type { CountryListItem, CheckoutPaymentMethodSlug } from '@automattic/wpcom-checkout';
 
 const { colors } = colorStudio;
 const debug = debugFactory( 'calypso:composite-checkout:composite-checkout' );
@@ -348,10 +344,8 @@ export default function CheckoutMain( {
 		// Only wait for stored cards to load if we are using cards
 		( allowedPaymentMethods.includes( 'card' ) && isLoadingStoredCards );
 
-	const contactDetails: ManagedContactDetails | undefined = useSelect( ( select ) =>
-		select( 'wpcom-checkout' )?.getContactInfo()
-	);
-	const recaptchaClientId: number | undefined = useSelect( ( select ) =>
+	const contactDetails = useSelect( ( select ) => select( 'wpcom-checkout' )?.getContactInfo() );
+	const recaptchaClientId = useSelect( ( select ) =>
 		select( 'wpcom-checkout' )?.getRecaptchaClientId()
 	);
 

--- a/client/my-sites/checkout/composite-checkout/components/contact-details-container.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/contact-details-container.tsx
@@ -52,15 +52,21 @@ export default function ContactDetailsContainer( {
 		.filter( ( product ) => isDomainProduct( product ) || isDomainTransfer( product ) )
 		.filter( ( product ) => ! isDomainMapping( product ) )
 		.map( getDomain );
+	const checkoutActions = useDispatch( 'wpcom-checkout' );
+	const { email } = useSelect( ( select ) => select( 'wpcom-checkout' )?.getContactInfo() ?? {} );
+
+	if ( ! checkoutActions ) {
+		return null;
+	}
+
 	const { updateDomainContactFields, updateCountryCode, updatePostalCode, updateEmail } =
-		useDispatch( 'wpcom-checkout' );
+		checkoutActions;
 	const contactDetails = prepareDomainContactDetails( contactInfo );
 	const contactDetailsErrors = prepareDomainContactDetailsErrors( contactInfo );
 	const onChangeContactInfo = ( newInfo: ManagedContactDetails ) => {
 		updateCountryCode( newInfo.countryCode?.value ?? '' );
 		updatePostalCode( newInfo.postalCode?.value ?? '' );
 	};
-	const { email } = useSelect( ( select ) => select( 'wpcom-checkout' ).getContactInfo() );
 
 	const updateDomainContactRelatedData = ( details: DomainContactDetailsData ) => {
 		updateDomainContactFields( details );
@@ -118,8 +124,8 @@ export default function ContactDetailsContainer( {
 								updateEmail( value );
 							} }
 							autoComplete="email"
-							isError={ email.isTouched && ! isValid( email ) }
-							errorMessage={ email.errors[ 0 ] || '' }
+							isError={ email?.isTouched && ! isValid( email ) }
+							errorMessage={ email?.errors[ 0 ] || '' }
 							description={ String(
 								translate( "You'll use this email address to access your account later" )
 							) }

--- a/client/my-sites/checkout/composite-checkout/components/international-fee-notice.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/international-fee-notice.tsx
@@ -1,14 +1,11 @@
 import { useSelect } from '@wordpress/data';
 import { translate } from 'i18n-calypso';
 import CheckoutTermsItem from 'calypso/my-sites/checkout/composite-checkout/components/checkout-terms-item';
-import type { ManagedContactDetails } from '@automattic/wpcom-checkout';
 
 export const InternationalFeeNotice = () => {
-	const contactInfo: ManagedContactDetails = useSelect( ( select ) =>
-		select( 'wpcom-checkout' ).getContactInfo()
-	);
+	const contactInfo = useSelect( ( select ) => select( 'wpcom-checkout' )?.getContactInfo() );
 
-	if ( contactInfo.countryCode?.value !== 'US' ) {
+	if ( contactInfo?.countryCode?.value !== 'US' ) {
 		const internationalFeeAgreement = translate(
 			`Your issuing bank may choose to charge an international transaction fee or a currency exchange fee. Your bank may be able to provide more information as to when this is necessary.`
 		);

--- a/client/my-sites/checkout/composite-checkout/components/vat-form/index.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/vat-form/index.tsx
@@ -1,4 +1,4 @@
-import { Field, VatDetails } from '@automattic/wpcom-checkout';
+import { Field } from '@automattic/wpcom-checkout';
 import { CheckboxControl } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
@@ -62,11 +62,11 @@ export function VatForm( {
 	countryCode: string | undefined;
 } ) {
 	const translate = useTranslate();
-	const vatDetailsInForm: VatDetails = useSelect( ( select ) =>
-		select( 'wpcom-checkout' ).getVatDetails()
+	const vatDetailsInForm = useSelect(
+		( select ) => select( 'wpcom-checkout' )?.getVatDetails() ?? {}
 	);
 	const wpcomStoreActions = useDispatch( 'wpcom-checkout' );
-	const setVatDetailsInForm = wpcomStoreActions.setVatDetails as ( vat: VatDetails ) => void;
+	const setVatDetailsInForm = wpcomStoreActions?.setVatDetails;
 	const { vatDetails: vatDetailsFromServer, isLoading: isLoadingVatDetails } = useVatDetails();
 	const [ isFormActive, setIsFormActive ] = useState< boolean >( false );
 
@@ -74,7 +74,13 @@ export function VatForm( {
 	// actions.
 	const previousCountryCode = useRef< string >( '' );
 	useEffect( () => {
-		if ( ! countryCode || isLoadingVatDetails || countryCode === previousCountryCode.current ) {
+		if (
+			! vatDetailsInForm ||
+			! setVatDetailsInForm ||
+			! countryCode ||
+			isLoadingVatDetails ||
+			countryCode === previousCountryCode.current
+		) {
 			return;
 		}
 
@@ -130,6 +136,15 @@ export function VatForm( {
 
 	const reduxDispatch = useReduxDispatch();
 
+	if (
+		! setVatDetailsInForm ||
+		! countryCode ||
+		isLoadingVatDetails ||
+		! isVatSupportedFor( countryCode )
+	) {
+		return null;
+	}
+
 	const toggleVatForm = ( isChecked: boolean ) => {
 		if ( ! isChecked ) {
 			// Clear the VAT form when the checkbox is unchecked so that the VAT
@@ -166,10 +181,6 @@ export function VatForm( {
 	const clickSupport = () => {
 		reduxDispatch( recordTracksEvent( 'calypso_vat_details_support_click' ) );
 	};
-
-	if ( ! countryCode || isLoadingVatDetails || ! isVatSupportedFor( countryCode ) ) {
-		return null;
-	}
 
 	if ( ! isFormActive ) {
 		return (

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
@@ -66,11 +66,7 @@ import WPContactFormSummary from './wp-contact-form-summary';
 import type { OnChangeItemVariant } from './item-variation-picker';
 import type { CheckoutPageErrorCallback } from '@automattic/composite-checkout';
 import type { RemoveProductFromCart, MinimalRequestCartProduct } from '@automattic/shopping-cart';
-import type {
-	CountryListItem,
-	ManagedContactDetails,
-	VatDetails,
-} from '@automattic/wpcom-checkout';
+import type { CountryListItem } from '@automattic/wpcom-checkout';
 
 const debug = debugFactory( 'calypso:composite-checkout:wp-checkout' );
 
@@ -188,18 +184,12 @@ export default function WPCheckout( {
 
 	const contactDetailsType = getContactDetailsType( responseCart );
 
-	const contactInfo: ManagedContactDetails = useSelect( ( sel ) =>
-		sel( 'wpcom-checkout' ).getContactInfo()
-	);
+	const contactInfo = useSelect( ( sel ) => sel( 'wpcom-checkout' )?.getContactInfo() ?? {} );
 
-	const vatDetails: VatDetails = useSelect( ( sel ) => sel( 'wpcom-checkout' ).getVatDetails() );
+	const vatDetails = useSelect( ( sel ) => sel( 'wpcom-checkout' )?.getVatDetails() ?? {} );
 	const { setVatDetails } = useVatDetails();
 
-	const {
-		touchContactFields,
-		applyDomainContactValidationResults,
-		clearDomainContactErrorMessages,
-	} = useDispatch( 'wpcom-checkout' );
+	const checkoutActions = useDispatch( 'wpcom-checkout' );
 
 	const [ shouldShowContactDetailsValidationErrors, setShouldShowContactDetailsValidationErrors ] =
 		useState( true );
@@ -257,6 +247,16 @@ export default function WPCheckout( {
 		}
 		return true;
 	};
+
+	if ( ! checkoutActions ) {
+		return null;
+	}
+
+	const {
+		touchContactFields,
+		applyDomainContactValidationResults,
+		clearDomainContactErrorMessages,
+	} = checkoutActions;
 
 	const isWcMobile = isWcMobileApp();
 

--- a/client/my-sites/checkout/composite-checkout/components/wp-contact-form-summary.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-contact-form-summary.tsx
@@ -26,9 +26,7 @@ export default function WPContactFormSummary( {
 	isGSuiteInCart: boolean;
 	isLoggedOutCart: boolean;
 } ) {
-	const contactInfo: ManagedContactDetails = useSelect( ( select ) =>
-		select( 'wpcom-checkout' ).getContactInfo()
-	);
+	const contactInfo = useSelect( ( select ) => select( 'wpcom-checkout' )?.getContactInfo() ?? {} );
 	const cartKey = useCartKey();
 	const { responseCart } = useShoppingCart( cartKey );
 	const isRenewal = hasOnlyRenewalItems( responseCart );

--- a/client/my-sites/checkout/composite-checkout/components/wp-contact-form.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-contact-form.tsx
@@ -3,11 +3,7 @@ import styled from '@emotion/styled';
 import { useSelect } from '@wordpress/data';
 import useCachedDomainContactDetails from '../hooks/use-cached-domain-contact-details';
 import ContactDetailsContainer from './contact-details-container';
-import type {
-	CountryListItem,
-	ContactDetailsType,
-	ManagedContactDetails,
-} from '@automattic/wpcom-checkout';
+import type { CountryListItem, ContactDetailsType } from '@automattic/wpcom-checkout';
 
 const BillingFormFields = styled.div`
 	margin-bottom: 16px;
@@ -38,9 +34,7 @@ export default function WPContactForm( {
 	isLoggedOutCart: boolean;
 	setShouldShowContactDetailsValidationErrors: ( allowed: boolean ) => void;
 } ) {
-	const contactInfo: ManagedContactDetails = useSelect( ( select ) =>
-		select( 'wpcom-checkout' ).getContactInfo()
-	);
+	const contactInfo = useSelect( ( select ) => select( 'wpcom-checkout' )?.getContactInfo() ?? {} );
 	const { formStatus } = useFormStatus();
 	const isStepActive = useIsStepActive();
 	const isDisabled = ! isStepActive || formStatus !== FormStatus.READY;

--- a/client/my-sites/checkout/composite-checkout/hooks/use-cached-domain-contact-details.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-cached-domain-contact-details.ts
@@ -85,11 +85,7 @@ function useCachedContactDetailsForCheckoutForm(
 		}
 		debug( 'using fetched cached contact details for checkout data store', cachedContactDetails );
 		didFillForm.current = true;
-		// NOTE: the types for `@wordpress/data` actions imply that actions return
-		// `void` by default but they actually return `Promise<void>` so I override
-		// this type here until the actual types can be improved. See
-		// https://github.com/DefinitelyTyped/DefinitelyTyped/pull/60693
-		loadDomainContactDetailsFromCache< Promise< void > >( {
+		loadDomainContactDetailsFromCache( {
 			...cachedContactDetails,
 			postalCode: arePostalCodesSupported ? cachedContactDetails.postalCode : '',
 		} )

--- a/client/my-sites/checkout/composite-checkout/hooks/use-detected-country-code.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-detected-country-code.ts
@@ -9,11 +9,15 @@ const debug = debugFactory( 'calypso:composite-checkout:use-detected-country-cod
 export default function useDetectedCountryCode(): void {
 	const detectedCountryCode = useSelector( getCurrentUserCountryCode );
 	const refHaveUsedDetectedCountryCode = useRef( false );
-	const { loadCountryCodeFromGeoIP } = useDispatch( 'wpcom-checkout' );
+	const { loadCountryCodeFromGeoIP } = useDispatch( 'wpcom-checkout' ) ?? {};
 
 	useEffect( () => {
 		// Dispatch exactly once
-		if ( detectedCountryCode && ! refHaveUsedDetectedCountryCode.current ) {
+		if (
+			detectedCountryCode &&
+			! refHaveUsedDetectedCountryCode.current &&
+			loadCountryCodeFromGeoIP
+		) {
 			debug( 'using detected country code "' + detectedCountryCode + '"' );
 			loadCountryCodeFromGeoIP( detectedCountryCode );
 			refHaveUsedDetectedCountryCode.current = true;

--- a/client/my-sites/checkout/composite-checkout/hooks/wpcom-store.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/wpcom-store.ts
@@ -36,7 +36,7 @@ type WpcomStoreAction =
 	  }
 	| { type: 'SET_VAT_DETAILS'; payload: VatDetails };
 
-type StoreKey = 'wpcom-checkout';
+export const STORE_KEY = 'wpcom-checkout';
 
 export interface WpcomCheckoutStore extends ReturnType< typeof registerStore > {
 	getState: () => WpcomStoreState;
@@ -63,10 +63,8 @@ export type WpcomCheckoutStoreSelectors = Selectors;
 export type WpcomCheckoutStoreActions = Actions;
 
 declare module '@wordpress/data' {
-	// We also add undefined to these to cover the case where this store has not
-	// been defined yet.
-	function select( key: StoreKey ): WpcomCheckoutStoreSelectors | undefined;
-	function dispatch( key: StoreKey ): WpcomCheckoutStoreActions | undefined;
+	function select( key: typeof STORE_KEY ): WpcomCheckoutStoreSelectors | undefined;
+	function dispatch( key: typeof STORE_KEY ): WpcomCheckoutStoreActions | undefined;
 }
 
 const actions = {
@@ -204,7 +202,7 @@ export function useWpcomStore(): WpcomCheckoutStore | undefined {
 		}
 	}
 
-	return registerStore( 'wpcom-checkout', {
+	return registerStore( STORE_KEY, {
 		reducer( state: WpcomStoreState | undefined, action: WpcomStoreAction ): WpcomStoreState {
 			const checkedState =
 				state === undefined ? getInitialWpcomStoreState( emptyManagedContactDetails ) : state;

--- a/client/my-sites/checkout/composite-checkout/hooks/wpcom-store.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/wpcom-store.ts
@@ -5,6 +5,7 @@ import {
 	getInitialWpcomStoreState,
 	managedContactDetailsUpdaters as updaters,
 } from '../types/wpcom-store-state';
+import type { DispatchFromMap, SelectFromMap } from '@automattic/data-stores';
 import type { DomainContactDetails } from '@automattic/shopping-cart';
 import type {
 	PossiblyCompleteDomainContactDetails,
@@ -42,25 +43,8 @@ export interface WpcomCheckoutStore extends ReturnType< typeof registerStore > {
 	getState: () => WpcomStoreState;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type OmitFirstArg< F > = F extends ( x: any, ...args: infer P ) => infer R
-	? ( ...args: P ) => R
-	: never;
-type OmitFirstArgs< O > = {
-	[ K in keyof O ]: OmitFirstArg< O[ K ] >;
-};
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type ChangeReturnTypeToPromise< F > = F extends ( ...args: infer P ) => any
-	? ( ...args: P ) => Promise< void >
-	: never;
-type RemoveReturnTypes< O > = {
-	[ K in keyof O ]: ChangeReturnTypeToPromise< O[ K ] >;
-};
-
-type Selectors = OmitFirstArgs< typeof selectors >;
-type Actions = RemoveReturnTypes< typeof actions >;
-export type WpcomCheckoutStoreSelectors = Selectors;
-export type WpcomCheckoutStoreActions = Actions;
+export type WpcomCheckoutStoreSelectors = SelectFromMap< typeof selectors >;
+export type WpcomCheckoutStoreActions = DispatchFromMap< typeof actions >;
 
 declare module '@wordpress/data' {
 	function select( key: typeof STORE_KEY ): WpcomCheckoutStoreSelectors | undefined;

--- a/client/my-sites/checkout/composite-checkout/test/use-cached-domain-contact-details.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/use-cached-domain-contact-details.tsx
@@ -20,7 +20,7 @@ import {
 	mockCartEndpoint,
 	mockCachedContactDetailsEndpoint,
 } from './util';
-import type { CountryListItem, ManagedContactDetails } from '@automattic/wpcom-checkout';
+import type { CountryListItem } from '@automattic/wpcom-checkout';
 
 const initialCart = getEmptyResponseCart();
 const { getCart, setCart } = mockCartEndpoint( initialCart, 'USD', 'US' );
@@ -64,9 +64,7 @@ function MyTestContent( { countries }: { countries: CountryListItem[] } ) {
 		initialCart.cart_key
 	);
 	useCachedDomainContactDetails( () => null, countries );
-	const contactInfo: ManagedContactDetails = useSelect( ( select ) =>
-		select( 'wpcom-checkout' ).getContactInfo()
-	);
+	const contactInfo = useSelect( ( select ) => select( 'wpcom-checkout' ).getContactInfo() );
 	const [ localLocation, setLocation ] = useState( { countryCode: '', postalCode: '' } );
 	const onChangeCountry = ( evt ) => {
 		const newVal = evt.target.value;

--- a/client/signup/recaptcha/index.jsx
+++ b/client/signup/recaptcha/index.jsx
@@ -6,7 +6,7 @@ import { initGoogleRecaptcha } from 'calypso/lib/analytics/recaptcha';
 import './style.scss';
 
 function Recaptcha( { badgePosition } ) {
-	const { setRecaptchaClientId } = useDispatch( 'wpcom-checkout' );
+	const { setRecaptchaClientId } = useDispatch( 'wpcom-checkout' ) ?? {};
 	useEffect( () => {
 		initGoogleRecaptcha( 'g-recaptcha', config( 'google_recaptcha_site_key' ) ).then(
 			( clientId ) => {
@@ -14,7 +14,7 @@ function Recaptcha( { badgePosition } ) {
 					return;
 				}
 
-				setRecaptchaClientId( parseInt( clientId ) );
+				setRecaptchaClientId?.( parseInt( clientId ) );
 			}
 		);
 	}, [ setRecaptchaClientId ] );


### PR DESCRIPTION
#### Proposed Changes

Checkout uses a global data store built using the `@wordpress/data` package. This data store is somewhat like Redux and has Actions and Selectors, but there are some differences. Adding TypeScript types to a store is fairly complicated, so up until this point we've relied on the consumer to clarify the types of actions and selectors but this has several downsides. The biggest downside is that sometimes the data store has not been initialized, and in that case TypeScript will say that an action or selector is available when in fact it is undefined (one bug caused by this is the one fixed by https://github.com/Automattic/wp-calypso/pull/72827).

In this PR we jump through the hoops required to add types to the `'wpcom-checkout'` data store and then fix the type errors that are exposed as a result.

#### Testing Instructions

Automated tests should cover this.