### PR TITLE
Site Assembler: Replace with-theme flow with with-theme-assembler

### DIFF
--- a/client/components/themes-list/index.jsx
+++ b/client/components/themes-list/index.jsx
@@ -2,7 +2,7 @@ import { isEnabled } from '@automattic/calypso-config';
 import { FEATURE_INSTALL_THEMES } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
 import { PatternAssemblerCta, BLANK_CANVAS_DESIGN } from '@automattic/design-picker';
-import { SITE_ASSEMBLER_FLOW } from '@automattic/onboarding';
+import { SITE_ASSEMBLER_FLOW, WITH_THEME_ASSEMBLER_FLOW } from '@automattic/onboarding';
 import { Icon, addTemplate, brush, cloudUpload } from '@wordpress/icons';
 import { localize } from 'i18n-calypso';
 import { isEmpty, times } from 'lodash';
@@ -40,7 +40,7 @@ export const ThemesList = ( props ) => {
 			theme: BLANK_CANVAS_DESIGN.slug,
 			destination_flow: SITE_ASSEMBLER_FLOW,
 		} );
-		window.location.assign( `/start/with-theme?${ params }` );
+		window.location.assign( `/start/${ WITH_THEME_ASSEMBLER_FLOW }?${ params }` );
 	};
 
 	const matchingWpOrgThemes = useMemo(

--- a/client/components/themes-list/index.jsx
+++ b/client/components/themes-list/index.jsx
@@ -2,7 +2,7 @@ import { isEnabled } from '@automattic/calypso-config';
 import { FEATURE_INSTALL_THEMES } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
 import { PatternAssemblerCta, BLANK_CANVAS_DESIGN } from '@automattic/design-picker';
-import { SITE_ASSEMBLER_FLOW, WITH_THEME_ASSEMBLER_FLOW } from '@automattic/onboarding';
+import { WITH_THEME_ASSEMBLER_FLOW } from '@automattic/onboarding';
 import { Icon, addTemplate, brush, cloudUpload } from '@wordpress/icons';
 import { localize } from 'i18n-calypso';
 import { isEmpty, times } from 'lodash';
@@ -38,7 +38,6 @@ export const ThemesList = ( props ) => {
 		const params = new URLSearchParams( {
 			ref: 'calypshowcase',
 			theme: BLANK_CANVAS_DESIGN.slug,
-			destination_flow: SITE_ASSEMBLER_FLOW,
 		} );
 		window.location.assign( `/start/${ WITH_THEME_ASSEMBLER_FLOW }?${ params }` );
 	};

--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -74,7 +74,7 @@ button {
 .free-setup,
 .free-post-setup,
 .free,
-.site-assembler {
+.with-theme-assembler {
 	padding: 60px 0 0;
 	box-sizing: border-box;
 

--- a/client/landing/stepper/declarative-flow/internals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/index.tsx
@@ -103,7 +103,14 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 				throw new Error( assertCondition.message ?? 'An error has occurred.' );
 		}
 
-		return <step.component navigation={ stepNavigation } flow={ flow.name } data={ stepData } />;
+		return (
+			<step.component
+				navigation={ stepNavigation }
+				flow={ flow.name }
+				stepName={ step.slug }
+				data={ stepData }
+			/>
+		);
 	};
 
 	const getDocumentHeadTitle = () => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -23,7 +23,7 @@ import type { Pattern } from './types';
 import type { DesignRecipe, Design } from '@automattic/design-picker/src/types';
 import './style.scss';
 
-const PatternAssembler: Step = ( { navigation, flow } ) => {
+const PatternAssembler: Step = ( { navigation, flow, stepName } ) => {
 	const translate = useTranslate();
 	const [ showPatternSelectorType, setShowPatternSelectorType ] = useState< string | null >( null );
 	const [ header, setHeader ] = useState< Pattern | null >( null );
@@ -43,6 +43,11 @@ const PatternAssembler: Step = ( { navigation, flow } ) => {
 	const siteId = useSiteIdParam();
 	const siteSlugOrId = siteSlug ? siteSlug : siteId;
 	const allPatterns = useAllPatterns();
+	const commonEventProps = {
+		flow,
+		step: stepName,
+		intent,
+	};
 
 	const largePreviewProps = {
 		placeholder: null,
@@ -82,6 +87,7 @@ const PatternAssembler: Step = ( { navigation, flow } ) => {
 
 	const trackEventPatternAdd = ( patternType: string ) => {
 		recordTracksEvent( 'calypso_signup_pattern_assembler_pattern_add_click', {
+			...commonEventProps,
 			pattern_type: patternType,
 		} );
 	};
@@ -96,6 +102,7 @@ const PatternAssembler: Step = ( { navigation, flow } ) => {
 		patternName: string;
 	} ) => {
 		recordTracksEvent( 'calypso_signup_pattern_assembler_pattern_select_click', {
+			...commonEventProps,
 			pattern_type: patternType,
 			pattern_id: patternId,
 			pattern_name: patternName,
@@ -105,6 +112,7 @@ const PatternAssembler: Step = ( { navigation, flow } ) => {
 	const trackEventContinue = () => {
 		const patterns = getPatterns();
 		recordTracksEvent( 'calypso_signup_pattern_assembler_continue_click', {
+			...commonEventProps,
 			pattern_types: [ header && 'header', sections.length && 'section', footer && 'footer' ]
 				.filter( Boolean )
 				.join( ',' ),
@@ -114,6 +122,7 @@ const PatternAssembler: Step = ( { navigation, flow } ) => {
 		} );
 		patterns.forEach( ( { id, name, category } ) => {
 			recordTracksEvent( 'calypso_signup_pattern_assembler_pattern_final_select', {
+				...commonEventProps,
 				pattern_id: id,
 				pattern_name: name,
 				pattern_category: category,
@@ -227,6 +236,7 @@ const PatternAssembler: Step = ( { navigation, flow } ) => {
 	const onBack = () => {
 		const patterns = getPatterns();
 		recordTracksEvent( 'calypso_signup_pattern_assembler_back_click', {
+			...commonEventProps,
 			has_selected_patterns: patterns.length > 0,
 			pattern_count: patterns.length,
 		} );
@@ -293,6 +303,7 @@ const PatternAssembler: Step = ( { navigation, flow } ) => {
 					onDoneClick={ () => {
 						const patterns = getPatterns( showPatternSelectorType );
 						recordTracksEvent( 'calypso_signup_pattern_assembler_pattern_select_done_click', {
+							...commonEventProps,
 							pattern_type: showPatternSelectorType,
 							pattern_ids: patterns.map( ( { id } ) => id ).join( ',' ),
 							pattern_names: patterns.map( ( { name } ) => name ).join( ',' ),
@@ -302,6 +313,7 @@ const PatternAssembler: Step = ( { navigation, flow } ) => {
 					} }
 					onBack={ () => {
 						recordTracksEvent( 'calypso_signup_pattern_assembler_pattern_select_back_click', {
+							...commonEventProps,
 							pattern_type: showPatternSelectorType,
 						} );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -1,5 +1,5 @@
 import { isEnabled } from '@automattic/calypso-config';
-import { StepContainer, SITE_SETUP_FLOW, SITE_ASSEMBLER_FLOW } from '@automattic/onboarding';
+import { StepContainer, SITE_SETUP_FLOW, WITH_THEME_ASSEMBLER_FLOW } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
 import { useState, useRef, useEffect } from 'react';
@@ -376,7 +376,7 @@ const PatternAssembler: Step = ( { navigation, flow } ) => {
 			<DocumentHead title={ translate( 'Design your home' ) } />
 			<StepContainer
 				stepName="pattern-assembler"
-				hideBack={ showPatternSelectorType !== null || flow === SITE_ASSEMBLER_FLOW }
+				hideBack={ showPatternSelectorType !== null || flow === WITH_THEME_ASSEMBLER_FLOW }
 				goBack={ onBack }
 				goNext={ goNext }
 				isHorizontalLayout={ false }

--- a/client/landing/stepper/declarative-flow/internals/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/types.ts
@@ -85,7 +85,7 @@ export type Flow = {
 
 export type StepProps = {
 	navigation: NavigationControls;
-	stepName?: string | null;
+	stepName: string;
 	flow: string | null;
 	data?: Record< string, unknown >;
 };

--- a/client/landing/stepper/declarative-flow/registered-flows.ts
+++ b/client/landing/stepper/declarative-flow/registered-flows.ts
@@ -47,8 +47,8 @@ const availableFlows: Record< string, () => Promise< { default: Flow } > > = {
 
 	free: () => import( /* webpackChunkName: "free-flow" */ '../declarative-flow/free' ),
 
-	'site-assembler': () =>
-		import( /* webpackChunkName: "site-assembler-flow" */ './site-assembler-flow' ),
+	'with-theme-assembler': () =>
+		import( /* webpackChunkName: "with-theme-assembler-flow" */ './with-theme-assembler-flow' ),
 
 	'free-post-setup': () =>
 		import( /* webpackChunkName: "free-post-setup-flow" */ '../declarative-flow/free-post-setup' ),

--- a/client/landing/stepper/declarative-flow/with-theme-assembler-flow.ts
+++ b/client/landing/stepper/declarative-flow/with-theme-assembler-flow.ts
@@ -1,6 +1,7 @@
+import { Onboard } from '@automattic/data-stores';
 import { BLANK_CANVAS_DESIGN } from '@automattic/design-picker';
 import { useFlowProgress, WITH_THEME_ASSEMBLER_FLOW } from '@automattic/onboarding';
-import { useDispatch } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect } from 'react';
 import { useQuery } from '../hooks/use-query';
 import { useSiteSlug } from '../hooks/use-site-slug';
@@ -11,10 +12,12 @@ import Processing from './internals/steps-repository/processing-step';
 import { Flow, ProvidedDependencies } from './internals/types';
 import type { Design } from '@automattic/design-picker/src/types';
 
+const SiteIntent = Onboard.SiteIntent;
+
 const withThemeAssemblerFlow: Flow = {
 	name: WITH_THEME_ASSEMBLER_FLOW,
 	useSideEffect() {
-		const { setSelectedDesign } = useDispatch( ONBOARD_STORE );
+		const { setSelectedDesign, setIntent } = useDispatch( ONBOARD_STORE );
 		const selectedTheme = useQuery().get( 'theme' );
 
 		useEffect( () => {
@@ -22,6 +25,8 @@ const withThemeAssemblerFlow: Flow = {
 				// User has selected blank-canvas-3 theme from theme showcase and enter assembler flow
 				setSelectedDesign( BLANK_CANVAS_DESIGN as Design );
 			}
+
+			setIntent( SiteIntent.WithThemeAssembler );
 		}, [] );
 	},
 
@@ -34,6 +39,7 @@ const withThemeAssemblerFlow: Flow = {
 
 	useStepNavigation( _currentStep, navigate ) {
 		const flowName = this.name;
+		const intent = useSelect( ( select ) => select( ONBOARD_STORE ).getIntent() );
 		const { setStepProgress, setPendingAction } = useDispatch( ONBOARD_STORE );
 		const flowProgress = useFlowProgress( { stepName: _currentStep, flowName } );
 		setStepProgress( flowProgress );
@@ -50,7 +56,7 @@ const withThemeAssemblerFlow: Flow = {
 		};
 
 		const submit = ( providedDependencies: ProvidedDependencies = {} ) => {
-			recordSubmitStep( providedDependencies, '', flowName, _currentStep );
+			recordSubmitStep( providedDependencies, intent, flowName, _currentStep );
 
 			switch ( _currentStep ) {
 				case 'processing':

--- a/client/landing/stepper/declarative-flow/with-theme-assembler-flow.ts
+++ b/client/landing/stepper/declarative-flow/with-theme-assembler-flow.ts
@@ -1,5 +1,5 @@
 import { BLANK_CANVAS_DESIGN } from '@automattic/design-picker';
-import { useFlowProgress, SITE_ASSEMBLER_FLOW } from '@automattic/onboarding';
+import { useFlowProgress, WITH_THEME_ASSEMBLER_FLOW } from '@automattic/onboarding';
 import { useDispatch } from '@wordpress/data';
 import { useEffect } from 'react';
 import { useQuery } from '../hooks/use-query';
@@ -11,14 +11,14 @@ import Processing from './internals/steps-repository/processing-step';
 import { Flow, ProvidedDependencies } from './internals/types';
 import type { Design } from '@automattic/design-picker/src/types';
 
-const siteAssemblerFlow: Flow = {
-	name: SITE_ASSEMBLER_FLOW,
+const withThemeAssemblerFlow: Flow = {
+	name: WITH_THEME_ASSEMBLER_FLOW,
 	useSteps() {
 		const { setSelectedDesign } = useDispatch( ONBOARD_STORE );
 		const selectedTheme = useQuery().get( 'theme' );
 
 		useEffect( () => {
-			if ( selectedTheme === BLANK_CANVAS_DESIGN.slug && this.name === SITE_ASSEMBLER_FLOW ) {
+			if ( selectedTheme === BLANK_CANVAS_DESIGN.slug ) {
 				// User has selected blank-canvas-3 theme from theme showcase and enter assembler flow
 				setSelectedDesign( BLANK_CANVAS_DESIGN as Design );
 			}
@@ -65,4 +65,4 @@ const siteAssemblerFlow: Flow = {
 	},
 };
 
-export default siteAssemblerFlow;
+export default withThemeAssemblerFlow;

--- a/client/landing/stepper/declarative-flow/with-theme-assembler-flow.ts
+++ b/client/landing/stepper/declarative-flow/with-theme-assembler-flow.ts
@@ -13,7 +13,7 @@ import type { Design } from '@automattic/design-picker/src/types';
 
 const withThemeAssemblerFlow: Flow = {
 	name: WITH_THEME_ASSEMBLER_FLOW,
-	useSteps() {
+	useSideEffect() {
 		const { setSelectedDesign } = useDispatch( ONBOARD_STORE );
 		const selectedTheme = useQuery().get( 'theme' );
 
@@ -23,7 +23,9 @@ const withThemeAssemblerFlow: Flow = {
 				setSelectedDesign( BLANK_CANVAS_DESIGN as Design );
 			}
 		}, [] );
+	},
 
+	useSteps() {
 		return [
 			{ slug: 'patternAssembler', component: PatternAssembler },
 			{ slug: 'processing', component: Processing },

--- a/client/lib/signup/flow-controller.ts
+++ b/client/lib/signup/flow-controller.ts
@@ -449,7 +449,14 @@ export default class SignupFlowController {
 		if ( typeof this._flow.destination === 'function' ) {
 			const goesThroughCheckout = this._getNeedsToGoThroughCheckout();
 			const localeSlug = getCurrentLocaleSlug( this._reduxStore.getState() );
-			return this._flow.destination( dependencies, localeSlug, goesThroughCheckout );
+			return this._flow.destination(
+				{
+					flowName: this._flowName,
+					...dependencies,
+				},
+				localeSlug,
+				goesThroughCheckout
+			);
 		}
 
 		return this._flow.destination;

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -86,6 +86,14 @@ export function generateFlows( {
 			showRecaptcha: true,
 		},
 		{
+			name: 'with-theme-assembler',
+			steps: [ 'user', 'domains-theme-preselected', 'plans' ],
+			destination: getChecklistThemeDestination,
+			description: 'Preselect a theme to activate/buy from an external source with the assembler.',
+			lastModified: '2023-02-06',
+			showRecaptcha: true,
+		},
+		{
 			name: 'design-first',
 			steps: [
 				'template-first-themes',

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -1,6 +1,6 @@
 import config from '@automattic/calypso-config';
 import { BLANK_CANVAS_DESIGN } from '@automattic/design-picker';
-import { SITE_ASSEMBLER_FLOW } from '@automattic/onboarding';
+import { isSiteAssemblerFlow } from '@automattic/onboarding';
 import { isDesktop } from '@automattic/viewport';
 import { get, includes, reject } from 'lodash';
 import detectHistoryNavigation from 'calypso/lib/detect-history-navigation';
@@ -110,21 +110,21 @@ function getThankYouNoSiteDestination() {
 	return `/checkout/thank-you/no-site`;
 }
 
-function getChecklistThemeDestination( { siteSlug, themeParameter, destinationFlowParameter } ) {
-	const canGoToAssemblerFlow = isDesktop();
-
+function getChecklistThemeDestination( { flowName, siteSlug, themeParameter } ) {
 	if (
-		destinationFlowParameter === SITE_ASSEMBLER_FLOW &&
+		isSiteAssemblerFlow( flowName ) &&
 		themeParameter === BLANK_CANVAS_DESIGN.slug &&
 		config.isEnabled( 'pattern-assembler/logged-out-showcase' )
 	) {
-		if ( canGoToAssemblerFlow ) {
+		// Go to the site assembler flow if viewport width >= 960px as the layout doesn't support small
+		// screen for now
+		if ( isDesktop() ) {
 			return addQueryArgs(
 				{
 					theme: themeParameter,
 					siteSlug: siteSlug,
 				},
-				`/setup/site-assembler`
+				`/setup/with-theme-assembler`
 			);
 		}
 

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -288,13 +288,10 @@ export default {
 		const refParameter = query && query.ref;
 		// Set theme parameter in signup depencency store so we can retrieve it in getChecklistThemeDestination().
 		const themeParameter = query && query.theme;
-		// Set destination parameter in signup depencency store so we can retrieve it in getChecklistThemeDestination().
-		const destinationFlowParameter = query && query.destination_flow;
 
 		const additionalDependencies = {
 			...( refParameter && { refParameter } ),
 			...( themeParameter && { themeParameter } ),
-			...( destinationFlowParameter && { destinationFlowParameter } ),
 		};
 		if ( ! isEmpty( additionalDependencies ) ) {
 			context.store.dispatch( updateDependencies( additionalDependencies ) );

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -1,4 +1,8 @@
-import { VIDEOPRESS_FLOW, isNewsletterOrLinkInBioFlow } from '@automattic/onboarding';
+import {
+	VIDEOPRESS_FLOW,
+	isNewsletterOrLinkInBioFlow,
+	isWithThemeFlow,
+} from '@automattic/onboarding';
 import { isTailoredSignupFlow } from '@automattic/onboarding/src';
 import { localize } from 'i18n-calypso';
 import { defer, get, isEmpty } from 'lodash';
@@ -722,7 +726,7 @@ class DomainsStep extends Component {
 	}
 
 	shouldHideNavButtons() {
-		return 'with-theme' === this.props.flowName || this.isTailoredFlow();
+		return isWithThemeFlow( this.props.flowName ) || this.isTailoredFlow();
 	}
 
 	renderContent() {

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -10,11 +10,11 @@ import { getUrlParts } from '@automattic/calypso-url';
 import { Button } from '@automattic/components';
 import {
 	isLinkInBioFlow,
-	NEWSLETTER_FLOW,
 	isNewsletterOrLinkInBioFlow,
-	SITE_ASSEMBLER_FLOW,
+	isSiteAssemblerFlow,
+	isTailoredSignupFlow,
+	NEWSLETTER_FLOW,
 } from '@automattic/onboarding';
-import { isTailoredSignupFlow } from '@automattic/onboarding/src';
 import { isDesktop, subscribeIsDesktop } from '@automattic/viewport';
 import classNames from 'classnames';
 import i18n, { localize } from 'i18n-calypso';
@@ -372,7 +372,7 @@ export class PlansStep extends Component {
 
 	shouldHideEcommercePlan() {
 		// Site Assembler doesn't support atomic site, so we have to hide the plan
-		return this.props.signupDependencies.destinationFlowParameter === SITE_ASSEMBLER_FLOW;
+		return isSiteAssemblerFlow( this.props.signupDependencies.destinationFlowParameter );
 	}
 
 	plansFeaturesSelection() {

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -371,8 +371,8 @@ export class PlansStep extends Component {
 	}
 
 	shouldHideEcommercePlan() {
-		// Site Assembler doesn't support atomic site, so we have to hide the plan
-		return isSiteAssemblerFlow( this.props.signupDependencies.destinationFlowParameter );
+		// The flow with the Site Assembler step doesn't support atomic site, so we have to hide the plan
+		return isSiteAssemblerFlow( this.props.flowName );
 	}
 
 	plansFeaturesSelection() {

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -292,7 +292,11 @@ export class UserStep extends Component {
 			},
 		};
 
-		this.props.recordTracksEvent( 'calypso_signup_user_step_submit', analyticsData );
+		this.props.recordTracksEvent( 'calypso_signup_user_step_submit', {
+			flow: this.props.flowName,
+			step: this.props.stepName,
+			...analyticsData,
+		} );
 
 		const isRecaptchaLoaded = typeof this.state.recaptchaClientId === 'number';
 

--- a/client/state/signup/progress/actions.js
+++ b/client/state/signup/progress/actions.js
@@ -25,7 +25,7 @@ function addProvidedDependencies( step, providedDependencies ) {
 	return { ...step, providedDependencies };
 }
 
-function recordSubmitStep( stepName, providedDependencies, optionalProps ) {
+function recordSubmitStep( flow, stepName, providedDependencies, optionalProps ) {
 	// Transform the keys since tracks events only accept snaked prop names.
 	// And anonymize personally identifiable information.
 	const inputs = reduce(
@@ -88,6 +88,7 @@ function recordSubmitStep( stepName, providedDependencies, optionalProps ) {
 	const device = resolveDeviceTypeByViewPort();
 	return recordTracksEvent( 'calypso_signup_actions_submit_step', {
 		device,
+		flow,
 		step: stepName,
 		...optionalProps,
 		...inputs,
@@ -113,7 +114,7 @@ export function submitSignupStep( step, providedDependencies ) {
 		const lastUpdated = Date.now();
 		const { intent } = getSignupDependencyStore( getState() );
 
-		dispatch( recordSubmitStep( step.stepName, providedDependencies, { intent } ) );
+		dispatch( recordSubmitStep( lastKnownFlow, step.stepName, providedDependencies, { intent } ) );
 
 		dispatch( {
 			type: SIGNUP_PROGRESS_SUBMIT_STEP,

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -199,6 +199,7 @@
 		"simple",
 		"woocommerce-install",
 		"with-theme",
+		"with-theme-assembler",
 		"free",
 		"personal",
 		"personal-monthly",

--- a/packages/data-stores/src/onboard/constants.ts
+++ b/packages/data-stores/src/onboard/constants.ts
@@ -16,4 +16,5 @@ export enum SiteIntent {
 	DIFM = 'difm', // "Do It For Me"
 	WpAdmin = 'wpadmin',
 	Import = 'import', // deprecated
+	WithThemeAssembler = 'with-theme-assembler',
 }

--- a/packages/onboarding/src/utils/flows.ts
+++ b/packages/onboarding/src/utils/flows.ts
@@ -14,7 +14,6 @@ export const MIGRATION_FLOW = 'import-focused';
 export const COPY_SITE_FLOW = 'copy-site';
 export const BUILD_FLOW = 'build';
 export const WRITE_FLOW = 'write';
-export const SITE_ASSEMBLER_FLOW = 'site-assembler';
 export const SITE_SETUP_FLOW = 'site-setup';
 export const WITH_THEME_FLOW = 'with-theme';
 export const WITH_THEME_ASSEMBLER_FLOW = 'with-theme-assembler';
@@ -70,7 +69,7 @@ export const isBuildFlow = ( flowName: string | null ) => {
 };
 
 export const isSiteAssemblerFlow = ( flowName: string | null ) => {
-	const SITE_ASSEMBLER_FLOWS = [ SITE_ASSEMBLER_FLOW, WITH_THEME_ASSEMBLER_FLOW ];
+	const SITE_ASSEMBLER_FLOWS = [ WITH_THEME_ASSEMBLER_FLOW ];
 
 	return !! flowName && SITE_ASSEMBLER_FLOWS.includes( flowName );
 };

--- a/packages/onboarding/src/utils/flows.ts
+++ b/packages/onboarding/src/utils/flows.ts
@@ -16,6 +16,8 @@ export const BUILD_FLOW = 'build';
 export const WRITE_FLOW = 'write';
 export const SITE_ASSEMBLER_FLOW = 'site-assembler';
 export const SITE_SETUP_FLOW = 'site-setup';
+export const WITH_THEME_FLOW = 'with-theme';
+export const WITH_THEME_ASSEMBLER_FLOW = 'with-theme-assembler';
 
 export const isLinkInBioFlow = ( flowName: string | null ) => {
 	return Boolean(
@@ -65,6 +67,18 @@ export const isWooExpressFlow = ( flowName: string | null ) => {
 
 export const isBuildFlow = ( flowName: string | null ) => {
 	return Boolean( flowName && [ BUILD_FLOW ].includes( flowName ) );
+};
+
+export const isSiteAssemblerFlow = ( flowName: string | null ) => {
+	const SITE_ASSEMBLER_FLOWS = [ SITE_ASSEMBLER_FLOW, WITH_THEME_ASSEMBLER_FLOW ];
+
+	return !! flowName && SITE_ASSEMBLER_FLOWS.includes( flowName );
+};
+
+export const isWithThemeFlow = ( flowName: string | null ) => {
+	const WITH_THEME_FLOWS = [ WITH_THEME_FLOW, WITH_THEME_ASSEMBLER_FLOW ];
+
+	return !! flowName && WITH_THEME_FLOWS.includes( flowName );
 };
 
 export const ecommerceFlowRecurTypes = {


### PR DESCRIPTION
#### Proposed Changes

* Referring to p1675649656104429-slack-CRWCHQGUB, we want to have a different flow name for the `with-theme` flow that ends with `site-assembler`. So, this PR proposes to create a new flow called `with-theme-assembler`, and all behaviors are the same as `with-theme` flow except the final destination.

| Land on the `with-theme-assembler` flow | Land on the `pattern-assembler` step |
| - | - |
| ![image](https://user-images.githubusercontent.com/13596067/216878664-588b473a-55b5-4a3a-b4d6-7de2f9b4535d.png) | ![image](https://user-images.githubusercontent.com/13596067/216905771-2134ea83-fafd-4dbd-914c-52d1a36de283.png) |

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the browser in Incognito mode
* Go to /themes
* Scroll down and select the Pattern Assembler CTA
* Verify you're going to `/start/with-theme-assembler` and the flow name of the track events is `with-theme-assembler`
* Verify you're going to `/setup/with-theme-assembler` when you finish the signup and create a new site. Moreover, the flow name of the track event should be `with-theme-assembler` as well.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1675649656104429-slack-CRWCHQGUB