### PR TITLE
Pricing 2023: Fix failing prerelease e2e tests and enable feature flag on wpcalypso

### DIFF
--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -99,7 +99,7 @@
 		"onboarding/import-light": false,
 		"onboarding/import-light-url-screen": true,
 		"onboarding/import-redirect-to-themes": true,
-		"onboarding/2023-pricing-grid": false,
+		"onboarding/2023-pricing-grid": true,
 		"p2/p2-plus": true,
 		"pattern-assembler/client-side-render": true,
 		"pattern-assembler/logged-out-showcase": false,

--- a/packages/calypso-e2e/src/lib/pages/plans-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plans-page.ts
@@ -16,7 +16,7 @@ const selectors = {
 		if ( name === 'Free' ) {
 			// Free plan is a pseudo-button presented as a
 			// link.
-			return `button:text-matches("${ name }", "i")`;
+			return `button:text-matches("${ name }", "i"):visible`;
 		}
 		return `button.is-${ name.toLowerCase() }-plan:visible`;
 	},

--- a/packages/calypso-e2e/src/lib/pages/plans-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plans-page.ts
@@ -33,7 +33,7 @@ const selectors = {
 		const viewportSuffix = envVariables.VIEWPORT_NAME === 'mobile' ? 'mobile' : 'table';
 		return `.plan-features__${ viewportSuffix } >> .plan-features__actions-button.is-${ plan.toLowerCase() }-plan:has-text("${ buttonText }")`;
 	},
-	activePlan: ( plan: Plans ) => `th .is-${ plan.toLowerCase() }-plan:has(.plan-pill)`,
+	activePlan: ( plan: Plans ) => `a.is-${ plan.toLowerCase() }-plan.is-current-plan:visible`,
 
 	// My Plans tab
 	myPlanTitle: ( planName: Plans ) => `.my-plan-card__title:has-text("${ planName }")`,
@@ -104,7 +104,10 @@ export class PlansPage {
 	async validateActivePlan( expectedPlan: Plans ): Promise< void > {
 		await Promise.race( [
 			this.page.locator( selectors.myPlanTitle( expectedPlan ) ).waitFor(),
-			this.page.locator( selectors.activePlan( expectedPlan ) ).waitFor(),
+			// There can be lots of these link buttons for different viewports.
+			// We only need one to be there! We must use strict selection.
+			// Any of these link buttons means the right plan is selected.
+			this.page.locator( selectors.activePlan( expectedPlan ) ).first().waitFor(),
 		] );
 	}
 


### PR DESCRIPTION
#### Proposed Changes

This is a follow-up to https://github.com/Automattic/wp-calypso/pull/72765 to fix the failing e2e tests and restore the New Pricing Grid flag on wpcalypso.
The issue was caused by having multiple, hidden CTAs for the Plans page. This PR ensure the CTA element selector only captures visible targets.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure all e2e tests pass

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/martech/issues/1453
