### PR TITLE
Theme Showcase: Show pricing in logged-out theme showcase

### DIFF
--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -510,7 +510,6 @@ export class Theme extends Component {
 			price,
 			theme,
 			translate,
-			upsellUrl,
 			hasPremiumThemesFeature,
 			isPremiumTheme,
 			didPurchaseTheme,
@@ -526,10 +525,9 @@ export class Theme extends Component {
 		} );
 
 		const themeNeedsPurchase = isPremiumTheme && ! hasPremiumThemesFeature && ! didPurchaseTheme;
-		const showUpsell = upsellUrl && ( isPremiumTheme || isExternallyManagedTheme ) && ! active;
+		const showUpsell = ( isPremiumTheme || isExternallyManagedTheme ) && ! active;
 		const priceClass = classNames( 'theme__badge-price', {
 			'theme__badge-price-upgrade': ! themeNeedsPurchase,
-			'theme__badge-price-upsell': showUpsell,
 		} );
 
 		const themeDescription = decodeEntities( description );
@@ -610,13 +608,12 @@ export class Theme extends Component {
 							<span className={ priceClass }>{ price }</span>
 						) }
 						{ isNewDetailsAndPreview && ! active && this.renderStyleVariations() }
-						{ upsellUrl && // Do not show any pricing related infomation if there's no upsell action link.
-							( showUpsell
-								? this.renderUpsell()
-								: ( isNewCardsOnly || isNewDetailsAndPreview ) &&
-								  ! active && (
-										<span className="theme__info-upsell-description">{ translate( 'Free' ) }</span>
-								  ) ) }
+						{ showUpsell
+							? this.renderUpsell()
+							: ( isNewCardsOnly || isNewDetailsAndPreview ) &&
+							  ! active && (
+									<span className="theme__info-upsell-description">{ translate( 'Free' ) }</span>
+							  ) }
 						{ this.renderMoreButton() }
 					</div>
 				</div>

--- a/client/my-sites/themes/test/logged-out.jsx
+++ b/client/my-sites/themes/test/logged-out.jsx
@@ -12,6 +12,9 @@ import { DEFAULT_THEME_QUERY } from 'calypso/state/themes/constants';
 import LoggedOutShowcase from '../logged-out';
 
 jest.mock( 'calypso/lib/analytics/tracks', () => ( {} ) );
+jest.mock( 'calypso/lib/analytics/track-component-view', () =>
+	require( 'calypso/components/empty-component' )
+);
 jest.mock( 'calypso/lib/analytics/page-view-tracker', () =>
 	require( 'calypso/components/empty-component' )
 );


### PR DESCRIPTION
#### Proposed Changes

This PR shows theme pricing upsell in the logged-out theme showcase. Previously, we would only theme upsell when `upsellUrl` is available. This PR decouples the `upsellUrl` dependency, since we are still interested in displaying the upsell in the UI. See p1675112160128929-slack-C048CUFRGFQ for the full discussion.

| Before | After |
| --- | --- |
| ![Screenshot 2023-02-01 at 12 44 32 PM](https://user-images.githubusercontent.com/797888/215952742-3c2a14ab-dc8c-47ed-8372-ad930e4f9ea1.png) |  ![Screenshot 2023-02-01 at 12 45 30 PM](https://user-images.githubusercontent.com/797888/215952809-5f4c9628-dd0e-476f-bd33-3e9e8e5a36fb.png)


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the logged-out Theme Showcase `/themes`.
* Ensure that the upsells match with the production's logged-in Theme Showcase.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
