### PR TITLE
WIP: Fix Safari 14 error in stats on macOS Mojave

### DIFF
--- a/packages/components/src/number-formatters/formatted-number.tsx
+++ b/packages/components/src/number-formatters/formatted-number.tsx
@@ -4,7 +4,7 @@ export default function formattedNumber( number: number | null ) {
 		try {
 			return Intl.NumberFormat().format( number as number );
 		} catch {
-			return '-';
+			return number;
 		}
 	}
 

--- a/packages/components/src/number-formatters/formatted-number.tsx
+++ b/packages/components/src/number-formatters/formatted-number.tsx
@@ -1,4 +1,12 @@
-const FORMATTER = new Intl.NumberFormat();
 export default function formattedNumber( number: number | null ) {
-	return Number.isFinite( number ) ? FORMATTER.format( number as number ) : '-';
+	if ( Number.isFinite( number ) ) {
+		// Safari 14 on Mojave can throw errors: https://github.com/google/site-kit-wp/issues/3255
+		try {
+			return Intl.NumberFormat().format( number as number );
+		} catch {
+			return '-';
+		}
+	}
+
+	return '-';
 }


### PR DESCRIPTION
Reported by a customer in 59135490-zen. See similar issue, https://github.com/google/site-kit-wp/issues/3418

#### Proposed Changes

*

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
