### PR TITLE
Themes: Add new an action to fetch a specific theme

### DIFF
--- a/client/state/themes/actions/index.js
+++ b/client/state/themes/actions/index.js
@@ -23,6 +23,7 @@ export {
 } from 'calypso/state/themes/actions/trending-themes';
 export { requestActiveTheme } from 'calypso/state/themes/actions/request-active-theme';
 export { requestTheme } from 'calypso/state/themes/actions/request-theme';
+export { requestThemeOnAtomic } from 'calypso/state/themes/actions/request-theme-on-atomic';
 export { requestThenActivate } from 'calypso/state/themes/actions/request-then-activate';
 export { requestThemeFilters } from 'calypso/state/themes/actions/request-theme-filters';
 export { requestThemes } from 'calypso/state/themes/actions/request-themes';

--- a/client/state/themes/actions/request-theme-on-atomic.js
+++ b/client/state/themes/actions/request-theme-on-atomic.js
@@ -8,7 +8,7 @@ import { normalizeJetpackTheme } from 'calypso/state/themes/utils';
 import 'calypso/state/themes/init';
 
 /**
- * Triggers a network request to fetch a specific theme from an atomic site.
+ * Triggers a network request to fetch a specific theme on an atomic site.
  *
  * @param  {string}   themeId Theme ID
  * @param  {number}   siteId  Site ID
@@ -22,7 +22,10 @@ export function requestThemeOnAtomic( themeId, siteId ) {
 			themeId,
 		} );
 		return wpcom.req
-			.get( `/sites/${ siteId }/themes/${ themeId }` )
+			.get( {
+				path: `/sites/${ siteId }/themes/${ themeId }`,
+				apiNamespace: 'wp/v2',
+			} )
 			.then( ( { themes } ) => {
 				dispatch( receiveThemes( map( themes, normalizeJetpackTheme ), siteId ) );
 				dispatch( {

--- a/client/state/themes/actions/request-theme-on-atomic.js
+++ b/client/state/themes/actions/request-theme-on-atomic.js
@@ -1,0 +1,38 @@
+import { map } from 'lodash';
+import wpcom from 'calypso/lib/wp';
+import { THEME_REQUEST, THEME_REQUEST_SUCCESS } from 'calypso/state/themes/action-types';
+import { receiveThemes } from 'calypso/state/themes/actions/receive-themes';
+import { themeRequestFailure } from 'calypso/state/themes/actions/theme-request-failure';
+import { normalizeJetpackTheme } from 'calypso/state/themes/utils';
+
+import 'calypso/state/themes/init';
+
+/**
+ * Triggers a network request to fetch a specific theme from an atomic site.
+ *
+ * @param  {string}   themeId Theme ID
+ * @param  {number}   siteId  Site ID
+ * @returns {Function}         Action thunk
+ */
+export function requestThemeOnAtomic( themeId, siteId ) {
+	return ( dispatch ) => {
+		dispatch( {
+			type: THEME_REQUEST,
+			siteId,
+			themeId,
+		} );
+		return wpcom.req
+			.get( `/sites/${ siteId }/themes/${ themeId }` )
+			.then( ( { themes } ) => {
+				dispatch( receiveThemes( map( themes, normalizeJetpackTheme ), siteId ) );
+				dispatch( {
+					type: THEME_REQUEST_SUCCESS,
+					siteId,
+					themeId,
+				} );
+			} )
+			.catch( ( error ) => {
+				dispatch( themeRequestFailure( siteId, themeId, error ) );
+			} );
+	};
+}

--- a/client/state/themes/actions/request-theme-on-atomic.js
+++ b/client/state/themes/actions/request-theme-on-atomic.js
@@ -15,27 +15,26 @@ import 'calypso/state/themes/init';
  * @returns {Function}         Action thunk
  */
 export function requestThemeOnAtomic( themeId, siteId ) {
-	return ( dispatch ) => {
+	return async ( dispatch ) => {
 		dispatch( {
 			type: THEME_REQUEST,
 			siteId,
 			themeId,
 		} );
-		return wpcom.req
-			.get( {
+
+		try {
+			const { themes } = await wpcom.req.get( {
 				path: `/sites/${ siteId }/themes/${ themeId }`,
 				apiNamespace: 'wp/v2',
-			} )
-			.then( ( { themes } ) => {
-				dispatch( receiveThemes( map( themes, normalizeJetpackTheme ), siteId ) );
-				dispatch( {
-					type: THEME_REQUEST_SUCCESS,
-					siteId,
-					themeId,
-				} );
-			} )
-			.catch( ( error ) => {
-				dispatch( themeRequestFailure( siteId, themeId, error ) );
 			} );
+			dispatch( receiveThemes( map( themes, normalizeJetpackTheme ), siteId ) );
+			dispatch( {
+				type: THEME_REQUEST_SUCCESS,
+				siteId,
+				themeId,
+			} );
+		} catch ( error ) {
+			dispatch( themeRequestFailure( siteId, themeId, error ) );
+		}
 	};
 }

--- a/client/state/themes/test/actions.js
+++ b/client/state/themes/test/actions.js
@@ -46,6 +46,7 @@ import {
 	receiveThemes,
 	requestThemes,
 	requestTheme,
+	requestThemeOnAtomic,
 	pollThemeTransferStatus,
 	initiateThemeTransfer,
 	installTheme,
@@ -1439,6 +1440,57 @@ describe( 'actions', () => {
 			await expect(
 				addExternalManagedThemeToCart( twentyfifteenTheme.id, siteId )( spy, getState )
 			).rejects.toThrowError( 'Theme is already purchased' );
+		} );
+	} );
+
+	describe( '#requestThemeOnAtomic()', () => {
+		useNock( ( nock ) => {
+			nock( 'https://public-api.wordpress.com:443' )
+				.persist()
+				.get( '/wp/v2/sites/1234/themes/makoney' )
+				.reply( 200, { id: 'makoney', name: 'Makoney' } )
+				.get( '/wp/v2/sites/1234/themes/solarone' )
+				.reply( 404, {
+					error: 'unknown_theme',
+					message: 'Unknown theme',
+				} );
+		} );
+
+		test( 'should dispatch THEME_REQUEST', () => {
+			requestThemeOnAtomic( 'makoney', 1234 )( spy );
+
+			expect( spy ).toBeCalledWith( {
+				type: THEME_REQUEST,
+				siteId: 1234,
+				themeId: 'makoney',
+			} );
+		} );
+
+		test( 'should dispatch THEME_REQUEST_SUCCESS on success', () => {
+			return requestThemeOnAtomic(
+				'makoney',
+				1234
+			)( spy ).then( () => {
+				expect( spy ).toBeCalledWith( {
+					type: THEME_REQUEST_SUCCESS,
+					siteId: 1234,
+					themeId: 'makoney',
+				} );
+			} );
+		} );
+
+		test( 'should dispatch THEME_REQUEST_FAILURE on failure', () => {
+			return requestThemeOnAtomic(
+				'solarone',
+				1234
+			)( spy ).finally( () => {
+				expect( spy ).toBeCalledWith( {
+					type: THEME_REQUEST_FAILURE,
+					siteId: 1234,
+					themeId: 'solarone',
+					error: expect.objectContaining( { message: 'Unknown theme' } ),
+				} );
+			} );
 		} );
 	} );
 } );


### PR DESCRIPTION
#### Proposed Changes

* Adds a new action to fetch a specific theme.  This will be used on #72837 to determine if the theme is ready to be activated after the site is transferred to atomic.

#### Testing Instructions

* This action is not being used yet. I added some unit tests that can be run with the following command:
```bash
node 'node_modules/.bin/jest' './client/state/themes/test/actions.js' -c './test/client/jest.config.js'
```

#### Pre-merge Checklist

Related to #72837
