### PR TITLE
Remove links to /courses and replace it with /learn in Universal Header & Footer Navbars for Calypso

### DIFF
--- a/client/layout/universal-navbar-footer/index.tsx
+++ b/client/layout/universal-navbar-footer/index.tsx
@@ -1,5 +1,9 @@
 import './style.scss';
-import { useLocalizeUrl, removeLocaleFromPathLocaleInFront } from '@automattic/i18n-utils';
+import {
+	useLocalizeUrl,
+	removeLocaleFromPathLocaleInFront,
+	useIsEnglishLocale,
+} from '@automattic/i18n-utils';
 import { useTranslate, getLocaleSlug } from 'i18n-calypso';
 import { useCallback, useState } from 'react';
 import { useSelector } from 'react-redux';
@@ -18,7 +22,7 @@ const UniversalNavbarFooter = () => {
 	const { shouldSeeDoNotSell, isDoNotSell, onSetDoNotSell } = useDoNotSell();
 	const [ isDialogOpen, setIsDialogOpen ] = useState( false );
 	const isLoggedIn = useSelector( isUserLoggedIn );
-
+	const isEnglishLocale = useIsEnglishLocale();
 	const currentRoute = useSelector( getCurrentRoute );
 	const pathNameWithoutLocale = removeLocaleFromPathLocaleInFront( currentRoute ).slice( 1 );
 
@@ -176,9 +180,11 @@ const UniversalNavbarFooter = () => {
 									</a>
 								</li>
 								<li>
-									<a href={ localizeUrl( 'https://wordpress.com/courses/' ) } target="_self">
-										{ translate( 'WordPress Courses' ) }
-									</a>
+									{ isEnglishLocale && (
+										<a href={ localizeUrl( 'https://wordpress.com/learn/' ) } target="_self">
+											{ translate( 'Learn WordPress' ) }
+										</a>
+									) }
 								</li>
 								<li>
 									<a

--- a/client/layout/universal-navbar-header/index.jsx
+++ b/client/layout/universal-navbar-header/index.jsx
@@ -1,5 +1,5 @@
 import './nav-style.scss';
-import { useLocalizeUrl } from '@automattic/i18n-utils';
+import { useLocalizeUrl, useIsEnglishLocale } from '@automattic/i18n-utils';
 import { useTranslate, getLocaleSlug } from 'i18n-calypso';
 import { useState } from 'react';
 import { useSelector } from 'react-redux';
@@ -17,6 +17,7 @@ const UniversalNavbarHeader = () => {
 	const [ isMobileMenuOpen, setMobileMenuOpen ] = useState( false );
 	const sectionName = useSelector( getSectionName );
 	const isLoggedIn = useSelector( isUserLoggedIn );
+	const isEnglishLocale = useIsEnglishLocale();
 
 	const startUrl = addQueryArgs(
 		{
@@ -206,13 +207,15 @@ const UniversalNavbarHeader = () => {
 													type="dropdown"
 													target="_self"
 												/>
-												<UniversalNavbarLiMenuItem
-													titleValue={ translate( 'WordPress Courses' ) }
-													elementContent={ translate( 'WordPress Courses' ) }
-													urlValue={ localizeUrl( '//wordpress.com/courses/' ) }
-													type="dropdown"
-													target="_self"
-												/>
+												{ isEnglishLocale && (
+													<UniversalNavbarLiMenuItem
+														titleValue={ translate( 'Learn WordPress' ) }
+														elementContent={ translate( 'Learn WordPress' ) }
+														urlValue={ localizeUrl( '//wordpress.com/learn/' ) }
+														type="dropdown"
+														target="_self"
+													/>
+												) }
 											</ul>
 										</div>
 									</li>
@@ -422,12 +425,14 @@ const UniversalNavbarHeader = () => {
 										urlValue={ localizeUrl( '//wordpress.com/webinars/' ) }
 										type="menu"
 									/>
-									<UniversalNavbarLiMenuItem
-										titleValue={ translate( 'WordPress Courses' ) }
-										elementContent={ translate( 'WordPress Courses' ) }
-										urlValue={ localizeUrl( '//wordpress.com/courses/' ) }
-										type="menu"
-									/>
+									{ isEnglishLocale && (
+										<UniversalNavbarLiMenuItem
+											titleValue={ translate( 'Learn WordPress' ) }
+											elementContent={ translate( 'Learn WordPress' ) }
+											urlValue={ localizeUrl( '//wordpress.com/learn/' ) }
+											type="menu"
+										/>
+									) }
 								</ul>
 							</div>
 						</div>


### PR DESCRIPTION
#### Proposed Changes

* Contexte: p5uIfZ-cyH-p2 & 1244-gh-Automattic/martech

#### Testing Instructions
* Navigate to /themes or /plugins in an incognito/logged-out session.
* Ensure that you see the "Learn WordPress" link in the "Resources" menu item in the header (for /themes and /plugins)
* Ensure that you see the "Learn WordPress" link in the "Resources" section in the footer (for /plugins)

* Switch locale via the footer select field, or by going to /es/plugins or /es/themes
    * Verify that the link to WPcourses is not visible, and the new /learn link is hidden

Note: If you switch locale, and still see the page in English, you probably need to build the language files. You can do that by running `yarn build-languages` or `BUILD_TRANSLATION_CHUNKS=true yarn start`.

Alternatively, test it via the Calypso live below, as that build will have the language files. 

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
