### PR TITLE
Inject writing prompt card into reader stream

### DIFF
--- a/client/my-sites/customer-home/cards/features/blogging-prompt/index.jsx
+++ b/client/my-sites/customer-home/cards/features/blogging-prompt/index.jsx
@@ -1,6 +1,7 @@
 import { Card, Button, Gridicon } from '@automattic/components';
 import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
+import { sortBy } from 'lodash';
 import { useSelector, useDispatch } from 'react-redux';
 import CardHeading from 'calypso/components/card-heading';
 import EllipsisMenu from 'calypso/components/ellipsis-menu';
@@ -8,6 +9,8 @@ import { useBloggingPrompts } from 'calypso/data/blogging-prompt/use-blogging-pr
 import useSkipCurrentViewMutation from 'calypso/data/home/use-skip-current-view-mutation';
 import { SECTION_BLOGGING_PROMPT } from 'calypso/my-sites/customer-home/cards/constants';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import getSitesItems from 'calypso/state/selectors/get-sites-items';
+import { setSelectedSiteId } from 'calypso/state/ui/actions';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import BellOffIcon from './bell-off-icon';
 import LightbulbIcon from './lightbulb-icon';
@@ -18,7 +21,22 @@ import './style.scss';
 const BloggingPromptCard = () => {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
-	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
+	const selectedSiteId = useSelector( ( state ) => getSelectedSiteId( state ) );
+	let sites = useSelector( ( state ) => getSitesItems( state ) );
+	let siteId = selectedSiteId;
+
+	// Set selected site ID to first site with write site_intent
+	if ( siteId === null ) {
+		sites = sortBy( sites, [ 'ID' ] );
+		const blogs = Object.values( sites ).filter( ( site ) => {
+			return site.options?.site_intent === 'write';
+		} );
+		if ( blogs.length > 0 ) {
+			siteId = blogs[ 0 ].ID;
+			dispatch( setSelectedSiteId( siteId ) );
+		}
+	}
+
 	const siteSlug = useSelector( ( state ) => getSelectedSiteSlug( state ) );
 	const maxNumberOfPrompts = 10;
 	const { data: prompts } = useBloggingPrompts( siteId, maxNumberOfPrompts );

--- a/client/my-sites/customer-home/cards/features/blogging-prompt/index.jsx
+++ b/client/my-sites/customer-home/cards/features/blogging-prompt/index.jsx
@@ -9,6 +9,7 @@ import { useBloggingPrompts } from 'calypso/data/blogging-prompt/use-blogging-pr
 import useSkipCurrentViewMutation from 'calypso/data/home/use-skip-current-view-mutation';
 import { SECTION_BLOGGING_PROMPT } from 'calypso/my-sites/customer-home/cards/constants';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import getPrimarySiteId from 'calypso/state/selectors/get-primary-site-id';
 import getSitesItems from 'calypso/state/selectors/get-sites-items';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import BellOffIcon from './bell-off-icon';
@@ -21,6 +22,7 @@ const BloggingPromptCard = () => {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 	const selectedSiteId = useSelector( ( state ) => getSelectedSiteId( state ) );
+	const primarySiteId = useSelector( ( state ) => getPrimarySiteId( state ) );
 	let sites = useSelector( ( state ) => getSitesItems( state ) );
 	let siteId = selectedSiteId;
 
@@ -32,6 +34,9 @@ const BloggingPromptCard = () => {
 		} );
 		if ( blogs.length > 0 ) {
 			siteId = blogs[ 0 ].ID;
+		} else {
+			// Fallback to using Primary blog id so we can request prompts
+			siteId = primarySiteId;
 		}
 	}
 

--- a/client/my-sites/customer-home/cards/features/blogging-prompt/index.jsx
+++ b/client/my-sites/customer-home/cards/features/blogging-prompt/index.jsx
@@ -1,7 +1,6 @@
 import { Card, Button, Gridicon } from '@automattic/components';
 import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import { sortBy } from 'lodash';
 import { useSelector, useDispatch } from 'react-redux';
 import CardHeading from 'calypso/components/card-heading';
 import EllipsisMenu from 'calypso/components/ellipsis-menu';
@@ -10,7 +9,6 @@ import useSkipCurrentViewMutation from 'calypso/data/home/use-skip-current-view-
 import { SECTION_BLOGGING_PROMPT } from 'calypso/my-sites/customer-home/cards/constants';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import getPrimarySiteId from 'calypso/state/selectors/get-primary-site-id';
-import getSitesItems from 'calypso/state/selectors/get-sites-items';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import BellOffIcon from './bell-off-icon';
 import LightbulbIcon from './lightbulb-icon';
@@ -23,21 +21,11 @@ const BloggingPromptCard = () => {
 	const translate = useTranslate();
 	const selectedSiteId = useSelector( ( state ) => getSelectedSiteId( state ) );
 	const primarySiteId = useSelector( ( state ) => getPrimarySiteId( state ) );
-	let sites = useSelector( ( state ) => getSitesItems( state ) );
 	let siteId = selectedSiteId;
 
-	// If no selected site ID, set site ID to first site with write site_intent
+	// If no selected site ID, fallback to using Primary blog id so we can request prompts
 	if ( siteId === null ) {
-		sites = sortBy( sites, [ 'ID' ] );
-		const blogs = Object.values( sites ).filter( ( site ) => {
-			return site.options?.site_intent === 'write';
-		} );
-		if ( blogs.length > 0 ) {
-			siteId = blogs[ 0 ].ID;
-		} else {
-			// Fallback to using Primary blog id so we can request prompts
-			siteId = primarySiteId;
-		}
+		siteId = primarySiteId;
 	}
 
 	const siteSlug = useSelector( ( state ) => getSelectedSiteSlug( state ) );

--- a/client/my-sites/customer-home/cards/features/blogging-prompt/index.jsx
+++ b/client/my-sites/customer-home/cards/features/blogging-prompt/index.jsx
@@ -23,7 +23,8 @@ const BloggingPromptCard = () => {
 	const primarySiteId = useSelector( ( state ) => getPrimarySiteId( state ) );
 	let siteId = selectedSiteId;
 
-	// If no selected site ID, fallback to using Primary blog id so we can request prompts
+	// We need a site ID to request prompts
+	// If no selected site ID, fallback to using Primary site ID
 	if ( siteId === null ) {
 		siteId = primarySiteId;
 	}

--- a/client/my-sites/customer-home/cards/features/blogging-prompt/index.jsx
+++ b/client/my-sites/customer-home/cards/features/blogging-prompt/index.jsx
@@ -10,7 +10,6 @@ import useSkipCurrentViewMutation from 'calypso/data/home/use-skip-current-view-
 import { SECTION_BLOGGING_PROMPT } from 'calypso/my-sites/customer-home/cards/constants';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import getSitesItems from 'calypso/state/selectors/get-sites-items';
-import { setSelectedSiteId } from 'calypso/state/ui/actions';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import BellOffIcon from './bell-off-icon';
 import LightbulbIcon from './lightbulb-icon';
@@ -25,7 +24,7 @@ const BloggingPromptCard = () => {
 	let sites = useSelector( ( state ) => getSitesItems( state ) );
 	let siteId = selectedSiteId;
 
-	// Set selected site ID to first site with write site_intent
+	// If no selected site ID, set site ID to first site with write site_intent
 	if ( siteId === null ) {
 		sites = sortBy( sites, [ 'ID' ] );
 		const blogs = Object.values( sites ).filter( ( site ) => {
@@ -33,11 +32,12 @@ const BloggingPromptCard = () => {
 		} );
 		if ( blogs.length > 0 ) {
 			siteId = blogs[ 0 ].ID;
-			dispatch( setSelectedSiteId( siteId ) );
 		}
 	}
 
 	const siteSlug = useSelector( ( state ) => getSelectedSiteSlug( state ) );
+	const notificationSettingsLink = '/me/notifications' + siteSlug ? '#' + siteSlug : '';
+
 	const maxNumberOfPrompts = 10;
 	const { data: prompts } = useBloggingPrompts( siteId, maxNumberOfPrompts );
 
@@ -54,8 +54,6 @@ const BloggingPromptCard = () => {
 			} )
 		);
 	};
-
-	const notificationSettingsLink = `/me/notifications#${ siteSlug }`;
 
 	return (
 		<div className="blogging-prompt">

--- a/client/my-sites/customer-home/cards/features/blogging-prompt/index.jsx
+++ b/client/my-sites/customer-home/cards/features/blogging-prompt/index.jsx
@@ -30,7 +30,7 @@ const BloggingPromptCard = () => {
 	}
 
 	const siteSlug = useSelector( ( state ) => getSelectedSiteSlug( state ) );
-	const notificationSettingsLink = '/me/notifications' + siteSlug ? '#' + siteSlug : '';
+	const notificationSettingsLink = '/me/notifications' + ( siteSlug ? '#' + siteSlug : '' );
 
 	const maxNumberOfPrompts = 10;
 	const { data: prompts } = useBloggingPrompts( siteId, maxNumberOfPrompts );

--- a/client/my-sites/customer-home/cards/features/blogging-prompt/prompts-navigation.jsx
+++ b/client/my-sites/customer-home/cards/features/blogging-prompt/prompts-navigation.jsx
@@ -24,7 +24,9 @@ const PromptsNavigation = ( { prompts } ) => {
 		return prompts !== undefined ? prompts[ promptIndex ] : null;
 	};
 
-	const getNewPostLink = () => addQueryArgs( editorUrl, { answer_prompt: getPrompt()?.id } );
+	// If no site ID set, go through site selector before rendering post editor
+	const getNewPostLink = () =>
+		addQueryArgs( siteId ? editorUrl : '/post', { answer_prompt: getPrompt()?.id } );
 
 	const goToPreviousStep = () => {
 		let nextIndex = promptIndex - 1;

--- a/client/reader/post-key.js
+++ b/client/reader/post-key.js
@@ -50,6 +50,8 @@ export function keyToString( postKey ) {
 
 	if ( postKey.isRecommendationBlock ) {
 		return `rec-${ postKey.index }`;
+	} else if ( postKey.isPromptBlock ) {
+		return `prompt-${ postKey.index }`;
 	} else if ( postKey.feedId ) {
 		return `${ postKey.postId }-${ postKey.feedId }`;
 	} else if ( postKey.blogId ) {

--- a/client/reader/stream/post-lifecycle.jsx
+++ b/client/reader/stream/post-lifecycle.jsx
@@ -5,6 +5,7 @@ import { connect } from 'react-redux';
 import PostBlocked from 'calypso/blocks/reader-post-card/blocked';
 import QueryReaderPost from 'calypso/components/data/query-reader-post';
 import compareProps from 'calypso/lib/compare-props';
+import BloggingPromptCard from 'calypso/my-sites/customer-home/cards/features/blogging-prompt';
 import { IN_STREAM_RECOMMENDATION } from 'calypso/reader/follow-sources';
 import ListGap from 'calypso/reader/list-gap';
 import XPostHelper, { isXPost } from 'calypso/reader/xpost-helper';
@@ -35,6 +36,12 @@ class PostLifecycle extends Component {
 					streamKey={ recsStreamKey }
 					followSource={ IN_STREAM_RECOMMENDATION }
 				/>
+			);
+		} else if ( postKey.isPromptBlock ) {
+			return (
+				<div className="reader-stream__blogging-prompt">
+					<BloggingPromptCard />
+				</div>
 			);
 		} else if ( streamKey.indexOf( 'rec' ) > -1 ) {
 			return <EmptySearchRecommendedPost post={ post } site={ postKey } />;

--- a/client/reader/stream/post-lifecycle.jsx
+++ b/client/reader/stream/post-lifecycle.jsx
@@ -39,7 +39,10 @@ class PostLifecycle extends Component {
 			);
 		} else if ( postKey.isPromptBlock ) {
 			return (
-				<div className="reader-stream__blogging-prompt">
+				<div
+					className="reader-stream__blogging-prompt"
+					key={ 'blogging-prompt-card-' + postKey.index }
+				>
 					<BloggingPromptCard />
 				</div>
 			);

--- a/client/reader/stream/style.scss
+++ b/client/reader/stream/style.scss
@@ -725,3 +725,16 @@
 		width: 100%;
 	}
 }
+
+.reader-stream__blogging-prompt {
+	border-bottom: 5px solid var(--color-neutral-0);
+	box-shadow: none;
+	margin: 0;
+	padding: 12px 15px 20px;
+	position: relative;
+
+	@include breakpoint-deprecated(">660px") {
+		border-bottom: 1px solid var(--color-neutral-5);
+		padding: 12px 0 0 0;
+	}
+}

--- a/client/reader/stream/style.scss
+++ b/client/reader/stream/style.scss
@@ -737,4 +737,8 @@
 		border-bottom: 1px solid var(--color-neutral-5);
 		padding: 12px 0 0 0;
 	}
+
+	.blogging-prompt__menu {
+		display: none;
+	}
 }

--- a/client/reader/stream/style.scss
+++ b/client/reader/stream/style.scss
@@ -727,18 +727,32 @@
 }
 
 .reader-stream__blogging-prompt {
-	border-bottom: 5px solid var(--color-neutral-0);
-	box-shadow: none;
-	margin: 0;
-	padding: 12px 15px 20px;
-	position: relative;
+	padding: 12px 15px 4px 0;
+	clear: both;
+	display: flex;
+	flex-direction: column;
+	margin-left: 16px;
+	margin-top: 6px;
 
 	@include breakpoint-deprecated(">660px") {
-		border-bottom: 1px solid var(--color-neutral-5);
-		padding: 12px 0 0 0;
+		padding: 12px 0 4px 0;
+		margin-left: 52px;
 	}
 
 	.blogging-prompt__menu {
 		display: none;
+	}
+
+	+ article.reader-post-card {
+		border-top: 5px solid var(--color-neutral-0);
+
+		@include breakpoint-deprecated(">660px") {
+			border-top: 1px solid var(--color-neutral-5);
+		}
+	}
+
+	.blogging-prompt__card,
+	.blogging-prompt__prompt-answers a {
+		border-radius: 6px; /* stylelint-disable-line scales/radii */
 	}
 }

--- a/client/reader/stream/style.scss
+++ b/client/reader/stream/style.scss
@@ -731,12 +731,10 @@
 	clear: both;
 	display: flex;
 	flex-direction: column;
-	margin-left: 16px;
 	margin-top: 6px;
 
 	@include breakpoint-deprecated(">660px") {
 		padding: 12px 0 4px 0;
-		margin-left: 52px;
 	}
 
 	.blogging-prompt__menu {

--- a/client/reader/stream/utils.js
+++ b/client/reader/stream/utils.js
@@ -99,6 +99,7 @@ export function injectPrompts( posts, itemsBetweenPrompts ) {
 		if ( index && index % itemsBetweenPrompts === 0 ) {
 			const promptBlock = {
 				isPromptBlock: true,
+				index: index,
 			};
 			return [ promptBlock, post ];
 		}

--- a/client/reader/stream/utils.js
+++ b/client/reader/stream/utils.js
@@ -89,3 +89,19 @@ export function getDistanceBetweenRecs( totalSubs ) {
 		MAX_DISTANCE_BETWEEN_RECS
 	);
 }
+
+export function injectPrompts( posts, itemsBetweenPrompts ) {
+	if ( posts.length < itemsBetweenPrompts ) {
+		return posts;
+	}
+
+	return flatMap( posts, ( post, index ) => {
+		if ( index && index % itemsBetweenPrompts === 0 ) {
+			const promptBlock = {
+				isPromptBlock: true,
+			};
+			return [ promptBlock, post ];
+		}
+		return post;
+	} );
+}

--- a/client/reader/stream/utils.js
+++ b/client/reader/stream/utils.js
@@ -90,6 +90,31 @@ export function getDistanceBetweenRecs( totalSubs ) {
 	);
 }
 
+const MIN_DISTANCE_BETWEEN_PROMPTS = 10;
+const MAX_DISTANCE_BETWEEN_PROMPTS = 50;
+
+export function getDistanceBetweenPrompts( totalSubs ) {
+	// the distance between recs changes based on how many subscriptions the user has.
+	// We cap it at MAX_DISTANCE_BETWEEN_PROMPTS.
+	// It grows at the natural log of the number of subs, times a multiplier, offset by a constant.
+	// This lets the distance between prompts grow quickly as you add subs early on, and slow down as you
+	// become a common user of the reader.
+	if ( totalSubs <= 0 ) {
+		// 0 means either we don't know yet, or the user actually has zero subs.
+		// if a user has zero subs, we don't show posts at all, so just treat 0 as 'unknown' and
+		// push recs to the max.
+		return MAX_DISTANCE_BETWEEN_PROMPTS;
+	}
+
+	return Math.min(
+		Math.max(
+			Math.floor( Math.log( totalSubs ) * Math.LOG2E * 5 - 3 ),
+			MIN_DISTANCE_BETWEEN_PROMPTS
+		),
+		MAX_DISTANCE_BETWEEN_PROMPTS
+	);
+}
+
 export function injectPrompts( posts, itemsBetweenPrompts ) {
 	if ( posts.length < itemsBetweenPrompts ) {
 		return posts;

--- a/client/reader/stream/utils.js
+++ b/client/reader/stream/utils.js
@@ -108,7 +108,7 @@ export function getDistanceBetweenPrompts( totalSubs ) {
 
 	return Math.min(
 		Math.max(
-			Math.floor( Math.log( totalSubs ) * Math.LOG2E * 5 - 3 ),
+			Math.floor( Math.log( totalSubs ) * Math.LOG2E * 7 - 3 ),
 			MIN_DISTANCE_BETWEEN_PROMPTS
 		),
 		MAX_DISTANCE_BETWEEN_PROMPTS

--- a/client/state/reader/streams/selectors/get-reader-stream-transformed-items.js
+++ b/client/state/reader/streams/selectors/get-reader-stream-transformed-items.js
@@ -1,5 +1,9 @@
 import treeSelect from '@automattic/tree-select';
-import { injectRecommendations, getDistanceBetweenRecs } from 'calypso/reader/stream/utils';
+import {
+	injectRecommendations,
+	getDistanceBetweenRecs,
+	injectPrompts,
+} from 'calypso/reader/stream/utils';
 import { getReaderFollows } from 'calypso/state/reader/follows/selectors';
 import getReaderStream from 'calypso/state/reader/streams/selectors/get-reader-stream';
 
@@ -25,6 +29,8 @@ export const getTransformedStreamItems = treeSelect(
 		if ( recs.length > 0 ) {
 			items = injectRecommendations( items, recs, getDistanceBetweenRecs( follows.length ) );
 		}
+
+		items = injectPrompts( items, 10 );
 
 		return items;
 	},

--- a/client/state/reader/streams/selectors/get-reader-stream-transformed-items.js
+++ b/client/state/reader/streams/selectors/get-reader-stream-transformed-items.js
@@ -3,6 +3,7 @@ import {
 	injectRecommendations,
 	getDistanceBetweenRecs,
 	injectPrompts,
+	getDistanceBetweenPrompts,
 } from 'calypso/reader/stream/utils';
 import { getReaderFollows } from 'calypso/state/reader/follows/selectors';
 import getReaderStream from 'calypso/state/reader/streams/selectors/get-reader-stream';
@@ -30,7 +31,7 @@ export const getTransformedStreamItems = treeSelect(
 			items = injectRecommendations( items, recs, getDistanceBetweenRecs( follows.length ) );
 		}
 
-		items = injectPrompts( items, 10 );
+		items = injectPrompts( items, getDistanceBetweenPrompts( follows.length ) );
 
 		return items;
 	},


### PR DESCRIPTION
This PR intends to inject the writing prompt home card into the Reader following stream.

![Image](https://user-images.githubusercontent.com/5634774/212122435-eca3f336-a1b9-4623-a02b-37763673768b.png)

Ref - https://github.com/Automattic/wp-calypso/issues/72015

Things to work out;

- [x] How do we inject an component into the post stream on Reader?
- [x] How often should the prompt card be rendered in that stream?
- [x] What site will link to when rendering the prompt card? (where will the answer be posted?)

