### PR TITLE
Plans Grid 2023: Fix broken interval switch

### DIFF
--- a/client/my-sites/plan-features-2023-grid/plan-comparison-grid.tsx
+++ b/client/my-sites/plan-features-2023-grid/plan-comparison-grid.tsx
@@ -486,6 +486,7 @@ export const PlanComparisonGrid: React.FC< PlanComparisonGridProps > = ( {
 		}
 		return acc;
 	}, [] );
+
 	return (
 		<div className="plan-comparison-grid">
 			<PlanComparisonHeader className="wp-brand-font">
@@ -500,6 +501,8 @@ export const PlanComparisonGrid: React.FC< PlanComparisonGridProps > = ( {
 				intervalType={ planTypeSelectorProps.intervalType }
 				customerType={ planTypeSelectorProps.customerType }
 				hidePersonalPlan={ planTypeSelectorProps.hidePersonalPlan }
+				basePlansPath={ planTypeSelectorProps.basePlansPath }
+				siteSlug={ planTypeSelectorProps.siteSlug }
 				hideDiscountLabel={ true }
 			/>
 			<Grid>
@@ -514,7 +517,6 @@ export const PlanComparisonGrid: React.FC< PlanComparisonGridProps > = ( {
 					manageHref={ manageHref }
 					canUserPurchasePlan={ canUserPurchasePlan }
 				/>
-
 				{ Object.values( featureGroupMap ).map( ( featureGroup: FeatureGroup ) => {
 					const features = featureGroup.get2023PricingGridSignupWpcomFeatures();
 					const featureObjects = getPlanFeaturesObject( features );

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -158,12 +158,14 @@ export class PlansFeaturesMain extends Component {
 				intervalType,
 			};
 			const planTypeSelectorProps = {
+				basePlansPath: this.props.basePlansPath,
 				isInSignup: this.props.isInSignup,
 				eligibleForWpcomMonthlyPlans: this.props.eligibleForWpcomMonthlyPlans,
 				isPlansInsideStepper: this.props.isPlansInsideStepper,
 				intervalType: this.props.intervalType,
 				customerType: this.props.customerType,
 				hidePersonalPlan: this.props.hidePersonalPlan,
+				siteSlug: this.props.siteSlug,
 			};
 			const asyncPlanFeatures2023Grid = (
 				<AsyncLoad
@@ -172,6 +174,7 @@ export class PlansFeaturesMain extends Component {
 					planTypeSelectorProps={ planTypeSelectorProps }
 				/>
 			);
+
 			return (
 				<div
 					className={ classNames(

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -124,6 +124,7 @@ export class PlansFeaturesMain extends Component {
 			isPlansInsideStepper,
 			is2023OnboardingPricingGrid,
 			intervalType,
+			planTypeSelectorProps,
 		} = this.props;
 
 		const plans = this.getPlansForPlanFeatures();
@@ -156,16 +157,6 @@ export class PlansFeaturesMain extends Component {
 				isReskinned,
 				isPlansInsideStepper,
 				intervalType,
-			};
-			const planTypeSelectorProps = {
-				basePlansPath: this.props.basePlansPath,
-				isInSignup: this.props.isInSignup,
-				eligibleForWpcomMonthlyPlans: this.props.eligibleForWpcomMonthlyPlans,
-				isPlansInsideStepper: this.props.isPlansInsideStepper,
-				intervalType: this.props.intervalType,
-				customerType: this.props.customerType,
-				hidePersonalPlan: this.props.hidePersonalPlan,
-				siteSlug: this.props.siteSlug,
 			};
 			const asyncPlanFeatures2023Grid = (
 				<AsyncLoad
@@ -583,8 +574,13 @@ export class PlansFeaturesMain extends Component {
 	}
 
 	render() {
-		const { siteId, redirectToAddDomainFlow, domainAndPlanPackage, is2023OnboardingPricingGrid } =
-			this.props;
+		const {
+			siteId,
+			redirectToAddDomainFlow,
+			domainAndPlanPackage,
+			is2023OnboardingPricingGrid,
+			planTypeSelectorProps,
+		} = this.props;
 
 		const plans = this.getPlansForPlanFeatures();
 		const visiblePlans = this.getVisiblePlansForPlanFeatures( plans );
@@ -613,7 +609,7 @@ export class PlansFeaturesMain extends Component {
 				<div className="plans-features-main__notice" />
 				{ ! hidePlanSelector && (
 					<PlanTypeSelector
-						{ ...this.props }
+						{ ...planTypeSelectorProps }
 						kind={ kindOfPlanTypeSelector }
 						plans={ visiblePlans }
 					/>
@@ -691,6 +687,7 @@ export default connect(
 		const sitePlanSlug = sitePlan?.product_slug;
 		const eligibleForWpcomMonthlyPlans = isEligibleForWpComMonthlyPlan( state, siteId );
 		const titanMonthlyRenewalCost = getProductDisplayCost( state, TITAN_MAIL_MONTHLY_SLUG );
+		const siteSlug = getSiteSlug( state, get( props.site, [ 'ID' ] ) );
 
 		let customerType = chooseDefaultCustomerType( {
 			currentCustomerType: props.customerType,
@@ -707,6 +704,17 @@ export default connect(
 			customerType = 'business';
 		}
 		const is2023OnboardingPricingGrid = isEnabled( 'onboarding/2023-pricing-grid' );
+		const planTypeSelectorProps = {
+			basePlansPath: props.basePlansPath,
+			isInSignup: props.isInSignup,
+			eligibleForWpcomMonthlyPlans: eligibleForWpcomMonthlyPlans,
+			isPlansInsideStepper: props.isPlansInsideStepper,
+			intervalType: props.intervalType,
+			customerType: customerType,
+			hidePersonalPlan: props.hidePersonalPlan,
+			siteSlug,
+		};
+
 		return {
 			isCurrentPlanRetired: isProPlan( sitePlanSlug ) || isStarterPlan( sitePlanSlug ),
 			currentPurchaseIsInAppPurchase: currentPurchase?.isInAppPurchase,
@@ -717,12 +725,13 @@ export default connect(
 			isMultisite: isJetpackSiteMultiSite( state, siteId ),
 			previousRoute: getPreviousRoute( state ),
 			siteId,
-			siteSlug: getSiteSlug( state, get( props.site, [ 'ID' ] ) ),
+			siteSlug,
 			sitePlanSlug,
 			eligibleForWpcomMonthlyPlans,
 			titanMonthlyRenewalCost,
 			is2023OnboardingPricingGrid,
 			showFAQ: !! props.showFAQ && ! is2023OnboardingPricingGrid,
+			planTypeSelectorProps,
 		};
 	},
 	{


### PR DESCRIPTION
#### Proposed Changes

Addresses https://github.com/Automattic/martech/issues/1454

Fixes the interval switch in the plans grid by passing through missing props to the switch component.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Activate the onboarding/2023-pricing-grid feature flag
2. Navigate to `/plans` in Calypso [http://calypso.localhost:3000/plans/[foo.com]](http://calypso.localhost:3000/plans/%5Bfoo.com%5D)
3. Toggle between "Pay Monthly" and "Pay Yearly" from the two switches at the top and bottom. Confirm switching between terms works as expected.
4. Do the same in the Signup flow `/start/plans` and ensure nothing's broken.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes Automattic/martech#1454
