### PR TITLE
Reading Settings: Unset `page_for_posts` when `page_on_front` is changed to default

### DIFF
--- a/client/my-sites/site-settings/reading-site-settings/YourHomepageDisplaysSetting.tsx
+++ b/client/my-sites/site-settings/reading-site-settings/YourHomepageDisplaysSetting.tsx
@@ -119,7 +119,7 @@ const YourHomepageDisplaysSetting = ( {
 				<FormSelect
 					id="posts-page-select"
 					name="page_for_posts"
-					disabled={ disabled || isLoading || ! pages?.length }
+					disabled={ disabled || isLoading || ! pages?.length || page_on_front === '' }
 					value={ page_for_posts }
 					onChange={ handlePageForPostsChange }
 				>

--- a/client/my-sites/site-settings/reading-site-settings/YourHomepageDisplaysSetting.tsx
+++ b/client/my-sites/site-settings/reading-site-settings/YourHomepageDisplaysSetting.tsx
@@ -73,8 +73,8 @@ const YourHomepageDisplaysSetting = ( {
 	const handlePageOnFrontChange: React.FormEventHandler = ( { target } ) => {
 		const selectedPageId: string = ( target as HTMLSelectElement ).value;
 		if ( selectedPageId === '' ) {
-			// Default was selected, so we need to set show_on_front to 'posts'
-			onChange?.( { show_on_front: 'posts', page_on_front: '' } );
+			// Default was selected, so we need to set show_on_front to 'posts' and unset page_for_posts.
+			onChange?.( { show_on_front: 'posts', page_on_front: '', page_for_posts: '' } );
 		} else {
 			onChange?.( { show_on_front: 'page', page_on_front: selectedPageId } );
 		}


### PR DESCRIPTION
#### Proposed Changes

* Unset `page_for_posts` when `page_on_front` is changed to default
* Disable `page_for_posts` select input when `page_on_front` is set to its default value (an empty string)

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `http://calypso.localhost:3000/settings/reading/${yourTetstSize}`
* Set "**Your homepage displays**" and "**Default posts page**" settings to some valid static pages.
* Save any changes you made
* Change the "**Your homepage displays**" selection to "— Default —"
  * Ensure the "**Default posts page**" input value was cleared and the input is now disabled
  * You can also test here if the "**Default posts page**" input becomes enabled again if you were to select some static page in "**Your homepage displays**" again
*  Save the settings while watching **Network** traffic in you chrome devtools and ensure the expected request body
* Reload the page to ensure the setting is persisted as expected - that the previously saved settings still apply

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/72826
