### PR TITLE
Proposal: WooExpress, Change default site creation from private to coming soon

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
@@ -69,21 +69,17 @@ const SiteCreationStep: Step = function SiteCreationStep( { navigation, flow } )
 
 	// Default visibility is public
 	let siteVisibility = Site.Visibility.PublicIndexed;
+	const wooFlows = [ ECOMMERCE_FLOW, WOOEXPRESS_FLOW ];
 
-	// Link-in-bio flow defaults to "Coming Soon"
+	// These flows default to "Coming Soon"
 	if (
 		isLinkInBioFlow( flow ) ||
 		isFreeFlow( flow ) ||
 		isMigrationFlow( flow ) ||
-		isCopySiteFlow( flow )
+		isCopySiteFlow( flow ) ||
+		wooFlows.includes( flow || '' )
 	) {
 		siteVisibility = Site.Visibility.PublicNotIndexed;
-	}
-
-	// Certain flows should default to private.
-	const privateFlows = [ ECOMMERCE_FLOW, WOOEXPRESS_FLOW ];
-	if ( privateFlows.includes( flow || '' ) ) {
-		siteVisibility = Site.Visibility.Private;
 	}
 
 	const signupDestinationCookieExists = retrieveSignupDestination();

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -367,6 +367,7 @@ export class SiteSettingsFormGeneral extends Component {
 			siteId,
 			site,
 			isComingSoon,
+			isSiteOnECommerceTrial,
 		} = this.props;
 
 		const blogPublic = parseInt( fields.blog_public, 10 );
@@ -384,7 +385,7 @@ export class SiteSettingsFormGeneral extends Component {
 				'is-coming-soon-disabled': isComingSoonDisabled,
 			}
 		);
-		const showPreviewLink = isComingSoon && hasSitePreviewLink;
+		const showPreviewLink = isComingSoon && hasSitePreviewLink && ! isSiteOnECommerceTrial;
 		return (
 			<FormFieldset>
 				{ ! isNonAtomicJetpackSite &&
@@ -615,7 +616,7 @@ export class SiteSettingsFormGeneral extends Component {
 		// isPrivateAndUnlaunched means it is an unlaunched coming soon v1 site
 		const isPrivateAndUnlaunched = -1 === blogPublic && this.props.isUnlaunchedSite;
 
-		const showPreviewLink = isComingSoon && hasSitePreviewLink;
+		const showPreviewLink = isComingSoon && hasSitePreviewLink && ! isSiteOnECommerceTrial;
 
 		const LaunchCard = showPreviewLink ? CompactCard : Card;
 


### PR DESCRIPTION
#### Proposed Changes

* Set ecommerce trial sites to "Coming Soon" (public not indexed) upon site creation instead of private
* Hide the ability to create a preview link when the site is on the ecommerce trial
* Works around a long-standing known issue with private atomic sites and the Calypso media library where media image thumbs do not show up: #52520 #72512

**Before**
<img width="746" alt="Screen Shot 2023-02-01 at 12 11 39 PM" src="https://user-images.githubusercontent.com/2124984/216122129-ddefa9a7-dcb4-4e35-b9e0-bb03ce2ff13b.png">

<img width="1372" alt="Screen Shot 2023-02-01 at 12 49 33 PM" src="https://user-images.githubusercontent.com/2124984/216122704-22ccf645-7760-45d9-8b9f-db333ad4f6cc.png">

**After**
<img width="761" alt="Screen Shot 2023-02-01 at 12 19 41 PM" src="https://user-images.githubusercontent.com/2124984/216122052-675de158-28ab-4145-b1c5-333ed9c4d9fe.png">

<img width="1368" alt="Screen Shot 2023-02-01 at 12 19 55 PM" src="https://user-images.githubusercontent.com/2124984/216122157-40cb64d3-1933-4662-8365-e2b9826b4785.png">

#### Testing Instructions

* Switch to this PR, navigate to `/setup/wooexpress`
* Your new site should show the same Coming Soon screen on the front end
* Go to Settings -> General after site creation
* You should not be able to change the site's privacy settings without launching your site
* You should not have the ability to enable a private site link
* Image thumbnails in the Calypso media library at `/media/[siteSlug]` should be visible

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- NA Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- NA Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- NA For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
