### PR TITLE
Plans 2023: Update breakpoints for the /plans page

### DIFF
--- a/client/my-sites/plan-features-2023-grid/_media-queries.scss
+++ b/client/my-sites/plan-features-2023-grid/_media-queries.scss
@@ -29,10 +29,22 @@ $plans-2023-large-breakpoint: 1500px;
 /**
  * Media queries for the plans grid on the /plans page.
  * Since there is a sidebar on internal pages,
- * this should stretch to fill it's container on non-mobile resolutions.
+ * we add the sidebar width to the default breakpoints.
  */
 @mixin pricing-grid-2023-plans-section-breakpoints {
-	max-width: 100%;
+	max-width: 414px;
+
+	@media ( min-width: $plans-2023-small-breakpoint  + $plan-features-sidebar-width  ) {
+		max-width: 860px;
+	}
+
+	@media ( min-width: $plans-2023-medium-breakpoint  + $plan-features-sidebar-width  ) {
+		max-width: 1320px;
+	}
+
+	@media ( min-width: $plans-2023-large-breakpoint  + $plan-features-sidebar-width  ) {
+		max-width: 1480px;
+	}
 }
 
 /**


### PR DESCRIPTION
#### Proposed Changes

* Updates breakpoints so that the plans grid on the /plans page does not stretch to fill the width of the page.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/plans/<site slug>?flags=onboarding/2023-pricing-grid`.
* Confirm that the width of the pricing grid has fixed widths at different breakpoints.


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
