### PR TITLE
Plans 2023: Fix breakpoints on logged in plans page

### DIFF
--- a/client/my-sites/plan-features-2023-grid/_media-queries.scss
+++ b/client/my-sites/plan-features-2023-grid/_media-queries.scss
@@ -1,0 +1,109 @@
+// Variables
+$plan-features-sidebar-width: 272px;
+$plan-features-header-banner-height: 20px;
+
+// Breakpoints
+$plans-2023-small-breakpoint: 880px;
+$plans-2023-medium-breakpoint: 1340px;
+$plans-2023-large-breakpoint: 1500px;
+
+/**
+ * Media queries for the plans grid in onboarding/signup
+ */
+@mixin onboarding-2023-pricing-grid-plans-breakpoints {
+	max-width: 414px;
+
+	@media ( min-width: $plans-2023-small-breakpoint ) {
+		max-width: 860px;
+	}
+
+	@media ( min-width: $plans-2023-medium-breakpoint ) {
+		max-width: 1320px;
+	}
+
+	@media ( min-width: $plans-2023-large-breakpoint ) {
+		max-width: 1480px;
+	}
+}
+
+/**
+ * Media queries for the plans grid on the /plans page.
+ * Since there is a sidebar on internal pages,
+ * this should stretch to fill it's container on non-mobile resolutions.
+ */
+@mixin pricing-grid-2023-plans-section-breakpoints {
+	max-width: 414px;
+
+	@media ( min-width: ( $plans-2023-small-breakpoint ) ) {
+		max-width: 100%;
+	}
+}
+
+/**
+ * Show/hide desktop/tablet/mobile layouts based on the screen width.
+ * Desktop layout: width > $plans-2023-medium-breakpoint
+ * Tablet layout:  $plans-2023-small-breakpoint < width < $plans-2023-medium-breakpoint
+ * Mobile layout:  width < $plans-2023-small-breakpoint
+ */
+@mixin plan-features-layout-switcher-onboarding {
+	.plan-features-2023-grid__desktop-view {
+		display: none;
+
+		@media ( min-width: $plans-2023-medium-breakpoint ) {
+			display: block;
+		}
+	}
+
+	.plan-features-2023-grid__tablet-view {
+		display: none;
+
+		@media ( min-width: $plans-2023-small-breakpoint ) {
+			display: block;
+		}
+
+		@media ( min-width: $plans-2023-medium-breakpoint ) {
+			display: none;
+		}
+	}
+
+	.plan-features-2023-grid__mobile-view {
+		display: block;
+
+		@media ( min-width: $plans-2023-small-breakpoint ) {
+			display: none;
+		}
+	}
+}
+
+/**
+ * Same as `plan-features-layout-switcher-onboarding`, except that we add the sidebar width to the breakpoints.
+ */
+@mixin plan-features-layout-switcher-onboarding-plans-section {
+	.plan-features-2023-grid__desktop-view {
+		display: none;
+
+		@media ( min-width: ( $plans-2023-medium-breakpoint + $plan-features-sidebar-width ) ) {
+			display: block;
+		}
+	}
+
+	.plan-features-2023-grid__tablet-view {
+		display: none;
+
+		@media ( min-width: ( $plans-2023-small-breakpoint + $plan-features-sidebar-width ) ) {
+			display: block;
+		}
+
+		@media ( min-width: ( $plans-2023-medium-breakpoint + $plan-features-sidebar-width ) ) {
+			display: none;
+		}
+	}
+
+	.plan-features-2023-grid__mobile-view {
+		display: block;
+
+		@media ( min-width: ( $plans-2023-small-breakpoint + $plan-features-sidebar-width ) ) {
+			display: none;
+		}
+	}
+}

--- a/client/my-sites/plan-features-2023-grid/_media-queries.scss
+++ b/client/my-sites/plan-features-2023-grid/_media-queries.scss
@@ -32,11 +32,7 @@ $plans-2023-large-breakpoint: 1500px;
  * this should stretch to fill it's container on non-mobile resolutions.
  */
 @mixin pricing-grid-2023-plans-section-breakpoints {
-	max-width: 414px;
-
-	@media ( min-width: ( $plans-2023-small-breakpoint ) ) {
-		max-width: 100%;
-	}
+	max-width: 100%;
 }
 
 /**

--- a/client/my-sites/plan-features-2023-grid/_media-queries.scss
+++ b/client/my-sites/plan-features-2023-grid/_media-queries.scss
@@ -109,7 +109,7 @@ $plans-2023-large-breakpoint: 1500px;
 }
 
 @mixin plans-2023-break-small() {
-	.is-section-signup & {
+	body.is-section-signup.is-white-signup & {
 		@media ( min-width: $plans-2023-small-breakpoint ) {
 			@content;
 		}
@@ -123,7 +123,7 @@ $plans-2023-large-breakpoint: 1500px;
 }
 
 @mixin plans-2023-break-medium() {
-	.is-section-signup & {
+	body.is-section-signup.is-white-signup & {
 		@media ( min-width: $plans-2023-medium-breakpoint ) {
 			@content;
 		}

--- a/client/my-sites/plan-features-2023-grid/_media-queries.scss
+++ b/client/my-sites/plan-features-2023-grid/_media-queries.scss
@@ -107,3 +107,31 @@ $plans-2023-large-breakpoint: 1500px;
 		}
 	}
 }
+
+@mixin plans-2023-break-small() {
+	.is-section-signup & {
+		@media ( min-width: $plans-2023-small-breakpoint ) {
+			@content;
+		}
+	}
+
+	.is-section-plans & {
+		@media ( min-width: $plans-2023-small-breakpoint + $plan-features-sidebar-width ) {
+			@content;
+		}
+	}
+}
+
+@mixin plans-2023-break-medium() {
+	.is-section-signup & {
+		@media ( min-width: $plans-2023-medium-breakpoint ) {
+			@content;
+		}
+	}
+
+	.is-section-plans & {
+		@media ( min-width: $plans-2023-medium-breakpoint + $plan-features-sidebar-width ) {
+			@content;
+		}
+	}
+}

--- a/client/my-sites/plan-features-2023-grid/plan-comparison-grid.tsx
+++ b/client/my-sites/plan-features-2023-grid/plan-comparison-grid.tsx
@@ -29,6 +29,13 @@ import { Plans2023Tooltip } from './plans-2023-tooltip';
 import { PlanProperties } from './types';
 import { usePricingBreakpoint } from './util';
 
+function getMobileBreakpoint( { isInSignup }: { isInSignup: boolean } ) {
+	if ( isInSignup ) {
+		return '880px';
+	}
+	return '1152px'; // 880px + 272px (sidebar)
+}
+
 const JetpackIconContainer = styled.div`
 	padding-left: 6px;
 	display: inline-block;
@@ -42,7 +49,7 @@ const PlanComparisonHeader = styled.h1`
 	margin: 48px 0;
 `;
 
-const Title = styled.div< { isHiddenInMobile?: boolean } >`
+const Title = styled.div< { isHiddenInMobile?: boolean; isInSignup: boolean } >`
 	font-weight: 500;
 	font-size: 20px;
 	padding: 14px;
@@ -59,7 +66,7 @@ const Title = styled.div< { isHiddenInMobile?: boolean } >`
 			props.isHiddenInMobile ? 'rotateZ( 180deg )' : 'rotateZ( 0deg )' };
 	}
 
-	@media ( min-width: 880px ) {
+	@media ( min-width: ${ getMobileBreakpoint } ) {
 		padding-left: 0;
 		border: none;
 		padding: 0;
@@ -80,13 +87,13 @@ const Grid = styled.div`
 		border-radius: 5px;
 	}
 `;
-const Row = styled.div< { isHiddenInMobile?: boolean } >`
+const Row = styled.div< { isHiddenInMobile?: boolean; isInSignup: boolean } >`
 	justify-content: space-between;
 	margin-bottom: -1px;
 	align-items: center;
 	display: ${ ( props ) => ( props.isHiddenInMobile ? 'none' : 'flex' ) };
 
-	@media ( min-width: 880px ) {
+	@media ( min-width: ${ getMobileBreakpoint } ) {
 		display: flex;
 		margin: 0 20px;
 		padding: 12px 0;
@@ -94,11 +101,11 @@ const Row = styled.div< { isHiddenInMobile?: boolean } >`
 	}
 `;
 
-const TitleRow = styled( Row )`
+const TitleRow = styled( Row )< { isInSignup: boolean } >`
 	cursor: pointer;
 	display: flex;
 
-	@media ( min-width: 880px ) {
+	@media ( min-width: ${ getMobileBreakpoint } ) {
 		cursor: default;
 		border-bottom: none;
 		padding: 20px 0 10px;
@@ -106,7 +113,7 @@ const TitleRow = styled( Row )`
 	}
 `;
 
-const Cell = styled.div< { textAlign?: string; isInSignup?: boolean } >`
+const Cell = styled.div< { textAlign?: string; isInSignup: boolean } >`
 	text-align: ${ ( props ) => props.textAlign ?? 'left' };
 	display: flex;
 	flex: 1;
@@ -131,7 +138,7 @@ const Cell = styled.div< { textAlign?: string; isInSignup?: boolean } >`
 		}
 	}
 
-	@media ( min-width: 880px ) {
+	@media ( min-width: ${ getMobileBreakpoint } ) {
 		padding: 0 14px;
 		max-width: ${ ( { isInSignup } ) => ( isInSignup ? '180px' : '160px' ) };
 
@@ -142,7 +149,7 @@ const Cell = styled.div< { textAlign?: string; isInSignup?: boolean } >`
 			padding-right: 0;
 		}
 	}
-	@media ( min-width: 880px ) {
+	@media ( min-width: ${ getMobileBreakpoint } ) {
 		min-width: 180px;
 	}
 
@@ -151,10 +158,10 @@ const Cell = styled.div< { textAlign?: string; isInSignup?: boolean } >`
 	}
 `;
 
-const RowHead = styled.div`
+const RowHead = styled.div< { isInSignup: boolean } >`
 	display: none;
 	font-size: 14px;
-	@media ( min-width: 880px ) {
+	@media ( min-width: ${ getMobileBreakpoint } ) {
 		display: block;
 		flex: 1;
 	}
@@ -188,7 +195,7 @@ const PlanSelector = styled.header`
 	}
 `;
 
-const StorageButton = styled.div`
+const StorageButton = styled.div< { isInSignup: boolean } >`
 	background: #f2f2f2;
 	border-radius: 5px;
 	padding: 4px 0;
@@ -202,7 +209,7 @@ const StorageButton = styled.div`
 	min-width: 64px;
 	margin-top: 10px;
 
-	@media ( min-width: 880px ) {
+	@media ( min-width: ${ getMobileBreakpoint } ) {
 		margin-top: 0;
 	}
 `;
@@ -249,10 +256,11 @@ const PlanComparisonGridHeader: React.FC< PlanComparisonGridHeaderProps > = ( {
 	const currencyCode = useSelector( getCurrentUserCurrencyCode );
 	const allVisible = visiblePlansProperties.length === displayedPlansProperties.length;
 	return (
-		<Row className="plan-comparison-grid__plan-row">
+		<Row className="plan-comparison-grid__plan-row" isInSignup={ isInSignup }>
 			<RowHead
 				key="feature-name"
 				className="plan-comparison-grid__header plan-comparison-grid__interval-toggle"
+				isInSignup={ isInSignup }
 			/>
 			{ visiblePlansProperties.map(
 				( { planName, planConstantObj, availableForPurchase, current, ...planPropertiesObj } ) => {
@@ -271,7 +279,12 @@ const PlanComparisonGridHeader: React.FC< PlanComparisonGridHeaderProps > = ( {
 					const showPlanSelect = ! allVisible && ! current;
 
 					return (
-						<Cell key={ planName } className={ headerClasses } textAlign="left">
+						<Cell
+							key={ planName }
+							isInSignup={ isInSignup }
+							className={ headerClasses }
+							textAlign="left"
+						>
 							{ isBusinessPlan( planName ) && (
 								<div className="plan-features-2023-grid__popular-badge">
 									<PlanPill isInSignup={ isInSignup }>{ translate( 'Popular' ) }</PlanPill>
@@ -535,10 +548,12 @@ export const PlanComparisonGrid: React.FC< PlanComparisonGridProps > = ( {
 						<div key={ featureGroupClass } className={ featureGroup.slug }>
 							<TitleRow
 								className="plan-comparison-grid__group-title-row"
+								isInSignup={ isInSignup }
 								onClick={ () => toggleFeatureGroup( featureGroup.slug ) }
 							>
 								<Title
 									isHiddenInMobile={ isHiddenInMobile }
+									isInSignup={ isInSignup }
 									className={ `plan-comparison-grid__group-${ featureGroup.slug }` }
 								>
 									<Gridicon icon="chevron-up" size={ 12 } color="#1E1E1E" />
@@ -551,11 +566,13 @@ export const PlanComparisonGrid: React.FC< PlanComparisonGridProps > = ( {
 									<Row
 										key={ featureSlug }
 										isHiddenInMobile={ isHiddenInMobile }
+										isInSignup={ isInSignup }
 										className="plan-comparison-grid__feature-row"
 									>
 										<RowHead
 											key="feature-name"
 											className={ `plan-comparison-grid__feature-feature-name ${ feature.getTitle() }` }
+											isInSignup={ isInSignup }
 										>
 											<Plans2023Tooltip text={ feature.getDescription?.() }>
 												{ feature.getTitle() }
@@ -580,7 +597,12 @@ export const PlanComparisonGrid: React.FC< PlanComparisonGridProps > = ( {
 											);
 
 											return (
-												<Cell key={ planName } className={ cellClasses } textAlign="center">
+												<Cell
+													key={ planName }
+													isInSignup={ isInSignup }
+													className={ cellClasses }
+													textAlign="center"
+												>
 													{ feature.getIcon && (
 														<span className="plan-comparison-grid__plan-image">
 															{ feature.getIcon() }
@@ -609,11 +631,13 @@ export const PlanComparisonGrid: React.FC< PlanComparisonGridProps > = ( {
 								<Row
 									key="feature-storage"
 									isHiddenInMobile={ isHiddenInMobile }
+									isInSignup={ isInSignup }
 									className="plan-comparison-grid__feature-storage"
 								>
 									<RowHead
 										key="feature-name"
 										className="plan-comparison-grid__feature-feature-name storage"
+										isInSignup={ isInSignup }
 									>
 										<Plans2023Tooltip
 											text={ translate( 'Space to store your photos, media, and more.' ) }
@@ -634,12 +658,18 @@ export const PlanComparisonGrid: React.FC< PlanComparisonGridProps > = ( {
 										);
 
 										return (
-											<Cell key={ planName } className={ cellClasses } textAlign="center">
+											<Cell
+												key={ planName }
+												isInSignup={ isInSignup }
+												className={ cellClasses }
+												textAlign="center"
+											>
 												<span className="plan-comparison-grid__plan-title">
 													{ translate( 'Storage' ) }
 												</span>
 												<StorageButton
 													className="plan-features-2023-grid__storage-button"
+													isInSignup={ isInSignup }
 													key={ planName }
 												>
 													{ featureObject.getCompareTitle?.() }

--- a/client/my-sites/plan-features-2023-grid/plan-comparison-grid.tsx
+++ b/client/my-sites/plan-features-2023-grid/plan-comparison-grid.tsx
@@ -122,7 +122,7 @@ const Cell = styled.div< { textAlign?: string; isInSignup: boolean } >`
 	align-items: center;
 	padding: 33px 20px 0;
 
-	@media ( max-width: 879px ) {
+	@media ( max-width: ${ getMobileBreakpoint } ) {
 		&.title-is-subtitle {
 			padding-top: 0;
 		}

--- a/client/my-sites/plan-features-2023-grid/style.scss
+++ b/client/my-sites/plan-features-2023-grid/style.scss
@@ -1096,7 +1096,7 @@ body.is-section-signup.is-white-signup .is-onboarding-2023-pricing-grid .signup_
 .plan-features-2023-grid__toggle-plan-comparison-button-container {
 	display: flex;
 	justify-content: center;
-	margin: 32px 20px 0 20px;
+	margin-top: 32px;
 
 	button {
 		background: var(--studio-white);
@@ -1112,7 +1112,7 @@ body.is-section-signup.is-white-signup .is-onboarding-2023-pricing-grid .signup_
 		padding: 0 24px;
 		width: 100%;
 
-		@media ( min-width: $plans-2023-small-breakpoint ) {
+		@include plans-2023-break-small {
 			width: initial;
 			height: 40px;
 		}

--- a/client/my-sites/plan-features-2023-grid/style.scss
+++ b/client/my-sites/plan-features-2023-grid/style.scss
@@ -692,9 +692,9 @@ body.is-section-signup.is-white-signup,
 			bottom: 0;
 			border-radius: 4px;
 			background-color: var(--studio-gray-80);
-			transform: translate(20px, 0);
-			@media ( max-width: 880px ) {
-				transform: translate(20px, -50px);
+			transform: translate(20px, -50px);
+			@include plans-2023-break-small {
+				transform: translate(20px, 0);
 			}
 		}
 

--- a/client/my-sites/plan-features-2023-grid/style.scss
+++ b/client/my-sites/plan-features-2023-grid/style.scss
@@ -1,7 +1,5 @@
 @import "@automattic/onboarding/styles/mixins";
-@import "calypso/signup/steps/plans/style.scss";
-$plan-features-header-banner-height: 20px;
-$plan-features-sidebar-width: 272px;
+@import "calypso/my-sites/plan-features-2023-grid/media-queries";
 
 .plan-features--loading-container {
 	margin-top: 300px;
@@ -91,7 +89,7 @@ $plan-features-sidebar-width: 272px;
 .plan-features-2023-grid__header-logo {
 	padding-left: 20px;
 
-	@media ( min-width: 880px ) {
+	@media ( min-width: $plans-2023-small-breakpoint ) {
 		margin-top: 36px;
 
 		.plan-features-2023-grid__table-top & {
@@ -99,7 +97,7 @@ $plan-features-sidebar-width: 272px;
 		}
 	}
 
-	@media ( min-width: 1340px ) {
+	@media ( min-width: $plans-2023-medium-breakpoint ) {
 		margin-top: 36px;
 	}
 }
@@ -123,12 +121,12 @@ $plan-features-sidebar-width: 272px;
 	transform: translateY(-20px);
 	overflow-x: hidden;
 
-	@media ( min-width: 880px ) {
+	@media ( min-width: $plans-2023-small-breakpoint ) {
 		padding-top: 64px;
 		overflow-x: auto;
 	}
 
-	@media ( min-width: 1340px ) {
+	@media ( min-width: $plans-2023-medium-breakpoint ) {
 		padding-top: 103px;
 		overflow-x: auto;
 	}
@@ -141,32 +139,13 @@ $plan-features-sidebar-width: 272px;
 		width: auto;
 	}
 
-	.plan-features-2023-grid__desktop-view {
-		display: none;
+	@include plan-features-layout-switcher-onboarding;
 
-		@media ( min-width: 1340px ) {
-			display: block;
-		}
-	}
-
-	.plan-features-2023-grid__tablet-view {
-		display: none;
-
-		@media ( min-width: 880px ) {
-			display: block;
-		}
-
-		@media ( min-width: 1340px ) {
-			display: none;
-		}
+	.is-section-plans & {
+		@include plan-features-layout-switcher-onboarding-plans-section;
 	}
 
 	.plan-features-2023-grid__mobile-view {
-		display: block;
-
-		@media ( min-width: 880px ) {
-			display: none;
-		}
 
 		.plan-features-2023-grid__mobile-plan-card {
 			background-color: var(--studio-white);
@@ -285,12 +264,12 @@ $plan-features-sidebar-width: 272px;
 		font-weight: 400;
 		padding: 0 20px 24px 20px;
 
-		@media ( min-width: 880px ) {
+		@media ( min-width: $plans-2023-small-breakpoint ) {
 			font-size: $font-body-small;
 			line-height: 20px;
 		}
 
-		@media ( min-width: 1340px ) {
+		@media ( min-width: $plans-2023-medium-breakpoint ) {
 			font-size: 0.813rem; /* stylelint-disable-line */
 			line-height: 16px;
 			padding-bottom: 8px;
@@ -308,7 +287,7 @@ $plan-features-sidebar-width: 272px;
 			font-weight: 600;
 		}
 
-		@media ( min-width: 880px ) {
+		@media ( min-width: $plans-2023-small-breakpoint ) {
 			border-right: solid 1px #e0e0e0;
 			border-left: solid 1px #e0e0e0;
 
@@ -358,7 +337,7 @@ $plan-features-sidebar-width: 272px;
 				transform: rotate(16deg);
 				border-color: #000;
 
-				@media ( min-width: 880px ) {
+				@media ( min-width: $plans-2023-small-breakpoint ) {
 					right: 68%;
 				}
 			}
@@ -429,7 +408,7 @@ $plan-features-sidebar-width: 272px;
 				font-weight: 600;
 			}
 
-			@media ( min-width: 880px ) {
+			@media ( min-width: $plans-2023-small-breakpoint ) {
 				font-size: $font-body-extra-small;
 				line-height: 16px;
 			}
@@ -674,7 +653,7 @@ body.is-section-signup.is-white-signup,
 			font-size: $font-body-extra-small;
 			padding: 0 19px 24px 20px;
 
-			@media ( min-width: 880px ) {
+			@media ( min-width: $plans-2023-small-breakpoint ) {
 				padding-bottom: 16px;
 			}
 
@@ -684,12 +663,12 @@ body.is-section-signup.is-white-signup,
 				font-weight: 400;
 				color: var(--studio-gray-80);
 
-				@media ( min-width: 880px ) {
+				@media ( min-width: $plans-2023-small-breakpoint ) {
 					font-size: $font-body-small;
 					line-height: 20px;
 				}
 
-				@media ( min-width: 1340px ) {
+				@media ( min-width: $plans-2023-medium-breakpoint ) {
 					font-size: $font-body-extra-small;
 					line-height: 16px;
 				}
@@ -728,7 +707,7 @@ body.is-section-signup.is-white-signup,
 				color: #fff;
 				padding: 0 0 17px;
 
-				@media ( min-width: 880px ) {
+				@media ( min-width: $plans-2023-small-breakpoint ) {
 					position: absolute;
 					top: -38px;
 					right: -1px;
@@ -781,7 +760,7 @@ body.is-section-signup.is-white-signup,
 			padding: 0 20px;
 			margin-bottom: 12px;
 
-			@media ( min-width: 880px ) {
+			@media ( min-width: $plans-2023-small-breakpoint ) {
 				margin-top: 36px;
 				font-size: $font-body-extra-small;
 			}
@@ -822,7 +801,7 @@ body.is-section-signup.is-white-signup,
 	.step-wrapper__header {
 		margin: 24px 20px 38px;
 
-		@media ( min-width: 880px ) {
+		@media ( min-width: $plans-2023-small-breakpoint ) {
 			margin: 24px 20px;
 		}
 	}
@@ -835,7 +814,7 @@ body.is-section-signup.is-white-signup .is-onboarding-2023-pricing-grid .signup_
 	width: 100%;
 	margin: 0 22px;
 
-	@media ( min-width: 880px ) {
+	@media ( min-width: $plans-2023-small-breakpoint ) {
 		max-width: unset;
 		width: auto;
 		margin: 0 auto;

--- a/client/my-sites/plan-features-2023-grid/style.scss
+++ b/client/my-sites/plan-features-2023-grid/style.scss
@@ -89,7 +89,7 @@
 .plan-features-2023-grid__header-logo {
 	padding-left: 20px;
 
-	@media ( min-width: $plans-2023-small-breakpoint ) {
+	@include plans-2023-break-small {
 		margin-top: 36px;
 
 		.plan-features-2023-grid__table-top & {
@@ -97,7 +97,7 @@
 		}
 	}
 
-	@media ( min-width: $plans-2023-medium-breakpoint ) {
+	@include plans-2023-break-medium {
 		margin-top: 36px;
 	}
 }
@@ -121,12 +121,12 @@
 	transform: translateY(-20px);
 	overflow-x: hidden;
 
-	@media ( min-width: $plans-2023-small-breakpoint ) {
+	@include plans-2023-break-small {
 		padding-top: 64px;
 		overflow-x: auto;
 	}
 
-	@media ( min-width: $plans-2023-medium-breakpoint ) {
+	@include plans-2023-break-medium {
 		padding-top: 103px;
 		overflow-x: auto;
 	}
@@ -139,7 +139,9 @@
 		width: auto;
 	}
 
-	@include plan-features-layout-switcher-onboarding;
+	.is-section-signup & {
+		@include plan-features-layout-switcher-onboarding;
+	}
 
 	.is-section-plans & {
 		@include plan-features-layout-switcher-onboarding-plans-section;
@@ -264,12 +266,12 @@
 		font-weight: 400;
 		padding: 0 20px 24px 20px;
 
-		@media ( min-width: $plans-2023-small-breakpoint ) {
+		@include plans-2023-break-small {
 			font-size: $font-body-small;
 			line-height: 20px;
 		}
 
-		@media ( min-width: $plans-2023-medium-breakpoint ) {
+		@include plans-2023-break-medium {
 			font-size: 0.813rem; /* stylelint-disable-line */
 			line-height: 16px;
 			padding-bottom: 8px;
@@ -287,7 +289,7 @@
 			font-weight: 600;
 		}
 
-		@media ( min-width: $plans-2023-small-breakpoint ) {
+		@include plans-2023-break-small {
 			border-right: solid 1px #e0e0e0;
 			border-left: solid 1px #e0e0e0;
 
@@ -337,7 +339,7 @@
 				transform: rotate(16deg);
 				border-color: #000;
 
-				@media ( min-width: $plans-2023-small-breakpoint ) {
+				@include plans-2023-break-small {
 					right: 68%;
 				}
 			}
@@ -408,7 +410,7 @@
 				font-weight: 600;
 			}
 
-			@media ( min-width: $plans-2023-small-breakpoint ) {
+			@include plans-2023-break-small {
 				font-size: $font-body-extra-small;
 				line-height: 16px;
 			}
@@ -495,7 +497,7 @@
 				padding-top: 12px;
 			}
 
-			@media ( min-width: $plans-2023-small-breakpoint ) {
+			@include plans-2023-break-small {
 				position: relative;
 				top: 10px;
 				padding-top: 0;
@@ -538,7 +540,7 @@
 				}
 			}
 
-			@media ( min-width: $plans-2023-medium-breakpoint ) {
+			@include plans-2023-break-medium {
 				img:nth-child(1) {
 					padding-right: 24px;
 				}
@@ -653,7 +655,7 @@ body.is-section-signup.is-white-signup,
 			font-size: $font-body-extra-small;
 			padding: 0 19px 24px 20px;
 
-			@media ( min-width: $plans-2023-small-breakpoint ) {
+			@include plans-2023-break-small {
 				padding-bottom: 16px;
 			}
 
@@ -663,12 +665,12 @@ body.is-section-signup.is-white-signup,
 				font-weight: 400;
 				color: var(--studio-gray-80);
 
-				@media ( min-width: $plans-2023-small-breakpoint ) {
+				@include plans-2023-break-small {
 					font-size: $font-body-small;
 					line-height: 20px;
 				}
 
-				@media ( min-width: $plans-2023-medium-breakpoint ) {
+				@include plans-2023-break-medium {
 					font-size: $font-body-extra-small;
 					line-height: 16px;
 				}
@@ -707,7 +709,7 @@ body.is-section-signup.is-white-signup,
 				color: #fff;
 				padding: 0 0 17px;
 
-				@media ( min-width: $plans-2023-small-breakpoint ) {
+				@include plans-2023-break-small {
 					position: absolute;
 					top: -38px;
 					right: -1px;
@@ -760,7 +762,7 @@ body.is-section-signup.is-white-signup,
 			padding: 0 20px;
 			margin-bottom: 12px;
 
-			@media ( min-width: $plans-2023-small-breakpoint ) {
+			@include plans-2023-break-small {
 				margin-top: 36px;
 				font-size: $font-body-extra-small;
 			}
@@ -801,7 +803,7 @@ body.is-section-signup.is-white-signup,
 	.step-wrapper__header {
 		margin: 24px 20px 38px;
 
-		@media ( min-width: $plans-2023-small-breakpoint ) {
+		@include plans-2023-break-small {
 			margin: 24px 20px;
 		}
 	}
@@ -814,7 +816,7 @@ body.is-section-signup.is-white-signup .is-onboarding-2023-pricing-grid .signup_
 	width: 100%;
 	margin: 0 22px;
 
-	@media ( min-width: $plans-2023-small-breakpoint ) {
+	@include plans-2023-break-small {
 		max-width: unset;
 		width: auto;
 		margin: 0 auto;
@@ -869,7 +871,7 @@ body.is-section-signup.is-white-signup .is-onboarding-2023-pricing-grid .signup_
 			display: none;
 		}
 
-		@media ( min-width: $plans-2023-small-breakpoint ) {
+		@include plans-2023-break-small {
 			&:last-of-type {
 				display: flex;
 			}
@@ -883,7 +885,7 @@ body.is-section-signup.is-white-signup .is-onboarding-2023-pricing-grid .signup_
 		padding-top: 46px;
 		padding-bottom: 20px;
 
-		@media ( min-width: $plans-2023-small-breakpoint ) {
+		@include plans-2023-break-small {
 			padding-top: 34px;
 
 			&.popular-plan-parent-class {
@@ -899,7 +901,7 @@ body.is-section-signup.is-white-signup .is-onboarding-2023-pricing-grid .signup_
 			}
 		}
 
-		@media ( min-width: $plans-2023-medium-breakpoint ) {
+		@include plans-2023-break-medium {
 			&.plan-is-footer {
 				padding-top: 110px;
 			}
@@ -916,7 +918,7 @@ body.is-section-signup.is-white-signup .is-onboarding-2023-pricing-grid .signup_
 				}
 			}
 
-			@media ( min-width: $plans-2023-small-breakpoint ) {
+			@include plans-2023-break-small {
 				.plan-features-2023-grid__popular-badge {
 					padding: 20px 0 25px;
 					position: absolute;
@@ -951,10 +953,10 @@ body.is-section-signup.is-white-signup .is-onboarding-2023-pricing-grid .signup_
 			border-radius: 4px;
 			background-color: var(--studio-gray-80);
 
-			@media ( min-width: $plans-2023-small-breakpoint ) {
+			@include plans-2023-break-small {
 				left: 15px;
 			}
-			@media ( min-width: $plans-2023-medium-breakpoint ) {
+			@include plans-2023-break-medium {
 				top: 55px;
 			}
 		}
@@ -991,7 +993,7 @@ body.is-section-signup.is-white-signup .is-onboarding-2023-pricing-grid .signup_
 			}
 		}
 
-		@media ( min-width: $plans-2023-small-breakpoint ) {
+		@include plans-2023-break-small {
 			.plan-comparison-grid__plan-image,
 			.plan-comparison-grid__plan-title,
 			.plan-comparison-grid__plan-subtitle {
@@ -1021,7 +1023,7 @@ body.is-section-signup.is-white-signup .is-onboarding-2023-pricing-grid .signup_
 			right: -1px;
 		}
 
-		@media ( min-width: $plans-2023-small-breakpoint ) {
+		@include plans-2023-break-small {
 			&::before,
 			&:not(:last-of-type)::after {
 				display: block;
@@ -1068,7 +1070,7 @@ body.is-section-signup.is-white-signup .is-onboarding-2023-pricing-grid .signup_
 		min-height: 30px;
 		line-height: 1.3;
 
-		@media ( min-width: $plans-2023-small-breakpoint ) {
+		@include plans-2023-break-small {
 			margin: 7px 0 10px;
 		}
 
@@ -1078,12 +1080,12 @@ body.is-section-signup.is-white-signup .is-onboarding-2023-pricing-grid .signup_
 			font-weight: 400;
 			color: var(--studio-gray-80);
 
-			@media ( min-width: $plans-2023-small-breakpoint ) {
+			@include plans-2023-break-small {
 				font-size: $font-body-small;
 				line-height: 20px;
 			}
 
-			@media ( min-width: $plans-2023-medium-breakpoint ) {
+			@include plans-2023-break-medium {
 				font-size: $font-body-extra-small;
 				line-height: 16px;
 			}

--- a/client/my-sites/plans-features-main/style.scss
+++ b/client/my-sites/plans-features-main/style.scss
@@ -55,7 +55,14 @@
 	margin: auto;
 	max-width: 335px;
 
-	@include onboarding-2023-pricing-grid-plans-breakpoints;
+	.is-section-signup & {
+		@include onboarding-2023-pricing-grid-plans-breakpoints;
+	}
+
+	.is-section-plans & {
+		@include pricing-grid-2023-plans-section-breakpoints;
+
+	}
 
 }
 

--- a/client/my-sites/plans-features-main/style.scss
+++ b/client/my-sites/plans-features-main/style.scss
@@ -1,6 +1,6 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
-@import "calypso/signup/steps/plans/style.scss";
+@import "calypso/my-sites/plan-features-2023-grid/media-queries";
 
 // Content group
 .plans-features-main__group {

--- a/client/signup/steps/plans/style.scss
+++ b/client/signup/steps/plans/style.scss
@@ -1,6 +1,6 @@
 @import "calypso/my-sites/plan-features-2023-grid/media-queries";
 
-.plans-features-main__group.is-2023-pricing-grid {
+.is-section-signup .plans-features-main__group.is-2023-pricing-grid {
 	@include onboarding-2023-pricing-grid-plans-breakpoints;
 }
 

--- a/client/signup/steps/plans/style.scss
+++ b/client/signup/steps/plans/style.scss
@@ -1,45 +1,11 @@
-$plans-2023-small-breakpoint: 880px;
-$plans-2023-medium-breakpoint: 1340px;
-$plans-2023-large-breakpoint: 1500px;
-
-@mixin onboarding-2023-pricing-grid-plans-breakpoints {
-	max-width: 414px;
-
-	@media ( min-width: $plans-2023-small-breakpoint ) {
-		max-width: 860px;
-	}
-
-	@media ( min-width: $plans-2023-medium-breakpoint ) {
-		max-width: 1320px;
-	}
-
-	@media ( min-width: $plans-2023-large-breakpoint ) {
-		max-width: 1480px;
-	}
-}
-
-@mixin internal-plans-page {
-	max-width: 414px;
-
-	@media ( min-width: $plans-2023-small-breakpoint ) {
-		max-width: 860px;
-	}
-
-	@media ( min-width: $plans-2023-medium-breakpoint ) {
-		max-width: 1320px;
-	}
-
-	@media ( min-width: $plans-2023-large-breakpoint ) {
-		max-width: 1566px;
-	}
-}
+@import "calypso/my-sites/plan-features-2023-grid/media-queries";
 
 .plans-features-main__group.is-2023-pricing-grid {
 	@include onboarding-2023-pricing-grid-plans-breakpoints;
 }
 
-.is-full-width-layout .plans-features-main__group.is-2023-pricing-grid {
-	@include internal-plans-page;
+.is-section-plans .plans-features-main__group.is-2023-pricing-grid {
+	@include pricing-grid-2023-plans-section-breakpoints;
 
 }
 


### PR DESCRIPTION
#### Proposed Changes

* Fixes responsiveness on the logged-in /plans page.
* Moved the breakpoints to a new SCSS partial, and added initial documentation for it.

The aim was to make it easier to understand these breakpoints so that they can be changed easily and rules dependent on these can be tracked. Please see the comments below for more info.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/plans/<site slug>??flags=onboarding/2023-pricing-grid` and confirm that the plans grid renders correctly on all resolutions.
* Go to `/start/plans?flags=onboarding/2023-pricing-grid` and confirm that there are no regressions in terms of responsiveness. 

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes Automattic/martech#1455
