### PR TITLE
Prevent GitHub from appearing in /marketing/connections view

### DIFF
--- a/client/state/sharing/services/selectors.js
+++ b/client/state/sharing/services/selectors.js
@@ -116,6 +116,11 @@ export function getEligibleKeyringServices( state, siteId, type ) {
 			return false;
 		}
 
+		// Omit the GitHub deployment app so it doesn't appear in the list of "other" services
+		if ( 'github-deploy' === service.ID ) {
+			return false;
+		}
+
 		return true;
 	} );
 }


### PR DESCRIPTION
#### Proposed Changes

In preparation for D99604-code merging, we don't want the new service to appear in the UI yet.
This PR updates the `getEligibleKeyringServices` selector so that `github-deploy` is never eligible, so it doesn't appear in the marketing connections UI.

The marketing connections page shows external services in the `"publicize"` and `"other"` categories (those are the only categories that exist). Another approach to preventing GitHub from appearing in the UI would be to create a new category especially for `github-deploy`.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply D99604-code to sandbox
* Navigate to `/marketing/connections` in Calypso
* Open network tools and confirm the `/wpcom/v2/sites/{ sideId }/external-services` request returned `github-deploy` in the response body
* Confirm that GitHub doesn't appear as one of the options in the connections list