### PR TITLE
Stats: Restore totals under Tools → Earn.

### DIFF
--- a/client/my-sites/stats/wordads/index.jsx
+++ b/client/my-sites/stats/wordads/index.jsx
@@ -245,7 +245,7 @@ class WordAds extends Component {
 								</>
 
 								<div className="stats__module-list stats__module-headerless--unified">
-									<WordAdsEarnings site={ site } />
+									<WordAdsEarnings site={ site } showTotals={ false } />
 								</div>
 							</div>
 


### PR DESCRIPTION
The WordAdsEarnings component now takes a prop to control visibility of the totals section so we can remove it under Stats → Ads without modifying the behaviour under Tools → Earn.

#### Proposed Changes

* Restores previous code paths for titles in the WordAdsEarnings component.
* Adds a prop to WordAdsEarnings to allow us to selectively disable the output of totals.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open Calypso Live link.
* Visit Stats → Ads and confirm totals are shown at the top as highlight cards.
* Visit Tools → Earn → View ad dashboard and confirm the totals are once again visible above the earnings history table.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #72950.
