### PR TITLE
Marketplace: show only launched products from the dynamic catalog

### DIFF
--- a/client/data/marketplace/use-wpcom-plugins-query.ts
+++ b/client/data/marketplace/use-wpcom-plugins-query.ts
@@ -15,7 +15,7 @@ import {
 import wpcom from 'calypso/lib/wp';
 import { BASE_STALE_TIME } from 'calypso/state/initial-state';
 
-type Type = 'all' | 'featured';
+type Type = 'all' | 'featured' | 'launched';
 
 const pluginsApiBase = '/marketplace/products';
 const dynamicPluginsApiBase = '/marketplace/products-dynamic';

--- a/client/my-sites/plugins/use-plugins/index.ts
+++ b/client/my-sites/plugins/use-plugins/index.ts
@@ -76,7 +76,7 @@ const usePlugins = ( {
 	} ) as WPORGResponse;
 
 	const { data: dotComPlugins = [], isLoading: isFetchingDotCom } = useWPCOMPluginsList(
-		'all',
+		config.isEnabled( 'marketplace-fetch-all-dynamic-products' ) ? 'all' : 'launched',
 		search,
 		tag,
 		{

--- a/config/development.json
+++ b/config/development.json
@@ -108,6 +108,7 @@
 		"manage/import/site-importer-endpoints": true,
 		"marketplace-domain-bundle": true,
 		"marketplace-fetch-dynamic-plugin-details": true,
+		"marketplace-fetch-all-dynamic-products": true,
 		"marketplace-jetpack-plugin-search": true,
 		"marketplace-personal-premium": false,
 		"marketplace-test": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -71,6 +71,7 @@
 		"mailchimp": false,
 		"marketplace-domain-bundle": false,
 		"marketplace-fetch-dynamic-plugin-details": false,
+		"marketplace-fetch-all-dynamic-products": true,
 		"marketplace-jetpack-plugin-search": true,
 		"marketplace-personal-premium": false,
 		"marketplace-test": false,

--- a/config/production.json
+++ b/config/production.json
@@ -78,6 +78,7 @@
 		"mailchimp": true,
 		"marketplace-domain-bundle": false,
 		"marketplace-fetch-dynamic-plugin-details": false,
+		"marketplace-fetch-all-dynamic-products": false,
 		"marketplace-jetpack-plugin-search": true,
 		"marketplace-personal-premium": false,
 		"marketplace-test": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -75,6 +75,7 @@
 		"mailchimp": true,
 		"marketplace-domain-bundle": true,
 		"marketplace-fetch-dynamic-plugin-details": false,
+		"marketplace-fetch-all-dynamic-products": false,
 		"marketplace-jetpack-plugin-search": true,
 		"marketplace-personal-premium": false,
 		"marketplace-test": true,

--- a/config/test.json
+++ b/config/test.json
@@ -63,6 +63,7 @@
 		"limit-global-styles": true,
 		"mailchimp": true,
 		"marketplace-fetch-dynamic-plugin-details": false,
+		"marketplace-fetch-all-dynamic-products": false,
 		"marketplace-jetpack-plugin-search": true,
 		"marketplace-personal-premium": false,
 		"me/account-close": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -82,6 +82,7 @@
 		"mailchimp": true,
 		"marketplace-domain-bundle": true,
 		"marketplace-fetch-dynamic-plugin-details": false,
+		"marketplace-fetch-all-dynamic-products": false,
 		"marketplace-jetpack-plugin-search": true,
 		"marketplace-personal-premium": false,
 		"marketplace-test": true,


### PR DESCRIPTION
#### Proposed Changes

* This PR changes the way the marketplace products are retrieved. It introduces a new query type `launched` which will only retrieve launched products from the dynamic product catalog. 

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this branch on your local
* Open network console
* Visit `http://calypso.localhost:3000/plugins/browse/paid/{site}`
* Make sure the `products` endpoint is called with type `all`.
* Make sure you see all products available in the marketplace including `Presto Player Pro` since it was marked as hidden product on WPCOM. 
* Now set the `marketplace-fetch-all-dynamic-products` flag to `false` in `development.json`
* Visit `http://calypso.localhost:3000/plugins/browse/paid/{site}`
* Make sure this time the `products` endpoint is called with type `launched`.
* Make sure you don't see the Presto Player Pro product in the list of paid plugins.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/1555
