### PR TITLE
Hosting Config: Remove fallback copy from hosting config upsell

### DIFF
--- a/client/my-sites/hosting/hosting-upsell-nudge/index.tsx
+++ b/client/my-sites/hosting/hosting-upsell-nudge/index.tsx
@@ -1,6 +1,5 @@
 import { FEATURE_SFTP, PLAN_BUSINESS } from '@automattic/calypso-products';
-import { useIsEnglishLocale } from '@automattic/i18n-utils';
-import i18n, { useTranslate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
 import { preventWidows } from 'calypso/lib/formatting';
 import iconCloud from './icons/icon-cloud.svg';
@@ -50,85 +49,48 @@ export function HostingUpsellNudge( { siteId }: { siteId: number | null } ) {
 
 function useFeatureList(): FeatureListItem[] {
 	const translate = useTranslate();
-	const isEn = useIsEnglishLocale();
 
 	return [
 		{
 			title: translate( 'SFTP' ),
-			description:
-				isEn ||
-				i18n.hasTranslation(
-					'Streamline your workflow and edit your files with precision using an SFTP client.'
-				)
-					? translate(
-							'Streamline your workflow and edit your files with precision using an SFTP client.'
-					  )
-					: translate( `Access and edit your website's files directly using an SFTP client` ),
+			description: translate(
+				'Streamline your workflow and edit your files with precision using an SFTP client.'
+			),
 			icon: iconCloud,
 		},
 		{
 			title: translate( 'CLI Access' ),
-			description:
-				isEn ||
-				i18n.hasTranslation(
-					'Use WP-CLI to manage plugins and users, or automate repetitive tasks from your terminal.'
-				)
-					? translate(
-							'Use WP-CLI to manage plugins and users, or automate repetitive tasks from your terminal.'
-					  )
-					: translate(
-							'Use WP-CLI to manage plugins and users, or perform search-and-replace across your site'
-					  ),
+			description: translate(
+				'Use WP-CLI to manage plugins and users, or automate repetitive tasks from your terminal.'
+			),
 			icon: iconTerminal,
 		},
 		{
 			title: translate( 'SSH' ),
-			description:
-				isEn ||
-				i18n.hasTranslation( 'Take control of your website’s performance and security using SSH.' )
-					? translate( 'Take control of your website’s performance and security using SSH.' )
-					: translate( `Work the way you're used to working with SSH access to your website` ),
+			description: translate(
+				'Take control of your website’s performance and security using SSH.'
+			),
 			icon: iconSSH,
 		},
 		{
 			title: translate( 'Pick Your Data Center' ),
-			description:
-				isEn ||
-				i18n.hasTranslation(
-					'Choose a primary data center for your site while still enjoying geo-redundant architecture.'
-				)
-					? translate(
-							'Choose a primary data center for your site while still enjoying geo-redundant architecture.'
-					  )
-					: translate(
-							'Choose a primary data center for your site while still enjoying multi-region redundancy'
-					  ),
+			description: translate(
+				'Choose a primary data center for your site while still enjoying geo-redundant architecture.'
+			),
 			icon: iconServerRacks,
 		},
 		{
 			title: translate( 'Database Access' ),
-			description:
-				isEn ||
-				i18n.hasTranslation(
-					'Manage your website’s data easily, using phpMyAdmin to inspect tables and run queries.'
-				)
-					? translate(
-							'Manage your website’s data easily, using phpMyAdmin to inspect tables and run queries.'
-					  )
-					: translate( `Inspect your website's tables and run SQL queries via phpMyAdmin` ),
+			description: translate(
+				'Manage your website’s data easily, using phpMyAdmin to inspect tables and run queries.'
+			),
 			icon: iconDatabase,
 		},
 		{
 			title: translate( 'Live Support' ),
-			description:
-				isEn ||
-				i18n.hasTranslation(
-					'Whenever you’re stuck, our Happiness Engineers have the answers on hand.'
-				)
-					? translate( 'Whenever you’re stuck, our Happiness Engineers have the answers on hand.' )
-					: translate(
-							'Either have questions or need help, get instant support from our Happiness Engineers'
-					  ),
+			description: translate(
+				'Whenever you’re stuck, our Happiness Engineers have the answers on hand.'
+			),
 			icon: iconComments,
 		},
 	];


### PR DESCRIPTION
#### Proposed Changes

New copy was added to the hosting config upsell in #72356 (see image)

![image](https://user-images.githubusercontent.com/1500769/216463789-d5112adc-47b8-4f28-af13-73c0c6eb445b.png)

[The translations are now complete](https://translate.wordpress.com/deliverables/overview/7765989) so the fallback code is no longer required.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Visit `/hosting-config` with a site that doesn't have a Business plan and confirm translations still work.

