### PR TITLE
Flaky E2E: extend timeout when force dismissing the welcome tour.

### DIFF
--- a/packages/calypso-e2e/src/lib/components/editor-welcome-tour-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-welcome-tour-component.ts
@@ -1,4 +1,5 @@
 import { Page, Locator } from 'playwright';
+import { EXTENDED_EDITOR_WAIT_TIMEOUT } from '../pages/editor-page';
 
 /**
  * Represents the welcome tour that shows in a popover when the editor loads.
@@ -25,7 +26,9 @@ export class EditorWelcomeTourComponent {
 	 */
 	async forceDismissWelcomeTour(): Promise< void > {
 		// Locator API doesn't have waitForFunction yet. We need a Frame for now.
-		const editorElement = await this.editor.elementHandle();
+		const editorElement = await this.editor.elementHandle( {
+			timeout: EXTENDED_EDITOR_WAIT_TIMEOUT,
+		} );
 		const editorFrame = await editorElement?.ownerFrame();
 		if ( ! editorFrame ) {
 			return;

--- a/packages/calypso-e2e/src/lib/pages/editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/editor-page.ts
@@ -41,7 +41,7 @@ const selectors = {
 	// Welcome tour
 	welcomeTourCloseButton: 'button[aria-label="Close Tour"]',
 };
-const EXTENDED_TIMEOUT = 30 * 1000;
+export const EXTENDED_EDITOR_WAIT_TIMEOUT = 30 * 1000;
 
 /**
  * Represents an instance of the WPCOM's Gutenberg editor page.
@@ -154,7 +154,7 @@ export class EditorPage {
 		// In a typical loading scenario, this request is one of the last to fire.
 		// Lacking a perfect cross-site type (Simple/Atomic) way to check the loading state,
 		// it is a fairly good stand-in.
-		await this.page.waitForResponse( /.*posts.*/, { timeout: EXTENDED_TIMEOUT } );
+		await this.page.waitForResponse( /.*posts.*/, { timeout: EXTENDED_EDITOR_WAIT_TIMEOUT } );
 
 		// Dismiss the Welcome Tour.
 		await this.editorWelcomeTourComponent.forceDismissWelcomeTour();


### PR DESCRIPTION
#### Proposed Changes

Key changes:
- export the `EXTENDED_EDITOR_WAIT_TIMEOUT` value to be used elsewhere.
- extend the timeout when waiting to obtain the `elementHandle` of the editor.

#### Testing Instructions

Ensure the following build configurations are passing:
  - [x] Gutenberg E2E (desktop)
  - [x] Calypso E2E (desktop)
  - [x] Calypso E2E (mobile)
  - [x] Pre-Release E2E

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/wp-calypso/issues/72622.
