### PR TITLE
Launchpad: Disable Launchpad on Goals page revisit

### DIFF
--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -184,7 +184,7 @@ const siteSetupFlow: Flow = {
 					if ( typeof siteId === 'number' ) {
 						pendingActions.push(
 							saveSiteSettings( siteId, {
-								launchpad_screen: isLaunchpadIntent( intent ) ? 'full' : null,
+								launchpad_screen: isLaunchpadIntent( intent ) ? 'full' : 'off',
 							} )
 						);
 					}

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -180,9 +180,13 @@ const siteSetupFlow: Flow = {
 						);
 					}
 
-					// Add Launchpad to selected intents in General Onboarding
-					if ( isLaunchpadIntent( intent ) && typeof siteId === 'number' ) {
-						pendingActions.push( saveSiteSettings( siteId, { launchpad_screen: 'full' } ) );
+					// Update Launchpad option based on site intent
+					if ( siteId ) {
+						pendingActions.push(
+							saveSiteSettings( siteId, {
+								launchpad_screen: isLaunchpadIntent( intent ) ? 'full' : 'off',
+							} )
+						);
 					}
 
 					let redirectionUrl = to;

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -181,7 +181,7 @@ const siteSetupFlow: Flow = {
 					}
 
 					// Update Launchpad option based on site intent
-					if ( siteId ) {
+					if ( typeof siteId === 'number' ) {
 						pendingActions.push(
 							saveSiteSettings( siteId, {
 								launchpad_screen: isLaunchpadIntent( intent ) ? 'full' : null,

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -184,7 +184,7 @@ const siteSetupFlow: Flow = {
 					if ( siteId ) {
 						pendingActions.push(
 							saveSiteSettings( siteId, {
-								launchpad_screen: isLaunchpadIntent( intent ) ? 'full' : 'off',
+								launchpad_screen: isLaunchpadIntent( intent ) ? 'full' : null,
 							} )
 						);
 					}


### PR DESCRIPTION
Fixes #72885 

### Time Estimate
Review: Short
Test: Short

### Summary
Currently, if the user selects a Launchpad selected flow on the Goals page and later revisits the Goals page and select a non-Launchpad flow we are not disabling Launchpad.

### Testing

##### Test current behavior
1. Go to https://wordpress.com/start
2. Once you arrive at the Goals page save the URL
3. On the Goal page select "Other"
4. After finishing the flow confirm that you are redirected to Launchpad
5. Go back to the Goals page from the URL you saved
6. On the Goal page select "Sell"
7. After finishing the flow confirm that you are redirected to Launchpad

##### Test Fix
1. Go to http://calypso.localhost:3000/start
2. Once you arrive at the Goals page save the URL
3. On the Goal page select "Other"
4. After finishing the flow confirm that you are redirected to Launchpad
5. Go back to the Goals page from the URL you saved
6. On the Goal page select "Sell"
7. After finishing the flow confirm that you are NOT redirected to Launchpad