### PR TITLE
Plans Grid 2023: mobile card margins

### DIFF
--- a/client/my-sites/plan-features-2023-grid/style.scss
+++ b/client/my-sites/plan-features-2023-grid/style.scss
@@ -177,9 +177,12 @@
 			border: 1px solid #e0e0e0;
 			/* stylelint-disable-next-line */
 			border-radius: 5px;
-			margin-bottom: 12px;
+			margin: 20px;
 			padding: 38px 0 20px 0;
 
+			&:first-of-type {
+				margin-top: 0;
+			}
 
 			.foldable-card__main .foldable-card__expand .gridicon {
 				width: 14px;


### PR DESCRIPTION
#### Proposed Changes

Addresses https://github.com/Automattic/martech/issues/1430. 
Adds a 20px margin around the cards on mobile (or "mobile cards").

**Note:** will need a rebase as it's based off https://github.com/Automattic/wp-calypso/pull/72869. Let's maybe wait for it to ship first as it's in the middle of bigger style overhauls.

#### Media

<img width="455" alt="Screenshot 2023-02-02 at 2 52 54 PM" src="https://user-images.githubusercontent.com/1705499/216330931-192dec2e-55c8-4d1d-bac4-9aaf41f1b233.png">


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Navigate to `/plans/[site_slug]?flags=onboarding/2023-pricing-grid` with a site on a paid plan 
2. Switch to mobile viewport and confirm the changes.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes Automattic/martech#1430
