### PR TITLE
Improve reader focus management when using "J" and "K" keyboard navigation

### DIFF
--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -125,6 +125,7 @@ class ReaderStream extends Component {
 
 		if ( ! keysAreEqual( selectedPostKey, this.props.selectedPostKey ) ) {
 			this.scrollToSelectedPost( true );
+			this.focusSelectedPost( this.props.selectedPostKey );
 		}
 
 		if ( this.props.shouldRequestRecs ) {
@@ -134,6 +135,23 @@ class ReaderStream extends Component {
 			} );
 		}
 	}
+
+	focusSelectedPost = ( selectedPostKey ) => {
+		const postRefKey = this.getPostRef( selectedPostKey );
+		const ref = this.listRef.current.refs[ postRefKey ];
+		const node = ReactDom.findDOMNode( ref );
+
+		// if the post is found, focus the first anchor tag within it.
+		if ( node ) {
+			const firstLink = node.querySelector( 'a' );
+
+			if ( firstLink ) {
+				setTimeout( () => {
+					firstLink.focus();
+				} );
+			}
+		}
+	};
 
 	_popstate = () => {
 		if ( this.props.selectedPostKey && window.history.scrollRestoration !== 'manual' ) {

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -138,7 +138,7 @@ class ReaderStream extends Component {
 
 	focusSelectedPost = ( selectedPostKey ) => {
 		const postRefKey = this.getPostRef( selectedPostKey );
-		const ref = this.listRef.current.refs[ postRefKey ];
+		const ref = this.listRef.current && this.listRef.current.refs[ postRefKey ];
 		const node = ReactDom.findDOMNode( ref );
 
 		// if the post is found, focus the first anchor tag within it.
@@ -146,9 +146,7 @@ class ReaderStream extends Component {
 			const firstLink = node.querySelector( 'a' );
 
 			if ( firstLink ) {
-				setTimeout( () => {
-					firstLink.focus();
-				} );
+				firstLink.focus();
 			}
 		}
 	};


### PR DESCRIPTION
#### Proposed Changes
Part of https://github.com/Automattic/wp-calypso/issues/61318

When navigating with "J" and "K" on the keyboard, update the focus to the first anchor in the selected post.

https://user-images.githubusercontent.com/22446385/216486493-e5d6ff8a-ab18-4bf0-9453-6a1a07e3aea4.mov

I haven't included the second part of #61318, as the focus will be moved when they next use the "J" key to change selection.
> When you open a single post from the reader list view, then close that post again, the currently tabbed element is reset to the start of the page, but the current post stays as it was prior to it being opened.

#### Testing Instructions
go too /read and use the "J" key to navigate through the posts. 
Press the TAB key, and see that the focus has been moved to the start of the selected post
