### PR TITLE
Repo Gardening: remove unnecessary action in job

### DIFF
--- a/.github/workflows/gardening.yml
+++ b/.github/workflows/gardening.yml
@@ -29,11 +29,6 @@ jobs:
        with:
          node-version: ^18.13.0
 
-     - name: Wait for prior instances of the workflow to finish
-       uses: softprops/turnstyle@v1
-       env:
-         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
      - name: 'Run gardening action'
        uses: automattic/action-repo-gardening@trunk
        with:


### PR DESCRIPTION
#### Proposed Changes

This action should no longer be necessary now that GitHub handles `concurrency` a bit better. It will also avoid deprecation warnings since that specific action was running on node 12.

#### Testing Instructions

* I will be making a few changes to labels here to see if the Repo Gardening action behaves properly. Ultimately though, the test will be once this gets merged.

#### Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
