### PR TITLE
Added new domain flow strings for translation

### DIFF
--- a/client/my-sites/domains/domain-experiment-strings.js
+++ b/client/my-sites/domains/domain-experiment-strings.js
@@ -1,0 +1,29 @@
+import { translate } from 'i18n-calypso';
+
+translate( 'Claim your domain' );
+translate(
+	'Stake your claim on your corner of the web with a custom %(domainName) that’s easy to find, share, and follow. Not sure yet?',
+	{
+		args: {
+			domainName: 'example.blog',
+		},
+	}
+);
+translate( 'Decide later.' );
+
+translate( 'Select a domain' );
+translate( 'Select a plan' );
+translate( 'Complete your purchase' );
+
+translate( 'Choose the perfect plan' );
+translate(
+	'With your annual plan, you’ll get %(domainName) {{strong}}free for the first year{{/strong}}. You’ll also unlock advanced features that make it easy to build and grow your site.',
+	{
+		args: {
+			domainName: 'example.blog',
+		},
+		components: {
+			strong: <strong />,
+		},
+	}
+);

--- a/client/my-sites/domains/domain-experiment-strings.js
+++ b/client/my-sites/domains/domain-experiment-strings.js
@@ -2,12 +2,7 @@ import { translate } from 'i18n-calypso';
 
 translate( 'Claim your domain' );
 translate(
-	'Stake your claim on your corner of the web with a custom %(domainName) that’s easy to find, share, and follow. Not sure yet?',
-	{
-		args: {
-			domainName: 'example.blog',
-		},
-	}
+	'Stake your claim on your corner of the web with a custom domain name that’s easy to find, share, and follow. Not sure yet?'
 );
 translate( 'Decide later.' );
 

--- a/client/my-sites/domains/domain-experiment-strings.js
+++ b/client/my-sites/domains/domain-experiment-strings.js
@@ -12,7 +12,7 @@ translate( 'Complete your purchase' );
 
 translate( 'Choose the perfect plan' );
 translate(
-	'With your annual plan, you’ll get %(domainName) {{strong}}free for the first year{{/strong}}. You’ll also unlock advanced features that make it easy to build and grow your site.',
+	'With your annual plan, you’ll get %(domainName)s {{strong}}free for the first year{{/strong}}. You’ll also unlock advanced features that make it easy to build and grow your site.',
 	{
 		args: {
 			domainName: 'example.blog',


### PR DESCRIPTION
### Proposed Changes
This PR adds preemptive translations for strings found in our design docs. When the project is in production and fully translated to the mag-16, this file and its containing folder can be removed.

### Testing Instructions
- Ensure this code is never executed.
- Ensure we have all strings [from our new flow](https://github.com/Automattic/wp-calypso/issues/72516)

Please proof read the copy and make sure it matches what is in the Figma, linked in the comment here: pebzTe-Fx-p2#comment-1131

Is anything missing? Do the translation functions look ok?

### Prints to help with translation


Header:

![image](https://user-images.githubusercontent.com/1044309/216347336-d89bed61-db22-47e5-84be-1ff6aae05e24.png)


Domain page:

![image](https://user-images.githubusercontent.com/1044309/216347077-6331439a-dbcf-4e2a-afc6-a54d188a5f79.png)

Plans page:

![image](https://user-images.githubusercontent.com/1044309/216347222-92c06d58-39b9-4b21-ad6a-37583fb2ac25.png)
