### PR TITLE
Plan Grid 2023: Adds free plan by default and buttons for managing

### DIFF
--- a/client/my-sites/plan-features-2023-grid/actions.tsx
+++ b/client/my-sites/plan-features-2023-grid/actions.tsx
@@ -143,6 +143,12 @@ const LoggedInPlansFeatureActionButton = ( {
 				</Button>
 			);
 		}
+
+		return (
+			<Button className={ classes } disabled={ true }>
+				{ translate( 'Constact support', { context: 'verb' } ) }
+			</Button>
+		);
 	}
 
 	if ( current && planType !== PLAN_P2_FREE ) {
@@ -166,17 +172,7 @@ const LoggedInPlansFeatureActionButton = ( {
 		);
 	}
 
-	let buttonTextFallback = freePlan
-		? translate( 'Select Free', { context: 'button' } )
-		: translate( 'Upgrade', { context: 'verb' } );
-
-	if ( buttonText ) {
-		buttonTextFallback = buttonText;
-	} else {
-		buttonTextFallback = freePlan
-			? translate( 'Select Free', { context: 'button' } )
-			: translate( 'Upgrade', { context: 'verb' } );
-	}
+	const buttonTextFallback = buttonText ?? translate( 'Upgrade', { context: 'verb' } );
 
 	if ( availableForPurchase || isPlaceholder ) {
 		return (

--- a/client/my-sites/plan-features-2023-grid/actions.tsx
+++ b/client/my-sites/plan-features-2023-grid/actions.tsx
@@ -1,4 +1,4 @@
-import { getPlanClass, isMonthly, PLAN_P2_FREE } from '@automattic/calypso-products';
+import { getPlanClass, isMonthly, PLAN_P2_FREE, isFreePlan } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
 import classNames from 'classnames';
 import { localize, TranslateResult, useTranslate } from 'i18n-calypso';
@@ -24,6 +24,7 @@ type PlanFeaturesActionsButtonProps = {
 	flowName: string;
 	buttonText?: string;
 	isWpcomEnterpriseGridPlan: boolean;
+	selectedSiteSlug: string | null;
 };
 
 const SignupFlowPlanFeatureActionButton = ( {
@@ -112,6 +113,7 @@ const LoggedInPlansFeatureActionButton = ( {
 	currentSitePlanSlug,
 	buttonText,
 	forceDisplayButton,
+	selectedSiteSlug,
 }: {
 	freePlan: boolean;
 	isPlaceholder: boolean;
@@ -125,8 +127,24 @@ const LoggedInPlansFeatureActionButton = ( {
 	currentSitePlanSlug?: string;
 	buttonText?: string;
 	forceDisplayButton: boolean;
+	selectedSiteSlug: string | null;
 } ) => {
 	const translate = useTranslate();
+
+	if ( freePlan ) {
+		if ( currentSitePlanSlug && isFreePlan( currentSitePlanSlug ) ) {
+			return (
+				<Button
+					className={ classes }
+					href={ `/add-ons/${ selectedSiteSlug }` }
+					disabled={ ! manageHref }
+				>
+					{ translate( 'Manage add-ons', { context: 'verb' } ) }
+				</Button>
+			);
+		}
+	}
+
 	if ( current && planType !== PLAN_P2_FREE ) {
 		return (
 			<Button className={ classes } href={ manageHref } disabled={ ! manageHref }>
@@ -175,6 +193,7 @@ const LoggedInPlansFeatureActionButton = ( {
 			</Button>
 		);
 	}
+
 	return null;
 };
 
@@ -196,6 +215,7 @@ const PlanFeaturesActionsButton: React.FC< PlanFeaturesActionsButtonProps > = ( 
 	flowName,
 	buttonText,
 	isWpcomEnterpriseGridPlan = false,
+	selectedSiteSlug,
 } ) => {
 	const translate = useTranslate();
 
@@ -274,6 +294,7 @@ const PlanFeaturesActionsButton: React.FC< PlanFeaturesActionsButtonProps > = ( 
 			currentSitePlanSlug={ currentSitePlanSlug }
 			buttonText={ buttonText }
 			forceDisplayButton={ forceDisplayButton }
+			selectedSiteSlug={ selectedSiteSlug }
 		/>
 	);
 };

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -174,6 +174,7 @@ export class PlanFeatures2023Grid extends Component<
 			manageHref,
 			canUserPurchasePlan,
 			translate,
+			selectedSiteSlug,
 		} = this.props;
 		return (
 			<div className="plans-wrapper">
@@ -214,6 +215,7 @@ export class PlanFeatures2023Grid extends Component<
 							currentSitePlanSlug={ currentSitePlanSlug }
 							manageHref={ manageHref }
 							canUserPurchasePlan={ canUserPurchasePlan }
+							selectedSiteSlug={ selectedSiteSlug }
 						/>
 						<div className="plan-features-2023-grid__toggle-plan-comparison-button-container">
 							<Button onClick={ this.toggleShowPlansComparisonGrid }>
@@ -526,6 +528,7 @@ export class PlanFeatures2023Grid extends Component<
 			canUserPurchasePlan,
 			manageHref,
 			currentSitePlanSlug,
+			selectedSiteSlug,
 		} = this.props;
 
 		return planPropertiesObj.map( ( properties: PlanProperties ) => {
@@ -550,6 +553,7 @@ export class PlanFeatures2023Grid extends Component<
 						flowName={ flowName }
 						current={ current ?? false }
 						currentSitePlanSlug={ currentSitePlanSlug }
+						selectedSiteSlug={ selectedSiteSlug }
 					/>
 				</Container>
 			);
@@ -820,14 +824,16 @@ const ConnectedPlanFeatures2023Grid = connect(
 			);
 		}
 
+		const manageHref =
+			purchaseId && selectedSiteSlug
+				? getManagePurchaseUrlFor( selectedSiteSlug, purchaseId )
+				: `/plans/my-plan/${ siteId }`;
+
 		return {
 			currentSitePlanSlug: currentSitePlan?.productSlug,
 			planProperties,
 			canUserPurchasePlan,
-			manageHref:
-				purchaseId && selectedSiteSlug
-					? getManagePurchaseUrlFor( selectedSiteSlug, purchaseId )
-					: `/plans/my-plan/${ siteId }`,
+			manageHref,
 			selectedSiteSlug,
 		};
 	},

--- a/client/my-sites/plan-features-2023-grid/plan-comparison-grid.tsx
+++ b/client/my-sites/plan-features-2023-grid/plan-comparison-grid.tsx
@@ -216,6 +216,7 @@ type PlanComparisonGridProps = {
 	currentSitePlanSlug: string;
 	manageHref: string;
 	canUserPurchasePlan: boolean;
+	selectedSiteSlug: string | null;
 };
 type PlanComparisonGridHeaderProps = {
 	displayedPlansProperties: Array< PlanProperties >;
@@ -228,6 +229,7 @@ type PlanComparisonGridHeaderProps = {
 	currentSitePlanSlug: string;
 	manageHref: string;
 	canUserPurchasePlan: boolean;
+	selectedSiteSlug: string | null;
 };
 
 const PlanComparisonGridHeader: React.FC< PlanComparisonGridHeaderProps > = ( {
@@ -241,6 +243,7 @@ const PlanComparisonGridHeader: React.FC< PlanComparisonGridHeaderProps > = ( {
 	currentSitePlanSlug,
 	manageHref,
 	canUserPurchasePlan,
+	selectedSiteSlug,
 } ) => {
 	const translate = useTranslate();
 	const currencyCode = useSelector( getCurrentUserCurrencyCode );
@@ -339,6 +342,7 @@ const PlanComparisonGridHeader: React.FC< PlanComparisonGridHeaderProps > = ( {
 								planName={ planConstantObj.getTitle() }
 								planType={ planName }
 								flowName={ flowName }
+								selectedSiteSlug={ selectedSiteSlug }
 							/>
 						</Cell>
 					);
@@ -358,6 +362,7 @@ export const PlanComparisonGrid: React.FC< PlanComparisonGridProps > = ( {
 	currentSitePlanSlug,
 	manageHref,
 	canUserPurchasePlan,
+	selectedSiteSlug,
 } ) => {
 	const translate = useTranslate();
 	const featureGroupMap = getPlanFeaturesGrouped();
@@ -517,6 +522,7 @@ export const PlanComparisonGrid: React.FC< PlanComparisonGridProps > = ( {
 					currentSitePlanSlug={ currentSitePlanSlug }
 					manageHref={ manageHref }
 					canUserPurchasePlan={ canUserPurchasePlan }
+					selectedSiteSlug={ selectedSiteSlug }
 				/>
 				{ Object.values( featureGroupMap ).map( ( featureGroup: FeatureGroup ) => {
 					const features = featureGroup.get2023PricingGridSignupWpcomFeatures();
@@ -656,6 +662,7 @@ export const PlanComparisonGrid: React.FC< PlanComparisonGridProps > = ( {
 					currentSitePlanSlug={ currentSitePlanSlug }
 					manageHref={ manageHref }
 					canUserPurchasePlan={ canUserPurchasePlan }
+					selectedSiteSlug={ selectedSiteSlug }
 				/>
 			</Grid>
 		</div>

--- a/client/my-sites/plan-features-2023-grid/style.scss
+++ b/client/my-sites/plan-features-2023-grid/style.scss
@@ -63,6 +63,13 @@ $plan-features-sidebar-width: 272px;
 					box-shadow: inset 0 0 0 1px var(--studio-gray-80);
 				}
 			}
+
+			&.disabled,
+			&[disabled] {
+				background-color: var(--studio-white);
+				color: var(--color-neutral-light);
+				box-shadow: inset 0 0 0 1px #e0e0e0;
+			}
 		}
 	}
 }

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -2,7 +2,6 @@ import { isEnabled } from '@automattic/calypso-config';
 import {
 	getPlan,
 	getIntervalTypeForTerm,
-	isFreePlan,
 	PLAN_FREE,
 	PLAN_ECOMMERCE_TRIAL_MONTHLY,
 } from '@automattic/calypso-products';
@@ -144,9 +143,7 @@ class Plans extends Component {
 			);
 		}
 
-		const hideFreePlan = isEnabled( 'onboarding/2023-pricing-grid' )
-			? ! isFreePlan( currentPlan.productSlug )
-			: true;
+		const hideFreePlan = ! isEnabled( 'onboarding/2023-pricing-grid' );
 
 		return (
 			<PlansFeaturesMain


### PR DESCRIPTION
#### Proposed Changes

Partially addresses Automattic/martech#1450 (no background color changes)

- Adds the free plan to the grid for all cases
- A button to redirect to `/add-ons` when plan is current
- Disabled button to "contact support" otherwise

#### Media

_Current free plan_

<img width="500" alt="Screenshot 2023-02-01 at 3 09 26 PM" src="https://user-images.githubusercontent.com/1705499/216052127-ab4c911b-8e4a-44c4-9aff-556d47d2b93f.png">

_Current not free_

<img width="500" alt="Screenshot 2023-02-01 at 3 09 07 PM" src="https://user-images.githubusercontent.com/1705499/216052168-dcd96667-f408-4dbf-a9da-d9f0bbc0e0a9.png">

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Activate the `onboarding/2023-pricing-grid` feature flag
2. Navigate to `/plans` in Calypso [http://calypso.localhost:3000/plans/[foo.com]](http://calypso.localhost:3000/plans/%5Bfoo.com%5D)
3. Confirm the changes outlined above.
4. Do the same in the Signup flow `/start/plans` and ensure nothing's changed/broken.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Automattic/martech#1450
