### PR TITLE
(POC) Theme Showcase: Style selection in the theme details page

### DIFF
--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -402,12 +402,24 @@
 .theme__sheet-style-variations {
 	.card {
 		display: flex;
-		gap: 4px;
+		gap: 8px;
+		overflow: scroll;
 		padding: 12px 20px;
+	}
+
+	&-badges {
+		.card {
+			gap: 4px;
+		}
 	}
 
 	.style-variation__badge-wrapper {
 		flex-basis: 20px;
+	}
+
+	.design-preview__style-variation-wrapper {
+		flex-basis: 120px;
+		flex-shrink: 0;
 	}
 }
 

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -133,7 +133,8 @@
 	font-size: 90%; /* stylelint-disable-line declaration-property-unit-allowed-list */
 }
 
-.theme__sheet-screenshot {
+.theme__sheet-screenshot,
+.theme__sheet-web-preview {
 	display: block;
 	margin-top: -156px;
 	width: 98%;
@@ -175,6 +176,14 @@
 				0 0 0 1px var(--color-neutral-light),
 				0 2px 10px 0 rgba(var(--color-neutral-dark-rgb), 0.5);
 		}
+	}
+}
+
+.theme__sheet-web-preview {
+	position: relative;
+
+	@include breakpoint-deprecated( ">960px" ) {
+		height: 85vh;
 	}
 }
 
@@ -388,6 +397,18 @@
 	color: transparent;
 	background-color: rgba(255, 255, 255, 0.4);
 	animation: loading-fade 1.6s ease-in-out infinite;
+}
+
+.theme__sheet-style-variations {
+	.card {
+		display: flex;
+		gap: 4px;
+		padding: 12px 20px;
+	}
+
+	.style-variation__badge-wrapper {
+		flex-basis: 20px;
+	}
 }
 
 .theme__sheet-features-list {


### PR DESCRIPTION
#### Proposed Changes

*

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
