### PR TITLE
Reading Settings: Update Reading settings fallback menu URL

### DIFF
--- a/client/my-sites/sidebar/static-data/fallback-menu.js
+++ b/client/my-sites/sidebar/static-data/fallback-menu.js
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { translate } from 'i18n-calypso';
 /* eslint-disable jsdoc/require-param */
 /**
@@ -530,7 +531,9 @@ export default function buildFallbackResponse( {
 					slug: 'options-reading-php',
 					title: translate( 'Reading' ),
 					type: 'submenu-item',
-					url: `https://${ siteDomain }/wp-admin/options-reading.php`,
+					url: config.isEnabled( 'settings/modernize-reading-settings' )
+						? `/settings/general/${ siteDomain }`
+						: `https://${ siteDomain }/wp-admin/options-reading.php`,
 				},
 				{
 					parent: 'options-general.php',

--- a/client/my-sites/sidebar/static-data/fallback-menu.js
+++ b/client/my-sites/sidebar/static-data/fallback-menu.js
@@ -532,7 +532,7 @@ export default function buildFallbackResponse( {
 					title: translate( 'Reading' ),
 					type: 'submenu-item',
 					url: config.isEnabled( 'settings/modernize-reading-settings' )
-						? `/settings/general/${ siteDomain }`
+						? `/settings/reading/${ siteDomain }`
 						: `https://${ siteDomain }/wp-admin/options-reading.php`,
 				},
 				{


### PR DESCRIPTION
#### Proposed Changes

* If the `settings/modernize-reading-settings` feature flag is enabled, use `/settings/general/${ siteDomain }` as the default fallback URL for the Reading settings page menu link. Otherwise use the old `https://${ siteDomain }/wp-admin/options-reading.php` link.

Closes https://github.com/Automattic/wp-calypso/issues/72719.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the PR.
2. Make sure the fallback menu items are returned by editing `client/my-sites/sidebar/use-site-menu-items.js`:
![Markup on 2023-02-01 at 12:20:19](https://user-images.githubusercontent.com/25105483/216041272-9e2f05a2-e34c-40d1-8b7a-a7f27ddb0266.png)
3. Build the PR.
4. Load Calypso with and without the `settings/modernize-reading-settings` feature flag enabled. If the feature flag is enabled, clicking the Reading link should get you to the Reading settings page in WP Admin. Otherwise it should lead to the new Reading settings page in Calypso.

Flag can be disabled via URL: `http://calypso.localhost:3000/[site-address]?flags=-settings/modernize-reading-settings`

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #72719
