### PR TITLE
Plans: Update getPlans selector to clarify it can return undefined

### DIFF
--- a/client/state/plans/selectors/plan.ts
+++ b/client/state/plans/selectors/plan.ts
@@ -8,7 +8,7 @@ import 'calypso/state/plans/init';
 /**
  * Return WordPress plans getting from state object
  */
-export const getPlans = ( state: AppState ): PricedAPIPlan[] => {
+export const getPlans = ( state: AppState ): PricedAPIPlan[] | undefined => {
 	return state.plans.items;
 };
 
@@ -24,7 +24,7 @@ export const isRequestingPlans = ( state: AppState ): boolean => {
  */
 export const getPlan = createSelector(
 	( state: AppState, productId: string | number ): PricedAPIPlan | undefined =>
-		getPlans( state ).find( ( plan ) => plan.product_id === productId ),
+		getPlans( state )?.find( ( plan ) => plan.product_id === productId ),
 	( state: AppState ) => getPlans( state )
 );
 


### PR DESCRIPTION
#### Proposed Changes

In https://github.com/Automattic/wp-calypso/pull/72032 (which was merged to trunk as part of https://github.com/Automattic/wp-calypso/pull/71912), I changed the `getPlan()` selector to switch from using lodash's `find` to native JS `find`. This seemed safe because it appeared that the `getPlans()` selector (on which `getPlan` is based) always returned an array. However, recent fatal errors have shown that this is not always the case. Presumably lodash `find()` was hiding this fact.

In this PR we clarify that `getPlans` can return undefined and use optional chaining in `getPlan` to prevent fatals.

#### Testing Instructions

TypeScript should cover these changes.