### PR TITLE
Plans 2023: Add notices on the /plans page

### DIFF
--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -46,6 +46,7 @@ import wooLogo from 'calypso/assets/images/onboarding/woo-logo.svg';
 import QueryActivePromotions from 'calypso/components/data/query-active-promotions';
 import FoldableCard from 'calypso/components/foldable-card';
 import JetpackLogo from 'calypso/components/jetpack-logo';
+import MarketingMessage from 'calypso/components/marketing-message';
 import Notice from 'calypso/components/notice';
 import PlanPill from 'calypso/components/plans/plan-pill';
 import { retargetViewPlans } from 'calypso/lib/analytics/ad-tracking';
@@ -744,9 +745,53 @@ export class PlanFeatures2023Grid extends Component<
 	renderNotice() {
 		return (
 			this.renderUpgradeDisabledNotice() ||
-			// this.renderDiscountNotice() ||
-			this.renderCreditNotice()
-			// || this.renderMarketingMessage()
+			this.renderDiscountNotice() ||
+			this.renderCreditNotice() ||
+			this.renderMarketingMessage()
+		);
+	}
+
+	renderMarketingMessage() {
+		const { siteId, hasPlaceholders, isInSignup } = this.props;
+
+		if ( hasPlaceholders || isInSignup ) {
+			return null;
+		}
+
+		const bannerContainer = this.getBannerContainer();
+		if ( ! bannerContainer ) {
+			return null;
+		}
+
+		return ReactDOM.createPortal( <MarketingMessage siteId={ siteId } />, bannerContainer );
+	}
+
+	renderDiscountNotice() {
+		if ( ! this.hasDiscountNotice() ) {
+			return false;
+		}
+
+		const bannerContainer = this.getBannerContainer();
+		const activeDiscount = getDiscountByName( this.props.withDiscount );
+		if ( ! bannerContainer || ! activeDiscount ) {
+			return false;
+		}
+		return ReactDOM.createPortal(
+			<Notice
+				className="plan-features__notice-credits"
+				showDismiss={ false }
+				icon="info-outline"
+				status="is-success"
+			>
+				{ activeDiscount?.plansPageNoticeTextTitle && (
+					<strong>
+						{ activeDiscount?.plansPageNoticeTextTitle }
+						<br />
+					</strong>
+				) }
+				{ activeDiscount.plansPageNoticeText }
+			</Notice>,
+			bannerContainer
 		);
 	}
 

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -67,7 +67,11 @@ import {
 } from 'calypso/state/plans/selectors';
 import getCurrentPlanPurchaseId from 'calypso/state/selectors/get-current-plan-purchase-id';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
-import { getCurrentPlan, isCurrentUserCurrentPlanOwner } from 'calypso/state/sites/plans/selectors';
+import {
+	getCurrentPlan,
+	isCurrentUserCurrentPlanOwner,
+	getPlanDiscountedRawPrice,
+} from 'calypso/state/sites/plans/selectors';
 import isPlanAvailableForPurchase from 'calypso/state/sites/plans/selectors/is-plan-available-for-purchase';
 import {
 	getSiteSlug,
@@ -906,7 +910,11 @@ const ConnectedPlanFeatures2023Grid = connect(
 			);
 
 			const rawPrice = getPlanRawPrice( state, planProductId, showMonthlyPrice );
-			const discountPrice = getDiscountedRawPrice( state, planProductId, showMonthlyPrice );
+			const isMonthlyObj = { isMonthly: showMonthlyPrice };
+
+			const discountPrice = siteId
+				? getPlanDiscountedRawPrice( state, siteId, plan, isMonthlyObj )
+				: getDiscountedRawPrice( state, planProductId, showMonthlyPrice );
 
 			let annualPricePerMonth = discountPrice || rawPrice;
 			if ( isMonthlyPlan ) {


### PR DESCRIPTION
#### Proposed Changes

This restores Notice banners on /plans by copying and integrating the previous functionality.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/plans/{SITE_NAME}?flags=onboarding/onboarding/2023-pricing-grid` and make sure the following banners are visible when the conditions are met:

**Pro-rated credits**
This should show when you already have an annual paid plan:

<img width="420" alt="Screenshot 2023-02-03 at 13 51 44" src="https://user-images.githubusercontent.com/2749938/216596916-cd56c372-481f-4a76-a79e-2851ca849b05.png">


**Upgrade disabled**
This should show if you're not the owner of the current paid plan site:

<img width="420" alt="Screenshot 2023-02-03 at 13 12 42" src="https://user-images.githubusercontent.com/2749938/216590494-6843f33d-24e3-48f2-9e5e-0bde1fcb74ce.png">

**Marketing**
You'll need to sandbox the public API and follow the instructions in `2efed-pb`  to trigger it:

<img width="420" alt="Screenshot 2023-02-03 at 13 09 34" src="https://user-images.githubusercontent.com/2749938/216590759-1835be30-38dc-4774-8357-4d0fc2d1a43e.png">



#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/martech/issues/1462
