### PR TITLE
HappyBlocks: Remove automatic domain detection in Pricing Plans block

### DIFF
--- a/apps/happy-blocks/src/pricing-plans/edit.tsx
+++ b/apps/happy-blocks/src/pricing-plans/edit.tsx
@@ -40,38 +40,6 @@ export const Edit: FunctionComponent< BlockEditProps< BlockAttributes > > = ( {
 		} );
 	}, [ attributes.planTypeOptions.length, attributes.productSlug, plans, setAttributes ] );
 
-	useEffect( () => {
-		if ( attributes.domain ) {
-			return;
-		}
-
-		const blogIdSelect: HTMLSelectElement | null =
-			document.querySelector( 'select[name="blog_id"]' );
-
-		if ( ! blogIdSelect ) {
-			return;
-		}
-
-		const updateBlogId = () => {
-			const url = blogIdSelect.options[ blogIdSelect.selectedIndex ].text;
-			const domain = url.replace( /^https?:\/\//, '' );
-
-			if ( domain !== '--' ) {
-				setAttributes( { domain } );
-			} else {
-				// This needs to be 'false' when unset, see https://github.com/Automattic/wp-calypso/pull/70402#discussion_r1033299970
-				setAttributes( { domain: false } );
-			}
-		};
-
-		updateBlogId();
-		blogIdSelect.addEventListener( 'change', updateBlogId );
-
-		return () => {
-			blogIdSelect.removeEventListener( 'change', updateBlogId );
-		};
-	}, [ attributes.domain, setAttributes ] );
-
 	const blockProps = useBlockProps();
 
 	if ( isLoading || ! plans?.length ) {

--- a/apps/happy-blocks/src/pricing-plans/view.scss
+++ b/apps/happy-blocks/src/pricing-plans/view.scss
@@ -19,11 +19,33 @@ $brand-display: "SF Pro Display", $sans;
 	}
 }
 
-// Workaround for forums global and broad styles overriding this block styles
+// Workaround for forums global and broad styles overriding this block's styles
 .spf-reply__content {
-	& .hb-pricing-plans-embed:last-child {
-		margin: 24px 0;
+	.hb-pricing-plans-embed {
+		&:last-child {
+			margin: 24px 0;
+		}
+
+		a.components-button:link,
+		& a.components-button:visited {
+			color: var(--wp-components-color-accent-inverted, #fff);
+			text-decoration: none;
+		}
 	}
+}
+
+
+// Workaround for forums global and broad styles overriding this block's styles
+.spf-topic-form  label.hb-pricing-plans-embed__billing-option-label {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	font-family: $brand-text;
+	font-weight: 400;
+	font-size: 0.875rem;
+	line-height: 1.42;
+	letter-spacing: -0.15px;
+	color: $studio-gray-60;
 }
 
 .hb-pricing-plans-embed {

--- a/apps/happy-blocks/src/pricing-plans/view.scss
+++ b/apps/happy-blocks/src/pricing-plans/view.scss
@@ -19,6 +19,13 @@ $brand-display: "SF Pro Display", $sans;
 	}
 }
 
+// Workaround for forums global and broad styles overriding this block styles
+.spf-reply__content {
+	& .hb-pricing-plans-embed:last-child {
+		margin: 24px 0;
+	}
+}
+
 .hb-pricing-plans-embed {
 	flex-wrap: wrap;
 	padding: 28px;

--- a/apps/happy-blocks/src/pricing-plans/view.scss
+++ b/apps/happy-blocks/src/pricing-plans/view.scss
@@ -19,35 +19,6 @@ $brand-display: "SF Pro Display", $sans;
 	}
 }
 
-// Workaround for forums global and broad styles overriding this block's styles
-.spf-reply__content {
-	.hb-pricing-plans-embed {
-		&:last-child {
-			margin: 24px 0;
-		}
-
-		a.components-button:link,
-		& a.components-button:visited {
-			color: var(--wp-components-color-accent-inverted, #fff);
-			text-decoration: none;
-		}
-	}
-}
-
-
-// Workaround for forums global and broad styles overriding this block's styles
-.spf-topic-form  label.hb-pricing-plans-embed__billing-option-label {
-	display: flex;
-	align-items: center;
-	gap: 8px;
-	font-family: $brand-text;
-	font-weight: 400;
-	font-size: 0.875rem;
-	line-height: 1.42;
-	letter-spacing: -0.15px;
-	color: $studio-gray-60;
-}
-
 .hb-pricing-plans-embed {
 	flex-wrap: wrap;
 	padding: 28px;


### PR DESCRIPTION
#### Proposed Changes

fixes 237-gh-Automattic/lighthouse-forums

This PR changes the behaviour of the Pricing Plans block so that the domain has to be explicitly set in the block settings.

There are several behavioural corner cases we'll need to carefully rethink for this to work properly, such as:

* Priority of values: what's more important, the custom entered value or the selected one from the topic's form?
* In case one of those sources of information changes, should we update or should we preserve the previous value?
* If there's no custom value, does that mean we want the block to not have a domain? Or does that mean we should default to the one from the topic? Etc.

Until we clearly define the behaviour it's better to remove this functionality to avoid bugs as the one linked above.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Sync these changes with `yarn dev --sync`
* Create a new topic, add a new Pricing Plan block by typing `/personal` in the editor
* Ensure the block is shown without the byline "for [domain]..." under the plan name
* In the block properties, set a domain
* Ensure the block now shows the byline with "for [domain_you_entered]".

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
