### PR TITLE
Sharing buttons: add Mastodon colors

### DIFF
--- a/client/components/social-logo/docs/example.jsx
+++ b/client/components/social-logo/docs/example.jsx
@@ -22,6 +22,7 @@ const logos = [
 	'instagram',
 	'linkedin',
 	'mail',
+	'mastodon',
 	'medium',
 	'pinterest',
 	'pinterest-alt',

--- a/client/my-sites/marketing/style.scss
+++ b/client/my-sites/marketing/style.scss
@@ -929,6 +929,7 @@
 @include sharing-button-service( "skype", var( --color-skype ) );
 @include sharing-button-service( "telegram", var( --color-telegram ) );
 @include sharing-button-service( "jetpack-whatsapp", var( --color-whatsapp ) );
+@include sharing-button-service( "mastodon", var( --color-mastodon ) );
 
 .sharing-buttons-preview__panel {
 	position: relative;

--- a/client/package.json
+++ b/client/package.json
@@ -187,7 +187,7 @@
 		"redux-dynamic-middlewares": "^2.0.0",
 		"redux-thunk": "^2.3.0",
 		"regenerator-runtime": "^0.13.9",
-		"social-logos": "^2.4.0",
+		"social-logos": "^2.5.2",
 		"socket.io-client": "^2.3.0",
 		"source-map-support": "^0.5.19",
 		"store": "^2.0.12",

--- a/packages/calypso-color-schemes/CHANGELOG.md
+++ b/packages/calypso-color-schemes/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## trunk
 
+- Added a new color for Mastodon.
 - Switched from `node-sass` to `sass` (Dart Sass) for processing Sass files.
   - Removed dependency `node-sass`
   - Added dependency `sass ^1.32.13`

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_classic-dark.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_classic-dark.scss
@@ -305,6 +305,7 @@
 	--color-google-plus: #df4a32;
 	--color-instagram: #d93174;
 	--color-linkedin: #0976b4;
+	--color-mastodon: #6364ff;
 	--color-medium: #12100e;
 	--color-pinterest: #cc2127;
 	--color-pocket: #ee4256;

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_default.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_default.scss
@@ -305,6 +305,7 @@
 	--color-google-plus: #df4a32;
 	--color-instagram: #d93174;
 	--color-linkedin: #0976b4;
+	--color-mastodon: #6364ff;
 	--color-medium: #12100e;
 	--color-pinterest: #cc2127;
 	--color-pocket: #ee4256;

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## next
 
+- Update social-logos to ^2.5.2 (#72876)
+
 ## 2.0.1
 
 - Add missing dependencies: `@automattic/typography` and `wpcom-proxy-request`

--- a/yarn.lock
+++ b/yarn.lock
@@ -11912,7 +11912,7 @@ __metadata:
     redux-mock-store: ^1.5.4
     redux-thunk: ^2.3.0
     regenerator-runtime: ^0.13.9
-    social-logos: ^2.4.0
+    social-logos: ^2.5.2
     socket.io-client: ^2.3.0
     source-map-support: ^0.5.19
     store: ^2.0.12
@@ -30257,14 +30257,14 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"social-logos@npm:^2.4.0":
-  version: 2.4.0
-  resolution: "social-logos@npm:2.4.0"
+"social-logos@npm:^2.5.2":
+  version: 2.5.2
+  resolution: "social-logos@npm:2.5.2"
   dependencies:
     prop-types: ^15.5.7
   peerDependencies:
-    react: 15 - 17
-  checksum: 7ea4a21c5e2f38221ab4bcec4ebdcdcfe4d2420bf748fe132a88bfc8d5fa359948e73df59d12dd4f2379abf2eb4e5a17e671195f0aec1a0da599e1e2ca204e94
+    react: 15 - 18
+  checksum: 60a5d5440b9b8b57a29bd60340ad62a063da7da29a2b437ebdbaaaf29596ebfa264cdd0aa1d09a3e4bc6e3cb2c220d6dbf8e8a17c2b27bc307a9059d3adddcbd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
#### Proposed Changes

This adds colors for an upcoming Mastodon button.

<img width="703" alt="image" src="https://user-images.githubusercontent.com/426388/216099364-f7314069-e9f5-4021-930d-182ed65f29e2.png">

<img width="1123" alt="image" src="https://user-images.githubusercontent.com/426388/216104273-941eec89-e606-470c-ba09-431966526e5d.png">

#### Testing Instructions

* Go to https://container-competent-colden.calypso.live/devdocs/design/social-logo ; you should see the new Mastodon logo.

* To see the change in the sharing buttons settings, this will need to be merged: https://github.com/Automattic/jetpack/pull/28694

Until then, you should be able to test by looking at a site where you have checked out the branch from that PR.

* Go to `https://wordpress.com/marketing/sharing-buttons/yoursite.com`
* Try to add a Mastodon sharing button.

#### Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?

Related discussion: pewaj1-3x-p2
