### PR TITLE
Jetpack Cloud: Add a third section to licensing that introduces WooCommerce products

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/issue-multiple-licenses-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-multiple-licenses-form/index.tsx
@@ -56,7 +56,12 @@ export default function IssueMultipleLicensesForm( {
 		) || [];
 	const products =
 		allProducts?.filter(
-			( { family_slug }: { family_slug: string } ) => family_slug !== 'jetpack-packs'
+			( { family_slug }: { family_slug: string } ) =>
+				family_slug !== 'jetpack-packs' && ! family_slug.includes( 'woocommerce-extension' )
+		) || [];
+	const wooProducts =
+		allProducts?.filter( ( { family_slug }: { family_slug: string } ) =>
+			family_slug.includes( 'woocommerce-extension' )
 		) || [];
 
 	const hasPurchasedProductsWithoutBundle = useSelector( ( state ) =>
@@ -194,9 +199,10 @@ export default function IssueMultipleLicensesForm( {
 								/>
 							) ) }
 					</div>
+
 					<hr className="issue-multiple-licenses-form__separator" />
 					<p className="issue-multiple-licenses-form__description">
-						{ translate( 'Or select any of our {{strong}}recommended bundles{{/strong}}:', {
+						{ translate( 'Or select any of our recommended {{strong}}Jetpack bundles{{/strong}}:', {
 							components: { strong: <strong /> },
 						} ) }
 					</p>
@@ -208,6 +214,31 @@ export default function IssueMultipleLicensesForm( {
 									product={ productOption }
 									onSelectProduct={ onSelectProduct }
 									tabIndex={ 100 + ( products?.length || 0 ) + i }
+								/>
+							) ) }
+					</div>
+
+					<hr className="issue-multiple-licenses-form__separator" />
+					<p className="issue-multiple-licenses-form__description">
+						{ translate(
+							'Or select from the following {{strong}}WooCommerce extensions{{/strong}}:',
+							{
+								components: { strong: <strong /> },
+							}
+						) }
+					</p>
+					<div className="issue-multiple-licenses-form__bottom">
+						{ wooProducts &&
+							wooProducts.map( ( productOption, i ) => (
+								<LicenseProductCard
+									isMultiSelect
+									key={ productOption.slug }
+									product={ productOption }
+									onSelectProduct={ onSelectProduct }
+									isSelected={ selectedProductSlugs.includes( productOption.slug ) }
+									isDisabled={ disabledProductSlugs.includes( productOption.slug ) }
+									tabIndex={ 100 + i }
+									suggestedProduct={ suggestedProduct }
 								/>
 							) ) }
 					</div>


### PR DESCRIPTION
#### Proposed Changes

* This PR adds a third product group to the license issue form which will display WooCommerce products.
* Also separates out anything with `woocommerce-extension` in the product slug from `allProducts` on this page, so that we have proper groups of products.

#### Testing Instructions

* TBD, but you will need D99932-code and the appropriate billing scheme assigned to your partner key.
* I will release better testing instructions when we're ready to test. In the mean time, contact me for more details if you'd like to test.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #