### PR TITLE
Add filename suffix option to Webpack RTL plugin

### DIFF
--- a/packages/webpack-rtl-plugin/README.md
+++ b/packages/webpack-rtl-plugin/README.md
@@ -62,9 +62,11 @@ This will create the normal `style.css` and an additionnal `style.rtl.css`.
 new WebpackRTLPlugin({
   options: {},
   plugins: [],
+  filenameSuffix: '',
 })
 ```
 
 - `test` a RegExp (object or string) that must match asset filename.
 - `options` Options given to `rtlcss`. See the [rtlcss documentation for available options](http://rtlcss.com/learn/usage-guide/options/).
 - `plugins` RTLCSS plugins given to `rtlcss`. See the [rtlcss documentation for writing plugins](http://rtlcss.com/learn/extending-rtlcss/writing-a-plugin/). Default to `[]`.
+- `filenameSuffix` allows customization of the filename suffix. Default to `.rtl.css`.

--- a/packages/webpack-rtl-plugin/src/index.js
+++ b/packages/webpack-rtl-plugin/src/index.js
@@ -8,6 +8,7 @@ class WebpackRTLPlugin {
 		this.options = {
 			options: {},
 			plugins: [],
+			filenameSuffix: null,
 			...options,
 		};
 		this.cache = new WeakMap();
@@ -35,7 +36,7 @@ class WebpackRTLPlugin {
 								}
 
 								// Compute the filename
-								const filename = asset.replace( cssRe, '.rtl$&' );
+								const filename = asset.replace( cssRe, this.options.filenameSuffix || `.rtl$&` );
 								const assetInstance = assets[ asset ];
 								chunk.files.add( filename );
 

--- a/packages/webpack-rtl-plugin/test/index.js
+++ b/packages/webpack-rtl-plugin/test/index.js
@@ -81,6 +81,51 @@ describe( 'Webpack RTL Plugin', () => {
 		} );
 	} );
 
+	describe( 'Filename suffix option', () => {
+		const bundlePath = path.join( __dirname, 'dist/bundle.js' );
+		const cssBundlePath = path.join( __dirname, 'dist/style.css' );
+		const rtlCssWithCustomFilenameSuffixBundlePath = path.join( __dirname, 'dist/style-rtl.css' );
+
+		beforeAll(
+			() =>
+				new Promise( ( done ) => {
+					webpack(
+						{
+							...baseConfig,
+							plugins: [
+								...baseConfig.plugins,
+								new WebpackRTLPlugin( { filenameSuffix: '-rtl.css' } ),
+							],
+						},
+						( err, stats ) => {
+							if ( err ) {
+								return done( err );
+							}
+
+							if ( stats.hasErrors() ) {
+								return done( new Error( stats.toString() ) );
+							}
+							done();
+						}
+					);
+				} )
+		);
+
+		it( 'should create a second bundle', () => {
+			expect( fs.existsSync( bundlePath ) ).toBe( true );
+			expect( fs.existsSync( cssBundlePath ) ).toBe( true );
+			expect( fs.existsSync( rtlCssWithCustomFilenameSuffixBundlePath ) ).toBe( true );
+		} );
+
+		it( 'should contain the correct content', () => {
+			const contentCss = fs.readFileSync( cssBundlePath, 'utf-8' );
+			const contentRrlCss = fs.readFileSync( rtlCssWithCustomFilenameSuffixBundlePath, 'utf-8' );
+
+			expect( contentCss ).toContain( 'padding-left: 10px;' );
+			expect( contentRrlCss ).toContain( 'padding-right: 10px;' );
+		} );
+	} );
+
 	describe( 'Test option', () => {
 		let bundlePath;
 		let cssBundlePath;


### PR DESCRIPTION
Currently, the Webpack RTL plugin always appends .rtl.css to the filename. Despite it covers many use cases, there are some situations where it limits the plugin usage in other projects. For example, in the [WordPress codex](https://codex.wordpress.org/Right-to-Left_Language_Support), they suggest two ways to add RTL Language support:
```
1. By creating a fully mirror of your style.css file named style-rtl.css
2. By overwriting all the horizontal positioning attributes of your CSS stylesheet in a separate stylesheet file named rtl.css.
```
In the original plugin created by Romain Berger (that was adapted by this package) there was also an option to customize the filename, so I think we can benefit from having this option.

#### Proposed Changes

* Add `filenameSuffix` option to Webpack RTL Plugin configuration object so users can override the default `.rtl.css` suffix.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Go to the file `packages/calypso-build/webpack/sass.js` and replace the Webpack RTL Configuration to look like this:
```
new WebpackRTLPlugin( { filenameSuffix: '-rtl.css' } ),
```
2. Run the command `yarn build-client` and wait for it to complete;
3. After the build is complete, go inside the folder `public` and check if there are `.css` files with their corresponding RTL version with the filename suffix we defined above. For example: `plugins.css` and `plugins-rtl.css`

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] ~~Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?~~
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~~
- [ ] ~~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)~~?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #72961
