### PR TITLE
Payment Methods: Make the placeholder submit button disabled

### DIFF
--- a/client/me/purchases/components/payment-method-loader/index.jsx
+++ b/client/me/purchases/components/payment-method-loader/index.jsx
@@ -16,7 +16,7 @@ export default function PaymentMethodLoader( { title } ) {
 					<Card className="payment-method-loader__credit-card-content credit-card-form__content">
 						<CreditCardFormFieldsLoadingPlaceholder />
 
-						<FormButton isPrimary={ false } />
+						<FormButton isPrimary={ false } disabled />
 					</Card>
 				</Column>
 				<Column type="sidebar">

--- a/client/me/purchases/manage-purchase/change-payment-method/index.tsx
+++ b/client/me/purchases/manage-purchase/change-payment-method/index.tsx
@@ -29,7 +29,6 @@ import { getSelectedSite } from 'calypso/state/ui/selectors';
 import PaymentMethodSelector from '../payment-method-selector';
 import getPaymentMethodIdFromPayment from '../payment-method-selector/get-payment-method-id-from-payment';
 import useCreateAssignablePaymentMethods from './use-create-assignable-payment-methods';
-import type { PurchasePayment, Purchase } from 'calypso/lib/purchases/types';
 
 interface ChangePaymentMethodProps {
 	getManagePurchaseUrlFor: ( siteSlug: string, purchaseId: number ) => string;
@@ -47,12 +46,8 @@ function ChangePaymentMethod( {
 	const hasLoadedSites = useSelector( ( state ) => ! isRequestingSites( state ) );
 	const hasLoadedStoredCards = useSelector( hasLoadedStoredCardsFromServer );
 	const hasLoadedUserPurchases = useSelector( hasLoadedUserPurchasesFromServer );
-	const purchase: Purchase | undefined = useSelector( ( state ) =>
-		getByPurchaseId( state, purchaseId )
-	);
-	const payment: PurchasePayment | undefined = useSelector(
-		( state ) => getByPurchaseId( state, purchaseId )?.payment
-	);
+	const purchase = useSelector( ( state ) => getByPurchaseId( state, purchaseId ) );
+	const payment = useSelector( ( state ) => getByPurchaseId( state, purchaseId )?.payment );
 	const selectedSite = useSelector( getSelectedSite );
 
 	const { isStripeLoading } = useStripe();


### PR DESCRIPTION
#### Proposed Changes

This is a minor cleanup of things I noticed while working on https://github.com/Automattic/wp-calypso/pull/72839. The only relevant change is that the placeholder "Save" button on the "Add/Change Payment Method" form will now be disabled.

#### Testing Instructions

Visit `/me/purchases/add-payment-method` and verify that the submit button still works as expected.