### PR TITLE
Redux state: Convert storedCards state to TypeScript

### DIFF
--- a/client/me/purchases/payment-methods/payment-method-delete.tsx
+++ b/client/me/purchases/payment-methods/payment-method-delete.tsx
@@ -12,7 +12,7 @@ import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import { deleteStoredCard } from 'calypso/state/stored-cards/actions';
 import { isDeletingStoredCard } from 'calypso/state/stored-cards/selectors';
 import PaymentMethodDeleteDialog from './payment-method-delete-dialog';
-import type { CalypsoDispatch } from 'calypso/state/types';
+import type { CalypsoDispatch, IAppState } from 'calypso/state/types';
 
 interface Props {
 	card: PaymentMethod;
@@ -20,7 +20,7 @@ interface Props {
 
 const PaymentMethodDelete: FunctionComponent< Props > = ( { card } ) => {
 	const translate = useTranslate();
-	const isDeleting = useSelector( ( state ) =>
+	const isDeleting = useSelector( ( state: IAppState ) =>
 		isDeletingStoredCard( state, card.stored_details_id )
 	);
 	const reduxDispatch = useDispatch< CalypsoDispatch >();

--- a/client/me/purchases/payment-methods/payment-method-list.tsx
+++ b/client/me/purchases/payment-methods/payment-method-list.tsx
@@ -16,6 +16,7 @@ import {
 } from 'calypso/state/stored-cards/selectors';
 import type { PaymentMethod as PaymentMethodType } from 'calypso/lib/checkout/payment-methods';
 import type { StoredCard } from 'calypso/my-sites/checkout/composite-checkout/types/stored-cards';
+import type { IAppState } from 'calypso/state/types';
 
 import 'calypso/me/purchases/payment-methods/style.scss';
 
@@ -93,7 +94,7 @@ class PaymentMethodList extends Component< PaymentMethodListProps > {
 	}
 }
 
-export default connect( ( state ) => ( {
+export default connect( ( state: IAppState ) => ( {
 	cards: getAllStoredCards( state ),
 	paymentAgreements: getUniquePaymentAgreements( state ),
 	hasLoadedFromServer: hasLoadedStoredCardsFromServer( state ),

--- a/client/my-sites/checkout/upsell-nudge/index.tsx
+++ b/client/my-sites/checkout/upsell-nudge/index.tsx
@@ -59,6 +59,7 @@ import { extractStoredCardMetaValue } from './purchase-modal/util';
 import { QuickstartSessionsRetirement } from './quickstart-sessions-retirement';
 import type { WithShoppingCartProps, MinimalRequestCartProduct } from '@automattic/shopping-cart';
 import type { PaymentMethod } from 'calypso/lib/checkout/payment-methods';
+import type { IAppState } from 'calypso/state/types';
 
 import './style.scss';
 
@@ -521,7 +522,7 @@ const getProductSlug = ( upsellType: string, productAlias: string, planTerm: str
 };
 
 export default connect(
-	( state: UpsellNudgeState, props: UpsellNudgeManualProps ) => {
+	( state: IAppState, props: UpsellNudgeManualProps ) => {
 		const { siteSlugParam, upgradeItem, upsellType } = props;
 		const selectedSiteId = getSelectedSiteId( state );
 		const productsList = getProductsList( state );

--- a/client/state/stored-cards/reducer.js
+++ b/client/state/stored-cards/reducer.js
@@ -1,5 +1,3 @@
-/* eslint-disable no-case-declarations */
-
 import { withStorageKey } from '@automattic/state-utils';
 import {
 	STORED_CARDS_ADD_COMPLETED,
@@ -113,10 +111,11 @@ export const isDeleting = ( state = {}, action ) => {
 			};
 
 		case STORED_CARDS_DELETE_FAILED:
-		case STORED_CARDS_DELETE_COMPLETED:
+		case STORED_CARDS_DELETE_COMPLETED: {
 			const nextState = { ...state };
 			delete nextState[ action.card.stored_details_id ];
 			return nextState;
+		}
 	}
 
 	return state;

--- a/client/state/stored-cards/reducer.ts
+++ b/client/state/stored-cards/reducer.ts
@@ -11,60 +11,59 @@ import {
 } from 'calypso/state/action-types';
 import { combineReducers, withSchemaValidation } from 'calypso/state/utils';
 import { storedCardsSchema } from './schema';
+import type { StoredCardsActions, StoredCardsState } from './types';
 
 /**
  * `Reducer` function which handles request/response actions
  * concerning stored cards data updates
- *
- * @param  {Array}  state  Current state
- * @param  {Object} action storeCard action
- * @returns {Array}         Updated state
  */
-export const items = withSchemaValidation( storedCardsSchema, ( state = [], action ) => {
-	switch ( action.type ) {
-		case STORED_CARDS_ADD_COMPLETED: {
-			const { item } = action;
-			return [ ...state, item ];
+export const items = withSchemaValidation(
+	storedCardsSchema,
+	( state: StoredCardsState[ 'items' ] | undefined = [], action: StoredCardsActions ) => {
+		switch ( action.type ) {
+			case STORED_CARDS_ADD_COMPLETED: {
+				const { item } = action;
+				return [ ...state, item ];
+			}
+
+			case STORED_CARDS_FETCH_COMPLETED: {
+				const { list } = action;
+				return list;
+			}
+			case STORED_CARDS_DELETE_COMPLETED: {
+				const { card } = action;
+				return state.filter(
+					( item ) => ! card.allStoredDetailsIds.includes( item.stored_details_id )
+				);
+			}
+			case STORED_CARDS_UPDATE_IS_BACKUP_COMPLETED: {
+				const { stored_details_id, is_backup } = action;
+				return state.map( ( item ) => {
+					if ( item.stored_details_id === stored_details_id && item.meta ) {
+						return {
+							...item,
+							meta: [
+								...( item.meta?.filter( ( meta ) => meta.meta_key !== 'is_backup' ) ?? {} ),
+								{ meta_key: 'is_backup', meta_value: is_backup ? 'backup' : null },
+							],
+						};
+					}
+					return item;
+				} );
+			}
 		}
 
-		case STORED_CARDS_FETCH_COMPLETED: {
-			const { list } = action;
-			return list;
-		}
-		case STORED_CARDS_DELETE_COMPLETED: {
-			const { card } = action;
-			return state.filter(
-				( item ) => ! card.allStoredDetailsIds.includes( item.stored_details_id )
-			);
-		}
-		case STORED_CARDS_UPDATE_IS_BACKUP_COMPLETED: {
-			const { stored_details_id, is_backup } = action;
-			return state.map( ( item ) => {
-				if ( item.stored_details_id === stored_details_id && item.meta ) {
-					return {
-						...item,
-						meta: [
-							...( item.meta?.filter( ( meta ) => meta.meta_key !== 'is_backup' ) ?? {} ),
-							{ meta_key: 'is_backup', meta_value: is_backup ? 'backup' : null },
-						],
-					};
-				}
-				return item;
-			} );
-		}
+		return state;
 	}
-
-	return state;
-} );
+);
 
 /**
  * Returns whether the list of stored cards has been loaded from the server in reaction to the specified action.
- *
- * @param {Array} state - current state
- * @param {Object} action - action payload
- * @returns {boolean} - updated state
  */
-export const hasLoadedFromServer = ( state = false, action ) => {
+export const hasLoadedFromServer = (
+	state: StoredCardsState[ 'hasLoadedFromServer' ] | undefined = false,
+	action: StoredCardsActions
+) => {
 	switch ( action.type ) {
 		case STORED_CARDS_FETCH_COMPLETED:
 			return true;
@@ -76,12 +75,11 @@ export const hasLoadedFromServer = ( state = false, action ) => {
 /**
  * `Reducer` function which handles request/response actions
  * concerning stored cards fetching
- *
- * @param {Object} state - current state
- * @param {Object} action - storedCard action
- * @returns {Object} updated state
  */
-export const isFetching = ( state = false, action ) => {
+export const isFetching = (
+	state: StoredCardsState[ 'isFetching' ] | undefined = false,
+	action: StoredCardsActions
+) => {
 	switch ( action.type ) {
 		case STORED_CARDS_FETCH:
 			return true;
@@ -97,12 +95,11 @@ export const isFetching = ( state = false, action ) => {
 /**
  * `Reducer` function which handles request/response actions
  * concerning stored card deletion
- *
- * @param {Object} state - current state
- * @param {Object} action - storedCard action
- * @returns {Object} updated state
  */
-export const isDeleting = ( state = {}, action ) => {
+export const isDeleting = (
+	state: StoredCardsState[ 'isDeleting' ] | undefined = {},
+	action: StoredCardsActions
+) => {
 	switch ( action.type ) {
 		case STORED_CARDS_DELETE:
 			return {

--- a/client/state/stored-cards/selectors.ts
+++ b/client/state/stored-cards/selectors.ts
@@ -1,16 +1,15 @@
 import { groupBy } from 'lodash';
 import { isPaymentAgreement, isCreditCard } from 'calypso/lib/checkout/payment-methods';
+import type { StoredCard } from 'calypso/my-sites/checkout/composite-checkout/types/stored-cards';
+import type { AppState } from 'calypso/types';
 
 import 'calypso/state/stored-cards/init';
 
 /**
  * Return user's stored cards from state object
- *
- * @param {Object} state - current state object
- * @returns {import('calypso/my-sites/checkout/composite-checkout/types/stored-cards.ts').StoredCard[]} Stored Cards
  */
-export const getStoredCards = ( state ) =>
-	( state.storedCards?.items ?? [] )
+export const getStoredCards = ( state: AppState ): StoredCard[] =>
+	( ( state.storedCards?.items ?? [] ) as StoredCard[] )
 		.filter( ( method ) => isCreditCard( method ) )
 		.filter( ( method ) => ! method.is_expired )
 		.map( ( card ) => ( {
@@ -20,12 +19,9 @@ export const getStoredCards = ( state ) =>
 
 /**
  * Return user's stored cards including expired cards
- *
- * @param {Object} state - current state object
- * @returns {import('calypso/my-sites/checkout/composite-checkout/types/stored-cards.ts').StoredCard[]} Stored Cards
  */
-export const getAllStoredCards = ( state ) =>
-	( state.storedCards?.items ?? [] )
+export const getAllStoredCards = ( state: AppState ): StoredCard[] =>
+	( ( state.storedCards?.items ?? [] ) as StoredCard[] )
 		.filter( ( method ) => isCreditCard( method ) )
 		.map( ( card ) => ( {
 			...card,
@@ -39,8 +35,8 @@ export const getAllStoredCards = ( state ) =>
  * @param {Object} state - current state object
  * @returns {Array} Stored Payment Agreements
  */
-export const getStoredPaymentAgreements = ( state ) =>
-	( state.storedCards?.items ?? [] )
+export const getStoredPaymentAgreements = ( state: AppState ): StoredCard[] =>
+	( ( state.storedCards?.items ?? [] ) as StoredCard[] )
 		.filter( ( stored ) => isPaymentAgreement( stored ) )
 		.map( ( method ) => ( {
 			...method,
@@ -54,7 +50,7 @@ export const getStoredPaymentAgreements = ( state ) =>
  * @param {Object} state - current state object
  * @returns {Array} Stored Payment Methods excluding cards
  */
-export const getUniquePaymentAgreements = ( state ) => {
+export const getUniquePaymentAgreements = ( state: AppState ): StoredCard[] => {
 	const paymentMethods = getStoredPaymentAgreements( state );
 	const groups = groupBy( paymentMethods, 'email' );
 	const paymentMethodsGroups = Object.values( groups );
@@ -69,20 +65,22 @@ export const getUniquePaymentAgreements = ( state ) => {
 
 /**
  * Returns a Stored Card
- *
- * @param  {Object} state      global state
- * @param  {number} cardId  the card id
- * @returns {undefined|import('calypso/my-sites/checkout/composite-checkout/types/stored-cards.ts').StoredCard} the matching card if there is one
  */
-export const getStoredCardById = ( state, cardId ) =>
+export const getStoredCardById = (
+	state: AppState,
+	cardId: StoredCard[ 'stored_details_id' ]
+): undefined | StoredCard =>
 	getStoredCards( state )
 		.filter( ( card ) => card.stored_details_id === cardId )
 		.shift();
 
-export const hasLoadedStoredCardsFromServer = ( state ) =>
+export const hasLoadedStoredCardsFromServer = ( state: AppState ) =>
 	Boolean( state.storedCards?.hasLoadedFromServer );
 
-export const isDeletingStoredCard = ( state, cardId ) =>
-	Boolean( state.storedCards?.isDeleting[ cardId ] );
+export const isDeletingStoredCard = (
+	state: AppState,
+	cardId: StoredCard[ 'stored_details_id' ]
+) => Boolean( state.storedCards?.isDeleting[ cardId ] );
 
-export const isFetchingStoredCards = ( state ) => Boolean( state.storedCards?.isFetching );
+export const isFetchingStoredCards = ( state: AppState ) =>
+	Boolean( state.storedCards?.isFetching );

--- a/client/state/stored-cards/selectors.ts
+++ b/client/state/stored-cards/selectors.ts
@@ -1,17 +1,14 @@
 import { groupBy } from 'lodash';
 import { isPaymentAgreement, isCreditCard } from 'calypso/lib/checkout/payment-methods';
-import type { StoredCardsState } from './types';
 import type { StoredCard } from 'calypso/my-sites/checkout/composite-checkout/types/stored-cards';
+import type { IAppState } from 'calypso/state/types';
 
 import 'calypso/state/stored-cards/init';
-
-// AppState isn't actually defined yet so we're going to use StoredCardsState here until it is.
-type CombinedState = { storedCards: StoredCardsState };
 
 /**
  * Return user's stored cards from state object
  */
-export const getStoredCards = ( state: CombinedState ): StoredCard[] =>
+export const getStoredCards = ( state: IAppState ): StoredCard[] =>
 	( state.storedCards?.items ?? [] )
 		.filter( ( method ) => isCreditCard( method ) )
 		.filter( ( method ) => ! method.is_expired )
@@ -23,7 +20,7 @@ export const getStoredCards = ( state: CombinedState ): StoredCard[] =>
 /**
  * Return user's stored cards including expired cards
  */
-export const getAllStoredCards = ( state: CombinedState ): StoredCard[] =>
+export const getAllStoredCards = ( state: IAppState ): StoredCard[] =>
 	( state.storedCards?.items ?? [] )
 		.filter( ( method ) => isCreditCard( method ) )
 		.map( ( card ) => ( {
@@ -38,7 +35,7 @@ export const getAllStoredCards = ( state: CombinedState ): StoredCard[] =>
  * @param {Object} state - current state object
  * @returns {Array} Stored Payment Agreements
  */
-export const getStoredPaymentAgreements = ( state: CombinedState ): StoredCard[] =>
+export const getStoredPaymentAgreements = ( state: IAppState ): StoredCard[] =>
 	( state.storedCards?.items ?? [] )
 		.filter( ( stored ) => isPaymentAgreement( stored ) )
 		.map( ( method ) => ( {
@@ -53,7 +50,7 @@ export const getStoredPaymentAgreements = ( state: CombinedState ): StoredCard[]
  * @param {Object} state - current state object
  * @returns {Array} Stored Payment Methods excluding cards
  */
-export const getUniquePaymentAgreements = ( state: CombinedState ): StoredCard[] => {
+export const getUniquePaymentAgreements = ( state: IAppState ): StoredCard[] => {
 	const paymentMethods = getStoredPaymentAgreements( state );
 	const groups = groupBy( paymentMethods, 'email' );
 	const paymentMethodsGroups = Object.values( groups );
@@ -70,20 +67,20 @@ export const getUniquePaymentAgreements = ( state: CombinedState ): StoredCard[]
  * Returns a Stored Card
  */
 export const getStoredCardById = (
-	state: CombinedState,
+	state: IAppState,
 	cardId: StoredCard[ 'stored_details_id' ]
 ): undefined | StoredCard =>
 	getStoredCards( state )
 		.filter( ( card ) => card.stored_details_id === cardId )
 		.shift();
 
-export const hasLoadedStoredCardsFromServer = ( state: CombinedState ) =>
+export const hasLoadedStoredCardsFromServer = ( state: IAppState ) =>
 	Boolean( state.storedCards?.hasLoadedFromServer );
 
 export const isDeletingStoredCard = (
-	state: CombinedState,
+	state: IAppState,
 	cardId: StoredCard[ 'stored_details_id' ]
 ) => Boolean( state.storedCards?.isDeleting[ cardId ] );
 
-export const isFetchingStoredCards = ( state: CombinedState ) =>
+export const isFetchingStoredCards = ( state: IAppState ) =>
 	Boolean( state.storedCards?.isFetching );

--- a/client/state/stored-cards/selectors.ts
+++ b/client/state/stored-cards/selectors.ts
@@ -1,15 +1,18 @@
 import { groupBy } from 'lodash';
 import { isPaymentAgreement, isCreditCard } from 'calypso/lib/checkout/payment-methods';
+import type { StoredCardsState } from './types';
 import type { StoredCard } from 'calypso/my-sites/checkout/composite-checkout/types/stored-cards';
-import type { AppState } from 'calypso/types';
 
 import 'calypso/state/stored-cards/init';
+
+// AppState isn't actually defined yet so we're going to use StoredCardsState here until it is.
+type CombinedState = { storedCards: StoredCardsState };
 
 /**
  * Return user's stored cards from state object
  */
-export const getStoredCards = ( state: AppState ): StoredCard[] =>
-	( ( state.storedCards?.items ?? [] ) as StoredCard[] )
+export const getStoredCards = ( state: CombinedState ): StoredCard[] =>
+	( state.storedCards?.items ?? [] )
 		.filter( ( method ) => isCreditCard( method ) )
 		.filter( ( method ) => ! method.is_expired )
 		.map( ( card ) => ( {
@@ -20,8 +23,8 @@ export const getStoredCards = ( state: AppState ): StoredCard[] =>
 /**
  * Return user's stored cards including expired cards
  */
-export const getAllStoredCards = ( state: AppState ): StoredCard[] =>
-	( ( state.storedCards?.items ?? [] ) as StoredCard[] )
+export const getAllStoredCards = ( state: CombinedState ): StoredCard[] =>
+	( state.storedCards?.items ?? [] )
 		.filter( ( method ) => isCreditCard( method ) )
 		.map( ( card ) => ( {
 			...card,
@@ -35,8 +38,8 @@ export const getAllStoredCards = ( state: AppState ): StoredCard[] =>
  * @param {Object} state - current state object
  * @returns {Array} Stored Payment Agreements
  */
-export const getStoredPaymentAgreements = ( state: AppState ): StoredCard[] =>
-	( ( state.storedCards?.items ?? [] ) as StoredCard[] )
+export const getStoredPaymentAgreements = ( state: CombinedState ): StoredCard[] =>
+	( state.storedCards?.items ?? [] )
 		.filter( ( stored ) => isPaymentAgreement( stored ) )
 		.map( ( method ) => ( {
 			...method,
@@ -50,7 +53,7 @@ export const getStoredPaymentAgreements = ( state: AppState ): StoredCard[] =>
  * @param {Object} state - current state object
  * @returns {Array} Stored Payment Methods excluding cards
  */
-export const getUniquePaymentAgreements = ( state: AppState ): StoredCard[] => {
+export const getUniquePaymentAgreements = ( state: CombinedState ): StoredCard[] => {
 	const paymentMethods = getStoredPaymentAgreements( state );
 	const groups = groupBy( paymentMethods, 'email' );
 	const paymentMethodsGroups = Object.values( groups );
@@ -67,20 +70,20 @@ export const getUniquePaymentAgreements = ( state: AppState ): StoredCard[] => {
  * Returns a Stored Card
  */
 export const getStoredCardById = (
-	state: AppState,
+	state: CombinedState,
 	cardId: StoredCard[ 'stored_details_id' ]
 ): undefined | StoredCard =>
 	getStoredCards( state )
 		.filter( ( card ) => card.stored_details_id === cardId )
 		.shift();
 
-export const hasLoadedStoredCardsFromServer = ( state: AppState ) =>
+export const hasLoadedStoredCardsFromServer = ( state: CombinedState ) =>
 	Boolean( state.storedCards?.hasLoadedFromServer );
 
 export const isDeletingStoredCard = (
-	state: AppState,
+	state: CombinedState,
 	cardId: StoredCard[ 'stored_details_id' ]
 ) => Boolean( state.storedCards?.isDeleting[ cardId ] );
 
-export const isFetchingStoredCards = ( state: AppState ) =>
+export const isFetchingStoredCards = ( state: CombinedState ) =>
 	Boolean( state.storedCards?.isFetching );

--- a/client/state/stored-cards/types.ts
+++ b/client/state/stored-cards/types.ts
@@ -1,0 +1,8 @@
+import type { StoredCard } from 'calypso/my-sites/checkout/composite-checkout/types/stored-cards';
+
+export interface StoredCardsState {
+	items: StoredCard[];
+	hasLoadedFromServer: boolean;
+	isDeleting: Record< StoredCard[ 'stored_details_id' ], true | undefined >;
+	isFetching: boolean;
+}

--- a/client/state/stored-cards/types.ts
+++ b/client/state/stored-cards/types.ts
@@ -1,3 +1,13 @@
+import {
+	STORED_CARDS_ADD_COMPLETED,
+	STORED_CARDS_FETCH,
+	STORED_CARDS_FETCH_COMPLETED,
+	STORED_CARDS_FETCH_FAILED,
+	STORED_CARDS_DELETE,
+	STORED_CARDS_DELETE_COMPLETED,
+	STORED_CARDS_DELETE_FAILED,
+	STORED_CARDS_UPDATE_IS_BACKUP_COMPLETED,
+} from 'calypso/state/action-types';
 import type { StoredCard } from 'calypso/my-sites/checkout/composite-checkout/types/stored-cards';
 
 export interface StoredCardsState {
@@ -6,3 +16,55 @@ export interface StoredCardsState {
 	isDeleting: Record< StoredCard[ 'stored_details_id' ], true | undefined >;
 	isFetching: boolean;
 }
+
+export type StoredCardsAddCompletedAction = {
+	type: typeof STORED_CARDS_ADD_COMPLETED;
+	item: StoredCard;
+};
+
+export type StoredCardsFetchCompletedAction = {
+	type: typeof STORED_CARDS_FETCH_COMPLETED;
+	list: StoredCard[];
+};
+
+export type StoredCardsDeleteCompletedAction = {
+	type: typeof STORED_CARDS_DELETE_COMPLETED;
+	card: {
+		allStoredDetailsIds: StoredCard[ 'stored_details_id' ][];
+		stored_details_id: StoredCard[ 'stored_details_id' ];
+	};
+};
+
+export type StoredCardsUpdateIsBackupCompleted = {
+	type: typeof STORED_CARDS_UPDATE_IS_BACKUP_COMPLETED;
+	stored_details_id: StoredCard[ 'stored_details_id' ];
+	is_backup: boolean;
+};
+
+export type StoredCardsFetch = {
+	type: typeof STORED_CARDS_FETCH;
+};
+
+export type StoredCardsFetchFailed = {
+	type: typeof STORED_CARDS_FETCH_FAILED;
+};
+
+export type StoredCardsDelete = {
+	type: typeof STORED_CARDS_DELETE;
+	card: { stored_details_id: StoredCard[ 'stored_details_id' ] };
+};
+
+export type StoredCardsDeleteFailed = {
+	type: typeof STORED_CARDS_DELETE_FAILED;
+	card: { stored_details_id: StoredCard[ 'stored_details_id' ] };
+};
+
+export type StoredCardsActions =
+	| StoredCardsAddCompletedAction
+	| StoredCardsFetchCompletedAction
+	| StoredCardsDeleteCompletedAction
+	| StoredCardsUpdateIsBackupCompleted
+	| StoredCardsFetch
+	| StoredCardsFetchFailed
+	| StoredCardsDelete
+	| StoredCardsDeleteFailed;

--- a/client/state/types.ts
+++ b/client/state/types.ts
@@ -1,5 +1,6 @@
 import type { IMarketplaceState } from 'calypso/state/marketplace/types';
 import type { IPluginsState } from 'calypso/state/plugins/reducer';
+import type { StoredCardsState } from 'calypso/state/stored-cards/types';
 import type { DefaultRootState } from 'react-redux';
 import type { AnyAction } from 'redux';
 import type { ThunkDispatch } from 'redux-thunk';
@@ -10,6 +11,7 @@ import type { ThunkDispatch } from 'redux-thunk';
 export interface IAppState extends DefaultRootState {
 	plugins: IPluginsState;
 	marketplace: IMarketplaceState;
+	storedCards: StoredCardsState;
 }
 
 /**


### PR DESCRIPTION
#### Proposed Changes

This converts the `storedCards` reducer, actions, and selectors to TypeScript. It adds that reducer to `IAppState` which appears to be a type we can use for our full Redux state tree.

#### Testing Instructions

This should not make any actual changes to the code, so it should not require any testing if the unit tests pass.

However, you can verify that stored cards still appear in checkout.