### PR TITLE
Logged-out TS: Hide eCommerce plan if destination flow is site assembler

### DIFF
--- a/client/components/themes-list/index.jsx
+++ b/client/components/themes-list/index.jsx
@@ -2,6 +2,7 @@ import { isEnabled } from '@automattic/calypso-config';
 import { FEATURE_INSTALL_THEMES, PLAN_BUSINESS } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
 import { PatternAssemblerCta, BLANK_CANVAS_DESIGN } from '@automattic/design-picker';
+import { SITE_ASSEMBLER_FLOW } from '@automattic/onboarding';
 import { localize } from 'i18n-calypso';
 import { isEmpty, times } from 'lodash';
 import page from 'page';
@@ -33,6 +34,15 @@ export const ThemesList = ( props ) => {
 		[ props.fetchNextPage ]
 	);
 
+	const goToSiteAssemblerFlow = () => {
+		const params = new URLSearchParams( {
+			ref: 'calypshowcase',
+			theme: BLANK_CANVAS_DESIGN.slug,
+			destination_flow: SITE_ASSEMBLER_FLOW,
+		} );
+		window.location.assign( `/start/with-theme?${ params }` );
+	};
+
 	if ( ! props.loading && props.themes.length === 0 ) {
 		return (
 			<Empty
@@ -55,15 +65,7 @@ export const ThemesList = ( props ) => {
 			{ /* The Pattern Assembler CTA will display on the fourth row and the behavior is controlled by CSS */ }
 			{ isEnabled( 'pattern-assembler/logged-out-showcase' ) &&
 				props.themes.length > 0 &&
-				! isLoggedIn && (
-					<PatternAssemblerCta
-						onButtonClick={ () =>
-							window.location.assign(
-								`/start/with-theme?ref=calypshowcase&theme=${ BLANK_CANVAS_DESIGN.slug }`
-							)
-						}
-					/>
-				) }
+				! isLoggedIn && <PatternAssemblerCta onButtonClick={ goToSiteAssemblerFlow } /> }
 			{ props.loading && <LoadingPlaceholders placeholderCount={ props.placeholderCount } /> }
 			<InfiniteScroll nextPageMethod={ fetchNextPage } />
 		</div>

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -351,6 +351,7 @@ export class PlansFeaturesMain extends Component {
 			hideFreePlan,
 			hidePersonalPlan,
 			hidePremiumPlan,
+			hideEcommercePlan,
 			sitePlanSlug,
 			showTreatmentPlansReorderTest,
 			flowName,
@@ -390,6 +391,10 @@ export class PlansFeaturesMain extends Component {
 
 		if ( hidePremiumPlan ) {
 			plans = plans.filter( ( planSlug ) => ! isPremiumPlan( planSlug ) );
+		}
+
+		if ( hideEcommercePlan ) {
+			plans = plans.filter( ( planSlug ) => ! isEcommercePlan( planSlug ) );
 		}
 
 		if ( isNewsletterOrLinkInBioFlow( flowName ) ) {
@@ -640,6 +645,7 @@ PlansFeaturesMain.propTypes = {
 	hideFreePlan: PropTypes.bool,
 	hidePersonalPlan: PropTypes.bool,
 	hidePremiumPlan: PropTypes.bool,
+	hideEcommercePlan: PropTypes.bool,
 	customerType: PropTypes.string,
 	flowName: PropTypes.string,
 	intervalType: PropTypes.oneOf( [ 'monthly', 'yearly' ] ),

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -1,5 +1,6 @@
 import config from '@automattic/calypso-config';
 import { BLANK_CANVAS_DESIGN } from '@automattic/design-picker';
+import { SITE_ASSEMBLER_FLOW } from '@automattic/onboarding';
 import { isDesktop } from '@automattic/viewport';
 import { get, includes, reject } from 'lodash';
 import detectHistoryNavigation from 'calypso/lib/detect-history-navigation';
@@ -109,10 +110,11 @@ function getThankYouNoSiteDestination() {
 	return `/checkout/thank-you/no-site`;
 }
 
-function getChecklistThemeDestination( { siteSlug, themeParameter } ) {
+function getChecklistThemeDestination( { siteSlug, themeParameter, destinationFlowParameter } ) {
 	const canGoToAssemblerFlow = isDesktop();
 
 	if (
+		destinationFlowParameter === SITE_ASSEMBLER_FLOW &&
 		themeParameter === BLANK_CANVAS_DESIGN.slug &&
 		config.isEnabled( 'pattern-assembler/logged-out-showcase' )
 	) {

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -288,9 +288,13 @@ export default {
 		const refParameter = query && query.ref;
 		// Set theme parameter in signup depencency store so we can retrieve it in getChecklistThemeDestination().
 		const themeParameter = query && query.theme;
+		// Set destination parameter in signup depencency store so we can retrieve it in getChecklistThemeDestination().
+		const destinationFlowParameter = query && query.destination_flow;
+
 		const additionalDependencies = {
 			...( refParameter && { refParameter } ),
 			...( themeParameter && { themeParameter } ),
+			...( destinationFlowParameter && { destinationFlowParameter } ),
 		};
 		if ( ! isEmpty( additionalDependencies ) ) {
 			context.store.dispatch( updateDependencies( additionalDependencies ) );

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -12,6 +12,7 @@ import {
 	isLinkInBioFlow,
 	NEWSLETTER_FLOW,
 	isNewsletterOrLinkInBioFlow,
+	SITE_ASSEMBLER_FLOW,
 } from '@automattic/onboarding';
 import { isTailoredSignupFlow } from '@automattic/onboarding/src';
 import { isDesktop, subscribeIsDesktop } from '@automattic/viewport';
@@ -242,6 +243,7 @@ export class PlansStep extends Component {
 					site={ selectedSite || {} } // `PlanFeaturesMain` expects a default prop of `{}` if no site is provided
 					showFAQ={ this.state.isDesktop && ! this.isTailoredFlow() }
 					hideFreePlan={ hideFreePlan }
+					hideEcommercePlan={ this.shouldHideEcommercePlan() }
 					isInSignup={ true }
 					isLaunchPage={ isLaunchPage }
 					intervalType={ this.getIntervalType() }
@@ -366,6 +368,11 @@ export class PlansStep extends Component {
 
 	isTailoredFlow() {
 		return isNewsletterOrLinkInBioFlow( this.props.flowName );
+	}
+
+	shouldHideEcommercePlan() {
+		// Site Assembler doesn't support atomic site, so we have to hide the plan
+		return this.props.signupDependencies.destinationFlowParameter === SITE_ASSEMBLER_FLOW;
 	}
 
 	plansFeaturesSelection() {


### PR DESCRIPTION
#### Proposed Changes

Referring to p1675233608414999/1675233514.738739-slack-CRWCHQGUB and p1675305886405959/1675301136.567349-slack-CRWCHQGUB, there are 2 issues for leading people from the Logged-out Theme Showcase to the Site Assembler flow
  * The Site Assembler doesn't support atomic sites, so if the user selects an eCommerce plan, the result is not expected. Moreover, we will lead to eCommerce flow if the user selects an eCommerce plan and it's weird for the user who clicks on the Pattern Assembler CTA in the Logged-out Theme Showcase.
  * For now we only use the `theme` from the query string to determine whether to go to the Site Assembler flow. However, if we add the Blank Canvas theme back to the Theme Showcase, the user will land on the Site Assembler flow too even if they just want to activate the Blank Canvas theme.

Hence, this PR is proposing adding the `destination_flow=site_assembler` (any better naming?) to the query string when the user clicks on the Pattern Assembler CTA.

https://user-images.githubusercontent.com/13596067/216254448-b2b34877-1b31-4e6a-99a6-9e90e22e7dfd.mov

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the browser with Incognito mode
* Open the developer console and run below code to make sure the feature flag is enabled
  * `document.cookie = 'flags=pattern-assembler/logged-out-showcase;max-age=1209600;path=/'`
* Go to /themes
* Select the Pattern Assembler CTA
* When you land on the plan step, check whether the eCommerce plan is hidden
* Finish the flow and check you land on the Site Assembler

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1675233608414999/1675233514.738739-slack-CRWCHQGUB and p1675305886405959/1675301136.567349-slack-CRWCHQGUB