### PR TITLE
Plans 2023 : Always show free plan for the new pricing grid pages

### DIFF
--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -763,11 +763,13 @@ class Signup extends Component {
 		// Hide the free option in the signup flow
 		const selectedHideFreePlan = get( this.props, 'signupDependencies.shouldHideFreePlan', false );
 
-		const hideFreePlan =
-			config.isEnabled( 'onboarding/2023-pricing-grid' ) &&
-			this.props.flowName === 'onboarding-2023-pricing-grid'
-				? false
-				: planWithDomain || this.props.isDomainOnlySite || selectedHideFreePlan;
+		// For the onboarding/2023-pricing-grid hiding the free plan is not yet supported and breaks the plans comparison grid
+		// If there is any condition upon which the free plan should be hidden these issues need to be resolved.
+		// For now we always show the free plan for the 2023-pricing-grid
+		// More Context : Automattic/martech#1464
+		const hideFreePlan = config.isEnabled( 'onboarding/2023-pricing-grid' )
+			? false
+			: planWithDomain || this.props.isDomainOnlySite || selectedHideFreePlan;
 		const shouldRenderLocaleSuggestions = 0 === this.getPositionInFlow() && ! this.props.isLoggedIn;
 
 		let propsForCurrentStep = propsFromConfig;


### PR DESCRIPTION
#### Proposed Changes
* Disable the `hideFreePlan` flag completely so that the free plan is always visible
* Fixes (Hides) a bug where plan comparison grid would not show the proper ticks.

#### Testing Instructions

* Go through the sign up flow /start?flags=onboarding/2023-pricing-grid
* Select a paid domain OR click on `Choose my domain later` or `Use a domain I own`
* Make sure the free plan is visible

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
Fixes Automattic/martech#1464