### PR TITLE
Hosting Config: Update hosting upsell margin to match Figma mockup

### DIFF
--- a/client/my-sites/hosting/hosting-upsell-nudge/style.scss
+++ b/client/my-sites/hosting/hosting-upsell-nudge/style.scss
@@ -42,9 +42,8 @@
 
 	ul {
 		display: grid;
-		grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+		grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
 		gap: 22px 24px;
-		margin-right: 16px;
 	}
 
 	.hosting-upsell-nudge__feature-icon {


### PR DESCRIPTION
#### Proposed Changes

Seems like the English line-wrapping in the upsell regressed when I implemented it according to the mockup to ensure it didn't wrap awkwardly.

<img src="https://user-images.githubusercontent.com/1500769/216470765-7003d841-c32e-427c-bb37-e687caa82a10.png" alt="CleanShot 2023-02-03 at 12 02 05@2x" style="max-width: 100%;" width="50%">

After double-checking the Figma RyA76dAps3CQX3Vzyz368L-fi-79%3A490 I see I had the margin wrong.

It now looks like this

<img width="544" alt="CleanShot 2023-02-03 at 12 05 06@2x" src="https://user-images.githubusercontent.com/1500769/216471113-b5a48512-a6cf-4aaa-8481-4a4ea0b397b0.png" width="50%">


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Smoke test `/hosting-config` with a site that has no Business plan
