### PR TITLE
Add queryParam to invalid cache when navigating away from site setup flow

### DIFF
--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -5,6 +5,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { useDispatch as reduxDispatch, useSelector } from 'react-redux';
 import { ImporterMainPlatform } from 'calypso/blocks/import/types';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
+import { addQueryArgs } from 'calypso/lib/route';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { getActiveTheme, getCanonicalTheme } from 'calypso/state/themes/selectors';
@@ -184,7 +185,14 @@ const siteSetupFlow: Flow = {
 						pendingActions.push( saveSiteSettings( siteId, { launchpad_screen: 'full' } ) );
 					}
 
-					Promise.all( pendingActions ).then( () => window.location.assign( to ) );
+					let redirectionUrl = to;
+
+					// Forcing cache invalidation to retrieve latest launchpad_screen option value
+					if ( isLaunchpadIntent( intent ) ) {
+						redirectionUrl = addQueryArgs( { postOnboarding: true }, to );
+					}
+
+					Promise.all( pendingActions ).then( () => window.location.assign( redirectionUrl ) );
 				} );
 			} );
 

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -189,7 +189,7 @@ const siteSetupFlow: Flow = {
 
 					// Forcing cache invalidation to retrieve latest launchpad_screen option value
 					if ( isLaunchpadIntent( intent ) ) {
-						redirectionUrl = addQueryArgs( { postOnboarding: true }, to );
+						redirectionUrl = addQueryArgs( { showLaunchpad: true }, to );
 					}
 
 					Promise.all( pendingActions ).then( () => window.location.assign( redirectionUrl ) );

--- a/client/my-sites/customer-home/controller.jsx
+++ b/client/my-sites/customer-home/controller.jsx
@@ -38,6 +38,7 @@ export async function maybeRedirect( context, next ) {
 
 	const siteId = getSelectedSiteId( state );
 	const maybeStalelaunchpadScreenOption = getSiteOptions( state, siteId )?.launchpad_screen;
+	const currentUrl = window.location.href;
 
 	// We need the latest site info to determine if a user should be redirected to Launchpad.
 	// As a result, we can't use locally cached data, which might think that Launchpad is
@@ -45,7 +46,10 @@ export async function maybeRedirect( context, next ) {
 	// disabled. Because of this, we refetch site information and limit traffic by scoping down
 	// requests to launchpad enabled sites.
 	// See https://cylonp2.wordpress.com/2022/09/19/question-about-infinite-redirect/#comment-1731
-	if ( maybeStalelaunchpadScreenOption && maybeStalelaunchpadScreenOption === 'full' ) {
+	if (
+		( maybeStalelaunchpadScreenOption && maybeStalelaunchpadScreenOption === 'full' ) ||
+		currentUrl?.includes( 'postOnboarding=true' )
+	) {
 		await context.store.dispatch( requestSite( siteId ) );
 	}
 

--- a/client/my-sites/customer-home/controller.jsx
+++ b/client/my-sites/customer-home/controller.jsx
@@ -48,7 +48,7 @@ export async function maybeRedirect( context, next ) {
 	// See https://cylonp2.wordpress.com/2022/09/19/question-about-infinite-redirect/#comment-1731
 	if (
 		( maybeStalelaunchpadScreenOption && maybeStalelaunchpadScreenOption === 'full' ) ||
-		currentUrl?.includes( 'postOnboarding=true' )
+		currentUrl?.includes( 'showLaunchpad=true' )
 	) {
 		await context.store.dispatch( requestSite( siteId ) );
 	}


### PR DESCRIPTION
#### Testing/Review: 

Test: short
Review: short


#### Proposed Changes

* After a user walks through the general onboarding and selects a launchpad enabled goal (`Write` or `Build`), the user may be navigated to the home screen instead of the launchpad screen. These changes add the `postOnboarding=true` query parameter to site setup exit flow redirection URL, invalids the site data and fetches it again.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Check out this branch
- `yarn start`
- Start general onboarding at calypso.localhost:3000/start
- At the goals step, select the `write` site intent
- Click on continue
- Click on the skip to dashboard button
- The user should see the `postOnboarding=true` query param in the /home url before being redirected to Launchpad
- If the redirect is too fast to see, then comment out the following code https://github.com/Automattic/wp-calypso/blob/70ac415c7a013ea1a182511ec3d2cd77ede3a328/client/my-sites/customer-home/controller.jsx#L55-L62

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #72872
