### PR TITLE
Site Assembler - Move query patterns to the top of the list for all flows

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/patterns-data.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/patterns-data.ts
@@ -192,6 +192,51 @@ const useSectionPatterns = () => {
 		() =>
 			[
 				{
+					id: 5645,
+					name: 'Four Recent Blog Posts',
+					category: posts,
+				},
+				{
+					id: 1784,
+					name: 'Recent Posts',
+					category: posts,
+				},
+				{
+					id: 8421,
+					name: 'Grid of posts 2x3',
+					category: posts,
+				},
+				{
+					id: 8435,
+					name: 'Grid of Posts 3x2',
+					category: posts,
+				},
+				{
+					id: 7996,
+					name: 'Grid of Posts 4x2',
+					category: posts,
+				},
+				{
+					id: 8437,
+					name: 'List of posts',
+					category: posts,
+				},
+				{
+					id: 3213,
+					name: 'Latest podcast episodes',
+					category: posts,
+				},
+				{
+					id: 6305,
+					name: 'Heading with Image Grid',
+					category: images,
+				},
+				{
+					id: 7149,
+					name: 'Two column image grid',
+					category: images,
+				},
+				{
 					id: 7156,
 					name: 'Media and text with image on the right',
 					category: callToAction,
@@ -255,56 +300,6 @@ const useSectionPatterns = () => {
 					id: 6312,
 					name: 'Two Column CTA',
 					category: callToAction,
-				},
-				{
-					id: 5645,
-					name: 'Four Recent Blog Posts',
-					category: posts,
-				},
-				{
-					id: 1784,
-					name: 'Recent Posts',
-					category: posts,
-				},
-				{
-					id: 8421,
-					name: 'Grid of posts 2x3',
-					category: posts,
-				},
-				{
-					id: 8435,
-					name: 'Grid of Posts 3x2',
-					category: posts,
-				},
-				{
-					id: 7996,
-					name: 'Grid of Posts 4x2',
-					category: posts,
-				},
-				{
-					id: 8437,
-					name: 'List of posts',
-					category: posts,
-				},
-				{
-					id: 3213,
-					name: 'Latest podcast episodes',
-					category: posts,
-				},
-				{
-					id: 6305,
-					name: 'Heading with Image Grid',
-					category: images,
-				},
-				{
-					id: 7149,
-					name: 'Two column image grid',
-					category: images,
-				},
-				{
-					id: 7149,
-					name: 'Two column image grid',
-					category: images,
 				},
 				{
 					id: 5691,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/patterns-data.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/patterns-data.ts
@@ -227,16 +227,6 @@ const useSectionPatterns = () => {
 					category: posts,
 				},
 				{
-					id: 6305,
-					name: 'Heading with Image Grid',
-					category: images,
-				},
-				{
-					id: 7149,
-					name: 'Two column image grid',
-					category: images,
-				},
-				{
 					id: 7156,
 					name: 'Media and text with image on the right',
 					category: callToAction,
@@ -300,6 +290,16 @@ const useSectionPatterns = () => {
 					id: 6312,
 					name: 'Two Column CTA',
 					category: callToAction,
+				},
+				{
+					id: 6305,
+					name: 'Heading with Image Grid',
+					category: images,
+				},
+				{
+					id: 7149,
+					name: 'Two column image grid',
+					category: images,
 				},
 				{
 					id: 5691,


### PR DESCRIPTION
#### Proposed Changes

* Put query patterns at the top of the list

Note that all patterns are shown for all flows, for now. We could consider to put the query patterns at the top of the list only for the Write flow.

|Before|After|
|------|-----|
|<img width="341" alt="Screenshot 2566-02-06 at 09 49 44" src="https://user-images.githubusercontent.com/1881481/216872582-4609f02d-d8b5-4ec5-a3cc-11aefc348a2c.png">|<img width="341" alt="Screenshot 2566-02-06 at 09 49 32" src="https://user-images.githubusercontent.com/1881481/216872566-e0450a1a-e739-44a5-9b92-ee22767f0e9f.png">|

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new site
* Select any goal
* Access the assembler from the bottom of the design picker
* Add sections and check the query patterns are in the top position

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [X] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [X] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [X] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [X] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [X] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/72748 https://github.com/Automattic/wp-calypso/issues/72565
