### PR TITLE
WooExpress: Update plans page upgrade button copy

### DIFF
--- a/client/my-sites/plan-features-2023-grid/actions.tsx
+++ b/client/my-sites/plan-features-2023-grid/actions.tsx
@@ -178,7 +178,8 @@ const LoggedInPlansFeatureActionButton = ( {
 		( availableForPurchase || isPlaceholder ) &&
 		currentSitePlanSlug &&
 		isMonthly( currentSitePlanSlug ) &&
-		getPlanClass( planType ) === getPlanClass( currentSitePlanSlug )
+		getPlanClass( planType ) === getPlanClass( currentSitePlanSlug ) &&
+		currentSitePlanSlug !== 'ecommerce-trial-bundle-monthly'
 	) {
 		return (
 			<Button className={ classes } onClick={ handleUpgradeButtonClick } disabled={ isPlaceholder }>

--- a/client/my-sites/plan-features-2023-grid/actions.tsx
+++ b/client/my-sites/plan-features-2023-grid/actions.tsx
@@ -1,5 +1,11 @@
 import { isEnabled } from '@automattic/calypso-config';
-import { getPlanClass, isMonthly, PLAN_P2_FREE, isFreePlan } from '@automattic/calypso-products';
+import {
+	getPlanClass,
+	isMonthly,
+	PLAN_ECOMMERCE_TRIAL_MONTHLY,
+	PLAN_P2_FREE,
+	isFreePlan,
+} from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
 import styled from '@emotion/styled';
 import classNames from 'classnames';
@@ -179,7 +185,7 @@ const LoggedInPlansFeatureActionButton = ( {
 		currentSitePlanSlug &&
 		isMonthly( currentSitePlanSlug ) &&
 		getPlanClass( planType ) === getPlanClass( currentSitePlanSlug ) &&
-		currentSitePlanSlug !== 'ecommerce-trial-bundle-monthly'
+		currentSitePlanSlug !== PLAN_ECOMMERCE_TRIAL_MONTHLY
 	) {
 		return (
 			<Button className={ classes } onClick={ handleUpgradeButtonClick } disabled={ isPlaceholder }>

--- a/client/my-sites/plan-features/actions.jsx
+++ b/client/my-sites/plan-features/actions.jsx
@@ -15,15 +15,6 @@ import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 const noop = () => {};
-const PlanFeaturesActions = ( props ) => {
-	return (
-		<div className="plan-features__actions">
-			<div className="plan-features__actions-buttons">
-				<PlanFeaturesActionsButton { ...props } />
-			</div>
-		</div>
-	);
-};
 
 const PlanFeaturesActionsButton = ( {
 	availableForPurchase = true,
@@ -83,7 +74,8 @@ const PlanFeaturesActionsButton = ( {
 	if (
 		( availableForPurchase || isPlaceholder ) &&
 		isMonthly( currentSitePlanSlug ) &&
-		getPlanClass( planType ) === getPlanClass( currentSitePlanSlug )
+		getPlanClass( planType ) === getPlanClass( currentSitePlanSlug ) &&
+		currentSitePlanSlug !== 'ecommerce-trial-bundle-monthly'
 	) {
 		return (
 			<Button className={ classes } onClick={ handleUpgradeButtonClick } disabled={ isPlaceholder }>
@@ -166,6 +158,16 @@ const PlanFeaturesActionsButton = ( {
 	}
 
 	return null;
+};
+
+const PlanFeaturesActions = ( props ) => {
+	return (
+		<div className="plan-features__actions">
+			<div className="plan-features__actions-buttons">
+				<PlanFeaturesActionsButton { ...props } />
+			</div>
+		</div>
+	);
 };
 
 PlanFeaturesActions.propTypes = {

--- a/client/my-sites/plan-features/actions.jsx
+++ b/client/my-sites/plan-features/actions.jsx
@@ -3,6 +3,7 @@ import {
 	PLAN_P2_FREE,
 	getPlanClass,
 	planLevelsMatch,
+	PLAN_ECOMMERCE_TRIAL_MONTHLY,
 } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
 import classNames from 'classnames';
@@ -75,7 +76,7 @@ const PlanFeaturesActionsButton = ( {
 		( availableForPurchase || isPlaceholder ) &&
 		isMonthly( currentSitePlanSlug ) &&
 		getPlanClass( planType ) === getPlanClass( currentSitePlanSlug ) &&
-		currentSitePlanSlug !== 'ecommerce-trial-bundle-monthly'
+		currentSitePlanSlug !== PLAN_ECOMMERCE_TRIAL_MONTHLY
 	) {
 		return (
 			<Button className={ classes } onClick={ handleUpgradeButtonClick } disabled={ isPlaceholder }>


### PR DESCRIPTION
#### Proposed Changes

* The ecommerce trial is treated like a monthly subscription, but it's not quite. This adds an exception for the ecomm trial on the Plans page where buttons would normally say "Upgrade to Yearly" for a monthly product. The buttons should simply say "Upgrade" instead.
* This updates both the old plans page and the newer one.

**Before**

<img width="1112" alt="Screen Shot 2023-01-31 at 1 37 01 PM" src="https://user-images.githubusercontent.com/2124984/215852970-e39748d9-a356-450d-92d1-26ce4bb1e58c.png">

<img width="1496" alt="Screen Shot 2023-01-31 at 1 42 48 PM" src="https://user-images.githubusercontent.com/2124984/215853158-36b374ab-6f33-4769-b42e-0c8c0d3da97d.png">

**After**

<img width="1170" alt="Screen Shot 2023-01-31 at 1 53 55 PM" src="https://user-images.githubusercontent.com/2124984/215855508-28faa4b1-32f4-447a-98c4-d96b44f8d6df.png">

<img width="1492" alt="Screen Shot 2023-01-31 at 1 36 23 PM" src="https://user-images.githubusercontent.com/2124984/215853011-546da378-1081-4d5d-8ae1-ab6e7da92770.png">


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to this PR, navigate to `/plans/[siteSlug]` on a site with the ecommerce trial
* You should see the only upgrade path is to ecommerce, with button text "Upgrade"
* Switch to other sites on other plans, ensure they still work as expected

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- NA [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- NA Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- NA For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #72772
