### PR TITLE
Fix premium domain not rendering the correct price when not returned from the suggestion endpoint

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -921,6 +921,14 @@ class RegisterDomainStep extends Component {
 						AVAILABLE_PREMIUM === status &&
 						result?.is_supported_premium_domain;
 
+					/**
+					 * In rare cases we don't get the FQDN as suggestion from the suggestion engine but only
+					 * from the availability endpoint. Let's make sure the `is_premium` flag is set.
+					 */
+					if ( result?.is_supported_premium_domain ) {
+						result.is_premium = true;
+					}
+
 					// Mapped status always overrides other statuses.
 					const availabilityStatus = isDomainMapped ? mappable : status;
 


### PR DESCRIPTION
When we show domain suggestions for FQDNs we actually merge and render the result of two separate API calls - the FQDN availability check and the suggestion results. In some cases we might not get the FQDN in the suggestion results even though it is available domain. When this domain is premium domain we're in trouble because the availability properties are different than the suggestion properties. This is a quick fix for that - let's just set `is_premium` to true if there is `is_supported_premium_domain` property in the results. I'll also check why we don't get the domain entered from the suggestion endpoint.

#### Proposed Changes

* Set `is_premium` to true in the suggestion results if the `is_supported_premium_domain` is true

#### Testing Instructions

* I've noticed this in sandboxed mode where searching for a premium .link domain doesn't return the domain from the suggestion endpoint.

#### Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?

