### PR TITLE
Stats: Better localized formatting in highlights

### DIFF
--- a/client/my-sites/stats/wordads/highlights-section.jsx
+++ b/client/my-sites/stats/wordads/highlights-section.jsx
@@ -11,14 +11,15 @@ import HighlightCardSimple from './highlight-card-simple';
 // Then refactor this Comp to use HighlightCard again.
 
 function getAmountAsFormattedString( amount ) {
+	if ( amount === 0 ) {
+		// Per design spec we don't want "$0.00" as a result.
+		// https://github.com/Automattic/wp-calypso/issues/72045
+		// We'll return "$0" in this scenario.
+		return '$0';
+	}
 	// Takes a Number, formats it to 2 decimal places, and prepends a "$".
-	// This mimics the existing behaviour. I'm assuming we only view/report
-	// on earnings in USD.
-	const formattedAmount = '$' + numberFormat( amount, 2 );
-	// Differs from previous behaviour in that we don't want "$0.00" as a result.
-	// Per design spec we'll return "$0" in this scenario.
-	// https://github.com/Automattic/wp-calypso/issues/72045
-	return formattedAmount === '$0.00' ? '$0' : formattedAmount;
+	// Amounts are in USD with localized formatting.
+	return '$' + numberFormat( amount, 2 );
 }
 
 function getHighlights( earnings ) {


### PR DESCRIPTION
Watch for and handle special case before formatting as a string.

#### Proposed Changes

Tweak to special casing how zero amounts are handled so it works as expected in languages that don't use a period as the decimal separator.

**Before:**

<img width="546" alt="SCR-20230201-phh" src="https://user-images.githubusercontent.com/40267301/216016448-5176dc56-5ae3-44c4-acb4-e8cc7cb7cf60.png">

**After:**

<img width="548" alt="SCR-20230201-pik" src="https://user-images.githubusercontent.com/40267301/216016763-ed5a3ab5-7658-420f-bd23-f6e23f312ba9.png">

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open Calypso Live link.
* Visit a site with Ads enabled.
* Visit Stats → Ads.
* Confirm highlight cards with zero amount show as "$0".
* Change language (try German) and reload the page.
* Confirm amounts are still shown as "$0".

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #72492.
