### PR TITLE
Plans 2023: Fix width of interval toggle

### DIFF
--- a/client/my-sites/plan-features-2023-grid/_media-queries.scss
+++ b/client/my-sites/plan-features-2023-grid/_media-queries.scss
@@ -34,15 +34,15 @@ $plans-2023-large-breakpoint: 1500px;
 @mixin pricing-grid-2023-plans-section-breakpoints {
 	max-width: 414px;
 
-	@media ( min-width: $plans-2023-small-breakpoint  + $plan-features-sidebar-width  ) {
+	@media ( min-width: $plans-2023-small-breakpoint + $plan-features-sidebar-width ) {
 		max-width: 860px;
 	}
 
-	@media ( min-width: $plans-2023-medium-breakpoint  + $plan-features-sidebar-width  ) {
+	@media ( min-width: $plans-2023-medium-breakpoint + $plan-features-sidebar-width ) {
 		max-width: 1320px;
 	}
 
-	@media ( min-width: $plans-2023-large-breakpoint  + $plan-features-sidebar-width  ) {
+	@media ( min-width: $plans-2023-large-breakpoint + $plan-features-sidebar-width ) {
 		max-width: 1480px;
 	}
 }

--- a/client/my-sites/plan-features-2023-grid/plan-comparison-grid.tsx
+++ b/client/my-sites/plan-features-2023-grid/plan-comparison-grid.tsx
@@ -90,7 +90,7 @@ const Grid = styled.div`
 const Row = styled.div< { isHiddenInMobile?: boolean; isInSignup: boolean } >`
 	justify-content: space-between;
 	margin-bottom: -1px;
-	align-items: center;
+	align-items: stretch;
 	display: ${ ( props ) => ( props.isHiddenInMobile ? 'none' : 'flex' ) };
 
 	@media ( min-width: ${ getMobileBreakpoint } ) {

--- a/client/my-sites/plan-features-2023-grid/style.scss
+++ b/client/my-sites/plan-features-2023-grid/style.scss
@@ -836,14 +836,12 @@ body.is-section-signup.is-white-signup,
 body.is-section-signup.is-white-signup .is-onboarding-2023-pricing-grid .signup__step .segmented-control.price-toggle,
 #primary .is-pricing-grid-2023-plans-features-main .segmented-control.price-toggle {
 	background-color: #f2f2f2;
-	max-width: 375px;
-	width: 100%;
-	margin: 0 22px;
+	width: 414px; // width of mobile plans grid
+	margin: 0 auto;
 
 	@include plans-2023-break-small {
-		max-width: unset;
+		max-width: fit-content;
 		width: auto;
-		margin: 0 auto;
 	}
 
 	.segmented-control__link {


### PR DESCRIPTION
#### Proposed Changes

* Fixes the width of the interval toggle (Pay yearly/Pay monthly) on both `/start/plans` and the `/plans` page.

### Screenshots
* /start/plans (Desktop/Tablet)
<img width="1296" alt="image" src="https://user-images.githubusercontent.com/5436027/216624130-6c924092-cad4-446c-94ca-2e03a5ddf441.png">

* /start/plans (Mobile)
<img width="344" alt="image" src="https://user-images.githubusercontent.com/5436027/216624298-f0a2aa51-e484-4503-9ad6-e847b2a5ca82.png">

* /plans (Desktop)
<img width="919" alt="image" src="https://user-images.githubusercontent.com/5436027/216624410-6b0e29b6-b7f4-476f-acf6-4d59b7095db5.png">

* /plans (Tablet)
<img width="575" alt="image" src="https://user-images.githubusercontent.com/5436027/216624725-4b754a23-c82c-40c7-be17-705ba6d1f0e7.png">


* /plans (Mobile)
<img width="343" alt="image" src="https://user-images.githubusercontent.com/5436027/216624527-ba66e78d-1928-4031-9e9a-afa71276ff89.png">



#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/plans/{SITE_ID}?flags=onboarding/2023-pricing-grid` and confirm that the interval type toggle renders correctly according to the screenshots.
* Go to `/start/plans?flags=onboarding/2023-pricing-grid` and confirm that the interval type toggle renders correctly according to the screenshots.


#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
