### PR TITLE
Removing monthly toggle from paid media signup flow

### DIFF
--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -1,5 +1,10 @@
 import config from '@automattic/calypso-config';
-import { WPCOM_DIFM_LITE } from '@automattic/calypso-products';
+import {
+	WPCOM_DIFM_LITE,
+	planHasFeature,
+	FEATURE_UPLOAD_THEMES_PLUGINS,
+	isEcommerce,
+} from '@automattic/calypso-products';
 import { getUrlParts } from '@automattic/calypso-url';
 import { Site } from '@automattic/data-stores';
 import { isBlankCanvasDesign } from '@automattic/design-picker';
@@ -39,7 +44,6 @@ import { getSiteType } from 'calypso/state/signup/steps/site-type/selectors';
 import { getWebsiteContent } from 'calypso/state/signup/steps/website-content/selectors';
 import { requestSite } from 'calypso/state/sites/actions';
 import { getSiteId } from 'calypso/state/sites/selectors';
-
 const Visibility = Site.Visibility;
 const debug = debugFactory( 'calypso:signup:step-actions' );
 
@@ -1164,3 +1168,79 @@ export function isNewOrExistingSiteFulfilled( stepName, defaultDependencies, nex
 		flows.excludeStep( stepName );
 	}
 }
+
+export const buildUpgradeFunction = ( planProps, cartItem ) => {
+	const {
+		additionalStepData,
+		flowName,
+		launchSite,
+		selectedSite,
+		stepName,
+		stepSectionName,
+		themeSlugWithRepo,
+		goToNextStep,
+		submitSignupStep,
+	} = planProps;
+
+	if ( cartItem ) {
+		recordTracksEvent( 'calypso_signup_plan_select', {
+			product_slug: cartItem.product_slug,
+			free_trial: cartItem.free_trial,
+			from_section: stepSectionName ? stepSectionName : 'default',
+		} );
+
+		// If we're inside the store signup flow and the cart item is a Business or eCommerce Plan,
+		// set a flag on it. It will trigger Automated Transfer when the product is being
+		// activated at the end of the checkout process.
+		if (
+			flowName === 'ecommerce' &&
+			planHasFeature( cartItem.product_slug, FEATURE_UPLOAD_THEMES_PLUGINS )
+		) {
+			cartItem.extra = Object.assign( cartItem.extra || {}, {
+				is_store_signup: true,
+			} );
+		}
+	} else {
+		recordTracksEvent( 'calypso_signup_free_plan_select', {
+			from_section: stepSectionName ? stepSectionName : 'default',
+		} );
+	}
+
+	const step = {
+		stepName,
+		stepSectionName,
+		cartItem,
+		...additionalStepData,
+	};
+
+	if ( selectedSite && flowName === 'site-selected' && ! cartItem ) {
+		wpcom.req.post(
+			`/domains/${ selectedSite.ID }/${ selectedSite.name }/convert-domain-only-to-site`,
+			{},
+			( error ) => {
+				if ( error ) {
+					errorNotice( error.message );
+					return;
+				}
+				submitSignupStep( step, {
+					cartItem,
+				} );
+				goToNextStep();
+			}
+		);
+		return;
+	}
+
+	const signupVals = {
+		cartItem,
+		...( themeSlugWithRepo && { themeSlugWithRepo } ),
+		...( launchSite && { comingSoon: 0 } ),
+	};
+
+	if ( cartItem && isEcommerce( cartItem ) ) {
+		signupVals.themeSlugWithRepo = 'pub/twentytwentytwo';
+	}
+
+	submitSignupStep( step, signupVals );
+	goToNextStep();
+};

--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -1180,10 +1180,11 @@ export const buildUpgradeFunction = ( planProps, cartItem ) => {
 		themeSlugWithRepo,
 		goToNextStep,
 		submitSignupStep,
+		recordTracksEvent: rte,
 	} = planProps;
 
 	if ( cartItem ) {
-		recordTracksEvent( 'calypso_signup_plan_select', {
+		rte( 'calypso_signup_plan_select', {
 			product_slug: cartItem.product_slug,
 			free_trial: cartItem.free_trial,
 			from_section: stepSectionName ? stepSectionName : 'default',
@@ -1201,7 +1202,7 @@ export const buildUpgradeFunction = ( planProps, cartItem ) => {
 			} );
 		}
 	} else {
-		recordTracksEvent( 'calypso_signup_free_plan_select', {
+		rte( 'calypso_signup_free_plan_select', {
 			from_section: stepSectionName ? stepSectionName : 'default',
 		} );
 	}

--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -1180,11 +1180,10 @@ export const buildUpgradeFunction = ( planProps, cartItem ) => {
 		themeSlugWithRepo,
 		goToNextStep,
 		submitSignupStep,
-		recordTracksEvent: rte,
 	} = planProps;
 
 	if ( cartItem ) {
-		rte( 'calypso_signup_plan_select', {
+		planProps.recordTracksEvent( 'calypso_signup_plan_select', {
 			product_slug: cartItem.product_slug,
 			free_trial: cartItem.free_trial,
 			from_section: stepSectionName ? stepSectionName : 'default',
@@ -1202,7 +1201,7 @@ export const buildUpgradeFunction = ( planProps, cartItem ) => {
 			} );
 		}
 	} else {
-		rte( 'calypso_signup_free_plan_select', {
+		planProps.recordTracksEvent( 'calypso_signup_free_plan_select', {
 			from_section: stepSectionName ? stepSectionName : 'default',
 		} );
 	}

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -139,7 +139,7 @@ export function generateFlows( {
 		},
 		{
 			name: 'onboarding-pm',
-			steps: [ 'user', 'domains', 'plans' ],
+			steps: [ 'user', 'domains', 'plans-pm' ],
 			destination: getSignupDestination,
 			description:
 				'Paid media version of the onboarding flow. Read more in https://wp.me/pau2Xa-4Kk.',

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -29,6 +29,7 @@ const stepNameToModuleName = {
 	'plans-new': 'plans',
 	'plans-business': 'plans',
 	'plans-ecommerce': 'plans',
+	'plans-pm': 'plans-pm',
 	'plans-pro': 'plans',
 	'plans-starter': 'plans',
 	'plans-import': 'plans',

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -205,6 +205,15 @@ export function generateSteps( {
 			fulfilledStepCallback: isPlanFulfilled,
 		},
 
+		'plans-pm': {
+			stepName: 'plans-pm',
+			apiRequestFunction: addPlanToCart,
+			dependencies: [ 'siteSlug' ],
+			optionalDependencies: [ 'emailItem', 'themeSlugWithRepo' ],
+			providesDependencies: [ 'cartItem', 'themeSlugWithRepo' ],
+			fulfilledStepCallback: isPlanFulfilled,
+		},
+
 		'plans-newsletter': {
 			stepName: 'plans',
 			apiRequestFunction: addPlanToCart,

--- a/client/signup/steps/plans-pm/index.jsx
+++ b/client/signup/steps/plans-pm/index.jsx
@@ -1,0 +1,185 @@
+import { Button } from '@automattic/components';
+import { isDesktop, subscribeIsDesktop } from '@automattic/viewport';
+import classNames from 'classnames';
+import { localize } from 'i18n-calypso';
+import { Component } from 'react';
+import { connect } from 'react-redux';
+import QueryPlans from 'calypso/components/data/query-plans';
+import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
+import MarketingMessage from 'calypso/components/marketing-message';
+import Notice from 'calypso/components/notice';
+import { loadExperimentAssignment } from 'calypso/lib/explat';
+import { buildUpgradeFunction } from 'calypso/lib/signup/step-actions';
+import StepWrapper from 'calypso/signup/step-wrapper';
+import { getDomainName, getIntervalType } from 'calypso/signup/steps/plans/util';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { errorNotice } from 'calypso/state/notices/actions';
+import { saveSignupStep, submitSignupStep } from 'calypso/state/signup/progress/actions';
+import PlansFeaturesMainPM from './plans-features-main-pm';
+import 'calypso/signup/steps/plans/style.scss';
+
+export class PlansStepPM extends Component {
+	constructor( props ) {
+		super( props );
+		this.state = {
+			isDesktop: isDesktop(),
+			experiment: null,
+			experimentIsLoading: true,
+		};
+	}
+	componentDidMount() {
+		this.unsubscribe = subscribeIsDesktop( ( matchesDesktop ) =>
+			this.setState( { isDesktop: matchesDesktop } )
+		);
+		this.props.saveSignupStep( { stepName: this.props.stepName } );
+
+		loadExperimentAssignment( 'paid_media_signup_2023_02_hide_monthly' ).then(
+			( experimentName ) => {
+				this.setState( { experiment: experimentName } );
+				this.setState( { experimentIsLoading: false } );
+			}
+		);
+	}
+
+	componentWillUnmount() {
+		this.unsubscribe();
+	}
+
+	plansFeaturesList() {
+		const { flowName } = this.props;
+
+		let errorDisplay;
+		if ( 'invalid' === this.props.step?.status ) {
+			errorDisplay = (
+				<div>
+					<Notice status="is-error" showDismiss={ false }>
+						{ this.props.step.errors.message }
+					</Notice>
+				</div>
+			);
+		}
+
+		return (
+			<div>
+				{ errorDisplay }
+				<PlansFeaturesMainPM
+					site={ {} }
+					showFAQ={ true }
+					hideFreePlan={ true }
+					intervalType={ getIntervalType() }
+					onUpgradeClick={ ( cartItem ) => buildUpgradeFunction( this.props, cartItem ) }
+					domainName={ getDomainName( this.props.signupDependencies.domainItem ) }
+					plansWithScroll={ this.state.isDesktop }
+					flowName={ flowName }
+					isAllPaidPlansShown={ true }
+					isInSignup={ true }
+					shouldShowPlansFeatureComparison={ this.state.isDesktop } // Show feature comparison layout in signup flow and desktop resolutions
+					shouldHideMonthlyToggle={ this.state.experiment?.variationName === 'treatment' }
+				/>
+			</div>
+		);
+	}
+
+	getHeaderText() {
+		const { headerText, translate } = this.props;
+
+		if ( headerText ) {
+			return headerText;
+		}
+
+		if ( this.state.isDesktop ) {
+			return translate( 'Choose a plan' );
+		}
+
+		return translate( "Pick a plan that's right for you." );
+	}
+
+	getSubHeaderText() {
+		const { translate } = this.props;
+		const freePlanButton = (
+			<Button onClick={ () => buildUpgradeFunction( this.props, null ) } borderless />
+		);
+
+		if ( this.state.isDesktop ) {
+			return translate(
+				"Pick one that's right for you and unlock features that help you grow. Or {{link}}start with a free site{{/link}}.",
+				{ components: { link: freePlanButton } }
+			);
+		}
+
+		return translate( 'Choose a plan or {{link}}start with a free site{{/link}}.', {
+			components: { link: freePlanButton },
+		} );
+	}
+
+	plansFeaturesSelection() {
+		const { flowName, stepName, positionInFlow, steps } = this.props;
+		const headerText = this.getHeaderText();
+		const fallbackHeaderText = this.props.fallbackHeaderText || headerText;
+		const subHeaderText = this.getSubHeaderText();
+		const fallbackSubHeaderText = this.props.fallbackSubHeaderText || subHeaderText;
+
+		const previousStepName = steps[ this.props.positionInFlow - 1 ];
+		const previousStep = this.props.progress?.[ previousStepName ];
+		const isComingFromUseYourDomainStep = 'use-your-domain' === previousStep?.stepSectionName;
+		let queryParams;
+
+		if ( isComingFromUseYourDomainStep ) {
+			queryParams = {
+				...this.props.queryParams,
+				step: 'transfer-or-connect',
+				initialQuery: previousStep?.siteUrl,
+			};
+		}
+
+		return (
+			<>
+				<StepWrapper
+					flowName={ flowName }
+					stepName={ stepName }
+					positionInFlow={ positionInFlow }
+					headerText={ headerText }
+					fallbackHeaderText={ fallbackHeaderText }
+					subHeaderText={ subHeaderText }
+					fallbackSubHeaderText={ fallbackSubHeaderText }
+					stepContent={ this.plansFeaturesList() }
+					queryParams={ queryParams }
+				/>
+			</>
+		);
+	}
+
+	renderLoading() {
+		return (
+			<div className="plans__loading">
+				<LoadingEllipsis active />
+			</div>
+		);
+	}
+
+	render() {
+		const classes = classNames( 'plans plans-step', {
+			'in-vertically-scrolled-plans-experiment': true,
+			'has-no-sidebar': false,
+			'is-wide-layout': true,
+		} );
+
+		if ( this.state.experimentIsLoading ) {
+			return this.renderLoading();
+		}
+		return (
+			<>
+				<QueryPlans />
+				<MarketingMessage path="signup/plans" />
+				<div className={ classes }>{ this.plansFeaturesSelection() }</div>
+			</>
+		);
+	}
+}
+
+export default connect( null, {
+	recordTracksEvent,
+	saveSignupStep,
+	submitSignupStep,
+	errorNotice,
+} )( localize( PlansStepPM ) );

--- a/client/signup/steps/plans-pm/plans-features-main-pm.jsx
+++ b/client/signup/steps/plans-pm/plans-features-main-pm.jsx
@@ -1,0 +1,217 @@
+import {
+	findPlansKeys,
+	getPlan,
+	getPopularPlanSpec,
+	isFreePlan,
+	TYPE_FREE,
+	TYPE_PERSONAL,
+	TYPE_PREMIUM,
+	TYPE_BUSINESS,
+	TYPE_ECOMMERCE,
+	TERM_MONTHLY,
+	TERM_ANNUALLY,
+	TERM_BIENNIALLY,
+	TERM_TRIENNIALLY,
+	GROUP_WPCOM,
+} from '@automattic/calypso-products';
+import classNames from 'classnames';
+import PropTypes from 'prop-types';
+import { Component } from 'react';
+import FormattedHeader from 'calypso/components/formatted-header';
+import PlanFeatures from 'calypso/my-sites/plan-features';
+import PlanFeaturesComparison from 'calypso/my-sites/plan-features-comparison';
+import PlanTypeSelector from 'calypso/my-sites/plans-features-main/plan-type-selector';
+import PlanFAQ from 'calypso/my-sites/plans-features-main/plansStepFaq';
+
+import 'calypso/my-sites/plans-features-main/style.scss';
+
+export class PlansFeaturesMainPM extends Component {
+	showPricingGrid() {
+		const {
+			customerType,
+			discountEndDate,
+			domainName,
+			flowName,
+			isInSignup,
+			onUpgradeClick,
+			plansWithScroll,
+			selectedPlan,
+			shouldShowPlansFeatureComparison,
+			withDiscount,
+		} = this.props;
+
+		const plans = this.getPlans();
+
+		if ( shouldShowPlansFeatureComparison ) {
+			return (
+				<div
+					className={ classNames(
+						'plans-features-main__group',
+						'is-wpcom',
+						`is-customer-${ customerType }`,
+						{
+							'is-scrollable': plansWithScroll,
+						}
+					) }
+					data-e2e-plans="wpcom"
+				>
+					<PlanFeaturesComparison
+						discountEndDate={ discountEndDate }
+						domainName={ domainName }
+						flowName={ flowName }
+						isInSignup={ isInSignup }
+						isReskinned={ true }
+						onUpgradeClick={ onUpgradeClick }
+						plans={ plans }
+						popularPlanSpec={ getPopularPlanSpec( {
+							flowName,
+							customerType,
+							availablePlans: plans,
+						} ) }
+						visiblePlans={ plans }
+						withDiscount={ withDiscount }
+						withScroll={ plansWithScroll }
+					/>
+				</div>
+			);
+		}
+		return (
+			<div
+				className={ classNames(
+					'plans-features-main__group',
+					'is-wpcom',
+					`is-customer-${ customerType }`,
+					{
+						'is-scrollable': plansWithScroll,
+					}
+				) }
+				data-e2e-plans="wpcom"
+			>
+				{ this.renderSecondaryFormattedHeader() }
+				<PlanFeatures
+					domainName={ domainName }
+					discountEndDate={ discountEndDate }
+					flowName={ flowName }
+					isInSignup={ isInSignup }
+					isInVerticalScrollingPlansExperiment={ true }
+					kindOfPlanTypeSelector={ this.props.planTypeSelector }
+					nonDotBlogDomains={ [] }
+					onUpgradeClick={ onUpgradeClick }
+					plans={ plans }
+					popularPlanSpec={ getPopularPlanSpec( {
+						flowName,
+						customerType,
+						availablePlans: plans,
+					} ) }
+					selectedPlan={ selectedPlan }
+					withDiscount={ withDiscount }
+					withScroll={ plansWithScroll }
+				/>
+			</div>
+		);
+	}
+	renderSecondaryFormattedHeader() {
+		let headerText;
+		let subHeaderText;
+
+		if ( ! headerText ) {
+			return null;
+		}
+
+		return (
+			<FormattedHeader
+				headerText={ headerText }
+				subHeaderText={ subHeaderText }
+				compactOnMobile
+				isSecondary
+			/>
+		);
+	}
+
+	getPlanBillingPeriod( intervalType, defaultValue = null ) {
+		const plans = {
+			monthly: TERM_MONTHLY,
+			yearly: TERM_ANNUALLY,
+			'2yearly': TERM_BIENNIALLY,
+			'3yearly': TERM_TRIENNIALLY,
+		};
+
+		return plans[ intervalType ] || defaultValue || TERM_ANNUALLY;
+	}
+
+	getPlans() {
+		const { intervalType, selectedPlan, hideFreePlan } = this.props;
+
+		const term = this.getPlanBillingPeriod( intervalType, getPlan( selectedPlan )?.term );
+		let plans = [
+			findPlansKeys( { group: GROUP_WPCOM, type: TYPE_FREE } )[ 0 ],
+			findPlansKeys( { group: GROUP_WPCOM, term, type: TYPE_PERSONAL } )[ 0 ],
+			findPlansKeys( { group: GROUP_WPCOM, term, type: TYPE_PREMIUM } )[ 0 ],
+			findPlansKeys( { group: GROUP_WPCOM, term, type: TYPE_BUSINESS } )[ 0 ],
+			findPlansKeys( { group: GROUP_WPCOM, term, type: TYPE_ECOMMERCE } )[ 0 ],
+		].filter( ( el ) => el );
+
+		if ( hideFreePlan ) {
+			plans = plans.filter( ( planSlug ) => ! isFreePlan( planSlug ) );
+		}
+		return plans;
+	}
+
+	getPlanTypeSelector() {
+		const { shouldHideMonthlyToggle } = this.props;
+		const planTypeSelector = {
+			basePlansPath: this.props.basePlansPath,
+			customerType: 'personal',
+			eligibleForWpcomMonthlyPlans: true,
+			isInSignup: this.props.isInSignup,
+			intervalType: this.props.intervalType,
+		};
+		const plans = this.getPlans();
+		if ( shouldHideMonthlyToggle === false ) {
+			return <PlanTypeSelector { ...planTypeSelector } kind="interval" plans={ plans } />;
+		}
+	}
+
+	render() {
+		return (
+			<div className={ classNames( 'plans-features-main' ) }>
+				<div className="plans-features-main__notice" />
+				{ this.getPlanTypeSelector() }
+				{ this.showPricingGrid() }
+				<PlanFAQ />
+			</div>
+		);
+	}
+}
+
+PlansFeaturesMainPM.propTypes = {
+	basePlansPath: PropTypes.string,
+	customerType: PropTypes.string,
+	flowName: PropTypes.string,
+	hideFreePlan: PropTypes.bool,
+	intervalType: PropTypes.oneOf( [ 'monthly', 'yearly' ] ),
+	isInSignup: PropTypes.bool,
+	isReskinned: PropTypes.bool,
+	onUpgradeClick: PropTypes.func,
+	plansWithScroll: PropTypes.bool,
+	planTypeSelector: PropTypes.string,
+	redirectToAddDomainFlow: PropTypes.bool,
+	shouldHideMonthlyToggle: PropTypes.bool,
+	shouldShowPlansFeatureComparison: PropTypes.bool,
+	showFAQ: PropTypes.bool,
+};
+
+PlansFeaturesMainPM.defaultProps = {
+	basePlansPath: null,
+	hideFreePlan: false,
+	intervalType: 'yearly',
+	isInSignup: true,
+	isReskinned: true,
+	plansWithScroll: false,
+	planTypeSelector: 'interval',
+	showFAQ: true,
+	shouldHideMonthlyToggle: false,
+	shouldShowPlansFeatureComparison: true,
+};
+
+export default PlansFeaturesMainPM;

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -1,12 +1,4 @@
-import {
-	planHasFeature,
-	FEATURE_UPLOAD_THEMES_PLUGINS,
-	getPlan,
-	PLAN_FREE,
-	isEcommerce,
-	is2023PricingGridActivePage,
-} from '@automattic/calypso-products';
-import { getUrlParts } from '@automattic/calypso-url';
+import { is2023PricingGridActivePage, getPlan, PLAN_FREE } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
 import {
 	isLinkInBioFlow,
@@ -29,6 +21,7 @@ import MarketingMessage from 'calypso/components/marketing-message';
 import Notice from 'calypso/components/notice';
 import { getTld, isSubdomain } from 'calypso/lib/domains';
 import { getSiteTypePropertyValue } from 'calypso/lib/signup/site-type';
+import { buildUpgradeFunction } from 'calypso/lib/signup/step-actions';
 import wp from 'calypso/lib/wp';
 import PlansComparison, {
 	isEligibleForProPlan,
@@ -45,6 +38,7 @@ import hasInitializedSites from 'calypso/state/selectors/has-initialized-sites';
 import { saveSignupStep, submitSignupStep } from 'calypso/state/signup/progress/actions';
 import { getSiteType } from 'calypso/state/signup/steps/site-type/selectors';
 import { getSiteBySlug } from 'calypso/state/sites/selectors';
+import { getDomainName, getIntervalType } from './util';
 import './style.scss';
 
 export class PlansStep extends Component {
@@ -77,84 +71,8 @@ export class PlansStep extends Component {
 		this.unsubscribe();
 	}
 
-	onSelectPlan = ( cartItem ) => {
-		const {
-			additionalStepData,
-			stepSectionName,
-			stepName,
-			flowName,
-			themeSlugWithRepo,
-			launchSite,
-			goToNextStep,
-		} = this.props;
-
-		if ( cartItem ) {
-			this.props.recordTracksEvent( 'calypso_signup_plan_select', {
-				product_slug: cartItem.product_slug,
-				free_trial: cartItem.free_trial,
-				from_section: stepSectionName ? stepSectionName : 'default',
-			} );
-
-			// If we're inside the store signup flow and the cart item is a Business or eCommerce Plan,
-			// set a flag on it. It will trigger Automated Transfer when the product is being
-			// activated at the end of the checkout process.
-			if (
-				flowName === 'ecommerce' &&
-				planHasFeature( cartItem.product_slug, FEATURE_UPLOAD_THEMES_PLUGINS )
-			) {
-				cartItem.extra = Object.assign( cartItem.extra || {}, {
-					is_store_signup: true,
-				} );
-			}
-		} else {
-			this.props.recordTracksEvent( 'calypso_signup_free_plan_select', {
-				from_section: stepSectionName ? stepSectionName : 'default',
-			} );
-		}
-
-		const step = {
-			stepName,
-			stepSectionName,
-			cartItem,
-			...additionalStepData,
-		};
-
-		if ( flowName === 'site-selected' && ! cartItem ) {
-			wp.req.post(
-				`/domains/${ this.props.selectedSite.ID }/${ this.props.selectedSite.name }/convert-domain-only-to-site`,
-				{},
-				( error ) => {
-					if ( error ) {
-						this.props.errorNotice( error.message );
-						return;
-					}
-					this.props.submitSignupStep( step, {
-						cartItem,
-					} );
-					goToNextStep();
-				}
-			);
-			return;
-		}
-
-		const signupVals = {
-			cartItem,
-			...( themeSlugWithRepo && { themeSlugWithRepo } ),
-			...( launchSite && { comingSoon: 0 } ),
-		};
-
-		if ( cartItem && isEcommerce( cartItem ) ) {
-			signupVals.themeSlugWithRepo = 'pub/twentytwentytwo';
-		}
-
-		this.props.submitSignupStep( step, signupVals );
-		goToNextStep();
-	};
-
-	getDomainName() {
-		return (
-			this.props.signupDependencies.domainItem && this.props.signupDependencies.domainItem.meta
-		);
+	onSelectPlan( cartItem ) {
+		buildUpgradeFunction( this.props, cartItem );
 	}
 
 	getCustomerType() {
@@ -166,22 +84,6 @@ export class PlansStep extends Component {
 			getSiteTypePropertyValue( 'slug', this.props.siteType, 'customerType' ) || 'personal';
 
 		return customerType;
-	}
-
-	handleFreePlanButtonClick = () => {
-		this.onSelectPlan( null ); // onUpgradeClick expects a cart item -- null means Free Plan.
-	};
-
-	getIntervalType() {
-		const urlParts = getUrlParts( typeof window !== 'undefined' ? window.location?.href : '' );
-		const intervalType = urlParts?.searchParams.get( 'intervalType' );
-
-		if ( [ 'yearly', 'monthly' ].includes( intervalType ) ) {
-			return intervalType;
-		}
-
-		// Default value
-		return 'yearly';
 	}
 
 	plansFeaturesList() {
@@ -216,7 +118,7 @@ export class PlansStep extends Component {
 		if ( eligibleForProPlan ) {
 			const selectedDomainConnection =
 				this.props.progress?.domains?.domainItem?.product_slug === 'domain_map';
-			const intervalType = this.getIntervalType();
+			const intervalType = getIntervalType();
 			return (
 				<div>
 					{ errorDisplay }
@@ -229,7 +131,7 @@ export class PlansStep extends Component {
 					<PlansComparison
 						isInSignup={ true }
 						intervalType={ intervalType }
-						onSelectPlan={ this.onSelectPlan }
+						onSelectPlan={ ( cartItem ) => this.onSelectPlan( cartItem ) }
 						selectedSiteId={ selectedSite?.ID || undefined }
 						selectedDomainConnection={ selectedDomainConnection }
 					/>
@@ -247,9 +149,9 @@ export class PlansStep extends Component {
 					hideEcommercePlan={ this.shouldHideEcommercePlan() }
 					isInSignup={ true }
 					isLaunchPage={ isLaunchPage }
-					intervalType={ this.getIntervalType() }
-					onUpgradeClick={ this.onSelectPlan }
-					domainName={ this.getDomainName() }
+					intervalType={ getIntervalType() }
+					onUpgradeClick={ ( cartItem ) => this.onSelectPlan( cartItem ) }
+					domainName={ getDomainName( this.props.signupDependencies.domainItem ) }
 					customerType={ this.getCustomerType() }
 					disableBloggerPlanWithNonBlogDomain={ disableBloggerPlanWithNonBlogDomain }
 					plansWithScroll={ this.state.isDesktop }
@@ -309,7 +211,9 @@ export class PlansStep extends Component {
 			is2023PricingGridVisible,
 		} = this.props;
 
-		const freePlanButton = <Button onClick={ this.handleFreePlanButtonClick } borderless />;
+		const freePlanButton = (
+			<Button onClick={ () => buildUpgradeFunction( this.props, null ) } borderless />
+		);
 
 		if ( flowName === NEWSLETTER_FLOW ) {
 			return hideFreePlan

--- a/client/signup/steps/plans/util.ts
+++ b/client/signup/steps/plans/util.ts
@@ -1,0 +1,23 @@
+import { getUrlParts } from '@automattic/calypso-url';
+
+type DomainItem = {
+	is_domain_registration?: boolean;
+	meta?: string;
+	product_slug?: string;
+};
+
+export const getIntervalType = (): string => {
+	const urlParts = getUrlParts( typeof window !== 'undefined' ? window.location?.href : '' );
+	const intervalType = urlParts?.searchParams.get( 'intervalType' ) || '';
+
+	if ( [ 'yearly', 'monthly' ].includes( intervalType ) ) {
+		return intervalType;
+	}
+
+	// Default value
+	return 'yearly';
+};
+
+export const getDomainName = ( domainItem: DomainItem ): string | undefined => {
+	return domainItem && domainItem.meta;
+};

--- a/client/signup/utils.js
+++ b/client/signup/utils.js
@@ -197,8 +197,8 @@ export const isPlanSelectionAvailableLaterInFlow = ( flowSteps ) => {
 	 * i.e. Check flow "domain"
 	 */
 
-	const plansIndex = flowSteps.findIndex(
-		( stepName ) => getStepModuleName( stepName ) === 'plans'
+	const plansIndex = flowSteps.findIndex( ( stepName ) =>
+		[ 'plans', 'plans-pm' ].includes( getStepModuleName( stepName ) )
 	);
 	const domainsIndex = flowSteps.findIndex(
 		( stepName ) => getStepModuleName( stepName ) === 'domains'


### PR DESCRIPTION
#### Proposed Changes

* Run an A/B test that removes the monthly subscription option for paid media traffic. Context is at pcbrnV-4Pi-p2.
* Creates separate components for the paid media version of the plans step (`plans-pm`). I chose to implement separate components to avoid adding yet another use case to the display logic, especially since the timing overlaps with the broader plans page overhaul.
* Creates a new `util` file that contains functions shared by the `PlansStep` and `PlansStepPM` components.
* The test is implemented using Explat, experiment name `paid_media_signup_2023_02_hide_monthly`
* Experiment post is available at pbxNRc-2jS-p2.

#### Testing Instructions
* Checkout this PR and start Calypso locally.
* Open the Abacus page for this experiment (`paid_media_signup_2023_02_hide_monthly`) and assign yourself to either the control or treatment variation.
* Navigate to `/start/onboarding-pm`
* Select a domain and proceed to the Plans step.
* Confirm that the monthly toggle is showing for the control variation and not showing for the treatment variation.
* Confirm that the Plans step works in both mobile and desktop viewports
* Select a plan and proceed to checkout.
* Confirm that checkout works as expected.
* Start a new signup session and stress test the domains step, choosing a variety of options from that step, including the 'choose later' and the 'use a domain I already own' paths.
* Test other flows that use the `Plans` step: `onboarding`, the tailored flows, wpcc, and Calypso admin.


Related to #
