### PR TITLE
Fix breakpoint related UI issues

### DIFF
--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -394,10 +394,7 @@ export class PlanFeatures2023Grid extends Component<
 			const classes = classNames( 'plan-features-2023-grid__table-item', 'is-bottom-aligned', {
 				'has-border-top': ! isReskinned,
 			} );
-
-			if ( rawPrice === undefined || rawPrice === null ) {
-				return;
-			}
+			const hasNoPrice = rawPrice === undefined || rawPrice === null;
 
 			return (
 				<Container
@@ -406,14 +403,16 @@ export class PlanFeatures2023Grid extends Component<
 					className={ classes }
 					isMobile={ options?.isMobile }
 				>
-					<PlanFeatures2023GridHeaderPrice
-						currencyCode={ currencyCode }
-						discountPrice={ discountPrice }
-						rawPrice={ rawPrice }
-						planName={ planName }
-						is2023OnboardingPricingGrid={ is2023OnboardingPricingGrid }
-						isLargeCurrency={ isLargeCurrency }
-					/>
+					{ ! hasNoPrice && (
+						<PlanFeatures2023GridHeaderPrice
+							currencyCode={ currencyCode }
+							discountPrice={ discountPrice }
+							rawPrice={ rawPrice }
+							planName={ planName }
+							is2023OnboardingPricingGrid={ is2023OnboardingPricingGrid }
+							isLargeCurrency={ isLargeCurrency }
+						/>
+					) }
 				</Container>
 			);
 		} );

--- a/client/my-sites/plan-features-2023-grid/plan-comparison-grid.tsx
+++ b/client/my-sites/plan-features-2023-grid/plan-comparison-grid.tsx
@@ -90,7 +90,7 @@ const Grid = styled.div`
 const Row = styled.div< { isHiddenInMobile?: boolean; isInSignup: boolean } >`
 	justify-content: space-between;
 	margin-bottom: -1px;
-	align-items: center;
+	align-items: stretch;
 	display: ${ ( props ) => ( props.isHiddenInMobile ? 'none' : 'flex' ) };
 
 	@media ( min-width: ${ getMobileBreakpoint } ) {

--- a/client/my-sites/plan-features-2023-grid/style.scss
+++ b/client/my-sites/plan-features-2023-grid/style.scss
@@ -483,166 +483,12 @@
 		}
 
 		&.plan-features-2023-grid__enterprise-logo {
-			padding-top: 32px;
-
-			img:nth-child(1) {
-				padding-right: 32px;
-			}
-
-			img:nth-child(2) {
-				padding-right: 32px;
-			}
-
-			img:nth-child(3) {
-				padding-right: 32px;
-			}
-
-			img:nth-child(4) {
-				padding-right: 0;
-			}
-
-			img:nth-child(5) {
-				padding-right: 24px;
-				padding-top: 12px;
-			}
-
-			img:nth-child(6) {
-				padding-right: 24px;
-				padding-top: 12px;
-			}
-
-			img:nth-child(7) {
-				padding-right: 24px;
-				padding-top: 12px;
-			}
-
-			img:nth-child(8) {
-				padding-right: 0;
-				padding-top: 12px;
-			}
-
-			@include plans-2023-break-small {
-				position: relative;
-				top: 10px;
-				padding-top: 0;
-
-				img:nth-child(1) {
-					padding-right: 32px;
-				}
-
-				img:nth-child(2) {
-					padding-right: 32px;
-				}
-
-				img:nth-child(3) {
-					padding-right: 0;
-				}
-
-				img:nth-child(4) {
-					padding-right: 32px;
-					padding-top: 12px;
-				}
-
-				img:nth-child(5) {
-					padding-right: 32px;
-					padding-top: 12px;
-				}
-
-				img:nth-child(6) {
-					padding-right: 0;
-					padding-top: 12px;
-				}
-
-				img:nth-child(7) {
-					padding-right: 32px;
-					padding-top: 12px;
-				}
-
-				img:nth-child(8) {
-					padding-right: 0;
-					padding-top: 12px;
-				}
-			}
-
-			@include plans-2023-break-medium {
-				img:nth-child(1) {
-					padding-right: 24px;
-				}
-
-				img:nth-child(2) {
-					padding-right: 24px;
-				}
-
-				img:nth-child(3) {
-					padding-right: 24px;
-					padding-top: 12px;
-				}
-
-				img:nth-child(4) {
-					padding-right: 18px;
-					padding-top: 12px;
-				}
-
-				img:nth-child(5) {
-					padding-right: 0;
-					padding-top: 12px;
-				}
-
-				img:nth-child(6) {
-					padding-right: 16px;
-					padding-top: 12px;
-				}
-
-				img:nth-child(7) {
-					padding-right: 0;
-					padding-top: 12px;
-				}
-
-				img:nth-child(8) {
-					padding-right: 0;
-					padding-top: 12px;
-				}
-			}
-
-			@media ( min-width: $plans-2023-large-breakpoint ) {
-				img:nth-child(1) {
-					padding-right: 24px;
-				}
-
-				img:nth-child(2) {
-					padding-right: 24px;
-				}
-
-				img:nth-child(3) {
-					padding-right: 0;
-				}
-
-				img:nth-child(4) {
-					padding-right: 24px;
-					padding-top: 12px;
-				}
-
-				img:nth-child(5) {
-					padding-right: 24px;
-					padding-top: 12px;
-				}
-
-				img:nth-child(6) {
-					padding-right: 0;
-					padding-top: 12px;
-				}
-
-				img:nth-child(7) {
-					padding-right: 24px;
-					padding-top: 12px;
-				}
-
-				img:nth-child(8) {
-					padding-right: 0;
-					padding-top: 12px;
-				}
-			}
-
+			display: flex;
+			flex-wrap: wrap;
+			column-gap: 32px;
+			row-gap: 14px;
+			position: relative;
+			top: 14px;
 		}
 	}
 }
@@ -665,7 +511,7 @@
 body.is-section-signup.is-white-signup,
 .is-2023-pricing-grid {
 
-	.plan-features-2023-grid__table-item {
+	.plan-features-2023-grid__table-item.plan-features-2023-grid__table-item {
 		border-right: none;
 		background-color: transparent;
 
@@ -717,6 +563,7 @@ body.is-section-signup.is-white-signup,
 			border-radius: 4px;
 			background-color: var(--studio-gray-80);
 			transform: translate(20px, -50px);
+			text-transform: unset;
 			@include plans-2023-break-small {
 				transform: translate(20px, 0);
 			}
@@ -981,6 +828,7 @@ body.is-section-signup.is-white-signup .is-onboarding-2023-pricing-grid .signup_
 			right: unset;
 			border-radius: 4px;
 			background-color: var(--studio-gray-80);
+			text-transform: unset;
 
 			@include plans-2023-break-small {
 				left: 15px;

--- a/client/my-sites/plan-features-2023-grid/style.scss
+++ b/client/my-sites/plan-features-2023-grid/style.scss
@@ -485,10 +485,15 @@
 		&.plan-features-2023-grid__enterprise-logo {
 			display: flex;
 			flex-wrap: wrap;
-			column-gap: 32px;
+			column-gap: 20px;
 			row-gap: 14px;
 			position: relative;
-			top: 14px;
+			margin: 32px 0 0;
+
+			@include plans-2023-break-small {
+				margin: 0;
+				top: 14px;
+			}
 		}
 	}
 }


### PR DESCRIPTION
#### Proposed Changes

This fixes the following breakpoint-related issues:
* there are double borders between the plans
* the plan headers are misaligned in the Plan Comparison grid
* the enterprise logos are misaligned

<img width="420" alt="Screenshot 2023-02-03 at 16 06 19" src="https://user-images.githubusercontent.com/2749938/216623692-501276c4-5bcb-45ed-a6cf-adcc0366aa37.png">

<img width="420" alt="Screenshot 2023-02-03 at 16 07 03" src="https://user-images.githubusercontent.com/2749938/216623682-6a885899-ffb8-4f57-8067-6f3602a2e838.png">

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/plans/{SITE_ID}?flags=onboarding/2023-pricing-grid`
* Make sure the issues in the description have been addressed

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
