### PR TITLE
Theme Showcase: Clean up flag themes/showcase i4/cards-only

### DIFF
--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -16,7 +16,6 @@ import photon from 'photon';
 import PropTypes from 'prop-types';
 import { Component, createRef } from 'react';
 import { connect } from 'react-redux';
-import InfoPopover from 'calypso/components/info-popover';
 import PulsingDot from 'calypso/components/pulsing-dot';
 import Tooltip from 'calypso/components/tooltip';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
@@ -56,13 +55,10 @@ export class Theme extends Component {
 			stylesheet: PropTypes.string,
 			taxonomies: PropTypes.object,
 			update: PropTypes.object,
-			price: PropTypes.any,
 			soft_launched: PropTypes.bool,
 		} ),
 		// If true, highlight this theme as active
 		active: PropTypes.bool,
-		// Theme price (pre-formatted string) -- empty string indicates free theme
-		price: PropTypes.string,
 		// If true, the theme is being installed
 		installing: PropTypes.bool,
 		// If true, render a placeholder
@@ -131,7 +127,6 @@ export class Theme extends Component {
 		return (
 			nextProps.theme.id !== this.props.theme.id ||
 			nextProps.active !== this.props.active ||
-			nextProps.price !== this.props.price ||
 			nextProps.installing !== this.props.installing ||
 			! isEqual(
 				Object.keys( nextProps.buttonContents ),
@@ -435,15 +430,7 @@ export class Theme extends Component {
 	};
 
 	renderUpsell = () => {
-		const { active, isPremiumTheme, isPremiumThemeAvailable, theme } = this.props;
-
-		/*
-		 * Only show the Premium badge if we're not already showing the price
-		 * and the theme isn't the active theme.
-		 */
-		const showPremiumBadge = isPremiumTheme && isPremiumThemeAvailable && ! active;
-		const isNewCardsOnly = isEnabled( 'themes/showcase-i4/cards-only' );
-		const isNewDetailsAndPreview = isEnabled( 'themes/showcase-i4/details-and-preview' );
+		const { theme } = this.props;
 
 		return (
 			<span className="theme__upsell">
@@ -451,21 +438,7 @@ export class Theme extends Component {
 					eventName="calypso_upgrade_nudge_impression"
 					eventProperties={ { cta_name: 'theme-upsell', theme: theme.id } }
 				/>
-				{ isNewCardsOnly || isNewDetailsAndPreview ? (
-					this.getPremiumThemeBadge()
-				) : (
-					<InfoPopover
-						icon="star"
-						showOnHover={ true }
-						className={ classNames(
-							'theme__upsell-popover',
-							isPremiumThemeAvailable || showPremiumBadge ? 'active' : null
-						) }
-						position="top"
-					>
-						{ this.getUpsellPopoverContent() }
-					</InfoPopover>
-				) }
+				{ this.getPremiumThemeBadge() }
 			</span>
 		);
 	};
@@ -522,18 +495,8 @@ export class Theme extends Component {
 	};
 
 	render() {
-		const {
-			active,
-			price,
-			theme,
-			translate,
-			hasPremiumThemesFeature,
-			isPremiumTheme,
-			didPurchaseTheme,
-			isExternallyManagedTheme,
-		} = this.props;
+		const { active, theme, translate, isPremiumTheme, isExternallyManagedTheme } = this.props;
 		const { name, description, screenshot, style_variations = [] } = theme;
-		const isNewCardsOnly = isEnabled( 'themes/showcase-i4/cards-only' );
 		const isNewDetailsAndPreview = isEnabled( 'themes/showcase-i4/details-and-preview' );
 		const isActionable = this.props.screenshotClickUrl || this.props.onScreenshotClick;
 		const themeClass = classNames( 'theme', {
@@ -541,12 +504,7 @@ export class Theme extends Component {
 			'is-actionable': isActionable,
 		} );
 
-		const themeNeedsPurchase = isPremiumTheme && ! hasPremiumThemesFeature && ! didPurchaseTheme;
 		const showUpsell = ( isPremiumTheme || isExternallyManagedTheme ) && ! active;
-		const priceClass = classNames( 'theme__badge-price', {
-			'theme__badge-price-upgrade': ! themeNeedsPurchase,
-		} );
-
 		const themeDescription = decodeEntities( description );
 
 		// for performance testing
@@ -621,16 +579,13 @@ export class Theme extends Component {
 								} ) }
 							</span>
 						) }
-						{ ! isNewCardsOnly && ! isNewDetailsAndPreview && active && (
-							<span className={ priceClass }>{ price }</span>
-						) }
 						{ isNewDetailsAndPreview && ! active && this.renderStyleVariations() }
-						{ showUpsell
-							? this.renderUpsell()
-							: ( isNewCardsOnly || isNewDetailsAndPreview ) &&
-							  ! active && (
-									<span className="theme__info-upsell-description">{ translate( 'Free' ) }</span>
-							  ) }
+						{ ! active &&
+							( showUpsell ? (
+								this.renderUpsell()
+							) : (
+								<span className="theme__info-upsell-description">{ translate( 'Free' ) }</span>
+							) ) }
 						{ this.renderMoreButton() }
 					</div>
 				</div>

--- a/client/components/theme/test/__snapshots__/index.jsx.snap
+++ b/client/components/theme/test/__snapshots__/index.jsx.snap
@@ -31,6 +31,11 @@ exports[`Theme rendering with default display buttonContents should match snapsh
         Twenty Seventeen
       </h2>
       <span
+        class="theme__info-upsell-description"
+      >
+        Free
+      </span>
+      <span
         class="theme__more-button"
       >
         <button

--- a/client/components/theme/test/index.jsx
+++ b/client/components/theme/test/index.jsx
@@ -98,15 +98,6 @@ describe( 'Theme', () => {
 		} );
 	} );
 
-	describe( 'when the theme has a price', () => {
-		test( 'should show a price', () => {
-			const { container } = render( <Theme { ...props } price="$50" active /> );
-			expect( container.getElementsByClassName( 'theme__badge-price' )[ 0 ].textContent ).toBe(
-				'$50'
-			);
-		} );
-	} );
-
 	describe( 'Update themes', () => {
 		test( 'Should show the update message', () => {
 			const updateThemeProps = {

--- a/client/my-sites/themes/logged-out.jsx
+++ b/client/my-sites/themes/logged-out.jsx
@@ -10,9 +10,6 @@ export default ( props ) => (
 	<Main fullWidthLayout className="themes">
 		<BodySectionCssClass
 			bodyClass={ [
-				...( isEnabled( 'themes/showcase-i4/cards-only' )
-					? [ 'is-section-themes-i4-cards-only' ]
-					: [] ),
 				...( isEnabled( 'themes/showcase-i4/details-and-preview' )
 					? [ 'is-section-themes-i4-2' ]
 					: [] ),

--- a/client/my-sites/themes/single-site-jetpack.jsx
+++ b/client/my-sites/themes/single-site-jetpack.jsx
@@ -49,7 +49,6 @@ const ConnectedSingleSiteJetpack = connectOptions( ( props ) => {
 		requestingSitePlans,
 	} = props;
 
-	const isNewCardsOnly = isEnabled( 'themes/showcase-i4/cards-only' );
 	const isNewDetailsAndPreview = isEnabled( 'themes/showcase-i4/details-and-preview' );
 	const displayUpsellBanner = isAtomic && ! requestingSitePlans && currentPlan;
 	const upsellUrl =
@@ -74,10 +73,7 @@ const ConnectedSingleSiteJetpack = connectOptions( ( props ) => {
 	return (
 		<Main fullWidthLayout className="themes">
 			<BodySectionCssClass
-				bodyClass={ [
-					...( isNewCardsOnly ? [ 'is-section-themes-i4-cards-only' ] : [] ),
-					...( isNewDetailsAndPreview ? [ 'is-section-themes-i4-2' ] : [] ),
-				] }
+				bodyClass={ [ ...( isNewDetailsAndPreview ? [ 'is-section-themes-i4-2' ] : [] ) ] }
 			/>
 			<QueryActiveTheme siteId={ siteId } />
 			{ currentThemeId && <QueryCanonicalTheme themeId={ currentThemeId } siteId={ siteId } /> }

--- a/client/my-sites/themes/single-site-wpcom.jsx
+++ b/client/my-sites/themes/single-site-wpcom.jsx
@@ -28,7 +28,6 @@ const ConnectedSingleSiteWpcom = connectOptions( ( props ) => {
 	const { currentPlan, currentThemeId, isVip, requestingSitePlans, siteId, siteSlug, translate } =
 		props;
 
-	const isNewCardsOnly = isEnabled( 'themes/showcase-i4/cards-only' );
 	const isNewDetailsAndPreview = isEnabled( 'themes/showcase-i4/details-and-preview' );
 	const displayUpsellBanner = ! requestingSitePlans && currentPlan && ! isVip;
 	const upsellUrl = `/plans/${ siteSlug }`;
@@ -88,10 +87,7 @@ const ConnectedSingleSiteWpcom = connectOptions( ( props ) => {
 	return (
 		<Main fullWidthLayout className="themes">
 			<BodySectionCssClass
-				bodyClass={ [
-					...( isNewCardsOnly ? [ 'is-section-themes-i4-cards-only' ] : [] ),
-					...( isNewDetailsAndPreview ? [ 'is-section-themes-i4-2' ] : [] ),
-				] }
+				bodyClass={ [ ...( isNewDetailsAndPreview ? [ 'is-section-themes-i4-2' ] : [] ) ] }
 			/>
 			<QueryActiveTheme siteId={ siteId } />
 			{ currentThemeId && <QueryCanonicalTheme themeId={ currentThemeId } siteId={ siteId } /> }

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -11,105 +11,7 @@ body.is-section-themes {
 	.layout:not(.has-no-sidebar) .layout__content {
 		padding-top: var(--masterbar-height);
 	}
-}
 
-.theme-showcase {
-	.themes__selection .themes-list {
-		margin: 32px -16px 0;
-
-		.theme {
-			margin: 0 16px 32px;
-		}
-	}
-
-	.themes__content .upsell-nudge {
-		background-color: #f0f7fc;
-		border: none;
-		box-shadow: none;
-		margin-top: 32px;
-		margin-bottom: 0;
-		padding: 24px 30px;
-		border-radius: 4px;
-
-		&.is-dismissible {
-			.dismissible-card__close-button {
-				height: 16px;
-				width: 16px;
-
-				svg {
-					height: 16px;
-					width: 16px;
-				}
-			}
-		}
-
-		.banner__content {
-			gap: 16px;
-
-			@include breakpoint-deprecated( ">660px" ) {
-				gap: 32px;
-			}
-		}
-
-		.banner__title,
-		.banner__description {
-			color: var(--color-neutral-80);
-			font-size: $font-body-small;
-			line-height: 20px;
-		}
-
-		.banner__title {
-			font-weight: 500;
-		}
-
-		.banner__icon {
-			background-color: var(--studio-blue-50);
-			display: none;
-		}
-
-		.banner__icon-circle {
-			background-color: var(--studio-blue-50);
-		}
-
-		.banner__action .button {
-			background-color: var(--studio-blue-50);
-			border: none;
-			font-size: $font-body-small;
-			font-weight: 400;
-			line-height: 22px;
-			padding: 8px 14px;
-			white-space: nowrap;
-
-			&:hover {
-				background-color: var(--studio-blue-60);
-			}
-
-			.accessible-focus &:focus {
-				box-shadow: 0 0 0 2px var(--color-primary-light);
-				outline: 0;
-			}
-		}
-	}
-
-	.themes__install-theme-button-container {
-		margin: 0;
-
-		.button {
-			border-radius: 4px;
-			box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
-			box-sizing: border-box;
-			color: var(--color-neutral-100);
-			display: block;
-			font-size: 0.875rem;
-			line-height: 20px;
-			padding: 8px 16px;
-			white-space: nowrap;
-		}
-	}
-}
-
-body.is-section-themes-i4-cards-only,
-body.is-section-themes-i4-2 {
 	.themes__selection .themes-list .theme {
 		background: none;
 		border-radius: 2px;
@@ -278,6 +180,101 @@ body.is-section-themes-i4-2 {
 
 		.theme__upsell-header {
 			color: var(--color-neutral-100);
+		}
+	}
+}
+
+.theme-showcase {
+	.themes__selection .themes-list {
+		margin: 32px -16px 0;
+
+		.theme {
+			margin: 0 16px 32px;
+		}
+	}
+
+	.themes__content .upsell-nudge {
+		background-color: #f0f7fc;
+		border: none;
+		box-shadow: none;
+		margin-top: 32px;
+		margin-bottom: 0;
+		padding: 24px 30px;
+		border-radius: 4px;
+
+		&.is-dismissible {
+			.dismissible-card__close-button {
+				height: 16px;
+				width: 16px;
+
+				svg {
+					height: 16px;
+					width: 16px;
+				}
+			}
+		}
+
+		.banner__content {
+			gap: 16px;
+
+			@include breakpoint-deprecated( ">660px" ) {
+				gap: 32px;
+			}
+		}
+
+		.banner__title,
+		.banner__description {
+			color: var(--color-neutral-80);
+			font-size: $font-body-small;
+			line-height: 20px;
+		}
+
+		.banner__title {
+			font-weight: 500;
+		}
+
+		.banner__icon {
+			background-color: var(--studio-blue-50);
+			display: none;
+		}
+
+		.banner__icon-circle {
+			background-color: var(--studio-blue-50);
+		}
+
+		.banner__action .button {
+			background-color: var(--studio-blue-50);
+			border: none;
+			font-size: $font-body-small;
+			font-weight: 400;
+			line-height: 22px;
+			padding: 8px 14px;
+			white-space: nowrap;
+
+			&:hover {
+				background-color: var(--studio-blue-60);
+			}
+
+			.accessible-focus &:focus {
+				box-shadow: 0 0 0 2px var(--color-primary-light);
+				outline: 0;
+			}
+		}
+	}
+
+	.themes__install-theme-button-container {
+		margin: 0;
+
+		.button {
+			border-radius: 4px;
+			box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+			box-sizing: border-box;
+			color: var(--color-neutral-100);
+			display: block;
+			font-size: 0.875rem;
+			line-height: 20px;
+			padding: 8px 16px;
+			white-space: nowrap;
 		}
 	}
 }

--- a/config/development.json
+++ b/config/development.json
@@ -178,7 +178,6 @@
 		"subscription-gifting": true,
 		"themes/atomic-homepage-replace": true,
 		"themes/premium": true,
-		"themes/showcase-i4/cards-only": true,
 		"themes/showcase-i4/details-and-preview": true,
 		"themes/subscription-purchases": true,
 		"themes/theme-switch-persist-template": false,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -122,7 +122,6 @@
 		"subscription-gifting": true,
 		"themes/atomic-homepage-replace": true,
 		"themes/premium": true,
-		"themes/showcase-i4/cards-only": true,
 		"themes/showcase-i4/details-and-preview": false,
 		"themes/subscription-purchases": false,
 		"themes/theme-switch-persist-template": false,

--- a/config/production.json
+++ b/config/production.json
@@ -142,7 +142,6 @@
 		"subscription-gifting": true,
 		"themes/atomic-homepage-replace": true,
 		"themes/premium": true,
-		"themes/showcase-i4/cards-only": true,
 		"themes/showcase-i4/details-and-preview": false,
 		"themes/subscription-purchases": false,
 		"themes/theme-switch-persist-template": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -138,7 +138,6 @@
 		"subscription-gifting": true,
 		"themes/atomic-homepage-replace": true,
 		"themes/premium": true,
-		"themes/showcase-i4/cards-only": true,
 		"themes/showcase-i4/details-and-preview": false,
 		"themes/subscription-purchases": false,
 		"themes/theme-switch-persist-template": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -148,7 +148,6 @@
 		"subscription-gifting": true,
 		"themes/atomic-homepage-replace": true,
 		"themes/premium": true,
-		"themes/showcase-i4/cards-only": true,
 		"themes/showcase-i4/details-and-preview": false,
 		"themes/subscription-purchases": false,
 		"themes/theme-switch-persist-template": false,


### PR DESCRIPTION
#### Proposed Changes

This PR retires the flag `themes/showcase i4/cards-only` since it's already been shipped for all environments in #72753. 

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure that all references to the flag `themes/showcase i4/cards-only` has been removed.
* Ensure that theme cards in the Theme Showcase works the same as the ones on production.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

