### PR TITLE
HappyBlocks: Add common custom blocks class

### DIFF
--- a/apps/happy-blocks/src/pricing-plans/components/pricing-plans.tsx
+++ b/apps/happy-blocks/src/pricing-plans/components/pricing-plans.tsx
@@ -23,7 +23,7 @@ const PricingPlans: FunctionComponent<
 	const onSetPlan = ( productSlug: string ) => setAttributes( { productSlug } );
 
 	return (
-		<div className="hb-pricing-plans-embed">
+		<div className="hb-pricing-plans-embed wp-block-embed">
 			{ attributes.planTypeOptions.length > 1 && (
 				<PricingPlansTabs
 					attributes={ attributes }


### PR DESCRIPTION
#### Proposed Changes

partially fixes 237-gh-Automattic/lighthouse-forums

This PR adds the `wp-block-embed` class to the HappyBlock's Pricing Plans embed. This class is common to most custom blocks and is used in the forums as a way to narrow down styles so that they don't affect the internals of custom blocks

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Code review

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
