### PR TITLE
Payment Methods: Add tests for ChangePaymentMethod

### DIFF
--- a/client/me/purchases/manage-purchase/test/change-payment-method.tsx
+++ b/client/me/purchases/manage-purchase/test/change-payment-method.tsx
@@ -5,7 +5,10 @@ import { render, screen } from '@testing-library/react';
 import nock from 'nock';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import { Provider as ReduxProvider } from 'react-redux';
-import { stripeConfiguration } from 'calypso/my-sites/checkout/composite-checkout/test/util';
+import {
+	stripeConfiguration,
+	mockStripeElements,
+} from 'calypso/my-sites/checkout/composite-checkout/test/util';
 import { createReduxStore } from 'calypso/state';
 import { PURCHASES_SITE_FETCH_COMPLETED } from 'calypso/state/action-types';
 import { getInitialState, getStateFromCache } from 'calypso/state/initial-state';
@@ -15,57 +18,18 @@ import { setSelectedSiteId } from 'calypso/state/ui/actions';
 import ChangePaymentMethod from '../change-payment-method';
 import type { StoredCard } from 'calypso/my-sites/checkout/composite-checkout/types/stored-cards';
 
-const mockElement = () => ( {
-	mount: jest.fn(),
-	destroy: jest.fn(),
-	on: jest.fn(),
-	update: jest.fn(),
-} );
-
-const mockElements = () => {
-	const elements = {};
-	return {
-		create: jest.fn( ( type ) => {
-			elements[ type ] = mockElement();
-			return elements[ type ];
-		} ),
-		getElement: jest.fn( ( type ) => {
-			return elements[ type ] || null;
-		} ),
-	};
-};
-
-const mockStripe = () => ( {
-	elements: jest.fn( () => mockElements() ),
-	createToken: jest.fn(),
-	createSource: jest.fn(),
-	createPaymentMethod: jest.fn(),
-	confirmCardPayment: jest.fn(),
-	confirmCardSetup: jest.fn(),
-	paymentRequest: jest.fn(),
-	_registerWrapper: jest.fn(),
-} );
-
 jest.mock( '@stripe/react-stripe-js', () => {
 	const stripe = jest.requireActual( '@stripe/react-stripe-js' );
 
 	return {
 		...stripe,
-		Element: () => {
-			return mockElement();
-		},
-		useStripe: () => {
-			return mockStripe();
-		},
-		useElements: () => {
-			return mockElements();
-		},
+		...mockStripeElements(),
 	};
 } );
 
 jest.mock( '@stripe/stripe-js', () => {
 	return {
-		loadStripe: async () => mockStripe(),
+		loadStripe: async () => mockStripeElements().useStripe(),
 	};
 } );
 

--- a/client/me/purchases/manage-purchase/test/change-payment-method.tsx
+++ b/client/me/purchases/manage-purchase/test/change-payment-method.tsx
@@ -274,4 +274,33 @@ describe( 'ChangePaymentMethod', () => {
 
 		expect( await screen.findByLabelText( 'Credit or debit card' ) ).toBeInTheDocument();
 	} );
+
+	it( 'renders a PayPal payment method', async () => {
+		const queryClient = new QueryClient();
+
+		const paymentMethods: StoredCard[] = [ storedCard1 ];
+		nock( 'https://public-api.wordpress.com' )
+			.get( '/rest/v1.1/me/payment-methods?expired=include' )
+			.reply( 200, paymentMethods );
+		nock( 'https://public-api.wordpress.com' )
+			.get( '/rest/v1.1/me/stripe-configuration' )
+			.reply( 200, stripeConfiguration );
+
+		render(
+			<ReduxProvider store={ createTestReduxStore() }>
+				<QueryClientProvider client={ queryClient }>
+					<ChangePaymentMethod
+						getManagePurchaseUrlFor={ ( siteSlug: string, purchaseId: number ) =>
+							`/manage-purchase-url/${ siteSlug }/${ purchaseId }`
+						}
+						purchaseId={ 1 }
+						purchaseListUrl="purchase-list-url"
+						siteSlug="example.com"
+					/>
+				</QueryClientProvider>
+			</ReduxProvider>
+		);
+
+		expect( await screen.findByLabelText( 'PayPal' ) ).toBeInTheDocument();
+	} );
 } );

--- a/client/me/purchases/manage-purchase/test/change-payment-method.tsx
+++ b/client/me/purchases/manage-purchase/test/change-payment-method.tsx
@@ -80,11 +80,11 @@ const storedCard1: StoredCard = {
 	added: '2022-05-23',
 	card: '4242',
 	card_type: 'visa',
-	email: 'foo@example.com',
-	expiry: '05/33',
+	email: '',
+	expiry: '2033-11-30',
 	is_expired: false,
-	last_service: '',
-	last_used: '',
+	last_service: 'wordpress-com',
+	last_used: '2022-01-26 17:19:54',
 	meta: [],
 	mp_ref: '12345abcd',
 	name: 'Human Person',
@@ -243,6 +243,35 @@ describe( 'ChangePaymentMethod', () => {
 			</ReduxProvider>
 		);
 
-		expect( await screen.findByText( storedCard1.name ) ).toBeInTheDocument();
+		expect( await screen.findByLabelText( new RegExp( storedCard1.name ) ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders a new credit card payment method', async () => {
+		const queryClient = new QueryClient();
+
+		const paymentMethods: StoredCard[] = [ storedCard1 ];
+		nock( 'https://public-api.wordpress.com' )
+			.get( '/rest/v1.1/me/payment-methods?expired=include' )
+			.reply( 200, paymentMethods );
+		nock( 'https://public-api.wordpress.com' )
+			.get( '/rest/v1.1/me/stripe-configuration' )
+			.reply( 200, stripeConfiguration );
+
+		render(
+			<ReduxProvider store={ createTestReduxStore() }>
+				<QueryClientProvider client={ queryClient }>
+					<ChangePaymentMethod
+						getManagePurchaseUrlFor={ ( siteSlug: string, purchaseId: number ) =>
+							`/manage-purchase-url/${ siteSlug }/${ purchaseId }`
+						}
+						purchaseId={ 1 }
+						purchaseListUrl="purchase-list-url"
+						siteSlug="example.com"
+					/>
+				</QueryClientProvider>
+			</ReduxProvider>
+		);
+
+		expect( await screen.findByLabelText( 'Credit or debit card' ) ).toBeInTheDocument();
 	} );
 } );

--- a/client/me/purchases/manage-purchase/test/change-payment-method.tsx
+++ b/client/me/purchases/manage-purchase/test/change-payment-method.tsx
@@ -1,0 +1,248 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import nock from 'nock';
+import { QueryClient, QueryClientProvider } from 'react-query';
+import { Provider as ReduxProvider } from 'react-redux';
+import { stripeConfiguration } from 'calypso/my-sites/checkout/composite-checkout/test/util';
+import { createReduxStore } from 'calypso/state';
+import { PURCHASES_SITE_FETCH_COMPLETED } from 'calypso/state/action-types';
+import { getInitialState, getStateFromCache } from 'calypso/state/initial-state';
+import initialReducer from 'calypso/state/reducer';
+import { setStore } from 'calypso/state/redux-store';
+import { setSelectedSiteId } from 'calypso/state/ui/actions';
+import ChangePaymentMethod from '../change-payment-method';
+import type { StoredCard } from 'calypso/my-sites/checkout/composite-checkout/types/stored-cards';
+
+const mockElement = () => ( {
+	mount: jest.fn(),
+	destroy: jest.fn(),
+	on: jest.fn(),
+	update: jest.fn(),
+} );
+
+const mockElements = () => {
+	const elements = {};
+	return {
+		create: jest.fn( ( type ) => {
+			elements[ type ] = mockElement();
+			return elements[ type ];
+		} ),
+		getElement: jest.fn( ( type ) => {
+			return elements[ type ] || null;
+		} ),
+	};
+};
+
+const mockStripe = () => ( {
+	elements: jest.fn( () => mockElements() ),
+	createToken: jest.fn(),
+	createSource: jest.fn(),
+	createPaymentMethod: jest.fn(),
+	confirmCardPayment: jest.fn(),
+	confirmCardSetup: jest.fn(),
+	paymentRequest: jest.fn(),
+	_registerWrapper: jest.fn(),
+} );
+
+jest.mock( '@stripe/react-stripe-js', () => {
+	const stripe = jest.requireActual( '@stripe/react-stripe-js' );
+
+	return {
+		...stripe,
+		Element: () => {
+			return mockElement();
+		},
+		useStripe: () => {
+			return mockStripe();
+		},
+		useElements: () => {
+			return mockElements();
+		},
+	};
+} );
+
+jest.mock( '@stripe/stripe-js', () => {
+	return {
+		loadStripe: async () => mockStripe(),
+	};
+} );
+
+// `recordPageView()` calls `fetch` for analytics with no guards and it is not
+// available outside of a browser so we must mock it here to avoid fatals.
+global.fetch = jest.fn( () => Promise.resolve() );
+
+const userId = 1;
+const siteId = 1;
+
+const storedCard1: StoredCard = {
+	added: '2022-05-23',
+	card: '4242',
+	card_type: 'visa',
+	email: 'foo@example.com',
+	expiry: '05/33',
+	is_expired: false,
+	last_service: '',
+	last_used: '',
+	meta: [],
+	mp_ref: '12345abcd',
+	name: 'Human Person',
+	payment_partner: 'stripe',
+	remember: '1',
+	stored_details_id: '1',
+	user_id: String( userId ),
+};
+
+const initialPurchases = [
+	{
+		ID: 1,
+		active: true,
+		amount: 100,
+		attached_to_purchase_id: 0,
+		bill_period_days: 365,
+		bill_period_label: 'yearly',
+		most_recent_renew_date: '',
+		can_disable_auto_renew: true,
+		can_reenable_auto_renewal: true,
+		can_explicit_renew: true,
+		cost_to_unbundle: undefined,
+		cost_to_unbundle_display: undefined,
+		price_text: '$100',
+		currency_code: 'USD',
+		currency_symbol: '$',
+		description: 'something here',
+		domain: '',
+		domain_registration_agreement_url: undefined,
+		blog_created_date: '2021-01-01',
+		expiry_date: '3040-01-01',
+		expiry_status: 'not-expired',
+		iap_purchase_management_link: null,
+		included_domain: '',
+		included_domain_purchase_amount: 0,
+		introductory_offer: null,
+		is_cancelable: true,
+		is_domain_registration: false,
+		is_locked: false,
+		is_iap_purchase: false,
+		is_rechargable: false,
+		is_refundable: false,
+		is_renewable: false,
+		is_renewal: false,
+		meta: undefined,
+		partner_name: undefined,
+		partner_slug: undefined,
+		partner_key_id: undefined,
+		payment_name: 'who knows',
+		payment_type: 'credit_card',
+		payment_country_name: 'United States',
+		payment_country_code: 'US',
+		stored_details_id: 1,
+		pending_transfer: false,
+		product_id: 1,
+		product_name: 'Personal',
+		product_slug: 'personal-bundle',
+		product_type: 'bundle',
+		product_display_price: '$100',
+		price_integer: 10000,
+		total_refund_amount: 0,
+		total_refund_text: '0',
+		refund_amount: 0,
+		refund_text: '0',
+		refund_currency_symbol: '$',
+		refund_options: null,
+		refund_period_in_days: 31,
+		regular_price_text: '$100',
+		regular_price_integer: 10000,
+		renew_date: '2023-01-01',
+		sale_amount: undefined,
+		sale_amount_integer: undefined,
+		blog_id: 1,
+		blogname: 'example.com',
+		subscribed_date: '2021-01-01',
+		subscription_status: 'active',
+		tag_line: '',
+		tax_amount: undefined,
+		tax_text: undefined,
+		renewal_price_tier_usage_quantity: undefined,
+		user_id: 1,
+		auto_renew: '1',
+		payment_card_id: 1,
+		payment_card_type: 'visa',
+		payment_card_processor: 'stripe',
+		payment_details: '4242',
+		payment_expiry: '02/45',
+	},
+];
+
+function createTestReduxStore() {
+	const initialState = getInitialState( initialReducer, userId );
+	const reduxStore = createReduxStore(
+		{
+			...initialState,
+			currentUser: { id: userId },
+			sites: {
+				items: {
+					[ siteId ]: {
+						ID: 1,
+						URL: 'example.com',
+						capabilities: {},
+						description: 'something',
+						domain: '',
+						jetpack: false,
+						launch_status: 'sure',
+						locale: 'en',
+						name: undefined,
+						options: {},
+						slug: 'example.com',
+					},
+				},
+			},
+		},
+		initialReducer
+	);
+	setStore( reduxStore, getStateFromCache( userId ) );
+
+	// Dispatch actions on the store to set `ui` and `purchases`. They cannot be
+	// included in the initial state because the reducer does not support them
+	// until we call `setStore()` to initialize support for dynamic reducers.
+	reduxStore.dispatch( setSelectedSiteId( siteId ) );
+	reduxStore.dispatch( {
+		type: PURCHASES_SITE_FETCH_COMPLETED,
+		siteId,
+		purchases: initialPurchases,
+	} );
+
+	return reduxStore;
+}
+
+describe( 'ChangePaymentMethod', () => {
+	it( 'renders a list of existing cards', async () => {
+		const queryClient = new QueryClient();
+
+		const paymentMethods: StoredCard[] = [ storedCard1 ];
+		nock( 'https://public-api.wordpress.com' )
+			.get( '/rest/v1.1/me/payment-methods?expired=include' )
+			.reply( 200, paymentMethods );
+		nock( 'https://public-api.wordpress.com' )
+			.get( '/rest/v1.1/me/stripe-configuration' )
+			.reply( 200, stripeConfiguration );
+
+		render(
+			<ReduxProvider store={ createTestReduxStore() }>
+				<QueryClientProvider client={ queryClient }>
+					<ChangePaymentMethod
+						getManagePurchaseUrlFor={ ( siteSlug: string, purchaseId: number ) =>
+							`/manage-purchase-url/${ siteSlug }/${ purchaseId }`
+						}
+						purchaseId={ 1 }
+						purchaseListUrl="purchase-list-url"
+						siteSlug="example.com"
+					/>
+				</QueryClientProvider>
+			</ReduxProvider>
+		);
+
+		expect( await screen.findByText( storedCard1.name ) ).toBeInTheDocument();
+	} );
+} );


### PR DESCRIPTION
#### Proposed Changes

This PR adds basic tests to prove that the `ChangePaymentMethod` component renders as expected.

This would have caught the fatal error that was fixed by https://github.com/Automattic/wp-calypso/pull/72827

To do:

- [x] Add test to prove that existing cards are rendered.
- [x] Add test to prove that new card method is rendered.
- [x] Add test to prove that PayPal is rendered.

#### Testing Instructions

This just adds tests so if the automated tests pass, then this should be good to go.