### PR TITLE
Fix unified importer flag for Jetpack & Atomic edge cases

### DIFF
--- a/client/lib/importer/importer-config.tsx
+++ b/client/lib/importer/importer-config.tsx
@@ -28,12 +28,16 @@ interface ImporterConfigMap {
 
 interface ImporterConfigArgs {
 	siteTitle?: string;
+	isAtomic?: boolean;
+	isJetpack?: boolean;
 }
 
-function getConfig( args: ImporterConfigArgs = { siteTitle: '' } ): {
+function getConfig(
+	args: ImporterConfigArgs = { siteTitle: '', isAtomic: false, isJetpack: false }
+): {
 	[ key: string ]: ImporterConfig;
 } {
-	const importerConfig: ImporterConfigMap = {};
+	let importerConfig: ImporterConfigMap = {};
 
 	importerConfig.wordpress = {
 		engine: 'wordpress',
@@ -254,6 +258,22 @@ function getConfig( args: ImporterConfigArgs = { siteTitle: '' } ): {
 		} ),
 		weight: 0,
 	};
+
+	// For Jetpack sites, we don't support migration as destination,
+	// so we remove the override here.
+	if ( config.isEnabled( 'importer/unified' ) && args.isJetpack && ! args.isAtomic ) {
+		delete importerConfig.wordpress.overrideDestination;
+	}
+
+	// For Atomic and Jetpack sites, we've not implemented the Wix importer yet.
+	if ( config.isEnabled( 'importer/unified' ) && ( args.isAtomic || args.isJetpack ) ) {
+		delete importerConfig.wix;
+	}
+
+	// Filter out all importers except the WordPress ones for Atomic sites.
+	if ( ! config.isEnabled( 'importer/unified' ) && args.isAtomic ) {
+		importerConfig = { wordpress: importerConfig.wordpress };
+	}
 
 	return importerConfig;
 }

--- a/client/my-sites/importer/importer-wordpress.jsx
+++ b/client/my-sites/importer/importer-wordpress.jsx
@@ -9,6 +9,8 @@ class ImporterWordPress extends PureComponent {
 
 	static propTypes = {
 		siteTitle: PropTypes.string.isRequired,
+		isAtomic: PropTypes.bool,
+		isJetpack: PropTypes.bool,
 		importerStatus: PropTypes.shape( {
 			importerState: PropTypes.string.isRequired,
 			errorData: PropTypes.shape( {
@@ -22,6 +24,8 @@ class ImporterWordPress extends PureComponent {
 	render() {
 		const importerData = importerConfig( {
 			siteTitle: this.props.siteTitle,
+			isAtomic: this.props.isAtomic,
+			isJetpack: this.props.isJetpack,
 		} ).wordpress;
 
 		return <FileImporter importerData={ importerData } { ...this.props } />;

--- a/client/my-sites/importer/section-import.jsx
+++ b/client/my-sites/importer/section-import.jsx
@@ -144,12 +144,10 @@ class SectionImport extends Component {
 	 */
 	renderIdleImporters( importerState ) {
 		const { site, siteTitle } = this.props;
-		let importers = getImporters();
-
-		// Filter out all importers except the WordPress ones for Atomic sites.
-		if ( ! isEnabled( 'importer/unified' ) && site.options.is_wpcom_atomic ) {
-			importers = importers.filter( ( importer ) => importer.engine === 'wordpress' );
-		}
+		const importers = getImporters( {
+			isAtomic: site.options.is_wpcom_atomic,
+			isJetpack: site.jetpack,
+		} );
 
 		const importerElements = importers.map( ( { engine } ) => {
 			const ImporterComponent = importerComponents[ engine ];
@@ -169,6 +167,8 @@ class SectionImport extends Component {
 					site={ site }
 					siteTitle={ siteTitle }
 					importerStatus={ importerStatus }
+					isAtomic={ site.options.is_wpcom_atomic }
+					isJetpack={ site.jetpack }
 				/>
 			);
 		} );


### PR DESCRIPTION
#### Proposed Changes

This fixes Calypso to handle all edge cases for the first iteration of the Unified Importer codebase. There's a bunch of nuanced changes, so please follow the testing instructions carefully.

#### Testing Instructions

Please make sure you have slugs for:
* A Simple site
* An Atomic site
* A Jetpack-connected site.

First, let's ensure that **without the flag**, the behavior remains the same, I'll post links and expected screenshots:

<table>
<tr>
	<td>Simple: <code>/import/slug</code>
	<td>
<img width="841" alt="CleanShot 2023-02-03 at 17 05 57@2x" src="https://user-images.githubusercontent.com/533/216593822-65b04f49-1806-432a-add2-65521ff959e5.png">
	<td>Make sure Wix can be clicked through without any problem. Clicking on WordPress should go to the Migrator. Clicking `upload it to import content` from the migrator should go to the content importer.
<tr>
	<td>Atomic: <code>/import/slug</code>
	<td><img width="806" alt="CleanShot 2023-02-03 at 17 08 59@2x" src="https://user-images.githubusercontent.com/533/216594400-45db5ebe-c26d-4279-ba9a-780345af7741.png">
	<td>Make sure clicking on WordPress should go to the Migrator. Clicking `upload it to import content` from the migrator should go to the /wp-admin page of importers.
<tr>
	<td>Jetpack: <code>/import/slug</code>
	<td><img width="848" alt="CleanShot 2023-02-03 at 17 10 25@2x" src="https://user-images.githubusercontent.com/533/216594612-3120bb42-7c24-4abb-833a-3315ea2e73f3.png">
	<td>Make sure clicking on `Import into :site name:` will take you to wp-admin. Make sure that Tools > Import also redirects to /wp-admin.
</table>

Now, let's turn on the flag:

<table>
<tr>
	<td>Simple: <code>/import/slug?flags=importer/unified</code>
	<td>Same as previous, unchanged.
	<td>Same as previous, unchanged.
<tr>
	<td>Atomic: <code>/import/slug?flags=importer/unified</code>
	<td><img width="813" alt="CleanShot 2023-02-03 at 17 13 25@2x" src="https://user-images.githubusercontent.com/533/216595159-3e8e8b5c-6e59-47b5-b801-b5c5e15f7c71.png">
	<td>Make sure the Wix importer is unavailable. Clicking on WordPress should redirect to the migrator. Clicking `upload it to import content` from the migrator should go to the content importer.
<tr>
	<td>Jetpack: <code>/import/slug?flags=importer/unified</code>
	<td><img width="770" alt="CleanShot 2023-02-03 at 17 14 53@2x" src="https://user-images.githubusercontent.com/533/216595389-7b83afdf-8994-45e5-bb14-d63b8e9fbcfc.png">
	<td>Make sure the Wix importer is unavailable. Clicking on WordPress should redirect directly to the content importer.
</table>


#### Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] ~~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~~ Does not apply currently as it's feature flagged.
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] ~~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~~ No new strings have been introduced.
- [ ] ~~For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~~ Changes do not affect Jetpack.

Related to https://github.com/Automattic/dotcom-forge/issues/1576
