### PR TITLE
@wordpress/data: Change DispatchFromMap to return Promise<void> instead of void

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/create-site-error/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/create-site-error/index.tsx
@@ -20,7 +20,7 @@ const CreateSiteError: FunctionComponent< Props > = ( { linkTo } ) => {
 
 	const { resetNewSiteFailed } = useDispatch( SITE_STORE );
 
-	useEffect( () => resetNewSiteFailed );
+	useEffect( () => void resetNewSiteFailed() );
 
 	return (
 		<div className="create-site-error">

--- a/packages/data-stores/src/mapped-types.ts
+++ b/packages/data-stores/src/mapped-types.ts
@@ -40,7 +40,7 @@ export type DispatchFromMap< A extends Record< string, ( ...args: any[] ) => any
 		...args: Parameters< A[ actionCreator ] >
 	) => A[ actionCreator ] extends ( ...args: any[] ) => Generator
 		? Promise< GeneratorReturnType< A[ actionCreator ] > >
-		: void;
+		: Promise< void >;
 };
 
 /**


### PR DESCRIPTION
#### Proposed Changes

This changes the types of `@wordpress/data` to show that a dispatched action will return `Promise<void>` instead of `void`.

See https://github.com/WordPress/gutenberg/blob/6aef6e6b9b5cf2f5aeff6145cd24181edf0d43f0/packages/data/README.md#user-content-dispatch

> Note: Action creators returned by the dispatch will return a promise when they are called.

This was previously [fixed in the DT types](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/60693) but it's come back in the package types.

This was discovered when I tried to use the mapped dispatch type in https://github.com/Automattic/wp-calypso/pull/72835 (props @pottedmeat).

#### Testing Instructions

None should be required. You can see that this solves the issue in https://github.com/Automattic/wp-calypso/pull/72835. I guess just verify that I'm not wrong about this return type.