### PR TITLE
Themes: Fix DIFM link in emtpy search

### DIFF
--- a/client/components/themes-list/index.jsx
+++ b/client/components/themes-list/index.jsx
@@ -217,7 +217,7 @@ function Options( { isFSEActive, recordTracksEvent, searchTerm, translate, upsel
 				site_plan: sitePlan,
 				search_term: searchTerm,
 			} ),
-		url: 'https://wordpress.com/do-it-for-me/',
+		url: 'https://wordpress.com/marketing/do-it-for-me/',
 		buttonText: translate( 'Hire an expert' ),
 	} );
 


### PR DESCRIPTION
#### Proposed Changes

Fixes the DIFM link on the theme empty search card

#### Testing Instructions

- Use the Calypso live link below
- Go to Appearance > Themes
- Enter a term that doesn't produce any result
- Click on the DIFM option
- Make sure it redirects to the DIFM page