### PR TITLE
Stats: Enable tooltips of the 7-day highlights cards

### DIFF
--- a/client/my-sites/stats/highlights-section/index.tsx
+++ b/client/my-sites/stats/highlights-section/index.tsx
@@ -34,13 +34,14 @@ export default function HighlightsSection( { siteId }: { siteId: number } ) {
 
 	return (
 		<HighlightCards
+			className="has-background-color"
 			counts={ counts }
 			previousCounts={ previousCounts }
+			showValueTooltip={ true }
 			onClickComments={ () => null }
 			onClickLikes={ () => null }
 			onClickViews={ () => null }
 			onClickVisitors={ () => null }
-			className="has-background-color"
 		/>
 	);
 }

--- a/packages/components/src/highlight-cards/highlight-card.tsx
+++ b/packages/components/src/highlight-cards/highlight-card.tsx
@@ -43,12 +43,15 @@ export default function HighlightCard( {
 		: null;
 	const textRef = useRef( null );
 	const [ isTooltipVisible, setTooltipVisible ] = useState( false );
+
 	return (
 		<Card className="highlight-card">
 			<div className="highlight-card-icon">{ icon }</div>
 			<div className="highlight-card-heading">{ heading }</div>
 			<div
-				className="highlight-card-count"
+				className={ classNames( 'highlight-card-count', {
+					'is-pointer': showValueTooltip,
+				} ) }
 				onMouseEnter={ () => setTooltipVisible( true ) }
 				onMouseLeave={ () => setTooltipVisible( false ) }
 			>

--- a/packages/components/src/highlight-cards/index.tsx
+++ b/packages/components/src/highlight-cards/index.tsx
@@ -19,6 +19,7 @@ export type HighlightCardsProps = {
 		views: number | null;
 		visitors: number | null;
 	};
+	showValueTooltip?: boolean | null;
 	onClickComments: ( event: MouseEvent ) => void;
 	onClickLikes: ( event: MouseEvent ) => void;
 	onClickViews: ( event: MouseEvent ) => void;
@@ -33,6 +34,7 @@ export default function HighlightCards( {
 	onClickViews,
 	onClickVisitors,
 	previousCounts,
+	showValueTooltip,
 }: HighlightCardsProps ) {
 	const translate = useTranslate();
 
@@ -49,6 +51,7 @@ export default function HighlightCards( {
 					icon={ <Icon icon={ people } /> }
 					count={ counts?.visitors ?? null }
 					previousCount={ previousCounts?.visitors ?? null }
+					showValueTooltip={ showValueTooltip }
 					onClick={ onClickVisitors }
 				/>
 				<HighlightCard
@@ -56,6 +59,7 @@ export default function HighlightCards( {
 					icon={ <Icon icon={ eye } /> }
 					count={ counts?.views ?? null }
 					previousCount={ previousCounts?.views ?? null }
+					showValueTooltip={ showValueTooltip }
 					onClick={ onClickViews }
 				/>
 				<HighlightCard
@@ -63,6 +67,7 @@ export default function HighlightCards( {
 					icon={ <Icon icon={ starEmpty } /> }
 					count={ counts?.likes ?? null }
 					previousCount={ previousCounts?.likes ?? null }
+					showValueTooltip={ showValueTooltip }
 					onClick={ onClickLikes }
 				/>
 				<HighlightCard
@@ -70,6 +75,7 @@ export default function HighlightCards( {
 					icon={ <Icon icon={ commentContent } /> }
 					count={ counts?.comments ?? null }
 					previousCount={ previousCounts?.comments ?? null }
+					showValueTooltip={ showValueTooltip }
 					onClick={ onClickComments }
 				/>
 			</div>

--- a/packages/components/src/highlight-cards/style.scss
+++ b/packages/components/src/highlight-cards/style.scss
@@ -109,6 +109,10 @@ $highlight-card-tooltip-font: Inter, $sans !default;
 	font-size: 36px; // stylelint-disable-line declaration-property-unit-allowed-list
 	font-weight: 400;
 	line-height: 40px;
+
+	&.is-pointer {
+		cursor: pointer;
+	}
 }
 
 .highlight-card-count-value {


### PR DESCRIPTION
#### Proposed Changes

* Enable the tooltips of cards via prop `showValueTooltip` to component `HighlightCard`.
* Modify the cursor pointer of the anchor for the tooltips.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up this change with the Calypso Live link.
* Navigate to the `Stats` > `Traffic` page.
* Ensure the tooltips on the 7-day highlights cards show when the mouse hovers over the count values.

<img width="1285" alt="截圖 2023-02-04 上午4 38 37" src="https://user-images.githubusercontent.com/6869813/216706252-d2210eff-6b66-4f85-9b28-c1235ae3517b.png">

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #70089 
