### PR TITLE
Theme: Fix DIFM link in empty search (take 2)

### DIFF
--- a/client/components/themes-list/index.jsx
+++ b/client/components/themes-list/index.jsx
@@ -212,12 +212,14 @@ function Options( { isFSEActive, recordTracksEvent, searchTerm, translate, upsel
 		description: translate(
 			'A WordPress.com professional will create layouts for up to 5 pages of your site.'
 		),
-		onClick: () =>
+		onClick: () => {
 			recordTracksEvent( 'calypso_themeshowcase_more_options_difm_click', {
 				site_plan: sitePlan,
 				search_term: searchTerm,
-			} ),
-		url: 'https://wordpress.com/marketing/do-it-for-me/',
+			} );
+			window.location.replace( 'https://wordpress.com/do-it-for-me/' );
+		},
+		url: 'https://wordpress.com/do-it-for-me/',
 		buttonText: translate( 'Hire an expert' ),
 	} );
 


### PR DESCRIPTION
#### Proposed Changes

Fixes the DIFM link on the empty search card for the logged-out theme showcase

#### Testing Instructions

- Use the Calypso live link below on an incognito window
- Go to `/themes`
- Enter a term that doesn't produce any result
- Click on the DIFM option
- Make sure it redirects to the DIFM page