### PR TITLE
Prepare the domain page to work with the experiment

### DIFF
--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -2,6 +2,7 @@ import config from '@automattic/calypso-config';
 import { getLanguageSlugs } from '@automattic/i18n-utils';
 import { translate } from 'i18n-calypso';
 import page from 'page';
+import { useEffect } from 'react';
 import { QueryClientProvider } from 'react-query';
 import { Provider as ReduxProvider } from 'react-redux';
 import CalypsoI18nProvider from 'calypso/components/calypso-i18n-provider';
@@ -10,6 +11,7 @@ import MomentProvider from 'calypso/components/localized-moment/provider';
 import { RouteProvider } from 'calypso/components/route';
 import Layout from 'calypso/layout';
 import LayoutLoggedOut from 'calypso/layout/logged-out';
+import { loadExperimentAssignment } from 'calypso/lib/explat';
 import { login } from 'calypso/lib/paths';
 import { CalypsoReactQueryDevtools } from 'calypso/lib/react-query-devtools-helper';
 import { getSiteFragment } from 'calypso/lib/route';
@@ -39,6 +41,18 @@ export const ProviderWrappedLayout = ( {
 } ) => {
 	const state = store.getState();
 	const userLoggedIn = isUserLoggedIn( state );
+
+	useEffect( () => {
+		async function loadExperiment() {
+			const experimentAssignment = await loadExperimentAssignment(
+				'calypso_sidebar_upsell_dedicated_upgrade_flow_202301'
+			);
+			const variationName2 = experimentAssignment?.variationName;
+			sessionStorage.setItem( 'calypso_sidebar_upsell_experiment', variationName2 );
+		}
+
+		loadExperiment();
+	}, [] );
 
 	const layout = userLoggedIn ? (
 		<Layout primary={ primary } secondary={ secondary } />

--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -47,8 +47,8 @@ export const ProviderWrappedLayout = ( {
 			const experimentAssignment = await loadExperimentAssignment(
 				'calypso_sidebar_upsell_dedicated_upgrade_flow_202301'
 			);
-			const variationName2 = experimentAssignment?.variationName;
-			sessionStorage.setItem( 'calypso_sidebar_upsell_experiment', variationName2 );
+			const variationName = experimentAssignment?.variationName;
+			sessionStorage.setItem( 'calypso_sidebar_upsell_experiment', variationName );
 		}
 
 		loadExperiment();

--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -2,7 +2,7 @@ import config from '@automattic/calypso-config';
 import { getLanguageSlugs } from '@automattic/i18n-utils';
 import { translate } from 'i18n-calypso';
 import page from 'page';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { QueryClientProvider } from 'react-query';
 import { Provider as ReduxProvider } from 'react-redux';
 import CalypsoI18nProvider from 'calypso/components/calypso-i18n-provider';
@@ -53,18 +53,20 @@ export const ProviderWrappedLayout = ( {
 		setIsExperimentLoaded( true );
 	}
 
-	function shouldLoadDomainExperiment() {
-		return (
+	const shouldLoadDomainExperiment = useCallback( () => {
+		const domainAndPackage = currentQuery && 'true' === currentQuery.domainAndPlanPackage;
+		const experimentPages =
 			window.location.pathname.startsWith( '/domains/add' ) ||
-			window.location.pathname.startsWith( '/plans/yearly' )
-		);
-	}
+			window.location.pathname.startsWith( '/plans/yearly' );
+
+		return domainAndPackage && experimentPages;
+	}, [ currentQuery ] );
 
 	useEffect( () => {
 		if ( shouldLoadDomainExperiment() ) {
 			loadDomainExperiment();
 		}
-	}, [ currentRoute ] );
+	}, [ currentRoute, currentQuery, shouldLoadDomainExperiment ] );
 
 	if ( shouldLoadDomainExperiment() && ! isExperimentLoaded ) {
 		return null;

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -384,8 +384,15 @@ export default withCurrentRoute(
 		const isJetpack =
 			( isJetpackSite( state, siteId ) && ! isAtomicSite( state, siteId ) ) ||
 			currentRoute.startsWith( '/checkout/jetpack' );
-		const noMasterbarForRoute = isJetpackLogin || currentRoute === '/me/account/closed';
-		const noMasterbarForSection = [ 'signup', 'jetpack-connect' ].includes( sectionName );
+		const userBelongsToExperiment =
+			'treatment' === sessionStorage.getItem( 'calypso_sidebar_upsell_experiment' );
+		const isStartDomainExperiment =
+			( currentRoute.startsWith( '/domains/add' ) || currentRoute.startsWith( '/plans/yearly' ) ) &&
+			userBelongsToExperiment;
+		const noMasterbarForRoute =
+			isStartDomainExperiment || isJetpackLogin || currentRoute === '/me/account/closed';
+		const noMasterbarForSection =
+			isStartDomainExperiment || [ 'signup', 'jetpack-connect' ].includes( sectionName );
 		const masterbarIsHidden =
 			! masterbarIsVisible( state ) ||
 			noMasterbarForSection ||
@@ -409,7 +416,7 @@ export default withCurrentRoute(
 			'plugins',
 			'comments',
 		].includes( sectionName );
-		const sidebarIsHidden = ! secondary || isWcMobileApp();
+		const sidebarIsHidden = isStartDomainExperiment || ! secondary || isWcMobileApp();
 		const chatIsDocked = ! [ 'reader', 'theme' ].includes( sectionName ) && ! sidebarIsHidden;
 
 		const userAllowedToHelpCenter =

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -28,6 +28,7 @@ import { isWpMobileApp, isWcMobileApp } from 'calypso/lib/mobile-app';
 import { isWooOAuth2Client } from 'calypso/lib/oauth2-clients';
 import { getMessagePathForJITM } from 'calypso/lib/route';
 import UserVerificationChecker from 'calypso/lib/user/verification-checker';
+import { isDomainSidebarExperimentUser } from 'calypso/my-sites/controller';
 import { isOffline } from 'calypso/state/application/selectors';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import hasActiveHappychatSession from 'calypso/state/happychat/selectors/has-active-happychat-session';
@@ -384,11 +385,9 @@ export default withCurrentRoute(
 		const isJetpack =
 			( isJetpackSite( state, siteId ) && ! isAtomicSite( state, siteId ) ) ||
 			currentRoute.startsWith( '/checkout/jetpack' );
-		const userBelongsToExperiment =
-			'treatment' === sessionStorage.getItem( 'calypso_sidebar_upsell_experiment' );
 		const isStartDomainExperiment =
 			( currentRoute.startsWith( '/domains/add' ) || currentRoute.startsWith( '/plans/yearly' ) ) &&
-			userBelongsToExperiment;
+			isDomainSidebarExperimentUser();
 		const noMasterbarForRoute =
 			isStartDomainExperiment || isJetpackLogin || currentRoute === '/me/account/closed';
 		const noMasterbarForSection =

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -13,6 +13,7 @@ import { cloudSiteSelection } from 'calypso/jetpack-cloud/controller';
 import { recordPageView } from 'calypso/lib/analytics/page-view';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { loadExperimentAssignment } from 'calypso/lib/explat';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { navigate } from 'calypso/lib/navigate';
 import { onboardingUrl } from 'calypso/lib/paths';
@@ -425,6 +426,17 @@ export function noSite( context, next ) {
 
 	context.store.dispatch( setSelectedSiteId( null ) );
 	return next();
+}
+
+export async function setExperimentVariation( context, next ) {
+	const experimentAssignment = await loadExperimentAssignment(
+		'calypso_sidebar_upsell_dedicated_upgrade_flow_202301'
+	);
+
+	const variationName = experimentAssignment?.variationName;
+	sessionStorage.setItem( 'calypso_sidebar_upsell_experiment', variationName );
+
+	next();
 }
 
 /*

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -13,7 +13,6 @@ import { cloudSiteSelection } from 'calypso/jetpack-cloud/controller';
 import { recordPageView } from 'calypso/lib/analytics/page-view';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import { loadExperimentAssignment } from 'calypso/lib/explat';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { navigate } from 'calypso/lib/navigate';
 import { onboardingUrl } from 'calypso/lib/paths';
@@ -426,17 +425,6 @@ export function noSite( context, next ) {
 
 	context.store.dispatch( setSelectedSiteId( null ) );
 	return next();
-}
-
-export async function setExperimentVariation( context, next ) {
-	const experimentAssignment = await loadExperimentAssignment(
-		'calypso_sidebar_upsell_dedicated_upgrade_flow_202301'
-	);
-
-	const variationName = experimentAssignment?.variationName;
-	sessionStorage.setItem( 'calypso_sidebar_upsell_experiment', variationName );
-
-	next();
 }
 
 /*

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -718,7 +718,11 @@ export function shouldRedirectToJetpackAuthorize( context, site ) {
  * @returns {boolean} Whether the user is in the Domain sidebar upsell experiment.
  */
 export const isDomainSidebarExperimentUser = () => {
-	return 'treatment' === sessionStorage.getItem( 'calypso_sidebar_upsell_experiment' );
+	const domainAndPackage = new URL( document.location ).searchParams.has( 'domainAndPlanPackage' );
+	return (
+		domainAndPackage &&
+		'treatment' === sessionStorage.getItem( 'calypso_sidebar_upsell_experiment' )
+	);
 };
 
 /**

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -725,6 +725,15 @@ export function shouldRedirectToJetpackAuthorize( context, site ) {
 }
 
 /**
+ * Whether the user is in the Domain sidebar upsell experiment.
+ *
+ * @returns {boolean} Whether the user is in the Domain sidebar upsell experiment.
+ */
+export const isDomainSidebarExperimentUser = () => {
+	return 'treatment' === sessionStorage.getItem( 'calypso_sidebar_upsell_experiment' );
+};
+
+/**
  * Get redirect URL to the Jetpack site for authorization.
  *
  * @param {Object} context -- The context object.

--- a/client/my-sites/domains/domain-search/index.jsx
+++ b/client/my-sites/domains/domain-search/index.jsx
@@ -24,6 +24,7 @@ import {
 } from 'calypso/lib/cart-values/cart-items';
 import { getSuggestionsVendor } from 'calypso/lib/domains/suggestions';
 import withCartKey from 'calypso/my-sites/checkout/with-cart-key';
+import { isDomainSidebarExperimentUser } from 'calypso/my-sites/controller';
 import NewDomainsRedirectionNoticeUpsell from 'calypso/my-sites/domains/domain-management/components/domain/new-domains-redirection-notice-upsell';
 import {
 	domainAddEmailUpsell,
@@ -101,6 +102,9 @@ class DomainSearch extends Component {
 	};
 
 	componentDidMount() {
+		if ( isDomainSidebarExperimentUser() ) {
+			document.body.classList.add( 'is-experiment-user' );
+		}
 		this.checkSiteIsUpgradeable();
 
 		this.isMounted = true;
@@ -113,6 +117,10 @@ class DomainSearch extends Component {
 	}
 
 	componentWillUnmount() {
+		if ( isDomainSidebarExperimentUser() ) {
+			document.body.classList.remove( 'is-experiment-user' );
+		}
+
 		this.isMounted = false;
 	}
 
@@ -236,24 +244,46 @@ class DomainSearch extends Component {
 			content = (
 				<span>
 					<div className="domain-search__content">
-						<BackButton
-							className="domain-search__go-back"
-							href={ domainManagementList( selectedSiteSlug ) }
-						>
-							<Gridicon icon="arrow-left" size={ 18 } />
-							{ translate( 'Back' ) }
-						</BackButton>
+						{ false === isDomainSidebarExperimentUser() && (
+							<BackButton
+								className="domain-search__go-back"
+								href={ domainManagementList( selectedSiteSlug ) }
+							>
+								<Gridicon icon="arrow-left" size={ 18 } />
+								{ translate( 'Back' ) }
+							</BackButton>
+						) }
+
 						{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace */ }
 						<div className="domains__header">
-							<FormattedHeader
-								brandFont
-								headerText={
-									isManagingAllDomains
-										? translate( 'All Domains' )
-										: translate( 'Search for a domain' )
-								}
-								align="left"
-							/>
+							{ isDomainSidebarExperimentUser() && (
+								<>
+									<FormattedHeader
+										brandFont
+										headerText={ translate( 'Claim your domain' ) }
+										align="center"
+									/>
+
+									<p>
+										{ translate(
+											'Stake your claim on your corner of the web with a custom domain name that’s easy to find, share, and follow. Not sure yet?'
+										) }
+										<a href="/support/domains/">{ translate( 'Decide later.' ) }</a>
+									</p>
+								</>
+							) }
+
+							{ false === isDomainSidebarExperimentUser() && (
+								<FormattedHeader
+									brandFont
+									headerText={
+										isManagingAllDomains
+											? translate( 'All Domains' )
+											: translate( 'Search for a domain' )
+									}
+									align="left"
+								/>
+							) }
 						</div>
 
 						<EmailVerificationGate

--- a/client/my-sites/domains/index.js
+++ b/client/my-sites/domains/index.js
@@ -6,7 +6,6 @@ import {
 	siteSelection,
 	sites,
 	wpForTeamsGeneralNotSupportedRedirect,
-	setExperimentVariation,
 } from 'calypso/my-sites/controller';
 import domainsController from './controller';
 import domainManagementController from './domain-management/controller';
@@ -205,7 +204,6 @@ export default function () {
 	page(
 		'/domains/add/:domain',
 		siteSelection,
-		setExperimentVariation,
 		navigation,
 		domainsController.redirectIfNoSite( '/domains/add' ),
 		domainsController.redirectToUseYourDomainIfVipSite(),

--- a/client/my-sites/domains/index.js
+++ b/client/my-sites/domains/index.js
@@ -6,6 +6,7 @@ import {
 	siteSelection,
 	sites,
 	wpForTeamsGeneralNotSupportedRedirect,
+	setExperimentVariation,
 } from 'calypso/my-sites/controller';
 import domainsController from './controller';
 import domainManagementController from './domain-management/controller';
@@ -204,6 +205,7 @@ export default function () {
 	page(
 		'/domains/add/:domain',
 		siteSelection,
+		setExperimentVariation,
 		navigation,
 		domainsController.redirectIfNoSite( '/domains/add' ),
 		domainsController.redirectToUseYourDomainIfVipSite(),

--- a/client/my-sites/domains/style.scss
+++ b/client/my-sites/domains/style.scss
@@ -1,5 +1,6 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "@automattic/typography/styles/variables";
 
 .domains__header {
 	display: flex;
@@ -8,5 +9,47 @@
 
 	@include breakpoint-deprecated( "<660px" ) {
 		align-items: center;
+	}
+}
+
+body.is-section-domains.is-experiment-user {
+	background: #fdfdfd;
+
+	.domains__header {
+		display: block;
+
+		h1 {
+			font-family: $brand-serif;
+			font-size: $font-headline-small;
+		}
+
+		p {
+			font-size: $font-body;
+			color: var(--color-text-subtle);
+			text-align: center;
+			padding: 0 10px;
+		}
+
+		a {
+			color: var(--studio-gray-90);
+			font-weight: 500;
+			padding-left: 5px;
+			text-decoration: underline;
+		}
+	}
+
+	@include break-small {
+		.domains__header {
+			h1 {
+				font-size: $font-headline-medium;
+			}
+			p {
+				padding: 0 80px;
+			}
+		}
+	}
+
+	.main.is-wide-layout {
+		max-width: $break-medium;
 	}
 }


### PR DESCRIPTION
#### Proposed Changes

* Prepare the domain page to work with the experiment. We're focusing on the New header, background color, and centralizing the content. Domain filtering section [will be handled in another task](https://github.com/Automattic/wp-calypso/issues/72894), as well as [the Domain Header](https://github.com/Automattic/wp-calypso/issues/72892).


<img width="1066" alt="image" src="https://user-images.githubusercontent.com/1044309/216463226-d4ae84f8-1a3b-417b-b54f-40ff949ee384.png">


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Access the current Domain upsell flow starting at `Upgrade` button on your side menu
* The domain page should look like the production one (assuming you're at the control group)
* Using tab `Application` of your console development tool, delete any previous local storage data related to the experiment (here how to do that: pb5gDS-2nD-p2#pro-tip-for-calypso-users) and also delete the Session Storage key `calypso_sidebar_upsell_experiment`
* Change your variation to `treatment` at the experiment `21025-calypso-sidebar-upsell-dedicated-upgrade-flow-202301` following these tips: pb5gDS-2nD-p2#connecting-an-experiment-to-a-jitm
* **IMPORTANT**: First access [the Calypso home](http://calypso.localhost:3000/), and after click at the CTA on the left menu (to ensure our [CSS rules](https://github.com/Automattic/wp-calypso/pull/72932/files#diff-e9d5bbfeb0cc388a1ec2501f08f49524a97724605eca06bc1f3f626bf12cfab4R105) will be applied as expected)
* Make sure your change will work as expected
* You should now see the new interface, make sure it aligns with our design expectations: pebzTe-Fx-p2#comment-1131


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #