### PR TITLE
Logged-out TS: Add event to track the user clicks the BCPA CTA

### DIFF
--- a/client/components/themes-list/index.jsx
+++ b/client/components/themes-list/index.jsx
@@ -34,7 +34,11 @@ export const ThemesList = ( props ) => {
 		[ props.fetchNextPage ]
 	);
 
-	const goToSiteAssemblerFlow = () => {
+	const goToSiteAssemblerFlow = ( shouldGoToAssemblerStep ) => {
+		props.recordTracksEvent( 'calypso_themeshowcase_pattern_assembler_cta_click', {
+			goes_to_assembler_step: shouldGoToAssemblerStep,
+		} );
+
 		const params = new URLSearchParams( {
 			ref: 'calypshowcase',
 			theme: BLANK_CANVAS_DESIGN.slug,


### PR DESCRIPTION
#### Proposed Changes

As the title, add the new event as followed

| Event Name | Props |
| - | - |
| `calypso_themeshowcase_pattern_assembler_cta_click` | `goes_to_assembler_step`: boolean. True if viewport width >= 960px |

![image](https://user-images.githubusercontent.com/13596067/216559894-e3f17814-a471-4236-9829-ebb5b46e4475.png)

See FigJam: 58MP46f44oGKl5Bin5bSp1-fi-1701%3A843

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the browser in Incognito mode
* Go to /themes
* Scroll down and select the Pattern Assembler CTA
* Verify whether the event is fired

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1675403293787519/1675399587.068519-slack-CRWCHQGUB