### PR TITLE
ETK: update loading coming-soon check

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -345,7 +345,7 @@ function load_coming_soon() {
 	}
 }
 // Todo: once coming-soon is migrated to the new jetpack-mu-wpcom plugin, coming-soon can be removed from ETK.
-if ( class_exists( 'Automattic\Jetpack\Jetpack_Mu_Wpcom' ) && Automattic\Jetpack\Jetpack_Mu_Wpcom::$initialized === false ) {
+if ( has_action( 'plugins_loaded', 'Automattic\Jetpack\Jetpack_Mu_Wpcom::load_coming_soon' ) === false ) {
 	add_action( 'plugins_loaded', __NAMESPACE__ . '\load_coming_soon' );
 }
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -345,7 +345,7 @@ function load_coming_soon() {
 	}
 }
 // Todo: once coming-soon is migrated to the new jetpack-mu-wpcom plugin, coming-soon can be removed from ETK.
-if ( has_action( 'plugins_loaded', 'Jetpack\Mu_Wpcom\load_coming_soon' ) === false ) {
+if ( class_exists( 'Automattic\Jetpack\Jetpack_Mu_Wpcom' ) && Automattic\Jetpack\Jetpack_Mu_Wpcom::$initialized === false ) {
 	add_action( 'plugins_loaded', __NAMESPACE__ . '\load_coming_soon' );
 }
 


### PR DESCRIPTION
#### Proposed Changes

Updates the check added in #71012 to align with https://github.com/Automattic/jetpack/pull/28498

#### Testing Instructions

https://github.com/Automattic/jetpack/pull/28498 is not in production yet, so this PR has no functional changes just yet. Once we start loading jetpack-mu-wpcom on simple wpcom sites, we'll be sure to test the implementation.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
