### PR TITLE
Sites Management Page: Render site icon fallback if mShots fails

### DIFF
--- a/packages/components/src/site-thumbnail/fetch-await-redirect.ts
+++ b/packages/components/src/site-thumbnail/fetch-await-redirect.ts
@@ -1,0 +1,7 @@
+export async function fetchAwaitRedirect( url: string ) {
+	const { status, redirected } = await fetch( url, { method: 'HEAD', cache: 'no-cache' } );
+	return {
+		isError: status >= 400,
+		isRedirect: redirected,
+	};
+}

--- a/packages/components/src/site-thumbnail/fetch-is-redirect.ts
+++ b/packages/components/src/site-thumbnail/fetch-is-redirect.ts
@@ -1,4 +1,0 @@
-export async function fetchIsRedirect( url: string ) {
-	const { redirected } = await fetch( url, { method: 'HEAD', cache: 'no-cache' } );
-	return redirected;
-}

--- a/packages/components/src/site-thumbnail/index.tsx
+++ b/packages/components/src/site-thumbnail/index.tsx
@@ -76,14 +76,14 @@ export const SiteThumbnail = ( {
 					style={ { backgroundImage: `url(${ bgColorImgUrl })` } }
 				></div>
 			) }
-			{ isLoading && (
+			{ ( isLoading || isError ) && (
 				<div
 					className={ classnames( { 'site-thumbnail-loader': showLoader }, 'site-thumbnail-icon' ) }
 				>
 					{ children }
 				</div>
 			) }
-			{ imgProps.src && ! isLoading && (
+			{ imgProps.src && ! isLoading && ! isError && (
 				<img
 					className="site-thumbnail__image"
 					alt={ alt }

--- a/packages/components/src/site-thumbnail/use-mshots-img.tsx
+++ b/packages/components/src/site-thumbnail/use-mshots-img.tsx
@@ -1,6 +1,6 @@
 import { addQueryArgs } from '@wordpress/url';
 import { useState, useEffect, useMemo, useRef, useCallback } from 'react';
-import { fetchIsRedirect } from './fetch-is-redirect';
+import { fetchAwaitRedirect } from './fetch-await-redirect';
 
 export function mshotsUrl( targetUrl: string, options: MShotsOptions, countToRefresh = 0 ): string {
 	if ( ! targetUrl ) {
@@ -78,7 +78,11 @@ export const useMshotsImg = (
 		}
 
 		async function checkRedirectImage() {
-			const isRedirect = await fetchIsRedirect( mshotUrl );
+			const { isError, isRedirect } = await fetchAwaitRedirect( mshotUrl );
+			if ( isError ) {
+				setIsLoading( false );
+				setIsError( true );
+			}
 			// 307 is the status code for a temporary redirect used by mshots.
 			// If we `follow` the redirect, the `response.url` will be 'https://s0.wp.com/mshots/v1/default'
 			// and the `response.headers.get('content-type)` will be 'image/gif'


### PR DESCRIPTION
Fixes #72967

## Proposed Changes

Improves `<SiteThumbnail />` to render the Site Icon fallback if mShots returns a response code >= 400.

## Testing Instructions

1. Visit `/sites` and verify one of your public sites displays a thumbnail as expected.
2. Apply the patch below, refresh `/sites`, and verify the public site displays the site icon fallback instead.

```diff
diff --git a/packages/components/src/site-thumbnail/fetch-await-redirect.ts b/packages/components/src/site-thumbnail/fetch-await-redirect.ts
index 00e7c10917..823a96ef4b 100644
--- a/packages/components/src/site-thumbnail/fetch-await-redirect.ts
+++ b/packages/components/src/site-thumbnail/fetch-await-redirect.ts
@@ -1,7 +1,7 @@
 export async function fetchAwaitRedirect( url: string ) {
 	const { status, redirected } = await fetch( url, { method: 'HEAD', cache: 'no-cache' } );
 	return {
-		isError: status >= 400,
+		isError: status >= 200,
 		isRedirect: redirected,
 	};
 }
```