### PR TITLE
Merge trunk to branch docker image builds

### DIFF
--- a/.teamcity/_self/lib/utils/MergeTrunk.kt
+++ b/.teamcity/_self/lib/utils/MergeTrunk.kt
@@ -27,7 +27,7 @@ fun BuildSteps.mergeTrunk(skipIfConflict: Boolean = false): ScriptBuildStep {
 			# parameter in the project settings.
 			if ! git merge trunk ; then
 				if [ "$skipIfConflict" = false ] ; then
-					echo "##teamcity[buildProblem description='There is a merge conflict with trunk. Skipping this step to allow the build to continue.']"
+					echo "##teamcity[buildProblem description='There is a merge conflict with trunk. Rebase on trunk to resolve this problem.' identity='merge_conflict']]"
 					exit
 				fi
 				# If do want to skip if there's a conflict, reset the merge.

--- a/.teamcity/_self/lib/utils/MergeTrunk.kt
+++ b/.teamcity/_self/lib/utils/MergeTrunk.kt
@@ -4,32 +4,37 @@ import _self.bashNodeScript
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildSteps
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.ScriptBuildStep
 
-fun BuildSteps.mergeTrunk(): ScriptBuildStep {
+// Merge the trunk branch as a build step.
+// - For WPCOM plugins, our builds and tests include the latest merged version of the plugin being built.
+//   Otherwise, we can get into a situation where the current plugin build appears "different", but that's
+//   just because it's older.
+// - For metric tracking: (for example, tracking TypeScript errors). Merging trunk ensures any potential fix
+//   in trunk is included. Otherwise, we can get into a situation where trunk includes a fix for TypeScript
+//   and this branch adds a new error, resulting in a net total increase when it is merged.
+fun BuildSteps.mergeTrunk(skipIfConflict: Boolean = false): ScriptBuildStep {
 	return bashNodeScript {
 		name = "Merge trunk"
+		conditions {
+			doesNotEqual("teamcity.build.branch.is_default", "true")
+		}
 		scriptContent = """
 			set -x
+			# git operations will fail if no user is set.
+			git config --local user.email "tcbuildagent@example.com"
+			git config --local user.name "TeamCity Build Agent"
 
-			# Merge the trunk branch first.
-			# - For WPCOM plugins, our builds and tests include the latest merged version of the plugin being built.
-			#   Otherwise, we can get into a situation where the current plugin build appears "different", but that's
-			#   just because it's older.
-			# - For metric tracking: (for example, tracking TypeScript errors). Merging trunk ensures any potential fix
-			#   in trunk is included. Otherwise, we can get into a situation where trunk includes a fix for TypeScript
-			#   and this branch adds a new error, resulting in a net total increase when it is merged.
-			if [[ "%teamcity.build.branch.is_default%" != "true" ]] ; then
-				# git operations will fail if no user is set.
-				git config --local user.email "tcbuildagent@example.com"
-				git config --local user.name "TeamCity Build Agent"
-				# Note that `trunk` is already up-to-date from the `teamcity.git.fetchAllHeads`
-				# parameter in the project settings.
-				if ! git merge trunk ; then
-					echo "##teamcity[buildProblem description='There is a merge conflict with trunk. Rebase on trunk to resolve this problem.' identity='merge_conflict']]"
+			# Note that `trunk` is already up-to-date from the `teamcity.git.fetchAllHeads`
+			# parameter in the project settings.
+			if ! git merge trunk ; then
+				if [ "$skipIfConflict" = false ] ; then
+					echo "##teamcity[buildProblem description='There is a merge conflict with trunk. Skipping this step to allow the build to continue.']"
 					exit
 				fi
-				# See if the trunk commit shows up:
-				git --no-pager log --oneline -n 5
+				# If do want to skip if there's a conflict, reset the merge.
+				git reset --merge
 			fi
+			# See if the trunk commit shows up:
+			git --no-pager log --oneline -n 5
 		"""
 	}
 }

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -110,7 +110,7 @@ object BuildDockerImage : BuildType({
 			"""
 		}
 
-		// We want calypso.live and e2e tests to run even if there's a merg conflict,
+		// We want calypso.live and Calypso e2e tests to run even if there's a merge conflict,
 		// just to keep things going. However, if we can merge, the webpack cache
 		// can be better utilized, since it's kept up-to-date for trunk commits. 
 		// Note that this only happens on non-trunk

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -110,6 +110,12 @@ object BuildDockerImage : BuildType({
 			"""
 		}
 
+		// We want calypso.live and e2e tests to run even if there's a merg conflict,
+		// just to keep things going. However, if we can merge, the webpack cache
+		// can be better utilized, since it's kept up-to-date for trunk commits. 
+		// Note that this only happens on non-trunk
+		mergeTrunk( skipIfConflict = true )
+
 		script {
 			name = "Restore git mtime"
 			scriptContent = """

--- a/bin/check-log-for-cache-invalidation.sh
+++ b/bin/check-log-for-cache-invalidation.sh
@@ -11,10 +11,10 @@ if [[ ! -f $build_file ]] ; then
 	exit 0
 fi
 
-# if grep "resolving of build dependencies is invalid" $build_file ; then
-# 	echo "##teamcity[message text='Webpack cache invalidated!' errorDetails='This commit invalidated the webpack cache. Base image will be updated with new cache contents if on trunk.' status='warning']"
-# 	echo "Relevant details:"
-# 	grep "cache.PackFileCacheStrategy" $build_file
+if grep "resolving of build dependencies is invalid" $build_file ; then
+	echo "##teamcity[message text='Webpack cache invalidated!' errorDetails='This commit invalidated the webpack cache. Base image will be updated with new cache contents if on trunk.' status='warning']"
+	echo "Relevant details:"
+	grep "cache.PackFileCacheStrategy" $build_file
 
-# 	echo "##teamcity[setParameter name='env.WEBPACK_CACHE_INVALIDATED' value='true']"
-# fi
+	echo "##teamcity[setParameter name='env.WEBPACK_CACHE_INVALIDATED' value='true']"
+fi

--- a/bin/check-log-for-cache-invalidation.sh
+++ b/bin/check-log-for-cache-invalidation.sh
@@ -11,10 +11,10 @@ if [[ ! -f $build_file ]] ; then
 	exit 0
 fi
 
-if grep "resolving of build dependencies is invalid" $build_file ; then
-	echo "##teamcity[message text='Webpack cache invalidated!' errorDetails='This commit invalidated the webpack cache. Base image will be updated with new cache contents if on trunk.' status='warning']"
-	echo "Relevant details:"
-	grep "cache.PackFileCacheStrategy" $build_file
+# if grep "resolving of build dependencies is invalid" $build_file ; then
+# 	echo "##teamcity[message text='Webpack cache invalidated!' errorDetails='This commit invalidated the webpack cache. Base image will be updated with new cache contents if on trunk.' status='warning']"
+# 	echo "Relevant details:"
+# 	grep "cache.PackFileCacheStrategy" $build_file
 
-	echo "##teamcity[setParameter name='env.WEBPACK_CACHE_INVALIDATED' value='true']"
-fi
+# 	echo "##teamcity[setParameter name='env.WEBPACK_CACHE_INVALIDATED' value='true']"
+# fi


### PR DESCRIPTION
### Proposed Changes
In #72687, we update the webpack cache whenever it invalidates on trunk. To fully utilize this, a PR's code needs to be up-to-date with trunk. Otherwise, the PR can contain an older file which will also cause the webpack cache to invalidate. (Which adds 2 minutes to the build). 

This does not run on trunk, and merges are skipped if there are conflicts to avoid blocking developers.

### Testing
Check the TeamCity output.