### PR TITLE
Demo: Passing experiment data into Layout

### DIFF
--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -10,6 +10,7 @@ import MomentProvider from 'calypso/components/localized-moment/provider';
 import { RouteProvider } from 'calypso/components/route';
 import Layout from 'calypso/layout';
 import LayoutLoggedOut from 'calypso/layout/logged-out';
+import { useExperiment } from 'calypso/lib/explat';
 import { login } from 'calypso/lib/paths';
 import { CalypsoReactQueryDevtools } from 'calypso/lib/react-query-devtools-helper';
 import { getSiteFragment } from 'calypso/lib/route';
@@ -39,9 +40,16 @@ export const ProviderWrappedLayout = ( {
 } ) => {
 	const state = store.getState();
 	const userLoggedIn = isUserLoggedIn( state );
+	const [ , experimentAssignment ] = useExperiment(
+		'calypso_sidebar_upsell_dedicated_upgrade_flow_202301'
+	);
 
 	const layout = userLoggedIn ? (
-		<Layout primary={ primary } secondary={ secondary } />
+		<Layout
+			primary={ primary }
+			secondary={ secondary }
+			experimentAssignment={ experimentAssignment }
+		/>
 	) : (
 		<LayoutLoggedOut primary={ primary } secondary={ secondary } redirectUri={ redirectUri } />
 	);

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -13,7 +13,7 @@ import { cloudSiteSelection } from 'calypso/jetpack-cloud/controller';
 import { recordPageView } from 'calypso/lib/analytics/page-view';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import { loadExperimentAssignment } from 'calypso/lib/explat';
+// import { loadExperimentAssignment } from 'calypso/lib/explat';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { navigate } from 'calypso/lib/navigate';
 import { onboardingUrl } from 'calypso/lib/paths';
@@ -428,16 +428,16 @@ export function noSite( context, next ) {
 	return next();
 }
 
-export async function setExperimentVariation( context, next ) {
-	const experimentAssignment = await loadExperimentAssignment(
-		'calypso_sidebar_upsell_dedicated_upgrade_flow_202301'
-	);
+// export async function setExperimentVariation( context, next ) {
+// 	const experimentAssignment = await loadExperimentAssignment(
+// 		'calypso_sidebar_upsell_dedicated_upgrade_flow_202301'
+// 	);
 
-	const variationName = experimentAssignment?.variationName;
-	sessionStorage.setItem( 'calypso_sidebar_upsell_experiment', variationName );
+// 	const variationName = experimentAssignment?.variationName;
+// 	sessionStorage.setItem( 'calypso_sidebar_upsell_experiment', variationName );
 
-	next();
-}
+// 	next();
+// }
 
 /*
  * Set up site selection based on last URL param and/or handle no-sites error cases

--- a/client/my-sites/domains/index.js
+++ b/client/my-sites/domains/index.js
@@ -6,7 +6,6 @@ import {
 	siteSelection,
 	sites,
 	wpForTeamsGeneralNotSupportedRedirect,
-	setExperimentVariation,
 } from 'calypso/my-sites/controller';
 import domainsController from './controller';
 import domainManagementController from './domain-management/controller';
@@ -205,7 +204,6 @@ export default function () {
 	page(
 		'/domains/add/:domain',
 		siteSelection,
-		setExperimentVariation,
 		navigation,
 		domainsController.redirectIfNoSite( '/domains/add' ),
 		domainsController.redirectToUseYourDomainIfVipSite(),


### PR DESCRIPTION
#### Proposed Changes

Still works as the original PR https://github.com/Automattic/wp-calypso/pull/72932
Please check out the demo and testing instructions there.

* Instead of using `sessionStorage`, this PR loads the experiment data from an upper level and passes into <Layout />.
* Fixes: the error mentioned [here](https://github.com/Automattic/wp-calypso/pull/72932#issuecomment-1414511295)

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Please check out the demo and testing instructions in https://github.com/Automattic/wp-calypso/pull/72932


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
