### PR TITLE
Write to webpack cache on trunk

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -125,8 +125,8 @@ object BuildDockerImage : BuildType({
 		
 		// Read only cache should be disabled on trunk -- e.g., when we're on the
 		// default branch, we should write to the cache. In branches, we should
-		// not write to the cache.
-		val readonlyCache = ! "%teamcity.build.branch.is_default%".toBoolean()
+		// not write to the cache. (Except when we enable it via the testing arg.)
+		val readonlyCache = ! ( "%teamcity.build.branch.is_default%".toBoolean() || "%UPDATE_BASE_IMAGE_CACHE%".toBoolean() )
 
 		val commonArgs = """
 			--label com.a8c.image-builder=teamcity

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -123,6 +123,11 @@ object BuildDockerImage : BuildType({
 			dockerImagePlatform = ScriptBuildStep.ImagePlatform.Linux
 		}
 		
+		// Read only cache should be disabled on trunk -- e.g., when we're on the
+		// default branch, we should write to the cache. In branches, we should
+		// not write to the cache.
+		val readonlyCache = ! "%teamcity.build.branch.is_default%".toBoolean()
+
 		val commonArgs = """
 			--label com.a8c.image-builder=teamcity
 			--label com.a8c.build-id=%teamcity.build.id%
@@ -134,6 +139,7 @@ object BuildDockerImage : BuildType({
 			--build-arg manual_sentry_release=%MANUAL_SENTRY_RELEASE%
 			--build-arg is_default_branch=%teamcity.build.branch.is_default%
 			--build-arg sentry_auth_token=%SENTRY_AUTH_TOKEN%
+			--build-arg readonly_cache=$readonlyCache
 		""".trimIndent().replace("\n"," ")
 
 		dockerCommand {

--- a/Dockerfile
+++ b/Dockerfile
@@ -82,7 +82,7 @@ FROM ${base_image} as update-base-cache
 # Update webpack cache in the base image so that it can be re-used in future builds.
 # We only copy this part of the cache to make --push faster, and because webpack
 # is the main thing which will impact build performance when the cache invalidates.
-COPY --from=builder --chown=$UID /calypso/.cache/evergreen/webpack /calypso/.cache/evergreen/webpack
+COPY --from=builder /calypso/.cache/evergreen/webpack /calypso/.cache/evergreen/webpack
 
 ###################
 FROM node:${node_version}-alpine as app

--- a/Dockerfile
+++ b/Dockerfile
@@ -78,7 +78,6 @@ RUN find /calypso/build /calypso/public -name "*.*.map" -exec rm {} \;
 ###################
 # A cache-only update can be generated with "docker build --target update-base-cache"
 FROM ${base_image} as update-base-cache
-ARG UID=1003
 
 # Update webpack cache in the base image so that it can be re-used in future builds.
 # We only copy this part of the cache to make --push faster, and because webpack


### PR DESCRIPTION
This disables the readonly cache for trunk builds, since we're experimenting with updating the cache frequently, whenever it invalidates. In other words, we do want webpack to write the cache on trunk builds.

We keep the readonly cache for branch builds.