### PR TITLE
[Wordads] Add missing earnings summary

### DIFF
--- a/client/my-sites/earn/main.jsx
+++ b/client/my-sites/earn/main.jsx
@@ -74,7 +74,7 @@ class EarningsMain extends Component {
 			case 'ads-earnings':
 				return (
 					<AdsWrapper section={ this.props.section }>
-						<WordAdsEarnings site={ this.props.site } />
+						<WordAdsEarnings site={ this.props.site } showSummary />
 					</AdsWrapper>
 				);
 			case 'ads-payments':

--- a/client/my-sites/stats/wordads/earnings-summary.jsx
+++ b/client/my-sites/stats/wordads/earnings-summary.jsx
@@ -1,0 +1,70 @@
+import { Card, Gridicon } from '@automattic/components';
+import classNames from 'classnames';
+import { translate } from 'i18n-calypso';
+import { useState } from 'react';
+import { getEarningsSummaries, getPayoutNotices } from './utils';
+
+const PayoutsNotice = ( { earnings } ) => {
+	const notices = getPayoutNotices( earnings );
+	const combinedNotice = notices.map( ( item ) => item.value ).join( ' ' );
+
+	return (
+		<div className="ads__module-content-text module-content-text module-content-text-info">
+			<p>{ combinedNotice }</p>
+		</div>
+	);
+};
+
+const EarningsBreakdown = ( { earnings } ) => {
+	const summaries = getEarningsSummaries( earnings );
+
+	return (
+		<ul className="ads__earnings-breakdown-list">
+			{ summaries.map( ( summary ) => (
+				<li key={ summary.id } className="ads__earnings-breakdown-item">
+					<span className="ads__earnings-breakdown-label">{ summary.heading }</span>
+					<span className="ads__earnings-breakdown-value">{ summary.formattedAmount }</span>
+				</li>
+			) ) }
+		</ul>
+	);
+};
+
+const EarningsSummary = ( { earnings } ) => {
+	const [ showEarningsNotice, setShowEarningsNotice ] = useState( false );
+	const infoIcon = showEarningsNotice ? 'info' : 'info-outline';
+	const classes = classNames( 'earnings_breakdown', {
+		'is-showing-info': showEarningsNotice,
+	} );
+
+	const handleEarningsNoticeToggle = ( event ) => {
+		event.preventDefault();
+		setShowEarningsNotice( ! showEarningsNotice );
+	};
+
+	return (
+		<Card className={ classes }>
+			<div className="ads__module-header module-header">
+				<h1 className="ads__module-header-title module-header-title">{ translate( 'Totals' ) }</h1>
+				<ul className="ads__module-header-actions module-header-actions">
+					<li className="ads__module-header-action module-header-action toggle-info">
+						<button
+							className="ads__module-header-action-link module-header-action-link"
+							aria-label={ translate( 'Show or hide panel information' ) }
+							title={ translate( 'Show or hide panel information' ) }
+							onClick={ handleEarningsNoticeToggle }
+						>
+							<Gridicon icon={ infoIcon } />
+						</button>
+					</li>
+				</ul>
+			</div>
+			<div className="ads__module-content module-content">
+				<PayoutsNotice earnings={ earnings } />
+				<EarningsBreakdown earnings={ earnings } />
+			</div>
+		</Card>
+	);
+};
+
+export default EarningsSummary;

--- a/client/my-sites/stats/wordads/earnings.jsx
+++ b/client/my-sites/stats/wordads/earnings.jsx
@@ -7,6 +7,7 @@ import { connect } from 'react-redux';
 import QueryWordadsEarnings from 'calypso/components/data/query-wordads-earnings';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { getWordAdsEarnings } from 'calypso/state/wordads/earnings/selectors';
+import EarningsSummary from './earnings-summary';
 
 class WordAdsEarnings extends Component {
 	static propTypes = {
@@ -210,12 +211,12 @@ class WordAdsEarnings extends Component {
 	}
 
 	render() {
-		const { siteId, earnings, translate } = this.props;
+		const { siteId, earnings, translate, showSummary = false } = this.props;
 
 		return (
 			<div>
 				<QueryWordadsEarnings siteId={ siteId } />
-
+				{ showSummary && <EarningsSummary earnings={ earnings } /> }
 				{ earnings && this.checkSize( earnings.wordads )
 					? this.earningsTable( earnings.wordads, translate( 'Earnings history' ), 'wordads' )
 					: null }

--- a/client/my-sites/stats/wordads/utils.ts
+++ b/client/my-sites/stats/wordads/utils.ts
@@ -1,0 +1,97 @@
+import { payment, receipt, tip } from '@wordpress/icons';
+import { numberFormat, translate } from 'i18n-calypso';
+
+interface Earnings {
+	total_amount_owed?: number;
+	total_earnings?: number;
+}
+
+export const highlightIconById = {
+	earnings: payment,
+	paid: receipt,
+	'outstanding-amount': tip,
+};
+
+export function getAmountAsFormattedString( amount: number ) {
+	if ( amount === 0 ) {
+		// Per design spec we don't want "$0.00" as a result.
+		// https://github.com/Automattic/wp-calypso/issues/72045
+		// We'll return "$0" in this scenario.
+		return '$0';
+	}
+	// Takes a Number, formats it to 2 decimal places, and prepends a "$".
+	// Amounts are in USD with localized formatting.
+	return '$' + numberFormat( amount, 2 );
+}
+
+export function getEarningsSummaryValues( earnings: Earnings ) {
+	const total = earnings?.total_earnings ? Number( earnings.total_earnings ) : 0;
+	const owed = earnings?.total_amount_owed ? Number( earnings.total_amount_owed ) : 0;
+	const paid = total - owed;
+	return {
+		total,
+		owed,
+		paid,
+	};
+}
+
+export function getPayoutNotices( earnings: Earnings ) {
+	const amountOwed = earnings?.total_amount_owed || 0;
+	const amountOwedFormatted = getAmountAsFormattedString( amountOwed );
+	const notice = {
+		id: 'notice',
+		value: translate(
+			'Outstanding amount of %(amountOwed)s does not exceed the minimum $100 needed to make the payment.',
+			{
+				comment: 'WordAds: Insufficient balance for payout.',
+				args: { amountOwed: amountOwedFormatted },
+			}
+		),
+	};
+	const limit = {
+		id: 'limit',
+		value: translate(
+			'Payment will be made as soon as the total outstanding amount has reached $100.',
+			{
+				comment: 'WordAds: Payout limit description.',
+			}
+		),
+	};
+	const payout = {
+		id: 'payout',
+		value: translate(
+			'Outstanding amount of %(amountOwed)s will be paid approximately 45 days following the end of the month in which it was earned.',
+			{
+				comment: 'WordAds: Payout will proceed.',
+				args: { amountOwed: amountOwedFormatted },
+			}
+		),
+	};
+	return amountOwed < 100 ? [ notice, limit ] : [ payout ];
+}
+
+export function getEarningsSummaries( earnings: Earnings ) {
+	const { total, owed, paid } = getEarningsSummaryValues( earnings );
+
+	return [
+		{
+			id: 'earnings',
+			heading: translate( 'Earnings', { comment: 'Total WordAds earnings to date' } ),
+			formattedAmount: getAmountAsFormattedString( total ),
+		},
+		{
+			id: 'paid',
+			heading: translate( 'Paid', {
+				comment: 'Total WordAds earnings that have been paid out',
+			} ),
+			formattedAmount: getAmountAsFormattedString( paid ),
+		},
+		{
+			id: 'outstanding-amount',
+			heading: translate( 'Outstanding amount', {
+				comment: 'Total WordAds earnings currently unpaid',
+			} ),
+			formattedAmount: getAmountAsFormattedString( owed ),
+		},
+	];
+}


### PR DESCRIPTION
#### Proposed Changes

* Add missing earnings summary to  `Tools -> Earn -> Earnings` tab page
<img width="1536" alt="earn summary" src="https://user-images.githubusercontent.com/9039613/216675826-683234f0-d2b3-4345-bf81-c5cd3e1606ba.png">

#### Testing Instructions

Test 1

* Visit the Calypso Live link.
* View a site with WordAds enabled.
* Visit `Tools → Earn → Earnings`  tab.
* The earning summary tab should now be visible.
* Confirm the info toggle displays/hide the notice message as expected.
<img width="1568" alt="earnings summary" src="https://user-images.githubusercontent.com/9039613/216678287-c2d95e44-fed6-4622-bb5e-3dcc849340f9.png">


Test 2

* Visit the `Stats → Ads`  tab.
* Confirm the existing highlight section remains visible.
* Confirm there is no duplicate earnings summary section above the earning history section. i.e The "Earnings summary" in `Tools → Earn → Earnings` should not be displayed on top of the "earning history" in `Stats → Ads`

<img width="1728" alt="stats" src="https://user-images.githubusercontent.com/9039613/216679807-cba9440e-5e85-4015-ab2a-3fea3495efb9.png">

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
