### PR TITLE
Jetpack Connection: redirect to user connection from checkout page

### DIFF
--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -500,6 +500,9 @@ export function siteSelection( context, next ) {
 	}
 
 	const siteId = getSiteId( getState(), siteFragment );
+
+	// Making sure non-connected users get redirected to user connection flow.
+	// Details: p9dueE-6Hf-p2
 	const isUnlinkedCheckout =
 		'1' === context.query?.unlinked &&
 		context.pathname.match( /^\/checkout\/[^/]+\/jetpack_/i ) &&

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -502,8 +502,8 @@ export function siteSelection( context, next ) {
 	const siteId = getSiteId( getState(), siteFragment );
 	const isUnlinkedCheckout =
 		'1' === context.query?.unlinked &&
-		null !== context.pathname.match( /^\/checkout\/[^/]+\/jetpack_/i ) &&
-		false === context.pathname.includes( 'jetpack_boost' );
+		context.pathname.match( /^\/checkout\/[^/]+\/jetpack_/i ) &&
+		context.pathname.includes( 'jetpack_boost' );
 
 	if ( siteId && ! isUnlinkedCheckout ) {
 		// onSelectedSiteAvailable might render an error page about domain-only sites or redirect

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -500,7 +500,12 @@ export function siteSelection( context, next ) {
 	}
 
 	const siteId = getSiteId( getState(), siteFragment );
-	if ( siteId ) {
+	const isUnlinkedCheckout =
+		'1' === context.query?.unlinked &&
+		null !== context.pathname.match( /^\/checkout\/[^/]+\/jetpack_/i ) &&
+		false === context.pathname.includes( 'jetpack_boost' );
+
+	if ( siteId && ! isUnlinkedCheckout ) {
 		// onSelectedSiteAvailable might render an error page about domain-only sites or redirect
 		// to wp-admin. In that case, don't continue handling the route.
 		dispatch( setSelectedSiteId( siteId ) );
@@ -533,7 +538,7 @@ export function siteSelection( context, next ) {
 					freshSiteId = getSiteId( getState(), wpcomStagingFragment );
 				}
 
-				if ( freshSiteId ) {
+				if ( freshSiteId && ! isUnlinkedCheckout ) {
 					// onSelectedSiteAvailable might render an error page about domain-only sites or redirect
 					// to wp-admin. In that case, don't continue handling the route.
 					dispatch( setSelectedSiteId( freshSiteId ) );


### PR DESCRIPTION
#### Proposed Changes
Fixing an issue with Checkout not redirecting users to Jetpack Connection flow.

p9dueE-6Hf-p2

#### Testing Instructions
Testing of the PR is complicated by the fact that the standalone plugins have `wordpress.com` hardcoded in the redirect to the Checkout page.
To change this for the Backup plugin, you will need to edit the file `wp-content/plugins/jetpack-backup-dev/jetpack_vendor/automattic/jetpack-backup/build/index.js`.
Find the line `https://wordpress.com/checkout/` and replace it with your local/dev Calypso URL.
In addition to that, open the `wp-config.php` file and set the Calypso local environment constant: `define( 'CALYPSO_ENV', 'development' );`

You can use the JN website I created specifically for this PR, with the values already changed to `http://calypso.localhost:3000`: 2f03a-pb

1. Disconnect Jetpack if connected.
3. Go to the Jetpack VaultPress Backup dashboard, try to purchase a plan. You will get redirected to Calypso Checkout page.
4. The Checkout page will determine that you are missing the user connection, and redirect you to the user connection page.
5. After clicking “Approve” and thus establishing user connection, you will get redirected to checkout. Everything works fine at this point.
6. Do not purchase the plan, go back to your site and disconnect from WPCOM.
7. Now go to the plugin dashboard again and try to purchase the plan once more.
8. Confirm that you're once again redirected to the user connection page, and do not get stuck on the Checkout page covered in errors.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->