### PR TITLE
Marketplace Themes: Fix the customize CTA on the theme page

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -676,7 +676,7 @@ class ThemeSheet extends Component {
 	};
 
 	renderButton = () => {
-		const { getUrl } = this.props.defaultOption;
+		const { getUrl, key } = this.props.defaultOption;
 		const label = this.getDefaultOptionLabel();
 		const price = this.renderPrice();
 		const placeholder = <span className="theme__sheet-button-placeholder">loading......</span>;
@@ -688,7 +688,8 @@ class ThemeSheet extends Component {
 				className="theme__sheet-primary-button"
 				href={
 					getUrl &&
-					( ! isExternallyManagedTheme ||
+					( key === 'customize' ||
+						! isExternallyManagedTheme ||
 						! isLoggedIn ||
 						! config.isEnabled( 'themes/third-party-premium' ) )
 						? getUrl( this.props.themeId )


### PR DESCRIPTION
#### Proposed Changes

* The `Customize site` button was not working on the theme page.

#### Testing Instructions

* Subscribe to `Makoney`
* After the transfer is completed, go to `/theme/makoney/{SITE_SLUG}`
* When you see the `Customize site` CTA, click on it. The site editor should open up on a new tab.

Closes #72921
