### PR TITLE
Jetpack Pricing page | Add E2E tests

### DIFF
--- a/test/e2e/specs/jetpack-cloud/jetpack-cloud__pricing--get-backup.ts
+++ b/test/e2e/specs/jetpack-cloud/jetpack-cloud__pricing--get-backup.ts
@@ -1,0 +1,94 @@
+/**
+ * @group jetpack
+ */
+
+import {
+	BrowserManager,
+	CartCheckoutPage,
+	DataHelper,
+	LoginPage,
+	TestAccount,
+} from '@automattic/calypso-e2e';
+import { Page, Browser } from 'playwright';
+
+declare const browser: Browser;
+
+describe(
+	DataHelper.createSuiteTitle( 'Jetpack Cloud: Pricing - get backup as exising user' ),
+	function () {
+		let page: Page;
+		let testAccount: TestAccount;
+
+		beforeAll( async function () {
+			// Launch a new browser window
+			page = await browser.newPage();
+
+			/* Login the test user */
+			/* This can be extracted to a separate utility function/class */
+			await page.goto( DataHelper.getCalypsoURL( '/pricing' ) );
+			await page.locator( 'a:text-is("Log in")' ).click();
+			// wait for navigation to complete
+			await page.waitForNavigation();
+			const loginPage = new LoginPage( page );
+			testAccount = new TestAccount( 'calypsoPreReleaseUser' );
+			await loginPage.logInWithCredentials(
+				testAccount.credentials.username,
+				testAccount.credentials.password
+			);
+		} );
+
+		describe( 'Purchase single backup product', function () {
+			let cartCheckoutPage: CartCheckoutPage;
+
+			beforeAll( async function () {
+				// Set the store cookie to simulate payment processing.
+				await BrowserManager.setStoreCookie( page );
+			} );
+
+			it( 'Navigate to pricing page', async function () {
+				await page.goto( DataHelper.getCalypsoURL( '/pricing' ) );
+			} );
+
+			it( 'Select "Get VaultPress Backup"', async function () {
+				// Select the "Get" button for VaultPress Backup
+				const startWithFreeBtn = page.locator( '[aria-label="Get VaultPress Backup"]' );
+				// Click the button
+				await startWithFreeBtn.click();
+			} );
+
+			it( 'Validate checkout items', async function () {
+				cartCheckoutPage = new CartCheckoutPage( page );
+				// Validate that the cart contains the correct product
+				await cartCheckoutPage.validateCartItem( 'Jetpack VaultPress Backup (10GB)' );
+			} );
+
+			it( 'Enter payment details', async function () {
+				await cartCheckoutPage.selectSavedCard( 'End to End Testing' );
+			} );
+
+			it( 'Compelete the purchase', async function () {
+				await cartCheckoutPage.purchase( { timeout: 60 * 1000 } );
+
+				// wait for navigation to complete
+				await page.waitForNavigation();
+			} );
+
+			it( 'Validate that the purchase was successful', async function () {
+				const url = new URL( page.url() );
+
+				// Confirm that the page URL is correct
+				expect( url.pathname.includes( '/thank-you' ) ).toBe( true );
+
+				// Confirm that the page heading is correct
+				const h1Content = await page.locator( 'h1' ).textContent();
+
+				// Normalize whitespace to avoid &nbsp; being converted to "U+00a0"
+				expect( h1Content?.replace( /\s+/g, ' ' ) ).toBe(
+					`Ok, let's install Jetpack VaultPress Backup`
+				);
+			} );
+
+			// TODO: May be add tests to validate the links and copy license key on the thank you page
+		} );
+	}
+);

--- a/test/e2e/specs/jetpack-cloud/jetpack-cloud__pricing--start-with-free.ts
+++ b/test/e2e/specs/jetpack-cloud/jetpack-cloud__pricing--start-with-free.ts
@@ -1,0 +1,45 @@
+/**
+ * @group jetpack
+ */
+
+import { DataHelper } from '@automattic/calypso-e2e';
+import { Page, Browser } from 'playwright';
+
+declare const browser: Browser;
+
+describe( DataHelper.createSuiteTitle( 'Jetpack Cloud: Pricing - start with free' ), function () {
+	let page: Page;
+
+	beforeAll( async () => {
+		// Launch a new browser window
+		page = await browser.newPage();
+	} );
+
+	describe( 'Visit as a logged out user', function () {
+		it( 'Navigate to pricing page', async function () {
+			await page.goto( DataHelper.getCalypsoURL( '/pricing' ) );
+		} );
+
+		it( 'Select "Start with Jetpack Free"', async function () {
+			// Select the "Start with Jetpack Free" button
+			const startWithFreeBtn = page.locator( ':text-is("Start with Jetpack Free")' );
+			// Click the button
+			await startWithFreeBtn.click();
+
+			// wait for the page to load
+			await page.waitForLoadState( 'networkidle' );
+		} );
+
+		it( 'Validate welcome page', async function () {
+			// Confirm that the page URL is correct
+			expect( page.url().endsWith( '/jetpack-free/welcome' ) ).toBe( true );
+
+			const h1Content = await page.locator( 'h1' ).textContent();
+
+			// Confirm that the page heading is correct
+			expect( h1Content ).toBe( 'Welcome to Jetpack! 🎉' );
+		} );
+
+		// TODO: May be add tests to validate the links on the welcome page
+	} );
+} );


### PR DESCRIPTION
Jetpack Cloud pricing page is an area that is not guarded with E2E tests

#### Proposed Changes

* Add E2E tests for Get Started for free
* Add E2E tests for purchasing Backup

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
