### PR TITLE
Plans 2023: Match Plans header width to My Plan

### DIFF
--- a/client/my-sites/plan-features-2023-grid/plan-comparison-grid.tsx
+++ b/client/my-sites/plan-features-2023-grid/plan-comparison-grid.tsx
@@ -77,9 +77,9 @@ const Title = styled.div< { isHiddenInMobile?: boolean; isInSignup: boolean } >`
 	}
 `;
 
-const Grid = styled.div`
+const Grid = styled.div< { isInSignup: boolean } >`
 	display: grid;
-	margin-top: 90px;
+	margin-top: ${ ( props ) => ( props.isInSignup ? '90px' : '64px' ) };
 	background: #fff;
 	border: solid 1px #e0e0e0;
 
@@ -529,7 +529,7 @@ export const PlanComparisonGrid: React.FC< PlanComparisonGridProps > = ( {
 				siteSlug={ planTypeSelectorProps.siteSlug }
 				hideDiscountLabel={ true }
 			/>
-			<Grid>
+			<Grid isInSignup={ isInSignup }>
 				<PlanComparisonGridHeader
 					displayedPlansProperties={ displayedPlansProperties }
 					visiblePlansProperties={ visiblePlansProperties }

--- a/client/my-sites/plan-features-2023-grid/style.scss
+++ b/client/my-sites/plan-features-2023-grid/style.scss
@@ -151,7 +151,6 @@
 	}
 
 	@include plans-2023-break-medium {
-		padding-top: 103px;
 		overflow-x: auto;
 	}
 }

--- a/client/my-sites/plans/header.scss
+++ b/client/my-sites/plans/header.scss
@@ -52,3 +52,17 @@
 		margin: 0 24px;
 	}
 }
+
+
+.is-2023-pricing-grid {
+	.formatted-header.formatted-header,
+	.notice.notice,
+	.section-nav.section-nav {
+		max-width: 1040px;
+		margin-left: auto;
+		margin-right: auto;
+	}
+	.notice.notice {
+		margin-bottom: 0;
+	}
+}

--- a/client/my-sites/plans/header.scss
+++ b/client/my-sites/plans/header.scss
@@ -62,7 +62,10 @@
 		margin-left: auto;
 		margin-right: auto;
 	}
-	.notice.notice {
-		margin-bottom: 0;
+
+	@media (max-width: 660px) {
+		.formatted-header.formatted-header {
+			margin: 16px;
+		}
 	}
 }

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -186,7 +186,7 @@ class Plans extends Component {
 		}
 
 		return (
-			<div>
+			<div className={ is2023OnboardingPricingGrid ? 'is-2023-pricing-grid' : '' }>
 				{ selectedSite.ID && <QuerySitePurchases siteId={ selectedSite.ID } /> }
 				<DocumentHead title={ translate( 'Plans', { textOnly: true } ) } />
 				<PageViewTracker path="/plans/:site" title="Plans" />


### PR DESCRIPTION
#### Proposed Changes

This ensures that the header on the plan section doesn't extend full width, causing inconsistency with My Plans 
More info: #72775 

https://user-images.githubusercontent.com/1705499/215507423-56149f8e-ebc2-412d-a6ae-89c77b73fdab.mov

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/plans/{SITE_ID}?flags=onboarding/2023-pricing-grid`
* The Plan header width should match the My Plan header width
<img width="420" alt="Screenshot 2023-02-03 at 17 04 06" src="https://user-images.githubusercontent.com/2749938/216638142-23555eb2-d3a9-4dc7-9c8c-3ed8e1114470.png">

<img width="420" alt="Screenshot 2023-02-03 at 17 11 35" src="https://user-images.githubusercontent.com/2749938/216638250-6e71963c-db22-4924-94bc-8fcdda783597.png">

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #72775 
