### PR TITLE
Plans Grid 2023: Fix typo in button

### DIFF
--- a/client/my-sites/plan-features-2023-grid/actions.tsx
+++ b/client/my-sites/plan-features-2023-grid/actions.tsx
@@ -167,7 +167,7 @@ const LoggedInPlansFeatureActionButton = ( {
 
 		return (
 			<Button className={ classes } disabled={ true }>
-				{ translate( 'Constact support', { context: 'verb' } ) }
+				{ translate( 'Contact support', { context: 'verb' } ) }
 			</Button>
 		);
 	}


### PR DESCRIPTION
#### Proposed Changes

Fixes a typo in the grid. Thanks, @dlind1.

#### Media

<img width="489" alt="Screenshot 2023-02-02 at 11 28 57 AM" src="https://user-images.githubusercontent.com/1705499/216285408-befad187-3a14-41df-a8f0-48ec39199436.png">


#### Testing Instructions

1. Activate the onboarding/2023-pricing-grid feature flag
2. Navigate to /plans in Calypso on a paid plan [http://calypso.localhost:3000/plans/[foo.com]](http://calypso.localhost:3000/plans/%5Bfoo.com%5D)
3. Confirm the free plan button reads "Contact support".

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
