### PR TITLE
Sensei Tailored Flow: Change Sensei Pro plugin, break up plan setup

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/sensei-step-container/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/sensei-step-container/index.tsx
@@ -4,6 +4,7 @@ import { createInterpolateElement } from '@wordpress/element';
 import { Icon, wordpress } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import React from 'react';
+import DocumentHead from 'calypso/components/data/document-head';
 import { Container, TitleContainer, Title, Footer, FooterText } from './components';
 import './styles.scss';
 
@@ -34,6 +35,7 @@ export const SenseiStepContainer: React.FC< SenseiStepContainerProps > = ( {
 				<Container>
 					<TitleContainer>
 						<Icon icon={ wordpress } />
+						<DocumentHead title={ __( 'Course Creator' ) } />
 						<Title>{ __( 'Course Creator' ) }</Title>
 					</TitleContainer>
 					{ formattedHeader && <div className="step-container__header">{ formattedHeader }</div> }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-launch/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-launch/index.tsx
@@ -19,6 +19,8 @@ interface InstalledPlugin {
 	active: boolean;
 }
 
+const SENSEI_PRO_PLUGIN_SLUG = 'sensei-pro';
+
 const SenseiLaunch = () => {
 	const { __ } = useI18n();
 	const site = useSite();
@@ -42,7 +44,7 @@ const SenseiLaunch = () => {
 
 	useEffect( () => {
 		const intervalId = setInterval( () => {
-			const woothemesSensei = plugins.find( ( plugin ) => plugin.slug === 'woothemes-sensei' );
+			const woothemesSensei = plugins.find( ( plugin ) => plugin.slug === SENSEI_PRO_PLUGIN_SLUG );
 			if ( ! woothemesSensei?.active && retries < maxRetries ) {
 				setRetries( retries + 1 );
 				dispatch( fetchSitePlugins( siteId ) );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-plan/create-sensei-site.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-plan/create-sensei-site.ts
@@ -1,0 +1,120 @@
+import { useLocale } from '@automattic/i18n-utils';
+import { SENSEI_FLOW } from '@automattic/onboarding';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { useCallback, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { useNewSiteVisibility } from 'calypso/landing/gutenboarding/hooks/use-selected-plan';
+import { ONBOARD_STORE, SITE_STORE, USER_STORE } from 'calypso/landing/stepper/stores';
+import wpcom from 'calypso/lib/wp';
+import { Progress } from '../sensei-setup/sensei-step-progress';
+import type { StyleVariation } from 'calypso/../packages/design-picker';
+
+const getStyleVariations = ( siteId: number, stylesheet: string ): Promise< StyleVariation[] > =>
+	wpcom.req.get( {
+		path: `/sites/${ siteId }/global-styles/themes/${ stylesheet }/variations`,
+		apiNamespace: 'wp/v2',
+	} );
+
+type Theme = {
+	_links: {
+		'wp:user-global-styles': { href: string }[];
+	};
+};
+const getSiteTheme = ( siteId: number, stylesheet: string ): Promise< Theme > =>
+	wpcom.req.get( {
+		path: `/sites/${ siteId }/themes/${ stylesheet }`,
+		apiNamespace: 'wp/v2',
+	} );
+
+const updateGlobalStyles = (
+	siteId: number,
+	globalStylesId: number,
+	styleVariation: StyleVariation
+) =>
+	wpcom.req.post( {
+		path: `/sites/${ siteId }/global-styles/${ globalStylesId }`,
+		apiNamespace: 'wp/v2',
+		body: styleVariation,
+	} );
+
+export const useCreateSenseiSite = () => {
+	const { getNewSite } = useSelect( ( select ) => select( SITE_STORE ) );
+	const { setIntentOnSite } = useDispatch( SITE_STORE );
+	const currentUser = useSelect( ( select ) => select( USER_STORE ).getCurrentUser() );
+	const { createSenseiSite, setSelectedSite } = useDispatch( ONBOARD_STORE );
+	const { getSelectedStyleVariation } = useSelect( ( select ) => select( ONBOARD_STORE ) );
+
+	const [ progress, setProgress ] = useState< Progress >( {
+		percentage: 0,
+		title: '',
+	} );
+
+	const locale = useLocale();
+	const visibility = useNewSiteVisibility();
+
+	const createAndConfigureSite = useCallback( async () => {
+		const siteProgressTitle = __( 'Laying out the foundations' );
+		const cartProgressTitle = __( 'Preparing Your Bundle' );
+		const styleProgressTitle = __( 'Applying your site styles' );
+
+		setProgress( {
+			percentage: 25,
+			title: siteProgressTitle,
+		} );
+
+		await createSenseiSite( {
+			username: currentUser?.username || '',
+			languageSlug: locale,
+			visibility,
+		} );
+
+		setProgress( {
+			percentage: 50,
+			title: cartProgressTitle,
+		} );
+
+		const newSite = getNewSite();
+		const siteId = newSite?.blogid;
+		setSelectedSite( newSite?.blogid );
+		await Promise.all( [ setIntentOnSite( newSite?.site_slug as string, SENSEI_FLOW ) ] );
+
+		setProgress( {
+			percentage: 75,
+			title: styleProgressTitle,
+		} );
+
+		if ( siteId ) {
+			const selectedStyleVariationTitle = getSelectedStyleVariation()?.title;
+			const [ styleVariations, theme ]: [ StyleVariation[], Theme ] = await Promise.all( [
+				getStyleVariations( siteId, 'pub/course' ),
+				getSiteTheme( siteId, 'pub/course' ),
+			] );
+			const userGlobalStylesLink: string =
+				theme?._links?.[ 'wp:user-global-styles' ]?.[ 0 ]?.href || '';
+			const userGlobalStylesId = parseInt( userGlobalStylesLink.split( '/' ).pop() || '', 10 );
+			const styleVariation = styleVariations.find(
+				( variation ) => variation.title === selectedStyleVariationTitle
+			);
+			if ( styleVariation && userGlobalStylesId ) {
+				await updateGlobalStyles( siteId, userGlobalStylesId, styleVariation );
+			}
+		}
+		setProgress( {
+			percentage: 100,
+			title: styleProgressTitle,
+		} );
+
+		return { site: newSite };
+	}, [
+		createSenseiSite,
+		currentUser?.username,
+		getNewSite,
+		getSelectedStyleVariation,
+		locale,
+		setIntentOnSite,
+		setSelectedSite,
+		visibility,
+	] );
+
+	return { createAndConfigureSite, progress };
+};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-plan/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-plan/index.tsx
@@ -1,233 +1,63 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 import { useLocale } from '@automattic/i18n-utils';
-import { SENSEI_FLOW } from '@automattic/onboarding';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 import { useCallback, useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
-import { Plans } from 'calypso/../packages/data-stores/src';
 import formatCurrency from 'calypso/../packages/format-currency/src';
-import { useSupportedPlans } from 'calypso/../packages/plans-grid/src/hooks';
 import PlanItem from 'calypso/../packages/plans-grid/src/plans-table/plan-item';
-import { useNewSiteVisibility } from 'calypso/landing/gutenboarding/hooks/use-selected-plan';
-import { PLANS_STORE } from 'calypso/landing/gutenboarding/stores/plans';
-import {
-	USER_STORE,
-	ONBOARD_STORE,
-	SITE_STORE,
-	PRODUCTS_LIST_STORE,
-} from 'calypso/landing/stepper/stores';
+import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { domainRegistration } from 'calypso/lib/cart-values/cart-items';
-import wpcom from 'calypso/lib/wp';
 import { cartManagerClient } from 'calypso/my-sites/checkout/cart-manager-client';
 import { SenseiStepContainer } from '../components/sensei-step-container';
 import { SenseiStepError } from '../sensei-setup/sensei-step-error';
-import { SenseiStepProgress, Progress } from '../sensei-setup/sensei-step-progress';
-import { Tagline, Title, PlansIntervalToggle } from './components';
-import { Status, features } from './constants';
+import { SenseiStepProgress } from '../sensei-setup/sensei-step-progress';
+import { PlansIntervalToggle, Tagline, Title } from './components';
+import { features, Status } from './constants';
+import { useCreateSenseiSite } from './create-sensei-site';
+import { useBusinessPlanPricing, useSenseiProPricing } from './sensei-plan-products';
 import type { Step } from '../../types';
-import type { StyleVariation } from 'calypso/../packages/design-picker/src/types';
+import type { PlanBillingPeriod } from 'calypso/../packages/data-stores';
+
 import 'calypso/../packages/plans-grid/src/plans-table/style.scss';
 import './styles.scss';
 
-const siteProgressTitle: string = __( 'Laying out the foundations' );
-const cartProgressTitle: string = __( 'Preparing Your Bundle' );
-const styleProgressTitle: string = __( 'Applying your site styles' );
-
-const getStyleVariations = ( siteId: number, stylesheet: string ): Promise< StyleVariation[] > =>
-	wpcom.req.get( {
-		path: `/sites/${ siteId }/global-styles/themes/${ stylesheet }/variations`,
-		apiNamespace: 'wp/v2',
-	} );
-
-type Theme = {
-	_links: {
-		'wp:user-global-styles': { href: string }[];
-	};
-};
-const getSiteTheme = ( siteId: number, stylesheet: string ): Promise< Theme > =>
-	wpcom.req.get( {
-		path: `/sites/${ siteId }/themes/${ stylesheet }`,
-		apiNamespace: 'wp/v2',
-	} );
-
-const updateGlobalStyles = (
-	siteId: number,
-	globalStylesId: number,
-	styleVariation: StyleVariation
-) =>
-	wpcom.req.post( {
-		path: `/sites/${ siteId }/global-styles/${ globalStylesId }`,
-		apiNamespace: 'wp/v2',
-		body: styleVariation,
-	} );
-
 const SenseiPlan: Step = ( { flow, navigation: { submit } } ) => {
-	const [ billingPeriod, setBillingPeriod ] = useState< Plans.PlanBillingPeriod >( 'ANNUALLY' );
-	const billingPeriodIsAnnually = billingPeriod === 'ANNUALLY';
+	const [ billingPeriod, setBillingPeriod ] = useState< PlanBillingPeriod >( 'ANNUALLY' );
 	const [ status, setStatus ] = useState< Status >( Status.Initial );
-	const [ progress, setProgress ] = useState< Progress >( {
-		percentage: 0,
-		title: siteProgressTitle,
-	} );
-
-	const { hasTranslation } = useI18n();
 	const locale = useLocale();
-	const visibility = useNewSiteVisibility();
-	const currentUser = useSelect( ( select ) => select( USER_STORE ).getCurrentUser() );
-	const { supportedPlans } = useSupportedPlans( locale, billingPeriod );
-	const { createSenseiSite, setSelectedSite } = useDispatch( ONBOARD_STORE );
-	const { getSelectedDomain, getSelectedStyleVariation } = useSelect( ( select ) =>
-		select( ONBOARD_STORE )
-	);
-	const domain = getSelectedDomain();
-	const { getNewSite } = useSelect( ( select ) => select( SITE_STORE ) );
-	const { getPlanProduct } = useSelect( ( select ) => select( PLANS_STORE ) );
+	const { hasTranslation } = useI18n();
 
-	const { saveSiteSettings, setIntentOnSite } = useDispatch( SITE_STORE );
+	const domain = useSelect( ( select ) => select( ONBOARD_STORE ).getSelectedDomain() );
 
-	const planObject = supportedPlans.find( ( plan ) => {
-		return plan && 'business' === plan.periodAgnosticSlug;
-	} );
-
-	const handlePlanBillingPeriodChange = ( newBillingPeriod: Plans.PlanBillingPeriod ) => {
-		setBillingPeriod( newBillingPeriod );
-	};
-
-	const woothemesProduct = useSelect(
-		( select ) => {
-			const yearly = select( PRODUCTS_LIST_STORE ).getProductBySlug( 'woothemes_sensei_yearly' );
-			const monthly = select( PRODUCTS_LIST_STORE ).getProductBySlug( 'woothemes_sensei_monthly' );
-
-			if ( ! yearly || ! monthly ) {
-				return {
-					monthlyPrice: 0,
-					yearlyPrice: 0,
-					price: 0,
-					productSlug: '',
-					currencyCode: '',
-				};
-			}
-
-			return {
-				monthlyPrice: monthly.cost,
-				yearlyPrice: yearly.cost,
-				price: billingPeriodIsAnnually ? Math.ceil( yearly.cost / 12 ) : monthly.cost,
-				productSlug: billingPeriodIsAnnually ? yearly.product_slug : monthly.product_slug,
-				currencyCode: yearly.currency_code,
-			};
-		},
-		[ billingPeriodIsAnnually ]
-	);
-
-	const planProduct = useSelect(
-		( select ) => {
-			const monthly = select( PLANS_STORE ).getPlanProduct(
-				planObject?.periodAgnosticSlug,
-				'MONTHLY'
-			);
-			const yearly = select( PLANS_STORE ).getPlanProduct(
-				planObject?.periodAgnosticSlug,
-				'ANNUALLY'
-			);
-			if ( ! yearly || ! monthly ) {
-				return {
-					monthlyPrice: 0,
-					yearlyPrice: 0,
-					price: 0,
-					productSlug: '',
-				};
-			}
-
-			return {
-				monthlyPrice: monthly.rawPrice,
-				yearlyPrice: yearly.rawPrice,
-				price: billingPeriodIsAnnually ? Math.ceil( yearly.rawPrice / 12 ) : monthly.rawPrice,
-				productSlug: '',
-			};
-		},
-		[ billingPeriodIsAnnually, planObject ]
-	);
+	const senseiProPricing = useSenseiProPricing( billingPeriod );
+	const { businessPlanPricing, businessPlanProduct } = useBusinessPlanPricing( billingPeriod );
 
 	const goToDomainStep = useCallback( () => {
+		// TODO this doesn't go back?
 		if ( submit ) {
 			submit();
 		}
 	}, [ submit ] );
 
-	const onPlanSelect = async () => {
-		try {
-			setStatus( Status.Bundling );
+	const { createAndConfigureSite, progress } = useCreateSenseiSite();
 
-			// Wait for a bit to get an animation in the beginning of site creation.
-			await new Promise( ( res ) => setTimeout( res, 100 ) );
-
-			setProgress( {
-				percentage: 25,
-				title: siteProgressTitle,
-			} );
-
-			await createSenseiSite( {
-				username: currentUser?.username || '',
-				languageSlug: locale,
-				visibility,
-			} );
-
-			setProgress( {
-				percentage: 50,
-				title: cartProgressTitle,
-			} );
-
-			const newSite = getNewSite();
-			const siteId = newSite?.blogid;
-			setSelectedSite( newSite?.blogid );
-			await Promise.all( [
-				setIntentOnSite( newSite?.site_slug as string, SENSEI_FLOW ),
-				saveSiteSettings( newSite?.blogid as number, { launchpad_screen: 'full' } ),
-			] );
-
-			setProgress( {
-				percentage: 75,
-				title: styleProgressTitle,
-			} );
-
-			if ( siteId ) {
-				const selectedStyleVariationTitle = getSelectedStyleVariation()?.title;
-				const [ styleVariations, theme ]: [ StyleVariation[], Theme ] = await Promise.all( [
-					getStyleVariations( siteId, 'pub/course' ),
-					getSiteTheme( siteId, 'pub/course' ),
-				] );
-				const userGlobalStylesLink: string =
-					theme?._links?.[ 'wp:user-global-styles' ]?.[ 0 ]?.href || '';
-				const userGlobalStylesId = parseInt( userGlobalStylesLink.split( '/' ).pop() || '', 10 );
-				const styleVariation = styleVariations.find(
-					( variation ) => variation.title === selectedStyleVariationTitle
-				);
-				if ( styleVariation && userGlobalStylesId ) {
-					await updateGlobalStyles( siteId, userGlobalStylesId, styleVariation );
-				}
-			}
-			setProgress( {
-				percentage: 100,
-				title: styleProgressTitle,
-			} );
-
-			const planProductObject = getPlanProduct( planObject?.periodAgnosticSlug, billingPeriod );
-
-			const cartKey = await cartManagerClient.getCartKeyForSiteSlug( newSite?.site_slug as string );
+	const createCheckoutCart = useCallback(
+		async ( site ) => {
+			const cartKey = await cartManagerClient.getCartKeyForSiteSlug( site?.site_slug as string );
 
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any
 			const productsToAdd: any[] = [
 				{
-					product_slug: planProductObject?.storeSlug,
+					product_slug: businessPlanProduct?.storeSlug,
 					extra: {
 						signup_flow: flow,
 					},
 				},
 				{
-					product_slug: woothemesProduct.productSlug,
+					product_slug: senseiProPricing.productSlug,
 					extra: {
 						signup_flow: flow,
 					},
@@ -246,23 +76,36 @@ const SenseiPlan: Step = ( { flow, navigation: { submit } } ) => {
 
 			await cartManagerClient.forCartKey( cartKey ).actions.addProductsToCart( productsToAdd );
 			const redirectTo = encodeURIComponent(
-				`/setup/sensei/senseiLaunch?siteSlug=${ newSite?.site_slug }&siteId=${ newSite?.blogid }`
+				`/setup/sensei/senseiLaunch?siteSlug=${ site?.site_slug }&siteId=${ site?.blogid }`
 			);
 
-			return window.location.replace(
-				`/checkout/${ newSite?.site_slug }?signup=1&redirect_to=${ redirectTo }`
-			);
+			return `/checkout/${ site?.site_slug }?signup=1&redirect_to=${ redirectTo }`;
+		},
+		[ businessPlanProduct?.storeSlug, domain, flow, senseiProPricing.productSlug ]
+	);
+
+	const onPlanSelect = async () => {
+		try {
+			setStatus( Status.Bundling );
+
+			// Wait for a bit to get an animation in the beginning of site creation.
+			await new Promise( ( res ) => setTimeout( res, 100 ) );
+
+			const { site } = await createAndConfigureSite();
+			const checkoutUrl = await createCheckoutCart( site );
+
+			return window.location.assign( checkoutUrl );
 		} catch ( err ) {
 			setStatus( Status.Error );
 		}
 	};
 
-	const currencyCode = woothemesProduct.currencyCode;
-	const isLoading = ! planProduct.monthlyPrice || ! woothemesProduct.monthlyPrice;
-	const price = planProduct.price + woothemesProduct.price;
+	const currencyCode = senseiProPricing.currencyCode;
+	const isLoading = ! businessPlanPricing.monthlyPrice || ! senseiProPricing.monthlyPrice;
+	const price = businessPlanPricing.price + senseiProPricing.price;
 	const priceStr = formatCurrency( price, currencyCode, { stripZeros: true } );
-	const monthlyPrice = planProduct.monthlyPrice + woothemesProduct.monthlyPrice;
-	const annualPrice = planProduct.yearlyPrice + woothemesProduct.yearlyPrice;
+	const monthlyPrice = businessPlanPricing.monthlyPrice + senseiProPricing.monthlyPrice;
+	const annualPrice = businessPlanPricing.yearlyPrice + senseiProPricing.yearlyPrice;
 	const annualPriceStr = formatCurrency( annualPrice, currencyCode, { stripZeros: true } );
 	const annualSavings = monthlyPrice * 12 - annualPrice;
 	const annualSavingsStr = formatCurrency( annualSavings, currencyCode, { stripZeros: true } );
@@ -295,7 +138,7 @@ const SenseiPlan: Step = ( { flow, navigation: { submit } } ) => {
 
 					<PlansIntervalToggle
 						intervalType={ billingPeriod }
-						onChange={ handlePlanBillingPeriodChange }
+						onChange={ setBillingPeriod }
 						maxMonthlyDiscountPercentage={ annualDiscount }
 					/>
 
@@ -317,12 +160,6 @@ const SenseiPlan: Step = ( { flow, navigation: { submit } } ) => {
 								? planItemPriceLabelAnnually
 								: planItemPriceLabelMonthly }
 						</div>
-
-						{ /*
-							For the free plan, the following div is still rendered invisible
-							and ignored by screen readers (via aria-hidden) to ensure the same
-							vertical spacing as the rest of the plan cards
-						 */ }
 						<div
 							className={ classnames( 'plan-item__price-discount', {
 								'plan-item__price-discount--disabled': billingPeriod !== 'ANNUALLY',

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-plan/sensei-plan-products.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-plan/sensei-plan-products.ts
@@ -1,0 +1,81 @@
+import { useLocale } from '@automattic/i18n-utils';
+import { useSelect } from '@wordpress/data';
+import { useSupportedPlans } from 'calypso/../packages/plans-grid/src/hooks';
+import { PLANS_STORE } from 'calypso/landing/gutenboarding/stores/plans';
+import { PRODUCTS_LIST_STORE } from 'calypso/landing/stepper/stores';
+import type { PlanBillingPeriod } from 'calypso/../packages/data-stores';
+
+const SENSEI_PRO_PRODUCT_YEARLY = 'sensei_pro_yearly';
+const SENSEI_PRO_PRODUCT_MONTHLY = 'sensei_pro_monthly';
+
+export function useSenseiProPricing( billingPeriod: PlanBillingPeriod ) {
+	const isYearly = billingPeriod === 'ANNUALLY';
+
+	return useSelect(
+		( select ) => {
+			const yearly = select( PRODUCTS_LIST_STORE ).getProductBySlug( SENSEI_PRO_PRODUCT_YEARLY );
+			const monthly = select( PRODUCTS_LIST_STORE ).getProductBySlug( SENSEI_PRO_PRODUCT_MONTHLY );
+
+			if ( ! yearly || ! monthly ) {
+				return {
+					monthlyPrice: 0,
+					yearlyPrice: 0,
+					price: 0,
+					productSlug: '',
+					currencyCode: '',
+				};
+			}
+
+			return {
+				monthlyPrice: monthly.cost,
+				yearlyPrice: yearly.cost,
+				price: isYearly ? Math.ceil( yearly.cost / 12 ) : monthly.cost,
+				productSlug: isYearly ? yearly.product_slug : monthly.product_slug,
+				currencyCode: yearly.currency_code,
+			};
+		},
+		[ isYearly ]
+	);
+}
+
+export function useBusinessPlanPricing( billingPeriod: 'MONTHLY' | 'ANNUALLY' ) {
+	const isYearly = billingPeriod === 'ANNUALLY';
+	const locale = useLocale();
+	const { supportedPlans } = useSupportedPlans( locale, billingPeriod );
+
+	const businessPlan = supportedPlans.find( ( plan ) => {
+		return plan && 'business' === plan.periodAgnosticSlug;
+	} );
+
+	const slug = businessPlan?.periodAgnosticSlug;
+
+	const businessPlanProduct = useSelect(
+		( select ) => select( PLANS_STORE ).getPlanProduct( slug, billingPeriod ),
+		[ slug, billingPeriod ]
+	);
+
+	const businessPlanPricing = useSelect(
+		( select ) => {
+			const monthly = select( PLANS_STORE ).getPlanProduct( slug, 'MONTHLY' );
+			const yearly = select( PLANS_STORE ).getPlanProduct( slug, 'ANNUALLY' );
+			if ( ! yearly || ! monthly ) {
+				return {
+					monthlyPrice: 0,
+					yearlyPrice: 0,
+					price: 0,
+					productSlug: '',
+				};
+			}
+
+			return {
+				monthlyPrice: monthly.rawPrice,
+				yearlyPrice: yearly.rawPrice,
+				price: isYearly ? Math.ceil( yearly.rawPrice / 12 ) : monthly.rawPrice,
+				productSlug: '',
+			};
+		},
+		[ isYearly, slug ]
+	);
+
+	return { businessPlanPricing, businessPlanProduct };
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-setup/index.tsx
@@ -4,7 +4,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { useCallback, useState } from '@wordpress/element';
 import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
-import { CSSProperties } from 'react';
+import { CSSProperties, useEffect } from 'react';
 import FormRadioWithThumbnail from 'calypso/components/forms/form-radio-with-thumbnail';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { ONBOARD_STORE } from '../../../../stores';
@@ -69,6 +69,11 @@ const SenseiSetup: Step = ( { navigation } ) => {
 
 	const { submit } = navigation;
 	const dispatch = useDispatch( ONBOARD_STORE );
+
+	useEffect( () => {
+		dispatch.resetOnboardStore();
+	}, [ dispatch ] );
+
 	const handleSubmit = useCallback( () => {
 		dispatch.setSiteTitle( siteTitle );
 		const variation = styles.find( ( style ) => style.name === checked ) || styles[ 0 ];


### PR DESCRIPTION
#### Proposed Changes

* Change the plugin slug used from `woothemes-sensei` to `sensei-pro`
* Also update the associated products in the plan selection screen
* Break up the plan setup component to more files & functions
* Make sure the page title is set (set this to 'Course Creator')
* Clear previous onboarding data in the first step (this fixes the domain search being pre-filled from a previous setup flow)

#### Testing Instructions

* Complete a site creation with the Sensei flow via `/setup/sensei`
* After the site is ready, check the plugins installed:
  * Sensei LMS should be installed
  * Sensei Pro should be installed
  * WooCommerce, WooCommerce Payments should NOT be installed

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
